### PR TITLE
[AI-Assisted] feat(dynamics): transact local push buttons

### DIFF
--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -465,6 +465,29 @@ metadata rather than integrated physical sensor dynamics. This gate does not qua
 placement, fire/gas dispersion, voting, reliability, alarm/trip integrity, ESD action, external
 I/O, safety integrity, certification, virtual commissioning or OTS use.
 
+## Local manual push-button transaction coverage
+
+A concrete local `PushButton` participates when registered as a measurement device in a
+`ProcessSystem`. Its snapshot preserves stable transaction identity, the pushed latch, optional
+blowdown-valve binding, automatic-activation configuration, logic-binding list and complete
+inherited measurement/alarm state. A lazily recreated empty logic-binding list also keeps older
+serialized buttons restartable after the field was introduced as transient state.
+
+Together with the existing `EventScheduler` snapshot, this closes the local side effect of a
+scheduled manual push: rejection restores both pending/fired event membership and the button,
+replay produces the same latch and alarm continuation, and accepted commit retains the push.
+Quantitative evidence covers two coordinated `ProcessModel` areas, binding/configuration rollback,
+alarm delay, exact binary replay, stable identity, foreign/null snapshots and Java-serialization
+restart.
+
+Automatic activation of a linked `BlowdownValve` and every linked `ProcessLogic` remain
+fail-closed because those paths mutate equipment or sequence state that does not yet have complete
+transaction coverage. A valve may remain bound with automatic activation disabled; then pushing
+the button changes only the snapshotted local latch. Concrete descendants and online-signal mode
+also fail closed. This gate proves numerical rollback mechanics only; it does not qualify manual
+input reliability, ESD action, safety integrity, external DCS/I/O, virtual commissioning or OTS
+use.
+
 ## State-mutating derived-instrument transaction coverage
 
 Concrete local `pHProbe`, `SoftSensor`, and `FlowInducedVibrationAnalyser` instances participate

--- a/docs/process/equipment/measurement_devices.md
+++ b/docs/process/equipment/measurement_devices.md
@@ -512,6 +512,21 @@ configured response time and detection delay are retained settings; the current 
 not integrate those values as physical sensor dynamics. External I/O, voting logic, ESD action,
 detector coverage, reliability and safety-integrity qualification remain outside this support.
 
+### PushButton transaction boundary
+
+A registered concrete local `PushButton` participates in transient-step transactions. Rollback
+restores its pushed latch, optional blowdown-valve binding, automatic-activation setting,
+logic-binding list and inherited measurement/alarm state. Scheduled pushes can therefore be
+rejected and replayed together with `EventScheduler` pending/fired bookkeeping, and Java
+serialization preserves the transaction identity and local restart state.
+
+Automatic activation of a bound `BlowdownValve` and linked `ProcessLogic` actions fail the
+transaction preflight because they mutate state outside the button. Setting automatic valve
+activation to `false` permits a valve binding to remain as configuration while the push changes
+only local state. Subclasses and online-signal operation also remain fail-closed. This is rollback
+mechanics, not ESD, manual-input reliability, safety-integrity, external-I/O, virtual-commissioning
+or OTS qualification.
+
 ## Quality Analysers
 
 ### MolarMassAnalyser

--- a/src/main/java/neqsim/process/measurementdevice/PushButton.java
+++ b/src/main/java/neqsim/process/measurementdevice/PushButton.java
@@ -1,7 +1,10 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.valve.BlowdownValve;
 import neqsim.process.logic.ProcessLogic;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
@@ -24,6 +27,12 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * <li>Measured value: 1.0 when pushed, 0.0 when not pushed</li>
  * <li>Supports alarm configuration for activation logging</li>
  * </ul>
+ *
+ * <p>
+ * A concrete local push button registered in a process participates in transient-step transactions. Rollback restores
+ * its latch, configuration, bindings, and inherited alarm/measurement state. Automatic blowdown-valve activation,
+ * linked process logic, subclasses, and online-signal bindings remain fail-closed because those paths may mutate state
+ * outside the button.
  *
  * <p>
  * Typical usage with blowdown valve:
@@ -50,9 +59,13 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * @author ESOL
  * @version $Id: $Id
  */
-public class PushButton extends MeasurementDeviceBaseClass {
+public class PushButton extends MeasurementDeviceBaseClass
+    implements TransientStateParticipant<PushButton.PushButtonState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /** Indicates if button is currently pushed (active). */
   private boolean isPushed = false;
@@ -121,8 +134,9 @@ public class PushButton extends MeasurementDeviceBaseClass {
    * @param logic process logic to activate when button is pushed
    */
   public void linkToLogic(ProcessLogic logic) {
-    if (!linkedLogics.contains(logic)) {
-      linkedLogics.add(logic);
+    List<ProcessLogic> logics = getOrCreateLinkedLogics();
+    if (!logics.contains(logic)) {
+      logics.add(logic);
     }
   }
 
@@ -132,7 +146,7 @@ public class PushButton extends MeasurementDeviceBaseClass {
    * @return list of linked logic sequences (unmodifiable)
    */
   public List<ProcessLogic> getLinkedLogics() {
-    return new ArrayList<>(linkedLogics);
+    return new ArrayList<>(getOrCreateLinkedLogics());
   }
 
   /**
@@ -152,7 +166,7 @@ public class PushButton extends MeasurementDeviceBaseClass {
     }
 
     // Activate all linked logic sequences
-    for (ProcessLogic logic : linkedLogics) {
+    for (ProcessLogic logic : getOrCreateLinkedLogics()) {
       logic.activate();
     }
   }
@@ -258,17 +272,109 @@ public class PushButton extends MeasurementDeviceBaseClass {
       sb.append(", Linked to: ").append(linkedBlowdownValve.getName());
       sb.append(" (").append(linkedBlowdownValve.isActivated() ? "ACTIVATED" : "NOT ACTIVATED").append(")");
     }
-    if (!linkedLogics.isEmpty()) {
+    List<ProcessLogic> logics = getOrCreateLinkedLogics();
+    if (!logics.isEmpty()) {
       sb.append(", Linked Logic: [");
-      for (int i = 0; i < linkedLogics.size(); i++) {
+      for (int i = 0; i < logics.size(); i++) {
         if (i > 0) {
           sb.append(", ");
         }
-        ProcessLogic logic = linkedLogics.get(i);
+        ProcessLogic logic = logics.get(i);
         sb.append(logic.getName()).append(" (").append(logic.getState()).append(")");
       }
       sb.append("]");
     }
     return sb.toString();
+  }
+
+  /**
+   * Lazily recreates the transient logic-binding list after Java deserialization.
+   *
+   * @return non-null mutable logic-binding list
+   */
+  private List<ProcessLogic> getOrCreateLinkedLogics() {
+    if (linkedLogics == null) {
+      linkedLogics = new ArrayList<>();
+    }
+    return linkedLogics;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:push-button:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for a concrete local button without automatic external actions.
+   *
+   * @return blocking diagnostic for descendants, external I/O, or linked action side effects; otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != PushButton.class) {
+      return "push-button subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    String measurementIssue = getMeasurementTransientStateCoverageIssue();
+    if (measurementIssue != null) {
+      return measurementIssue;
+    }
+    if (linkedBlowdownValve != null && autoActivateValve) {
+      return "automatic blowdown-valve activation may mutate linked equipment without complete transient state "
+          + "coverage";
+    }
+    if (!getOrCreateLinkedLogics().isEmpty()) {
+      return "linked process logic may mutate equipment or sequence state without a rejected-step commit/defer "
+          + "contract";
+    }
+    return null;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public PushButtonState captureTransientState() {
+    return new PushButtonState(getTransientStateIdentity(), isPushed, linkedBlowdownValve, autoActivateValve,
+        getOrCreateLinkedLogics(), captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(PushButtonState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Push-button transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException("Push-button snapshot identity does not match " + getTransientStateIdentity());
+    }
+    isPushed = snapshot.pushed;
+    linkedBlowdownValve = snapshot.linkedBlowdownValve;
+    autoActivateValve = snapshot.autoActivateValve;
+    linkedLogics = new ArrayList<>(snapshot.linkedLogics);
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable local push-button rollback point. */
+  public static final class PushButtonState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final boolean pushed;
+    private final BlowdownValve linkedBlowdownValve;
+    private final boolean autoActivateValve;
+    private final List<ProcessLogic> linkedLogics;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private PushButtonState(String stateIdentity, boolean pushed, BlowdownValve linkedBlowdownValve,
+        boolean autoActivateValve, List<ProcessLogic> linkedLogics, MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.pushed = pushed;
+      this.linkedBlowdownValve = linkedBlowdownValve;
+      this.autoActivateValve = autoActivateValve;
+      this.linkedLogics = new ArrayList<>(linkedLogics);
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/test/java/neqsim/process/measurementdevice/PushButtonTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/PushButtonTransientStateTransactionTest.java
@@ -1,0 +1,185 @@
+package neqsim.process.measurementdevice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import neqsim.process.alarm.AlarmConfig;
+import neqsim.process.alarm.AlarmState;
+import neqsim.process.dynamics.EventScheduler;
+import neqsim.process.dynamics.TransientStepTransaction;
+import neqsim.process.dynamics.TransientTransactionCoverage;
+import neqsim.process.equipment.valve.BlowdownValve;
+import neqsim.process.equipment.valve.ControlValve;
+import neqsim.process.logic.control.PressureControlLogic;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+
+/** Rollback, event replay, restart, and side-effect boundary evidence for local push buttons. */
+class PushButtonTransientStateTransactionTest extends neqsim.NeqSimTest {
+  @Test
+  void multiAreaRollbackRestoresScheduledPushesConfigurationAndAlarmState() {
+    PushButton first = new PushButton("ESD-PB-101");
+    AlarmConfig firstAlarm = AlarmConfig.builder().highLimit(0.5).delay(2.0).unit("binary").build();
+    first.setAlarmConfig(firstAlarm);
+    AlarmState originalFirstAlarmState = first.getAlarmState();
+
+    BlowdownValve observedValve = new BlowdownValve("BDV-201");
+    PushButton second = new PushButton("ESD-PB-201", observedValve);
+    second.setAutoActivateValve(false);
+    AlarmConfig secondAlarm = AlarmConfig.builder().highLimit(0.5).delay(2.0).unit("binary").build();
+    second.setAlarmConfig(secondAlarm);
+    AlarmState originalSecondAlarmState = second.getAlarmState();
+
+    ProcessSystem firstArea = new ProcessSystem("first manual-input area");
+    firstArea.setEventScheduler(new EventScheduler());
+    firstArea.add(first);
+    ProcessSystem secondArea = new ProcessSystem("second manual-input area");
+    secondArea.setEventScheduler(new EventScheduler());
+    secondArea.add(second);
+    assertCompleteCoverage(firstArea.getTransientTransactionCoverage(), 1);
+    assertCompleteCoverage(secondArea.getTransientTransactionCoverage(), 1);
+
+    ProcessModel model = new ProcessModel();
+    model.add("first", firstArea);
+    model.add("second", secondArea);
+    assertCompleteCoverage(model.getTransientTransactionCoverage(), 2);
+
+    firstArea.getEventScheduler().scheduleEvent(1.0, "first manual push", first::push);
+    secondArea.getEventScheduler().scheduleEvent(1.0, "second manual push", second::push);
+
+    String firstIdentity = first.getTransientStateIdentity();
+    String secondIdentity = second.getTransientStateIdentity();
+    TransientStepTransaction transaction = model.beginTransientStepTransaction();
+
+    assertEquals(1, firstArea.getEventScheduler().fireDueEvents(1.0));
+    assertEquals(1, secondArea.getEventScheduler().fireDueEvents(1.0));
+    assertTrue(first.isPushed());
+    assertTrue(second.isPushed());
+    assertFalse(observedValve.isActivated());
+    assertTrue(first.evaluateAlarm(first.getMeasuredValue(), 1.0, 1.0).isEmpty());
+    assertTrue(second.evaluateAlarm(second.getMeasuredValue(), 1.0, 1.0).isEmpty());
+
+    first.setName("trial first button");
+    first.setAutoActivateValve(false);
+    second.setName("trial second button");
+    second.linkToBlowdownValve(new BlowdownValve("trial valve"));
+    second.setAutoActivateValve(true);
+    transaction.rollback();
+
+    assertEquals(firstIdentity, first.getTransientStateIdentity());
+    assertEquals(secondIdentity, second.getTransientStateIdentity());
+    assertEquals("ESD-PB-101", first.getName());
+    assertEquals("ESD-PB-201", second.getName());
+    assertFalse(first.isPushed());
+    assertFalse(second.isPushed());
+    assertSame(observedValve, second.getLinkedBlowdownValve());
+    assertFalse(second.isAutoActivateValve());
+    assertSame(firstAlarm, first.getAlarmConfig());
+    assertSame(secondAlarm, second.getAlarmConfig());
+    assertSame(originalFirstAlarmState, first.getAlarmState());
+    assertSame(originalSecondAlarmState, second.getAlarmState());
+    assertEquals(1, firstArea.getEventScheduler().getPendingEvents().size());
+    assertEquals(0, firstArea.getEventScheduler().getFiredEvents().size());
+    assertEquals(1, secondArea.getEventScheduler().getPendingEvents().size());
+    assertEquals(0, secondArea.getEventScheduler().getFiredEvents().size());
+
+    TransientStepTransaction replay = model.beginTransientStepTransaction();
+    assertEquals(1, firstArea.getEventScheduler().fireDueEvents(1.0));
+    assertEquals(1, secondArea.getEventScheduler().fireDueEvents(1.0));
+    assertTrue(first.isPushed());
+    assertTrue(second.isPushed());
+    assertFalse(observedValve.isActivated());
+    assertTrue(first.evaluateAlarm(first.getMeasuredValue(), 1.0, 1.0).isEmpty());
+    assertEquals(1, first.evaluateAlarm(first.getMeasuredValue(), 1.0, 2.0).size());
+    assertTrue(second.evaluateAlarm(second.getMeasuredValue(), 1.0, 1.0).isEmpty());
+    assertEquals(1, second.evaluateAlarm(second.getMeasuredValue(), 1.0, 2.0).size());
+    replay.commit();
+
+    assertEquals(0, firstArea.getEventScheduler().getPendingEvents().size());
+    assertEquals(1, firstArea.getEventScheduler().getFiredEvents().size());
+    assertEquals(0, secondArea.getEventScheduler().getPendingEvents().size());
+    assertEquals(1, secondArea.getEventScheduler().getFiredEvents().size());
+  }
+
+  @Test
+  void serializedButtonAndSnapshotRestoreRestartStateAndBindings() throws Exception {
+    BlowdownValve valve = new BlowdownValve("BDV-301");
+    PushButton button = new PushButton("ESD-PB-301", valve);
+    button.setAutoActivateValve(false);
+    String identity = button.getTransientStateIdentity();
+    PushButton.PushButtonState snapshot = button.captureTransientState();
+    button.push();
+    button.setName("trial button");
+    button.setAutoActivateValve(true);
+
+    byte[] serialized;
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(button);
+      output.writeObject(snapshot);
+      serialized = bytes.toByteArray();
+    }
+
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      PushButton restored = (PushButton) input.readObject();
+      PushButton.PushButtonState restoredSnapshot = (PushButton.PushButtonState) input.readObject();
+      restored.restoreTransientState(restoredSnapshot);
+
+      assertEquals(identity, restored.getTransientStateIdentity());
+      assertEquals("ESD-PB-301", restored.getName());
+      assertFalse(restored.isPushed());
+      assertFalse(restored.isAutoActivateValve());
+      assertEquals("BDV-301", restored.getLinkedBlowdownValve().getName());
+      assertTrue(restored.getLinkedLogics().isEmpty());
+    }
+  }
+
+  @Test
+  void descendantsOnlineAndLinkedActionSideEffectsFailClosed() {
+    PushButton subclass = new PushButton("subclass") {
+      private static final long serialVersionUID = 1000L;
+    };
+    assertBlocked(subclass, "subclass-owned mutable state");
+
+    PushButton online = new PushButton("online");
+    online.setIsOnlineSignal(true, "plant", "PB-ONLINE");
+    assertBlocked(online, "external I/O");
+
+    PushButton automaticValve = new PushButton("automatic valve", new BlowdownValve("BDV-401"));
+    assertBlocked(automaticValve, "automatic blowdown-valve activation");
+
+    PushButton linkedLogic = new PushButton("linked logic");
+    linkedLogic.linkToLogic(new PressureControlLogic("pressure action", new ControlValve("PCV-401"), 20.0));
+    assertBlocked(linkedLogic, "linked process logic");
+
+    PushButton first = new PushButton("first");
+    PushButton second = new PushButton("second");
+    assertThrows(IllegalArgumentException.class, () -> second.restoreTransientState(first.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> first.restoreTransientState(null));
+  }
+
+  private static void assertBlocked(PushButton button, String expectedText) {
+    ProcessSystem process = new ProcessSystem("push-button blocker");
+    process.add(button);
+    TransientTransactionCoverage coverage = process.getTransientTransactionCoverage();
+    assertEquals(1, coverage.getProcessElementCount());
+    assertEquals(1, coverage.getParticipantCount());
+    assertFalse(coverage.isComplete());
+    assertEquals(1, coverage.getBlockingIssues().size());
+    assertTrue(coverage.getBlockingIssues().get(0).contains(expectedText));
+  }
+
+  private static void assertCompleteCoverage(TransientTransactionCoverage coverage, int expectedCount) {
+    assertEquals(expectedCount, coverage.getProcessElementCount());
+    assertEquals(expectedCount, coverage.getParticipantCount());
+    assertTrue(coverage.isComplete(), coverage.getBlockingIssues().toString());
+  }
+}


### PR DESCRIPTION
## Roadmap

Advances #2911 Phase 1 shared transient orchestration after merged tranche DYN-C012.

Base: `36b64de41a8a73347e710db3eee1befc1901f977`
Publication head: `a38f3dd2d838a5a113b5904c97634968c84f037b`

## Engineering problem

A scheduled `PushButton.push()` mutates a registered measurement device, but the button had no identity-preserving snapshot. A rejected multi-area step could therefore restore scheduler bookkeeping while leaving the manual-input latch and inherited alarm state advanced.

## Complete tranche

- makes a concrete local `PushButton` a typed transient-state participant
- snapshots stable provenance identity, pushed latch, optional valve binding, automatic-activation configuration, defensive logic-binding membership, and complete inherited measurement/alarm state
- restores a missing transient logic list lazily after Java deserialization
- rejects null and foreign snapshots
- fails transaction coverage closed for:
  - subclasses with unaudited mutable state
  - online/external I/O mode
  - automatic activation of a linked `BlowdownValve`
  - any linked `ProcessLogic`
- permits a valve to remain bound only when automatic activation is disabled, because the push then mutates only covered local button state
- adds two-area rollback/replay/commit, delayed-alarm, exact scheduler bookkeeping, stable identity, binding/configuration, serialization/restart, and diagnostic regressions
- documents the public state and qualification boundary

This is rollback mechanics only. It does not qualify ESD action, manual-input reliability, safety integrity, external DCS/I/O, virtual commissioning, or OTS use. It does not enter #2935 species transport, #2907 multiphase closures/slugging, or Huldra dataset work.

## Validation

Passed locally on the exact published content:

- `MAVEN_OPTS='-Dmaven.repo.local=/tmp/neqsim-m2k/repository' HOME=/tmp/neqsim-home ./mvnw -o -q -Dtest=PushButtonTransientStateTransactionTest test`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- `git diff --check`

**VALIDATION PENDING CI** for the remaining full-suite and repository-required exact-head checks.