### PR TITLE
[AI-Assisted] feat(process): transact recycle controller state

### DIFF
--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -559,3 +559,25 @@ This gate establishes deterministic in-memory rollback and restart mechanics onl
 qualify the MPC model structure, optimization quality, constraint tuning, plant identification,
 closed-loop stability, scan-time fidelity, external DCS commands, safety action, virtual
 commissioning or OTS use.
+
+
+## Shared recycle-controller transaction coverage
+
+`ProcessSystem` now captures its shared `RecycleController` orchestration state in the same
+identity-preserving step transaction as registered process elements. The controller snapshot preserves a stable
+provenance identity, recycle registration and priority order, current/minimum/maximum priority, coordinated-acceleration
+configuration, accepted-state seed membership, and the complete Broyden continuation state. Rollback restores the same
+controller and accelerator instances. Java serialization also retains coordinated Broyden and accepted-seed continuation
+instead of silently restarting those solver memories.
+
+The controller snapshot is orchestration state, so it is intentionally outside the quantitative process-element and
+participant counts reported by `TransientTransactionCoverage`. Every `Recycle` unit remains a separate
+registered process element and does not yet implement `TransientStateParticipant`; a realistic flowsheet that
+contains a recycle therefore still fails closed on that equipment state. This tranche removes only the additional shared
+controller blocker and establishes the reusable boundary needed before recycle equipment inventory, internal streams and
+acceleration state can be qualified.
+
+Coverage includes exact in-memory rollback of priority and coordinated Broyden state, stable object identity, defensive
+matrix/vector copies, foreign/null snapshot rejection, recycle-registration restoration and exact Java-serialization
+continuation. It does not qualify recycle thermodynamics, convergence tolerances, strongly coupled DAE behaviour,
+timestep independence, external side effects, safety action, virtual commissioning or OTS use.

--- a/src/main/java/neqsim/process/equipment/util/BroydenAccelerator.java
+++ b/src/main/java/neqsim/process/equipment/util/BroydenAccelerator.java
@@ -465,4 +465,3 @@ public class BroydenAccelerator implements Serializable {
     }
   }
 }
-

--- a/src/main/java/neqsim/process/equipment/util/BroydenAccelerator.java
+++ b/src/main/java/neqsim/process/equipment/util/BroydenAccelerator.java
@@ -2,6 +2,7 @@ package neqsim.process.equipment.util;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -383,4 +384,85 @@ public class BroydenAccelerator implements Serializable {
     }
     return vectorNorm(previousF);
   }
+
+  /**
+   * Captures all mutable quasi-Newton continuation state.
+   *
+   * @return immutable, defensively copied accelerator state
+   */
+  public Snapshot captureState() {
+    return new Snapshot(dimension, copyMatrix(inverseJacobian), copyVector(previousX), copyVector(previousF),
+        iterationCount, delayIterations, relaxationFactor, maxStepSize);
+  }
+
+  /**
+   * Restores a previously captured continuation state to this accelerator instance.
+   *
+   * @param snapshot snapshot returned by {@link #captureState()}
+   * @throws NullPointerException if {@code snapshot} is null
+   */
+  public void restoreState(Snapshot snapshot) {
+    Objects.requireNonNull(snapshot, "snapshot cannot be null");
+    dimension = snapshot.dimension;
+    inverseJacobian = copyMatrix(snapshot.inverseJacobian);
+    previousX = copyVector(snapshot.previousX);
+    previousF = copyVector(snapshot.previousF);
+    iterationCount = snapshot.iterationCount;
+    delayIterations = snapshot.delayIterations;
+    relaxationFactor = snapshot.relaxationFactor;
+    maxStepSize = snapshot.maxStepSize;
+  }
+
+  /**
+   * Copies one vector while retaining a null marker.
+   *
+   * @param vector source vector
+   * @return defensive copy, or null
+   */
+  private static double[] copyVector(double[] vector) {
+    return vector == null ? null : vector.clone();
+  }
+
+  /**
+   * Copies a possibly null rectangular matrix.
+   *
+   * @param matrix source matrix
+   * @return deep defensive copy, or null
+   */
+  private static double[][] copyMatrix(double[][] matrix) {
+    if (matrix == null) {
+      return null;
+    }
+    double[][] copy = new double[matrix.length][];
+    for (int i = 0; i < matrix.length; i++) {
+      copy[i] = matrix[i] == null ? null : matrix[i].clone();
+    }
+    return copy;
+  }
+
+  /** Immutable serializable Broyden continuation state. */
+  public static final class Snapshot implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final int dimension;
+    private final double[][] inverseJacobian;
+    private final double[] previousX;
+    private final double[] previousF;
+    private final int iterationCount;
+    private final int delayIterations;
+    private final double relaxationFactor;
+    private final double maxStepSize;
+
+    private Snapshot(int dimension, double[][] inverseJacobian, double[] previousX, double[] previousF,
+        int iterationCount, int delayIterations, double relaxationFactor, double maxStepSize) {
+      this.dimension = dimension;
+      this.inverseJacobian = inverseJacobian;
+      this.previousX = previousX;
+      this.previousF = previousF;
+      this.iterationCount = iterationCount;
+      this.delayIterations = delayIterations;
+      this.relaxationFactor = relaxationFactor;
+      this.maxStepSize = maxStepSize;
+    }
+  }
 }
+

--- a/src/main/java/neqsim/process/equipment/util/RecycleController.java
+++ b/src/main/java/neqsim/process/equipment/util/RecycleController.java
@@ -835,8 +835,8 @@ public class RecycleController implements Serializable {
     }
     return new Snapshot(getTransientStateIdentity(), new ArrayList<Recycle>(recycleArray),
         new ArrayList<Integer>(priorityArray), currentPriorityLevel, minimumPriorityLevel, maximumPriorityLevel,
-        useCoordinatedAcceleration,
-        coordinatedAccelerator == null ? null : coordinatedAccelerator.captureState(), acceptedSeedIndexes);
+        useCoordinatedAcceleration, coordinatedAccelerator == null ? null : coordinatedAccelerator.captureState(),
+        acceptedSeedIndexes);
   }
 
   /**
@@ -909,4 +909,3 @@ public class RecycleController implements Serializable {
     }
   }
 }
-

--- a/src/main/java/neqsim/process/equipment/util/RecycleController.java
+++ b/src/main/java/neqsim/process/equipment/util/RecycleController.java
@@ -1,10 +1,12 @@
 package neqsim.process.equipment.util;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.process.util.uncertainty.SensitivityMatrix;
@@ -23,7 +25,7 @@ import neqsim.process.util.uncertainty.SensitivityMatrix;
  * @author asmund
  * @version $Id: $Id
  */
-public class RecycleController implements java.io.Serializable {
+public class RecycleController implements Serializable {
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(RecycleController.class);
   /** Serialization version UID. */
@@ -39,13 +41,16 @@ public class RecycleController implements java.io.Serializable {
   private int maximumPriorityLevel = 100;
 
   /** Coordinated Broyden accelerator for multi-recycle systems. */
-  private transient BroydenAccelerator coordinatedAccelerator = null;
+  private BroydenAccelerator coordinatedAccelerator = null;
 
   /** Whether to use coordinated acceleration across all recycles at current priority. */
   private boolean useCoordinatedAcceleration = false;
 
   /** Recycles whose previously accepted state can seed the first observation of this solve. */
-  private transient Map<Recycle, Boolean> acceptedRecycleSeeds = new IdentityHashMap<>();
+  private Map<Recycle, Boolean> acceptedRecycleSeeds = new IdentityHashMap<>();
+
+  /** Stable provenance identity for this controller's transaction state. */
+  private String transientStateIdentity = UUID.randomUUID().toString();
 
   /**
    * Constructor for RecycleController.
@@ -797,4 +802,111 @@ public class RecycleController implements java.io.Serializable {
     return coordinatedAccelerator != null && coordinatedAccelerator.getInverseJacobian() != null
         && coordinatedAccelerator.getIterationCount() > 2;
   }
+
+  /**
+   * Returns the stable identity used to reject snapshots captured from another controller.
+   *
+   * @return non-empty identity preserved by Java serialization
+   */
+  public String getTransientStateIdentity() {
+    if (transientStateIdentity == null || transientStateIdentity.trim().isEmpty()) {
+      transientStateIdentity = UUID.randomUUID().toString();
+    }
+    return transientStateIdentity;
+  }
+
+  /**
+   * Captures controller-owned recycle orchestration and coordinated solver state.
+   *
+   * <p>
+   * Recycle equipment state is intentionally not captured here. Every registered recycle remains responsible for its
+   * own future {@code TransientStateParticipant} contract.
+   * </p>
+   *
+   * @return immutable serializable controller snapshot
+   */
+  public Snapshot captureTransientState() {
+    ArrayList<Integer> acceptedSeedIndexes = new ArrayList<Integer>();
+    Map<Recycle, Boolean> seeds = acceptedRecycleSeeds();
+    for (int i = 0; i < recycleArray.size(); i++) {
+      if (seeds.containsKey(recycleArray.get(i))) {
+        acceptedSeedIndexes.add(i);
+      }
+    }
+    return new Snapshot(getTransientStateIdentity(), new ArrayList<Recycle>(recycleArray),
+        new ArrayList<Integer>(priorityArray), currentPriorityLevel, minimumPriorityLevel, maximumPriorityLevel,
+        useCoordinatedAcceleration,
+        coordinatedAccelerator == null ? null : coordinatedAccelerator.captureState(), acceptedSeedIndexes);
+  }
+
+  /**
+   * Restores a captured controller snapshot without replacing this controller instance.
+   *
+   * @param snapshot snapshot returned by {@link #captureTransientState()}
+   * @throws NullPointerException if {@code snapshot} is null
+   * @throws IllegalArgumentException if the snapshot belongs to another controller
+   */
+  public void restoreTransientState(Snapshot snapshot) {
+    Objects.requireNonNull(snapshot, "snapshot cannot be null");
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException("Snapshot belongs to another RecycleController");
+    }
+
+    recycleArray.clear();
+    recycleArray.addAll(snapshot.recycles);
+    priorityArray.clear();
+    priorityArray.addAll(snapshot.priorities);
+    currentPriorityLevel = snapshot.currentPriorityLevel;
+    minimumPriorityLevel = snapshot.minimumPriorityLevel;
+    maximumPriorityLevel = snapshot.maximumPriorityLevel;
+    useCoordinatedAcceleration = snapshot.useCoordinatedAcceleration;
+
+    if (snapshot.coordinatedAcceleratorState == null) {
+      coordinatedAccelerator = null;
+    } else {
+      if (coordinatedAccelerator == null) {
+        coordinatedAccelerator = new BroydenAccelerator();
+      }
+      coordinatedAccelerator.restoreState(snapshot.coordinatedAcceleratorState);
+    }
+
+    Map<Recycle, Boolean> seeds = acceptedRecycleSeeds();
+    seeds.clear();
+    for (int index : snapshot.acceptedSeedIndexes) {
+      if (index < 0 || index >= recycleArray.size()) {
+        throw new IllegalArgumentException("Snapshot contains an invalid accepted-recycle index " + index);
+      }
+      seeds.put(recycleArray.get(index), Boolean.TRUE);
+    }
+  }
+
+  /** Immutable serializable state owned by one recycle controller. */
+  public static final class Snapshot implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final ArrayList<Recycle> recycles;
+    private final ArrayList<Integer> priorities;
+    private final int currentPriorityLevel;
+    private final int minimumPriorityLevel;
+    private final int maximumPriorityLevel;
+    private final boolean useCoordinatedAcceleration;
+    private final BroydenAccelerator.Snapshot coordinatedAcceleratorState;
+    private final ArrayList<Integer> acceptedSeedIndexes;
+
+    private Snapshot(String stateIdentity, ArrayList<Recycle> recycles, ArrayList<Integer> priorities,
+        int currentPriorityLevel, int minimumPriorityLevel, int maximumPriorityLevel,
+        boolean useCoordinatedAcceleration, BroydenAccelerator.Snapshot coordinatedAcceleratorState,
+        ArrayList<Integer> acceptedSeedIndexes) {
+      this.stateIdentity = stateIdentity;
+      this.recycles = recycles;
+      this.priorities = priorities;
+      this.currentPriorityLevel = currentPriorityLevel;
+      this.minimumPriorityLevel = minimumPriorityLevel;
+      this.maximumPriorityLevel = maximumPriorityLevel;
+      this.useCoordinatedAcceleration = useCoordinatedAcceleration;
+      this.coordinatedAcceleratorState = coordinatedAcceleratorState;
+      this.acceptedSeedIndexes = acceptedSeedIndexes;
+    }
+  }
 }
+

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -5213,8 +5213,8 @@ public class ProcessSystem extends SimulationBaseClass {
    *
    * <p>
    * Duplicate registrations of the same Java object are counted once. State identities must be non-empty and unique
-   * among the participating objects. Recycle execution remains blocked until the shared {@link RecycleController} has
-   * an in-place snapshot contract in addition to each recycle unit's own state contract.
+   * among the participating objects. Shared {@link RecycleController} orchestration is captured separately and is not
+   * included in the process-element or participant counts; each recycle unit must still provide its own state contract.
    * </p>
    *
    * @return immutable quantitative coverage report
@@ -5266,10 +5266,6 @@ public class ProcessSystem extends SimulationBaseClass {
       }
     }
 
-    if (recycleController != null && recycleController.getRecycleCount() > 0) {
-      blockingIssues.add("shared RecycleController owns mutable convergence state for "
-          + recycleController.getRecycleCount() + " recycle unit(s) but has no in-place transient snapshot contract");
-    }
     if (parallelTransientEnabled) {
       blockingIssues.add("parallel transient execution may leave same-level workers running after one worker fails; "
           + "rollback cannot start until worker quiescence is guaranteed");
@@ -5319,9 +5315,12 @@ public class ProcessSystem extends SimulationBaseClass {
       participantCheckpoints.add(new TransientParticipantCheckpoint(participant, stateIdentity, snapshot));
     }
 
+    RecycleController capturedRecycleController = recycleController;
+    RecycleController.Snapshot recycleControllerSnapshot =
+        capturedRecycleController == null ? null : capturedRecycleController.captureTransientState();
     ProcessSystemStepTransaction transaction = new ProcessSystemStepTransaction(elements, participantCheckpoints,
-        eventScheduler, eventScheduler == null ? null : eventScheduler.snapshot(),
-        new ArrayList<>(alarmManager.getHistory()));
+        capturedRecycleController, recycleControllerSnapshot, eventScheduler,
+        eventScheduler == null ? null : eventScheduler.snapshot(), new ArrayList<>(alarmManager.getHistory()));
     activeTransientStepTransaction = transaction;
     return transaction;
   }
@@ -5463,17 +5462,23 @@ public class ProcessSystem extends SimulationBaseClass {
     private final double capturedPreviousTotalMass = previousTotalMass;
     private final double capturedMassBalanceError = massBalanceError;
     private final ProcessSystem capturedInitialStateSnapshot = initialStateSnapshot;
+    private final RecycleController capturedRecycleController;
+    private final RecycleController.Snapshot capturedRecycleControllerSnapshot;
     private final EventScheduler capturedEventScheduler;
     private final EventScheduler.Snapshot capturedEventSchedulerSnapshot;
     private final List<neqsim.process.alarm.AlarmEvent> capturedAlarmHistory;
     private Status status = Status.OPEN;
 
     private ProcessSystemStepTransaction(List<ProcessElementInterface> elementIdentities,
-        List<TransientParticipantCheckpoint> participantCheckpoints, EventScheduler capturedEventScheduler,
+        List<TransientParticipantCheckpoint> participantCheckpoints,
+        RecycleController capturedRecycleController,
+        RecycleController.Snapshot capturedRecycleControllerSnapshot, EventScheduler capturedEventScheduler,
         EventScheduler.Snapshot capturedEventSchedulerSnapshot,
         List<neqsim.process.alarm.AlarmEvent> capturedAlarmHistory) {
       this.elementIdentities = new ArrayList<ProcessElementInterface>(elementIdentities);
       this.participantCheckpoints = new ArrayList<TransientParticipantCheckpoint>(participantCheckpoints);
+      this.capturedRecycleController = capturedRecycleController;
+      this.capturedRecycleControllerSnapshot = capturedRecycleControllerSnapshot;
       this.capturedEventScheduler = capturedEventScheduler;
       this.capturedEventSchedulerSnapshot = capturedEventSchedulerSnapshot;
       this.capturedAlarmHistory = new ArrayList<neqsim.process.alarm.AlarmEvent>(capturedAlarmHistory);
@@ -5528,6 +5533,20 @@ public class ProcessSystem extends SimulationBaseClass {
             failure = accumulateTransactionFailure(failure,
                 "Failed to restore transient state participant '" + checkpoint.stateIdentity + "'", ex);
           }
+        }
+
+        try {
+          if (recycleController != capturedRecycleController) {
+            failure = accumulateTransactionFailure(failure,
+                "RecycleController identity changed during transient transaction",
+                new IllegalStateException("Expected the captured RecycleController instance"));
+            recycleController = capturedRecycleController;
+          }
+          if (capturedRecycleController != null) {
+            capturedRecycleController.restoreTransientState(capturedRecycleControllerSnapshot);
+          }
+        } catch (RuntimeException ex) {
+          failure = accumulateTransactionFailure(failure, "Failed to restore RecycleController state", ex);
         }
 
         try {
@@ -5610,6 +5629,9 @@ public class ProcessSystem extends SimulationBaseClass {
           return new IllegalStateException("Transient state identity changed during transaction from '"
               + checkpoint.stateIdentity + "' to '" + currentIdentity + "'");
         }
+      }
+      if (recycleController != capturedRecycleController) {
+        return new IllegalStateException("RecycleController identity changed during transient transaction");
       }
       return null;
     }

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -5316,8 +5316,8 @@ public class ProcessSystem extends SimulationBaseClass {
     }
 
     RecycleController capturedRecycleController = recycleController;
-    RecycleController.Snapshot recycleControllerSnapshot =
-        capturedRecycleController == null ? null : capturedRecycleController.captureTransientState();
+    RecycleController.Snapshot recycleControllerSnapshot = capturedRecycleController == null ? null
+        : capturedRecycleController.captureTransientState();
     ProcessSystemStepTransaction transaction = new ProcessSystemStepTransaction(elements, participantCheckpoints,
         capturedRecycleController, recycleControllerSnapshot, eventScheduler,
         eventScheduler == null ? null : eventScheduler.snapshot(), new ArrayList<>(alarmManager.getHistory()));
@@ -5470,8 +5470,7 @@ public class ProcessSystem extends SimulationBaseClass {
     private Status status = Status.OPEN;
 
     private ProcessSystemStepTransaction(List<ProcessElementInterface> elementIdentities,
-        List<TransientParticipantCheckpoint> participantCheckpoints,
-        RecycleController capturedRecycleController,
+        List<TransientParticipantCheckpoint> participantCheckpoints, RecycleController capturedRecycleController,
         RecycleController.Snapshot capturedRecycleControllerSnapshot, EventScheduler capturedEventScheduler,
         EventScheduler.Snapshot capturedEventSchedulerSnapshot,
         List<neqsim.process.alarm.AlarmEvent> capturedAlarmHistory) {

--- a/src/test/java/neqsim/process/equipment/util/RecycleControllerAcceptedSeedTransactionTest.java
+++ b/src/test/java/neqsim/process/equipment/util/RecycleControllerAcceptedSeedTransactionTest.java
@@ -35,8 +35,7 @@ class RecycleControllerAcceptedSeedTransactionTest extends neqsim.NeqSimTest {
     Recycle restartedRecycle = restarted.getRecycles().get(0);
     assertEquals(0, restartedRecycle.getIterations());
     assertTrue(restarted.doSolveRecycle(restartedRecycle));
-    assertEquals(1, restartedRecycle.getIterations(),
-        "Java serialization must retain accepted seed membership");
+    assertEquals(1, restartedRecycle.getIterations(), "Java serialization must retain accepted seed membership");
   }
 
   private static RecycleController controllerWithAcceptedSeed() {
@@ -74,8 +73,7 @@ class RecycleControllerAcceptedSeedTransactionTest extends neqsim.NeqSimTest {
     try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
       output.writeObject(value);
     }
-    try (ObjectInputStream input =
-        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
       return (T) input.readObject();
     }
   }

--- a/src/test/java/neqsim/process/equipment/util/RecycleControllerAcceptedSeedTransactionTest.java
+++ b/src/test/java/neqsim/process/equipment/util/RecycleControllerAcceptedSeedTransactionTest.java
@@ -1,0 +1,82 @@
+package neqsim.process.equipment.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression evidence for accepted recycle-state seed rollback and restart. */
+class RecycleControllerAcceptedSeedTransactionTest extends neqsim.NeqSimTest {
+  @Test
+  void acceptedSeedMembershipRestoresInPlaceAndSurvivesSerialization() throws Exception {
+    RecycleController controller = controllerWithAcceptedSeed();
+    Recycle recycle = controller.getRecycles().get(0);
+    RecycleController.Snapshot snapshot = controller.captureTransientState();
+
+    controller.init();
+    recycle.iterations = 0;
+    assertTrue(controller.doSolveRecycle(recycle));
+    assertEquals(0, recycle.getIterations(), "the second init must clear the accepted seed");
+
+    controller.restoreTransientState(snapshot);
+    assertSame(recycle, controller.getRecycles().get(0));
+    recycle.iterations = 0;
+    assertTrue(controller.doSolveRecycle(recycle));
+    assertEquals(1, recycle.getIterations(), "rollback must restore accepted seed membership");
+
+    RecycleController restarted = roundTrip(controllerWithAcceptedSeed());
+    Recycle restartedRecycle = restarted.getRecycles().get(0);
+    assertEquals(0, restartedRecycle.getIterations());
+    assertTrue(restarted.doSolveRecycle(restartedRecycle));
+    assertEquals(1, restartedRecycle.getIterations(),
+        "Java serialization must retain accepted seed membership");
+  }
+
+  private static RecycleController controllerWithAcceptedSeed() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 30.0);
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.1);
+    fluid.setMixingRule("classic");
+
+    Stream inlet = new Stream("accepted seed inlet", fluid.clone());
+    inlet.setFlowRate(100.0, "kg/hr");
+    inlet.run();
+    Stream outlet = new Stream("accepted seed outlet", fluid.clone());
+    outlet.setFlowRate(100.0, "kg/hr");
+    outlet.run();
+
+    Recycle recycle = new Recycle("accepted seed recycle");
+    recycle.addStream(inlet);
+    recycle.setOutletStream(outlet);
+    recycle.setErrorCompositon(0.0);
+    recycle.setErrorFlow(0.0);
+    recycle.setErrorTemperature(0.0);
+    recycle.setErrorPressure(0.0);
+    recycle.iterations = 2;
+
+    RecycleController controller = new RecycleController();
+    controller.addRecycle(recycle);
+    controller.init();
+    assertEquals(0, recycle.getIterations());
+    return controller;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T roundTrip(T value) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(value);
+    }
+    try (ObjectInputStream input =
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (T) input.readObject();
+    }
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/RecycleControllerTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/processmodel/RecycleControllerTransientStateTransactionTest.java
@@ -1,0 +1,207 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.dynamics.TransientStateParticipant;
+import neqsim.process.dynamics.TransientStepTransaction;
+import neqsim.process.dynamics.TransientTransactionCoverage;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.util.BroydenAccelerator;
+import neqsim.process.equipment.util.Recycle;
+import neqsim.process.equipment.util.RecycleController;
+
+/**
+ * Quantitative rollback and restart tests for shared recycle-controller orchestration state.
+ */
+public class RecycleControllerTransientStateTransactionTest extends neqsim.NeqSimTest {
+  private static final double TOLERANCE = 1.0e-12;
+
+  @Test
+  void processTransactionRestoresControllerAndCoordinatedAcceleratorInPlace() {
+    ProcessSystem process = new ProcessSystem("recycle-controller-transaction");
+    process.add(new TransactionalUnit("covered-unit"));
+
+    Recycle first = new Recycle("first");
+    first.setPriority(20);
+    Recycle second = new Recycle("second");
+    second.setPriority(80);
+    process.recycleController.addRecycle(first);
+    process.recycleController.addRecycle(second);
+    process.recycleController.init();
+    process.recycleController.setUseCoordinatedAcceleration(true);
+
+    BroydenAccelerator accelerator = process.recycleController.getCoordinatedAccelerator();
+    accelerator.setDelayIterations(0);
+    accelerateThreeTimes(accelerator);
+    int capturedIterations = accelerator.getIterationCount();
+    double capturedResidual = accelerator.getResidualNorm();
+    double[][] capturedJacobian = accelerator.getInverseJacobian();
+
+    TransientTransactionCoverage coverage = process.getTransientTransactionCoverage();
+    assertTrue(coverage.isComplete());
+    assertEquals(1, coverage.getProcessElementCount());
+    assertEquals(1, coverage.getParticipantCount());
+
+    TransientStepTransaction transaction = process.beginTransientStepTransaction();
+    process.recycleController.setCurrentPriorityLevel(999);
+    process.recycleController.setUseCoordinatedAcceleration(false);
+    accelerator.setRelaxationFactor(0.25);
+    accelerator.accelerate(new double[] {1.4, 2.3}, new double[] {1.6, 2.5});
+    transaction.rollback();
+
+    assertEquals(TransientStepTransaction.Status.ROLLED_BACK, transaction.getStatus());
+    assertEquals(20, process.recycleController.getCurrentPriorityLevel());
+    assertTrue(process.recycleController.isUseCoordinatedAcceleration());
+    assertSame(accelerator, process.recycleController.getCoordinatedAccelerator());
+    assertEquals(capturedIterations, accelerator.getIterationCount());
+    assertEquals(capturedResidual, accelerator.getResidualNorm(), TOLERANCE);
+    assertEquals(1.0, accelerator.getRelaxationFactor(), TOLERANCE);
+    assertMatrixEquals(capturedJacobian, accelerator.getInverseJacobian());
+    assertSame(first, process.recycleController.getRecycles().get(0));
+    assertSame(second, process.recycleController.getRecycles().get(1));
+  }
+
+  @Test
+  void directSnapshotRestoresStructureConfigurationAndForeignSnapshotIsRejected() {
+    RecycleController controller = configuredController();
+    RecycleController.Snapshot snapshot = controller.captureTransientState();
+    List<Recycle> capturedRecycles = controller.getRecycles();
+    BroydenAccelerator capturedAccelerator = controller.getCoordinatedAccelerator();
+    int capturedIterations = capturedAccelerator.getIterationCount();
+    double[][] capturedJacobian = capturedAccelerator.getInverseJacobian();
+
+    controller.clear();
+    controller.setUseCoordinatedAcceleration(false);
+    controller.restoreTransientState(snapshot);
+
+    assertEquals(2, controller.getRecycleCount());
+    assertSame(capturedRecycles.get(0), controller.getRecycles().get(0));
+    assertSame(capturedRecycles.get(1), controller.getRecycles().get(1));
+    assertEquals(20, controller.getCurrentPriorityLevel());
+    assertTrue(controller.isUseCoordinatedAcceleration());
+    assertSame(capturedAccelerator, controller.getCoordinatedAccelerator());
+    assertEquals(capturedIterations, capturedAccelerator.getIterationCount());
+    assertMatrixEquals(capturedJacobian, capturedAccelerator.getInverseJacobian());
+
+    RecycleController foreign = configuredController();
+    assertThrows(IllegalArgumentException.class, () -> foreign.restoreTransientState(snapshot));
+    assertThrows(NullPointerException.class, () -> controller.restoreTransientState(null));
+  }
+
+  @Test
+  void javaSerializationPreservesExactCoordinatedSolverContinuation() throws Exception {
+    RecycleController original = configuredController();
+    RecycleController restarted = roundTrip(original);
+
+    assertEquals(original.getTransientStateIdentity(), restarted.getTransientStateIdentity());
+    assertEquals(original.getRecycleCount(), restarted.getRecycleCount());
+    assertEquals(original.getCurrentPriorityLevel(), restarted.getCurrentPriorityLevel());
+    assertNotNull(restarted.getCoordinatedAccelerator());
+    assertEquals(original.getCoordinatedAccelerator().getIterationCount(),
+        restarted.getCoordinatedAccelerator().getIterationCount());
+    assertEquals(original.getCoordinatedAccelerator().getResidualNorm(),
+        restarted.getCoordinatedAccelerator().getResidualNorm(), TOLERANCE);
+    assertMatrixEquals(original.getCoordinatedAccelerator().getInverseJacobian(),
+        restarted.getCoordinatedAccelerator().getInverseJacobian());
+
+    double[] input = {1.4, 2.3};
+    double[] output = {1.6, 2.5};
+    assertArrayEquals(original.getCoordinatedAccelerator().accelerate(input, output),
+        restarted.getCoordinatedAccelerator().accelerate(input, output), TOLERANCE);
+  }
+
+  private static RecycleController configuredController() {
+    RecycleController controller = new RecycleController();
+    Recycle first = new Recycle("first");
+    first.setPriority(20);
+    Recycle second = new Recycle("second");
+    second.setPriority(80);
+    controller.addRecycle(first);
+    controller.addRecycle(second);
+    controller.init();
+    controller.setUseCoordinatedAcceleration(true);
+    controller.getCoordinatedAccelerator().setDelayIterations(0);
+    accelerateThreeTimes(controller.getCoordinatedAccelerator());
+    return controller;
+  }
+
+  private static void accelerateThreeTimes(BroydenAccelerator accelerator) {
+    accelerator.accelerate(new double[] {1.0, 2.0}, new double[] {1.2, 2.2});
+    accelerator.accelerate(new double[] {1.2, 2.2}, new double[] {1.3, 2.25});
+    accelerator.accelerate(new double[] {1.3, 2.25}, new double[] {1.35, 2.28});
+  }
+
+  private static void assertMatrixEquals(double[][] expected, double[][] actual) {
+    assertEquals(expected.length, actual.length);
+    for (int row = 0; row < expected.length; row++) {
+      assertArrayEquals(expected[row], actual[row], TOLERANCE);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends Serializable> T roundTrip(T value)
+      throws IOException, ClassNotFoundException {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(value);
+    }
+    try (ObjectInputStream input =
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (T) input.readObject();
+    }
+  }
+
+  /** Minimal covered process element used to isolate shared orchestration rollback. */
+  private static final class TransactionalUnit extends ProcessEquipmentBaseClass
+      implements TransientStateParticipant<TransactionalUnit.Snapshot> {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity = UUID.randomUUID().toString();
+
+    private TransactionalUnit(String name) {
+      super(name);
+    }
+
+    @Override
+    public void run(UUID id) {
+      setCalculationIdentifier(id);
+    }
+
+    @Override
+    public String getTransientStateIdentity() {
+      return stateIdentity;
+    }
+
+    @Override
+    public Snapshot captureTransientState() {
+      return new Snapshot(getCalculationIdentifier());
+    }
+
+    @Override
+    public void restoreTransientState(Snapshot snapshot) {
+      setCalculationIdentifier(snapshot.calculationIdentifier);
+    }
+
+    /** Immutable unit snapshot. */
+    private static final class Snapshot implements Serializable {
+      private static final long serialVersionUID = 1000L;
+      private final UUID calculationIdentifier;
+
+      private Snapshot(UUID calculationIdentifier) {
+        this.calculationIdentifier = calculationIdentifier;
+      }
+    }
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/RecycleControllerTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/processmodel/RecycleControllerTransientStateTransactionTest.java
@@ -59,7 +59,7 @@ public class RecycleControllerTransientStateTransactionTest extends neqsim.NeqSi
     process.recycleController.setCurrentPriorityLevel(999);
     process.recycleController.setUseCoordinatedAcceleration(false);
     accelerator.setRelaxationFactor(0.25);
-    accelerator.accelerate(new double[] {1.4, 2.3}, new double[] {1.6, 2.5});
+    accelerator.accelerate(new double[] { 1.4, 2.3 }, new double[] { 1.6, 2.5 });
     transaction.rollback();
 
     assertEquals(TransientStepTransaction.Status.ROLLED_BACK, transaction.getStatus());
@@ -117,8 +117,8 @@ public class RecycleControllerTransientStateTransactionTest extends neqsim.NeqSi
     assertMatrixEquals(original.getCoordinatedAccelerator().getInverseJacobian(),
         restarted.getCoordinatedAccelerator().getInverseJacobian());
 
-    double[] input = {1.4, 2.3};
-    double[] output = {1.6, 2.5};
+    double[] input = { 1.4, 2.3 };
+    double[] output = { 1.6, 2.5 };
     assertArrayEquals(original.getCoordinatedAccelerator().accelerate(input, output),
         restarted.getCoordinatedAccelerator().accelerate(input, output), TOLERANCE);
   }
@@ -139,9 +139,9 @@ public class RecycleControllerTransientStateTransactionTest extends neqsim.NeqSi
   }
 
   private static void accelerateThreeTimes(BroydenAccelerator accelerator) {
-    accelerator.accelerate(new double[] {1.0, 2.0}, new double[] {1.2, 2.2});
-    accelerator.accelerate(new double[] {1.2, 2.2}, new double[] {1.3, 2.25});
-    accelerator.accelerate(new double[] {1.3, 2.25}, new double[] {1.35, 2.28});
+    accelerator.accelerate(new double[] { 1.0, 2.0 }, new double[] { 1.2, 2.2 });
+    accelerator.accelerate(new double[] { 1.2, 2.2 }, new double[] { 1.3, 2.25 });
+    accelerator.accelerate(new double[] { 1.3, 2.25 }, new double[] { 1.35, 2.28 });
   }
 
   private static void assertMatrixEquals(double[][] expected, double[][] actual) {
@@ -152,14 +152,12 @@ public class RecycleControllerTransientStateTransactionTest extends neqsim.NeqSi
   }
 
   @SuppressWarnings("unchecked")
-  private static <T extends Serializable> T roundTrip(T value)
-      throws IOException, ClassNotFoundException {
+  private static <T extends Serializable> T roundTrip(T value) throws IOException, ClassNotFoundException {
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
       output.writeObject(value);
     }
-    try (ObjectInputStream input =
-        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
       return (T) input.readObject();
     }
   }


### PR DESCRIPTION
## Roadmap

Advances #2911 as **DYN-C016**: identity-preserving transaction and restart coverage for shared recycle-controller orchestration.

Base: `dca199ff5d4c43ec7e07a9fc15a117fa9981be7b`
Publication head: `efcc4993f0fce96dbc08089b73328d5e82ff1631`
Branch: `campaign-2911-recycle-controller-transaction`

## Engineering question

Can the shared `RecycleController` participate in the existing `ProcessSystem` step transaction without retaining priority, accepted-state seed, or coordinated Broyden memory from a rejected trial, while preserving exact continuation after Java serialization?

## Complete tranche

- adds a stable serialized controller-state identity and rejects foreign/null snapshots;
- snapshots recycle registration/priority order, current/minimum/maximum priority, coordinated-acceleration configuration and accepted-state seed membership;
- adds defensively copied `BroydenAccelerator` continuation snapshots covering dimension, inverse Jacobian, previous input/residual vectors, iteration count, delay, relaxation and step limit;
- restores the same controller and coordinated-accelerator instances during `ProcessSystem` rollback;
- persists coordinated accelerator and accepted seed state across Java serialization instead of silently resetting them;
- captures shared controller orchestration separately from quantitative process-element participant counts;
- removes only the obsolete shared-controller blocker while keeping every unqualified `Recycle` process element fail-closed;
- documents the exact boundary, evidence and non-qualification limits.

## Quantitative regression evidence added

The focused test suite covers:

- `1/1` registered process-element coverage while an internal shared controller owns two recycle registrations;
- exact rollback of controller priority, configuration, inverse Jacobian, residual, iteration and relaxation state at `1e-12`;
- same Java object identity for controller, accelerator and both registered recycle references;
- recycle-registration restoration after direct snapshot mutation;
- foreign and null snapshot rejection;
- accepted-state seed membership rollback and Java-serialization restart;
- exact coordinated Broyden continuation after Java serialization at `1e-12`.

## Validation

**VALIDATION PENDING CI.**

The GitHub connector was the authoritative source and publication path. The exact six-file branch was re-read from head `efcc4993f0fce96dbc08089b73328d5e82ff1631` and compared against base: three commits ahead, zero behind, 532 additions and 12 deletions. The exact Spotless patch generated by GitHub Actions for the previous head was applied unchanged in the third commit.

A local checkout, repository Spotless runner, Maven build, documentation-search script and pre-commit environment are unavailable in this workspace, so none is claimed as passed. Hosted exact-head CI is the validator; attributable findings will be repaired on this draft PR.

## Documentation impact

Updated `docs/process/dynamic-capability-contract.md` with controller-owned state, restart behavior, quantitative counting semantics, remaining `Recycle` blocker and engineering limits.

## Compatibility and stop boundary

Existing recycle equations, tolerances, priority API and acceleration algorithms are unchanged. Serialization now retains shared coordinated convergence continuation; older serialized controllers remain readable because the identity and accepted-seed map are lazily recreated when absent.

This tranche deliberately does **not** claim a realistic recycle flowsheet is transaction-ready: `Recycle` itself still lacks a complete participant snapshot for its internal stream, residual, adaptive/Wegstein/Broyden and base-equipment state. It does not add a plant-wide DAE solver, qualify convergence physics, enter #2935 species transport, enter #2907 multiphase closures/slugging, or start Huldra dataset work.
