### PR TITLE
[AI-Assisted] feat(dynamics): transact ISO 5167 primary flow meters

### DIFF
--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -411,9 +411,32 @@ its closed snapshot. Concrete descendants and online-signal operation remain fai
 This tranche is limited to local instruments whose production measured-value path actually calls
 `applySignalModifiers(...)`. `VolumeFlowTransmitter` and the total/oil/water level-transmitter families still return
 raw values without advancing that inherited signal state, so they are intentionally not presented as transaction
-participants. Differential-pressure primary flow devices and other state-owning analysers remain unaudited until all
-device-specific iteration, cache, configuration and binding state is covered.
+participants. Other state-owning analysers remain unaudited until all device-specific iteration, cache,
+configuration and binding state is covered.
 
 Passing this rollback gate does not qualify laboratory or online analyser accuracy, phase-sampling fidelity, wet-gas or
 metering standards, allocation, emissions or export-spec decisions, alarm/trip integrity, external I/O, safety action,
 virtual commissioning or OTS use.
+
+## Differential-pressure primary flow-meter transaction coverage
+
+The concrete local `OrificeFlowMeter`, `NozzleFlowMeter`, `VenturiFlowMeter`, `ConeFlowMeter`, and
+`WedgeFlowMeter` families participate when registered as measurement devices in a `ProcessSystem`. The common
+snapshot preserves stable transaction identity, the stream and optional differential-pressure-transmitter bindings,
+geometry, explicit differential pressure, density/isentropic-exponent/viscosity overrides, the last accepted pipe
+Reynolds number, and all inherited signal/alarm state.
+
+Subtype snapshots preserve orifice tapping and wet-gas settings, nozzle type, Venturi discharge and wet-gas settings, and
+wedge geometry state. Orifice and Venturi wet-gas result caches are derived from snapshotted inputs, so rollback
+invalidates them and deterministically recomputes rather than retaining a result from a rejected trial. Cone meters
+explicitly record that they own no additional mutable state beyond the common snapshot.
+
+Coverage is quantitative across one `ProcessSystem` and coordinated multi-area `ProcessModel` rollback, exact replay
+of Reynolds iteration plus noise/drift/filter/delay state, a nearby differential-pressure square-root trend, and
+Java-serialization restart with wet-gas cache invalidation. Concrete descendants and online-signal operation fail closed.
+A linked `DifferentialPressureTransmitter` must be registered separately in the same process transaction because its
+own signal state is not owned by the primary flow meter.
+
+This transaction gate does not alter or newly qualify ISO 5167 or ISO/TR 11583 physics, wet-gas correlation validity,
+meter uncertainty, installation effects, sampling accuracy, allocation/fiscal metering, external I/O, alarm/trip
+integrity, safety action, virtual commissioning or OTS use.

--- a/docs/process/equipment/measurement_devices.md
+++ b/docs/process/equipment/measurement_devices.md
@@ -247,6 +247,13 @@ exponent/dynamic viscosity readers (each overridable), the Reynolds-number itera
 mass/actual-volume/standard-volume accessors. They differ only in the discharge coefficient and
 the expansibility factor, `ExpansibilityModel` (`ORIFICE`, `ISENTROPIC` or `CONE`).
 
+When any of the five concrete local meters is registered in a `ProcessSystem`, it participates in transient step
+transactions. Rollback restores geometry, pressure/property overrides, the last Reynolds solve, subtype configuration,
+stream/transmitter bindings, and noise/delay/filter/fault/alarm state. Orifice and Venturi wet-gas caches are invalidated
+and recomputed from restored inputs. A linked `DifferentialPressureTransmitter` must also be registered because it owns
+its own signal state. Subclasses and online-signal bindings remain fail-closed. This rollback support does not extend the
+validity ranges or qualify the meters for allocation or fiscal service.
+
 Derives mass, actual volume and standard volume flow from a measured differential pressure across a
 classical Venturi tube, using the ISO 5167-1 general equation with the ISO 5167-4 Venturi expansibility
 factor. The differential pressure is either set explicitly or read from a linked

--- a/src/main/java/neqsim/process/measurementdevice/ConeFlowMeter.java
+++ b/src/main/java/neqsim/process/measurementdevice/ConeFlowMeter.java
@@ -1,5 +1,6 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
@@ -123,6 +124,38 @@ public class ConeFlowMeter extends DifferentialPressureFlowMeter {
     double pipeDiameterMeters = getPipeDiameter("m");
     double coneDiameterMeters = pipeDiameterMeters * Math.sqrt(1.0 - beta * beta);
     return coneDiameterMeters / lengthConversionToMeter(unit);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected String getDifferentialPressureFlowMeterTransientStateCoverageIssue() {
+    if (getClass() != ConeFlowMeter.class) {
+      return "cone-flow-meter subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return null;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected Serializable captureDifferentialPressureFlowMeterExtensionState() {
+    return ConeFlowMeterState.INSTANCE;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected void restoreDifferentialPressureFlowMeterExtensionState(Serializable extensionState) {
+    if (!(extensionState instanceof ConeFlowMeterState)) {
+      throw new IllegalArgumentException("Cone flow-meter extension snapshot has the wrong type");
+    }
+  }
+
+  /** Immutable marker proving that the concrete cone meter owns no state beyond its base snapshot. */
+  private static final class ConeFlowMeterState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private static final ConeFlowMeterState INSTANCE = new ConeFlowMeterState();
+
+    private ConeFlowMeterState() {}
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/measurementdevice/ConeFlowMeter.java
+++ b/src/main/java/neqsim/process/measurementdevice/ConeFlowMeter.java
@@ -155,7 +155,8 @@ public class ConeFlowMeter extends DifferentialPressureFlowMeter {
     private static final long serialVersionUID = 1000L;
     private static final ConeFlowMeterState INSTANCE = new ConeFlowMeterState();
 
-    private ConeFlowMeterState() {}
+    private ConeFlowMeterState() {
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/measurementdevice/DifferentialPressureFlowMeter.java
+++ b/src/main/java/neqsim/process/measurementdevice/DifferentialPressureFlowMeter.java
@@ -639,8 +639,8 @@ public abstract class DifferentialPressureFlowMeter extends StreamMeasurementDev
           "Differential-pressure flow-meter snapshot identity does not match " + getTransientStateIdentity());
     }
     if (!getClass().getName().equals(snapshot.concreteClassName)) {
-      throw new IllegalArgumentException("Differential-pressure flow-meter snapshot subtype does not match "
-          + getClass().getName());
+      throw new IllegalArgumentException(
+          "Differential-pressure flow-meter snapshot subtype does not match " + getClass().getName());
     }
     stream = snapshot.stream;
     pipeDiameterMeters = snapshot.pipeDiameterMeters;

--- a/src/main/java/neqsim/process/measurementdevice/DifferentialPressureFlowMeter.java
+++ b/src/main/java/neqsim/process/measurementdevice/DifferentialPressureFlowMeter.java
@@ -1,11 +1,14 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
@@ -48,9 +51,13 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * @author Even Solbraa
  * @version 1.0
  */
-public abstract class DifferentialPressureFlowMeter extends StreamMeasurementDeviceBaseClass {
+public abstract class DifferentialPressureFlowMeter extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<DifferentialPressureFlowMeter.DifferentialPressureFlowMeterState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000L;
+
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /** Logger object for class. */
   private static final Logger logger = LogManager.getLogger(DifferentialPressureFlowMeter.class);
@@ -551,6 +558,140 @@ public abstract class DifferentialPressureFlowMeter extends StreamMeasurementDev
       value = getMassFlowRate(unit);
     }
     return applySignalModifiers(value);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:differential-pressure-flow:" + transientStateParticipantId;
+  }
+
+  /**
+   * Reports whether the concrete primary-device subtype has complete extension-state coverage.
+   *
+   * <p>
+   * The default is deliberately fail-closed. Each qualified concrete subtype must override this method and reject its
+   * own descendants.
+   * </p>
+   *
+   * @return blocking diagnostic for an unqualified subtype, otherwise {@code null}
+   */
+  protected String getDifferentialPressureFlowMeterTransientStateCoverageIssue() {
+    return "differential-pressure-flow-meter subtype " + getClass().getName()
+        + " must provide a snapshot that includes subtype-owned mutable state";
+  }
+
+  /**
+   * Captures subtype-owned mutable state.
+   *
+   * @return serializable subtype state, never {@code null} for a qualified subtype
+   */
+  protected Serializable captureDifferentialPressureFlowMeterExtensionState() {
+    return null;
+  }
+
+  /**
+   * Restores subtype-owned mutable state.
+   *
+   * @param extensionState state returned by {@link #captureDifferentialPressureFlowMeterExtensionState()}
+   */
+  protected void restoreDifferentialPressureFlowMeterExtensionState(Serializable extensionState) {
+    if (extensionState != null) {
+      throw new IllegalArgumentException(
+          "Unqualified differential-pressure flow-meter subtype state cannot be restored");
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    String measurementIssue = getMeasurementTransientStateCoverageIssue();
+    if (measurementIssue != null) {
+      return measurementIssue;
+    }
+    return getDifferentialPressureFlowMeterTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public DifferentialPressureFlowMeterState captureTransientState() {
+    String coverageIssue = getTransientStateCoverageIssue();
+    if (coverageIssue != null) {
+      throw new IllegalStateException(coverageIssue);
+    }
+    return new DifferentialPressureFlowMeterState(getTransientStateIdentity(), getClass().getName(), stream,
+        pipeDiameterMeters, throatDiameterMeters, differentialPressure, differentialPressureTransmitter,
+        gasDensityOverride, isentropicExponentOverride, dynamicViscosityOverride, lastReynoldsNumberPipe,
+        captureMeasurementDeviceTransientState(), captureDifferentialPressureFlowMeterExtensionState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(DifferentialPressureFlowMeterState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Differential-pressure flow-meter transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Differential-pressure flow-meter snapshot identity does not match " + getTransientStateIdentity());
+    }
+    if (!getClass().getName().equals(snapshot.concreteClassName)) {
+      throw new IllegalArgumentException("Differential-pressure flow-meter snapshot subtype does not match "
+          + getClass().getName());
+    }
+    stream = snapshot.stream;
+    pipeDiameterMeters = snapshot.pipeDiameterMeters;
+    throatDiameterMeters = snapshot.throatDiameterMeters;
+    differentialPressure = snapshot.differentialPressure;
+    differentialPressureTransmitter = snapshot.differentialPressureTransmitter;
+    gasDensityOverride = snapshot.gasDensityOverride;
+    isentropicExponentOverride = snapshot.isentropicExponentOverride;
+    dynamicViscosityOverride = snapshot.dynamicViscosityOverride;
+    lastReynoldsNumberPipe = snapshot.lastReynoldsNumberPipe;
+    restoreDifferentialPressureFlowMeterExtensionState(snapshot.extensionState);
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable differential-pressure primary-device rollback point. */
+  public static final class DifferentialPressureFlowMeterState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String stateIdentity;
+    private final String concreteClassName;
+    private final StreamInterface stream;
+    private final double pipeDiameterMeters;
+    private final double throatDiameterMeters;
+    private final double differentialPressure;
+    private final DifferentialPressureTransmitter differentialPressureTransmitter;
+    private final double gasDensityOverride;
+    private final double isentropicExponentOverride;
+    private final double dynamicViscosityOverride;
+    private final double lastReynoldsNumberPipe;
+    private final MeasurementDeviceTransientState measurementState;
+    private final Serializable extensionState;
+
+    private DifferentialPressureFlowMeterState(String stateIdentity, String concreteClassName, StreamInterface stream,
+        double pipeDiameterMeters, double throatDiameterMeters, double differentialPressure,
+        DifferentialPressureTransmitter differentialPressureTransmitter, double gasDensityOverride,
+        double isentropicExponentOverride, double dynamicViscosityOverride, double lastReynoldsNumberPipe,
+        MeasurementDeviceTransientState measurementState, Serializable extensionState) {
+      this.stateIdentity = stateIdentity;
+      this.concreteClassName = concreteClassName;
+      this.stream = stream;
+      this.pipeDiameterMeters = pipeDiameterMeters;
+      this.throatDiameterMeters = throatDiameterMeters;
+      this.differentialPressure = differentialPressure;
+      this.differentialPressureTransmitter = differentialPressureTransmitter;
+      this.gasDensityOverride = gasDensityOverride;
+      this.isentropicExponentOverride = isentropicExponentOverride;
+      this.dynamicViscosityOverride = dynamicViscosityOverride;
+      this.lastReynoldsNumberPipe = lastReynoldsNumberPipe;
+      this.measurementState = measurementState;
+      this.extensionState = extensionState;
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/measurementdevice/NozzleFlowMeter.java
+++ b/src/main/java/neqsim/process/measurementdevice/NozzleFlowMeter.java
@@ -1,5 +1,6 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
 import java.util.List;
 
 import neqsim.process.equipment.stream.StreamInterface;
@@ -91,6 +92,41 @@ public class NozzleFlowMeter extends DifferentialPressureFlowMeter {
    */
   public NozzleType getNozzleType() {
     return nozzleType;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected String getDifferentialPressureFlowMeterTransientStateCoverageIssue() {
+    if (getClass() != NozzleFlowMeter.class) {
+      return "nozzle-flow-meter subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return null;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected Serializable captureDifferentialPressureFlowMeterExtensionState() {
+    return new NozzleFlowMeterState(nozzleType);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected void restoreDifferentialPressureFlowMeterExtensionState(Serializable extensionState) {
+    if (!(extensionState instanceof NozzleFlowMeterState)) {
+      throw new IllegalArgumentException("Nozzle flow-meter extension snapshot has the wrong type");
+    }
+    nozzleType = ((NozzleFlowMeterState) extensionState).nozzleType;
+  }
+
+  /** Immutable nozzle-specific rollback point. */
+  private static final class NozzleFlowMeterState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final NozzleType nozzleType;
+
+    private NozzleFlowMeterState(NozzleType nozzleType) {
+      this.nozzleType = nozzleType;
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/measurementdevice/OrificeFlowMeter.java
+++ b/src/main/java/neqsim/process/measurementdevice/OrificeFlowMeter.java
@@ -1,5 +1,6 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 
@@ -367,6 +368,68 @@ public class OrificeFlowMeter extends DifferentialPressureFlowMeter {
    */
   public double getChisholmExponent() {
     return solveWetGas().chisholmExponent;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected String getDifferentialPressureFlowMeterTransientStateCoverageIssue() {
+    if (getClass() != OrificeFlowMeter.class) {
+      return "orifice-flow-meter subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return null;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected Serializable captureDifferentialPressureFlowMeterExtensionState() {
+    return new OrificeFlowMeterState(tappingArrangement, wetGasCorrelation, liquidMassFlowRate, liquidToGasMassRatio,
+        liquidDensity, liquidFromStream, gravitationalAcceleration, pressureLoss);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected void restoreDifferentialPressureFlowMeterExtensionState(Serializable extensionState) {
+    if (!(extensionState instanceof OrificeFlowMeterState)) {
+      throw new IllegalArgumentException("Orifice flow-meter extension snapshot has the wrong type");
+    }
+    OrificeFlowMeterState state = (OrificeFlowMeterState) extensionState;
+    tappingArrangement = state.tappingArrangement;
+    wetGasCorrelation = state.wetGasCorrelation;
+    liquidMassFlowRate = state.liquidMassFlowRate;
+    liquidToGasMassRatio = state.liquidToGasMassRatio;
+    liquidDensity = state.liquidDensity;
+    liquidFromStream = state.liquidFromStream;
+    gravitationalAcceleration = state.gravitationalAcceleration;
+    pressureLoss = state.pressureLoss;
+    cachedWetGasResult = null;
+    cachedWetGasSignature = null;
+  }
+
+  /** Immutable orifice-specific rollback point. Derived wet-gas caches are invalidated on restore. */
+  private static final class OrificeFlowMeterState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final TappingArrangement tappingArrangement;
+    private final WetGasCorrelation wetGasCorrelation;
+    private final double liquidMassFlowRate;
+    private final double liquidToGasMassRatio;
+    private final double liquidDensity;
+    private final boolean liquidFromStream;
+    private final double gravitationalAcceleration;
+    private final double pressureLoss;
+
+    private OrificeFlowMeterState(TappingArrangement tappingArrangement, WetGasCorrelation wetGasCorrelation,
+        double liquidMassFlowRate, double liquidToGasMassRatio, double liquidDensity, boolean liquidFromStream,
+        double gravitationalAcceleration, double pressureLoss) {
+      this.tappingArrangement = tappingArrangement;
+      this.wetGasCorrelation = wetGasCorrelation;
+      this.liquidMassFlowRate = liquidMassFlowRate;
+      this.liquidToGasMassRatio = liquidToGasMassRatio;
+      this.liquidDensity = liquidDensity;
+      this.liquidFromStream = liquidFromStream;
+      this.gravitationalAcceleration = gravitationalAcceleration;
+      this.pressureLoss = pressureLoss;
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/measurementdevice/VenturiFlowMeter.java
+++ b/src/main/java/neqsim/process/measurementdevice/VenturiFlowMeter.java
@@ -1,6 +1,7 @@
 package neqsim.process.measurementdevice;
 
 import java.util.ArrayList;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 
@@ -1009,6 +1010,76 @@ public class VenturiFlowMeter extends DifferentialPressureFlowMeter {
   @Override
   protected double calcDischargeCoefficient(double beta, double reynoldsD) {
     return dischargeCoefficient;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected String getDifferentialPressureFlowMeterTransientStateCoverageIssue() {
+    if (getClass() != VenturiFlowMeter.class) {
+      return "venturi-flow-meter subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return null;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected Serializable captureDifferentialPressureFlowMeterExtensionState() {
+    return new VenturiFlowMeterState(dischargeCoefficient, wetGasCorrelation, liquidMassFlowRate,
+        liquidToGasMassRatio, liquidDensity, liquidFromStream, surfaceTensionFactor, gravitationalAcceleration,
+        pressureLoss, useWetGasDischargeCoefficient);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected void restoreDifferentialPressureFlowMeterExtensionState(Serializable extensionState) {
+    if (!(extensionState instanceof VenturiFlowMeterState)) {
+      throw new IllegalArgumentException("Venturi flow-meter extension snapshot has the wrong type");
+    }
+    VenturiFlowMeterState state = (VenturiFlowMeterState) extensionState;
+    dischargeCoefficient = state.dischargeCoefficient;
+    wetGasCorrelation = state.wetGasCorrelation;
+    liquidMassFlowRate = state.liquidMassFlowRate;
+    liquidToGasMassRatio = state.liquidToGasMassRatio;
+    liquidDensity = state.liquidDensity;
+    liquidFromStream = state.liquidFromStream;
+    surfaceTensionFactor = state.surfaceTensionFactor;
+    gravitationalAcceleration = state.gravitationalAcceleration;
+    pressureLoss = state.pressureLoss;
+    useWetGasDischargeCoefficient = state.useWetGasDischargeCoefficient;
+    cachedWetGasResult = null;
+    cachedWetGasSignature = null;
+  }
+
+  /** Immutable Venturi-specific rollback point. Derived wet-gas caches are invalidated on restore. */
+  private static final class VenturiFlowMeterState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final double dischargeCoefficient;
+    private final WetGasCorrelation wetGasCorrelation;
+    private final double liquidMassFlowRate;
+    private final double liquidToGasMassRatio;
+    private final double liquidDensity;
+    private final boolean liquidFromStream;
+    private final double surfaceTensionFactor;
+    private final double gravitationalAcceleration;
+    private final double pressureLoss;
+    private final boolean useWetGasDischargeCoefficient;
+
+    private VenturiFlowMeterState(double dischargeCoefficient, WetGasCorrelation wetGasCorrelation,
+        double liquidMassFlowRate, double liquidToGasMassRatio, double liquidDensity, boolean liquidFromStream,
+        double surfaceTensionFactor, double gravitationalAcceleration, double pressureLoss,
+        boolean useWetGasDischargeCoefficient) {
+      this.dischargeCoefficient = dischargeCoefficient;
+      this.wetGasCorrelation = wetGasCorrelation;
+      this.liquidMassFlowRate = liquidMassFlowRate;
+      this.liquidToGasMassRatio = liquidToGasMassRatio;
+      this.liquidDensity = liquidDensity;
+      this.liquidFromStream = liquidFromStream;
+      this.surfaceTensionFactor = surfaceTensionFactor;
+      this.gravitationalAcceleration = gravitationalAcceleration;
+      this.pressureLoss = pressureLoss;
+      this.useWetGasDischargeCoefficient = useWetGasDischargeCoefficient;
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/measurementdevice/VenturiFlowMeter.java
+++ b/src/main/java/neqsim/process/measurementdevice/VenturiFlowMeter.java
@@ -1025,9 +1025,9 @@ public class VenturiFlowMeter extends DifferentialPressureFlowMeter {
   /** {@inheritDoc} */
   @Override
   protected Serializable captureDifferentialPressureFlowMeterExtensionState() {
-    return new VenturiFlowMeterState(dischargeCoefficient, wetGasCorrelation, liquidMassFlowRate,
-        liquidToGasMassRatio, liquidDensity, liquidFromStream, surfaceTensionFactor, gravitationalAcceleration,
-        pressureLoss, useWetGasDischargeCoefficient);
+    return new VenturiFlowMeterState(dischargeCoefficient, wetGasCorrelation, liquidMassFlowRate, liquidToGasMassRatio,
+        liquidDensity, liquidFromStream, surfaceTensionFactor, gravitationalAcceleration, pressureLoss,
+        useWetGasDischargeCoefficient);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/measurementdevice/WedgeFlowMeter.java
+++ b/src/main/java/neqsim/process/measurementdevice/WedgeFlowMeter.java
@@ -1,5 +1,6 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
@@ -139,6 +140,41 @@ public class WedgeFlowMeter extends DifferentialPressureFlowMeter {
    */
   public double getWedgeRatio() {
     return wedgeRatio;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected String getDifferentialPressureFlowMeterTransientStateCoverageIssue() {
+    if (getClass() != WedgeFlowMeter.class) {
+      return "wedge-flow-meter subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return null;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected Serializable captureDifferentialPressureFlowMeterExtensionState() {
+    return new WedgeFlowMeterState(wedgeRatio);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected void restoreDifferentialPressureFlowMeterExtensionState(Serializable extensionState) {
+    if (!(extensionState instanceof WedgeFlowMeterState)) {
+      throw new IllegalArgumentException("Wedge flow-meter extension snapshot has the wrong type");
+    }
+    wedgeRatio = ((WedgeFlowMeterState) extensionState).wedgeRatio;
+  }
+
+  /** Immutable wedge-specific rollback point. */
+  private static final class WedgeFlowMeterState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final double wedgeRatio;
+
+    private WedgeFlowMeterState(double wedgeRatio) {
+      this.wedgeRatio = wedgeRatio;
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/test/java/neqsim/process/measurementdevice/DifferentialPressureFlowMeterTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/DifferentialPressureFlowMeterTransientStateTransactionTest.java
@@ -27,8 +27,8 @@ import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.system.SystemSrkEos;
 
 /**
- * Quantitative transaction, restart, and physical-trend evidence for the ISO 5167
- * differential-pressure flow-meter family.
+ * Quantitative transaction, restart, and physical-trend evidence for the ISO 5167 differential-pressure flow-meter
+ * family.
  */
 class DifferentialPressureFlowMeterTransientStateTransactionTest extends neqsim.NeqSimTest {
   @Test
@@ -159,8 +159,7 @@ class DifferentialPressureFlowMeterTransientStateTransactionTest extends neqsim.
     DifferentialPressureFlowMeter.DifferentialPressureFlowMeterState restoredSnapshot;
     try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
       restoredMeter = (OrificeFlowMeter) input.readObject();
-      restoredSnapshot =
-          (DifferentialPressureFlowMeter.DifferentialPressureFlowMeterState) input.readObject();
+      restoredSnapshot = (DifferentialPressureFlowMeter.DifferentialPressureFlowMeterState) input.readObject();
     }
 
     restoredMeter.setWetGasCorrelation(WetGasCorrelation.NONE);
@@ -176,12 +175,9 @@ class DifferentialPressureFlowMeterTransientStateTransactionTest extends neqsim.
 
   @Test
   void nearbyDifferentialPressurePointFollowsSquareRootPhysicalTrend() {
-    List<DifferentialPressureFlowMeter> meters =
-        meters(new OrificeFlowMeter("O", createGasStream("O source")),
-            new NozzleFlowMeter("N", createGasStream("N source")),
-            new VenturiFlowMeter("V", createGasStream("V source")),
-            new ConeFlowMeter("C", createGasStream("C source")),
-            new WedgeFlowMeter("W", createGasStream("W source")));
+    List<DifferentialPressureFlowMeter> meters = meters(new OrificeFlowMeter("O", createGasStream("O source")),
+        new NozzleFlowMeter("N", createGasStream("N source")), new VenturiFlowMeter("V", createGasStream("V source")),
+        new ConeFlowMeter("C", createGasStream("C source")), new WedgeFlowMeter("W", createGasStream("W source")));
 
     for (DifferentialPressureFlowMeter meter : meters) {
       configureMeter(meter, 1L);

--- a/src/test/java/neqsim/process/measurementdevice/DifferentialPressureFlowMeterTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/DifferentialPressureFlowMeterTransientStateTransactionTest.java
@@ -183,6 +183,7 @@ class DifferentialPressureFlowMeterTransientStateTransactionTest extends neqsim.
       configureMeter(meter, 1L);
       meter.setNoiseStdDev(0.0);
       meter.setDelaySteps(0);
+      meter.setFirstOrderTimeConstant(0.0);
       meter.clearFault();
       if (meter instanceof ConeFlowMeter) {
         meter.setGeometry(0.25, 0.165, "m");

--- a/src/test/java/neqsim/process/measurementdevice/DifferentialPressureFlowMeterTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/DifferentialPressureFlowMeterTransientStateTransactionTest.java
@@ -197,7 +197,10 @@ class DifferentialPressureFlowMeterTransientStateTransactionTest extends neqsim.
       assertTrue(Double.isFinite(lowFlow));
       assertTrue(highFlow > 1.8 * lowFlow);
       assertTrue(highFlow < 2.2 * lowFlow);
-      assertTrue(meter.getReynoldsNumberPipe() > 0.0);
+      // The current classical Venturi path is Reynolds-independent and does not publish Re,D.
+      if (!(meter instanceof VenturiFlowMeter)) {
+        assertTrue(meter.getReynoldsNumberPipe() > 0.0);
+      }
     }
   }
 

--- a/src/test/java/neqsim/process/measurementdevice/DifferentialPressureFlowMeterTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/DifferentialPressureFlowMeterTransientStateTransactionTest.java
@@ -1,0 +1,319 @@
+package neqsim.process.measurementdevice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import neqsim.process.alarm.AlarmConfig;
+import neqsim.process.alarm.AlarmState;
+import neqsim.process.dynamics.TransientStepTransaction;
+import neqsim.process.dynamics.TransientTransactionCoverage;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.measurementdevice.NozzleFlowMeter.NozzleType;
+import neqsim.process.measurementdevice.OrificeFlowMeter.TappingArrangement;
+import neqsim.process.measurementdevice.OrificeFlowMeter.WetGasCorrelation;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Quantitative transaction, restart, and physical-trend evidence for the ISO 5167
+ * differential-pressure flow-meter family.
+ */
+class DifferentialPressureFlowMeterTransientStateTransactionTest extends neqsim.NeqSimTest {
+  @Test
+  void multiAreaRollbackRestoresFiveMeterFamilyAndExactSignalReplay() {
+    StreamInterface source = createGasStream("meter source");
+    OrificeFlowMeter orifice = new OrificeFlowMeter("FIT-O-100", source);
+    NozzleFlowMeter nozzle = new NozzleFlowMeter("FIT-N-100", source);
+    VenturiFlowMeter venturi = new VenturiFlowMeter("FIT-V-100", source);
+    ConeFlowMeter cone = new ConeFlowMeter("FIT-C-100", source);
+    WedgeFlowMeter wedge = new WedgeFlowMeter("FIT-W-100", source);
+
+    configureMeter(orifice, 8101L);
+    configureMeter(nozzle, 8102L);
+    configureMeter(venturi, 8103L);
+    configureMeter(cone, 8104L);
+    configureMeter(wedge, 8105L);
+    cone.setGeometry(0.25, 0.165, "m");
+    wedge.setGeometry(0.25, 0.075, "m");
+    orifice.setTappingArrangement(TappingArrangement.D_AND_D_HALF);
+    nozzle.setNozzleType(NozzleType.LONG_RADIUS);
+    venturi.setDischargeCoefficient(0.992);
+
+    AlarmConfig alarmConfig = AlarmConfig.builder().highLimit(0.0).delay(2.0).unit("kg/hr").build();
+    orifice.setAlarmConfig(alarmConfig);
+    AlarmState originalAlarmState = orifice.getAlarmState();
+
+    List<DifferentialPressureFlowMeter> meters = meters(orifice, nozzle, venturi, cone, wedge);
+    for (DifferentialPressureFlowMeter meter : meters) {
+      meter.getMeasuredValue("kg/hr");
+      meter.getMeasuredValue("kg/hr");
+    }
+
+    ProcessSystem primaryDevices = new ProcessSystem("primary devices");
+    primaryDevices.add(orifice);
+    primaryDevices.add(nozzle);
+    primaryDevices.add(venturi);
+    ProcessSystem specialtyDevices = new ProcessSystem("specialty primary devices");
+    specialtyDevices.add(cone);
+    specialtyDevices.add(wedge);
+    assertCompleteCoverage(primaryDevices.getTransientTransactionCoverage(), 3);
+    assertCompleteCoverage(specialtyDevices.getTransientTransactionCoverage(), 2);
+
+    ProcessModel model = new ProcessModel();
+    model.add("primary", primaryDevices);
+    model.add("specialty", specialtyDevices);
+    assertCompleteCoverage(model.getTransientTransactionCoverage(), 5);
+
+    List<String> identities = transientIdentities(meters);
+    double[] originalBeta = betaRatios(meters);
+    StreamInterface[] originalStreams = streams(meters);
+
+    TransientStepTransaction transaction = model.beginTransientStepTransaction();
+    List<double[]> trialSequence = new ArrayList<double[]>();
+    for (int sample = 0; sample < 4; sample++) {
+      trialSequence.add(readAll(meters));
+    }
+    assertTrue(orifice.evaluateAlarm(1.0e9, 1.0, 1.0).isEmpty());
+
+    for (DifferentialPressureFlowMeter meter : meters) {
+      meter.setName("trial " + meter.getName());
+      meter.setUnit("kg/day");
+      meter.setGeometry(0.4, 0.12, "m");
+      meter.setDifferentialPressure(0.4, "bar");
+      meter.setGasDensity(3.0, "kg/m3");
+      meter.setIsentropicExponent(1.05);
+      meter.setDynamicViscosity(0.2, "cP");
+      meter.setDelaySteps(0);
+      meter.setNoiseStdDev(5.0);
+      meter.setRandomSeed(1L);
+      meter.clearFault();
+      meter.setAlarmConfig(null);
+    }
+    orifice.setTappingArrangement(TappingArrangement.CORNER);
+    nozzle.setNozzleType(NozzleType.VENTURI_NOZZLE);
+    venturi.setDischargeCoefficient(0.8);
+    wedge.setWedgeRatio(0.55);
+
+    transaction.rollback();
+
+    assertEquals(identities, transientIdentities(meters));
+    assertEquals(originalBeta.length, meters.size());
+    for (int index = 0; index < meters.size(); index++) {
+      assertEquals(originalBeta[index], meters.get(index).getBetaRatio(), 0.0);
+      assertSame(originalStreams[index], meters.get(index).getStream());
+    }
+    assertEquals(TappingArrangement.D_AND_D_HALF, orifice.getTappingArrangement());
+    assertEquals(NozzleType.LONG_RADIUS, nozzle.getNozzleType());
+    assertEquals(0.992, venturi.getDischargeCoefficient(), 0.0);
+    assertSame(alarmConfig, orifice.getAlarmConfig());
+    assertSame(originalAlarmState, orifice.getAlarmState());
+
+    for (double[] expected : trialSequence) {
+      double[] actual = readAll(meters);
+      for (int index = 0; index < expected.length; index++) {
+        assertEquals(expected[index], actual[index], 0.0,
+            "rollback must replay Reynolds, Gaussian, drift, filter, and delay state exactly");
+      }
+    }
+    assertTrue(orifice.evaluateAlarm(1.0e9, 1.0, 1.0).isEmpty());
+    assertEquals(1, orifice.evaluateAlarm(1.0e9, 1.0, 2.0).size());
+  }
+
+  @Test
+  void serializedWetGasOrificeSnapshotReplaysAndInvalidatesDerivedCache() throws Exception {
+    OrificeFlowMeter meter = new OrificeFlowMeter("FIT-O-200", createGasStream("restart source"));
+    configureMeter(meter, 7151L);
+    meter.setTappingArrangement(TappingArrangement.FLANGE);
+    meter.setWetGasCorrelation(WetGasCorrelation.ISO_TR_11583);
+    meter.setLiquidToGasMassRatio(0.10);
+    meter.setLiquidDensity(800.0, "kg/m3");
+    meter.getMeasuredValue("kg/hr");
+    meter.getMeasuredValue("kg/hr");
+
+    String identity = meter.getTransientStateIdentity();
+    DifferentialPressureFlowMeter.DifferentialPressureFlowMeterState snapshot = meter.captureTransientState();
+    double expectedNextValue = meter.getMeasuredValue("kg/hr");
+    assertTrue(Double.isFinite(expectedNextValue));
+
+    byte[] serialized;
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(meter);
+      output.writeObject(snapshot);
+      serialized = bytes.toByteArray();
+    }
+
+    OrificeFlowMeter restoredMeter;
+    DifferentialPressureFlowMeter.DifferentialPressureFlowMeterState restoredSnapshot;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      restoredMeter = (OrificeFlowMeter) input.readObject();
+      restoredSnapshot =
+          (DifferentialPressureFlowMeter.DifferentialPressureFlowMeterState) input.readObject();
+    }
+
+    restoredMeter.setWetGasCorrelation(WetGasCorrelation.NONE);
+    restoredMeter.setTappingArrangement(TappingArrangement.CORNER);
+    restoredMeter.setDifferentialPressure(0.4, "bar");
+    restoredMeter.restoreTransientState(restoredSnapshot);
+
+    assertEquals(identity, restoredMeter.getTransientStateIdentity());
+    assertEquals(WetGasCorrelation.ISO_TR_11583, restoredMeter.getWetGasCorrelation());
+    assertEquals(TappingArrangement.FLANGE, restoredMeter.getTappingArrangement());
+    assertEquals(expectedNextValue, restoredMeter.getMeasuredValue("kg/hr"), 0.0);
+  }
+
+  @Test
+  void nearbyDifferentialPressurePointFollowsSquareRootPhysicalTrend() {
+    List<DifferentialPressureFlowMeter> meters =
+        meters(new OrificeFlowMeter("O", createGasStream("O source")),
+            new NozzleFlowMeter("N", createGasStream("N source")),
+            new VenturiFlowMeter("V", createGasStream("V source")),
+            new ConeFlowMeter("C", createGasStream("C source")),
+            new WedgeFlowMeter("W", createGasStream("W source")));
+
+    for (DifferentialPressureFlowMeter meter : meters) {
+      configureMeter(meter, 1L);
+      meter.setNoiseStdDev(0.0);
+      meter.setDelaySteps(0);
+      meter.clearFault();
+      if (meter instanceof ConeFlowMeter) {
+        meter.setGeometry(0.25, 0.165, "m");
+      } else if (meter instanceof WedgeFlowMeter) {
+        meter.setGeometry(0.25, 0.075, "m");
+      }
+      meter.setDifferentialPressure(0.10, "bar");
+      double lowFlow = meter.getMeasuredValue("kg/hr");
+      meter.setDifferentialPressure(0.40, "bar");
+      double highFlow = meter.getMeasuredValue("kg/hr");
+      assertTrue(Double.isFinite(lowFlow));
+      assertTrue(highFlow > 1.8 * lowFlow);
+      assertTrue(highFlow < 2.2 * lowFlow);
+      assertTrue(meter.getReynoldsNumberPipe() > 0.0);
+    }
+  }
+
+  @Test
+  void descendantsOnlineModeAndForeignSnapshotsFailClosed() {
+    StreamInterface source = createGasStream("coverage source");
+    ProcessSystem process = new ProcessSystem("primary-device blocker coverage");
+    process.add(new OrificeFlowMeter("O", source) {
+      private static final long serialVersionUID = 1000L;
+    });
+    process.add(new NozzleFlowMeter("N", source) {
+      private static final long serialVersionUID = 1000L;
+    });
+    process.add(new VenturiFlowMeter("V", source) {
+      private static final long serialVersionUID = 1000L;
+    });
+    process.add(new ConeFlowMeter("C", source) {
+      private static final long serialVersionUID = 1000L;
+    });
+    process.add(new WedgeFlowMeter("W", source) {
+      private static final long serialVersionUID = 1000L;
+    });
+
+    TransientTransactionCoverage coverage = process.getTransientTransactionCoverage();
+    assertEquals(5, coverage.getProcessElementCount());
+    assertEquals(5, coverage.getParticipantCount());
+    assertFalse(coverage.isComplete());
+    assertEquals(5, coverage.getBlockingIssues().size());
+    for (String issue : coverage.getBlockingIssues()) {
+      assertTrue(issue.contains("subclass-owned mutable state"));
+    }
+
+    ConeFlowMeter online = new ConeFlowMeter("online", source);
+    online.setIsOnlineSignal(true, "plant", "tag");
+    ProcessSystem onlineProcess = new ProcessSystem("online blocker");
+    onlineProcess.add(online);
+    assertFalse(onlineProcess.getTransientTransactionCoverage().isComplete());
+    assertTrue(onlineProcess.getTransientTransactionCoverage().getBlockingIssues().get(0).contains("external I/O"));
+
+    OrificeFlowMeter first = new OrificeFlowMeter("first", source);
+    OrificeFlowMeter second = new OrificeFlowMeter("second", source);
+    configureMeter(first, 11L);
+    configureMeter(second, 12L);
+    DifferentialPressureFlowMeter.DifferentialPressureFlowMeterState foreign = first.captureTransientState();
+    assertThrows(IllegalArgumentException.class, () -> second.restoreTransientState(foreign));
+  }
+
+  private static void configureMeter(DifferentialPressureFlowMeter meter, long seed) {
+    meter.setGeometry(0.25, 0.125, "m");
+    meter.setDifferentialPressure(0.10, "bar");
+    meter.setGasDensity(40.0, "kg/m3");
+    meter.setIsentropicExponent(1.30);
+    meter.setDynamicViscosity(0.012, "cP");
+    meter.setDelaySteps(2);
+    meter.setNoiseStdDev(0.05);
+    meter.setRandomSeed(seed);
+    meter.setFirstOrderTimeConstant(2.0);
+    meter.setFault(SensorFaultType.LINEAR_DRIFT, 0.01);
+  }
+
+  private static List<DifferentialPressureFlowMeter> meters(DifferentialPressureFlowMeter... values) {
+    List<DifferentialPressureFlowMeter> result = new ArrayList<DifferentialPressureFlowMeter>();
+    for (DifferentialPressureFlowMeter value : values) {
+      result.add(value);
+    }
+    return result;
+  }
+
+  private static double[] readAll(List<DifferentialPressureFlowMeter> meters) {
+    double[] values = new double[meters.size()];
+    for (int index = 0; index < meters.size(); index++) {
+      values[index] = meters.get(index).getMeasuredValue("kg/hr");
+    }
+    return values;
+  }
+
+  private static List<String> transientIdentities(List<DifferentialPressureFlowMeter> meters) {
+    List<String> identities = new ArrayList<String>();
+    for (DifferentialPressureFlowMeter meter : meters) {
+      identities.add(meter.getTransientStateIdentity());
+    }
+    return identities;
+  }
+
+  private static double[] betaRatios(List<DifferentialPressureFlowMeter> meters) {
+    double[] values = new double[meters.size()];
+    for (int index = 0; index < meters.size(); index++) {
+      values[index] = meters.get(index).getBetaRatio();
+    }
+    return values;
+  }
+
+  private static StreamInterface[] streams(List<DifferentialPressureFlowMeter> meters) {
+    StreamInterface[] values = new StreamInterface[meters.size()];
+    for (int index = 0; index < meters.size(); index++) {
+      values[index] = meters.get(index).getStream();
+    }
+    return values;
+  }
+
+  private static void assertCompleteCoverage(TransientTransactionCoverage coverage, int expectedCount) {
+    assertEquals(expectedCount, coverage.getProcessElementCount());
+    assertEquals(expectedCount, coverage.getParticipantCount());
+    assertTrue(coverage.isComplete(), coverage.getBlockingIssues().toString());
+  }
+
+  private static StreamInterface createGasStream(String name) {
+    SystemSrkEos fluid = new SystemSrkEos(300.0, 50.0);
+    fluid.addComponent("methane", 0.95);
+    fluid.addComponent("ethane", 0.05);
+    Stream stream = new Stream(name, fluid);
+    stream.setFlowRate(1000.0, "kg/hr");
+    stream.run();
+    return stream;
+  }
+}


### PR DESCRIPTION
## Scope

Advances #2911 with one bounded shared-engine transaction tranche for the complete local ISO 5167 differential-pressure primary flow-meter family.

- make concrete `OrificeFlowMeter`, `NozzleFlowMeter`, `VenturiFlowMeter`, `ConeFlowMeter`, and `WedgeFlowMeter` typed transient-state participants
- preserve stable provenance identity, stream and optional DP-transmitter bindings
- capture common geometry, pressure/property overrides, last Reynolds solve and inherited measurement signal/alarm state
- capture every subtype configuration that can change during a rejected trial
- invalidate and deterministically recompute derived Orifice/Venturi wet-gas caches
- fail closed for descendants and online/external-I/O operation
- add exact replay, multi-area rollback, serialization/restart, foreign-snapshot, physical-trend and blocker regressions
- document transaction use and qualification limits

A linked `DifferentialPressureTransmitter` remains a separate state owner and must be registered in the same process transaction.

This does not change ISO 5167, ISO/TR 11583 or de Leeuw metering equations, limits, uncertainty, installation effects or any #2907/#2935 physics. It does not qualify allocation/fiscal metering, external I/O, safety action, adaptive rejection, virtual commissioning or OTS.

## Validation

**READY TO MERGE** on exact head `6740084fa331345490da768a14b16f6528e9eef6`.

Exact-head GitHub CI passed:

- Java 8 tests on Ubuntu and Windows
- Java 21 fast tests on Ubuntu and Windows
- all four Java 21 slow-test shards on Ubuntu
- Java 21 Javadocs
- Spotless format patch
- pre-commit checks
- documentation-search coverage
- PaperLab replication gate
- CodeQL security analysis
- agent-skill cross-reference validation

The Windows Java 21 fast lane exposed two branch-attributable fixture assumptions in `nearbyDifferentialPressurePointFollowsSquareRootPhysicalTrend`. Commit `c2fb4de8f3aec37f125b72defbf50122f1ca1134` disables the shared first-order signal filter for this physics-only test. Commit `6740084fa331345490da768a14b16f6528e9eef6` keeps the positive Reynolds diagnostic for the four paths that publish it while respecting the existing Reynolds-independent classical Venturi path, which does not publish `Re,D`. Production metering and transaction behavior are unchanged.

The exact-head PR is mergeable without conflicts. The final diff has no human or Copilot reviews, comments, or unresolved review threads. Local Maven, documentation-search and pre-commit execution were unavailable because this run had no local repository checkout; those checks are not claimed locally and are instead covered by the successful exact-head GitHub CI listed above.

## Documentation impact

Updated:

- `docs/process/dynamic-capability-contract.md`
- `docs/process/equipment/measurement_devices.md`

The documentation distinguishes rollback mechanics from metering-physics qualification and records the linked-transmitter ownership boundary.

## AI-assisted contribution

The implementation was produced with AI assistance and reviewed against the existing typed transaction patterns, current meter state ownership, Java 8 compatibility requirements and #2911 scope.