### PR TITLE
[AI-Assisted] feat: consolidate analyser transactions and balance assessment

### DIFF
--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -134,12 +134,40 @@ residual divides that result by the larger absolute inlet or outlet total and is
 are zero. Stream enthalpy flow is `massFlow [kg/s] * specificEnthalpy [J/kg]` in W; its residual is the
 inlet total minus the outlet total, and its relative residual uses the same larger-total denominator.
 It intentionally excludes equipment heat duties and shaft work, so it is not a complete energy
-balance. Component balances,
-reconciliation, tolerances, and approved project boundaries remain later engineering layers.
+balance.
+
+### Explicit tolerance assessment
+
+`EngineeringDiagramBalanceAssessment` evaluates existing residuals against explicit, sourced
+criteria without changing any stream value. Each criterion identifies one stable balance and
+declares absolute and relative limits for mass residual (kg/s and dimensionless) and stream-enthalpy
+residual (W and dimensionless). A quantity is `WITHIN_TOLERANCE` only when both residual magnitudes
+satisfy their declared limits. Missing, duplicate, unknown, incomplete, or exceeded criteria remain
+visible through deterministic status values and structured diagnostics.
+
+```java
+EngineeringDiagramBalanceAssessment.Criteria criteria =
+    new EngineeringDiagramBalanceAssessment.Criteria(
+        "BAL-AREA-01",
+        0.01,
+        0.001,
+        1000.0,
+        0.01,
+        "project-balance-criteria:BAL-AREA-01",
+        EngineeringDiagramBalanceTable.EvidenceState.PROPOSED);
+EngineeringDiagramBalanceAssessment assessment =
+    EngineeringDiagramBalanceAssessment.fromBalanceTable(
+        balanceTable, Collections.singletonList(criteria));
+```
+
+This is a tolerance check, not statistical data reconciliation. It does not adjust measured or
+calculated values, supply component balances, close heat/work terms, infer project tolerances, or
+approve a balance. Component balances, heat/work closure, reconciliation methods, and approved
+project boundary registers remain later engineering layers.
 
 Building either companion does not change Classic DOT/Graphviz, native SVG/PDF, DEXPI 2.0 Process
-exchange, or the Proteus/DEXPI P&ID workflow. `REVIEWED` boundary evidence does not approve a PFD,
-P&ID, simulation result, balance, or design data.
+exchange, or the Proteus/DEXPI P&ID workflow. `REVIEWED` boundary or criterion evidence does not
+approve a PFD, P&ID, simulation result, balance, tolerance, or design data.
 
 Canonical source names and carried connection names are retained as source designations. They are
 not silently promoted to project-approved equipment tags or line numbers. Project-entered tags and
@@ -329,7 +357,8 @@ Run the focused regression with:
 ```bash
 ./mvnw -Dtest=ProcessDiagramDocumentSetAdapterTest test
 ./mvnw -Dtest=NativeEngineeringDiagramRendererTest test
-./mvnw -Dtest=EngineeringDiagramStreamTableTest,EngineeringDiagramBalanceTableTest test
+./mvnw -Dtest=EngineeringDiagramStreamTableTest,EngineeringDiagramBalanceTableTest,\
+EngineeringDiagramBalanceAssessmentTest test
 ```
 
 The regression verifies deterministic single- and multi-area output, immutable collections,
@@ -346,4 +375,3 @@ coordinates and protected routes, reciprocal off-page references, deterministic 
 route/object and route-label obstacle diagnostics, collision, clipping, label-overflow and
 broken-reference diagnostics, normalized visual fingerprints, multi-page drawing sets, fresh-model
 determinism, and unchanged Classic DOT and controlled-document JSON.
-

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -488,6 +488,27 @@ also fail closed. This gate proves numerical rollback mechanics only; it does no
 input reliability, ESD action, safety integrity, external DCS/I/O, virtual commissioning or OTS
 use.
 
+## Thermodynamic-limit analyser transaction coverage
+
+Concrete local `CricondenbarAnalyser`, `HydrateEquilibriumTemperatureAnalyser`,
+`HydrocarbonDewPointAnalyser`, and `WaterDewPointAnalyser` instances participate when registered
+as measurement devices in a `ProcessSystem`. Every snapshot preserves stable transaction identity,
+the original stream binding and complete inherited measurement/alarm state. The hydrate analyser
+also preserves its reference pressure; both dew-point analysers preserve reference pressure and
+method.
+
+Together with the existing `EventScheduler` snapshot, this closes scheduled in-memory changes to
+those analyser bindings and settings. Quantitative evidence covers four coordinated
+`ProcessModel` areas, exact reference-pressure and method rollback, deterministic Bukacek result
+replay, delayed-alarm continuation, commit, foreign/null snapshots and Java-serialization restart
+for every family member.
+
+Concrete descendants and online/external-I/O operation fail closed. The thermodynamic calculations
+continue to use temporary fluid clones and are unchanged by this transaction contract. This gate
+does not newly validate phase-envelope, dew-point, hydrate or empirical-correlation physics, fluid
+characterization, sampling, analyser accuracy, alarm/trip integrity, external I/O, virtual
+commissioning or OTS use.
+
 ## State-mutating derived-instrument transaction coverage
 
 Concrete local `pHProbe`, `SoftSensor`, and `FlowInducedVibrationAnalyser` instances participate

--- a/docs/process/equipment/measurement_devices.md
+++ b/docs/process/equipment/measurement_devices.md
@@ -83,7 +83,7 @@ import neqsim.process.measurementdevice.HydrocarbonDewPointAnalyser;
 
 HydrocarbonDewPointAnalyser hcdp =
     new HydrocarbonDewPointAnalyser("HC Dew Point", gasStream);
-hcdp.setReferencePressure(50.0, "bara");
+hcdp.setReferencePressure(50.0);  // bara
 
 double dewPointC = hcdp.getMeasuredValue("C");  // hydrocarbon dew point, degC
 ```
@@ -97,7 +97,7 @@ import neqsim.process.measurementdevice.WaterDewPointAnalyser;
 
 WaterDewPointAnalyser wdp =
     new WaterDewPointAnalyser("Water Dew Point", gasStream);
-wdp.setReferencePressure(50.0, "bara");
+wdp.setReferencePressure(50.0);  // bara
 
 double waterDewPoint = wdp.getMeasuredValue("C");  // water dew point, degC
 ```
@@ -124,6 +124,18 @@ HydrateEquilibriumTemperatureAnalyser hydrateAnalyser =
     new HydrateEquilibriumTemperatureAnalyser(gasStream);
 double hydrateTemp = hydrateAnalyser.getMeasuredValue("C");  // hydrate formation temperature, degC
 ```
+
+Concrete local instances of these four thermodynamic-limit analysers participate in transient-step
+transactions when registered in a `ProcessSystem`. Rollback restores each stream binding and
+complete inherited measurement/alarm state. It also restores reference pressure for the hydrate,
+hydrocarbon-dew-point and water-dew-point analysers, plus the configured method for both dew-point
+analysers. Scheduled configuration changes therefore replay together with `EventScheduler`
+pending/fired bookkeeping, and Java serialization preserves identity and restart state.
+
+Concrete descendants and online-signal operation fail closed. This support changes no phase
+envelope, dew-point, hydrate or empirical correlation. It establishes rollback mechanics only; it
+does not qualify thermodynamic model selection, fluid characterization, sampling, analyser
+accuracy, alarm/trip integrity, external I/O, virtual commissioning or OTS use.
 
 ## Vibration Analysis
 

--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1809,6 +1809,11 @@ Commercial process simulators do not publish all implementation details, but pub
   their existing initialization paths. Seed provenance does not relax acceptance: exactly two distinct phases,
   bounded and normalized beta/compositions, material balance and log-fugacity residuals below `1e-8`, and lower Gibbs
   energy are still required.
+- Multiphase stability cleanup merges two same-type liquid phases when their maximum component-composition difference
+  is below `1e-6` and they are either a supported CPA duplicate or the two hydrocarbon roots beside an aqueous phase in
+  a neutral cubic-EOS three-phase trial. Their phase fractions are added before the redundant phase is removed, so the
+  resulting two-phase endpoint retains material balance. Compositionally distinct gas/oil/aqueous equilibria remain
+  three phase.
 - A water-rich ordinary two-phase endpoint that fails the strict equilibrium gate can retain useful phase-composition
   information even when its cold multiphase candidate collapses to one phase. After that cold candidate is rejected,
   the existing split seeds one fully initialized `TPmultiflash` calculation. A water-rich multiphase endpoint that

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramBalanceAssessment.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramBalanceAssessment.java
@@ -1,0 +1,523 @@
+package neqsim.process.engineering.model;
+
+import com.google.gson.GsonBuilder;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Balance;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.EvidenceState;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Severity;
+
+/**
+ * Immutable, deterministic assessment of balance residuals against explicit tolerances.
+ *
+ * <p>
+ * The assessment consumes a governed {@link EngineeringDiagramBalanceTable}. It classifies the existing residuals but
+ * never adjusts stream values, reconciles measurements, approves a balance, or infers project acceptance criteria.
+ * </p>
+ */
+public final class EngineeringDiagramBalanceAssessment implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  public static final String SCHEMA_VERSION = "neqsim_engineering_diagram_balance_assessment.v1";
+
+  /** Assessment status for one governed quantity. */
+  public enum Status {
+    /** No criterion was supplied for the source balance. */
+    NOT_ASSESSED,
+    /** Complete residual evidence satisfies both declared tolerance limits. */
+    WITHIN_TOLERANCE,
+    /** Complete residual evidence exceeds at least one declared tolerance limit. */
+    OUTSIDE_TOLERANCE,
+    /** The source balance lacks complete governed values. */
+    INCOMPLETE
+  }
+
+  /** Explicit tolerance criteria for one stable balance identity. */
+  public static final class Criteria implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String balanceId;
+    private final double massAbsoluteTolerance;
+    private final double massRelativeTolerance;
+    private final double streamEnthalpyAbsoluteTolerance;
+    private final double streamEnthalpyRelativeTolerance;
+    private final String sourceReference;
+    private final EvidenceState evidenceState;
+
+    /**
+     * Creates explicit tolerance criteria.
+     *
+     * <p>
+     * A quantity is within tolerance only when both its absolute and relative residual magnitudes are no greater than
+     * the corresponding limits.
+     * </p>
+     *
+     * @param balanceId stable source-balance identity
+     * @param massAbsoluteTolerance absolute mass-residual tolerance in kg/s
+     * @param massRelativeTolerance dimensionless relative mass-residual tolerance
+     * @param streamEnthalpyAbsoluteTolerance absolute stream-enthalpy-residual tolerance in W
+     * @param streamEnthalpyRelativeTolerance dimensionless relative stream-enthalpy tolerance
+     * @param sourceReference source or register reference for the criteria
+     * @param evidenceState review evidence state without design-approval implication
+     */
+    public Criteria(String balanceId, double massAbsoluteTolerance, double massRelativeTolerance,
+        double streamEnthalpyAbsoluteTolerance, double streamEnthalpyRelativeTolerance, String sourceReference,
+        EvidenceState evidenceState) {
+      this.balanceId = requireText(balanceId, "balanceId");
+      this.massAbsoluteTolerance = requireTolerance(massAbsoluteTolerance, "massAbsoluteTolerance");
+      this.massRelativeTolerance = requireTolerance(massRelativeTolerance, "massRelativeTolerance");
+      this.streamEnthalpyAbsoluteTolerance = requireTolerance(streamEnthalpyAbsoluteTolerance,
+          "streamEnthalpyAbsoluteTolerance");
+      this.streamEnthalpyRelativeTolerance = requireTolerance(streamEnthalpyRelativeTolerance,
+          "streamEnthalpyRelativeTolerance");
+      this.sourceReference = requireText(sourceReference, "sourceReference");
+      if (evidenceState == null) {
+        throw new IllegalArgumentException("evidenceState must not be null");
+      }
+      this.evidenceState = evidenceState;
+    }
+
+    /** @return stable source-balance identity */
+    public String getBalanceId() {
+      return balanceId;
+    }
+
+    /** @return absolute mass-residual tolerance in kg/s */
+    public double getMassAbsoluteTolerance() {
+      return massAbsoluteTolerance;
+    }
+
+    /** @return dimensionless relative mass-residual tolerance */
+    public double getMassRelativeTolerance() {
+      return massRelativeTolerance;
+    }
+
+    /** @return absolute stream-enthalpy-residual tolerance in W */
+    public double getStreamEnthalpyAbsoluteTolerance() {
+      return streamEnthalpyAbsoluteTolerance;
+    }
+
+    /** @return dimensionless relative stream-enthalpy tolerance */
+    public double getStreamEnthalpyRelativeTolerance() {
+      return streamEnthalpyRelativeTolerance;
+    }
+
+    /** @return source or register reference for the criteria */
+    public String getSourceReference() {
+      return sourceReference;
+    }
+
+    /** @return review evidence state without design-approval implication */
+    public EvidenceState getEvidenceState() {
+      return evidenceState;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("balanceId", balanceId);
+      result.put("massAbsoluteTolerance", Double.valueOf(massAbsoluteTolerance));
+      result.put("massAbsoluteToleranceUnit", "kg/s");
+      result.put("massRelativeTolerance", Double.valueOf(massRelativeTolerance));
+      result.put("streamEnthalpyAbsoluteTolerance", Double.valueOf(streamEnthalpyAbsoluteTolerance));
+      result.put("streamEnthalpyAbsoluteToleranceUnit", "W");
+      result.put("streamEnthalpyRelativeTolerance", Double.valueOf(streamEnthalpyRelativeTolerance));
+      result.put("sourceReference", sourceReference);
+      result.put("evidenceState", evidenceState.name());
+      return result;
+    }
+  }
+
+  /** One deterministic assessment result. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String balanceId;
+    private final double massAbsoluteResidual;
+    private final double massRelativeResidual;
+    private final double streamEnthalpyAbsoluteResidual;
+    private final double streamEnthalpyRelativeResidual;
+    private final Status massStatus;
+    private final Status streamEnthalpyStatus;
+
+    private Result(Balance balance, Status massStatus, Status streamEnthalpyStatus) {
+      this.balanceId = balance.getBalanceId();
+      this.massAbsoluteResidual = Math.abs(balance.getMassResidual());
+      this.massRelativeResidual = Math.abs(balance.getRelativeMassResidual());
+      this.streamEnthalpyAbsoluteResidual = Math.abs(balance.getStreamEnthalpyResidual());
+      this.streamEnthalpyRelativeResidual = Math.abs(balance.getRelativeStreamEnthalpyResidual());
+      this.massStatus = massStatus;
+      this.streamEnthalpyStatus = streamEnthalpyStatus;
+    }
+
+    /** @return stable source-balance identity */
+    public String getBalanceId() {
+      return balanceId;
+    }
+
+    /** @return absolute mass-residual magnitude in kg/s */
+    public double getMassAbsoluteResidual() {
+      return massAbsoluteResidual;
+    }
+
+    /** @return dimensionless relative mass-residual magnitude */
+    public double getMassRelativeResidual() {
+      return massRelativeResidual;
+    }
+
+    /** @return absolute stream-enthalpy-residual magnitude in W */
+    public double getStreamEnthalpyAbsoluteResidual() {
+      return streamEnthalpyAbsoluteResidual;
+    }
+
+    /** @return dimensionless relative stream-enthalpy-residual magnitude */
+    public double getStreamEnthalpyRelativeResidual() {
+      return streamEnthalpyRelativeResidual;
+    }
+
+    /** @return mass-residual assessment status */
+    public Status getMassStatus() {
+      return massStatus;
+    }
+
+    /** @return stream-enthalpy-residual assessment status */
+    public Status getStreamEnthalpyStatus() {
+      return streamEnthalpyStatus;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("balanceId", balanceId);
+      result.put("massAbsoluteResidual", Double.valueOf(massAbsoluteResidual));
+      result.put("massAbsoluteResidualUnit", "kg/s");
+      result.put("massRelativeResidual", Double.valueOf(massRelativeResidual));
+      result.put("streamEnthalpyAbsoluteResidual", Double.valueOf(streamEnthalpyAbsoluteResidual));
+      result.put("streamEnthalpyAbsoluteResidualUnit", "W");
+      result.put("streamEnthalpyRelativeResidual", Double.valueOf(streamEnthalpyRelativeResidual));
+      result.put("massStatus", massStatus.name());
+      result.put("streamEnthalpyStatus", streamEnthalpyStatus.name());
+      return result;
+    }
+  }
+
+  /** One structured assessment diagnostic. */
+  public static final class Diagnostic implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Severity severity;
+    private final String code;
+    private final String message;
+    private final String subjectId;
+
+    private Diagnostic(Severity severity, String code, String message, String subjectId) {
+      this.severity = severity;
+      this.code = code;
+      this.message = message;
+      this.subjectId = subjectId;
+    }
+
+    /** @return diagnostic severity */
+    public Severity getSeverity() {
+      return severity;
+    }
+
+    /** @return stable machine-readable diagnostic code */
+    public String getCode() {
+      return code;
+    }
+
+    /** @return human-readable diagnostic message */
+    public String getMessage() {
+      return message;
+    }
+
+    /** @return affected stable identity */
+    public String getSubjectId() {
+      return subjectId;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("severity", severity.name());
+      result.put("code", code);
+      result.put("message", message);
+      result.put("subjectId", subjectId);
+      return result;
+    }
+  }
+
+  private final String documentSetId;
+  private final String sourceGraphFingerprint;
+  private final String designCaseId;
+  private final String sourceBalanceTableFingerprint;
+  private final List<Criteria> criteria;
+  private final List<Result> results;
+  private final List<Diagnostic> diagnostics;
+
+  private EngineeringDiagramBalanceAssessment(EngineeringDiagramBalanceTable balanceTable, List<Criteria> criteria,
+      List<Result> results, List<Diagnostic> diagnostics) {
+    this.documentSetId = balanceTable.getDocumentSetId();
+    this.sourceGraphFingerprint = balanceTable.getSourceGraphFingerprint();
+    this.designCaseId = balanceTable.getDesignCaseId();
+    this.sourceBalanceTableFingerprint = balanceTable.toMap().get("fingerprint").toString();
+    this.criteria = Collections.unmodifiableList(new ArrayList<Criteria>(criteria));
+    this.results = Collections.unmodifiableList(new ArrayList<Result>(results));
+    this.diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+  }
+
+  /**
+   * Assesses governed balance residuals against explicit criteria.
+   *
+   * @param balanceTable governed source balance table
+   * @param criteria explicit criteria grouped by stable balance identity
+   * @return immutable assessment with deterministic diagnostics
+   */
+  public static EngineeringDiagramBalanceAssessment fromBalanceTable(EngineeringDiagramBalanceTable balanceTable,
+      List<Criteria> criteria) {
+    if (balanceTable == null) {
+      throw new IllegalArgumentException("balanceTable must not be null");
+    }
+    if (criteria == null) {
+      throw new IllegalArgumentException("criteria must not be null");
+    }
+    List<Criteria> sortedCriteria = new ArrayList<Criteria>(criteria);
+    if (containsNull(sortedCriteria)) {
+      throw new IllegalArgumentException("criteria must not contain null");
+    }
+    Collections.sort(sortedCriteria, criteriaComparator());
+    List<Diagnostic> diagnostics = sourceDiagnostics(balanceTable);
+    if (sortedCriteria.isEmpty()) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_ASSESSMENT_CRITERIA_NOT_DECLARED",
+          "At least one explicit balance-tolerance criterion is required", ""));
+    }
+
+    Map<String, Balance> balancesById = new LinkedHashMap<String, Balance>();
+    for (Balance balance : balanceTable.getBalances()) {
+      balancesById.put(balance.getBalanceId(), balance);
+    }
+    Map<String, Criteria> criteriaById = new LinkedHashMap<String, Criteria>();
+    for (Criteria criterion : sortedCriteria) {
+      if (!balancesById.containsKey(criterion.getBalanceId())) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_ASSESSMENT_UNKNOWN_BALANCE",
+            "Tolerance criteria reference a balance absent from the governed balance table", criterion.getBalanceId()));
+        continue;
+      }
+      if (criteriaById.containsKey(criterion.getBalanceId())) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_ASSESSMENT_DUPLICATE_CRITERIA",
+            "A balance may have only one explicit tolerance criterion", criterion.getBalanceId()));
+        continue;
+      }
+      criteriaById.put(criterion.getBalanceId(), criterion);
+    }
+
+    List<Result> results = new ArrayList<Result>();
+    for (Balance balance : balanceTable.getBalances()) {
+      Criteria criterion = criteriaById.get(balance.getBalanceId());
+      if (criterion == null) {
+        diagnostics.add(new Diagnostic(Severity.WARNING, "BALANCE_ASSESSMENT_CRITERIA_MISSING",
+            "No explicit tolerance criterion was supplied for the source balance", balance.getBalanceId()));
+        results.add(new Result(balance, Status.NOT_ASSESSED, Status.NOT_ASSESSED));
+        continue;
+      }
+      Status massStatus = assessMass(balance, criterion);
+      Status enthalpyStatus = assessStreamEnthalpy(balance, criterion);
+      results.add(new Result(balance, massStatus, enthalpyStatus));
+      addStatusDiagnostic(balance.getBalanceId(), "MASS", massStatus, diagnostics);
+      addStatusDiagnostic(balance.getBalanceId(), "STREAM_ENTHALPY", enthalpyStatus, diagnostics);
+    }
+    Collections.sort(diagnostics, diagnosticComparator());
+    return new EngineeringDiagramBalanceAssessment(balanceTable, sortedCriteria, results, diagnostics);
+  }
+
+  /** @return source controlled-document identity */
+  public String getDocumentSetId() {
+    return documentSetId;
+  }
+
+  /** @return canonical source-graph fingerprint */
+  public String getSourceGraphFingerprint() {
+    return sourceGraphFingerprint;
+  }
+
+  /** @return selected operating-case identity */
+  public String getDesignCaseId() {
+    return designCaseId;
+  }
+
+  /** @return deterministic fingerprint of the source balance table */
+  public String getSourceBalanceTableFingerprint() {
+    return sourceBalanceTableFingerprint;
+  }
+
+  /** @return immutable explicit criteria in deterministic order */
+  public List<Criteria> getCriteria() {
+    return Collections.unmodifiableList(new ArrayList<Criteria>(criteria));
+  }
+
+  /** @return immutable assessment results in source-balance order */
+  public List<Result> getResults() {
+    return Collections.unmodifiableList(new ArrayList<Result>(results));
+  }
+
+  /** @return immutable structured diagnostics */
+  public List<Diagnostic> getDiagnostics() {
+    return Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+  }
+
+  /** @return true when no error-severity diagnostic is present */
+  public boolean isValid() {
+    for (Diagnostic diagnostic : diagnostics) {
+      if (diagnostic.getSeverity() == Severity.ERROR) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** @return deterministic machine-readable representation */
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", SCHEMA_VERSION);
+    result.put("documentSetId", documentSetId);
+    result.put("sourceGraphFingerprint", sourceGraphFingerprint);
+    result.put("designCaseId", designCaseId);
+    result.put("sourceBalanceTableFingerprint", sourceBalanceTableFingerprint);
+    List<Map<String, Object>> criteriaMaps = new ArrayList<Map<String, Object>>();
+    for (Criteria criterion : criteria) {
+      criteriaMaps.add(criterion.toMap());
+    }
+    result.put("criteria", criteriaMaps);
+    List<Map<String, Object>> resultMaps = new ArrayList<Map<String, Object>>();
+    for (Result assessmentResult : results) {
+      resultMaps.add(assessmentResult.toMap());
+    }
+    result.put("results", resultMaps);
+    List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
+    for (Diagnostic diagnostic : diagnostics) {
+      diagnosticMaps.add(diagnostic.toMap());
+    }
+    result.put("diagnostics", diagnosticMaps);
+    result.put("fingerprint", fingerprint(result));
+    return result;
+  }
+
+  /** @return deterministic pretty-printed JSON */
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+  }
+
+  private static Status assessMass(Balance balance, Criteria criterion) {
+    if (!balance.isMassFlowComplete()) {
+      return Status.INCOMPLETE;
+    }
+    return within(Math.abs(balance.getMassResidual()), criterion.getMassAbsoluteTolerance(),
+        Math.abs(balance.getRelativeMassResidual()), criterion.getMassRelativeTolerance()) ? Status.WITHIN_TOLERANCE
+            : Status.OUTSIDE_TOLERANCE;
+  }
+
+  private static Status assessStreamEnthalpy(Balance balance, Criteria criterion) {
+    if (!balance.isStreamEnthalpyFlowComplete()) {
+      return Status.INCOMPLETE;
+    }
+    return within(Math.abs(balance.getStreamEnthalpyResidual()), criterion.getStreamEnthalpyAbsoluteTolerance(),
+        Math.abs(balance.getRelativeStreamEnthalpyResidual()), criterion.getStreamEnthalpyRelativeTolerance())
+            ? Status.WITHIN_TOLERANCE
+            : Status.OUTSIDE_TOLERANCE;
+  }
+
+  private static boolean within(double absoluteResidual, double absoluteTolerance, double relativeResidual,
+      double relativeTolerance) {
+    return absoluteResidual <= absoluteTolerance && relativeResidual <= relativeTolerance;
+  }
+
+  private static void addStatusDiagnostic(String balanceId, String quantity, Status status,
+      List<Diagnostic> diagnostics) {
+    if (status == Status.OUTSIDE_TOLERANCE) {
+      diagnostics.add(new Diagnostic(Severity.WARNING, "BALANCE_ASSESSMENT_" + quantity + "_OUTSIDE_TOLERANCE",
+          "The governed residual exceeds at least one explicit tolerance limit", balanceId));
+    } else if (status == Status.INCOMPLETE) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "BALANCE_ASSESSMENT_" + quantity + "_INCOMPLETE",
+          "The governed residual is incomplete and cannot be assessed", balanceId));
+    }
+  }
+
+  private static List<Diagnostic> sourceDiagnostics(EngineeringDiagramBalanceTable balanceTable) {
+    List<Diagnostic> result = new ArrayList<Diagnostic>();
+    for (EngineeringDiagramBalanceTable.Diagnostic diagnostic : balanceTable.getDiagnostics()) {
+      result.add(new Diagnostic(diagnostic.getSeverity(), "BALANCE_ASSESSMENT_SOURCE_" + diagnostic.getCode(),
+          diagnostic.getMessage(), diagnostic.getSubjectId()));
+    }
+    return result;
+  }
+
+  private static boolean containsNull(List<Criteria> criteria) {
+    for (Criteria criterion : criteria) {
+      if (criterion == null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static Comparator<Criteria> criteriaComparator() {
+    return new Comparator<Criteria>() {
+      @Override
+      public int compare(Criteria left, Criteria right) {
+        int order = left.getBalanceId().compareTo(right.getBalanceId());
+        if (order != 0) {
+          return order;
+        }
+        return left.getSourceReference().compareTo(right.getSourceReference());
+      }
+    };
+  }
+
+  private static Comparator<Diagnostic> diagnosticComparator() {
+    return new Comparator<Diagnostic>() {
+      @Override
+      public int compare(Diagnostic left, Diagnostic right) {
+        int order = left.getSubjectId().compareTo(right.getSubjectId());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getCode().compareTo(right.getCode());
+        if (order != 0) {
+          return order;
+        }
+        return left.getMessage().compareTo(right.getMessage());
+      }
+    };
+  }
+
+  private static String fingerprint(Map<String, Object> value) {
+    String canonical = new GsonBuilder().create().toJson(value);
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(canonical.getBytes(StandardCharsets.UTF_8));
+      StringBuilder result = new StringBuilder();
+      for (byte item : hash) {
+        result.append(String.format("%02x", item & 0xff));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is not available", exception);
+    }
+  }
+
+  private static String requireText(String value, String name) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static double requireTolerance(double value, String name) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and non-negative");
+    }
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/measurementdevice/CricondenbarAnalyser.java
+++ b/src/main/java/neqsim/process/measurementdevice/CricondenbarAnalyser.java
@@ -1,7 +1,10 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -10,12 +13,19 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
 /**
  * CricondenbarAnalyser class.
  *
+ * <p>
+ * Concrete local instances participate in transient-step transactions. The snapshot restores the stream binding and
+ * inherited measurement/alarm state. Descendants and online-signal operation remain fail-closed.
+ *
  * @author ESOL
  * @version $Id: $Id
  */
-public class CricondenbarAnalyser extends StreamMeasurementDeviceBaseClass {
+public class CricondenbarAnalyser extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<CricondenbarAnalyser.CricondenbarAnalyserState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(CricondenbarAnalyser.class);
 
@@ -90,5 +100,63 @@ public class CricondenbarAnalyser extends StreamMeasurementDeviceBaseClass {
       logger.error(ex.getMessage(), ex);
     }
     return thermoOps.getSaturationPressure();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:cricondenbar:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local analyser.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != CricondenbarAnalyser.class) {
+      return "cricondenbar-analyser subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public CricondenbarAnalyserState captureTransientState() {
+    return new CricondenbarAnalyserState(getTransientStateIdentity(), stream, captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(CricondenbarAnalyserState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Cricondenbar analyser transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Cricondenbar analyser snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable cricondenbar-analyser rollback point. */
+  public static final class CricondenbarAnalyserState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private CricondenbarAnalyserState(String stateIdentity, StreamInterface stream,
+        MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/HydrateEquilibriumTemperatureAnalyser.java
+++ b/src/main/java/neqsim/process/measurementdevice/HydrateEquilibriumTemperatureAnalyser.java
@@ -1,7 +1,10 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -10,12 +13,19 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
 /**
  * HydrateEquilibriumTemperatureAnalyser class.
  *
+ * <p>
+ * Concrete local instances participate in transient-step transactions. The snapshot restores the stream binding,
+ * reference pressure and inherited measurement/alarm state. Descendants and online-signal operation remain fail-closed.
+ *
  * @author ESOL
  * @version $Id: $Id
  */
-public class HydrateEquilibriumTemperatureAnalyser extends StreamMeasurementDeviceBaseClass {
+public class HydrateEquilibriumTemperatureAnalyser extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<HydrateEquilibriumTemperatureAnalyser.HydrateAnalyserState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(HydrateEquilibriumTemperatureAnalyser.class);
 
@@ -81,5 +91,67 @@ public class HydrateEquilibriumTemperatureAnalyser extends StreamMeasurementDevi
    */
   public void setReferencePressure(double referencePressure) {
     this.referencePressure = referencePressure;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:hydrate-equilibrium-temperature:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local analyser.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != HydrateEquilibriumTemperatureAnalyser.class) {
+      return "hydrate-equilibrium-temperature-analyser subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public HydrateAnalyserState captureTransientState() {
+    return new HydrateAnalyserState(getTransientStateIdentity(), stream, referencePressure,
+        captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(HydrateAnalyserState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Hydrate analyser transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Hydrate analyser snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    referencePressure = snapshot.referencePressure;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable hydrate-equilibrium-temperature-analyser rollback point. */
+  public static final class HydrateAnalyserState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final double referencePressure;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private HydrateAnalyserState(String stateIdentity, StreamInterface stream, double referencePressure,
+        MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.referencePressure = referencePressure;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/HydrocarbonDewPointAnalyser.java
+++ b/src/main/java/neqsim/process/measurementdevice/HydrocarbonDewPointAnalyser.java
@@ -1,21 +1,32 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
 /**
- * WaterDewPointAnalyser class.
+ * HydrocarbonDewPointAnalyser class.
+ *
+ * <p>
+ * Concrete local instances participate in transient-step transactions. The snapshot restores the stream binding,
+ * reference pressure, method and inherited measurement/alarm state. Descendants and online-signal operation remain
+ * fail-closed.
  *
  * @author ESOL
  * @version $Id: $Id
  */
-public class HydrocarbonDewPointAnalyser extends StreamMeasurementDeviceBaseClass {
+public class HydrocarbonDewPointAnalyser extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<HydrocarbonDewPointAnalyser.HydrocarbonDewPointAnalyserState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(WaterDewPointAnalyser.class);
 
@@ -108,5 +119,70 @@ public class HydrocarbonDewPointAnalyser extends StreamMeasurementDeviceBaseClas
    */
   public void setMethod(String method) {
     this.method = method;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:hydrocarbon-dew-point:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local analyser.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != HydrocarbonDewPointAnalyser.class) {
+      return "hydrocarbon-dew-point-analyser subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public HydrocarbonDewPointAnalyserState captureTransientState() {
+    return new HydrocarbonDewPointAnalyserState(getTransientStateIdentity(), stream, referencePressure, method,
+        captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(HydrocarbonDewPointAnalyserState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Hydrocarbon-dew-point analyser transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Hydrocarbon-dew-point analyser snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    referencePressure = snapshot.referencePressure;
+    method = snapshot.method;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable hydrocarbon-dew-point-analyser rollback point. */
+  public static final class HydrocarbonDewPointAnalyserState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final double referencePressure;
+    private final String method;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private HydrocarbonDewPointAnalyserState(String stateIdentity, StreamInterface stream, double referencePressure,
+        String method, MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.referencePressure = referencePressure;
+      this.method = method;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/WaterDewPointAnalyser.java
+++ b/src/main/java/neqsim/process/measurementdevice/WaterDewPointAnalyser.java
@@ -1,7 +1,10 @@
 package neqsim.process.measurementdevice;
 
+import java.io.Serializable;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.util.empiric.BukacekWaterInGas;
@@ -11,12 +14,20 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
 /**
  * WaterDewPointAnalyser class.
  *
+ * <p>
+ * Concrete local instances participate in transient-step transactions. The snapshot restores the stream binding,
+ * reference pressure, method and inherited measurement/alarm state. Descendants and online-signal operation remain
+ * fail-closed.
+ *
  * @author ESOL
  * @version $Id: $Id
  */
-public class WaterDewPointAnalyser extends StreamMeasurementDeviceBaseClass {
+public class WaterDewPointAnalyser extends StreamMeasurementDeviceBaseClass
+    implements TransientStateParticipant<WaterDewPointAnalyser.WaterDewPointAnalyserState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(WaterDewPointAnalyser.class);
 
@@ -152,5 +163,70 @@ public class WaterDewPointAnalyser extends StreamMeasurementDeviceBaseClass {
    */
   public void setMethod(String method) {
     this.method = method;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "measurement:water-dew-point:" + transientStateParticipantId;
+  }
+
+  /**
+   * The snapshot is complete only for the concrete local analyser.
+   *
+   * @return blocking diagnostic for descendants or external online-signal operation, otherwise {@code null}
+   */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != WaterDewPointAnalyser.class) {
+      return "water-dew-point-analyser subclass " + getClass().getName()
+          + " must provide a snapshot that includes subclass-owned mutable state";
+    }
+    return getMeasurementTransientStateCoverageIssue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public WaterDewPointAnalyserState captureTransientState() {
+    return new WaterDewPointAnalyserState(getTransientStateIdentity(), stream, referencePressure, method,
+        captureMeasurementDeviceTransientState());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(WaterDewPointAnalyserState snapshot) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("Water-dew-point analyser transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException(
+          "Water-dew-point analyser snapshot identity does not match " + getTransientStateIdentity());
+    }
+    stream = snapshot.stream;
+    referencePressure = snapshot.referencePressure;
+    method = snapshot.method;
+    restoreMeasurementDeviceTransientState(snapshot.measurementState);
+  }
+
+  /** Immutable water-dew-point-analyser rollback point. */
+  public static final class WaterDewPointAnalyserState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final StreamInterface stream;
+    private final double referencePressure;
+    private final String method;
+    private final MeasurementDeviceTransientState measurementState;
+
+    private WaterDewPointAnalyserState(String stateIdentity, StreamInterface stream, double referencePressure,
+        String method, MeasurementDeviceTransientState measurementState) {
+      this.stateIdentity = stateIdentity;
+      this.stream = stream;
+      this.referencePressure = referencePressure;
+      this.method = method;
+      this.measurementState = measurementState;
+    }
   }
 }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -2695,10 +2695,10 @@ public class TPmultiflash extends TPflash {
       // avoids removing legitimate near-critical V/L pairs (issue #1980).
       //
       // CPA-family models may produce duplicate phases at material phase fractions
-      // (issue #2117). Cubic EOS can also retain an already-disappeared phase just
-      // above the generic beta-removal threshold. Extend the composition test to
-      // every model only for such trace phases; this cannot collapse a material
-      // near-critical V/L pair and still requires the same PhaseType and composition.
+      // (issue #2117). A neutral cubic-EOS aqueous trial can also converge two
+      // material liquid fractions to the same hydrocarbon root. Such a three-phase
+      // state is a two-phase equilibrium with duplicated phase storage. Chemical and
+      // ionic models keep the prior conservative trace-phase restriction.
       String modelName = system.getModelName();
       boolean isCpaModel = modelName != null && modelName.contains("CPA");
       boolean hasTracePhase = false;
@@ -2708,7 +2708,9 @@ public class TPmultiflash extends TPflash {
           break;
         }
       }
-      if (isCpaModel || hasTracePhase) {
+      boolean neutralAqueousThreePhaseDuplicate = system.getNumberOfPhases() == 3
+          && system.hasPhaseType(PhaseType.AQUEOUS) && !system.isChemicalSystem() && !hasIons;
+      if (isCpaModel || hasTracePhase || neutralAqueousThreePhaseDuplicate) {
         for (int i = 0; i < system.getNumberOfPhases() - 1; i++) {
           for (int j = i + 1; j < system.getNumberOfPhases(); j++) {
             if (system.getPhase(i).getType() != system.getPhase(j).getType()) {
@@ -2721,7 +2723,7 @@ public class TPmultiflash extends TPflash {
             }
             boolean traceDuplicatePair = Math.min(system.getBeta(i), system.getBeta(j)) < 10.0
                 * phaseFractionMinimumLimit;
-            if (maxCompDiff < 1.0e-6 && (isCpaModel || traceDuplicatePair)) {
+            if (maxCompDiff < 1.0e-6 && (isCpaModel || traceDuplicatePair || neutralAqueousThreePhaseDuplicate)) {
               mergeAndRemoveDuplicatePhase(i, j);
               doStabilityAnalysis = false;
               hasRemovedPhase = true;

--- a/src/test/java/neqsim/process/measurementdevice/ThermodynamicLimitAnalyserTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/ThermodynamicLimitAnalyserTransientStateTransactionTest.java
@@ -1,0 +1,275 @@
+package neqsim.process.measurementdevice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import neqsim.process.alarm.AlarmConfig;
+import neqsim.process.alarm.AlarmState;
+import neqsim.process.dynamics.EventScheduler;
+import neqsim.process.dynamics.TransientStepTransaction;
+import neqsim.process.dynamics.TransientTransactionCoverage;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Transaction, replay, restart, and blocker evidence for local thermodynamic-limit analysers. */
+class ThermodynamicLimitAnalyserTransientStateTransactionTest extends neqsim.NeqSimTest {
+  @Test
+  void multiAreaRollbackRestoresScheduledConfigurationAndAlarmState() {
+    StreamInterface originalStream = createGasStream("original gas", 22.0e-6);
+    StreamInterface trialStream = createGasStream("trial gas", 35.0e-6);
+
+    CricondenbarAnalyser cricondenbar = new CricondenbarAnalyser("cricondenbar", originalStream);
+    HydrateEquilibriumTemperatureAnalyser hydrate = new HydrateEquilibriumTemperatureAnalyser("hydrate equilibrium",
+        originalStream);
+    HydrocarbonDewPointAnalyser hydrocarbon = new HydrocarbonDewPointAnalyser("hydrocarbon dew point", originalStream);
+    WaterDewPointAnalyser water = new WaterDewPointAnalyser("water dew point", originalStream);
+    water.setAlarmConfig(AlarmConfig.builder().highLimit(-30.0).delay(2.0).unit("C").build());
+    AlarmState originalAlarmState = water.getAlarmState();
+    double originalWaterDewPoint = water.getMeasuredValue("C");
+
+    ProcessSystem cricondenbarArea = area("cricondenbar area", cricondenbar);
+    ProcessSystem hydrateArea = area("hydrate area", hydrate);
+    ProcessSystem hydrocarbonArea = area("hydrocarbon area", hydrocarbon);
+    ProcessSystem waterArea = area("water area", water);
+
+    ProcessModel model = new ProcessModel();
+    model.add("cricondenbar", cricondenbarArea);
+    model.add("hydrate", hydrateArea);
+    model.add("hydrocarbon", hydrocarbonArea);
+    model.add("water", waterArea);
+    assertCompleteCoverage(model.getTransientTransactionCoverage(), 4);
+
+    cricondenbarArea.getEventScheduler().scheduleEvent(1.0, "change cricondenbar binding",
+        () -> cricondenbar.setStream(trialStream));
+    hydrateArea.getEventScheduler().scheduleEvent(1.0, "change hydrate conditions", () -> {
+      hydrate.setStream(trialStream);
+      hydrate.setReferencePressure(80.0);
+    });
+    hydrocarbonArea.getEventScheduler().scheduleEvent(1.0, "change hydrocarbon conditions", () -> {
+      hydrocarbon.setStream(trialStream);
+      hydrocarbon.setReferencePressure(40.0);
+      hydrocarbon.setMethod("trial method");
+    });
+    waterArea.getEventScheduler().scheduleEvent(1.0, "change water conditions", () -> {
+      water.setStream(trialStream);
+      water.setReferencePressure(60.0);
+      water.setMethod("multiphase");
+    });
+
+    String waterIdentity = water.getTransientStateIdentity();
+    TransientStepTransaction transaction = model.beginTransientStepTransaction();
+    fireAll(cricondenbarArea, hydrateArea, hydrocarbonArea, waterArea);
+    assertTrue(water.evaluateAlarm(-20.0, 1.0, 1.0).isEmpty());
+    transaction.rollback();
+
+    assertEquals(waterIdentity, water.getTransientStateIdentity());
+    assertSame(originalStream, cricondenbar.getStream());
+    assertSame(originalStream, hydrate.getStream());
+    assertSame(originalStream, hydrocarbon.getStream());
+    assertSame(originalStream, water.getStream());
+    assertEquals(0.0, hydrate.getReferencePressure(), 0.0);
+    assertEquals(50.0, hydrocarbon.getReferencePressure(), 0.0);
+    assertEquals("EOS", hydrocarbon.getMethod());
+    assertEquals(70.0, water.getReferencePressure(), 0.0);
+    assertEquals("Bukacek", water.getMethod());
+    assertSame(originalAlarmState, water.getAlarmState());
+    assertEquals(originalWaterDewPoint, water.getMeasuredValue("C"), 0.0);
+    assertSchedulerRestored(cricondenbarArea, hydrateArea, hydrocarbonArea, waterArea);
+
+    TransientStepTransaction replay = model.beginTransientStepTransaction();
+    fireAll(cricondenbarArea, hydrateArea, hydrocarbonArea, waterArea);
+    assertSame(trialStream, cricondenbar.getStream());
+    assertEquals(80.0, hydrate.getReferencePressure(), 0.0);
+    assertEquals(40.0, hydrocarbon.getReferencePressure(), 0.0);
+    assertEquals("trial method", hydrocarbon.getMethod());
+    assertEquals(60.0, water.getReferencePressure(), 0.0);
+    assertEquals("multiphase", water.getMethod());
+    assertTrue(water.evaluateAlarm(-20.0, 1.0, 1.0).isEmpty());
+    assertEquals(1, water.evaluateAlarm(-20.0, 1.0, 2.0).size());
+    replay.commit();
+
+    assertSchedulerCommitted(cricondenbarArea, hydrateArea, hydrocarbonArea, waterArea);
+  }
+
+  @Test
+  void serializedAnalysersAndSnapshotsRestoreRestartState() throws Exception {
+    StreamInterface originalStream = createGasStream("restart gas", 22.0e-6);
+    StreamInterface trialStream = createGasStream("trial restart gas", 35.0e-6);
+
+    CricondenbarAnalyser cricondenbar = new CricondenbarAnalyser("cricondenbar", originalStream);
+    CricondenbarAnalyser.CricondenbarAnalyserState cricondenbarState = cricondenbar.captureTransientState();
+    cricondenbar.setStream(trialStream);
+
+    HydrateEquilibriumTemperatureAnalyser hydrate = new HydrateEquilibriumTemperatureAnalyser("hydrate",
+        originalStream);
+    hydrate.setReferencePressure(65.0);
+    HydrateEquilibriumTemperatureAnalyser.HydrateAnalyserState hydrateState = hydrate.captureTransientState();
+    hydrate.setReferencePressure(90.0);
+
+    HydrocarbonDewPointAnalyser hydrocarbon = new HydrocarbonDewPointAnalyser("hydrocarbon", originalStream);
+    hydrocarbon.setReferencePressure(45.0);
+    HydrocarbonDewPointAnalyser.HydrocarbonDewPointAnalyserState hydrocarbonState = hydrocarbon.captureTransientState();
+    hydrocarbon.setMethod("trial method");
+
+    WaterDewPointAnalyser water = new WaterDewPointAnalyser("water", originalStream);
+    water.setMethod("Bukacek");
+    WaterDewPointAnalyser.WaterDewPointAnalyserState waterState = water.captureTransientState();
+    water.setReferencePressure(55.0);
+
+    Object[] restored = roundTrip(cricondenbar, cricondenbarState, hydrate, hydrateState, hydrocarbon, hydrocarbonState,
+        water, waterState);
+
+    CricondenbarAnalyser restoredCricondenbar = (CricondenbarAnalyser) restored[0];
+    restoredCricondenbar.restoreTransientState((CricondenbarAnalyser.CricondenbarAnalyserState) restored[1]);
+    assertEquals("restart gas", restoredCricondenbar.getStream().getName());
+
+    HydrateEquilibriumTemperatureAnalyser restoredHydrate = (HydrateEquilibriumTemperatureAnalyser) restored[2];
+    restoredHydrate.restoreTransientState((HydrateEquilibriumTemperatureAnalyser.HydrateAnalyserState) restored[3]);
+    assertEquals(65.0, restoredHydrate.getReferencePressure(), 0.0);
+
+    HydrocarbonDewPointAnalyser restoredHydrocarbon = (HydrocarbonDewPointAnalyser) restored[4];
+    restoredHydrocarbon
+        .restoreTransientState((HydrocarbonDewPointAnalyser.HydrocarbonDewPointAnalyserState) restored[5]);
+    assertEquals(45.0, restoredHydrocarbon.getReferencePressure(), 0.0);
+    assertEquals("EOS", restoredHydrocarbon.getMethod());
+
+    WaterDewPointAnalyser restoredWater = (WaterDewPointAnalyser) restored[6];
+    restoredWater.restoreTransientState((WaterDewPointAnalyser.WaterDewPointAnalyserState) restored[7]);
+    assertEquals(70.0, restoredWater.getReferencePressure(), 0.0);
+    assertEquals("Bukacek", restoredWater.getMethod());
+
+    assertEquals(cricondenbar.getTransientStateIdentity(), restoredCricondenbar.getTransientStateIdentity());
+    assertEquals(hydrate.getTransientStateIdentity(), restoredHydrate.getTransientStateIdentity());
+    assertEquals(hydrocarbon.getTransientStateIdentity(), restoredHydrocarbon.getTransientStateIdentity());
+    assertEquals(water.getTransientStateIdentity(), restoredWater.getTransientStateIdentity());
+  }
+
+  @Test
+  void descendantsOnlineAndForeignSnapshotsFailClosed() {
+    StreamInterface stream = createGasStream("blocker gas", 22.0e-6);
+
+    assertBlocked(new CricondenbarAnalyser("subclass", stream) {
+      private static final long serialVersionUID = 1000L;
+    }, "subclass-owned mutable state");
+    assertBlocked(new HydrateEquilibriumTemperatureAnalyser("subclass", stream) {
+      private static final long serialVersionUID = 1000L;
+    }, "subclass-owned mutable state");
+    assertBlocked(new HydrocarbonDewPointAnalyser("subclass", stream) {
+      private static final long serialVersionUID = 1000L;
+    }, "subclass-owned mutable state");
+    assertBlocked(new WaterDewPointAnalyser("subclass", stream) {
+      private static final long serialVersionUID = 1000L;
+    }, "subclass-owned mutable state");
+
+    WaterDewPointAnalyser online = new WaterDewPointAnalyser("online", stream);
+    online.setIsOnlineSignal(true, "plant", "WDP-ONLINE");
+    assertBlocked(online, "external I/O");
+
+    CricondenbarAnalyser firstCricondenbar = new CricondenbarAnalyser("first", stream);
+    CricondenbarAnalyser secondCricondenbar = new CricondenbarAnalyser("second", stream);
+    assertThrows(IllegalArgumentException.class,
+        () -> secondCricondenbar.restoreTransientState(firstCricondenbar.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> firstCricondenbar.restoreTransientState(null));
+
+    HydrateEquilibriumTemperatureAnalyser firstHydrate = new HydrateEquilibriumTemperatureAnalyser("first", stream);
+    HydrateEquilibriumTemperatureAnalyser secondHydrate = new HydrateEquilibriumTemperatureAnalyser("second", stream);
+    assertThrows(IllegalArgumentException.class,
+        () -> secondHydrate.restoreTransientState(firstHydrate.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> firstHydrate.restoreTransientState(null));
+
+    HydrocarbonDewPointAnalyser firstHydrocarbon = new HydrocarbonDewPointAnalyser("first", stream);
+    HydrocarbonDewPointAnalyser secondHydrocarbon = new HydrocarbonDewPointAnalyser("second", stream);
+    assertThrows(IllegalArgumentException.class,
+        () -> secondHydrocarbon.restoreTransientState(firstHydrocarbon.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> firstHydrocarbon.restoreTransientState(null));
+
+    WaterDewPointAnalyser firstWater = new WaterDewPointAnalyser("first", stream);
+    WaterDewPointAnalyser secondWater = new WaterDewPointAnalyser("second", stream);
+    assertThrows(IllegalArgumentException.class,
+        () -> secondWater.restoreTransientState(firstWater.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> firstWater.restoreTransientState(null));
+  }
+
+  private static StreamInterface createGasStream(String name, double waterFraction) {
+    SystemInterface fluid = new SystemSrkEos(298.15, 70.0);
+    fluid.addComponent("methane", 1.0 - waterFraction);
+    fluid.addComponent("water", waterFraction);
+    fluid.setMixingRule("classic");
+    Stream stream = new Stream(name, fluid);
+    stream.run();
+    return stream;
+  }
+
+  private static ProcessSystem area(String name, MeasurementDeviceInterface analyser) {
+    ProcessSystem area = new ProcessSystem(name);
+    area.setEventScheduler(new EventScheduler());
+    area.add(analyser);
+    assertCompleteCoverage(area.getTransientTransactionCoverage(), 1);
+    return area;
+  }
+
+  private static void fireAll(ProcessSystem... areas) {
+    for (ProcessSystem area : areas) {
+      assertEquals(1, area.getEventScheduler().fireDueEvents(1.0));
+    }
+  }
+
+  private static void assertSchedulerRestored(ProcessSystem... areas) {
+    for (ProcessSystem area : areas) {
+      assertEquals(1, area.getEventScheduler().getPendingEvents().size());
+      assertEquals(0, area.getEventScheduler().getFiredEvents().size());
+    }
+  }
+
+  private static void assertSchedulerCommitted(ProcessSystem... areas) {
+    for (ProcessSystem area : areas) {
+      assertEquals(0, area.getEventScheduler().getPendingEvents().size());
+      assertEquals(1, area.getEventScheduler().getFiredEvents().size());
+    }
+  }
+
+  private static Object[] roundTrip(Object... values) throws Exception {
+    byte[] serialized;
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      for (Object value : values) {
+        output.writeObject(value);
+      }
+      serialized = bytes.toByteArray();
+    }
+    Object[] restored = new Object[values.length];
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      for (int i = 0; i < restored.length; i++) {
+        restored[i] = input.readObject();
+      }
+    }
+    return restored;
+  }
+
+  private static void assertBlocked(MeasurementDeviceInterface analyser, String expectedText) {
+    ProcessSystem process = new ProcessSystem("thermodynamic-limit blocker");
+    process.add(analyser);
+    TransientTransactionCoverage coverage = process.getTransientTransactionCoverage();
+    assertEquals(1, coverage.getProcessElementCount());
+    assertEquals(1, coverage.getParticipantCount());
+    assertEquals(1, coverage.getBlockingIssues().size());
+    assertTrue(coverage.getBlockingIssues().get(0).contains(expectedText));
+  }
+
+  private static void assertCompleteCoverage(TransientTransactionCoverage coverage, int expectedCount) {
+    assertEquals(expectedCount, coverage.getProcessElementCount());
+    assertEquals(expectedCount, coverage.getParticipantCount());
+    assertTrue(coverage.isComplete(), coverage.getBlockingIssues().toString());
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramBalanceAssessmentTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramBalanceAssessmentTest.java
@@ -1,0 +1,207 @@
+package neqsim.process.processmodel.diagram;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceAssessment;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceAssessment.Criteria;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceAssessment.Result;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceAssessment.Status;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Boundary;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Direction;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.EvidenceState;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Quantity;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Row;
+import neqsim.process.equipment.stream.StreamInterface;
+import org.junit.jupiter.api.Test;
+
+/** Regression tests for governed balance-tolerance assessment. */
+class EngineeringDiagramBalanceAssessmentTest {
+
+  @Test
+  void assessesExplicitCriteriaWithoutReconcilingSourceValues() {
+    EngineeringDiagramBalanceTable balanceTable = balanceTable(completeBoundaryCase());
+    String sourceJson = balanceTable.toJson();
+    Criteria criterion = criteria(1.0e-8, 1.0e-8, Double.MAX_VALUE, 2.0);
+
+    EngineeringDiagramBalanceAssessment assessment = EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+        Collections.singletonList(criterion));
+
+    assertTrue(assessment.isValid());
+    assertEquals(1, assessment.getResults().size());
+    Result result = assessment.getResults().get(0);
+    assertEquals("BAL-SIMPLE-01", result.getBalanceId());
+    assertEquals(Status.WITHIN_TOLERANCE, result.getMassStatus());
+    assertEquals(Status.WITHIN_TOLERANCE, result.getStreamEnthalpyStatus());
+    assertTrue(result.getMassAbsoluteResidual() >= 0.0);
+    assertTrue(result.getStreamEnthalpyAbsoluteResidual() >= 0.0);
+    assertEquals(sourceJson, balanceTable.toJson());
+    assertFalse(assessment.getSourceBalanceTableFingerprint().isEmpty());
+    assertNotSame(assessment.getCriteria(), assessment.getCriteria());
+    assertNotSame(assessment.getResults(), assessment.getResults());
+    assertNotSame(assessment.getDiagnostics(), assessment.getDiagnostics());
+    assertThrows(UnsupportedOperationException.class, () -> assessment.getCriteria().clear());
+    assertTrue(assessment.toJson().contains("\"massAbsoluteToleranceUnit\": \"kg/s\""));
+    assertTrue(assessment.toJson().contains("\"streamEnthalpyAbsoluteToleranceUnit\": \"W\""));
+  }
+
+  @Test
+  void flagsCompleteResidualsOutsideExplicitTolerance() {
+    EngineeringDiagramBalanceTable balanceTable = inletOnlyBalanceTable(completeBoundaryCase());
+    Criteria criterion = criteria(1.0e-8, 1.0e-8, 0.0, 0.0);
+
+    EngineeringDiagramBalanceAssessment assessment = EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+        Collections.singletonList(criterion));
+
+    assertTrue(assessment.isValid());
+    assertEquals(Status.OUTSIDE_TOLERANCE, assessment.getResults().get(0).getMassStatus());
+    assertEquals(Status.OUTSIDE_TOLERANCE, assessment.getResults().get(0).getStreamEnthalpyStatus());
+    assertTrue(hasDiagnostic(assessment, "BALANCE_ASSESSMENT_MASS_OUTSIDE_TOLERANCE"));
+    assertTrue(hasDiagnostic(assessment, "BALANCE_ASSESSMENT_STREAM_ENTHALPY_OUTSIDE_TOLERANCE"));
+  }
+
+  @Test
+  void rejectsMissingUnknownAndDuplicateCriteria() {
+    EngineeringDiagramBalanceTable balanceTable = balanceTable(completeBoundaryCase());
+    Criteria declared = criteria(1.0, 1.0, 1.0, 1.0);
+    Criteria unknown = new Criteria("BAL-MISSING", 1.0, 1.0, 1.0, 1.0, "project-balance-criteria:test",
+        EvidenceState.PROPOSED);
+
+    EngineeringDiagramBalanceAssessment missing = EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+        Collections.<Criteria>emptyList());
+    EngineeringDiagramBalanceAssessment duplicate = EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+        Arrays.asList(declared, declared));
+    EngineeringDiagramBalanceAssessment unknownAssessment = EngineeringDiagramBalanceAssessment
+        .fromBalanceTable(balanceTable, Collections.singletonList(unknown));
+
+    assertFalse(missing.isValid());
+    assertTrue(hasDiagnostic(missing, "BALANCE_ASSESSMENT_CRITERIA_NOT_DECLARED"));
+    assertEquals(Status.NOT_ASSESSED, missing.getResults().get(0).getMassStatus());
+    assertFalse(duplicate.isValid());
+    assertTrue(hasDiagnostic(duplicate, "BALANCE_ASSESSMENT_DUPLICATE_CRITERIA"));
+    assertFalse(unknownAssessment.isValid());
+    assertTrue(hasDiagnostic(unknownAssessment, "BALANCE_ASSESSMENT_UNKNOWN_BALANCE"));
+  }
+
+  @Test
+  void reportsIncompleteGovernedSourceValues() {
+    EngineeringDiagramBalanceTable balanceTable = incompleteBalanceTable(completeBoundaryCase());
+
+    EngineeringDiagramBalanceAssessment assessment = EngineeringDiagramBalanceAssessment.fromBalanceTable(balanceTable,
+        Collections.singletonList(criteria(1.0, 1.0, 1.0, 1.0)));
+
+    assertFalse(assessment.isValid());
+    assertEquals(Status.INCOMPLETE, assessment.getResults().get(0).getMassStatus());
+    assertEquals(Status.INCOMPLETE, assessment.getResults().get(0).getStreamEnthalpyStatus());
+    assertTrue(hasDiagnostic(assessment, "BALANCE_ASSESSMENT_MASS_INCOMPLETE"));
+    assertTrue(hasDiagnostic(assessment, "BALANCE_ASSESSMENT_STREAM_ENTHALPY_INCOMPLETE"));
+    assertTrue(hasDiagnostic(assessment, "BALANCE_ASSESSMENT_SOURCE_BALANCE_BOUNDARY_UNKNOWN_STREAM"));
+  }
+
+  @Test
+  void isDeterministicForFreshSystemsAndCriteriaOrder() {
+    EngineeringDiagramBalanceAssessment first = EngineeringDiagramBalanceAssessment.fromBalanceTable(
+        balanceTable(completeBoundaryCase()), Collections.singletonList(criteria(1.0, 1.0, Double.MAX_VALUE, 2.0)));
+    List<Criteria> secondCriteria = new ArrayList<Criteria>();
+    secondCriteria.add(criteria(1.0, 1.0, Double.MAX_VALUE, 2.0));
+    Collections.reverse(secondCriteria);
+    EngineeringDiagramBalanceAssessment second = EngineeringDiagramBalanceAssessment
+        .fromBalanceTable(balanceTable(completeBoundaryCase()), secondCriteria);
+
+    assertEquals(first.toJson(), second.toJson());
+  }
+
+  @Test
+  void rejectsInvalidCriteriaConstruction() {
+    assertThrows(IllegalArgumentException.class, () -> new Criteria("BAL-SIMPLE-01", -1.0, 1.0, 1.0, 1.0,
+        "project-balance-criteria:test", EvidenceState.PROPOSED));
+    assertThrows(IllegalArgumentException.class, () -> new Criteria("BAL-SIMPLE-01", 1.0, Double.NaN, 1.0, 1.0,
+        "project-balance-criteria:test", EvidenceState.PROPOSED));
+    assertThrows(IllegalArgumentException.class, () -> new Criteria("BAL-SIMPLE-01", 1.0, 1.0, Double.POSITIVE_INFINITY,
+        1.0, "project-balance-criteria:test", EvidenceState.PROPOSED));
+  }
+
+  private static Criteria criteria(double massAbsolute, double massRelative, double enthalpyAbsolute,
+      double enthalpyRelative) {
+    return new Criteria("BAL-SIMPLE-01", massAbsolute, massRelative, enthalpyAbsolute, enthalpyRelative,
+        "project-balance-criteria:test", EvidenceState.PROPOSED);
+  }
+
+  private static EngineeringDiagramReferenceFixtures.SystemCase completeBoundaryCase() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
+    for (StreamInterface product : reference.getProducts()) {
+      reference.getProcessSystem().add(product);
+    }
+    reference.getProcessSystem().run();
+    return reference;
+  }
+
+  private static EngineeringDiagramBalanceTable balanceTable(EngineeringDiagramReferenceFixtures.SystemCase reference) {
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-006", "Boundary tolerance assessment",
+        ContentProfile.PFD, "NORMAL-01");
+    EngineeringDiagramStreamTable streamTable = EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
+    List<Boundary> boundaries = new ArrayList<Boundary>();
+    Row feed = completeRow(streamTable, reference.getFeed().getName());
+    boundaries.add(new Boundary("BAL-SIMPLE-01", feed.getSemanticObjectId(), Direction.INLET,
+        "project-balance-register:test", EvidenceState.PROPOSED));
+    for (StreamInterface product : reference.getProducts()) {
+      Row row = completeRow(streamTable, product.getName());
+      boundaries.add(new Boundary("BAL-SIMPLE-01", row.getSemanticObjectId(), Direction.OUTLET,
+          "project-balance-register:test", EvidenceState.PROPOSED));
+    }
+    return EngineeringDiagramBalanceTable.fromStreamTable(streamTable, boundaries);
+  }
+
+  private static EngineeringDiagramBalanceTable inletOnlyBalanceTable(
+      EngineeringDiagramReferenceFixtures.SystemCase reference) {
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-006", "Boundary tolerance assessment",
+        ContentProfile.PFD, "NORMAL-01");
+    EngineeringDiagramStreamTable streamTable = EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
+    Row feed = completeRow(streamTable, reference.getFeed().getName());
+    Boundary boundary = new Boundary("BAL-SIMPLE-01", feed.getSemanticObjectId(), Direction.INLET,
+        "project-balance-register:test", EvidenceState.PROPOSED);
+    return EngineeringDiagramBalanceTable.fromStreamTable(streamTable, Collections.singletonList(boundary));
+  }
+
+  private static EngineeringDiagramBalanceTable incompleteBalanceTable(
+      EngineeringDiagramReferenceFixtures.SystemCase reference) {
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-006", "Boundary tolerance assessment",
+        ContentProfile.PFD, "NORMAL-01");
+    EngineeringDiagramStreamTable streamTable = EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
+    Boundary boundary = new Boundary("BAL-SIMPLE-01", "line:missing", Direction.INLET, "project-balance-register:test",
+        EvidenceState.PROPOSED);
+    return EngineeringDiagramBalanceTable.fromStreamTable(streamTable, Collections.singletonList(boundary));
+  }
+
+  private static Row completeRow(EngineeringDiagramStreamTable table, String sourceLabel) {
+    for (Row row : table.getRows()) {
+      if (sourceLabel.equals(row.getSourceLabel()) && row.getValues().size() == Quantity.values().length) {
+        return row;
+      }
+    }
+    throw new AssertionError("No complete stream-table row for " + sourceLabel);
+  }
+
+  private static boolean hasDiagnostic(EngineeringDiagramBalanceAssessment assessment, String code) {
+    for (EngineeringDiagramBalanceAssessment.Diagnostic diagnostic : assessment.getDiagnostics()) {
+      if (code.equals(diagnostic.getCode())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterRichColdSeedConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterRichColdSeedConsistencyTest.java
@@ -65,13 +65,15 @@ class TPflashWaterRichColdSeedConsistencyTest extends neqsim.NeqSimTest {
   }
 
   @Test
-  void genuineThreePhaseCandidateIsNotForcedIntoTwoPhaseAcceptance() {
-    SystemInterface ordinary = flash(createSystem(230.0, 91.0, FEED, false), false);
+  void duplicateOilTrialIsMergedWithoutLosingMaterialBalance() {
     SystemInterface multiphase = flash(createSystem(230.0, 91.0, FEED, true), false);
 
-    assertTrue(ordinary.getNumberOfPhases() < 3);
-    assertEquals(3, multiphase.getNumberOfPhases());
-    assertTrue(maximumComponentBalanceResidual(multiphase) < 1.0e-10);
+    assertEquals(2, multiphase.getNumberOfPhases());
+    assertTrue(multiphase.hasPhaseType(PhaseType.OIL));
+    assertTrue(multiphase.hasPhaseType(PhaseType.AQUEOUS));
+    assertEquals(0.95019654, multiphase.getPhase("oil").getBeta(), 1.0e-8);
+    assertEquals(0.04980346, multiphase.getPhase("aqueous").getBeta(), 1.0e-8);
+    assertPhysicalEquilibrium(multiphase);
   }
 
   private static SystemInterface createSystem(double temperature, double pressure, double[] composition,


### PR DESCRIPTION
## Summary

Consolidates and supersedes the two recently closed, unmerged pull requests:

- #3032 — thermodynamic-limit analyser transient transactions
- #3033 — explicit engineering-diagram balance tolerance assessment

It also fixes the current-`master` `TPflashWaterRichColdSeedConsistencyTest` failures reported while rebuilding the combined change.

## Included work

### Thermodynamic-limit analyser transactions

Advances #2911 by making the local `CricondenbarAnalyser`, `HydrateEquilibriumTemperatureAnalyser`, `HydrocarbonDewPointAnalyser`, and `WaterDewPointAnalyser` families participate in identity-preserving transient rollback/commit.

The snapshots retain stream binding, inherited measurement/alarm state, reference conditions, configured method, scheduler bookkeeping, replay behavior, and serialization. Null/foreign snapshots, subclasses, and online/external-I/O operation remain fail-closed.

### Explicit balance tolerance assessment

Coordinates #1332 and #2899 with an immutable, serializable `EngineeringDiagramBalanceAssessment` companion projection.

Assessments are bound to the source document, graph, operating case, and balance fingerprint; require explicit absolute/relative mass and stream-enthalpy limits with units and evidence; apply the conservative both-limits rule; and publish deterministic status/diagnostic JSON without performing reconciliation or implying engineering approval.

### Water-rich TP flash regression

A neutral cubic-EOS aqueous stability trial could retain two material OIL phase fractions that had converged to the same hydrocarbon root. At 230 K around 90 bara their component compositions differed by less than `1e-6`, so the result was duplicated phase storage rather than a distinct three-phase equilibrium. That caused ordinary and multiphase cold seeds to disagree and produced the two reported test failures.

`TPmultiflash` now merges the duplicate betas before removing the redundant same-type phase for neutral cubic-EOS aqueous three-phase trials. Chemical and ionic models retain the prior conservative restriction, and compositionally distinct gas/oil/aqueous equilibria remain three phase. The neighboring 91-bara regression now verifies the consolidated OIL+AQUEOUS result, phase fractions, material balance, and fugacity closure.

## Compatibility and limits

- Existing analyser thermodynamic calculations are unchanged.
- The balance assessment is opt-in; existing diagram, balance-table, DEXPI/Proteus, SVG/PDF, Graphviz, and controlled-document APIs remain unchanged.
- No data reconciliation, inferred project tolerance, standards-conformance, design approval, external-I/O qualification, analyser-accuracy claim, or new phase-equilibrium model is introduced.

## Documentation impact

Updated the dynamic capability contract, measurement-device guide, engineering-diagram document model, and TP-flash algorithm documentation for the new transaction boundary, assessment semantics/units, duplicate-phase consolidation, and limitations.

## Validation

Passed on exact combined tree `792b30705620ba1de2a602569a7214cf2dbd35fe` based on current `master` `c67c3765df113e1448ff7942744a58020d189cba`:

- `./mvnw -Dtest=TPflashWaterRichColdSeedConsistencyTest test` — 3 tests, 0 failures/errors/skips
- focused consolidated and adjacent three-phase suite — 49 tests, 0 failures/errors/skips:
  - `ThermodynamicLimitAnalyserTransientStateTransactionTest`
  - `HydrocarbonDewPointAnalyserTest`
  - `EngineeringDiagramBalanceAssessmentTest`
  - `TPflashWaterRichColdSeedConsistencyTest`
  - `TPflashAqueousPhaseRemovalRecoveryTest`
  - `TPflashSrkAqueousLowerGibbsRootTest`
  - `TPflashTerminalEquilibriumRefinementTest`
  - `TPmultiflashPhaseDisappearanceTest`
  - `TPflashWarmStartThreePhaseTest`
  - `TPmultiflashHighWaterGasSeedTest`
  - `TPFlashTest`
  - `TPflashCpaHydrocarbonLiquidStabilityTest`
  - `TPflashSourGasConsistencyTest`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py` — audited 653 Markdown pages and 1 standalone HTML page
- `git diff --check`

The local `pre-commit` executable was unavailable, so no local pre-commit/pre-push hook result is claimed. Hosted CI is pending.

## Publication

One commit, 13 files, 1,391 additions and 24 deletions. This PR intentionally combines the two disjoint closed tranches at the request of the maintainer and does not merge automatically.