### PR TITLE
[AI-Assisted] fix(release): restore Java 8 Javadoc build

### DIFF
--- a/pomJava8.xml
+++ b/pomJava8.xml
@@ -51,13 +51,13 @@
 	<repositories>
 		<repository>
 			<id>central</id>
-			<url>https://repo1.maven.org/maven2/</url>
+			<url>https://repo.maven.apache.org/maven2/</url>
 		</repository>
 	</repositories>
 	<pluginRepositories>
 		<pluginRepository>
 			<id>central</id>
-			<url>https://repo1.maven.org/maven2/</url>
+			<url>https://repo.maven.apache.org/maven2/</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -314,9 +314,8 @@ public class TPmultiflash extends TPflash {
    *
    * <p>
    * EJML's raw common-operations solve can report success for a singular matrix while writing NaN values to the
-   * correction vector. The former {@link SimpleMatrix#solve(SimpleMatrix)} path raised a singular-matrix exception in
-   * that case, allowing enhanced mode to regularize the Hessian and ordinary mode to stop without corrupting phase
-   * fractions.
+   * correction vector. The former {@code SimpleMatrix.solve(...)} path raised a singular-matrix exception in that case,
+   * allowing enhanced mode to regularize the Hessian and ordinary mode to stop without corrupting phase fractions.
    * </p>
    *
    * @param betaHessian beta-Hessian matrix
@@ -1228,8 +1227,8 @@ public class TPmultiflash extends TPflash {
    * A negative tangent-plane distance establishes that the current topology is unstable, but it does not determine the
    * equilibrium amount of the new phase. Seeding beta from the trial's dominant overall component can therefore
    * introduce an order-one material phase before the phase-fraction solve. Use the existing ordinary beta solver's
-   * regularization scale so the trial is incipient without being pinned below the solver's useful correction scale, then
-   * let the beta/equilibrium solve grow or remove it.
+   * regularization scale so the trial is incipient without being pinned below the solver's useful correction scale,
+   * then let the beta/equilibrium solve grow or remove it.
    * </p>
    *
    * @param dominantComponent index of the largest component in the trial composition


### PR DESCRIPTION
## Problem

The Java 8 draft-release workflow fails while generating Javadoc for `TPmultiflash`. The source contains a member link to `SimpleMatrix.solve(SimpleMatrix)`, but the published EJML type does not expose that exact signature to Javadoc resolution.

The Java 8 Maven profile also points at the legacy `repo1.maven.org` hostname for both dependencies and plugins.

## Changes

- Render the EJML call as code text in Javadoc so documentation generation does not try to resolve a nonexistent signature.
- Use Maven Central's canonical `repo.maven.apache.org` endpoint in `pomJava8.xml`.
- Apply the repository's Spotless formatting to the touched Java source.

## Validation

Local passes:

- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- `git diff --check`

GitHub passes on this PR:

- Java 21 Javadoc
- Pre-commit
- Spotless patch
- PaperLab
- Automatic Dependency Submission
- CodeQL

The full build matrix is red only on pre-existing failures reproduced on the exact base commit `b848c65efa420be3da4bc408d9dc833977b4287c`:

- Slow shard 2/4: `SystemElectrolyteCPATest.testHydrateTemperatureWithMethanolAndSalt` fails with the same values on the [PR run](https://github.com/equinor/neqsim/actions/runs/31896062595) and [base `master` run](https://github.com/equinor/neqsim/actions/runs/31894800751).
- Slow shard 3/4: `HydrocarbonScrubberSaturationPressureStabilityTest.ordinaryAndEnhancedChecksRetainPhysicalSaturationBoundary` fails with the same expected/actual values on both runs.
- The base `master` run additionally has three unrelated Windows fast-test failures.

These production-test failures are unrelated to this PR's two-file scope: Javadoc prose and the Java 8 Maven repository URL. The targeted Javadoc gate passes.

## Impact

No runtime, thermodynamic, or public API behavior changes. Documentation impact is limited to correcting the Javadoc rendering.