### PR TITLE
[AI-Assisted] feat(dynamics): transact thermodynamic limit analysers

### DIFF
--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -488,6 +488,27 @@ also fail closed. This gate proves numerical rollback mechanics only; it does no
 input reliability, ESD action, safety integrity, external DCS/I/O, virtual commissioning or OTS
 use.
 
+## Thermodynamic-limit analyser transaction coverage
+
+Concrete local `CricondenbarAnalyser`, `HydrateEquilibriumTemperatureAnalyser`,
+`HydrocarbonDewPointAnalyser`, and `WaterDewPointAnalyser` instances participate when registered
+as measurement devices in a `ProcessSystem`. Every snapshot preserves stable transaction identity,
+the original stream binding and complete inherited measurement/alarm state. The hydrate analyser
+also preserves its reference pressure; both dew-point analysers preserve reference pressure and
+method.
+
+Together with the existing `EventScheduler` snapshot, this closes scheduled in-memory changes to
+those analyser bindings and settings. Quantitative evidence covers four coordinated
+`ProcessModel` areas, exact reference-pressure and method rollback, deterministic Bukacek result
+replay, delayed-alarm continuation, commit, foreign/null snapshots and Java-serialization restart
+for every family member.
+
+Concrete descendants and online/external-I/O operation fail closed. The thermodynamic calculations
+continue to use temporary fluid clones and are unchanged by this transaction contract. This gate
+does not newly validate phase-envelope, dew-point, hydrate or empirical-correlation physics, fluid
+characterization, sampling, analyser accuracy, alarm/trip integrity, external I/O, virtual
+commissioning or OTS use.
+
 ## State-mutating derived-instrument transaction coverage
 
 Concrete local `pHProbe`, `SoftSensor`, and `FlowInducedVibrationAnalyser` instances participate

--- a/docs/process/equipment/measurement_devices.md
+++ b/docs/process/equipment/measurement_devices.md
@@ -83,7 +83,7 @@ import neqsim.process.measurementdevice.HydrocarbonDewPointAnalyser;
 
 HydrocarbonDewPointAnalyser hcdp =
     new HydrocarbonDewPointAnalyser("HC Dew Point", gasStream);
-hcdp.setReferencePressure(50.0, "bara");
+hcdp.setReferencePressure(50.0);  // bara
 
 double dewPointC = hcdp.getMeasuredValue("C");  // hydrocarbon dew point, degC
 ```
@@ -97,7 +97,7 @@ import neqsim.process.measurementdevice.WaterDewPointAnalyser;
 
 WaterDewPointAnalyser wdp =
     new WaterDewPointAnalyser("Water Dew Point", gasStream);
-wdp.setReferencePressure(50.0, "bara");
+wdp.setReferencePressure(50.0);  // bara
 
 double waterDewPoint = wdp.getMeasuredValue("C");  // water dew point, degC
 ```
@@ -124,6 +124,18 @@ HydrateEquilibriumTemperatureAnalyser hydrateAnalyser =
     new HydrateEquilibriumTemperatureAnalyser(gasStream);
 double hydrateTemp = hydrateAnalyser.getMeasuredValue("C");  // hydrate formation temperature, degC
 ```
+
+Concrete local instances of these four thermodynamic-limit analysers participate in transient-step
+transactions when registered in a `ProcessSystem`. Rollback restores each stream binding and
+complete inherited measurement/alarm state. It also restores reference pressure for the hydrate,
+hydrocarbon-dew-point and water-dew-point analysers, plus the configured method for both dew-point
+analysers. Scheduled configuration changes therefore replay together with `EventScheduler`
+pending/fired bookkeeping, and Java serialization preserves identity and restart state.
+
+Concrete descendants and online-signal operation fail closed. This support changes no phase
+envelope, dew-point, hydrate or empirical correlation. It establishes rollback mechanics only; it
+does not qualify thermodynamic model selection, fluid characterization, sampling, analyser
+accuracy, alarm/trip integrity, external I/O, virtual commissioning or OTS use.
 
 ## Vibration Analysis
 

--- a/src/main/java/neqsim/process/measurementdevice/CricondenbarAnalyser.java
+++ b/src/main/java/neqsim/process/measurementdevice/CricondenbarAnalyser.java
@@ -1,7 +1,10 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -10,12 +13,19 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
 /**
  * CricondenbarAnalyser class.
  *
+ * <p>
+ * Concrete local instances participate in transient-step transactions. The snapshot restores the stream binding and
+ * inherited measurement/alarm state. Descendants and online-signal operation remain fail-closed.
+ *
  * @author ESOL
  * @version $Id: $Id
  */
-public class CricondenbarAnalyser extends StreamMeasurementDeviceBaseClass {
+public class CricondenbarAnalyser extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<CricondenbarAnalyser.CricondenbarAnalyserState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(CricondenbarAnalyser.class);
 
@@ -90,5 +100,63 @@ public class CricondenbarAnalyser extends StreamMeasurementDeviceBaseClass {
       logger.error(ex.getMessage(), ex);
     }
     return thermoOps.getSaturationPressure();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:cricondenbar:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local analyser.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != CricondenbarAnalyser.class) {
+      return "cricondenbar-analyser subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public CricondenbarAnalyserState captureTransientState() {
+    return new CricondenbarAnalyserState(getTransientStateIdentity(), stream, captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(CricondenbarAnalyserState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Cricondenbar analyser transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Cricondenbar analyser snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable cricondenbar-analyser rollback point. */
+  public static final class CricondenbarAnalyserState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private CricondenbarAnalyserState(String stateIdentity, StreamInterface stream,
+        MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/HydrateEquilibriumTemperatureAnalyser.java
+++ b/src/main/java/neqsim/process/measurementdevice/HydrateEquilibriumTemperatureAnalyser.java
@@ -1,7 +1,10 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -10,12 +13,19 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
 /**
  * HydrateEquilibriumTemperatureAnalyser class.
  *
+ * <p>
+ * Concrete local instances participate in transient-step transactions. The snapshot restores the stream binding,
+ * reference pressure and inherited measurement/alarm state. Descendants and online-signal operation remain fail-closed.
+ *
  * @author ESOL
  * @version $Id: $Id
  */
-public class HydrateEquilibriumTemperatureAnalyser extends StreamMeasurementDeviceBaseClass {
+public class HydrateEquilibriumTemperatureAnalyser extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<HydrateEquilibriumTemperatureAnalyser.HydrateAnalyserState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(HydrateEquilibriumTemperatureAnalyser.class);
 
@@ -81,5 +91,67 @@ public class HydrateEquilibriumTemperatureAnalyser extends StreamMeasurementDevi
    */
   public void setReferencePressure(double referencePressure) {
     this.referencePressure = referencePressure;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:hydrate-equilibrium-temperature:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local analyser.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != HydrateEquilibriumTemperatureAnalyser.class) {
+      return "hydrate-equilibrium-temperature-analyser subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public HydrateAnalyserState captureTransientState() {
+    return new HydrateAnalyserState(getTransientStateIdentity(), stream, referencePressure,
+        captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(HydrateAnalyserState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Hydrate analyser transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Hydrate analyser snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    referencePressure = snapshot.referencePressure;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable hydrate-equilibrium-temperature-analyser rollback point. */
+  public static final class HydrateAnalyserState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final double referencePressure;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private HydrateAnalyserState(String stateIdentity, StreamInterface stream, double referencePressure,
+        MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.referencePressure = referencePressure;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/HydrocarbonDewPointAnalyser.java
+++ b/src/main/java/neqsim/process/measurementdevice/HydrocarbonDewPointAnalyser.java
@@ -1,21 +1,32 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
 /**
- * WaterDewPointAnalyser class.
+ * HydrocarbonDewPointAnalyser class.
+ *
+ * <p>
+ * Concrete local instances participate in transient-step transactions. The snapshot restores the stream binding,
+ * reference pressure, method and inherited measurement/alarm state. Descendants and online-signal operation remain
+ * fail-closed.
  *
  * @author ESOL
  * @version $Id: $Id
  */
-public class HydrocarbonDewPointAnalyser extends StreamMeasurementDeviceBaseClass {
+public class HydrocarbonDewPointAnalyser extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<HydrocarbonDewPointAnalyser.HydrocarbonDewPointAnalyserState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(WaterDewPointAnalyser.class);
 
@@ -108,5 +119,70 @@ public class HydrocarbonDewPointAnalyser extends StreamMeasurementDeviceBaseClas
    */
   public void setMethod(String method) {
     this.method = method;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:hydrocarbon-dew-point:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local analyser.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != HydrocarbonDewPointAnalyser.class) {
+      return "hydrocarbon-dew-point-analyser subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public HydrocarbonDewPointAnalyserState captureTransientState() {
+    return new HydrocarbonDewPointAnalyserState(getTransientStateIdentity(), stream, referencePressure, method,
+        captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(HydrocarbonDewPointAnalyserState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Hydrocarbon-dew-point analyser transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Hydrocarbon-dew-point analyser snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    referencePressure = snapshot.referencePressure;
+    method = snapshot.method;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable hydrocarbon-dew-point-analyser rollback point. */
+  public static final class HydrocarbonDewPointAnalyserState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final double referencePressure;
+    private final String method;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private HydrocarbonDewPointAnalyserState(String stateIdentity, StreamInterface stream, double referencePressure,
+        String method, MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.referencePressure = referencePressure;
+      this.method = method;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/WaterDewPointAnalyser.java
+++ b/src/main/java/neqsim/process/measurementdevice/WaterDewPointAnalyser.java
@@ -1,7 +1,10 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.util.empiric.BukacekWaterInGas;
@@ -11,12 +14,20 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
 /**
  * WaterDewPointAnalyser class.
  *
+ * <p>
+ * Concrete local instances participate in transient-step transactions. The snapshot restores the stream binding,
+ * reference pressure, method and inherited measurement/alarm state. Descendants and online-signal operation remain
+ * fail-closed.
+ *
  * @author ESOL
  * @version $Id: $Id
  */
-public class WaterDewPointAnalyser extends StreamMeasurementDeviceBaseClass {
+public class WaterDewPointAnalyser extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<WaterDewPointAnalyser.WaterDewPointAnalyserState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(WaterDewPointAnalyser.class);
 
@@ -152,5 +163,70 @@ public class WaterDewPointAnalyser extends StreamMeasurementDeviceBaseClass {
    */
   public void setMethod(String method) {
     this.method = method;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:water-dew-point:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local analyser.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != WaterDewPointAnalyser.class) {
+      return "water-dew-point-analyser subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public WaterDewPointAnalyserState captureTransientState() {
+    return new WaterDewPointAnalyserState(getTransientStateIdentity(), stream, referencePressure, method,
+        captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(WaterDewPointAnalyserState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Water-dew-point analyser transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Water-dew-point analyser snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    referencePressure = snapshot.referencePressure;
+    method = snapshot.method;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable water-dew-point-analyser rollback point. */
+  public static final class WaterDewPointAnalyserState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final double referencePressure;
+    private final String method;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private WaterDewPointAnalyserState(String stateIdentity, StreamInterface stream, double referencePressure,
+        String method, MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.referencePressure = referencePressure;
+      this.method = method;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/test/java/neqsim/process/measurementdevice/ThermodynamicLimitAnalyserTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/ThermodynamicLimitAnalyserTransientStateTransactionTest.java
@@ -1,0 +1,275 @@
+package neqsim.process.measurementdevice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import neqsim.process.alarm.AlarmConfig;
+import neqsim.process.alarm.AlarmState;
+import neqsim.process.dynamics.EventScheduler;
+import neqsim.process.dynamics.TransientStepTransaction;
+import neqsim.process.dynamics.TransientTransactionCoverage;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Transaction, replay, restart, and blocker evidence for local thermodynamic-limit analysers. */
+class ThermodynamicLimitAnalyserTransientStateTransactionTest extends neqsim.NeqSimTest {
+  @Test
+  void multiAreaRollbackRestoresScheduledConfigurationAndAlarmState() {
+    StreamInterface originalStream = createGasStream("original gas", 22.0e-6);
+    StreamInterface trialStream = createGasStream("trial gas", 35.0e-6);
+
+    CricondenbarAnalyser cricondenbar = new CricondenbarAnalyser("cricondenbar", originalStream);
+    HydrateEquilibriumTemperatureAnalyser hydrate = new HydrateEquilibriumTemperatureAnalyser("hydrate equilibrium",
+        originalStream);
+    HydrocarbonDewPointAnalyser hydrocarbon = new HydrocarbonDewPointAnalyser("hydrocarbon dew point", originalStream);
+    WaterDewPointAnalyser water = new WaterDewPointAnalyser("water dew point", originalStream);
+    water.setAlarmConfig(AlarmConfig.builder().highLimit(-30.0).delay(2.0).unit("C").build());
+    AlarmState originalAlarmState = water.getAlarmState();
+    double originalWaterDewPoint = water.getMeasuredValue("C");
+
+    ProcessSystem cricondenbarArea = area("cricondenbar area", cricondenbar);
+    ProcessSystem hydrateArea = area("hydrate area", hydrate);
+    ProcessSystem hydrocarbonArea = area("hydrocarbon area", hydrocarbon);
+    ProcessSystem waterArea = area("water area", water);
+
+    ProcessModel model = new ProcessModel();
+    model.add("cricondenbar", cricondenbarArea);
+    model.add("hydrate", hydrateArea);
+    model.add("hydrocarbon", hydrocarbonArea);
+    model.add("water", waterArea);
+    assertCompleteCoverage(model.getTransientTransactionCoverage(), 4);
+
+    cricondenbarArea.getEventScheduler().scheduleEvent(1.0, "change cricondenbar binding",
+        () -> cricondenbar.setStream(trialStream));
+    hydrateArea.getEventScheduler().scheduleEvent(1.0, "change hydrate conditions", () -> {
+      hydrate.setStream(trialStream);
+      hydrate.setReferencePressure(80.0);
+    });
+    hydrocarbonArea.getEventScheduler().scheduleEvent(1.0, "change hydrocarbon conditions", () -> {
+      hydrocarbon.setStream(trialStream);
+      hydrocarbon.setReferencePressure(40.0);
+      hydrocarbon.setMethod("trial method");
+    });
+    waterArea.getEventScheduler().scheduleEvent(1.0, "change water conditions", () -> {
+      water.setStream(trialStream);
+      water.setReferencePressure(60.0);
+      water.setMethod("multiphase");
+    });
+
+    String waterIdentity = water.getTransientStateIdentity();
+    TransientStepTransaction transaction = model.beginTransientStepTransaction();
+    fireAll(cricondenbarArea, hydrateArea, hydrocarbonArea, waterArea);
+    assertTrue(water.evaluateAlarm(-20.0, 1.0, 1.0).isEmpty());
+    transaction.rollback();
+
+    assertEquals(waterIdentity, water.getTransientStateIdentity());
+    assertSame(originalStream, cricondenbar.getStream());
+    assertSame(originalStream, hydrate.getStream());
+    assertSame(originalStream, hydrocarbon.getStream());
+    assertSame(originalStream, water.getStream());
+    assertEquals(0.0, hydrate.getReferencePressure(), 0.0);
+    assertEquals(50.0, hydrocarbon.getReferencePressure(), 0.0);
+    assertEquals("EOS", hydrocarbon.getMethod());
+    assertEquals(70.0, water.getReferencePressure(), 0.0);
+    assertEquals("Bukacek", water.getMethod());
+    assertSame(originalAlarmState, water.getAlarmState());
+    assertEquals(originalWaterDewPoint, water.getMeasuredValue("C"), 0.0);
+    assertSchedulerRestored(cricondenbarArea, hydrateArea, hydrocarbonArea, waterArea);
+
+    TransientStepTransaction replay = model.beginTransientStepTransaction();
+    fireAll(cricondenbarArea, hydrateArea, hydrocarbonArea, waterArea);
+    assertSame(trialStream, cricondenbar.getStream());
+    assertEquals(80.0, hydrate.getReferencePressure(), 0.0);
+    assertEquals(40.0, hydrocarbon.getReferencePressure(), 0.0);
+    assertEquals("trial method", hydrocarbon.getMethod());
+    assertEquals(60.0, water.getReferencePressure(), 0.0);
+    assertEquals("multiphase", water.getMethod());
+    assertTrue(water.evaluateAlarm(-20.0, 1.0, 1.0).isEmpty());
+    assertEquals(1, water.evaluateAlarm(-20.0, 1.0, 2.0).size());
+    replay.commit();
+
+    assertSchedulerCommitted(cricondenbarArea, hydrateArea, hydrocarbonArea, waterArea);
+  }
+
+  @Test
+  void serializedAnalysersAndSnapshotsRestoreRestartState() throws Exception {
+    StreamInterface originalStream = createGasStream("restart gas", 22.0e-6);
+    StreamInterface trialStream = createGasStream("trial restart gas", 35.0e-6);
+
+    CricondenbarAnalyser cricondenbar = new CricondenbarAnalyser("cricondenbar", originalStream);
+    CricondenbarAnalyser.CricondenbarAnalyserState cricondenbarState = cricondenbar.captureTransientState();
+    cricondenbar.setStream(trialStream);
+
+    HydrateEquilibriumTemperatureAnalyser hydrate = new HydrateEquilibriumTemperatureAnalyser("hydrate",
+        originalStream);
+    hydrate.setReferencePressure(65.0);
+    HydrateEquilibriumTemperatureAnalyser.HydrateAnalyserState hydrateState = hydrate.captureTransientState();
+    hydrate.setReferencePressure(90.0);
+
+    HydrocarbonDewPointAnalyser hydrocarbon = new HydrocarbonDewPointAnalyser("hydrocarbon", originalStream);
+    hydrocarbon.setReferencePressure(45.0);
+    HydrocarbonDewPointAnalyser.HydrocarbonDewPointAnalyserState hydrocarbonState = hydrocarbon.captureTransientState();
+    hydrocarbon.setMethod("trial method");
+
+    WaterDewPointAnalyser water = new WaterDewPointAnalyser("water", originalStream);
+    water.setMethod("Bukacek");
+    WaterDewPointAnalyser.WaterDewPointAnalyserState waterState = water.captureTransientState();
+    water.setReferencePressure(55.0);
+
+    Object[] restored = roundTrip(cricondenbar, cricondenbarState, hydrate, hydrateState, hydrocarbon, hydrocarbonState,
+        water, waterState);
+
+    CricondenbarAnalyser restoredCricondenbar = (CricondenbarAnalyser) restored[0];
+    restoredCricondenbar.restoreTransientState((CricondenbarAnalyser.CricondenbarAnalyserState) restored[1]);
+    assertEquals("restart gas", restoredCricondenbar.getStream().getName());
+
+    HydrateEquilibriumTemperatureAnalyser restoredHydrate = (HydrateEquilibriumTemperatureAnalyser) restored[2];
+    restoredHydrate.restoreTransientState((HydrateEquilibriumTemperatureAnalyser.HydrateAnalyserState) restored[3]);
+    assertEquals(65.0, restoredHydrate.getReferencePressure(), 0.0);
+
+    HydrocarbonDewPointAnalyser restoredHydrocarbon = (HydrocarbonDewPointAnalyser) restored[4];
+    restoredHydrocarbon
+        .restoreTransientState((HydrocarbonDewPointAnalyser.HydrocarbonDewPointAnalyserState) restored[5]);
+    assertEquals(45.0, restoredHydrocarbon.getReferencePressure(), 0.0);
+    assertEquals("EOS", restoredHydrocarbon.getMethod());
+
+    WaterDewPointAnalyser restoredWater = (WaterDewPointAnalyser) restored[6];
+    restoredWater.restoreTransientState((WaterDewPointAnalyser.WaterDewPointAnalyserState) restored[7]);
+    assertEquals(70.0, restoredWater.getReferencePressure(), 0.0);
+    assertEquals("Bukacek", restoredWater.getMethod());
+
+    assertEquals(cricondenbar.getTransientStateIdentity(), restoredCricondenbar.getTransientStateIdentity());
+    assertEquals(hydrate.getTransientStateIdentity(), restoredHydrate.getTransientStateIdentity());
+    assertEquals(hydrocarbon.getTransientStateIdentity(), restoredHydrocarbon.getTransientStateIdentity());
+    assertEquals(water.getTransientStateIdentity(), restoredWater.getTransientStateIdentity());
+  }
+
+  @Test
+  void descendantsOnlineAndForeignSnapshotsFailClosed() {
+    StreamInterface stream = createGasStream("blocker gas", 22.0e-6);
+
+    assertBlocked(new CricondenbarAnalyser("subclass", stream) {
+      private static final long serialVersionUID = 1000L;
+    }, "subclass-owned mutable state");
+    assertBlocked(new HydrateEquilibriumTemperatureAnalyser("subclass", stream) {
+      private static final long serialVersionUID = 1000L;
+    }, "subclass-owned mutable state");
+    assertBlocked(new HydrocarbonDewPointAnalyser("subclass", stream) {
+      private static final long serialVersionUID = 1000L;
+    }, "subclass-owned mutable state");
+    assertBlocked(new WaterDewPointAnalyser("subclass", stream) {
+      private static final long serialVersionUID = 1000L;
+    }, "subclass-owned mutable state");
+
+    WaterDewPointAnalyser online = new WaterDewPointAnalyser("online", stream);
+    online.setIsOnlineSignal(true, "plant", "WDP-ONLINE");
+    assertBlocked(online, "external I/O");
+
+    CricondenbarAnalyser firstCricondenbar = new CricondenbarAnalyser("first", stream);
+    CricondenbarAnalyser secondCricondenbar = new CricondenbarAnalyser("second", stream);
+    assertThrows(IllegalArgumentException.class,
+        () -> secondCricondenbar.restoreTransientState(firstCricondenbar.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> firstCricondenbar.restoreTransientState(null));
+
+    HydrateEquilibriumTemperatureAnalyser firstHydrate = new HydrateEquilibriumTemperatureAnalyser("first", stream);
+    HydrateEquilibriumTemperatureAnalyser secondHydrate = new HydrateEquilibriumTemperatureAnalyser("second", stream);
+    assertThrows(IllegalArgumentException.class,
+        () -> secondHydrate.restoreTransientState(firstHydrate.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> firstHydrate.restoreTransientState(null));
+
+    HydrocarbonDewPointAnalyser firstHydrocarbon = new HydrocarbonDewPointAnalyser("first", stream);
+    HydrocarbonDewPointAnalyser secondHydrocarbon = new HydrocarbonDewPointAnalyser("second", stream);
+    assertThrows(IllegalArgumentException.class,
+        () -> secondHydrocarbon.restoreTransientState(firstHydrocarbon.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> firstHydrocarbon.restoreTransientState(null));
+
+    WaterDewPointAnalyser firstWater = new WaterDewPointAnalyser("first", stream);
+    WaterDewPointAnalyser secondWater = new WaterDewPointAnalyser("second", stream);
+    assertThrows(IllegalArgumentException.class,
+        () -> secondWater.restoreTransientState(firstWater.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> firstWater.restoreTransientState(null));
+  }
+
+  private static StreamInterface createGasStream(String name, double waterFraction) {
+    SystemInterface fluid = new SystemSrkEos(298.15, 70.0);
+    fluid.addComponent("methane", 1.0 - waterFraction);
+    fluid.addComponent("water", waterFraction);
+    fluid.setMixingRule("classic");
+    Stream stream = new Stream(name, fluid);
+    stream.run();
+    return stream;
+  }
+
+  private static ProcessSystem area(String name, MeasurementDeviceInterface analyser) {
+    ProcessSystem area = new ProcessSystem(name);
+    area.setEventScheduler(new EventScheduler());
+    area.add(analyser);
+    assertCompleteCoverage(area.getTransientTransactionCoverage(), 1);
+    return area;
+  }
+
+  private static void fireAll(ProcessSystem... areas) {
+    for (ProcessSystem area : areas) {
+      assertEquals(1, area.getEventScheduler().fireDueEvents(1.0));
+    }
+  }
+
+  private static void assertSchedulerRestored(ProcessSystem... areas) {
+    for (ProcessSystem area : areas) {
+      assertEquals(1, area.getEventScheduler().getPendingEvents().size());
+      assertEquals(0, area.getEventScheduler().getFiredEvents().size());
+    }
+  }
+
+  private static void assertSchedulerCommitted(ProcessSystem... areas) {
+    for (ProcessSystem area : areas) {
+      assertEquals(0, area.getEventScheduler().getPendingEvents().size());
+      assertEquals(1, area.getEventScheduler().getFiredEvents().size());
+    }
+  }
+
+  private static Object[] roundTrip(Object... values) throws Exception {
+    byte[] serialized;
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      for (Object value : values) {
+        output.writeObject(value);
+      }
+      serialized = bytes.toByteArray();
+    }
+    Object[] restored = new Object[values.length];
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      for (int i = 0; i < restored.length; i++) {
+        restored[i] = input.readObject();
+      }
+    }
+    return restored;
+  }
+
+  private static void assertBlocked(MeasurementDeviceInterface analyser, String expectedText) {
+    ProcessSystem process = new ProcessSystem("thermodynamic-limit blocker");
+    process.add(analyser);
+    TransientTransactionCoverage coverage = process.getTransientTransactionCoverage();
+    assertEquals(1, coverage.getProcessElementCount());
+    assertEquals(1, coverage.getParticipantCount());
+    assertEquals(1, coverage.getBlockingIssues().size());
+    assertTrue(coverage.getBlockingIssues().get(0).contains(expectedText));
+  }
+
+  private static void assertCompleteCoverage(TransientTransactionCoverage coverage, int expectedCount) {
+    assertEquals(expectedCount, coverage.getProcessElementCount());
+    assertEquals(expectedCount, coverage.getParticipantCount());
+    assertTrue(coverage.isComplete(), coverage.getBlockingIssues().toString());
+  }
+}


### PR DESCRIPTION
## Roadmap

Advances #2911 Phase 1 shared transient orchestration after merged tranche DYN-C013.

Base refreshed from `master`: `9a371fb1448bb713990072c2d3d4a291c71dab68`
Publication head: `f054872f801ad08d8d6a7beafa46566d6a998d9d`

## Engineering problem

The four local thermodynamic-limit measurement families are registered orchestration elements whose stream bindings, reference conditions, configured method, names and alarm state can be changed by scheduled events. They did not participate in the identity-preserving transaction, so scheduler rollback could leave analyser configuration or alarm progress advanced after a rejected multi-area trial.

## Complete tranche

- qualifies concrete local `CricondenbarAnalyser`, `HydrateEquilibriumTemperatureAnalyser`, `HydrocarbonDewPointAnalyser`, and `WaterDewPointAnalyser`
- preserves stable transaction identity, stream binding and complete inherited measurement/alarm state for every family member
- preserves hydrate reference pressure and both dew-point analysers' reference pressure/method
- rejects null and foreign snapshots
- fails closed for subclasses and online/external-I/O operation
- proves four-area `ProcessModel` rollback, replay and commit with exact scheduler pending/fired bookkeeping
- proves exact reference-pressure/method restore, deterministic Bukacek result replay and delayed-alarm continuation
- serializes every analyser together with its snapshot and verifies restart identity/configuration
- corrects the adjacent public examples to use the actual one-argument reference-pressure API
- documents the transaction and non-qualification boundary

The analyser thermodynamic calculations continue to use temporary fluid clones and are unchanged. This does not newly qualify phase-envelope, dew-point, hydrate or empirical-correlation physics, fluid characterization, sampling, analyser accuracy, alarm/trip integrity, external I/O, virtual commissioning or OTS. It does not enter #2935 species transport, #2907 multiphase physics, or Huldra dataset work.

## Validation

Passed locally on exact refreshed head `f054872f801ad08d8d6a7beafa46566d6a998d9d`:

- `./mvnw -o -q -Dtest=ThermodynamicLimitAnalyserTransientStateTransactionTest,HydrocarbonDewPointAnalyserTest test`
  - new regression: 3 tests, 0 failures/errors/skips
  - nearby hydrocarbon-dew-point regression also passes
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- `git diff --check 9a371fb1448bb713990072c2d3d4a291c71dab68...HEAD`
- exact diff remains the intended seven files

Hosted exact-head status:

- **PASS** — Pre-commit checks
- **PASS** — Spotless format patch
- **PASS** — Documentation search coverage
- **PASS** — PaperLab Replication Gate
- **PASS** — CodeQL
- **PASS** — Java 21 Javadoc
- **PASS** — slow shards 1/4 and 4/4
- **PASS for this tranche** — Windows executed 11,848 tests (three more than the 11,845-test base run) and reported only the base run's same three failures; the three new analyser transaction tests therefore passed
- **CANCELLED BY RED MATRIX** — Ubuntu fast tests; Java 8 jobs were skipped by workflow dependencies

**VALIDATION BLOCKED BY BASELINE** — the two completed slow shards fail only on already-verified `master` regressions, with the same values recorded on the base run and in merged PR #3030:

- slow 2/4: `SystemElectrolyteCPATest.testHydrateTemperatureWithMethanolAndSalt` — methanol-only `-4.5626191958 °C`, methanol+salt `-2.4559782475 °C`
- slow 3/4: `HydrocarbonScrubberSaturationPressureStabilityTest` — expected `105.9 bara`, actual `72.244468689 bara`

Windows fast-test baseline comparison:

- exact head: 11,848 tests, 3 failures — `EclipseFluidReadWriteTest.testFluidWater3`, `TPFlashTest.testRun5`, `TPflashIncipientPhaseStabilityTest.subResidualTpdDoesNotOverrideExistingUmrPruSolution`
- base: 11,845 tests, the same 3 failures with identical expected/actual values

Current exact-head run: https://github.com/equinor/neqsim/actions/runs/31897375725
Base reproduction: https://github.com/equinor/neqsim/actions/runs/31894800751

No branch-attributable CI failure or review finding remains. The PR stays draft and is not classified READY TO MERGE because required repository CI is red/cancelled on baseline failures.

The superseded `e56de9b4` pre-commit failure was likewise caused solely by the pre-existing `TPmultiflash.java` wrapping violation. #3030 fixed that baseline and is merged; this branch incorporates its merge commit without adding either baseline-fix file to the PR diff. No pending hosted check is claimed as passed.