### PR TITLE
fix(flash): retain cold water-rich stability seed

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1800,6 +1800,15 @@ Commercial process simulators do not publish all implementation details, but pub
   live system to rebuild the cubic/aqueous storage mapping; a recursion guard prevents fallback ping-pong. Genuine
   OIL+AQUEOUS liquid-liquid endpoints, already-feasible multiphase states, and dry systems do not run the additional
   flash.
+- For an ordinary neutral non-CPA water-rich asymmetric feed, the reciprocal multiphase calculation retains the cold
+  pre-iteration state instead of cloning the final endpoint. A post-flash clone can preserve collapsed phase-storage
+  and cubic-root history even after beta and compositions are reset, causing it to revisit a rejected three-phase
+  stationary point while the unchanged cold feed reaches a feasible OIL+AQUEOUS equilibrium. The cold seed is allocated
+  only when water feed is at least `0.01` and the existing critical-temperature/composition screen identifies an
+  asymmetric neutral mixture. Dry, CPA, chemical, ionic, solid, wax, and non-asymmetric water-bearing flashes remain on
+  their existing initialization paths. Seed provenance does not relax acceptance: exactly two distinct phases,
+  bounded and normalized beta/compositions, material balance and log-fugacity residuals below `1e-8`, and lower Gibbs
+  energy are still required.
 - A water-rich ordinary two-phase endpoint that fails the strict equilibrium gate can retain useful phase-composition
   information even when its cold multiphase candidate collapses to one phase. After that cold candidate is rejected,
   the existing split seeds one fully initialized `TPmultiflash` calculation. A water-rich multiphase endpoint that

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -649,6 +649,7 @@ public class TPflash extends Flash {
     int minGibbsPhase = 0;
     double minimumGibbsEnergy = 0;
 
+    BalancedTwoPhaseState balancedWaterRichInput = balancedWaterRichInputBeforeOrdinaryIteration();
     system.init(0);
     prepareMultiphaseEndpointRescueSeed();
     if (gammaPhiModel != null) {
@@ -1114,6 +1115,8 @@ public class TPflash extends Flash {
     refineInvalidNeutralTwoPhaseEndpoint();
     rescueLowerGibbsNeutralEndpoint();
     rescueSinglePhaseMultiphaseEndpoint();
+    restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(balancedWaterRichInput);
+    restoreLowerGibbsReferenceAfterSinglePhaseCollapse(balancedWaterRichInput);
     normalizeSourGasSinglePhaseEndpoint();
 
     // Final chemical equilibrium call after all phase reordering
@@ -1404,10 +1407,12 @@ public class TPflash extends Flash {
    * concentrates water. Full recursive flashing is avoided. A multiphase-enabled water-rich gas/aqueous endpoint uses
    * one cold ordinary candidate; a genuine oil/aqueous liquid-liquid endpoint remains on the multiphase path. A
    * water-rich multiphase endpoint that collapsed to one hydrocarbon phase also uses a cold ordinary candidate, whose
-   * invalid two-phase cubic-root split may seed the multiphase solver. For an ordinary endpoint, an existing invalid
-   * two-phase split is retained as the multiphase phase-set seed when the existing cold candidate is rejected. Trying
-   * the cold candidate first preserves its gas/oil cubic-root classification whenever it already reaches the same
-   * feasible equilibrium. The nested candidates cannot start a reciprocal fallback cycle. A candidate replaces the
+   * invalid two-phase cubic-root split may seed the multiphase solver. An ordinary neutral non-CPA water-rich asymmetric
+   * feed retains its pre-iteration state for this reciprocal calculation; cloning the final endpoint can retain the
+   * collapsed phase/root history and miss the cold phase set. For an ordinary endpoint, an existing invalid two-phase
+   * split is retained as the multiphase phase-set seed when the existing cold candidate is rejected. Trying the cold
+   * candidate first preserves its gas/oil cubic-root classification whenever it already reaches the same feasible
+   * equilibrium. The nested candidates cannot start a reciprocal fallback cycle. A candidate replaces the
    * original state only after strict phase-fraction, composition-normalization, material-balance, fugacity,
    * distinct-composition, and lower-Gibbs checks pass. A collapsed multiphase endpoint additionally requires the
    * candidate to restore the missing aqueous phase, keeping ordinary gas appearance outside this fallback's scope.
@@ -1458,7 +1463,10 @@ public class TPflash extends Flash {
     boolean ordinaryFallback = (gasAqueousMultiphaseEndpoint || singlePhaseWaterRichMultiphaseEndpoint)
         && waterFeedFraction >= WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT;
     SystemInterface candidate;
-    if (ordinaryFallback) {
+    if (!system.doMultiPhaseCheck() && multiphaseEndpointRescueSeed != null) {
+      candidate = multiphaseEndpointRescueSeed;
+      multiphaseEndpointRescueSeed = null;
+    } else if (ordinaryFallback) {
       double totalMoles = system.getTotalNumberOfMoles();
       double[] feedComposition = system.getzvector();
       candidate = system.phaseToSystem(0);
@@ -2296,23 +2304,79 @@ public class TPflash extends Flash {
    * <p>
    * Once a stability trial has collapsed a phase, cloning that endpoint also copies its local cubic-root and
    * phase-storage history. A later retry can then reproduce the same homogeneous minimum even though a cold flash finds
-   * a lower-Gibbs split. The seed is therefore captured before the two-phase iteration, but only for multiphase flashes
-   * or ordinary sour-gas flashes whose deterministic asymmetric and Wilson endpoint screens justify a possible retry.
-   * It is consumed at most once and cleared when the operation returns. Strong hydrocarbon Wilson splits retain the
-   * existing nearby-temperature continuation instead, so ordinary non-sour-gas flashes allocate nothing.
+   * a lower-Gibbs split. The seed is therefore captured before the two-phase iteration for multiphase flashes, ordinary
+   * sour-gas flashes whose deterministic asymmetric and Wilson endpoint screens justify a possible retry, and ordinary
+   * non-CPA water-rich asymmetric feeds whose post-flash clone may otherwise retain a collapsed phase history. It is
+   * consumed at most once and cleared when the operation returns. Ordinary dry, CPA, chemical, ionic, solid, wax, and
+   * non-asymmetric water-bearing flashes remain outside the additional cold-seed allocation.
    * </p>
    */
   private void prepareMultiphaseEndpointRescueSeed() {
     multiphaseEndpointRescueSeed = null;
     boolean ordinarySourGasCandidate = !system.doMultiPhaseCheck() && isSourGasConsistencyRefinementCase();
-    if ((!system.doMultiPhaseCheck() && !ordinarySourGasCandidate) || system.isChemicalSystem() || system.hasIons()
-        || solidCheck || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck() || directGammaPhiModel != null
-        || hybridEosGeFlashModel != null || system.getPhase(0).getNumberOfComponents() <= 1
-        || !hasPotentialAsymmetricNeutralInstability(MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN)
-        || !(hasPotentialMultiphaseEndpoint(PhaseType.GAS) || hasPotentialMultiphaseEndpoint(PhaseType.LIQUID))) {
+    boolean ordinaryWaterRichCandidate = hasPotentialWaterRichColdSeedInstability();
+    if ((!system.doMultiPhaseCheck() && !ordinarySourGasCandidate && !ordinaryWaterRichCandidate)
+        || system.isChemicalSystem() || system.hasIons() || solidCheck || system.doSolidPhaseCheck()
+        || system.isMultiphaseWaxCheck() || directGammaPhiModel != null || hybridEosGeFlashModel != null
+        || system.getPhase(0).getNumberOfComponents() <= 1
+        || (!ordinaryWaterRichCandidate
+            && (!hasPotentialAsymmetricNeutralInstability(MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN)
+                || !(hasPotentialMultiphaseEndpoint(PhaseType.GAS)
+                    || hasPotentialMultiphaseEndpoint(PhaseType.LIQUID))))) {
       return;
     }
     multiphaseEndpointRescueSeed = system.clone();
+  }
+
+  /**
+   * Screens an ordinary cubic-EOS water-rich asymmetric feed for a cold reciprocal-stability seed.
+   *
+   * <p>
+   * This screen mirrors the existing neutral liquid-liquid composition/critical-temperature gate while permitting the
+   * water component that defines this fallback. A substantial non-hydrocarbon fraction and a condensable hydrocarbon
+   * are both required, so ordinary hydrocarbon/water process flashes do not allocate a seed merely because water is
+   * present. The later multiphase solve and strict feasibility, equilibrium, and Gibbs gates decide stability.
+   * </p>
+   *
+   * @return true when retaining one cold pre-iteration state is justified
+   */
+  private boolean hasPotentialWaterRichColdSeedInstability() {
+    if (system.doMultiPhaseCheck()) {
+      return false;
+    }
+    String modelName = system.getModelName();
+    if (modelName != null && modelName.contains("CPA")) {
+      return false;
+    }
+    double waterFraction = 0.0;
+    double nonHydrocarbonFraction = 0.0;
+    double minimumCriticalTemperature = Double.POSITIVE_INFINITY;
+    double maximumCriticalTemperature = Double.NEGATIVE_INFINITY;
+    double condensableHydrocarbonFraction = 0.0;
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      double feedFraction = component.getz();
+      if (feedFraction <= LIQUID_LIQUID_ACTIVE_COMPONENT_LIMIT) {
+        continue;
+      }
+      if ("water".equalsIgnoreCase(component.getComponentName())) {
+        waterFraction += feedFraction;
+        nonHydrocarbonFraction += feedFraction;
+        continue;
+      }
+      double criticalTemperature = component.getTC();
+      minimumCriticalTemperature = Math.min(minimumCriticalTemperature, criticalTemperature);
+      maximumCriticalTemperature = Math.max(maximumCriticalTemperature, criticalTemperature);
+      if (!component.isHydrocarbon()) {
+        nonHydrocarbonFraction += feedFraction;
+      } else if (criticalTemperature > system.getTemperature() + MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN) {
+        condensableHydrocarbonFraction += feedFraction;
+      }
+    }
+    return waterFraction >= WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT
+        && nonHydrocarbonFraction >= LIQUID_LIQUID_NON_HYDROCARBON_FRACTION_LIMIT
+        && condensableHydrocarbonFraction >= WATER_RICH_REFINEMENT_FEED_FRACTION_LIMIT
+        && maximumCriticalTemperature - minimumCriticalTemperature >= LIQUID_LIQUID_CRITICAL_TEMPERATURE_SPAN;
   }
 
   /**
@@ -2711,6 +2775,36 @@ public class TPflash extends Flash {
       return null;
     }
     return new BalancedTwoPhaseState(system);
+  }
+
+  /**
+   * Captures a feasible water-rich ordinary input before the two-phase iteration mutates it.
+   *
+   * <p>
+   * Repeating an ordinary flash on an already converged OIL+AQUEOUS state can collapse the split before the reciprocal
+   * stability fallback runs. The retained state is eligible only when it is independently balanced and equilibrated at
+   * the current temperature, pressure, and composition. Changed-state inputs that are no longer equilibrium therefore
+   * cannot be restored as stale results.
+   * </p>
+   *
+   * @return balanced current-state snapshot, or {@code null} when repeat protection is not applicable
+   */
+  private BalancedTwoPhaseState balancedWaterRichInputBeforeOrdinaryIteration() {
+    if (system.doMultiPhaseCheck() || system.getNumberOfPhases() != 2 || !system.hasPhaseType(PhaseType.AQUEOUS)
+        || system.isChemicalSystem() || system.hasIons() || solidCheck || system.doSolidPhaseCheck()
+        || system.isMultiphaseWaxCheck()) {
+      return null;
+    }
+    SystemInterface candidate = system.clone();
+    try {
+      candidate.init(1);
+      if (isBalancedEquilibriumCandidate(candidate)) {
+        return new BalancedTwoPhaseState(candidate);
+      }
+    } catch (Exception ex) {
+      logger.debug("Water-rich input repeat snapshot failed: {}", ex.getMessage());
+    }
+    return null;
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -1407,12 +1407,12 @@ public class TPflash extends Flash {
    * concentrates water. Full recursive flashing is avoided. A multiphase-enabled water-rich gas/aqueous endpoint uses
    * one cold ordinary candidate; a genuine oil/aqueous liquid-liquid endpoint remains on the multiphase path. A
    * water-rich multiphase endpoint that collapsed to one hydrocarbon phase also uses a cold ordinary candidate, whose
-   * invalid two-phase cubic-root split may seed the multiphase solver. An ordinary neutral non-CPA water-rich asymmetric
-   * feed retains its pre-iteration state for this reciprocal calculation; cloning the final endpoint can retain the
-   * collapsed phase/root history and miss the cold phase set. For an ordinary endpoint, an existing invalid two-phase
-   * split is retained as the multiphase phase-set seed when the existing cold candidate is rejected. Trying the cold
-   * candidate first preserves its gas/oil cubic-root classification whenever it already reaches the same feasible
-   * equilibrium. The nested candidates cannot start a reciprocal fallback cycle. A candidate replaces the
+   * invalid two-phase cubic-root split may seed the multiphase solver. An ordinary neutral non-CPA water-rich
+   * asymmetric feed retains its pre-iteration state for this reciprocal calculation; cloning the final endpoint can
+   * retain the collapsed phase/root history and miss the cold phase set. For an ordinary endpoint, an existing invalid
+   * two-phase split is retained as the multiphase phase-set seed when the existing cold candidate is rejected. Trying
+   * the cold candidate first preserves its gas/oil cubic-root classification whenever it already reaches the same
+   * feasible equilibrium. The nested candidates cannot start a reciprocal fallback cycle. A candidate replaces the
    * original state only after strict phase-fraction, composition-normalization, material-balance, fugacity,
    * distinct-composition, and lower-Gibbs checks pass. A collapsed multiphase endpoint additionally requires the
    * candidate to restore the missing aqueous phase, keeping ordinary gas appearance outside this fallback's scope.
@@ -2319,10 +2319,9 @@ public class TPflash extends Flash {
         || system.isChemicalSystem() || system.hasIons() || solidCheck || system.doSolidPhaseCheck()
         || system.isMultiphaseWaxCheck() || directGammaPhiModel != null || hybridEosGeFlashModel != null
         || system.getPhase(0).getNumberOfComponents() <= 1
-        || (!ordinaryWaterRichCandidate
-            && (!hasPotentialAsymmetricNeutralInstability(MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN)
-                || !(hasPotentialMultiphaseEndpoint(PhaseType.GAS)
-                    || hasPotentialMultiphaseEndpoint(PhaseType.LIQUID))))) {
+        || (!ordinaryWaterRichCandidate && (!hasPotentialAsymmetricNeutralInstability(
+            MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN)
+            || !(hasPotentialMultiphaseEndpoint(PhaseType.GAS) || hasPotentialMultiphaseEndpoint(PhaseType.LIQUID))))) {
       return;
     }
     multiphaseEndpointRescueSeed = system.clone();

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -1228,8 +1228,8 @@ public class TPmultiflash extends TPflash {
    * A negative tangent-plane distance establishes that the current topology is unstable, but it does not determine the
    * equilibrium amount of the new phase. Seeding beta from the trial's dominant overall component can therefore
    * introduce an order-one material phase before the phase-fraction solve. Use the existing ordinary beta solver's
-   * regularization scale so the trial is incipient without being pinned below the solver's useful correction scale, then
-   * let the beta/equilibrium solve grow or remove it.
+   * regularization scale so the trial is incipient without being pinned below the solver's useful correction scale,
+   * then let the beta/equilibrium solve grow or remove it.
    * </p>
    *
    * @param dominantComponent index of the largest component in the trial composition

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterRichColdSeedConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterRichColdSeedConsistencyTest.java
@@ -10,8 +10,8 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 /** Regression coverage for cold-state reciprocal stability of water-rich cubic-EOS feeds. */
 class TPflashWaterRichColdSeedConsistencyTest extends neqsim.NeqSimTest {
-  private static final String[] COMPONENTS = {"CO2", "methane", "ethane", "nC10", "water"};
-  private static final double[] FEED = {0.74, 0.15, 0.05, 0.01, 0.05};
+  private static final String[] COMPONENTS = { "CO2", "methane", "ethane", "nC10", "water" };
+  private static final double[] FEED = { 0.74, 0.15, 0.05, 0.01, 0.05 };
 
   @Test
   void coldSeedRecoversBalancedOilAqueousEndpoint() {
@@ -39,10 +39,8 @@ class TPflashWaterRichColdSeedConsistencyTest extends neqsim.NeqSimTest {
 
   @Test
   void nearbyStatesAndChangedFeedRemainContinuousAndDeterministic() {
-    double[][] stablePoints = {
-        {229.0, 92.0}, {229.5, 92.0}, {230.0, 90.0}, {231.0, 88.0},
-        {231.0, 90.0}, {231.0, 92.0}, {232.0, 88.0}, {232.0, 92.0}, {234.0, 90.0}
-    };
+    double[][] stablePoints = { { 229.0, 92.0 }, { 229.5, 92.0 }, { 230.0, 90.0 }, { 231.0, 88.0 }, { 231.0, 90.0 },
+        { 231.0, 92.0 }, { 232.0, 88.0 }, { 232.0, 92.0 }, { 234.0, 90.0 } };
     for (double[] point : stablePoints) {
       SystemInterface ordinary = flash(createSystem(point[0], point[1], FEED, false), false);
       SystemInterface multiphase = flash(createSystem(point[0], point[1], FEED, true), false);
@@ -55,12 +53,11 @@ class TPflashWaterRichColdSeedConsistencyTest extends neqsim.NeqSimTest {
     continued = flash(continued, false);
     assertEquivalentOilAqueousState(continued, flash(createSystem(232.0, 90.0, FEED, true), false));
 
-    double[] nearbyFeed = {0.75, 0.15, 0.05, 0.01, 0.04};
+    double[] nearbyFeed = { 0.75, 0.15, 0.05, 0.01, 0.04 };
     continued.setTemperature(230.0, "K");
     continued.setMolarComposition(nearbyFeed);
     continued = flash(continued, false);
-    assertEquivalentOilAqueousState(continued,
-        flash(createSystem(230.0, 90.0, nearbyFeed, true), false));
+    assertEquivalentOilAqueousState(continued, flash(createSystem(230.0, 90.0, nearbyFeed, true), false));
 
     continued.setMolarComposition(FEED);
     continued = flash(continued, false);
@@ -77,8 +74,8 @@ class TPflashWaterRichColdSeedConsistencyTest extends neqsim.NeqSimTest {
     assertTrue(maximumComponentBalanceResidual(multiphase) < 1.0e-10);
   }
 
-  private static SystemInterface createSystem(double temperature, double pressure,
-      double[] composition, boolean multiphase) {
+  private static SystemInterface createSystem(double temperature, double pressure, double[] composition,
+      boolean multiphase) {
     SystemInterface system = new SystemSrkEos(temperature, pressure);
     for (int component = 0; component < COMPONENTS.length; component++) {
       system.addComponent(COMPONENTS[component], composition[component]);
@@ -108,7 +105,7 @@ class TPflashWaterRichColdSeedConsistencyTest extends neqsim.NeqSimTest {
     assertPhysicalEquilibrium(first);
     assertPhysicalEquilibrium(second);
 
-    for (PhaseType type : new PhaseType[] {PhaseType.OIL, PhaseType.AQUEOUS}) {
+    for (PhaseType type : new PhaseType[] { PhaseType.OIL, PhaseType.AQUEOUS }) {
       assertEquals(first.getPhase(type.getDesc()).getBeta(), second.getPhase(type.getDesc()).getBeta(), 1.0e-10);
       assertEquals(first.getPhase(type.getDesc()).getZ(), second.getPhase(type.getDesc()).getZ(), 1.0e-10);
       assertCompositionEquals(phaseComposition(first, type), phaseComposition(second, type), 1.0e-10);
@@ -150,8 +147,7 @@ class TPflashWaterRichColdSeedConsistencyTest extends neqsim.NeqSimTest {
       for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
         recovered += system.getBeta(phase) * system.getPhase(phase).getComponent(component).getx();
       }
-      maximum = Math.max(maximum,
-          Math.abs(system.getPhase(0).getComponent(component).getz() - recovered));
+      maximum = Math.max(maximum, Math.abs(system.getPhase(0).getComponent(component).getz() - recovered));
     }
     return maximum;
   }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterRichColdSeedConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterRichColdSeedConsistencyTest.java
@@ -1,0 +1,185 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Regression coverage for cold-state reciprocal stability of water-rich cubic-EOS feeds. */
+class TPflashWaterRichColdSeedConsistencyTest extends neqsim.NeqSimTest {
+  private static final String[] COMPONENTS = {"CO2", "methane", "ethane", "nC10", "water"};
+  private static final double[] FEED = {0.74, 0.15, 0.05, 0.01, 0.05};
+
+  @Test
+  void coldSeedRecoversBalancedOilAqueousEndpoint() {
+    SystemInterface ordinary = flash(createSystem(230.0, 90.0, FEED, false), false);
+    SystemInterface multiphase = flash(createSystem(230.0, 90.0, FEED, true), false);
+
+    assertEquivalentOilAqueousState(ordinary, multiphase);
+    assertEquals(0.95019632, ordinary.getPhase("oil").getBeta(), 1.0e-8);
+    assertEquals(0.04980368, ordinary.getPhase("aqueous").getBeta(), 1.0e-8);
+
+    SystemInterface poorGuess = flash(createSystem(230.0, 90.0, FEED, false), true);
+    assertEquivalentOilAqueousState(ordinary, poorGuess);
+
+    double firstGibbsEnergy = ordinary.getGibbsEnergy();
+    double firstOilBeta = ordinary.getPhase("oil").getBeta();
+    double[] firstOilComposition = phaseComposition(ordinary, PhaseType.OIL);
+    new ThermodynamicOperations(ordinary).TPflash();
+    ordinary.init(1);
+
+    assertEquals(firstGibbsEnergy, ordinary.getGibbsEnergy(), 1.0e-6);
+    assertEquals(firstOilBeta, ordinary.getPhase("oil").getBeta(), 1.0e-12);
+    assertCompositionEquals(firstOilComposition, phaseComposition(ordinary, PhaseType.OIL), 1.0e-12);
+    assertPhysicalEquilibrium(ordinary);
+  }
+
+  @Test
+  void nearbyStatesAndChangedFeedRemainContinuousAndDeterministic() {
+    double[][] stablePoints = {
+        {229.0, 92.0}, {229.5, 92.0}, {230.0, 90.0}, {231.0, 88.0},
+        {231.0, 90.0}, {231.0, 92.0}, {232.0, 88.0}, {232.0, 92.0}, {234.0, 90.0}
+    };
+    for (double[] point : stablePoints) {
+      SystemInterface ordinary = flash(createSystem(point[0], point[1], FEED, false), false);
+      SystemInterface multiphase = flash(createSystem(point[0], point[1], FEED, true), false);
+      assertEquivalentOilAqueousState(ordinary, multiphase);
+    }
+
+    SystemInterface continued = flash(createSystem(230.0, 90.0, FEED, false), false);
+    continued.setTemperature(232.0, "K");
+    continued.setPressure(90.0, "bara");
+    continued = flash(continued, false);
+    assertEquivalentOilAqueousState(continued, flash(createSystem(232.0, 90.0, FEED, true), false));
+
+    double[] nearbyFeed = {0.75, 0.15, 0.05, 0.01, 0.04};
+    continued.setTemperature(230.0, "K");
+    continued.setMolarComposition(nearbyFeed);
+    continued = flash(continued, false);
+    assertEquivalentOilAqueousState(continued,
+        flash(createSystem(230.0, 90.0, nearbyFeed, true), false));
+
+    continued.setMolarComposition(FEED);
+    continued = flash(continued, false);
+    assertEquivalentOilAqueousState(continued, flash(createSystem(230.0, 90.0, FEED, true), false));
+  }
+
+  @Test
+  void genuineThreePhaseCandidateIsNotForcedIntoTwoPhaseAcceptance() {
+    SystemInterface ordinary = flash(createSystem(230.0, 91.0, FEED, false), false);
+    SystemInterface multiphase = flash(createSystem(230.0, 91.0, FEED, true), false);
+
+    assertTrue(ordinary.getNumberOfPhases() < 3);
+    assertEquals(3, multiphase.getNumberOfPhases());
+    assertTrue(maximumComponentBalanceResidual(multiphase) < 1.0e-10);
+  }
+
+  private static SystemInterface createSystem(double temperature, double pressure,
+      double[] composition, boolean multiphase) {
+    SystemInterface system = new SystemSrkEos(temperature, pressure);
+    for (int component = 0; component < COMPONENTS.length; component++) {
+      system.addComponent(COMPONENTS[component], composition[component]);
+    }
+    system.setMixingRule(2);
+    system.setMultiPhaseCheck(multiphase);
+    return system;
+  }
+
+  private static SystemInterface flash(SystemInterface system, boolean poorGuess) {
+    if (poorGuess) {
+      system.setBeta(0, 1.0e-10);
+      system.setBeta(1, 1.0 - 1.0e-10);
+    }
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private static void assertEquivalentOilAqueousState(SystemInterface first, SystemInterface second) {
+    assertEquals(2, first.getNumberOfPhases());
+    assertEquals(2, second.getNumberOfPhases());
+    assertTrue(first.hasPhaseType(PhaseType.OIL));
+    assertTrue(first.hasPhaseType(PhaseType.AQUEOUS));
+    assertTrue(second.hasPhaseType(PhaseType.OIL));
+    assertTrue(second.hasPhaseType(PhaseType.AQUEOUS));
+    assertPhysicalEquilibrium(first);
+    assertPhysicalEquilibrium(second);
+
+    for (PhaseType type : new PhaseType[] {PhaseType.OIL, PhaseType.AQUEOUS}) {
+      assertEquals(first.getPhase(type.getDesc()).getBeta(), second.getPhase(type.getDesc()).getBeta(), 1.0e-10);
+      assertEquals(first.getPhase(type.getDesc()).getZ(), second.getPhase(type.getDesc()).getZ(), 1.0e-10);
+      assertCompositionEquals(phaseComposition(first, type), phaseComposition(second, type), 1.0e-10);
+    }
+    assertEquals(first.getGibbsEnergy(), second.getGibbsEnergy(), 1.0e-6);
+  }
+
+  private static void assertPhysicalEquilibrium(SystemInterface system) {
+    assertEquals(1.0, betaSum(system), 1.0e-12);
+    for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+      assertTrue(system.getBeta(phase) >= 0.0 && system.getBeta(phase) <= 1.0);
+      double compositionSum = 0.0;
+      for (int component = 0; component < system.getPhase(phase).getNumberOfComponents(); component++) {
+        double composition = system.getPhase(phase).getComponent(component).getx();
+        assertTrue(Double.isFinite(composition));
+        assertTrue(composition >= 0.0 && composition <= 1.0);
+        compositionSum += composition;
+      }
+      assertEquals(1.0, compositionSum, 1.0e-12);
+    }
+    assertTrue(maximumComponentBalanceResidual(system) < 1.0e-10);
+    if (system.getNumberOfPhases() == 2) {
+      assertTrue(maximumLogFugacityResidual(system) < 1.0e-8);
+    }
+  }
+
+  private static double betaSum(SystemInterface system) {
+    double sum = 0.0;
+    for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+      sum += system.getBeta(phase);
+    }
+    return sum;
+  }
+
+  private static double maximumComponentBalanceResidual(SystemInterface system) {
+    double maximum = 0.0;
+    for (int component = 0; component < system.getPhase(0).getNumberOfComponents(); component++) {
+      double recovered = 0.0;
+      for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+        recovered += system.getBeta(phase) * system.getPhase(phase).getComponent(component).getx();
+      }
+      maximum = Math.max(maximum,
+          Math.abs(system.getPhase(0).getComponent(component).getz() - recovered));
+    }
+    return maximum;
+  }
+
+  private static double maximumLogFugacityResidual(SystemInterface system) {
+    double maximum = 0.0;
+    for (int component = 0; component < system.getPhase(0).getNumberOfComponents(); component++) {
+      double first = system.getPhase(0).getComponent(component).getx()
+          * system.getPhase(0).getComponent(component).getFugacityCoefficient();
+      double second = system.getPhase(1).getComponent(component).getx()
+          * system.getPhase(1).getComponent(component).getFugacityCoefficient();
+      maximum = Math.max(maximum, Math.abs(Math.log(first / second)));
+    }
+    return maximum;
+  }
+
+  private static double[] phaseComposition(SystemInterface system, PhaseType type) {
+    double[] composition = new double[system.getPhase(type.getDesc()).getNumberOfComponents()];
+    for (int component = 0; component < composition.length; component++) {
+      composition[component] = system.getPhase(type.getDesc()).getComponent(component).getx();
+    }
+    return composition;
+  }
+
+  private static void assertCompositionEquals(double[] expected, double[] actual, double tolerance) {
+    assertEquals(expected.length, actual.length);
+    for (int component = 0; component < expected.length; component++) {
+      assertEquals(expected[component], actual[component], tolerance);
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Advances #2937.

On exact master `b848c65efa420be3da4bc408d9dc833977b4287c`, an ordinary neutral SRK TPflash can collapse a CO2-rich/water feed to an invalid single OIL phase while explicit multiphase TPflash finds a balanced, fugacity-equilibrated OIL+AQUEOUS equilibrium.

Minimal normalized reproducer: `SystemSrkEos`, classic mixing rule 2, 230 K, 90 bara; CO2/methane/ethane/nC10/water = `0.74/0.15/0.05/0.01/0.05`.

| Path on master | State | Component-balance residual | Gibbs (J) |
|---|---|---:|---:|
| ordinary | OIL, beta 1 | 3.232e-5 | 2961.622862408 |
| explicit multiphase | OIL+AQUEOUS, beta 0.95019632 / 0.049803679 | 1.202e-14 | 2555.037971823 |

The missed Gibbs reduction is `406.584890585 J`; the multiphase maximum log-fugacity residual is `2.931e-13`.

This became an applicable two-phase comparison after merged #3026 improved incipient Wilson trial seeding. It does not change or duplicate that Wilson-seed algorithm.

## Root cause

The existing water-rich reciprocal fallback cloned the final ordinary endpoint. Even after resetting beta, composition, and Wilson K-values, that clone retained collapsed phase-storage/cubic-root history and revisited a rejected three-phase stationary point. The unchanged cold feed reached the feasible two-phase equilibrium.

A repeated ordinary flash exposed the reciprocal stale-state problem: after the first corrected OIL+AQUEOUS result, the ordinary iteration could collapse it again before fallback acceptance.

## Method

For an ordinary, neutral, non-CPA, water-rich asymmetric cubic-EOS feed, retain one pre-iteration system state for the already-existing reciprocal multiphase stability calculation. The allocation screen requires:

1. water feed at least `0.01`;
2. non-hydrocarbon feed at least `0.20`;
3. condensable-hydrocarbon feed at least `0.01` with `T_c > T + 80 K`;
4. active-component critical-temperature span at least 150 K.

These values are performance screens, not stability decisions. The existing candidate gate remains authoritative: exactly two distinct phases, finite bounded normalized beta/compositions, component balance and interphase log-fugacity residual below `1e-8`, and a lower extensive Gibbs energy.

A compact input-state snapshot protects repeat execution only when the existing two-phase aqueous input independently passes those same closure/equilibrium checks at the current T/P/composition. Changed-state inputs cannot restore a stale snapshot.

The method follows Michelsen's stability/phase-split separation: a trial establishes instability, while the equilibrium solve and Gibbs comparison determine the accepted phase amount and state:

- Michelsen, *The isothermal flash problem. Part I. Stability*, Fluid Phase Equilibria 9 (1982), https://doi.org/10.1016/0378-3812(82)85001-2.
- Michelsen, *The isothermal flash problem. Part II. Phase-split calculation*, Fluid Phase Equilibria 9 (1982), https://doi.org/10.1016/0378-3812(82)85002-4.

## Before/after evidence

Focused regression:

- exact master source plus current merged `TPmultiflash`: 1/3 methods pass;
- candidate: 3/3 methods pass.

At the exact reproducer after the change:

- ordinary and multiphase both return OIL+AQUEOUS;
- beta, phase compositions, and compressibility factors agree within `1e-10`;
- ordinary component-balance residual: `1.202e-14`;
- ordinary log-fugacity residual: `2.52e-13`;
- ordinary/multiphase Gibbs difference: `2.55e-9 J`.

Coverage includes poor beta `1e-10 / (1 - 1e-10)`, deterministic repeat, same-object T/P and composition changes, nine nearby stable two-phase points from 229–234 K and 88–92 bara, and a genuine three-phase point that remains outside two-phase acceptance.

The frozen 444-state PR/SRK/CPA, hydrocarbon/oil/water, CO2-rich, H2-rich, near-critical, large-volatility-contrast, trace-water, and supported-electrolyte matrix completed with zero exceptions:

| Metric | Master | Candidate |
|---|---:|---:|
| applicable one/two-phase comparisons | 304 | 304 |
| genuine three-phase results | 140 | 140 |
| invalid ordinary endpoints | 16 | 15 |
| material ordinary/multiphase differences | 15 | 14 |
| invalid multiphase endpoints | 22 | 22 |

No new disagreement appeared. Existing invalid UMR configuration and reactive-electrolyte comparisons, plus genuine three-phase projections, remain outside this increment.

## Performance

No speedup is claimed. Separate-process warmed complete-flash medians were noisy:

| Case | Master | Candidate |
|---|---:|---:|
| affected 230 K/90 bara | 11.48 ms (wrong) | 12.41 ms (correct) |
| already-valid 234 K/90 bara aqueous control | 12.17 ms | 12.05 ms |
| guard-false dry SRK control | 6.91 ms | 7.38 ms |

The dry-path timing difference is treated as process noise because the screen returns before any new allocation or flash. The correctness path retains one cold clone instead of allocating the previous post-flash candidate clone; repeated already-equilibrated aqueous inputs additionally allocate one compact validation snapshot.

## Tests and validation

Local support validation used OpenJDK 17.0.19, exact connector-fetched master source compiled through the `jdk.compiler` module, and the installed NeqSim 3.17.0 runtime for unchanged dependencies:

- direct candidate source compilation: passed;
- new focused regression: 3/3 passed;
- new regression plus the current CPA liquid-stability and sour-gas consistency regressions: 10/10 passed;
- exact-master fail-before-fix run: 1/3 passed;
- broader deterministic matrix: 444 states, zero exceptions.

**VALIDATION PENDING CI.** The working directory is not a full repository checkout. Required repository commands were attempted and are not claimed as passing:

- `python devtools/run_spotless.py apply` — blocked: script absent;
- `python devtools/run_spotless.py check` — blocked: script absent;
- `python devtools/check_documentation_search.py` — blocked: script absent;
- `pre-commit ... pre-commit/pre-push` — blocked: executable absent.

Hosted exact-head Spotless, pre-commit, documentation search, Java 8/21 fast and slow suites, Javadocs, CodeQL, and relevant repository checks are required before merge readiness.

## Compatibility and risk

No public API, serialized field, EOS parameter, mixing rule, phase-fraction equation, convergence tolerance, or `TPmultiflash` kernel changes. CPA, dry, chemical/electrolyte, ionic, solid, wax, and non-asymmetric water-bearing feeds are excluded from the new cold-seed screen. A genuine or rejected three-phase candidate cannot replace the ordinary endpoint.

The principal risk is an extra early clone for a neutral non-CPA water-rich asymmetric feed whose ordinary endpoint is already valid; the focused control showed no measurable regression, but hosted broader timing is still informative.

## Documentation impact

Updated private-method Javadocs and `docs/thermodynamicoperations/TPflash_algorithm.md` to document cold-versus-post-flash seed provenance, the allocation screen, strict acceptance gate, exclusions, repeat-state guard, and solver cost. No notebook changed.

## Scope boundary

No Column Solver, Process Performance, process caching, public Huldra dataset, digital-twin, diagram/control, or Huldra acceptance work is included. No merge, auto-merge, ready-for-review transition, or master write is requested.

## Current exact-head CI assessment

**VALIDATION BLOCKED BY PRE-EXISTING MASTER FAILURES** on head `792eb1018c1b57c0d27680f454813ed1f56264c6`, based on master `9a371fb1448bb713990072c2d3d4a291c71dab68`.

Passing hosted checks: pre-commit, Spotless format patch, documentation search coverage, CodeQL, PaperLab replication gate, Java 21 Javadoc, slow shards 1/4 and 4/4. Focused Maven validation on the exact merged checkout passed the new regression together with `TPflashCpaHydrocarbonLiquidStabilityTest` and `TPflashSourGasConsistencyTest` (10 tests, 0 failures).

The aggregate build workflow is red only for failures independently reproduced on the exact master baseline or already present with identical values on the merged predecessor PR #3026:

- `HydrocarbonScrubberSaturationPressureStabilityTest`: expected 105.9 bara; master and this head both return `72.24446868896484` bara.
- `SystemElectrolyteCPATest#testHydrateTemperatureWithMethanolAndSalt`: master and this head both return `-4.562619195803904 °C` (methanol) and `-2.4559782474698864 °C` (methanol + salt).
- Windows fast suite: `EclipseFluidReadWriteTest.testFluidWater3`, `TPflashIncipientPhaseStabilityTest.subResidualTpdDoesNotOverrideExistingUmrPruSolution`, and `TPFlashTest.testRun5` fail with the same values on predecessor PR #3026 before this tranche existed.

These baseline defects were not folded into this PR. The branch is mergeable, 0 commits behind master, has no review threads, and the final diff is limited to `TPflash.java`, its focused regression, and TP-flash algorithm documentation. It is **not classified READY TO MERGE** while the required aggregate workflow remains unsuccessful.