### PR TITLE
fix(process): unify StaticMixer with Mixer without serial execution

### DIFF
--- a/docs/process/equipment/mixers_splitters.md
+++ b/docs/process/equipment/mixers_splitters.md
@@ -169,8 +169,9 @@ clamped to zero.
 
 ## Static mixer
 
-`StaticMixer` supports the same multi-inlet connection pattern but uses its own mixing
-implementation. This snippet reuses `richGas` and `leanGas` from the complete mixer example:
+`StaticMixer` is a backward-compatible type that uses the same mixing implementation as `Mixer`.
+Existing models can retain the `StaticMixer` class name, while new models can normally use
+`Mixer`. This snippet reuses `richGas` and `leanGas` from the complete mixer example:
 
 ```java
 // Continue from the complete mixer example above.

--- a/src/main/java/neqsim/process/equipment/mixer/StaticMixer.java
+++ b/src/main/java/neqsim/process/equipment/mixer/StaticMixer.java
@@ -6,16 +6,13 @@
 
 package neqsim.process.equipment.mixer;
 
-import java.util.UUID;
-import com.google.gson.GsonBuilder;
-import neqsim.process.util.monitor.MixerResponse;
-import neqsim.process.util.report.ReportConfig;
-import neqsim.process.util.report.ReportConfig.DetailLevel;
-import neqsim.thermo.system.SystemSoreideWhitson;
-import neqsim.thermodynamicoperations.ThermodynamicOperations;
-
 /**
- * StaticMixer class.
+ * Backward-compatible mixer type using the standard {@link Mixer} implementation.
+ *
+ * <p>
+ * Keeping this class preserves source and serialization compatibility for existing process models while ensuring that
+ * both mixer names use the same phase bookkeeping, mass balance, and optimized-execution behavior.
+ * </p>
  *
  * @author Even Solbraa
  * @version $Id: $Id
@@ -31,117 +28,5 @@ public class StaticMixer extends Mixer {
    */
   public StaticMixer(String name) {
     super(name);
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public void mixStream() {
-    int index = 0;
-    String compName = new String();
-    for (int k = 1; k < streams.size(); k++) {
-      for (int i = 0; i < streams.get(k).getThermoSystem().getPhases()[0].getNumberOfComponents(); i++) {
-        boolean gotComponent = false;
-        String componentName = streams.get(k).getThermoSystem().getPhases()[0].getComponent(i).getName();
-        // System.out.println("adding: " + componentName);
-        double moles = streams.get(k).getThermoSystem().getPhases()[0].getComponent(i).getNumberOfmoles();
-        // System.out.println("moles: " + moles + " " +
-        // mixedStream.getThermoSystem().getPhases()[0].getNumberOfComponents());
-        for (int p = 0; p < mixedStream.getThermoSystem().getPhases()[0].getNumberOfComponents(); p++) {
-          if (mixedStream.getThermoSystem().getPhases()[0].getComponent(p).getName().equals(componentName)) {
-            gotComponent = true;
-            index = mixedStream.getThermoSystem().getPhases()[0].getComponent(p).getComponentNumber();
-            compName = mixedStream.getThermoSystem().getPhases()[0].getComponent(p).getComponentName();
-            break;
-          }
-        }
-
-        if (gotComponent) {
-          // System.out.println("adding moles starting....");
-          mixedStream.getThermoSystem().addComponent(index, moles, 0);
-          // mixedStream.getThermoSystem().init_x_y();
-          // System.out.println("adding moles finished");
-        } else {
-          // System.out.println("ikke gaa hit");
-          mixedStream.getThermoSystem().addComponent(compName, moles, 0);
-        }
-      }
-    }
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public double guessTemperature() {
-    double gtemp = 0;
-    for (int k = 0; k < streams.size(); k++) {
-      gtemp += streams.get(k).getThermoSystem().getTemperature() * streams.get(k).getThermoSystem().getNumberOfMoles()
-          / mixedStream.getThermoSystem().getNumberOfMoles();
-    }
-    return gtemp;
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public double calcMixStreamEnthalpy() {
-    double enthalpy = 0;
-    for (int k = 0; k < streams.size(); k++) {
-      streams.get(k).getThermoSystem().init(3);
-      enthalpy += streams.get(k).getThermoSystem().getEnthalpy();
-      System.out.println("total enthalpy k : " + streams.get(k).getThermoSystem().getEnthalpy());
-    }
-    System.out.println("total enthalpy of streams: " + enthalpy);
-    return enthalpy;
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public void run(UUID id) {
-    double enthalpy = 0.0;
-    for (int k = 0; k < streams.size(); k++) {
-      streams.get(k).getThermoSystem().init(3);
-      enthalpy += streams.get(k).getThermoSystem().getEnthalpy();
-    }
-    mixedStream.setThermoSystem((streams.get(0).getThermoSystem().clone()));
-    mixedStream.getThermoSystem().setNumberOfPhases(2);
-    mixedStream.getThermoSystem().reInitPhaseType();
-    mixStream();
-    // System.out.println("filan temp " + mixedStream.getTemperature());
-
-    ThermodynamicOperations testOps = new ThermodynamicOperations(mixedStream.getThermoSystem());
-    try {
-      if (Double.isNaN(enthalpy)) {
-        logger.error("error in StaticMixer calc0 - enthalpy NaN");
-        testOps.TPflash();
-      } else {
-        testOps.PHflash(enthalpy, 0);
-      }
-      // System.out.println("enthalp ok " + enthalpy);
-    } catch (Exception ex) {
-      logger.error(ex.getMessage(), ex);
-    }
-    // System.out.println("temp " + mixedStream.getThermoSystem().getTemperature());
-    mixedStream.getThermoSystem().initProperties();
-    if (mixedStream.getFluid().getClass().getName().equals("neqsim.thermo.system.SystemSoreideWhitson")) {
-      ((SystemSoreideWhitson) mixedStream.getFluid()).setSalinity(getMixedSalinity(), "mole/sec");
-      mixedStream.run();
-    }
-
-    setCalculationIdentifier(id);
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public String toJson() {
-    return new GsonBuilder().serializeSpecialFloatingPointValues().create().toJson(new MixerResponse(this));
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public String toJson(ReportConfig cfg) {
-    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
-      return null;
-    }
-    MixerResponse res = new MixerResponse(this);
-    res.applyConfig(cfg);
-    return new GsonBuilder().serializeSpecialFloatingPointValues().create().toJson(res);
   }
 }

--- a/src/test/java/neqsim/process/equipment/mixer/StaticMixerTest.java
+++ b/src/test/java/neqsim/process/equipment/mixer/StaticMixerTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
 import neqsim.thermo.system.SystemSrkEos;
 
 class StaticMixerTest {
@@ -44,6 +45,44 @@ class StaticMixerTest {
     double outletFlow = mixer.getOutletStream().getThermoSystem().getFlowRate("MSm3/day");
     // Sum of two 5 MSm3/day streams should be ~10
     assertEquals(10.0, outletFlow, 0.5);
+  }
+
+  @Test
+  void testReusedMixerRetainsGasPhaseAfterChangingInhibitorFlow() {
+    neqsim.thermo.system.SystemInterface gasFluid = new SystemSrkCPAstatoil(278.45, 37.21325);
+    gasFluid.addComponent("methane", 5.0);
+    gasFluid.addComponent("water", 0.11833608283886514);
+    gasFluid.addComponent("MEG", 0.0);
+    gasFluid.setMixingRule(10);
+    gasFluid.setMultiPhaseCheck(true);
+
+    neqsim.thermo.system.SystemInterface megFluid = gasFluid.clone();
+    megFluid.setMolarComposition(new double[] { 0.0, 0.1099744114900417, 0.8900255885099583 });
+
+    Stream gasStream = new Stream("gas", gasFluid);
+    gasStream.setFlowRate(168958.0, "Sm3/hr");
+    gasStream.setTemperature(29.0, "C");
+    gasStream.setPressure(74.1, "barg");
+
+    Stream megStream = new Stream("MEG", megFluid);
+    megStream.setFlowRate(0.01, "kg/hr");
+    megStream.setTemperature(29.0, "C");
+    megStream.setPressure(74.1, "barg");
+
+    StaticMixer mixer = new StaticMixer("reused multiphase mixer");
+    mixer.addStream(megStream);
+    mixer.addStream(gasStream);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(gasStream);
+    process.add(megStream);
+    process.add(mixer);
+    process.run();
+
+    megStream.setFlowRate(0.1, "kg/hr");
+    process.run();
+
+    assertTrue(mixer.getOutletStream().getFluid().hasPhaseType("gas"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Keep `StaticMixer` as a source- and serialization-compatible subclass of `Mixer`.
- Remove the duplicate legacy mixing/flash implementation so both class names use the same phase bookkeeping, mass-balance handling, and recalculation cache.
- Add the exact reused gas/MEG regression from #3029.
- Document that `StaticMixer` is the compatibility type for the standard implementation.

## Root cause

The legacy `StaticMixer.run` cloned an inlet that could already be aqueous-only, forced two phases, and reset only phase labels. Reused systems could therefore retain stale phase-index and beta bookkeeping and lose the gas phase after the inhibitor flow changed.

The standard `Mixer` path already handles reused multiphase state, inactive flows, inlet-pressure ordering, pseudo-components, mass conservation, and recalculation state. Maintaining a second implementation was the source of the divergence.

## Performance

This PR does **not** force processes containing mixers through `runSequential`. `ProcessSystem` is unchanged and continues to use topological parallel execution for multi-input feed-forward flowsheets. The existing `Mixer` recalculation cache is retained.

This is proposed as the non-serializing alternative to #3029.

## Validation

- Java 8 source compilation of current `Mixer`, `StaticMixer`, `StaticNeqMixer`, `StaticPhaseMixer`, current process/thermo support classes, and affected tests: passed.
- Mixer-focused JUnit suite: 23/23 passed:
  - `MixerTest`
  - `MixerMassConservationTest`
  - `StaticMixerTest`
  - `StaticPhaseMixerTest`
- `SystemThermoSerializationInventoryTest#deserializedProcessReusesMultiphaseMixerWithParallelExecution`: passed.
- `MixerSplitterDocumentationTest#specifiedTemperatureAndStaticMixerExamplesUseCurrentApis`: passed.
- Execution-strategy check confirmed `parallel (topological levels with union-find grouping)`.
- `git diff --check`: passed.
- `python devtools/check_documentation_search.py`: passed (653 Markdown pages and one standalone HTML page).
- Full Maven and local Spotless execution were blocked because Maven Central could not be resolved in the local environment. The draft PR therefore relies on GitHub CI for those gates; no unrun check is claimed as passed.

## Documentation impact

Updated `docs/process/equipment/mixers_splitters.md` to describe `StaticMixer` as the backward-compatible type using the standard `Mixer` implementation.
