### PR TITLE
fix(flash): recover sour-gas boundary split from cold seed

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -152,7 +152,7 @@ public class TPflash extends Flash {
   private PhaseType referenceSinglePhaseType = null;
   /** True after the bounded water-bearing ordinary-flash retry has been attempted in this run. */
   private boolean waterBearingRescueAttempted = false;
-  /** Cold initial state retained only for a screened asymmetric multiphase endpoint retry. */
+  /** Cold initial state retained only for a screened asymmetric endpoint retry. */
   private transient SystemInterface multiphaseEndpointRescueSeed;
   /** Prevents a bounded water-rich cross-algorithm fallback from recursively starting another fallback. */
   private boolean waterRichCrossAlgorithmFallbackAllowed = true;
@@ -1240,8 +1240,9 @@ public class TPflash extends Flash {
    *
    * <p>
    * The accepted candidate must contain exactly two neutral fluid phases, close material balance and fugacity equality,
-   * and lower Gibbs energy. Chemical/electrolyte, aqueous, solid, wax, ordinary gas-only, and compositions outside the
-   * instability screen remain on the existing fast path.
+   * and lower Gibbs energy. Chemical/electrolyte, aqueous, solid, wax, and compositions outside the instability screen
+   * remain on the existing fast path. A screened single-phase sour-gas endpoint is normalized to the feed before its
+   * Gibbs energy is compared, because an incipient phase composition is not a valid one-phase reference state.
    * </p>
    */
   private void rescueLowerGibbsNeutralEndpoint() {
@@ -1272,14 +1273,22 @@ public class TPflash extends Flash {
       }
     }
 
-    system.init(1);
+    if (system.getNumberOfPhases() == 1) {
+      normalizeSourGasSinglePhaseEndpoint();
+    } else {
+      system.init(1);
+    }
     double referenceGibbsEnergy = system.getGibbsEnergy();
-    SystemInterface candidate = system.clone();
+    boolean hasColdSeed = multiphaseEndpointRescueSeed != null;
+    SystemInterface candidate = hasColdSeed ? multiphaseEndpointRescueSeed : system.clone();
+    multiphaseEndpointRescueSeed = null;
     MULTIPHASE_RESCUE_ACTIVE.set(Boolean.TRUE);
     try {
       candidate.setMultiPhaseCheck(true);
       candidate.setEnhancedMultiPhaseCheck(false);
-      if (system.getNumberOfPhases() == 2 && hasGasPhase) {
+      if (hasColdSeed && system.getNumberOfPhases() == 1) {
+        new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
+      } else if (system.getNumberOfPhases() == 2 && hasGasPhase) {
         new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
       } else {
         new TPmultiflash(candidate, candidate.doSolidPhaseCheck()).run();
@@ -2237,18 +2246,19 @@ public class TPflash extends Flash {
    * Retains the cold pre-iteration state for a narrowly screened multiphase endpoint retry.
    *
    * <p>
-   * Once a multiphase stability trial has collapsed a phase, cloning that endpoint also copies its local cubic-root and
-   * phase-storage history. A later ordinary retry can then reproduce the same homogeneous minimum even though a cold
-   * ordinary flash finds a lower-Gibbs split. The seed is therefore captured before the two-phase iteration, but only
-   * for neutral asymmetric mixtures whose deterministic Wilson endpoint test already justifies a possible retry. It is
-   * consumed at most once and cleared when the operation returns. Strong hydrocarbon Wilson splits retain the existing
-   * nearby-temperature continuation instead, so normal flashes allocate nothing.
+   * Once a stability trial has collapsed a phase, cloning that endpoint also copies its local cubic-root and
+   * phase-storage history. A later retry can then reproduce the same homogeneous minimum even though a cold flash finds
+   * a lower-Gibbs split. The seed is therefore captured before the two-phase iteration, but only for multiphase flashes
+   * or ordinary sour-gas flashes whose deterministic asymmetric and Wilson endpoint screens justify a possible retry.
+   * It is consumed at most once and cleared when the operation returns. Strong hydrocarbon Wilson splits retain the
+   * existing nearby-temperature continuation instead, so ordinary non-sour-gas flashes allocate nothing.
    * </p>
    */
   private void prepareMultiphaseEndpointRescueSeed() {
     multiphaseEndpointRescueSeed = null;
-    if (!system.doMultiPhaseCheck() || system.isChemicalSystem() || system.hasIons() || solidCheck
-        || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck() || directGammaPhiModel != null
+    boolean ordinarySourGasCandidate = !system.doMultiPhaseCheck() && isSourGasConsistencyRefinementCase();
+    if ((!system.doMultiPhaseCheck() && !ordinarySourGasCandidate) || system.isChemicalSystem() || system.hasIons()
+        || solidCheck || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck() || directGammaPhiModel != null
         || hybridEosGeFlashModel != null || system.getPhase(0).getNumberOfComponents() <= 1
         || !hasPotentialAsymmetricNeutralInstability(MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN)
         || !(hasPotentialMultiphaseEndpoint(PhaseType.GAS) || hasPotentialMultiphaseEndpoint(PhaseType.LIQUID))) {

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashSourGasConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashSourGasConsistencyTest.java
@@ -39,6 +39,22 @@ class TPflashSourGasConsistencyTest {
     }
   }
 
+  @Test
+  void ordinaryBoundaryFlashRecoversStableSplitFromColdFeedSeed() {
+    SystemInterface ordinary = flash(245.0, 100.80, false, false);
+    SystemInterface multiphase = flash(245.0, 100.80, true, false);
+
+    assertEquals(2, ordinary.getNumberOfPhases());
+    assertEquivalent(multiphase, ordinary, 1.0e-10, "cold boundary flash");
+    assertEquals(5204.65719950532, ordinary.getGibbsEnergy(), 1.0e-6);
+    assertEquals(0.330402477242444, ordinary.getBeta(phaseOrder(ordinary)[0]), 1.0e-10);
+
+    SystemInterface repeatedReference = ordinary.clone();
+    new ThermodynamicOperations(ordinary).TPflash();
+    ordinary.init(1);
+    assertEquivalent(repeatedReference, ordinary, 1.0e-10, "repeated boundary flash");
+  }
+
   private SystemInterface flash(double temperature, double pressure, boolean multiphase, boolean enhanced) {
     SystemInterface system = new SystemPrEos(temperature, pressure);
     for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {


### PR DESCRIPTION
## Problem

Closes the next bounded increment in #2937.

For the public methane/CO2/H2S feed (49.88/9.87/40.22 mol%) with PR EOS and classic mixing at 245 K and 100.8 bara, current master returns different stable states:

- ordinary TPflash: one GAS phase, Gibbs energy 5205.33379535522 J;
- multiphase TPflash: GAS+OIL, gas beta 0.330402477242444, Gibbs energy 5204.65719950532 J.

The multiphase state closes component balance to 6.25e-12 and interphase log-fugacity equality to 2.26e-9. It is 0.676595849896 J lower in Gibbs energy. This is therefore a phase-selection defect, not a label difference.

## Root cause

The ordinary path reaches a one-phase endpoint carrying an incipient trial composition. Calling `init(1)` on that stale composition produces a non-feed Gibbs reference (5204.32831892614 J), so the valid two-phase candidate is incorrectly rejected as higher-Gibbs. In addition, cloning that converged endpoint reuses its cubic-root/phase-storage history and repeats the same local minimum.

## Method

This change reuses the existing, strictly screened pre-iteration seed for ordinary sour-gas endpoints as well as multiphase endpoints. Before Gibbs comparison, a one-phase ordinary endpoint is normalized to beta=1 and the overall feed composition. The cold candidate is then solved through the multiphase stability path.

Acceptance is unchanged and remains strict:

- exactly two neutral fluid phases;
- bounded/non-vanishing normalized phase fractions;
- distinct normalized phase compositions;
- component material balance;
- interphase log-fugacity residual;
- lower total Gibbs energy.

Chemical/electrolyte, aqueous, solid, wax, direct gamma-phi, hybrid EOS-GE, non-sour-gas, and mixtures outside the asymmetric/Wilson screen remain excluded. Ordinary non-sour-gas flashes allocate no new seed.

This follows Michelsen's tangent-plane stability and phase-split principle: a candidate split is accepted only when it is feasible, equilibrated, and below the valid feed-composition reference Gibbs energy. See [Part I](https://doi.org/10.1016/0378-3812(82)85001-2) and [Part II](https://doi.org/10.1016/0378-3812(82)85002-4).

## Regression and numerical tolerances

The focused regression freezes:

- topology: exactly two phases;
- ordinary/multiphase beta, Z, and composition agreement: 1e-10;
- expected Gibbs energy: 5204.65719950532 J ± 1e-6 J;
- gas beta: 0.330402477242444 ± 1e-10;
- component material balance: existing 1e-10 gate;
- maximum log-fugacity residual: existing 1e-8 gate;
- deterministic repeat at the same state: 1e-10 state agreement.

Fresh nearby controls at 242.5/245/247.5 K and 95.81/100.8/105.79 bara were also probed. All ordinary/multiphase pairs returned the same two-phase topology; maximum measured balance residual was 9.36e-12 and maximum log-fugacity residual was 6.24e-9.

A separate changed-state sequence (95.81 → 105.79 bara on the same already-flashed object) still exposes deeper cubic-root history in current master and this branch. It is recorded in #2937 as the next distinct initialization/continuation dependency rather than hidden by this cold-endpoint fix.

## Before/after evidence

- Baseline focused harness: the new boundary assertion fails (ordinary one phase vs multiphase two phases).
- Patched focused class: 3/3 test methods pass, including the pre-existing 14 sour-gas cross-algorithm states, the new boundary case, and exact repeat.
- Corrected ordinary boundary: balance 6.25e-12; log-fugacity residual 2.26e-9.
- Gibbs improvement over the rejected ordinary endpoint: 0.676595849896 J.

Local source-mode timing medians (11 batches × 100 fresh flashes, same JVM/environment):

| Case | Baseline | Candidate | Interpretation |
|---|---:|---:|---|
| ordinary non-sour PR control | 2913.6 µs | 2761.0 µs | no slowdown claim; noise dominates |
| sour gas outside screen | 2745.8 µs | 2825.2 µs | +2.9%, not treated as significant |
| corrected boundary, ordinary | — | 8291.0 µs | correct solution |
| corrected boundary, multiphase | — | 8545.8 µs | ordinary was 3.0% lower in this harness |

The incorrect baseline boundary runtime is intentionally not compared with the corrected solution.

## Validation

- Exact current-master TPflash source blob `97e2a7cbfffb25cc83307f201f4ffe534b729ae5`.
- Exact current-master test blob `a8d3bbfe1e98d69590f7edbc9e5bfee02bc56515`.
- Java source-mode compile and focused test runner: PASS (3/3 methods).
- Deterministic six-state fresh probe: PASS.
- Whitespace/error diff check: PASS.
- `python devtools/run_spotless.py apply`: **not run locally** (no exact writable checkout with resolved Maven); hosted Spotless is authoritative follow-up.
- `python devtools/run_spotless.py check`: **not run locally**.
- `python devtools/check_documentation_search.py`: **not run locally**.
- pre-commit/pre-push: **not run locally**.
- Full Maven suite: **not run locally**.
- Hosted Spotless format workflow: PASS on exact head.
- Hosted pre-commit workflow: PASS on exact head.
- Hosted PaperLab workflow: PASS on exact head.
- Hosted CodeQL and build/test/Javadocs workflows: in progress.

**VALIDATION PENDING CI**

## Compatibility and risk

The change is private to `TPflash`; no public API, units, configuration, global convergence tolerance, or equations change. The principal risk is extra clone/flash work for the narrow ordinary sour-gas endpoint screen. The screen and strict acceptance gates constrain that risk, while ordinary non-sour-gas and excluded model paths are unchanged.

## Documentation impact

Documentation impact: none. This is a private numerical safeguard with updated private-field/method Javadocs; there is no user-facing API, option, unit, workflow, or behavior contract to document. The reproduced case, method basis, gates, tolerances, and limitation are documented here and in #2937.
