### PR TITLE
[AI-Assisted] feat(dynamics): transact stateful derived instruments

### DIFF
--- a/docs/integration/ai_platform_integration.md
+++ b/docs/integration/ai_platform_integration.md
@@ -196,6 +196,12 @@ String unit = gorSensor.getUnit();
 double sensitivity = gorSensor.getSensitivity("pressure");
 ```
 
+When a concrete local `SoftSensor` is registered as a process measurement device, transient
+transactions preserve its stream binding, selected property, input map, last estimate and
+sensitivity vector, together with inherited measurement/alarm state. Snapshots use defensive
+copies for mutable collections and arrays, and support Java-serialization restart. This provides
+rollback and replay mechanics; it is not an accuracy or validation claim for any estimate.
+
 **Available Property Types:**
 - `GOR` - Gas-Oil Ratio
 - `WATER_CUT` - Water Cut

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -464,3 +464,26 @@ independently. The detector response-time and detection-delay values are current
 metadata rather than integrated physical sensor dynamics. This gate does not qualify detector
 placement, fire/gas dispersion, voting, reliability, alarm/trip integrity, ESD action, external
 I/O, safety integrity, certification, virtual commissioning or OTS use.
+
+## State-mutating derived-instrument transaction coverage
+
+Concrete local `pHProbe`, `SoftSensor`, and `FlowInducedVibrationAnalyser` instances participate
+when registered as measurement devices in a `ProcessSystem`. Their snapshots include stable
+transaction identity and inherited measurement/alarm state. Device-specific state covers the pH
+probe's stream/reactive-system bindings, alkalinity, reaction scratch objects and last cached
+input/result; the soft sensor's stream binding, selected property, defensively copied input map,
+last estimate and sensitivity vector; and the vibration analyser's pipe binding, support and
+method configuration, segment set and implicitly selected segment.
+
+Quantitative tests place one participant in each of three coordinated `ProcessModel` areas.
+Rejection restores original bindings, configuration and exact cached or derived readings, replay
+is deterministic, and commit retains accepted edits. Restart evidence serializes each participant
+together with its closed snapshot. Concrete descendants, online-signal operation, null snapshots
+and snapshots belonging to another participant fail closed.
+
+This tranche covers transaction mechanics for state already mutated by production read paths. It
+does not newly qualify aqueous reaction chemistry, soft-sensor estimate accuracy, FIV correlations
+or pipe physics, sampling, external I/O, alarm/trip integrity, safety action, virtual commissioning
+or OTS use. `VirtualFlowMeter` remains outside this gate because its wall-clock result timestamps
+need a separate deterministic time/provenance design. `SevereSlugAnalyser` remains owned by the
+multiphase physics scope in issue #2907.

--- a/docs/process/equipment/measurement_devices.md
+++ b/docs/process/equipment/measurement_devices.md
@@ -165,6 +165,13 @@ double frms = fivAnalyser.getMeasuredValue("");
 - `"LOF"` - Likelihood of Failure (API RP 14E based)
 - `"FRMS"` - Fatigue Root Mean Square
 
+When a concrete local `FlowInducedVibrationAnalyser` is registered as a process measurement
+device, transient transactions preserve its pipe binding, support and method configuration,
+segment set, and the segment selected by an implicit calculation. Rejected trials can therefore
+restore the analyser configuration and reproduce the same derived value; accepted commits retain
+the update. This is transaction and restart coverage only and does not newly qualify the FIV
+correlations or the underlying pipe model.
+
 ## Process Monitors
 
 ### PressureTransmitter
@@ -539,6 +546,12 @@ import neqsim.process.measurementdevice.pHProbe;
 pHProbe ph = new pHProbe(aqueousStream);
 double phValue = ph.getMeasuredValue("");  // pH
 ```
+
+A registered concrete local `pHProbe` participates in transient transactions. Its snapshot
+preserves the stream and reactive-system bindings, alkalinity, reaction-calculation scratch
+objects, and the last cached pH input/result. Rollback therefore restores an exact cached reading
+instead of retaining work from a rejected trial. The coverage does not newly validate aqueous
+chemistry, alkalinity assumptions, sampling, or sensor accuracy.
 
 ## Multi-Phase Measurement
 

--- a/src/main/java/neqsim/process/measurementdevice/FlowInducedVibrationAnalyser.java
+++ b/src/main/java/neqsim/process/measurementdevice/FlowInducedVibrationAnalyser.java
@@ -1,7 +1,10 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.pipeline.PipeBeggsAndBrills;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
@@ -11,9 +14,12 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * @author SEROS
  * @version $Id: $Id
  */
-public class FlowInducedVibrationAnalyser extends MeasurementDeviceBaseClass {
+public class FlowInducedVibrationAnalyser extends MeasurementDeviceBaseClass
+    implements TransientStateParticipant<FlowInducedVibrationAnalyser.FlowInducedVibrationAnalyserState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(WaterDewPointAnalyser.class);
 
@@ -269,5 +275,87 @@ public class FlowInducedVibrationAnalyser extends MeasurementDeviceBaseClass {
    */
   public double getSupportDistance() {
     return supportDistance;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:flow-induced-vibration:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local analyser.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != FlowInducedVibrationAnalyser.class) {
+      return "flow-induced-vibration-analyser subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public FlowInducedVibrationAnalyserState captureTransientState() {
+    return new FlowInducedVibrationAnalyserState(getTransientStateIdentity(), supportDistance,
+        calcSupportArrangement, supportArrangement, method, pipe, segmentSet, segment, FRMSConstant,
+        captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(FlowInducedVibrationAnalyserState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Flow-induced-vibration analyser transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Flow-induced-vibration analyser snapshot identity does not match " + getTransientStateIdentity());
+    }
+    supportDistance = snapshot.supportDistance;
+    calcSupportArrangement = snapshot.calcSupportArrangement;
+    supportArrangement = snapshot.supportArrangement;
+    method = snapshot.method;
+    pipe = snapshot.pipe;
+    segmentSet = snapshot.segmentSet;
+    segment = snapshot.segment;
+    FRMSConstant = snapshot.frmsConstant;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable flow-induced-vibration-analyser rollback point. */
+  public static final class FlowInducedVibrationAnalyserState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final double supportDistance;
+    private final Boolean calcSupportArrangement;
+    private final String supportArrangement;
+    private final String method;
+    private final PipeBeggsAndBrills pipe;
+    private final Boolean segmentSet;
+    private final int segment;
+    private final double frmsConstant;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private FlowInducedVibrationAnalyserState(String stateIdentity, double supportDistance,
+        Boolean calcSupportArrangement, String supportArrangement, String method, PipeBeggsAndBrills pipe,
+        Boolean segmentSet, int segment, double frmsConstant, MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.supportDistance = supportDistance;
+      this.calcSupportArrangement = calcSupportArrangement;
+      this.supportArrangement = supportArrangement;
+      this.method = method;
+      this.pipe = pipe;
+      this.segmentSet = segmentSet;
+      this.segment = segment;
+      this.frmsConstant = frmsConstant;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/FlowInducedVibrationAnalyser.java
+++ b/src/main/java/neqsim/process/measurementdevice/FlowInducedVibrationAnalyser.java
@@ -303,9 +303,8 @@ public class FlowInducedVibrationAnalyser extends MeasurementDeviceBaseClass
   /** {@inheritDoc} */
   @Override
   public FlowInducedVibrationAnalyserState captureTransientState() {
-    return new FlowInducedVibrationAnalyserState(getTransientStateIdentity(), supportDistance,
-        calcSupportArrangement, supportArrangement, method, pipe, segmentSet, segment, FRMSConstant,
-        captureMeasurementDeviceTransientState());
+    return new FlowInducedVibrationAnalyserState(getTransientStateIdentity(), supportDistance, calcSupportArrangement,
+        supportArrangement, method, pipe, segmentSet, segment, FRMSConstant, captureMeasurementDeviceTransientState());
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/measurementdevice/pHProbe.java
+++ b/src/main/java/neqsim/process/measurementdevice/pHProbe.java
@@ -1,5 +1,10 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -10,9 +15,14 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * @author ESOL
  * @version $Id: $Id
  */
-public class pHProbe extends StreamMeasurementDeviceBaseClass {
+public class pHProbe extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<pHProbe.PHProbeState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Logger object for this class. */
+  private static final Logger logger = LogManager.getLogger(pHProbe.class);
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   protected SystemInterface reactiveThermoSystem;
   protected ThermodynamicOperations thermoOps;
@@ -88,11 +98,11 @@ public class pHProbe extends StreamMeasurementDeviceBaseClass {
         run();
         return hasCachedPH ? lastMeasuredPH : Double.NaN;
       } else {
-        System.out.println("no aqueous phase for pH analyser");
+        logger.warn("No aqueous phase is available for pH analyser '{}'", getName());
         return 7.0;
       }
     } else {
-      System.out.println("no stream connected to pH analyser");
+      logger.warn("No stream is connected to pH analyser '{}'", getName());
     }
     return Double.NaN;
   }
@@ -113,5 +123,87 @@ public class pHProbe extends StreamMeasurementDeviceBaseClass {
    */
   public void setAlkalinity(double alkalinity) {
     this.alkalinity = alkalinity;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:ph-probe:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local pH probe.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != pHProbe.class) {
+      return "pH-probe subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public PHProbeState captureTransientState() {
+    return new PHProbeState(getTransientStateIdentity(), stream, reactiveThermoSystem, thermoOps, alkalinity,
+        lastMeasuredStream, lastMeasuredAlkalinity, lastMeasuredPH, hasCachedPH,
+        captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(PHProbeState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("pH-probe transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException("pH-probe snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    reactiveThermoSystem = snapshot.reactiveThermoSystem;
+    thermoOps = snapshot.thermoOps;
+    alkalinity = snapshot.alkalinity;
+    lastMeasuredStream = snapshot.lastMeasuredStream;
+    lastMeasuredAlkalinity = snapshot.lastMeasuredAlkalinity;
+    lastMeasuredPH = snapshot.lastMeasuredPH;
+    hasCachedPH = snapshot.hasCachedPH;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable pH-probe rollback point. */
+  public static final class PHProbeState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final SystemInterface reactiveThermoSystem;
+    private final ThermodynamicOperations thermoOps;
+    private final double alkalinity;
+    private final StreamInterface lastMeasuredStream;
+    private final double lastMeasuredAlkalinity;
+    private final double lastMeasuredPH;
+    private final boolean hasCachedPH;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private PHProbeState(String stateIdentity, StreamInterface stream, SystemInterface reactiveThermoSystem,
+        ThermodynamicOperations thermoOps, double alkalinity, StreamInterface lastMeasuredStream,
+        double lastMeasuredAlkalinity, double lastMeasuredPH, boolean hasCachedPH,
+        MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.reactiveThermoSystem = reactiveThermoSystem;
+      this.thermoOps = thermoOps;
+      this.alkalinity = alkalinity;
+      this.lastMeasuredStream = lastMeasuredStream;
+      this.lastMeasuredAlkalinity = lastMeasuredAlkalinity;
+      this.lastMeasuredPH = lastMeasuredPH;
+      this.hasCachedPH = hasCachedPH;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/vfm/SoftSensor.java
+++ b/src/main/java/neqsim/process/measurementdevice/vfm/SoftSensor.java
@@ -1,7 +1,10 @@
 package neqsim.process.measurementdevice.vfm;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.measurementdevice.StreamMeasurementDeviceBaseClass;
 import neqsim.thermo.system.SystemInterface;
@@ -30,8 +33,11 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
  * @author ESOL
  * @version 1.0
  */
-public class SoftSensor extends StreamMeasurementDeviceBaseClass {
+public class SoftSensor extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<SoftSensor.SoftSensorState> {
   private static final long serialVersionUID = 1000L;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /**
    * Types of properties that can be estimated.
@@ -376,5 +382,78 @@ public class SoftSensor extends StreamMeasurementDeviceBaseClass {
     }
 
     return value;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:soft-sensor:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local soft sensor.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != SoftSensor.class) {
+      return "soft-sensor subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public SoftSensorState captureTransientState() {
+    return new SoftSensorState(getTransientStateIdentity(), stream, propertyType,
+        new HashMap<String, Double>(inputValues), lastEstimate,
+        lastSensitivity == null ? null : lastSensitivity.clone(), captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(SoftSensorState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Soft-sensor transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Soft-sensor snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    propertyType = snapshot.propertyType;
+    inputValues = new HashMap<String, Double>(snapshot.inputValues);
+    lastEstimate = snapshot.lastEstimate;
+    lastSensitivity = snapshot.lastSensitivity == null ? null : snapshot.lastSensitivity.clone();
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable soft-sensor rollback point. */
+  public static final class SoftSensorState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final PropertyType propertyType;
+    private final Map<String, Double> inputValues;
+    private final double lastEstimate;
+    private final double[] lastSensitivity;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private SoftSensorState(String stateIdentity, StreamInterface stream, PropertyType propertyType,
+        Map<String, Double> inputValues, double lastEstimate, double[] lastSensitivity,
+        MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.propertyType = propertyType;
+      this.inputValues = inputValues;
+      this.lastEstimate = lastEstimate;
+      this.lastSensitivity = lastSensitivity;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/vfm/SoftSensor.java
+++ b/src/main/java/neqsim/process/measurementdevice/vfm/SoftSensor.java
@@ -422,8 +422,7 @@ public class SoftSensor extends StreamMeasurementDeviceBaseClass
       throw new IllegalArgumentException("Soft-sensor transient snapshot cannot be null");
     }
     if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
-      throw new IllegalArgumentException(
-          "Soft-sensor snapshot identity does not match " + getTransientStateIdentity());
+      throw new IllegalArgumentException("Soft-sensor snapshot identity does not match " + getTransientStateIdentity());
     }
     stream = snapshot.stream;
     propertyType = snapshot.propertyType;

--- a/src/test/java/neqsim/process/measurementdevice/StatefulDerivedInstrumentTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/StatefulDerivedInstrumentTransientStateTransactionTest.java
@@ -1,0 +1,272 @@
+package neqsim.process.measurementdevice;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import neqsim.process.dynamics.TransientStepTransaction;
+import neqsim.process.dynamics.TransientTransactionCoverage;
+import neqsim.process.equipment.pipeline.PipeBeggsAndBrills;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.measurementdevice.vfm.SoftSensor;
+import neqsim.process.measurementdevice.vfm.SoftSensor.PropertyType;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Rollback, restart, and multi-area evidence for state-mutating derived instruments. */
+class StatefulDerivedInstrumentTransientStateTransactionTest extends neqsim.NeqSimTest {
+  @Test
+  void multiAreaRollbackRestoresCachedDerivedStateBindingsAndConfiguration() {
+    StreamInterface phStream = createAqueousStream("pH source");
+    pHProbe probe = new pHProbe("AIT-PH-100", phStream);
+    probe.run();
+    double expectedPH = probe.getMeasuredValue();
+
+    StreamInterface softSensorStream = createSoftSensorStream("soft-sensor source");
+    SoftSensor softSensor = new SoftSensor("AIT-SS-100", softSensorStream, PropertyType.DENSITY);
+    softSensor.setInput("pressure", 30.0);
+    softSensor.setInput("temperature", 300.0);
+    double expectedEstimate = softSensor.estimate();
+    double[] expectedSensitivity = softSensor.getSensitivity().clone();
+
+    PipeBeggsAndBrills pipe = createSolvedPipe();
+    FlowInducedVibrationAnalyser vibration = new FlowInducedVibrationAnalyser("AIT-FIV-100", pipe);
+    vibration.setMethod("LOF");
+    vibration.setSupportArrangement("Stiff");
+    vibration.setSupportDistance(3.0);
+    double expectedVibration = vibration.getMeasuredValue();
+
+    ProcessSystem chemistryArea = new ProcessSystem("chemistry area");
+    chemistryArea.add(probe);
+    ProcessSystem inferenceArea = new ProcessSystem("inference area");
+    inferenceArea.add(softSensor);
+    ProcessSystem integrityArea = new ProcessSystem("integrity area");
+    integrityArea.add(vibration);
+    ProcessModel model = new ProcessModel();
+    model.add("chemistry", chemistryArea);
+    model.add("inference", inferenceArea);
+    model.add("integrity", integrityArea);
+
+    assertCompleteCoverage(model.getTransientTransactionCoverage(), 3);
+    String probeIdentity = probe.getTransientStateIdentity();
+    String softSensorIdentity = softSensor.getTransientStateIdentity();
+    String vibrationIdentity = vibration.getTransientStateIdentity();
+
+    TransientStepTransaction transaction = model.beginTransientStepTransaction();
+    probe.setName("trial pH");
+    probe.setAlkalinity(50.0);
+    probe.setStream(createAqueousStream("trial pH source"));
+    probe.run();
+    softSensor.setName("trial soft sensor");
+    softSensor.setPropertyType(PropertyType.WATER_CUT);
+    softSensor.setInput("pressure", 5.0);
+    softSensor.setInput("temperature", 330.0);
+    softSensor.getSensitivity();
+    vibration.setName("trial vibration");
+    vibration.setMethod("FRMS");
+    vibration.setSupportArrangement("Flexible");
+    vibration.setSupportDistance(12.0);
+    vibration.setSegment(0);
+    vibration.getMeasuredValue();
+    transaction.rollback();
+
+    assertEquals(probeIdentity, probe.getTransientStateIdentity());
+    assertEquals(softSensorIdentity, softSensor.getTransientStateIdentity());
+    assertEquals(vibrationIdentity, vibration.getTransientStateIdentity());
+    assertEquals("AIT-PH-100", probe.getName());
+    assertSame(phStream, probe.getStream());
+    assertEquals(0.0, probe.getAlkalinity(), 0.0);
+    assertEquals(expectedPH, probe.getMeasuredValue(), 0.0, "rollback must restore the cached pH exactly");
+    assertEquals("AIT-SS-100", softSensor.getName());
+    assertSame(softSensorStream, softSensor.getStream());
+    assertEquals(PropertyType.DENSITY, softSensor.getPropertyType());
+    assertArrayEquals(expectedSensitivity, softSensor.getLastSensitivity(), 0.0);
+    assertEquals(expectedEstimate, softSensor.estimate(), 1.0e-12);
+    assertEquals("AIT-FIV-100", vibration.getName());
+    assertEquals("LOF", vibration.getMethod());
+    assertEquals("Stiff", vibration.getSupportArrangement());
+    assertEquals(3.0, vibration.getSupportDistance(), 0.0);
+    assertEquals(expectedVibration, vibration.getMeasuredValue(), 0.0);
+
+    TransientStepTransaction accepted = model.beginTransientStepTransaction();
+    probe.setAlkalinity(25.0);
+    softSensor.setPropertyType(PropertyType.GOR);
+    vibration.setSupportArrangement("Medium");
+    accepted.commit();
+    assertEquals(25.0, probe.getAlkalinity(), 0.0);
+    assertEquals(PropertyType.GOR, softSensor.getPropertyType());
+    assertEquals("Medium", vibration.getSupportArrangement());
+  }
+
+  @Test
+  void serializedClosedSnapshotsRestoreDerivedInstrumentContinuation() throws Exception {
+    pHProbe probe = new pHProbe("AIT-PH-200", createAqueousStream("restart pH source"));
+    probe.run();
+    double expectedPH = probe.getMeasuredValue();
+    pHProbe.PHProbeState probeState = probe.captureTransientState();
+
+    SoftSensor softSensor = new SoftSensor("AIT-SS-200", createSoftSensorStream("restart soft source"),
+        PropertyType.DENSITY);
+    softSensor.setInput("pressure", 30.0);
+    softSensor.setInput("temperature", 300.0);
+    softSensor.estimate();
+    double[] expectedSensitivity = softSensor.getSensitivity().clone();
+    SoftSensor.SoftSensorState softSensorState = softSensor.captureTransientState();
+
+    FlowInducedVibrationAnalyser vibration = new FlowInducedVibrationAnalyser("AIT-FIV-200", createSolvedPipe());
+    vibration.setMethod("LOF");
+    vibration.setSupportArrangement("Stiff");
+    double expectedVibration = vibration.getMeasuredValue();
+    FlowInducedVibrationAnalyser.FlowInducedVibrationAnalyserState vibrationState =
+        vibration.captureTransientState();
+
+    byte[] serialized;
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(probe);
+      output.writeObject(probeState);
+      output.writeObject(softSensor);
+      output.writeObject(softSensorState);
+      output.writeObject(vibration);
+      output.writeObject(vibrationState);
+      serialized = bytes.toByteArray();
+    }
+
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      pHProbe restoredProbe = (pHProbe) input.readObject();
+      pHProbe.PHProbeState restoredProbeState = (pHProbe.PHProbeState) input.readObject();
+      SoftSensor restoredSoftSensor = (SoftSensor) input.readObject();
+      SoftSensor.SoftSensorState restoredSoftSensorState = (SoftSensor.SoftSensorState) input.readObject();
+      FlowInducedVibrationAnalyser restoredVibration = (FlowInducedVibrationAnalyser) input.readObject();
+      FlowInducedVibrationAnalyser.FlowInducedVibrationAnalyserState restoredVibrationState =
+          (FlowInducedVibrationAnalyser.FlowInducedVibrationAnalyserState) input.readObject();
+
+      restoredProbe.setAlkalinity(50.0);
+      restoredProbe.restoreTransientState(restoredProbeState);
+      restoredSoftSensor.setPropertyType(PropertyType.WATER_CUT);
+      restoredSoftSensor.restoreTransientState(restoredSoftSensorState);
+      restoredVibration.setMethod("FRMS");
+      restoredVibration.restoreTransientState(restoredVibrationState);
+
+      assertEquals(expectedPH, restoredProbe.getMeasuredValue(), 0.0);
+      assertArrayEquals(expectedSensitivity, restoredSoftSensor.getLastSensitivity(), 0.0);
+      assertEquals(PropertyType.DENSITY, restoredSoftSensor.getPropertyType());
+      assertEquals(expectedVibration, restoredVibration.getMeasuredValue(), 0.0);
+    }
+  }
+
+  @Test
+  void descendantsOnlineModesNullAndForeignSnapshotsFailClosed() {
+    StreamInterface phStream = createAqueousStream("coverage pH source");
+    StreamInterface softStream = createSoftSensorStream("coverage soft source");
+    PipeBeggsAndBrills pipe = createSolvedPipe();
+    ProcessSystem descendants = new ProcessSystem("derived instrument descendants");
+    descendants.add(new pHProbe(phStream) {
+      private static final long serialVersionUID = 1000L;
+    });
+    descendants.add(new SoftSensor("derived soft sensor", softStream, PropertyType.DENSITY) {
+      private static final long serialVersionUID = 1000L;
+    });
+    descendants.add(new FlowInducedVibrationAnalyser("derived vibration", pipe) {
+      private static final long serialVersionUID = 1000L;
+    });
+    TransientTransactionCoverage descendantCoverage = descendants.getTransientTransactionCoverage();
+    assertEquals(3, descendantCoverage.getParticipantCount());
+    assertFalse(descendantCoverage.isComplete());
+    assertEquals(3, descendantCoverage.getBlockingIssues().size());
+    for (String issue : descendantCoverage.getBlockingIssues()) {
+      assertTrue(issue.contains("subclass-owned mutable state"));
+    }
+
+    SoftSensor online = new SoftSensor("online soft sensor", softStream, PropertyType.DENSITY);
+    online.setIsOnlineSignal(true, "plant", "tag");
+    ProcessSystem onlineProcess = new ProcessSystem("online derived instrument");
+    onlineProcess.add(online);
+    assertFalse(onlineProcess.getTransientTransactionCoverage().isComplete());
+    assertTrue(onlineProcess.getTransientTransactionCoverage().getBlockingIssues().get(0).contains("external I/O"));
+
+    pHProbe firstProbe = new pHProbe(phStream);
+    pHProbe secondProbe = new pHProbe(phStream);
+    assertThrows(IllegalArgumentException.class,
+        () -> secondProbe.restoreTransientState(firstProbe.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> firstProbe.restoreTransientState(null));
+    SoftSensor firstSoft = new SoftSensor("first soft", softStream, PropertyType.DENSITY);
+    SoftSensor secondSoft = new SoftSensor("second soft", softStream, PropertyType.DENSITY);
+    assertThrows(IllegalArgumentException.class,
+        () -> secondSoft.restoreTransientState(firstSoft.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> firstSoft.restoreTransientState(null));
+    FlowInducedVibrationAnalyser firstVibration = new FlowInducedVibrationAnalyser("first vibration", pipe);
+    FlowInducedVibrationAnalyser secondVibration = new FlowInducedVibrationAnalyser("second vibration", pipe);
+    assertThrows(IllegalArgumentException.class,
+        () -> secondVibration.restoreTransientState(firstVibration.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> firstVibration.restoreTransientState(null));
+  }
+
+  private static StreamInterface createAqueousStream(String name) {
+    SystemInterface fluid = new SystemSrkCPAstatoil(318.15, 50.0);
+    fluid.addComponent("nitrogen", 1.205);
+    fluid.addComponent("CO2", 1.340);
+    fluid.addComponent("methane", 87.974);
+    fluid.addComponent("ethane", 5.258);
+    fluid.addComponent("propane", 3.283);
+    fluid.addComponent("nC10", 14.053);
+    fluid.addComponent("water", 141.053);
+    fluid.setMixingRule(10);
+    fluid.setMultiPhaseCheck(true);
+    Stream stream = new Stream(name, fluid);
+    stream.run();
+    return stream;
+  }
+
+  private static StreamInterface createSoftSensorStream(String name) {
+    SystemInterface fluid = new SystemSrkEos(300.0, 30.0);
+    fluid.addComponent("methane", 0.80);
+    fluid.addComponent("n-heptane", 0.15);
+    fluid.addComponent("water", 0.05);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    Stream stream = new Stream(name, fluid);
+    stream.setFlowRate(1000.0, "kg/hr");
+    stream.run();
+    return stream;
+  }
+
+  private static PipeBeggsAndBrills createSolvedPipe() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 70.0);
+    fluid.addComponent("methane", 0.90);
+    fluid.addComponent("ethane", 0.10);
+    fluid.setMixingRule("classic");
+    fluid.setTotalFlowRate(100.0, "kg/hr");
+    Stream stream = new Stream("vibration source", fluid);
+    PipeBeggsAndBrills pipe = new PipeBeggsAndBrills("vibration pipe", stream);
+    pipe.setDiameter(0.1);
+    pipe.setThickness(0.01);
+    pipe.setLength(50.0);
+    pipe.setElevation(0.0);
+    pipe.setPipeWallRoughness(1.0e-5);
+    pipe.setNumberOfIncrements(10);
+    ProcessSystem process = new ProcessSystem("vibration source process");
+    process.add(stream);
+    process.add(pipe);
+    process.run();
+    return pipe;
+  }
+
+  private static void assertCompleteCoverage(TransientTransactionCoverage coverage, int expectedCount) {
+    assertEquals(expectedCount, coverage.getProcessElementCount());
+    assertEquals(expectedCount, coverage.getParticipantCount());
+    assertTrue(coverage.isComplete(), coverage.getBlockingIssues().toString());
+  }
+}

--- a/src/test/java/neqsim/process/measurementdevice/StatefulDerivedInstrumentTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/StatefulDerivedInstrumentTransientStateTransactionTest.java
@@ -129,8 +129,7 @@ class StatefulDerivedInstrumentTransientStateTransactionTest extends neqsim.NeqS
     vibration.setMethod("LOF");
     vibration.setSupportArrangement("Stiff");
     double expectedVibration = vibration.getMeasuredValue();
-    FlowInducedVibrationAnalyser.FlowInducedVibrationAnalyserState vibrationState =
-        vibration.captureTransientState();
+    FlowInducedVibrationAnalyser.FlowInducedVibrationAnalyserState vibrationState = vibration.captureTransientState();
 
     byte[] serialized;
     try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
@@ -150,8 +149,8 @@ class StatefulDerivedInstrumentTransientStateTransactionTest extends neqsim.NeqS
       SoftSensor restoredSoftSensor = (SoftSensor) input.readObject();
       SoftSensor.SoftSensorState restoredSoftSensorState = (SoftSensor.SoftSensorState) input.readObject();
       FlowInducedVibrationAnalyser restoredVibration = (FlowInducedVibrationAnalyser) input.readObject();
-      FlowInducedVibrationAnalyser.FlowInducedVibrationAnalyserState restoredVibrationState =
-          (FlowInducedVibrationAnalyser.FlowInducedVibrationAnalyserState) input.readObject();
+      FlowInducedVibrationAnalyser.FlowInducedVibrationAnalyserState restoredVibrationState = (FlowInducedVibrationAnalyser.FlowInducedVibrationAnalyserState) input
+          .readObject();
 
       restoredProbe.setAlkalinity(50.0);
       restoredProbe.restoreTransientState(restoredProbeState);


### PR DESCRIPTION
## Roadmap

Advances #2911 Phase 1 snapshot/restore coverage after verified merged DYN-C011 / #3019.

Exact base: `2e8a6fd4e3d341bb3071df1c99ad2a36a9733ad7`.
Exact publication head: `de0f165e66638ad3e6292ce75beeac9908722e5c`.

## Problem

Three local derived instruments mutate device-owned state while evaluating a reading but were not transient-state participants:

- `pHProbe` updates reaction scratch objects and an input/result cache;
- `SoftSensor` updates its last estimate and sensitivity vector while retaining editable inputs;
- `FlowInducedVibrationAnalyser` may select and retain a pipe segment while reading.

A rejected trial could therefore leave cached/derived state, configuration, or bindings from the rejected path, making replay and restart diverge.

## Coherent implementation

- make the three concrete local instruments identity-preserving transient-state participants;
- capture their stream/pipe bindings, editable configuration, caches, scratch references and derived histories;
- defensively copy the soft-sensor input map and sensitivity vector;
- include the complete inherited measurement/alarm snapshot;
- preserve stable participant identity across rollback and Java serialization, with lazy identity creation for older serialized objects;
- restore state on the same participant and reject null or foreign snapshots;
- fail closed for subclasses until subclass-owned mutable state is covered;
- fail closed for online-signal bindings because external I/O has no rejected-step commit/defer contract;
- replace two adjacent pH console writes with structured warnings.

## Quantitative regression and restart evidence

`StatefulDerivedInstrumentTransientStateTransactionTest` covers:

- a three-area `ProcessModel` with one participant per area;
- complete 3/3 transaction coverage;
- coordinated rollback of bindings, names, configuration, pH cache, soft-sensor estimate/sensitivity and implicit FIV segment selection;
- exact pH, sensitivity and FIV replay, with a `1e-12` soft-sensor estimate tolerance;
- accepted commit retaining edits;
- stable transaction identities;
- Java serialization of every participant together with its closed snapshot;
- foreign/null snapshot rejection;
- fail-closed anonymous subclasses and online-signal operation.

## State boundary

The pH snapshot covers the stream and reactive-system bindings, thermodynamic operation scratch object, alkalinity, cached input identity/alkalinity/result and cache-valid flag. The soft-sensor snapshot covers its stream, property type, input map, last estimate and sensitivity vector. The FIV snapshot covers its pipe binding, support/method configuration, automatic-support flag, segment-set flag, selected segment and FRMS constant.

This is transaction mechanics for state already mutated by production read paths. It does not newly qualify aqueous reaction chemistry, soft-sensor accuracy, FIV correlations, pipe physics, sampling, external I/O, alarm/trip integrity, safety action, virtual commissioning or OTS behavior.

`VirtualFlowMeter` is deliberately excluded because its wall-clock result timestamps need a separate deterministic time/provenance design. `SevereSlugAnalyser` remains in the #2907 multiphase-physics lane. No #2935 pipeline species-transport work is included. No Huldra data is fetched or modeled.

## Compatibility and performance

Existing constructors and public method signatures are unchanged. The public transaction behavior follows the already merged `TransientStateParticipant` contract; persistent additions are private identity fields and serializable snapshot types. Ordinary reads pay no transaction cost unless the instrument is registered and a transaction is opened.

## Documentation impact

Updated the dynamic capability contract, measurement-device guide, and AI-platform soft-sensor guide with the supported state, evidence and explicit exclusions. No notebook changed.

## Validation

**VALIDATION COMPLETE — READY TO MERGE** on exact head `de0f165e66638ad3e6292ce75beeac9908722e5c`.

GitHub-hosted validation is complete on this exact head:

- Spotless, pre-commit, PaperLab, documentation search, and CodeQL passed;
- Javadocs and repository-contract checks passed;
- Java 21 fast tests passed on Ubuntu and Windows;
- all four Java 21 Ubuntu slow-test shards passed;
- Java 8 tests passed on Ubuntu and Windows.

The final diff remains limited to three instrument implementations, their focused transaction regression, and three directly affected documentation pages. GitHub reports the branch mergeable and current with `master`; there are no comments, reviews, requested changes, or unresolved human/Copilot threads.

Local focused Maven, Spotless, pre-commit, and documentation-search commands were not run on this exact head because the earlier runtime was blocked by Maven/DNS and local-state constraints. They are not claimed as local passes; the exact-head hosted checks above are the validation evidence.

The pull request remains a draft. This update does not mark it ready, merge it, or enable auto-merge.

## Next dependency

After merge, continue Phase 1 only with another demonstrably state-mutating shared orchestration family, stopping before wall-clock provenance, specialist multiphase physics, or pipeline species transport.