### PR TITLE
[AI-Assisted] fix(dexpi): stabilize numeric serialization

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -284,9 +284,9 @@ Each piping connection carries operating line data and a NORSOK Z-003 line-ident
 - Operating pressure, temperature and flow generic attributes when available on the stream
 - A line-number text label (e.g. `PG-001`) composed by `NorsokLineNumber`
 
-The writer serializes numeric generic-attribute values with at most nine fractional digits. This
-canonical engineering precision suppresses insignificant solver noise so repeated exports remain
-stable while retaining substantially more resolution than typical drawing data.
+The writer serializes numeric generic-attribute values with eleven significant digits. This
+scale-aware canonical precision suppresses insignificant solver noise so repeated exports remain
+stable without rounding small, non-zero engineering values to zero.
 
 Battery-limit feeds and products that are not wired to another unit on the sheet are marked with
 off-page connector symbols carrying `FEED` / `PRODUCT` cross references, and instrument tags are

--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -284,6 +284,10 @@ Each piping connection carries operating line data and a NORSOK Z-003 line-ident
 - Operating pressure, temperature and flow generic attributes when available on the stream
 - A line-number text label (e.g. `PG-001`) composed by `NorsokLineNumber`
 
+The writer serializes numeric generic-attribute values with at most nine fractional digits. This
+canonical engineering precision suppresses insignificant solver noise so repeated exports remain
+stable while retaining substantially more resolution than typical drawing data.
+
 Battery-limit feeds and products that are not wired to another unit on the sheet are marked with
 off-page connector symbols carrying `FEED` / `PRODUCT` cross references, and instrument tags are
 checked against ISA-5.1 with a `TagConformanceWarning` attribute added for non-conforming tags.

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
@@ -95,8 +95,7 @@ public final class DexpiXmlWriter {
     format.setGroupingUsed(false);
     return format;
   });
-  private static final MathContext NUMERIC_ATTRIBUTE_PRECISION =
-      new MathContext(11, RoundingMode.HALF_EVEN);
+  private static final MathContext NUMERIC_ATTRIBUTE_PRECISION = new MathContext(11, RoundingMode.HALF_EVEN);
 
   /**
    * Thread-local flag controlling whether the root {@code PlantModel} element declares the DEXPI default XML namespace.

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
@@ -6,6 +6,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.time.LocalDate;
@@ -87,11 +90,13 @@ public final class DexpiXmlWriter {
   private static final Pattern COMMON_SAFETY_TRIP_TAG = Pattern.compile("^(?:[PLTF](?:S|A)(?:HH|LL)|FSL)$");
   private static final transient ThreadLocal<DecimalFormat> DECIMAL_FORMAT = ThreadLocal.withInitial(() -> {
     DecimalFormatSymbols symbols = DecimalFormatSymbols.getInstance(Locale.ROOT);
-    DecimalFormat format = new DecimalFormat("0.#########", symbols);
-    format.setMaximumFractionDigits(9);
+    DecimalFormat format = new DecimalFormat("0.############", symbols);
+    format.setMaximumFractionDigits(12);
     format.setGroupingUsed(false);
     return format;
   });
+  private static final MathContext NUMERIC_ATTRIBUTE_PRECISION =
+      new MathContext(11, RoundingMode.HALF_EVEN);
 
   /**
    * Thread-local flag controlling whether the root {@code PlantModel} element declares the DEXPI default XML namespace.
@@ -1832,7 +1837,11 @@ public final class DexpiXmlWriter {
     if (Double.isNaN(value) || Double.isInfinite(value)) {
       return;
     }
-    appendGenericAttribute(document, parent, name, DECIMAL_FORMAT.get().format(value), unit);
+    appendGenericAttribute(document, parent, name, formatNumericAttribute(value), unit);
+  }
+
+  static String formatNumericAttribute(double value) {
+    return BigDecimal.valueOf(value).round(NUMERIC_ATTRIBUTE_PRECISION).stripTrailingZeros().toPlainString();
   }
 
   /**

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
@@ -1839,6 +1839,12 @@ public final class DexpiXmlWriter {
     appendGenericAttribute(document, parent, name, formatNumericAttribute(value), unit);
   }
 
+  /**
+   * Formats a finite engineering value as a deterministic, scale-aware decimal attribute.
+   *
+   * @param value finite numeric value to format
+   * @return canonical decimal representation using the writer's significant-digit precision
+   */
   static String formatNumericAttribute(double value) {
     return BigDecimal.valueOf(value).round(NUMERIC_ATTRIBUTE_PRECISION).stripTrailingZeros().toPlainString();
   }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
@@ -87,8 +87,8 @@ public final class DexpiXmlWriter {
   private static final Pattern COMMON_SAFETY_TRIP_TAG = Pattern.compile("^(?:[PLTF](?:S|A)(?:HH|LL)|FSL)$");
   private static final transient ThreadLocal<DecimalFormat> DECIMAL_FORMAT = ThreadLocal.withInitial(() -> {
     DecimalFormatSymbols symbols = DecimalFormatSymbols.getInstance(Locale.ROOT);
-    DecimalFormat format = new DecimalFormat("0.############", symbols);
-    format.setMaximumFractionDigits(12);
+    DecimalFormat format = new DecimalFormat("0.#########", symbols);
+    format.setMaximumFractionDigits(9);
     format.setGroupingUsed(false);
     return format;
   });

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
@@ -342,7 +342,9 @@ public class DexpiXmlWriterTest extends NeqSimTest {
     String secondXml = secondOut.toString(StandardCharsets.UTF_8.name());
 
     assertTrue(firstXml.contains("Name=\"OperatingTemperatureValue\" Unit=\"C\" Value=\"30.707918389\""));
-    assertEquals(normalizeEmissionMetadata(firstXml), normalizeEmissionMetadata(secondXml));\n    assertEquals("0.00000012345678901",\n        DexpiXmlWriter.formatNumericAttribute(0.0000001234567890123));
+    assertEquals(normalizeEmissionMetadata(firstXml), normalizeEmissionMetadata(secondXml));
+    assertEquals("0.00000012345678901",
+        DexpiXmlWriter.formatNumericAttribute(0.0000001234567890123));
   }
 
   private static String normalizeEmissionMetadata(String xml) {

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
@@ -317,6 +317,40 @@ public class DexpiXmlWriterTest extends NeqSimTest {
   }
 
   /**
+   * Tests that insignificant solver noise beyond the canonical DEXPI precision does not change the exported document.
+   *
+   * @throws IOException if writing fails
+   */
+  @Test
+  public void testSimulationResultPrecisionIsDeterministic() throws IOException {
+    Stream feed = createFeedStream();
+    Separator sep = new Separator("HP-Sep", feed);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(sep);
+    process.run();
+
+    sep.getGasOutStream().setTemperature(30.707918388829, "C");
+    ByteArrayOutputStream firstOut = new ByteArrayOutputStream();
+    DexpiXmlWriter.write(process, firstOut);
+    String firstXml = firstOut.toString(StandardCharsets.UTF_8.name());
+
+    sep.getGasOutStream().setTemperature(30.707918388769, "C");
+    ByteArrayOutputStream secondOut = new ByteArrayOutputStream();
+    DexpiXmlWriter.write(process, secondOut);
+    String secondXml = secondOut.toString(StandardCharsets.UTF_8.name());
+
+    assertTrue(firstXml.contains("Name=\"OperatingTemperatureValue\" Unit=\"C\" Value=\"30.707918389\""));
+    assertEquals(normalizeEmissionMetadata(firstXml), normalizeEmissionMetadata(secondXml));
+  }
+
+  private static String normalizeEmissionMetadata(String xml) {
+    return xml.replaceFirst(" Date=\"[^\"]+\"", " Date=\"<generated-date>\"").replaceFirst(" Time=\"[^\"]+\"",
+        " Time=\"<generated-time>\"");
+  }
+
+  /**
    * Tests that round-trip write-then-read produces a valid ProcessSystem without throwing.
    *
    * @throws Exception if write or read fails

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
@@ -343,8 +343,7 @@ public class DexpiXmlWriterTest extends NeqSimTest {
 
     assertTrue(firstXml.contains("Name=\"OperatingTemperatureValue\" Unit=\"C\" Value=\"30.707918389\""));
     assertEquals(normalizeEmissionMetadata(firstXml), normalizeEmissionMetadata(secondXml));
-    assertEquals("0.00000012345678901",
-        DexpiXmlWriter.formatNumericAttribute(0.0000001234567890123));
+    assertEquals("0.00000012345678901", DexpiXmlWriter.formatNumericAttribute(0.0000001234567890123));
   }
 
   private static String normalizeEmissionMetadata(String xml) {

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
@@ -342,7 +342,7 @@ public class DexpiXmlWriterTest extends NeqSimTest {
     String secondXml = secondOut.toString(StandardCharsets.UTF_8.name());
 
     assertTrue(firstXml.contains("Name=\"OperatingTemperatureValue\" Unit=\"C\" Value=\"30.707918389\""));
-    assertEquals(normalizeEmissionMetadata(firstXml), normalizeEmissionMetadata(secondXml));
+    assertEquals(normalizeEmissionMetadata(firstXml), normalizeEmissionMetadata(secondXml));\n    assertEquals("0.00000012345678901",\n        DexpiXmlWriter.formatNumericAttribute(0.0000001234567890123));
   }
 
   private static String normalizeEmissionMetadata(String xml) {


### PR DESCRIPTION
## Summary

- serialize DEXPI numeric `GenericAttribute` values with eleven significant digits
- keep precision scale-aware so small non-zero engineering values are not rounded to zero
- add focused regressions for the two Windows-jitter temperatures and a small-value case
- document the canonical precision used by the DEXPI writer

## Root cause

The Windows Java 21 job in [workflow run 31878766097](https://github.com/equinor/neqsim/actions/runs/31878766097/job/94998431760) ran 11,772 tests and failed only `EngineeringDiagramReferenceCasesTest.branchedReferenceCasePreservesDeterministicExchangeAndProposalBoundaries`.

Two independently executed reference models produced `30.707918388829 °C` and `30.707918388769 °C`. The physical difference is only `6e-11 °C`, but the writer retained enough solver noise for the otherwise identical XML documents to differ byte-for-byte.

The first repair capped all values at nine fractional digits. Exact-head follow-up replaced that with eleven significant digits: it produces the same canonical `30.707918389 °C` for both failing values while preserving small values such as `1.234567890123e-7` as `0.00000012345678901` instead of reducing their useful precision or rounding sufficiently small values to zero. Unrelated drawing stream-table formatting remains unchanged.

## Compatibility and engineering boundary

This is a deterministic serialization repair for the existing Proteus-compatible DEXPI/P&ID writer. It does not change public APIs, topology, Classic DOT/Graphviz, native DEXPI 2.0 Process, native SVG/PDF, or P&ID approval state. It makes no standards-conformance or accountable-design claim.

## Validation

Exact current head: `d0d5d610bf2edf8b7af1fe9da2ed682c9430ac6a`.

**VALIDATION PENDING CI** on the exact current head after applying the exact hosted Spotless patch and completing formatter Javadoc. The predecessor head `1c2666544fb62469c28f9d93d771a5353ee0b8e7` failed pre-commit only because Spotless required two line-wrap changes; documentation search passed in that run.

Completed locally on the predecessor head `1725caf85d10fbea7e9c42f3b3b090a4dfba4520`:

- `./mvnw -B test -ntp -Dtest=DexpiXmlWriterTest,EngineeringDiagramReferenceCasesTest -Djacoco.skip=true` — **PASS**, 28 tests
- `python devtools/run_spotless.py apply` — **PASS**
- `python devtools/run_spotless.py check` — **PASS**
- `python devtools/check_documentation_search.py` — **PASS**, 652 Markdown pages and 1 standalone HTML page
- `pre-commit run --all-files --hook-stage pre-commit` — **PASS**
- `pre-commit run --all-files --hook-stage pre-push` — **PASS**
- `git diff --check` — **PASS**

The exact current head was published through the connected GitHub source API; no local Maven, Spotless, pre-commit, or documentation command is claimed on that head. GitHub CI is the authoritative validator, especially for Windows Java 21.

## Documentation impact

Updated `docs/integration/dexpi-reader.md` to state the scale-aware canonical precision and determinism rationale.

## Roadmap status

This open draft is in-progress repair evidence for the coordinated #1332/#2899 diagram lane. No merge-dependent roadmap criterion is claimed complete. Heat/material-balance aggregation remains the next separate dependency after this PR is merged or closed.