### PR TITLE
feat(dynamics): transact local quality instrument state

### DIFF
--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -394,3 +394,26 @@ signal state and that all subclass-owned state is covered.
 This coverage establishes in-memory rollback, deterministic replay, and Java-serialization mechanics. It does not qualify
 sensor accuracy, sample-time or network jitter, alarm or trip integrity, external historian/DCS writes, safety action,
 virtual commissioning, or OTS behavior.
+
+## Local process-quality instrument transaction coverage
+
+The concrete local `MolarMassAnalyser`, `WaterContentAnalyser`, `CompositionAnalyzer`, `FlowRatioMeter`, and
+`ImpurityMonitor` families participate when registered as measurement devices in a `ProcessSystem`. Each snapshot
+includes its original stream binding or bindings plus all inherited signal state described above. The flow-ratio snapshot
+also preserves the selected mass, mole, or volume basis. The impurity-monitor snapshot defensively copies the primary
+component and ordered tracked-component/threshold map, then restores the original map object in place.
+
+Rejected trials therefore restore Gaussian continuation, drift, first-order-filter memory, sample delay, alarm state and
+event-editable configuration together with analyser-specific bindings and configuration. Coverage is quantitative across
+one process system and coordinated multi-area process models, and restart evidence serializes both the participant and
+its closed snapshot. Concrete descendants and online-signal operation remain fail-closed.
+
+This tranche is limited to local instruments whose production measured-value path actually calls
+`applySignalModifiers(...)`. `VolumeFlowTransmitter` and the total/oil/water level-transmitter families still return
+raw values without advancing that inherited signal state, so they are intentionally not presented as transaction
+participants. Differential-pressure primary flow devices and other state-owning analysers remain unaudited until all
+device-specific iteration, cache, configuration and binding state is covered.
+
+Passing this rollback gate does not qualify laboratory or online analyser accuracy, phase-sampling fidelity, wet-gas or
+metering standards, allocation, emissions or export-spec decisions, alarm/trip integrity, external I/O, safety action,
+virtual commissioning or OTS use.

--- a/src/main/java/neqsim/process/measurementdevice/CompositionAnalyzer.java
+++ b/src/main/java/neqsim/process/measurementdevice/CompositionAnalyzer.java
@@ -1,5 +1,8 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
@@ -15,9 +18,12 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * @author Even Solbraa
  * @version 1.0
  */
-public class CompositionAnalyzer extends StreamMeasurementDeviceBaseClass {
+public class CompositionAnalyzer extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<CompositionAnalyzer.CompositionAnalyzerState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000L;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /** Phase enumeration for the analyzer pickup point. */
   public enum AnalyzerPhase {
@@ -125,5 +131,63 @@ public class CompositionAnalyzer extends StreamMeasurementDeviceBaseClass {
   @ExcludeFromJacocoGeneratedReport
   public void displayResult() {
     System.out.println(getName() + " " + componentName + " [" + analyzerPhase + "] = " + getMeasuredValue("mole/mole"));
+  }
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:composition:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local composition analyser.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != CompositionAnalyzer.class) {
+      return "composition-analyser subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public CompositionAnalyzerState captureTransientState() {
+    return new CompositionAnalyzerState(getTransientStateIdentity(), stream,
+        captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(CompositionAnalyzerState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Composition analyser transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Composition analyser snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable composition-analyser rollback point. */
+  public static final class CompositionAnalyzerState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private CompositionAnalyzerState(String stateIdentity, StreamInterface stream,
+        MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/CompositionAnalyzer.java
+++ b/src/main/java/neqsim/process/measurementdevice/CompositionAnalyzer.java
@@ -132,6 +132,7 @@ public class CompositionAnalyzer extends StreamMeasurementDeviceBaseClass
   public void displayResult() {
     System.out.println(getName() + " " + componentName + " [" + analyzerPhase + "] = " + getMeasuredValue("mole/mole"));
   }
+
   /** {@inheritDoc} */
   @Override
   public String getTransientStateIdentity() {
@@ -158,8 +159,7 @@ public class CompositionAnalyzer extends StreamMeasurementDeviceBaseClass
   /** {@inheritDoc} */
   @Override
   public CompositionAnalyzerState captureTransientState() {
-    return new CompositionAnalyzerState(getTransientStateIdentity(), stream,
-        captureMeasurementDeviceTransientState());
+    return new CompositionAnalyzerState(getTransientStateIdentity(), stream, captureMeasurementDeviceTransientState());
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/measurementdevice/FlowRatioMeter.java
+++ b/src/main/java/neqsim/process/measurementdevice/FlowRatioMeter.java
@@ -1,5 +1,8 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
@@ -15,9 +18,12 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * @author Even Solbraa
  * @version 1.0
  */
-public class FlowRatioMeter extends MeasurementDeviceBaseClass {
+public class FlowRatioMeter extends MeasurementDeviceBaseClass
+    implements TransientStateParticipant<FlowRatioMeter.FlowRatioMeterState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000L;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /** Basis for ratio computation. */
   public enum FlowBasis {
@@ -128,5 +134,70 @@ public class FlowRatioMeter extends MeasurementDeviceBaseClass {
   @ExcludeFromJacocoGeneratedReport
   public void displayResult() {
     System.out.println(getName() + " [" + flowBasis + "] ratio = " + getMeasuredValue(""));
+  }
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:flow-ratio:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local flow-ratio meter.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != FlowRatioMeter.class) {
+      return "flow-ratio-meter subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public FlowRatioMeterState captureTransientState() {
+    return new FlowRatioMeterState(getTransientStateIdentity(), numeratorStream, denominatorStream, flowBasis,
+        captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(FlowRatioMeterState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Flow-ratio meter transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Flow-ratio meter snapshot identity does not match " + getTransientStateIdentity());
+    }
+    numeratorStream = snapshot.numeratorStream;
+    denominatorStream = snapshot.denominatorStream;
+    flowBasis = snapshot.flowBasis;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable flow-ratio-meter rollback point. */
+  public static final class FlowRatioMeterState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final StreamInterface numeratorStream;
+    private final StreamInterface denominatorStream;
+    private final FlowBasis flowBasis;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private FlowRatioMeterState(String stateIdentity, StreamInterface numeratorStream,
+        StreamInterface denominatorStream, FlowBasis flowBasis,
+        MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.numeratorStream = numeratorStream;
+      this.denominatorStream = denominatorStream;
+      this.flowBasis = flowBasis;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/FlowRatioMeter.java
+++ b/src/main/java/neqsim/process/measurementdevice/FlowRatioMeter.java
@@ -135,6 +135,7 @@ public class FlowRatioMeter extends MeasurementDeviceBaseClass
   public void displayResult() {
     System.out.println(getName() + " [" + flowBasis + "] ratio = " + getMeasuredValue(""));
   }
+
   /** {@inheritDoc} */
   @Override
   public String getTransientStateIdentity() {
@@ -191,8 +192,7 @@ public class FlowRatioMeter extends MeasurementDeviceBaseClass
     private final MeasurementDeviceTransientState measurementState;
 
     private FlowRatioMeterState(String stateIdentity, StreamInterface numeratorStream,
-        StreamInterface denominatorStream, FlowBasis flowBasis,
-        MeasurementDeviceTransientState measurementState) {
+        StreamInterface denominatorStream, FlowBasis flowBasis, MeasurementDeviceTransientState measurementState) {
       this.stateIdentity = stateIdentity;
       this.numeratorStream = numeratorStream;
       this.denominatorStream = denominatorStream;

--- a/src/main/java/neqsim/process/measurementdevice/ImpurityMonitor.java
+++ b/src/main/java/neqsim/process/measurementdevice/ImpurityMonitor.java
@@ -1,7 +1,10 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.UUID;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 
@@ -36,9 +39,12 @@ import neqsim.thermo.system.SystemInterface;
  * @author neqsim
  * @version 1.0
  */
-public class ImpurityMonitor extends StreamMeasurementDeviceBaseClass {
+public class ImpurityMonitor extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<ImpurityMonitor.ImpurityMonitorState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /** Primary component to report via getMeasuredValue(). */
   private String primaryComponent = "";
@@ -293,6 +299,71 @@ public class ImpurityMonitor extends StreamMeasurementDeviceBaseClass {
       if (isAlarmExceeded(comp)) {
         System.out.println("  *** ALARM: exceeds " + trackedComponents.get(comp) + " threshold");
       }
+    }
+  }
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:impurity-monitor:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local impurity monitor.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != ImpurityMonitor.class) {
+      return "impurity-monitor subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ImpurityMonitorState captureTransientState() {
+    return new ImpurityMonitorState(getTransientStateIdentity(), stream, primaryComponent,
+        new LinkedHashMap<String, Double>(trackedComponents), captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(ImpurityMonitorState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Impurity-monitor transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Impurity-monitor snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    primaryComponent = snapshot.primaryComponent;
+    trackedComponents.clear();
+    trackedComponents.putAll(snapshot.trackedComponents);
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable impurity-monitor rollback point. */
+  public static final class ImpurityMonitorState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final String primaryComponent;
+    private final Map<String, Double> trackedComponents;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private ImpurityMonitorState(String stateIdentity, StreamInterface stream, String primaryComponent,
+        Map<String, Double> trackedComponents, MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.primaryComponent = primaryComponent;
+      this.trackedComponents = trackedComponents;
+      this.measurementState = measurementState;
     }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/ImpurityMonitor.java
+++ b/src/main/java/neqsim/process/measurementdevice/ImpurityMonitor.java
@@ -301,6 +301,7 @@ public class ImpurityMonitor extends StreamMeasurementDeviceBaseClass
       }
     }
   }
+
   /** {@inheritDoc} */
   @Override
   public String getTransientStateIdentity() {

--- a/src/main/java/neqsim/process/measurementdevice/MolarMassAnalyser.java
+++ b/src/main/java/neqsim/process/measurementdevice/MolarMassAnalyser.java
@@ -1,5 +1,8 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
@@ -9,9 +12,12 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * @author ESOL
  * @version $Id: $Id
  */
-public class MolarMassAnalyser extends StreamMeasurementDeviceBaseClass {
+public class MolarMassAnalyser extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<MolarMassAnalyser.MolarMassAnalyserState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /**
    * Constructor for MolarMassAnalyser.
@@ -47,5 +53,64 @@ public class MolarMassAnalyser extends StreamMeasurementDeviceBaseClass {
           "currently only supports \"gr/mol\""));
     }
     return applySignalModifiers(stream.getThermoSystem().getMolarMass() * 1000.0);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:molar-mass:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local molar-mass analyser.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != MolarMassAnalyser.class) {
+      return "molar-mass-analyser subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public MolarMassAnalyserState captureTransientState() {
+    return new MolarMassAnalyserState(getTransientStateIdentity(), stream,
+        captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(MolarMassAnalyserState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Molar-mass analyser transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Molar-mass analyser snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable molar-mass-analyser rollback point. */
+  public static final class MolarMassAnalyserState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private MolarMassAnalyserState(String stateIdentity, StreamInterface stream,
+        MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/MolarMassAnalyser.java
+++ b/src/main/java/neqsim/process/measurementdevice/MolarMassAnalyser.java
@@ -81,8 +81,7 @@ public class MolarMassAnalyser extends StreamMeasurementDeviceBaseClass
   /** {@inheritDoc} */
   @Override
   public MolarMassAnalyserState captureTransientState() {
-    return new MolarMassAnalyserState(getTransientStateIdentity(), stream,
-        captureMeasurementDeviceTransientState());
+    return new MolarMassAnalyserState(getTransientStateIdentity(), stream, captureMeasurementDeviceTransientState());
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/measurementdevice/WaterContentAnalyser.java
+++ b/src/main/java/neqsim/process/measurementdevice/WaterContentAnalyser.java
@@ -1,5 +1,8 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
@@ -9,9 +12,12 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * @author ESOL
  * @version $Id: $Id
  */
-public class WaterContentAnalyser extends StreamMeasurementDeviceBaseClass {
+public class WaterContentAnalyser extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<WaterContentAnalyser.WaterContentAnalyserState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /**
    * Constructor for WaterContentAnalyser.
@@ -52,5 +58,63 @@ public class WaterContentAnalyser extends StreamMeasurementDeviceBaseClass {
     double raw = stream.getThermoSystem().getPhase(0).getComponent("water").getNumberOfmoles()
         * stream.getThermoSystem().getPhase(0).getComponent("water").getMolarMass() * 3600 * 24;
     return applySignalModifiers(raw);
+  }
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:water-content:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local water-content analyser.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != WaterContentAnalyser.class) {
+      return "water-content-analyser subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public WaterContentAnalyserState captureTransientState() {
+    return new WaterContentAnalyserState(getTransientStateIdentity(), stream,
+        captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(WaterContentAnalyserState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Water-content analyser transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Water-content analyser snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable water-content-analyser rollback point. */
+  public static final class WaterContentAnalyserState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private WaterContentAnalyserState(String stateIdentity, StreamInterface stream,
+        MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/WaterContentAnalyser.java
+++ b/src/main/java/neqsim/process/measurementdevice/WaterContentAnalyser.java
@@ -59,6 +59,7 @@ public class WaterContentAnalyser extends StreamMeasurementDeviceBaseClass
         * stream.getThermoSystem().getPhase(0).getComponent("water").getMolarMass() * 3600 * 24;
     return applySignalModifiers(raw);
   }
+
   /** {@inheritDoc} */
   @Override
   public String getTransientStateIdentity() {
@@ -85,8 +86,7 @@ public class WaterContentAnalyser extends StreamMeasurementDeviceBaseClass
   /** {@inheritDoc} */
   @Override
   public WaterContentAnalyserState captureTransientState() {
-    return new WaterContentAnalyserState(getTransientStateIdentity(), stream,
-        captureMeasurementDeviceTransientState());
+    return new WaterContentAnalyserState(getTransientStateIdentity(), stream, captureMeasurementDeviceTransientState());
   }
 
   /** {@inheritDoc} */

--- a/src/test/java/neqsim/process/measurementdevice/ProcessQualityInstrumentTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/ProcessQualityInstrumentTransientStateTransactionTest.java
@@ -1,0 +1,261 @@
+package neqsim.process.measurementdevice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import neqsim.process.alarm.AlarmConfig;
+import neqsim.process.alarm.AlarmState;
+import neqsim.process.dynamics.TransientStepTransaction;
+import neqsim.process.dynamics.TransientTransactionCoverage;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.measurementdevice.CompositionAnalyzer.AnalyzerPhase;
+import neqsim.process.measurementdevice.FlowRatioMeter.FlowBasis;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Quantitative rollback, replay, multi-area coverage, and restart evidence for local process-quality instruments.
+ */
+class ProcessQualityInstrumentTransientStateTransactionTest extends neqsim.NeqSimTest {
+  @Test
+  void multiAreaRollbackRestoresBindingsConfigurationAndExactSignalReplay() {
+    StreamInterface source = createStream("quality source", 120.0);
+    StreamInterface denominator = createStream("ratio denominator", 80.0);
+
+    MolarMassAnalyser molarMass = new MolarMassAnalyser("AIT-MM-100", source);
+    WaterContentAnalyser waterContent = new WaterContentAnalyser("AIT-W-100", source);
+    CompositionAnalyzer composition =
+        new CompositionAnalyzer("AIT-Z-100", source, "methane", AnalyzerPhase.OVERALL);
+    FlowRatioMeter flowRatio =
+        new FlowRatioMeter("FIT-R-100", source, denominator, FlowBasis.MASS);
+    ImpurityMonitor impurity = new ImpurityMonitor("AIT-I-100", source);
+    impurity.addTrackedComponent("methane", 0.50);
+
+    List<MeasurementDeviceBaseClass> devices = new ArrayList<MeasurementDeviceBaseClass>();
+    devices.add(molarMass);
+    devices.add(waterContent);
+    devices.add(composition);
+    devices.add(flowRatio);
+    devices.add(impurity);
+    for (int i = 0; i < devices.size(); i++) {
+      configureSignalDynamics(devices.get(i), 9100L + i);
+      devices.get(i).getMeasuredValue();
+      devices.get(i).getMeasuredValue();
+    }
+
+    AlarmConfig alarmConfig = AlarmConfig.builder().highLimit(0.0).delay(2.0).unit("gr/mol").build();
+    molarMass.setAlarmConfig(alarmConfig);
+    AlarmState originalAlarmState = molarMass.getAlarmState();
+
+    ProcessSystem qualityArea = new ProcessSystem("quality area");
+    qualityArea.add(molarMass);
+    qualityArea.add(waterContent);
+    qualityArea.add(composition);
+    ProcessSystem meteringArea = new ProcessSystem("metering area");
+    meteringArea.add(flowRatio);
+    meteringArea.add(impurity);
+
+    assertCompleteCoverage(qualityArea.getTransientTransactionCoverage(), 3);
+    assertCompleteCoverage(meteringArea.getTransientTransactionCoverage(), 2);
+
+    ProcessModel model = new ProcessModel();
+    model.add("quality", qualityArea);
+    model.add("metering", meteringArea);
+    assertCompleteCoverage(model.getTransientTransactionCoverage(), 5);
+
+    StreamInterface originalMolarMassStream = molarMass.getStream();
+    StreamInterface originalWaterContentStream = waterContent.getStream();
+    StreamInterface originalCompositionStream = composition.getStream();
+    StreamInterface originalNumeratorStream = flowRatio.getNumeratorStream();
+    StreamInterface originalDenominatorStream = flowRatio.getDenominatorStream();
+    StreamInterface originalImpurityStream = impurity.getStream();
+    List<String> identities = transientIdentities(molarMass, waterContent, composition, flowRatio, impurity);
+
+    TransientStepTransaction transaction = model.beginTransientStepTransaction();
+    List<double[]> trialSequence = new ArrayList<double[]>();
+    for (int i = 0; i < 4; i++) {
+      trialSequence.add(readAll(molarMass, waterContent, composition, flowRatio, impurity));
+    }
+    assertTrue(molarMass.evaluateAlarm(100.0, 1.0, 1.0).isEmpty());
+
+    StreamInterface trialStream = createStream("trial source", 15.0);
+    for (MeasurementDeviceBaseClass device : devices) {
+      device.setName("trial " + device.getName());
+      device.setUnit("trial");
+      device.setDelaySteps(0);
+      device.setNoiseStdDev(9.0);
+      device.setRandomSeed(1L);
+      device.setFirstOrderTimeConstant(0.0);
+      device.clearFault();
+      device.setAlarmConfig(null);
+    }
+    molarMass.setStream(trialStream);
+    waterContent.setStream(trialStream);
+    composition.setStream(trialStream);
+    impurity.setStream(trialStream);
+    impurity.setPrimaryComponent("water");
+    impurity.addTrackedComponent("hydrogen", 0.01);
+    transaction.rollback();
+
+    assertEquals(identities,
+        transientIdentities(molarMass, waterContent, composition, flowRatio, impurity));
+    assertEquals("AIT-MM-100", molarMass.getName());
+    assertEquals("AIT-W-100", waterContent.getName());
+    assertEquals("AIT-Z-100", composition.getName());
+    assertEquals("FIT-R-100", flowRatio.getName());
+    assertEquals("AIT-I-100", impurity.getName());
+    assertSame(originalMolarMassStream, molarMass.getStream());
+    assertSame(originalWaterContentStream, waterContent.getStream());
+    assertSame(originalCompositionStream, composition.getStream());
+    assertSame(originalNumeratorStream, flowRatio.getNumeratorStream());
+    assertSame(originalDenominatorStream, flowRatio.getDenominatorStream());
+    assertSame(originalImpurityStream, impurity.getStream());
+    assertSame(alarmConfig, molarMass.getAlarmConfig());
+    assertSame(originalAlarmState, molarMass.getAlarmState());
+    assertFalse(impurity.getFullReport().containsKey("hydrogen"));
+
+    for (double[] expected : trialSequence) {
+      double[] actual = readAll(molarMass, waterContent, composition, flowRatio, impurity);
+      for (int i = 0; i < expected.length; i++) {
+        assertEquals(expected[i], actual[i], 0.0,
+            "rollback must replay Gaussian, drift, filter, and delay state exactly");
+      }
+    }
+    assertTrue(molarMass.evaluateAlarm(100.0, 1.0, 1.0).isEmpty());
+    assertEquals(1, molarMass.evaluateAlarm(100.0, 1.0, 2.0).size());
+  }
+
+  @Test
+  void serializedImpuritySnapshotRestoresSubclassStateAndRandomContinuation() throws Exception {
+    ImpurityMonitor monitor = new ImpurityMonitor("AIT-I-200", createStream("restart source", 100.0));
+    monitor.addTrackedComponent("methane", 0.50);
+    configureSignalDynamics(monitor, 7151L);
+    monitor.getMeasuredValue();
+    String identity = monitor.getTransientStateIdentity();
+    ImpurityMonitor.ImpurityMonitorState snapshot = monitor.captureTransientState();
+    double expectedNextValue = monitor.getMeasuredValue();
+
+    byte[] serialized;
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(monitor);
+      output.writeObject(snapshot);
+      serialized = bytes.toByteArray();
+    }
+
+    ImpurityMonitor restoredMonitor;
+    ImpurityMonitor.ImpurityMonitorState restoredSnapshot;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      restoredMonitor = (ImpurityMonitor) input.readObject();
+      restoredSnapshot = (ImpurityMonitor.ImpurityMonitorState) input.readObject();
+    }
+
+    assertEquals(identity, restoredMonitor.getTransientStateIdentity());
+    restoredMonitor.setPrimaryComponent("water");
+    restoredMonitor.addTrackedComponent("hydrogen", 0.01);
+    restoredMonitor.restoreTransientState(restoredSnapshot);
+    assertEquals(identity, restoredMonitor.getTransientStateIdentity());
+    assertFalse(restoredMonitor.getFullReport().containsKey("hydrogen"));
+    assertEquals(expectedNextValue, restoredMonitor.getMeasuredValue(), 0.0);
+  }
+
+  @Test
+  void descendantsOnlineModesAndForeignSnapshotsFailClosed() {
+    StreamInterface source = createStream("coverage source", 100.0);
+    StreamInterface denominator = createStream("coverage denominator", 75.0);
+    ProcessSystem process = new ProcessSystem("quality instrument blocker coverage");
+    process.add(new MolarMassAnalyser(source) {
+      private static final long serialVersionUID = 1000L;
+    });
+    process.add(new WaterContentAnalyser(source) {
+      private static final long serialVersionUID = 1000L;
+    });
+    process.add(new CompositionAnalyzer(source, "methane", AnalyzerPhase.OVERALL) {
+      private static final long serialVersionUID = 1000L;
+    });
+    process.add(new FlowRatioMeter(source, denominator, FlowBasis.MASS) {
+      private static final long serialVersionUID = 1000L;
+    });
+    process.add(new ImpurityMonitor(source) {
+      private static final long serialVersionUID = 1000L;
+    });
+
+    TransientTransactionCoverage coverage = process.getTransientTransactionCoverage();
+    assertEquals(5, coverage.getProcessElementCount());
+    assertEquals(5, coverage.getParticipantCount());
+    assertFalse(coverage.isComplete());
+    assertEquals(5, coverage.getBlockingIssues().size());
+    for (String issue : coverage.getBlockingIssues()) {
+      assertTrue(issue.contains("subclass-owned mutable state"));
+    }
+
+    MolarMassAnalyser online = new MolarMassAnalyser(source);
+    online.setIsOnlineSignal(true, "plant", "tag");
+    ProcessSystem onlineProcess = new ProcessSystem("online blocker");
+    onlineProcess.add(online);
+    assertFalse(onlineProcess.getTransientTransactionCoverage().isComplete());
+    assertTrue(onlineProcess.getTransientTransactionCoverage().getBlockingIssues().get(0)
+        .contains("external I/O"));
+
+    MolarMassAnalyser first = new MolarMassAnalyser(source);
+    MolarMassAnalyser second = new MolarMassAnalyser(source);
+    MolarMassAnalyser.MolarMassAnalyserState foreign = first.captureTransientState();
+    assertThrows(IllegalArgumentException.class, () -> second.restoreTransientState(foreign));
+  }
+
+  private static void configureSignalDynamics(MeasurementDeviceBaseClass device, long seed) {
+    device.setDelaySteps(2);
+    device.setNoiseStdDev(0.05);
+    device.setRandomSeed(seed);
+    device.setFirstOrderTimeConstant(2.0);
+    device.setFault(SensorFaultType.LINEAR_DRIFT, 0.01);
+  }
+
+  private static double[] readAll(MolarMassAnalyser molarMass, WaterContentAnalyser waterContent,
+      CompositionAnalyzer composition, FlowRatioMeter flowRatio, ImpurityMonitor impurity) {
+    return new double[] {molarMass.getMeasuredValue("gr/mol"), waterContent.getMeasuredValue("kg/day"),
+        composition.getMeasuredValue("mole/mole"), flowRatio.getMeasuredValue(""),
+        impurity.getMeasuredValue("mol%")};
+  }
+
+  private static List<String> transientIdentities(MolarMassAnalyser molarMass,
+      WaterContentAnalyser waterContent, CompositionAnalyzer composition, FlowRatioMeter flowRatio,
+      ImpurityMonitor impurity) {
+    List<String> identities = new ArrayList<String>();
+    identities.add(molarMass.getTransientStateIdentity());
+    identities.add(waterContent.getTransientStateIdentity());
+    identities.add(composition.getTransientStateIdentity());
+    identities.add(flowRatio.getTransientStateIdentity());
+    identities.add(impurity.getTransientStateIdentity());
+    return identities;
+  }
+
+  private static void assertCompleteCoverage(TransientTransactionCoverage coverage, int expectedCount) {
+    assertEquals(expectedCount, coverage.getProcessElementCount());
+    assertEquals(expectedCount, coverage.getParticipantCount());
+    assertTrue(coverage.isComplete(), coverage.getBlockingIssues().toString());
+  }
+
+  private static StreamInterface createStream(String name, double massFlowKgPerHour) {
+    SystemSrkEos fluid = new SystemSrkEos(300.0, 10.0);
+    fluid.addComponent("methane", 0.99);
+    fluid.addComponent("water", 0.01);
+    fluid.setMultiPhaseCheck(true);
+    Stream stream = new Stream(name, fluid);
+    stream.setFlowRate(massFlowKgPerHour, "kg/hr");
+    stream.run();
+    return stream;
+  }
+}

--- a/src/test/java/neqsim/process/measurementdevice/ProcessQualityInstrumentTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/ProcessQualityInstrumentTransientStateTransactionTest.java
@@ -36,10 +36,8 @@ class ProcessQualityInstrumentTransientStateTransactionTest extends neqsim.NeqSi
 
     MolarMassAnalyser molarMass = new MolarMassAnalyser("AIT-MM-100", source);
     WaterContentAnalyser waterContent = new WaterContentAnalyser("AIT-W-100", source);
-    CompositionAnalyzer composition =
-        new CompositionAnalyzer("AIT-Z-100", source, "methane", AnalyzerPhase.OVERALL);
-    FlowRatioMeter flowRatio =
-        new FlowRatioMeter("FIT-R-100", source, denominator, FlowBasis.MASS);
+    CompositionAnalyzer composition = new CompositionAnalyzer("AIT-Z-100", source, "methane", AnalyzerPhase.OVERALL);
+    FlowRatioMeter flowRatio = new FlowRatioMeter("FIT-R-100", source, denominator, FlowBasis.MASS);
     ImpurityMonitor impurity = new ImpurityMonitor("AIT-I-100", source);
     impurity.addTrackedComponent("methane", 0.50);
 
@@ -109,8 +107,7 @@ class ProcessQualityInstrumentTransientStateTransactionTest extends neqsim.NeqSi
     impurity.addTrackedComponent("hydrogen", 0.01);
     transaction.rollback();
 
-    assertEquals(identities,
-        transientIdentities(molarMass, waterContent, composition, flowRatio, impurity));
+    assertEquals(identities, transientIdentities(molarMass, waterContent, composition, flowRatio, impurity));
     assertEquals("AIT-MM-100", molarMass.getName());
     assertEquals("AIT-W-100", waterContent.getName());
     assertEquals("AIT-Z-100", composition.getName());
@@ -206,8 +203,7 @@ class ProcessQualityInstrumentTransientStateTransactionTest extends neqsim.NeqSi
     ProcessSystem onlineProcess = new ProcessSystem("online blocker");
     onlineProcess.add(online);
     assertFalse(onlineProcess.getTransientTransactionCoverage().isComplete());
-    assertTrue(onlineProcess.getTransientTransactionCoverage().getBlockingIssues().get(0)
-        .contains("external I/O"));
+    assertTrue(onlineProcess.getTransientTransactionCoverage().getBlockingIssues().get(0).contains("external I/O"));
 
     MolarMassAnalyser first = new MolarMassAnalyser(source);
     MolarMassAnalyser second = new MolarMassAnalyser(source);
@@ -225,14 +221,12 @@ class ProcessQualityInstrumentTransientStateTransactionTest extends neqsim.NeqSi
 
   private static double[] readAll(MolarMassAnalyser molarMass, WaterContentAnalyser waterContent,
       CompositionAnalyzer composition, FlowRatioMeter flowRatio, ImpurityMonitor impurity) {
-    return new double[] {molarMass.getMeasuredValue("gr/mol"), waterContent.getMeasuredValue("kg/day"),
-        composition.getMeasuredValue("mole/mole"), flowRatio.getMeasuredValue(""),
-        impurity.getMeasuredValue("mol%")};
+    return new double[] { molarMass.getMeasuredValue("gr/mol"), waterContent.getMeasuredValue("kg/day"),
+        composition.getMeasuredValue("mole/mole"), flowRatio.getMeasuredValue(""), impurity.getMeasuredValue("mol%") };
   }
 
-  private static List<String> transientIdentities(MolarMassAnalyser molarMass,
-      WaterContentAnalyser waterContent, CompositionAnalyzer composition, FlowRatioMeter flowRatio,
-      ImpurityMonitor impurity) {
+  private static List<String> transientIdentities(MolarMassAnalyser molarMass, WaterContentAnalyser waterContent,
+      CompositionAnalyzer composition, FlowRatioMeter flowRatio, ImpurityMonitor impurity) {
     List<String> identities = new ArrayList<String>();
     identities.add(molarMass.getTransientStateIdentity());
     identities.add(waterContent.getTransientStateIdentity());


### PR DESCRIPTION
## Scope

Advances #2911 with one bounded shared-engine transaction tranche for local process-quality instruments whose production read path already mutates inherited signal state.

- make concrete `MolarMassAnalyser`, `WaterContentAnalyser`, `CompositionAnalyzer`, `FlowRatioMeter`, and `ImpurityMonitor` typed transient-state participants
- preserve stable provenance identity and original stream bindings
- capture inherited noise RNG (including cached Gaussian), delay, filter, drift/fault, alarm and instrument configuration
- capture flow-ratio basis and both stream bindings
- defensively copy/restore impurity primary component and ordered tracked-component thresholds
- fail closed for descendants and online/external-I/O mode
- add quantitative exact replay, multi-area rollback, serialization/restart, foreign-snapshot and blocker regressions
- document qualification and explicit non-qualification boundaries

This does not change analyser physics, metering correlations, species transport, multiphase closures, safety actions, external I/O, or adaptive integration. `VolumeFlowTransmitter` and level families remain outside the tranche because their current production reads do not advance inherited signal-modifier state.

## Validation

**VALIDATION PENDING CI** on exact head `d1b5c5270c59c2264fbe2452774c91d3d05c4fa3`.

Passed on the exact head:

- Spotless and pre-commit/pre-push
- documentation search coverage
- Java 21 Javadocs
- PaperLab replication gate
- CodeQL security analysis

Still running:

- Java 21 fast tests on Ubuntu and Windows
- all four Java 21 slow-test shards on Ubuntu

Attempted locally:

- `./mvnw -q -Dmaven.repo.local=/tmp/neqsim-m2/repository -DskipITs -Dtest=ProcessQualityInstrumentTransientStateTransactionTest test`

The local focused test could not resolve `maven-enforcer-plugin:3.6.3` because `repo.maven.apache.org` DNS resolution was unavailable. It is not claimed as passed; exact-head GitHub CI is the validator.

Relates to #2911.