### PR TITLE
[AI-Assisted] feat(controller): transact complete local MPC state

### DIFF
--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -531,3 +531,31 @@ or pipe physics, sampling, external I/O, alarm/trip integrity, safety action, vi
 or OTS use. `VirtualFlowMeter` remains outside this gate because its wall-clock result timestamps
 need a separate deterministic time/provenance design. `SevereSlugAnalyser` remains owned by the
 multiphase physics scope in issue #2907.
+
+## Local model-predictive-controller transaction coverage
+
+A concrete local `ModelPredictiveController` participates when registered as a controller in a
+`ProcessSystem`. Its immutable snapshot covers the controller name, stable transaction identity,
+transmitter binding, set point, unit, activation and reverse-action configuration, output and move
+limits, process model, quadratic weights, prediction horizon, last physical-step identity,
+measurement/control history and current response.
+
+Multivariable state is included rather than treated as an independent side channel: control names,
+current/previous vectors, limits, weights and preferred values are defensively copied. Each quality
+constraint snapshots its measurement binding, unit, limit/margin, control/composition/rate
+sensitivities and mutable observed/predicted values. Feedforward composition/rate state, predicted
+quality values, moving-horizon sample windows and the last identified model are also restored.
+Quality constraints and moving-horizon estimates are serializable so restart preserves the same
+configured optimization problem and estimator continuation.
+
+Quantitative evidence covers exact single-input and multivariable rejected-trial replay,
+physical-step idempotence, coordinated two-area `ProcessModel` rollback, moving-horizon
+continuation, foreign/null snapshot rejection and Java-serialization restart. Concrete descendants
+fail closed until they extend the snapshot for their own state. Online/external-I/O transmitter or
+quality-measurement bindings also fail closed because their timing and side effects do not yet have
+a rejected-step commit/defer contract.
+
+This gate establishes deterministic in-memory rollback and restart mechanics only. It does not
+qualify the MPC model structure, optimization quality, constraint tuning, plant identification,
+closed-loop stability, scan-time fidelity, external DCS commands, safety action, virtual
+commissioning or OTS use.

--- a/src/main/java/neqsim/process/controllerdevice/ModelPredictiveController.java
+++ b/src/main/java/neqsim/process/controllerdevice/ModelPredictiveController.java
@@ -1,5 +1,6 @@
 package neqsim.process.controllerdevice;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -11,6 +12,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.measurementdevice.MeasurementDeviceInterface;
 import neqsim.util.NamedBaseClass;
 
@@ -29,7 +31,8 @@ import neqsim.util.NamedBaseClass;
  * operating on real process data without requiring external optimisation packages.
  * </p>
  */
-public class ModelPredictiveController extends NamedBaseClass implements ControllerDeviceInterface {
+public class ModelPredictiveController extends NamedBaseClass implements ControllerDeviceInterface,
+    TransientStateParticipant<ModelPredictiveController.MpcTransientState> {
   private static final long serialVersionUID = 1000L;
 
   private static final int MIN_ESTIMATION_SAMPLES = 5;
@@ -67,7 +70,7 @@ public class ModelPredictiveController extends NamedBaseClass implements Control
   private double[] controlWeightsVector = new double[0];
   private double[] moveWeightsVector = new double[0];
   private int primaryControlIndex = 0;
-  private final transient List<QualityConstraint> qualityConstraints = new ArrayList<>();
+  private final List<QualityConstraint> qualityConstraints = new ArrayList<>();
   private Map<String, Double> lastFeedComposition = new LinkedHashMap<>();
   private Map<String, Double> pendingFeedComposition = new LinkedHashMap<>();
   private double lastFeedRate = 0.0;
@@ -79,7 +82,9 @@ public class ModelPredictiveController extends NamedBaseClass implements Control
   private final List<Double> estimationMeasurements = new ArrayList<>();
   private final List<Double> estimationControls = new ArrayList<>();
   private final List<Double> estimationSampleTimes = new ArrayList<>();
-  private transient MovingHorizonEstimate lastMovingHorizonEstimate;
+  private MovingHorizonEstimate lastMovingHorizonEstimate;
+  /** Persistent identity used only for transient transaction provenance. */
+  private String transientStateParticipantId = UUID.randomUUID().toString();
 
   /**
    * Representation of a quality constraint handled by the MPC. Each constraint links a measurement device with linear
@@ -87,7 +92,8 @@ public class ModelPredictiveController extends NamedBaseClass implements Control
    * changes. Inequality limits are enforced softly by the quadratic program to keep the process within specification
    * while still penalising unnecessary control effort.
    */
-  public static final class QualityConstraint {
+  public static final class QualityConstraint implements Serializable {
+    private static final long serialVersionUID = 1000L;
     private final String name;
     private final MeasurementDeviceInterface measurement;
     private final String unit;
@@ -266,7 +272,8 @@ public class ModelPredictiveController extends NamedBaseClass implements Control
    * Result from the moving horizon estimation routine. The estimate captures the identified first-order process
    * parameters together with a mean squared prediction error and the number of samples used.
    */
-  public static final class MovingHorizonEstimate {
+  public static final class MovingHorizonEstimate implements Serializable {
+    private static final long serialVersionUID = 1000L;
     private final double processGain;
     private final double timeConstant;
     private final double processBias;
@@ -1287,6 +1294,9 @@ public class ModelPredictiveController extends NamedBaseClass implements Control
 
   @Override
   public void runTransient(double initResponse, double dt, UUID id) {
+    if (id != null && id.equals(calcIdentifier)) {
+      return;
+    }
     calcIdentifier = id;
     lastSampleTime = dt;
     if (!qualityConstraints.isEmpty()) {
@@ -2042,6 +2052,268 @@ public class ModelPredictiveController extends NamedBaseClass implements Control
     return trajectory;
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateParticipantId == null || transientStateParticipantId.trim().isEmpty()) {
+      transientStateParticipantId = UUID.randomUUID().toString();
+    }
+    return "controller:mpc:" + transientStateParticipantId;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != ModelPredictiveController.class) {
+      return "MPC subclass " + getClass().getName()
+          + " must provide a complete transient-state snapshot before transactional execution";
+    }
+    if (transmitter != null && transmitter.isOnlineSignal()) {
+      return "MPC transmitter '" + transmitter.getName()
+          + "' uses online/external I/O without a rejected-step commit/defer contract";
+    }
+    for (QualityConstraint constraint : qualityConstraints) {
+      MeasurementDeviceInterface measurement = constraint.getMeasurement();
+      if (measurement != null && measurement.isOnlineSignal()) {
+        return "MPC quality constraint '" + constraint.getName() + "' uses online/external I/O through measurement '"
+            + measurement.getName() + "'";
+      }
+    }
+    return null;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public MpcTransientState captureTransientState() {
+    String coverageIssue = getTransientStateCoverageIssue();
+    if (coverageIssue != null) {
+      throw new IllegalStateException(coverageIssue);
+    }
+    return new MpcTransientState(this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(MpcTransientState state) {
+    if (state == null) {
+      throw new IllegalArgumentException("MPC transient snapshot cannot be null");
+    }
+    if (!getTransientStateIdentity().equals(state.stateIdentity)) {
+      throw new IllegalArgumentException("MPC transient snapshot belongs to '" + state.stateIdentity
+          + "', not '" + getTransientStateIdentity() + "'");
+    }
+
+    setName(state.name);
+    transmitter = state.transmitter;
+    controllerSetPoint = state.controllerSetPoint;
+    unit = state.unit;
+    reverseActing = state.reverseActing;
+    isActive = state.active;
+    response = state.response;
+    minResponse = state.minResponse;
+    maxResponse = state.maxResponse;
+    minMove = state.minMove;
+    maxMove = state.maxMove;
+    processGain = state.processGain;
+    timeConstant = state.timeConstant;
+    processBias = state.processBias;
+    predictionHorizon = state.predictionHorizon;
+    outputWeight = state.outputWeight;
+    controlWeight = state.controlWeight;
+    moveWeight = state.moveWeight;
+    preferredControlValue = state.preferredControlValue;
+    calcIdentifier = state.calcIdentifier;
+    lastSampledValue = state.lastSampledValue;
+    lastSampleTime = state.lastSampleTime;
+    lastAppliedControl = state.lastAppliedControl;
+    controlNames.clear();
+    controlNames.addAll(state.controlNames);
+    controlVector = state.controlVector.clone();
+    lastControlVector = state.lastControlVector.clone();
+    minControlVector = state.minControlVector.clone();
+    maxControlVector = state.maxControlVector.clone();
+    minControlMoveVector = state.minControlMoveVector.clone();
+    maxControlMoveVector = state.maxControlMoveVector.clone();
+    preferredControlVector = state.preferredControlVector.clone();
+    controlWeightsVector = state.controlWeightsVector.clone();
+    moveWeightsVector = state.moveWeightsVector.clone();
+    primaryControlIndex = state.primaryControlIndex;
+    qualityConstraints.clear();
+    for (MpcQualityConstraintState constraintState : state.qualityConstraints) {
+      qualityConstraints.add(constraintState.toConstraint());
+    }
+    lastFeedComposition = new LinkedHashMap<>(state.lastFeedComposition);
+    pendingFeedComposition = new LinkedHashMap<>(state.pendingFeedComposition);
+    lastFeedRate = state.lastFeedRate;
+    pendingFeedRate = state.pendingFeedRate;
+    feedInitialised = state.feedInitialised;
+    predictedQualityValues.clear();
+    predictedQualityValues.putAll(state.predictedQualityValues);
+    movingHorizonEstimationEnabled = state.movingHorizonEstimationEnabled;
+    movingHorizonWindow = state.movingHorizonWindow;
+    estimationMeasurements.clear();
+    estimationMeasurements.addAll(state.estimationMeasurements);
+    estimationControls.clear();
+    estimationControls.addAll(state.estimationControls);
+    estimationSampleTimes.clear();
+    estimationSampleTimes.addAll(state.estimationSampleTimes);
+    lastMovingHorizonEstimate = copyEstimate(state.lastMovingHorizonEstimate);
+  }
+
+  private static MovingHorizonEstimate copyEstimate(MovingHorizonEstimate estimate) {
+    if (estimate == null) {
+      return null;
+    }
+    return new MovingHorizonEstimate(estimate.processGain, estimate.timeConstant, estimate.processBias,
+        estimate.meanSquaredError, estimate.sampleCount);
+  }
+
+  /** Immutable, serializable rollback snapshot for one concrete local MPC. */
+  public static final class MpcTransientState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String stateIdentity;
+    private final String name;
+    private final MeasurementDeviceInterface transmitter;
+    private final double controllerSetPoint;
+    private final String unit;
+    private final boolean reverseActing;
+    private final boolean active;
+    private final double response;
+    private final double minResponse;
+    private final double maxResponse;
+    private final double minMove;
+    private final double maxMove;
+    private final double processGain;
+    private final double timeConstant;
+    private final double processBias;
+    private final int predictionHorizon;
+    private final double outputWeight;
+    private final double controlWeight;
+    private final double moveWeight;
+    private final double preferredControlValue;
+    private final UUID calcIdentifier;
+    private final double lastSampledValue;
+    private final double lastSampleTime;
+    private final double lastAppliedControl;
+    private final List<String> controlNames;
+    private final double[] controlVector;
+    private final double[] lastControlVector;
+    private final double[] minControlVector;
+    private final double[] maxControlVector;
+    private final double[] minControlMoveVector;
+    private final double[] maxControlMoveVector;
+    private final double[] preferredControlVector;
+    private final double[] controlWeightsVector;
+    private final double[] moveWeightsVector;
+    private final int primaryControlIndex;
+    private final List<MpcQualityConstraintState> qualityConstraints;
+    private final Map<String, Double> lastFeedComposition;
+    private final Map<String, Double> pendingFeedComposition;
+    private final double lastFeedRate;
+    private final double pendingFeedRate;
+    private final boolean feedInitialised;
+    private final Map<String, Double> predictedQualityValues;
+    private final boolean movingHorizonEstimationEnabled;
+    private final int movingHorizonWindow;
+    private final List<Double> estimationMeasurements;
+    private final List<Double> estimationControls;
+    private final List<Double> estimationSampleTimes;
+    private final MovingHorizonEstimate lastMovingHorizonEstimate;
+
+    private MpcTransientState(ModelPredictiveController controller) {
+      stateIdentity = controller.getTransientStateIdentity();
+      name = controller.getName();
+      transmitter = controller.transmitter;
+      controllerSetPoint = controller.controllerSetPoint;
+      unit = controller.unit;
+      reverseActing = controller.reverseActing;
+      active = controller.isActive;
+      response = controller.response;
+      minResponse = controller.minResponse;
+      maxResponse = controller.maxResponse;
+      minMove = controller.minMove;
+      maxMove = controller.maxMove;
+      processGain = controller.processGain;
+      timeConstant = controller.timeConstant;
+      processBias = controller.processBias;
+      predictionHorizon = controller.predictionHorizon;
+      outputWeight = controller.outputWeight;
+      controlWeight = controller.controlWeight;
+      moveWeight = controller.moveWeight;
+      preferredControlValue = controller.preferredControlValue;
+      calcIdentifier = controller.calcIdentifier;
+      lastSampledValue = controller.lastSampledValue;
+      lastSampleTime = controller.lastSampleTime;
+      lastAppliedControl = controller.lastAppliedControl;
+      controlNames = new ArrayList<>(controller.controlNames);
+      controlVector = controller.controlVector.clone();
+      lastControlVector = controller.lastControlVector.clone();
+      minControlVector = controller.minControlVector.clone();
+      maxControlVector = controller.maxControlVector.clone();
+      minControlMoveVector = controller.minControlMoveVector.clone();
+      maxControlMoveVector = controller.maxControlMoveVector.clone();
+      preferredControlVector = controller.preferredControlVector.clone();
+      controlWeightsVector = controller.controlWeightsVector.clone();
+      moveWeightsVector = controller.moveWeightsVector.clone();
+      primaryControlIndex = controller.primaryControlIndex;
+      qualityConstraints = new ArrayList<>();
+      for (QualityConstraint constraint : controller.qualityConstraints) {
+        qualityConstraints.add(new MpcQualityConstraintState(constraint));
+      }
+      lastFeedComposition = new LinkedHashMap<>(controller.lastFeedComposition);
+      pendingFeedComposition = new LinkedHashMap<>(controller.pendingFeedComposition);
+      lastFeedRate = controller.lastFeedRate;
+      pendingFeedRate = controller.pendingFeedRate;
+      feedInitialised = controller.feedInitialised;
+      predictedQualityValues = new LinkedHashMap<>(controller.predictedQualityValues);
+      movingHorizonEstimationEnabled = controller.movingHorizonEstimationEnabled;
+      movingHorizonWindow = controller.movingHorizonWindow;
+      estimationMeasurements = new ArrayList<>(controller.estimationMeasurements);
+      estimationControls = new ArrayList<>(controller.estimationControls);
+      estimationSampleTimes = new ArrayList<>(controller.estimationSampleTimes);
+      lastMovingHorizonEstimate = copyEstimate(controller.lastMovingHorizonEstimate);
+    }
+  }
+
+  /** Serializable copy of one quality constraint, including its mutable observation cache. */
+  private static final class MpcQualityConstraintState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String name;
+    private final MeasurementDeviceInterface measurement;
+    private final String unit;
+    private final double limit;
+    private final double margin;
+    private final double[] controlSensitivity;
+    private final Map<String, Double> compositionSensitivity;
+    private final double rateSensitivity;
+    private final double lastMeasurement;
+    private final double predictedValue;
+
+    private MpcQualityConstraintState(QualityConstraint constraint) {
+      name = constraint.name;
+      measurement = constraint.measurement;
+      unit = constraint.unit;
+      limit = constraint.limit;
+      margin = constraint.margin;
+      controlSensitivity = constraint.controlSensitivity.clone();
+      compositionSensitivity = new LinkedHashMap<>(constraint.compositionSensitivity);
+      rateSensitivity = constraint.rateSensitivity;
+      lastMeasurement = constraint.lastMeasurement;
+      predictedValue = constraint.predictedValue;
+    }
+
+    private QualityConstraint toConstraint() {
+      QualityConstraint constraint = QualityConstraint.builder(name).measurement(measurement).unit(unit).limit(limit)
+          .margin(margin).controlSensitivity(controlSensitivity).compositionSensitivities(compositionSensitivity)
+          .rateSensitivity(rateSensitivity).build();
+      constraint.setLastMeasurement(lastMeasurement);
+      constraint.setPredictedValue(predictedValue);
+      return constraint;
+    }
+  }
+
   @Override
   public void setActive(boolean isActive) {
     this.isActive = isActive;
@@ -2076,6 +2348,12 @@ public class ModelPredictiveController extends NamedBaseClass implements Control
    */
   public UUID getCalcIdentifier() {
     return calcIdentifier;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean hasRunTransient(UUID id) {
+    return id != null && id.equals(calcIdentifier);
   }
 
   /**

--- a/src/main/java/neqsim/process/controllerdevice/ModelPredictiveController.java
+++ b/src/main/java/neqsim/process/controllerdevice/ModelPredictiveController.java
@@ -33,8 +33,8 @@ import neqsim.util.NamedBaseClass;
  * operating on real process data without requiring external optimisation packages.
  * </p>
  */
-public class ModelPredictiveController extends NamedBaseClass implements ControllerDeviceInterface,
-    TransientStateParticipant<ModelPredictiveController.MpcTransientState> {
+public class ModelPredictiveController extends NamedBaseClass
+    implements ControllerDeviceInterface, TransientStateParticipant<ModelPredictiveController.MpcTransientState> {
   private static final long serialVersionUID = 1000L;
 
   private static final int MIN_ESTIMATION_SAMPLES = 5;
@@ -2115,8 +2115,8 @@ public class ModelPredictiveController extends NamedBaseClass implements Control
       throw new IllegalArgumentException("MPC transient snapshot cannot be null");
     }
     if (!getTransientStateIdentity().equals(state.stateIdentity)) {
-      throw new IllegalArgumentException("MPC transient snapshot belongs to '" + state.stateIdentity
-          + "', not '" + getTransientStateIdentity() + "'");
+      throw new IllegalArgumentException(
+          "MPC transient snapshot belongs to '" + state.stateIdentity + "', not '" + getTransientStateIdentity() + "'");
     }
 
     setName(state.name);

--- a/src/main/java/neqsim/process/controllerdevice/ModelPredictiveController.java
+++ b/src/main/java/neqsim/process/controllerdevice/ModelPredictiveController.java
@@ -1,5 +1,7 @@
 package neqsim.process.controllerdevice;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -70,7 +72,7 @@ public class ModelPredictiveController extends NamedBaseClass implements Control
   private double[] controlWeightsVector = new double[0];
   private double[] moveWeightsVector = new double[0];
   private int primaryControlIndex = 0;
-  private final List<QualityConstraint> qualityConstraints = new ArrayList<>();
+  private List<QualityConstraint> qualityConstraints = new ArrayList<>();
   private Map<String, Double> lastFeedComposition = new LinkedHashMap<>();
   private Map<String, Double> pendingFeedComposition = new LinkedHashMap<>();
   private double lastFeedRate = 0.0;
@@ -572,6 +574,20 @@ public class ModelPredictiveController extends NamedBaseClass implements Control
    */
   public ModelPredictiveController(String name) {
     super(name);
+  }
+
+  /**
+   * Restores fields introduced after the original MPC serialization contract.
+   *
+   * @param input serialized object input
+   * @throws IOException if the stream cannot be read
+   * @throws ClassNotFoundException if a serialized field type is unavailable
+   */
+  private void readObject(ObjectInputStream input) throws IOException, ClassNotFoundException {
+    input.defaultReadObject();
+    if (qualityConstraints == null) {
+      qualityConstraints = new ArrayList<>();
+    }
   }
 
   /**

--- a/src/test/java/neqsim/process/controllerdevice/ModelPredictiveControllerTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/controllerdevice/ModelPredictiveControllerTransientStateTransactionTest.java
@@ -103,8 +103,7 @@ class ModelPredictiveControllerTransientStateTransactionTest extends neqsim.NeqS
     controller.enableMovingHorizonEstimation(8);
     for (int i = 0; i < 8; i++) {
       measurement.setValue(20.0 + 5.0 * Math.pow(0.75, i));
-      controller.runTransient(5.0, 1.0,
-          TransientStepIdentifier.deterministicPhysicalStep("mpc-estimation", i));
+      controller.runTransient(5.0, 1.0, TransientStepIdentifier.deterministicPhysicalStep("mpc-estimation", i));
     }
     assertNotNull(controller.getLastMovingHorizonEstimate());
 

--- a/src/test/java/neqsim/process/controllerdevice/ModelPredictiveControllerTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/controllerdevice/ModelPredictiveControllerTransientStateTransactionTest.java
@@ -114,8 +114,7 @@ class ModelPredictiveControllerTransientStateTransactionTest extends neqsim.NeqS
     ProcessSystem process = new ProcessSystem("mpc restart");
     process.add(controller);
     ProcessSystem restartedProcess = process.copy();
-    ModelPredictiveController restarted =
-        (ModelPredictiveController) restartedProcess.getControllerDevices().get(0);
+    ModelPredictiveController restarted = (ModelPredictiveController) restartedProcess.getControllerDevices().get(0);
     assertTrue(restartedProcess.getTransientTransactionCoverage().isComplete());
     assertEquals(controller.getTransientStateIdentity(), restarted.getTransientStateIdentity());
 
@@ -173,8 +172,7 @@ class ModelPredictiveControllerTransientStateTransactionTest extends neqsim.NeqS
 
     ModelPredictiveController first = configuredSingleInput("first", new MutableMeasurement("first", "C", 1.0));
     ModelPredictiveController second = configuredSingleInput("second", new MutableMeasurement("second", "C", 1.0));
-    assertThrows(IllegalArgumentException.class,
-        () -> first.restoreTransientState(second.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> first.restoreTransientState(second.captureTransientState()));
     assertThrows(IllegalArgumentException.class, () -> first.restoreTransientState(null));
 
     MutableMeasurement online = new MutableMeasurement("online", "C", 1.0);
@@ -211,8 +209,8 @@ class ModelPredictiveControllerTransientStateTransactionTest extends neqsim.NeqS
     controller.setMoveWeights(2.0, 2.5);
     controller.setPreferredControlVector(5.0, 5.0);
     controller.addQualityConstraint(ModelPredictiveController.QualityConstraint.builder("product").measurement(quality)
-        .unit("ppm").limit(10.0).margin(0.5).controlSensitivity(-0.8, 0.4)
-        .compositionSensitivity("heavy", 3.0).rateSensitivity(0.5).build());
+        .unit("ppm").limit(10.0).margin(0.5).controlSensitivity(-0.8, 0.4).compositionSensitivity("heavy", 3.0)
+        .rateSensitivity(0.5).build());
     Map<String, Double> initialFeed = new LinkedHashMap<>();
     initialFeed.put("heavy", 0.10);
     controller.updateFeedConditions(initialFeed, 1.0);

--- a/src/test/java/neqsim/process/controllerdevice/ModelPredictiveControllerTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/controllerdevice/ModelPredictiveControllerTransientStateTransactionTest.java
@@ -1,0 +1,260 @@
+package neqsim.process.controllerdevice;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.dynamics.TransientStepIdentifier;
+import neqsim.process.dynamics.TransientStepTransaction;
+import neqsim.process.measurementdevice.MeasurementDeviceBaseClass;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+
+/**
+ * Quantitative rollback, replay, multi-area, fail-closed and restart evidence for the concrete local MPC.
+ */
+class ModelPredictiveControllerTransientStateTransactionTest extends neqsim.NeqSimTest {
+  private static final double TOLERANCE = 1.0e-12;
+
+  @Test
+  void singleInputRollbackRestoresConfigurationAndReplaysExactly() {
+    MutableMeasurement measurement = new MutableMeasurement("temperature", "C", 35.0);
+    ModelPredictiveController controller = configuredSingleInput("mpc", measurement);
+    ProcessSystem process = new ProcessSystem("mpc transaction");
+    process.add(controller);
+
+    assertEquals(1, process.getTransientTransactionCoverage().getProcessElementCount());
+    assertEquals(1, process.getTransientTransactionCoverage().getParticipantCount());
+    assertTrue(process.getTransientTransactionCoverage().isComplete());
+
+    String originalName = controller.getName();
+    UUID stepId = TransientStepIdentifier.deterministicPhysicalStep("mpc-replay", 0L);
+    TransientStepTransaction transaction = process.beginTransientStepTransaction();
+    controller.setName("trial name");
+    controller.setControllerSetPoint(62.0);
+    controller.setProcessModel(3.0, 4.0);
+    controller.runTransient(15.0, 0.5, stepId);
+    double trialResponse = controller.getResponse();
+    double trialMeasurement = controller.getLastSampledValue();
+    transaction.rollback();
+
+    assertEquals(originalName, controller.getName());
+    assertEquals(50.0, controller.getControllerSetPoint(), 0.0);
+    assertEquals(2.0, controller.getProcessGain(), 0.0);
+    assertEquals(8.0, controller.getTimeConstant(), 0.0);
+    assertFalse(stepId.equals(controller.getCalcIdentifier()));
+
+    controller.setControllerSetPoint(62.0);
+    controller.setProcessModel(3.0, 4.0);
+    controller.runTransient(15.0, 0.5, stepId);
+    assertEquals(trialResponse, controller.getResponse(), TOLERANCE);
+    assertEquals(trialMeasurement, controller.getLastSampledValue(), 0.0);
+
+    controller.runTransient(-999.0, 0.5, stepId);
+    assertEquals(trialResponse, controller.getResponse(), 0.0,
+        "one physical-step identifier must not advance MPC state twice");
+  }
+
+  @Test
+  void multivariableRollbackRestoresQualityFeedAndControlVectors() {
+    MutableMeasurement quality = new MutableMeasurement("quality", "ppm", 9.0);
+    ModelPredictiveController controller = configuredMultivariable("multivariable", quality);
+    ProcessSystem process = new ProcessSystem("multivariable transaction");
+    process.add(controller);
+
+    double[] initialControls = controller.getControlVector();
+    Map<String, Double> trialFeed = new LinkedHashMap<>();
+    trialFeed.put("heavy", 0.30);
+    UUID stepId = TransientStepIdentifier.deterministicPhysicalStep("mpc-mv-replay", 0L);
+    TransientStepTransaction transaction = process.beginTransientStepTransaction();
+    quality.setValue(13.0);
+    controller.updateQualityMeasurement("product", 13.0);
+    controller.updateFeedConditions(trialFeed, 1.25);
+    controller.runTransient(controller.getResponse(), 1.0, stepId);
+    double[] trialControls = controller.getControlVector();
+    double trialPrediction = controller.getPredictedQuality("product");
+    transaction.rollback();
+
+    assertArrayEquals(initialControls, controller.getControlVector(), 0.0);
+    assertTrue(Double.isNaN(controller.getPredictedQuality("product")));
+    controller.updateQualityMeasurement("product", 13.0);
+    controller.updateFeedConditions(trialFeed, 1.25);
+    controller.runTransient(controller.getResponse(), 1.0, stepId);
+    assertArrayEquals(trialControls, controller.getControlVector(), TOLERANCE);
+    assertEquals(trialPrediction, controller.getPredictedQuality("product"), TOLERANCE);
+  }
+
+  @Test
+  void movingHorizonStateAndSerializableSnapshotContinueExactlyAfterRestart() throws Exception {
+    MutableMeasurement measurement = new MutableMeasurement("temperature", "C", 25.0);
+    ModelPredictiveController controller = configuredSingleInput("restart", measurement);
+    controller.enableMovingHorizonEstimation(8);
+    for (int i = 0; i < 8; i++) {
+      measurement.setValue(25.0 + 1.5 * i);
+      controller.runTransient(controller.getResponse(), 1.0,
+          TransientStepIdentifier.deterministicPhysicalStep("mpc-estimation", i));
+    }
+    assertNotNull(controller.getLastMovingHorizonEstimate());
+
+    ModelPredictiveController.MpcTransientState snapshot = roundTrip(controller.captureTransientState());
+    controller.restoreTransientState(snapshot);
+
+    ProcessSystem process = new ProcessSystem("mpc restart");
+    process.add(controller);
+    ProcessSystem restartedProcess = process.copy();
+    ModelPredictiveController restarted =
+        (ModelPredictiveController) restartedProcess.getControllerDevices().get(0);
+    assertTrue(restartedProcess.getTransientTransactionCoverage().isComplete());
+    assertEquals(controller.getTransientStateIdentity(), restarted.getTransientStateIdentity());
+
+    UUID nextId = TransientStepIdentifier.deterministicPhysicalStep("mpc-estimation", 8L);
+    controller.runTransient(controller.getResponse(), 0.5, nextId);
+    restarted.runTransient(restarted.getResponse(), 0.5, nextId);
+
+    assertEquals(controller.getResponse(), restarted.getResponse(), TOLERANCE);
+    assertEquals(controller.getProcessGain(), restarted.getProcessGain(), TOLERANCE);
+    assertEquals(controller.getTimeConstant(), restarted.getTimeConstant(), TOLERANCE);
+    assertEquals(controller.getProcessBias(), restarted.getProcessBias(), TOLERANCE);
+    assertEquals(controller.getLastMovingHorizonEstimate().getMeanSquaredError(),
+        restarted.getLastMovingHorizonEstimate().getMeanSquaredError(), TOLERANCE);
+  }
+
+  @Test
+  void coordinatedMultiAreaRollbackRestoresBothControllers() {
+    MutableMeasurement firstMeasurement = new MutableMeasurement("first measurement", "C", 20.0);
+    MutableMeasurement secondMeasurement = new MutableMeasurement("second measurement", "C", 30.0);
+    ModelPredictiveController first = configuredSingleInput("first controller", firstMeasurement);
+    ModelPredictiveController second = configuredSingleInput("second controller", secondMeasurement);
+    ProcessSystem firstArea = new ProcessSystem("first area");
+    ProcessSystem secondArea = new ProcessSystem("second area");
+    firstArea.add(first);
+    secondArea.add(second);
+    ProcessModel model = new ProcessModel();
+    model.add("first", firstArea);
+    model.add("second", secondArea);
+
+    assertEquals(2, model.getTransientTransactionCoverage().getProcessElementCount());
+    assertEquals(2, model.getTransientTransactionCoverage().getParticipantCount());
+    assertTrue(model.getTransientTransactionCoverage().isComplete());
+    double firstResponse = first.getResponse();
+    double secondResponse = second.getResponse();
+    TransientStepTransaction transaction = model.beginTransientStepTransaction();
+    firstMeasurement.setValue(80.0);
+    secondMeasurement.setValue(5.0);
+    first.runTransient(firstResponse, 1.0, UUID.randomUUID());
+    second.runTransient(secondResponse, 1.0, UUID.randomUUID());
+    transaction.rollback();
+
+    assertEquals(firstResponse, first.getResponse(), 0.0);
+    assertEquals(secondResponse, second.getResponse(), 0.0);
+    assertEquals(80.0, first.getMeasuredValue(), 0.0);
+    assertEquals(5.0, second.getMeasuredValue(), 0.0);
+  }
+
+  @Test
+  void descendantsForeignSnapshotsAndOnlineMeasurementsFailClosed() {
+    ProcessSystem descendantProcess = new ProcessSystem("unsupported MPC descendant");
+    descendantProcess.add(new DerivedModelPredictiveController());
+    assertFalse(descendantProcess.getTransientTransactionCoverage().isComplete());
+    assertTrue(descendantProcess.getTransientTransactionCoverage().getBlockingIssues().get(0)
+        .contains(DerivedModelPredictiveController.class.getName()));
+
+    ModelPredictiveController first = configuredSingleInput("first", new MutableMeasurement("first", "C", 1.0));
+    ModelPredictiveController second = configuredSingleInput("second", new MutableMeasurement("second", "C", 1.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> first.restoreTransientState(second.captureTransientState()));
+    assertThrows(IllegalArgumentException.class, () -> first.restoreTransientState(null));
+
+    MutableMeasurement online = new MutableMeasurement("online", "C", 1.0);
+    online.setIsOnlineSignal(true, "plant", "TT-1");
+    ProcessSystem onlineProcess = new ProcessSystem("online MPC");
+    onlineProcess.add(configuredSingleInput("online controller", online));
+    assertFalse(onlineProcess.getTransientTransactionCoverage().isComplete());
+    assertTrue(onlineProcess.getTransientTransactionCoverage().getBlockingIssues().get(0).contains("external I/O"));
+  }
+
+  private static ModelPredictiveController configuredSingleInput(String name, MutableMeasurement measurement) {
+    ModelPredictiveController controller = new ModelPredictiveController(name);
+    controller.setTransmitter(measurement);
+    controller.setUnit(measurement.getUnit());
+    controller.setControllerSetPoint(50.0);
+    controller.setProcessModel(2.0, 8.0);
+    controller.setProcessBias(10.0);
+    controller.setWeights(2.0, 0.2, 0.8);
+    controller.setPreferredControlValue(5.0);
+    controller.setOutputLimits(-100.0, 100.0);
+    controller.setMoveLimits(-20.0, 20.0);
+    return controller;
+  }
+
+  private static ModelPredictiveController configuredMultivariable(String name, MutableMeasurement quality) {
+    ModelPredictiveController controller = new ModelPredictiveController(name);
+    controller.configureControls("heater", "cooler");
+    controller.setInitialControlValues(4.0, 6.0);
+    controller.setControlLimits(0, 0.0, 20.0);
+    controller.setControlLimits(1, 0.0, 20.0);
+    controller.setControlMoveLimits(0, -2.0, 2.0);
+    controller.setControlMoveLimits(1, -2.0, 2.0);
+    controller.setControlWeights(1.0, 1.5);
+    controller.setMoveWeights(2.0, 2.5);
+    controller.setPreferredControlVector(5.0, 5.0);
+    controller.addQualityConstraint(ModelPredictiveController.QualityConstraint.builder("product").measurement(quality)
+        .unit("ppm").limit(10.0).margin(0.5).controlSensitivity(-0.8, 0.4)
+        .compositionSensitivity("heavy", 3.0).rateSensitivity(0.5).build());
+    Map<String, Double> initialFeed = new LinkedHashMap<>();
+    initialFeed.put("heavy", 0.10);
+    controller.updateFeedConditions(initialFeed, 1.0);
+    return controller;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends Serializable> T roundTrip(T value) throws Exception {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(buffer)) {
+      output.writeObject(value);
+    }
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()))) {
+      return (T) input.readObject();
+    }
+  }
+
+  /** Serializable controllable local measurement used by the transaction regression. */
+  private static final class MutableMeasurement extends MeasurementDeviceBaseClass {
+    private static final long serialVersionUID = 1000L;
+    private double value;
+
+    private MutableMeasurement(String name, String unit, double value) {
+      super(name, unit);
+      this.value = value;
+    }
+
+    private void setValue(double value) {
+      this.value = value;
+    }
+
+    @Override
+    public double getMeasuredValue(String unit) {
+      if (unit == null || unit.isEmpty() || unit.equals(getUnit())) {
+        return value;
+      }
+      throw new IllegalArgumentException("Unsupported unit " + unit);
+    }
+  }
+
+  /** Deliberately unqualified descendant used to prove fail-closed coverage. */
+  private static final class DerivedModelPredictiveController extends ModelPredictiveController {
+    private static final long serialVersionUID = 1000L;
+  }
+}

--- a/src/test/java/neqsim/process/controllerdevice/ModelPredictiveControllerTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/controllerdevice/ModelPredictiveControllerTransientStateTransactionTest.java
@@ -102,8 +102,8 @@ class ModelPredictiveControllerTransientStateTransactionTest extends neqsim.NeqS
     ModelPredictiveController controller = configuredSingleInput("restart", measurement);
     controller.enableMovingHorizonEstimation(8);
     for (int i = 0; i < 8; i++) {
-      measurement.setValue(25.0 + 1.5 * i);
-      controller.runTransient(controller.getResponse(), 1.0,
+      measurement.setValue(20.0 + 5.0 * Math.pow(0.75, i));
+      controller.runTransient(5.0, 1.0,
           TransientStepIdentifier.deterministicPhysicalStep("mpc-estimation", i));
     }
     assertNotNull(controller.getLastMovingHorizonEstimate());


### PR DESCRIPTION
## Roadmap

Advances #2911 as **DYN-C015**: identity-preserving whole-step transaction adoption for the concrete local `ModelPredictiveController`.

Base: `0f922b53e4ae64b00da068c6057366ff23a3b4d3`
Publication head: `4ec838b7cc188d529af346ba7d00bd837d3339a2`
Branch: `campaign-2911-mpc-transaction`

## Engineering question

Can a local SISO or multivariable MPC participate in the existing `ProcessSystem` / coordinated `ProcessModel` step transaction without retaining state from a rejected trial, while preserving deterministic physical-step replay and Java-serialization restart?

## Complete tranche

- implements `TransientStateParticipant<MpcTransientState>` on the concrete MPC;
- adds persistent transaction provenance and repeated non-null physical-step idempotence;
- snapshots/restores name, transmitter binding, set point/unit/mode, response and limits, process model, weights, horizon, last calculation identity, measurement and actuation history;
- defensively captures every multivariable vector, limit, weight and preferred-control array;
- captures quality-constraint bindings/configuration plus mutable observed/predicted values;
- restores feedforward composition/rate state and predicted-quality cache;
- restores moving-horizon sample windows, enabled/window configuration and last identified model;
- makes quality constraints and moving-horizon estimates serializable so restart retains the configured optimization/estimation state;
- lazily recreates the constraint list when reading older serialized MPC objects that predate persisted constraints;
- fails closed for concrete descendants and online/external-I/O transmitter or quality-measurement bindings.

## Quantitative regression evidence added

The new focused test suite covers:

- `1/1` concrete SISO `ProcessSystem` transaction coverage;
- exact rejected-trial response/measurement replay at `1e-12`;
- same-physical-step idempotence;
- exact multivariable control-vector and predicted-quality replay at `1e-12`;
- coordinated two-area `ProcessModel` coverage and rollback (`2/2`);
- moving-horizon snapshot serialization and `ProcessSystem.copy()` continuation;
- stable transaction identity after restart;
- foreign/null snapshot rejection;
- descendant and online-I/O fail-closed diagnostics.

## Validation

**VALIDATION PENDING CI.** Spotless formatter output from the first exact-head run was applied verbatim.

Verified on exact head `4ec838b7cc188d529af346ba7d00bd837d3339a2`:

- Spotless, pre-commit, Javadoc, PaperLab and CodeQL pass;
- slow-test shards 2/4 and 3/4 pass;
- Ubuntu/Windows fast tests and slow-test shards 1/4 and 4/4 are still running;
- documentation search itself passes, but the documentation workflow is red on the unchanged `MercuryRemoval_LNG_Pretreatment.md` title assertion. This PR changes only the MPC source, its focused test and `dynamic-capability-contract.md`, so that failure is not attributable to this diff.

The GitHub connector was the authoritative source and publication path. The exact three-file remote branch was re-read against base before publication. A local Java compiler, Maven checkout, repository Spotless runner, documentation search and pre-commit environment were unavailable in this ephemeral workspace, so no unrun check is claimed as passed. Hosted exact-head CI is the validator.

## Documentation impact

Updated `docs/process/dynamic-capability-contract.md` with the exact MPC-owned state, quality/feedforward/MHE restart behavior, fail-closed I/O and subclass boundaries, evidence shape and non-qualification limits.

## Compatibility and stop boundary

Existing MPC equations, objective, limits and public configuration methods are unchanged. Reusing a completed non-null physical-step identifier now correctly avoids advancing the controller twice, matching the controller scan contract.

This proves local in-memory rollback/restart mechanics only. It does not qualify MPC model structure, optimization quality, constraint tuning, plant identification, closed-loop stability, scan timing, external DCS commands, safety action, virtual commissioning or OTS. It does not enable adaptive whole-step rejection and does not enter #2935 species transport, #2907 multiphase physics or Huldra dataset work.

## Latest CI repair

At exact head `2bde1f76576a7271715bf7f7d049731064e4e2b7`, the moving-horizon restart regression uses a deterministic stable first-order measurement response and fixed applied control. The previous monotonically rising fixture caused the estimator to reject the identified non-decaying model (`alpha >= 0`), leaving the estimate null on hosted Windows CI; that fixture did not isolate transaction serialization. The follow-up commit applies the exact hosted Spotless layout.

The earlier documentation-search failure was the merged-base Mercury guide regression and is fixed on `master` by #3044; the current documentation-search rerun passed.

**VALIDATION PENDING CI.** The initial exact-head rerun passed documentation search, Spotless patch and PaperLab; pre-commit reported only the now-corrected Spotless layout. The new exact-head build, pre-commit and remaining hosted checks are pending. This connector-only repair was not executed locally.

Documentation impact: none — these commits change only the deterministic regression fixture and its formatting; they do not alter the MPC API, behavior, units, defaults, or documented transaction contract.
