### PR TITLE
perf(process): reuse unchanged boundary diagnostics

### DIFF
--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -441,6 +441,8 @@ public class ProcessModel implements Runnable, Serializable {
   private int lastBoundaryStreamCount = 0;
   /** Per-boundary-stream convergence errors recorded on the last outer iteration. */
   private List<BoundaryStreamError> lastBoundaryStreamErrors = new ArrayList<>();
+  /** Identity cache for immutable boundary diagnostics reused across unchanged observations. */
+  private transient Map<Object, BoundaryStreamError> boundaryStreamErrorCache = new IdentityHashMap<>();
 
   /**
    * Per-stream convergence diagnostics for a single boundary stream.
@@ -3103,6 +3105,9 @@ public class ProcessModel implements Runnable, Serializable {
     int expectedStreamErrors = lastBoundaryStreamErrors == null ? 0
         : Math.min(current.size(), lastBoundaryStreamErrors.size());
     List<BoundaryStreamError> streamErrors = new ArrayList<>(expectedStreamErrors);
+    Map<Object, BoundaryStreamError> priorStreamErrors = boundaryStreamErrorCache;
+    Map<Object, BoundaryStreamError> nextStreamErrors =
+        current.isEmpty() ? null : new IdentityHashMap<>(current.size());
 
     for (Object key : current.keySet()) {
       if (previous.containsKey(key)) {
@@ -3139,13 +3144,34 @@ public class ProcessModel implements Runnable, Serializable {
         double pressErr = Math.abs(curr[2] - prev[2]) / pressBase;
         maxPressErr = Math.max(maxPressErr, pressErr);
 
-        streamErrors.add(new BoundaryStreamError(getStreamName(key), getStreamProducerLabel(key, areaPlan), flowErr,
-            tempErr, pressErr, prev[0], curr[0]));
+        String streamName = getStreamName(key);
+        String producerLabel = getStreamProducerLabel(key, areaPlan);
+        BoundaryStreamError streamError = priorStreamErrors == null ? null : priorStreamErrors.get(key);
+        if (!matchesBoundaryStreamError(streamError, streamName, producerLabel, flowErr, tempErr, pressErr, prev[0],
+            curr[0])) {
+          streamError = new BoundaryStreamError(streamName, producerLabel, flowErr, tempErr, pressErr,
+              prev[0], curr[0]);
+        }
+        streamErrors.add(streamError);
+        nextStreamErrors.put(key, streamError);
       }
     }
 
     lastBoundaryStreamErrors = streamErrors;
+    boundaryStreamErrorCache = nextStreamErrors;
     return new double[] { maxFlowErr, maxTempErr, maxPressErr };
+  }
+
+  /** Returns whether an immutable cached diagnostic exactly represents the current boundary observation. */
+  private boolean matchesBoundaryStreamError(BoundaryStreamError cached, String streamName, String producerLabel,
+      double flowError, double temperatureError, double pressureError, double previousFlow, double currentFlow) {
+    return cached != null && java.util.Objects.equals(cached.getStreamName(), streamName)
+        && java.util.Objects.equals(cached.getProducerLabel(), producerLabel)
+        && Double.doubleToLongBits(cached.getFlowError()) == Double.doubleToLongBits(flowError)
+        && Double.doubleToLongBits(cached.getTemperatureError()) == Double.doubleToLongBits(temperatureError)
+        && Double.doubleToLongBits(cached.getPressureError()) == Double.doubleToLongBits(pressureError)
+        && Double.doubleToLongBits(cached.getPreviousFlow()) == Double.doubleToLongBits(previousFlow)
+        && Double.doubleToLongBits(cached.getCurrentFlow()) == Double.doubleToLongBits(currentFlow);
   }
 
   /**

--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -3106,7 +3106,7 @@ public class ProcessModel implements Runnable, Serializable {
         : Math.min(current.size(), lastBoundaryStreamErrors.size());
     List<BoundaryStreamError> streamErrors = new ArrayList<>(expectedStreamErrors);
     Map<Object, BoundaryStreamError> priorStreamErrors = boundaryStreamErrorCache;
-    Map<Object, BoundaryStreamError> nextStreamErrors = current.isEmpty() ? null
+    Map<Object, BoundaryStreamError> nextStreamErrors = current.isEmpty() ? Collections.emptyMap()
         : new IdentityHashMap<>(current.size());
 
     for (Object key : current.keySet()) {

--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -3106,8 +3106,8 @@ public class ProcessModel implements Runnable, Serializable {
         : Math.min(current.size(), lastBoundaryStreamErrors.size());
     List<BoundaryStreamError> streamErrors = new ArrayList<>(expectedStreamErrors);
     Map<Object, BoundaryStreamError> priorStreamErrors = boundaryStreamErrorCache;
-    Map<Object, BoundaryStreamError> nextStreamErrors =
-        current.isEmpty() ? null : new IdentityHashMap<>(current.size());
+    Map<Object, BoundaryStreamError> nextStreamErrors = current.isEmpty() ? null
+        : new IdentityHashMap<>(current.size());
 
     for (Object key : current.keySet()) {
       if (previous.containsKey(key)) {
@@ -3149,8 +3149,8 @@ public class ProcessModel implements Runnable, Serializable {
         BoundaryStreamError streamError = priorStreamErrors == null ? null : priorStreamErrors.get(key);
         if (!matchesBoundaryStreamError(streamError, streamName, producerLabel, flowErr, tempErr, pressErr, prev[0],
             curr[0])) {
-          streamError = new BoundaryStreamError(streamName, producerLabel, flowErr, tempErr, pressErr,
-              prev[0], curr[0]);
+          streamError = new BoundaryStreamError(streamName, producerLabel, flowErr, tempErr, pressErr, prev[0],
+              curr[0]);
         }
         streamErrors.add(streamError);
         nextStreamErrors.put(key, streamError);

--- a/src/test/java/neqsim/process/processmodel/ProcessModelExecutionOptimizationTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessModelExecutionOptimizationTest.java
@@ -2,6 +2,8 @@ package neqsim.process.processmodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.UUID;
@@ -295,6 +297,57 @@ class ProcessModelExecutionOptimizationTest {
     assertEquals(1, upstream.getRuns(), "clean producer should not rerun");
     assertEquals(2, downstream.getRuns(), "changed boundary consumer should rerun");
     assertTrue(model.isModelConverged(), "changed boundary model should converge after downstream confirmation");
+  }
+
+  /**
+   * Verifies that immutable diagnostics are reused only while the exact boundary observation remains unchanged.
+   */
+  @Test
+  void boundaryDiagnosticsReuseExactObservationsAndInvalidateAfterChange() {
+    Stream feed = new Stream("feed", createGasFluid());
+    feed.setFlowRate(1000.0, "kg/hr");
+    Heater producer = new Heater("producer", feed);
+    producer.setOutTemperature(298.15);
+    StreamInterface boundary = producer.getOutletStream();
+    Separator consumer = new Separator("consumer", boundary);
+
+    BoundaryRecordingProcessSystem upstream = new BoundaryRecordingProcessSystem("upstream", boundary);
+    upstream.add(feed);
+    upstream.add(producer);
+    BoundaryRecordingProcessSystem downstream = new BoundaryRecordingProcessSystem("downstream", null);
+    downstream.add(consumer);
+
+    ProcessModel model = new ProcessModel();
+    model.setFlowTolerance(1.0e-8);
+    model.add("upstream", upstream);
+    model.add("downstream", downstream);
+    model.run();
+    ProcessModel.BoundaryStreamError initial = model.getLastBoundaryStreamErrors().get(0);
+
+    model.run();
+    ProcessModel.BoundaryStreamError unchanged = model.getLastBoundaryStreamErrors().get(0);
+    assertSame(initial, unchanged, "an exact immutable diagnostic should be reused");
+
+    upstream.updateBoundaryOnNextRun(1100.0);
+    model.run();
+    ProcessModel.BoundaryStreamError changed = model.getLastBoundaryStreamErrors().get(0);
+    assertNotSame(unchanged, changed, "a changed flow observation must invalidate the cached diagnostic");
+    assertEquals(1100.0, changed.getPreviousFlow(), 1.0e-9);
+    assertEquals(1100.0, changed.getCurrentFlow(), 1.0e-9);
+
+    model.run();
+    assertSame(changed, model.getLastBoundaryStreamErrors().get(0),
+        "the new exact observation should become reusable after convergence");
+
+    boundary.setName("renamed boundary");
+    model.run();
+    ProcessModel.BoundaryStreamError renamed = model.getLastBoundaryStreamErrors().get(0);
+    assertNotSame(changed, renamed, "a changed stream label must invalidate the cached diagnostic");
+    assertEquals("renamed boundary", renamed.getStreamName());
+
+    model.run();
+    assertSame(renamed, model.getLastBoundaryStreamErrors().get(0),
+        "the renamed exact observation should become reusable after convergence");
   }
 
   /**


### PR DESCRIPTION
## Roadmap increment

Advances #2939 with one measured process-layer allocation bottleneck. No TP-flash, column, dynamics, Two-Fluid, or production-optimization internals are changed.

## Bottleneck and change

`ProcessModel.calculateConvergenceErrors` rebuilt every immutable `BoundaryStreamError` on every convergence observation, even when the same boundary stream had bit-identical flow, temperature, pressure, previous/current flow, name, and producer.

This change keeps an instance-local, transient identity cache and reuses a diagnostic only after exact field and label matching. A changed value, stream name, producer, removed stream, or different stream object rebuilds the diagnostic. The result list is still rebuilt for each observation.

## Representative benchmark

Exact current `ProcessModel` source blob: `affe508999ffaf832ecc260211d17cc93ac34cc1` (unchanged between benchmark base `d317e63c73165` and PR base `cbb6308c14ea`).

Environment: OpenJDK 17.0.19, Linux, G1, 768 MiB fixed heap, `-XX:ActiveProcessorCount=2`. Each dense result uses seven alternating baseline/candidate fresh-JVM pairs, 100 warmups and 750 measured runs per fork. The workload is a full 10-area `ProcessModel` with 900 actual NeqSim `Stream` boundaries and two convergence observations.

| Workload | Baseline median | Candidate median | Change | Paired wins | Main-thread allocation |
|---|---:|---:|---:|---:|---:|
| Stable repeated model | 3.406846 ms | 2.809589 ms | **17.53% faster** | 6/7 | ~394,118 -> ~311,756 B/run (**-20.9%**) |
| Nearby alternating flow | 3.310199 ms | 3.030751 ms | **8.44% faster** | 6/7 | ~396,912 -> ~314,953 B/run (**-20.65%**) |

Exact stable checksum remained `340876500.0035738`; exact nearby checksum remained `340876687.50713253`. Both retained 2 observations, 900 diagnostics, and identical area-run counts.

## Scientific and regression controls

Three alternating pairs on an actual four-area cooler/separator/compressor/aftercooler/scrubber/valve/heater/delivery-separator process:

| Control | Baseline median | Candidate median | Result |
|---|---:|---:|---|
| SRK stable | 25.912 ms | 25.796 ms | exact checksum `760710.468859696`, 2 observations, 0 nonconverged, zero mass error |
| SRK nearby 50,000/50,500 kg/hr | 27.183 ms | 26.396 ms | exact checksum `764372.3062039946`, same convergence and mass closure |
| SRK-CPA gas/water | 414.120 ms | 408.729 ms | exact checksum `204181.82060473916`, same topology/convergence/mass closure |
| No-boundary orchestration | 105.502 µs | 101.323 µs | exact checksum `20000.0`, 1 observation, 0 diagnostics; allocation difference was noise-level |

The final exact candidate was recompiled and the dense stable, nearby, and no-boundary checks were rerun after the last source edit; checksums and diagnostic cardinality remained exact.

## Regression coverage

`ProcessModelExecutionOptimizationTest` now proves that:

- an unchanged exact observation reuses the immutable diagnostic;
- a changed flow invalidates it and preserves the correct previous/current flow;
- the converged changed observation becomes reusable;
- a changed stream name invalidates it and exposes the new name;
- the renamed exact observation becomes reusable.

Local source-overlay compilation passed. The full focused class passed **14/14** with JUnit Platform 1.11.4.

## Compatibility and safety

- no public API, default, convergence tolerance, ordering, or thermodynamic calculation changes;
- identity matching prevents cross-stream reuse;
- bit-exact double matching prevents stale numerical diagnostics;
- no static/shared state; the cache belongs to one mutable `ProcessModel` instance;
- `transient` preserves the serialized form and causes post-deserialization rebuild;
- removed or filtered streams are dropped when each new observation replaces the cache;
- phase behavior, balances, calculation identifiers, area scheduling, and fallback behavior are unchanged.

## Documentation impact

Documentation impact: none. This is internal allocation reuse for already-public immutable diagnostic values; API signatures, values, ordering, units, configuration, and recommended usage do not change. Repository search found no user guide or example tied to diagnostic object identity.

## Validation

Exact current head: `e030a127e20d1f88001fa77cb621f10fa6533796`, including a non-force merge of current master `92e75b597172`.

**VALIDATION PENDING CI**

Completed locally:

- exact current production source compiled against the current supporting source overlay;
- focused `ProcessModelExecutionOptimizationTest`: 14/14 passed;
- representative dense, nearby, SRK, SRK-CPA, and no-boundary A/B controls above;
- connector read-back equals the reviewed local source byte-for-byte;
- connector compare shows exactly two intended files, 5 commits ahead and 0 behind after the formatter repair, current-master merge, and review repair;
- changed lines are within 120 characters; no notebook changed;
- hosted Spotless patch, PaperLab, and documentation search passed on preceding head `7357781d3176`;
- pre-commit on that head failed only on two reported Spotless line wraps; the exact formatter diff was applied in `a70c43058daa`, then source compilation and the 14/14 focused class were rerun successfully;
- exact-head `07698c6da83e` subsequently passed Spotless, pre-commit/documentation search, PaperLab, CodeQL, and Javadocs before being superseded;
- the automated nullable-map review was accepted in `e030a127e20d` using `Collections.emptyMap()`; 14/14 focused tests plus dense and no-boundary exact-checksum controls passed after that edit, and the thread is resolved.

Not run locally and not claimed as passed:

- Maven full-tree tests;
- `python devtools/run_spotless.py apply`;
- `python devtools/run_spotless.py check`;
- `python devtools/check_documentation_search.py`;
- pre-commit pre-commit/pre-push stages.

This workspace is a source overlay rather than a complete checkout. Hosted CI is rerunning on the exact current head and remains the authoritative full-tree formatting, documentation, Java 8/21, Javadoc, static-analysis, and test validator; attributable findings will be repaired on this draft.

## Limitations and stop boundary

The benefit is material for large multi-area models with dense repeated boundary diagnostics. Thermodynamics-dominated small models remain effectively unchanged. Further flash, column, dynamics, Two-Fluid, or optimizer work belongs to its owning roadmap and is deliberately excluded.