### PR TITLE
[AI-Assisted] fix(column): reject invalid terminal ratios atomically

### DIFF
--- a/docs/process/equipment/distillation.md
+++ b/docs/process/equipment/distillation.md
@@ -214,10 +214,15 @@ warm solves.
 
 `setReboilerVaporBoilupRatio(ratio)` configures the direct reboiler mode.
 `setReboilerBoilupRatio(ratio)` also records the target as the bottom `REFLUX_RATIO`
-specification. After either route, `setReboilerMode(DistillationColumn.ReboilerMode.EQUILIBRIUM)`
-clears the active reboiler ratio and any stored bottom reflux-ratio specification, so a later run
-cannot silently restore the old ratio. Bottom purity, recovery, product-flow, and duty
-specifications are preserved.
+specification. Terminal ratios supplied through either the column API or the condenser/reboiler
+objects must be finite and non-negative. Invalid values fail before the active ratio, stored
+specification, initialization flag, or accepted warm products are changed; invalid ratio state
+retained by an older serialized model also fails before a terminal flash. A valid legacy boilup
+setter call marks the column for reinitialization so the next nearby-point solve cannot reuse an
+incompatible terminal state. After either route,
+`setReboilerMode(DistillationColumn.ReboilerMode.EQUILIBRIUM)` clears the active reboiler ratio and
+any stored bottom reflux-ratio specification, so a later run cannot silently restore the old
+ratio. Bottom purity, recovery, product-flow, and duty specifications are preserved.
 
 `setCondenserLiquidReflux(value, unit)` configures the `LIQUID_REFLUX_SPLIT` mode. Use it instead
 of calling `setCondenserMode(LIQUID_REFLUX_SPLIT)` directly because the fixed reflux flow is

--- a/src/main/java/neqsim/process/equipment/distillation/Condenser.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Condenser.java
@@ -185,9 +185,13 @@ public class Condenser extends SimpleTray {
   /**
    * Setter for the field <code>refluxRatio</code>.
    *
-   * @param refluxRatio the refluxRatio to set
+   * @param refluxRatio finite non-negative liquid-to-distillate reflux ratio
+   * @throws IllegalArgumentException if the ratio is negative or non-finite
    */
   public void setRefluxRatio(double refluxRatio) {
+    if (!Double.isFinite(refluxRatio) || refluxRatio < 0.0) {
+      throw new IllegalArgumentException("Condenser reflux ratio must be finite and >= 0");
+    }
     this.refluxRatio = refluxRatio;
     refluxIsSet = true;
   }
@@ -290,6 +294,11 @@ public class Condenser extends SimpleTray {
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
+    if (refluxIsSet && !separation_with_liquid_reflux
+        && (!Double.isFinite(refluxRatio) || refluxRatio < 0.0)) {
+      throw new IllegalStateException(
+          "Condenser " + getName() + " has invalid reflux ratio " + refluxRatio);
+    }
     if (totalCondenser && (!refluxIsSet || separation_with_liquid_reflux)) {
       throw new IllegalStateException(
           "Total condenser " + getName() + " requires an explicit reflux ratio before it can run");

--- a/src/main/java/neqsim/process/equipment/distillation/Condenser.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Condenser.java
@@ -294,10 +294,8 @@ public class Condenser extends SimpleTray {
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
-    if (refluxIsSet && !separation_with_liquid_reflux
-        && (!Double.isFinite(refluxRatio) || refluxRatio < 0.0)) {
-      throw new IllegalStateException(
-          "Condenser " + getName() + " has invalid reflux ratio " + refluxRatio);
+    if (refluxIsSet && !separation_with_liquid_reflux && (!Double.isFinite(refluxRatio) || refluxRatio < 0.0)) {
+      throw new IllegalStateException("Condenser " + getName() + " has invalid reflux ratio " + refluxRatio);
     }
     if (totalCondenser && (!refluxIsSet || separation_with_liquid_reflux)) {
       throw new IllegalStateException(

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -14633,17 +14633,16 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
    * Convenience method to specify a reboiler boilup ratio (V/B).
    *
    * <p>
-   * The specification is validated before either terminal hardware or stored control state is
-   * changed, so rejected values leave an accepted warm column unchanged.
+   * The specification is validated before either terminal hardware or stored control state is changed, so rejected
+   * values leave an accepted warm column unchanged.
    * </p>
    *
    * @param boilupRatio finite non-negative boilup ratio
    * @throws IllegalArgumentException if the ratio is negative or non-finite
    */
   public void setReboilerBoilupRatio(double boilupRatio) {
-    ColumnSpecification specification =
-        new ColumnSpecification(ColumnSpecification.SpecificationType.REFLUX_RATIO,
-            ColumnSpecification.ProductLocation.BOTTOM, boilupRatio);
+    ColumnSpecification specification = new ColumnSpecification(ColumnSpecification.SpecificationType.REFLUX_RATIO,
+        ColumnSpecification.ProductLocation.BOTTOM, boilupRatio);
     if (hasReboiler) {
       getReboiler().setRefluxRatio(boilupRatio);
     }

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -14632,14 +14632,23 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   /**
    * Convenience method to specify a reboiler boilup ratio (V/B).
    *
-   * @param boilupRatio the desired boilup ratio
+   * <p>
+   * The specification is validated before either terminal hardware or stored control state is
+   * changed, so rejected values leave an accepted warm column unchanged.
+   * </p>
+   *
+   * @param boilupRatio finite non-negative boilup ratio
+   * @throws IllegalArgumentException if the ratio is negative or non-finite
    */
   public void setReboilerBoilupRatio(double boilupRatio) {
+    ColumnSpecification specification =
+        new ColumnSpecification(ColumnSpecification.SpecificationType.REFLUX_RATIO,
+            ColumnSpecification.ProductLocation.BOTTOM, boilupRatio);
     if (hasReboiler) {
       getReboiler().setRefluxRatio(boilupRatio);
     }
-    this.bottomSpecification = new ColumnSpecification(ColumnSpecification.SpecificationType.REFLUX_RATIO,
-        ColumnSpecification.ProductLocation.BOTTOM, boilupRatio);
+    this.bottomSpecification = specification;
+    setDoInitializion(true);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/Reboiler.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Reboiler.java
@@ -125,8 +125,7 @@ public class Reboiler extends neqsim.process.equipment.distillation.SimpleTray {
   @Override
   public void run(UUID id) {
     if (refluxIsSet && (!Double.isFinite(refluxRatio) || refluxRatio < 0.0)) {
-      throw new IllegalStateException(
-          "Reboiler " + getName() + " has invalid vapor boilup ratio " + refluxRatio);
+      throw new IllegalStateException("Reboiler " + getName() + " has invalid vapor boilup ratio " + refluxRatio);
     }
     if (!refluxIsSet) {
       UUID oldid = getCalculationIdentifier();

--- a/src/main/java/neqsim/process/equipment/distillation/Reboiler.java
+++ b/src/main/java/neqsim/process/equipment/distillation/Reboiler.java
@@ -73,9 +73,13 @@ public class Reboiler extends neqsim.process.equipment.distillation.SimpleTray {
   /**
    * Setter for the field <code>refluxRatio</code>.
    *
-   * @param refluxRatio the refluxRatio to set
+   * @param refluxRatio finite non-negative vapor boilup-to-bottoms ratio
+   * @throws IllegalArgumentException if the ratio is negative or non-finite
    */
   public void setRefluxRatio(double refluxRatio) {
+    if (!Double.isFinite(refluxRatio) || refluxRatio < 0.0) {
+      throw new IllegalArgumentException("Reboiler vapor boilup ratio must be finite and >= 0");
+    }
     this.refluxRatio = refluxRatio;
     refluxIsSet = true;
   }
@@ -120,6 +124,10 @@ public class Reboiler extends neqsim.process.equipment.distillation.SimpleTray {
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
+    if (refluxIsSet && (!Double.isFinite(refluxRatio) || refluxRatio < 0.0)) {
+      throw new IllegalStateException(
+          "Reboiler " + getName() + " has invalid vapor boilup ratio " + refluxRatio);
+    }
     if (!refluxIsSet) {
       UUID oldid = getCalculationIdentifier();
       super.run(id);

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnModeTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnModeTest.java
@@ -128,25 +128,20 @@ public class DistillationColumnModeTest {
     ColumnSpecification topSpecification = column.getTopSpecification();
     ColumnSpecification bottomSpecification = column.getBottomSpecification();
 
-    assertThrows(IllegalArgumentException.class,
-        () -> column.getCondenser().setRefluxRatio(-1.0));
-    assertThrows(IllegalArgumentException.class,
-        () -> column.getReboiler().setRefluxRatio(Double.NaN));
-    assertThrows(IllegalArgumentException.class,
-        () -> column.setReboilerBoilupRatio(Double.POSITIVE_INFINITY));
+    assertThrows(IllegalArgumentException.class, () -> column.getCondenser().setRefluxRatio(-1.0));
+    assertThrows(IllegalArgumentException.class, () -> column.getReboiler().setRefluxRatio(Double.NaN));
+    assertThrows(IllegalArgumentException.class, () -> column.setReboilerBoilupRatio(Double.POSITIVE_INFINITY));
 
     assertEquals(condenserRatio, column.getCondenser().getRefluxRatio(), 0.0);
     assertEquals(reboilerRatio, column.getReboiler().getRefluxRatio(), 0.0);
     assertSame(topSpecification, column.getTopSpecification());
     assertSame(bottomSpecification, column.getBottomSpecification());
     assertEquals(DistillationColumn.CondenserMode.PARTIAL, column.getCondenserMode());
-    assertEquals(DistillationColumn.ReboilerMode.VAPOR_BOILUP_RATIO,
-        column.getReboilerMode());
+    assertEquals(DistillationColumn.ReboilerMode.VAPOR_BOILUP_RATIO, column.getReboilerMode());
   }
 
   /**
-   * Qualify partial-condenser and vapor-boilup ratio control across a repeated solve and nearby
-   * operating point.
+   * Qualify partial-condenser and vapor-boilup ratio control across a repeated solve and nearby operating point.
    */
   @Test
   public void partialCondenserAndVaporBoilupRatiosRemainPhysicalAcrossNearbyPoints() {
@@ -157,8 +152,7 @@ public class DistillationColumnModeTest {
 
     assertTrue(column.solved(), column.getConvergenceDiagnostics());
     assertEquals(DistillationColumn.CondenserMode.PARTIAL, column.getCondenserMode());
-    assertEquals(DistillationColumn.ReboilerMode.VAPOR_BOILUP_RATIO,
-        column.getReboilerMode());
+    assertEquals(DistillationColumn.ReboilerMode.VAPOR_BOILUP_RATIO, column.getReboilerMode());
     assertTerminalRatioProductsPhysicalAndBalanced(column);
     double firstGasFlow = column.getGasOutStream().getFlowRate("mol/hr");
     double firstLiquidFlow = column.getLiquidOutStream().getFlowRate("mol/hr");
@@ -167,8 +161,7 @@ public class DistillationColumnModeTest {
 
     assertTrue(column.solved(), column.getConvergenceDiagnostics());
     assertTerminalRatioProductsPhysicalAndBalanced(column);
-    assertEquals(firstGasFlow, column.getGasOutStream().getFlowRate("mol/hr"),
-        Math.max(1.0e-8, 5.0e-5 * firstGasFlow));
+    assertEquals(firstGasFlow, column.getGasOutStream().getFlowRate("mol/hr"), Math.max(1.0e-8, 5.0e-5 * firstGasFlow));
     assertEquals(firstLiquidFlow, column.getLiquidOutStream().getFlowRate("mol/hr"),
         Math.max(1.0e-8, 5.0e-5 * firstLiquidFlow));
 
@@ -183,13 +176,11 @@ public class DistillationColumnModeTest {
   }
 
   /**
-   * Verify conservation, bounds, diagnostics, and direct specification satisfaction for a
-   * terminal-ratio case.
+   * Verify conservation, bounds, diagnostics, and direct specification satisfaction for a terminal-ratio case.
    *
    * @param column solved ratio-controlled column
    */
-  private void assertTerminalRatioProductsPhysicalAndBalanced(
-      DistillationColumn column) {
+  private void assertTerminalRatioProductsPhysicalAndBalanced(DistillationColumn column) {
     StreamInterface feed = column.getFeedStreams(3).get(0);
     StreamInterface gas = column.getGasOutStream();
     StreamInterface liquid = column.getLiquidOutStream();
@@ -205,23 +196,18 @@ public class DistillationColumnModeTest {
     assertTrue(Double.isFinite(column.getEnergyBalanceError()));
     assertTrue(Double.isFinite(column.getLastMeshResidualNorm()));
     assertTrue(Double.isFinite(column.getLastSpecificationResidual()));
-    assertTrue(column.getLastSpecificationResidual()
-        <= column.getTopSpecification().getTolerance());
+    assertTrue(column.getLastSpecificationResidual() <= column.getTopSpecification().getTolerance());
 
     double[] feedComposition = feed.getThermoSystem().getMolarComposition();
     double[] gasComposition = gas.getThermoSystem().getMolarComposition();
     double[] liquidComposition = liquid.getThermoSystem().getMolarComposition();
-    for (int componentIndex = 0; componentIndex < feedComposition.length;
-        componentIndex++) {
-      assertTrue(gasComposition[componentIndex] >= 0.0
-          && gasComposition[componentIndex] <= 1.0);
-      assertTrue(liquidComposition[componentIndex] >= 0.0
-          && liquidComposition[componentIndex] <= 1.0);
+    for (int componentIndex = 0; componentIndex < feedComposition.length; componentIndex++) {
+      assertTrue(gasComposition[componentIndex] >= 0.0 && gasComposition[componentIndex] <= 1.0);
+      assertTrue(liquidComposition[componentIndex] >= 0.0 && liquidComposition[componentIndex] <= 1.0);
       double feedComponentFlow = feedFlow * feedComposition[componentIndex];
       double productComponentFlow = gasFlow * gasComposition[componentIndex]
           + liquidFlow * liquidComposition[componentIndex];
-      assertEquals(feedComponentFlow, productComponentFlow,
-          Math.max(1.0e-6, 5.0e-3 * Math.abs(feedComponentFlow)));
+      assertEquals(feedComponentFlow, productComponentFlow, Math.max(1.0e-6, 5.0e-3 * Math.abs(feedComponentFlow)));
     }
   }
 

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnModeTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnModeTest.java
@@ -116,6 +116,116 @@ public class DistillationColumnModeTest {
   }
 
   /**
+   * Reject invalid terminal ratios without changing valid direct or stored ratio controls.
+   */
+  @Test
+  public void invalidTerminalRatiosFailAtomically() {
+    DistillationColumn column = createTerminalControlColumn("atomic terminal ratio column");
+    column.setReboilerBoilupRatio(0.8);
+
+    double condenserRatio = column.getCondenser().getRefluxRatio();
+    double reboilerRatio = column.getReboiler().getRefluxRatio();
+    ColumnSpecification topSpecification = column.getTopSpecification();
+    ColumnSpecification bottomSpecification = column.getBottomSpecification();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> column.getCondenser().setRefluxRatio(-1.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> column.getReboiler().setRefluxRatio(Double.NaN));
+    assertThrows(IllegalArgumentException.class,
+        () -> column.setReboilerBoilupRatio(Double.POSITIVE_INFINITY));
+
+    assertEquals(condenserRatio, column.getCondenser().getRefluxRatio(), 0.0);
+    assertEquals(reboilerRatio, column.getReboiler().getRefluxRatio(), 0.0);
+    assertSame(topSpecification, column.getTopSpecification());
+    assertSame(bottomSpecification, column.getBottomSpecification());
+    assertEquals(DistillationColumn.CondenserMode.PARTIAL, column.getCondenserMode());
+    assertEquals(DistillationColumn.ReboilerMode.VAPOR_BOILUP_RATIO,
+        column.getReboilerMode());
+  }
+
+  /**
+   * Qualify partial-condenser and vapor-boilup ratio control across a repeated solve and nearby
+   * operating point.
+   */
+  @Test
+  public void partialCondenserAndVaporBoilupRatiosRemainPhysicalAcrossNearbyPoints() {
+    DistillationColumn column = createTerminalControlColumn("nearby terminal ratio column");
+    column.setReboilerVaporBoilupRatio(1.20);
+
+    column.run(UUID.randomUUID());
+
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertEquals(DistillationColumn.CondenserMode.PARTIAL, column.getCondenserMode());
+    assertEquals(DistillationColumn.ReboilerMode.VAPOR_BOILUP_RATIO,
+        column.getReboilerMode());
+    assertTerminalRatioProductsPhysicalAndBalanced(column);
+    double firstGasFlow = column.getGasOutStream().getFlowRate("mol/hr");
+    double firstLiquidFlow = column.getLiquidOutStream().getFlowRate("mol/hr");
+
+    column.run(UUID.randomUUID());
+
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertTerminalRatioProductsPhysicalAndBalanced(column);
+    assertEquals(firstGasFlow, column.getGasOutStream().getFlowRate("mol/hr"),
+        Math.max(1.0e-8, 5.0e-5 * firstGasFlow));
+    assertEquals(firstLiquidFlow, column.getLiquidOutStream().getFlowRate("mol/hr"),
+        Math.max(1.0e-8, 5.0e-5 * firstLiquidFlow));
+
+    column.setReboilerVaporBoilupRatio(1.25);
+    column.run(UUID.randomUUID());
+
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertTerminalRatioProductsPhysicalAndBalanced(column);
+    double feedFlow = column.getFeedStreams(3).get(0).getFlowRate("mol/hr");
+    double nearbyGasFlow = column.getGasOutStream().getFlowRate("mol/hr");
+    assertTrue(Math.abs(nearbyGasFlow - firstGasFlow) > 1.0e-8 * feedFlow);
+  }
+
+  /**
+   * Verify conservation, bounds, diagnostics, and direct specification satisfaction for a
+   * terminal-ratio case.
+   *
+   * @param column solved ratio-controlled column
+   */
+  private void assertTerminalRatioProductsPhysicalAndBalanced(
+      DistillationColumn column) {
+    StreamInterface feed = column.getFeedStreams(3).get(0);
+    StreamInterface gas = column.getGasOutStream();
+    StreamInterface liquid = column.getLiquidOutStream();
+    double feedFlow = feed.getFlowRate("mol/hr");
+    double gasFlow = gas.getFlowRate("mol/hr");
+    double liquidFlow = liquid.getFlowRate("mol/hr");
+
+    assertTrue(Double.isFinite(gasFlow) && gasFlow > 0.0);
+    assertTrue(Double.isFinite(liquidFlow) && liquidFlow > 0.0);
+    assertTrue(Double.isFinite(gas.getTemperature()) && gas.getTemperature() > 0.0);
+    assertTrue(Double.isFinite(liquid.getTemperature()) && liquid.getTemperature() > 0.0);
+    assertEquals(feedFlow, gasFlow + liquidFlow, 5.0e-3 * feedFlow);
+    assertTrue(Double.isFinite(column.getEnergyBalanceError()));
+    assertTrue(Double.isFinite(column.getLastMeshResidualNorm()));
+    assertTrue(Double.isFinite(column.getLastSpecificationResidual()));
+    assertTrue(column.getLastSpecificationResidual()
+        <= column.getTopSpecification().getTolerance());
+
+    double[] feedComposition = feed.getThermoSystem().getMolarComposition();
+    double[] gasComposition = gas.getThermoSystem().getMolarComposition();
+    double[] liquidComposition = liquid.getThermoSystem().getMolarComposition();
+    for (int componentIndex = 0; componentIndex < feedComposition.length;
+        componentIndex++) {
+      assertTrue(gasComposition[componentIndex] >= 0.0
+          && gasComposition[componentIndex] <= 1.0);
+      assertTrue(liquidComposition[componentIndex] >= 0.0
+          && liquidComposition[componentIndex] <= 1.0);
+      double feedComponentFlow = feedFlow * feedComposition[componentIndex];
+      double productComponentFlow = gasFlow * gasComposition[componentIndex]
+          + liquidFlow * liquidComposition[componentIndex];
+      assertEquals(feedComponentFlow, productComponentFlow,
+          Math.max(1.0e-6, 5.0e-3 * Math.abs(feedComponentFlow)));
+    }
+  }
+
+  /**
    * Test that missing hardware is reported clearly.
    */
   @Test


### PR DESCRIPTION
## Summary

Advances #2936 with a coherent terminal-ratio integrity and qualification slice for partial condensers and ratio-controlled reboilers.

- reject negative and non-finite condenser reflux and reboiler boilup ratios at the direct equipment APIs
- preserve accepted terminal hardware, stored specifications, and warm state when a column-level ratio request is invalid
- fail before a terminal flash when a legacy serialized model retains an invalid active ratio
- mark valid legacy reboiler-boilup setter changes for reinitialization
- qualify a realistic multicomponent partial-condenser/vapor-boilup column across a repeated solve and nearby operating point

## Problem and root cause

On current `master` at `360699de810894cd789d23a2d1e1c822616b58ed`, `Condenser.setRefluxRatio` and `Reboiler.setRefluxRatio` accepted negative, NaN, and infinite values. More importantly, `DistillationColumn.setReboilerBoilupRatio` changed reboiler hardware before constructing the validated `ColumnSpecification`. A rejected request could therefore leave a previously accepted warm column partially mutated. The legacy setter also did not request reinitialization.

This is reproduced deterministically by the new atomicity regression: configure valid terminal ratios, submit invalid values through the direct equipment APIs and legacy column API, and verify the exceptions plus unchanged ratios, specification identities, and modes.

## Implementation

- Equipment setters now require finite, non-negative ratios.
- Terminal `run` methods defensively reject invalid active ratios before flash work, covering retained state from older serialized models.
- The legacy column boilup setter constructs the validated specification first, then updates hardware and stored control state, and finally requests initialization.
- Javadocs and the distillation user guide document the numerical domain, atomic failure behavior, retained-state guard, and initialization behavior.

No TPflash, generic process-execution, serialization format, default solver tolerance, or public method signature is changed.

## Engineering regression coverage

`DistillationColumnModeTest` adds:

1. atomic invalid-input coverage for negative, NaN, and positive-infinite terminal ratios;
2. a six-stage C3/C4/C5 column with partial condenser reflux ratio 1.8 and direct vapor boilup ratio 1.20;
3. total and component molar balance checks, positive finite product flows and temperatures, composition bounds, finite energy/MESH/specification diagnostics, and top-specification satisfaction;
4. a repeated run for retained-state repeatability;
5. a nearby boilup-ratio point at 1.25 with the same physical/conservation checks and a nonzero product response.

The test deliberately uses iteration-independent physical and residual evidence rather than wall-clock assertions.

## Validation

**VALIDATION COMPLETE** on exact head `f0fb28a2fbe4bd0d3311b83068aae6f7d5b0daa2`.

The exact committed source and diff were reviewed through the connected GitHub interface. Local Maven, Spotless, documentation-search, and pre-commit commands were not run in this connector-first environment; no local check is claimed.

Hosted validation evidence:

- initial head `fab7249b375df3fe2fd9ba87aa3b28ca9b37a66a`: PaperLab and the dedicated Spotless patch workflow succeeded; pre-commit failed only because four Java files required Spotless formatting; documentation search passed inside that job
- repair commit `f0fb28a2fbe4bd0d3311b83068aae6f7d5b0daa2` applies the exact formatter artifact (destination blob SHAs matched the artifact patch)
- exact repair head: Spotless, pre-commit, documentation search, PaperLab, CodeQL, Java compilation through CodeQL, and Java 21 Javadoc succeeded
- exact repair head: Java 21 Ubuntu/Windows fast tests, all four Ubuntu slow-test shards, and Java 8 Ubuntu/Windows fast tests succeeded

No completed check is represented as broader than its actual scope. The full exact-head workflow completed successfully; no human or Copilot review submission or thread remained.

## Documentation impact

User-visible validation and failure behavior changed. Updated `docs/process/equipment/distillation.md` and affected public Javadocs in the same commit.

## Compatibility and risk

Valid finite non-negative ratios retain their existing meaning. Newly rejected inputs were already physically invalid and could corrupt convergence state. The defensive run guards make invalid legacy retained state explicit instead of passing it into thermodynamic flash calculations. The numerical qualification is limited to existing terminal modes; no new solver architecture or fallback policy is introduced.

## Scope boundary

This PR is column-owned and does not alter shared TPflash or generic process performance code. It contains no notebook or Huldra dataset/model work.