### PR TITLE
feat(diagram): add deterministic drawing quality diagnostics

### DIFF
--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -198,6 +198,14 @@ sheet. Use `exportSvg(directory)` or `exportPdf(path)` when files are required. 
 modify the source document set, legacy DOT/Graphviz output, DEXPI 2.0 Process exchange, or the
 Proteus/DEXPI P&ID workflow.
 
+The rendering result also carries deterministic drawing-quality diagnostics. It reports overlapping
+object symbols, symbols clipped by the border/header/title-block boundary, primary labels estimated
+to exceed their available symbol width, and missing semantic-object references. Existing controlled-
+document diagnostics are retained in the same report, including broken reciprocal off-page pairs and
+stale manual layout references. Errors make `Result.isComplete()` false; warnings retain the proposed
+geometry unchanged for review. These geometric and text-width checks are conservative proposal gates,
+not proof of standards compliance or accountable visual approval.
+
 Compare two revisions of the same document-set and plant identity with `baseline.compareTo(revised)`.
 The returned `EngineeringDiagramRevisionImpact` has deterministic added, removed, and modified
 semantic-object IDs. It projects those changes to the sheets and drawings containing each object in
@@ -244,6 +252,6 @@ designation mismatches, deterministic cross-sheet revision impact, persistent ma
 unchanged semantic identities after layout-only revision changes, protected-route retention, and
 fail-visible stale layout references.
 The native-renderer regression verifies byte-deterministic SVG/PDF, A3 and A1 geometry, exact pinned
-coordinates and protected routes, reciprocal off-page references, structured layout-loss
-diagnostics, multi-page drawing sets, fresh-model determinism, and unchanged Classic DOT and
-controlled-document JSON.
+coordinates and protected routes, reciprocal off-page references, deterministic collision, clipping,
+label-overflow and broken-reference diagnostics, multi-page drawing sets, fresh-model determinism,
+and unchanged Classic DOT and controlled-document JSON.

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -588,8 +588,7 @@ public final class NativeEngineeringDiagramRenderer {
 
   private static boolean objectInside(Point point, double width, double contentBottom) {
     return point.x - OBJECT_WIDTH / 2.0 >= 8.0 && point.x + OBJECT_WIDTH / 2.0 <= width - 8.0
-        && point.y - OBJECT_HEIGHT / 2.0 >= CONTENT_TOP
-        && point.y + OBJECT_HEIGHT / 2.0 <= contentBottom;
+        && point.y - OBJECT_HEIGHT / 2.0 >= CONTENT_TOP && point.y + OBJECT_HEIGHT / 2.0 <= contentBottom;
   }
 
   private static boolean overlaps(Point left, Point right) {

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -72,6 +72,8 @@ public final class NativeEngineeringDiagramRenderer {
 
   /** Renderer diagnostic severity. */
   public enum Severity {
+    /** Informational source-document evidence retained in the rendering report. */
+    INFO,
     /** Recoverable rendering limitation requiring review. */
     WARNING,
     /** Broken source or rendering state that prevents a complete view. */
@@ -187,6 +189,7 @@ public final class NativeEngineeringDiagramRenderer {
    */
   public Result render() {
     List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
+    addDocumentDiagnostics(diagnostics);
     Map<String, SemanticObject> objects = objectsById();
     List<Page> pages = new ArrayList<Page>();
     for (Drawing drawing : documentSet.getDrawings()) {
@@ -258,6 +261,7 @@ public final class NativeEngineeringDiagramRenderer {
         drawing.getContentProfile().name() + " / " + format.name(), "#374151", "sheet-format", "end"));
 
     Map<String, Point> positions = layoutPositions(sheet, objects, contentRight, contentBottom, diagnostics);
+    addDrawingQualityDiagnostics(sheet, objects, positions, page.width, contentBottom, diagnostics);
     Map<String, OffPageConnector> connectors = new TreeMap<String, OffPageConnector>();
     for (OffPageConnector connector : sheet.getOffPageConnectors()) {
       connectors.put(connector.getSemanticConnectionId(), connector);
@@ -276,7 +280,10 @@ public final class NativeEngineeringDiagramRenderer {
     Collections.sort(ids);
     for (String id : ids) {
       SemanticObject object = objects.get(id);
-      if (object != null && isConnection(object.getKind())) {
+      if (object == null) {
+        diagnostics.add(diagnostic(Severity.ERROR, "DIAGRAM_RENDER_BROKEN_OBJECT_REFERENCE",
+            "Controlled sheet references a semantic object that is absent from the document set", id));
+      } else if (isConnection(object.getKind())) {
         addConnection(page, object, positions, connectors.get(id), protectedRoutes.get(id), objects, contentRight,
             contentBottom, diagnostics);
       }
@@ -293,6 +300,51 @@ public final class NativeEngineeringDiagramRenderer {
     }
     addTitleBlock(page, drawing, sheet);
     return page;
+  }
+
+  private void addDocumentDiagnostics(List<Diagnostic> diagnostics) {
+    for (EngineeringDiagramDocumentSet.Diagnostic source : documentSet.getDiagnostics()) {
+      Severity severity = Severity.INFO;
+      if (source.getSeverity() == EngineeringDiagramDocumentSet.Severity.WARNING) {
+        severity = Severity.WARNING;
+      } else if (source.getSeverity() == EngineeringDiagramDocumentSet.Severity.ERROR) {
+        severity = Severity.ERROR;
+      }
+      diagnostics.add(diagnostic(severity, source.getCode(), source.getMessage(), source.getSubjectId()));
+    }
+  }
+
+  private void addDrawingQualityDiagnostics(Sheet sheet, Map<String, SemanticObject> objects,
+      Map<String, Point> positions, double pageWidth, double contentBottom, List<Diagnostic> diagnostics) {
+    List<String> drawableIds = new ArrayList<String>();
+    for (String id : sheet.getObjectNodeIds()) {
+      SemanticObject object = objects.get(id);
+      if (object != null && isDrawableNode(object.getKind()) && positions.containsKey(id)) {
+        drawableIds.add(id);
+      }
+    }
+    Collections.sort(drawableIds);
+    for (int index = 0; index < drawableIds.size(); index++) {
+      String id = drawableIds.get(index);
+      SemanticObject object = objects.get(id);
+      Point position = positions.get(id);
+      if (!objectInside(position, pageWidth, contentBottom)) {
+        diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_OBJECT_CLIPPED",
+            "Rendered object boundary intersects the sheet border, document header, or title-block area", id));
+      }
+      String label = displayLabel(object);
+      if (estimatedTextWidth(label, 2.8) > OBJECT_WIDTH - 4.0) {
+        diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_LABEL_OVERFLOW",
+            "Primary object label exceeds the available symbol width and requires drawing review", id));
+      }
+      for (int otherIndex = index + 1; otherIndex < drawableIds.size(); otherIndex++) {
+        String otherId = drawableIds.get(otherIndex);
+        if (overlaps(position, positions.get(otherId))) {
+          diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_OBJECT_COLLISION",
+              "Rendered object overlaps semantic object " + otherId, id));
+        }
+      }
+    }
   }
 
   private Map<String, Point> layoutPositions(Sheet sheet, Map<String, SemanticObject> objects, double contentRight,
@@ -532,6 +584,20 @@ public final class NativeEngineeringDiagramRenderer {
 
   private static boolean inside(double x, double y, double width, double contentBottom) {
     return x >= 8.0 && x <= width - 8.0 && y >= 8.0 && y <= contentBottom;
+  }
+
+  private static boolean objectInside(Point point, double width, double contentBottom) {
+    return point.x - OBJECT_WIDTH / 2.0 >= 8.0 && point.x + OBJECT_WIDTH / 2.0 <= width - 8.0
+        && point.y - OBJECT_HEIGHT / 2.0 >= CONTENT_TOP
+        && point.y + OBJECT_HEIGHT / 2.0 <= contentBottom;
+  }
+
+  private static boolean overlaps(Point left, Point right) {
+    return Math.abs(left.x - right.x) < OBJECT_WIDTH && Math.abs(left.y - right.y) < OBJECT_HEIGHT;
+  }
+
+  private static double estimatedTextWidth(String value, double fontSize) {
+    return value.length() * fontSize * 0.52;
   }
 
   private static boolean insideAll(List<Waypoint> waypoints, double width, double contentBottom) {

--- a/src/main/java/neqsim/process/processmodel/diagram/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/package-info.java
@@ -24,6 +24,8 @@
  * project review evidence without changing process topology</li>
  * <li><b>Native controlled output</b> - Deterministic vector SVG sheets and multi-page PDF consume the same controlled
  * document model without requiring Graphviz</li>
+ * <li><b>Drawing-quality diagnostics</b> - Deterministic collision, clipping, label-overflow, and broken-reference
+ * evidence remains structured and fail-visible without silently moving reviewed geometry</li>
  * <li><b>Revision impact</b> - Deterministic changed-object, affected-sheet, and affected-drawing evidence</li>
  * <li><b>Multiple detail levels</b> - MINIMAL, STANDARD, DETAILED, DEBUG</li>
  * <li><b>Deterministic output</b> - Same model always produces same diagram</li>

--- a/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
@@ -123,9 +123,9 @@ class NativeEngineeringDiagramRendererTest {
     SemanticObject separator = findObject(baseline, EngineeringNode.Kind.EQUIPMENT, "equipmentName", "10-VA-001");
     SemanticObject valve = findObject(baseline, EngineeringNode.Kind.EQUIPMENT, "equipmentName", "10-XV-001");
     EngineeringDiagramDesignationRegister designations = new EngineeringDiagramDesignationRegister()
-        .withDesignation(new Designation(separator.getId(), Kind.EQUIPMENT_TAG,
-            "10-VERY-LONG-SEPARATOR-DESIGNATION", "equipment-register:PFD-NATIVE-005", ReviewState.REVIEWED,
-            "Process discipline", "review:PFD-NATIVE-005", "2026-08-14T18:00:00Z", "A"));
+        .withDesignation(new Designation(separator.getId(), Kind.EQUIPMENT_TAG, "10-VERY-LONG-SEPARATOR-DESIGNATION",
+            "equipment-register:PFD-NATIVE-005", ReviewState.REVIEWED, "Process discipline", "review:PFD-NATIVE-005",
+            "2026-08-14T18:00:00Z", "A"));
     EngineeringDiagramLayoutRegister layout = new EngineeringDiagramLayoutRegister()
         .withPinnedPosition(reviewedPosition(separator.getId(), sheetKey, 10.0, 60.0))
         .withPinnedPosition(reviewedPosition(valve.getId(), sheetKey, 10.0, 60.0));

--- a/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
@@ -6,9 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister;
+import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister.Designation;
+import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister.Kind;
+import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister.ReviewState;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.SemanticObject;
@@ -109,6 +114,56 @@ class NativeEngineeringDiagramRendererTest {
   }
 
   @Test
+  void reportsDeterministicCollisionClippingAndReadabilityDiagnostics() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
+    EngineeringDiagramDocumentSet baseline = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-NATIVE-005", "Drawing quality diagnostics",
+        ContentProfile.PFD);
+    String sheetKey = baseline.getDrawings().get(0).getSheets().get(0).getKey();
+    SemanticObject separator = findObject(baseline, EngineeringNode.Kind.EQUIPMENT, "equipmentName", "10-VA-001");
+    SemanticObject valve = findObject(baseline, EngineeringNode.Kind.EQUIPMENT, "equipmentName", "10-XV-001");
+    EngineeringDiagramDesignationRegister designations = new EngineeringDiagramDesignationRegister()
+        .withDesignation(new Designation(separator.getId(), Kind.EQUIPMENT_TAG,
+            "10-VERY-LONG-SEPARATOR-DESIGNATION", "equipment-register:PFD-NATIVE-005", ReviewState.REVIEWED,
+            "Process discipline", "review:PFD-NATIVE-005", "2026-08-14T18:00:00Z", "A"));
+    EngineeringDiagramLayoutRegister layout = new EngineeringDiagramLayoutRegister()
+        .withPinnedPosition(reviewedPosition(separator.getId(), sheetKey, 10.0, 60.0))
+        .withPinnedPosition(reviewedPosition(valve.getId(), sheetKey, 10.0, 60.0));
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-NATIVE-005", "Drawing quality diagnostics",
+        ContentProfile.PFD, designations, layout);
+
+    NativeEngineeringDiagramRenderer renderer = new NativeEngineeringDiagramRenderer(documents);
+    NativeEngineeringDiagramRenderer.Result first = renderer.render();
+    NativeEngineeringDiagramRenderer.Result second = renderer.render();
+
+    assertTrue(hasDiagnostic(first, "DIAGRAM_RENDER_OBJECT_COLLISION"));
+    assertTrue(hasDiagnostic(first, "DIAGRAM_RENDER_OBJECT_CLIPPED"));
+    assertTrue(hasDiagnostic(first, "DIAGRAM_RENDER_LABEL_OVERFLOW"));
+    assertEquals(diagnosticSignatures(first), diagnosticSignatures(second));
+    assertTrue(first.isComplete());
+  }
+
+  @Test
+  void propagatesBrokenControlledDocumentReferencesAsRendererErrors() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
+    EngineeringDiagramDocumentSet baseline = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-NATIVE-006", "Broken reference diagnostics",
+        ContentProfile.PFD);
+    String sheetKey = baseline.getDrawings().get(0).getSheets().get(0).getKey();
+    EngineeringDiagramLayoutRegister layout = new EngineeringDiagramLayoutRegister()
+        .withPinnedPosition(reviewedPosition("missing-semantic-object", sheetKey, 80.0, 60.0));
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-NATIVE-006", "Broken reference diagnostics",
+        ContentProfile.PFD, new EngineeringDiagramDesignationRegister(), layout);
+
+    NativeEngineeringDiagramRenderer.Result result = new NativeEngineeringDiagramRenderer(documents).render();
+
+    assertTrue(hasDiagnostic(result, "DIAGRAM_DOCUMENT_LAYOUT_UNKNOWN_OBJECT"));
+    assertFalse(result.isComplete());
+  }
+
+  @Test
   void keepsSheetOrderAndRenderedBytesStableAcrossFreshEquivalentModels() {
     Map<String, String> expectedSvg = null;
     byte[] expectedPdf = null;
@@ -158,5 +213,13 @@ class NativeEngineeringDiagramRendererTest {
       }
     }
     return false;
+  }
+
+  private static List<String> diagnosticSignatures(NativeEngineeringDiagramRenderer.Result result) {
+    List<String> signatures = new ArrayList<String>();
+    for (NativeEngineeringDiagramRenderer.Diagnostic diagnostic : result.getDiagnostics()) {
+      signatures.add(diagnostic.getSeverity().name() + ":" + diagnostic.getCode() + ":" + diagnostic.getSubjectId());
+    }
+    return signatures;
   }
 }


### PR DESCRIPTION
## Roadmap increment

Advances #1332 Phase 3 drawing-quality diagnostics after merged PFD-C016 and #2899 Phase 2 shared renderer quality evidence after DEXPI-C015.

## Problem and engineering value

The native controlled SVG/PDF renderer preserves reviewed layout intent, but its result currently cannot distinguish a clean drawing proposal from overlapping symbols, clipped object boxes, unreadably long primary labels, or a broken controlled-document reference. Those conditions must remain deterministic and fail-visible before native output can be used for disciplined visual review.

## Coherent scope

- retain controlled-document diagnostics in the native rendering result with their stable code, subject, message and severity;
- treat source-document errors, including stale layout and broken reciprocal off-page references, as incomplete native results;
- report sheet references to absent semantic objects as renderer errors;
- report deterministic object-symbol collisions;
- report object boxes crossing the sheet border, document header or title-block boundary;
- report primary labels whose conservative text-width estimate exceeds the generic symbol box;
- retain proposed geometry and rendering bytes unchanged for warnings rather than silently moving reviewed objects;
- add focused deterministic regression coverage and document the proposal/qualification boundary.

## Deliberate exclusions

This PR does not add automatic repair, obstacle-aware routing, route/label collision qualification, a visual-regression image baseline, symbol/profile selection, licensed ISO/ISA mapping, P&ID object expansion, DEXPI exchange changes, commercial interoperability qualification, or accountable drawing approval. Generic native output remains an engineering proposal.

## Compatibility

The change is additive to the native renderer. Existing public APIs and rendering formats remain available; Severity.INFO preserves informational source-document evidence. Valid SVG/PDF page planning and bytes, Classic DOT/Graphviz, controlled-document JSON, native DEXPI 2.0 Process and Proteus/P&ID paths are not modified.

## Documentation impact

Updated the controlled engineering-diagram guide and package Javadocs with the new deterministic diagnostics, severity behavior and explicit non-qualification boundary.

## Validation

**READY TO MERGE** on exact head `2cda3167ba699fbaa48606b66ec5a8711b7b153f`.

Hosted exact-head validation is complete:

- Spotless format patch: passed;
- pre-commit checks: passed;
- PaperLab replication gate: passed;
- documentation search coverage: passed;
- CodeQL security analysis: passed;
- Javadocs and the Java 8/21 Ubuntu/Windows fast/slow test matrix: passed.

GitHub reports the PR mergeable. The final diff remains limited to the renderer, focused regression test, package Javadocs, and engineering-diagram guide. No unresolved human or Copilot review threads are present.

The PR remains a draft; a maintainer must mark it ready, review, and merge it.

## Next dependency

After exact-head CI and review, the next separate decision is whether to add route/label obstacle metrics and normalized rendered visual baselines. Qualified symbol/profile selection remains blocked on licensed standards mapping and accountable engineering review.