### PR TITLE
test(process): preserve parallel mixer execution

### DIFF
--- a/src/test/java/neqsim/process/processmodel/ProcessSystemDataflowDispatchTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemDataflowDispatchTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.mixer.StaticMixer;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
@@ -16,6 +17,7 @@ class ProcessSystemDataflowDispatchTest {
     private static final long serialVersionUID = 1000L;
     private int parallelRuns;
     private int dataflowRuns;
+    private int sequentialRuns;
 
     /** Creates an empty recording process. */
     RecordingProcessSystem() {
@@ -33,6 +35,13 @@ class ProcessSystemDataflowDispatchTest {
     @Override
     public synchronized void runDataflow(UUID id) {
       dataflowRuns++;
+      setCalculationIdentifier(id);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public synchronized void runSequential(UUID id) {
+      sequentialRuns++;
       setCalculationIdentifier(id);
     }
   }
@@ -96,5 +105,25 @@ class ProcessSystemDataflowDispatchTest {
 
     assertEquals(0, process.parallelRuns);
     assertEquals(1, process.dataflowRuns);
+  }
+
+  /** Verifies multi-input equipment retains level-based parallel dispatch. */
+  @Test
+  void multiInputEquipmentUsesParallelLevels() {
+    RecordingProcessSystem process = new RecordingProcessSystem();
+    Stream firstFeed = new Stream("first feed", createFluid());
+    Stream secondFeed = new Stream("second feed", createFluid());
+    StaticMixer mixer = new StaticMixer("mixer");
+    mixer.addStream(firstFeed);
+    mixer.addStream(secondFeed);
+    process.add(firstFeed);
+    process.add(secondFeed);
+    process.add(mixer);
+
+    process.runOptimized(UUID.randomUUID());
+
+    assertEquals(1, process.parallelRuns);
+    assertEquals(0, process.dataflowRuns);
+    assertEquals(0, process.sequentialRuns, "multi-input topology should not disable parallel execution");
   }
 }

--- a/src/test/java/neqsim/thermo/system/SystemThermoSerializationInventoryTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemThermoSerializationInventoryTest.java
@@ -7,6 +7,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.mixer.StaticMixer;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.phase.PhaseType;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
@@ -49,6 +52,61 @@ class SystemThermoSerializationInventoryTest extends neqsim.NeqSimTest {
 
     assertEquals(expectedInventory, restored.getTotalNumberOfMoles(), 1.0e-12);
     assertEquals(expectedInventory, sumComponentMoles(restored), 1.0e-12);
+  }
+
+  @Test
+  void deserializedProcessReusesMultiphaseMixerWithParallelExecution() {
+    SystemThermo gasFluid = new SystemSrkCPAstatoil(278.45, 37.21325);
+    gasFluid.addComponent("methane", 5.0);
+    gasFluid.addComponent("water", 0.11833608283886514);
+    gasFluid.addComponent("MEG", 0.0);
+    gasFluid.setMixingRule(10);
+    gasFluid.setMultiPhaseCheck(true);
+
+    SystemThermo megFluid = gasFluid.clone();
+    megFluid.setMolarComposition(new double[] { 0.0, 0.1099744114900417, 0.8900255885099583 });
+
+    Stream gasStream = new Stream("gas", gasFluid);
+    gasStream.setFlowRate(168958.0, "Sm3/hr");
+    gasStream.setTemperature(29.0, "C");
+    gasStream.setPressure(74.1, "barg");
+
+    Stream megStream = new Stream("MEG", megFluid);
+    megStream.setFlowRate(0.01, "kg/hr");
+    megStream.setTemperature(29.0, "C");
+    megStream.setPressure(74.1, "barg");
+
+    StaticMixer mixer = new StaticMixer("reused multiphase mixer");
+    mixer.addStream(megStream);
+    mixer.addStream(gasStream);
+
+    ProcessSystem process = new ProcessSystem("serialized mixer process");
+    process.add(gasStream);
+    process.add(megStream);
+    process.add(mixer);
+    process.runOptimized();
+
+    gasFluid.setTotalNumberOfMolesRaw(1986.7470206432324);
+    ProcessSystem restored = process.copy();
+    Stream restoredGasStream = (Stream) restored.getUnit("gas");
+    Stream restoredMegStream = (Stream) restored.getUnit("MEG");
+    StaticMixer restoredMixer = (StaticMixer) restored.getUnit("reused multiphase mixer");
+
+    SystemThermo restoredGasFluid = (SystemThermo) restoredGasStream.getFluid();
+    double restoredGasInventory = sumComponentMoles(restoredGasFluid);
+    assertEquals(restoredGasInventory, restoredGasFluid.getTotalNumberOfMoles(), restoredGasInventory * 1.0e-12);
+
+    restoredMegStream.setFlowRate(0.1, "kg/hr");
+    restored.runOptimized();
+
+    SystemThermo outletFluid = (SystemThermo) restoredMixer.getOutletStream().getFluid();
+    double inletMassFlow = restoredGasStream.getFlowRate("kg/hr") + restoredMegStream.getFlowRate("kg/hr");
+    double outletMassFlow = restoredMixer.getOutletStream().getFlowRate("kg/hr");
+    double outletInventory = sumComponentMoles(outletFluid);
+
+    assertTrue(outletFluid.hasPhaseType("gas"));
+    assertEquals(inletMassFlow, outletMassFlow, inletMassFlow * 1.0e-8);
+    assertEquals(outletInventory, outletFluid.getTotalNumberOfMoles(), outletInventory * 1.0e-12);
   }
 
   private static double sumComponentMoles(SystemThermo fluid) {


### PR DESCRIPTION
## Summary

- Add a process-level regression that serializes and restores a stale thermodynamic inventory, changes the MEG inlet flow, and reruns the reused multiphase mixer through `runOptimized()`.
- Assert that the restored mixer retains a gas phase and preserves inlet/outlet mass and component/total-mole inventory.
- Add a dispatcher regression proving that multi-input equipment continues to use level-based `runParallel(UUID)`, not flowsheet-wide sequential execution.

## Why

The stale thermodynamic inventory is already repaired at the deserialization boundary by #3026. The process graph records every mixer input dependency, and level-based parallel execution waits for all input producers before running the mixer.

Changing all multi-input flowsheets to `runSequential(UUID)`, as proposed in #3029, is therefore broader than the defect and would remove independent-branch concurrency and optimized dirty-unit skipping. These tests preserve the reported mixer scenario while keeping the existing parallel execution policy.

This is a test-only alternative to #3029; it does not change production behavior.

## Validation

Base: `344dc98bec07abcaaf29ed17d8dbe8619406e1fe`  
NeqSim: `3.17.0`  
Java: OpenJDK `17.0.19`  
Maven: `3.9.12`

- `./mvnw -o -Dtest=StaticMixerTest,ProcessSystemDataflowDispatchTest,SystemThermoSerializationInventoryTest,GraphVsSequentialExecutionTest,ParallelBenchmarkTest test` — 20 tests passed.
- Final focused run: `./mvnw -o -Dtest=ProcessSystemDataflowDispatchTest,SystemThermoSerializationInventoryTest test` — 6 tests passed.
- `python devtools/run_spotless.py apply` — passed with a clean final tree.
- `pre-commit run --all-files --hook-stage pre-commit` — passed.
- `python devtools/run_spotless.py check` — passed.
- `python devtools/check_documentation_search.py` — passed.
- `pre-commit run --all-files --hook-stage pre-push` — passed.

Documentation impact: none — this PR only adds regression tests and changes no public API, runtime behavior, units, configuration, or recommended usage.
