### PR TITLE
fix(thermo): reconcile stale serialized total moles

### DIFF
--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -3611,6 +3611,7 @@ public abstract class SystemThermo implements SystemInterface {
   /** {@inheritDoc} */
   @Override
   public void init(int initType) {
+    reconcileTotalMolesWithComponentInventory();
     if (!this.isInitialized) {
       initBeta();
       init_x_y();
@@ -3647,6 +3648,30 @@ public abstract class SystemThermo implements SystemInterface {
             .setx(getPhase(j).getComponent(i).getNumberOfMolesInPhase() / getPhase(j).getNumberOfMolesInPhase());
       }
       getPhase(j).normalize();
+    }
+  }
+
+  /**
+   * Reconciles a stale scalar total with the overall component inventory.
+   *
+   * <p>
+   * Serialized systems can retain the total flow of an upstream fluid after their component inventory has been replaced
+   * by a separated phase. The overall mole fractions are derived from the component moles divided by this scalar total,
+   * so this mismatch creates a non-normalized feed and corrupts the following flash.
+   * </p>
+   */
+  private void reconcileTotalMolesWithComponentInventory() {
+    if (phaseArray == null || numberOfComponents == 0 || phaseArray[phaseIndex[0]] == null) {
+      return;
+    }
+    double componentMoles = 0.0;
+    for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+      componentMoles += getPhase(0).getComponent(componentIndex).getNumberOfmoles();
+    }
+    if (componentMoles > 1.0e-100
+        && Math.abs(componentMoles - totalNumberOfMoles) > 1.0e-12 * Math.max(1.0, componentMoles)) {
+      setTotalNumberOfMolesRaw(componentMoles);
+      isInitialized = false;
     }
   }
 

--- a/src/test/java/neqsim/thermo/system/SystemThermoTotalNumberOfMolesTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemThermoTotalNumberOfMolesTest.java
@@ -167,4 +167,28 @@ public class SystemThermoTotalNumberOfMolesTest {
     assertEquals(0.2986026976360107, fluid.getPhase(0).getComponent("water").getx(), 1e-10);
     assertEquals(0.7013973023639892, fluid.getPhase(0).getComponent("MEG").getx(), 1e-10);
   }
+
+  /**
+   * A stale serialized total on a wet-gas-plus-MEG feed used to leave the overall composition non-normalized, which
+   * could collapse the flash onto a single named phase and make {@code getPhase("gas")} or {@code
+   * getPhase("aqueous")} throw depending on the trial point (as seen when a GDR-style MEG injection solver sweeps flow
+   * between 0.1 and 100 kg/hr on a deserialized process).
+   */
+  @Test
+  public void testFlashReconcilesStaleSerializedTotalForWetGasWithMeg() {
+    SystemThermo fluid = new SystemSrkCPAstatoil(278.45, 37.21325);
+    fluid.addComponent("methane", 5.0);
+    fluid.addComponent("water", 0.11833608283886514);
+    fluid.addComponent("MEG", 0.2779633604538873);
+    fluid.setMixingRule(10);
+    fluid.setMultiPhaseCheck(true);
+    fluid.setTotalNumberOfMolesRaw(1986.7470206432324);
+
+    new ThermodynamicOperations(fluid).TPflash();
+
+    assertEquals(1.0, sumOverallMoleFractions(fluid), 1e-12);
+    assertTrue(fluid.getNumberOfPhases() >= 2);
+    assertEquals(PhaseType.GAS, fluid.getPhase("gas").getType());
+    assertEquals(PhaseType.AQUEOUS, fluid.getPhase("aqueous").getType());
+  }
 }

--- a/src/test/java/neqsim/thermo/system/SystemThermoTotalNumberOfMolesTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemThermoTotalNumberOfMolesTest.java
@@ -3,6 +3,7 @@ package neqsim.thermo.system;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 /**
@@ -143,5 +144,27 @@ public class SystemThermoTotalNumberOfMolesTest {
 
     assertEquals(4.0, fluid.getTotalNumberOfMoles(), 1e-12);
     assertEquals(4.0, sumComponentMoles(fluid), 1e-12);
+  }
+
+  /**
+   * A stale serialized total must be reconciled with the retained component inventory before a flash.
+   */
+  @Test
+  public void testFlashReconcilesStaleSerializedTotalForAqueousMegFluid() {
+    SystemThermo fluid = new SystemSrkCPAstatoil(278.45, 37.21325);
+    fluid.addComponent("water", 0.11833608283886514);
+    fluid.addComponent("MEG", 0.2779633604538873);
+    fluid.setMixingRule(10);
+    fluid.setMultiPhaseCheck(true);
+    fluid.setTotalNumberOfMolesRaw(1986.7470206432324);
+
+    new ThermodynamicOperations(fluid).TPflash();
+
+    assertEquals(0.39629944329275244, fluid.getTotalNumberOfMoles(), 1e-12);
+    assertEquals(1.0, sumOverallMoleFractions(fluid), 1e-12);
+    assertEquals(1, fluid.getNumberOfPhases());
+    assertEquals(PhaseType.AQUEOUS, fluid.getPhase(0).getType());
+    assertEquals(0.2986026976360107, fluid.getPhase(0).getComponent("water").getx(), 1e-10);
+    assertEquals(0.7013973023639892, fluid.getPhase(0).getComponent("MEG").getx(), 1e-10);
   }
 }


### PR DESCRIPTION
## Summary

Fixes an XStream deserialization failure where a separated fluid retained the total mole inventory of its upstream fluid while retaining only the component inventory of the separated phase.

`SystemThermo.init(...)` now reconciles the scalar `totalNumberOfMoles` with the sum of the retained overall component moles when they are inconsistent. This restores a normalized feed composition before phase equilibrium calculations.

## Root Cause

The supplied CPA MEG/water XML deserialized with:

- `totalNumberOfMoles = 1986.7470206432324`
- retained water + MEG inventory = `0.39629944329275244 mol`
- $\sum z_i = 1.9947151759887674 \times 10^{-4}$

The non-normalized composition caused `TPflash` and `TPmultiflash` to classify the feed as a single gas phase.

## Result

After the reconciliation, the exact serialized input flashes to one `AQUEOUS` phase with:

- water: `0.2986026976` mole fraction
- MEG: `0.7013973024` mole fraction

## Tests

- `./mvnw test -Dtest=SystemThermoTotalNumberOfMolesTest,TPflashCpaAqueousStabilityConsistencyTest,TPflashAqueousCrossAlgorithmFallbackTest`
  - 11 tests passed
- `./mvnw spotless:check`
  - passed

A regression test covers a CPA water/MEG system with the stale serialized total and verifies total-mole reconciliation, normalized composition, and aqueous phase selection.