### PR TITLE
fix(flash): recover high-water CPA liquid splits

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -213,6 +213,13 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │     → Accept a lower-Gibbs physical candidate, or replace a non-conservative     │
 │       reference only with a balanced, equilibrated physical candidate            │
 │                                                                                 │
+│  IF ordinary CPA flash ends in one AQUEOUS phase with water feed ≥ 0.01:        │
+│     → Require f_water / p_water_sat ≥ 0.8 and at least 0.01 condensable          │
+│       hydrocarbon feed with T_c > T + 80 K; these checks gate cost only          │
+│     → Evaluate one cloned multiphase stability candidate                         │
+│     → Accept only an exactly-two-phase, normalized, balanced, fugacity-equal,    │
+│       distinct, lower-Gibbs OIL+AQUEOUS endpoint                                │
+│                                                                                 │
 │  IF trace water, GAS+OIL, min(β) ≤ 0.01, and x_water,oil ≥ 10 z_water:           │
 │     → Run the existing aqueous tangent-plane stability trial on a clone          │
 │     → Solve the multiphase beta problem, remove exactly one disappearing phase   │
@@ -285,6 +292,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Supplementary stability TPD limit | -1e-6 | Accept a converged amplified-K or composition-perturbation trial only when its reduced TPD exceeds that SSI solve's residual/step resolution and the trial composition is non-trivial |
 | Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid phase-search overhead for valid trace-water flashes. An already-active neutral aqueous split bypasses only this feed threshold when `max abs(Delta z_i)` is non-finite or above `1e-8`, allowing the bounded beta correction below without another stability calculation. An incipient trace-water GAS+OIL endpoint with `min(beta) <= 1e-4` also bypasses the threshold when its confirmed log-fugacity residual is non-finite or at least `1e-8`; the guarded candidate must then pass the strict feasibility and lower-Gibbs gates. |
 | Water-rich cross-algorithm fallback | water feed `>= 0.01` and current `max abs(Delta ln(f_i)) >= 1e-8`, material-balance failure, or multiphase collapse to one hydrocarbon phase | Evaluate the existing cold candidate through the alternate path first. If an invalid ordinary two-phase split remains after that candidate is rejected, preserve its compositions as the seed for one fully initialized `TPmultiflash` trial. A multiphase endpoint collapsed to one phase may try the ordinary path, including the same seeded refinement when the cold ordinary result is invalid, but accepts only a result that restores an AQUEOUS phase; ordinary gas appearance remains outside this aqueous-recovery fallback. Genuine OIL+AQUEOUS liquid-liquid endpoints remain on the multiphase path. Prevent reciprocal recursion and replace the endpoint only when the candidate has exactly two distinct bounded phases, normalized beta and compositions, material balance and fugacity residuals below `1e-8`, and a Gibbs reduction larger than `max(1e-6 J, 1e-8 abs(G))`. Already-feasible two-phase endpoints incur only the residual acceptance scan. |
+| CPA high-water hydrocarbon-liquid stability screen | ordinary one-phase AQUEOUS CPA endpoint, water feed `>= 0.01`, `f_water / p_water_sat >= 0.8`, and at least 0.01 hydrocarbon feed with `T_c > T + 80 K` | Use the water saturation, composition, and critical-temperature checks only as a performance gate for one cloned multiphase stability calculation. Accept only an exactly-two-phase, distinct, bounded, normalized result with material-balance and log-fugacity residuals below `1e-8` and a Gibbs reduction larger than `max(1e-8 J, 1e-12 abs(G))`. Chemical, ionic, solid, wax, non-CPA, explicit-multiphase, gas, and non-aqueous endpoints retain their existing paths. |
 | Trace-water aqueous-stability screen | water feed `< 0.01`, GAS+OIL, `min(beta) <= 0.01`, and `x_water,oil >= 10 z_water` | Use the structural conditions only as a performance gate for an aqueous TPD trial. The TPD result, reduced-active-set convergence below `1e-10`, phase normalization, `1e-8` material/fugacity checks, distinct compositions, and lower Gibbs energy determine acceptance. Full recursive TPmultiflash is not run. |
 | CPA one-phase aqueous-stability screen | water feed `< 0.01`, one ordinary phase, CPA model, and `f_water / p_water_sat >= 0.8` | Use the fugacity ratio only as a conservative performance gate for the existing aqueous TPD trial. When the trial adds one phase, rebuild the two-phase active set and require beta-solver residual `< 1e-10`, phase normalization, `1e-8` material/fugacity checks, distinct compositions, and a Gibbs reduction larger than `max(1e-8 J, 1e-12 abs(G))`. The tighter Gibbs tolerance retains independently converged incipient aqueous fractions without treating the saturation screen itself as a stability criterion. |
 | Water-rich material-balance tolerance | 1e-8 in `max abs(Delta z_i)` | Reject a non-conservative reference before comparing feasible Gibbs minima |
@@ -1766,6 +1774,15 @@ Commercial process simulators do not publish all implementation details, but pub
   feasible lower-Gibbs result. That invalid-endpoint retry is restricted to an incipient secondary phase with
   `min(beta) <= 1e-4`, so established valid gas/oil splits avoid even the component residual scan unless they satisfy
   the separate aqueous-stability screen.
+- An ordinary, neutral CPA endpoint containing substantial water can select the aqueous minimum before testing a
+  competing hydrocarbon-liquid minimum. A one-phase AQUEOUS result therefore receives one cloned multiphase stability
+  calculation only when water feed is at least `0.01`, `f_water / p_water_sat >= 0.8`, and at least `0.01` of the
+  feed is hydrocarbon with `T_c > T + 80 K`. These are performance screens, not stability evidence. The candidate
+  replaces the endpoint only when it contains exactly two distinct phases, has finite bounded and normalized phase
+  fractions and compositions, closes component balance and interphase log-fugacity residuals below `1e-8`, and lowers
+  Gibbs energy by more than `max(1e-8 J, 1e-12 abs(G))`. Stable polar aqueous endpoints without condensable
+  hydrocarbons stay on the ordinary fast path. Chemical, ionic, solid, wax, and explicit-multiphase calculations are
+  excluded.
 - The same strict gate is reciprocal for a water-rich multiphase GAS+AQUEOUS endpoint. If phase-appearance cleanup
   returns that phase set with a non-finite or at-least `1e-8` log-fugacity residual, one cold ordinary candidate is
   evaluated from the unchanged feed. It replaces the multiphase endpoint only when it is independently feasible and

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1522,8 +1522,8 @@ public class TPflash extends Flash {
    */
   private boolean shouldRefineSinglePhaseCpaAqueousEndpoint(double waterFeedFraction) {
     String modelName = system.getModelName();
-    if (system.doMultiPhaseCheck() || system.getNumberOfPhases() != 1
-        || !system.hasPhaseType(PhaseType.AQUEOUS) || modelName == null || !modelName.contains("CPA")
+    if (system.doMultiPhaseCheck() || system.getNumberOfPhases() != 1 || !system.hasPhaseType(PhaseType.AQUEOUS)
+        || modelName == null || !modelName.contains("CPA")
         || waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT
         || !isCpaWaterNearSaturation(CPA_WATER_SUPERSATURATION_SCREEN_LIMIT)) {
       return false;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1420,9 +1420,6 @@ public class TPflash extends Flash {
     }
 
     boolean hasAqueousPhase = system.hasPhaseType(PhaseType.AQUEOUS);
-    if (hasAqueousPhase && system.getNumberOfPhases() < 2) {
-      return;
-    }
     double waterFeedFraction = 0.0;
     for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
       neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
@@ -1430,6 +1427,10 @@ public class TPflash extends Flash {
         waterFeedFraction = component.getz();
         break;
       }
+    }
+    boolean singlePhaseCpaAqueousEndpoint = shouldRefineSinglePhaseCpaAqueousEndpoint(waterFeedFraction);
+    if (hasAqueousPhase && system.getNumberOfPhases() < 2 && !singlePhaseCpaAqueousEndpoint) {
+      return;
     }
     if (waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT
         && (waterFeedFraction <= 0.0 || !shouldRefineTraceWaterAqueousEndpoint(waterFeedFraction))) {
@@ -1446,7 +1447,7 @@ public class TPflash extends Flash {
     double materialBalanceResidual = maximumComponentMaterialBalanceResidual(system);
     boolean materialBalanceInvalid = !Double.isFinite(materialBalanceResidual)
         || materialBalanceResidual > WATER_RICH_MATERIAL_BALANCE_TOLERANCE;
-    if (hasAqueousPhase && !materialBalanceInvalid
+    if (hasAqueousPhase && !singlePhaseCpaAqueousEndpoint && !materialBalanceInvalid
         && maximumLogFugacityResidualWithReplacement(0, system.getPhase(0)) < PHASE_ROOT_EQUILIBRIUM_TOLERANCE) {
       return;
     }
@@ -1502,6 +1503,43 @@ public class TPflash extends Flash {
     if (invalidOrdinaryTwoPhaseSeed) {
       trySeededWaterRichPhaseSet(referenceGibbsEnergy, materialBalanceInvalid);
     }
+  }
+
+  /**
+   * Screens a single-phase CPA aqueous endpoint for a missed hydrocarbon-liquid phase.
+   *
+   * <p>
+   * A substantial water feed can make the ordinary vapor-liquid stability trial select the aqueous minimum and never
+   * test the competing hydrocarbon-liquid minimum. The screen is restricted to an ordinary, neutral CPA aqueous
+   * endpoint with at least one substantial hydrocarbon whose critical temperature remains well above the flash
+   * temperature. Water fugacity must also be near pure-water saturation. These checks use only the converged endpoint
+   * and immutable component data; the subsequent multiphase stability calculation and strict balance, fugacity, phase
+   * fraction, distinct-composition, and lower-Gibbs gates remain authoritative.
+   * </p>
+   *
+   * @param waterFeedFraction overall water mole fraction
+   * @return true when a guarded multiphase stability refinement is justified
+   */
+  private boolean shouldRefineSinglePhaseCpaAqueousEndpoint(double waterFeedFraction) {
+    String modelName = system.getModelName();
+    if (system.doMultiPhaseCheck() || system.getNumberOfPhases() != 1
+        || !system.hasPhaseType(PhaseType.AQUEOUS) || modelName == null || !modelName.contains("CPA")
+        || waterFeedFraction < WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT
+        || !isCpaWaterNearSaturation(CPA_WATER_SUPERSATURATION_SCREEN_LIMIT)) {
+      return false;
+    }
+    double condensableHydrocarbonFraction = 0.0;
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      double feedFraction = component.getz();
+      if (feedFraction <= LIQUID_LIQUID_ACTIVE_COMPONENT_LIMIT || !component.isHydrocarbon()) {
+        continue;
+      }
+      if (component.getTC() > system.getTemperature() + MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN) {
+        condensableHydrocarbonFraction += feedFraction;
+      }
+    }
+    return condensableHydrocarbonFraction >= WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT;
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashCpaHydrocarbonLiquidStabilityTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashCpaHydrocarbonLiquidStabilityTest.java
@@ -34,8 +34,8 @@ class TPflashCpaHydrocarbonLiquidStabilityTest {
 
   @Test
   void nearbyStatesCompositionsAndChangedPressureRemainConsistent() {
-    double[][] conditions = { { 280.0, 100.0 }, { 280.0, 200.0 }, { 300.0, 150.0 }, { 300.0, 175.0 },
-        { 313.15, 200.0 }, { 325.0, 225.0 }, { 350.0, 225.0 } };
+    double[][] conditions = { { 280.0, 100.0 }, { 280.0, 200.0 }, { 300.0, 150.0 }, { 300.0, 175.0 }, { 313.15, 200.0 },
+        { 325.0, 225.0 }, { 350.0, 225.0 } };
     for (double[] condition : conditions) {
       SystemInterface ordinary = createAndFlash(condition[0], condition[1], 0.65, false, false);
       SystemInterface multiphase = createAndFlash(condition[0], condition[1], 0.65, true, false);

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashCpaHydrocarbonLiquidStabilityTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashCpaHydrocarbonLiquidStabilityTest.java
@@ -1,0 +1,186 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashCpaHydrocarbonLiquidStabilityTest {
+  private static final String[] COMPONENTS = { "methane", "ethane", "propane", "n-heptane", "nC10", "water" };
+  private static final double[] BASE_FEED = { 0.12, 0.03, 0.03, 0.08, 0.09, 0.65 };
+
+  @Test
+  void ordinaryHighWaterCpaFlashRecoversLowerGibbsOilAqueousState() {
+    SystemInterface ordinary = createAndFlash(300.0, 200.0, 0.65, false, false);
+    SystemInterface multiphase = createAndFlash(300.0, 200.0, 0.65, true, false);
+    SystemInterface poorGuess = createAndFlash(300.0, 200.0, 0.65, false, true);
+
+    assertOilAqueousEquilibrium(ordinary);
+    assertEquals(0.3488579645, ordinary.getBeta(findPhase(ordinary, PhaseType.OIL)), 1.0e-10);
+    assertEquals(-5702.359476, ordinary.getGibbsEnergy(), 1.0e-5);
+    assertEquivalentEquilibrium(multiphase, ordinary);
+    assertEquivalentEquilibrium(ordinary, poorGuess);
+
+    SystemInterface repeatedReference = ordinary.clone();
+    new ThermodynamicOperations(ordinary).TPflash();
+    ordinary.init(3);
+    assertEquivalentEquilibrium(repeatedReference, ordinary);
+  }
+
+  @Test
+  void nearbyStatesCompositionsAndChangedPressureRemainConsistent() {
+    double[][] conditions = { { 280.0, 100.0 }, { 280.0, 200.0 }, { 300.0, 150.0 }, { 300.0, 175.0 },
+        { 313.15, 200.0 }, { 325.0, 225.0 }, { 350.0, 225.0 } };
+    for (double[] condition : conditions) {
+      SystemInterface ordinary = createAndFlash(condition[0], condition[1], 0.65, false, false);
+      SystemInterface multiphase = createAndFlash(condition[0], condition[1], 0.65, true, false);
+      assertOilAqueousEquilibrium(ordinary);
+      assertEquivalentEquilibrium(multiphase, ordinary);
+    }
+
+    for (double waterFraction : new double[] {0.50, 0.60, 0.65, 0.70, 0.80}) {
+      SystemInterface ordinary = createAndFlash(300.0, 200.0, waterFraction, false, false);
+      SystemInterface multiphase = createAndFlash(300.0, 200.0, waterFraction, true, false);
+      assertOilAqueousEquilibrium(ordinary);
+      assertEquivalentEquilibrium(multiphase, ordinary);
+    }
+
+    SystemInterface changedState = createAndFlash(300.0, 100.0, 0.65, false, false);
+    changedState.setPressure(200.0, "bara");
+    new ThermodynamicOperations(changedState).TPflash();
+    changedState.init(3);
+    SystemInterface target = createAndFlash(300.0, 200.0, 0.65, true, false);
+    assertEquivalentEquilibrium(target, changedState);
+
+    changedState.setPressure(100.0, "bara");
+    new ThermodynamicOperations(changedState).TPflash();
+    changedState.init(3);
+    SystemInterface reverseTarget = createAndFlash(300.0, 100.0, 0.65, true, false);
+    assertEquivalentEquilibrium(reverseTarget, changedState);
+  }
+
+  @Test
+  void stablePolarAqueousEndpointOutsideHydrocarbonScreenIsUnchanged() {
+    SystemInterface ordinary = new SystemSrkCPAstatoil(300.0, 200.0);
+    ordinary.addComponent("methanol", 0.35);
+    ordinary.addComponent("water", 0.65);
+    ordinary.setMixingRule(10);
+    ordinary.setMultiPhaseCheck(false);
+    new ThermodynamicOperations(ordinary).TPflash();
+    ordinary.init(3);
+
+    SystemInterface multiphase = ordinary.clone();
+    multiphase.setMultiPhaseCheck(true);
+    new ThermodynamicOperations(multiphase).TPflash();
+    multiphase.init(3);
+
+    assertEquals(1, ordinary.getNumberOfPhases());
+    assertEquals(PhaseType.AQUEOUS, ordinary.getPhase(0).getType());
+    assertEquivalentEquilibrium(ordinary, multiphase);
+
+    SystemInterface repeatedReference = ordinary.clone();
+    new ThermodynamicOperations(ordinary).TPflash();
+    ordinary.init(3);
+    assertEquivalentEquilibrium(repeatedReference, ordinary);
+  }
+
+  private SystemInterface createAndFlash(double temperature, double pressure, double waterFraction,
+      boolean multiphaseCheck, boolean poorGuess) {
+    SystemInterface system = new SystemSrkCPAstatoil(temperature, pressure);
+    double hydrocarbonScale = (1.0 - waterFraction) / (1.0 - BASE_FEED[BASE_FEED.length - 1]);
+    for (int componentIndex = 0; componentIndex < COMPONENTS.length - 1; componentIndex++) {
+      system.addComponent(COMPONENTS[componentIndex], BASE_FEED[componentIndex] * hydrocarbonScale);
+    }
+    system.addComponent("water", waterFraction);
+    system.setMixingRule(10);
+    system.setMultiPhaseCheck(multiphaseCheck);
+    if (poorGuess) {
+      system.setBeta(0, 1.0e-10);
+      system.setBeta(1, 1.0 - 1.0e-10);
+    }
+    new ThermodynamicOperations(system).TPflash();
+    system.init(3);
+    return system;
+  }
+
+  private void assertOilAqueousEquilibrium(SystemInterface system) {
+    assertEquals(2, system.getNumberOfPhases());
+    assertTrue(system.hasPhaseType(PhaseType.OIL));
+    assertTrue(system.hasPhaseType(PhaseType.AQUEOUS));
+    assertTrue(maximumComponentMaterialBalanceResidual(system) < 1.0e-10);
+    assertTrue(maximumLogFugacityResidual(system) < 1.0e-8);
+
+    double betaTotal = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      double beta = system.getBeta(phaseIndex);
+      assertTrue(Double.isFinite(beta) && beta > 0.0 && beta < 1.0);
+      betaTotal += beta;
+      double compositionTotal = 0.0;
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        double composition = system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        assertTrue(Double.isFinite(composition) && composition >= 0.0 && composition <= 1.0);
+        compositionTotal += composition;
+      }
+      assertEquals(1.0, compositionTotal, 1.0e-10);
+    }
+    assertEquals(1.0, betaTotal, 1.0e-12);
+  }
+
+  private void assertEquivalentEquilibrium(SystemInterface expected, SystemInterface actual) {
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-5);
+    assertEquals(expected.getEnthalpy(), actual.getEnthalpy(), 1.0e-5);
+    for (int expectedPhase = 0; expectedPhase < expected.getNumberOfPhases(); expectedPhase++) {
+      PhaseType phaseType = expected.getPhase(expectedPhase).getType();
+      int actualPhase = findPhase(actual, phaseType);
+      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), 1.0e-10);
+      assertEquals(expected.getPhase(expectedPhase).getZ(), actual.getPhase(actualPhase).getZ(), 1.0e-10);
+      assertEquals(expected.getPhase(expectedPhase).getDensity(), actual.getPhase(actualPhase).getDensity(), 1.0e-7);
+      for (int componentIndex = 0; componentIndex < expected.getPhase(expectedPhase)
+          .getNumberOfComponents(); componentIndex++) {
+        assertEquals(expected.getPhase(expectedPhase).getComponent(componentIndex).getx(),
+            actual.getPhase(actualPhase).getComponent(componentIndex).getx(), 1.0e-10);
+      }
+    }
+  }
+
+  private int findPhase(SystemInterface system, PhaseType phaseType) {
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (system.getPhase(phaseIndex).getType() == phaseType) return phaseIndex;
+    }
+    throw new AssertionError("Missing phase " + phaseType);
+  }
+
+  private double maximumComponentMaterialBalanceResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      double recoveredFeed = 0.0;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        recoveredFeed += system.getBeta(phaseIndex) * system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+      }
+      maximumResidual = Math.max(maximumResidual,
+          Math.abs(system.getPhase(0).getComponent(componentIndex).getz() - recoveredFeed));
+    }
+    return maximumResidual;
+  }
+
+  private double maximumLogFugacityResidual(SystemInterface system) {
+    if (system.getNumberOfPhases() < 2) return 0.0;
+    double maximumResidual = 0.0;
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      double firstLogFugacity = Math
+          .log(Math.max(system.getPhase(0).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
+      double secondLogFugacity = Math
+          .log(Math.max(system.getPhase(1).getComponent(componentIndex).getx(), Double.MIN_NORMAL))
+          + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
+      maximumResidual = Math.max(maximumResidual, Math.abs(firstLogFugacity - secondLogFugacity));
+    }
+    return maximumResidual;
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashCpaHydrocarbonLiquidStabilityTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashCpaHydrocarbonLiquidStabilityTest.java
@@ -22,7 +22,7 @@ class TPflashCpaHydrocarbonLiquidStabilityTest {
 
     assertOilAqueousEquilibrium(ordinary);
     assertEquals(0.3488579645, ordinary.getBeta(findPhase(ordinary, PhaseType.OIL)), 1.0e-10);
-    assertEquals(-5702.359476, ordinary.getGibbsEnergy(), 1.0e-5);
+    assertEquals(-5702.35947620, ordinary.getGibbsEnergy(), 1.0e-6);
     assertEquivalentEquilibrium(multiphase, ordinary);
     assertEquivalentEquilibrium(ordinary, poorGuess);
 
@@ -43,7 +43,7 @@ class TPflashCpaHydrocarbonLiquidStabilityTest {
       assertEquivalentEquilibrium(multiphase, ordinary);
     }
 
-    for (double waterFraction : new double[] {0.50, 0.60, 0.65, 0.70, 0.80}) {
+    for (double waterFraction : new double[] { 0.50, 0.60, 0.65, 0.70, 0.80 }) {
       SystemInterface ordinary = createAndFlash(300.0, 200.0, waterFraction, false, false);
       SystemInterface multiphase = createAndFlash(300.0, 200.0, waterFraction, true, false);
       assertOilAqueousEquilibrium(ordinary);
@@ -133,8 +133,8 @@ class TPflashCpaHydrocarbonLiquidStabilityTest {
 
   private void assertEquivalentEquilibrium(SystemInterface expected, SystemInterface actual) {
     assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
-    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 1.0e-5);
-    assertEquals(expected.getEnthalpy(), actual.getEnthalpy(), 1.0e-5);
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), 2.0e-6);
+    assertEquals(expected.getEnthalpy(), actual.getEnthalpy(), 2.0e-6);
     for (int expectedPhase = 0; expectedPhase < expected.getNumberOfPhases(); expectedPhase++) {
       PhaseType phaseType = expected.getPhase(expectedPhase).getType();
       int actualPhase = findPhase(actual, phaseType);
@@ -151,7 +151,9 @@ class TPflashCpaHydrocarbonLiquidStabilityTest {
 
   private int findPhase(SystemInterface system, PhaseType phaseType) {
     for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
-      if (system.getPhase(phaseIndex).getType() == phaseType) return phaseIndex;
+      if (system.getPhase(phaseIndex).getType() == phaseType) {
+        return phaseIndex;
+      }
     }
     throw new AssertionError("Missing phase " + phaseType);
   }
@@ -170,7 +172,9 @@ class TPflashCpaHydrocarbonLiquidStabilityTest {
   }
 
   private double maximumLogFugacityResidual(SystemInterface system) {
-    if (system.getNumberOfPhases() < 2) return 0.0;
+    if (system.getNumberOfPhases() < 2) {
+      return 0.0;
+    }
     double maximumResidual = 0.0;
     for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
       double firstLogFugacity = Math


### PR DESCRIPTION
## Problem

Advances #2937.

On exact master `dc3d907586a895dbac15db85643f4496be1645e9`, ordinary TPflash can accept a metastable single AQUEOUS phase for a substantial-water SRK-CPA feed even though explicit multiphase TPflash finds a balanced, fugacity-equilibrated OIL+AQUEOUS state with much lower Gibbs energy.

Minimal one-mole reproducer: `SystemSrkCPAstatoil`, mixing rule 10, 300 K, 200 bara; methane/ethane/propane/n-heptane/nC10/water = `0.12/0.03/0.03/0.08/0.09/0.65`.

| Path on master | Result | Gibbs (J) |
|---|---|---:|
| ordinary | AQUEOUS, beta 1 | -3303.96869706 |
| explicit multiphase | OIL+AQUEOUS, beta 0.3488579645 / 0.6511420355 | -5702.35947585 |

The missed reduction is `2398.39077878 J`. The explicit result has maximum component-balance residual `2.02e-14` and maximum interphase log-fugacity residual `1.74e-13`.

This is distinct from #2870, which repaired trace-water GAS to GAS+AQUEOUS appearance, and #2876, which seeded a missing gas phase in high-water multiphase VLLE.

## Root cause

`rescueWaterRichEndpoint()` returned immediately whenever an ordinary endpoint already had a single AQUEOUS phase. That phase label proves only which local minimum the ordinary vapor-liquid search selected; it does not test the competing hydrocarbon-liquid minimum. Consequently the existing cloned multiphase stability path was never considered.

## Method and evidence basis

A cheap, deterministic screen now permits one cloned multiphase stability refinement only for an ordinary, neutral, one-phase CPA AQUEOUS endpoint when:

1. water feed is at least `0.01`;
2. `f_water / p_water_sat >= 0.8`;
3. at least `0.01` of the feed is hydrocarbon with `T_c > T + 80 K`.

These conditions gate solver cost; they do not decide stability. The candidate replaces the endpoint only when the existing strict gates confirm exactly two distinct phases, finite/bounded/normalized beta and compositions, component material balance and interphase log-fugacity residual below `1e-8`, and a Gibbs reduction larger than `max(1e-8 J, 1e-12 |G|)`.

The method reuses NeqSim's existing Michelsen stability/multiphase solve and acceptance logic. Literature basis:

- Michelsen, “The isothermal flash problem. Part I. Stability,” *Fluid Phase Equilibria* 9 (1982), https://doi.org/10.1016/0378-3812(82)85001-2.
- Michelsen, “The isothermal flash problem. Part II. Phase-split calculation,” *Fluid Phase Equilibria* 9 (1982), https://doi.org/10.1016/0378-3812(82)85002-4.

Evidence: lower extensive Gibbs energy, material conservation, fugacity equality, deterministic repeatability, and ordinary/multiphase agreement. Inference: the water-saturation, feed-fraction, and critical-temperature margins are conservative performance screens; candidate stability remains authoritative.

## Before/after evidence

The focused regression is fail-before-fix:

- exact master source: 1/3 test methods pass; the exact and nearby/cross-algorithm methods fail because ordinary returns one phase;
- candidate source: 3/3 pass.

At 300 K/200 bara after the change:

- ordinary and multiphase both return OIL+AQUEOUS;
- beta and phase compositions agree within `1e-10`;
- maximum ordinary component-balance residual: `2.02e-14`;
- maximum ordinary log-fugacity residual: `2.16e-10`;
- ordinary/multiphase Gibbs difference: `3.52e-7 J`.

Frozen coverage includes:

- T/P points: 280 K/100 and 200 bara; 300 K/150, 175, and 200 bara; 313.15 K/200 bara; 325 and 350 K/225 bara;
- water fractions 0.50, 0.60, 0.65, 0.70, and 0.80 at 300 K/200 bara;
- poor beta `1e-10 / (1 - 1e-10)`;
- repeat on the same object;
- same-object pressure continuation 100 → 200 → 100 bara;
- a stable methanol/water CPA one-phase AQUEOUS control outside the hydrocarbon screen.

The 444-state broader hydrocarbon/oil/water, CO2-rich, H2-rich, near-critical, large-volatility-contrast, CPA, trace-water, and supported-electrolyte screen completed with zero exceptions. Applicable material differences decreased 14 → 13 and no new difference appeared. Genuine three-phase states and previously classified unsupported/invalid UMR or reactive-electrolyte comparisons remain outside this increment.

## Performance

The corrected path intentionally adds one cloned multiphase stability calculation. Warmed 300 K/200 bara medians were approximately:

| Path | Median complete-flash time |
|---|---:|
| master ordinary, incorrect endpoint | 1.96 ms |
| candidate ordinary, corrected endpoint | 13.97 ms |
| explicit multiphase | 11.32 ms |

No speedup is claimed. The measurable benefit is correct stable phase selection. Structurally guard-false paths execute no additional flash; the stable polar aqueous control is numerically unchanged.

## Tests and validation

Local support validation used OpenJDK 17.0.19 and the exact connector-fetched master `TPflash.java` and `TPmultiflash.java` compiled ahead of the installed NeqSim 3.17.0 runtime:

- new regression alone: 3/3 passed on candidate;
- new regression plus the current sour-gas consistency regression: 7/7 passed;
- broader deterministic matrix: 444 states, zero exceptions;
- direct Java source compilation: passed.

**VALIDATION COMPLETE — READY TO MERGE** on exact head `e65086e648e4bb37e617f82565bc41282b59cf3b`.

Local support validation used OpenJDK 17.0.19 and the exact connector-fetched master `TPflash.java` and `TPmultiflash.java` compiled ahead of the installed NeqSim 3.17.0 runtime:

- new regression alone: 3/3 passed on candidate;
- new regression plus the current sour-gas consistency regression: 7/7 passed;
- broader deterministic matrix: 444 states, zero exceptions;
- direct Java source compilation: passed.

Hosted exact-head validation completed successfully:

- Java 21 fast tests on Ubuntu and Windows;
- all four Java 21 slow-test shards;
- Java 8 tests on Ubuntu and Windows;
- Java 21 Javadocs;
- Spotless, pre-commit, and documentation-search coverage;
- PaperLab, agent-skill reference validation, and CodeQL.

GitHub reports the PR mergeable. The final diff remains scoped to the intended documentation, `TPflash` implementation, and focused CPA regression files. No human or Copilot reviews, comments, requested changes, or unresolved threads are present. The branch is one commit behind current `master` without a conflict.

## Compatibility and risk

No public API, serialized field, EOS parameter, mixing rule, convergence tolerance, or multiphase kernel changes. Chemical/electrolyte, ionic, solid, wax, non-CPA, explicit-multiphase, gas, and non-aqueous endpoints are excluded. The main compatibility risk is extra work for a stable one-phase CPA aqueous feed that passes all three conservative screens; strict stability/closure/Gibbs checks retain its original state.

Low-pressure cases where explicit multiphase TPflash finds three phases are intentionally not forced through the ordinary two-phase consistency gate.

## Documentation impact

Updated private-method Javadocs and `docs/thermodynamicoperations/TPflash_algorithm.md` to document the new performance screen, strict acceptance gate, exclusions, solver cost, and evidence-versus-inference distinction. No notebook changed.