### PR TITLE
[AI-Assisted] feat(diagram): add governed stream table foundation

### DIFF
--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -86,7 +86,7 @@ EngineeringDiagramDocumentSet operatingDocuments =
         "Gas processing facility",
         EngineeringDiagramDocumentSet.ContentProfile.PFD,
         "NORMAL-01",
-        register);
+        new EngineeringDiagramDesignationRegister());
 EngineeringDiagramStreamTable streamTable =
     EngineeringDiagramStreamTable.fromDocumentSet(operatingDocuments, "NORMAL-01");
 

--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -77,8 +77,18 @@ Missing cases or quantities, malformed values, duplicate values, and calculation
 unknown streams are reported as structured diagnostics rather than silently invented or discarded.
 
 ```java
+EngineeringDiagramDocumentSet operatingDocuments =
+    ProcessDiagramDocumentSetAdapter.fromProcessModel(
+        processModel,
+        "PLANT-01",
+        "B",
+        "PFD-01-001",
+        "Gas processing facility",
+        EngineeringDiagramDocumentSet.ContentProfile.PFD,
+        "NORMAL-01",
+        register);
 EngineeringDiagramStreamTable streamTable =
-    EngineeringDiagramStreamTable.fromDocumentSet(reviewedDocuments, "NORMAL-01");
+    EngineeringDiagramStreamTable.fromDocumentSet(operatingDocuments, "NORMAL-01");
 
 for (EngineeringDiagramStreamTable.Row row : streamTable.getRows()) {
   EngineeringDiagramStreamTable.Value pressure =

--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -62,6 +62,39 @@ bara, and mass flow in kg/s. Each value remains `CALCULATED` and `REVIEW_REQUIRE
 case and source semantic object, and includes simulation-result provenance. The topology-only
 overloads remain unchanged and do not read live operating values.
 
+### Governed stream-table companion
+
+`EngineeringDiagramStreamTable` creates an immutable, deterministic stream-table companion from one
+operating-case document snapshot. It reads only canonical `LINE` and `CALCULATION` semantic objects;
+it does not read live process objects or add fields to `EngineeringDiagramDocumentSet.toJson()`.
+Every row retains the canonical stream ID, external key, source label, and process area. Temperature,
+absolute pressure, and mass flow retain their explicit unit, quantity basis, engineering state,
+approval state, source calculation ID, and simulation-result provenance.
+
+A reviewed `STREAM_NUMBER` designation is preferred as the display identifier and its source
+reference is retained. Without reviewed evidence, the canonical source label remains visible.
+Missing cases or quantities, malformed values, duplicate values, and calculation references to
+unknown streams are reported as structured diagnostics rather than silently invented or discarded.
+
+```java
+EngineeringDiagramStreamTable streamTable =
+    EngineeringDiagramStreamTable.fromDocumentSet(reviewedDocuments, "NORMAL-01");
+
+for (EngineeringDiagramStreamTable.Row row : streamTable.getRows()) {
+  EngineeringDiagramStreamTable.Value pressure =
+      row.getValues().get(EngineeringDiagramStreamTable.Quantity.PRESSURE);
+  if (pressure != null) {
+    logger.info("{} pressure: {} {}", row.getDisplayIdentifier(), pressure.getResultValue(),
+        pressure.getResultUnit());
+  }
+}
+```
+
+This first companion is the stream-condition foundation for later heat/material-balance aggregation.
+It does not yet calculate component balances, enthalpy duties, or reconciliation residuals. Building
+the table does not change Classic DOT/Graphviz, native SVG/PDF, DEXPI 2.0 Process exchange, or the
+Proteus/DEXPI P&ID workflow, and it does not promote calculated values to approved design data.
+
 Canonical source names and carried connection names are retained as source designations. They are
 not silently promoted to project-approved equipment tags or line numbers. Project-entered tags and
 stream numbers require their own provenance and review state before they can supersede those source
@@ -250,6 +283,7 @@ Run the focused regression with:
 ```bash
 ./mvnw -Dtest=ProcessDiagramDocumentSetAdapterTest test
 ./mvnw -Dtest=NativeEngineeringDiagramRendererTest test
+./mvnw -Dtest=EngineeringDiagramStreamTableTest test
 ```
 
 The regression verifies deterministic single- and multi-area output, immutable collections,

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramStreamTable.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramStreamTable.java
@@ -220,7 +220,7 @@ public final class EngineeringDiagramStreamTable implements Serializable {
      * @return provenance snapshots
      */
     public List<ProvenanceRecord> getProvenance() {
-      return provenance;
+      return Collections.unmodifiableList(new ArrayList<ProvenanceRecord>(provenance));
     }
 
     private Map<String, Object> toMap() {
@@ -323,7 +323,7 @@ public final class EngineeringDiagramStreamTable implements Serializable {
      * @return values by quantity
      */
     public Map<Quantity, Value> getValues() {
-      return values;
+      return Collections.unmodifiableMap(new EnumMap<Quantity, Value>(values));
     }
 
     private Map<String, Object> toMap() {
@@ -453,7 +453,7 @@ public final class EngineeringDiagramStreamTable implements Serializable {
    * @return stream rows
    */
   public List<Row> getRows() {
-    return rows;
+    return Collections.unmodifiableList(new ArrayList<Row>(rows));
   }
 
   /**
@@ -462,7 +462,7 @@ public final class EngineeringDiagramStreamTable implements Serializable {
    * @return diagnostics
    */
   public List<Diagnostic> getDiagnostics() {
-    return diagnostics;
+    return Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
   }
 
   /**

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramStreamTable.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramStreamTable.java
@@ -22,10 +22,10 @@ import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Severity;
  * Immutable, deterministic stream-table projection of one governed operating case.
  *
  * <p>
- * The table is derived only from the canonical semantic-object snapshots in an
- * {@link EngineeringDiagramDocumentSet}. It does not read live process objects, change the controlled document JSON,
- * or imply accountable approval of calculated values. A reviewed stream number is preferred for display while the
- * canonical semantic-object identity remains authoritative.
+ * The table is derived only from the canonical semantic-object snapshots in an {@link EngineeringDiagramDocumentSet}.
+ * It does not read live process objects, change the controlled document JSON, or imply accountable approval of
+ * calculated values. A reviewed stream number is preferred for display while the canonical semantic-object identity
+ * remains authoritative.
  * </p>
  */
 public final class EngineeringDiagramStreamTable implements Serializable {
@@ -140,8 +140,7 @@ public final class EngineeringDiagramStreamTable implements Serializable {
     private final List<ProvenanceRecord> provenance;
 
     private Value(Quantity quantity, double resultValue, String resultUnit, String quantityBasis,
-        String engineeringState, String approvalStatus, String sourceCalculationId,
-        List<ProvenanceRecord> provenance) {
+        String engineeringState, String approvalStatus, String sourceCalculationId, List<ProvenanceRecord> provenance) {
       this.quantity = quantity;
       this.resultValue = resultValue;
       this.resultUnit = resultUnit;
@@ -399,8 +398,7 @@ public final class EngineeringDiagramStreamTable implements Serializable {
       for (Quantity quantity : Quantity.values()) {
         if (!values.containsKey(quantity)) {
           diagnostics.add(new Diagnostic(Severity.WARNING, "STREAM_TABLE_VALUE_MISSING",
-              "The requested operating case has no governed " + quantity.getPropertyName() + " value",
-              stream.getId()));
+              "The requested operating case has no governed " + quantity.getPropertyName() + " value", stream.getId()));
         }
       }
       Designation streamNumber = reviewedStreamNumber(stream);
@@ -589,8 +587,8 @@ public final class EngineeringDiagramStreamTable implements Serializable {
           "More than one governed value exists for the stream, case, and quantity", subjectId));
       return;
     }
-    values.put(quantity, new Value(quantity, number, unit, basis, engineeringState, approvalStatus,
-        calculation.getId(), calculation.getProvenance()));
+    values.put(quantity, new Value(quantity, number, unit, basis, engineeringState, approvalStatus, calculation.getId(),
+        calculation.getProvenance()));
     String areaName = optionalProperty(calculation, "areaName");
     if (!areaName.isEmpty() && !areaByStream.containsKey(subjectId)) {
       areaByStream.put(subjectId, areaName);

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramStreamTable.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramStreamTable.java
@@ -1,0 +1,661 @@
+package neqsim.process.engineering.model;
+
+import com.google.gson.GsonBuilder;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister.Designation;
+import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister.Kind;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ProvenanceRecord;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.SemanticObject;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Severity;
+
+/**
+ * Immutable, deterministic stream-table projection of one governed operating case.
+ *
+ * <p>
+ * The table is derived only from the canonical semantic-object snapshots in an
+ * {@link EngineeringDiagramDocumentSet}. It does not read live process objects, change the controlled document JSON,
+ * or imply accountable approval of calculated values. A reviewed stream number is preferred for display while the
+ * canonical semantic-object identity remains authoritative.
+ * </p>
+ */
+public final class EngineeringDiagramStreamTable implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  public static final String SCHEMA_VERSION = "neqsim_engineering_diagram_stream_table.v1";
+
+  /** Supported stream-table quantities in deterministic column order. */
+  public enum Quantity {
+    /** Thermodynamic absolute temperature. */
+    TEMPERATURE("temperature"),
+    /** Absolute pressure. */
+    PRESSURE("pressure"),
+    /** Mass-flow rate. */
+    MASS_FLOW("massFlow");
+
+    private final String propertyName;
+
+    Quantity(String propertyName) {
+      this.propertyName = propertyName;
+    }
+
+    /**
+     * Returns the canonical calculation property name.
+     *
+     * @return property name
+     */
+    public String getPropertyName() {
+      return propertyName;
+    }
+
+    private static Quantity fromPropertyName(String value) {
+      for (Quantity quantity : values()) {
+        if (quantity.propertyName.equals(value)) {
+          return quantity;
+        }
+      }
+      return null;
+    }
+  }
+
+  /** One structured extraction diagnostic. */
+  public static final class Diagnostic implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Severity severity;
+    private final String code;
+    private final String message;
+    private final String subjectId;
+
+    private Diagnostic(Severity severity, String code, String message, String subjectId) {
+      this.severity = severity;
+      this.code = code;
+      this.message = message;
+      this.subjectId = subjectId;
+    }
+
+    /**
+     * Returns diagnostic severity.
+     *
+     * @return severity
+     */
+    public Severity getSeverity() {
+      return severity;
+    }
+
+    /**
+     * Returns stable machine-readable diagnostic code.
+     *
+     * @return diagnostic code
+     */
+    public String getCode() {
+      return code;
+    }
+
+    /**
+     * Returns human-readable diagnostic message.
+     *
+     * @return message
+     */
+    public String getMessage() {
+      return message;
+    }
+
+    /**
+     * Returns the affected semantic-object identity.
+     *
+     * @return subject identity, or an empty string
+     */
+    public String getSubjectId() {
+      return subjectId;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("severity", severity.name());
+      result.put("code", code);
+      result.put("message", message);
+      result.put("subjectId", subjectId);
+      return result;
+    }
+  }
+
+  /** One governed quantity value in a stream row. */
+  public static final class Value implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Quantity quantity;
+    private final double resultValue;
+    private final String resultUnit;
+    private final String quantityBasis;
+    private final String engineeringState;
+    private final String approvalStatus;
+    private final String sourceCalculationId;
+    private final List<ProvenanceRecord> provenance;
+
+    private Value(Quantity quantity, double resultValue, String resultUnit, String quantityBasis,
+        String engineeringState, String approvalStatus, String sourceCalculationId,
+        List<ProvenanceRecord> provenance) {
+      this.quantity = quantity;
+      this.resultValue = resultValue;
+      this.resultUnit = resultUnit;
+      this.quantityBasis = quantityBasis;
+      this.engineeringState = engineeringState;
+      this.approvalStatus = approvalStatus;
+      this.sourceCalculationId = sourceCalculationId;
+      this.provenance = Collections.unmodifiableList(new ArrayList<ProvenanceRecord>(provenance));
+    }
+
+    /**
+     * Returns the quantity represented by this value.
+     *
+     * @return quantity
+     */
+    public Quantity getQuantity() {
+      return quantity;
+    }
+
+    /**
+     * Returns the numerical result.
+     *
+     * @return result value
+     */
+    public double getResultValue() {
+      return resultValue;
+    }
+
+    /**
+     * Returns the explicit result unit.
+     *
+     * @return result unit
+     */
+    public String getResultUnit() {
+      return resultUnit;
+    }
+
+    /**
+     * Returns the explicit quantity basis.
+     *
+     * @return quantity basis
+     */
+    public String getQuantityBasis() {
+      return quantityBasis;
+    }
+
+    /**
+     * Returns the engineering state carried by the calculation.
+     *
+     * @return engineering state
+     */
+    public String getEngineeringState() {
+      return engineeringState;
+    }
+
+    /**
+     * Returns the approval status carried by the calculation.
+     *
+     * @return approval status
+     */
+    public String getApprovalStatus() {
+      return approvalStatus;
+    }
+
+    /**
+     * Returns the stable source calculation identity.
+     *
+     * @return calculation identity
+     */
+    public String getSourceCalculationId() {
+      return sourceCalculationId;
+    }
+
+    /**
+     * Returns immutable provenance snapshots.
+     *
+     * @return provenance snapshots
+     */
+    public List<ProvenanceRecord> getProvenance() {
+      return provenance;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("quantity", quantity.name());
+      result.put("resultValue", Double.valueOf(resultValue));
+      result.put("resultUnit", resultUnit);
+      result.put("quantityBasis", quantityBasis);
+      result.put("engineeringState", engineeringState);
+      result.put("approvalStatus", approvalStatus);
+      result.put("sourceCalculationId", sourceCalculationId);
+      List<Map<String, Object>> provenanceMaps = new ArrayList<Map<String, Object>>();
+      for (ProvenanceRecord record : provenance) {
+        provenanceMaps.add(provenanceMap(record));
+      }
+      result.put("provenance", provenanceMaps);
+      return result;
+    }
+  }
+
+  /** One stable canonical stream row. */
+  public static final class Row implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String semanticObjectId;
+    private final String externalKey;
+    private final String sourceLabel;
+    private final String displayIdentifier;
+    private final String designationSourceReference;
+    private final String areaName;
+    private final Map<Quantity, Value> values;
+
+    private Row(SemanticObject stream, String displayIdentifier, String designationSourceReference, String areaName,
+        Map<Quantity, Value> values) {
+      this.semanticObjectId = stream.getId();
+      this.externalKey = stream.getExternalKey();
+      this.sourceLabel = stream.getLabel();
+      this.displayIdentifier = displayIdentifier;
+      this.designationSourceReference = designationSourceReference;
+      this.areaName = areaName;
+      this.values = Collections.unmodifiableMap(new EnumMap<Quantity, Value>(values));
+    }
+
+    /**
+     * Returns the stable canonical stream semantic-object identity.
+     *
+     * @return semantic-object identity
+     */
+    public String getSemanticObjectId() {
+      return semanticObjectId;
+    }
+
+    /**
+     * Returns the canonical external source key.
+     *
+     * @return external key
+     */
+    public String getExternalKey() {
+      return externalKey;
+    }
+
+    /**
+     * Returns the canonical source label.
+     *
+     * @return source label
+     */
+    public String getSourceLabel() {
+      return sourceLabel;
+    }
+
+    /**
+     * Returns the reviewed stream number when available, otherwise the canonical source label.
+     *
+     * @return display identifier
+     */
+    public String getDisplayIdentifier() {
+      return displayIdentifier;
+    }
+
+    /**
+     * Returns the source reference for the reviewed designation used for display.
+     *
+     * @return designation source reference, or an empty string
+     */
+    public String getDesignationSourceReference() {
+      return designationSourceReference;
+    }
+
+    /**
+     * Returns the source process-area name.
+     *
+     * @return area name, or an empty string
+     */
+    public String getAreaName() {
+      return areaName;
+    }
+
+    /**
+     * Returns immutable governed values by quantity.
+     *
+     * @return values by quantity
+     */
+    public Map<Quantity, Value> getValues() {
+      return values;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("semanticObjectId", semanticObjectId);
+      result.put("externalKey", externalKey);
+      result.put("sourceLabel", sourceLabel);
+      result.put("displayIdentifier", displayIdentifier);
+      result.put("designationSourceReference", designationSourceReference);
+      result.put("areaName", areaName);
+      List<Map<String, Object>> valueMaps = new ArrayList<Map<String, Object>>();
+      for (Quantity quantity : Quantity.values()) {
+        Value value = values.get(quantity);
+        if (value != null) {
+          valueMaps.add(value.toMap());
+        }
+      }
+      result.put("values", valueMaps);
+      return result;
+    }
+  }
+
+  private final String documentSetId;
+  private final String sourceGraphFingerprint;
+  private final String designCaseId;
+  private final List<Row> rows;
+  private final List<Diagnostic> diagnostics;
+
+  private EngineeringDiagramStreamTable(String documentSetId, String sourceGraphFingerprint, String designCaseId,
+      List<Row> rows, List<Diagnostic> diagnostics) {
+    this.documentSetId = documentSetId;
+    this.sourceGraphFingerprint = sourceGraphFingerprint;
+    this.designCaseId = designCaseId;
+    this.rows = Collections.unmodifiableList(new ArrayList<Row>(rows));
+    this.diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+  }
+
+  /**
+   * Creates a deterministic stream table from one controlled operating-case snapshot.
+   *
+   * @param documentSet controlled diagram document set
+   * @param designCaseId requested operating-case identity
+   * @return immutable stream table with structured loss diagnostics
+   * @throws IllegalArgumentException if either argument is missing
+   */
+  public static EngineeringDiagramStreamTable fromDocumentSet(EngineeringDiagramDocumentSet documentSet,
+      String designCaseId) {
+    if (documentSet == null) {
+      throw new IllegalArgumentException("documentSet must not be null");
+    }
+    String normalizedCaseId = requireText(designCaseId, "designCaseId");
+    List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
+    List<SemanticObject> calculations = calculationsForCase(documentSet, normalizedCaseId);
+    List<SemanticObject> streams = sortedStreams(documentSet);
+    if (calculations.isEmpty()) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "STREAM_TABLE_CASE_NOT_FOUND",
+          "No governed stream calculations were found for the requested operating case", normalizedCaseId));
+    }
+
+    Map<String, Map<Quantity, Value>> valuesByStream = new LinkedHashMap<String, Map<Quantity, Value>>();
+    Map<String, String> areaByStream = new LinkedHashMap<String, String>();
+    for (SemanticObject calculation : calculations) {
+      addCalculation(calculation, streams, valuesByStream, areaByStream, diagnostics);
+    }
+
+    List<Row> rows = new ArrayList<Row>();
+    for (SemanticObject stream : streams) {
+      Map<Quantity, Value> values = valuesByStream.get(stream.getId());
+      if (values == null) {
+        values = new EnumMap<Quantity, Value>(Quantity.class);
+      }
+      for (Quantity quantity : Quantity.values()) {
+        if (!values.containsKey(quantity)) {
+          diagnostics.add(new Diagnostic(Severity.WARNING, "STREAM_TABLE_VALUE_MISSING",
+              "The requested operating case has no governed " + quantity.getPropertyName() + " value",
+              stream.getId()));
+        }
+      }
+      Designation streamNumber = reviewedStreamNumber(stream);
+      String displayIdentifier = streamNumber == null ? fallback(stream.getLabel(), stream.getExternalKey())
+          : streamNumber.getValue();
+      String designationSourceReference = streamNumber == null ? "" : streamNumber.getSourceReference();
+      String areaName = areaByStream.containsKey(stream.getId()) ? areaByStream.get(stream.getId())
+          : optionalProperty(stream, "areaName");
+      rows.add(new Row(stream, displayIdentifier, designationSourceReference, areaName, values));
+    }
+    Collections.sort(diagnostics, new Comparator<Diagnostic>() {
+      @Override
+      public int compare(Diagnostic left, Diagnostic right) {
+        int subjectOrder = left.getSubjectId().compareTo(right.getSubjectId());
+        return subjectOrder != 0 ? subjectOrder : left.getCode().compareTo(right.getCode());
+      }
+    });
+    return new EngineeringDiagramStreamTable(documentSet.getId(), documentSet.getSourceGraphFingerprint(),
+        normalizedCaseId, rows, diagnostics);
+  }
+
+  /**
+   * Returns the source controlled-document identity.
+   *
+   * @return document-set identity
+   */
+  public String getDocumentSetId() {
+    return documentSetId;
+  }
+
+  /**
+   * Returns the canonical source-graph fingerprint.
+   *
+   * @return source-graph fingerprint
+   */
+  public String getSourceGraphFingerprint() {
+    return sourceGraphFingerprint;
+  }
+
+  /**
+   * Returns the selected operating-case identity.
+   *
+   * @return operating-case identity
+   */
+  public String getDesignCaseId() {
+    return designCaseId;
+  }
+
+  /**
+   * Returns immutable rows sorted by canonical semantic-object identity.
+   *
+   * @return stream rows
+   */
+  public List<Row> getRows() {
+    return rows;
+  }
+
+  /**
+   * Returns immutable structured extraction diagnostics.
+   *
+   * @return diagnostics
+   */
+  public List<Diagnostic> getDiagnostics() {
+    return diagnostics;
+  }
+
+  /**
+   * Returns true when extraction found no error-severity diagnostic.
+   *
+   * @return extraction validity
+   */
+  public boolean isValid() {
+    for (Diagnostic diagnostic : diagnostics) {
+      if (diagnostic.getSeverity() == Severity.ERROR) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Returns a deterministic machine-readable representation.
+   *
+   * @return stream-table representation
+   */
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", SCHEMA_VERSION);
+    result.put("documentSetId", documentSetId);
+    result.put("sourceGraphFingerprint", sourceGraphFingerprint);
+    result.put("designCaseId", designCaseId);
+    List<Map<String, Object>> rowMaps = new ArrayList<Map<String, Object>>();
+    for (Row row : rows) {
+      rowMaps.add(row.toMap());
+    }
+    result.put("rows", rowMaps);
+    List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
+    for (Diagnostic diagnostic : diagnostics) {
+      diagnosticMaps.add(diagnostic.toMap());
+    }
+    result.put("diagnostics", diagnosticMaps);
+    result.put("fingerprint", fingerprint(result));
+    return result;
+  }
+
+  /**
+   * Returns deterministic pretty-printed JSON.
+   *
+   * @return JSON representation
+   */
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+  }
+
+  private static List<SemanticObject> calculationsForCase(EngineeringDiagramDocumentSet documentSet,
+      String designCaseId) {
+    List<SemanticObject> result = new ArrayList<SemanticObject>();
+    for (SemanticObject object : documentSet.getSemanticObjects()) {
+      if (object.getKind() == EngineeringNode.Kind.CALCULATION
+          && designCaseId.equals(optionalProperty(object, "designCaseId"))) {
+        result.add(object);
+      }
+    }
+    Collections.sort(result, semanticObjectComparator());
+    return result;
+  }
+
+  private static List<SemanticObject> sortedStreams(EngineeringDiagramDocumentSet documentSet) {
+    List<SemanticObject> result = new ArrayList<SemanticObject>();
+    for (SemanticObject object : documentSet.getSemanticObjects()) {
+      if (object.getKind() == EngineeringNode.Kind.LINE) {
+        result.add(object);
+      }
+    }
+    Collections.sort(result, semanticObjectComparator());
+    return result;
+  }
+
+  private static Comparator<SemanticObject> semanticObjectComparator() {
+    return new Comparator<SemanticObject>() {
+      @Override
+      public int compare(SemanticObject left, SemanticObject right) {
+        return left.getId().compareTo(right.getId());
+      }
+    };
+  }
+
+  private static void addCalculation(SemanticObject calculation, List<SemanticObject> streams,
+      Map<String, Map<Quantity, Value>> valuesByStream, Map<String, String> areaByStream,
+      List<Diagnostic> diagnostics) {
+    Quantity quantity = Quantity.fromPropertyName(optionalProperty(calculation, "quantity"));
+    if (quantity == null) {
+      return;
+    }
+    String subjectId = optionalProperty(calculation, "subjectNodeId");
+    if (!containsSemanticObject(streams, subjectId)) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "STREAM_TABLE_UNKNOWN_STREAM",
+          "A governed stream value references a missing or non-stream semantic object", calculation.getId()));
+      return;
+    }
+    Object rawValue = calculation.getProperties().get("resultValue");
+    String unit = optionalProperty(calculation, "resultUnit");
+    String basis = optionalProperty(calculation, "quantityBasis");
+    String engineeringState = optionalProperty(calculation, "engineeringState");
+    String approvalStatus = optionalProperty(calculation, "approvalStatus");
+    if (subjectId.isEmpty() || !(rawValue instanceof Number) || unit.isEmpty() || basis.isEmpty()
+        || engineeringState.isEmpty() || approvalStatus.isEmpty() || calculation.getProvenance().isEmpty()) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "STREAM_TABLE_VALUE_INCOMPLETE",
+          "A governed stream value is missing identity, value, unit, basis, state, approval, or provenance",
+          calculation.getId()));
+      return;
+    }
+    double number = ((Number) rawValue).doubleValue();
+    if (!Double.isFinite(number)) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "STREAM_TABLE_VALUE_NONFINITE",
+          "A non-finite governed stream value was excluded", calculation.getId()));
+      return;
+    }
+    Map<Quantity, Value> values = valuesByStream.get(subjectId);
+    if (values == null) {
+      values = new EnumMap<Quantity, Value>(Quantity.class);
+      valuesByStream.put(subjectId, values);
+    }
+    if (values.containsKey(quantity)) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "STREAM_TABLE_DUPLICATE_VALUE",
+          "More than one governed value exists for the stream, case, and quantity", subjectId));
+      return;
+    }
+    values.put(quantity, new Value(quantity, number, unit, basis, engineeringState, approvalStatus,
+        calculation.getId(), calculation.getProvenance()));
+    String areaName = optionalProperty(calculation, "areaName");
+    if (!areaName.isEmpty() && !areaByStream.containsKey(subjectId)) {
+      areaByStream.put(subjectId, areaName);
+    }
+  }
+
+  private static boolean containsSemanticObject(List<SemanticObject> objects, String semanticObjectId) {
+    for (SemanticObject object : objects) {
+      if (object.getId().equals(semanticObjectId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static Designation reviewedStreamNumber(SemanticObject stream) {
+    for (Designation designation : stream.getDesignations()) {
+      if (designation.getKind() == Kind.STREAM_NUMBER) {
+        return designation;
+      }
+    }
+    return null;
+  }
+
+  private static String optionalProperty(SemanticObject object, String key) {
+    Object value = object.getProperties().get(key);
+    return value == null ? "" : value.toString().trim();
+  }
+
+  private static Map<String, Object> provenanceMap(ProvenanceRecord record) {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("sourceType", record.getSourceType());
+    result.put("sourceReference", record.getSourceReference());
+    result.put("method", record.getMethod());
+    result.put("designCaseId", record.getDesignCaseId());
+    result.put("approvalStatus", record.getApprovalStatus());
+    result.put("evidenceReferences", record.getEvidenceReferences());
+    return result;
+  }
+
+  private static String fallback(String preferred, String fallback) {
+    return preferred == null || preferred.trim().isEmpty() ? fallback : preferred;
+  }
+
+  private static String requireText(String value, String name) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static String fingerprint(Map<String, Object> map) {
+    Map<String, Object> content = new LinkedHashMap<String, Object>(map);
+    content.remove("fingerprint");
+    String json = new GsonBuilder().create().toJson(content);
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(json.getBytes(StandardCharsets.UTF_8));
+      StringBuilder result = new StringBuilder();
+      for (byte value : hash) {
+        result.append(String.format("%02x", value & 0xff));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is not available", exception);
+    }
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramStreamTableTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramStreamTableTest.java
@@ -1,0 +1,172 @@
+package neqsim.process.processmodel.diagram;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister;
+import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister.Designation;
+import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister.Kind;
+import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister.ReviewState;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.SemanticObject;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Quantity;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Row;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Value;
+import neqsim.process.engineering.model.EngineeringNode;
+import org.junit.jupiter.api.Test;
+
+/** Regression tests for governed, deterministic stream-table projections. */
+class EngineeringDiagramStreamTableTest {
+
+  @Test
+  void projectsUnitExplicitGovernedValuesWithoutChangingControlledDocument() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
+    reference.getProcessSystem().run();
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-001", "Stream table",
+        ContentProfile.PFD, "NORMAL-01");
+    String documentJson = documents.toJson();
+
+    EngineeringDiagramStreamTable table = EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
+
+    assertTrue(table.isValid());
+    assertFalse(table.getRows().isEmpty());
+    Row row = firstCompleteRow(table);
+    assertEquals(3, row.getValues().size());
+    assertValue(row, Quantity.TEMPERATURE, "K", "THERMODYNAMIC_ABSOLUTE");
+    assertValue(row, Quantity.PRESSURE, "bara", "ABSOLUTE");
+    assertValue(row, Quantity.MASS_FLOW, "kg/s", "MASS");
+    assertEquals("NORMAL-01", table.getDesignCaseId());
+    assertEquals(documents.getSourceGraphFingerprint(), table.getSourceGraphFingerprint());
+    assertEquals(documentJson, documents.toJson());
+    assertThrows(UnsupportedOperationException.class, () -> table.getRows().clear());
+    assertThrows(UnsupportedOperationException.class, () -> row.getValues().clear());
+  }
+
+  @Test
+  void isDeterministicForFreshMultiAreaProcessModels() {
+    EngineeringDiagramReferenceFixtures.ModelCase firstReference = EngineeringDiagramReferenceFixtures
+        .multiAreaFacility();
+    firstReference.getProcessModel().run();
+    EngineeringDiagramDocumentSet firstDocuments = ProcessDiagramDocumentSetAdapter.fromProcessModel(
+        firstReference.getProcessModel(), firstReference.getCaseId(), "A", "PFD-HMB-002", "Multi-area stream table",
+        ContentProfile.PFD, "NORMAL-01");
+
+    EngineeringDiagramReferenceFixtures.ModelCase secondReference = EngineeringDiagramReferenceFixtures
+        .multiAreaFacility();
+    secondReference.getProcessModel().run();
+    EngineeringDiagramDocumentSet secondDocuments = ProcessDiagramDocumentSetAdapter.fromProcessModel(
+        secondReference.getProcessModel(), secondReference.getCaseId(), "A", "PFD-HMB-002",
+        "Multi-area stream table", ContentProfile.PFD, "NORMAL-01");
+
+    EngineeringDiagramStreamTable first = EngineeringDiagramStreamTable.fromDocumentSet(firstDocuments,
+        "NORMAL-01");
+    EngineeringDiagramStreamTable second = EngineeringDiagramStreamTable.fromDocumentSet(secondDocuments,
+        "NORMAL-01");
+
+    assertEquals(first.toJson(), second.toJson());
+    assertTrue(first.isValid());
+    assertFalse(first.getRows().isEmpty());
+    assertTrue(hasArea(first));
+  }
+
+  @Test
+  void prefersReviewedStreamNumberWithoutReplacingCanonicalIdentity() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
+    reference.getProcessSystem().run();
+    EngineeringDiagramDocumentSet baseline = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "B", "PFD-HMB-003", "Reviewed stream number",
+        ContentProfile.PFD, "NORMAL-01");
+    SemanticObject stream = firstLine(baseline);
+    EngineeringDiagramDesignationRegister register = new EngineeringDiagramDesignationRegister()
+        .withDesignation(new Designation(stream.getId(), Kind.STREAM_NUMBER, "10-P-1001-A",
+            "project-register:stream-numbers", ReviewState.REVIEWED, "Process discipline", "review:STREAM-42",
+            "2026-08-15T08:00:00Z", "B"));
+    EngineeringDiagramDocumentSet reviewed = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "B", "PFD-HMB-003", "Reviewed stream number",
+        ContentProfile.PFD, "NORMAL-01", register);
+
+    EngineeringDiagramStreamTable table = EngineeringDiagramStreamTable.fromDocumentSet(reviewed, "NORMAL-01");
+    Row row = findRow(table, stream.getId());
+
+    assertEquals(stream.getId(), row.getSemanticObjectId());
+    assertEquals(stream.getLabel(), row.getSourceLabel());
+    assertEquals("10-P-1001-A", row.getDisplayIdentifier());
+    assertEquals("project-register:stream-numbers", row.getDesignationSourceReference());
+  }
+
+  @Test
+  void reportsMissingOperatingCaseAsStructuredLoss() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
+    EngineeringDiagramDocumentSet topologyOnly = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-004", "Topology only",
+        ContentProfile.PFD);
+
+    EngineeringDiagramStreamTable table = EngineeringDiagramStreamTable.fromDocumentSet(topologyOnly,
+        "MISSING-CASE");
+
+    assertFalse(table.isValid());
+    assertTrue(hasDiagnostic(table, "STREAM_TABLE_CASE_NOT_FOUND"));
+    assertTrue(hasDiagnostic(table, "STREAM_TABLE_VALUE_MISSING"));
+    assertFalse(table.getRows().isEmpty());
+  }
+
+  private static void assertValue(Row row, Quantity quantity, String unit, String basis) {
+    Value value = row.getValues().get(quantity);
+    assertEquals(unit, value.getResultUnit());
+    assertEquals(basis, value.getQuantityBasis());
+    assertEquals("CALCULATED", value.getEngineeringState());
+    assertEquals("REVIEW_REQUIRED", value.getApprovalStatus());
+    assertFalse(value.getSourceCalculationId().isEmpty());
+    assertEquals("SIMULATION_RESULT", value.getProvenance().get(0).getSourceType());
+    assertEquals("NORMAL-01", value.getProvenance().get(0).getDesignCaseId());
+  }
+
+  private static boolean hasArea(EngineeringDiagramStreamTable table) {
+    for (Row row : table.getRows()) {
+      if (!row.getAreaName().isEmpty()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static Row firstCompleteRow(EngineeringDiagramStreamTable table) {
+    for (Row row : table.getRows()) {
+      if (row.getValues().size() == Quantity.values().length) {
+        return row;
+      }
+    }
+    throw new AssertionError("No complete governed stream-table row found");
+  }
+
+  private static boolean hasDiagnostic(EngineeringDiagramStreamTable table, String code) {
+    for (EngineeringDiagramStreamTable.Diagnostic diagnostic : table.getDiagnostics()) {
+      if (code.equals(diagnostic.getCode())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static SemanticObject firstLine(EngineeringDiagramDocumentSet documents) {
+    for (SemanticObject object : documents.getSemanticObjects()) {
+      if (object.getKind() == EngineeringNode.Kind.LINE) {
+        return object;
+      }
+    }
+    throw new AssertionError("No canonical line object found");
+  }
+
+  private static Row findRow(EngineeringDiagramStreamTable table, String semanticObjectId) {
+    for (Row row : table.getRows()) {
+      if (semanticObjectId.equals(row.getSemanticObjectId())) {
+        return row;
+      }
+    }
+    throw new AssertionError("No stream-table row for " + semanticObjectId);
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramStreamTableTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramStreamTableTest.java
@@ -2,6 +2,7 @@ package neqsim.process.processmodel.diagram;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister;
@@ -42,6 +43,11 @@ class EngineeringDiagramStreamTableTest {
     assertEquals("NORMAL-01", table.getDesignCaseId());
     assertEquals(documents.getSourceGraphFingerprint(), table.getSourceGraphFingerprint());
     assertEquals(documentJson, documents.toJson());
+    assertNotSame(table.getRows(), table.getRows());
+    assertNotSame(table.getDiagnostics(), table.getDiagnostics());
+    assertNotSame(row.getValues(), row.getValues());
+    assertNotSame(row.getValues().get(Quantity.PRESSURE).getProvenance(),
+        row.getValues().get(Quantity.PRESSURE).getProvenance());
     assertThrows(UnsupportedOperationException.class, () -> table.getRows().clear());
     assertThrows(UnsupportedOperationException.class, () -> row.getValues().clear());
   }

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramStreamTableTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramStreamTableTest.java
@@ -26,8 +26,8 @@ class EngineeringDiagramStreamTableTest {
     EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
     reference.getProcessSystem().run();
     EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
-        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-001", "Stream table",
-        ContentProfile.PFD, "NORMAL-01");
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-001", "Stream table", ContentProfile.PFD,
+        "NORMAL-01");
     String documentJson = documents.toJson();
 
     EngineeringDiagramStreamTable table = EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
@@ -59,13 +59,11 @@ class EngineeringDiagramStreamTableTest {
         .multiAreaFacility();
     secondReference.getProcessModel().run();
     EngineeringDiagramDocumentSet secondDocuments = ProcessDiagramDocumentSetAdapter.fromProcessModel(
-        secondReference.getProcessModel(), secondReference.getCaseId(), "A", "PFD-HMB-002",
-        "Multi-area stream table", ContentProfile.PFD, "NORMAL-01");
+        secondReference.getProcessModel(), secondReference.getCaseId(), "A", "PFD-HMB-002", "Multi-area stream table",
+        ContentProfile.PFD, "NORMAL-01");
 
-    EngineeringDiagramStreamTable first = EngineeringDiagramStreamTable.fromDocumentSet(firstDocuments,
-        "NORMAL-01");
-    EngineeringDiagramStreamTable second = EngineeringDiagramStreamTable.fromDocumentSet(secondDocuments,
-        "NORMAL-01");
+    EngineeringDiagramStreamTable first = EngineeringDiagramStreamTable.fromDocumentSet(firstDocuments, "NORMAL-01");
+    EngineeringDiagramStreamTable second = EngineeringDiagramStreamTable.fromDocumentSet(secondDocuments, "NORMAL-01");
 
     assertEquals(first.toJson(), second.toJson());
     assertTrue(first.isValid());
@@ -81,10 +79,9 @@ class EngineeringDiagramStreamTableTest {
         reference.getProcessSystem(), reference.getCaseId(), "B", "PFD-HMB-003", "Reviewed stream number",
         ContentProfile.PFD, "NORMAL-01");
     SemanticObject stream = firstLine(baseline);
-    EngineeringDiagramDesignationRegister register = new EngineeringDiagramDesignationRegister()
-        .withDesignation(new Designation(stream.getId(), Kind.STREAM_NUMBER, "10-P-1001-A",
-            "project-register:stream-numbers", ReviewState.REVIEWED, "Process discipline", "review:STREAM-42",
-            "2026-08-15T08:00:00Z", "B"));
+    EngineeringDiagramDesignationRegister register = new EngineeringDiagramDesignationRegister().withDesignation(
+        new Designation(stream.getId(), Kind.STREAM_NUMBER, "10-P-1001-A", "project-register:stream-numbers",
+            ReviewState.REVIEWED, "Process discipline", "review:STREAM-42", "2026-08-15T08:00:00Z", "B"));
     EngineeringDiagramDocumentSet reviewed = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
         reference.getProcessSystem(), reference.getCaseId(), "B", "PFD-HMB-003", "Reviewed stream number",
         ContentProfile.PFD, "NORMAL-01", register);
@@ -102,11 +99,9 @@ class EngineeringDiagramStreamTableTest {
   void reportsMissingOperatingCaseAsStructuredLoss() {
     EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
     EngineeringDiagramDocumentSet topologyOnly = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
-        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-004", "Topology only",
-        ContentProfile.PFD);
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-004", "Topology only", ContentProfile.PFD);
 
-    EngineeringDiagramStreamTable table = EngineeringDiagramStreamTable.fromDocumentSet(topologyOnly,
-        "MISSING-CASE");
+    EngineeringDiagramStreamTable table = EngineeringDiagramStreamTable.fromDocumentSet(topologyOnly, "MISSING-CASE");
 
     assertFalse(table.isValid());
     assertTrue(hasDiagnostic(table, "STREAM_TABLE_CASE_NOT_FOUND"));


### PR DESCRIPTION
## Summary

- add an immutable, deterministic `EngineeringDiagramStreamTable` companion derived from the canonical controlled-document semantic model
- retain stable stream identity, area, reviewed stream-number evidence, explicit units and quantity bases, engineering/approval state, source calculation identity, and simulation-result provenance
- report missing cases/quantities, incomplete or non-finite values, duplicates, and unknown stream references as structured diagnostics
- cover ProcessSystem and multi-area ProcessModel extraction, fresh-model determinism, immutable defensive collections, designation precedence, and unchanged controlled-document JSON
- document the API, engineering boundary, and validation command

## Scope and compatibility

This is the dependency-ready Phase 2 stream-condition foundation shared by #1332 and #2899. It is additive and does not change `EngineeringDiagramDocumentSet.toJson()`, Classic DOT/Graphviz, native SVG/PDF rendering, DEXPI 2.0 Process exchange, or the existing Proteus/DEXPI P&ID workflow.

The companion does not yet calculate component balances, enthalpy duties, or reconciliation residuals. A P&ID remains an engineering proposal until accountable design data and review exist. No ISO 10628 or other standards-conformance claim is made.

## Review follow-up

Automated review identified mutable-collection exposure in getters. Exact-head fixes now return defensive unmodifiable copies for rows, diagnostics, quantity values, and provenance. Focused tests verify both immutability and distinct returned collection identities. Both review threads are resolved.

## Validation

**VALIDATION COMPLETE — READY TO MERGE** on exact head `1df6f0454894ea390f628a01dc2861db374602cd`.

GitHub-hosted validation is complete on this exact head:

- Spotless passed and its patch artifact was empty;
- pre-commit, PaperLab, documentation search, and CodeQL passed;
- both engineering acceptance-notebook workflows passed;
- Java 8 tests passed on Ubuntu and Windows;
- Java 21 fast tests passed on Ubuntu and Windows;
- all four Java 21 Ubuntu slow-test shards passed;
- Javadocs and the repository-contract jobs passed.

The final diff remains limited to the intended documentation page, additive stream-table implementation, and focused regression test. GitHub reports the branch mergeable, with no unresolved human or automated review threads. The branch is three commits behind `master`, but GitHub's test merge is currently clean.

The runtime has no local Java/Maven checkout. The focused local command below was not run and is not claimed as passed:

```bash
./mvnw -Dtest=EngineeringDiagramStreamTableTest test
```

The pull request remains a draft; this update does not mark it ready, merge it, or enable auto-merge.
