### PR TITLE
[AI-Assisted] feat(diagram): add route quality evidence

### DIFF
--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -181,6 +181,7 @@ NativeEngineeringDiagramRenderer.Result rendered =
 
 Map<String, String> svgBySheetId = rendered.getSvgBySheetId();
 byte[] multiPagePdf = rendered.getPdf();
+Map<String, String> visualFingerprints = rendered.getVisualFingerprintsBySheetId();
 for (NativeEngineeringDiagramRenderer.Diagnostic diagnostic : rendered.getDiagnostics()) {
   logger.warn("{}: {}", diagnostic.getCode(), diagnostic.getMessage());
 }
@@ -193,18 +194,27 @@ layout overflow remain fail-visible through structured diagnostics. Manual geome
 unchanged instead of being silently repaired.
 
 SVG output contains stable `data-sheet-id`, `data-semantic-id`, and protected-route attributes for
-machine inspection. PDF output is a deterministic vector drawing set with one page per controlled
-sheet. Use `exportSvg(directory)` or `exportPdf(path)` when files are required. Rendering does not
-modify the source document set, legacy DOT/Graphviz output, DEXPI 2.0 Process exchange, or the
-Proteus/DEXPI P&ID workflow.
+machine inspection. Every material, energy, and information connection receives a deterministic
+primary label at the geometric half-length of its rendered route. PDF output is a deterministic vector
+drawing set with one page per controlled sheet. Use `exportSvg(directory)` or `exportPdf(path)` when
+files are required. Rendering does not modify the source document set, legacy DOT/Graphviz output,
+DEXPI 2.0 Process exchange, or the Proteus/DEXPI P&ID workflow.
+
+`getVisualFingerprintsBySheetId()` exposes one normalized SHA-256 fingerprint per sheet. The
+fingerprint covers visible page geometry, text, and style shared by SVG and PDF while excluding XML/PDF
+serialization syntax and invisible semantic identifiers. Store a reviewed fingerprint as a regression
+baseline only together with the corresponding rendered artifacts and accountable visual review; a hash
+match is evidence of unchanged rendering, not evidence that the drawing is correct.
 
 The rendering result also carries deterministic drawing-quality diagnostics. It reports overlapping
 object symbols, symbols clipped by the border/header/title-block boundary, primary labels estimated
-to exceed their available symbol width, and missing semantic-object references. Existing controlled-
-document diagnostics are retained in the same report, including broken reciprocal off-page pairs and
-stale manual layout references. Errors make `Result.isComplete()` false; warnings retain the proposed
-geometry unchanged for review. These geometric and text-width checks are conservative proposal gates,
-not proof of standards compliance or accountable visual approval.
+to exceed their available symbol width, connection routes crossing non-endpoint objects, connection
+labels overlapping objects or other connection labels, missing connection labels, and missing
+semantic-object references. Existing controlled-document diagnostics are retained in the same report,
+including broken reciprocal off-page pairs and stale manual layout references. Errors make
+`Result.isComplete()` false; warnings retain the proposed geometry unchanged for review. These
+geometric and text-width checks are conservative proposal gates, not proof of standards compliance or
+accountable visual approval.
 
 Compare two revisions of the same document-set and plant identity with `baseline.compareTo(revised)`.
 The returned `EngineeringDiagramRevisionImpact` has deterministic added, removed, and modified
@@ -252,6 +262,8 @@ designation mismatches, deterministic cross-sheet revision impact, persistent ma
 unchanged semantic identities after layout-only revision changes, protected-route retention, and
 fail-visible stale layout references.
 The native-renderer regression verifies byte-deterministic SVG/PDF, A3 and A1 geometry, exact pinned
-coordinates and protected routes, reciprocal off-page references, deterministic collision, clipping,
-label-overflow and broken-reference diagnostics, multi-page drawing sets, fresh-model determinism,
-and unchanged Classic DOT and controlled-document JSON.
+coordinates and protected routes, reciprocal off-page references, deterministic connection labels,
+route/object and route-label obstacle diagnostics, collision, clipping, label-overflow and
+broken-reference diagnostics, normalized visual fingerprints, multi-page drawing sets, fresh-model
+determinism, and unchanged Classic DOT and controlled-document JSON.
+

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -119,11 +121,15 @@ public final class NativeEngineeringDiagramRenderer {
   public static final class Result {
     private final Map<String, String> svgBySheetId;
     private final byte[] pdf;
+    private final Map<String, String> visualFingerprintsBySheetId;
     private final List<Diagnostic> diagnostics;
 
-    private Result(Map<String, String> svgBySheetId, byte[] pdf, List<Diagnostic> diagnostics) {
+    private Result(Map<String, String> svgBySheetId, byte[] pdf, Map<String, String> visualFingerprintsBySheetId,
+        List<Diagnostic> diagnostics) {
       this.svgBySheetId = Collections.unmodifiableMap(new LinkedHashMap<String, String>(svgBySheetId));
       this.pdf = Arrays.copyOf(pdf, pdf.length);
+      this.visualFingerprintsBySheetId = Collections
+          .unmodifiableMap(new LinkedHashMap<String, String>(visualFingerprintsBySheetId));
       this.diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
     }
 
@@ -135,6 +141,20 @@ public final class NativeEngineeringDiagramRenderer {
     /** @return defensive copy of the deterministic multi-page native PDF */
     public byte[] getPdf() {
       return Arrays.copyOf(pdf, pdf.length);
+    }
+
+    /**
+     * Returns normalized visual fingerprints for reviewed-baseline comparison.
+     *
+     * <p>
+     * Each SHA-256 fingerprint covers visible page geometry, text and style shared by the SVG and PDF renderers while
+     * excluding serialization syntax and invisible semantic identifiers.
+     * </p>
+     *
+     * @return immutable stable sheet-ID-to-fingerprint map
+     */
+    public Map<String, String> getVisualFingerprintsBySheetId() {
+      return visualFingerprintsBySheetId;
     }
 
     /** @return immutable structured rendering diagnostics */
@@ -204,10 +224,12 @@ public final class NativeEngineeringDiagramRenderer {
       }
     });
     Map<String, String> svg = new LinkedHashMap<String, String>();
+    Map<String, String> visualFingerprints = new LinkedHashMap<String, String>();
     for (Page page : pages) {
       svg.put(page.sheetId, toSvg(page));
+      visualFingerprints.put(page.sheetId, visualFingerprint(page));
     }
-    return new Result(svg, toPdf(pages), diagnostics);
+    return new Result(svg, toPdf(pages), visualFingerprints, diagnostics);
   }
 
   /**
@@ -288,6 +310,7 @@ public final class NativeEngineeringDiagramRenderer {
             contentBottom, diagnostics);
       }
     }
+    addRouteQualityDiagnostics(page, positions, diagnostics);
     for (OffPageConnector connector : sheet.getOffPageConnectors()) {
       addOffPageConnector(page, connector, contentRight, contentBottom);
     }
@@ -423,6 +446,48 @@ public final class NativeEngineeringDiagramRenderer {
       dash = "2 2";
     }
     page.commands.add(Command.polyline(points, color, 0.8, dash, connection.getId(), protectedGeometry));
+    String label = displayLabel(connection);
+    Point labelPoint = routeLabelPoint(points);
+    if (label == null || label.trim().isEmpty()) {
+      diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_CONNECTION_LABEL_MISSING",
+          "Rendered connection has no primary label and requires drawing review", connection.getId()));
+      label = "";
+    } else {
+      page.commands.add(
+          Command.text(labelPoint.x, labelPoint.y - 3.0, 2.3, label, color, connection.getId(), "middle"));
+    }
+    page.routes.add(new RouteView(connection.getId(), points, label, labelPoint,
+        endpointOwnerId(connection, "sourceEndpointId", objects),
+        endpointOwnerId(connection, "targetEndpointId", objects)));
+  }
+
+  private void addRouteQualityDiagnostics(Page page, Map<String, Point> positions,
+      List<Diagnostic> diagnostics) {
+    List<String> objectIds = new ArrayList<String>(positions.keySet());
+    Collections.sort(objectIds);
+    for (int routeIndex = 0; routeIndex < page.routes.size(); routeIndex++) {
+      RouteView route = page.routes.get(routeIndex);
+      for (String objectId : objectIds) {
+        Point objectPosition = positions.get(objectId);
+        boolean endpointOwner = objectId.equals(route.sourceOwnerId) || objectId.equals(route.targetOwnerId);
+        if (!endpointOwner && polylineIntersectsObject(route.points, objectPosition)) {
+          diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_ROUTE_OBJECT_INTERSECTION",
+              "Rendered connection route intersects non-endpoint semantic object " + objectId, route.connectionId));
+        }
+        if (!route.label.isEmpty() && labelIntersectsObject(route.label, route.labelPoint, objectPosition)) {
+          diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_ROUTE_LABEL_OBJECT_COLLISION",
+              "Rendered connection label overlaps semantic object " + objectId, route.connectionId));
+        }
+      }
+      for (int otherIndex = routeIndex + 1; otherIndex < page.routes.size(); otherIndex++) {
+        RouteView other = page.routes.get(otherIndex);
+        if (!route.label.isEmpty() && !other.label.isEmpty()
+            && labelsOverlap(route.label, route.labelPoint, other.label, other.labelPoint)) {
+          diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_CONNECTION_LABEL_COLLISION",
+              "Rendered connection label overlaps connection label " + other.connectionId, route.connectionId));
+        }
+      }
+    }
   }
 
   private void addOffPageConnector(Page page, OffPageConnector connector, double contentRight, double contentBottom) {
@@ -487,6 +552,25 @@ public final class NativeEngineeringDiagramRenderer {
     }
     svg.append("  </g>\n</svg>\n");
     return svg.toString();
+  }
+
+  private static String visualFingerprint(Page page) {
+    StringBuilder normalized = new StringBuilder();
+    normalized.append(number(page.width)).append('x').append(number(page.height)).append('\n');
+    for (Command command : page.commands) {
+      command.appendVisualSignature(normalized);
+    }
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] bytes = digest.digest(normalized.toString().getBytes(StandardCharsets.UTF_8));
+      StringBuilder result = new StringBuilder(bytes.length * 2);
+      for (byte value : bytes) {
+        result.append(String.format(Locale.ROOT, "%02x", value & 0xff));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException ex) {
+      throw new IllegalStateException("SHA-256 is required by the Java runtime", ex);
+    }
   }
 
   private byte[] toPdf(List<Page> pages) {
@@ -595,6 +679,97 @@ public final class NativeEngineeringDiagramRenderer {
     return Math.abs(left.x - right.x) < OBJECT_WIDTH && Math.abs(left.y - right.y) < OBJECT_HEIGHT;
   }
 
+  private static Point routeLabelPoint(List<Point> points) {
+    double totalLength = 0.0;
+    for (int index = 1; index < points.size(); index++) {
+      totalLength += distance(points.get(index - 1), points.get(index));
+    }
+    double remaining = totalLength / 2.0;
+    for (int index = 1; index < points.size(); index++) {
+      Point start = points.get(index - 1);
+      Point end = points.get(index);
+      double segmentLength = distance(start, end);
+      if (remaining <= segmentLength || index == points.size() - 1) {
+        double fraction = segmentLength == 0.0 ? 0.0 : remaining / segmentLength;
+        return new Point(start.x + (end.x - start.x) * fraction, start.y + (end.y - start.y) * fraction);
+      }
+      remaining -= segmentLength;
+    }
+    return points.get(0);
+  }
+
+  private static double distance(Point start, Point end) {
+    double deltaX = end.x - start.x;
+    double deltaY = end.y - start.y;
+    return Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+  }
+
+  private static String endpointOwnerId(SemanticObject connection, String property,
+      Map<String, SemanticObject> objects) {
+    String endpointId = stringProperty(connection, property, "");
+    SemanticObject endpoint = objects.get(endpointId);
+    if (endpoint == null) {
+      return endpointId;
+    }
+    return stringProperty(endpoint, "ownerNodeId", endpointId);
+  }
+
+  private static boolean polylineIntersectsObject(List<Point> points, Point objectPosition) {
+    double left = objectPosition.x - OBJECT_WIDTH / 2.0;
+    double right = objectPosition.x + OBJECT_WIDTH / 2.0;
+    double top = objectPosition.y - OBJECT_HEIGHT / 2.0;
+    double bottom = objectPosition.y + OBJECT_HEIGHT / 2.0;
+    for (int index = 1; index < points.size(); index++) {
+      Point start = points.get(index - 1);
+      Point end = points.get(index);
+      if (pointInsideRectangle(start, left, right, top, bottom)
+          || pointInsideRectangle(end, left, right, top, bottom)
+          || segmentsIntersect(start, end, new Point(left, top), new Point(right, top))
+          || segmentsIntersect(start, end, new Point(right, top), new Point(right, bottom))
+          || segmentsIntersect(start, end, new Point(right, bottom), new Point(left, bottom))
+          || segmentsIntersect(start, end, new Point(left, bottom), new Point(left, top))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean pointInsideRectangle(Point point, double left, double right, double top, double bottom) {
+    return point.x >= left && point.x <= right && point.y >= top && point.y <= bottom;
+  }
+
+  private static boolean segmentsIntersect(Point firstStart, Point firstEnd, Point secondStart, Point secondEnd) {
+    double first = cross(firstStart, firstEnd, secondStart);
+    double second = cross(firstStart, firstEnd, secondEnd);
+    double third = cross(secondStart, secondEnd, firstStart);
+    double fourth = cross(secondStart, secondEnd, firstEnd);
+    return first * second <= 0.0 && third * fourth <= 0.0
+        && Math.max(Math.min(firstStart.x, firstEnd.x), Math.min(secondStart.x, secondEnd.x))
+            <= Math.min(Math.max(firstStart.x, firstEnd.x), Math.max(secondStart.x, secondEnd.x))
+        && Math.max(Math.min(firstStart.y, firstEnd.y), Math.min(secondStart.y, secondEnd.y))
+            <= Math.min(Math.max(firstStart.y, firstEnd.y), Math.max(secondStart.y, secondEnd.y));
+  }
+
+  private static double cross(Point start, Point end, Point point) {
+    return (end.x - start.x) * (point.y - start.y) - (end.y - start.y) * (point.x - start.x);
+  }
+
+  private static boolean labelIntersectsObject(String label, Point labelPoint, Point objectPosition) {
+    return rectanglesOverlap(labelPoint.x, labelPoint.y - 3.0, estimatedTextWidth(label, 2.3), 3.2,
+        objectPosition.x, objectPosition.y, OBJECT_WIDTH, OBJECT_HEIGHT);
+  }
+
+  private static boolean labelsOverlap(String firstLabel, Point firstPoint, String secondLabel, Point secondPoint) {
+    return rectanglesOverlap(firstPoint.x, firstPoint.y - 3.0, estimatedTextWidth(firstLabel, 2.3), 3.2,
+        secondPoint.x, secondPoint.y - 3.0, estimatedTextWidth(secondLabel, 2.3), 3.2);
+  }
+
+  private static boolean rectanglesOverlap(double firstX, double firstY, double firstWidth, double firstHeight,
+      double secondX, double secondY, double secondWidth, double secondHeight) {
+    return Math.abs(firstX - secondX) * 2.0 < firstWidth + secondWidth
+        && Math.abs(firstY - secondY) * 2.0 < firstHeight + secondHeight;
+  }
+
   private static double estimatedTextWidth(String value, double fontSize) {
     return value.length() * fontSize * 0.52;
   }
@@ -670,11 +845,31 @@ public final class NativeEngineeringDiagramRenderer {
     private final double width;
     private final double height;
     private final List<Command> commands = new ArrayList<Command>();
+    private final List<RouteView> routes = new ArrayList<RouteView>();
 
     private Page(String sheetId, double width, double height) {
       this.sheetId = sheetId;
       this.width = width;
       this.height = height;
+    }
+  }
+
+  private static final class RouteView {
+    private final String connectionId;
+    private final List<Point> points;
+    private final String label;
+    private final Point labelPoint;
+    private final String sourceOwnerId;
+    private final String targetOwnerId;
+
+    private RouteView(String connectionId, List<Point> points, String label, Point labelPoint, String sourceOwnerId,
+        String targetOwnerId) {
+      this.connectionId = connectionId;
+      this.points = Collections.unmodifiableList(new ArrayList<Point>(points));
+      this.label = label;
+      this.labelPoint = labelPoint;
+      this.sourceOwnerId = sourceOwnerId;
+      this.targetOwnerId = targetOwnerId;
     }
   }
 
@@ -779,6 +974,17 @@ public final class NativeEngineeringDiagramRenderer {
       return result.toString();
     }
 
+    private void appendVisualSignature(StringBuilder result) {
+      result.append(type).append('|').append(number(x)).append('|').append(number(y)).append('|')
+          .append(number(width)).append('|').append(number(height)).append('|').append(number(size)).append('|')
+          .append(stroke).append('|').append(fill).append('|').append(number(strokeWidth)).append('|').append(dash)
+          .append('|').append(anchor).append('|').append(text.length()).append(':').append(text);
+      for (Point point : points) {
+        result.append('|').append(number(point.x)).append(',').append(number(point.y));
+      }
+      result.append('\n');
+    }
+
     private String toPdf(double pageHeight) {
       StringBuilder result = new StringBuilder();
       if ("text".equals(type)) {
@@ -846,3 +1052,4 @@ public final class NativeEngineeringDiagramRenderer {
     }
   }
 }
+

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -453,16 +453,15 @@ public final class NativeEngineeringDiagramRenderer {
           "Rendered connection has no primary label and requires drawing review", connection.getId()));
       label = "";
     } else {
-      page.commands.add(
-          Command.text(labelPoint.x, labelPoint.y - 3.0, 2.3, label, color, connection.getId(), "middle"));
+      page.commands
+          .add(Command.text(labelPoint.x, labelPoint.y - 3.0, 2.3, label, color, connection.getId(), "middle"));
     }
     page.routes.add(new RouteView(connection.getId(), points, label, labelPoint,
         endpointOwnerId(connection, "sourceEndpointId", objects),
         endpointOwnerId(connection, "targetEndpointId", objects)));
   }
 
-  private void addRouteQualityDiagnostics(Page page, Map<String, Point> positions,
-      List<Diagnostic> diagnostics) {
+  private void addRouteQualityDiagnostics(Page page, Map<String, Point> positions, List<Diagnostic> diagnostics) {
     List<String> objectIds = new ArrayList<String>(positions.keySet());
     Collections.sort(objectIds);
     for (int routeIndex = 0; routeIndex < page.routes.size(); routeIndex++) {
@@ -722,8 +721,7 @@ public final class NativeEngineeringDiagramRenderer {
     for (int index = 1; index < points.size(); index++) {
       Point start = points.get(index - 1);
       Point end = points.get(index);
-      if (pointInsideRectangle(start, left, right, top, bottom)
-          || pointInsideRectangle(end, left, right, top, bottom)
+      if (pointInsideRectangle(start, left, right, top, bottom) || pointInsideRectangle(end, left, right, top, bottom)
           || segmentsIntersect(start, end, new Point(left, top), new Point(right, top))
           || segmentsIntersect(start, end, new Point(right, top), new Point(right, bottom))
           || segmentsIntersect(start, end, new Point(right, bottom), new Point(left, bottom))
@@ -744,10 +742,10 @@ public final class NativeEngineeringDiagramRenderer {
     double third = cross(secondStart, secondEnd, firstStart);
     double fourth = cross(secondStart, secondEnd, firstEnd);
     return first * second <= 0.0 && third * fourth <= 0.0
-        && Math.max(Math.min(firstStart.x, firstEnd.x), Math.min(secondStart.x, secondEnd.x))
-            <= Math.min(Math.max(firstStart.x, firstEnd.x), Math.max(secondStart.x, secondEnd.x))
-        && Math.max(Math.min(firstStart.y, firstEnd.y), Math.min(secondStart.y, secondEnd.y))
-            <= Math.min(Math.max(firstStart.y, firstEnd.y), Math.max(secondStart.y, secondEnd.y));
+        && Math.max(Math.min(firstStart.x, firstEnd.x), Math.min(secondStart.x, secondEnd.x)) <= Math
+            .min(Math.max(firstStart.x, firstEnd.x), Math.max(secondStart.x, secondEnd.x))
+        && Math.max(Math.min(firstStart.y, firstEnd.y), Math.min(secondStart.y, secondEnd.y)) <= Math
+            .min(Math.max(firstStart.y, firstEnd.y), Math.max(secondStart.y, secondEnd.y));
   }
 
   private static double cross(Point start, Point end, Point point) {
@@ -755,13 +753,13 @@ public final class NativeEngineeringDiagramRenderer {
   }
 
   private static boolean labelIntersectsObject(String label, Point labelPoint, Point objectPosition) {
-    return rectanglesOverlap(labelPoint.x, labelPoint.y - 3.0, estimatedTextWidth(label, 2.3), 3.2,
-        objectPosition.x, objectPosition.y, OBJECT_WIDTH, OBJECT_HEIGHT);
+    return rectanglesOverlap(labelPoint.x, labelPoint.y - 3.0, estimatedTextWidth(label, 2.3), 3.2, objectPosition.x,
+        objectPosition.y, OBJECT_WIDTH, OBJECT_HEIGHT);
   }
 
   private static boolean labelsOverlap(String firstLabel, Point firstPoint, String secondLabel, Point secondPoint) {
-    return rectanglesOverlap(firstPoint.x, firstPoint.y - 3.0, estimatedTextWidth(firstLabel, 2.3), 3.2,
-        secondPoint.x, secondPoint.y - 3.0, estimatedTextWidth(secondLabel, 2.3), 3.2);
+    return rectanglesOverlap(firstPoint.x, firstPoint.y - 3.0, estimatedTextWidth(firstLabel, 2.3), 3.2, secondPoint.x,
+        secondPoint.y - 3.0, estimatedTextWidth(secondLabel, 2.3), 3.2);
   }
 
   private static boolean rectanglesOverlap(double firstX, double firstY, double firstWidth, double firstHeight,
@@ -975,10 +973,10 @@ public final class NativeEngineeringDiagramRenderer {
     }
 
     private void appendVisualSignature(StringBuilder result) {
-      result.append(type).append('|').append(number(x)).append('|').append(number(y)).append('|')
-          .append(number(width)).append('|').append(number(height)).append('|').append(number(size)).append('|')
-          .append(stroke).append('|').append(fill).append('|').append(number(strokeWidth)).append('|').append(dash)
-          .append('|').append(anchor).append('|').append(text.length()).append(':').append(text);
+      result.append(type).append('|').append(number(x)).append('|').append(number(y)).append('|').append(number(width))
+          .append('|').append(number(height)).append('|').append(number(size)).append('|').append(stroke).append('|')
+          .append(fill).append('|').append(number(strokeWidth)).append('|').append(dash).append('|').append(anchor)
+          .append('|').append(text.length()).append(':').append(text);
       for (Point point : points) {
         result.append('|').append(number(point.x)).append(',').append(number(point.y));
       }
@@ -1052,4 +1050,3 @@ public final class NativeEngineeringDiagramRenderer {
     }
   }
 }
-

--- a/src/main/java/neqsim/process/processmodel/diagram/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/package-info.java
@@ -24,8 +24,11 @@
  * project review evidence without changing process topology</li>
  * <li><b>Native controlled output</b> - Deterministic vector SVG sheets and multi-page PDF consume the same controlled
  * document model without requiring Graphviz</li>
- * <li><b>Drawing-quality diagnostics</b> - Deterministic collision, clipping, label-overflow, and broken-reference
- * evidence remains structured and fail-visible without silently moving reviewed geometry</li>
+ * <li><b>Drawing-quality diagnostics</b> - Deterministic collision, clipping, route/object, connection-label,
+ * label-overflow, and broken-reference evidence remains structured and fail-visible without silently moving reviewed
+ * geometry</li>
+ * <li><b>Visual regression evidence</b> - Normalized per-sheet fingerprints cover visible geometry, text, and style
+ * shared by native SVG/PDF without implying visual approval</li>
  * <li><b>Revision impact</b> - Deterministic changed-object, affected-sheet, and affected-drawing evidence</li>
  * <li><b>Multiple detail levels</b> - MINIMAL, STANDARD, DETAILED, DEBUG</li>
  * <li><b>Deterministic output</b> - Same model always produces same diagram</li>
@@ -96,3 +99,4 @@
  * @see neqsim.process.processmodel.diagram.DexpiDiagramBridge
  */
 package neqsim.process.processmodel.diagram;
+

--- a/src/main/java/neqsim/process/processmodel/diagram/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/package-info.java
@@ -99,4 +99,3 @@
  * @see neqsim.process.processmodel.diagram.DexpiDiagramBridge
  */
 package neqsim.process.processmodel.diagram;
-

--- a/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
@@ -55,6 +55,9 @@ class NativeEngineeringDiagramRendererTest {
 
     assertEquals(first.getSvgBySheetId(), second.getSvgBySheetId());
     assertArrayEquals(first.getPdf(), second.getPdf());
+    assertEquals(first.getVisualFingerprintsBySheetId(), second.getVisualFingerprintsBySheetId());
+    assertEquals(first.getSvgBySheetId().keySet(), first.getVisualFingerprintsBySheetId().keySet());
+    assertTrue(first.getVisualFingerprintsBySheetId().values().iterator().next().matches("[0-9a-f]{64}"));
     assertTrue(svg.contains("width=\"420mm\" height=\"297mm\" viewBox=\"0 0 420 297\""));
     assertTrue(svg.contains("x=\"63\" y=\"52\" width=\"34\" height=\"16\""));
     assertTrue(svg.contains("points=\"10,20 40,20 40,50\""));
@@ -78,6 +81,7 @@ class NativeEngineeringDiagramRendererTest {
     String pdf = new String(result.getPdf(), StandardCharsets.ISO_8859_1);
 
     assertEquals(4, result.getSvgBySheetId().size());
+    assertEquals(4, result.getVisualFingerprintsBySheetId().size());
     assertTrue(pdf.contains("/Count 4"));
     for (Sheet sheet : documents.getDrawings().get(0).getSheets()) {
       String svg = result.getSvgBySheetId().get(sheet.getId());
@@ -145,6 +149,40 @@ class NativeEngineeringDiagramRendererTest {
   }
 
   @Test
+  void labelsConnectionsAndReportsDeterministicRouteAndLabelObstacles() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
+    EngineeringDiagramDocumentSet baseline = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-NATIVE-007", "Route quality diagnostics",
+        ContentProfile.PFD);
+    String sheetKey = baseline.getDrawings().get(0).getSheets().get(0).getKey();
+    SemanticObject separator = findObject(baseline, EngineeringNode.Kind.EQUIPMENT, "equipmentName", "10-VA-001");
+    SemanticObject feedConnection = findObject(baseline, EngineeringNode.Kind.PIPE_SEGMENT, "targetEquipment",
+        "10-XV-001");
+    ProtectedRoute obstructedRoute = new ProtectedRoute(feedConnection.getId(), sheetKey,
+        Arrays.asList(new Waypoint(20.0, 60.0), new Waypoint(140.0, 60.0)), CoordinateUnit.MILLIMETRE,
+        "project-layout:PFD-NATIVE-007", EvidenceState.REVIEWED, "Process discipline", "2026-08-15T00:00:00Z",
+        "A");
+    EngineeringDiagramLayoutRegister layout = new EngineeringDiagramLayoutRegister()
+        .withPinnedPosition(reviewedPosition(separator.getId(), sheetKey, 80.0, 60.0))
+        .withProtectedRoute(obstructedRoute);
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-NATIVE-007", "Route quality diagnostics",
+        ContentProfile.PFD, new EngineeringDiagramDesignationRegister(), layout);
+
+    NativeEngineeringDiagramRenderer renderer = new NativeEngineeringDiagramRenderer(documents);
+    NativeEngineeringDiagramRenderer.Result first = renderer.render();
+    NativeEngineeringDiagramRenderer.Result second = renderer.render();
+    String svg = first.getSvgBySheetId().values().iterator().next();
+
+    assertTrue(svg.contains(">" + feedConnection.getLabel() + "</text>"));
+    assertTrue(hasDiagnostic(first, "DIAGRAM_RENDER_ROUTE_OBJECT_INTERSECTION"));
+    assertTrue(hasDiagnostic(first, "DIAGRAM_RENDER_ROUTE_LABEL_OBJECT_COLLISION"));
+    assertEquals(first.getVisualFingerprintsBySheetId(), second.getVisualFingerprintsBySheetId());
+    assertEquals(diagnosticSignatures(first), diagnosticSignatures(second));
+    assertTrue(first.isComplete());
+  }
+
+  @Test
   void propagatesBrokenControlledDocumentReferencesAsRendererErrors() {
     EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
     EngineeringDiagramDocumentSet baseline = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
@@ -166,6 +204,7 @@ class NativeEngineeringDiagramRendererTest {
   @Test
   void keepsSheetOrderAndRenderedBytesStableAcrossFreshEquivalentModels() {
     Map<String, String> expectedSvg = null;
+    Map<String, String> expectedVisualFingerprints = null;
     byte[] expectedPdf = null;
     for (int attempt = 0; attempt < 4; attempt++) {
       EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessModel(
@@ -174,9 +213,11 @@ class NativeEngineeringDiagramRendererTest {
       NativeEngineeringDiagramRenderer.Result result = new NativeEngineeringDiagramRenderer(documents).render();
       if (expectedSvg == null) {
         expectedSvg = result.getSvgBySheetId();
+        expectedVisualFingerprints = result.getVisualFingerprintsBySheetId();
         expectedPdf = result.getPdf();
       } else {
         assertEquals(expectedSvg, result.getSvgBySheetId());
+        assertEquals(expectedVisualFingerprints, result.getVisualFingerprintsBySheetId());
         assertArrayEquals(expectedPdf, result.getPdf());
       }
     }
@@ -223,3 +264,4 @@ class NativeEngineeringDiagramRendererTest {
     return signatures;
   }
 }
+

--- a/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
@@ -160,8 +160,7 @@ class NativeEngineeringDiagramRendererTest {
         "10-XV-001");
     ProtectedRoute obstructedRoute = new ProtectedRoute(feedConnection.getId(), sheetKey,
         Arrays.asList(new Waypoint(20.0, 60.0), new Waypoint(140.0, 60.0)), CoordinateUnit.MILLIMETRE,
-        "project-layout:PFD-NATIVE-007", EvidenceState.REVIEWED, "Process discipline", "2026-08-15T00:00:00Z",
-        "A");
+        "project-layout:PFD-NATIVE-007", EvidenceState.REVIEWED, "Process discipline", "2026-08-15T00:00:00Z", "A");
     EngineeringDiagramLayoutRegister layout = new EngineeringDiagramLayoutRegister()
         .withPinnedPosition(reviewedPosition(separator.getId(), sheetKey, 80.0, 60.0))
         .withProtectedRoute(obstructedRoute);
@@ -264,4 +263,3 @@ class NativeEngineeringDiagramRendererTest {
     return signatures;
   }
 }
-


### PR DESCRIPTION
## Engineering value

Advances the shared engineering-diagram lane in #1332 and #2899 with deterministic drawing-review evidence on top of the merged native SVG/PDF renderer.

This tranche answers a bounded review question: can a simulation-driven PFD make connection identity and obvious route/label obstacles fail-visible, and can reviewers compare visible native output without comparing format-specific SVG/PDF bytes?

## Implementation

- renders one deterministic primary label at the geometric half-length of every material, energy, and information connection;
- reports structured deterministic warnings for:
  - routes intersecting non-endpoint objects;
  - connection labels overlapping objects;
  - connection labels overlapping other connection labels;
  - missing connection labels;
- exposes an immutable per-sheet SHA-256 visual fingerprint from `NativeEngineeringDiagramRenderer.Result`;
- normalizes the visible geometry, text, and style shared by the SVG and PDF command stream, excluding serialization syntax and invisible semantic IDs;
- adds focused determinism, multi-sheet, fresh-model, route/object, and route-label regressions;
- documents baseline use, compatibility, and accountable-review limitations.

## Scope boundary and compatibility

The public API change is additive. Existing `getSvgBySheetId()`, `getPdf()`, diagnostics, export methods, and completeness semantics are preserved.

Valid native SVG/PDF output intentionally changes because primary connection labels are now visible. Reviewed visual baselines therefore need explicit re-approval for this change. Classic DOT/Graphviz output, the canonical semantic/document model, DEXPI 2.0 Process exchange, and the Proteus/DEXPI P&ID workflow are unchanged.

This does not add automatic route repair, raster image comparison, qualified symbol libraries, accountable engineering approval, P&ID design data, or a standards-conformance claim. A PFD remains simulation-driven; a P&ID remains an engineering proposal until accountable design data and review exist.

## Validation

**READY TO MERGE** on exact head `583ca96440236ca6512f03f60b5696d3df5b4589`.

Exact-head GitHub CI passed:

- Java 8 tests on Ubuntu and Windows
- Java 21 fast tests on Ubuntu and Windows
- all four Java 21 slow-test shards on Ubuntu
- Java 21 Javadocs
- Spotless format patch
- pre-commit checks
- documentation-search coverage
- PaperLab replication gate
- CodeQL security analysis
- agent-skill cross-reference validation

The original Java 21 Ubuntu failure and a dependent Java 8 Windows failure were both the recurring unrelated `EngineeringDiagramReferenceCasesTest` Proteus XML mismatch. Each passed a targeted rerun without diagram source changes. The PR's native renderer tests passed across the exact-head Java matrix.

The exact-head PR is mergeable without conflicts. The final four-file diff remains limited to the native renderer, its focused regression tests, package Javadocs, and the engineering-diagram guide. There are no human or Copilot reviews, comments, requested changes, or unresolved review threads. Local Maven and hook execution were unavailable in the source-only workspace and are not claimed locally; the successful hosted gates above are the validation evidence.

## Documentation impact

Updated:

- `docs/integration/engineering-diagram-document-model.md`
- diagram package Javadocs

The guide documents the additive API, changed native output, diagnostics, reviewed-baseline workflow, and the fact that fingerprint equality is evidence of unchanged rendering—not proof that a drawing is correct.

## AI-assisted contribution

The implementation was produced with AI assistance and reviewed against current master, repository instructions, both roadmap ledgers, recent diagram work, Java 8 compatibility, and the shared PFD/DEXPI scope boundary.