### PR TITLE
fix(flash): preserve accepted root on cubic tie

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1998,8 +1998,8 @@ public class TPflash extends Flash {
    *
    * <p>
    * If retained cubic-root history makes both trial types reproduce the same compressibility factor, the candidate's
-   * declared gas/liquid class breaks the numerical tie. Otherwise iteration order could replace an accepted liquid
-   * root with a gas root during state transfer.
+   * declared gas/liquid class breaks the numerical tie. Otherwise iteration order could replace an accepted liquid root
+   * with a gas root during state transfer.
    * </p>
    *
    * @param source converged candidate system

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1996,12 +1996,19 @@ public class TPflash extends Flash {
   /**
    * Infers the cubic root that reproduces a converged phase's compressibility factor.
    *
+   * <p>
+   * If retained cubic-root history makes both trial types reproduce the same compressibility factor, the candidate's
+   * declared gas/liquid class breaks the numerical tie. Otherwise iteration order could replace an accepted liquid
+   * root with a gas root during state transfer.
+   * </p>
+   *
    * @param source converged candidate system
    * @param phaseIndex active phase index
    * @return gas-like or liquid-like cubic root closest to the converged phase
    */
   private PhaseType inferSelectedCubicRoot(SystemInterface source, int phaseIndex) {
     PhaseType selectedRoot = source.getPhase(phaseIndex).getType();
+    PhaseType declaredRoot = selectedRoot == PhaseType.GAS ? PhaseType.GAS : PhaseType.LIQUID;
     double selectedDifference = Double.POSITIVE_INFINITY;
     for (PhaseType trialRoot : CUBIC_ROOT_PHASE_TYPES) {
       try {
@@ -2009,7 +2016,10 @@ public class TPflash extends Flash {
         trialPhase.init(source.getTotalNumberOfMoles(), trialPhase.getNumberOfComponents(), 1, trialRoot,
             source.getBeta(phaseIndex));
         double difference = Math.abs(trialPhase.getZ() - source.getPhase(phaseIndex).getZ());
-        if (Double.isFinite(difference) && difference < selectedDifference) {
+        boolean tiedDeclaredRoot = Double.isFinite(difference) && Double.isFinite(selectedDifference)
+            && Math.abs(difference - selectedDifference) <= UNCHANGED_SINGLE_PHASE_STATE_TOLERANCE
+            && trialRoot == declaredRoot;
+        if (Double.isFinite(difference) && (difference < selectedDifference || tiedDeclaredRoot)) {
           selectedDifference = difference;
           selectedRoot = trialRoot;
         }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashSourGasConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashSourGasConsistencyTest.java
@@ -55,6 +55,36 @@ class TPflashSourGasConsistencyTest {
     assertEquivalent(repeatedReference, ordinary, 1.0e-10, "repeated boundary flash");
   }
 
+  @Test
+  void ordinaryLiquidLiquidBoundaryRetainsAcceptedCandidateRoot() {
+    SystemInterface ordinary = flash(225.0, 95.81, false, false);
+    SystemInterface multiphase = flash(225.0, 95.81, true, false);
+
+    assertEquals(2, ordinary.getNumberOfPhases());
+    assertEquivalent(multiphase, ordinary, 1.0e-10, "liquid-liquid root boundary");
+    assertEquals(3877.865927361861, ordinary.getGibbsEnergy(), 1.0e-6);
+    assertEquals(0.572813112145268, ordinary.getBeta(phaseOrder(ordinary)[0]), 1.0e-10);
+
+    double[][] nearbyConditions = { { 220.0, 95.81 }, { 225.0, 100.80 }, { 230.0, 95.81 } };
+    for (double[] condition : nearbyConditions) {
+      SystemInterface nearbyOrdinary = flash(condition[0], condition[1], false, false);
+      SystemInterface nearbyMultiphase = flash(condition[0], condition[1], true, false);
+      assertEquivalent(nearbyMultiphase, nearbyOrdinary, 2.0e-6,
+          "near liquid-liquid root boundary T=" + condition[0] + " K, P=" + condition[1] + " bara");
+    }
+
+    SystemInterface changedState = flash(225.0, 90.82, false, false);
+    changedState.setPressure(95.81, "bara");
+    new ThermodynamicOperations(changedState).TPflash();
+    changedState.init(1);
+    assertEquivalent(multiphase, changedState, 5.0e-6, "changed pressure at liquid-liquid root boundary");
+
+    SystemInterface repeatedReference = changedState.clone();
+    new ThermodynamicOperations(changedState).TPflash();
+    changedState.init(1);
+    assertEquivalent(repeatedReference, changedState, 1.0e-10, "repeated changed-state liquid-liquid boundary");
+  }
+
   private SystemInterface flash(double temperature, double pressure, boolean multiphase, boolean enhanced) {
     SystemInterface system = new SystemPrEos(temperature, pressure);
     for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {


### PR DESCRIPTION
## Problem

Advances #2937 after merged #3006.

On exact master `c4f557b2e03cb9a3feb7ca9c7d830b6b8f5480e2`, the public methane/CO2/H2S feed (49.88/9.87/40.22 mol%) with PR EOS and classic mixing at 225 K and 95.81 bara reaches inconsistent two-phase endpoints:

- ordinary TPflash: GAS+OIL, Gibbs 4432.027120977371 J, maximum log-fugacity residual 1.1275360745622436;
- multiphase TPflash: OIL+OIL, Gibbs 3877.865927361861 J, maximum component-balance residual 2.42e-11 and maximum log-fugacity residual 9.52e-9.

The multiphase endpoint is feasible, equilibrated, and 554.161193615510 J lower in Gibbs energy. This is a confirmed selected-root defect, not a phase-label-only difference.

## Root cause

The existing reciprocal fallback correctly finds and accepts the lower-Gibbs liquid-liquid candidate. During state transfer, `inferSelectedCubicRoot` reinitializes gas and liquid trial types and selects the trial with the closest Z.

For the candidate's light liquid phase (declared OIL, Z 0.2367946496793673), retained cubic-root history makes both GAS and LIQUID trial initialization reproduce exactly the same Z (difference 0.0). Because GAS is evaluated first, the old strict-less-than comparison retains GAS. Final initialization then moves that phase to the high-Z gas root (Z 0.987973648115954) and destroys fugacity equality.

## Method

When gas and liquid root trials reproduce the accepted candidate Z within the existing `1e-11` unchanged-state tolerance, the candidate's declared gas/liquid class now breaks the tie. Unambiguous closest-root selection is unchanged.

This is consistent with the existing Michelsen-style workflow: the reciprocal candidate is already accepted only after topology, phase-fraction, composition, material-balance, fugacity, and lower-Gibbs gates. The tie-break preserves that accepted equilibrium instead of allowing trial iteration order to replace it. See [Michelsen Part I](https://doi.org/10.1016/0378-3812(82)85001-2) and [Part II](https://doi.org/10.1016/0378-3812(82)85002-4).

No tolerance, stability screen, phase-split equation, or fallback trigger changes.

## Frozen regression and tolerances

The focused regression requires:

- exact topology and ordinary/multiphase state agreement at 225 K/95.81 bara: `1e-10`;
- Gibbs energy: 3877.865927361861 J ± `1e-6` J;
- light-phase beta: 0.572813112145268 ± `1e-10`;
- component material balance: existing `1e-10` gate;
- maximum interphase log-fugacity residual: existing `1e-8` gate;
- nearby 220 K/95.81, 225 K/100.80, and 230 K/95.81 states: `2e-6` cross-algorithm agreement;
- changed pressure on the same object (225 K, 90.82 → 95.81 bara): `5e-6` agreement;
- exact repeat after the changed-state solve: `1e-10`.

## Before/after evidence

- Baseline focused regression: FAIL, ordinary maximum log-fugacity residual 1.1275360745622436.
- Candidate focused class: PASS, 4/4 methods.
- Frozen 100–500 K × 1–500 bara map (81 × 101 = 8,181 fresh states):
  - genuine multiphase three-phase cells: 824 (unchanged);
  - applicable one-/two-phase cells: 7,357;
  - phase-class agreement: 7,356/7,357 → **7,357/7,357**;
  - invalid ordinary endpoints: 15 → 4;
  - invalid multiphase endpoints: 0 → 0;
  - maximum observed component-balance residual: 4.34e-11.
- The four remaining invalid ordinary endpoints are the previously identified ordinary projections inside the genuine three-phase domain; a maximum-two-phase flash cannot reproduce that three-phase state.

Fresh corrected endpoint:

- ordinary/multiphase OIL+OIL;
- beta 0.572813112145268 / 0.427186887854732;
- Z 0.236794649679367 / 0.201463822358399;
- maximum balance residual 2.42e-11;
- maximum log-fugacity residual 9.52e-9.

Source-mode timing medians (11 × 100 fresh target flashes, warmed JVM):

- baseline: 18.106 ms/flash;
- candidate: 18.336 ms/flash (+1.27%).

This change claims correctness, not speed; the timing difference is treated as measurement noise. Common paths do not call the changed helper unless a strictly screened reciprocal candidate has already been accepted.

## Validation

**VALIDATION COMPLETE — exact-head hosted CI passed before merge.**

Completed locally against the exact GitHub source plus the available NeqSim runtime classpath:

- current `TPflash.java` source compilation: PASS;
- baseline focused new regression: expected FAIL with residual 1.1275360745622436;
- candidate `TPflashSourGasConsistencyTest`: PASS (4/4);
- exact 8,181-state frozen sour-gas map: PASS, no exception;
- deterministic nearby and changed-state probe: PASS;
- final connector comparison: two commits ahead, zero behind; exactly two intended files (+41/-1).
- exact current head: `5ee060f7190b22b0d3378b5c8c744a8d8504e17c`.
- first-head pre-commit failed only on a Spotless Javadoc wrap; the hosted formatter delta was inspected and applied byte-for-byte in the second commit.
- current-head Spotless, pre-commit/documentation search, PaperLab, and CodeQL workflows: PASS.
- current-head build/test/Javadocs workflow: PASS, including Java 21 Ubuntu/Windows fast suites, all four Java 21 slow shards, Java 8 Ubuntu/Windows suites, and Javadocs.
- reviews and inline review threads: none.
- merged to current `master` as `dc3d907586a895dbac15db85643f4496be1645e9`.

Not run locally because this environment has no exact full writable repository checkout with resolved Maven:

- `python devtools/run_spotless.py apply`;
- `python devtools/run_spotless.py check`;
- `python devtools/check_documentation_search.py`;
- pre-commit/pre-push;
- full Maven test matrix and Javadocs.

Hosted exact-head CI supplied the unavailable full-repository validation before merge. No unrun local check is claimed as passed.

## Compatibility and risk

The change is private to an already-screened TPflash state-transfer helper. There is no public API, serialization, configuration, unit, model-default, global tolerance, or equation change. The declared phase class is used only as a numerical tie-break when root trials are indistinguishable within an existing tolerance; unambiguous root selection is unchanged.

## Documentation impact

Documentation impact: none. This is a private numerical tie-break with updated private-method Javadocs. It changes no public option, input, output contract, unit, workflow, or recommended usage; the reproduced behavior, numerical basis, validation, and limitations are documented here and in #2937.