### PR TITLE
[AI-Assisted] feat(diagram): assess explicit balance tolerances

### DIFF
--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -134,12 +134,40 @@ residual divides that result by the larger absolute inlet or outlet total and is
 are zero. Stream enthalpy flow is `massFlow [kg/s] * specificEnthalpy [J/kg]` in W; its residual is the
 inlet total minus the outlet total, and its relative residual uses the same larger-total denominator.
 It intentionally excludes equipment heat duties and shaft work, so it is not a complete energy
-balance. Component balances,
-reconciliation, tolerances, and approved project boundaries remain later engineering layers.
+balance.
+
+### Explicit tolerance assessment
+
+`EngineeringDiagramBalanceAssessment` evaluates existing residuals against explicit, sourced
+criteria without changing any stream value. Each criterion identifies one stable balance and
+declares absolute and relative limits for mass residual (kg/s and dimensionless) and stream-enthalpy
+residual (W and dimensionless). A quantity is `WITHIN_TOLERANCE` only when both residual magnitudes
+satisfy their declared limits. Missing, duplicate, unknown, incomplete, or exceeded criteria remain
+visible through deterministic status values and structured diagnostics.
+
+```java
+EngineeringDiagramBalanceAssessment.Criteria criteria =
+    new EngineeringDiagramBalanceAssessment.Criteria(
+        "BAL-AREA-01",
+        0.01,
+        0.001,
+        1000.0,
+        0.01,
+        "project-balance-criteria:BAL-AREA-01",
+        EngineeringDiagramBalanceTable.EvidenceState.PROPOSED);
+EngineeringDiagramBalanceAssessment assessment =
+    EngineeringDiagramBalanceAssessment.fromBalanceTable(
+        balanceTable, Collections.singletonList(criteria));
+```
+
+This is a tolerance check, not statistical data reconciliation. It does not adjust measured or
+calculated values, supply component balances, close heat/work terms, infer project tolerances, or
+approve a balance. Component balances, heat/work closure, reconciliation methods, and approved
+project boundary registers remain later engineering layers.
 
 Building either companion does not change Classic DOT/Graphviz, native SVG/PDF, DEXPI 2.0 Process
-exchange, or the Proteus/DEXPI P&ID workflow. `REVIEWED` boundary evidence does not approve a PFD,
-P&ID, simulation result, balance, or design data.
+exchange, or the Proteus/DEXPI P&ID workflow. `REVIEWED` boundary or criterion evidence does not
+approve a PFD, P&ID, simulation result, balance, tolerance, or design data.
 
 Canonical source names and carried connection names are retained as source designations. They are
 not silently promoted to project-approved equipment tags or line numbers. Project-entered tags and
@@ -329,7 +357,8 @@ Run the focused regression with:
 ```bash
 ./mvnw -Dtest=ProcessDiagramDocumentSetAdapterTest test
 ./mvnw -Dtest=NativeEngineeringDiagramRendererTest test
-./mvnw -Dtest=EngineeringDiagramStreamTableTest,EngineeringDiagramBalanceTableTest test
+./mvnw -Dtest=EngineeringDiagramStreamTableTest,EngineeringDiagramBalanceTableTest,\
+EngineeringDiagramBalanceAssessmentTest test
 ```
 
 The regression verifies deterministic single- and multi-area output, immutable collections,
@@ -346,4 +375,3 @@ coordinates and protected routes, reciprocal off-page references, deterministic 
 route/object and route-label obstacle diagnostics, collision, clipping, label-overflow and
 broken-reference diagnostics, normalized visual fingerprints, multi-page drawing sets, fresh-model
 determinism, and unchanged Classic DOT and controlled-document JSON.
-

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramBalanceAssessment.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramBalanceAssessment.java
@@ -1,0 +1,541 @@
+package neqsim.process.engineering.model;
+
+import com.google.gson.GsonBuilder;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Balance;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.EvidenceState;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Severity;
+
+/**
+ * Immutable, deterministic assessment of balance residuals against explicit tolerances.
+ *
+ * <p>
+ * The assessment consumes a governed {@link EngineeringDiagramBalanceTable}. It classifies the
+ * existing residuals but never adjusts stream values, reconciles measurements, approves a balance,
+ * or infers project acceptance criteria.
+ * </p>
+ */
+public final class EngineeringDiagramBalanceAssessment implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  public static final String SCHEMA_VERSION =
+      "neqsim_engineering_diagram_balance_assessment.v1";
+
+  /** Assessment status for one governed quantity. */
+  public enum Status {
+    /** No criterion was supplied for the source balance. */
+    NOT_ASSESSED,
+    /** Complete residual evidence satisfies both declared tolerance limits. */
+    WITHIN_TOLERANCE,
+    /** Complete residual evidence exceeds at least one declared tolerance limit. */
+    OUTSIDE_TOLERANCE,
+    /** The source balance lacks complete governed values. */
+    INCOMPLETE
+  }
+
+  /** Explicit tolerance criteria for one stable balance identity. */
+  public static final class Criteria implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String balanceId;
+    private final double massAbsoluteTolerance;
+    private final double massRelativeTolerance;
+    private final double streamEnthalpyAbsoluteTolerance;
+    private final double streamEnthalpyRelativeTolerance;
+    private final String sourceReference;
+    private final EvidenceState evidenceState;
+
+    /**
+     * Creates explicit tolerance criteria.
+     *
+     * <p>
+     * A quantity is within tolerance only when both its absolute and relative residual magnitudes
+     * are no greater than the corresponding limits.
+     * </p>
+     *
+     * @param balanceId stable source-balance identity
+     * @param massAbsoluteTolerance absolute mass-residual tolerance in kg/s
+     * @param massRelativeTolerance dimensionless relative mass-residual tolerance
+     * @param streamEnthalpyAbsoluteTolerance absolute stream-enthalpy-residual tolerance in W
+     * @param streamEnthalpyRelativeTolerance dimensionless relative stream-enthalpy tolerance
+     * @param sourceReference source or register reference for the criteria
+     * @param evidenceState review evidence state without design-approval implication
+     */
+    public Criteria(String balanceId, double massAbsoluteTolerance, double massRelativeTolerance,
+        double streamEnthalpyAbsoluteTolerance, double streamEnthalpyRelativeTolerance,
+        String sourceReference, EvidenceState evidenceState) {
+      this.balanceId = requireText(balanceId, "balanceId");
+      this.massAbsoluteTolerance =
+          requireTolerance(massAbsoluteTolerance, "massAbsoluteTolerance");
+      this.massRelativeTolerance =
+          requireTolerance(massRelativeTolerance, "massRelativeTolerance");
+      this.streamEnthalpyAbsoluteTolerance = requireTolerance(
+          streamEnthalpyAbsoluteTolerance, "streamEnthalpyAbsoluteTolerance");
+      this.streamEnthalpyRelativeTolerance = requireTolerance(
+          streamEnthalpyRelativeTolerance, "streamEnthalpyRelativeTolerance");
+      this.sourceReference = requireText(sourceReference, "sourceReference");
+      if (evidenceState == null) {
+        throw new IllegalArgumentException("evidenceState must not be null");
+      }
+      this.evidenceState = evidenceState;
+    }
+
+    /** @return stable source-balance identity */
+    public String getBalanceId() {
+      return balanceId;
+    }
+
+    /** @return absolute mass-residual tolerance in kg/s */
+    public double getMassAbsoluteTolerance() {
+      return massAbsoluteTolerance;
+    }
+
+    /** @return dimensionless relative mass-residual tolerance */
+    public double getMassRelativeTolerance() {
+      return massRelativeTolerance;
+    }
+
+    /** @return absolute stream-enthalpy-residual tolerance in W */
+    public double getStreamEnthalpyAbsoluteTolerance() {
+      return streamEnthalpyAbsoluteTolerance;
+    }
+
+    /** @return dimensionless relative stream-enthalpy tolerance */
+    public double getStreamEnthalpyRelativeTolerance() {
+      return streamEnthalpyRelativeTolerance;
+    }
+
+    /** @return source or register reference for the criteria */
+    public String getSourceReference() {
+      return sourceReference;
+    }
+
+    /** @return review evidence state without design-approval implication */
+    public EvidenceState getEvidenceState() {
+      return evidenceState;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("balanceId", balanceId);
+      result.put("massAbsoluteTolerance", Double.valueOf(massAbsoluteTolerance));
+      result.put("massAbsoluteToleranceUnit", "kg/s");
+      result.put("massRelativeTolerance", Double.valueOf(massRelativeTolerance));
+      result.put("streamEnthalpyAbsoluteTolerance",
+          Double.valueOf(streamEnthalpyAbsoluteTolerance));
+      result.put("streamEnthalpyAbsoluteToleranceUnit", "W");
+      result.put("streamEnthalpyRelativeTolerance",
+          Double.valueOf(streamEnthalpyRelativeTolerance));
+      result.put("sourceReference", sourceReference);
+      result.put("evidenceState", evidenceState.name());
+      return result;
+    }
+  }
+
+  /** One deterministic assessment result. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String balanceId;
+    private final double massAbsoluteResidual;
+    private final double massRelativeResidual;
+    private final double streamEnthalpyAbsoluteResidual;
+    private final double streamEnthalpyRelativeResidual;
+    private final Status massStatus;
+    private final Status streamEnthalpyStatus;
+
+    private Result(Balance balance, Status massStatus, Status streamEnthalpyStatus) {
+      this.balanceId = balance.getBalanceId();
+      this.massAbsoluteResidual = Math.abs(balance.getMassResidual());
+      this.massRelativeResidual = Math.abs(balance.getRelativeMassResidual());
+      this.streamEnthalpyAbsoluteResidual = Math.abs(balance.getStreamEnthalpyResidual());
+      this.streamEnthalpyRelativeResidual =
+          Math.abs(balance.getRelativeStreamEnthalpyResidual());
+      this.massStatus = massStatus;
+      this.streamEnthalpyStatus = streamEnthalpyStatus;
+    }
+
+    /** @return stable source-balance identity */
+    public String getBalanceId() {
+      return balanceId;
+    }
+
+    /** @return absolute mass-residual magnitude in kg/s */
+    public double getMassAbsoluteResidual() {
+      return massAbsoluteResidual;
+    }
+
+    /** @return dimensionless relative mass-residual magnitude */
+    public double getMassRelativeResidual() {
+      return massRelativeResidual;
+    }
+
+    /** @return absolute stream-enthalpy-residual magnitude in W */
+    public double getStreamEnthalpyAbsoluteResidual() {
+      return streamEnthalpyAbsoluteResidual;
+    }
+
+    /** @return dimensionless relative stream-enthalpy-residual magnitude */
+    public double getStreamEnthalpyRelativeResidual() {
+      return streamEnthalpyRelativeResidual;
+    }
+
+    /** @return mass-residual assessment status */
+    public Status getMassStatus() {
+      return massStatus;
+    }
+
+    /** @return stream-enthalpy-residual assessment status */
+    public Status getStreamEnthalpyStatus() {
+      return streamEnthalpyStatus;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("balanceId", balanceId);
+      result.put("massAbsoluteResidual", Double.valueOf(massAbsoluteResidual));
+      result.put("massAbsoluteResidualUnit", "kg/s");
+      result.put("massRelativeResidual", Double.valueOf(massRelativeResidual));
+      result.put("streamEnthalpyAbsoluteResidual",
+          Double.valueOf(streamEnthalpyAbsoluteResidual));
+      result.put("streamEnthalpyAbsoluteResidualUnit", "W");
+      result.put("streamEnthalpyRelativeResidual",
+          Double.valueOf(streamEnthalpyRelativeResidual));
+      result.put("massStatus", massStatus.name());
+      result.put("streamEnthalpyStatus", streamEnthalpyStatus.name());
+      return result;
+    }
+  }
+
+  /** One structured assessment diagnostic. */
+  public static final class Diagnostic implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Severity severity;
+    private final String code;
+    private final String message;
+    private final String subjectId;
+
+    private Diagnostic(Severity severity, String code, String message, String subjectId) {
+      this.severity = severity;
+      this.code = code;
+      this.message = message;
+      this.subjectId = subjectId;
+    }
+
+    /** @return diagnostic severity */
+    public Severity getSeverity() {
+      return severity;
+    }
+
+    /** @return stable machine-readable diagnostic code */
+    public String getCode() {
+      return code;
+    }
+
+    /** @return human-readable diagnostic message */
+    public String getMessage() {
+      return message;
+    }
+
+    /** @return affected stable identity */
+    public String getSubjectId() {
+      return subjectId;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("severity", severity.name());
+      result.put("code", code);
+      result.put("message", message);
+      result.put("subjectId", subjectId);
+      return result;
+    }
+  }
+
+  private final String documentSetId;
+  private final String sourceGraphFingerprint;
+  private final String designCaseId;
+  private final String sourceBalanceTableFingerprint;
+  private final List<Criteria> criteria;
+  private final List<Result> results;
+  private final List<Diagnostic> diagnostics;
+
+  private EngineeringDiagramBalanceAssessment(EngineeringDiagramBalanceTable balanceTable,
+      List<Criteria> criteria, List<Result> results, List<Diagnostic> diagnostics) {
+    this.documentSetId = balanceTable.getDocumentSetId();
+    this.sourceGraphFingerprint = balanceTable.getSourceGraphFingerprint();
+    this.designCaseId = balanceTable.getDesignCaseId();
+    this.sourceBalanceTableFingerprint = balanceTable.toMap().get("fingerprint").toString();
+    this.criteria = Collections.unmodifiableList(new ArrayList<Criteria>(criteria));
+    this.results = Collections.unmodifiableList(new ArrayList<Result>(results));
+    this.diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+  }
+
+  /**
+   * Assesses governed balance residuals against explicit criteria.
+   *
+   * @param balanceTable governed source balance table
+   * @param criteria explicit criteria grouped by stable balance identity
+   * @return immutable assessment with deterministic diagnostics
+   */
+  public static EngineeringDiagramBalanceAssessment fromBalanceTable(
+      EngineeringDiagramBalanceTable balanceTable, List<Criteria> criteria) {
+    if (balanceTable == null) {
+      throw new IllegalArgumentException("balanceTable must not be null");
+    }
+    if (criteria == null) {
+      throw new IllegalArgumentException("criteria must not be null");
+    }
+    List<Criteria> sortedCriteria = new ArrayList<Criteria>(criteria);
+    if (containsNull(sortedCriteria)) {
+      throw new IllegalArgumentException("criteria must not contain null");
+    }
+    Collections.sort(sortedCriteria, criteriaComparator());
+    List<Diagnostic> diagnostics = sourceDiagnostics(balanceTable);
+    if (sortedCriteria.isEmpty()) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_ASSESSMENT_CRITERIA_NOT_DECLARED",
+          "At least one explicit balance-tolerance criterion is required", ""));
+    }
+
+    Map<String, Balance> balancesById = new LinkedHashMap<String, Balance>();
+    for (Balance balance : balanceTable.getBalances()) {
+      balancesById.put(balance.getBalanceId(), balance);
+    }
+    Map<String, Criteria> criteriaById = new LinkedHashMap<String, Criteria>();
+    for (Criteria criterion : sortedCriteria) {
+      if (!balancesById.containsKey(criterion.getBalanceId())) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_ASSESSMENT_UNKNOWN_BALANCE",
+            "Tolerance criteria reference a balance absent from the governed balance table",
+            criterion.getBalanceId()));
+        continue;
+      }
+      if (criteriaById.containsKey(criterion.getBalanceId())) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_ASSESSMENT_DUPLICATE_CRITERIA",
+            "A balance may have only one explicit tolerance criterion", criterion.getBalanceId()));
+        continue;
+      }
+      criteriaById.put(criterion.getBalanceId(), criterion);
+    }
+
+    List<Result> results = new ArrayList<Result>();
+    for (Balance balance : balanceTable.getBalances()) {
+      Criteria criterion = criteriaById.get(balance.getBalanceId());
+      if (criterion == null) {
+        diagnostics.add(new Diagnostic(Severity.WARNING, "BALANCE_ASSESSMENT_CRITERIA_MISSING",
+            "No explicit tolerance criterion was supplied for the source balance",
+            balance.getBalanceId()));
+        results.add(new Result(balance, Status.NOT_ASSESSED, Status.NOT_ASSESSED));
+        continue;
+      }
+      Status massStatus = assessMass(balance, criterion);
+      Status enthalpyStatus = assessStreamEnthalpy(balance, criterion);
+      results.add(new Result(balance, massStatus, enthalpyStatus));
+      addStatusDiagnostic(balance.getBalanceId(), "MASS", massStatus, diagnostics);
+      addStatusDiagnostic(balance.getBalanceId(), "STREAM_ENTHALPY", enthalpyStatus,
+          diagnostics);
+    }
+    Collections.sort(diagnostics, diagnosticComparator());
+    return new EngineeringDiagramBalanceAssessment(balanceTable, sortedCriteria, results,
+        diagnostics);
+  }
+
+  /** @return source controlled-document identity */
+  public String getDocumentSetId() {
+    return documentSetId;
+  }
+
+  /** @return canonical source-graph fingerprint */
+  public String getSourceGraphFingerprint() {
+    return sourceGraphFingerprint;
+  }
+
+  /** @return selected operating-case identity */
+  public String getDesignCaseId() {
+    return designCaseId;
+  }
+
+  /** @return deterministic fingerprint of the source balance table */
+  public String getSourceBalanceTableFingerprint() {
+    return sourceBalanceTableFingerprint;
+  }
+
+  /** @return immutable explicit criteria in deterministic order */
+  public List<Criteria> getCriteria() {
+    return Collections.unmodifiableList(new ArrayList<Criteria>(criteria));
+  }
+
+  /** @return immutable assessment results in source-balance order */
+  public List<Result> getResults() {
+    return Collections.unmodifiableList(new ArrayList<Result>(results));
+  }
+
+  /** @return immutable structured diagnostics */
+  public List<Diagnostic> getDiagnostics() {
+    return Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+  }
+
+  /** @return true when no error-severity diagnostic is present */
+  public boolean isValid() {
+    for (Diagnostic diagnostic : diagnostics) {
+      if (diagnostic.getSeverity() == Severity.ERROR) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** @return deterministic machine-readable representation */
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", SCHEMA_VERSION);
+    result.put("documentSetId", documentSetId);
+    result.put("sourceGraphFingerprint", sourceGraphFingerprint);
+    result.put("designCaseId", designCaseId);
+    result.put("sourceBalanceTableFingerprint", sourceBalanceTableFingerprint);
+    List<Map<String, Object>> criteriaMaps = new ArrayList<Map<String, Object>>();
+    for (Criteria criterion : criteria) {
+      criteriaMaps.add(criterion.toMap());
+    }
+    result.put("criteria", criteriaMaps);
+    List<Map<String, Object>> resultMaps = new ArrayList<Map<String, Object>>();
+    for (Result assessmentResult : results) {
+      resultMaps.add(assessmentResult.toMap());
+    }
+    result.put("results", resultMaps);
+    List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
+    for (Diagnostic diagnostic : diagnostics) {
+      diagnosticMaps.add(diagnostic.toMap());
+    }
+    result.put("diagnostics", diagnosticMaps);
+    result.put("fingerprint", fingerprint(result));
+    return result;
+  }
+
+  /** @return deterministic pretty-printed JSON */
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+  }
+
+  private static Status assessMass(Balance balance, Criteria criterion) {
+    if (!balance.isMassFlowComplete()) {
+      return Status.INCOMPLETE;
+    }
+    return within(Math.abs(balance.getMassResidual()), criterion.getMassAbsoluteTolerance(),
+        Math.abs(balance.getRelativeMassResidual()), criterion.getMassRelativeTolerance())
+            ? Status.WITHIN_TOLERANCE : Status.OUTSIDE_TOLERANCE;
+  }
+
+  private static Status assessStreamEnthalpy(Balance balance, Criteria criterion) {
+    if (!balance.isStreamEnthalpyFlowComplete()) {
+      return Status.INCOMPLETE;
+    }
+    return within(Math.abs(balance.getStreamEnthalpyResidual()),
+        criterion.getStreamEnthalpyAbsoluteTolerance(),
+        Math.abs(balance.getRelativeStreamEnthalpyResidual()),
+        criterion.getStreamEnthalpyRelativeTolerance()) ? Status.WITHIN_TOLERANCE
+            : Status.OUTSIDE_TOLERANCE;
+  }
+
+  private static boolean within(double absoluteResidual, double absoluteTolerance,
+      double relativeResidual, double relativeTolerance) {
+    return absoluteResidual <= absoluteTolerance && relativeResidual <= relativeTolerance;
+  }
+
+  private static void addStatusDiagnostic(String balanceId, String quantity, Status status,
+      List<Diagnostic> diagnostics) {
+    if (status == Status.OUTSIDE_TOLERANCE) {
+      diagnostics.add(new Diagnostic(Severity.WARNING,
+          "BALANCE_ASSESSMENT_" + quantity + "_OUTSIDE_TOLERANCE",
+          "The governed residual exceeds at least one explicit tolerance limit", balanceId));
+    } else if (status == Status.INCOMPLETE) {
+      diagnostics.add(new Diagnostic(Severity.ERROR,
+          "BALANCE_ASSESSMENT_" + quantity + "_INCOMPLETE",
+          "The governed residual is incomplete and cannot be assessed", balanceId));
+    }
+  }
+
+  private static List<Diagnostic> sourceDiagnostics(
+      EngineeringDiagramBalanceTable balanceTable) {
+    List<Diagnostic> result = new ArrayList<Diagnostic>();
+    for (EngineeringDiagramBalanceTable.Diagnostic diagnostic : balanceTable.getDiagnostics()) {
+      result.add(new Diagnostic(diagnostic.getSeverity(),
+          "BALANCE_ASSESSMENT_SOURCE_" + diagnostic.getCode(), diagnostic.getMessage(),
+          diagnostic.getSubjectId()));
+    }
+    return result;
+  }
+
+  private static boolean containsNull(List<Criteria> criteria) {
+    for (Criteria criterion : criteria) {
+      if (criterion == null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static Comparator<Criteria> criteriaComparator() {
+    return new Comparator<Criteria>() {
+      @Override
+      public int compare(Criteria left, Criteria right) {
+        int order = left.getBalanceId().compareTo(right.getBalanceId());
+        if (order != 0) {
+          return order;
+        }
+        return left.getSourceReference().compareTo(right.getSourceReference());
+      }
+    };
+  }
+
+  private static Comparator<Diagnostic> diagnosticComparator() {
+    return new Comparator<Diagnostic>() {
+      @Override
+      public int compare(Diagnostic left, Diagnostic right) {
+        int order = left.getSubjectId().compareTo(right.getSubjectId());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getCode().compareTo(right.getCode());
+        if (order != 0) {
+          return order;
+        }
+        return left.getMessage().compareTo(right.getMessage());
+      }
+    };
+  }
+
+  private static String fingerprint(Map<String, Object> value) {
+    String canonical = new GsonBuilder().create().toJson(value);
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(canonical.getBytes(StandardCharsets.UTF_8));
+      StringBuilder result = new StringBuilder();
+      for (byte item : hash) {
+        result.append(String.format("%02x", item & 0xff));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is not available", exception);
+    }
+  }
+
+  private static String requireText(String value, String name) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static double requireTolerance(double value, String name) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and non-negative");
+    }
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramBalanceAssessment.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramBalanceAssessment.java
@@ -19,15 +19,13 @@ import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Severity;
  * Immutable, deterministic assessment of balance residuals against explicit tolerances.
  *
  * <p>
- * The assessment consumes a governed {@link EngineeringDiagramBalanceTable}. It classifies the
- * existing residuals but never adjusts stream values, reconciles measurements, approves a balance,
- * or infers project acceptance criteria.
+ * The assessment consumes a governed {@link EngineeringDiagramBalanceTable}. It classifies the existing residuals but
+ * never adjusts stream values, reconciles measurements, approves a balance, or infers project acceptance criteria.
  * </p>
  */
 public final class EngineeringDiagramBalanceAssessment implements Serializable {
   private static final long serialVersionUID = 1000L;
-  public static final String SCHEMA_VERSION =
-      "neqsim_engineering_diagram_balance_assessment.v1";
+  public static final String SCHEMA_VERSION = "neqsim_engineering_diagram_balance_assessment.v1";
 
   /** Assessment status for one governed quantity. */
   public enum Status {
@@ -56,8 +54,8 @@ public final class EngineeringDiagramBalanceAssessment implements Serializable {
      * Creates explicit tolerance criteria.
      *
      * <p>
-     * A quantity is within tolerance only when both its absolute and relative residual magnitudes
-     * are no greater than the corresponding limits.
+     * A quantity is within tolerance only when both its absolute and relative residual magnitudes are no greater than
+     * the corresponding limits.
      * </p>
      *
      * @param balanceId stable source-balance identity
@@ -69,17 +67,15 @@ public final class EngineeringDiagramBalanceAssessment implements Serializable {
      * @param evidenceState review evidence state without design-approval implication
      */
     public Criteria(String balanceId, double massAbsoluteTolerance, double massRelativeTolerance,
-        double streamEnthalpyAbsoluteTolerance, double streamEnthalpyRelativeTolerance,
-        String sourceReference, EvidenceState evidenceState) {
+        double streamEnthalpyAbsoluteTolerance, double streamEnthalpyRelativeTolerance, String sourceReference,
+        EvidenceState evidenceState) {
       this.balanceId = requireText(balanceId, "balanceId");
-      this.massAbsoluteTolerance =
-          requireTolerance(massAbsoluteTolerance, "massAbsoluteTolerance");
-      this.massRelativeTolerance =
-          requireTolerance(massRelativeTolerance, "massRelativeTolerance");
-      this.streamEnthalpyAbsoluteTolerance = requireTolerance(
-          streamEnthalpyAbsoluteTolerance, "streamEnthalpyAbsoluteTolerance");
-      this.streamEnthalpyRelativeTolerance = requireTolerance(
-          streamEnthalpyRelativeTolerance, "streamEnthalpyRelativeTolerance");
+      this.massAbsoluteTolerance = requireTolerance(massAbsoluteTolerance, "massAbsoluteTolerance");
+      this.massRelativeTolerance = requireTolerance(massRelativeTolerance, "massRelativeTolerance");
+      this.streamEnthalpyAbsoluteTolerance = requireTolerance(streamEnthalpyAbsoluteTolerance,
+          "streamEnthalpyAbsoluteTolerance");
+      this.streamEnthalpyRelativeTolerance = requireTolerance(streamEnthalpyRelativeTolerance,
+          "streamEnthalpyRelativeTolerance");
       this.sourceReference = requireText(sourceReference, "sourceReference");
       if (evidenceState == null) {
         throw new IllegalArgumentException("evidenceState must not be null");
@@ -128,11 +124,9 @@ public final class EngineeringDiagramBalanceAssessment implements Serializable {
       result.put("massAbsoluteTolerance", Double.valueOf(massAbsoluteTolerance));
       result.put("massAbsoluteToleranceUnit", "kg/s");
       result.put("massRelativeTolerance", Double.valueOf(massRelativeTolerance));
-      result.put("streamEnthalpyAbsoluteTolerance",
-          Double.valueOf(streamEnthalpyAbsoluteTolerance));
+      result.put("streamEnthalpyAbsoluteTolerance", Double.valueOf(streamEnthalpyAbsoluteTolerance));
       result.put("streamEnthalpyAbsoluteToleranceUnit", "W");
-      result.put("streamEnthalpyRelativeTolerance",
-          Double.valueOf(streamEnthalpyRelativeTolerance));
+      result.put("streamEnthalpyRelativeTolerance", Double.valueOf(streamEnthalpyRelativeTolerance));
       result.put("sourceReference", sourceReference);
       result.put("evidenceState", evidenceState.name());
       return result;
@@ -155,8 +149,7 @@ public final class EngineeringDiagramBalanceAssessment implements Serializable {
       this.massAbsoluteResidual = Math.abs(balance.getMassResidual());
       this.massRelativeResidual = Math.abs(balance.getRelativeMassResidual());
       this.streamEnthalpyAbsoluteResidual = Math.abs(balance.getStreamEnthalpyResidual());
-      this.streamEnthalpyRelativeResidual =
-          Math.abs(balance.getRelativeStreamEnthalpyResidual());
+      this.streamEnthalpyRelativeResidual = Math.abs(balance.getRelativeStreamEnthalpyResidual());
       this.massStatus = massStatus;
       this.streamEnthalpyStatus = streamEnthalpyStatus;
     }
@@ -202,11 +195,9 @@ public final class EngineeringDiagramBalanceAssessment implements Serializable {
       result.put("massAbsoluteResidual", Double.valueOf(massAbsoluteResidual));
       result.put("massAbsoluteResidualUnit", "kg/s");
       result.put("massRelativeResidual", Double.valueOf(massRelativeResidual));
-      result.put("streamEnthalpyAbsoluteResidual",
-          Double.valueOf(streamEnthalpyAbsoluteResidual));
+      result.put("streamEnthalpyAbsoluteResidual", Double.valueOf(streamEnthalpyAbsoluteResidual));
       result.put("streamEnthalpyAbsoluteResidualUnit", "W");
-      result.put("streamEnthalpyRelativeResidual",
-          Double.valueOf(streamEnthalpyRelativeResidual));
+      result.put("streamEnthalpyRelativeResidual", Double.valueOf(streamEnthalpyRelativeResidual));
       result.put("massStatus", massStatus.name());
       result.put("streamEnthalpyStatus", streamEnthalpyStatus.name());
       return result;
@@ -266,8 +257,8 @@ public final class EngineeringDiagramBalanceAssessment implements Serializable {
   private final List<Result> results;
   private final List<Diagnostic> diagnostics;
 
-  private EngineeringDiagramBalanceAssessment(EngineeringDiagramBalanceTable balanceTable,
-      List<Criteria> criteria, List<Result> results, List<Diagnostic> diagnostics) {
+  private EngineeringDiagramBalanceAssessment(EngineeringDiagramBalanceTable balanceTable, List<Criteria> criteria,
+      List<Result> results, List<Diagnostic> diagnostics) {
     this.documentSetId = balanceTable.getDocumentSetId();
     this.sourceGraphFingerprint = balanceTable.getSourceGraphFingerprint();
     this.designCaseId = balanceTable.getDesignCaseId();
@@ -284,8 +275,8 @@ public final class EngineeringDiagramBalanceAssessment implements Serializable {
    * @param criteria explicit criteria grouped by stable balance identity
    * @return immutable assessment with deterministic diagnostics
    */
-  public static EngineeringDiagramBalanceAssessment fromBalanceTable(
-      EngineeringDiagramBalanceTable balanceTable, List<Criteria> criteria) {
+  public static EngineeringDiagramBalanceAssessment fromBalanceTable(EngineeringDiagramBalanceTable balanceTable,
+      List<Criteria> criteria) {
     if (balanceTable == null) {
       throw new IllegalArgumentException("balanceTable must not be null");
     }
@@ -311,8 +302,7 @@ public final class EngineeringDiagramBalanceAssessment implements Serializable {
     for (Criteria criterion : sortedCriteria) {
       if (!balancesById.containsKey(criterion.getBalanceId())) {
         diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_ASSESSMENT_UNKNOWN_BALANCE",
-            "Tolerance criteria reference a balance absent from the governed balance table",
-            criterion.getBalanceId()));
+            "Tolerance criteria reference a balance absent from the governed balance table", criterion.getBalanceId()));
         continue;
       }
       if (criteriaById.containsKey(criterion.getBalanceId())) {
@@ -328,8 +318,7 @@ public final class EngineeringDiagramBalanceAssessment implements Serializable {
       Criteria criterion = criteriaById.get(balance.getBalanceId());
       if (criterion == null) {
         diagnostics.add(new Diagnostic(Severity.WARNING, "BALANCE_ASSESSMENT_CRITERIA_MISSING",
-            "No explicit tolerance criterion was supplied for the source balance",
-            balance.getBalanceId()));
+            "No explicit tolerance criterion was supplied for the source balance", balance.getBalanceId()));
         results.add(new Result(balance, Status.NOT_ASSESSED, Status.NOT_ASSESSED));
         continue;
       }
@@ -337,12 +326,10 @@ public final class EngineeringDiagramBalanceAssessment implements Serializable {
       Status enthalpyStatus = assessStreamEnthalpy(balance, criterion);
       results.add(new Result(balance, massStatus, enthalpyStatus));
       addStatusDiagnostic(balance.getBalanceId(), "MASS", massStatus, diagnostics);
-      addStatusDiagnostic(balance.getBalanceId(), "STREAM_ENTHALPY", enthalpyStatus,
-          diagnostics);
+      addStatusDiagnostic(balance.getBalanceId(), "STREAM_ENTHALPY", enthalpyStatus, diagnostics);
     }
     Collections.sort(diagnostics, diagnosticComparator());
-    return new EngineeringDiagramBalanceAssessment(balanceTable, sortedCriteria, results,
-        diagnostics);
+    return new EngineeringDiagramBalanceAssessment(balanceTable, sortedCriteria, results, diagnostics);
   }
 
   /** @return source controlled-document identity */
@@ -427,46 +414,41 @@ public final class EngineeringDiagramBalanceAssessment implements Serializable {
       return Status.INCOMPLETE;
     }
     return within(Math.abs(balance.getMassResidual()), criterion.getMassAbsoluteTolerance(),
-        Math.abs(balance.getRelativeMassResidual()), criterion.getMassRelativeTolerance())
-            ? Status.WITHIN_TOLERANCE : Status.OUTSIDE_TOLERANCE;
+        Math.abs(balance.getRelativeMassResidual()), criterion.getMassRelativeTolerance()) ? Status.WITHIN_TOLERANCE
+            : Status.OUTSIDE_TOLERANCE;
   }
 
   private static Status assessStreamEnthalpy(Balance balance, Criteria criterion) {
     if (!balance.isStreamEnthalpyFlowComplete()) {
       return Status.INCOMPLETE;
     }
-    return within(Math.abs(balance.getStreamEnthalpyResidual()),
-        criterion.getStreamEnthalpyAbsoluteTolerance(),
-        Math.abs(balance.getRelativeStreamEnthalpyResidual()),
-        criterion.getStreamEnthalpyRelativeTolerance()) ? Status.WITHIN_TOLERANCE
+    return within(Math.abs(balance.getStreamEnthalpyResidual()), criterion.getStreamEnthalpyAbsoluteTolerance(),
+        Math.abs(balance.getRelativeStreamEnthalpyResidual()), criterion.getStreamEnthalpyRelativeTolerance())
+            ? Status.WITHIN_TOLERANCE
             : Status.OUTSIDE_TOLERANCE;
   }
 
-  private static boolean within(double absoluteResidual, double absoluteTolerance,
-      double relativeResidual, double relativeTolerance) {
+  private static boolean within(double absoluteResidual, double absoluteTolerance, double relativeResidual,
+      double relativeTolerance) {
     return absoluteResidual <= absoluteTolerance && relativeResidual <= relativeTolerance;
   }
 
   private static void addStatusDiagnostic(String balanceId, String quantity, Status status,
       List<Diagnostic> diagnostics) {
     if (status == Status.OUTSIDE_TOLERANCE) {
-      diagnostics.add(new Diagnostic(Severity.WARNING,
-          "BALANCE_ASSESSMENT_" + quantity + "_OUTSIDE_TOLERANCE",
+      diagnostics.add(new Diagnostic(Severity.WARNING, "BALANCE_ASSESSMENT_" + quantity + "_OUTSIDE_TOLERANCE",
           "The governed residual exceeds at least one explicit tolerance limit", balanceId));
     } else if (status == Status.INCOMPLETE) {
-      diagnostics.add(new Diagnostic(Severity.ERROR,
-          "BALANCE_ASSESSMENT_" + quantity + "_INCOMPLETE",
+      diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_ASSESSMENT_" + quantity + "_INCOMPLETE",
           "The governed residual is incomplete and cannot be assessed", balanceId));
     }
   }
 
-  private static List<Diagnostic> sourceDiagnostics(
-      EngineeringDiagramBalanceTable balanceTable) {
+  private static List<Diagnostic> sourceDiagnostics(EngineeringDiagramBalanceTable balanceTable) {
     List<Diagnostic> result = new ArrayList<Diagnostic>();
     for (EngineeringDiagramBalanceTable.Diagnostic diagnostic : balanceTable.getDiagnostics()) {
-      result.add(new Diagnostic(diagnostic.getSeverity(),
-          "BALANCE_ASSESSMENT_SOURCE_" + diagnostic.getCode(), diagnostic.getMessage(),
-          diagnostic.getSubjectId()));
+      result.add(new Diagnostic(diagnostic.getSeverity(), "BALANCE_ASSESSMENT_SOURCE_" + diagnostic.getCode(),
+          diagnostic.getMessage(), diagnostic.getSubjectId()));
     }
     return result;
   }

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramBalanceAssessmentTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramBalanceAssessmentTest.java
@@ -103,6 +103,24 @@ class EngineeringDiagramBalanceAssessmentTest {
   }
 
   @Test
+  void reportsIncompleteGovernedSourceValues() {
+    EngineeringDiagramBalanceTable balanceTable = incompleteBalanceTable(completeBoundaryCase());
+
+    EngineeringDiagramBalanceAssessment assessment =
+        EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+            Collections.singletonList(criteria(1.0, 1.0, 1.0, 1.0)));
+
+    assertFalse(assessment.isValid());
+    assertEquals(Status.INCOMPLETE, assessment.getResults().get(0).getMassStatus());
+    assertEquals(Status.INCOMPLETE,
+        assessment.getResults().get(0).getStreamEnthalpyStatus());
+    assertTrue(hasDiagnostic(assessment, "BALANCE_ASSESSMENT_MASS_INCOMPLETE"));
+    assertTrue(hasDiagnostic(assessment, "BALANCE_ASSESSMENT_STREAM_ENTHALPY_INCOMPLETE"));
+    assertTrue(hasDiagnostic(assessment,
+        "BALANCE_ASSESSMENT_SOURCE_BALANCE_BOUNDARY_UNKNOWN_STREAM"));
+  }
+
+  @Test
   void isDeterministicForFreshSystemsAndCriteriaOrder() {
     EngineeringDiagramBalanceAssessment first =
         EngineeringDiagramBalanceAssessment.fromBalanceTable(
@@ -178,6 +196,20 @@ class EngineeringDiagramBalanceAssessmentTest {
     Row feed = completeRow(streamTable, reference.getFeed().getName());
     Boundary boundary = new Boundary("BAL-SIMPLE-01", feed.getSemanticObjectId(),
         Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED);
+    return EngineeringDiagramBalanceTable.fromStreamTable(streamTable,
+        Collections.singletonList(boundary));
+  }
+
+  private static EngineeringDiagramBalanceTable incompleteBalanceTable(
+      EngineeringDiagramReferenceFixtures.SystemCase reference) {
+    EngineeringDiagramDocumentSet documents =
+        ProcessDiagramDocumentSetAdapter.fromProcessSystem(reference.getProcessSystem(),
+            reference.getCaseId(), "A", "PFD-HMB-006", "Boundary tolerance assessment",
+            ContentProfile.PFD, "NORMAL-01");
+    EngineeringDiagramStreamTable streamTable =
+        EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
+    Boundary boundary = new Boundary("BAL-SIMPLE-01", "line:missing", Direction.INLET,
+        "project-balance-register:test", EvidenceState.PROPOSED);
     return EngineeringDiagramBalanceTable.fromStreamTable(streamTable,
         Collections.singletonList(boundary));
   }

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramBalanceAssessmentTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramBalanceAssessmentTest.java
@@ -1,0 +1,205 @@
+package neqsim.process.processmodel.diagram;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceAssessment;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceAssessment.Criteria;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceAssessment.Result;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceAssessment.Status;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Boundary;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Direction;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.EvidenceState;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Quantity;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Row;
+import neqsim.process.equipment.stream.StreamInterface;
+import org.junit.jupiter.api.Test;
+
+/** Regression tests for governed balance-tolerance assessment. */
+class EngineeringDiagramBalanceAssessmentTest {
+
+  @Test
+  void assessesExplicitCriteriaWithoutReconcilingSourceValues() {
+    EngineeringDiagramBalanceTable balanceTable = balanceTable(completeBoundaryCase());
+    String sourceJson = balanceTable.toJson();
+    Criteria criterion = criteria(1.0e-8, 1.0e-8, Double.MAX_VALUE, 2.0);
+
+    EngineeringDiagramBalanceAssessment assessment =
+        EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+            Collections.singletonList(criterion));
+
+    assertTrue(assessment.isValid());
+    assertEquals(1, assessment.getResults().size());
+    Result result = assessment.getResults().get(0);
+    assertEquals("BAL-SIMPLE-01", result.getBalanceId());
+    assertEquals(Status.WITHIN_TOLERANCE, result.getMassStatus());
+    assertEquals(Status.WITHIN_TOLERANCE, result.getStreamEnthalpyStatus());
+    assertTrue(result.getMassAbsoluteResidual() >= 0.0);
+    assertTrue(result.getStreamEnthalpyAbsoluteResidual() >= 0.0);
+    assertEquals(sourceJson, balanceTable.toJson());
+    assertFalse(assessment.getSourceBalanceTableFingerprint().isEmpty());
+    assertNotSame(assessment.getCriteria(), assessment.getCriteria());
+    assertNotSame(assessment.getResults(), assessment.getResults());
+    assertNotSame(assessment.getDiagnostics(), assessment.getDiagnostics());
+    assertThrows(UnsupportedOperationException.class, () -> assessment.getCriteria().clear());
+    assertTrue(assessment.toJson().contains("\"massAbsoluteToleranceUnit\": \"kg/s\""));
+    assertTrue(assessment.toJson()
+        .contains("\"streamEnthalpyAbsoluteToleranceUnit\": \"W\""));
+  }
+
+  @Test
+  void flagsCompleteResidualsOutsideExplicitTolerance() {
+    EngineeringDiagramBalanceTable balanceTable = inletOnlyBalanceTable(completeBoundaryCase());
+    Criteria criterion = criteria(1.0e-8, 1.0e-8, 0.0, 0.0);
+
+    EngineeringDiagramBalanceAssessment assessment =
+        EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+            Collections.singletonList(criterion));
+
+    assertTrue(assessment.isValid());
+    assertEquals(Status.OUTSIDE_TOLERANCE, assessment.getResults().get(0).getMassStatus());
+    assertEquals(Status.OUTSIDE_TOLERANCE,
+        assessment.getResults().get(0).getStreamEnthalpyStatus());
+    assertTrue(hasDiagnostic(assessment, "BALANCE_ASSESSMENT_MASS_OUTSIDE_TOLERANCE"));
+    assertTrue(hasDiagnostic(assessment,
+        "BALANCE_ASSESSMENT_STREAM_ENTHALPY_OUTSIDE_TOLERANCE"));
+  }
+
+  @Test
+  void rejectsMissingUnknownAndDuplicateCriteria() {
+    EngineeringDiagramBalanceTable balanceTable = balanceTable(completeBoundaryCase());
+    Criteria declared = criteria(1.0, 1.0, 1.0, 1.0);
+    Criteria unknown = new Criteria("BAL-MISSING", 1.0, 1.0, 1.0, 1.0,
+        "project-balance-criteria:test", EvidenceState.PROPOSED);
+
+    EngineeringDiagramBalanceAssessment missing =
+        EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+            Collections.<Criteria>emptyList());
+    EngineeringDiagramBalanceAssessment duplicate =
+        EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+            Arrays.asList(declared, declared));
+    EngineeringDiagramBalanceAssessment unknownAssessment =
+        EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+            Collections.singletonList(unknown));
+
+    assertFalse(missing.isValid());
+    assertTrue(hasDiagnostic(missing, "BALANCE_ASSESSMENT_CRITERIA_NOT_DECLARED"));
+    assertEquals(Status.NOT_ASSESSED, missing.getResults().get(0).getMassStatus());
+    assertFalse(duplicate.isValid());
+    assertTrue(hasDiagnostic(duplicate, "BALANCE_ASSESSMENT_DUPLICATE_CRITERIA"));
+    assertFalse(unknownAssessment.isValid());
+    assertTrue(hasDiagnostic(unknownAssessment, "BALANCE_ASSESSMENT_UNKNOWN_BALANCE"));
+  }
+
+  @Test
+  void isDeterministicForFreshSystemsAndCriteriaOrder() {
+    EngineeringDiagramBalanceAssessment first =
+        EngineeringDiagramBalanceAssessment.fromBalanceTable(
+            balanceTable(completeBoundaryCase()), Collections.singletonList(criteria(1.0, 1.0,
+                Double.MAX_VALUE, 2.0)));
+    List<Criteria> secondCriteria = new ArrayList<Criteria>();
+    secondCriteria.add(criteria(1.0, 1.0, Double.MAX_VALUE, 2.0));
+    Collections.reverse(secondCriteria);
+    EngineeringDiagramBalanceAssessment second =
+        EngineeringDiagramBalanceAssessment.fromBalanceTable(
+            balanceTable(completeBoundaryCase()), secondCriteria);
+
+    assertEquals(first.toJson(), second.toJson());
+  }
+
+  @Test
+  void rejectsInvalidCriteriaConstruction() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new Criteria("BAL-SIMPLE-01", -1.0, 1.0, 1.0, 1.0,
+            "project-balance-criteria:test", EvidenceState.PROPOSED));
+    assertThrows(IllegalArgumentException.class,
+        () -> new Criteria("BAL-SIMPLE-01", 1.0, Double.NaN, 1.0, 1.0,
+            "project-balance-criteria:test", EvidenceState.PROPOSED));
+    assertThrows(IllegalArgumentException.class,
+        () -> new Criteria("BAL-SIMPLE-01", 1.0, 1.0, Double.POSITIVE_INFINITY, 1.0,
+            "project-balance-criteria:test", EvidenceState.PROPOSED));
+  }
+
+  private static Criteria criteria(double massAbsolute, double massRelative,
+      double enthalpyAbsolute, double enthalpyRelative) {
+    return new Criteria("BAL-SIMPLE-01", massAbsolute, massRelative, enthalpyAbsolute,
+        enthalpyRelative, "project-balance-criteria:test", EvidenceState.PROPOSED);
+  }
+
+  private static EngineeringDiagramReferenceFixtures.SystemCase completeBoundaryCase() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference =
+        EngineeringDiagramReferenceFixtures.simpleTrain();
+    for (StreamInterface product : reference.getProducts()) {
+      reference.getProcessSystem().add(product);
+    }
+    reference.getProcessSystem().run();
+    return reference;
+  }
+
+  private static EngineeringDiagramBalanceTable balanceTable(
+      EngineeringDiagramReferenceFixtures.SystemCase reference) {
+    EngineeringDiagramDocumentSet documents =
+        ProcessDiagramDocumentSetAdapter.fromProcessSystem(reference.getProcessSystem(),
+            reference.getCaseId(), "A", "PFD-HMB-006", "Boundary tolerance assessment",
+            ContentProfile.PFD, "NORMAL-01");
+    EngineeringDiagramStreamTable streamTable =
+        EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
+    List<Boundary> boundaries = new ArrayList<Boundary>();
+    Row feed = completeRow(streamTable, reference.getFeed().getName());
+    boundaries.add(new Boundary("BAL-SIMPLE-01", feed.getSemanticObjectId(), Direction.INLET,
+        "project-balance-register:test", EvidenceState.PROPOSED));
+    for (StreamInterface product : reference.getProducts()) {
+      Row row = completeRow(streamTable, product.getName());
+      boundaries.add(new Boundary("BAL-SIMPLE-01", row.getSemanticObjectId(), Direction.OUTLET,
+          "project-balance-register:test", EvidenceState.PROPOSED));
+    }
+    return EngineeringDiagramBalanceTable.fromStreamTable(streamTable, boundaries);
+  }
+
+  private static EngineeringDiagramBalanceTable inletOnlyBalanceTable(
+      EngineeringDiagramReferenceFixtures.SystemCase reference) {
+    EngineeringDiagramDocumentSet documents =
+        ProcessDiagramDocumentSetAdapter.fromProcessSystem(reference.getProcessSystem(),
+            reference.getCaseId(), "A", "PFD-HMB-006", "Boundary tolerance assessment",
+            ContentProfile.PFD, "NORMAL-01");
+    EngineeringDiagramStreamTable streamTable =
+        EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
+    Row feed = completeRow(streamTable, reference.getFeed().getName());
+    Boundary boundary = new Boundary("BAL-SIMPLE-01", feed.getSemanticObjectId(),
+        Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED);
+    return EngineeringDiagramBalanceTable.fromStreamTable(streamTable,
+        Collections.singletonList(boundary));
+  }
+
+  private static Row completeRow(EngineeringDiagramStreamTable table, String sourceLabel) {
+    for (Row row : table.getRows()) {
+      if (sourceLabel.equals(row.getSourceLabel())
+          && row.getValues().size() == Quantity.values().length) {
+        return row;
+      }
+    }
+    throw new AssertionError("No complete stream-table row for " + sourceLabel);
+  }
+
+  private static boolean hasDiagnostic(EngineeringDiagramBalanceAssessment assessment,
+      String code) {
+    for (EngineeringDiagramBalanceAssessment.Diagnostic diagnostic :
+        assessment.getDiagnostics()) {
+      if (code.equals(diagnostic.getCode())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramBalanceAssessmentTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramBalanceAssessmentTest.java
@@ -35,9 +35,8 @@ class EngineeringDiagramBalanceAssessmentTest {
     String sourceJson = balanceTable.toJson();
     Criteria criterion = criteria(1.0e-8, 1.0e-8, Double.MAX_VALUE, 2.0);
 
-    EngineeringDiagramBalanceAssessment assessment =
-        EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
-            Collections.singletonList(criterion));
+    EngineeringDiagramBalanceAssessment assessment = EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+        Collections.singletonList(criterion));
 
     assertTrue(assessment.isValid());
     assertEquals(1, assessment.getResults().size());
@@ -54,8 +53,7 @@ class EngineeringDiagramBalanceAssessmentTest {
     assertNotSame(assessment.getDiagnostics(), assessment.getDiagnostics());
     assertThrows(UnsupportedOperationException.class, () -> assessment.getCriteria().clear());
     assertTrue(assessment.toJson().contains("\"massAbsoluteToleranceUnit\": \"kg/s\""));
-    assertTrue(assessment.toJson()
-        .contains("\"streamEnthalpyAbsoluteToleranceUnit\": \"W\""));
+    assertTrue(assessment.toJson().contains("\"streamEnthalpyAbsoluteToleranceUnit\": \"W\""));
   }
 
   @Test
@@ -63,35 +61,29 @@ class EngineeringDiagramBalanceAssessmentTest {
     EngineeringDiagramBalanceTable balanceTable = inletOnlyBalanceTable(completeBoundaryCase());
     Criteria criterion = criteria(1.0e-8, 1.0e-8, 0.0, 0.0);
 
-    EngineeringDiagramBalanceAssessment assessment =
-        EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
-            Collections.singletonList(criterion));
+    EngineeringDiagramBalanceAssessment assessment = EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+        Collections.singletonList(criterion));
 
     assertTrue(assessment.isValid());
     assertEquals(Status.OUTSIDE_TOLERANCE, assessment.getResults().get(0).getMassStatus());
-    assertEquals(Status.OUTSIDE_TOLERANCE,
-        assessment.getResults().get(0).getStreamEnthalpyStatus());
+    assertEquals(Status.OUTSIDE_TOLERANCE, assessment.getResults().get(0).getStreamEnthalpyStatus());
     assertTrue(hasDiagnostic(assessment, "BALANCE_ASSESSMENT_MASS_OUTSIDE_TOLERANCE"));
-    assertTrue(hasDiagnostic(assessment,
-        "BALANCE_ASSESSMENT_STREAM_ENTHALPY_OUTSIDE_TOLERANCE"));
+    assertTrue(hasDiagnostic(assessment, "BALANCE_ASSESSMENT_STREAM_ENTHALPY_OUTSIDE_TOLERANCE"));
   }
 
   @Test
   void rejectsMissingUnknownAndDuplicateCriteria() {
     EngineeringDiagramBalanceTable balanceTable = balanceTable(completeBoundaryCase());
     Criteria declared = criteria(1.0, 1.0, 1.0, 1.0);
-    Criteria unknown = new Criteria("BAL-MISSING", 1.0, 1.0, 1.0, 1.0,
-        "project-balance-criteria:test", EvidenceState.PROPOSED);
+    Criteria unknown = new Criteria("BAL-MISSING", 1.0, 1.0, 1.0, 1.0, "project-balance-criteria:test",
+        EvidenceState.PROPOSED);
 
-    EngineeringDiagramBalanceAssessment missing =
-        EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
-            Collections.<Criteria>emptyList());
-    EngineeringDiagramBalanceAssessment duplicate =
-        EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
-            Arrays.asList(declared, declared));
-    EngineeringDiagramBalanceAssessment unknownAssessment =
-        EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
-            Collections.singletonList(unknown));
+    EngineeringDiagramBalanceAssessment missing = EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+        Collections.<Criteria>emptyList());
+    EngineeringDiagramBalanceAssessment duplicate = EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+        Arrays.asList(declared, declared));
+    EngineeringDiagramBalanceAssessment unknownAssessment = EngineeringDiagramBalanceAssessment
+        .fromBalanceTable(balanceTable, Collections.singletonList(unknown));
 
     assertFalse(missing.isValid());
     assertTrue(hasDiagnostic(missing, "BALANCE_ASSESSMENT_CRITERIA_NOT_DECLARED"));
@@ -106,58 +98,48 @@ class EngineeringDiagramBalanceAssessmentTest {
   void reportsIncompleteGovernedSourceValues() {
     EngineeringDiagramBalanceTable balanceTable = incompleteBalanceTable(completeBoundaryCase());
 
-    EngineeringDiagramBalanceAssessment assessment =
-        EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
-            Collections.singletonList(criteria(1.0, 1.0, 1.0, 1.0)));
+    EngineeringDiagramBalanceAssessment assessment = EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+        Collections.singletonList(criteria(1.0, 1.0, 1.0, 1.0)));
 
     assertFalse(assessment.isValid());
     assertEquals(Status.INCOMPLETE, assessment.getResults().get(0).getMassStatus());
-    assertEquals(Status.INCOMPLETE,
-        assessment.getResults().get(0).getStreamEnthalpyStatus());
+    assertEquals(Status.INCOMPLETE, assessment.getResults().get(0).getStreamEnthalpyStatus());
     assertTrue(hasDiagnostic(assessment, "BALANCE_ASSESSMENT_MASS_INCOMPLETE"));
     assertTrue(hasDiagnostic(assessment, "BALANCE_ASSESSMENT_STREAM_ENTHALPY_INCOMPLETE"));
-    assertTrue(hasDiagnostic(assessment,
-        "BALANCE_ASSESSMENT_SOURCE_BALANCE_BOUNDARY_UNKNOWN_STREAM"));
+    assertTrue(hasDiagnostic(assessment, "BALANCE_ASSESSMENT_SOURCE_BALANCE_BOUNDARY_UNKNOWN_STREAM"));
   }
 
   @Test
   void isDeterministicForFreshSystemsAndCriteriaOrder() {
-    EngineeringDiagramBalanceAssessment first =
-        EngineeringDiagramBalanceAssessment.fromBalanceTable(
-            balanceTable(completeBoundaryCase()), Collections.singletonList(criteria(1.0, 1.0,
-                Double.MAX_VALUE, 2.0)));
+    EngineeringDiagramBalanceAssessment first = EngineeringDiagramBalanceAssessment.fromBalanceTable(
+        balanceTable(completeBoundaryCase()), Collections.singletonList(criteria(1.0, 1.0, Double.MAX_VALUE, 2.0)));
     List<Criteria> secondCriteria = new ArrayList<Criteria>();
     secondCriteria.add(criteria(1.0, 1.0, Double.MAX_VALUE, 2.0));
     Collections.reverse(secondCriteria);
-    EngineeringDiagramBalanceAssessment second =
-        EngineeringDiagramBalanceAssessment.fromBalanceTable(
-            balanceTable(completeBoundaryCase()), secondCriteria);
+    EngineeringDiagramBalanceAssessment second = EngineeringDiagramBalanceAssessment
+        .fromBalanceTable(balanceTable(completeBoundaryCase()), secondCriteria);
 
     assertEquals(first.toJson(), second.toJson());
   }
 
   @Test
   void rejectsInvalidCriteriaConstruction() {
-    assertThrows(IllegalArgumentException.class,
-        () -> new Criteria("BAL-SIMPLE-01", -1.0, 1.0, 1.0, 1.0,
-            "project-balance-criteria:test", EvidenceState.PROPOSED));
-    assertThrows(IllegalArgumentException.class,
-        () -> new Criteria("BAL-SIMPLE-01", 1.0, Double.NaN, 1.0, 1.0,
-            "project-balance-criteria:test", EvidenceState.PROPOSED));
-    assertThrows(IllegalArgumentException.class,
-        () -> new Criteria("BAL-SIMPLE-01", 1.0, 1.0, Double.POSITIVE_INFINITY, 1.0,
-            "project-balance-criteria:test", EvidenceState.PROPOSED));
+    assertThrows(IllegalArgumentException.class, () -> new Criteria("BAL-SIMPLE-01", -1.0, 1.0, 1.0, 1.0,
+        "project-balance-criteria:test", EvidenceState.PROPOSED));
+    assertThrows(IllegalArgumentException.class, () -> new Criteria("BAL-SIMPLE-01", 1.0, Double.NaN, 1.0, 1.0,
+        "project-balance-criteria:test", EvidenceState.PROPOSED));
+    assertThrows(IllegalArgumentException.class, () -> new Criteria("BAL-SIMPLE-01", 1.0, 1.0, Double.POSITIVE_INFINITY,
+        1.0, "project-balance-criteria:test", EvidenceState.PROPOSED));
   }
 
-  private static Criteria criteria(double massAbsolute, double massRelative,
-      double enthalpyAbsolute, double enthalpyRelative) {
-    return new Criteria("BAL-SIMPLE-01", massAbsolute, massRelative, enthalpyAbsolute,
-        enthalpyRelative, "project-balance-criteria:test", EvidenceState.PROPOSED);
+  private static Criteria criteria(double massAbsolute, double massRelative, double enthalpyAbsolute,
+      double enthalpyRelative) {
+    return new Criteria("BAL-SIMPLE-01", massAbsolute, massRelative, enthalpyAbsolute, enthalpyRelative,
+        "project-balance-criteria:test", EvidenceState.PROPOSED);
   }
 
   private static EngineeringDiagramReferenceFixtures.SystemCase completeBoundaryCase() {
-    EngineeringDiagramReferenceFixtures.SystemCase reference =
-        EngineeringDiagramReferenceFixtures.simpleTrain();
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
     for (StreamInterface product : reference.getProducts()) {
       reference.getProcessSystem().add(product);
     }
@@ -165,14 +147,11 @@ class EngineeringDiagramBalanceAssessmentTest {
     return reference;
   }
 
-  private static EngineeringDiagramBalanceTable balanceTable(
-      EngineeringDiagramReferenceFixtures.SystemCase reference) {
-    EngineeringDiagramDocumentSet documents =
-        ProcessDiagramDocumentSetAdapter.fromProcessSystem(reference.getProcessSystem(),
-            reference.getCaseId(), "A", "PFD-HMB-006", "Boundary tolerance assessment",
-            ContentProfile.PFD, "NORMAL-01");
-    EngineeringDiagramStreamTable streamTable =
-        EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
+  private static EngineeringDiagramBalanceTable balanceTable(EngineeringDiagramReferenceFixtures.SystemCase reference) {
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-006", "Boundary tolerance assessment",
+        ContentProfile.PFD, "NORMAL-01");
+    EngineeringDiagramStreamTable streamTable = EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
     List<Boundary> boundaries = new ArrayList<Boundary>();
     Row feed = completeRow(streamTable, reference.getFeed().getName());
     boundaries.add(new Boundary("BAL-SIMPLE-01", feed.getSemanticObjectId(), Direction.INLET,
@@ -187,47 +166,38 @@ class EngineeringDiagramBalanceAssessmentTest {
 
   private static EngineeringDiagramBalanceTable inletOnlyBalanceTable(
       EngineeringDiagramReferenceFixtures.SystemCase reference) {
-    EngineeringDiagramDocumentSet documents =
-        ProcessDiagramDocumentSetAdapter.fromProcessSystem(reference.getProcessSystem(),
-            reference.getCaseId(), "A", "PFD-HMB-006", "Boundary tolerance assessment",
-            ContentProfile.PFD, "NORMAL-01");
-    EngineeringDiagramStreamTable streamTable =
-        EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-006", "Boundary tolerance assessment",
+        ContentProfile.PFD, "NORMAL-01");
+    EngineeringDiagramStreamTable streamTable = EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
     Row feed = completeRow(streamTable, reference.getFeed().getName());
-    Boundary boundary = new Boundary("BAL-SIMPLE-01", feed.getSemanticObjectId(),
-        Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED);
-    return EngineeringDiagramBalanceTable.fromStreamTable(streamTable,
-        Collections.singletonList(boundary));
+    Boundary boundary = new Boundary("BAL-SIMPLE-01", feed.getSemanticObjectId(), Direction.INLET,
+        "project-balance-register:test", EvidenceState.PROPOSED);
+    return EngineeringDiagramBalanceTable.fromStreamTable(streamTable, Collections.singletonList(boundary));
   }
 
   private static EngineeringDiagramBalanceTable incompleteBalanceTable(
       EngineeringDiagramReferenceFixtures.SystemCase reference) {
-    EngineeringDiagramDocumentSet documents =
-        ProcessDiagramDocumentSetAdapter.fromProcessSystem(reference.getProcessSystem(),
-            reference.getCaseId(), "A", "PFD-HMB-006", "Boundary tolerance assessment",
-            ContentProfile.PFD, "NORMAL-01");
-    EngineeringDiagramStreamTable streamTable =
-        EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
-    Boundary boundary = new Boundary("BAL-SIMPLE-01", "line:missing", Direction.INLET,
-        "project-balance-register:test", EvidenceState.PROPOSED);
-    return EngineeringDiagramBalanceTable.fromStreamTable(streamTable,
-        Collections.singletonList(boundary));
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-006", "Boundary tolerance assessment",
+        ContentProfile.PFD, "NORMAL-01");
+    EngineeringDiagramStreamTable streamTable = EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
+    Boundary boundary = new Boundary("BAL-SIMPLE-01", "line:missing", Direction.INLET, "project-balance-register:test",
+        EvidenceState.PROPOSED);
+    return EngineeringDiagramBalanceTable.fromStreamTable(streamTable, Collections.singletonList(boundary));
   }
 
   private static Row completeRow(EngineeringDiagramStreamTable table, String sourceLabel) {
     for (Row row : table.getRows()) {
-      if (sourceLabel.equals(row.getSourceLabel())
-          && row.getValues().size() == Quantity.values().length) {
+      if (sourceLabel.equals(row.getSourceLabel()) && row.getValues().size() == Quantity.values().length) {
         return row;
       }
     }
     throw new AssertionError("No complete stream-table row for " + sourceLabel);
   }
 
-  private static boolean hasDiagnostic(EngineeringDiagramBalanceAssessment assessment,
-      String code) {
-    for (EngineeringDiagramBalanceAssessment.Diagnostic diagnostic :
-        assessment.getDiagnostics()) {
+  private static boolean hasDiagnostic(EngineeringDiagramBalanceAssessment assessment, String code) {
+    for (EngineeringDiagramBalanceAssessment.Diagnostic diagnostic : assessment.getDiagnostics()) {
       if (code.equals(diagnostic.getCode())) {
         return true;
       }


### PR DESCRIPTION
## Roadmap

Coordinates #1332 and #2899 as one engineering-diagram implementation lane. This is the dependency-ready tolerance-assessment tranche after merged explicit boundary balances #3028.

Base: `9a371fb1448bb713990072c2d3d4a291c71dab68`
Publication head: `37b339c4bd006d740dca306b06a7242d4f347696`
Branch: `campaign-1332-2899-balance-tolerance-assessment`

## Engineering problem

The canonical balance model now publishes governed mass and stream-enthalpy residuals, but consumers must compare them ad hoc, can omit units and source evidence, and can accidentally describe a tolerance check as data reconciliation or engineering approval.

## Complete tranche

- adds immutable, serializable `EngineeringDiagramBalanceAssessment`
- binds every assessment to the source document, graph, operating case and balance-table fingerprint
- requires explicit stable balance identity, kg/s and dimensionless mass limits, W and dimensionless stream-enthalpy limits, source reference and evidence state
- applies the conservative documented rule that both absolute and relative residual magnitudes must satisfy their declared limits
- publishes `NOT_ASSESSED`, `WITHIN_TOLERANCE`, `OUTSIDE_TOLERANCE` and `INCOMPLETE` independently for mass and stream enthalpy
- retains assessed residual magnitudes and units in deterministic JSON
- rejects or reports absent, duplicate and unknown criteria, non-finite or negative limits, incomplete source values and inherited balance losses
- preserves deterministic ordering, defensive immutability and fresh-model output
- adds focused regression coverage and updates the engineering-diagram guide/Javadocs

## Semantics and limitations

This is classification against supplied criteria. It never adjusts measured or calculated values and is not statistical data reconciliation. It does not infer project tolerances, supply component balances, close equipment heat/work terms, or approve a balance.

A `REVIEWED` criterion records evidence only. It does not approve a PFD, P&ID, simulation result, tolerance or design data. No standards-conformance claim is made.

## Compatibility

This is an opt-in companion projection. Existing balance-table JSON and Java APIs, Classic DOT/Graphviz, native SVG/PDF PFD, DEXPI 2.0 Process exchange, Proteus/DEXPI P&ID behavior, topology-only adapters and controlled-document JSON remain unchanged.

## Documentation impact

Updated `docs/integration/engineering-diagram-document-model.md` and complete API Javadocs to define inputs, units, the both-limits rule, statuses, diagnostics, non-reconciliation boundary and approval limitations.

## Validation

**VALIDATION BLOCKED BY BASELINE — exact head `37b339c4bd006d740dca306b06a7242d4f347696`, base `9a371fb1448bb713990072c2d3d4a291c71dab68`**

Successful exact-head evidence:

- Spotless format patch (confirmed empty)
- pre-commit checks
- documentation search
- PaperLab
- CodeQL
- both engineering-notebook workflows
- Java 21 Javadocs
- Java 21 slow shards 1/4 and 4/4
- Windows Java 21 executed 11,851 tests; the new `EngineeringDiagramBalanceAssessmentTest` passed 6/6

The aggregate build is red only on five failures independently reproduced on the exact base run with identical values:

- slow 2/4: `SystemElectrolyteCPATest.testHydrateTemperatureWithMethanolAndSalt` — methanol-only `-4.562619195803904 °C`, methanol+salt `-2.4559782474698864 °C`
- slow 3/4: `HydrocarbonScrubberSaturationPressureStabilityTest` — expected `105.9 bara`, actual `72.24446868896484 bara`
- Windows fast: `EclipseFluidReadWriteTest.testFluidWater3` — expected `-4639.239569750378`, actual `-4646.270755989724`
- Windows fast: `TPFlashTest.testRun5` — expected one phase, actual two
- Windows fast: `TPflashIncipientPhaseStabilityTest.subResidualTpdDoesNotOverrideExistingUmrPruSolution` — expected one phase, actual two

Ubuntu fast tests were cancelled after the independent red shards, and Java 8 matrix jobs were consequently skipped. No branch-attributable CI failure or review finding remains, but the PR is not classified READY TO MERGE while required repository CI is unsuccessful.

Exact-head run: https://github.com/equinor/neqsim/actions/runs/31898745957  
Exact-base reproduction: https://github.com/equinor/neqsim/actions/runs/31894800751

The GitHub-connected workflow is authoritative. The exact hosted Spotless artifact from the previous head was inspected and applied without semantic changes. Local Java/Maven, Spotless, documentation-search and pre-commit execution are unavailable in this runtime, so no unrun local check is claimed as passed.

Static checks completed before publication:

- exact connector comparison: three intended files, 764 additions and 6 deletions
- no trailing whitespace in the three-file tree
- no Java source/test line exceeds 120 characters
