### PR TITLE
feat(diagram): add deterministic native SVG/PDF rendering

### DIFF
--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -7,7 +7,7 @@ description: Immutable controlled-document views, stable sheet identities, recip
 
 NeqSim can project one canonical process topology into an immutable controlled-document proposal.
 The document model is separate from process execution scheduling and from every renderer or exchange
-format. It is the shared semantic layer for future native SVG/PDF PFD drawing sets and the existing
+format. It is the shared semantic layer for native SVG/PDF PFD drawing sets and the existing
 DEXPI/Proteus P&ID workflow.
 
 The initial model provides:
@@ -164,6 +164,40 @@ Coordinates and waypoints are renderer-neutral proposal data. The register does 
 route is physically constructible, that a layout complies with a drawing standard, or that an
 accountable engineer has approved the result.
 
+### Deterministic native SVG/PDF rendering
+
+`NativeEngineeringDiagramRenderer` projects the controlled document set directly to native SVG and
+PDF without Graphviz. Both formats consume the same deterministic page plan. The renderer preserves
+stable sheet and semantic-object IDs, positions pinned in drawing-paper millimetres, protected route
+waypoints, reciprocal off-page references, drawing/sheet titles, revision, status, issue purpose,
+and source-graph fingerprint.
+
+```java
+NativeEngineeringDiagramRenderer.Result rendered =
+    new NativeEngineeringDiagramRenderer(
+            manuallyArranged,
+            NativeEngineeringDiagramRenderer.SheetFormat.A3_LANDSCAPE)
+        .render();
+
+Map<String, String> svgBySheetId = rendered.getSvgBySheetId();
+byte[] multiPagePdf = rendered.getPdf();
+for (NativeEngineeringDiagramRenderer.Diagnostic diagnostic : rendered.getDiagnostics()) {
+  logger.warn("{}: {}", diagnostic.getCode(), diagnostic.getMessage());
+}
+```
+
+`A3_LANDSCAPE` and `A1_LANDSCAPE` provide controlled paper geometry in millimetres. They identify
+the paper dimensions only; they do not assert standards conformance. Unpinned objects receive a
+stable grid position, while out-of-bounds pinned coordinates, protected routes, and automatic
+layout overflow remain fail-visible through structured diagnostics. Manual geometry is retained
+unchanged instead of being silently repaired.
+
+SVG output contains stable `data-sheet-id`, `data-semantic-id`, and protected-route attributes for
+machine inspection. PDF output is a deterministic vector drawing set with one page per controlled
+sheet. Use `exportSvg(directory)` or `exportPdf(path)` when files are required. Rendering does not
+modify the source document set, legacy DOT/Graphviz output, DEXPI 2.0 Process exchange, or the
+Proteus/DEXPI P&ID workflow.
+
 Compare two revisions of the same document-set and plant identity with `baseline.compareTo(revised)`.
 The returned `EngineeringDiagramRevisionImpact` has deterministic added, removed, and modified
 semantic-object IDs. It projects those changes to the sheets and drawings containing each object in
@@ -185,10 +219,11 @@ Designation and layout registers record review evidence only. They do not repres
 approval, do not authorize a P&ID or PFD for design or construction, and do not replace project
 ownership of piping, valve, nozzle, instrument, safeguard, routing, or design data.
 
-The document model does not claim ISO 10628, ISO 5457, ISO 7200, ISO 14617, ISA, DEXPI EV, or
-commercial CAE conformance. Licensed standards mapping, project conventions, qualified symbols,
-rendered visual review, external-product round trips, and accountable discipline approval remain
-separate evidence gates.
+The document model and native renderer do not claim ISO 10628, ISO 5457, ISO 7200, ISO 14617, ISA,
+DEXPI EV, or commercial CAE conformance. Licensed standards mapping, project conventions, qualified
+symbols, rendered visual review, external-product round trips, and accountable discipline approval
+remain separate evidence gates. Working proposals carry an explicit not-approved-for-design-or-
+construction banner in native output.
 
 ## Validation
 
@@ -196,6 +231,7 @@ Run the focused regression with:
 
 ```bash
 ./mvnw -Dtest=ProcessDiagramDocumentSetAdapterTest test
+./mvnw -Dtest=NativeEngineeringDiagramRendererTest test
 ```
 
 The regression verifies deterministic single- and multi-area output, immutable collections,
@@ -207,3 +243,7 @@ calculation graphs, unchanged topology-only behavior, reviewed designation gover
 designation mismatches, deterministic cross-sheet revision impact, persistent manual layout evidence,
 unchanged semantic identities after layout-only revision changes, protected-route retention, and
 fail-visible stale layout references.
+The native-renderer regression verifies byte-deterministic SVG/PDF, A3 and A1 geometry, exact pinned
+coordinates and protected routes, reciprocal off-page references, structured layout-loss
+diagnostics, multi-page drawing sets, fresh-model determinism, and unchanged Classic DOT and
+controlled-document JSON.

--- a/docs/process/processmodel/diagram_export.md
+++ b/docs/process/processmodel/diagram_export.md
@@ -9,6 +9,14 @@ NeqSim can export deterministic simulator-style process flow diagrams (PFDs) as 
 when Graphviz is installed, SVG or PDF. These exports help inspect simulation topology; they are not
 qualified engineering drawings and do not claim ISO 10628 conformance.
 
+For controlled multi-sheet drawing proposals, first create an `EngineeringDiagramDocumentSet` with
+`ProcessDiagramDocumentSetAdapter`, then use `NativeEngineeringDiagramRenderer`. The native renderer
+does not require Graphviz and emits deterministic vector SVG sheets plus one multi-page PDF from the
+same semantic document model. It preserves pinned millimetre positions, protected routes,
+reciprocal off-page references, and title/revision metadata. The result remains an engineering
+proposal and is not a qualified P&amp;ID or standards-conformance claim. See
+[Engineering diagram document and sheet model](../../integration/engineering-diagram-document-model.md).
+
 ## Canonical Topology Foundation
 
 Use `ProcessDiagramGraphAdapter` when a downstream renderer or exchange workflow needs a stable,

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -30,10 +30,10 @@ import neqsim.process.engineering.model.EngineeringNode;
  *
  * <p>
  * The renderer consumes the immutable semantic document model directly. It does not invoke Graphviz and therefore
- * preserves stable sheet identities, pinned millimetre positions, protected routes, reciprocal off-page references,
- * and controlled title/revision metadata. Automatically placed objects use a deterministic grid. Native output is an
- * engineering proposal unless the source document set carries accountable approval evidence; rendering does not
- * qualify symbols, layout, or content against ISO 10628 or any other drawing standard.
+ * preserves stable sheet identities, pinned millimetre positions, protected routes, reciprocal off-page references, and
+ * controlled title/revision metadata. Automatically placed objects use a deterministic grid. Native output is an
+ * engineering proposal unless the source document set carries accountable approval evidence; rendering does not qualify
+ * symbols, layout, or content against ISO 10628 or any other drawing standard.
  * </p>
  */
 public final class NativeEngineeringDiagramRenderer {
@@ -251,8 +251,8 @@ public final class NativeEngineeringDiagramRenderer {
     Page page = new Page(sheet.getId(), format.getWidthMillimetres(), format.getHeightMillimetres());
     double contentRight = page.width - CONTENT_LEFT;
     double contentBottom = page.height - TITLE_BLOCK_HEIGHT - 7.0;
-    page.commands.add(Command.rect(8.0, 8.0, page.width - 16.0, page.height - 16.0, "#1f2937", "none", 0.5,
-        "sheet-border", ""));
+    page.commands
+        .add(Command.rect(8.0, 8.0, page.width - 16.0, page.height - 16.0, "#1f2937", "none", 0.5, "sheet-border", ""));
     page.commands.add(Command.text(12.0, 17.0, 4.2, documentSet.getTitle(), "#111827", "document-title", ""));
     page.commands.add(Command.text(page.width - 12.0, 17.0, 2.7,
         drawing.getContentProfile().name() + " / " + format.name(), "#374151", "sheet-format", "end"));
@@ -376,8 +376,9 @@ public final class NativeEngineeringDiagramRenderer {
   private void addOffPageConnector(Page page, OffPageConnector connector, double contentRight, double contentBottom) {
     Point point = connectorPoint(connector, contentRight, contentBottom);
     double direction = connector.getRole() == EngineeringDiagramDocumentSet.ConnectorRole.SOURCE ? 1.0 : -1.0;
-    List<Point> triangle = Arrays.asList(new Point(point.x, point.y), new Point(point.x - direction * 5.0, point.y - 3.0),
-        new Point(point.x - direction * 5.0, point.y + 3.0), new Point(point.x, point.y));
+    List<Point> triangle = Arrays.asList(new Point(point.x, point.y),
+        new Point(point.x - direction * 5.0, point.y - 3.0), new Point(point.x - direction * 5.0, point.y + 3.0),
+        new Point(point.x, point.y));
     page.commands.add(Command.polyline(triangle, "#111827", 0.7, "", connector.getId(), false));
     String label = "TO/FROM " + connector.getZoneReference() + " [" + connector.getPeerSheetId() + "]";
     double textX = point.x - direction * 7.0;
@@ -392,24 +393,23 @@ public final class NativeEngineeringDiagramRenderer {
     page.commands.add(Command.rect(x, y, OBJECT_WIDTH, OBJECT_HEIGHT, "#1f2937", fill, 0.7, object.getId(), ""));
     String primary = displayLabel(object);
     page.commands.add(Command.text(position.x, position.y - 0.8, 2.8, primary, "#111827", object.getId(), "middle"));
-    page.commands.add(Command.text(position.x, position.y + 4.0, 2.0, object.getKind().name(), "#4b5563",
-        object.getId(), "middle"));
+    page.commands.add(
+        Command.text(position.x, position.y + 4.0, 2.0, object.getKind().name(), "#4b5563", object.getId(), "middle"));
   }
 
   private void addTitleBlock(Page page, Drawing drawing, Sheet sheet) {
     double top = page.height - TITLE_BLOCK_HEIGHT;
-    page.commands.add(Command.rect(8.0, top, page.width - 16.0, TITLE_BLOCK_HEIGHT - 8.0, "#1f2937", "#ffffff",
-        0.5, "title-block", ""));
-    page.commands.add(Command.line(page.width * 0.58, top, page.width * 0.58, page.height - 8.0, "#1f2937", 0.4,
+    page.commands.add(Command.rect(8.0, top, page.width - 16.0, TITLE_BLOCK_HEIGHT - 8.0, "#1f2937", "#ffffff", 0.5,
         "title-block", ""));
+    page.commands.add(
+        Command.line(page.width * 0.58, top, page.width * 0.58, page.height - 8.0, "#1f2937", 0.4, "title-block", ""));
     page.commands.add(Command.text(12.0, top + 6.0, 3.0, drawing.getTitle(), "#111827", "drawing-title", ""));
-    page.commands.add(Command.text(12.0, top + 12.0, 2.5, "DRAWING " + drawing.getNumber(), "#111827",
-        "drawing-number", ""));
+    page.commands
+        .add(Command.text(12.0, top + 12.0, 2.5, "DRAWING " + drawing.getNumber(), "#111827", "drawing-number", ""));
     page.commands.add(Command.text(12.0, top + 17.0, 2.3, "SHEET " + sheet.getNumber() + " - " + sheet.getTitle(),
         "#111827", "sheet-number", ""));
     page.commands.add(Command.text(page.width * 0.60, top + 6.0, 2.4,
-        "REV " + documentSet.getRevision() + "  STATUS " + documentSet.getStatus().name(), "#111827",
-        "revision", ""));
+        "REV " + documentSet.getRevision() + "  STATUS " + documentSet.getStatus().name(), "#111827", "revision", ""));
     page.commands.add(Command.text(page.width * 0.60, top + 11.0, 2.2,
         "PURPOSE " + documentSet.getIssuePurpose().name(), "#111827", "issue-purpose", ""));
     page.commands.add(Command.text(page.width * 0.60, top + 16.0, 1.8,
@@ -417,18 +417,16 @@ public final class NativeEngineeringDiagramRenderer {
     if (documentSet.getStatus() != EngineeringDiagramDocumentSet.DocumentStatus.APPROVED
         || documentSet.getIssuePurpose() == EngineeringDiagramDocumentSet.IssuePurpose.ENGINEERING_PROPOSAL) {
       page.commands.add(Command.text(page.width / 2.0, top - 3.0, 3.0,
-          "ENGINEERING PROPOSAL - NOT APPROVED FOR DESIGN OR CONSTRUCTION", "#b91c1c", "proposal-boundary",
-          "middle"));
+          "ENGINEERING PROPOSAL - NOT APPROVED FOR DESIGN OR CONSTRUCTION", "#b91c1c", "proposal-boundary", "middle"));
     }
   }
 
   private String toSvg(Page page) {
     StringBuilder svg = new StringBuilder();
     svg.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-    svg.append("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"").append(number(page.width))
-        .append("mm\" height=\"").append(number(page.height)).append("mm\" viewBox=\"0 0 ")
-        .append(number(page.width)).append(' ').append(number(page.height)).append("\" data-sheet-id=\"")
-        .append(xml(page.sheetId)).append("\">\n");
+    svg.append("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"").append(number(page.width)).append("mm\" height=\"")
+        .append(number(page.height)).append("mm\" viewBox=\"0 0 ").append(number(page.width)).append(' ')
+        .append(number(page.height)).append("\" data-sheet-id=\"").append(xml(page.sheetId)).append("\">\n");
     svg.append("  <title>").append(xml(documentSet.getTitle())).append(" - ").append(xml(page.sheetId))
         .append("</title>\n");
     svg.append("  <g font-family=\"Arial,Helvetica,sans-serif\" fill=\"none\">\n");
@@ -481,8 +479,8 @@ public final class NativeEngineeringDiagramRenderer {
     for (int index = 1; index < offsets.size(); index++) {
       write(output, bytes(String.format(Locale.ROOT, "%010d 00000 n \n", offsets.get(index))));
     }
-    write(output, bytes("trailer\n<< /Size " + (objects.size() + 1) + " /Root 1 0 R >>\nstartxref\n" + xref
-        + "\n%%EOF\n"));
+    write(output,
+        bytes("trailer\n<< /Size " + (objects.size() + 1) + " /Root 1 0 R >>\nstartxref\n" + xref + "\n%%EOF\n"));
     return output.toByteArray();
   }
 
@@ -670,8 +668,8 @@ public final class NativeEngineeringDiagramRenderer {
     }
 
     private static Command text(double x, double y, double size, String text, String fill, String id, String anchor) {
-      return new Command("text", Collections.<Point>emptyList(), x, y, 0.0, 0.0, size, text, "none", fill, 0.0, "",
-          id, anchor, false);
+      return new Command("text", Collections.<Point>emptyList(), x, y, 0.0, 0.0, size, text, "none", fill, 0.0, "", id,
+          anchor, false);
     }
 
     private String toSvg() {
@@ -680,8 +678,8 @@ public final class NativeEngineeringDiagramRenderer {
         result.append("rect x=\"").append(number(x)).append("\" y=\"").append(number(y)).append("\" width=\"")
             .append(number(width)).append("\" height=\"").append(number(height)).append("\"");
       } else if ("text".equals(type)) {
-        result.append("text x=\"").append(number(x)).append("\" y=\"").append(number(y))
-            .append("\" font-size=\"").append(number(size)).append("\" dominant-baseline=\"middle\"");
+        result.append("text x=\"").append(number(x)).append("\" y=\"").append(number(y)).append("\" font-size=\"")
+            .append(number(size)).append("\" dominant-baseline=\"middle\"");
         if (!anchor.isEmpty()) {
           result.append(" text-anchor=\"").append(anchor).append("\"");
         }
@@ -751,8 +749,8 @@ public final class NativeEngineeringDiagramRenderer {
             .append(" m ");
         for (int index = 1; index < points.size(); index++) {
           Point point = points.get(index);
-          result.append(number(point.x * MM_TO_POINT)).append(' ')
-              .append(number((pageHeight - point.y) * MM_TO_POINT)).append(" l ");
+          result.append(number(point.x * MM_TO_POINT)).append(' ').append(number((pageHeight - point.y) * MM_TO_POINT))
+              .append(" l ");
         }
         result.append("S\n");
       }

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -1,0 +1,773 @@
+package neqsim.process.processmodel.diagram;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Drawing;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.OffPageConnector;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.SemanticObject;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Sheet;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.PinnedPosition;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.ProtectedRoute;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.Waypoint;
+import neqsim.process.engineering.model.EngineeringNode;
+
+/**
+ * Deterministic native SVG and PDF renderer for controlled engineering-diagram document sets.
+ *
+ * <p>
+ * The renderer consumes the immutable semantic document model directly. It does not invoke Graphviz and therefore
+ * preserves stable sheet identities, pinned millimetre positions, protected routes, reciprocal off-page references,
+ * and controlled title/revision metadata. Automatically placed objects use a deterministic grid. Native output is an
+ * engineering proposal unless the source document set carries accountable approval evidence; rendering does not
+ * qualify symbols, layout, or content against ISO 10628 or any other drawing standard.
+ * </p>
+ */
+public final class NativeEngineeringDiagramRenderer {
+  private static final double MM_TO_POINT = 72.0 / 25.4;
+  private static final double CONTENT_LEFT = 16.0;
+  private static final double CONTENT_TOP = 24.0;
+  private static final double TITLE_BLOCK_HEIGHT = 30.0;
+  private static final double OBJECT_WIDTH = 34.0;
+  private static final double OBJECT_HEIGHT = 16.0;
+
+  /** Controlled paper sizes supported by the native renderer. */
+  public enum SheetFormat {
+    /** ISO A3 landscape paper geometry (420 x 297 mm); no conformance claim is implied. */
+    A3_LANDSCAPE(420.0, 297.0),
+    /** ISO A1 landscape paper geometry (841 x 594 mm); no conformance claim is implied. */
+    A1_LANDSCAPE(841.0, 594.0);
+
+    private final double widthMillimetres;
+    private final double heightMillimetres;
+
+    SheetFormat(double widthMillimetres, double heightMillimetres) {
+      this.widthMillimetres = widthMillimetres;
+      this.heightMillimetres = heightMillimetres;
+    }
+
+    /** @return sheet width in drawing-paper millimetres */
+    public double getWidthMillimetres() {
+      return widthMillimetres;
+    }
+
+    /** @return sheet height in drawing-paper millimetres */
+    public double getHeightMillimetres() {
+      return heightMillimetres;
+    }
+  }
+
+  /** Renderer diagnostic severity. */
+  public enum Severity {
+    /** Recoverable rendering limitation requiring review. */
+    WARNING,
+    /** Broken source or rendering state that prevents a complete view. */
+    ERROR
+  }
+
+  /** Immutable structured rendering diagnostic. */
+  public static final class Diagnostic {
+    private final Severity severity;
+    private final String code;
+    private final String message;
+    private final String subjectId;
+
+    private Diagnostic(Severity severity, String code, String message, String subjectId) {
+      this.severity = severity;
+      this.code = code;
+      this.message = message;
+      this.subjectId = subjectId;
+    }
+
+    /** @return diagnostic severity */
+    public Severity getSeverity() {
+      return severity;
+    }
+
+    /** @return stable machine-readable diagnostic code */
+    public String getCode() {
+      return code;
+    }
+
+    /** @return human-readable diagnostic message */
+    public String getMessage() {
+      return message;
+    }
+
+    /** @return stable source subject identity, or an empty string */
+    public String getSubjectId() {
+      return subjectId;
+    }
+  }
+
+  /** Immutable rendering result containing every SVG sheet, one PDF drawing set, and diagnostics. */
+  public static final class Result {
+    private final Map<String, String> svgBySheetId;
+    private final byte[] pdf;
+    private final List<Diagnostic> diagnostics;
+
+    private Result(Map<String, String> svgBySheetId, byte[] pdf, List<Diagnostic> diagnostics) {
+      this.svgBySheetId = Collections.unmodifiableMap(new LinkedHashMap<String, String>(svgBySheetId));
+      this.pdf = Arrays.copyOf(pdf, pdf.length);
+      this.diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+    }
+
+    /** @return deterministic sheet-ID-ordered native SVG documents */
+    public Map<String, String> getSvgBySheetId() {
+      return svgBySheetId;
+    }
+
+    /** @return defensive copy of the deterministic multi-page native PDF */
+    public byte[] getPdf() {
+      return Arrays.copyOf(pdf, pdf.length);
+    }
+
+    /** @return immutable structured rendering diagnostics */
+    public List<Diagnostic> getDiagnostics() {
+      return diagnostics;
+    }
+
+    /** @return {@code true} when no renderer error was recorded */
+    public boolean isComplete() {
+      for (Diagnostic diagnostic : diagnostics) {
+        if (diagnostic.getSeverity() == Severity.ERROR) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+
+  private final EngineeringDiagramDocumentSet documentSet;
+  private final SheetFormat format;
+
+  /**
+   * Creates an A3-landscape native renderer.
+   *
+   * @param documentSet immutable controlled engineering-diagram document set
+   */
+  public NativeEngineeringDiagramRenderer(EngineeringDiagramDocumentSet documentSet) {
+    this(documentSet, SheetFormat.A3_LANDSCAPE);
+  }
+
+  /**
+   * Creates a native renderer with explicit controlled sheet geometry.
+   *
+   * @param documentSet immutable controlled engineering-diagram document set
+   * @param format paper geometry
+   */
+  public NativeEngineeringDiagramRenderer(EngineeringDiagramDocumentSet documentSet, SheetFormat format) {
+    if (documentSet == null) {
+      throw new IllegalArgumentException("documentSet must not be null");
+    }
+    if (format == null) {
+      throw new IllegalArgumentException("format must not be null");
+    }
+    this.documentSet = documentSet;
+    this.format = format;
+  }
+
+  /**
+   * Renders every controlled sheet to native SVG and the drawing set to one multi-page native PDF.
+   *
+   * @return deterministic rendering result
+   */
+  public Result render() {
+    List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
+    Map<String, SemanticObject> objects = objectsById();
+    List<Page> pages = new ArrayList<Page>();
+    for (Drawing drawing : documentSet.getDrawings()) {
+      for (Sheet sheet : drawing.getSheets()) {
+        pages.add(buildPage(drawing, sheet, objects, diagnostics));
+      }
+    }
+    Collections.sort(pages, new Comparator<Page>() {
+      @Override
+      public int compare(Page left, Page right) {
+        return left.sheetId.compareTo(right.sheetId);
+      }
+    });
+    Map<String, String> svg = new LinkedHashMap<String, String>();
+    for (Page page : pages) {
+      svg.put(page.sheetId, toSvg(page));
+    }
+    return new Result(svg, toPdf(pages), diagnostics);
+  }
+
+  /**
+   * Writes one SVG file per stable sheet ID.
+   *
+   * @param directory target directory
+   * @return stable sheet-ID-to-path map
+   * @throws IOException when output cannot be written
+   */
+  public Map<String, Path> exportSvg(Path directory) throws IOException {
+    if (directory == null) {
+      throw new IllegalArgumentException("directory must not be null");
+    }
+    Result result = render();
+    Files.createDirectories(directory);
+    Map<String, Path> paths = new LinkedHashMap<String, Path>();
+    for (Map.Entry<String, String> entry : result.getSvgBySheetId().entrySet()) {
+      Path path = directory.resolve(fileName(entry.getKey()) + ".svg");
+      Files.write(path, entry.getValue().getBytes(StandardCharsets.UTF_8));
+      paths.put(entry.getKey(), path);
+    }
+    return Collections.unmodifiableMap(paths);
+  }
+
+  /**
+   * Writes one deterministic multi-page native PDF drawing set.
+   *
+   * @param path target PDF path
+   * @throws IOException when output cannot be written
+   */
+  public void exportPdf(Path path) throws IOException {
+    if (path == null) {
+      throw new IllegalArgumentException("path must not be null");
+    }
+    Path parent = path.toAbsolutePath().getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    Files.write(path, render().getPdf());
+  }
+
+  private Page buildPage(Drawing drawing, Sheet sheet, Map<String, SemanticObject> objects,
+      List<Diagnostic> diagnostics) {
+    Page page = new Page(sheet.getId(), format.getWidthMillimetres(), format.getHeightMillimetres());
+    double contentRight = page.width - CONTENT_LEFT;
+    double contentBottom = page.height - TITLE_BLOCK_HEIGHT - 7.0;
+    page.commands.add(Command.rect(8.0, 8.0, page.width - 16.0, page.height - 16.0, "#1f2937", "none", 0.5,
+        "sheet-border", ""));
+    page.commands.add(Command.text(12.0, 17.0, 4.2, documentSet.getTitle(), "#111827", "document-title", ""));
+    page.commands.add(Command.text(page.width - 12.0, 17.0, 2.7,
+        drawing.getContentProfile().name() + " / " + format.name(), "#374151", "sheet-format", "end"));
+
+    Map<String, Point> positions = layoutPositions(sheet, objects, contentRight, contentBottom, diagnostics);
+    Map<String, OffPageConnector> connectors = new TreeMap<String, OffPageConnector>();
+    for (OffPageConnector connector : sheet.getOffPageConnectors()) {
+      connectors.put(connector.getSemanticConnectionId(), connector);
+    }
+    Map<String, ProtectedRoute> protectedRoutes = new TreeMap<String, ProtectedRoute>();
+    for (ProtectedRoute route : sheet.getProtectedRoutes()) {
+      protectedRoutes.put(route.getSemanticConnectionId(), route);
+      if (!insideAll(route.getWaypoints(), page.width, contentBottom)) {
+        diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_ROUTE_OUTSIDE_SHEET",
+            "Protected route contains a waypoint outside the drawable sheet area and is retained unchanged",
+            route.getSemanticConnectionId()));
+      }
+    }
+
+    List<String> ids = new ArrayList<String>(sheet.getObjectNodeIds());
+    Collections.sort(ids);
+    for (String id : ids) {
+      SemanticObject object = objects.get(id);
+      if (object != null && isConnection(object.getKind())) {
+        addConnection(page, object, positions, connectors.get(id), protectedRoutes.get(id), objects, contentRight,
+            contentBottom, diagnostics);
+      }
+    }
+    for (OffPageConnector connector : sheet.getOffPageConnectors()) {
+      addOffPageConnector(page, connector, contentRight, contentBottom);
+    }
+    for (String id : ids) {
+      SemanticObject object = objects.get(id);
+      Point position = positions.get(id);
+      if (object != null && position != null && isDrawableNode(object.getKind())) {
+        addObject(page, object, position);
+      }
+    }
+    addTitleBlock(page, drawing, sheet);
+    return page;
+  }
+
+  private Map<String, Point> layoutPositions(Sheet sheet, Map<String, SemanticObject> objects, double contentRight,
+      double contentBottom, List<Diagnostic> diagnostics) {
+    Map<String, Point> result = new TreeMap<String, Point>();
+    for (PinnedPosition pinned : sheet.getPinnedPositions()) {
+      result.put(pinned.getSemanticObjectId(), new Point(pinned.getX(), pinned.getY()));
+      if (!inside(pinned.getX(), pinned.getY(), format.getWidthMillimetres(), contentBottom)) {
+        diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_PIN_OUTSIDE_SHEET",
+            "Pinned millimetre position is outside the drawable sheet area and is retained unchanged",
+            pinned.getSemanticObjectId()));
+      }
+    }
+    List<String> automatic = new ArrayList<String>();
+    for (String id : sheet.getObjectNodeIds()) {
+      SemanticObject object = objects.get(id);
+      if (object != null && isDrawableNode(object.getKind()) && !result.containsKey(id)) {
+        automatic.add(id);
+      }
+    }
+    Collections.sort(automatic);
+    int columns = Math.max(1, (int) Math.floor((contentRight - CONTENT_LEFT) / 62.0));
+    for (int index = 0; index < automatic.size(); index++) {
+      int column = index % columns;
+      int row = index / columns;
+      double x = CONTENT_LEFT + 24.0 + column * 62.0;
+      double y = CONTENT_TOP + 18.0 + row * 34.0;
+      if (y > contentBottom - OBJECT_HEIGHT) {
+        diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_AUTO_LAYOUT_OVERFLOW",
+            "Automatic grid placement exceeds the drawable area; manual sheet assignment or pinned layout is needed",
+            automatic.get(index)));
+      }
+      result.put(automatic.get(index), new Point(x, y));
+    }
+    return result;
+  }
+
+  private void addConnection(Page page, SemanticObject connection, Map<String, Point> positions,
+      OffPageConnector connector, ProtectedRoute protectedRoute, Map<String, SemanticObject> objects,
+      double contentRight, double contentBottom, List<Diagnostic> diagnostics) {
+    List<Point> points = new ArrayList<Point>();
+    boolean protectedGeometry = protectedRoute != null;
+    if (protectedGeometry) {
+      for (Waypoint waypoint : protectedRoute.getWaypoints()) {
+        points.add(new Point(waypoint.getX(), waypoint.getY()));
+      }
+    } else {
+      Point source = endpointPosition(connection, "sourceEndpointId", positions, objects);
+      Point target = endpointPosition(connection, "targetEndpointId", positions, objects);
+      Point offPage = connector == null ? null : connectorPoint(connector, contentRight, contentBottom);
+      if (connector != null && connector.getRole() == EngineeringDiagramDocumentSet.ConnectorRole.SOURCE) {
+        target = offPage;
+      } else if (connector != null) {
+        source = offPage;
+      }
+      if (source != null && target != null) {
+        points.add(source);
+        points.add(new Point((source.x + target.x) / 2.0, source.y));
+        points.add(new Point((source.x + target.x) / 2.0, target.y));
+        points.add(target);
+      } else {
+        diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_CONNECTION_ENDPOINT_OMITTED",
+            "Connection endpoints cannot both be placed on this sheet; the semantic connection remains in the source document",
+            connection.getId()));
+        return;
+      }
+    }
+    String connectionType = stringProperty(connection, "connectionType", "MATERIAL");
+    String color = "#1f2937";
+    String dash = "";
+    if ("ENERGY".equals(connectionType)) {
+      color = "#b45309";
+      dash = "4 2";
+    } else if ("SIGNAL".equals(connectionType)) {
+      color = "#2563eb";
+      dash = "2 2";
+    }
+    page.commands.add(Command.polyline(points, color, 0.8, dash, connection.getId(), protectedGeometry));
+  }
+
+  private void addOffPageConnector(Page page, OffPageConnector connector, double contentRight, double contentBottom) {
+    Point point = connectorPoint(connector, contentRight, contentBottom);
+    double direction = connector.getRole() == EngineeringDiagramDocumentSet.ConnectorRole.SOURCE ? 1.0 : -1.0;
+    List<Point> triangle = Arrays.asList(new Point(point.x, point.y), new Point(point.x - direction * 5.0, point.y - 3.0),
+        new Point(point.x - direction * 5.0, point.y + 3.0), new Point(point.x, point.y));
+    page.commands.add(Command.polyline(triangle, "#111827", 0.7, "", connector.getId(), false));
+    String label = "TO/FROM " + connector.getZoneReference() + " [" + connector.getPeerSheetId() + "]";
+    double textX = point.x - direction * 7.0;
+    page.commands.add(Command.text(textX, point.y - 4.0, 2.4, label, "#111827", connector.getId(),
+        direction > 0.0 ? "end" : "start"));
+  }
+
+  private void addObject(Page page, SemanticObject object, Point position) {
+    double x = position.x - OBJECT_WIDTH / 2.0;
+    double y = position.y - OBJECT_HEIGHT / 2.0;
+    String fill = object.getKind() == EngineeringNode.Kind.EQUIPMENT ? "#eef6ee" : "#eff6ff";
+    page.commands.add(Command.rect(x, y, OBJECT_WIDTH, OBJECT_HEIGHT, "#1f2937", fill, 0.7, object.getId(), ""));
+    String primary = displayLabel(object);
+    page.commands.add(Command.text(position.x, position.y - 0.8, 2.8, primary, "#111827", object.getId(), "middle"));
+    page.commands.add(Command.text(position.x, position.y + 4.0, 2.0, object.getKind().name(), "#4b5563",
+        object.getId(), "middle"));
+  }
+
+  private void addTitleBlock(Page page, Drawing drawing, Sheet sheet) {
+    double top = page.height - TITLE_BLOCK_HEIGHT;
+    page.commands.add(Command.rect(8.0, top, page.width - 16.0, TITLE_BLOCK_HEIGHT - 8.0, "#1f2937", "#ffffff",
+        0.5, "title-block", ""));
+    page.commands.add(Command.line(page.width * 0.58, top, page.width * 0.58, page.height - 8.0, "#1f2937", 0.4,
+        "title-block", ""));
+    page.commands.add(Command.text(12.0, top + 6.0, 3.0, drawing.getTitle(), "#111827", "drawing-title", ""));
+    page.commands.add(Command.text(12.0, top + 12.0, 2.5, "DRAWING " + drawing.getNumber(), "#111827",
+        "drawing-number", ""));
+    page.commands.add(Command.text(12.0, top + 17.0, 2.3, "SHEET " + sheet.getNumber() + " - " + sheet.getTitle(),
+        "#111827", "sheet-number", ""));
+    page.commands.add(Command.text(page.width * 0.60, top + 6.0, 2.4,
+        "REV " + documentSet.getRevision() + "  STATUS " + documentSet.getStatus().name(), "#111827",
+        "revision", ""));
+    page.commands.add(Command.text(page.width * 0.60, top + 11.0, 2.2,
+        "PURPOSE " + documentSet.getIssuePurpose().name(), "#111827", "issue-purpose", ""));
+    page.commands.add(Command.text(page.width * 0.60, top + 16.0, 1.8,
+        "SOURCE " + documentSet.getSourceGraphFingerprint(), "#4b5563", "fingerprint", ""));
+    if (documentSet.getStatus() != EngineeringDiagramDocumentSet.DocumentStatus.APPROVED
+        || documentSet.getIssuePurpose() == EngineeringDiagramDocumentSet.IssuePurpose.ENGINEERING_PROPOSAL) {
+      page.commands.add(Command.text(page.width / 2.0, top - 3.0, 3.0,
+          "ENGINEERING PROPOSAL - NOT APPROVED FOR DESIGN OR CONSTRUCTION", "#b91c1c", "proposal-boundary",
+          "middle"));
+    }
+  }
+
+  private String toSvg(Page page) {
+    StringBuilder svg = new StringBuilder();
+    svg.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    svg.append("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"").append(number(page.width))
+        .append("mm\" height=\"").append(number(page.height)).append("mm\" viewBox=\"0 0 ")
+        .append(number(page.width)).append(' ').append(number(page.height)).append("\" data-sheet-id=\"")
+        .append(xml(page.sheetId)).append("\">\n");
+    svg.append("  <title>").append(xml(documentSet.getTitle())).append(" - ").append(xml(page.sheetId))
+        .append("</title>\n");
+    svg.append("  <g font-family=\"Arial,Helvetica,sans-serif\" fill=\"none\">\n");
+    for (Command command : page.commands) {
+      svg.append(command.toSvg());
+    }
+    svg.append("  </g>\n</svg>\n");
+    return svg.toString();
+  }
+
+  private byte[] toPdf(List<Page> pages) {
+    List<byte[]> objects = new ArrayList<byte[]>();
+    objects.add(bytes("<< /Type /Catalog /Pages 2 0 R >>"));
+    StringBuilder kids = new StringBuilder();
+    for (int index = 0; index < pages.size(); index++) {
+      kids.append(4 + index * 2).append(" 0 R ");
+    }
+    objects.add(bytes("<< /Type /Pages /Kids [" + kids + "] /Count " + pages.size() + " >>"));
+    objects.add(bytes("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"));
+    for (int index = 0; index < pages.size(); index++) {
+      Page page = pages.get(index);
+      int contentObject = 5 + index * 2;
+      String mediaBox = "0 0 " + number(page.width * MM_TO_POINT) + " " + number(page.height * MM_TO_POINT);
+      objects.add(bytes("<< /Type /Page /Parent 2 0 R /MediaBox [" + mediaBox
+          + "] /Resources << /Font << /F1 3 0 R >> >> /Contents " + contentObject + " 0 R >>"));
+      StringBuilder stream = new StringBuilder("q\n");
+      for (Command command : page.commands) {
+        stream.append(command.toPdf(page.height));
+      }
+      stream.append("Q\n");
+      byte[] streamBytes = bytes(stream.toString());
+      ByteArrayOutputStream content = new ByteArrayOutputStream();
+      write(content, bytes("<< /Length " + streamBytes.length + " >>\nstream\n"));
+      write(content, streamBytes);
+      write(content, bytes("endstream"));
+      objects.add(content.toByteArray());
+    }
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    write(output, bytes("%PDF-1.4\n%âãÏÓ\n"));
+    List<Integer> offsets = new ArrayList<Integer>();
+    offsets.add(Integer.valueOf(0));
+    for (int index = 0; index < objects.size(); index++) {
+      offsets.add(Integer.valueOf(output.size()));
+      write(output, bytes((index + 1) + " 0 obj\n"));
+      write(output, objects.get(index));
+      write(output, bytes("\nendobj\n"));
+    }
+    int xref = output.size();
+    write(output, bytes("xref\n0 " + (objects.size() + 1) + "\n0000000000 65535 f \n"));
+    for (int index = 1; index < offsets.size(); index++) {
+      write(output, bytes(String.format(Locale.ROOT, "%010d 00000 n \n", offsets.get(index))));
+    }
+    write(output, bytes("trailer\n<< /Size " + (objects.size() + 1) + " /Root 1 0 R >>\nstartxref\n" + xref
+        + "\n%%EOF\n"));
+    return output.toByteArray();
+  }
+
+  private Map<String, SemanticObject> objectsById() {
+    Map<String, SemanticObject> result = new TreeMap<String, SemanticObject>();
+    for (SemanticObject object : documentSet.getSemanticObjects()) {
+      result.put(object.getId(), object);
+    }
+    return result;
+  }
+
+  private static Point endpointPosition(SemanticObject connection, String property, Map<String, Point> positions,
+      Map<String, SemanticObject> objects) {
+    String endpointId = stringProperty(connection, property, "");
+    Point direct = positions.get(endpointId);
+    if (direct != null) {
+      return direct;
+    }
+    SemanticObject endpoint = objects.get(endpointId);
+    if (endpoint == null) {
+      return null;
+    }
+    return positions.get(stringProperty(endpoint, "ownerNodeId", ""));
+  }
+
+  private static Point connectorPoint(OffPageConnector connector, double contentRight, double contentBottom) {
+    int bucket = Math.abs(connector.getPairId().hashCode() % 7);
+    double y = Math.min(contentBottom - 10.0, CONTENT_TOP + 20.0 + bucket * 22.0);
+    double x = connector.getRole() == EngineeringDiagramDocumentSet.ConnectorRole.SOURCE ? contentRight : CONTENT_LEFT;
+    return new Point(x, y);
+  }
+
+  private static String displayLabel(SemanticObject object) {
+    for (EngineeringDiagramDesignationRegister.Designation designation : object.getDesignations()) {
+      return designation.getValue();
+    }
+    return object.getLabel();
+  }
+
+  private static boolean isDrawableNode(EngineeringNode.Kind kind) {
+    return kind == EngineeringNode.Kind.EQUIPMENT || kind == EngineeringNode.Kind.INSTRUMENT
+        || kind == EngineeringNode.Kind.BOUNDARY || kind == EngineeringNode.Kind.PROCESS_TAP;
+  }
+
+  private static boolean isConnection(EngineeringNode.Kind kind) {
+    return kind == EngineeringNode.Kind.PIPE_SEGMENT || kind == EngineeringNode.Kind.SIGNAL_CONNECTION
+        || kind == EngineeringNode.Kind.ENERGY_CONNECTION;
+  }
+
+  private static boolean inside(double x, double y, double width, double contentBottom) {
+    return x >= 8.0 && x <= width - 8.0 && y >= 8.0 && y <= contentBottom;
+  }
+
+  private static boolean insideAll(List<Waypoint> waypoints, double width, double contentBottom) {
+    for (Waypoint waypoint : waypoints) {
+      if (!inside(waypoint.getX(), waypoint.getY(), width, contentBottom)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static String stringProperty(SemanticObject object, String name, String fallback) {
+    Object value = object.getProperties().get(name);
+    return value == null ? fallback : String.valueOf(value);
+  }
+
+  private static Diagnostic diagnostic(Severity severity, String code, String message, String subjectId) {
+    return new Diagnostic(severity, code, message, subjectId == null ? "" : subjectId);
+  }
+
+  private static String fileName(String value) {
+    return value.replaceAll("[^A-Za-z0-9._-]+", "-");
+  }
+
+  private static String number(double value) {
+    if (Math.abs(value - Math.rint(value)) < 0.0000001) {
+      return Long.toString(Math.round(value));
+    }
+    return String.format(Locale.ROOT, "%.4f", value).replaceAll("0+$", "").replaceAll("\\.$", "");
+  }
+
+  private static String xml(String value) {
+    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+  }
+
+  private static String pdf(String value) {
+    StringBuilder result = new StringBuilder();
+    for (int index = 0; index < value.length(); index++) {
+      char character = value.charAt(index);
+      if (character == '(' || character == ')' || character == '\\') {
+        result.append('\\').append(character);
+      } else if (character >= 32 && character <= 255) {
+        result.append(character);
+      } else {
+        result.append('?');
+      }
+    }
+    return result.toString();
+  }
+
+  private static byte[] bytes(String value) {
+    return value.getBytes(StandardCharsets.ISO_8859_1);
+  }
+
+  private static void write(ByteArrayOutputStream output, byte[] value) {
+    output.write(value, 0, value.length);
+  }
+
+  private static final class Point {
+    private final double x;
+    private final double y;
+
+    private Point(double x, double y) {
+      this.x = x;
+      this.y = y;
+    }
+  }
+
+  private static final class Page {
+    private final String sheetId;
+    private final double width;
+    private final double height;
+    private final List<Command> commands = new ArrayList<Command>();
+
+    private Page(String sheetId, double width, double height) {
+      this.sheetId = sheetId;
+      this.width = width;
+      this.height = height;
+    }
+  }
+
+  private static final class Command {
+    private final String type;
+    private final List<Point> points;
+    private final double x;
+    private final double y;
+    private final double width;
+    private final double height;
+    private final double size;
+    private final String text;
+    private final String stroke;
+    private final String fill;
+    private final double strokeWidth;
+    private final String dash;
+    private final String id;
+    private final String anchor;
+    private final boolean protectedGeometry;
+
+    private Command(String type, List<Point> points, double x, double y, double width, double height, double size,
+        String text, String stroke, String fill, double strokeWidth, String dash, String id, String anchor,
+        boolean protectedGeometry) {
+      this.type = type;
+      this.points = points;
+      this.x = x;
+      this.y = y;
+      this.width = width;
+      this.height = height;
+      this.size = size;
+      this.text = text;
+      this.stroke = stroke;
+      this.fill = fill;
+      this.strokeWidth = strokeWidth;
+      this.dash = dash;
+      this.id = id;
+      this.anchor = anchor;
+      this.protectedGeometry = protectedGeometry;
+    }
+
+    private static Command rect(double x, double y, double width, double height, String stroke, String fill,
+        double strokeWidth, String id, String dash) {
+      return new Command("rect", Collections.<Point>emptyList(), x, y, width, height, 0.0, "", stroke, fill,
+          strokeWidth, dash, id, "", false);
+    }
+
+    private static Command line(double x1, double y1, double x2, double y2, String stroke, double strokeWidth,
+        String id, String dash) {
+      return polyline(Arrays.asList(new Point(x1, y1), new Point(x2, y2)), stroke, strokeWidth, dash, id, false);
+    }
+
+    private static Command polyline(List<Point> points, String stroke, double strokeWidth, String dash, String id,
+        boolean protectedGeometry) {
+      return new Command("polyline", new ArrayList<Point>(points), 0.0, 0.0, 0.0, 0.0, 0.0, "", stroke, "none",
+          strokeWidth, dash, id, "", protectedGeometry);
+    }
+
+    private static Command text(double x, double y, double size, String text, String fill, String id, String anchor) {
+      return new Command("text", Collections.<Point>emptyList(), x, y, 0.0, 0.0, size, text, "none", fill, 0.0, "",
+          id, anchor, false);
+    }
+
+    private String toSvg() {
+      StringBuilder result = new StringBuilder("    <");
+      if ("rect".equals(type)) {
+        result.append("rect x=\"").append(number(x)).append("\" y=\"").append(number(y)).append("\" width=\"")
+            .append(number(width)).append("\" height=\"").append(number(height)).append("\"");
+      } else if ("text".equals(type)) {
+        result.append("text x=\"").append(number(x)).append("\" y=\"").append(number(y))
+            .append("\" font-size=\"").append(number(size)).append("\" dominant-baseline=\"middle\"");
+        if (!anchor.isEmpty()) {
+          result.append(" text-anchor=\"").append(anchor).append("\"");
+        }
+      } else {
+        result.append("polyline points=\"");
+        for (int index = 0; index < points.size(); index++) {
+          if (index > 0) {
+            result.append(' ');
+          }
+          result.append(number(points.get(index).x)).append(',').append(number(points.get(index).y));
+        }
+        result.append("\"");
+      }
+      result.append(" stroke=\"").append(stroke).append("\" fill=\"").append(fill).append("\"");
+      if (strokeWidth > 0.0) {
+        result.append(" stroke-width=\"").append(number(strokeWidth)).append("\"");
+      }
+      if (!dash.isEmpty()) {
+        result.append(" stroke-dasharray=\"").append(dash).append("\"");
+      }
+      if (!id.isEmpty()) {
+        result.append(" data-semantic-id=\"").append(xml(id)).append("\"");
+      }
+      if (protectedGeometry) {
+        result.append(" data-protected-route=\"true\"");
+      }
+      if ("text".equals(type)) {
+        result.append('>').append(xml(text)).append("</text>\n");
+      } else {
+        result.append("/>\n");
+      }
+      return result.toString();
+    }
+
+    private String toPdf(double pageHeight) {
+      StringBuilder result = new StringBuilder();
+      if ("text".equals(type)) {
+        double adjustedX = x;
+        if ("middle".equals(anchor)) {
+          adjustedX -= text.length() * size * 0.24;
+        } else if ("end".equals(anchor)) {
+          adjustedX -= text.length() * size * 0.48;
+        }
+        result.append(rgb(fill, false)).append(" BT /F1 ").append(number(size * MM_TO_POINT * 0.78)).append(" Tf ")
+            .append(number(adjustedX * MM_TO_POINT)).append(' ').append(number((pageHeight - y) * MM_TO_POINT))
+            .append(" Td (").append(pdf(text)).append(") Tj ET\n");
+        return result.toString();
+      }
+      result.append(rgb(stroke, true)).append(' ').append(number(strokeWidth * MM_TO_POINT)).append(" w ");
+      if (dash.isEmpty()) {
+        result.append("[] 0 d ");
+      } else {
+        result.append('[');
+        for (String item : dash.split(" ")) {
+          result.append(number(Double.parseDouble(item) * MM_TO_POINT)).append(' ');
+        }
+        result.append("] 0 d ");
+      }
+      if ("rect".equals(type)) {
+        result.append(rgb(fill, false)).append(' ').append(number(x * MM_TO_POINT)).append(' ')
+            .append(number((pageHeight - y - height) * MM_TO_POINT)).append(' ').append(number(width * MM_TO_POINT))
+            .append(' ').append(number(height * MM_TO_POINT)).append(" re ");
+        result.append("none".equals(fill) ? "S\n" : "B\n");
+      } else if (!points.isEmpty()) {
+        Point first = points.get(0);
+        result.append(number(first.x * MM_TO_POINT)).append(' ').append(number((pageHeight - first.y) * MM_TO_POINT))
+            .append(" m ");
+        for (int index = 1; index < points.size(); index++) {
+          Point point = points.get(index);
+          result.append(number(point.x * MM_TO_POINT)).append(' ')
+              .append(number((pageHeight - point.y) * MM_TO_POINT)).append(" l ");
+        }
+        result.append("S\n");
+      }
+      return result.toString();
+    }
+
+    private static String rgb(String value, boolean stroke) {
+      if (value == null || "none".equals(value)) {
+        return "0 0 0 " + (stroke ? "RG" : "rg");
+      }
+      int red = Integer.parseInt(value.substring(1, 3), 16);
+      int green = Integer.parseInt(value.substring(3, 5), 16);
+      int blue = Integer.parseInt(value.substring(5, 7), 16);
+      return number(red / 255.0) + " " + number(green / 255.0) + " " + number(blue / 255.0) + " "
+          + (stroke ? "RG" : "rg");
+    }
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -734,7 +734,14 @@ public final class NativeEngineeringDiagramRenderer {
       } else {
         result.append('[');
         for (String item : dash.split(" ")) {
-          result.append(number(Double.parseDouble(item) * MM_TO_POINT)).append(' ');
+          if (item.isEmpty()) {
+            continue;
+          }
+          try {
+            result.append(number(Double.parseDouble(item) * MM_TO_POINT)).append(' ');
+          } catch (NumberFormatException exception) {
+            // Ignore malformed dash tokens while retaining every valid dash length.
+          }
         }
         result.append("] 0 d ");
       }
@@ -758,14 +765,19 @@ public final class NativeEngineeringDiagramRenderer {
     }
 
     private static String rgb(String value, boolean stroke) {
-      if (value == null || "none".equals(value)) {
-        return "0 0 0 " + (stroke ? "RG" : "rg");
+      String fallback = "0 0 0 " + (stroke ? "RG" : "rg");
+      if (value == null || "none".equals(value) || value.length() != 7 || value.charAt(0) != '#') {
+        return fallback;
       }
-      int red = Integer.parseInt(value.substring(1, 3), 16);
-      int green = Integer.parseInt(value.substring(3, 5), 16);
-      int blue = Integer.parseInt(value.substring(5, 7), 16);
-      return number(red / 255.0) + " " + number(green / 255.0) + " " + number(blue / 255.0) + " "
-          + (stroke ? "RG" : "rg");
+      try {
+        int red = Integer.parseInt(value.substring(1, 3), 16);
+        int green = Integer.parseInt(value.substring(3, 5), 16);
+        int blue = Integer.parseInt(value.substring(5, 7), 16);
+        return number(red / 255.0) + " " + number(green / 255.0) + " " + number(blue / 255.0) + " "
+            + (stroke ? "RG" : "rg");
+      } catch (NumberFormatException exception) {
+        return fallback;
+      }
     }
   }
 }

--- a/src/main/java/neqsim/process/processmodel/diagram/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/package-info.java
@@ -22,6 +22,8 @@
  * replacing canonical source labels</li>
  * <li><b>Manual layout evidence</b> - Opt-in stable sheet assignments, pinned positions, and protected routes retain
  * project review evidence without changing process topology</li>
+ * <li><b>Native controlled output</b> - Deterministic vector SVG sheets and multi-page PDF consume the same controlled
+ * document model without requiring Graphviz</li>
  * <li><b>Revision impact</b> - Deterministic changed-object, affected-sheet, and affected-drawing evidence</li>
  * <li><b>Multiple detail levels</b> - MINIMAL, STANDARD, DETAILED, DEBUG</li>
  * <li><b>Deterministic output</b> - Same model always produces same diagram</li>
@@ -63,6 +65,8 @@
  * engineering graph model</li>
  * <li>{@link neqsim.process.processmodel.diagram.ProcessDiagramDocumentSetAdapter} - Immutable controlled drawing and
  * sheet proposal adapter</li>
+ * <li>{@link neqsim.process.processmodel.diagram.NativeEngineeringDiagramRenderer} - Deterministic native SVG/PDF
+ * renderer for controlled drawing sets</li>
  * <li>{@link neqsim.process.engineering.model.EngineeringDiagramLayoutRegister} - Persistent reviewed manual sheet,
  * position, and route intent</li>
  * <li>{@link neqsim.process.processmodel.diagram.ProcessDiagramExporter} - Main exporter class</li>

--- a/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
@@ -128,8 +128,8 @@ class NativeEngineeringDiagramRendererTest {
   }
 
   private static PinnedPosition reviewedPosition(String semanticObjectId, String sheetKey, double x, double y) {
-    return new PinnedPosition(semanticObjectId, sheetKey, x, y, CoordinateUnit.MILLIMETRE,
-        "project-layout:PFD-NATIVE", EvidenceState.REVIEWED, "Process discipline", "2026-08-14T08:00:00Z", "B");
+    return new PinnedPosition(semanticObjectId, sheetKey, x, y, CoordinateUnit.MILLIMETRE, "project-layout:PFD-NATIVE",
+        EvidenceState.REVIEWED, "Process discipline", "2026-08-14T08:00:00Z", "B");
   }
 
   private static ProtectedRoute reviewedRoute(String connectionId, String sheetKey) {

--- a/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
@@ -1,0 +1,162 @@
+package neqsim.process.processmodel.diagram;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.SemanticObject;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Sheet;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.CoordinateUnit;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.EvidenceState;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.PinnedPosition;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.ProtectedRoute;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.Waypoint;
+import neqsim.process.engineering.model.EngineeringNode;
+import neqsim.process.processmodel.ProcessSystem;
+import org.junit.jupiter.api.Test;
+
+class NativeEngineeringDiagramRendererTest {
+  @Test
+  void rendersDeterministicNativeSvgAndPdfWithoutChangingClassicOutputs() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
+    ProcessSystem process = reference.getProcessSystem();
+    String classicDot = process.toDOT();
+    EngineeringDiagramDocumentSet baseline = ProcessDiagramDocumentSetAdapter.fromProcessSystem(process,
+        reference.getCaseId(), "A", "PFD-NATIVE-001", "Native renderer reference", ContentProfile.PFD);
+    String sheetKey = baseline.getDrawings().get(0).getSheets().get(0).getKey();
+    SemanticObject separator = findObject(baseline, EngineeringNode.Kind.EQUIPMENT, "equipmentName", "10-VA-001");
+    SemanticObject feedConnection = findObject(baseline, EngineeringNode.Kind.PIPE_SEGMENT, "targetEquipment",
+        "10-XV-001");
+    EngineeringDiagramLayoutRegister layout = new EngineeringDiagramLayoutRegister()
+        .withPinnedPosition(reviewedPosition(separator.getId(), sheetKey, 80.0, 60.0))
+        .withProtectedRoute(reviewedRoute(feedConnection.getId(), sheetKey));
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(process,
+        reference.getCaseId(), "A", "PFD-NATIVE-001", "Native renderer reference", ContentProfile.PFD,
+        new EngineeringDiagramDesignationRegister(), layout);
+    String controlledJson = documents.toJson();
+
+    NativeEngineeringDiagramRenderer renderer = new NativeEngineeringDiagramRenderer(documents);
+    NativeEngineeringDiagramRenderer.Result first = renderer.render();
+    NativeEngineeringDiagramRenderer.Result second = renderer.render();
+    String svg = first.getSvgBySheetId().values().iterator().next();
+
+    assertEquals(first.getSvgBySheetId(), second.getSvgBySheetId());
+    assertArrayEquals(first.getPdf(), second.getPdf());
+    assertTrue(svg.contains("width=\"420mm\" height=\"297mm\" viewBox=\"0 0 420 297\""));
+    assertTrue(svg.contains("x=\"63\" y=\"52\" width=\"34\" height=\"16\""));
+    assertTrue(svg.contains("points=\"10,20 40,20 40,50\""));
+    assertTrue(svg.contains("data-protected-route=\"true\""));
+    assertTrue(svg.contains("REV A  STATUS WORKING"));
+    assertTrue(svg.contains("ENGINEERING PROPOSAL - NOT APPROVED FOR DESIGN OR CONSTRUCTION"));
+    assertTrue(new String(first.getPdf(), 0, 8, StandardCharsets.ISO_8859_1).startsWith("%PDF-1.4"));
+    assertTrue(first.isComplete());
+    assertEquals(controlledJson, documents.toJson());
+    assertEquals(classicDot, process.toDOT());
+  }
+
+  @Test
+  void rendersEveryMultiAreaSheetWithReciprocalOffPageReferencesInOnePdf() {
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessModel(
+        EngineeringDiagramReferenceFixtures.multiAreaFacility().getProcessModel(), "DEXPI-REF-MULTI-AREA", "B",
+        "PFD-NATIVE-002", "Multi-area native drawing set", ContentProfile.PFD);
+
+    NativeEngineeringDiagramRenderer.Result result = new NativeEngineeringDiagramRenderer(documents,
+        NativeEngineeringDiagramRenderer.SheetFormat.A1_LANDSCAPE).render();
+    String pdf = new String(result.getPdf(), StandardCharsets.ISO_8859_1);
+
+    assertEquals(4, result.getSvgBySheetId().size());
+    assertTrue(pdf.contains("/Count 4"));
+    for (Sheet sheet : documents.getDrawings().get(0).getSheets()) {
+      String svg = result.getSvgBySheetId().get(sheet.getId());
+      assertTrue(svg.contains("width=\"841mm\" height=\"594mm\" viewBox=\"0 0 841 594\""));
+      for (EngineeringDiagramDocumentSet.OffPageConnector connector : sheet.getOffPageConnectors()) {
+        assertTrue(svg.contains(connector.getId()));
+        assertTrue(svg.contains(connector.getPeerSheetId()));
+        assertTrue(svg.contains(connector.getZoneReference()));
+      }
+    }
+    assertTrue(result.isComplete());
+  }
+
+  @Test
+  void reportsOutOfBoundsManualGeometryWithoutSilentlyReplacingIt() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
+    EngineeringDiagramDocumentSet baseline = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-NATIVE-003", "Layout loss diagnostics",
+        ContentProfile.PFD);
+    String sheetKey = baseline.getDrawings().get(0).getSheets().get(0).getKey();
+    SemanticObject separator = findObject(baseline, EngineeringNode.Kind.EQUIPMENT, "equipmentName", "10-VA-001");
+    EngineeringDiagramLayoutRegister layout = new EngineeringDiagramLayoutRegister()
+        .withPinnedPosition(reviewedPosition(separator.getId(), sheetKey, 600.0, 60.0));
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-NATIVE-003", "Layout loss diagnostics",
+        ContentProfile.PFD, new EngineeringDiagramDesignationRegister(), layout);
+
+    NativeEngineeringDiagramRenderer.Result result = new NativeEngineeringDiagramRenderer(documents).render();
+    String svg = result.getSvgBySheetId().values().iterator().next();
+
+    assertTrue(hasDiagnostic(result, "DIAGRAM_RENDER_PIN_OUTSIDE_SHEET"));
+    assertTrue(svg.contains("x=\"583\" y=\"52\" width=\"34\" height=\"16\""));
+    assertTrue(result.isComplete());
+  }
+
+  @Test
+  void keepsSheetOrderAndRenderedBytesStableAcrossFreshEquivalentModels() {
+    Map<String, String> expectedSvg = null;
+    byte[] expectedPdf = null;
+    for (int attempt = 0; attempt < 4; attempt++) {
+      EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessModel(
+          EngineeringDiagramReferenceFixtures.multiAreaFacility().getProcessModel(), "DEXPI-REF-MULTI-AREA", "A",
+          "PFD-NATIVE-004", "Fresh deterministic rendering", ContentProfile.PFD);
+      NativeEngineeringDiagramRenderer.Result result = new NativeEngineeringDiagramRenderer(documents).render();
+      if (expectedSvg == null) {
+        expectedSvg = result.getSvgBySheetId();
+        expectedPdf = result.getPdf();
+      } else {
+        assertEquals(expectedSvg, result.getSvgBySheetId());
+        assertArrayEquals(expectedPdf, result.getPdf());
+      }
+    }
+  }
+
+  private static PinnedPosition reviewedPosition(String semanticObjectId, String sheetKey, double x, double y) {
+    return new PinnedPosition(semanticObjectId, sheetKey, x, y, CoordinateUnit.MILLIMETRE,
+        "project-layout:PFD-NATIVE", EvidenceState.REVIEWED, "Process discipline", "2026-08-14T08:00:00Z", "B");
+  }
+
+  private static ProtectedRoute reviewedRoute(String connectionId, String sheetKey) {
+    return new ProtectedRoute(connectionId, sheetKey,
+        Arrays.asList(new Waypoint(10.0, 20.0), new Waypoint(40.0, 20.0), new Waypoint(40.0, 50.0)),
+        CoordinateUnit.MILLIMETRE, "project-layout:PFD-NATIVE", EvidenceState.REVIEWED, "Process discipline",
+        "2026-08-14T08:00:00Z", "B");
+  }
+
+  private static SemanticObject findObject(EngineeringDiagramDocumentSet documents, EngineeringNode.Kind kind,
+      String property, String value) {
+    for (SemanticObject object : documents.getSemanticObjects()) {
+      if (object.getKind() == kind && value.equals(object.getProperties().get(property))) {
+        return object;
+      }
+    }
+    throw new AssertionError("Missing semantic object " + kind + " with " + property + "=" + value);
+  }
+
+  private static boolean hasDiagnostic(NativeEngineeringDiagramRenderer.Result result, String code) {
+    for (NativeEngineeringDiagramRenderer.Diagnostic diagnostic : result.getDiagnostics()) {
+      if (code.equals(diagnostic.getCode())) {
+        assertFalse(diagnostic.getMessage().isEmpty());
+        assertFalse(diagnostic.getSubjectId().isEmpty());
+        return true;
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## Roadmap increment

Advances #1332 Phase 3 after PFD-C015 and #2899 shared rendering infrastructure after DEXPI-C014.

## Problem and engineering value

The controlled diagram model already preserves stable sheets, semantic objects, pinned millimetre positions, protected routes, reciprocal off-page references, and revision metadata, but no native renderer consumes that intent. Existing SVG/PDF export remains Graphviz-based and cannot produce one controlled multi-sheet drawing set from those persisted semantics.

## Coherent scope

- add `NativeEngineeringDiagramRenderer` consuming `EngineeringDiagramDocumentSet` directly;
- build native SVG sheets and one deterministic vector PDF from the same page plan, without Graphviz;
- support controlled A3- and A1-landscape paper geometry in drawing-paper millimetres;
- retain stable sheet/semantic IDs, exact pinned coordinates, exact protected waypoints, material/energy/signal line styles, reciprocal off-page peer references, and drawing/sheet title and revision metadata;
- keep deterministic grid placement for unpinned objects;
- report out-of-bounds manual geometry, automatic overflow, and unresolved connection endpoints through structured renderer diagnostics;
- carry an explicit engineering-proposal/not-approved boundary into native output;
- add focused ProcessSystem and multi-area ProcessModel regressions for deterministic SVG/PDF, exact geometry, reciprocal references, multi-page output, structured diagnostics, and unchanged Classic DOT/document JSON;
- document the public workflow and limitations.

## Deliberate exclusions

This PR does not add or qualify an ISO 10628/14617 symbol catalog, licensed ISO 5457/7200 mapping, collision/readability qualification, P&ID valves/nozzles/instruments/safeguards, DEXPI exchange changes, commercial CAE qualification, or accountable approval. The generic vector result remains an engineering proposal. Legacy DOT/Graphviz, native DEXPI 2.0 Process, and Proteus/DEXPI P&ID APIs and outputs are unchanged.

## Compatibility

The change is additive. Existing public APIs, process execution, semantic-document JSON, Classic DOT/Graphviz, DEXPI 2.0 Process, and Proteus/P&ID paths are not modified.

## Documentation impact

Updated the controlled engineering-diagram guide, PFD export guide, package Javadocs, executable API example, validation commands, and qualification boundary.

## Validation

**VALIDATED ON EXACT HEAD `6b8d7da52e8ed50bd84d0ecf43811629790eeb74`**

GitHub Actions completed successfully on the exact head:

- Java 8 and Java 21 test suites passed on Ubuntu and Windows.
- All four Java 21 slow-test shards and Javadocs passed.
- The focused `NativeEngineeringDiagramRendererTest` passed within the hosted test suites.
- Spotless, pre-commit, documentation search, CodeQL, PaperLab, and agent-skill reference checks passed.
- The four code-quality review threads were addressed by validating PDF dash/color inputs and safely retaining valid style values; all threads are resolved.

Completed locally on exact base `6e0464555bb7854b7c560fdacbb22efc0aed70cd`:

- Eclipse ECJ 3.42 compiled the renderer with Java 8 source/target compatibility.
- A standalone canonical-graph smoke case executed the renderer twice: 1 SVG sheet, 2,337 deterministic PDF bytes, zero renderer diagnostics, byte-identical PDF output, exact protected route, and explicit proposal banner.
- Poppler `pdfinfo` parsed the result as PDF 1.4, one A3 page (1190.55 x 841.89 pt), unencrypted and without JavaScript.
- The rendered PDF page was rasterized and visually inspected for border, equipment, exact route, title/revision block, and proposal banner.
- `python devtools/check_documentation_search.py` passed: 652 Markdown pages and one standalone HTML page.
- `git diff --check` passed.

Local Maven execution is unavailable: the sandbox Java process cannot reach its task-local proxy/Maven Central, and the image has a Java runtime but no `javac`. Consequently these commands did not run to completion and are not claimed as passed:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `pre-commit run --all-files --hook-stage pre-commit`
- `pre-commit run --all-files --hook-stage pre-push`
- `./mvnw -Dtest=NativeEngineeringDiagramRendererTest test`
- broader Maven tests and Javadocs

GitHub CI is the authoritative validator for formatting, focused/broader Java 8/21 tests, Javadocs, and repository gates.

## Next dependency

After this tranche is merged and exact-head CI evidence is recorded, the next rendering increment is qualified symbol/profile selection plus collision, clipping, and readability diagnostics. Licensed standards interpretation and accountable engineering approval remain explicit stop decisions.