### PR TITLE
fix(column): reject dependent terminal specifications

### DIFF
--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -151,10 +151,22 @@ column.setTopSpecification(topFlow);
 
 The selected unit is retained through specification homotopy, diagnostics, warm-state identity,
 copying, and serialization. Feasibility screening compares each flow target with external feed flow
-in the same unit. When both terminal flow targets use the same unit, their sum is screened as well;
-mixed-unit terminal targets are evaluated during the solve because their product compositions may
-differ. `getLastTopSpecificationResidual()` and `getLastBottomSpecificationResidual()` report flow
-residuals in the corresponding target unit.
+in the same unit. When both terminal flow targets use the same unit, their sum is screened as well.
+Mixed-unit terminal targets on a column with an external side draw are evaluated during the solve
+because their product compositions may differ. `getLastTopSpecificationResidual()` and
+`getLastBottomSpecificationResidual()` report flow residuals in the corresponding target unit.
+
+Without an external side draw, top and bottom product-flow targets are not two independent
+specifications: steady-state total material balance fixes one terminal flow after the feed and the
+other terminal flow are known. The run preflight and `validateSpecifications()` therefore reject
+the pair even when its targets sum exactly to feed. Use one product-flow target and an independent
+purity, component-recovery, duty, or reflux specification. For the same reason, top and bottom
+recovery targets for the same component are dependent without an external side draw and are
+rejected before iteration. Different-component recovery targets remain independent. When an
+external side draw is active, paired terminal controls can be structurally independent; paired
+recoveries for one component are still screened so their sum cannot exceed the feed-component
+inventory. These checks intentionally prevent rank-deficient outer solves and leave any previously
+accepted tray and product state untouched.
 
 For iterative specifications, NeqSim wraps the selected inner solver in an outer adjustment loop and
 uses condenser or reboiler temperature as the manipulated variable where possible. Product purity,

--- a/src/main/java/neqsim/process/equipment/distillation/ColumnSpecification.java
+++ b/src/main/java/neqsim/process/equipment/distillation/ColumnSpecification.java
@@ -26,13 +26,20 @@ import java.io.Serializable;
  * ColumnSpecification topSpec = new ColumnSpecification(ColumnSpecification.SpecificationType.PRODUCT_PURITY,
  *     ColumnSpecification.ProductLocation.TOP, 0.95, "methane");
  *
- * // Specify reflux ratio of 3.0 at the condenser
- * ColumnSpecification condenserSpec = new ColumnSpecification(ColumnSpecification.SpecificationType.REFLUX_RATIO,
- *     ColumnSpecification.ProductLocation.TOP, 3.0);
+ * // Specify boilup ratio of 2.0 at the reboiler
+ * ColumnSpecification bottomSpec = new ColumnSpecification(ColumnSpecification.SpecificationType.REFLUX_RATIO,
+ *     ColumnSpecification.ProductLocation.BOTTOM, 2.0);
  *
  * column.setTopSpecification(topSpec);
- * column.setBottomSpecification(condenserSpec);
+ * column.setBottomSpecification(bottomSpec);
  * </pre>
+ *
+ * <p>
+ * On a column without an external side draw, top and bottom product-flow targets are linked by total material balance,
+ * and top and bottom recoveries of the same component are linked by component balance. Use one member of either pair
+ * with an independent purity, recovery, duty, or reflux specification. The column validator and run preflight reject
+ * dependent pairs before solver iteration.
+ * </p>
  *
  * @author esol
  * @version 1.0

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2226,6 +2226,69 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   }
 
   /**
+   * Check whether both terminal specifications control conservation-linked product flows.
+   *
+   * <p>
+   * Without an external side draw, steady-state total material balance fixes one terminal flow once the other and the
+   * feed are known. Treating both as independent temperature controls creates a rank-deficient outer problem even when
+   * their targets sum exactly to the feed.
+   * </p>
+   *
+   * @return {@code true} when top and bottom product-flow specifications are dependent
+   */
+  private boolean hasDependentTerminalProductFlowSpecifications() {
+    return !hasActiveSideDrawFractions() && isProductFlowSpecification(topSpecification)
+        && isProductFlowSpecification(bottomSpecification);
+  }
+
+  /**
+   * Check whether both terminal specifications control recovery of the same component.
+   *
+   * @return {@code true} when top and bottom recoveries refer to the same feed component
+   */
+  private boolean hasMatchingTerminalComponentRecoverySpecifications() {
+    return isComponentRecoverySpecification(topSpecification)
+        && isComponentRecoverySpecification(bottomSpecification)
+        && topSpecification.getComponentName().equals(bottomSpecification.getComponentName());
+  }
+
+  /**
+   * Check whether matching terminal recoveries are conservation-linked.
+   *
+   * <p>
+   * Without an external side draw, component balance fixes bottom recovery as one minus top recovery. The pair
+   * therefore supplies only one independent degree of freedom.
+   * </p>
+   *
+   * @return {@code true} when matching top and bottom recoveries are dependent
+   */
+  private boolean hasDependentTerminalComponentRecoverySpecifications() {
+    return !hasActiveSideDrawFractions() && hasMatchingTerminalComponentRecoverySpecifications();
+  }
+
+  /**
+   * Create an actionable message for dependent terminal product-flow controls.
+   *
+   * @return degrees-of-freedom error message
+   */
+  private String createDependentTerminalProductFlowSpecificationsMessage() {
+    return "Column " + getName()
+        + " cannot combine top and bottom product-flow specifications without an external side draw; total material "
+        + "balance makes the terminal flows dependent";
+  }
+
+  /**
+   * Create an actionable message for dependent terminal component-recovery controls.
+   *
+   * @return degrees-of-freedom error message
+   */
+  private String createDependentTerminalComponentRecoverySpecificationsMessage() {
+    return "Column " + getName() + " cannot combine top and bottom recovery specifications for component "
+        + topSpecification.getComponentName()
+        + " without an external side draw; component balance makes the terminal recoveries dependent";
+  }
+
+  /**
    * Create an actionable message for contradictory condenser reflux controls.
    *
    * @return degrees-of-freedom error message
@@ -2243,6 +2306,12 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   private void ensureIndependentTerminalSpecifications() {
     if (hasConflictingCondenserRefluxSpecifications()) {
       throw new IllegalStateException(createConflictingCondenserRefluxSpecificationsMessage());
+    }
+    if (hasDependentTerminalProductFlowSpecifications()) {
+      throw new IllegalStateException(createDependentTerminalProductFlowSpecificationsMessage());
+    }
+    if (hasDependentTerminalComponentRecoverySpecifications()) {
+      throw new IllegalStateException(createDependentTerminalComponentRecoverySpecificationsMessage());
     }
   }
 
@@ -13546,10 +13615,32 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   private void validateColumnSpecifications(ValidationResult result) {
     validateColumnSpecification(result, topSpecification, ColumnSpecification.ProductLocation.TOP);
     validateColumnSpecification(result, bottomSpecification, ColumnSpecification.ProductLocation.BOTTOM);
+    validateTerminalSpecificationIndependence(result);
     validateProductFlowSpecificationsAgainstFeed(result);
+    validatePairedComponentRecoverySpecifications(result);
     if (hasConflictingCondenserRefluxSpecifications()) {
       result.addError("specification.degreesOfFreedom", createConflictingCondenserRefluxSpecificationsMessage(),
           "Call setCondenserMode(DistillationColumn.CondenserMode.PARTIAL) or setCondenserMode(DistillationColumn.CondenserMode.TOTAL) to clear fixed-flow mode, or remove the top reflux-ratio specification");
+    }
+  }
+
+  /**
+   * Validate that top and bottom specifications own independent column degrees of freedom.
+   *
+   * @param result validation result receiving degrees-of-freedom errors
+   */
+  private void validateTerminalSpecificationIndependence(ValidationResult result) {
+    if (hasDependentTerminalProductFlowSpecifications()) {
+      result.addError("specification.degreesOfFreedom",
+          createDependentTerminalProductFlowSpecificationsMessage(),
+          "Keep one terminal product-flow target and replace the other with purity, recovery, duty, or reflux "
+              + "specification");
+    }
+    if (hasDependentTerminalComponentRecoverySpecifications()) {
+      result.addError("specification.degreesOfFreedom",
+          createDependentTerminalComponentRecoverySpecificationsMessage(),
+          "Keep one recovery target for that component and replace the other terminal target with an independent "
+              + "specification");
     }
   }
 
@@ -13606,6 +13697,30 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   }
 
   /**
+   * Validate paired component-recovery targets against component conservation.
+   *
+   * <p>
+   * A side draw can carry the recovery not assigned to the two terminal products, but the two terminal recoveries can
+   * never exceed the available feed component.
+   * </p>
+   *
+   * @param result validation result receiving component-recovery feasibility errors
+   */
+  private void validatePairedComponentRecoverySpecifications(ValidationResult result) {
+    if (!hasMatchingTerminalComponentRecoverySpecifications()
+        || hasDependentTerminalComponentRecoverySpecifications()) {
+      return;
+    }
+    double recoverySum = topSpecification.getTargetValue() + bottomSpecification.getTargetValue();
+    if (recoverySum > 1.0 + 1.0e-12) {
+      result.addError("specification.componentRecovery.sum",
+          "Top and bottom recovery targets for component " + topSpecification.getComponentName()
+              + " exceed the available feed component",
+          "Reduce one recovery target so their sum is at most one, including any recovery required in side draws");
+    }
+  }
+
+  /**
    * Check whether a specification controls total product flow.
    *
    * @param specification specification to inspect
@@ -13613,6 +13728,17 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    */
   private boolean isProductFlowSpecification(ColumnSpecification specification) {
     return specification != null && specification.getType() == ColumnSpecification.SpecificationType.PRODUCT_FLOW_RATE;
+  }
+
+  /**
+   * Check whether a specification controls component recovery.
+   *
+   * @param specification specification to inspect
+   * @return {@code true} for component-recovery specifications
+   */
+  private boolean isComponentRecoverySpecification(ColumnSpecification specification) {
+    return specification != null
+        && specification.getType() == ColumnSpecification.SpecificationType.COMPONENT_RECOVERY;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2247,8 +2247,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @return {@code true} when top and bottom recoveries refer to the same feed component
    */
   private boolean hasMatchingTerminalComponentRecoverySpecifications() {
-    return isComponentRecoverySpecification(topSpecification)
-        && isComponentRecoverySpecification(bottomSpecification)
+    return isComponentRecoverySpecification(topSpecification) && isComponentRecoverySpecification(bottomSpecification)
         && topSpecification.getComponentName() != null
         && topSpecification.getComponentName().equals(bottomSpecification.getComponentName());
   }
@@ -13632,14 +13631,12 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    */
   private void validateTerminalSpecificationIndependence(ValidationResult result) {
     if (hasDependentTerminalProductFlowSpecifications()) {
-      result.addError("specification.degreesOfFreedom",
-          createDependentTerminalProductFlowSpecificationsMessage(),
+      result.addError("specification.degreesOfFreedom", createDependentTerminalProductFlowSpecificationsMessage(),
           "Keep one terminal product-flow target and replace the other with purity, recovery, duty, or reflux "
               + "specification");
     }
     if (hasDependentTerminalComponentRecoverySpecifications()) {
-      result.addError("specification.degreesOfFreedom",
-          createDependentTerminalComponentRecoverySpecificationsMessage(),
+      result.addError("specification.degreesOfFreedom", createDependentTerminalComponentRecoverySpecificationsMessage(),
           "Keep one recovery target for that component and replace the other terminal target with an independent "
               + "specification");
     }
@@ -13738,8 +13735,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * @return {@code true} for component-recovery specifications
    */
   private boolean isComponentRecoverySpecification(ColumnSpecification specification) {
-    return specification != null
-        && specification.getType() == ColumnSpecification.SpecificationType.COMPONENT_RECOVERY;
+    return specification != null && specification.getType() == ColumnSpecification.SpecificationType.COMPONENT_RECOVERY;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -2249,6 +2249,7 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   private boolean hasMatchingTerminalComponentRecoverySpecifications() {
     return isComponentRecoverySpecification(topSpecification)
         && isComponentRecoverySpecification(bottomSpecification)
+        && topSpecification.getComponentName() != null
         && topSpecification.getComponentName().equals(bottomSpecification.getComponentName());
   }
 

--- a/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/ColumnSpecificationTest.java
@@ -372,7 +372,70 @@ public class ColumnSpecificationTest {
   }
 
   /**
-   * Test mass-unit product-flow control, conservation, physical bounds, repeatability, and an equivalent molar target.
+   * Test that matching terminal recoveries are dependent without a side draw.
+   */
+  @Test
+  public void validateSpecificationsRejectsDependentSameComponentRecoveries() {
+    SystemSrkEos testSystem = new SystemSrkEos(273.15 + 35.0, 12.0);
+    testSystem.addComponent("methane", 0.55);
+    testSystem.addComponent("ethane", 0.25);
+    testSystem.addComponent("propane", 0.12);
+    testSystem.addComponent("n-butane", 0.08);
+    testSystem.setMixingRule("classic");
+
+    Stream feed = new Stream("recovery independence feed", testSystem);
+    feed.setFlowRate(180.0, "kg/hr");
+
+    DistillationColumn column = new DistillationColumn("RecoveryIndependenceColumn", 6, true, true);
+    column.addFeedStream(feed, 3);
+    column.setTopComponentRecovery("methane", 0.70);
+    column.setBottomComponentRecovery("methane", 0.30);
+
+    ValidationResult result = column.validateSpecifications();
+
+    assertFalse(result.isValid());
+    assertTrue(result.getReport().contains("component balance makes the terminal recoveries dependent"));
+    IllegalStateException exception = assertThrows(IllegalStateException.class, column::run);
+    assertTrue(exception.getMessage().contains("component balance makes the terminal recoveries dependent"));
+
+    column.setBottomComponentRecovery("n-butane", 0.80);
+    assertTrue(column.validateSpecifications().isValid());
+  }
+
+  /**
+   * Test recovery inventory screening when a side draw makes terminal recoveries structurally independent.
+   */
+  @Test
+  public void validateSpecificationsScreensPairedRecoveriesWithSideDraw() {
+    SystemSrkEos testSystem = new SystemSrkEos(273.15 + 35.0, 12.0);
+    testSystem.addComponent("methane", 0.55);
+    testSystem.addComponent("ethane", 0.25);
+    testSystem.addComponent("propane", 0.12);
+    testSystem.addComponent("n-butane", 0.08);
+    testSystem.setMixingRule("classic");
+
+    Stream feed = new Stream("side draw recovery feed", testSystem);
+    feed.setFlowRate(180.0, "kg/hr");
+
+    DistillationColumn column = new DistillationColumn("SideDrawRecoveryColumn", 6, true, true);
+    column.addFeedStream(feed, 3);
+    column.setLiquidSideDrawFraction(2, 0.10);
+    column.setTopComponentRecovery("methane", 0.80);
+    column.setBottomComponentRecovery("methane", 0.30);
+
+    ValidationResult excessiveResult = column.validateSpecifications();
+
+    assertFalse(excessiveResult.isValid());
+    assertTrue(excessiveResult.getReport().contains("exceed the available feed component"));
+    assertFalse(excessiveResult.getReport().contains("terminal recoveries dependent"));
+
+    column.setBottomComponentRecovery("methane", 0.20);
+    assertTrue(column.validateSpecifications().isValid());
+  }
+
+  /**
+   * Test mass-unit product-flow control, conservation, physical bounds, repeatability, an equivalent molar target, and
+   * rejection of conservation-linked terminal flow controls without disturbing an accepted warm state.
    */
   @Test
   public void multicomponentProductFlowSpecificationHonorsMassUnit() {
@@ -426,6 +489,27 @@ public class ColumnSpecificationTest {
     column.setTopProductFlowRate(equivalentMolPerHour, "mol/hr");
     column.getTopSpecification().setTolerance(Math.max(1.0e-3, equivalentMolPerHour * 1.0e-4));
     column.getTopSpecification().setMaxIterations(8);
+    column.run();
+
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertEquals(equivalentMolPerHour, column.getGasOutStream().getFlowRate("mol/hr"),
+        column.getTopSpecification().getTolerance());
+    assertColumnFlowSpecificationBalances(column, feed);
+
+    double acceptedTopMolPerHour = column.getGasOutStream().getFlowRate("mol/hr");
+    double acceptedBottomMolPerHour = column.getLiquidOutStream().getFlowRate("mol/hr");
+    column.setBottomProductFlowRate(acceptedBottomMolPerHour, "mol/hr");
+
+    ValidationResult dependentFlowResult = column.validateSpecifications();
+
+    assertFalse(dependentFlowResult.isValid());
+    assertTrue(dependentFlowResult.getReport().contains("total material balance makes the terminal flows dependent"));
+    IllegalStateException exception = assertThrows(IllegalStateException.class, column::run);
+    assertTrue(exception.getMessage().contains("total material balance makes the terminal flows dependent"));
+    assertEquals(acceptedTopMolPerHour, column.getGasOutStream().getFlowRate("mol/hr"), 0.0);
+    assertEquals(acceptedBottomMolPerHour, column.getLiquidOutStream().getFlowRate("mol/hr"), 0.0);
+
+    column.setBottomSpecification(null);
     column.run();
 
     assertTrue(column.solved(), column.getConvergenceDiagnostics());


### PR DESCRIPTION
## Roadmap

Advances #2936 C1 degrees-of-freedom and specification integrity after merged #3014 completed unit-aware product-flow targets.

## Problem and current-master reproduction

Exact base: `dc3d907586a895dbac15db85643f4496be1645e9`.

For a full fractionator with no external side draw, current `master` accepts both top and bottom product-flow specifications. Even when their targets exactly match the already accepted product flows and sum to feed, total material balance makes one target a consequence of the other. The outer loop nevertheless treats the pair as two independent terminal-temperature controls, creating a rank-deficient specification problem instead of rejecting it before iteration.

The same defect exists for top and bottom recovery specifications of the same component: without an external side product, component balance fixes one recovery as one minus the other.

## Coherent change

- detect conservation-linked terminal product-flow pairs when no side draw is active;
- detect conservation-linked top/bottom recovery pairs for the same component;
- report actionable `specification.degreesOfFreedom` validation errors;
- fail the run preflight before tray, product, or accepted warm-state mutation;
- retain structurally independent different-component recovery and mixed specification pairs;
- allow a real side draw to provide an additional external degree of freedom;
- still reject paired same-component recoveries above total feed-component inventory when a side draw is active;
- correct and extend adjacent Javadocs and user documentation.

No solver equation, tolerance, line search, homotopy, warm-state fingerprint, TPflash path, generic process execution, terminal split, or public API is changed.

## Regression and engineering evidence

Focused coverage adds:

- top/bottom same-component recovery rejection before solver iteration;
- acceptance of different-component recovery targets;
- side-draw structural independence plus component-inventory screening;
- extension of the realistic seven-stage, five-component SRK fractionator regression;
- reproduction using the exact accepted top/bottom molar product flows, proving that even a conservation-consistent pair is dependent;
- preflight exception and bit-exact preservation of accepted top/bottom product flows;
- removal of the conflicting bottom target followed by a successful warm re-solve;
- total and per-component material closure, energy residual, physical temperature/flow bounds, specification satisfaction, and repeated-run evidence through the existing realistic fixture.

No wall-clock assertion is used.

## Compatibility and risk

This intentionally rejects a previously accepted but mathematically dependent configuration on columns without external side draws. Keep one terminal flow or same-component recovery target and replace the other with an independent purity, different-component recovery, duty, or reflux specification. Columns with external side draws retain paired terminal control when structurally possible.

The guard runs before solver iteration and does not clear retained trays or products. Legacy serialized configurations receive the same actionable preflight failure.

## Documentation impact

Updated `ColumnSpecification` Javadocs (including correction of an invalid location example) and `docs/process/equipment/distillation.md` with the degrees-of-freedom rule, side-draw boundary, recovery inventory screening, remedy, and retained-state behavior. No notebook changed.

## Validation

**MERGED** as `07468dd6b2a9f54c291cf8ce665db26d76517769` after engineering readiness on exact head `452478b64e81368c1c37975e4ee527f9a72652bb`.

The runtime had no local NeqSim checkout, so local Maven/JUnit, `python devtools/run_spotless.py apply/check`, pre-commit/pre-push, documentation search, and Javadocs are not claimed. The initial hosted Spotless artifact contained four formatting-only line joins in `DistillationColumn`; its exact target blob `c3a5499` was inspected and applied byte-for-byte through the connector. A later normal two-parent merge refreshed the branch onto unrelated ISO 15403 documentation work; all current-head gates were rerun.

Exact-head GitHub CI passed:

- Java 8 tests on Ubuntu and Windows;
- Java 21 fast tests on Ubuntu and Windows;
- all four Java 21 slow-test shards on Ubuntu;
- Java 21 Javadocs;
- CodeQL security analysis;
- Spotless format patch;
- pre-commit checks;
- documentation-search coverage;
- PaperLab replication gate;
- agent-skill cross-reference validation.

The final connector comparison was seven commits ahead, zero behind, with exactly the four intended files. The PR was mergeable without conflicts. No human or Copilot review, requested change, suggested-change block, PR comment, or unresolved review thread existed at the final audit.

Merged-`master` verification confirms the four exact accepted blobs: distillation guide `85c6a46`, specification model/Javadocs `81eab13`, column implementation `c3a5499`, and focused regression `95d037d`.