### PR TITLE
[AI-Assisted] feat(diagram): aggregate explicit boundary balances

### DIFF
--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -133,8 +133,9 @@ For each balance, mass residual is inlet mass flow minus outlet mass flow in kg/
 residual divides that result by the larger absolute inlet or outlet total and is zero when both totals
 are zero. Stream enthalpy flow is `massFlow [kg/s] * specificEnthalpy [J/kg]` in W; its residual is the
 inlet total minus the outlet total. It intentionally excludes equipment heat duties and shaft work,
-so it is not a complete energy balance. Component balances, reconciliation, tolerances, and approved
-project boundaries remain later engineering layers.
+and its relative residual uses the same larger-total denominator. It intentionally excludes equipment
+heat duties and shaft work, so it is not a complete energy balance. Component balances,
+reconciliation, tolerances, and approved project boundaries remain later engineering layers.
 
 Building either companion does not change Classic DOT/Graphviz, native SVG/PDF, DEXPI 2.0 Process
 exchange, or the Proteus/DEXPI P&ID workflow. `REVIEWED` boundary evidence does not approve a PFD,

--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -132,9 +132,9 @@ EngineeringDiagramBalanceTable balanceTable =
 For each balance, mass residual is inlet mass flow minus outlet mass flow in kg/s. Relative mass
 residual divides that result by the larger absolute inlet or outlet total and is zero when both totals
 are zero. Stream enthalpy flow is `massFlow [kg/s] * specificEnthalpy [J/kg]` in W; its residual is the
-inlet total minus the outlet total. It intentionally excludes equipment heat duties and shaft work,
-and its relative residual uses the same larger-total denominator. It intentionally excludes equipment
-heat duties and shaft work, so it is not a complete energy balance. Component balances,
+inlet total minus the outlet total, and its relative residual uses the same larger-total denominator.
+It intentionally excludes equipment heat duties and shaft work, so it is not a complete energy
+balance. Component balances,
 reconciliation, tolerances, and approved project boundaries remain later engineering layers.
 
 Building either companion does not change Classic DOT/Graphviz, native SVG/PDF, DEXPI 2.0 Process

--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -58,8 +58,9 @@ String controlledProposalJson = documents.toJson();
 
 Use the overload with a final operating-case ID after a successful process run to retain governed
 stream results in the same controlled snapshot. Temperature is stored in K, absolute pressure in
-bara, and mass flow in kg/s. Each value remains `CALCULATED` and `REVIEW_REQUIRED`, identifies its
-case and source semantic object, and includes simulation-result provenance. The topology-only
+bara, mass flow in kg/s, and mass-specific enthalpy in J/kg. Each value remains `CALCULATED` and
+`REVIEW_REQUIRED`, identifies its case and source semantic object, and includes simulation-result
+provenance. The topology-only
 overloads remain unchanged and do not read live operating values.
 
 ### Governed stream-table companion
@@ -68,8 +69,8 @@ overloads remain unchanged and do not read live operating values.
 operating-case document snapshot. It reads only canonical `LINE` and `CALCULATION` semantic objects;
 it does not read live process objects or add fields to `EngineeringDiagramDocumentSet.toJson()`.
 Every row retains the canonical stream ID, external key, source label, and process area. Temperature,
-absolute pressure, and mass flow retain their explicit unit, quantity basis, engineering state,
-approval state, source calculation ID, and simulation-result provenance.
+absolute pressure, mass flow, and mass-specific enthalpy retain their explicit unit, quantity basis,
+engineering state, approval state, source calculation ID, and simulation-result provenance.
 
 A reviewed `STREAM_NUMBER` designation is preferred as the display identifier and its source
 reference is retained. Without reviewed evidence, the canonical source label remains visible.
@@ -100,10 +101,44 @@ for (EngineeringDiagramStreamTable.Row row : streamTable.getRows()) {
 }
 ```
 
-This first companion is the stream-condition foundation for later heat/material-balance aggregation.
-It does not yet calculate component balances, enthalpy duties, or reconciliation residuals. Building
-the table does not change Classic DOT/Graphviz, native SVG/PDF, DEXPI 2.0 Process exchange, or the
-Proteus/DEXPI P&ID workflow, and it does not promote calculated values to approved design data.
+### Explicit-boundary mass and stream-enthalpy balances
+
+`EngineeringDiagramBalanceTable` aggregates only explicit boundary assignments against a governed
+stream table. Each assignment records a stable balance ID, canonical stream semantic ID, inlet or
+outlet direction, source reference, and `PROPOSED` or `REVIEWED` evidence state. The aggregator never
+guesses direction from drawing topology. Unknown or duplicate assignments, missing values, wrong
+units or bases, negative boundary flow, non-finite results, and source-table losses remain visible as
+structured diagnostics.
+
+```java
+List<EngineeringDiagramBalanceTable.Boundary> boundaries =
+    Arrays.asList(
+        new EngineeringDiagramBalanceTable.Boundary(
+            "BAL-AREA-01",
+            feedStreamId,
+            EngineeringDiagramBalanceTable.Direction.INLET,
+            "project-balance-register:BAL-AREA-01",
+            EngineeringDiagramBalanceTable.EvidenceState.PROPOSED),
+        new EngineeringDiagramBalanceTable.Boundary(
+            productStreamId,
+            productStreamId,
+            EngineeringDiagramBalanceTable.Direction.OUTLET,
+            "project-balance-register:BAL-AREA-01",
+            EngineeringDiagramBalanceTable.EvidenceState.PROPOSED));
+EngineeringDiagramBalanceTable balanceTable =
+    EngineeringDiagramBalanceTable.fromStreamTable(streamTable, boundaries);
+```
+
+For each balance, mass residual is inlet mass flow minus outlet mass flow in kg/s. Relative mass
+residual divides that result by the larger absolute inlet or outlet total and is zero when both totals
+are zero. Stream enthalpy flow is `massFlow [kg/s] * specificEnthalpy [J/kg]` in W; its residual is the
+inlet total minus the outlet total. It intentionally excludes equipment heat duties and shaft work,
+so it is not a complete energy balance. Component balances, reconciliation, tolerances, and approved
+project boundaries remain later engineering layers.
+
+Building either companion does not change Classic DOT/Graphviz, native SVG/PDF, DEXPI 2.0 Process
+exchange, or the Proteus/DEXPI P&ID workflow. `REVIEWED` boundary evidence does not approve a PFD,
+P&ID, simulation result, balance, or design data.
 
 Canonical source names and carried connection names are retained as source designations. They are
 not silently promoted to project-approved equipment tags or line numbers. Project-entered tags and
@@ -293,7 +328,7 @@ Run the focused regression with:
 ```bash
 ./mvnw -Dtest=ProcessDiagramDocumentSetAdapterTest test
 ./mvnw -Dtest=NativeEngineeringDiagramRendererTest test
-./mvnw -Dtest=EngineeringDiagramStreamTableTest test
+./mvnw -Dtest=EngineeringDiagramStreamTableTest,EngineeringDiagramBalanceTableTest test
 ```
 
 The regression verifies deterministic single- and multi-area output, immutable collections,

--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -120,7 +120,7 @@ List<EngineeringDiagramBalanceTable.Boundary> boundaries =
             "project-balance-register:BAL-AREA-01",
             EngineeringDiagramBalanceTable.EvidenceState.PROPOSED),
         new EngineeringDiagramBalanceTable.Boundary(
-            productStreamId,
+            "BAL-AREA-01",
             productStreamId,
             EngineeringDiagramBalanceTable.Direction.OUTLET,
             "project-balance-register:BAL-AREA-01",

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramBalanceTable.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramBalanceTable.java
@@ -22,10 +22,9 @@ import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Value;
  * Immutable, deterministic mass and stream-enthalpy balance projection.
  *
  * <p>
- * The projection consumes a governed {@link EngineeringDiagramStreamTable} plus explicit boundary
- * assignments. It never guesses whether a stream is an inlet or outlet. Stream enthalpy flow is
- * calculated as mass flow times mass-specific enthalpy. The result therefore excludes equipment
- * heat duties and shaft work and is not a complete energy balance.
+ * The projection consumes a governed {@link EngineeringDiagramStreamTable} plus explicit boundary assignments. It never
+ * guesses whether a stream is an inlet or outlet. Stream enthalpy flow is calculated as mass flow times mass-specific
+ * enthalpy. The result therefore excludes equipment heat duties and shaft work and is not a complete energy balance.
  * </p>
  */
 public final class EngineeringDiagramBalanceTable implements Serializable {
@@ -66,8 +65,8 @@ public final class EngineeringDiagramBalanceTable implements Serializable {
      * @param sourceReference source or register reference for the assignment
      * @param evidenceState review evidence state
      */
-    public Boundary(String balanceId, String streamSemanticObjectId, Direction direction,
-        String sourceReference, EvidenceState evidenceState) {
+    public Boundary(String balanceId, String streamSemanticObjectId, Direction direction, String sourceReference,
+        EvidenceState evidenceState) {
       this.balanceId = requireText(balanceId, "balanceId");
       this.streamSemanticObjectId = requireText(streamSemanticObjectId, "streamSemanticObjectId");
       if (direction == null) {
@@ -190,10 +189,8 @@ public final class EngineeringDiagramBalanceTable implements Serializable {
       this.inletStreamEnthalpyFlow = values.inletStreamEnthalpyFlow;
       this.outletStreamEnthalpyFlow = values.outletStreamEnthalpyFlow;
       this.streamEnthalpyResidual = inletStreamEnthalpyFlow - outletStreamEnthalpyFlow;
-      double enthalpyScale =
-          Math.max(Math.abs(inletStreamEnthalpyFlow), Math.abs(outletStreamEnthalpyFlow));
-      this.relativeStreamEnthalpyResidual =
-          enthalpyScale == 0.0 ? 0.0 : streamEnthalpyResidual / enthalpyScale;
+      double enthalpyScale = Math.max(Math.abs(inletStreamEnthalpyFlow), Math.abs(outletStreamEnthalpyFlow));
+      this.relativeStreamEnthalpyResidual = enthalpyScale == 0.0 ? 0.0 : streamEnthalpyResidual / enthalpyScale;
       this.streamEnthalpyFlowComplete = values.streamEnthalpyFlowComplete;
     }
 
@@ -478,16 +475,14 @@ public final class EngineeringDiagramBalanceTable implements Serializable {
     Value enthalpy = row.getValues().get(Quantity.SPECIFIC_ENTHALPY);
     if (!validValue(enthalpy, "J/kg", "MASS_SPECIFIC")) {
       diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_SPECIFIC_ENTHALPY_UNAVAILABLE",
-          "A boundary stream requires specific enthalpy in J/kg on a MASS_SPECIFIC basis",
-          row.getSemanticObjectId()));
+          "A boundary stream requires specific enthalpy in J/kg on a MASS_SPECIFIC basis", row.getSemanticObjectId()));
       accumulator.streamEnthalpyFlowComplete = false;
       return;
     }
     double enthalpyFlow = mass * enthalpy.getResultValue();
     if (!Double.isFinite(enthalpyFlow)) {
       diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_STREAM_ENTHALPY_FLOW_NONFINITE",
-          "Mass flow times specific enthalpy produced a non-finite stream enthalpy flow",
-          row.getSemanticObjectId()));
+          "Mass flow times specific enthalpy produced a non-finite stream enthalpy flow", row.getSemanticObjectId()));
       accumulator.streamEnthalpyFlowComplete = false;
       return;
     }

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramBalanceTable.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramBalanceTable.java
@@ -1,0 +1,572 @@
+package neqsim.process.engineering.model;
+
+import com.google.gson.GsonBuilder;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Severity;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Quantity;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Row;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Value;
+
+/**
+ * Immutable, deterministic mass and stream-enthalpy balance projection.
+ *
+ * <p>
+ * The projection consumes a governed {@link EngineeringDiagramStreamTable} plus explicit boundary
+ * assignments. It never guesses whether a stream is an inlet or outlet. Stream enthalpy flow is
+ * calculated as mass flow times mass-specific enthalpy. The result therefore excludes equipment
+ * heat duties and shaft work and is not a complete energy balance.
+ * </p>
+ */
+public final class EngineeringDiagramBalanceTable implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  public static final String SCHEMA_VERSION = "neqsim_engineering_diagram_balance_table.v1";
+
+  /** Direction of a stream across a declared balance boundary. */
+  public enum Direction {
+    /** Stream enters the balance boundary. */
+    INLET,
+    /** Stream leaves the balance boundary. */
+    OUTLET
+  }
+
+  /** Evidence state of a boundary assignment. */
+  public enum EvidenceState {
+    /** Boundary assignment is an engineering proposal requiring review. */
+    PROPOSED,
+    /** Boundary assignment has review evidence, without implying design approval. */
+    REVIEWED
+  }
+
+  /** One explicit stream assignment to a named balance boundary. */
+  public static final class Boundary implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String balanceId;
+    private final String streamSemanticObjectId;
+    private final Direction direction;
+    private final String sourceReference;
+    private final EvidenceState evidenceState;
+
+    /**
+     * Creates an explicit balance-boundary assignment.
+     *
+     * @param balanceId stable balance identity
+     * @param streamSemanticObjectId canonical stream semantic-object identity
+     * @param direction direction across the balance boundary
+     * @param sourceReference source or register reference for the assignment
+     * @param evidenceState review evidence state
+     */
+    public Boundary(String balanceId, String streamSemanticObjectId, Direction direction,
+        String sourceReference, EvidenceState evidenceState) {
+      this.balanceId = requireText(balanceId, "balanceId");
+      this.streamSemanticObjectId = requireText(streamSemanticObjectId, "streamSemanticObjectId");
+      if (direction == null) {
+        throw new IllegalArgumentException("direction must not be null");
+      }
+      this.direction = direction;
+      this.sourceReference = requireText(sourceReference, "sourceReference");
+      if (evidenceState == null) {
+        throw new IllegalArgumentException("evidenceState must not be null");
+      }
+      this.evidenceState = evidenceState;
+    }
+
+    /** @return stable balance identity */
+    public String getBalanceId() {
+      return balanceId;
+    }
+
+    /** @return canonical stream semantic-object identity */
+    public String getStreamSemanticObjectId() {
+      return streamSemanticObjectId;
+    }
+
+    /** @return direction across the boundary */
+    public Direction getDirection() {
+      return direction;
+    }
+
+    /** @return source or register reference */
+    public String getSourceReference() {
+      return sourceReference;
+    }
+
+    /** @return evidence state */
+    public EvidenceState getEvidenceState() {
+      return evidenceState;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("balanceId", balanceId);
+      result.put("streamSemanticObjectId", streamSemanticObjectId);
+      result.put("direction", direction.name());
+      result.put("sourceReference", sourceReference);
+      result.put("evidenceState", evidenceState.name());
+      return result;
+    }
+  }
+
+  /** One structured balance diagnostic. */
+  public static final class Diagnostic implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Severity severity;
+    private final String code;
+    private final String message;
+    private final String subjectId;
+
+    private Diagnostic(Severity severity, String code, String message, String subjectId) {
+      this.severity = severity;
+      this.code = code;
+      this.message = message;
+      this.subjectId = subjectId;
+    }
+
+    /** @return diagnostic severity */
+    public Severity getSeverity() {
+      return severity;
+    }
+
+    /** @return stable machine-readable diagnostic code */
+    public String getCode() {
+      return code;
+    }
+
+    /** @return human-readable diagnostic message */
+    public String getMessage() {
+      return message;
+    }
+
+    /** @return affected stable identity */
+    public String getSubjectId() {
+      return subjectId;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("severity", severity.name());
+      result.put("code", code);
+      result.put("message", message);
+      result.put("subjectId", subjectId);
+      return result;
+    }
+  }
+
+  /** One aggregate balance result. */
+  public static final class Balance implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String balanceId;
+    private final int boundaryCount;
+    private final double inletMassFlow;
+    private final double outletMassFlow;
+    private final double massResidual;
+    private final double relativeMassResidual;
+    private final boolean massFlowComplete;
+    private final double inletStreamEnthalpyFlow;
+    private final double outletStreamEnthalpyFlow;
+    private final double streamEnthalpyResidual;
+    private final boolean streamEnthalpyFlowComplete;
+
+    private Balance(String balanceId, Accumulator values) {
+      this.balanceId = balanceId;
+      this.boundaryCount = values.boundaryCount;
+      this.inletMassFlow = values.inletMassFlow;
+      this.outletMassFlow = values.outletMassFlow;
+      this.massResidual = inletMassFlow - outletMassFlow;
+      double scale = Math.max(Math.abs(inletMassFlow), Math.abs(outletMassFlow));
+      this.relativeMassResidual = scale == 0.0 ? 0.0 : massResidual / scale;
+      this.massFlowComplete = values.massFlowComplete;
+      this.inletStreamEnthalpyFlow = values.inletStreamEnthalpyFlow;
+      this.outletStreamEnthalpyFlow = values.outletStreamEnthalpyFlow;
+      this.streamEnthalpyResidual = inletStreamEnthalpyFlow - outletStreamEnthalpyFlow;
+      this.streamEnthalpyFlowComplete = values.streamEnthalpyFlowComplete;
+    }
+
+    /** @return stable balance identity */
+    public String getBalanceId() {
+      return balanceId;
+    }
+
+    /** @return number of declared boundary streams */
+    public int getBoundaryCount() {
+      return boundaryCount;
+    }
+
+    /** @return inlet mass flow in kg/s */
+    public double getInletMassFlow() {
+      return inletMassFlow;
+    }
+
+    /** @return outlet mass flow in kg/s */
+    public double getOutletMassFlow() {
+      return outletMassFlow;
+    }
+
+    /** @return inlet minus outlet mass flow in kg/s */
+    public double getMassResidual() {
+      return massResidual;
+    }
+
+    /** @return mass residual divided by the larger absolute boundary total */
+    public double getRelativeMassResidual() {
+      return relativeMassResidual;
+    }
+
+    /** @return true when every boundary has a usable mass-flow value */
+    public boolean isMassFlowComplete() {
+      return massFlowComplete;
+    }
+
+    /** @return inlet stream enthalpy flow in W */
+    public double getInletStreamEnthalpyFlow() {
+      return inletStreamEnthalpyFlow;
+    }
+
+    /** @return outlet stream enthalpy flow in W */
+    public double getOutletStreamEnthalpyFlow() {
+      return outletStreamEnthalpyFlow;
+    }
+
+    /** @return inlet minus outlet stream enthalpy flow in W */
+    public double getStreamEnthalpyResidual() {
+      return streamEnthalpyResidual;
+    }
+
+    /** @return true when every boundary has usable mass flow and specific enthalpy */
+    public boolean isStreamEnthalpyFlowComplete() {
+      return streamEnthalpyFlowComplete;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("balanceId", balanceId);
+      result.put("boundaryCount", Integer.valueOf(boundaryCount));
+      result.put("inletMassFlow", Double.valueOf(inletMassFlow));
+      result.put("outletMassFlow", Double.valueOf(outletMassFlow));
+      result.put("massResidual", Double.valueOf(massResidual));
+      result.put("relativeMassResidual", Double.valueOf(relativeMassResidual));
+      result.put("massFlowUnit", "kg/s");
+      result.put("massFlowComplete", Boolean.valueOf(massFlowComplete));
+      result.put("inletStreamEnthalpyFlow", Double.valueOf(inletStreamEnthalpyFlow));
+      result.put("outletStreamEnthalpyFlow", Double.valueOf(outletStreamEnthalpyFlow));
+      result.put("streamEnthalpyResidual", Double.valueOf(streamEnthalpyResidual));
+      result.put("streamEnthalpyFlowUnit", "W");
+      result.put("streamEnthalpyFlowComplete", Boolean.valueOf(streamEnthalpyFlowComplete));
+      return result;
+    }
+  }
+
+  private static final class Accumulator {
+    private int boundaryCount;
+    private double inletMassFlow;
+    private double outletMassFlow;
+    private boolean massFlowComplete = true;
+    private double inletStreamEnthalpyFlow;
+    private double outletStreamEnthalpyFlow;
+    private boolean streamEnthalpyFlowComplete = true;
+  }
+
+  private final String documentSetId;
+  private final String sourceGraphFingerprint;
+  private final String designCaseId;
+  private final String sourceStreamTableFingerprint;
+  private final List<Boundary> boundaries;
+  private final List<Balance> balances;
+  private final List<Diagnostic> diagnostics;
+
+  private EngineeringDiagramBalanceTable(EngineeringDiagramStreamTable streamTable, List<Boundary> boundaries,
+      List<Balance> balances, List<Diagnostic> diagnostics) {
+    this.documentSetId = streamTable.getDocumentSetId();
+    this.sourceGraphFingerprint = streamTable.getSourceGraphFingerprint();
+    this.designCaseId = streamTable.getDesignCaseId();
+    this.sourceStreamTableFingerprint = streamTable.toMap().get("fingerprint").toString();
+    this.boundaries = Collections.unmodifiableList(new ArrayList<Boundary>(boundaries));
+    this.balances = Collections.unmodifiableList(new ArrayList<Balance>(balances));
+    this.diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+  }
+
+  /**
+   * Aggregates explicit boundary assignments from a governed stream table.
+   *
+   * @param streamTable governed stream table
+   * @param boundaries explicit stream directions grouped by stable balance identity
+   * @return immutable balance table with structured diagnostics
+   */
+  public static EngineeringDiagramBalanceTable fromStreamTable(EngineeringDiagramStreamTable streamTable,
+      List<Boundary> boundaries) {
+    if (streamTable == null) {
+      throw new IllegalArgumentException("streamTable must not be null");
+    }
+    if (boundaries == null) {
+      throw new IllegalArgumentException("boundaries must not be null");
+    }
+    List<Boundary> sortedBoundaries = new ArrayList<Boundary>(boundaries);
+    if (containsNull(sortedBoundaries)) {
+      throw new IllegalArgumentException("boundaries must not contain null");
+    }
+    Collections.sort(sortedBoundaries, boundaryComparator());
+    List<Diagnostic> diagnostics = sourceDiagnostics(streamTable);
+    if (sortedBoundaries.isEmpty()) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_BOUNDARY_NOT_DECLARED",
+          "At least one explicit balance-boundary assignment is required", ""));
+    }
+
+    Map<String, Row> rowsById = new LinkedHashMap<String, Row>();
+    for (Row row : streamTable.getRows()) {
+      rowsById.put(row.getSemanticObjectId(), row);
+    }
+    Map<String, Accumulator> valuesByBalance = new LinkedHashMap<String, Accumulator>();
+    Set<String> assignedStreams = new LinkedHashSet<String>();
+    for (Boundary boundary : sortedBoundaries) {
+      Accumulator accumulator = valuesByBalance.get(boundary.getBalanceId());
+      if (accumulator == null) {
+        accumulator = new Accumulator();
+        valuesByBalance.put(boundary.getBalanceId(), accumulator);
+      }
+      accumulator.boundaryCount++;
+      String assignmentKey = boundary.getBalanceId() + "|" + boundary.getStreamSemanticObjectId();
+      if (!assignedStreams.add(assignmentKey)) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_BOUNDARY_DUPLICATE_STREAM",
+            "A stream may be assigned only once to the same balance", boundary.getStreamSemanticObjectId()));
+        accumulator.massFlowComplete = false;
+        accumulator.streamEnthalpyFlowComplete = false;
+        continue;
+      }
+      Row row = rowsById.get(boundary.getStreamSemanticObjectId());
+      if (row == null) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_BOUNDARY_UNKNOWN_STREAM",
+            "A boundary assignment references a stream absent from the governed stream table",
+            boundary.getStreamSemanticObjectId()));
+        accumulator.massFlowComplete = false;
+        accumulator.streamEnthalpyFlowComplete = false;
+        continue;
+      }
+      addBoundaryValues(boundary, row, accumulator, diagnostics);
+    }
+
+    List<Balance> balances = new ArrayList<Balance>();
+    for (Map.Entry<String, Accumulator> entry : valuesByBalance.entrySet()) {
+      balances.add(new Balance(entry.getKey(), entry.getValue()));
+    }
+    Collections.sort(diagnostics, diagnosticComparator());
+    return new EngineeringDiagramBalanceTable(streamTable, sortedBoundaries, balances, diagnostics);
+  }
+
+  /** @return source controlled-document identity */
+  public String getDocumentSetId() {
+    return documentSetId;
+  }
+
+  /** @return canonical source-graph fingerprint */
+  public String getSourceGraphFingerprint() {
+    return sourceGraphFingerprint;
+  }
+
+  /** @return selected operating-case identity */
+  public String getDesignCaseId() {
+    return designCaseId;
+  }
+
+  /** @return deterministic fingerprint of the source stream-table representation */
+  public String getSourceStreamTableFingerprint() {
+    return sourceStreamTableFingerprint;
+  }
+
+  /** @return immutable explicit boundary assignments in deterministic order */
+  public List<Boundary> getBoundaries() {
+    return Collections.unmodifiableList(new ArrayList<Boundary>(boundaries));
+  }
+
+  /** @return immutable aggregate balances in deterministic order */
+  public List<Balance> getBalances() {
+    return Collections.unmodifiableList(new ArrayList<Balance>(balances));
+  }
+
+  /** @return immutable structured diagnostics */
+  public List<Diagnostic> getDiagnostics() {
+    return Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+  }
+
+  /** @return true when no error-severity diagnostic is present */
+  public boolean isValid() {
+    for (Diagnostic diagnostic : diagnostics) {
+      if (diagnostic.getSeverity() == Severity.ERROR) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** @return deterministic machine-readable representation */
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", SCHEMA_VERSION);
+    result.put("documentSetId", documentSetId);
+    result.put("sourceGraphFingerprint", sourceGraphFingerprint);
+    result.put("designCaseId", designCaseId);
+    result.put("sourceStreamTableFingerprint", sourceStreamTableFingerprint);
+    List<Map<String, Object>> boundaryMaps = new ArrayList<Map<String, Object>>();
+    for (Boundary boundary : boundaries) {
+      boundaryMaps.add(boundary.toMap());
+    }
+    result.put("boundaries", boundaryMaps);
+    List<Map<String, Object>> balanceMaps = new ArrayList<Map<String, Object>>();
+    for (Balance balance : balances) {
+      balanceMaps.add(balance.toMap());
+    }
+    result.put("balances", balanceMaps);
+    List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
+    for (Diagnostic diagnostic : diagnostics) {
+      diagnosticMaps.add(diagnostic.toMap());
+    }
+    result.put("diagnostics", diagnosticMaps);
+    result.put("fingerprint", fingerprint(result));
+    return result;
+  }
+
+  /** @return deterministic pretty-printed JSON */
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+  }
+
+  private static void addBoundaryValues(Boundary boundary, Row row, Accumulator accumulator,
+      List<Diagnostic> diagnostics) {
+    Value massFlow = row.getValues().get(Quantity.MASS_FLOW);
+    if (!validValue(massFlow, "kg/s", "MASS")) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_MASS_FLOW_UNAVAILABLE",
+          "A boundary stream requires mass flow in kg/s on a MASS basis", row.getSemanticObjectId()));
+      accumulator.massFlowComplete = false;
+      accumulator.streamEnthalpyFlowComplete = false;
+      return;
+    }
+    double mass = massFlow.getResultValue();
+    if (mass < 0.0) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_MASS_FLOW_NEGATIVE",
+          "Boundary direction must be explicit and boundary mass flow must be non-negative",
+          row.getSemanticObjectId()));
+      accumulator.massFlowComplete = false;
+      accumulator.streamEnthalpyFlowComplete = false;
+      return;
+    }
+    if (boundary.getDirection() == Direction.INLET) {
+      accumulator.inletMassFlow += mass;
+    } else {
+      accumulator.outletMassFlow += mass;
+    }
+
+    Value enthalpy = row.getValues().get(Quantity.SPECIFIC_ENTHALPY);
+    if (!validValue(enthalpy, "J/kg", "MASS_SPECIFIC")) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_SPECIFIC_ENTHALPY_UNAVAILABLE",
+          "A boundary stream requires specific enthalpy in J/kg on a MASS_SPECIFIC basis",
+          row.getSemanticObjectId()));
+      accumulator.streamEnthalpyFlowComplete = false;
+      return;
+    }
+    double enthalpyFlow = mass * enthalpy.getResultValue();
+    if (!Double.isFinite(enthalpyFlow)) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_STREAM_ENTHALPY_FLOW_NONFINITE",
+          "Mass flow times specific enthalpy produced a non-finite stream enthalpy flow",
+          row.getSemanticObjectId()));
+      accumulator.streamEnthalpyFlowComplete = false;
+      return;
+    }
+    if (boundary.getDirection() == Direction.INLET) {
+      accumulator.inletStreamEnthalpyFlow += enthalpyFlow;
+    } else {
+      accumulator.outletStreamEnthalpyFlow += enthalpyFlow;
+    }
+  }
+
+  private static boolean validValue(Value value, String unit, String basis) {
+    return value != null && unit.equals(value.getResultUnit()) && basis.equals(value.getQuantityBasis())
+        && Double.isFinite(value.getResultValue());
+  }
+
+  private static List<Diagnostic> sourceDiagnostics(EngineeringDiagramStreamTable streamTable) {
+    List<Diagnostic> result = new ArrayList<Diagnostic>();
+    for (EngineeringDiagramStreamTable.Diagnostic diagnostic : streamTable.getDiagnostics()) {
+      result.add(new Diagnostic(diagnostic.getSeverity(), "BALANCE_SOURCE_" + diagnostic.getCode(),
+          diagnostic.getMessage(), diagnostic.getSubjectId()));
+    }
+    return result;
+  }
+
+  private static boolean containsNull(List<Boundary> boundaries) {
+    for (Boundary boundary : boundaries) {
+      if (boundary == null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static Comparator<Boundary> boundaryComparator() {
+    return new Comparator<Boundary>() {
+      @Override
+      public int compare(Boundary left, Boundary right) {
+        int order = left.getBalanceId().compareTo(right.getBalanceId());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getStreamSemanticObjectId().compareTo(right.getStreamSemanticObjectId());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getDirection().compareTo(right.getDirection());
+        if (order != 0) {
+          return order;
+        }
+        return left.getSourceReference().compareTo(right.getSourceReference());
+      }
+    };
+  }
+
+  private static Comparator<Diagnostic> diagnosticComparator() {
+    return new Comparator<Diagnostic>() {
+      @Override
+      public int compare(Diagnostic left, Diagnostic right) {
+        int order = left.getSubjectId().compareTo(right.getSubjectId());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getCode().compareTo(right.getCode());
+        if (order != 0) {
+          return order;
+        }
+        return left.getMessage().compareTo(right.getMessage());
+      }
+    };
+  }
+
+  private static String fingerprint(Map<String, Object> value) {
+    String canonical = new GsonBuilder().create().toJson(value);
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(canonical.getBytes(StandardCharsets.UTF_8));
+      StringBuilder result = new StringBuilder();
+      for (byte item : hash) {
+        result.append(String.format("%02x", item & 0xff));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is not available", exception);
+    }
+  }
+
+  private static String requireText(String value, String name) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return value.trim();
+  }
+}

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramBalanceTable.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramBalanceTable.java
@@ -175,6 +175,7 @@ public final class EngineeringDiagramBalanceTable implements Serializable {
     private final double inletStreamEnthalpyFlow;
     private final double outletStreamEnthalpyFlow;
     private final double streamEnthalpyResidual;
+    private final double relativeStreamEnthalpyResidual;
     private final boolean streamEnthalpyFlowComplete;
 
     private Balance(String balanceId, Accumulator values) {
@@ -189,6 +190,10 @@ public final class EngineeringDiagramBalanceTable implements Serializable {
       this.inletStreamEnthalpyFlow = values.inletStreamEnthalpyFlow;
       this.outletStreamEnthalpyFlow = values.outletStreamEnthalpyFlow;
       this.streamEnthalpyResidual = inletStreamEnthalpyFlow - outletStreamEnthalpyFlow;
+      double enthalpyScale =
+          Math.max(Math.abs(inletStreamEnthalpyFlow), Math.abs(outletStreamEnthalpyFlow));
+      this.relativeStreamEnthalpyResidual =
+          enthalpyScale == 0.0 ? 0.0 : streamEnthalpyResidual / enthalpyScale;
       this.streamEnthalpyFlowComplete = values.streamEnthalpyFlowComplete;
     }
 
@@ -242,6 +247,11 @@ public final class EngineeringDiagramBalanceTable implements Serializable {
       return streamEnthalpyResidual;
     }
 
+    /** @return stream enthalpy residual divided by the larger absolute boundary total */
+    public double getRelativeStreamEnthalpyResidual() {
+      return relativeStreamEnthalpyResidual;
+    }
+
     /** @return true when every boundary has usable mass flow and specific enthalpy */
     public boolean isStreamEnthalpyFlowComplete() {
       return streamEnthalpyFlowComplete;
@@ -260,6 +270,7 @@ public final class EngineeringDiagramBalanceTable implements Serializable {
       result.put("inletStreamEnthalpyFlow", Double.valueOf(inletStreamEnthalpyFlow));
       result.put("outletStreamEnthalpyFlow", Double.valueOf(outletStreamEnthalpyFlow));
       result.put("streamEnthalpyResidual", Double.valueOf(streamEnthalpyResidual));
+      result.put("relativeStreamEnthalpyResidual", Double.valueOf(relativeStreamEnthalpyResidual));
       result.put("streamEnthalpyFlowUnit", "W");
       result.put("streamEnthalpyFlowComplete", Boolean.valueOf(streamEnthalpyFlowComplete));
       return result;

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramStreamTable.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramStreamTable.java
@@ -30,7 +30,7 @@ import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Severity;
  */
 public final class EngineeringDiagramStreamTable implements Serializable {
   private static final long serialVersionUID = 1000L;
-  public static final String SCHEMA_VERSION = "neqsim_engineering_diagram_stream_table.v1";
+  public static final String SCHEMA_VERSION = "neqsim_engineering_diagram_stream_table.v2";
 
   /** Supported stream-table quantities in deterministic column order. */
   public enum Quantity {
@@ -39,7 +39,9 @@ public final class EngineeringDiagramStreamTable implements Serializable {
     /** Absolute pressure. */
     PRESSURE("pressure"),
     /** Mass-flow rate. */
-    MASS_FLOW("massFlow");
+    MASS_FLOW("massFlow"),
+    /** Mass-specific enthalpy. */
+    SPECIFIC_ENTHALPY("specificEnthalpy");
 
     private final String propertyName;
 

--- a/src/main/java/neqsim/process/processmodel/diagram/ProcessDiagramGraphAdapter.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/ProcessDiagramGraphAdapter.java
@@ -485,6 +485,12 @@ public final class ProcessDiagramGraphAdapter {
       } catch (RuntimeException exception) {
         operatingValueUnavailable(element, caseId, "massFlow", exception);
       }
+      try {
+        addOperatingValue(element, caseId, caseNodeId, "specificEnthalpy",
+            stream.getThermoSystem().getEnthalpy("J/kg"), "J/kg", "MASS_SPECIFIC");
+      } catch (RuntimeException exception) {
+        operatingValueUnavailable(element, caseId, "specificEnthalpy", exception);
+      }
     }
 
     private void addOperatingValue(ElementReference element, String caseId, String caseNodeId, String quantity,

--- a/src/main/java/neqsim/process/processmodel/diagram/ProcessDiagramGraphAdapter.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/ProcessDiagramGraphAdapter.java
@@ -486,8 +486,8 @@ public final class ProcessDiagramGraphAdapter {
         operatingValueUnavailable(element, caseId, "massFlow", exception);
       }
       try {
-        addOperatingValue(element, caseId, caseNodeId, "specificEnthalpy",
-            stream.getThermoSystem().getEnthalpy("J/kg"), "J/kg", "MASS_SPECIFIC");
+        addOperatingValue(element, caseId, caseNodeId, "specificEnthalpy", stream.getThermoSystem().getEnthalpy("J/kg"),
+            "J/kg", "MASS_SPECIFIC");
       } catch (RuntimeException exception) {
         operatingValueUnavailable(element, caseId, "specificEnthalpy", exception);
       }

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramBalanceTableTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramBalanceTableTest.java
@@ -45,6 +45,7 @@ class EngineeringDiagramBalanceTableTest {
     assertEquals(0.0, balance.getMassResidual(), 1.0e-8);
     assertEquals(0.0, balance.getRelativeMassResidual(), 1.0e-8);
     assertTrue(Double.isFinite(balance.getStreamEnthalpyResidual()));
+    assertTrue(Double.isFinite(balance.getRelativeStreamEnthalpyResidual()));
     assertFalse(table.getSourceStreamTableFingerprint().isEmpty());
     assertNotSame(table.getBoundaries(), table.getBoundaries());
     assertNotSame(table.getBalances(), table.getBalances());

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramBalanceTableTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramBalanceTableTest.java
@@ -1,0 +1,156 @@
+package neqsim.process.processmodel.diagram;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Balance;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Boundary;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Direction;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.EvidenceState;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Quantity;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Row;
+import neqsim.process.equipment.stream.StreamInterface;
+import org.junit.jupiter.api.Test;
+
+/** Regression tests for deterministic, explicit-boundary engineering balances. */
+class EngineeringDiagramBalanceTableTest {
+
+  @Test
+  void aggregatesExplicitMassAndStreamEnthalpyBoundaries() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = completeBoundaryCase();
+    EngineeringDiagramStreamTable streamTable = streamTable(reference);
+    List<Boundary> boundaries = boundaries(reference, streamTable);
+
+    EngineeringDiagramBalanceTable table =
+        EngineeringDiagramBalanceTable.fromStreamTable(streamTable, boundaries);
+
+    assertTrue(table.isValid());
+    assertEquals(1, table.getBalances().size());
+    Balance balance = table.getBalances().get(0);
+    assertEquals("BAL-SIMPLE-01", balance.getBalanceId());
+    assertEquals(3, balance.getBoundaryCount());
+    assertTrue(balance.isMassFlowComplete());
+    assertTrue(balance.isStreamEnthalpyFlowComplete());
+    assertEquals(0.0, balance.getMassResidual(), 1.0e-8);
+    assertEquals(0.0, balance.getRelativeMassResidual(), 1.0e-8);
+    assertTrue(Double.isFinite(balance.getStreamEnthalpyResidual()));
+    assertFalse(table.getSourceStreamTableFingerprint().isEmpty());
+    assertNotSame(table.getBoundaries(), table.getBoundaries());
+    assertNotSame(table.getBalances(), table.getBalances());
+    assertNotSame(table.getDiagnostics(), table.getDiagnostics());
+    assertThrows(UnsupportedOperationException.class, () -> table.getBoundaries().clear());
+    assertTrue(table.toJson().contains("\"massFlowUnit\": \"kg/s\""));
+    assertTrue(table.toJson().contains("\"streamEnthalpyFlowUnit\": \"W\""));
+  }
+
+  @Test
+  void isDeterministicForFreshProcessSystemsAndBoundaryOrder() {
+    EngineeringDiagramReferenceFixtures.SystemCase firstReference = completeBoundaryCase();
+    EngineeringDiagramStreamTable firstStreamTable = streamTable(firstReference);
+    List<Boundary> firstBoundaries = boundaries(firstReference, firstStreamTable);
+
+    EngineeringDiagramReferenceFixtures.SystemCase secondReference = completeBoundaryCase();
+    EngineeringDiagramStreamTable secondStreamTable = streamTable(secondReference);
+    List<Boundary> secondBoundaries = boundaries(secondReference, secondStreamTable);
+    Collections.reverse(secondBoundaries);
+
+    EngineeringDiagramBalanceTable first =
+        EngineeringDiagramBalanceTable.fromStreamTable(firstStreamTable, firstBoundaries);
+    EngineeringDiagramBalanceTable second =
+        EngineeringDiagramBalanceTable.fromStreamTable(secondStreamTable, secondBoundaries);
+
+    assertEquals(first.toJson(), second.toJson());
+  }
+
+  @Test
+  void rejectsUnknownAndDuplicateBoundaryAssignments() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = completeBoundaryCase();
+    EngineeringDiagramStreamTable streamTable = streamTable(reference);
+    Row feed = completeRow(streamTable, reference.getFeed().getName());
+    Boundary declared = new Boundary("BAL-SIMPLE-01", feed.getSemanticObjectId(), Direction.INLET,
+        "project-balance-register:test", EvidenceState.PROPOSED);
+
+    EngineeringDiagramBalanceTable duplicate = EngineeringDiagramBalanceTable.fromStreamTable(streamTable,
+        Arrays.asList(declared, declared));
+    EngineeringDiagramBalanceTable unknown = EngineeringDiagramBalanceTable.fromStreamTable(streamTable,
+        Arrays.asList(new Boundary("BAL-SIMPLE-01", "line:missing", Direction.OUTLET,
+            "project-balance-register:test", EvidenceState.PROPOSED)));
+
+    assertFalse(duplicate.isValid());
+    assertTrue(hasDiagnostic(duplicate, "BALANCE_BOUNDARY_DUPLICATE_STREAM"));
+    assertFalse(unknown.isValid());
+    assertTrue(hasDiagnostic(unknown, "BALANCE_BOUNDARY_UNKNOWN_STREAM"));
+  }
+
+  @Test
+  void requiresExplicitBoundaryAssignments() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = completeBoundaryCase();
+
+    EngineeringDiagramBalanceTable table = EngineeringDiagramBalanceTable.fromStreamTable(streamTable(reference),
+        Collections.<Boundary>emptyList());
+
+    assertFalse(table.isValid());
+    assertTrue(hasDiagnostic(table, "BALANCE_BOUNDARY_NOT_DECLARED"));
+    assertTrue(table.getBalances().isEmpty());
+  }
+
+  private static EngineeringDiagramReferenceFixtures.SystemCase completeBoundaryCase() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
+    for (StreamInterface product : reference.getProducts()) {
+      reference.getProcessSystem().add(product);
+    }
+    reference.getProcessSystem().run();
+    return reference;
+  }
+
+  private static EngineeringDiagramStreamTable streamTable(
+      EngineeringDiagramReferenceFixtures.SystemCase reference) {
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-005", "Boundary balance",
+        ContentProfile.PFD, "NORMAL-01");
+    return EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
+  }
+
+  private static List<Boundary> boundaries(EngineeringDiagramReferenceFixtures.SystemCase reference,
+      EngineeringDiagramStreamTable streamTable) {
+    List<Boundary> result = new ArrayList<Boundary>();
+    Row feed = completeRow(streamTable, reference.getFeed().getName());
+    result.add(new Boundary("BAL-SIMPLE-01", feed.getSemanticObjectId(), Direction.INLET,
+        "project-balance-register:test", EvidenceState.PROPOSED));
+    for (StreamInterface product : reference.getProducts()) {
+      Row row = completeRow(streamTable, product.getName());
+      result.add(new Boundary("BAL-SIMPLE-01", row.getSemanticObjectId(), Direction.OUTLET,
+          "project-balance-register:test", EvidenceState.PROPOSED));
+    }
+    return result;
+  }
+
+  private static Row completeRow(EngineeringDiagramStreamTable table, String sourceLabel) {
+    for (Row row : table.getRows()) {
+      if (sourceLabel.equals(row.getSourceLabel()) && row.getValues().size() == Quantity.values().length) {
+        return row;
+      }
+    }
+    throw new AssertionError("No complete stream-table row for " + sourceLabel);
+  }
+
+  private static boolean hasDiagnostic(EngineeringDiagramBalanceTable table, String code) {
+    for (EngineeringDiagramBalanceTable.Diagnostic diagnostic : table.getDiagnostics()) {
+      if (code.equals(diagnostic.getCode())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramBalanceTableTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramBalanceTableTest.java
@@ -32,8 +32,7 @@ class EngineeringDiagramBalanceTableTest {
     EngineeringDiagramStreamTable streamTable = streamTable(reference);
     List<Boundary> boundaries = boundaries(reference, streamTable);
 
-    EngineeringDiagramBalanceTable table =
-        EngineeringDiagramBalanceTable.fromStreamTable(streamTable, boundaries);
+    EngineeringDiagramBalanceTable table = EngineeringDiagramBalanceTable.fromStreamTable(streamTable, boundaries);
 
     assertTrue(table.isValid());
     assertEquals(1, table.getBalances().size());
@@ -66,10 +65,10 @@ class EngineeringDiagramBalanceTableTest {
     List<Boundary> secondBoundaries = boundaries(secondReference, secondStreamTable);
     Collections.reverse(secondBoundaries);
 
-    EngineeringDiagramBalanceTable first =
-        EngineeringDiagramBalanceTable.fromStreamTable(firstStreamTable, firstBoundaries);
-    EngineeringDiagramBalanceTable second =
-        EngineeringDiagramBalanceTable.fromStreamTable(secondStreamTable, secondBoundaries);
+    EngineeringDiagramBalanceTable first = EngineeringDiagramBalanceTable.fromStreamTable(firstStreamTable,
+        firstBoundaries);
+    EngineeringDiagramBalanceTable second = EngineeringDiagramBalanceTable.fromStreamTable(secondStreamTable,
+        secondBoundaries);
 
     assertEquals(first.toJson(), second.toJson());
   }
@@ -85,8 +84,8 @@ class EngineeringDiagramBalanceTableTest {
     EngineeringDiagramBalanceTable duplicate = EngineeringDiagramBalanceTable.fromStreamTable(streamTable,
         Arrays.asList(declared, declared));
     EngineeringDiagramBalanceTable unknown = EngineeringDiagramBalanceTable.fromStreamTable(streamTable,
-        Arrays.asList(new Boundary("BAL-SIMPLE-01", "line:missing", Direction.OUTLET,
-            "project-balance-register:test", EvidenceState.PROPOSED)));
+        Arrays.asList(new Boundary("BAL-SIMPLE-01", "line:missing", Direction.OUTLET, "project-balance-register:test",
+            EvidenceState.PROPOSED)));
 
     assertFalse(duplicate.isValid());
     assertTrue(hasDiagnostic(duplicate, "BALANCE_BOUNDARY_DUPLICATE_STREAM"));
@@ -115,11 +114,10 @@ class EngineeringDiagramBalanceTableTest {
     return reference;
   }
 
-  private static EngineeringDiagramStreamTable streamTable(
-      EngineeringDiagramReferenceFixtures.SystemCase reference) {
+  private static EngineeringDiagramStreamTable streamTable(EngineeringDiagramReferenceFixtures.SystemCase reference) {
     EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
-        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-005", "Boundary balance",
-        ContentProfile.PFD, "NORMAL-01");
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-005", "Boundary balance", ContentProfile.PFD,
+        "NORMAL-01");
     return EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
   }
 

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramStreamTableTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramStreamTableTest.java
@@ -36,10 +36,11 @@ class EngineeringDiagramStreamTableTest {
     assertTrue(table.isValid());
     assertFalse(table.getRows().isEmpty());
     Row row = firstCompleteRow(table);
-    assertEquals(3, row.getValues().size());
+    assertEquals(4, row.getValues().size());
     assertValue(row, Quantity.TEMPERATURE, "K", "THERMODYNAMIC_ABSOLUTE");
     assertValue(row, Quantity.PRESSURE, "bara", "ABSOLUTE");
     assertValue(row, Quantity.MASS_FLOW, "kg/s", "MASS");
+    assertValue(row, Quantity.SPECIFIC_ENTHALPY, "J/kg", "MASS_SPECIFIC");
     assertEquals("NORMAL-01", table.getDesignCaseId());
     assertEquals(documents.getSourceGraphFingerprint(), table.getSourceGraphFingerprint());
     assertEquals(documentJson, documents.toJson());

--- a/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramGraphAdapterTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramGraphAdapterTest.java
@@ -226,14 +226,16 @@ class ProcessDiagramGraphAdapterTest {
     assertEquals(0, countNodeKind(topologyOnly, EngineeringNode.Kind.DESIGN_CASE));
     assertEquals(0, countNodeKind(topologyOnly, EngineeringNode.Kind.CALCULATION));
     assertEquals(1, countNodeKind(enriched, EngineeringNode.Kind.DESIGN_CASE));
-    assertEquals(3, countNodeKind(enriched, EngineeringNode.Kind.CALCULATION));
+    assertEquals(4, countNodeKind(enriched, EngineeringNode.Kind.CALCULATION));
 
     EngineeringNode pressure = findOperatingValue(enriched, "operating feed", "pressure");
     EngineeringNode temperature = findOperatingValue(enriched, "operating feed", "temperature");
     EngineeringNode massFlow = findOperatingValue(enriched, "operating feed", "massFlow");
+    EngineeringNode specificEnthalpy = findOperatingValue(enriched, "operating feed", "specificEnthalpy");
     assertNotNull(pressure);
     assertNotNull(temperature);
     assertNotNull(massFlow);
+    assertNotNull(specificEnthalpy);
     assertEquals(40.0, ((Number) pressure.getProperties().get("resultValue")).doubleValue(), 1.0e-12);
     assertEquals("bara", pressure.getProperties().get("resultUnit"));
     assertEquals("ABSOLUTE", pressure.getProperties().get("quantityBasis"));
@@ -241,6 +243,8 @@ class ProcessDiagramGraphAdapterTest {
     assertEquals("K", temperature.getProperties().get("resultUnit"));
     assertEquals(1000.0 / 3600.0, ((Number) massFlow.getProperties().get("resultValue")).doubleValue(), 1.0e-12);
     assertEquals("kg/s", massFlow.getProperties().get("resultUnit"));
+    assertEquals("J/kg", specificEnthalpy.getProperties().get("resultUnit"));
+    assertEquals("MASS_SPECIFIC", specificEnthalpy.getProperties().get("quantityBasis"));
     assertEquals("NORMAL-001", pressure.getProperties().get("designCaseId"));
     assertEquals("SIMULATION_RESULT", pressure.getProvenance().get(0).getSourceType());
     assertEquals("NORMAL-001", pressure.getProvenance().get(0).getDesignCaseId());
@@ -257,7 +261,7 @@ class ProcessDiagramGraphAdapterTest {
         "PLANT-MULTI-OPERATING", "A", "NORMAL-001");
 
     assertEquals(1, countNodeKind(result.getGraph(), EngineeringNode.Kind.DESIGN_CASE));
-    assertEquals(3, countNodeKind(result.getGraph(), EngineeringNode.Kind.CALCULATION));
+    assertEquals(4, countNodeKind(result.getGraph(), EngineeringNode.Kind.CALCULATION));
     assertNotNull(findOperatingValue(result.getGraph(), "deterministic feed", "pressure"));
     assertTrue(EngineeringPackageValidator.validateGraph(result.getGraph()).isValid());
   }


### PR DESCRIPTION
## Roadmap

Coordinates #1332 and #2899 as one engineering-diagram implementation lane. This is the dependency-ready heat/material-balance tranche after merged stream-table foundation #3020 and deterministic DEXPI numeric fix #3022.

Base: `c9cb4c5824b34643bbe463e286d1f9399816801c`
Publication head: `37c22a2c5f677066fa29d8b57f234ec4784dd67e`
Branch: `campaign-1332-2899-boundary-balances`

## Engineering problem

The canonical document model already retained case-scoped temperature, pressure, and mass flow, but it could not form a heat/material-balance companion without either guessing boundary direction or losing the unit, provenance, and review boundary of its inputs.

## Complete tranche

- captures mass-specific stream enthalpy as a governed `J/kg`, `MASS_SPECIFIC` operating-case value
- advances the stream-table schema to v2 while preserving its existing Java API and deterministic ordering
- adds immutable, serializable `EngineeringDiagramBalanceTable`
- requires explicit stable balance ID, canonical stream ID, inlet/outlet direction, source reference, and evidence state for every boundary assignment
- aggregates inlet/outlet mass flow, mass residual, relative mass residual, stream enthalpy flow, stream enthalpy residual, and relative stream enthalpy residual
- publishes units and completeness flags in deterministic JSON with source graph and stream-table fingerprints
- rejects or reports unknown streams, duplicate assignments, missing/wrong-basis values, negative boundary flow, non-finite results, absent boundaries, and inherited stream-table losses
- adds fresh-model determinism, defensive immutability, unit/basis, mass-closure, enthalpy-residual, and diagnostic regressions
- documents the public API, residual definitions, compatibility behavior, and engineering approval boundary

## Semantics and limitations

Boundary direction is never inferred from topology. Stream enthalpy flow is `massFlow [kg/s] * specificEnthalpy [J/kg]`. The reported enthalpy residual excludes equipment heat duties and shaft work, so it is not a complete energy balance. Component balances, reconciliation tolerances, and approved project boundary registers remain later dependencies.

A `REVIEWED` boundary assignment records review evidence only. It does not approve a PFD, P&ID, simulation result, balance, or design data, and this PR makes no standards-conformance claim.

## Compatibility

This is an opt-in companion projection. Classic DOT/Graphviz, native SVG/PDF PFD, DEXPI 2.0 Process exchange, existing Proteus/DEXPI P&ID behavior, topology-only adapters, and controlled-document JSON remain unchanged.

## Validation

**MERGED EVIDENCE — exact publication head `37c22a2c5f677066fa29d8b57f234ec4784dd67e`**

Successful exact-head workflows:

- Spotless (empty patch), pre-commit, documentation search, CodeQL, PaperLab, and both engineering notebooks
- Java 8 tests on Ubuntu and Windows
- Java 21 fast tests on Ubuntu and Windows
- Java 21 slow-test shards 1/4, 2/4, and 3/4
- Java 21 Javadocs

Slow-test shard 4/4 was cancelled when the PR merged, not by a test failure. The unchanged shard then passed on immediate descendant PR #3030 at exact head `99d3337c37135a75e2e2bd3718e9f9d901e387ad`, whose base is this merge commit. The two files changed after this merge are `pomJava8.xml` and `TPmultiflash.java`; none of this PR's seven diagram files changed.

No reviews or unresolved inline threads were present at merge. Local Java/Maven execution was unavailable; hosted GitHub validation is the recorded evidence.
