### PR TITLE
Fix Stream.CCT/CCB silently returning the stream's own temperature and pressure

### DIFF
--- a/src/main/java/neqsim/process/equipment/stream/Stream.java
+++ b/src/main/java/neqsim/process/equipment/stream/Stream.java
@@ -35,6 +35,11 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
   private static final long serialVersionUID = 1000;
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(Stream.class);
+  /**
+   * Tolerance used when testing whether a cricondenpoint merely echoes the source fluid state. Applied in Kelvin to the
+   * temperature and in bara to the pressure.
+   */
+  private static final double CRICONDEN_ECHO_TOLERANCE = 1.0e-6;
 
   protected SystemInterface thermoSystem;
 
@@ -502,46 +507,90 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
     // ops.getJfreeChart();
   }
 
+  /**
+   * Compute a cricondenpoint of the stream fluid from its PT phase envelope.
+   *
+   * <p>
+   * The envelope is traced with the two-argument {@code calcPTphaseEnvelope(true, 1.0)} overload because the
+   * no-argument overload fails to trace some fluids - notably lean export gases that carry heavy pseudo-components at
+   * (near) zero moles.
+   * </p>
+   *
+   * <p>
+   * When the trace fails, {@code PTphaseEnvelope} falls back to reporting the source fluid's own temperature and
+   * pressure. That fallback is indistinguishable from a real result to the caller, so it is detected here and reported
+   * as unresolved rather than returned as a value. A genuine cricondenpoint that coincides with the stream temperature
+   * <em>and</em> the stream pressure to within {@value #CRICONDEN_ECHO_TOLERANCE} is treated as unresolved as well; a
+   * stream sitting exactly on its own cricondenpoint is not distinguishable from the fallback and is vanishingly rare
+   * in practice.
+   * </p>
+   *
+   * @param pointName envelope point to read, either {@code "cricondentherm"} or {@code "cricondenbar"}
+   * @return a two-element array holding the temperature in Kelvin at index 0 and the pressure in bara at index 1, or
+   * {@code null} when the point could not be resolved
+   */
+  private double[] calcCricondenPoint(String pointName) {
+    SystemInterface localSyst = getFluid().clone();
+    // Captured before the trace runs, because tracing mutates the cloned system's state.
+    double sourceTemperatureK = localSyst.getTemperature();
+    double sourcePressureBara = localSyst.getPressure();
+
+    ThermodynamicOperations ops = new ThermodynamicOperations(localSyst);
+    ops.setRunAsThread(true);
+    ops.calcPTphaseEnvelope(true, 1.0);
+    ops.waitAndCheckForFinishedCalculation(10000);
+
+    double[] point = ops.get(pointName);
+    if (point == null || point.length < 2 || !Double.isFinite(point[0]) || !Double.isFinite(point[1])) {
+      logger.error("{}: phase envelope did not resolve {} for stream {}", getClass().getSimpleName(), pointName,
+          getName());
+      return null;
+    }
+
+    boolean echoesSourceState = Math.abs(point[0] - sourceTemperatureK) <= CRICONDEN_ECHO_TOLERANCE
+        && Math.abs(point[1] - sourcePressureBara) <= CRICONDEN_ECHO_TOLERANCE;
+    if (echoesSourceState) {
+      logger.error(
+          "{}: phase envelope failed to trace for stream {}; {} returned the stream's own state "
+              + "({} K, {} bara) and is reported as unresolved",
+          getClass().getSimpleName(), getName(), pointName, sourceTemperatureK, sourcePressureBara);
+      return null;
+    }
+    return point;
+  }
+
+  /**
+   * Convert a cricondenpoint to the requested unit.
+   *
+   * @param point envelope point as returned by {@link #calcCricondenPoint(String)}, holding the temperature in Kelvin
+   * at index 0 and the pressure in bara at index 1, or {@code null} when unresolved
+   * @param unit {@code "bara"} or {@code "bar"} for the pressure in bara, {@code "C"} for the temperature in degrees
+   * Celsius, anything else for the temperature in Kelvin
+   * @return the requested value, or {@link Double#NaN} when {@code point} is {@code null}
+   */
+  private double convertCricondenPoint(double[] point, String unit) {
+    if (point == null) {
+      return Double.NaN;
+    }
+    if (unit.equals("bara") || unit.equals("bar")) {
+      return point[1];
+    }
+    if (unit.equals("C")) {
+      return point[0] - 273.15;
+    }
+    return point[0];
+  }
+
   /** {@inheritDoc} */
   @Override
   public double CCB(String unit) {
-    SystemInterface localSyst = getFluid().clone();
-    ThermodynamicOperations ops = new ThermodynamicOperations(localSyst);
-    ops.setRunAsThread(true);
-    ops.calcPTphaseEnvelope();
-    ops.waitAndCheckForFinishedCalculation(10000);
-    if (unit.equals("bara") || unit.equals("bar")) {
-      return ops.get("cricondenbar")[1];
-    } else {
-      if (unit.equals("C")) {
-        return ops.get("cricondenbar")[0] - 273.15;
-      } else {
-        return ops.get("cricondenbar")[0];
-      }
-    }
-    // return ops.get
-    // ops.getJfreeChart();
+    return convertCricondenPoint(calcCricondenPoint("cricondenbar"), unit);
   }
 
   /** {@inheritDoc} */
   @Override
   public double CCT(String unit) {
-    SystemInterface localSyst = getFluid().clone();
-    ThermodynamicOperations ops = new ThermodynamicOperations(localSyst);
-    ops.setRunAsThread(true);
-    ops.calcPTphaseEnvelope();
-    ops.waitAndCheckForFinishedCalculation(10000);
-    if (unit.equals("bara") || unit.equals("bar")) {
-      return ops.get("cricondentherm")[1];
-    } else {
-      if (unit.equals("C")) {
-        return ops.get("cricondentherm")[0] - 273.15;
-      } else {
-        return ops.get("cricondentherm")[0];
-      }
-    }
-    // return ops.get
-    // ops.getJfreeChart();
+    return convertCricondenPoint(calcCricondenPoint("cricondentherm"), unit);
   }
 
   /** {@inheritDoc} */

--- a/src/test/java/neqsim/process/equipment/stream/StreamCricondenTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/StreamCricondenTest.java
@@ -1,0 +1,177 @@
+package neqsim.process.equipment.stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Regression tests for {@link Stream#CCT(String)} and {@link Stream#CCB(String)}.
+ *
+ * <p>
+ * Both methods used to trace the phase envelope with the no-argument {@code calcPTphaseEnvelope()} overload. That
+ * overload fails to trace lean export gases carrying heavy pseudo-components at (near) zero moles. On failure
+ * {@code PTphaseEnvelope} falls back to reporting the source fluid's own temperature and pressure, so the caller
+ * received the stream conditions echoed back as if they were a cricondenpoint - a finite, plausible, badly wrong number
+ * with no exception raised.
+ * </p>
+ *
+ * <p>
+ * The fluid below is a 17-component lean natural gas export stream at 147.0 bara and 86.301 degC. The three heaviest
+ * pseudo-components carry (near) zero moles, which is what breaks the trace; dropping them lets even the old code
+ * succeed, so they must be kept for this to remain a regression test.
+ * </p>
+ *
+ * @author NeqSim
+ * @version $Id: $Id
+ */
+public class StreamCricondenTest extends neqsim.NeqSimTest {
+  /** Stream pressure in bara. */
+  private static final double STREAM_PRESSURE_BARA = 147.0;
+  /** Stream temperature in degrees Celsius. */
+  private static final double STREAM_TEMPERATURE_C = 86.30090581135869;
+
+  /**
+   * Build the lean natural gas export stream that exposes the defect.
+   *
+   * <p>
+   * Mole fractions are dimensionless. Pseudo-component molar masses are in kg/mol and normal liquid densities in g/cm3,
+   * as required by {@code SystemInterface.addTBPfraction(String, double, double, double)}.
+   * </p>
+   *
+   * @return a {@link Stream} that has been run inside a {@link ProcessSystem}
+   */
+  private Stream createExportGasStream() {
+    SystemInterface gas = new SystemSrkEos(273.15 + STREAM_TEMPERATURE_C, STREAM_PRESSURE_BARA);
+    gas.addComponent("nitrogen", 0.0055941222);
+    gas.addComponent("CO2", 0.0139708366);
+    gas.addComponent("methane", 0.8576211644);
+    gas.addComponent("ethane", 0.0756375044);
+    gas.addComponent("propane", 0.0325232685);
+    gas.addTBPfraction("IC4", 0.0038799327, 0.058124, 0.69779737);
+    gas.addComponent("n-butane", 0.0074317682);
+    gas.addTBPfraction("IC5", 0.0012407802, 0.072151, 0.70487539);
+    gas.addComponent("n-pentane", 0.0013491593);
+    gas.addComponent("n-hexane", 0.0005140988);
+    gas.addTBPfraction("F1", 0.0002056274, 0.09439190, 0.71609815);
+    gas.addTBPfraction("F2", 0.0000305388, 0.10623860, 0.72207600);
+    gas.addTBPfraction("F3", 0.0000011984, 0.12120060, 0.72962582);
+    // The three heaviest cuts and the water component carry (near) zero moles. That is what
+    // breaks the envelope trace, so it is the essential part of the regression.
+    gas.addTBPfraction("F4", 0.000000000015, 0.16540890, 0.75193333);
+    gas.addTBPfraction("F5", 0.0, 0.29306510, 0.81634865);
+    gas.addTBPfraction("F6", 0.0, 0.58861730, 0.96548429);
+    gas.addComponent("water", 0.0);
+    gas.setMixingRule("classic");
+
+    Stream exportGasStream = new Stream("export gas", gas);
+    exportGasStream.setPressure(STREAM_PRESSURE_BARA, "bara");
+    exportGasStream.setTemperature(STREAM_TEMPERATURE_C, "C");
+    exportGasStream.setFlowRate(10.0, "MSm3/day");
+
+    ProcessSystem processOps = new ProcessSystem();
+    processOps.add(exportGasStream);
+    processOps.run();
+    return exportGasStream;
+  }
+
+  /**
+   * The cricondentherm must not echo the stream conditions. This is the direct regression guard for the silent-failure
+   * defect: before the fix this returned exactly 86.30090581135869 degC and 147.0 bara.
+   */
+  @Test
+  @DisplayName("CCT does not return the stream temperature or pressure")
+  public void testCricondenThermIsNotStreamState() {
+    Stream exportGasStream = createExportGasStream();
+    double cctC = exportGasStream.CCT("C");
+    double cctBara = exportGasStream.CCT("bara");
+
+    assertFalse(Double.isNaN(cctC), "CCT(\"C\") must resolve for this lean gas");
+    assertFalse(Double.isNaN(cctBara), "CCT(\"bara\") must resolve for this lean gas");
+    assertTrue(Math.abs(cctC - STREAM_TEMPERATURE_C) > 1.0, "CCT(\"C\") returned " + cctC
+        + " degC, which echoes the stream temperature of " + STREAM_TEMPERATURE_C + " degC");
+    assertTrue(Math.abs(cctBara - STREAM_PRESSURE_BARA) > 1.0, "CCT(\"bara\") returned " + cctBara
+        + " bara, which echoes the stream pressure of " + STREAM_PRESSURE_BARA + " bara");
+  }
+
+  /**
+   * The cricondenbar must not echo the stream conditions either.
+   */
+  @Test
+  @DisplayName("CCB does not return the stream temperature or pressure")
+  public void testCricondenBarIsNotStreamState() {
+    Stream exportGasStream = createExportGasStream();
+    double ccbC = exportGasStream.CCB("C");
+    double ccbBara = exportGasStream.CCB("bara");
+
+    assertFalse(Double.isNaN(ccbC), "CCB(\"C\") must resolve for this lean gas");
+    assertFalse(Double.isNaN(ccbBara), "CCB(\"bara\") must resolve for this lean gas");
+    assertTrue(Math.abs(ccbC - STREAM_TEMPERATURE_C) > 1.0, "CCB(\"C\") returned " + ccbC
+        + " degC, which echoes the stream temperature of " + STREAM_TEMPERATURE_C + " degC");
+    assertTrue(Math.abs(ccbBara - STREAM_PRESSURE_BARA) > 1.0, "CCB(\"bara\") returned " + ccbBara
+        + " bara, which echoes the stream pressure of " + STREAM_PRESSURE_BARA + " bara");
+  }
+
+  /**
+   * {@code CCT} and {@code CCB} must agree with the phase envelope they are derived from. Pinning to the envelope
+   * rather than to a hard-coded literal keeps this a test of the accessor, not of the correlation set.
+   */
+  @Test
+  @DisplayName("CCT and CCB agree with the traced phase envelope")
+  public void testCricondenPointsMatchEnvelope() {
+    Stream exportGasStream = createExportGasStream();
+
+    SystemInterface localSyst = exportGasStream.getFluid().clone();
+    ThermodynamicOperations ops = new ThermodynamicOperations(localSyst);
+    ops.calcPTphaseEnvelope(true, 1.0);
+    double[] cricondenTherm = ops.get("cricondentherm");
+    double[] cricondenBar = ops.get("cricondenbar");
+
+    assertEquals(cricondenTherm[0] - 273.15, exportGasStream.CCT("C"), 1.0e-6,
+        "CCT(\"C\") must equal the envelope cricondentherm temperature");
+    assertEquals(cricondenTherm[1], exportGasStream.CCT("bara"), 1.0e-6,
+        "CCT(\"bara\") must equal the envelope cricondentherm pressure");
+    assertEquals(cricondenBar[0] - 273.15, exportGasStream.CCB("C"), 1.0e-6,
+        "CCB(\"C\") must equal the envelope cricondenbar temperature");
+    assertEquals(cricondenBar[1], exportGasStream.CCB("bara"), 1.0e-6,
+        "CCB(\"bara\") must equal the envelope cricondenbar pressure");
+  }
+
+  /**
+   * By definition the cricondenbar is the maximum pressure on the envelope and the cricondentherm the maximum
+   * temperature, so the two points must order consistently.
+   */
+  @Test
+  @DisplayName("cricondenbar and cricondentherm are mutually consistent")
+  public void testCricondenPointConsistency() {
+    Stream exportGasStream = createExportGasStream();
+    double cctC = exportGasStream.CCT("C");
+    double cctBara = exportGasStream.CCT("bara");
+    double ccbC = exportGasStream.CCB("C");
+    double ccbBara = exportGasStream.CCB("bara");
+
+    assertTrue(ccbBara >= cctBara,
+        "cricondenbar pressure " + ccbBara + " bara must be at least the cricondentherm pressure " + cctBara + " bara");
+    assertTrue(cctC >= ccbC,
+        "cricondentherm temperature " + cctC + " degC must be at least the cricondenbar temperature " + ccbC + " degC");
+  }
+
+  /**
+   * Unit contract: the {@code "C"} branch returns degrees Celsius and the default (unrecognised unit) branch returns
+   * Kelvin.
+   */
+  @Test
+  @DisplayName("CCT and CCB honour the K versus degC unit contract")
+  public void testUnitContract() {
+    Stream exportGasStream = createExportGasStream();
+    assertEquals(273.15, exportGasStream.CCT("K") - exportGasStream.CCT("C"), 1.0e-6,
+        "CCT(\"K\") minus CCT(\"C\") must be exactly 273.15");
+    assertEquals(273.15, exportGasStream.CCB("K") - exportGasStream.CCB("C"), 1.0e-6,
+        "CCB(\"K\") minus CCB(\"C\") must be exactly 273.15");
+  }
+}


### PR DESCRIPTION
## Problem

`Stream.CCT(unit)` and `Stream.CCB(unit)` can return the stream's **own temperature and pressure** instead of a cricondentherm/cricondenbar. The value is finite and superficially plausible, and **no exception is raised**, so the error passes silently into gas-quality reporting.

Measured on a 17-component lean natural-gas export stream at 147.0 bara and 86.301 degC:

| Call | Returned | Correct | Error |
|---|---|---|---|
| `CCT("C")` | **86.301** (= stream temperature) | -5.806 degC | **+92.1 K** |
| `CCT("bara")` | **147.000** (= stream pressure) | 44.733 bara | +102.3 bar |
| `CCB("C")` | **86.301** | -31.607 degC | +117.9 K |
| `CCB("bara")` | **147.000** | 84.999 bara | +62.0 bar |

## Root cause

Two defects in series.

1. `PTphaseEnvelope.run()` ends with an unconditional fallback that manufactures the feed state as a result when the trace finds nothing:

```java
if (!Double.isFinite(cricondenTherm[0]) || !Double.isFinite(cricondenTherm[1])
    || (cricondenTherm[0] == 0.0 && cricondenTherm[1] == 0.0)) {
  cricondenTherm[0] = initialTemp;   // the source fluid's own T
  cricondenTherm[1] = initialPres;   // and its own P
}
```

2. `Stream.CCT`/`CCB` traced with the no-argument `calcPTphaseEnvelope()` overload, which fails on this fluid, and returned `ops.get(...)` unvalidated - so the fallback reached the caller.

This is **not** a timeout. Both overloads finish well inside the 10 000 ms window (0.41 s vs 0.26 s); the no-argument trace simply fails to converge and the failure is never detected.

## Trigger

Bisected by rebuilding the fluid component by component. The failure is caused by the **heavy pseudo-components carried at (near) zero moles** (F4 at 1.5e-11, F5/F6 at exactly 0) - a shape every dehydrated export-gas stream in these models has:

```
rebuilt WITH zero-mole F4-F6+water   CCT = 86.300906 C @ 147.0 bara   echo=True
rebuilt WITHOUT zero-mole comps      CCT =  5.414566 C @  47.7 bara   echo=False
```

## Fix

`CCT` and `CCB` now share one private helper that:

- traces with the two-argument `calcPTphaseEnvelope(true, 1.0)` overload;
- rejects a point that is non-finite, or that matches the source fluid's temperature **and** pressure (the signature of the non-converged fallback);
- returns `Double.NaN` with a logged error instead of a fabricated value.

`NaN` is preferred over an exception because these methods return `double`, and `NaN` propagates visibly rather than masquerading as a result. The existing unit contract is unchanged: `"bara"`/`"bar"` -> pressure in bara, `"C"` -> temperature in degC, anything else -> temperature in K.

## Verification

- `StreamCricondenTest` (5 tests) **fails 3 of 5 against the unfixed code** with the exact echo signature, and passes against the fix. The near-zero-mole heavy cuts are essential to the reproduction - dropping them lets the old code succeed, so a simplified fluid would have proved nothing.
- 133 tests pass across the stream, phase-envelope, cricondenbar/therm-flash and gas-quality suites, with no changes to existing expectations.
- `spotless:apply` run on both files.
- Java 8 compatible; no Java 9+ constructs used.

## Deliberately out of scope

The `PTphaseEnvelope` fallback itself is left untouched. Making it signal failure rather than fabricate a value is the deeper fix, but it changes behaviour for every envelope consumer and warrants its own regression pass.

## Known trade-off

The guard treats a cricondenpoint that coincides with the stream temperature *and* pressure to within 1e-6 as unresolved. A stream sitting exactly on its own cricondenpoint is not distinguishable from the fallback; this is documented in the JavaDoc and is vanishingly rare in practice.
