### PR TITLE
[AI-Assisted] feat(dynamics): transact fire-and-gas detector events

### DIFF
--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -440,3 +440,27 @@ own signal state is not owned by the primary flow meter.
 This transaction gate does not alter or newly qualify ISO 5167 or ISO/TR 11583 physics, wet-gas correlation validity,
 meter uncertainty, installation effects, sampling accuracy, allocation/fiscal metering, external I/O, alarm/trip
 integrity, safety action, virtual commissioning or OTS use.
+
+
+## Local fire-and-gas detector transaction coverage
+
+Concrete local `GasDetector` and `FireDetector` instances participate when registered as
+measurement devices in a `ProcessSystem`. Their snapshots include stable transaction identity,
+all inherited measurement/alarm state, and every detector field that an event or operator action
+can change. Gas snapshots preserve detector type, concentration, species, location, LEL and
+configured response time. Fire snapshots preserve the fire latch, signal level, threshold,
+configured delay and location.
+
+A `ProcessSystem` transaction already snapshots its `EventScheduler` pending/fired membership.
+Combining that bookkeeping snapshot with registered detector participants closes the in-memory
+side effect for scheduled fire/gas actions: rejection restores both the event boundary and detector
+state, while replay reproduces the same action and accepted commit retains it. Quantitative tests
+cover coordinated multi-area rollback, replay, commit, delayed-alarm continuation, object identity,
+fail-closed subclass/online modes, foreign-snapshot rejection and Java-serialization restart.
+
+Only registered, in-memory detector state is covered. Arbitrary event callbacks may mutate other
+objects or external systems and remain outside the transaction unless those objects participate
+independently. The detector response-time and detection-delay values are currently configuration
+metadata rather than integrated physical sensor dynamics. This gate does not qualify detector
+placement, fire/gas dispersion, voting, reliability, alarm/trip integrity, ESD action, external
+I/O, safety integrity, certification, virtual commissioning or OTS use.

--- a/docs/process/equipment/measurement_devices.md
+++ b/docs/process/equipment/measurement_devices.md
@@ -472,9 +472,10 @@ Simulates gas detection for safety systems.
 ```java
 import neqsim.process.measurementdevice.GasDetector;
 
-GasDetector gasDetector = new GasDetector("Gas Detector 1", stream);
-gasDetector.setDetectionLimit(20.0);  // % LEL
-boolean gasDetected = gasDetector.isTriggered();
+GasDetector gasDetector =
+    new GasDetector("Gas Detector 1", GasDetector.GasType.COMBUSTIBLE);
+gasDetector.setGasConcentration(25.0);  // % LEL
+boolean gasDetected = gasDetector.isGasDetected(20.0);
 ```
 
 ### FireDetector
@@ -485,9 +486,24 @@ Simulates fire detection for safety systems.
 import neqsim.process.measurementdevice.FireDetector;
 
 FireDetector fireDetector = new FireDetector("Fire Detector 1");
-fireDetector.setTemperatureThreshold(65.0);  // °C
-boolean fireDetected = fireDetector.isTriggered();
+fireDetector.setDetectionThreshold(0.8);
+fireDetector.setSignalLevel(0.9);
+boolean fireDetected = fireDetector.isFireDetected();
 ```
+
+
+When concrete local `GasDetector` and `FireDetector` instances are registered in a
+`ProcessSystem`, their complete detector and inherited alarm/measurement state participates in
+transient-step transactions. This includes gas type, concentration, species, location, LEL and
+response-time configuration, plus the fire latch, signal, threshold, configured delay and location.
+Scheduled event actions that change these detectors can therefore be rolled back and replayed
+deterministically together with scheduler pending/fired bookkeeping. Concrete descendants and
+online-signal bindings remain fail-closed.
+
+This is an in-memory numerical rollback contract, not fire-and-gas detector certification. The
+configured response time and detection delay are retained settings; the current detector classes do
+not integrate those values as physical sensor dynamics. External I/O, voting logic, ESD action,
+detector coverage, reliability and safety-integrity qualification remain outside this support.
 
 ## Quality Analysers
 

--- a/src/main/java/neqsim/process/measurementdevice/FireDetector.java
+++ b/src/main/java/neqsim/process/measurementdevice/FireDetector.java
@@ -51,9 +51,9 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * </pre>
  *
  * <p>
- * A concrete local detector registered in a process participates in transient-step transactions.
- * Rollback restores the fire latch, signal/configuration and inherited alarm/measurement state.
- * Subclasses and online-signal bindings remain fail-closed.
+ * A concrete local detector registered in a process participates in transient-step transactions. Rollback restores the
+ * fire latch, signal/configuration and inherited alarm/measurement state. Subclasses and online-signal bindings remain
+ * fail-closed.
  *
  * @author ESOL
  * @version $Id: $Id
@@ -339,8 +339,7 @@ public class FireDetector extends MeasurementDeviceBaseClass
     private final MeasurementDeviceTransientState measurementState;
 
     private FireDetectorState(String stateIdentity, boolean fireDetected, double detectionThreshold,
-        double detectionDelay, double signalLevel, String location,
-        MeasurementDeviceTransientState measurementState) {
+        double detectionDelay, double signalLevel, String location, MeasurementDeviceTransientState measurementState) {
       this.stateIdentity = stateIdentity;
       this.fireDetected = fireDetected;
       this.detectionThreshold = detectionThreshold;

--- a/src/main/java/neqsim/process/measurementdevice/FireDetector.java
+++ b/src/main/java/neqsim/process/measurementdevice/FireDetector.java
@@ -50,6 +50,11 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * fireDetector2.reset();
  * </pre>
  *
+ * <p>
+ * A concrete local detector registered in a process participates in transient-step transactions.
+ * Rollback restores the fire latch, signal/configuration and inherited alarm/measurement state.
+ * Subclasses and online-signal bindings remain fail-closed.
+ *
  * @author ESOL
  * @version $Id: $Id
  */

--- a/src/main/java/neqsim/process/measurementdevice/FireDetector.java
+++ b/src/main/java/neqsim/process/measurementdevice/FireDetector.java
@@ -1,5 +1,8 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
 /**
@@ -50,9 +53,12 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * @author ESOL
  * @version $Id: $Id
  */
-public class FireDetector extends MeasurementDeviceBaseClass {
+public class FireDetector extends MeasurementDeviceBaseClass
+    implements TransientStateParticipant<FireDetector.FireDetectorState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /** Indicates if fire is currently detected. */
   private boolean fireDetected = false;
@@ -266,5 +272,77 @@ public class FireDetector extends MeasurementDeviceBaseClass {
     sb.append("] - State: ").append(fireDetected ? "FIRE DETECTED" : "NO FIRE");
     sb.append(", Signal: ").append(String.format("%.2f", signalLevel));
     return sb.toString();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:fire-detector:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local fire detector.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != FireDetector.class) {
+      return "fire-detector subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public FireDetectorState captureTransientState() {
+    return new FireDetectorState(getTransientStateIdentity(), fireDetected, detectionThreshold, detectionDelay,
+        signalLevel, location, captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(FireDetectorState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Fire-detector transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Fire-detector snapshot identity does not match " + getTransientStateIdentity());
+    }
+    fireDetected = snapshot.fireDetected;
+    detectionThreshold = snapshot.detectionThreshold;
+    detectionDelay = snapshot.detectionDelay;
+    signalLevel = snapshot.signalLevel;
+    location = snapshot.location;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable fire-detector rollback point. */
+  public static final class FireDetectorState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final boolean fireDetected;
+    private final double detectionThreshold;
+    private final double detectionDelay;
+    private final double signalLevel;
+    private final String location;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private FireDetectorState(String stateIdentity, boolean fireDetected, double detectionThreshold,
+        double detectionDelay, double signalLevel, String location,
+        MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.fireDetected = fireDetected;
+      this.detectionThreshold = detectionThreshold;
+      this.detectionDelay = detectionDelay;
+      this.signalLevel = signalLevel;
+      this.location = location;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/GasDetector.java
+++ b/src/main/java/neqsim/process/measurementdevice/GasDetector.java
@@ -1,5 +1,8 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
 /**
@@ -63,9 +66,12 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * @author ESOL
  * @version $Id: $Id
  */
-public class GasDetector extends MeasurementDeviceBaseClass {
+public class GasDetector extends MeasurementDeviceBaseClass
+    implements TransientStateParticipant<GasDetector.GasDetectorState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /**
    * Enumeration of gas detector types.
@@ -436,5 +442,80 @@ public class GasDetector extends MeasurementDeviceBaseClass {
     sb.append(" [").append(gasSpecies).append("]");
 
     return sb.toString();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:gas-detector:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local gas detector.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != GasDetector.class) {
+      return "gas-detector subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public GasDetectorState captureTransientState() {
+    return new GasDetectorState(getTransientStateIdentity(), gasType, gasConcentration, gasSpecies, location,
+        lowerExplosiveLimit, responseTime, captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(GasDetectorState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Gas-detector transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Gas-detector snapshot identity does not match " + getTransientStateIdentity());
+    }
+    gasType = snapshot.gasType;
+    gasConcentration = snapshot.gasConcentration;
+    gasSpecies = snapshot.gasSpecies;
+    location = snapshot.location;
+    lowerExplosiveLimit = snapshot.lowerExplosiveLimit;
+    responseTime = snapshot.responseTime;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable gas-detector rollback point. */
+  public static final class GasDetectorState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final GasType gasType;
+    private final double gasConcentration;
+    private final String gasSpecies;
+    private final String location;
+    private final double lowerExplosiveLimit;
+    private final double responseTime;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private GasDetectorState(String stateIdentity, GasType gasType, double gasConcentration, String gasSpecies,
+        String location, double lowerExplosiveLimit, double responseTime,
+        MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.gasType = gasType;
+      this.gasConcentration = gasConcentration;
+      this.gasSpecies = gasSpecies;
+      this.location = location;
+      this.lowerExplosiveLimit = lowerExplosiveLimit;
+      this.responseTime = responseTime;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/GasDetector.java
+++ b/src/main/java/neqsim/process/measurementdevice/GasDetector.java
@@ -64,9 +64,9 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * </ul>
  *
  * <p>
- * A concrete local detector registered in a process participates in transient-step transactions.
- * Rollback restores detector configuration, concentration and inherited alarm/measurement state.
- * Subclasses and online-signal bindings remain fail-closed.
+ * A concrete local detector registered in a process participates in transient-step transactions. Rollback restores
+ * detector configuration, concentration and inherited alarm/measurement state. Subclasses and online-signal bindings
+ * remain fail-closed.
  *
  * @author ESOL
  * @version $Id: $Id

--- a/src/main/java/neqsim/process/measurementdevice/GasDetector.java
+++ b/src/main/java/neqsim/process/measurementdevice/GasDetector.java
@@ -63,6 +63,11 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * <li>Confined space monitoring</li>
  * </ul>
  *
+ * <p>
+ * A concrete local detector registered in a process participates in transient-step transactions.
+ * Rollback restores detector configuration, concentration and inherited alarm/measurement state.
+ * Subclasses and online-signal bindings remain fail-closed.
+ *
  * @author ESOL
  * @version $Id: $Id
  */

--- a/src/test/java/neqsim/process/measurementdevice/FireGasDetectorTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/FireGasDetectorTransientStateTransactionTest.java
@@ -13,6 +13,7 @@ import java.io.ObjectOutputStream;
 import org.junit.jupiter.api.Test;
 import neqsim.process.alarm.AlarmConfig;
 import neqsim.process.alarm.AlarmState;
+import neqsim.process.dynamics.EventScheduler;
 import neqsim.process.dynamics.TransientStepTransaction;
 import neqsim.process.dynamics.TransientTransactionCoverage;
 import neqsim.process.measurementdevice.GasDetector.GasType;
@@ -46,8 +47,10 @@ class FireGasDetectorTransientStateTransactionTest extends neqsim.NeqSimTest {
     AlarmState originalFireAlarmState = fire.getAlarmState();
 
     ProcessSystem gasArea = new ProcessSystem("gas detection area");
+    gasArea.setEventScheduler(new EventScheduler());
     gasArea.add(gas);
     ProcessSystem fireArea = new ProcessSystem("fire detection area");
+    fireArea.setEventScheduler(new EventScheduler());
     fireArea.add(fire);
     assertCompleteCoverage(gasArea.getTransientTransactionCoverage(), 1);
     assertCompleteCoverage(fireArea.getTransientTransactionCoverage(), 1);

--- a/src/test/java/neqsim/process/measurementdevice/FireGasDetectorTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/FireGasDetectorTransientStateTransactionTest.java
@@ -1,0 +1,239 @@
+package neqsim.process.measurementdevice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import neqsim.process.alarm.AlarmConfig;
+import neqsim.process.alarm.AlarmState;
+import neqsim.process.dynamics.TransientStepTransaction;
+import neqsim.process.dynamics.TransientTransactionCoverage;
+import neqsim.process.measurementdevice.GasDetector.GasType;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+
+/**
+ * Rollback, event replay, multi-area coverage, and restart evidence for local fire-and-gas
+ * detectors.
+ */
+class FireGasDetectorTransientStateTransactionTest extends neqsim.NeqSimTest {
+  @Test
+  void multiAreaRollbackRestoresScheduledDetectorActionsAndAlarmState() {
+    GasDetector gas = new GasDetector("GD-101", GasType.COMBUSTIBLE, "separator module");
+    gas.setGasConcentration(5.0);
+    gas.setGasSpecies("methane");
+    gas.setLowerExplosiveLimit(50000.0);
+    gas.setResponseTime(8.0);
+    AlarmConfig gasAlarm =
+        AlarmConfig.builder().highLimit(20.0).delay(2.0).unit("% LEL").build();
+    gas.setAlarmConfig(gasAlarm);
+    AlarmState originalGasAlarmState = gas.getAlarmState();
+
+    FireDetector fire = new FireDetector("FD-201", "compressor module");
+    fire.setDetectionThreshold(0.8);
+    fire.setDetectionDelay(3.0);
+    fire.setSignalLevel(0.2);
+    AlarmConfig fireAlarm =
+        AlarmConfig.builder().highLimit(0.5).delay(2.0).unit("binary").build();
+    fire.setAlarmConfig(fireAlarm);
+    AlarmState originalFireAlarmState = fire.getAlarmState();
+
+    ProcessSystem gasArea = new ProcessSystem("gas detection area");
+    gasArea.add(gas);
+    ProcessSystem fireArea = new ProcessSystem("fire detection area");
+    fireArea.add(fire);
+    assertCompleteCoverage(gasArea.getTransientTransactionCoverage(), 1);
+    assertCompleteCoverage(fireArea.getTransientTransactionCoverage(), 1);
+
+    ProcessModel model = new ProcessModel();
+    model.add("gas", gasArea);
+    model.add("fire", fireArea);
+    assertCompleteCoverage(model.getTransientTransactionCoverage(), 2);
+
+    gasArea.getEventScheduler().scheduleEvent(1.0, "gas release", () -> {
+      gas.setGasConcentration(70.0);
+      gas.setGasSpecies("propane");
+      gas.setLocation("trial gas zone");
+    });
+    fireArea.getEventScheduler().scheduleEvent(1.0, "fire", () -> {
+      fire.detectFire();
+      fire.setLocation("trial fire zone");
+    });
+
+    String gasIdentity = gas.getTransientStateIdentity();
+    String fireIdentity = fire.getTransientStateIdentity();
+    TransientStepTransaction transaction = model.beginTransientStepTransaction();
+
+    assertEquals(1, gasArea.getEventScheduler().fireDueEvents(1.0));
+    assertEquals(1, fireArea.getEventScheduler().fireDueEvents(1.0));
+    assertEquals(70.0, gas.getGasConcentration(), 0.0);
+    assertTrue(fire.isFireDetected());
+    assertTrue(gas.evaluateAlarm(gas.getMeasuredValue(), 1.0, 1.0).isEmpty());
+    assertTrue(fire.evaluateAlarm(fire.getMeasuredValue(), 1.0, 1.0).isEmpty());
+
+    gas.setLowerExplosiveLimit(21000.0);
+    gas.setResponseTime(1.0);
+    fire.setDetectionThreshold(0.1);
+    fire.setDetectionDelay(0.0);
+    gas.setName("trial gas detector");
+    fire.setName("trial fire detector");
+    transaction.rollback();
+
+    assertEquals(gasIdentity, gas.getTransientStateIdentity());
+    assertEquals(fireIdentity, fire.getTransientStateIdentity());
+    assertEquals("GD-101", gas.getName());
+    assertEquals("FD-201", fire.getName());
+    assertEquals(5.0, gas.getGasConcentration(), 0.0);
+    assertEquals("methane", gas.getGasSpecies());
+    assertEquals("separator module", gas.getLocation());
+    assertEquals(50000.0, gas.getLowerExplosiveLimit(), 0.0);
+    assertEquals(8.0, gas.getResponseTime(), 0.0);
+    assertFalse(fire.isFireDetected());
+    assertEquals(0.2, fire.getSignalLevel(), 0.0);
+    assertEquals(0.8, fire.getDetectionThreshold(), 0.0);
+    assertEquals(3.0, fire.getDetectionDelay(), 0.0);
+    assertEquals("compressor module", fire.getLocation());
+    assertSame(gasAlarm, gas.getAlarmConfig());
+    assertSame(fireAlarm, fire.getAlarmConfig());
+    assertSame(originalGasAlarmState, gas.getAlarmState());
+    assertSame(originalFireAlarmState, fire.getAlarmState());
+    assertEquals(1, gasArea.getEventScheduler().getPendingEvents().size());
+    assertEquals(0, gasArea.getEventScheduler().getFiredEvents().size());
+    assertEquals(1, fireArea.getEventScheduler().getPendingEvents().size());
+    assertEquals(0, fireArea.getEventScheduler().getFiredEvents().size());
+
+    TransientStepTransaction replay = model.beginTransientStepTransaction();
+    assertEquals(1, gasArea.getEventScheduler().fireDueEvents(1.0));
+    assertEquals(1, fireArea.getEventScheduler().fireDueEvents(1.0));
+    assertEquals(70.0, gas.getGasConcentration(), 0.0);
+    assertEquals("propane", gas.getGasSpecies());
+    assertEquals("trial gas zone", gas.getLocation());
+    assertTrue(fire.isFireDetected());
+    assertEquals(1.0, fire.getSignalLevel(), 0.0);
+    assertEquals("trial fire zone", fire.getLocation());
+    assertTrue(gas.evaluateAlarm(gas.getMeasuredValue(), 1.0, 1.0).isEmpty());
+    assertEquals(1, gas.evaluateAlarm(gas.getMeasuredValue(), 1.0, 2.0).size());
+    assertTrue(fire.evaluateAlarm(fire.getMeasuredValue(), 1.0, 1.0).isEmpty());
+    assertEquals(1, fire.evaluateAlarm(fire.getMeasuredValue(), 1.0, 2.0).size());
+    replay.commit();
+
+    assertEquals(0, gasArea.getEventScheduler().getPendingEvents().size());
+    assertEquals(1, gasArea.getEventScheduler().getFiredEvents().size());
+    assertEquals(0, fireArea.getEventScheduler().getPendingEvents().size());
+    assertEquals(1, fireArea.getEventScheduler().getFiredEvents().size());
+  }
+
+  @Test
+  void serializedDetectorSnapshotsRestoreRestartContinuation() throws Exception {
+    GasDetector gas = new GasDetector("GD-301", GasType.TOXIC, "utility area");
+    gas.setGasConcentration(15.0);
+    gas.setGasSpecies("H2S");
+    gas.setLowerExplosiveLimit(44000.0);
+    gas.setResponseTime(4.0);
+    String gasIdentity = gas.getTransientStateIdentity();
+    GasDetector.GasDetectorState gasSnapshot = gas.captureTransientState();
+    gas.setGasConcentration(200.0);
+    gas.setGasSpecies("CO");
+
+    FireDetector fire = new FireDetector("FD-301", "utility area");
+    fire.setDetectionThreshold(0.7);
+    fire.setDetectionDelay(2.5);
+    fire.setSignalLevel(0.4);
+    String fireIdentity = fire.getTransientStateIdentity();
+    FireDetector.FireDetectorState fireSnapshot = fire.captureTransientState();
+    fire.detectFire();
+
+    byte[] serialized;
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(gas);
+      output.writeObject(gasSnapshot);
+      output.writeObject(fire);
+      output.writeObject(fireSnapshot);
+      serialized = bytes.toByteArray();
+    }
+
+    try (ObjectInputStream input =
+        new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      GasDetector restoredGas = (GasDetector) input.readObject();
+      GasDetector.GasDetectorState restoredGasSnapshot =
+          (GasDetector.GasDetectorState) input.readObject();
+      FireDetector restoredFire = (FireDetector) input.readObject();
+      FireDetector.FireDetectorState restoredFireSnapshot =
+          (FireDetector.FireDetectorState) input.readObject();
+
+      restoredGas.restoreTransientState(restoredGasSnapshot);
+      restoredFire.restoreTransientState(restoredFireSnapshot);
+
+      assertEquals(gasIdentity, restoredGas.getTransientStateIdentity());
+      assertEquals(15.0, restoredGas.getGasConcentration(), 0.0);
+      assertEquals("H2S", restoredGas.getGasSpecies());
+      assertEquals(44000.0, restoredGas.getLowerExplosiveLimit(), 0.0);
+      assertEquals(4.0, restoredGas.getResponseTime(), 0.0);
+      assertEquals(fireIdentity, restoredFire.getTransientStateIdentity());
+      assertFalse(restoredFire.isFireDetected());
+      assertEquals(0.4, restoredFire.getSignalLevel(), 0.0);
+      assertEquals(0.7, restoredFire.getDetectionThreshold(), 0.0);
+      assertEquals(2.5, restoredFire.getDetectionDelay(), 0.0);
+    }
+  }
+
+  @Test
+  void descendantsOnlineModesNullAndForeignSnapshotsFailClosed() {
+    GasDetector gasSubclass = new GasDetector("gas subclass") {
+      private static final long serialVersionUID = 1000L;
+    };
+    FireDetector fireSubclass = new FireDetector("fire subclass") {
+      private static final long serialVersionUID = 1000L;
+    };
+    ProcessSystem process = new ProcessSystem("detector coverage blockers");
+    process.add(gasSubclass);
+    process.add(fireSubclass);
+
+    TransientTransactionCoverage coverage = process.getTransientTransactionCoverage();
+    assertEquals(2, coverage.getProcessElementCount());
+    assertEquals(2, coverage.getParticipantCount());
+    assertFalse(coverage.isComplete());
+    assertEquals(2, coverage.getBlockingIssues().size());
+    for (String issue : coverage.getBlockingIssues()) {
+      assertTrue(issue.contains("subclass-owned mutable state"));
+    }
+
+    GasDetector onlineGas = new GasDetector("online gas");
+    onlineGas.setIsOnlineSignal(true, "plant", "GD-ONLINE");
+    ProcessSystem onlineProcess = new ProcessSystem("online detector blocker");
+    onlineProcess.add(onlineGas);
+    assertFalse(onlineProcess.getTransientTransactionCoverage().isComplete());
+    assertTrue(
+        onlineProcess.getTransientTransactionCoverage().getBlockingIssues().get(0)
+            .contains("external I/O"));
+
+    GasDetector firstGas = new GasDetector("first gas");
+    GasDetector secondGas = new GasDetector("second gas");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> secondGas.restoreTransientState(firstGas.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> firstGas.restoreTransientState(null));
+
+    FireDetector firstFire = new FireDetector("first fire");
+    FireDetector secondFire = new FireDetector("second fire");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> secondFire.restoreTransientState(firstFire.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> firstFire.restoreTransientState(null));
+  }
+
+  private static void assertCompleteCoverage(
+      TransientTransactionCoverage coverage, int expectedCount) {
+    assertEquals(expectedCount, coverage.getProcessElementCount());
+    assertEquals(expectedCount, coverage.getParticipantCount());
+    assertTrue(coverage.isComplete(), coverage.getBlockingIssues().toString());
+  }
+}

--- a/src/test/java/neqsim/process/measurementdevice/FireGasDetectorTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/FireGasDetectorTransientStateTransactionTest.java
@@ -21,8 +21,7 @@ import neqsim.process.processmodel.ProcessModel;
 import neqsim.process.processmodel.ProcessSystem;
 
 /**
- * Rollback, event replay, multi-area coverage, and restart evidence for local fire-and-gas
- * detectors.
+ * Rollback, event replay, multi-area coverage, and restart evidence for local fire-and-gas detectors.
  */
 class FireGasDetectorTransientStateTransactionTest extends neqsim.NeqSimTest {
   @Test
@@ -32,8 +31,7 @@ class FireGasDetectorTransientStateTransactionTest extends neqsim.NeqSimTest {
     gas.setGasSpecies("methane");
     gas.setLowerExplosiveLimit(50000.0);
     gas.setResponseTime(8.0);
-    AlarmConfig gasAlarm =
-        AlarmConfig.builder().highLimit(20.0).delay(2.0).unit("% LEL").build();
+    AlarmConfig gasAlarm = AlarmConfig.builder().highLimit(20.0).delay(2.0).unit("% LEL").build();
     gas.setAlarmConfig(gasAlarm);
     AlarmState originalGasAlarmState = gas.getAlarmState();
 
@@ -41,8 +39,7 @@ class FireGasDetectorTransientStateTransactionTest extends neqsim.NeqSimTest {
     fire.setDetectionThreshold(0.8);
     fire.setDetectionDelay(3.0);
     fire.setSignalLevel(0.2);
-    AlarmConfig fireAlarm =
-        AlarmConfig.builder().highLimit(0.5).delay(2.0).unit("binary").build();
+    AlarmConfig fireAlarm = AlarmConfig.builder().highLimit(0.5).delay(2.0).unit("binary").build();
     fire.setAlarmConfig(fireAlarm);
     AlarmState originalFireAlarmState = fire.getAlarmState();
 
@@ -163,14 +160,11 @@ class FireGasDetectorTransientStateTransactionTest extends neqsim.NeqSimTest {
       serialized = bytes.toByteArray();
     }
 
-    try (ObjectInputStream input =
-        new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
       GasDetector restoredGas = (GasDetector) input.readObject();
-      GasDetector.GasDetectorState restoredGasSnapshot =
-          (GasDetector.GasDetectorState) input.readObject();
+      GasDetector.GasDetectorState restoredGasSnapshot = (GasDetector.GasDetectorState) input.readObject();
       FireDetector restoredFire = (FireDetector) input.readObject();
-      FireDetector.FireDetectorState restoredFireSnapshot =
-          (FireDetector.FireDetectorState) input.readObject();
+      FireDetector.FireDetectorState restoredFireSnapshot = (FireDetector.FireDetectorState) input.readObject();
 
       restoredGas.restoreTransientState(restoredGasSnapshot);
       restoredFire.restoreTransientState(restoredFireSnapshot);
@@ -214,27 +208,22 @@ class FireGasDetectorTransientStateTransactionTest extends neqsim.NeqSimTest {
     ProcessSystem onlineProcess = new ProcessSystem("online detector blocker");
     onlineProcess.add(onlineGas);
     assertFalse(onlineProcess.getTransientTransactionCoverage().isComplete());
-    assertTrue(
-        onlineProcess.getTransientTransactionCoverage().getBlockingIssues().get(0)
-            .contains("external I/O"));
+    assertTrue(onlineProcess.getTransientTransactionCoverage().getBlockingIssues().get(0).contains("external I/O"));
 
     GasDetector firstGas = new GasDetector("first gas");
     GasDetector secondGas = new GasDetector("second gas");
-    assertThrows(
-        IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> secondGas.restoreTransientState(firstGas.captureTransientState()));
     assertThrows(IllegalArgumentException.class, () -> firstGas.restoreTransientState(null));
 
     FireDetector firstFire = new FireDetector("first fire");
     FireDetector secondFire = new FireDetector("second fire");
-    assertThrows(
-        IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> secondFire.restoreTransientState(firstFire.captureTransientState()));
     assertThrows(IllegalArgumentException.class, () -> firstFire.restoreTransientState(null));
   }
 
-  private static void assertCompleteCoverage(
-      TransientTransactionCoverage coverage, int expectedCount) {
+  private static void assertCompleteCoverage(TransientTransactionCoverage coverage, int expectedCount) {
     assertEquals(expectedCount, coverage.getProcessElementCount());
     assertEquals(expectedCount, coverage.getParticipantCount());
     assertTrue(coverage.isComplete(), coverage.getBlockingIssues().toString());


### PR DESCRIPTION
## Roadmap

Advances #2911 Phase 1 snapshot/restore coverage after merged DYN-C010 / #3012.

Exact base: `9daf01d8a4ae3044136386c5bb599a468f7abf03`.
Exact head before publication: `ef4e8b3ed3bd6c4719f759f4343637b029aa5b23`.

## Problem

`ProcessSystem` transactions already restore `EventScheduler` pending/fired bookkeeping, but scheduler actions may also mutate fire-and-gas detector objects. Concrete `GasDetector` and `FireDetector` instances were not transient-state participants, so rejecting a trial could put the event back in the queue while retaining its detector side effect. Replaying that step then began from a different fire/gas state.

## Coherent implementation

- make concrete local `GasDetector` and `FireDetector` instances identity-preserving transient-state participants;
- capture every detector-owned mutable field plus the complete inherited measurement/alarm snapshot;
- restore detector and alarm state in place while retaining transaction provenance;
- fail closed for subclasses until subclass-owned state is explicitly covered;
- fail closed for online-signal bindings because external I/O has no rejected-step commit/defer contract;
- combine detector restoration with the existing scheduler snapshot for deterministic event rollback, replay and commit;
- correct the adjacent detector examples in the measurement guide.

## State and numerical basis

This tranche adds no new detector physics. It snapshots discrete/configuration state:

- gas type, concentration, species, location, LEL and configured response time;
- fire latch, signal level, threshold, configured detection delay and location;
- inherited name/tag/unit/range/field value, condition-analysis state, noise/filter/delay/fault state and alarm configuration/state;
- scheduler pending/fired membership through the already existing `ProcessSystem` transaction.

A rejected event trial restores the exact pre-event detector state and alarm-delay continuation. Replaying the scheduler boundary produces the same detector action; committing retains the accepted action.

## Regression and restart evidence

The focused regression covers:

- two-area `ProcessModel` coverage with one fire and one gas detector;
- scheduled event mutation in both areas;
- coordinated rollback of detector fields, names, alarm state and scheduler membership;
- deterministic replay and accepted commit;
- quantitative delayed-alarm continuation after rollback;
- stable participant identities and in-place alarm-state identity;
- Java serialization of each detector together with its closed snapshot;
- foreign/null snapshot rejection;
- fail-closed anonymous subclasses and online-signal operation.

## Deliberate exclusions and safety boundary

Only registered, in-memory detector state is covered. Arbitrary callbacks may mutate other objects or external systems and require their own participant or commit/defer contract. The existing response-time and detection-delay values remain configuration metadata; this PR does not implement physical sensor dynamics.

No detector placement/coverage model, gas dispersion, voting, reliability, ESD logic, safety-integrity qualification, certification, external I/O, virtual commissioning or OTS claim is added. No pipeline species transport (#2935), TwoFluid physics (#2907), thermodynamics, solver equation, timestep algorithm or public method signature changes.

## Compatibility and performance

Existing constructors and methods are unchanged. The only persistent additions are private participant identity fields. Existing serialized detectors deserialize with a lazily generated identity if the new field is absent. Runtime overhead occurs only when a transient transaction captures/restores a registered detector; ordinary measurements are unchanged.

## Documentation impact

Updated:

- `docs/process/dynamic-capability-contract.md` with the exact event/detector transaction boundary, evidence and exclusions;
- `docs/process/equipment/measurement_devices.md` with corrected public examples and safety limitations;
- detector class Javadocs with participation and fail-closed behavior.

No notebook changed.

## Validation

**VALIDATION COMPLETE — READY TO MERGE** on exact head `ef4e8b3ed3bd6c4719f759f4343637b029aa5b23`.

Hosted exact-head validation completed successfully:

- Java 21 fast tests on Ubuntu and Windows;
- all four Java 21 slow-test shards;
- Java 8 tests on Ubuntu and Windows;
- Java 21 Javadocs;
- Spotless, pre-commit, and documentation-search coverage;
- PaperLab, agent-skill reference validation, and CodeQL.

GitHub reports the PR mergeable. The final diff remains scoped to the two detector implementations, their focused transaction regression, and the two directly affected documentation files. No human or Copilot reviews, comments, requested changes, or unresolved threads are present. The branch is two commits behind current `master` without a conflict.

The runtime had no local NeqSim checkout, so no local Maven, Spotless, documentation-search, or pre-commit result is claimed; the hosted exact-head gates above are the authoritative validation.

## Next dependency

After merge, continue broadening fail-closed transaction coverage for another demonstrably state-mutating shared orchestration family before enabling full-step/two-half-step adaptive rejection.
