### PR TITLE
[AI-Assisted] feat(diagram): add component-resolved balances

### DIFF
--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -136,6 +136,52 @@ inlet total minus the outlet total, and its relative residual uses the same larg
 It intentionally excludes equipment heat duties and shaft work, so it is not a complete energy
 balance.
 
+### Explicit component-resolved mass balances
+
+`EngineeringDiagramComponentBalanceTable` is an additive companion to an existing explicit-boundary
+balance table. It binds user-supplied component mass-flow records to the same stable balance and
+stream identities. Every record retains the source component identity and name, explicit `kg/s`
+unit, `COMPONENT_MASS` basis, source reference, provenance, and `PROPOSED` or `REVIEWED` evidence
+state. A component requires one explicit zero or non-zero value on every declared boundary stream;
+missing, duplicate, unknown, non-finite, negative, wrongly based, or wrongly unitized values remain
+visible as structured diagnostics.
+
+```java
+List<EngineeringDiagramComponentBalanceTable.ComponentFlow> componentFlows =
+    Arrays.asList(
+        new EngineeringDiagramComponentBalanceTable.ComponentFlow(
+            "BAL-AREA-01",
+            feedStreamId,
+            "methane",
+            "methane",
+            8.5,
+            "kg/s",
+            "COMPONENT_MASS",
+            "project-component-register:BAL-AREA-01",
+            "simulation-case:NORMAL-01",
+            EngineeringDiagramBalanceTable.EvidenceState.PROPOSED),
+        new EngineeringDiagramComponentBalanceTable.ComponentFlow(
+            "BAL-AREA-01",
+            productStreamId,
+            "methane",
+            "methane",
+            8.5,
+            "kg/s",
+            "COMPONENT_MASS",
+            "project-component-register:BAL-AREA-01",
+            "simulation-case:NORMAL-01",
+            EngineeringDiagramBalanceTable.EvidenceState.PROPOSED));
+EngineeringDiagramComponentBalanceTable componentBalances =
+    EngineeringDiagramComponentBalanceTable.fromBalanceTable(balanceTable, componentFlows);
+```
+
+For each stable balance/component pair, the projection reports inlet and outlet component mass flow,
+their residual, the larger-total relative residual, declared and supplied boundary counts, and an
+explicit completeness flag. It does not derive composition from a live process object, infer omitted
+zeroes, apply tolerances, reconcile values, or close equipment heat/work terms. This separation keeps
+component data provenance explicit and leaves existing stream-table, balance-table, controlled
+document, Classic DOT/Graphviz, native SVG/PDF, DEXPI 2.0 Process, and Proteus/P&ID outputs unchanged.
+
 ### Explicit tolerance assessment
 
 `EngineeringDiagramBalanceAssessment` evaluates existing residuals against explicit, sourced
@@ -358,7 +404,7 @@ Run the focused regression with:
 ./mvnw -Dtest=ProcessDiagramDocumentSetAdapterTest test
 ./mvnw -Dtest=NativeEngineeringDiagramRendererTest test
 ./mvnw -Dtest=EngineeringDiagramStreamTableTest,EngineeringDiagramBalanceTableTest,\
-EngineeringDiagramBalanceAssessmentTest test
+EngineeringDiagramComponentBalanceTableTest,EngineeringDiagramBalanceAssessmentTest test
 ```
 
 The regression verifies deterministic single- and multi-area output, immutable collections,

--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -178,8 +178,10 @@ EngineeringDiagramComponentBalanceTable componentBalances =
 For each stable balance/component pair, the projection reports inlet and outlet component mass flow,
 their residual, the larger-total relative residual, declared and supplied boundary counts, and an
 explicit completeness flag. It does not derive composition from a live process object, infer omitted
-zeroes, apply tolerances, reconcile values, or close equipment heat/work terms. This separation keeps
-component data provenance explicit and leaves existing stream-table, balance-table, controlled
+zeroes, apply tolerances, reconcile values, or close equipment heat/work terms. The sum of supplied
+component inlet/outlet totals is also compared with the source total-mass balance; a difference is a
+warning with no inferred project tolerance. This separation keeps component data provenance explicit
+and leaves existing stream-table, balance-table, controlled
 document, Classic DOT/Graphviz, native SVG/PDF, DEXPI 2.0 Process, and Proteus/P&ID outputs unchanged.
 
 ### Explicit tolerance assessment

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramComponentBalanceTable.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramComponentBalanceTable.java
@@ -1,0 +1,613 @@
+package neqsim.process.engineering.model;
+
+import com.google.gson.GsonBuilder;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Boundary;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Direction;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.EvidenceState;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Severity;
+
+/**
+ * Immutable, deterministic component-resolved mass-balance projection.
+ *
+ * <p>
+ * The projection binds explicit component mass-flow records to the explicit stream boundaries in an
+ * {@link EngineeringDiagramBalanceTable}. It never infers a component slate, converts composition, or changes a
+ * governed stream value. Callers must provide one explicit zero or non-zero value for every component on every
+ * boundary stream. Missing, duplicate, unknown, wrongly based, and non-finite values remain visible as structured
+ * diagnostics.
+ * </p>
+ *
+ * <p>
+ * This class calculates residuals only. It does not apply project tolerances, reconcile data, close equipment heat or
+ * work terms, or promote review evidence to engineering approval.
+ * </p>
+ */
+public final class EngineeringDiagramComponentBalanceTable implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  public static final String SCHEMA_VERSION = "neqsim_engineering_diagram_component_balance_table.v1";
+
+  /** One explicit component mass-flow value on a declared boundary stream. */
+  public static final class ComponentFlow implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String balanceId;
+    private final String streamSemanticObjectId;
+    private final String componentId;
+    private final String componentName;
+    private final double resultValue;
+    private final String resultUnit;
+    private final String quantityBasis;
+    private final String sourceReference;
+    private final String provenance;
+    private final EvidenceState evidenceState;
+
+    /**
+     * Creates one explicit component mass-flow record.
+     *
+     * @param balanceId stable balance identity
+     * @param streamSemanticObjectId canonical boundary-stream identity
+     * @param componentId stable component identity within the source component register
+     * @param componentName source component name retained for review
+     * @param resultValue component mass flow
+     * @param resultUnit explicit result unit; aggregation requires {@code kg/s}
+     * @param quantityBasis explicit quantity basis; aggregation requires {@code COMPONENT_MASS}
+     * @param sourceReference source calculation or register reference
+     * @param provenance calculation or data lineage description
+     * @param evidenceState review evidence state
+     * @throws IllegalArgumentException if required identity, source, provenance, or evidence is missing
+     */
+    public ComponentFlow(String balanceId, String streamSemanticObjectId, String componentId, String componentName,
+        double resultValue, String resultUnit, String quantityBasis, String sourceReference, String provenance,
+        EvidenceState evidenceState) {
+      this.balanceId = requireText(balanceId, "balanceId");
+      this.streamSemanticObjectId = requireText(streamSemanticObjectId, "streamSemanticObjectId");
+      this.componentId = requireText(componentId, "componentId");
+      this.componentName = requireText(componentName, "componentName");
+      this.resultValue = resultValue;
+      this.resultUnit = requireText(resultUnit, "resultUnit");
+      this.quantityBasis = requireText(quantityBasis, "quantityBasis");
+      this.sourceReference = requireText(sourceReference, "sourceReference");
+      this.provenance = requireText(provenance, "provenance");
+      if (evidenceState == null) {
+        throw new IllegalArgumentException("evidenceState must not be null");
+      }
+      this.evidenceState = evidenceState;
+    }
+
+    /** @return stable balance identity */
+    public String getBalanceId() {
+      return balanceId;
+    }
+
+    /** @return canonical boundary-stream identity */
+    public String getStreamSemanticObjectId() {
+      return streamSemanticObjectId;
+    }
+
+    /** @return stable component identity */
+    public String getComponentId() {
+      return componentId;
+    }
+
+    /** @return source component name */
+    public String getComponentName() {
+      return componentName;
+    }
+
+    /** @return component mass-flow result */
+    public double getResultValue() {
+      return resultValue;
+    }
+
+    /** @return explicit result unit */
+    public String getResultUnit() {
+      return resultUnit;
+    }
+
+    /** @return explicit quantity basis */
+    public String getQuantityBasis() {
+      return quantityBasis;
+    }
+
+    /** @return source calculation or register reference */
+    public String getSourceReference() {
+      return sourceReference;
+    }
+
+    /** @return calculation or data lineage description */
+    public String getProvenance() {
+      return provenance;
+    }
+
+    /** @return review evidence state */
+    public EvidenceState getEvidenceState() {
+      return evidenceState;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("balanceId", balanceId);
+      result.put("streamSemanticObjectId", streamSemanticObjectId);
+      result.put("componentId", componentId);
+      result.put("componentName", componentName);
+      result.put("resultValue", Double.valueOf(resultValue));
+      result.put("resultUnit", resultUnit);
+      result.put("quantityBasis", quantityBasis);
+      result.put("sourceReference", sourceReference);
+      result.put("provenance", provenance);
+      result.put("evidenceState", evidenceState.name());
+      return result;
+    }
+  }
+
+  /** One aggregate component balance result. */
+  public static final class ComponentBalance implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String balanceId;
+    private final String componentId;
+    private final String componentName;
+    private final int boundaryCount;
+    private final int suppliedBoundaryCount;
+    private final double inletMassFlow;
+    private final double outletMassFlow;
+    private final double massResidual;
+    private final double relativeMassResidual;
+    private final boolean complete;
+
+    private ComponentBalance(String balanceId, String componentId, String componentName, Accumulator accumulator) {
+      this.balanceId = balanceId;
+      this.componentId = componentId;
+      this.componentName = componentName;
+      this.boundaryCount = accumulator.boundaryCount;
+      this.suppliedBoundaryCount = accumulator.suppliedBoundaryCount;
+      this.inletMassFlow = accumulator.inletMassFlow;
+      this.outletMassFlow = accumulator.outletMassFlow;
+      this.massResidual = inletMassFlow - outletMassFlow;
+      double scale = Math.max(Math.abs(inletMassFlow), Math.abs(outletMassFlow));
+      this.relativeMassResidual = scale == 0.0 ? 0.0 : massResidual / scale;
+      this.complete = accumulator.complete && boundaryCount == suppliedBoundaryCount;
+    }
+
+    /** @return stable balance identity */
+    public String getBalanceId() {
+      return balanceId;
+    }
+
+    /** @return stable component identity */
+    public String getComponentId() {
+      return componentId;
+    }
+
+    /** @return source component name */
+    public String getComponentName() {
+      return componentName;
+    }
+
+    /** @return number of declared boundary streams */
+    public int getBoundaryCount() {
+      return boundaryCount;
+    }
+
+    /** @return number of boundary streams with one usable component value */
+    public int getSuppliedBoundaryCount() {
+      return suppliedBoundaryCount;
+    }
+
+    /** @return inlet component mass flow in kg/s */
+    public double getInletMassFlow() {
+      return inletMassFlow;
+    }
+
+    /** @return outlet component mass flow in kg/s */
+    public double getOutletMassFlow() {
+      return outletMassFlow;
+    }
+
+    /** @return inlet minus outlet component mass flow in kg/s */
+    public double getMassResidual() {
+      return massResidual;
+    }
+
+    /** @return residual divided by the larger absolute inlet or outlet total */
+    public double getRelativeMassResidual() {
+      return relativeMassResidual;
+    }
+
+    /** @return true when every declared boundary has one usable value */
+    public boolean isComplete() {
+      return complete;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("balanceId", balanceId);
+      result.put("componentId", componentId);
+      result.put("componentName", componentName);
+      result.put("boundaryCount", Integer.valueOf(boundaryCount));
+      result.put("suppliedBoundaryCount", Integer.valueOf(suppliedBoundaryCount));
+      result.put("inletMassFlow", Double.valueOf(inletMassFlow));
+      result.put("outletMassFlow", Double.valueOf(outletMassFlow));
+      result.put("massResidual", Double.valueOf(massResidual));
+      result.put("relativeMassResidual", Double.valueOf(relativeMassResidual));
+      result.put("massFlowUnit", "kg/s");
+      result.put("complete", Boolean.valueOf(complete));
+      return result;
+    }
+  }
+
+  /** One structured component-balance diagnostic. */
+  public static final class Diagnostic implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Severity severity;
+    private final String code;
+    private final String message;
+    private final String subjectId;
+
+    private Diagnostic(Severity severity, String code, String message, String subjectId) {
+      this.severity = severity;
+      this.code = code;
+      this.message = message;
+      this.subjectId = subjectId;
+    }
+
+    /** @return diagnostic severity */
+    public Severity getSeverity() {
+      return severity;
+    }
+
+    /** @return stable machine-readable diagnostic code */
+    public String getCode() {
+      return code;
+    }
+
+    /** @return human-readable diagnostic message */
+    public String getMessage() {
+      return message;
+    }
+
+    /** @return affected stable identity */
+    public String getSubjectId() {
+      return subjectId;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("severity", severity.name());
+      result.put("code", code);
+      result.put("message", message);
+      result.put("subjectId", subjectId);
+      return result;
+    }
+  }
+
+  private static final class Accumulator {
+    private int boundaryCount;
+    private int suppliedBoundaryCount;
+    private double inletMassFlow;
+    private double outletMassFlow;
+    private boolean complete = true;
+  }
+
+  private final String documentSetId;
+  private final String sourceGraphFingerprint;
+  private final String designCaseId;
+  private final String sourceBalanceTableFingerprint;
+  private final List<ComponentFlow> componentFlows;
+  private final List<ComponentBalance> componentBalances;
+  private final List<Diagnostic> diagnostics;
+
+  private EngineeringDiagramComponentBalanceTable(EngineeringDiagramBalanceTable balanceTable,
+      List<ComponentFlow> componentFlows, List<ComponentBalance> componentBalances, List<Diagnostic> diagnostics) {
+    this.documentSetId = balanceTable.getDocumentSetId();
+    this.sourceGraphFingerprint = balanceTable.getSourceGraphFingerprint();
+    this.designCaseId = balanceTable.getDesignCaseId();
+    this.sourceBalanceTableFingerprint = balanceTable.toMap().get("fingerprint").toString();
+    this.componentFlows = Collections.unmodifiableList(new ArrayList<ComponentFlow>(componentFlows));
+    this.componentBalances = Collections.unmodifiableList(new ArrayList<ComponentBalance>(componentBalances));
+    this.diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+  }
+
+  /**
+   * Aggregates explicit component mass flows against an existing explicit-boundary balance table.
+   *
+   * @param balanceTable governed explicit-boundary balance table
+   * @param componentFlows explicit component values for every component and boundary stream
+   * @return immutable component-resolved balance table
+   * @throws IllegalArgumentException if either argument is null or the values contain null
+   */
+  public static EngineeringDiagramComponentBalanceTable fromBalanceTable(EngineeringDiagramBalanceTable balanceTable,
+      List<ComponentFlow> componentFlows) {
+    if (balanceTable == null) {
+      throw new IllegalArgumentException("balanceTable must not be null");
+    }
+    if (componentFlows == null) {
+      throw new IllegalArgumentException("componentFlows must not be null");
+    }
+    List<ComponentFlow> sortedFlows = new ArrayList<ComponentFlow>(componentFlows);
+    if (containsNull(sortedFlows)) {
+      throw new IllegalArgumentException("componentFlows must not contain null");
+    }
+    Collections.sort(sortedFlows, componentFlowComparator());
+    List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
+    if (!balanceTable.isValid()) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "COMPONENT_BALANCE_SOURCE_INVALID",
+          "The source explicit-boundary balance table contains error-severity diagnostics", ""));
+    }
+    if (sortedFlows.isEmpty()) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "COMPONENT_FLOW_NOT_DECLARED",
+          "At least one explicit component mass-flow value is required", ""));
+    }
+
+    Map<String, Boundary> boundariesByKey = new LinkedHashMap<String, Boundary>();
+    Map<String, List<Boundary>> boundariesByBalance = new LinkedHashMap<String, List<Boundary>>();
+    for (Boundary boundary : balanceTable.getBoundaries()) {
+      String key = boundaryKey(boundary.getBalanceId(), boundary.getStreamSemanticObjectId());
+      if (!boundariesByKey.containsKey(key)) {
+        boundariesByKey.put(key, boundary);
+      }
+      List<Boundary> balanceBoundaries = boundariesByBalance.get(boundary.getBalanceId());
+      if (balanceBoundaries == null) {
+        balanceBoundaries = new ArrayList<Boundary>();
+        boundariesByBalance.put(boundary.getBalanceId(), balanceBoundaries);
+      }
+      balanceBoundaries.add(boundary);
+    }
+
+    Map<String, ComponentFlow> validFlowsByKey = new LinkedHashMap<String, ComponentFlow>();
+    Map<String, Set<String>> componentsByBalance = new LinkedHashMap<String, Set<String>>();
+    Map<String, String> componentNamesByKey = new LinkedHashMap<String, String>();
+    for (ComponentFlow flow : sortedFlows) {
+      Boundary boundary = boundariesByKey.get(boundaryKey(flow.getBalanceId(), flow.getStreamSemanticObjectId()));
+      if (boundary == null) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "COMPONENT_FLOW_UNKNOWN_BOUNDARY",
+            "A component value references a stream that is not assigned to the named balance",
+            flow.getStreamSemanticObjectId()));
+        continue;
+      }
+      String flowKey = componentFlowKey(flow.getBalanceId(), flow.getStreamSemanticObjectId(), flow.getComponentId());
+      if (validFlowsByKey.containsKey(flowKey)) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "COMPONENT_FLOW_DUPLICATE",
+            "Only one component value may be supplied for a balance, stream, and component", flowKey));
+        continue;
+      }
+      if (!validFlow(flow)) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "COMPONENT_FLOW_VALUE_INVALID",
+            "Component mass flow must be finite, non-negative, in kg/s, and on a COMPONENT_MASS basis", flowKey));
+        continue;
+      }
+      String componentKey = flow.getBalanceId() + "|" + flow.getComponentId();
+      String existingName = componentNamesByKey.get(componentKey);
+      if (existingName != null && !existingName.equals(flow.getComponentName())) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "COMPONENT_NAME_CONFLICT",
+            "One stable component identity has conflicting source component names", componentKey));
+        continue;
+      }
+      componentNamesByKey.put(componentKey, flow.getComponentName());
+      validFlowsByKey.put(flowKey, flow);
+      Set<String> components = componentsByBalance.get(flow.getBalanceId());
+      if (components == null) {
+        components = new LinkedHashSet<String>();
+        componentsByBalance.put(flow.getBalanceId(), components);
+      }
+      components.add(flow.getComponentId());
+    }
+
+    List<ComponentBalance> balances = new ArrayList<ComponentBalance>();
+    for (Map.Entry<String, List<Boundary>> entry : boundariesByBalance.entrySet()) {
+      String balanceId = entry.getKey();
+      Set<String> components = componentsByBalance.get(balanceId);
+      if (components == null || components.isEmpty()) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "COMPONENT_BALANCE_COMPONENTS_MISSING",
+            "The declared balance has no usable component mass-flow values", balanceId));
+        continue;
+      }
+      List<String> sortedComponents = new ArrayList<String>(components);
+      Collections.sort(sortedComponents);
+      for (String componentId : sortedComponents) {
+        Accumulator accumulator = new Accumulator();
+        accumulator.boundaryCount = entry.getValue().size();
+        for (Boundary boundary : entry.getValue()) {
+          String flowKey = componentFlowKey(balanceId, boundary.getStreamSemanticObjectId(), componentId);
+          ComponentFlow flow = validFlowsByKey.get(flowKey);
+          if (flow == null) {
+            accumulator.complete = false;
+            diagnostics.add(new Diagnostic(Severity.ERROR, "COMPONENT_FLOW_MISSING",
+                "Every declared component requires an explicit zero or non-zero value on every boundary stream",
+                flowKey));
+            continue;
+          }
+          accumulator.suppliedBoundaryCount++;
+          if (boundary.getDirection() == Direction.INLET) {
+            accumulator.inletMassFlow += flow.getResultValue();
+          } else {
+            accumulator.outletMassFlow += flow.getResultValue();
+          }
+        }
+        String componentName = componentNamesByKey.get(balanceId + "|" + componentId);
+        balances.add(new ComponentBalance(balanceId, componentId, componentName, accumulator));
+      }
+    }
+    Collections.sort(balances, componentBalanceComparator());
+    Collections.sort(diagnostics, diagnosticComparator());
+    return new EngineeringDiagramComponentBalanceTable(balanceTable, sortedFlows, balances, diagnostics);
+  }
+
+  /** @return source controlled-document identity */
+  public String getDocumentSetId() {
+    return documentSetId;
+  }
+
+  /** @return canonical source-graph fingerprint */
+  public String getSourceGraphFingerprint() {
+    return sourceGraphFingerprint;
+  }
+
+  /** @return selected operating-case identity */
+  public String getDesignCaseId() {
+    return designCaseId;
+  }
+
+  /** @return deterministic fingerprint of the source balance-table representation */
+  public String getSourceBalanceTableFingerprint() {
+    return sourceBalanceTableFingerprint;
+  }
+
+  /** @return immutable explicit component values in deterministic order */
+  public List<ComponentFlow> getComponentFlows() {
+    return Collections.unmodifiableList(new ArrayList<ComponentFlow>(componentFlows));
+  }
+
+  /** @return immutable component balances in deterministic order */
+  public List<ComponentBalance> getComponentBalances() {
+    return Collections.unmodifiableList(new ArrayList<ComponentBalance>(componentBalances));
+  }
+
+  /** @return immutable structured diagnostics */
+  public List<Diagnostic> getDiagnostics() {
+    return Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+  }
+
+  /** @return true when no error-severity diagnostic is present */
+  public boolean isValid() {
+    for (Diagnostic diagnostic : diagnostics) {
+      if (diagnostic.getSeverity() == Severity.ERROR) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** @return deterministic machine-readable representation */
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", SCHEMA_VERSION);
+    result.put("documentSetId", documentSetId);
+    result.put("sourceGraphFingerprint", sourceGraphFingerprint);
+    result.put("designCaseId", designCaseId);
+    result.put("sourceBalanceTableFingerprint", sourceBalanceTableFingerprint);
+    List<Map<String, Object>> flowMaps = new ArrayList<Map<String, Object>>();
+    for (ComponentFlow flow : componentFlows) {
+      flowMaps.add(flow.toMap());
+    }
+    result.put("componentFlows", flowMaps);
+    List<Map<String, Object>> balanceMaps = new ArrayList<Map<String, Object>>();
+    for (ComponentBalance balance : componentBalances) {
+      balanceMaps.add(balance.toMap());
+    }
+    result.put("componentBalances", balanceMaps);
+    List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
+    for (Diagnostic diagnostic : diagnostics) {
+      diagnosticMaps.add(diagnostic.toMap());
+    }
+    result.put("diagnostics", diagnosticMaps);
+    result.put("fingerprint", fingerprint(result));
+    return result;
+  }
+
+  /** @return deterministic pretty-printed JSON */
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+  }
+
+  private static boolean validFlow(ComponentFlow flow) {
+    return Double.isFinite(flow.getResultValue()) && flow.getResultValue() >= 0.0
+        && "kg/s".equals(flow.getResultUnit()) && "COMPONENT_MASS".equals(flow.getQuantityBasis());
+  }
+
+  private static String boundaryKey(String balanceId, String streamId) {
+    return balanceId + "|" + streamId;
+  }
+
+  private static String componentFlowKey(String balanceId, String streamId, String componentId) {
+    return balanceId + "|" + streamId + "|" + componentId;
+  }
+
+  private static Comparator<ComponentFlow> componentFlowComparator() {
+    return new Comparator<ComponentFlow>() {
+      @Override
+      public int compare(ComponentFlow left, ComponentFlow right) {
+        int balanceOrder = left.getBalanceId().compareTo(right.getBalanceId());
+        if (balanceOrder != 0) {
+          return balanceOrder;
+        }
+        int componentOrder = left.getComponentId().compareTo(right.getComponentId());
+        if (componentOrder != 0) {
+          return componentOrder;
+        }
+        int streamOrder = left.getStreamSemanticObjectId().compareTo(right.getStreamSemanticObjectId());
+        if (streamOrder != 0) {
+          return streamOrder;
+        }
+        return left.getSourceReference().compareTo(right.getSourceReference());
+      }
+    };
+  }
+
+  private static Comparator<ComponentBalance> componentBalanceComparator() {
+    return new Comparator<ComponentBalance>() {
+      @Override
+      public int compare(ComponentBalance left, ComponentBalance right) {
+        int balanceOrder = left.getBalanceId().compareTo(right.getBalanceId());
+        return balanceOrder != 0 ? balanceOrder : left.getComponentId().compareTo(right.getComponentId());
+      }
+    };
+  }
+
+  private static Comparator<Diagnostic> diagnosticComparator() {
+    return new Comparator<Diagnostic>() {
+      @Override
+      public int compare(Diagnostic left, Diagnostic right) {
+        int subjectOrder = left.getSubjectId().compareTo(right.getSubjectId());
+        if (subjectOrder != 0) {
+          return subjectOrder;
+        }
+        int codeOrder = left.getCode().compareTo(right.getCode());
+        return codeOrder != 0 ? codeOrder : left.getMessage().compareTo(right.getMessage());
+      }
+    };
+  }
+
+  private static boolean containsNull(List<?> values) {
+    for (Object value : values) {
+      if (value == null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static String fingerprint(Map<String, Object> value) {
+    Map<String, Object> copy = new LinkedHashMap<String, Object>(value);
+    copy.remove("fingerprint");
+    byte[] bytes = new GsonBuilder().create().toJson(copy).getBytes(StandardCharsets.UTF_8);
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(bytes);
+      StringBuilder result = new StringBuilder();
+      for (byte element : hash) {
+        result.append(String.format("%02x", Integer.valueOf(element & 0xff)));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is unavailable", exception);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramComponentBalanceTable.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramComponentBalanceTable.java
@@ -594,7 +594,31 @@ public final class EngineeringDiagramComponentBalanceTable implements Serializab
         if (streamOrder != 0) {
           return streamOrder;
         }
-        return left.getSourceReference().compareTo(right.getSourceReference());
+        int nameOrder = left.getComponentName().compareTo(right.getComponentName());
+        if (nameOrder != 0) {
+          return nameOrder;
+        }
+        int valueOrder = Double.compare(left.getResultValue(), right.getResultValue());
+        if (valueOrder != 0) {
+          return valueOrder;
+        }
+        int unitOrder = left.getResultUnit().compareTo(right.getResultUnit());
+        if (unitOrder != 0) {
+          return unitOrder;
+        }
+        int basisOrder = left.getQuantityBasis().compareTo(right.getQuantityBasis());
+        if (basisOrder != 0) {
+          return basisOrder;
+        }
+        int sourceOrder = left.getSourceReference().compareTo(right.getSourceReference());
+        if (sourceOrder != 0) {
+          return sourceOrder;
+        }
+        int provenanceOrder = left.getProvenance().compareTo(right.getProvenance());
+        if (provenanceOrder != 0) {
+          return provenanceOrder;
+        }
+        return left.getEvidenceState().name().compareTo(right.getEvidenceState().name());
       }
     };
   }

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramComponentBalanceTable.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramComponentBalanceTable.java
@@ -25,9 +25,8 @@ import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Severity;
  * <p>
  * The projection binds explicit component mass-flow records to the explicit stream boundaries in an
  * {@link EngineeringDiagramBalanceTable}. It never infers a component slate, converts composition, or changes a
- * governed stream value. Callers must provide one explicit zero or non-zero value for every component on every
- * boundary stream. Missing, duplicate, unknown, wrongly based, and non-finite values remain visible as structured
- * diagnostics.
+ * governed stream value. Callers must provide one explicit zero or non-zero value for every component on every boundary
+ * stream. Missing, duplicate, unknown, wrongly based, and non-finite values remain visible as structured diagnostics.
  * </p>
  *
  * <p>
@@ -528,8 +527,8 @@ public final class EngineeringDiagramComponentBalanceTable implements Serializab
   }
 
   private static boolean validFlow(ComponentFlow flow) {
-    return Double.isFinite(flow.getResultValue()) && flow.getResultValue() >= 0.0
-        && "kg/s".equals(flow.getResultUnit()) && "COMPONENT_MASS".equals(flow.getQuantityBasis());
+    return Double.isFinite(flow.getResultValue()) && flow.getResultValue() >= 0.0 && "kg/s".equals(flow.getResultUnit())
+        && "COMPONENT_MASS".equals(flow.getQuantityBasis());
   }
 
   private static String nonFiniteLabel(double value) {

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramComponentBalanceTable.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramComponentBalanceTable.java
@@ -142,7 +142,12 @@ public final class EngineeringDiagramComponentBalanceTable implements Serializab
       result.put("streamSemanticObjectId", streamSemanticObjectId);
       result.put("componentId", componentId);
       result.put("componentName", componentName);
-      result.put("resultValue", Double.valueOf(resultValue));
+      if (Double.isFinite(resultValue)) {
+        result.put("resultValue", Double.valueOf(resultValue));
+      } else {
+        result.put("resultValue", null);
+        result.put("nonFiniteResult", nonFiniteLabel(resultValue));
+      }
       result.put("resultUnit", resultUnit);
       result.put("quantityBasis", quantityBasis);
       result.put("sourceReference", sourceReference);
@@ -525,6 +530,13 @@ public final class EngineeringDiagramComponentBalanceTable implements Serializab
   private static boolean validFlow(ComponentFlow flow) {
     return Double.isFinite(flow.getResultValue()) && flow.getResultValue() >= 0.0
         && "kg/s".equals(flow.getResultUnit()) && "COMPONENT_MASS".equals(flow.getQuantityBasis());
+  }
+
+  private static String nonFiniteLabel(double value) {
+    if (Double.isNaN(value)) {
+      return "NaN";
+    }
+    return value > 0.0 ? "POSITIVE_INFINITY" : "NEGATIVE_INFINITY";
   }
 
   private static void addMassCoverageDiagnostics(EngineeringDiagramBalanceTable balanceTable,

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramComponentBalanceTable.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramComponentBalanceTable.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Balance;
 import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Boundary;
 import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Direction;
 import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.EvidenceState;
@@ -439,6 +440,7 @@ public final class EngineeringDiagramComponentBalanceTable implements Serializab
       }
     }
     Collections.sort(balances, componentBalanceComparator());
+    addMassCoverageDiagnostics(balanceTable, balances, diagnostics);
     Collections.sort(diagnostics, diagnosticComparator());
     return new EngineeringDiagramComponentBalanceTable(balanceTable, sortedFlows, balances, diagnostics);
   }
@@ -523,6 +525,38 @@ public final class EngineeringDiagramComponentBalanceTable implements Serializab
   private static boolean validFlow(ComponentFlow flow) {
     return Double.isFinite(flow.getResultValue()) && flow.getResultValue() >= 0.0
         && "kg/s".equals(flow.getResultUnit()) && "COMPONENT_MASS".equals(flow.getQuantityBasis());
+  }
+
+  private static void addMassCoverageDiagnostics(EngineeringDiagramBalanceTable balanceTable,
+      List<ComponentBalance> componentBalances, List<Diagnostic> diagnostics) {
+    Map<String, double[]> componentTotalsByBalance = new LinkedHashMap<String, double[]>();
+    for (ComponentBalance componentBalance : componentBalances) {
+      double[] totals = componentTotalsByBalance.get(componentBalance.getBalanceId());
+      if (totals == null) {
+        totals = new double[2];
+        componentTotalsByBalance.put(componentBalance.getBalanceId(), totals);
+      }
+      totals[0] += componentBalance.getInletMassFlow();
+      totals[1] += componentBalance.getOutletMassFlow();
+    }
+    for (Balance balance : balanceTable.getBalances()) {
+      double[] componentTotals = componentTotalsByBalance.get(balance.getBalanceId());
+      if (componentTotals == null) {
+        continue;
+      }
+      if (materiallyDifferent(balance.getInletMassFlow(), componentTotals[0])
+          || materiallyDifferent(balance.getOutletMassFlow(), componentTotals[1])) {
+        diagnostics.add(new Diagnostic(Severity.WARNING, "COMPONENT_TOTAL_MASS_MISMATCH",
+            "Summed component inlet or outlet mass flow differs from the source total-mass balance; no project "
+                + "tolerance was inferred",
+            balance.getBalanceId()));
+      }
+    }
+  }
+
+  private static boolean materiallyDifferent(double expected, double actual) {
+    double scale = Math.max(Math.max(Math.abs(expected), Math.abs(actual)), 1.0);
+    return Math.abs(expected - actual) > 16.0 * Math.ulp(scale);
   }
 
   private static String boundaryKey(String balanceId, String streamId) {

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramComponentBalanceTableTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramComponentBalanceTableTest.java
@@ -76,6 +76,28 @@ class EngineeringDiagramComponentBalanceTableTest {
   }
 
   @Test
+  void isDeterministicForConflictingDuplicateInputOrder() {
+    Fixture fixture = fixture();
+    List<ComponentFlow> forward = completeFlows(fixture.boundaries);
+    ComponentFlow original = forward.get(0);
+    forward.add(new ComponentFlow(original.getBalanceId(), original.getStreamSemanticObjectId(),
+        original.getComponentId(), original.getComponentName(), original.getResultValue() + 0.5,
+        original.getResultUnit(), original.getQuantityBasis(), original.getSourceReference(),
+        "simulation-case:NORMAL-02", original.getEvidenceState()));
+    List<ComponentFlow> reverse = new ArrayList<ComponentFlow>(forward);
+    Collections.reverse(reverse);
+
+    EngineeringDiagramComponentBalanceTable first = EngineeringDiagramComponentBalanceTable
+        .fromBalanceTable(fixture.balanceTable, forward);
+    EngineeringDiagramComponentBalanceTable second = EngineeringDiagramComponentBalanceTable
+        .fromBalanceTable(fixture.balanceTable, reverse);
+
+    assertFalse(first.isValid());
+    assertTrue(hasDiagnostic(first, "COMPONENT_FLOW_DUPLICATE"));
+    assertEquals(first.toJson(), second.toJson());
+  }
+
+  @Test
   void diagnosesMissingDuplicateUnknownAndWrongBasisValues() {
     Fixture fixture = fixture();
     List<ComponentFlow> flows = completeFlows(fixture.boundaries);

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramComponentBalanceTableTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramComponentBalanceTableTest.java
@@ -88,6 +88,9 @@ class EngineeringDiagramComponentBalanceTableTest {
     flows.add(new ComponentFlow("BAL-SIMPLE-01", fixture.boundaries.get(0).getStreamSemanticObjectId(), "water",
         "water", 0.0, "kg/hr", "COMPONENT_MASS", "project-component-register:test",
         "simulation-case:NORMAL-01", EvidenceState.PROPOSED));
+    flows.add(new ComponentFlow("BAL-SIMPLE-01", fixture.boundaries.get(1).getStreamSemanticObjectId(), "nitrogen",
+        "nitrogen", Double.NaN, "kg/s", "COMPONENT_MASS", "project-component-register:test",
+        "simulation-case:NORMAL-01", EvidenceState.PROPOSED));
 
     EngineeringDiagramComponentBalanceTable table = EngineeringDiagramComponentBalanceTable
         .fromBalanceTable(fixture.balanceTable, flows);
@@ -97,6 +100,7 @@ class EngineeringDiagramComponentBalanceTableTest {
     assertTrue(hasDiagnostic(table, "COMPONENT_FLOW_UNKNOWN_BOUNDARY"));
     assertTrue(hasDiagnostic(table, "COMPONENT_FLOW_VALUE_INVALID"));
     assertTrue(hasDiagnostic(table, "COMPONENT_FLOW_MISSING"));
+    assertTrue(table.toJson().contains("\"nonFiniteResult\": \"NaN\""));
   }
 
   @Test

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramComponentBalanceTableTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramComponentBalanceTableTest.java
@@ -82,12 +82,11 @@ class EngineeringDiagramComponentBalanceTableTest {
     ComponentFlow first = flows.get(0);
     flows.add(first);
     flows.remove(1);
-    flows.add(new ComponentFlow("BAL-SIMPLE-01", "line:missing", "methane", "methane", 1.0, "kg/s",
-        "COMPONENT_MASS", "project-component-register:test", "simulation-case:NORMAL-01",
-        EvidenceState.PROPOSED));
+    flows.add(new ComponentFlow("BAL-SIMPLE-01", "line:missing", "methane", "methane", 1.0, "kg/s", "COMPONENT_MASS",
+        "project-component-register:test", "simulation-case:NORMAL-01", EvidenceState.PROPOSED));
     flows.add(new ComponentFlow("BAL-SIMPLE-01", fixture.boundaries.get(0).getStreamSemanticObjectId(), "water",
-        "water", 0.0, "kg/hr", "COMPONENT_MASS", "project-component-register:test",
-        "simulation-case:NORMAL-01", EvidenceState.PROPOSED));
+        "water", 0.0, "kg/hr", "COMPONENT_MASS", "project-component-register:test", "simulation-case:NORMAL-01",
+        EvidenceState.PROPOSED));
     flows.add(new ComponentFlow("BAL-SIMPLE-01", fixture.boundaries.get(1).getStreamSemanticObjectId(), "nitrogen",
         "nitrogen", Double.NaN, "kg/s", "COMPONENT_MASS", "project-component-register:test",
         "simulation-case:NORMAL-01", EvidenceState.PROPOSED));
@@ -130,11 +129,11 @@ class EngineeringDiagramComponentBalanceTableTest {
     EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
         reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-006", "Component balance",
         ContentProfile.PFD, "NORMAL-01");
-    EngineeringDiagramStreamTable streamTable = EngineeringDiagramStreamTable.fromDocumentSet(documents,
-        "NORMAL-01");
+    EngineeringDiagramStreamTable streamTable = EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
     List<Boundary> boundaries = new ArrayList<Boundary>();
-    boundaries.add(new Boundary("BAL-SIMPLE-01", completeRow(streamTable, reference.getFeed().getName()).getSemanticObjectId(),
-        Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED));
+    boundaries.add(
+        new Boundary("BAL-SIMPLE-01", completeRow(streamTable, reference.getFeed().getName()).getSemanticObjectId(),
+            Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED));
     for (StreamInterface product : reference.getProducts()) {
       boundaries.add(new Boundary("BAL-SIMPLE-01", completeRow(streamTable, product.getName()).getSemanticObjectId(),
           Direction.OUTLET, "project-balance-register:test", EvidenceState.PROPOSED));
@@ -148,9 +147,9 @@ class EngineeringDiagramComponentBalanceTableTest {
     Boundary inlet = direction(boundaries, Direction.INLET, 0);
     Boundary firstOutlet = direction(boundaries, Direction.OUTLET, 0);
     Boundary secondOutlet = direction(boundaries, Direction.OUTLET, 1);
-    return new ArrayList<ComponentFlow>(Arrays.asList(flow(inlet, "methane", 6.0), flow(inlet, "ethane", 4.0),
-        flow(firstOutlet, "methane", 4.0), flow(firstOutlet, "ethane", 1.0),
-        flow(secondOutlet, "methane", 2.0), flow(secondOutlet, "ethane", 3.0)));
+    return new ArrayList<ComponentFlow>(
+        Arrays.asList(flow(inlet, "methane", 6.0), flow(inlet, "ethane", 4.0), flow(firstOutlet, "methane", 4.0),
+            flow(firstOutlet, "ethane", 1.0), flow(secondOutlet, "methane", 2.0), flow(secondOutlet, "ethane", 3.0)));
   }
 
   private static ComponentFlow flow(Boundary boundary, String component, double massFlow) {

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramComponentBalanceTableTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramComponentBalanceTableTest.java
@@ -56,6 +56,7 @@ class EngineeringDiagramComponentBalanceTableTest {
     assertThrows(UnsupportedOperationException.class, () -> table.getComponentFlows().clear());
     assertTrue(table.toJson().contains("\"massFlowUnit\": \"kg/s\""));
     assertTrue(table.toJson().contains("\"provenance\": \"simulation-case:NORMAL-01\""));
+    assertTrue(hasDiagnostic(table, "COMPONENT_TOTAL_MASS_MISMATCH"));
   }
 
   @Test

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramComponentBalanceTableTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramComponentBalanceTableTest.java
@@ -1,0 +1,206 @@
+package neqsim.process.processmodel.diagram;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Boundary;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Direction;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.EvidenceState;
+import neqsim.process.engineering.model.EngineeringDiagramComponentBalanceTable;
+import neqsim.process.engineering.model.EngineeringDiagramComponentBalanceTable.ComponentBalance;
+import neqsim.process.engineering.model.EngineeringDiagramComponentBalanceTable.ComponentFlow;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Quantity;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Row;
+import neqsim.process.equipment.stream.StreamInterface;
+import org.junit.jupiter.api.Test;
+
+/** Regression tests for explicit, deterministic component-resolved boundary balances. */
+class EngineeringDiagramComponentBalanceTableTest {
+
+  @Test
+  void aggregatesExplicitComponentMassFlowsWithProvenance() {
+    Fixture fixture = fixture();
+    List<ComponentFlow> flows = completeFlows(fixture.boundaries);
+
+    EngineeringDiagramComponentBalanceTable table = EngineeringDiagramComponentBalanceTable
+        .fromBalanceTable(fixture.balanceTable, flows);
+
+    assertTrue(table.isValid());
+    assertEquals(2, table.getComponentBalances().size());
+    ComponentBalance ethane = component(table, "ethane");
+    ComponentBalance methane = component(table, "methane");
+    assertEquals(3, ethane.getBoundaryCount());
+    assertEquals(3, ethane.getSuppliedBoundaryCount());
+    assertTrue(ethane.isComplete());
+    assertEquals(4.0, ethane.getInletMassFlow(), 1.0e-12);
+    assertEquals(4.0, ethane.getOutletMassFlow(), 1.0e-12);
+    assertEquals(0.0, ethane.getMassResidual(), 1.0e-12);
+    assertEquals(6.0, methane.getInletMassFlow(), 1.0e-12);
+    assertEquals(6.0, methane.getOutletMassFlow(), 1.0e-12);
+    assertEquals(0.0, methane.getRelativeMassResidual(), 1.0e-12);
+    assertFalse(table.getSourceBalanceTableFingerprint().isEmpty());
+    assertNotSame(table.getComponentFlows(), table.getComponentFlows());
+    assertNotSame(table.getComponentBalances(), table.getComponentBalances());
+    assertNotSame(table.getDiagnostics(), table.getDiagnostics());
+    assertThrows(UnsupportedOperationException.class, () -> table.getComponentFlows().clear());
+    assertTrue(table.toJson().contains("\"massFlowUnit\": \"kg/s\""));
+    assertTrue(table.toJson().contains("\"provenance\": \"simulation-case:NORMAL-01\""));
+  }
+
+  @Test
+  void isDeterministicForFreshSystemsAndInputOrder() {
+    Fixture firstFixture = fixture();
+    Fixture secondFixture = fixture();
+    List<ComponentFlow> firstFlows = completeFlows(firstFixture.boundaries);
+    List<ComponentFlow> secondFlows = completeFlows(secondFixture.boundaries);
+    Collections.reverse(secondFlows);
+
+    EngineeringDiagramComponentBalanceTable first = EngineeringDiagramComponentBalanceTable
+        .fromBalanceTable(firstFixture.balanceTable, firstFlows);
+    EngineeringDiagramComponentBalanceTable second = EngineeringDiagramComponentBalanceTable
+        .fromBalanceTable(secondFixture.balanceTable, secondFlows);
+
+    assertEquals(first.toJson(), second.toJson());
+  }
+
+  @Test
+  void diagnosesMissingDuplicateUnknownAndWrongBasisValues() {
+    Fixture fixture = fixture();
+    List<ComponentFlow> flows = completeFlows(fixture.boundaries);
+    ComponentFlow first = flows.get(0);
+    flows.add(first);
+    flows.remove(1);
+    flows.add(new ComponentFlow("BAL-SIMPLE-01", "line:missing", "methane", "methane", 1.0, "kg/s",
+        "COMPONENT_MASS", "project-component-register:test", "simulation-case:NORMAL-01",
+        EvidenceState.PROPOSED));
+    flows.add(new ComponentFlow("BAL-SIMPLE-01", fixture.boundaries.get(0).getStreamSemanticObjectId(), "water",
+        "water", 0.0, "kg/hr", "COMPONENT_MASS", "project-component-register:test",
+        "simulation-case:NORMAL-01", EvidenceState.PROPOSED));
+
+    EngineeringDiagramComponentBalanceTable table = EngineeringDiagramComponentBalanceTable
+        .fromBalanceTable(fixture.balanceTable, flows);
+
+    assertFalse(table.isValid());
+    assertTrue(hasDiagnostic(table, "COMPONENT_FLOW_DUPLICATE"));
+    assertTrue(hasDiagnostic(table, "COMPONENT_FLOW_UNKNOWN_BOUNDARY"));
+    assertTrue(hasDiagnostic(table, "COMPONENT_FLOW_VALUE_INVALID"));
+    assertTrue(hasDiagnostic(table, "COMPONENT_FLOW_MISSING"));
+  }
+
+  @Test
+  void requiresExplicitComponentValuesAndArguments() {
+    Fixture fixture = fixture();
+
+    EngineeringDiagramComponentBalanceTable table = EngineeringDiagramComponentBalanceTable
+        .fromBalanceTable(fixture.balanceTable, Collections.<ComponentFlow>emptyList());
+
+    assertFalse(table.isValid());
+    assertTrue(hasDiagnostic(table, "COMPONENT_FLOW_NOT_DECLARED"));
+    assertTrue(hasDiagnostic(table, "COMPONENT_BALANCE_COMPONENTS_MISSING"));
+    assertThrows(IllegalArgumentException.class,
+        () -> EngineeringDiagramComponentBalanceTable.fromBalanceTable(null, Collections.<ComponentFlow>emptyList()));
+    assertThrows(IllegalArgumentException.class,
+        () -> EngineeringDiagramComponentBalanceTable.fromBalanceTable(fixture.balanceTable, null));
+    assertThrows(IllegalArgumentException.class, () -> new ComponentFlow("BAL-SIMPLE-01", "line:feed", "methane",
+        "methane", 1.0, "kg/s", "COMPONENT_MASS", "source", "provenance", null));
+  }
+
+  private static Fixture fixture() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
+    for (StreamInterface product : reference.getProducts()) {
+      reference.getProcessSystem().add(product);
+    }
+    reference.getProcessSystem().run();
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-006", "Component balance",
+        ContentProfile.PFD, "NORMAL-01");
+    EngineeringDiagramStreamTable streamTable = EngineeringDiagramStreamTable.fromDocumentSet(documents,
+        "NORMAL-01");
+    List<Boundary> boundaries = new ArrayList<Boundary>();
+    boundaries.add(new Boundary("BAL-SIMPLE-01", completeRow(streamTable, reference.getFeed().getName()).getSemanticObjectId(),
+        Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED));
+    for (StreamInterface product : reference.getProducts()) {
+      boundaries.add(new Boundary("BAL-SIMPLE-01", completeRow(streamTable, product.getName()).getSemanticObjectId(),
+          Direction.OUTLET, "project-balance-register:test", EvidenceState.PROPOSED));
+    }
+    EngineeringDiagramBalanceTable balanceTable = EngineeringDiagramBalanceTable.fromStreamTable(streamTable,
+        boundaries);
+    return new Fixture(balanceTable, boundaries);
+  }
+
+  private static List<ComponentFlow> completeFlows(List<Boundary> boundaries) {
+    Boundary inlet = direction(boundaries, Direction.INLET, 0);
+    Boundary firstOutlet = direction(boundaries, Direction.OUTLET, 0);
+    Boundary secondOutlet = direction(boundaries, Direction.OUTLET, 1);
+    return new ArrayList<ComponentFlow>(Arrays.asList(flow(inlet, "methane", 6.0), flow(inlet, "ethane", 4.0),
+        flow(firstOutlet, "methane", 4.0), flow(firstOutlet, "ethane", 1.0),
+        flow(secondOutlet, "methane", 2.0), flow(secondOutlet, "ethane", 3.0)));
+  }
+
+  private static ComponentFlow flow(Boundary boundary, String component, double massFlow) {
+    return new ComponentFlow(boundary.getBalanceId(), boundary.getStreamSemanticObjectId(), component, component,
+        massFlow, "kg/s", "COMPONENT_MASS", "project-component-register:test", "simulation-case:NORMAL-01",
+        EvidenceState.PROPOSED);
+  }
+
+  private static Boundary direction(List<Boundary> boundaries, Direction direction, int index) {
+    int match = 0;
+    for (Boundary boundary : boundaries) {
+      if (boundary.getDirection() == direction) {
+        if (match == index) {
+          return boundary;
+        }
+        match++;
+      }
+    }
+    throw new AssertionError("No boundary " + direction + " at index " + index);
+  }
+
+  private static Row completeRow(EngineeringDiagramStreamTable table, String sourceLabel) {
+    for (Row row : table.getRows()) {
+      if (sourceLabel.equals(row.getSourceLabel()) && row.getValues().size() == Quantity.values().length) {
+        return row;
+      }
+    }
+    throw new AssertionError("No complete stream-table row for " + sourceLabel);
+  }
+
+  private static ComponentBalance component(EngineeringDiagramComponentBalanceTable table, String componentId) {
+    for (ComponentBalance balance : table.getComponentBalances()) {
+      if (componentId.equals(balance.getComponentId())) {
+        return balance;
+      }
+    }
+    throw new AssertionError("No component balance for " + componentId);
+  }
+
+  private static boolean hasDiagnostic(EngineeringDiagramComponentBalanceTable table, String code) {
+    for (EngineeringDiagramComponentBalanceTable.Diagnostic diagnostic : table.getDiagnostics()) {
+      if (code.equals(diagnostic.getCode())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static final class Fixture {
+    private final EngineeringDiagramBalanceTable balanceTable;
+    private final List<Boundary> boundaries;
+
+    private Fixture(EngineeringDiagramBalanceTable balanceTable, List<Boundary> boundaries) {
+      this.balanceTable = balanceTable;
+      this.boundaries = boundaries;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add an immutable component-resolved mass-balance companion bound to the existing explicit boundary table
- require explicit zero/non-zero values for every component and boundary stream, with kg/s units, COMPONENT_MASS basis, source references, provenance and review evidence
- aggregate deterministic inlet/outlet component totals and residuals while surfacing missing, duplicate, unknown, invalid-unit/basis and conflicting-name diagnostics
- fully order conflicting duplicates so serialized output remains deterministic under reversed input order
- add focused fresh-system/duplicate determinism, immutability, aggregation and loss-diagnostic regressions
- document the additive API and its engineering/approval boundary

## Scope boundary
This PR implements the next dependency-ready component-balance tranche shared by #1332 and #2899. It does not derive live composition, apply tolerances, reconcile data, close equipment heat/shaft-work terms, alter controlled-document/Classic DOT/Graphviz/native SVG/PDF/DEXPI/Proteus output, or claim ISO 10628 conformance. Heat/work closure and statistical reconciliation remain separate dependencies.

## Validation
**VALIDATION BLOCKED BY LOCAL INFRASTRUCTURE / PENDING REMAINING CI**

Exact head: `63fba75c6033487c54e07a95c413e4938c463d2b`

Passed:
- local `git diff --check`
- hosted Spotless run 31945277823; artifact 9263109290 contains a verified zero-byte `spotless.patch`
- hosted pre-commit, PaperLab, documentation search and CodeQL
- both hosted engineering acceptance notebooks
- Java 21 Javadocs

Pending:
- the exact-head Java 21 Ubuntu/Windows fast tests and four Java 21 slow shards are still running
- Java 8 jobs have not started because they follow the Java 21 gates

Local Spotless/tests/Javadocs could not run because Maven dependency resolution was blocked by DNS access to Maven Central and this runtime has no `javac`. No unrun check is claimed as passed; GitHub Actions is the authoritative validator and the PR remains draft.

Refs #1332
Refs #2899