### PR TITLE
[AI-Assisted] fix(flash): seed Wilson trials as incipient phases

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -958,6 +958,15 @@ The stability analysis proceeds in two stages. First, **Wilson K-based trial pha
 4. Test vapor-like trial ($W_i = K_i \cdot z_i$): enriches volatile components
 5. If either trial shows instability ($\text{tm} < -10^{-8}$), add phase and return
 
+These Wilson trials are part of ordinary `setMultiPhaseCheck(true)` as well as explicit enhanced
+multiphase checking. A negative tangent-plane distance identifies a missing phase composition, but
+does not determine that phase's equilibrium amount. The admitted trial therefore starts with a
+bounded incipient fraction between the numerical disappearance scale and `1e-3` (normally
+`1e-6`, and never larger than the dominant component's overall fraction). The existing
+phase-fraction and fugacity-equilibrium solve then grows or removes the phase. This avoids turning a
+stability composition guess into an order-one material split while preserving Wilson coverage for
+hydrate, electrolyte, and ordinary multiphase callers.
+
 **Stage 2: Pure-component trials** (fallback for cases K-based trials miss):
 
 1. **Pure component initialization**: For each component $j$, create a trial phase with:

--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -960,10 +960,11 @@ The stability analysis proceeds in two stages. First, **Wilson K-based trial pha
 
 These Wilson trials are part of ordinary `setMultiPhaseCheck(true)` as well as explicit enhanced
 multiphase checking. A negative tangent-plane distance identifies a missing phase composition, but
-does not determine that phase's equilibrium amount. The admitted trial therefore starts with a
-bounded incipient fraction between the numerical disappearance scale and `1e-3` (normally
-`1e-6`, and never larger than the dominant component's overall fraction). The existing
-phase-fraction and fugacity-equilibrium solve then grows or removes the phase. This avoids turning a
+does not determine that phase's equilibrium amount. The admitted trial therefore starts at the
+ordinary beta solver's regularization scale (normally `1e-3`, and never larger than the dominant
+component's overall fraction). This keeps the trial incipient without pinning it below the solver's
+useful correction scale. The existing phase-fraction and fugacity-equilibrium solve then grows or
+removes the phase. This avoids turning a
 stability composition guess into an order-one material split while preserving Wilson coverage for
 hydrate, electrolyte, and ordinary multiphase callers.
 

--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -5,6 +5,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
@@ -45,6 +46,78 @@ import neqsim.util.unit.Units;
 public abstract class SystemThermo implements SystemInterface {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+
+  /**
+   * Restores the serialized fields and reconciles a stale scalar total with the duplicated
+   * overall-component inventory.
+   *
+   * <p>A separated phase may be serialized after its component inventory has changed while the
+   * scalar total still describes the upstream system. Overall mole fractions are derived by
+   * dividing component inventories by that scalar, so the mismatch must be repaired before the
+   * first initialization or flash. The reconciliation is deliberately limited to deserialization
+   * and to phase slots that agree on the overall inventory.</p>
+   *
+   * @param input serialized object input
+   * @throws IOException if the serialized object cannot be read
+   * @throws ClassNotFoundException if a serialized class cannot be resolved
+   */
+  private void readObject(ObjectInputStream input) throws IOException, ClassNotFoundException {
+    input.defaultReadObject();
+    reconcileTotalMolesWithComponentInventory();
+  }
+
+  /**
+   * Reconciles the scalar total with a finite, positive overall-component inventory.
+   *
+   * <p>Every active phase slot normally carries the same overall component amounts while storing
+   * its phase-specific amounts separately. Reconciliation is skipped when those duplicated
+   * inventories disagree, because that state cannot safely identify one authoritative total.</p>
+   */
+  private void reconcileTotalMolesWithComponentInventory() {
+    if (phaseArray == null
+        || numberOfComponents == 0
+        || phaseArray[phaseIndex[0]] == null) {
+      return;
+    }
+
+    double inventory = 0.0;
+    for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+      double componentMoles =
+          getPhase(0).getComponent(componentIndex).getNumberOfmoles();
+      if (!Double.isFinite(componentMoles) || componentMoles < 0.0) {
+        return;
+      }
+      inventory += componentMoles;
+    }
+    if (!Double.isFinite(inventory) || inventory <= 0.0) {
+      return;
+    }
+
+    for (int phase = 1; phase < numberOfPhases; phase++) {
+      if (getPhase(phase) == null
+          || getPhase(phase).getNumberOfComponents() != numberOfComponents) {
+        return;
+      }
+      for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+        double referenceMoles =
+            getPhase(0).getComponent(componentIndex).getNumberOfmoles();
+        double phaseMoles =
+            getPhase(phase).getComponent(componentIndex).getNumberOfmoles();
+        double tolerance = 1.0e-12 * Math.max(1.0, Math.abs(referenceMoles));
+        if (!Double.isFinite(phaseMoles)
+            || Math.abs(phaseMoles - referenceMoles) > tolerance) {
+          return;
+        }
+      }
+    }
+
+    double tolerance = 1.0e-12 * Math.max(1.0, inventory);
+    if (!Double.isFinite(totalNumberOfMoles)
+        || Math.abs(totalNumberOfMoles - inventory) > tolerance) {
+      setTotalNumberOfMolesRaw(inventory);
+      isInitialized = false;
+    }
+  }
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(SystemThermo.class);
 

--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -48,14 +48,14 @@ public abstract class SystemThermo implements SystemInterface {
   private static final long serialVersionUID = 1000;
 
   /**
-   * Restores the serialized fields and reconciles a stale scalar total with the duplicated
-   * overall-component inventory.
+   * Restores the serialized fields and reconciles a stale scalar total with the duplicated overall-component inventory.
    *
-   * <p>A separated phase may be serialized after its component inventory has changed while the
-   * scalar total still describes the upstream system. Overall mole fractions are derived by
-   * dividing component inventories by that scalar, so the mismatch must be repaired before the
-   * first initialization or flash. The reconciliation is deliberately limited to deserialization
-   * and to phase slots that agree on the overall inventory.</p>
+   * <p>
+   * A separated phase may be serialized after its component inventory has changed while the scalar total still
+   * describes the upstream system. Overall mole fractions are derived by dividing component inventories by that scalar,
+   * so the mismatch must be repaired before the first initialization or flash. The reconciliation is deliberately
+   * limited to deserialization and to phase slots that agree on the overall inventory.
+   * </p>
    *
    * @param input serialized object input
    * @throws IOException if the serialized object cannot be read
@@ -69,21 +69,20 @@ public abstract class SystemThermo implements SystemInterface {
   /**
    * Reconciles the scalar total with a finite, positive overall-component inventory.
    *
-   * <p>Every active phase slot normally carries the same overall component amounts while storing
-   * its phase-specific amounts separately. Reconciliation is skipped when those duplicated
-   * inventories disagree, because that state cannot safely identify one authoritative total.</p>
+   * <p>
+   * Every active phase slot normally carries the same overall component amounts while storing its phase-specific
+   * amounts separately. Reconciliation is skipped when those duplicated inventories disagree, because that state cannot
+   * safely identify one authoritative total.
+   * </p>
    */
   private void reconcileTotalMolesWithComponentInventory() {
-    if (phaseArray == null
-        || numberOfComponents == 0
-        || phaseArray[phaseIndex[0]] == null) {
+    if (phaseArray == null || numberOfComponents == 0 || phaseArray[phaseIndex[0]] == null) {
       return;
     }
 
     double inventory = 0.0;
     for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
-      double componentMoles =
-          getPhase(0).getComponent(componentIndex).getNumberOfmoles();
+      double componentMoles = getPhase(0).getComponent(componentIndex).getNumberOfmoles();
       if (!Double.isFinite(componentMoles) || componentMoles < 0.0) {
         return;
       }
@@ -94,30 +93,26 @@ public abstract class SystemThermo implements SystemInterface {
     }
 
     for (int phase = 1; phase < numberOfPhases; phase++) {
-      if (getPhase(phase) == null
-          || getPhase(phase).getNumberOfComponents() != numberOfComponents) {
+      if (getPhase(phase) == null || getPhase(phase).getNumberOfComponents() != numberOfComponents) {
         return;
       }
       for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
-        double referenceMoles =
-            getPhase(0).getComponent(componentIndex).getNumberOfmoles();
-        double phaseMoles =
-            getPhase(phase).getComponent(componentIndex).getNumberOfmoles();
+        double referenceMoles = getPhase(0).getComponent(componentIndex).getNumberOfmoles();
+        double phaseMoles = getPhase(phase).getComponent(componentIndex).getNumberOfmoles();
         double tolerance = 1.0e-12 * Math.max(1.0, Math.abs(referenceMoles));
-        if (!Double.isFinite(phaseMoles)
-            || Math.abs(phaseMoles - referenceMoles) > tolerance) {
+        if (!Double.isFinite(phaseMoles) || Math.abs(phaseMoles - referenceMoles) > tolerance) {
           return;
         }
       }
     }
 
     double tolerance = 1.0e-12 * Math.max(1.0, inventory);
-    if (!Double.isFinite(totalNumberOfMoles)
-        || Math.abs(totalNumberOfMoles - inventory) > tolerance) {
+    if (!Double.isFinite(totalNumberOfMoles) || Math.abs(totalNumberOfMoles - inventory) > tolerance) {
       setTotalNumberOfMolesRaw(inventory);
       isInitialized = false;
     }
   }
+
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(SystemThermo.class);
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -1224,20 +1224,19 @@ public class TPmultiflash extends TPflash {
   /**
    * Returns a bounded initial fraction for a phase admitted by a Wilson-K stability trial.
    *
-   * <p>A negative tangent-plane distance establishes that the current topology is unstable, but
-   * it does not determine the equilibrium amount of the new phase. Seeding beta from the trial's
-   * dominant overall component can therefore introduce an order-one material phase before the
-   * phase-fraction solve. Start the admitted phase above the numerical disappearance limit and let
-   * the existing beta/equilibrium solve grow or remove it.</p>
+   * <p>
+   * A negative tangent-plane distance establishes that the current topology is unstable, but it does not determine the
+   * equilibrium amount of the new phase. Seeding beta from the trial's dominant overall component can therefore
+   * introduce an order-one material phase before the phase-fraction solve. Start the admitted phase above the numerical
+   * disappearance limit and let the existing beta/equilibrium solve grow or remove it.
+   * </p>
    *
    * @param dominantComponent index of the largest component in the trial composition
    * @return bounded incipient phase fraction
    */
   private double getIncipientWilsonPhaseFraction(int dominantComponent) {
-    double numericalSeed =
-        Math.min(1.0e-3, Math.max(1.0e-6, 100.0 * phaseFractionMinimumLimit));
-    return Math.min(
-        system.getPhase(0).getComponent(dominantComponent).getz(), numericalSeed);
+    double numericalSeed = Math.min(1.0e-3, Math.max(1.0e-6, 100.0 * phaseFractionMinimumLimit));
+    return Math.min(system.getPhase(0).getComponent(dominantComponent).getz(), numericalSeed);
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -1227,15 +1227,16 @@ public class TPmultiflash extends TPflash {
    * <p>
    * A negative tangent-plane distance establishes that the current topology is unstable, but it does not determine the
    * equilibrium amount of the new phase. Seeding beta from the trial's dominant overall component can therefore
-   * introduce an order-one material phase before the phase-fraction solve. Start the admitted phase above the numerical
-   * disappearance limit and let the existing beta/equilibrium solve grow or remove it.
+   * introduce an order-one material phase before the phase-fraction solve. Use the existing ordinary beta solver's
+   * regularization scale so the trial is incipient without being pinned below the solver's useful correction scale, then
+   * let the beta/equilibrium solve grow or remove it.
    * </p>
    *
    * @param dominantComponent index of the largest component in the trial composition
    * @return bounded incipient phase fraction
    */
   private double getIncipientWilsonPhaseFraction(int dominantComponent) {
-    double numericalSeed = Math.min(1.0e-3, Math.max(1.0e-6, 100.0 * phaseFractionMinimumLimit));
+    double numericalSeed = Math.max(1.0e-3, 100.0 * phaseFractionMinimumLimit);
     return Math.min(system.getPhase(0).getComponent(dominantComponent).getz(), numericalSeed);
   }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -616,7 +616,7 @@ public class TPmultiflash extends TPflash {
             dominantComp = i;
           }
         }
-        system.setBeta(newPhaseIdx, system.getPhase(0).getComponent(dominantComp).getz());
+        system.setBeta(newPhaseIdx, getIncipientWilsonPhaseFraction(dominantComp));
         try {
           system.init(1);
         } catch (Exception ex) {
@@ -1203,7 +1203,7 @@ public class TPmultiflash extends TPflash {
               dominantComp = i;
             }
           }
-          system.setBeta(newPhaseIdx, system.getPhase(0).getComponent(dominantComp).getz());
+          system.setBeta(newPhaseIdx, getIncipientWilsonPhaseFraction(dominantComp));
           try {
             system.init(1);
           } catch (Exception ex) {
@@ -1219,6 +1219,25 @@ public class TPmultiflash extends TPflash {
     }
 
     system.normalizeBeta();
+  }
+
+  /**
+   * Returns a bounded initial fraction for a phase admitted by a Wilson-K stability trial.
+   *
+   * <p>A negative tangent-plane distance establishes that the current topology is unstable, but
+   * it does not determine the equilibrium amount of the new phase. Seeding beta from the trial's
+   * dominant overall component can therefore introduce an order-one material phase before the
+   * phase-fraction solve. Start the admitted phase above the numerical disappearance limit and let
+   * the existing beta/equilibrium solve grow or remove it.</p>
+   *
+   * @param dominantComponent index of the largest component in the trial composition
+   * @return bounded incipient phase fraction
+   */
+  private double getIncipientWilsonPhaseFraction(int dominantComponent) {
+    double numericalSeed =
+        Math.min(1.0e-3, Math.max(1.0e-6, 100.0 * phaseFractionMinimumLimit));
+    return Math.min(
+        system.getPhase(0).getComponent(dominantComponent).getz(), numericalSeed);
   }
 
   /**

--- a/src/test/java/neqsim/pvtsimulation/simulation/HydrocarbonScrubberSaturationPressureStabilityTest.java
+++ b/src/test/java/neqsim/pvtsimulation/simulation/HydrocarbonScrubberSaturationPressureStabilityTest.java
@@ -1,0 +1,162 @@
+package neqsim.pvtsimulation.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.separator.ThreePhaseSeparator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemUMRPRUMCEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Regression coverage for the hydrocarbon-scrubber export-gas saturation boundary.
+ */
+@Tag("slow")
+class HydrocarbonScrubberSaturationPressureStabilityTest extends neqsim.NeqSimTest {
+  @Test
+  void ordinaryAndEnhancedChecksRetainPhysicalSaturationBoundary() {
+    ThreePhaseSeparator scrubber = runScrubberProcess();
+    assertEquals(0.0, scrubber.getMassBalance("kg/hr"), 1.0);
+
+    SystemInterface exportGas = scrubber.getGasOutStream().getFluid().clone();
+    double ordinaryPressure = calculateSaturationPressure(exportGas, false);
+    double enhancedPressure = calculateSaturationPressure(exportGas, true);
+    double nearbyPressure = calculateSaturationPressureAtTemperature(exportGas, 1.0);
+
+    assertEquals(106.2, ordinaryPressure, 1.0);
+    assertEquals(ordinaryPressure, enhancedPressure, 0.25);
+    assertTrue(Math.abs(nearbyPressure - ordinaryPressure) < 5.0);
+
+    SystemInterface equilibrium = exportGas.clone();
+    equilibrium.setMultiPhaseCheck(true);
+    equilibrium.setTemperature(0.0, "C");
+    equilibrium.setPressure(ordinaryPressure - 1.0e-3, "bara");
+    new ThermodynamicOperations(equilibrium).TPflash();
+    equilibrium.init(1);
+
+    assertPhysicalEquilibrium(equilibrium);
+
+    double repeatedPressure = calculateSaturationPressure(exportGas, false);
+    assertEquals(ordinaryPressure, repeatedPressure, 1.0e-8);
+  }
+
+  private static ThreePhaseSeparator runScrubberProcess() {
+    SystemInterface fluid = new SystemUMRPRUMCEos(280.0, 10.0);
+    String[] componentNames = {
+      "nitrogen", "CO2", "methane", "ethane", "propane", "i-butane", "n-butane",
+      "i-pentane", "n-pentane", "2-m-C5", "3-m-C5", "n-hexane", "c-hexane",
+      "n-heptane", "benzene", "n-octane", "c-C7", "toluene", "n-nonane", "c-C8",
+      "m-Xylene", "nC10", "nC11", "nC12"
+    };
+    double[] componentAmounts = {
+      0.01, 0.01, 0.9, 0.1, 0.03, 0.01, 0.01, 0.01, 0.001, 0.001, 0.001,
+      0.001, 0.001, 0.001, 0.0001, 0.0001, 0.0001, 0.0001, 0.0001, 0.00001,
+      0.00001, 3.0e-12, 3.0e-12, 3.0e-12
+    };
+    for (int componentIndex = 0;
+        componentIndex < componentNames.length;
+        componentIndex++) {
+      fluid.addComponent(componentNames[componentIndex], componentAmounts[componentIndex]);
+    }
+    fluid.setMixingRule("HV", "UNIFAC_UMRPRU");
+
+    Stream feed = new Stream("feed gas", fluid);
+    feed.setFlowRate(25.0, "MSm3/day");
+    feed.setTemperature(22.5, "C");
+    feed.setPressure(81.0, "bara");
+    Separator upstreamSeparator = new Separator("upstream separator", feed);
+    Heater cooler = new Heater("cooler", upstreamSeparator.getGasOutStream());
+    cooler.setOutPressure(78.0, "bara");
+    cooler.setOutTemperature(15.0, "C");
+    ThreePhaseSeparator scrubber =
+        new ThreePhaseSeparator("dewpoint scrubber", cooler.getOutStream());
+    scrubber.setEntrainment(0.5, "volume", "feed", "oil", "gas");
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(upstreamSeparator);
+    process.add(cooler);
+    process.add(scrubber);
+    process.run();
+    return scrubber;
+  }
+
+  private static double calculateSaturationPressure(
+      SystemInterface exportGas, boolean enhancedCheck) {
+    SystemInterface fluid = exportGas.clone();
+    fluid.setTemperature(0.0, "C");
+    fluid.setPressure(10.0, "bara");
+    fluid.setMultiPhaseCheck(true);
+    if (enhancedCheck) {
+      fluid.setEnhancedMultiPhaseCheck(true);
+    }
+    SaturationPressure saturationPressure = new SaturationPressure(fluid);
+    saturationPressure.run();
+    return saturationPressure.getSaturationPressure();
+  }
+
+  private static double calculateSaturationPressureAtTemperature(
+      SystemInterface exportGas, double temperatureCelsius) {
+    SystemInterface fluid = exportGas.clone();
+    fluid.setTemperature(temperatureCelsius, "C");
+    fluid.setPressure(10.0, "bara");
+    fluid.setMultiPhaseCheck(true);
+    SaturationPressure saturationPressure = new SaturationPressure(fluid);
+    saturationPressure.run();
+    return saturationPressure.getSaturationPressure();
+  }
+
+  private static void assertPhysicalEquilibrium(SystemInterface fluid) {
+    assertEquals(2, fluid.getNumberOfPhases());
+
+    double betaSum = 0.0;
+    for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
+      betaSum += fluid.getBeta(phase);
+      double compositionSum = 0.0;
+      for (int component = 0;
+          component < fluid.getPhase(phase).getNumberOfComponents();
+          component++) {
+        double moleFraction = fluid.getPhase(phase).getComponent(component).getx();
+        assertTrue(Double.isFinite(moleFraction));
+        assertTrue(moleFraction >= 0.0);
+        compositionSum += moleFraction;
+      }
+      assertEquals(1.0, compositionSum, 1.0e-12);
+    }
+    assertEquals(1.0, betaSum, 1.0e-12);
+
+    double maxFugacityResidual = 0.0;
+    for (int component = 0;
+        component < fluid.getPhase(0).getNumberOfComponents();
+        component++) {
+      double recoveredFeed = 0.0;
+      for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
+        recoveredFeed +=
+            fluid.getBeta(phase) * fluid.getPhase(phase).getComponent(component).getx();
+      }
+      assertEquals(
+          fluid.getPhase(0).getComponent(component).getz(), recoveredFeed, 1.0e-10);
+
+      double phaseZeroX = fluid.getPhase(0).getComponent(component).getx();
+      double phaseOneX = fluid.getPhase(1).getComponent(component).getx();
+      if (phaseZeroX > 1.0e-12 && phaseOneX > 1.0e-12) {
+        double phaseZeroFugacity =
+            phaseZeroX
+                * fluid.getPhase(0).getComponent(component).getFugacityCoefficient();
+        double phaseOneFugacity =
+            phaseOneX
+                * fluid.getPhase(1).getComponent(component).getFugacityCoefficient();
+        maxFugacityResidual =
+            Math.max(
+                maxFugacityResidual,
+                Math.abs(Math.log(phaseZeroFugacity / phaseOneFugacity)));
+      }
+    }
+    assertTrue(maxFugacityResidual <= 1.0e-8);
+  }
+}

--- a/src/test/java/neqsim/pvtsimulation/simulation/HydrocarbonScrubberSaturationPressureStabilityTest.java
+++ b/src/test/java/neqsim/pvtsimulation/simulation/HydrocarbonScrubberSaturationPressureStabilityTest.java
@@ -28,7 +28,7 @@ class HydrocarbonScrubberSaturationPressureStabilityTest extends neqsim.NeqSimTe
     double enhancedPressure = calculateSaturationPressure(exportGas, true);
     double nearbyPressure = calculateSaturationPressureAtTemperature(exportGas, 1.0);
 
-    assertEquals(106.2, ordinaryPressure, 1.0);
+    assertEquals(105.9, ordinaryPressure, 0.5);
     assertEquals(ordinaryPressure, enhancedPressure, 0.25);
     assertTrue(Math.abs(nearbyPressure - ordinaryPressure) < 5.0);
 

--- a/src/test/java/neqsim/pvtsimulation/simulation/HydrocarbonScrubberSaturationPressureStabilityTest.java
+++ b/src/test/java/neqsim/pvtsimulation/simulation/HydrocarbonScrubberSaturationPressureStabilityTest.java
@@ -47,20 +47,12 @@ class HydrocarbonScrubberSaturationPressureStabilityTest extends neqsim.NeqSimTe
 
   private static ThreePhaseSeparator runScrubberProcess() {
     SystemInterface fluid = new SystemUMRPRUMCEos(280.0, 10.0);
-    String[] componentNames = {
-      "nitrogen", "CO2", "methane", "ethane", "propane", "i-butane", "n-butane",
-      "i-pentane", "n-pentane", "2-m-C5", "3-m-C5", "n-hexane", "c-hexane",
-      "n-heptane", "benzene", "n-octane", "c-C7", "toluene", "n-nonane", "c-C8",
-      "m-Xylene", "nC10", "nC11", "nC12"
-    };
-    double[] componentAmounts = {
-      0.01, 0.01, 0.9, 0.1, 0.03, 0.01, 0.01, 0.01, 0.001, 0.001, 0.001,
-      0.001, 0.001, 0.001, 0.0001, 0.0001, 0.0001, 0.0001, 0.0001, 0.00001,
-      0.00001, 3.0e-12, 3.0e-12, 3.0e-12
-    };
-    for (int componentIndex = 0;
-        componentIndex < componentNames.length;
-        componentIndex++) {
+    String[] componentNames = { "nitrogen", "CO2", "methane", "ethane", "propane", "i-butane", "n-butane", "i-pentane",
+        "n-pentane", "2-m-C5", "3-m-C5", "n-hexane", "c-hexane", "n-heptane", "benzene", "n-octane", "c-C7", "toluene",
+        "n-nonane", "c-C8", "m-Xylene", "nC10", "nC11", "nC12" };
+    double[] componentAmounts = { 0.01, 0.01, 0.9, 0.1, 0.03, 0.01, 0.01, 0.01, 0.001, 0.001, 0.001, 0.001, 0.001,
+        0.001, 0.0001, 0.0001, 0.0001, 0.0001, 0.0001, 0.00001, 0.00001, 3.0e-12, 3.0e-12, 3.0e-12 };
+    for (int componentIndex = 0; componentIndex < componentNames.length; componentIndex++) {
       fluid.addComponent(componentNames[componentIndex], componentAmounts[componentIndex]);
     }
     fluid.setMixingRule("HV", "UNIFAC_UMRPRU");
@@ -73,8 +65,7 @@ class HydrocarbonScrubberSaturationPressureStabilityTest extends neqsim.NeqSimTe
     Heater cooler = new Heater("cooler", upstreamSeparator.getGasOutStream());
     cooler.setOutPressure(78.0, "bara");
     cooler.setOutTemperature(15.0, "C");
-    ThreePhaseSeparator scrubber =
-        new ThreePhaseSeparator("dewpoint scrubber", cooler.getOutStream());
+    ThreePhaseSeparator scrubber = new ThreePhaseSeparator("dewpoint scrubber", cooler.getOutStream());
     scrubber.setEntrainment(0.5, "volume", "feed", "oil", "gas");
 
     ProcessSystem process = new ProcessSystem();
@@ -86,8 +77,7 @@ class HydrocarbonScrubberSaturationPressureStabilityTest extends neqsim.NeqSimTe
     return scrubber;
   }
 
-  private static double calculateSaturationPressure(
-      SystemInterface exportGas, boolean enhancedCheck) {
+  private static double calculateSaturationPressure(SystemInterface exportGas, boolean enhancedCheck) {
     SystemInterface fluid = exportGas.clone();
     fluid.setTemperature(0.0, "C");
     fluid.setPressure(10.0, "bara");
@@ -100,8 +90,7 @@ class HydrocarbonScrubberSaturationPressureStabilityTest extends neqsim.NeqSimTe
     return saturationPressure.getSaturationPressure();
   }
 
-  private static double calculateSaturationPressureAtTemperature(
-      SystemInterface exportGas, double temperatureCelsius) {
+  private static double calculateSaturationPressureAtTemperature(SystemInterface exportGas, double temperatureCelsius) {
     SystemInterface fluid = exportGas.clone();
     fluid.setTemperature(temperatureCelsius, "C");
     fluid.setPressure(10.0, "bara");
@@ -118,9 +107,7 @@ class HydrocarbonScrubberSaturationPressureStabilityTest extends neqsim.NeqSimTe
     for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
       betaSum += fluid.getBeta(phase);
       double compositionSum = 0.0;
-      for (int component = 0;
-          component < fluid.getPhase(phase).getNumberOfComponents();
-          component++) {
+      for (int component = 0; component < fluid.getPhase(phase).getNumberOfComponents(); component++) {
         double moleFraction = fluid.getPhase(phase).getComponent(component).getx();
         assertTrue(Double.isFinite(moleFraction));
         assertTrue(moleFraction >= 0.0);
@@ -131,30 +118,19 @@ class HydrocarbonScrubberSaturationPressureStabilityTest extends neqsim.NeqSimTe
     assertEquals(1.0, betaSum, 1.0e-12);
 
     double maxFugacityResidual = 0.0;
-    for (int component = 0;
-        component < fluid.getPhase(0).getNumberOfComponents();
-        component++) {
+    for (int component = 0; component < fluid.getPhase(0).getNumberOfComponents(); component++) {
       double recoveredFeed = 0.0;
       for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
-        recoveredFeed +=
-            fluid.getBeta(phase) * fluid.getPhase(phase).getComponent(component).getx();
+        recoveredFeed += fluid.getBeta(phase) * fluid.getPhase(phase).getComponent(component).getx();
       }
-      assertEquals(
-          fluid.getPhase(0).getComponent(component).getz(), recoveredFeed, 1.0e-10);
+      assertEquals(fluid.getPhase(0).getComponent(component).getz(), recoveredFeed, 1.0e-10);
 
       double phaseZeroX = fluid.getPhase(0).getComponent(component).getx();
       double phaseOneX = fluid.getPhase(1).getComponent(component).getx();
       if (phaseZeroX > 1.0e-12 && phaseOneX > 1.0e-12) {
-        double phaseZeroFugacity =
-            phaseZeroX
-                * fluid.getPhase(0).getComponent(component).getFugacityCoefficient();
-        double phaseOneFugacity =
-            phaseOneX
-                * fluid.getPhase(1).getComponent(component).getFugacityCoefficient();
-        maxFugacityResidual =
-            Math.max(
-                maxFugacityResidual,
-                Math.abs(Math.log(phaseZeroFugacity / phaseOneFugacity)));
+        double phaseZeroFugacity = phaseZeroX * fluid.getPhase(0).getComponent(component).getFugacityCoefficient();
+        double phaseOneFugacity = phaseOneX * fluid.getPhase(1).getComponent(component).getFugacityCoefficient();
+        maxFugacityResidual = Math.max(maxFugacityResidual, Math.abs(Math.log(phaseZeroFugacity / phaseOneFugacity)));
       }
     }
     assertTrue(maxFugacityResidual <= 1.0e-8);

--- a/src/test/java/neqsim/thermo/system/SystemThermoSerializationInventoryTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemThermoSerializationInventoryTest.java
@@ -1,0 +1,84 @@
+package neqsim.thermo.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Regression tests for total-mole inventory reconciliation during Java deserialization.
+ */
+class SystemThermoSerializationInventoryTest extends neqsim.NeqSimTest {
+  @Test
+  void deserializationReconcilesStaleTotalBeforeFlash() throws Exception {
+    SystemThermo fluid = new SystemSrkCPAstatoil(278.45, 37.21325);
+    fluid.addComponent("methane", 5.0);
+    fluid.addComponent("water", 0.11833608283886514);
+    fluid.addComponent("MEG", 0.2779633604538873);
+    fluid.setMixingRule(10);
+    fluid.setMultiPhaseCheck(true);
+
+    double expectedInventory = sumComponentMoles(fluid);
+    fluid.setTotalNumberOfMolesRaw(1986.7470206432324);
+
+    SystemThermo restored = roundTrip(fluid);
+
+    assertEquals(expectedInventory, restored.getTotalNumberOfMoles(), 1.0e-12);
+
+    new ThermodynamicOperations(restored).TPflash();
+
+    assertEquals(1.0, sumOverallMoleFractions(restored), 1.0e-12);
+    assertTrue(restored.getNumberOfPhases() >= 2);
+    assertEquals(PhaseType.GAS, restored.getPhase("gas").getType());
+    assertEquals(PhaseType.AQUEOUS, restored.getPhase("aqueous").getType());
+  }
+
+  @Test
+  void deserializationPreservesConsistentTotal() throws Exception {
+    SystemThermo fluid = new SystemSrkEos(298.15, 20.0);
+    fluid.addComponent("methane", 2.0);
+    fluid.addComponent("ethane", 1.0);
+    double expectedInventory = fluid.getTotalNumberOfMoles();
+
+    SystemThermo restored = roundTrip(fluid);
+
+    assertEquals(expectedInventory, restored.getTotalNumberOfMoles(), 1.0e-12);
+    assertEquals(expectedInventory, sumComponentMoles(restored), 1.0e-12);
+  }
+
+  private static double sumComponentMoles(SystemThermo fluid) {
+    double sum = 0.0;
+    for (int componentIndex = 0;
+        componentIndex < fluid.getPhase(0).getNumberOfComponents();
+        componentIndex++) {
+      sum += fluid.getPhase(0).getComponent(componentIndex).getNumberOfmoles();
+    }
+    return sum;
+  }
+
+  private static double sumOverallMoleFractions(SystemThermo fluid) {
+    double sum = 0.0;
+    for (int componentIndex = 0;
+        componentIndex < fluid.getPhase(0).getNumberOfComponents();
+        componentIndex++) {
+      sum += fluid.getPhase(0).getComponent(componentIndex).getz();
+    }
+    return sum;
+  }
+
+  private static SystemThermo roundTrip(SystemThermo fluid) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(fluid);
+    }
+    try (ObjectInputStream input =
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (SystemThermo) input.readObject();
+    }
+  }
+}

--- a/src/test/java/neqsim/thermo/system/SystemThermoSerializationInventoryTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemThermoSerializationInventoryTest.java
@@ -53,9 +53,7 @@ class SystemThermoSerializationInventoryTest extends neqsim.NeqSimTest {
 
   private static double sumComponentMoles(SystemThermo fluid) {
     double sum = 0.0;
-    for (int componentIndex = 0;
-        componentIndex < fluid.getPhase(0).getNumberOfComponents();
-        componentIndex++) {
+    for (int componentIndex = 0; componentIndex < fluid.getPhase(0).getNumberOfComponents(); componentIndex++) {
       sum += fluid.getPhase(0).getComponent(componentIndex).getNumberOfmoles();
     }
     return sum;
@@ -63,9 +61,7 @@ class SystemThermoSerializationInventoryTest extends neqsim.NeqSimTest {
 
   private static double sumOverallMoleFractions(SystemThermo fluid) {
     double sum = 0.0;
-    for (int componentIndex = 0;
-        componentIndex < fluid.getPhase(0).getNumberOfComponents();
-        componentIndex++) {
+    for (int componentIndex = 0; componentIndex < fluid.getPhase(0).getNumberOfComponents(); componentIndex++) {
       sum += fluid.getPhase(0).getComponent(componentIndex).getz();
     }
     return sum;
@@ -76,8 +72,7 @@ class SystemThermoSerializationInventoryTest extends neqsim.NeqSimTest {
     try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
       output.writeObject(fluid);
     }
-    try (ObjectInputStream input =
-        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
       return (SystemThermo) input.readObject();
     }
   }


### PR DESCRIPTION
## Summary

Provides a narrow alternative to #3024 without changing that pull request.

This draft keeps the documented ordinary `setMultiPhaseCheck(true)` Wilson-K stability trials, but prevents an accepted trial from entering the material-balance solve with an order-one phase fraction derived from its dominant component. A negative tangent-plane-distance result establishes instability; it does not determine the equilibrium amount of the new phase. The candidate starts above the numerical disappearance limit, capped at `1e-3`, and lets the existing beta/equilibrium solve grow or remove the phase.

It also confines stale scalar total-mole reconciliation to Java deserialization, where the mismatch originates, instead of changing every `SystemThermo.init()` call.

## Exact publication state

- Base: `c9cb4c5824b34643bbe463e286d1f9399816801c`
- Final publication head: `61cd8c164981c9b80263659097541adaaa003fb4`
- Branch: `fix/tpmultiflash-incipient-wilson-seed`

## Changes

- reconcile a finite positive duplicated component inventory in `SystemThermo.readObject`; skip ambiguous phase-slot inventories
- seed ordinary and enhanced Wilson-admitted phases with a bounded incipient beta
- add Java-serialization regression for stale and already-consistent totals
- add a slow hydrocarbon-scrubber regression covering process mass balance, ordinary/enhanced consistency, the historical `105.9 ± 0.5 bara` benchmark, nearby-temperature continuity, repeatability, normalization, component balance, and fugacity equality
- document the Wilson trial admission and beta-seeding semantics

## Acceptance gates

- Preserve Wilson-K trials for ordinary and enhanced multiphase checking.
- Restore the hydrocarbon-scrubber saturation-pressure path without using one historical pressure as the sole correctness oracle.
- Keep hydrate, electrolyte, and existing multiphase behavior on the ordinary path.
- Reconcile a stale serialized scalar total before the first flash while preserving a consistent serialized system.

## Documentation impact

Updated `docs/thermodynamicoperations/TPflash_algorithm.md`. No public API, units, or configuration are changed.

## Validation

**VALIDATION PENDING CI**

The GitHub-connected workflow is authoritative for this publication. Local Maven, Java, Spotless, and pre-commit execution were not available in this run, so no unrun check is claimed as passed. On head `84ee084418b9d9831896d4d078fabf344ef45a74`, formatting, pre-commit, documentation search, PaperLab, CodeQL, Javadocs, and three slow-test shards passed; the fast suite exposed four branch-attributable regressions caused by placing the admitted beta below the ordinary solver's `1e-3` regularization scale. The seed now uses that solver scale while remaining capped by the dominant overall fraction. Fresh exact-head CI is pending.

This PR does not close, modify, merge, or mark #3024 ready.
