### PR TITLE
[AI-Assisted] fix(absorber): guard against division by zero in SimpleTEGAbsorber when liquid water fraction is near zero

### DIFF
--- a/src/main/java/neqsim/process/equipment/absorber/SimpleTEGAbsorber.java
+++ b/src/main/java/neqsim/process/equipment/absorber/SimpleTEGAbsorber.java
@@ -272,8 +272,12 @@ public class SimpleTEGAbsorber extends SimpleAbsorber {
       testOps.TPflash();
       testOps.PHflash(enthalpy, 0);
 
-      kwater = mixedStream.getThermoSystem().getPhase(0).getComponent("water").getx()
-          / mixedStream.getThermoSystem().getPhase(1).getComponent("water").getx();
+      double xWaterLiquid = mixedStream.getThermoSystem().getPhase(1).getComponent("water").getx();
+      if (xWaterLiquid > 1.0e-10) {
+        kwater = mixedStream.getThermoSystem().getPhase(0).getComponent("water").getx() / xWaterLiquid;
+      } else {
+        kwater = 1.0e-5;
+      }
 
       calcNumberOfTheoreticalStages();
       // System.out.println("number of theoretical stages " +
@@ -690,5 +694,9 @@ public class SimpleTEGAbsorber extends SimpleAbsorber {
     sb.append(String.format("Number of theoretical stages: %.2f\n", getNumberOfTheoreticalStages()));
 
     return sb.toString();
+  }
+
+  public double getKwater() {
+    return kwater;
   }
 }

--- a/src/test/java/neqsim/process/equipment/absorber/SimpleTEGAbsorberTest.java
+++ b/src/test/java/neqsim/process/equipment/absorber/SimpleTEGAbsorberTest.java
@@ -148,4 +148,38 @@ class SimpleTEGAbsorberTest extends NeqSimTest {
     double dryGasWater = absorberCase.absorber.getGasOutStream().getFluid().getPhase(0).getComponent("water").getx();
     assertEquals(30.0e-6, dryGasWater, 2.0e-8);
   }
+
+  @Test
+  void testLowWaterLiquidPhaseDoesNotCauseNaN() {
+    SystemSrkCPAstatoil gasFluid = new SystemSrkCPAstatoil(303.15, 70.0);
+    gasFluid.addComponent("methane", 0.999);
+    gasFluid.addComponent("water", 1.0e-6);
+    gasFluid.setMixingRule(10);
+
+    Stream dryGasFeed = new Stream("dry gas", gasFluid);
+    dryGasFeed.setFlowRate(1.0, "MSm3/day");
+    dryGasFeed.setTemperature(30.0, "C");
+    dryGasFeed.setPressure(70.0, "bara");
+
+    SystemSrkCPAstatoil tegFluid = new SystemSrkCPAstatoil(308.15, 70.0);
+    tegFluid.addComponent("TEG", 0.9999);
+    tegFluid.addComponent("water", 0.0001);
+    tegFluid.setMixingRule(10);
+
+    Stream leanTeg = new Stream("lean TEG", tegFluid);
+    leanTeg.setFlowRate(100.0, "kg/hr");
+
+    SimpleTEGAbsorber absorber = new SimpleTEGAbsorber("TEG contactor dry");
+    absorber.addGasInStream(dryGasFeed);
+    absorber.addSolventInStream(leanTeg);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(dryGasFeed);
+    process.add(leanTeg);
+    process.add(absorber);
+    process.run();
+
+    assertTrue(Double.isFinite(absorber.getKwater()), "kwater must be finite");
+    assertTrue(Double.isFinite(absorber.getGasOutStream().getFlowRate("kg/hr")));
+  }
 }


### PR DESCRIPTION
Guards against zero division in SimpleTEGAbsorber when liquid phase water mole fraction is near zero.