### PR TITLE
Cache Stream CCT/CCB phase-envelope calculations

### DIFF
--- a/src/main/java/neqsim/process/equipment/stream/Stream.java
+++ b/src/main/java/neqsim/process/equipment/stream/Stream.java
@@ -740,7 +740,7 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
     if (system.getPhase(0) instanceof PhaseEosInterface) {
       EosMixingRulesInterface mixingRule = ((PhaseEosInterface) system.getPhase(0)).getEosMixingRule();
       if (mixingRule != null) {
-        signature = updateCricondenInputSignature(signature, componentCount * componentCount);
+        signature = updateCricondenInputSignature(signature, ((long) componentCount) * componentCount);
         for (int componentIndex = 0; componentIndex < componentCount; componentIndex++) {
           for (int otherComponentIndex = 0; otherComponentIndex < componentCount; otherComponentIndex++) {
             signature = updateCricondenInputSignature(signature,

--- a/src/main/java/neqsim/process/equipment/stream/Stream.java
+++ b/src/main/java/neqsim/process/equipment/stream/Stream.java
@@ -19,6 +19,9 @@ import neqsim.process.util.report.ReportConfig;
 import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.standards.gasquality.Standard_ISO6976;
 import neqsim.standards.oilquality.Standard_ASTM_D6377;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.mixingrule.EosMixingRulesInterface;
+import neqsim.thermo.phase.PhaseEosInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
@@ -40,6 +43,17 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
    * temperature and in bara to the pressure.
    */
   private static final double CRICONDEN_ECHO_TOLERANCE = 1.0e-6;
+  /** Initial value for the deterministic criconden-envelope input fingerprint. */
+  private static final long CRICONDEN_SIGNATURE_SEED = 1125899906842597L;
+
+  /** Fingerprint of the fluid state used for the cached criconden envelope. */
+  private transient long cachedCricondenInputSignature = Long.MIN_VALUE;
+  /** Whether both cached cricondenpoints were resolved successfully. */
+  private transient boolean hasCachedCricondenEnvelope = false;
+  /** Cached cricondentherm as temperature in Kelvin and pressure in bara. */
+  private transient double[] cachedCricondenTherm = null;
+  /** Cached cricondenbar as temperature in Kelvin and pressure in bara. */
+  private transient double[] cachedCricondenBar = null;
 
   protected SystemInterface thermoSystem;
 
@@ -604,6 +618,14 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
    * </p>
    *
    * <p>
+   * A single envelope contains both cricondenpoints. The result is therefore cached against a deterministic fingerprint
+   * of the complete EOS input used by the trace, so repeated {@link #CCT(String)} and {@link #CCB(String)} calls do not
+   * repeat the expensive envelope calculation. Temperature and pressure are part of the fingerprint because they seed
+   * the numerical trace. Composition, pseudo-component properties and EOS binary-interaction parameters are included to
+   * prevent stale reuse after direct mutation of the stream fluid.
+   * </p>
+   *
+   * <p>
    * When the trace fails, {@code PTphaseEnvelope} falls back to reporting the source fluid's own temperature and
    * pressure. That fallback is indistinguishable from a real result to the caller, so it is detected here and reported
    * as unresolved rather than returned as a value. A genuine cricondenpoint that coincides with the stream temperature
@@ -616,18 +638,60 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
    * @return a two-element array holding the temperature in Kelvin at index 0 and the pressure in bara at index 1, or
    * {@code null} when the point could not be resolved
    */
-  private double[] calcCricondenPoint(String pointName) {
-    SystemInterface localSyst = getFluid().clone();
-    // Captured before the trace runs, because tracing mutates the cloned system's state.
-    double sourceTemperatureK = localSyst.getTemperature();
-    double sourcePressureBara = localSyst.getPressure();
+  private synchronized double[] calcCricondenPoint(String pointName) {
+    SystemInterface sourceSystem = getFluid();
+    long inputSignature = calculateCricondenInputSignature(sourceSystem);
+    if (!hasCachedCricondenEnvelope || inputSignature != cachedCricondenInputSignature) {
+      SystemInterface localSyst = sourceSystem.clone();
+      // Captured before the trace runs, because tracing mutates the cloned system's state.
+      double sourceTemperatureK = localSyst.getTemperature();
+      double sourcePressureBara = localSyst.getPressure();
 
-    ThermodynamicOperations ops = new ThermodynamicOperations(localSyst);
-    ops.setRunAsThread(true);
-    ops.calcPTphaseEnvelope(true, 1.0);
-    ops.waitAndCheckForFinishedCalculation(10000);
+      ThermodynamicOperations ops = createCricondenOperations(localSyst);
+      ops.setRunAsThread(true);
+      ops.calcPTphaseEnvelope(true, 1.0);
+      ops.waitAndCheckForFinishedCalculation(10000);
 
-    double[] point = ops.get(pointName);
+      cachedCricondenTherm = validateCricondenPoint(ops.get("cricondentherm"), "cricondentherm", sourceTemperatureK,
+          sourcePressureBara);
+      cachedCricondenBar = validateCricondenPoint(ops.get("cricondenbar"), "cricondenbar", sourceTemperatureK,
+          sourcePressureBara);
+      cachedCricondenInputSignature = inputSignature;
+      hasCachedCricondenEnvelope = cachedCricondenTherm != null && cachedCricondenBar != null;
+    }
+
+    if ("cricondentherm".equals(pointName)) {
+      return cachedCricondenTherm;
+    }
+    return cachedCricondenBar;
+  }
+
+  /**
+   * Create the operations object used to trace a criconden envelope.
+   *
+   * <p>
+   * Package access keeps the production API unchanged while allowing the cache behavior to be counted in a focused
+   * regression test.
+   * </p>
+   *
+   * @param system cloned thermodynamic system to trace
+   * @return operations object for the supplied system
+   */
+  ThermodynamicOperations createCricondenOperations(SystemInterface system) {
+    return new ThermodynamicOperations(system);
+  }
+
+  /**
+   * Validate an envelope point and copy the two values retained by the stream cache.
+   *
+   * @param point raw point returned by the envelope operation
+   * @param pointName name used in diagnostics
+   * @param sourceTemperatureK source-stream temperature in Kelvin
+   * @param sourcePressureBara source-stream pressure in bara
+   * @return copied temperature-pressure pair, or {@code null} when unresolved
+   */
+  private double[] validateCricondenPoint(double[] point, String pointName, double sourceTemperatureK,
+      double sourcePressureBara) {
     if (point == null || point.length < 2 || !Double.isFinite(point[0]) || !Double.isFinite(point[1])) {
       logger.error("{}: phase envelope did not resolve {} for stream {}", getClass().getSimpleName(), pointName,
           getName());
@@ -643,7 +707,92 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
           getClass().getSimpleName(), getName(), pointName, sourceTemperatureK, sourcePressureBara);
       return null;
     }
-    return point;
+    return new double[] { point[0], point[1] };
+  }
+
+  /**
+   * Calculate a deterministic fingerprint of every EOS input that can affect the traced envelope.
+   *
+   * @param system stream fluid to fingerprint
+   * @return exact criconden-envelope input fingerprint
+   */
+  private long calculateCricondenInputSignature(SystemInterface system) {
+    long signature = CRICONDEN_SIGNATURE_SEED;
+    signature = updateCricondenInputSignature(signature, system.getClass().getName());
+    signature = updateCricondenInputSignature(signature, system.getModelName());
+    signature = updateCricondenInputSignature(signature, system.getMixingRuleName());
+    signature = updateCricondenInputSignature(signature, system.getTemperature());
+    signature = updateCricondenInputSignature(signature, system.getPressure());
+
+    int componentCount = system.getNumberOfComponents();
+    signature = updateCricondenInputSignature(signature, componentCount);
+    for (int componentIndex = 0; componentIndex < componentCount; componentIndex++) {
+      ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      signature = updateCricondenInputSignature(signature, component.getComponentName());
+      signature = updateCricondenInputSignature(signature, component.getz());
+      signature = updateCricondenInputSignature(signature, component.getMolarMass());
+      signature = updateCricondenInputSignature(signature, component.getNormalLiquidDensity());
+      signature = updateCricondenInputSignature(signature, component.getTC());
+      signature = updateCricondenInputSignature(signature, component.getPC());
+      signature = updateCricondenInputSignature(signature, component.getAcentricFactor());
+    }
+
+    if (system.getPhase(0) instanceof PhaseEosInterface) {
+      EosMixingRulesInterface mixingRule = ((PhaseEosInterface) system.getPhase(0)).getEosMixingRule();
+      if (mixingRule != null) {
+        signature = updateCricondenInputSignature(signature, componentCount * componentCount);
+        for (int componentIndex = 0; componentIndex < componentCount; componentIndex++) {
+          for (int otherComponentIndex = 0; otherComponentIndex < componentCount; otherComponentIndex++) {
+            signature = updateCricondenInputSignature(signature,
+                mixingRule.getBinaryInteractionParameter(componentIndex, otherComponentIndex));
+            signature = updateCricondenInputSignature(signature,
+                mixingRule.getBinaryInteractionParameterT1(componentIndex, otherComponentIndex));
+          }
+        }
+      }
+    }
+    return signature;
+  }
+
+  /**
+   * Add one numeric input to a criconden-envelope fingerprint.
+   *
+   * @param signature fingerprint accumulated so far
+   * @param value numeric input value
+   * @return updated fingerprint
+   */
+  private long updateCricondenInputSignature(long signature, double value) {
+    return updateCricondenInputSignature(signature, Double.doubleToLongBits(value));
+  }
+
+  /**
+   * Add one integral input to a criconden-envelope fingerprint.
+   *
+   * @param signature fingerprint accumulated so far
+   * @param value integral input value
+   * @return updated fingerprint
+   */
+  private long updateCricondenInputSignature(long signature, long value) {
+    return 31L * signature + value;
+  }
+
+  /**
+   * Add complete text content to a criconden-envelope fingerprint.
+   *
+   * @param signature fingerprint accumulated so far
+   * @param value text input, which may be null
+   * @return updated fingerprint
+   */
+  private long updateCricondenInputSignature(long signature, String value) {
+    if (value == null) {
+      return updateCricondenInputSignature(signature, -1L);
+    }
+    long updatedSignature = updateCricondenInputSignature(signature, value.length());
+    for (int index = 0; index < value.length(); index++) {
+      updatedSignature ^= value.charAt(index);
+      updatedSignature *= 0x100000001b3L;
+    }
+    return updatedSignature;
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/stream/StreamCricondenTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/StreamCricondenTest.java
@@ -36,6 +36,40 @@ public class StreamCricondenTest extends neqsim.NeqSimTest {
   /** Stream temperature in degrees Celsius. */
   private static final double STREAM_TEMPERATURE_C = 86.30090581135869;
 
+  /** Stream variant that counts actual phase-envelope traces. */
+  private static final class CountingStream extends Stream {
+    /** Serialization version UID. */
+    private static final long serialVersionUID = 1L;
+    /** Number of operations objects created for an envelope trace. */
+    private int cricondenTraceCount = 0;
+
+    /**
+     * Create a counting stream.
+     *
+     * @param name stream name
+     * @param fluid stream fluid
+     */
+    private CountingStream(String name, SystemInterface fluid) {
+      super(name, fluid);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    ThermodynamicOperations createCricondenOperations(SystemInterface system) {
+      cricondenTraceCount++;
+      return super.createCricondenOperations(system);
+    }
+
+    /**
+     * Get the number of actual envelope traces requested.
+     *
+     * @return trace count
+     */
+    private int getCricondenTraceCount() {
+      return cricondenTraceCount;
+    }
+  }
+
   /**
    * Build the lean natural gas export stream that exposes the defect.
    *
@@ -173,5 +207,34 @@ public class StreamCricondenTest extends neqsim.NeqSimTest {
         "CCT(\"K\") minus CCT(\"C\") must be exactly 273.15");
     assertEquals(273.15, exportGasStream.CCB("K") - exportGasStream.CCB("C"), 1.0e-6,
         "CCB(\"K\") minus CCB(\"C\") must be exactly 273.15");
+  }
+
+  /**
+   * One PT-envelope trace yields both cricondenpoints and every supported return unit. Repeated accessor calls for an
+   * unchanged stream must therefore reuse that trace, while direct fluid-state and EOS-parameter mutations must
+   * invalidate the cache.
+   */
+  @Test
+  @DisplayName("CCT and CCB share one envelope trace and invalidate it after input changes")
+  public void testCricondenEnvelopeCacheReuseAndInvalidation() {
+    Stream exportGasStream = createExportGasStream();
+    CountingStream countingStream = new CountingStream("counting export gas", exportGasStream.getFluid().clone());
+
+    assertFalse(Double.isNaN(countingStream.CCT("C")));
+    assertFalse(Double.isNaN(countingStream.CCT("bara")));
+    assertFalse(Double.isNaN(countingStream.CCB("C")));
+    assertFalse(Double.isNaN(countingStream.CCB("bara")));
+    assertEquals(1, countingStream.getCricondenTraceCount(),
+        "all criconden accessors for one unchanged state must share one phase-envelope trace");
+
+    countingStream.setTemperature(STREAM_TEMPERATURE_C + 1.0, "C");
+    countingStream.CCT("C");
+    assertEquals(2, countingStream.getCricondenTraceCount(),
+        "changing an input that seeds the envelope trace must invalidate the cache");
+
+    countingStream.getFluid().setBinaryInteractionParameter(0, 1, 0.0123);
+    countingStream.CCB("C");
+    assertEquals(3, countingStream.getCricondenTraceCount(),
+        "changing an EOS binary-interaction parameter must invalidate the cache");
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #3001. `Stream.CCT(String)` and `Stream.CCB(String)` now reuse one successful PT phase-envelope trace for an unchanged fluid instead of tracing the same envelope for every accessor call.

## Performance impact

This does not change ordinary `ProcessSystem.run()` performance because the phase envelope is only evaluated when callers explicitly request CCT or CCB.

A common reporting sequence reads:

- CCT temperature
- CCT pressure
- CCB temperature
- CCB pressure

All four values come from the same PT envelope. Before this change, that sequence ran four complete traces. This change runs one trace and reuses both cricondenpoints, eliminating three redundant calculations. For context, #3001 measured the selected trace at approximately 0.26 s for its 17-component exemplar fluid.

## Cache safety

The cached envelope is guarded by a deterministic signature covering:

- system class, EOS model and mixing rule;
- temperature and pressure, because they seed the numerical trace;
- ordered component identities and mole fractions;
- molar mass, normal liquid density, critical properties and acentric factor;
- EOS binary-interaction parameters and their temperature coefficients.

The calculation is synchronized per `Stream`. Returned arrays are copied before caching. A failed or unresolved trace is not cached, so the next accessor retries it.

## Verification

`StreamCricondenTest` now counts actual envelope-operation creation and verifies:

- four CCT/CCB accessor calls for one state create exactly one trace;
- changing stream temperature invalidates the cache;
- changing an EOS binary-interaction parameter invalidates the cache.

Validation completed:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `./mvnw -Dtest=StreamCricondenTest test` — 6 tests, 0 failures, 0 errors
- `python devtools/check_documentation_search.py`

Java 8-compatible language constructs only.

## Documentation impact

Documentation impact: none. This is internal memoization; public APIs, units, numerical results, defaults and recommended usage are unchanged.

## Automated review follow-up

- Widened `componentCount` before squaring it in the criconden cache signature, preventing intermediate `int` overflow without changing normal results.
- Exact head: `408bee140d319583b9b1fe3b8f450c532324f050`.
- Documentation impact: none; this is an internal arithmetic-safety repair.

**HOSTED EXACT-HEAD VALIDATION PASSED**

At `408bee140d319583b9b1fe3b8f450c532324f050` on 2026-08-14, GitHub Actions completed successfully for:

- build, Java 8/21 tests, slow-test shards, and Javadocs
- Spotless
- pre-commit
- CodeQL
- PaperLab

The focused local test and documentation-search validation remain recorded above.