### PR TITLE
docs: repair ISO 15403 CNG quality guide

### DIFF
--- a/docs/standards/iso15403_cng_quality.md
+++ b/docs/standards/iso15403_cng_quality.md
@@ -1,229 +1,133 @@
 ---
 title: "ISO 15403 - CNG Quality"
-description: "ISO 15403 specifies requirements for natural gas used as compressed fuel for vehicles (CNG)."
+description: "Calculate the NeqSim ISO 15403 motor octane and methane-number correlation, with its supported composition and compliance boundaries."
 ---
 
-# ISO 15403 - CNG Quality
+NeqSim's `Standard_ISO15403` class calculates a motor octane number (MON) and a
+methane-number result for compressed-natural-gas compositions. The class is a
+calculation helper; it does not perform a complete conformity assessment against
+[ISO 15403-1:2006](https://www.iso.org/standard/44211.html).
 
-ISO 15403 specifies requirements for natural gas used as compressed fuel for vehicles (CNG).
+## Implemented correlation
 
-## Table of Contents
-- [Overview](#overview)
-- [Calculated Parameters](#calculated-parameters)
-- [Implementation](#implementation)
-- [Usage Examples](#usage-examples)
-- [Methane Number Concepts](#methane-number-concepts)
+The current implementation evaluates
 
----
+$$MON=137.78x_{CH_4}+29.948x_{C_2H_6}-18.193x_{C_3H_8}-167.062(x_{nC_4}+x_{iC_4})+181.233x_{CO_2}+26.944x_{N_2}$$
 
-## Overview
+and then
 
-**Standard:** ISO 15403-1:2006 - Natural gas — Natural gas for use as a compressed fuel for vehicles
+$$NM=1.445MON-103.42$$
 
-**Purpose:** Assess natural gas quality for use in vehicle engines by calculating:
-- Motor Octane Number (MON)
-- Methane Number (MN)
+where each $x_i$ is the overall mole fraction stored by the thermodynamic
+system. Call `calculate()` before reading a result. The supported result keys
+are `"MON"` and `"NM"`; the usual methane-number abbreviation is not an
+accepted getter key.
 
-**Class:** `Standard_ISO15403`
+The six terms above are the complete component coverage of the current class.
+Hydrogen, C5+ hydrocarbons, and other unlisted components contribute zero to
+the implemented sum, so mixtures containing material amounts of those
+components require a method whose validity range covers them.
 
----
+Pure methane is a useful implementation anchor, not a definition of the
+methane-number scale: this correlation returns MON = 137.78 and NM = 95.6721.
+A hydrogen-only system would produce NM = -103.42 because hydrogen has no term;
+that extrapolation is outside the implemented component coverage and must not
+be interpreted as a hydrogen-fuel rating.
 
-## Calculated Parameters
+## Complete Java example
 
-### Motor Octane Number (MON)
-
-MON indicates knock resistance. Calculated from gas composition:
-
-$$MON = 137.78 \cdot x_{CH_4} + 29.948 \cdot x_{C_2H_6} - 18.193 \cdot x_{C_3H_8} - 167.062 \cdot (x_{nC_4} + x_{iC_4}) + 181.233 \cdot x_{CO_2} + 26.944 \cdot x_{N_2}$$
-
-where $x_i$ is the mole fraction of component i.
-
-### Methane Number (MN)
-
-MN is derived from MON:
-
-$$MN = 1.445 \cdot MON - 103.42$$
-
-**Interpretation:**
-- MN = 100: Pure methane
-- MN = 0: Pure hydrogen
-- Higher MN = better knock resistance
-
----
-
-## Implementation
-
-### Constructor
+This example keeps every case on the same one-mole composition basis. The
+sensitivity cases replace two mole percentage points of methane with either
+carbon dioxide or nitrogen instead of adding material to an existing system.
 
 ```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.standards.gasquality.Standard_ISO15403;
-
-// Create from gas composition
-Standard_ISO15403 iso15403 = new Standard_ISO15403(thermoSystem);
-```
-
-### Key Methods
-
-| Method | Description |
-|--------|-------------|
-| `calculate()` | Calculate MON and MN |
-| `getValue("MON")` | Get Motor Octane Number |
-| `getValue("MN")` | Get Methane Number |
-
----
-
-## Usage Examples
-
-### Basic Calculation
-
-```java
+import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
-import neqsim.standards.gasquality.Standard_ISO15403;
 
-// CNG composition
-SystemInterface cng = new SystemSrkEos(273.15 + 15, 200.0);
-cng.addComponent("methane", 0.92);
-cng.addComponent("ethane", 0.04);
-cng.addComponent("propane", 0.01);
-cng.addComponent("n-butane", 0.002);
-cng.addComponent("i-butane", 0.003);
-cng.addComponent("CO2", 0.015);
-cng.addComponent("nitrogen", 0.01);
-cng.setMixingRule("classic");
+public final class Iso15403Example {
+  private static final Logger logger = LogManager.getLogger(Iso15403Example.class);
 
-// Calculate methane number
-Standard_ISO15403 iso15403 = new Standard_ISO15403(cng);
-iso15403.calculate();
+  private Iso15403Example() {}
 
-double mon = iso15403.getValue("MON");
-double mn = iso15403.getValue("MN");
+  public static void main(String[] args) {
+    Standard_ISO15403 base = new Standard_ISO15403(createCng(0.92, 0.01, 0.01));
+    base.calculate();
+    double baseMon = base.getValue("MON");
+    double baseNm = base.getValue("NM");
 
-System.out.printf("Motor Octane Number (MON) = %.1f%n", mon);
-System.out.printf("Methane Number (MN) = %.1f%n", mn);
-```
+    Standard_ISO15403 carbonDioxideCase =
+        new Standard_ISO15403(createCng(0.90, 0.03, 0.01));
+    carbonDioxideCase.calculate();
+    double carbonDioxideNm = carbonDioxideCase.getValue("NM");
 
-### Effect of Composition on Methane Number
+    Standard_ISO15403 nitrogenCase =
+        new Standard_ISO15403(createCng(0.90, 0.01, 0.03));
+    nitrogenCase.calculate();
+    double nitrogenNm = nitrogenCase.getValue("NM");
 
-```java
-// Analyze MN sensitivity to C2+ content
-double[] ethaneContents = {0.01, 0.03, 0.05, 0.08, 0.10};
+    if (!Double.isFinite(baseMon) || !Double.isFinite(baseNm)) {
+      throw new IllegalStateException("ISO 15403 correlation returned a non-finite result");
+    }
+    if (!(carbonDioxideNm > baseNm && nitrogenNm < baseNm)) {
+      throw new IllegalStateException("Unexpected composition-sensitivity result");
+    }
 
-System.out.println("Ethane (mol%) | MON   | MN");
-System.out.println("--------------|-------|------");
+    logger.info("Base MON={}, base NM={}", baseMon, baseNm);
+    logger.info("NM after replacing methane with CO2={}", carbonDioxideNm);
+    logger.info("NM after replacing methane with N2={}", nitrogenNm);
+  }
 
-for (double c2 : ethaneContents) {
-    SystemInterface gas = new SystemSrkEos(273.15 + 15, 200.0);
-    gas.addComponent("methane", 0.97 - c2);
-    gas.addComponent("ethane", c2);
-    gas.addComponent("CO2", 0.02);
-    gas.addComponent("nitrogen", 0.01);
-    gas.setMixingRule("classic");
-    
-    Standard_ISO15403 std = new Standard_ISO15403(gas);
-    std.calculate();
-    
-    System.out.printf("%13.0f | %.1f | %.1f%n", 
-        c2 * 100, 
-        std.getValue("MON"), 
-        std.getValue("MN"));
+  private static SystemInterface createCng(
+      double methane, double carbonDioxide, double nitrogen) {
+    SystemInterface gas = new SystemSrkEos(288.15, 200.0);
+    gas.addComponent("methane", methane);
+    gas.addComponent("ethane", 0.04);
+    gas.addComponent("propane", 0.01);
+    gas.addComponent("n-butane", 0.005);
+    gas.addComponent("i-butane", 0.005);
+    gas.addComponent("CO2", carbonDioxide);
+    gas.addComponent("nitrogen", nitrogen);
+    gas.init(0);
+    return gas;
+  }
 }
 ```
 
-### CO2 and N2 Effects
+For these three normalized compositions, the current source correlation gives:
 
-```java
-// CO2 and N2 improve methane number
-SystemInterface leanGas = new SystemSrkEos(273.15 + 15, 200.0);
-leanGas.addComponent("methane", 0.85);
-leanGas.addComponent("ethane", 0.05);
-leanGas.addComponent("propane", 0.02);
+| Case | MON | NM | Engineering interpretation |
+|---|---:|---:|---|
+| Base composition | 128.18474 | 81.8069493 | Reference case |
+| Replace 2 mol% methane with CO2 | 129.05380 | 83.0627410 | Increases this correlation result |
+| Replace 2 mol% methane with N2 | 125.96802 | 78.6037889 | Decreases this correlation result |
 
-// Base case - no inerts
-leanGas.addComponent("CO2", 0.0);
-leanGas.addComponent("nitrogen", 0.0);
-leanGas.setMixingRule("classic");
+These trends are properties of the implemented coefficients and the stated
+replacement experiment. They are not universal claims about engine knock or
+arbitrary dilution paths.
 
-Standard_ISO15403 baseStd = new Standard_ISO15403(leanGas);
-baseStd.calculate();
-System.out.printf("Base case MN: %.1f%n", baseStd.getValue("MN"));
+## API and engineering boundaries
 
-// With 5% CO2
-SystemInterface withCO2 = leanGas.clone();
-withCO2.addComponent("CO2", 0.05);
-Standard_ISO15403 co2Std = new Standard_ISO15403(withCO2);
-co2Std.calculate();
-System.out.printf("With 5%% CO2 MN: %.1f%n", co2Std.getValue("MN"));
+| API | Current behavior |
+|---|---|
+| `new Standard_ISO15403(system)` | Uses the system's overall composition |
+| `calculate()` | Updates the stored MON and NM results |
+| `getValue("MON")` | Returns the dimensionless motor octane number |
+| `getValue("NM")` | Returns the dimensionless methane-number result |
+| `getUnit(...)` | Returns an empty string |
+| `isOnSpec()` | Always returns `true`; no acceptance limits are evaluated |
 
-// With 5% N2
-SystemInterface withN2 = leanGas.clone();
-withN2.addComponent("nitrogen", 0.05);
-Standard_ISO15403 n2Std = new Standard_ISO15403(withN2);
-n2Std.calculate();
-System.out.printf("With 5%% N2 MN: %.1f%n", n2Std.getValue("MN"));
-```
+Do not use `isOnSpec()` as evidence that a fuel complies with ISO 15403, a
+national fuel specification, or an engine manufacturer's limits. A conformity
+assessment also needs the applicable standard edition, sampling and analysis
+requirements, validated composition range, contractual limits, and any other
+required fuel properties.
 
----
+## Related documentation
 
-## Methane Number Concepts
+- [Standards overview](README.md)
+- [ISO 6976 calorific values and Wobbe index](iso6976_calorific_values.md)
+- [Dew-point methods](dew_point_standards.md)
 
-### Component Effects
-
-| Component | Effect on MN |
-|-----------|--------------|
-| Methane | Increases MN |
-| Ethane | Slight decrease |
-| Propane | Moderate decrease |
-| Butanes | Strong decrease |
-| CO₂ | Increases MN |
-| N₂ | Increases MN |
-| H₂ | Decreases MN |
-
-### Typical Values
-
-| Gas Type | Typical MN |
-|----------|------------|
-| Pure methane | 100 |
-| Lean natural gas | 85-95 |
-| Associated gas | 70-85 |
-| Biogas | 130-140 |
-| LNG regasified | 75-90 |
-
-### Specifications
-
-| Region | Minimum MN |
-|--------|------------|
-| Europe (typical) | 65-70 |
-| Germany (DIN 51624) | 70 |
-| California | 80 |
-
----
-
-## Technical Notes
-
-### Correlation Validity
-
-The correlation is valid for:
-- Methane content > 70%
-- Limited C4+ content
-- Typical natural gas compositions
-
-### Limitations
-
-1. Does not account for C5+ hydrocarbons
-2. Hydrogen effects not included in correlation
-3. Best for pipeline-quality natural gas
-
-### Alternative Methods
-
-For more complex gases, consider:
-- AVL Methane Number calculation
-- Wärtsilä MN method
-- GRI/MWM correlations
-
----
-
-## References
-
-1. ISO 15403-1:2006 - Natural gas — Natural gas for use as a compressed fuel for vehicles — Part 1: Designation of the quality
-2. DIN 51624 - Automotive fuels - Compressed natural gas - Requirements and test methods
-3. SAE J1616 - Recommended Practice for Compressed Natural Gas Vehicle Fuel

--- a/docs/test_iso15403_documentation.py
+++ b/docs/test_iso15403_documentation.py
@@ -1,0 +1,133 @@
+"""Hermetic contracts for the ISO 15403 CNG-quality documentation."""
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "standards" / "iso15403_cng_quality.md"
+SOURCE = (
+    ROOT
+    / "src"
+    / "main"
+    / "java"
+    / "neqsim"
+    / "standards"
+    / "gasquality"
+    / "Standard_ISO15403.java"
+)
+JAVA_TEST = (
+    ROOT
+    / "src"
+    / "test"
+    / "java"
+    / "neqsim"
+    / "standards"
+    / "gasquality"
+    / "StandardISO15403DocumentationTest.java"
+)
+STANDARDS_INDEX = ROOT / "docs" / "standards" / "README.md"
+REFERENCE_INDEX = ROOT / "docs" / "REFERENCE_MANUAL_INDEX.md"
+
+
+class Iso15403DocumentationContractTest(unittest.TestCase):
+    """Guard source accuracy, structure, discoverability, and example coverage."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = DOC.read_text(encoding="utf-8")
+        cls.source = SOURCE.read_text(encoding="utf-8")
+        cls.java_test = JAVA_TEST.read_text(encoding="utf-8")
+
+    def test_jekyll_structure_links_math_and_fences(self):
+        self.assertRegex(
+            self.doc,
+            r'^---\ntitle: "[^"]+"\ndescription: "[^"]+"\n---\n',
+        )
+        self.assertNotRegex(self.doc, r"(?m)^# ")
+        self.assertEqual(2, self.doc.count("```"))
+        self.assertEqual(1, self.doc.count("```java"))
+
+        for target in re.findall(r"\[[^\]]+\]\(([^)#]+\.md)(?:#[^)]+)?\)", self.doc):
+            resolved = (DOC.parent / target).resolve()
+            self.assertTrue(resolved.is_file(), target)
+
+        self.assertNotIn(r"\[", self.doc)
+        self.assertNotIn(r"\(", self.doc)
+        self.assertEqual(0, self.doc.count("$$") % 2)
+        math_segments = self.doc.split("$$")[1::2]
+        for segment in math_segments:
+            self.assertTrue(segment)
+            self.assertFalse(segment[0].isspace())
+            self.assertFalse(segment[-1].isspace())
+
+    def test_documented_contract_matches_current_source(self):
+        source_patterns = (
+            'getMolefraction("methane")',
+            'getMolefraction("ethane")',
+            'getMolefraction("propane")',
+            'getMolefraction("n-butane")',
+            'getMolefraction("i-butane")',
+            'getMolefraction("CO2")',
+            'getMolefraction("nitrogen")',
+            "NM = 1.445 * MON - 103.42",
+            'returnParameter.equals("MON")',
+            'returnParameter.equals("NM")',
+            "public boolean isOnSpec()",
+            "return true;",
+        )
+        for pattern in source_patterns:
+            self.assertIn(pattern, self.source)
+
+        required_doc_patterns = (
+            "MON = 137.78",
+            "NM = 95.6721",
+            "Hydrogen, C5+ hydrocarbons",
+            "same one-mole composition basis",
+            "public final class Iso15403Example",
+            "public static void main(String[] args)",
+            'base.getValue("MON")',
+            'base.getValue("NM")',
+            "isOnSpec()` | Always returns `true`",
+            "does not perform a complete conformity assessment",
+        )
+        for pattern in required_doc_patterns:
+            self.assertIn(pattern, self.doc)
+
+    def test_stale_and_unsafe_patterns_are_rejected(self):
+        rejected = (
+            'getValue("MN")',
+            "MN = 100: Pure methane",
+            "MN = 0: Pure hydrogen",
+            "CO2 and N2 improve methane number",
+            "System.out",
+            "System.err",
+            "Minimum MN",
+            "Typical MN",
+        )
+        for pattern in rejected:
+            self.assertNotIn(pattern, self.doc)
+
+    def test_focused_java_regression_exercises_every_documented_call(self):
+        calls = (
+            "new Standard_ISO15403(createCng(0.92, 0.01, 0.01))",
+            "base.calculate()",
+            'base.getValue("MON")',
+            'base.getValue("NM")',
+            'base.getUnit("MON")',
+            "base.isOnSpec()",
+            'standard.getValue("MN")',
+        )
+        for call in calls:
+            self.assertIn(call, self.java_test)
+
+    def test_page_is_discoverable_from_both_indexes(self):
+        standards_index = STANDARDS_INDEX.read_text(encoding="utf-8")
+        reference_index = REFERENCE_INDEX.read_text(encoding="utf-8")
+        self.assertIn("iso15403_cng_quality.md", standards_index)
+        self.assertIn("standards/iso15403_cng_quality", reference_index)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test/java/neqsim/standards/gasquality/StandardISO15403DocumentationTest.java
+++ b/src/test/java/neqsim/standards/gasquality/StandardISO15403DocumentationTest.java
@@ -1,0 +1,67 @@
+package neqsim.standards.gasquality;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Executes and verifies the ISO 15403 documentation workflow. */
+class StandardISO15403DocumentationTest extends NeqSimTest {
+  @Test
+  void documentedWorkflowMatchesCorrelationAndCompositionTrends() {
+    Standard_ISO15403 base = new Standard_ISO15403(createCng(0.92, 0.01, 0.01));
+    base.calculate();
+    double baseMon = base.getValue("MON");
+    double baseNm = base.getValue("NM");
+
+    Standard_ISO15403 carbonDioxideCase =
+        new Standard_ISO15403(createCng(0.90, 0.03, 0.01));
+    carbonDioxideCase.calculate();
+    double carbonDioxideNm = carbonDioxideCase.getValue("NM");
+
+    Standard_ISO15403 nitrogenCase =
+        new Standard_ISO15403(createCng(0.90, 0.01, 0.03));
+    nitrogenCase.calculate();
+    double nitrogenNm = nitrogenCase.getValue("NM");
+
+    assertEquals(128.18474, baseMon, 1.0e-10);
+    assertEquals(81.8069493, baseNm, 1.0e-10);
+    assertEquals(83.0627410, carbonDioxideNm, 1.0e-10);
+    assertEquals(78.6037889, nitrogenNm, 1.0e-10);
+    assertTrue(carbonDioxideNm > baseNm);
+    assertTrue(nitrogenNm < baseNm);
+    assertEquals("", base.getUnit("MON"));
+    assertTrue(base.isOnSpec());
+  }
+
+  @Test
+  void pureMethaneAnchorAndUnsupportedAliasMatchCurrentImplementation() {
+    SystemInterface methane = new SystemSrkEos(288.15, 200.0);
+    methane.addComponent("methane", 1.0);
+    methane.init(0);
+
+    Standard_ISO15403 standard = new Standard_ISO15403(methane);
+    standard.calculate();
+
+    assertEquals(137.78, standard.getValue("MON"), 1.0e-12);
+    assertEquals(95.6721, standard.getValue("NM"), 1.0e-12);
+    assertThrows(RuntimeException.class, () -> standard.getValue("MN"));
+  }
+
+  private SystemInterface createCng(double methane, double carbonDioxide, double nitrogen) {
+    SystemInterface gas = new SystemSrkEos(288.15, 200.0);
+    gas.addComponent("methane", methane);
+    gas.addComponent("ethane", 0.04);
+    gas.addComponent("propane", 0.01);
+    gas.addComponent("n-butane", 0.005);
+    gas.addComponent("i-butane", 0.005);
+    gas.addComponent("CO2", carbonDioxide);
+    gas.addComponent("nitrogen", nitrogen);
+    gas.init(0);
+    return gas;
+  }
+}

--- a/src/test/java/neqsim/standards/gasquality/StandardISO15403DocumentationTest.java
+++ b/src/test/java/neqsim/standards/gasquality/StandardISO15403DocumentationTest.java
@@ -18,13 +18,11 @@ class StandardISO15403DocumentationTest extends NeqSimTest {
     double baseMon = base.getValue("MON");
     double baseNm = base.getValue("NM");
 
-    Standard_ISO15403 carbonDioxideCase =
-        new Standard_ISO15403(createCng(0.90, 0.03, 0.01));
+    Standard_ISO15403 carbonDioxideCase = new Standard_ISO15403(createCng(0.90, 0.03, 0.01));
     carbonDioxideCase.calculate();
     double carbonDioxideNm = carbonDioxideCase.getValue("NM");
 
-    Standard_ISO15403 nitrogenCase =
-        new Standard_ISO15403(createCng(0.90, 0.01, 0.03));
+    Standard_ISO15403 nitrogenCase = new Standard_ISO15403(createCng(0.90, 0.01, 0.03));
     nitrogenCase.calculate();
     double nitrogenNm = nitrogenCase.getValue("NM");
 


### PR DESCRIPTION
Part of #2499 — documentation scan batch D059.

## Frozen scope

Base: `dc3d907586a895dbac15db85643f4496be1645e9`  
Head: `393f54718dc7167e209ec6b0b385e2132445e1f5`

Changed:
- `docs/standards/iso15403_cng_quality.md`
- `docs/test_iso15403_documentation.py`
- `src/test/java/neqsim/standards/gasquality/StandardISO15403DocumentationTest.java`

Inspected but intentionally unchanged:
- `docs/standards/README.md` and `docs/REFERENCE_MANUAL_INDEX.md` (both already index the page)
- `src/main/java/neqsim/standards/gasquality/Standard_ISO15403.java`
- `src/test/java/neqsim/standards/gasquality/Standard_ISO15403Test.java`

## Confirmed defects and root causes

- **High — non-running API:** the guide used `getValue("MN")`, while current source accepts only `"MON"` and `"NM"`.
- **High — non-compilable examples:** four fragments lacked complete declarations/imports and were not independently executable.
- **High — false scale endpoints:** the page stated pure methane = 100 and pure hydrogen = 0. The implemented correlation returns 95.6721 for pure methane; hydrogen has no coefficient and therefore falls outside the class's represented composition.
- **High — confounded sensitivity cases:** inert components were added to cloned mixtures, changing the total basis rather than replacing methane.
- **Medium — compliance overclaim:** the class evaluates one correlation and `isOnSpec()` always returns `true`; it is not a complete ISO conformity assessment.
- **Medium — unsupported tables:** regional minima and typical-value ranges had no traceable source or applicability boundary.
- **Medium — example hygiene:** eight `System.out` calls conflicted with repository guidance.
- **Medium — page structure:** the Markdown duplicated the front-matter title with an H1.

## Fix

- Replace the fragments with one complete Java 8-compatible example using normalized one-mole compositions and repository logging.
- Document the exact six-component source correlation, result keys, numerical anchor, omitted-component behavior, and unconditional `isOnSpec()` boundary.
- Show controlled CO2 and N2 replacement cases with source-derived values and opposite trends.
- Remove unsupported specification/typical-value claims.
- Add a hermetic documentation contract for Jekyll structure, internal links, compact math, source/API parity, stale-pattern rejection, executable coverage, and index discoverability.
- Add a focused Java regression that executes every documented API call, checks the three numerical cases, anchors pure methane, and proves the stale `"MN"` alias is rejected.

## Validation

Passed before publication:
- `python -m unittest proposal/docs/test_iso15403_documentation.py -v` — **PASS, 5/5** in the staged content harness against the connector-fetched source contract.
- `python -m py_compile proposal/docs/test_iso15403_documentation.py` — **PASS**.
- Independent coefficient calculation — **PASS**: base MON/NM 128.18474/81.8069493; CO2 replacement NM 83.0627410; N2 replacement NM 78.6037889; pure-methane NM 95.6721.
- Final GitHub compare — **PASS**: exactly three intended files, two focused commits, branch 2 ahead/0 behind.
- Official ISO link — **PASS on 2026-08-15**: published ISO 15403-1:2006 page resolves and identifies edition 1 as current pending revision.
- First-head documentation-search hook — **PASS**: 652 Markdown pages and one standalone HTML page audited.
- First-head Spotless patch — **applied exactly** in `393f547`: the CI formatter requested only two single-line declaration changes in the focused Java test.

## Exact-head hosted validation

Passed on `393f54718dc7167e209ec6b0b385e2132445e1f5`:
- pre-commit workflow, including Spotless check and documentation-search hook;
- dedicated documentation-search workflow;
- Spotless apply workflow with no remaining formatter diff;
- CodeQL security analysis;
- Java 21 Javadoc and change-detection/agent-reference jobs.

Still running: Ubuntu/Windows Java test matrices, including the focused regression and broader fast/slow suites.

## Local validation limitations

This environment has no complete local repository checkout, so the following repository commands were not run locally:
- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- `pre-commit run --all-files --hook-stage pre-commit`
- `pre-commit run --all-files --hook-stage pre-push`
- `./mvnw -Dtest=StandardISO15403DocumentationTest test`
- repository documentation/site rendering

Exact-head CI was restarted after applying the complete generated Spotless patch; all completed rerun checks are green. The Java diff was manually inspected against current repository conventions. No notebook or Python NeqSim execution is in scope, so the NeqSim Python bootstrap is not applicable. The batch remains **in progress** until merged evidence is available.