### PR TITLE
[AI-Assisted] docs(examples): correct transient slug control guide

### DIFF
--- a/docs/examples/transient_slug_separator_control_example.md
+++ b/docs/examples/transient_slug_separator_control_example.md
@@ -1,27 +1,106 @@
 ---
-title: Transient slug separator control example
-description: This example wires a terrain-affected transient flowline to an inlet separator that is controlled by independent liquid-level and gas-pressure loops. The flowline uses a sinusoidal elevation profile t...
+title: "Transient Slug Separator Control Example"
+description: "Interpret and run the deterministic inlet-flow disturbance and separator PID-control example, including its model boundaries and CSV output."
 ---
 
-# Transient slug separator control example
+This page documents the
+[Java example](https://github.com/equinor/neqsim/blob/master/examples/neqsim/process/controllerdevice/TransientSlugSeparatorControlExample.java)
+as it exists on current NeqSim `master`. The example applies a deterministic,
+slug-like mass-flow disturbance directly to a separator and records the response
+of its level and pressure controllers.
 
-This example wires a terrain-affected transient flowline to an inlet separator that is controlled by independent liquid-level and gas-pressure loops. The flowline uses a sinusoidal elevation profile to shed slugs into the separator while a choke on the inlet protects separator pressure and a pair of throttling valves, each driven by a transmitter/PID loop, work to hold the separator liquid level and gas outlet pressure near their set points. The sample program reports slug statistics plus the final liquid level and gas outlet pressure once the transient run finishes.
+The example is a control-response demonstration. It is not a mechanistic
+slug-flow, terrain, or transient-pipeline model, and its output is not a design
+or operability acceptance result.
 
-## Key setup
+## What the example models
 
-- The inlet stream represents a rich gas with water, flowing at 10 kg/s and 80 bara. It feeds a 1.5 km, 0.2 m diameter transient pipe split into 20 sections and a sinusoidal elevation dip that forces intermittent liquid holdup and slug formation before the pipe outlet. 【F:src/main/java/neqsim/process/controllerdevice/TransientSlugSeparatorControlExample.java†L55-L97】
-- A choke valve sits between the flowline and separator and is driven by a pressure controller to hold the separator near 70 bara while absorbing slug-induced surges. Downstream of the separator, a gas outlet valve uses its own pressure controller on the export stream, and the liquid valve is driven by a level transmitter/PID pair targeting a 45% level. 【F:src/main/java/neqsim/process/controllerdevice/TransientSlugSeparatorControlExample.java†L99-L135】
-- After steady-state initialization, the process advances 10 transient steps at 0.5 s per step to give the pipe time to generate slugs and let the controllers react. The example returns the slug tracker summary string along with the separator level and gas outlet pressure observed at the end of these steps. 【F:src/main/java/neqsim/process/controllerdevice/TransientSlugSeparatorControlExample.java†L120-L138】
+| Item | Source configuration |
+| --- | --- |
+| Fluid | Seven-component hydrocarbon fluid in `SystemSrkEos`, initialized at 288.15 K and 55 bara |
+| Inlet | Base mass flow of 20 kg/s applied directly to the separator inlet |
+| Disturbance | 60-second cycle, 15-second event, and peak increment of 80% of base flow |
+| Separator | 2.2 m internal diameter and 7.0 m length |
+| Liquid control | Outlet throttling valve driven toward a 0.50 liquid-level setpoint |
+| Pressure control | Gas-outlet throttling valve driven toward a 52 bar transmitter setpoint |
+| Time integration | 3,600 transient steps at 1 s per step, after the initial steady-state run |
 
-## What happens to level and pressure
+During an event, `calculateSlugFlow(...)` raises the mass flow quickly and then
+decays it exponentially. Between events it applies a deterministic sinusoidal
+variation of up to 2%. The process flowsheet contains the inlet stream,
+separator, two outlet valves, and the level and pressure transmitters. It does
+not contain an inlet choke, a discretized pipe, or an elevation profile.
 
-- The flowline’s sinusoidal dip causes alternating liquid accumulation and blowdown, so slug pockets intermittently hit the separator. As those pockets arrive, the level controller opens the liquid valve to drain the separator and then trims back toward the 45% target once the surge passes, keeping the level bounded around the set point rather than drifting. 【F:src/main/java/neqsim/process/controllerdevice/TransientSlugSeparatorControlExample.java†L78-L138】
-- Gas-side disturbances from slug arrival are handled first by the inlet choke, whose pressure controller clips separator pressure excursions near 70 bara, and then by the export valve, which throttles based on the downstream stream pressure target. The reported gas outlet pressure at the end of the run shows how the combined control brings the system back toward the set points after slug-induced swings. 【F:src/main/java/neqsim/process/controllerdevice/TransientSlugSeparatorControlExample.java†L99-L138】
+The source calls `process.runTransient()` after updating the inlet mass flow at
+each step. Its controller parameters are illustrative tuning choices. They are
+not validated settings for a particular vessel, valve, sensor, or production
+system.
 
-## Plotting the default run
+## Diagnostic pipe quantities are not pipe hydraulics
 
-The example records the separator liquid level and gas outlet pressure on every 0.5 s time step, and the `--series` flag prints those values as CSV for plotting. Over the ten-step transient, the separator level jumps toward 0.9 when the first slug reaches the vessel and stays elevated while the controller holds the outlet valve open, while the gas pressure peaks above 120 bara before decaying toward the 70 bara set point as the gas valve throttles. 【F:src/main/java/neqsim/process/controllerdevice/TransientSlugSeparatorControlExample.java†L22-L138】
+The result object also carries synthetic quantities named for an upstream pipe.
+The source declares a 0.25 m diameter and a 3,000 m `pipeLength`, but does not
+use `pipeLength` in a hydraulic calculation. It estimates:
 
-## How to run it
+- a nominal seven-bar pressure drop scaled by the square of the current-to-base
+  mass-flow ratio;
+- pipe outlet pressure from the separator gas-outlet pressure;
+- pipe inlet pressure as that outlet pressure plus the scaled drop; and
+- a heuristic slug velocity from mass flow, assumed phase densities, estimated
+  liquid fraction, and the 0.25 m cross-sectional area.
 
-Execute `TransientSlugSeparatorControlExample.main` to print the slug statistics, separator liquid level, and gas outlet pressure for the default 5 s transient run (10 steps × 0.5 s). Use the `--series` flag to emit comma-separated time, level, and gas pressure for plotting (as used to build the graph above). The accompanying JUnit test `TransientSlugSeparatorControlExampleTest` simply calls `runSimulation()` to verify the example produces populated slug statistics and non-zero separator conditions.
+These series are diagnostic constructions outside the NeqSim process
+flowsheet. Do not use them to infer terrain-slug frequency, liquid holdup,
+surge volume, pressure drop, or mechanical design limits. A pipeline or
+multiphase-flow study requires an appropriate pipe model, geometry, boundary
+conditions, fluid characterization, discretization, and validation evidence.
+
+## Results and command-line options
+
+`runSimulation()` returns the final separator state, a formatted statistics
+summary, and 3,601 samples including the initial state. The histories cover
+time, separator liquid level and pressure, gas-outlet pressure, inlet mass flow,
+both valve openings, both setpoints, heuristic slug quantities, separator
+liquid volume, and the diagnostic pipe pressures.
+
+`main(String[] args)` supports two flags:
+
+- `--series` prints CSV rows for time, liquid level, separator pressure,
+  gas-outlet pressure, inlet flow, and both valve openings.
+- `--noplot` suppresses the seven JFreeChart windows and is appropriate for a
+  headless runner. It can be combined with `--series`.
+
+Without `--noplot`, the plots show the last 600 one-second samples (10 minutes), not the complete 60-minute run. The repository stores no governed
+reference output for this example, so this page does not assert particular
+level or pressure extrema.
+
+The source file lives in the repository `examples/` tree rather than the
+standard Maven `src/main/java` tree. Run its `main` method with the NeqSim
+project runtime classpath, for example from an IDE configured for the checkout.
+The standard Maven test lifecycle does not currently execute this example. The
+hermetic documentation contract protects the page's source constants,
+structure, links, and model-boundary statements; it does not claim that the
+3,600-step simulation was executed.
+
+## Interpreting the demonstration
+
+Use the output to inspect qualitative controller response to the imposed inlet
+flow pattern. Before drawing an engineering conclusion, independently verify:
+
+- that the fluid and flow disturbance represent the intended case;
+- vessel geometry, residence-time basis, valve sizing, and controller action;
+- pressure and level measurement ranges and units;
+- numerical time-step sensitivity and initial conditions; and
+- a mechanistic pipeline/slug model when upstream hydrodynamics matter.
+
+The 0.50 and 52 bar setpoints are source inputs, not universal operating targets.
+The calculated histories remain simulation evidence requiring engineering
+review.
+
+## Related documentation
+
+- [Examples index](index.md)
+- [Dynamic simulation](../process/dynamic-simulation.md)
+- [Controllers](../process/controllers.md)
+- [Separators](../process/equipment/separators.md)
+- [Troubleshooting](../troubleshooting/index.md)

--- a/docs/test_transient_slug_separator_control_documentation.py
+++ b/docs/test_transient_slug_separator_control_documentation.py
@@ -1,0 +1,134 @@
+"""Hermetic contracts for the transient slug/separator-control example guide."""
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "examples" / "transient_slug_separator_control_example.md"
+SOURCE = (
+    ROOT
+    / "examples"
+    / "neqsim"
+    / "process"
+    / "controllerdevice"
+    / "TransientSlugSeparatorControlExample.java"
+)
+EXAMPLES_INDEX = ROOT / "docs" / "examples" / "index.md"
+REFERENCE_INDEX = ROOT / "docs" / "REFERENCE_MANUAL_INDEX.md"
+
+
+class TransientSlugSeparatorControlDocumentationContractTest(unittest.TestCase):
+    """Guard source accuracy, structure, discoverability, and model boundaries."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = DOC.read_text(encoding="utf-8")
+        cls.source = SOURCE.read_text(encoding="utf-8")
+
+    def test_jekyll_structure_and_internal_links(self):
+        self.assertRegex(
+            self.doc,
+            r'^---\ntitle: "[^"]+"\ndescription: "[^"]+"\n---\n',
+        )
+        self.assertNotRegex(self.doc, r"(?m)^# ")
+        self.assertNotIn("【F:", self.doc)
+        self.assertNotIn("t...", self.doc)
+
+        for target in re.findall(r"\[[^\]]+\]\(([^)#]+\.md)(?:#[^)]+)?\)", self.doc):
+            resolved = (DOC.parent / target).resolve()
+            self.assertTrue(resolved.is_file(), target)
+
+    def test_documented_configuration_matches_current_source(self):
+        source_patterns = (
+            "new SystemSrkEos(288.15, 55.0)",
+            "double baseFlowRate = 20.0;",
+            "double slugPeriod = 60.0;",
+            "double slugDuration = 15.0;",
+            "double slugAmplitude = 0.8;",
+            "inletSeparator.setInternalDiameter(2.2);",
+            "inletSeparator.setSeparatorLength(7.0);",
+            "double levelSetpoint = 0.50;",
+            "double pressureSetpoint = 52.0;",
+            "double timeStep = 1.0;",
+            "int numberOfSteps = 3600;",
+            "double pipeDiameter = 0.25;",
+            "double pipeLength = 3000.0;",
+            "process.runTransient();",
+            '"--series".equals(arg)',
+            '"--noplot".equals(arg)',
+            "int startIndex = Math.max(0, n - 600);",
+        )
+        for pattern in source_patterns:
+            self.assertIn(pattern, self.source)
+
+        doc_patterns = (
+            "288.15 K and 55 bara",
+            "20 kg/s",
+            "60-second cycle",
+            "15-second event",
+            "80% of base flow",
+            "2.2 m internal diameter",
+            "7.0 m length",
+            "0.50 liquid-level setpoint",
+            "52 bar transmitter setpoint",
+            "3,600 transient steps at 1 s per step",
+            "0.25 m diameter",
+            "3,000 m `pipeLength`",
+            "3,601 samples",
+            "10 minutes",
+        )
+        for pattern in doc_patterns:
+            self.assertIn(pattern, self.doc)
+        self.assertRegex(self.doc, r"does not\s+use `pipeLength`")
+
+    def test_model_boundaries_and_cli_are_explicit(self):
+        required = (
+            "not a mechanistic",
+            "does not contain an inlet choke, a discretized pipe, or an elevation profile",
+            "diagnostic constructions outside the NeqSim process flowsheet",
+            "The standard Maven test lifecycle does not currently execute this example",
+            "does not claim that the 3,600-step simulation was executed",
+            "`--series`",
+            "`--noplot`",
+            "stores no governed reference output",
+            "not universal operating targets",
+        )
+        for pattern in required:
+            self.assertIn(pattern, self.doc)
+
+        rejected = (
+            "1.5 km",
+            "0.2 m diameter",
+            "20 sections",
+            "sinusoidal elevation profile",
+            "10 kg/s and 80 bara",
+            "70 bara",
+            "45% level",
+            "10 transient steps at 0.5 s",
+            "peaks above 120 bara",
+            "TransientSlugSeparatorControlExampleTest",
+            "src/main/java/neqsim/process/controllerdevice/TransientSlugSeparatorControlExample.java",
+        )
+        for pattern in rejected:
+            self.assertNotIn(pattern, self.doc)
+
+    def test_actual_source_and_both_indexes_are_linked(self):
+        source_url = (
+            "https://github.com/equinor/neqsim/blob/master/examples/neqsim/process/"
+            "controllerdevice/TransientSlugSeparatorControlExample.java"
+        )
+        self.assertIn(source_url, self.doc)
+
+        examples_index = EXAMPLES_INDEX.read_text(encoding="utf-8")
+        reference_index = REFERENCE_INDEX.read_text(encoding="utf-8")
+        self.assertIn("transient_slug_separator_control_example.md", examples_index)
+        self.assertIn(
+            "docs/examples/transient_slug_separator_control_example.md",
+            reference_index,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/test_transient_slug_separator_control_documentation.py
+++ b/docs/test_transient_slug_separator_control_documentation.py
@@ -79,8 +79,9 @@ class TransientSlugSeparatorControlDocumentationContractTest(unittest.TestCase):
             "3,601 samples",
             "10 minutes",
         )
+        normalized_doc = re.sub(r"\\s+", " ", self.doc)
         for pattern in doc_patterns:
-            self.assertIn(pattern, self.doc)
+            self.assertIn(pattern, normalized_doc)
         self.assertRegex(self.doc, r"does not\s+use `pipeLength`")
 
     def test_model_boundaries_and_cli_are_explicit(self):
@@ -95,8 +96,9 @@ class TransientSlugSeparatorControlDocumentationContractTest(unittest.TestCase):
             "stores no governed reference output",
             "not universal operating targets",
         )
+        normalized_doc = re.sub(r"\\s+", " ", self.doc)
         for pattern in required:
-            self.assertIn(pattern, self.doc)
+            self.assertIn(pattern, normalized_doc)
 
         rejected = (
             "1.5 km",

--- a/docs/test_transient_slug_separator_control_documentation.py
+++ b/docs/test_transient_slug_separator_control_documentation.py
@@ -79,7 +79,7 @@ class TransientSlugSeparatorControlDocumentationContractTest(unittest.TestCase):
             "3,601 samples",
             "10 minutes",
         )
-        normalized_doc = re.sub(r"\\s+", " ", self.doc)
+        normalized_doc = re.sub(r"\s+", " ", self.doc)
         for pattern in doc_patterns:
             self.assertIn(pattern, normalized_doc)
         self.assertRegex(self.doc, r"does not\s+use `pipeLength`")
@@ -96,7 +96,7 @@ class TransientSlugSeparatorControlDocumentationContractTest(unittest.TestCase):
             "stores no governed reference output",
             "not universal operating targets",
         )
-        normalized_doc = re.sub(r"\\s+", " ", self.doc)
+        normalized_doc = re.sub(r"\s+", " ", self.doc)
         for pattern in required:
             self.assertIn(pattern, normalized_doc)
 


### PR DESCRIPTION
## Summary

D060 in documentation-quality campaign #2499 repairs the transient slug/separator-control guide against the exact current Java example.

The previous page described a terrain-affected discretized flowline, different feed and controller targets, a five-second run, unsupported extrema, and a regression test that do not exist in the source. This change documents the actual deterministic inlet-flow disturbance and its engineering boundaries, then adds a hermetic source/documentation contract.

Related to #2499.

## Frozen scan scope

- Rotation scope 6: tutorials, cookbook, troubleshooting, and examples
- Original scan base: [`2e8a6fd`](https://github.com/equinor/neqsim/commit/2e8a6fd4e3d341bb3071df1c99ad2a36a9733ad7)
- Current synced base: [`647b4b8`](https://github.com/equinor/neqsim/commit/647b4b84e10cf354e5688a22a72c359f801d0cc3)
- Changed:
  - `docs/examples/transient_slug_separator_control_example.md`
  - `docs/test_transient_slug_separator_control_documentation.py`
- Inspected but unchanged:
  - `examples/neqsim/process/controllerdevice/TransientSlugSeparatorControlExample.java`
  - `docs/examples/index.md`
  - `docs/REFERENCE_MANUAL_INDEX.md`
  - repository instructions and open PR file sets

No open PR overlaps the two changed paths or the inspected source example.

## Confirmed defects and fixes

| Severity | Defect / evidence | Fix |
| --- | --- | --- |
| High | Page described a 1.5 km, 20-section, sinusoidal-elevation pipe; source has no pipe unit or elevation profile | Reframed as a deterministic mass-flow disturbance applied directly to a separator |
| High | Page said water-bearing 10 kg/s at 80 bara; source uses a seven-hydrocarbon fluid at 20 kg/s and 55 bara | Recorded exact fluid boundary, temperature, pressure, and flow |
| High | Page invented an inlet choke and 70-bara/45% targets | Documented the actual gas/liquid outlet valves and 52 bar/0.50 setpoints |
| High | Page said 10 × 0.5 s; source runs 3,600 × 1 s | Corrected execution horizon and 3,601-sample result contract |
| High | Page asserted level near 0.9 and pressure above 120 bara without governed output | Removed invented extrema and stated that no governed reference output is stored |
| Medium | Algebraic pipe diagnostics were presented as transient hydraulics | Documented the squared-flow pressure estimate, unused `pipeLength`, heuristic velocity, and non-design boundary |
| Medium | Six `【F:...】` markers did not render and pointed to a nonexistent `src/main/java` path | Replaced them with one verified link to the actual `examples/...` Java source |
| Medium | Page claimed a nonexistent JUnit test | Removed the claim; accurately states that Maven does not execute this example |
| Medium | Front-matter description ended in `t...` | Replaced with a complete description |
| Medium | Body repeated the front-matter title as H1 | Removed the duplicate H1 |

## Regression coverage

The new hermetic contract checks:

- Jekyll front matter, absence of a duplicate H1, truncated metadata, and non-rendering source markers;
- all five changed internal links;
- exact current source constants, run loop, flags, and last-600-sample plot behavior;
- required model-boundary and validation language;
- removal of every stale operating-case, topology, numeric-output, source-path, and test claim;
- the exact source URL plus discoverability from both examples and reference indexes.

## Validation completed

- Exact remote branch head [`1bc103f`](https://github.com/equinor/neqsim/commit/1bc103fd8d60699850e5b44eb53eb42a3d50cca7) is 4 commits ahead / 0 behind `master` after a non-force merge of the non-overlapping base update.
- Exact remote blobs match the reviewed contents:
  - guide `2be8dd534efca59b1225f83a286d2894dd3f095b`
  - contract `a39cb17d52c123b612eb1e0065d7537ea511ee74`
- Connector-backed contract evaluation passed 64/64 assertions after the wrap-normalization correction against the exact source, guide, indexes, and repository tree.
- `python -m py_compile` on the exact contract content exited 0.
- All five internal Markdown targets exist.
- The only external target is the exact GitHub source file and was fetched successfully on 2026-08-15.
- The page contains no equations, images, notebooks, or code fences.
- Final diff is exactly two documentation/test files: 230 additions, 15 deletions. No production code, dependency, generated artifact, or sensitive material is changed.

## Hosted CI at exact synchronized head

All five workflows completed successfully on [`1bc103f`](https://github.com/equinor/neqsim/commit/1bc103fd8d60699850e5b44eb53eb42a3d50cca7):

- **Documentation search coverage:** source contracts, every documentation contract (including D060), Jekyll build, generated search index, and JavaScript syntax checks passed.
- **Pre-commit checks:** completed successfully.
- **Spotless format patch:** completed successfully; the downloaded artifact contains `spotless.patch` with exactly zero bytes.
- **Run build, test and javadoc:** agent-skill reference checks and Java/XML change detection passed; Java test matrices and Javadocs were skipped by the workflow's docs-only change detection.
- **CodeQL Security Analysis:** completed successfully.

A complete local checkout was not available. The 3,600-step Java example was not executed, and this PR makes no runtime-output claim. The example remains outside Maven's standard source tree; this PR intentionally does not change that architecture.

## Rendering, links, and review status

- No rendered-site artifact was available, so browser inspection is not claimed.
- No equation or image rendering is in scope.
- Final exact-head inspection found no human review, Copilot review, suggested-change block, PR conversation comment, or inline review thread.

## Deliberate exclusions

No changes to the example algorithm, production models, pipe hydraulics, controller tuning, source layout, indexes already containing the page, unrelated examples, or downstream Huldra work.

After D060 is merged and evidenced on `master`, the next rotation scope is D061: JavaDoc-facing examples, Python snippets, notebooks, images, and external links.