### PR TITLE
fix(column): honor product flow specification units

### DIFF
--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -129,23 +129,32 @@ column.setReboilerBoilupRatio(2.5);
 ```
 
 Product-quality and recovery targets use `ColumnSpecification`. Purity and recovery targets are
-dimensionless fractions from `0` to `1`; product-flow-rate specifications are evaluated internally
-in `mol/hr`.
+dimensionless fractions from `0` to `1`. Product-flow-rate targets and their absolute residuals use
+the unit supplied to `setTopProductFlowRate` or `setBottomProductFlowRate`; common molar and mass
+units such as `mol/hr` and `kg/hr` are supported by the product stream. Constructors that do not
+supply a unit remain backward compatible and default product flow to `mol/hr`.
 
 ```java
 column.setTopProductPurity("ethane", 0.95);
 column.setBottomProductPurity("propane", 0.98);
 column.setTopComponentRecovery("ethane", 0.99);
 column.setBottomComponentRecovery("propane", 0.99);
-column.setBottomProductFlowRate(1000.0, "mol/hr");
+column.setBottomProductFlowRate(1000.0, "kg/hr");
 
 ColumnSpecification topFlow = new ColumnSpecification(
     ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE,
-    ColumnSpecification.ProductLocation.TOP, 500.0);
-topFlow.setTolerance(1.0e-3);
+    ColumnSpecification.ProductLocation.TOP, 500.0, null, "kg/hr");
+topFlow.setTolerance(1.0e-3); // kg/hr, matching the target
 topFlow.setMaxIterations(30);
 column.setTopSpecification(topFlow);
 ```
+
+The selected unit is retained through specification homotopy, diagnostics, warm-state identity,
+copying, and serialization. Feasibility screening compares each flow target with external feed flow
+in the same unit. When both terminal flow targets use the same unit, their sum is screened as well;
+mixed-unit terminal targets are evaluated during the solve because their product compositions may
+differ. `getLastTopSpecificationResidual()` and `getLastBottomSpecificationResidual()` report flow
+residuals in the corresponding target unit.
 
 For iterative specifications, NeqSim wraps the selected inner solver in an outer adjustment loop and
 uses condenser or reboiler temperature as the manipulated variable where possible. Product purity,

--- a/src/main/java/neqsim/process/equipment/distillation/ColumnSpecification.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ColumnSpecification.java
@@ -92,6 +92,8 @@ public class ColumnSpecification implements Serializable {
   private final ProductLocation location;
   private final double targetValue;
   private final String componentName;
+  /** Unit used to interpret a product-flow target; null only in legacy serialized objects. */
+  private final String targetUnit;
   private double tolerance = DEFAULT_TOLERANCE;
   private int maxIterations = DEFAULT_MAX_ITERATIONS;
 
@@ -116,11 +118,48 @@ public class ColumnSpecification implements Serializable {
    */
   public ColumnSpecification(SpecificationType type, ProductLocation location, double targetValue,
       String componentName) {
+    this(type, location, targetValue, componentName, defaultTargetUnit(type));
+  }
+
+  /**
+   * Creates a column specification with an explicit target unit.
+   *
+   * <p>
+   * The explicit unit is currently used by {@link SpecificationType#PRODUCT_FLOW_RATE}; other specification types keep
+   * their established dimensionless or watt targets. Existing constructors remain source compatible and use mol/hr for
+   * product-flow specifications.
+   * </p>
+   *
+   * @param type the specification type
+   * @param location which end of the column this applies to
+   * @param targetValue the target value in {@code targetUnit}
+   * @param componentName component name for component-based specifications, otherwise {@code null}
+   * @param targetUnit unit for a product-flow target
+   */
+  public ColumnSpecification(SpecificationType type, ProductLocation location, double targetValue,
+      String componentName, String targetUnit) {
     this.type = type;
     this.location = location;
     this.targetValue = targetValue;
     this.componentName = componentName;
+    this.targetUnit = targetUnit;
     validate();
+  }
+
+  /**
+   * Return the backward-compatible target unit for a specification type.
+   *
+   * @param type specification type
+   * @return mol/hr for product flow, W for duty, or an empty string for dimensionless targets
+   */
+  private static String defaultTargetUnit(SpecificationType type) {
+    if (type == SpecificationType.PRODUCT_FLOW_RATE) {
+      return "mol/hr";
+    }
+    if (type == SpecificationType.DUTY) {
+      return "W";
+    }
+    return "";
   }
 
   /**
@@ -162,6 +201,9 @@ public class ColumnSpecification implements Serializable {
       if (targetValue <= 0.0) {
         throw new IllegalArgumentException("Product flow rate must be positive, got: " + targetValue);
       }
+      if (targetUnit == null || targetUnit.trim().isEmpty()) {
+        throw new IllegalArgumentException("Product flow rate requires a non-empty flow unit");
+      }
     }
   }
 
@@ -199,6 +241,20 @@ public class ColumnSpecification implements Serializable {
    */
   public String getComponentName() {
     return componentName;
+  }
+
+  /**
+   * Returns the unit used to interpret the target value.
+   *
+   * <p>
+   * Product-flow specifications created through the legacy constructors, including deserialized historical objects,
+   * use mol/hr. Duty specifications use W and fraction/ratio targets are dimensionless.
+   * </p>
+   *
+   * @return target unit, or an empty string for dimensionless specifications
+   */
+  public String getTargetUnit() {
+    return targetUnit == null ? defaultTargetUnit(type) : targetUnit;
   }
 
   /**
@@ -250,6 +306,9 @@ public class ColumnSpecification implements Serializable {
     sb.append("ColumnSpecification[type=").append(type);
     sb.append(", location=").append(location);
     sb.append(", target=").append(targetValue);
+    if (!getTargetUnit().isEmpty()) {
+      sb.append(" ").append(getTargetUnit());
+    }
     if (componentName != null) {
       sb.append(", component=").append(componentName);
     }

--- a/src/main/java/neqsim/process/equipment/distillation/ColumnSpecification.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ColumnSpecification.java
@@ -142,7 +142,8 @@ public class ColumnSpecification implements Serializable {
     this.location = location;
     this.targetValue = targetValue;
     this.componentName = componentName;
-    this.targetUnit = targetUnit;
+    this.targetUnit = type == SpecificationType.PRODUCT_FLOW_RATE && targetUnit != null ? targetUnit.trim()
+        : defaultTargetUnit(type);
     validate();
   }
 

--- a/src/main/java/neqsim/process/equipment/distillation/ColumnSpecification.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ColumnSpecification.java
@@ -136,8 +136,8 @@ public class ColumnSpecification implements Serializable {
    * @param componentName component name for component-based specifications, otherwise {@code null}
    * @param targetUnit unit for a product-flow target
    */
-  public ColumnSpecification(SpecificationType type, ProductLocation location, double targetValue,
-      String componentName, String targetUnit) {
+  public ColumnSpecification(SpecificationType type, ProductLocation location, double targetValue, String componentName,
+      String targetUnit) {
     this.type = type;
     this.location = location;
     this.targetValue = targetValue;
@@ -248,8 +248,8 @@ public class ColumnSpecification implements Serializable {
    * Returns the unit used to interpret the target value.
    *
    * <p>
-   * Product-flow specifications created through the legacy constructors, including deserialized historical objects,
-   * use mol/hr. Duty specifications use W and fraction/ratio targets are dimensionless.
+   * Product-flow specifications created through the legacy constructors, including deserialized historical objects, use
+   * mol/hr. Duty specifications use W and fraction/ratio targets are dimensionless.
    * </p>
    *
    * @return target unit, or an empty string for dimensionless specifications

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2731,7 +2731,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
     double target = startValue + boundedFraction * (specification.getTargetValue() - startValue);
     target = boundSpecificationTarget(specification, target);
     ColumnSpecification staged = new ColumnSpecification(specification.getType(), specification.getLocation(), target,
-        specification.getComponentName());
+        specification.getComponentName(), specification.getTargetUnit());
     staged.setTolerance(specification.getTolerance());
     staged.setMaxIterations(specification.getMaxIterations());
     return staged;
@@ -3280,6 +3280,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       signature = updateNaphtaliSandholmInputSignature(signature, topSpecification.getTolerance());
       signature = updateNaphtaliSandholmInputSignature(signature, topSpecification.getMaxIterations());
       signature = updateNaphtaliSandholmInputSignature(signature, topSpecification.getComponentName());
+      signature = updateNaphtaliSandholmInputSignature(signature, topSpecification.getTargetUnit());
     }
 
     signature = updateNaphtaliSandholmInputSignature(signature, bottomSpecification == null ? 0L : 1L);
@@ -3290,6 +3291,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       signature = updateNaphtaliSandholmInputSignature(signature, bottomSpecification.getTolerance());
       signature = updateNaphtaliSandholmInputSignature(signature, bottomSpecification.getMaxIterations());
       signature = updateNaphtaliSandholmInputSignature(signature, bottomSpecification.getComponentName());
+      signature = updateNaphtaliSandholmInputSignature(signature, bottomSpecification.getTargetUnit());
     }
 
     signature = updateColumnConfigurationSignature(signature);
@@ -4119,7 +4121,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       return recovery - spec.getTargetValue();
     }
     case PRODUCT_FLOW_RATE: {
-      double currentFlow = productStream.getFluid().getFlowRate("mol/hr");
+      double currentFlow = productStream.getFlowRate(spec.getTargetUnit());
       return currentFlow - spec.getTargetValue();
     }
     default:
@@ -9453,7 +9455,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   /**
    * Retrieve the latest top specification residual.
    *
-   * @return top specification residual as current value minus target value
+   * @return top specification residual as current value minus target value, in the specification target unit
    */
   public double getLastTopSpecificationResidual() {
     return lastTopSpecificationResidual;
@@ -9462,7 +9464,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   /**
    * Retrieve the latest bottom specification residual.
    *
-   * @return bottom specification residual as current value minus target value
+   * @return bottom specification residual as current value minus target value, in the specification target unit
    */
   public double getLastBottomSpecificationResidual() {
     return lastBottomSpecificationResidual;
@@ -13549,27 +13551,60 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @param result validation result receiving product-flow feasibility errors
    */
   private void validateProductFlowSpecificationsAgainstFeed(ValidationResult result) {
-    double totalFeedFlow = getTotalExternalFeedFlowMolPerHour();
+    validateProductFlowSpecificationAgainstFeed(result, topSpecification, "top");
+    validateProductFlowSpecificationAgainstFeed(result, bottomSpecification, "bottom");
+
+    if (!isProductFlowSpecification(topSpecification) || !isProductFlowSpecification(bottomSpecification)
+        || !topSpecification.getTargetUnit().equals(bottomSpecification.getTargetUnit())) {
+      return;
+    }
+    String unit = topSpecification.getTargetUnit();
+    double totalFeedFlow = getTotalExternalFeedFlow(unit);
     if (!Double.isFinite(totalFeedFlow) || totalFeedFlow <= 0.0) {
       return;
     }
-
-    double topProductFlowTarget = getProductFlowSpecificationTarget(topSpecification);
-    double bottomProductFlowTarget = getProductFlowSpecificationTarget(bottomSpecification);
-    if (topProductFlowTarget > totalFeedFlow * (1.0 + 1.0e-12)) {
-      result.addError("specification.productFlow", "Product-flow target for the top product exceeds total feed flow",
-          "Use a top product-flow target below the total feed flow or check the mol/hr units");
-    }
-    if (bottomProductFlowTarget > totalFeedFlow * (1.0 + 1.0e-12)) {
-      result.addError("specification.productFlow", "Product-flow target for the bottom product exceeds total feed flow",
-          "Use a bottom product-flow target below the total feed flow or check the mol/hr units");
-    }
-    double productFlowSum = positiveFiniteOrZero(topProductFlowTarget) + positiveFiniteOrZero(bottomProductFlowTarget);
+    double productFlowSum = topSpecification.getTargetValue() + bottomSpecification.getTargetValue();
     if (productFlowSum > totalFeedFlow * (1.0 + 1.0e-12)) {
       result.addError("specification.productFlow.sum", "Top and bottom product-flow targets exceed total feed flow",
-          "Reduce one product-flow target or replace one flow target with purity, "
-              + "recovery, duty, or reflux specification");
+          "Reduce one product-flow target or replace one flow target with purity, recovery, duty, or reflux "
+              + "specification; targets and feed were compared in " + unit);
     }
+  }
+
+  /**
+   * Validate one product-flow target against the external feed in the target's own unit.
+   *
+   * @param result validation result receiving errors
+   * @param specification specification to validate
+   * @param productName product-end label used in diagnostics
+   */
+  private void validateProductFlowSpecificationAgainstFeed(ValidationResult result,
+      ColumnSpecification specification, String productName) {
+    if (!isProductFlowSpecification(specification)) {
+      return;
+    }
+    String unit = specification.getTargetUnit();
+    double totalFeedFlow = getTotalExternalFeedFlow(unit);
+    if (!Double.isFinite(totalFeedFlow)) {
+      result.addError("specification.productFlow.unit", "Product-flow specification uses an unsupported unit: " + unit,
+          "Use a flow unit accepted by StreamInterface.getFlowRate, for example mol/hr or kg/hr");
+      return;
+    }
+    if (totalFeedFlow > 0.0 && specification.getTargetValue() > totalFeedFlow * (1.0 + 1.0e-12)) {
+      result.addError("specification.productFlow", "Product-flow target for the " + productName
+          + " product exceeds total feed flow in " + unit,
+          "Use a " + productName + " product-flow target below the total feed flow or check the supplied unit");
+    }
+  }
+
+  /**
+   * Check whether a specification controls total product flow.
+   *
+   * @param specification specification to inspect
+   * @return {@code true} for product-flow specifications
+   */
+  private boolean isProductFlowSpecification(ColumnSpecification specification) {
+    return specification != null && specification.getType() == ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE;
   }
 
   /**
@@ -13596,19 +13631,24 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   }
 
   /**
-   * Calculate total external feed flow in mol/hr.
+   * Calculate total external feed flow in a requested unit.
    *
-   * @return total molar feed flow in mol/hr
+   * @param unit flow-rate unit
+   * @return total feed flow, or {@link Double#NaN} when the unit is unsupported
    */
-  private double getTotalExternalFeedFlowMolPerHour() {
+  private double getTotalExternalFeedFlow(String unit) {
     double totalFeedFlow = 0.0;
     for (StreamInterface feed : getAllExternalFeedStreams()) {
       if (feed == null) {
         continue;
       }
-      double flow = feed.getFlowRate("mol/hr");
-      if (Double.isFinite(flow)) {
-        totalFeedFlow += Math.abs(flow);
+      try {
+        double flow = feed.getFlowRate(unit);
+        if (Double.isFinite(flow)) {
+          totalFeedFlow += Math.abs(flow);
+        }
+      } catch (RuntimeException exception) {
+        return Double.NaN;
       }
     }
     return totalFeedFlow;
@@ -14388,11 +14428,11 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * Convenience method to specify a target molar flow rate for the top product.
    *
    * @param flowRate the desired flow rate value
-   * @param unit the flow rate unit (currently expected as {@code mol/hr})
+   * @param unit the flow-rate unit used for the target and residual
    */
   public void setTopProductFlowRate(double flowRate, String unit) {
     this.topSpecification = new ColumnSpecification(ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE,
-        ColumnSpecification.ProductLocation.TOP, flowRate);
+        ColumnSpecification.ProductLocation.TOP, flowRate, null, unit);
   }
 
   /**
@@ -14402,10 +14442,8 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @param unit the flow rate unit (e.g. "mol/hr")
    */
   public void setBottomProductFlowRate(double flowRate, String unit) {
-    // Store the specification in mol/hr (the column evaluator uses mol/hr
-    // internally)
     this.bottomSpecification = new ColumnSpecification(ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE,
-        ColumnSpecification.ProductLocation.BOTTOM, flowRate);
+        ColumnSpecification.ProductLocation.BOTTOM, flowRate, null, unit);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -9705,6 +9705,14 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       diagnostics.append("    linear solve time: ").append(lastNaphtaliLinearSolveTimeSeconds).append(" s\n");
     }
     diagnostics.append("  Residuals:\n");
+    if (topSpecification != null) {
+      diagnostics.append("    top specification: ").append(topSpecification).append(", residual ")
+          .append(lastTopSpecificationResidual).append(" ").append(topSpecification.getTargetUnit()).append("\n");
+    }
+    if (bottomSpecification != null) {
+      diagnostics.append("    bottom specification: ").append(bottomSpecification).append(", residual ")
+          .append(lastBottomSpecificationResidual).append(" ").append(bottomSpecification.getTargetUnit()).append("\n");
+    }
     diagnostics.append("    temperature: ").append(lastTemperatureResidual).append(" K (tolerance ")
         .append(getEffectiveTemperatureTolerance()).append(")\n");
     diagnostics.append("    applied temperature step: ").append(lastAppliedTemperatureStepResidual).append(" K\n");
@@ -13605,29 +13613,6 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    */
   private boolean isProductFlowSpecification(ColumnSpecification specification) {
     return specification != null && specification.getType() == ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE;
-  }
-
-  /**
-   * Get the target value for a product-flow specification.
-   *
-   * @param specification column specification to inspect
-   * @return product-flow target in mol/hr, or {@link Double#NaN} when the specification is not a product-flow target
-   */
-  private double getProductFlowSpecificationTarget(ColumnSpecification specification) {
-    if (specification == null || specification.getType() != ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE) {
-      return Double.NaN;
-    }
-    return specification.getTargetValue();
-  }
-
-  /**
-   * Return a finite positive value, otherwise zero.
-   *
-   * @param value value to screen
-   * @return {@code value} when finite and positive, otherwise zero
-   */
-  private double positiveFiniteOrZero(double value) {
-    return Double.isFinite(value) && value > 0.0 ? value : 0.0;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -13586,8 +13586,8 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @param specification specification to validate
    * @param productName product-end label used in diagnostics
    */
-  private void validateProductFlowSpecificationAgainstFeed(ValidationResult result,
-      ColumnSpecification specification, String productName) {
+  private void validateProductFlowSpecificationAgainstFeed(ValidationResult result, ColumnSpecification specification,
+      String productName) {
     if (!isProductFlowSpecification(specification)) {
       return;
     }
@@ -13599,8 +13599,8 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
       return;
     }
     if (totalFeedFlow > 0.0 && specification.getTargetValue() > totalFeedFlow * (1.0 + 1.0e-12)) {
-      result.addError("specification.productFlow", "Product-flow target for the " + productName
-          + " product exceeds total feed flow in " + unit,
+      result.addError("specification.productFlow",
+          "Product-flow target for the " + productName + " product exceeds total feed flow in " + unit,
           "Use a " + productName + " product-flow target below the total feed flow or check the supplied unit");
     }
   }

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
@@ -43,6 +43,17 @@ public class ColumnSpecificationTest {
         ColumnSpecification.ProductLocation.TOP, 3.0);
     assertEquals(3.0, refluxSpec.getTargetValue(), 1e-10);
 
+    ColumnSpecification legacyFlowSpec = new ColumnSpecification(
+        ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE, ColumnSpecification.ProductLocation.TOP, 25.0);
+    assertEquals("mol/hr", legacyFlowSpec.getTargetUnit());
+    ColumnSpecification massFlowSpec = new ColumnSpecification(
+        ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE, ColumnSpecification.ProductLocation.BOTTOM, 25.0,
+        null, "kg/hr");
+    assertEquals("kg/hr", massFlowSpec.getTargetUnit());
+    assertThrows(IllegalArgumentException.class,
+        () -> new ColumnSpecification(ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE,
+            ColumnSpecification.ProductLocation.TOP, 25.0, null, ""));
+
     // Purity spec without component name should throw
     assertThrows(IllegalArgumentException.class,
         () -> new ColumnSpecification(ColumnSpecification.SpecificationType.PRODUCT_PURITY,
@@ -182,8 +193,9 @@ public class ColumnSpecificationTest {
     assertEquals(ColumnSpecification.SpecificationType.COMPONENT_RECOVERY, column.getTopSpecification().getType());
 
     // Test product flow rate convenience
-    column.setBottomProductFlowRate(50.0, "mol/hr");
+    column.setBottomProductFlowRate(50.0, "kg/hr");
     assertEquals(ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE, column.getBottomSpecification().getType());
+    assertEquals("kg/hr", column.getBottomSpecification().getTargetUnit());
   }
 
   /**
@@ -279,6 +291,33 @@ public class ColumnSpecificationTest {
   }
 
   /**
+   * Test that product-flow feasibility screening uses the supplied mass-flow unit.
+   */
+  @Test
+  public void validateSpecificationsUsesProductFlowTargetUnit() {
+    SystemSrkEos testSystem = new SystemSrkEos(273.15 + 25.0, 15.0);
+    testSystem.addComponent("methane", 0.60);
+    testSystem.addComponent("ethane", 0.20);
+    testSystem.addComponent("propane", 0.10);
+    testSystem.addComponent("n-butane", 0.07);
+    testSystem.addComponent("n-pentane", 0.03);
+    testSystem.setMixingRule("classic");
+
+    Stream feed = new Stream("mass flow validation feed", testSystem);
+    feed.setFlowRate(100.0, "kg/hr");
+
+    DistillationColumn column = new DistillationColumn("MassFlowValidationColumn", 6, true, true);
+    column.addFeedStream(feed, 3);
+    column.setBottomProductFlowRate(150.0, "kg/hr");
+
+    ValidationResult result = column.validateSpecifications();
+
+    assertEquals("kg/hr", column.getBottomSpecification().getTargetUnit());
+    assertFalse(result.isValid());
+    assertTrue(result.getReport().contains("exceeds total feed flow in kg/hr"));
+  }
+
+  /**
    * Test that paired top and bottom flow specifications cannot exceed total feed flow.
    */
   @Test
@@ -300,6 +339,93 @@ public class ColumnSpecificationTest {
 
     assertFalse(result.isValid());
     assertTrue(result.getReport().contains("Top and bottom product-flow targets"));
+  }
+
+  /**
+   * Test mass-unit product-flow control, conservation, physical bounds, repeatability, and an equivalent molar target.
+   */
+  @Test
+  public void multicomponentProductFlowSpecificationHonorsMassUnit() {
+    SystemSrkEos testSystem = new SystemSrkEos(273.15 + 45.0, 10.0);
+    testSystem.addComponent("methane", 0.05);
+    testSystem.addComponent("ethane", 0.15);
+    testSystem.addComponent("propane", 0.35);
+    testSystem.addComponent("n-butane", 0.30);
+    testSystem.addComponent("n-pentane", 0.15);
+    testSystem.setMixingRule("classic");
+
+    Stream feed = new Stream("unit aware flow feed", testSystem);
+    feed.setFlowRate(250.0, "kg/hr");
+    feed.run();
+
+    DistillationColumn column = new DistillationColumn("UnitAwareFlowColumn", 7, true, true);
+    column.addFeedStream(feed, 3);
+    column.setTopPressure(10.0);
+    column.setBottomPressure(10.5);
+    column.getCondenser().setOutTemperature(273.15 + 15.0);
+    column.getReboiler().setOutTemperature(273.15 + 85.0);
+    column.setTemperatureTolerance(5.0e-2);
+    column.setMassBalanceTolerance(5.0e-2);
+    column.setEnthalpyBalanceTolerance(5.0e-2);
+    column.setMaxNumberOfIterations(80);
+
+    column.run();
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    double targetKgPerHour = column.getGasOutStream().getFlowRate("kg/hr");
+    double equivalentMolPerHour = column.getGasOutStream().getFlowRate("mol/hr");
+    assertTrue(targetKgPerHour > 0.0 && targetKgPerHour < feed.getFlowRate("kg/hr"));
+
+    column.setTopProductFlowRate(targetKgPerHour, "kg/hr");
+    column.getTopSpecification().setTolerance(Math.max(1.0e-4, targetKgPerHour * 1.0e-4));
+    column.getTopSpecification().setMaxIterations(8);
+    column.run();
+
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertEquals("kg/hr", column.getTopSpecification().getTargetUnit());
+    assertEquals(targetKgPerHour, column.getGasOutStream().getFlowRate("kg/hr"),
+        column.getTopSpecification().getTolerance());
+    assertTrue(Math.abs(column.getLastTopSpecificationResidual()) <= column.getTopSpecification().getTolerance());
+    assertColumnFlowSpecificationBalances(column, feed);
+
+    double repeatedKgPerHour = column.getGasOutStream().getFlowRate("kg/hr");
+    column.run();
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertEquals(repeatedKgPerHour, column.getGasOutStream().getFlowRate("kg/hr"),
+        Math.max(1.0e-6, repeatedKgPerHour * 1.0e-6));
+
+    column.setTopProductFlowRate(equivalentMolPerHour, "mol/hr");
+    column.getTopSpecification().setTolerance(Math.max(1.0e-3, equivalentMolPerHour * 1.0e-4));
+    column.getTopSpecification().setMaxIterations(8);
+    column.run();
+
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertEquals(equivalentMolPerHour, column.getGasOutStream().getFlowRate("mol/hr"),
+        column.getTopSpecification().getTolerance());
+    assertColumnFlowSpecificationBalances(column, feed);
+  }
+
+  /**
+   * Assert engineering balances and physical product bounds for the unit-aware flow regression.
+   *
+   * @param column solved column
+   * @param feed external feed
+   */
+  private void assertColumnFlowSpecificationBalances(DistillationColumn column, Stream feed) {
+    double feedFlow = feed.getFlowRate("kg/hr");
+    assertTrue(Math.abs(column.getMassBalance("kg/hr")) <= feedFlow * column.getMassBalanceTolerance());
+    assertTrue(column.getLastEnergyResidual() <= column.getEnthalpyBalanceTolerance());
+    assertTrue(column.getGasOutStream().getFlowRate("kg/hr") >= 0.0);
+    assertTrue(column.getLiquidOutStream().getFlowRate("kg/hr") >= 0.0);
+    assertTrue(column.getGasOutStream().getTemperature("K") > 0.0);
+    assertTrue(column.getLiquidOutStream().getTemperature("K") > 0.0);
+    for (String componentName : feed.getFluid().getComponentNames()) {
+      double feedComponentFlow = feed.getFluid().getComponent(componentName).getTotalFlowRate("mol/hr");
+      double productComponentFlow = column.getGasOutStream().getFluid().getComponent(componentName)
+          .getTotalFlowRate("mol/hr") + column.getLiquidOutStream().getFluid().getComponent(componentName)
+              .getTotalFlowRate("mol/hr");
+      assertEquals(feedComponentFlow, productComponentFlow, Math.max(1.0e-8, feedComponentFlow * 5.0e-2),
+          componentName);
+    }
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
@@ -421,7 +421,7 @@ public class ColumnSpecificationTest {
     column.run();
     assertTrue(column.solved(), column.getConvergenceDiagnostics());
     assertEquals(repeatedKgPerHour, column.getGasOutStream().getFlowRate("kg/hr"),
-        Math.max(1.0e-6, repeatedKgPerHour * 1.0e-6));
+        column.getTopSpecification().getTolerance());
 
     column.setTopProductFlowRate(equivalentMolPerHour, "mol/hr");
     column.getTopSpecification().setTolerance(Math.max(1.0e-3, equivalentMolPerHour * 1.0e-4));

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
@@ -6,6 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Disabled;
@@ -101,6 +105,33 @@ public class ColumnSpecificationTest {
     long bbSignature = ((Long) signatureMethod.invoke(column)).longValue();
 
     assertNotEquals(aaSignature, bbSignature, "warm-state signatures must retain full component-name content");
+  }
+
+  /**
+   * Test that an explicit product-flow unit survives Java serialization.
+   *
+   * @throws Exception if serialization fails
+   */
+  @Test
+  public void productFlowTargetUnitSurvivesSerialization() throws Exception {
+    ColumnSpecification original = new ColumnSpecification(ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE,
+        ColumnSpecification.ProductLocation.TOP, 125.0, null, "kg/hr");
+    original.setTolerance(0.01);
+    original.setMaxIterations(12);
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(original);
+    }
+    ColumnSpecification restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored = (ColumnSpecification) input.readObject();
+    }
+
+    assertEquals("kg/hr", restored.getTargetUnit());
+    assertEquals(125.0, restored.getTargetValue(), 0.0);
+    assertEquals(0.01, restored.getTolerance(), 0.0);
+    assertEquals(12, restored.getMaxIterations());
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
@@ -50,9 +50,8 @@ public class ColumnSpecificationTest {
     ColumnSpecification legacyFlowSpec = new ColumnSpecification(
         ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE, ColumnSpecification.ProductLocation.TOP, 25.0);
     assertEquals("mol/hr", legacyFlowSpec.getTargetUnit());
-    ColumnSpecification massFlowSpec = new ColumnSpecification(
-        ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE, ColumnSpecification.ProductLocation.BOTTOM, 25.0,
-        null, "kg/hr");
+    ColumnSpecification massFlowSpec = new ColumnSpecification(ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE,
+        ColumnSpecification.ProductLocation.BOTTOM, 25.0, null, "kg/hr");
     assertEquals("kg/hr", massFlowSpec.getTargetUnit());
     assertThrows(IllegalArgumentException.class,
         () -> new ColumnSpecification(ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE,
@@ -451,9 +450,8 @@ public class ColumnSpecificationTest {
     assertTrue(column.getLiquidOutStream().getTemperature("K") > 0.0);
     for (String componentName : feed.getFluid().getComponentNames()) {
       double feedComponentFlow = feed.getFluid().getComponent(componentName).getTotalFlowRate("mol/hr");
-      double productComponentFlow = column.getGasOutStream().getFluid().getComponent(componentName)
-          .getTotalFlowRate("mol/hr") + column.getLiquidOutStream().getFluid().getComponent(componentName)
-              .getTotalFlowRate("mol/hr");
+      double productComponentFlow = column.getGasOutStream().getFluid().getComponent(componentName).getTotalFlowRate(
+          "mol/hr") + column.getLiquidOutStream().getFluid().getComponent(componentName).getTotalFlowRate("mol/hr");
       assertEquals(feedComponentFlow, productComponentFlow, Math.max(1.0e-8, feedComponentFlow * 5.0e-2),
           componentName);
     }


### PR DESCRIPTION
## Roadmap

Advances #2936 C1 specification integrity after merged #3002 completed the pumparound utility-duty/accounting foundation.

## Problem and current-master reproduction

Exact base: `c4f557b2e03cb9a3feb7ca9c7d830b6b8f5480e2`.

`setTopProductFlowRate(value, unit)` and `setBottomProductFlowRate(value, unit)` accepted a flow unit but discarded it. Both stored the raw number as a legacy `ColumnSpecification` and every residual, homotopy target, feasibility comparison, and diagnostic interpreted that number as mol/hr.

The deterministic reproduction uses a five-component SRK feed at 100 kg/hr and requests a 150 kg/hr bottoms flow. Before this change the validator compares 150 mol/hr with the feed molar flow and accepts the physically impossible target; the supplied kg/hr unit has no effect.

## Coherent change

- retain an explicit target unit in serializable `ColumnSpecification`;
- keep existing constructors backward compatible with mol/hr product-flow targets;
- make the public top/bottom flow setters store the supplied unit;
- evaluate product flow and absolute specification residual in that unit;
- preserve unit identity through staged homotopy and Naphtali–Sandholm input fingerprints;
- screen each target against total external feed in the same unit and screen paired targets when their units match;
- report active target and residual units in convergence diagnostics;
- canonicalize unit text while retaining historical serialized-object fallback to mol/hr.

No thermodynamic equation, solver tolerance, acceptance gate, TPflash path, generic process execution, or terminal split equation changes.

## Regression and engineering evidence

Focused tests add:

- five-component 100 kg/hr feasibility reproduction that rejects a 150 kg/hr product target;
- legacy-constructor mol/hr compatibility and explicit-unit validation;
- Java serialization round trip for target value, unit, tolerance, and iteration limit;
- realistic seven-stage five-component SRK fractionator;
- baseline-derived kg/hr flow target and a unit-equivalent mol/hr target;
- specification satisfaction and explicit residual-unit assertions;
- total and per-component material closure;
- energy residual and positive temperature/flow bounds;
- unchanged-run repeatability.

No wall-clock assertion is used.

## Compatibility and risk

- additive five-argument constructor and `getTargetUnit()`;
- unchanged three/four-argument constructors default product flow to mol/hr;
- same serialization UID; historical objects with no stored unit resolve to mol/hr;
- existing mol/hr setters retain their numerical behavior;
- intentional correction: non-molar setter units now control the requested physical quantity;
- paired different-unit flow targets are each screened against feed and then qualified by the solve; their raw numbers are not incorrectly summed.

## Documentation impact

Updated `docs/process/equipment/distillation.md` with unit semantics, constructor/setter examples, residual units, homotopy/identity behavior, feasibility screening, and mixed-unit limitation. No notebook changed.

## Validation

**READY TO MERGE** on exact head `dbcf9d814d1fabfba97144db2a1e9c3e06873a4d`.

The runtime has no local NeqSim checkout, so local Maven/JUnit, Spotless, pre-commit/pre-push, documentation search, and Javadocs are not claimed. Hosted exact-head GitHub CI is the validation evidence.

Current exact head: `dbcf9d814d1fabfba97144db2a1e9c3e06873a4d`. The initial hosted Spotless artifact contained formatting-only changes in three Java files. Its exact target blobs (`f9f6200`, `a3e0df7`, and `dd4d280`) were inspected and applied byte-for-byte through the connector; no production or test behavior changed. Slow-test shard 4 then showed that the new unchanged-run assertion used a 0.000102 kg/hr repeatability tolerance, tighter than the configured 0.01018 kg/hr column-specification acceptance tolerance; the repeat solve shifted 0.00627 kg/hr while remaining accepted. The focused fixture now evaluates repeatability against that existing specification tolerance. Production equations, solver settings, and acceptance tolerances are unchanged. The corrected regression passed on the exact head.

Exact-head GitHub CI passed:

- Java 8 tests on Ubuntu and Windows;
- Java 21 fast tests on Ubuntu and Windows;
- all four Java 21 slow-test shards on Ubuntu;
- Java 21 Javadocs;
- CodeQL security analysis;
- Spotless format patch;
- pre-commit checks;
- documentation-search coverage;
- PaperLab replication gate;
- agent-skill cross-reference validation.

The PR is mergeable without conflicts. The final four-file diff remains limited to the specification model, column implementation, focused regression, and adjacent documentation. There are no human or Copilot reviews, comments, requested changes, or unresolved review threads.

Current connector comparison: eleven commits ahead, zero behind; exactly four intended files—specification model, column implementation, focused regression, and adjacent documentation.

Closes no issue; #2936 remains the campaign roadmap.