### PR TITLE
test(process): verify collapsed recycle confirmation path

### DIFF
--- a/src/test/java/neqsim/process/processmodel/RecycleAcceptedStateReuseTest.java
+++ b/src/test/java/neqsim/process/processmodel/RecycleAcceptedStateReuseTest.java
@@ -173,12 +173,19 @@ class RecycleAcceptedStateReuseTest {
   void changedSplitterConfigurationRetainsLegacyConfirmationPass() throws Exception {
     Fixture fixture = createFixture(false, 50000.0);
     settle(fixture, ExecutionMode.SEQUENTIAL);
+    long mixerCalls = calls(fixture.process, "mixer");
+    long separatorCalls = calls(fixture.process, "separator");
+    long splitterCalls = calls(fixture.process, "splitter");
     long recycleCalls = calls(fixture.process, "recycle");
 
     fixture.splitter.setFlowRates(new double[] { 50000.0, 0.0 }, "kg/hr");
     run(fixture, ExecutionMode.SEQUENTIAL, UUID.randomUUID());
 
-    assertTrue(calls(fixture.process, "recycle") - recycleCalls >= 2L);
+    assertEquals(2L, calls(fixture.process, "mixer") - mixerCalls);
+    assertEquals(2L, calls(fixture.process, "separator") - separatorCalls);
+    assertEquals(2L, calls(fixture.process, "splitter") - splitterCalls);
+    assertEquals(1L, calls(fixture.process, "recycle") - recycleCalls);
+    assertEquals(2, fixture.recycle.getIterations());
     assertEquals(50000.0, fixture.product.getFlowRate("kg/hr"), 1.0e-6);
     assertEquals(0.0, fixture.splitter.getSplitStream(1).getFlowRate("kg/hr"), 1.0e-6);
     assertTrue(fixture.recycle.solved());


### PR DESCRIPTION
## Summary

- fix the current `master` CI failure in `RecycleAcceptedStateReuseTest.changedSplitterConfigurationRetainsLegacyConfirmationPass`
- verify the required second upstream confirmation pass through Mixer, Separator, and Splitter execution counts
- verify that the low-flow-deactivated Recycle is intentionally executed once, remains solved, and retains the legacy externally reported iteration count of two

## Root cause

Merged #3041 correctly requires a second process pass when an accepted active recycle collapses to zero flow, so stale loop inventory is flushed from upstream equipment. During the first pass, `Recycle.run(UUID)` marks the zero-flow recycle inactive. On the second pass, `ProcessSystem.runUnitProfiled(...)` intentionally skips inactive equipment and therefore does not record a second Recycle execution.

The failing assertion required at least two profiled Recycle calls, contradicting that established low-flow skip contract. The product-flow and solved-state assertions were already correct. This change makes the regression measure the units that must execute twice while explicitly protecting the one-call recycle optimization.

## Validation

Exact base: `dca199ff5d4c43ec7e07a9fc15a117fa9981be7b`. Exact head: `12e11aa88152eb544780ff9365c5203e68171157`.

- inspected failed hosted run [31938721895](https://github.com/equinor/neqsim/actions/runs/31938721895): one failure at line 181, all four slow shards and Javadocs passed
- compiled current `ProcessSystem`, `RecycleController`, transaction dependencies, and the four focused test classes with Temurin 17.0.20 using Java 8 source/target compatibility against the packaged NeqSim 3.17.0 dependency set: passed
- `RecycleAcceptedStateReuseTest`, `RecycleAdaptiveAccelerationTest`, `RecycleControllerTest`, and `ProcessSystemExecutionPreparationTest`: **35/35 passed**
- `git diff --check`: passed
- `python devtools/check_documentation_search.py`: passed (653 Markdown pages and one standalone HTML page)
- hosted Spotless format workflow: passed; uploaded `spotless.patch` is empty (0 bytes)
- hosted pre-commit checks: passed
- hosted Java 21 Javadocs and agent-skill cross-reference checks: passed
- hosted CodeQL: passed
- full hosted Java fast/slow/Java 8 matrix: running

The local Maven wrapper could not resolve Maven Central in this runtime, so no local Maven or wrapper-driven Spotless pass is claimed; hosted exact-head checks provide those repository gates.

## Documentation impact

Documentation impact: none — this is a test-contract correction. Production behavior, public APIs, process results, units, defaults, serialization, and recommended usage are unchanged.