### PR TITLE
[AI-Assisted] feat(diagram): close explicit heat and work balances

### DIFF
--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -184,6 +184,77 @@ warning with no inferred project tolerance. This separation keeps component data
 and leaves existing stream-table, balance-table, controlled
 document, Classic DOT/Graphviz, native SVG/PDF, DEXPI 2.0 Process, and Proteus/P&ID outputs unchanged.
 
+### Explicit heat-transfer and shaft-work closure
+
+`EngineeringDiagramEnergyBalanceTable` is an additive companion to an existing explicit-boundary
+balance table. It closes the source stream-enthalpy terms with explicitly declared heat-transfer and
+shaft-work ports. Every port retains a stable balance identity, canonical equipment or control-volume
+identity, distinct stable port identity, energy kind, direction relative to the control volume, source
+reference, and evidence state. Separate port identities preserve parallel energy connections without
+collapsing them.
+
+Energy-flow values are non-negative `W` values on an `ENERGY_RATE` basis. Direction comes only from
+the port declaration, never from a sign convention, drawing topology, or live equipment duty. Every
+declared port requires one explicit zero or non-zero flow with source, provenance, and evidence state.
+
+```java
+List<EngineeringDiagramEnergyBalanceTable.EnergyPort> energyPorts =
+    Arrays.asList(
+        new EngineeringDiagramEnergyBalanceTable.EnergyPort(
+            "BAL-AREA-01",
+            heaterSemanticObjectId,
+            "energy-port:heater-duty",
+            EngineeringDiagramEnergyBalanceTable.EnergyKind.HEAT_TRANSFER,
+            EngineeringDiagramEnergyBalanceTable.EnergyDirection.INTO_CONTROL_VOLUME,
+            "project-energy-register:BAL-AREA-01",
+            EngineeringDiagramBalanceTable.EvidenceState.PROPOSED),
+        new EngineeringDiagramEnergyBalanceTable.EnergyPort(
+            "BAL-AREA-01",
+            compressorSemanticObjectId,
+            "energy-port:compressor-shaft",
+            EngineeringDiagramEnergyBalanceTable.EnergyKind.SHAFT_WORK,
+            EngineeringDiagramEnergyBalanceTable.EnergyDirection.INTO_CONTROL_VOLUME,
+            "project-energy-register:BAL-AREA-01",
+            EngineeringDiagramBalanceTable.EvidenceState.PROPOSED));
+List<EngineeringDiagramEnergyBalanceTable.EnergyFlow> energyFlows =
+    Arrays.asList(
+        new EngineeringDiagramEnergyBalanceTable.EnergyFlow(
+            "BAL-AREA-01",
+            "energy-port:heater-duty",
+            250000.0,
+            "W",
+            "ENERGY_RATE",
+            "simulation-result:NORMAL-01:heater-duty",
+            "simulation-case:NORMAL-01",
+            EngineeringDiagramBalanceTable.EvidenceState.PROPOSED),
+        new EngineeringDiagramEnergyBalanceTable.EnergyFlow(
+            "BAL-AREA-01",
+            "energy-port:compressor-shaft",
+            125000.0,
+            "W",
+            "ENERGY_RATE",
+            "simulation-result:NORMAL-01:compressor-power",
+            "simulation-case:NORMAL-01",
+            EngineeringDiagramBalanceTable.EvidenceState.PROPOSED));
+EngineeringDiagramEnergyBalanceTable energyBalances =
+    EngineeringDiagramEnergyBalanceTable.fromBalanceTable(
+        balanceTable, energyPorts, energyFlows);
+```
+
+For each balance, total energy input is inlet stream enthalpy flow plus heat transfer and shaft work
+declared into the control volume. Total energy output is outlet stream enthalpy flow plus heat
+transfer and shaft work declared out of the control volume. The energy residual is total input minus
+total output in W; its relative residual divides by the larger absolute total and is zero when both
+totals are zero. A result is complete only when the source stream-enthalpy balance is complete, the
+balance has at least one explicit energy port, and every port has one usable flow value.
+
+Unknown or duplicate balances, ports, and flows; missing values; non-finite or negative rates; and
+wrong units or bases remain visible as structured diagnostics. A zero energy rate must be recorded
+explicitly. The companion does not read live equipment duties, infer absent heat/work terms, apply a
+project tolerance, reconcile data, or approve a balance. Existing balance/component APIs,
+controlled-document JSON, Classic DOT/Graphviz, native SVG/PDF, DEXPI 2.0 Process, and Proteus/P&ID
+outputs remain unchanged.
+
 ### Explicit tolerance assessment
 
 `EngineeringDiagramBalanceAssessment` evaluates existing residuals against explicit, sourced
@@ -406,7 +477,8 @@ Run the focused regression with:
 ./mvnw -Dtest=ProcessDiagramDocumentSetAdapterTest test
 ./mvnw -Dtest=NativeEngineeringDiagramRendererTest test
 ./mvnw -Dtest=EngineeringDiagramStreamTableTest,EngineeringDiagramBalanceTableTest,\
-EngineeringDiagramComponentBalanceTableTest,EngineeringDiagramBalanceAssessmentTest test
+EngineeringDiagramComponentBalanceTableTest,EngineeringDiagramEnergyBalanceTableTest,\
+EngineeringDiagramBalanceAssessmentTest test
 ```
 
 The regression verifies deterministic single- and multi-area output, immutable collections,

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramEnergyBalanceTable.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramEnergyBalanceTable.java
@@ -21,23 +21,20 @@ import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Severity;
  * Immutable, deterministic energy-balance closure projection.
  *
  * <p>
- * The projection adds explicit heat-transfer and shaft-work ports to the stream enthalpy terms in
- * an {@link EngineeringDiagramBalanceTable}. Port direction is always relative to the declared
- * control volume. Values are non-negative energy rates, so their sign is never inferred from an
- * equipment convention or drawing topology. Every declared port requires one explicit zero or
- * non-zero flow value.
+ * The projection adds explicit heat-transfer and shaft-work ports to the stream enthalpy terms in an
+ * {@link EngineeringDiagramBalanceTable}. Port direction is always relative to the declared control volume. Values are
+ * non-negative energy rates, so their sign is never inferred from an equipment convention or drawing topology. Every
+ * declared port requires one explicit zero or non-zero flow value.
  * </p>
  *
  * <p>
- * This class calculates first-law residuals only. It does not read live equipment duties, infer
- * missing ports, apply project tolerances, reconcile values, or promote review evidence to
- * engineering approval.
+ * This class calculates first-law residuals only. It does not read live equipment duties, infer missing ports, apply
+ * project tolerances, reconcile values, or promote review evidence to engineering approval.
  * </p>
  */
 public final class EngineeringDiagramEnergyBalanceTable implements Serializable {
   private static final long serialVersionUID = 1000L;
-  public static final String SCHEMA_VERSION =
-      "neqsim_engineering_diagram_energy_balance_table.v1";
+  public static final String SCHEMA_VERSION = "neqsim_engineering_diagram_energy_balance_table.v1";
 
   /** Type of energy crossing a declared control-volume port. */
   public enum EnergyKind {
@@ -76,15 +73,12 @@ public final class EngineeringDiagramEnergyBalanceTable implements Serializable 
      * @param direction explicit direction relative to the control volume
      * @param sourceReference source or register reference for the port declaration
      * @param evidenceState review evidence state
-     * @throws IllegalArgumentException if an identity, source, kind, direction, or evidence state
-     *         is missing
+     * @throws IllegalArgumentException if an identity, source, kind, direction, or evidence state is missing
      */
-    public EnergyPort(String balanceId, String equipmentSemanticObjectId,
-        String portSemanticObjectId, EnergyKind energyKind, EnergyDirection direction,
-        String sourceReference, EvidenceState evidenceState) {
+    public EnergyPort(String balanceId, String equipmentSemanticObjectId, String portSemanticObjectId,
+        EnergyKind energyKind, EnergyDirection direction, String sourceReference, EvidenceState evidenceState) {
       this.balanceId = requireText(balanceId, "balanceId");
-      this.equipmentSemanticObjectId =
-          requireText(equipmentSemanticObjectId, "equipmentSemanticObjectId");
+      this.equipmentSemanticObjectId = requireText(equipmentSemanticObjectId, "equipmentSemanticObjectId");
       this.portSemanticObjectId = requireText(portSemanticObjectId, "portSemanticObjectId");
       if (energyKind == null) {
         throw new IllegalArgumentException("energyKind must not be null");
@@ -172,12 +166,10 @@ public final class EngineeringDiagramEnergyBalanceTable implements Serializable 
      * @param sourceReference source calculation or register reference
      * @param provenance calculation or data lineage description
      * @param evidenceState review evidence state
-     * @throws IllegalArgumentException if an identity, source, provenance, or evidence state is
-     *         missing
+     * @throws IllegalArgumentException if an identity, source, provenance, or evidence state is missing
      */
-    public EnergyFlow(String balanceId, String portSemanticObjectId, double resultValue,
-        String resultUnit, String quantityBasis, String sourceReference, String provenance,
-        EvidenceState evidenceState) {
+    public EnergyFlow(String balanceId, String portSemanticObjectId, double resultValue, String resultUnit,
+        String quantityBasis, String sourceReference, String provenance, EvidenceState evidenceState) {
       this.balanceId = requireText(balanceId, "balanceId");
       this.portSemanticObjectId = requireText(portSemanticObjectId, "portSemanticObjectId");
       this.resultValue = resultValue;
@@ -278,15 +270,13 @@ public final class EngineeringDiagramEnergyBalanceTable implements Serializable 
       this.heatTransferOutOfControlVolume = accumulator.heatTransferOutOfControlVolume;
       this.shaftWorkIntoControlVolume = accumulator.shaftWorkIntoControlVolume;
       this.shaftWorkOutOfControlVolume = accumulator.shaftWorkOutOfControlVolume;
-      this.totalEnergyIn = inletStreamEnthalpyFlow + heatTransferIntoControlVolume
-          + shaftWorkIntoControlVolume;
-      this.totalEnergyOut = outletStreamEnthalpyFlow + heatTransferOutOfControlVolume
-          + shaftWorkOutOfControlVolume;
+      this.totalEnergyIn = inletStreamEnthalpyFlow + heatTransferIntoControlVolume + shaftWorkIntoControlVolume;
+      this.totalEnergyOut = outletStreamEnthalpyFlow + heatTransferOutOfControlVolume + shaftWorkOutOfControlVolume;
       this.energyResidual = totalEnergyIn - totalEnergyOut;
       double scale = Math.max(Math.abs(totalEnergyIn), Math.abs(totalEnergyOut));
       this.relativeEnergyResidual = scale == 0.0 ? 0.0 : energyResidual / scale;
-      this.complete = accumulator.complete && source.isStreamEnthalpyFlowComplete()
-          && declaredPortCount > 0 && declaredPortCount == suppliedFlowCount;
+      this.complete = accumulator.complete && source.isStreamEnthalpyFlowComplete() && declaredPortCount > 0
+          && declaredPortCount == suppliedFlowCount;
     }
 
     /** @return stable balance identity */
@@ -366,13 +356,10 @@ public final class EngineeringDiagramEnergyBalanceTable implements Serializable 
       result.put("suppliedFlowCount", Integer.valueOf(suppliedFlowCount));
       result.put("inletStreamEnthalpyFlow", Double.valueOf(inletStreamEnthalpyFlow));
       result.put("outletStreamEnthalpyFlow", Double.valueOf(outletStreamEnthalpyFlow));
-      result.put("heatTransferIntoControlVolume",
-          Double.valueOf(heatTransferIntoControlVolume));
-      result.put("heatTransferOutOfControlVolume",
-          Double.valueOf(heatTransferOutOfControlVolume));
+      result.put("heatTransferIntoControlVolume", Double.valueOf(heatTransferIntoControlVolume));
+      result.put("heatTransferOutOfControlVolume", Double.valueOf(heatTransferOutOfControlVolume));
       result.put("shaftWorkIntoControlVolume", Double.valueOf(shaftWorkIntoControlVolume));
-      result.put("shaftWorkOutOfControlVolume",
-          Double.valueOf(shaftWorkOutOfControlVolume));
+      result.put("shaftWorkOutOfControlVolume", Double.valueOf(shaftWorkOutOfControlVolume));
       result.put("totalEnergyIn", Double.valueOf(totalEnergyIn));
       result.put("totalEnergyOut", Double.valueOf(totalEnergyOut));
       result.put("energyResidual", Double.valueOf(energyResidual));
@@ -448,16 +435,15 @@ public final class EngineeringDiagramEnergyBalanceTable implements Serializable 
   private final List<Diagnostic> diagnostics;
 
   private EngineeringDiagramEnergyBalanceTable(EngineeringDiagramBalanceTable balanceTable,
-      List<EnergyPort> energyPorts, List<EnergyFlow> energyFlows,
-      List<EnergyBalance> energyBalances, List<Diagnostic> diagnostics) {
+      List<EnergyPort> energyPorts, List<EnergyFlow> energyFlows, List<EnergyBalance> energyBalances,
+      List<Diagnostic> diagnostics) {
     this.documentSetId = balanceTable.getDocumentSetId();
     this.sourceGraphFingerprint = balanceTable.getSourceGraphFingerprint();
     this.designCaseId = balanceTable.getDesignCaseId();
     this.sourceBalanceTableFingerprint = balanceTable.toMap().get("fingerprint").toString();
     this.energyPorts = Collections.unmodifiableList(new ArrayList<EnergyPort>(energyPorts));
     this.energyFlows = Collections.unmodifiableList(new ArrayList<EnergyFlow>(energyFlows));
-    this.energyBalances =
-        Collections.unmodifiableList(new ArrayList<EnergyBalance>(energyBalances));
+    this.energyBalances = Collections.unmodifiableList(new ArrayList<EnergyBalance>(energyBalances));
     this.diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
   }
 
@@ -470,9 +456,8 @@ public final class EngineeringDiagramEnergyBalanceTable implements Serializable 
    * @return immutable energy-balance closure table with structured diagnostics
    * @throws IllegalArgumentException if an argument is null or a list contains null
    */
-  public static EngineeringDiagramEnergyBalanceTable fromBalanceTable(
-      EngineeringDiagramBalanceTable balanceTable, List<EnergyPort> energyPorts,
-      List<EnergyFlow> energyFlows) {
+  public static EngineeringDiagramEnergyBalanceTable fromBalanceTable(EngineeringDiagramBalanceTable balanceTable,
+      List<EnergyPort> energyPorts, List<EnergyFlow> energyFlows) {
     if (balanceTable == null) {
       throw new IllegalArgumentException("balanceTable must not be null");
     }
@@ -512,14 +497,12 @@ public final class EngineeringDiagramEnergyBalanceTable implements Serializable 
       balancesById.put(balance.getBalanceId(), balance);
     }
     Map<String, EnergyPort> portsByKey = new LinkedHashMap<String, EnergyPort>();
-    Map<String, List<EnergyPort>> portsByBalance =
-        new LinkedHashMap<String, List<EnergyPort>>();
+    Map<String, List<EnergyPort>> portsByBalance = new LinkedHashMap<String, List<EnergyPort>>();
     Set<String> invalidBalances = new LinkedHashSet<String>();
     for (EnergyPort port : sortedPorts) {
       if (!balancesById.containsKey(port.getBalanceId())) {
         diagnostics.add(new Diagnostic(Severity.ERROR, "ENERGY_PORT_UNKNOWN_BALANCE",
-            "An energy port references a balance absent from the source balance table",
-            port.getBalanceId()));
+            "An energy port references a balance absent from the source balance table", port.getBalanceId()));
         continue;
       }
       String key = portKey(port.getBalanceId(), port.getPortSemanticObjectId());
@@ -555,8 +538,7 @@ public final class EngineeringDiagramEnergyBalanceTable implements Serializable 
       }
       if (!validFlow(flow)) {
         diagnostics.add(new Diagnostic(Severity.ERROR, "ENERGY_FLOW_VALUE_INVALID",
-            "Energy flow must be finite, non-negative, in W, and on an ENERGY_RATE basis",
-            key));
+            "Energy flow must be finite, non-negative, in W, and on an ENERGY_RATE basis", key));
         invalidBalances.add(flow.getBalanceId());
         continue;
       }
@@ -566,8 +548,7 @@ public final class EngineeringDiagramEnergyBalanceTable implements Serializable 
     List<EnergyBalance> balances = new ArrayList<EnergyBalance>();
     for (Balance source : balanceTable.getBalances()) {
       Accumulator accumulator = new Accumulator();
-      accumulator.complete = balanceTable.isValid()
-          && !invalidBalances.contains(source.getBalanceId());
+      accumulator.complete = balanceTable.isValid() && !invalidBalances.contains(source.getBalanceId());
       List<EnergyPort> balancePorts = portsByBalance.get(source.getBalanceId());
       if (balancePorts == null || balancePorts.isEmpty()) {
         accumulator.complete = false;
@@ -582,8 +563,7 @@ public final class EngineeringDiagramEnergyBalanceTable implements Serializable 
           if (flow == null) {
             accumulator.complete = false;
             diagnostics.add(new Diagnostic(Severity.ERROR, "ENERGY_FLOW_MISSING",
-                "Every declared energy port requires one explicit zero or non-zero flow value",
-                key));
+                "Every declared energy port requires one explicit zero or non-zero flow value", key));
             continue;
           }
           accumulator.suppliedFlowCount++;
@@ -593,8 +573,7 @@ public final class EngineeringDiagramEnergyBalanceTable implements Serializable 
       balances.add(new EnergyBalance(source, accumulator));
     }
     Collections.sort(diagnostics, diagnosticComparator());
-    return new EngineeringDiagramEnergyBalanceTable(balanceTable, sortedPorts, sortedFlows,
-        balances, diagnostics);
+    return new EngineeringDiagramEnergyBalanceTable(balanceTable, sortedPorts, sortedFlows, balances, diagnostics);
   }
 
   /** @return source controlled-document identity */
@@ -684,8 +663,7 @@ public final class EngineeringDiagramEnergyBalanceTable implements Serializable 
     return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
   }
 
-  private static void addEnergyFlow(EnergyPort port, EnergyFlow flow,
-      Accumulator accumulator) {
+  private static void addEnergyFlow(EnergyPort port, EnergyFlow flow, Accumulator accumulator) {
     double value = flow.getResultValue();
     if (port.getEnergyKind() == EnergyKind.HEAT_TRANSFER) {
       if (port.getDirection() == EnergyDirection.INTO_CONTROL_VOLUME) {
@@ -701,8 +679,7 @@ public final class EngineeringDiagramEnergyBalanceTable implements Serializable 
   }
 
   private static boolean validFlow(EnergyFlow flow) {
-    return Double.isFinite(flow.getResultValue()) && flow.getResultValue() >= 0.0
-        && "W".equals(flow.getResultUnit())
+    return Double.isFinite(flow.getResultValue()) && flow.getResultValue() >= 0.0 && "W".equals(flow.getResultUnit())
         && "ENERGY_RATE".equals(flow.getQuantityBasis());
   }
 
@@ -729,8 +706,7 @@ public final class EngineeringDiagramEnergyBalanceTable implements Serializable 
         if (order != 0) {
           return order;
         }
-        order = left.getEquipmentSemanticObjectId()
-            .compareTo(right.getEquipmentSemanticObjectId());
+        order = left.getEquipmentSemanticObjectId().compareTo(right.getEquipmentSemanticObjectId());
         if (order != 0) {
           return order;
         }

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramEnergyBalanceTable.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramEnergyBalanceTable.java
@@ -1,0 +1,837 @@
+package neqsim.process.engineering.model;
+
+import com.google.gson.GsonBuilder;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Balance;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.EvidenceState;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Severity;
+
+/**
+ * Immutable, deterministic energy-balance closure projection.
+ *
+ * <p>
+ * The projection adds explicit heat-transfer and shaft-work ports to the stream enthalpy terms in
+ * an {@link EngineeringDiagramBalanceTable}. Port direction is always relative to the declared
+ * control volume. Values are non-negative energy rates, so their sign is never inferred from an
+ * equipment convention or drawing topology. Every declared port requires one explicit zero or
+ * non-zero flow value.
+ * </p>
+ *
+ * <p>
+ * This class calculates first-law residuals only. It does not read live equipment duties, infer
+ * missing ports, apply project tolerances, reconcile values, or promote review evidence to
+ * engineering approval.
+ * </p>
+ */
+public final class EngineeringDiagramEnergyBalanceTable implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  public static final String SCHEMA_VERSION =
+      "neqsim_engineering_diagram_energy_balance_table.v1";
+
+  /** Type of energy crossing a declared control-volume port. */
+  public enum EnergyKind {
+    /** Heat transfer across the control-volume boundary. */
+    HEAT_TRANSFER,
+    /** Shaft work across the control-volume boundary. */
+    SHAFT_WORK
+  }
+
+  /** Explicit direction of an energy rate relative to the control volume. */
+  public enum EnergyDirection {
+    /** Energy enters the control volume. */
+    INTO_CONTROL_VOLUME,
+    /** Energy leaves the control volume. */
+    OUT_OF_CONTROL_VOLUME
+  }
+
+  /** One explicit energy port assigned to a named balance. */
+  public static final class EnergyPort implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String balanceId;
+    private final String equipmentSemanticObjectId;
+    private final String portSemanticObjectId;
+    private final EnergyKind energyKind;
+    private final EnergyDirection direction;
+    private final String sourceReference;
+    private final EvidenceState evidenceState;
+
+    /**
+     * Creates one explicit heat-transfer or shaft-work port.
+     *
+     * @param balanceId stable balance identity
+     * @param equipmentSemanticObjectId canonical equipment or control-volume identity
+     * @param portSemanticObjectId stable port identity, distinct for parallel energy connections
+     * @param energyKind kind of energy crossing the port
+     * @param direction explicit direction relative to the control volume
+     * @param sourceReference source or register reference for the port declaration
+     * @param evidenceState review evidence state
+     * @throws IllegalArgumentException if an identity, source, kind, direction, or evidence state
+     *         is missing
+     */
+    public EnergyPort(String balanceId, String equipmentSemanticObjectId,
+        String portSemanticObjectId, EnergyKind energyKind, EnergyDirection direction,
+        String sourceReference, EvidenceState evidenceState) {
+      this.balanceId = requireText(balanceId, "balanceId");
+      this.equipmentSemanticObjectId =
+          requireText(equipmentSemanticObjectId, "equipmentSemanticObjectId");
+      this.portSemanticObjectId = requireText(portSemanticObjectId, "portSemanticObjectId");
+      if (energyKind == null) {
+        throw new IllegalArgumentException("energyKind must not be null");
+      }
+      this.energyKind = energyKind;
+      if (direction == null) {
+        throw new IllegalArgumentException("direction must not be null");
+      }
+      this.direction = direction;
+      this.sourceReference = requireText(sourceReference, "sourceReference");
+      if (evidenceState == null) {
+        throw new IllegalArgumentException("evidenceState must not be null");
+      }
+      this.evidenceState = evidenceState;
+    }
+
+    /** @return stable balance identity */
+    public String getBalanceId() {
+      return balanceId;
+    }
+
+    /** @return canonical equipment or control-volume identity */
+    public String getEquipmentSemanticObjectId() {
+      return equipmentSemanticObjectId;
+    }
+
+    /** @return stable energy-port identity */
+    public String getPortSemanticObjectId() {
+      return portSemanticObjectId;
+    }
+
+    /** @return kind of energy crossing the port */
+    public EnergyKind getEnergyKind() {
+      return energyKind;
+    }
+
+    /** @return explicit direction relative to the control volume */
+    public EnergyDirection getDirection() {
+      return direction;
+    }
+
+    /** @return source or register reference */
+    public String getSourceReference() {
+      return sourceReference;
+    }
+
+    /** @return review evidence state */
+    public EvidenceState getEvidenceState() {
+      return evidenceState;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("balanceId", balanceId);
+      result.put("equipmentSemanticObjectId", equipmentSemanticObjectId);
+      result.put("portSemanticObjectId", portSemanticObjectId);
+      result.put("energyKind", energyKind.name());
+      result.put("direction", direction.name());
+      result.put("sourceReference", sourceReference);
+      result.put("evidenceState", evidenceState.name());
+      return result;
+    }
+  }
+
+  /** One explicit energy-rate value on a declared energy port. */
+  public static final class EnergyFlow implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String balanceId;
+    private final String portSemanticObjectId;
+    private final double resultValue;
+    private final String resultUnit;
+    private final String quantityBasis;
+    private final String sourceReference;
+    private final String provenance;
+    private final EvidenceState evidenceState;
+
+    /**
+     * Creates one explicit energy-rate value.
+     *
+     * @param balanceId stable balance identity
+     * @param portSemanticObjectId stable declared energy-port identity
+     * @param resultValue non-negative energy rate
+     * @param resultUnit explicit result unit; aggregation requires {@code W}
+     * @param quantityBasis explicit quantity basis; aggregation requires {@code ENERGY_RATE}
+     * @param sourceReference source calculation or register reference
+     * @param provenance calculation or data lineage description
+     * @param evidenceState review evidence state
+     * @throws IllegalArgumentException if an identity, source, provenance, or evidence state is
+     *         missing
+     */
+    public EnergyFlow(String balanceId, String portSemanticObjectId, double resultValue,
+        String resultUnit, String quantityBasis, String sourceReference, String provenance,
+        EvidenceState evidenceState) {
+      this.balanceId = requireText(balanceId, "balanceId");
+      this.portSemanticObjectId = requireText(portSemanticObjectId, "portSemanticObjectId");
+      this.resultValue = resultValue;
+      this.resultUnit = requireText(resultUnit, "resultUnit");
+      this.quantityBasis = requireText(quantityBasis, "quantityBasis");
+      this.sourceReference = requireText(sourceReference, "sourceReference");
+      this.provenance = requireText(provenance, "provenance");
+      if (evidenceState == null) {
+        throw new IllegalArgumentException("evidenceState must not be null");
+      }
+      this.evidenceState = evidenceState;
+    }
+
+    /** @return stable balance identity */
+    public String getBalanceId() {
+      return balanceId;
+    }
+
+    /** @return stable declared energy-port identity */
+    public String getPortSemanticObjectId() {
+      return portSemanticObjectId;
+    }
+
+    /** @return energy-rate result */
+    public double getResultValue() {
+      return resultValue;
+    }
+
+    /** @return explicit result unit */
+    public String getResultUnit() {
+      return resultUnit;
+    }
+
+    /** @return explicit quantity basis */
+    public String getQuantityBasis() {
+      return quantityBasis;
+    }
+
+    /** @return source calculation or register reference */
+    public String getSourceReference() {
+      return sourceReference;
+    }
+
+    /** @return calculation or data lineage description */
+    public String getProvenance() {
+      return provenance;
+    }
+
+    /** @return review evidence state */
+    public EvidenceState getEvidenceState() {
+      return evidenceState;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("balanceId", balanceId);
+      result.put("portSemanticObjectId", portSemanticObjectId);
+      if (Double.isFinite(resultValue)) {
+        result.put("resultValue", Double.valueOf(resultValue));
+      } else {
+        result.put("resultValue", null);
+        result.put("nonFiniteResult", nonFiniteLabel(resultValue));
+      }
+      result.put("resultUnit", resultUnit);
+      result.put("quantityBasis", quantityBasis);
+      result.put("sourceReference", sourceReference);
+      result.put("provenance", provenance);
+      result.put("evidenceState", evidenceState.name());
+      return result;
+    }
+  }
+
+  /** One complete or fail-visible energy-balance result. */
+  public static final class EnergyBalance implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String balanceId;
+    private final int declaredPortCount;
+    private final int suppliedFlowCount;
+    private final double inletStreamEnthalpyFlow;
+    private final double outletStreamEnthalpyFlow;
+    private final double heatTransferIntoControlVolume;
+    private final double heatTransferOutOfControlVolume;
+    private final double shaftWorkIntoControlVolume;
+    private final double shaftWorkOutOfControlVolume;
+    private final double totalEnergyIn;
+    private final double totalEnergyOut;
+    private final double energyResidual;
+    private final double relativeEnergyResidual;
+    private final boolean complete;
+
+    private EnergyBalance(Balance source, Accumulator accumulator) {
+      this.balanceId = source.getBalanceId();
+      this.declaredPortCount = accumulator.declaredPortCount;
+      this.suppliedFlowCount = accumulator.suppliedFlowCount;
+      this.inletStreamEnthalpyFlow = source.getInletStreamEnthalpyFlow();
+      this.outletStreamEnthalpyFlow = source.getOutletStreamEnthalpyFlow();
+      this.heatTransferIntoControlVolume = accumulator.heatTransferIntoControlVolume;
+      this.heatTransferOutOfControlVolume = accumulator.heatTransferOutOfControlVolume;
+      this.shaftWorkIntoControlVolume = accumulator.shaftWorkIntoControlVolume;
+      this.shaftWorkOutOfControlVolume = accumulator.shaftWorkOutOfControlVolume;
+      this.totalEnergyIn = inletStreamEnthalpyFlow + heatTransferIntoControlVolume
+          + shaftWorkIntoControlVolume;
+      this.totalEnergyOut = outletStreamEnthalpyFlow + heatTransferOutOfControlVolume
+          + shaftWorkOutOfControlVolume;
+      this.energyResidual = totalEnergyIn - totalEnergyOut;
+      double scale = Math.max(Math.abs(totalEnergyIn), Math.abs(totalEnergyOut));
+      this.relativeEnergyResidual = scale == 0.0 ? 0.0 : energyResidual / scale;
+      this.complete = accumulator.complete && source.isStreamEnthalpyFlowComplete()
+          && declaredPortCount > 0 && declaredPortCount == suppliedFlowCount;
+    }
+
+    /** @return stable balance identity */
+    public String getBalanceId() {
+      return balanceId;
+    }
+
+    /** @return number of explicitly declared energy ports */
+    public int getDeclaredPortCount() {
+      return declaredPortCount;
+    }
+
+    /** @return number of declared ports with one usable energy-rate value */
+    public int getSuppliedFlowCount() {
+      return suppliedFlowCount;
+    }
+
+    /** @return inlet stream enthalpy flow in W */
+    public double getInletStreamEnthalpyFlow() {
+      return inletStreamEnthalpyFlow;
+    }
+
+    /** @return outlet stream enthalpy flow in W */
+    public double getOutletStreamEnthalpyFlow() {
+      return outletStreamEnthalpyFlow;
+    }
+
+    /** @return heat transfer into the control volume in W */
+    public double getHeatTransferIntoControlVolume() {
+      return heatTransferIntoControlVolume;
+    }
+
+    /** @return heat transfer out of the control volume in W */
+    public double getHeatTransferOutOfControlVolume() {
+      return heatTransferOutOfControlVolume;
+    }
+
+    /** @return shaft work into the control volume in W */
+    public double getShaftWorkIntoControlVolume() {
+      return shaftWorkIntoControlVolume;
+    }
+
+    /** @return shaft work out of the control volume in W */
+    public double getShaftWorkOutOfControlVolume() {
+      return shaftWorkOutOfControlVolume;
+    }
+
+    /** @return total inlet stream enthalpy, heat transfer, and shaft work in W */
+    public double getTotalEnergyIn() {
+      return totalEnergyIn;
+    }
+
+    /** @return total outlet stream enthalpy, heat transfer, and shaft work in W */
+    public double getTotalEnergyOut() {
+      return totalEnergyOut;
+    }
+
+    /** @return total energy input minus total energy output in W */
+    public double getEnergyResidual() {
+      return energyResidual;
+    }
+
+    /** @return energy residual divided by the larger absolute inlet or outlet total */
+    public double getRelativeEnergyResidual() {
+      return relativeEnergyResidual;
+    }
+
+    /** @return true when source stream terms and all declared energy-port flows are complete */
+    public boolean isComplete() {
+      return complete;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("balanceId", balanceId);
+      result.put("declaredPortCount", Integer.valueOf(declaredPortCount));
+      result.put("suppliedFlowCount", Integer.valueOf(suppliedFlowCount));
+      result.put("inletStreamEnthalpyFlow", Double.valueOf(inletStreamEnthalpyFlow));
+      result.put("outletStreamEnthalpyFlow", Double.valueOf(outletStreamEnthalpyFlow));
+      result.put("heatTransferIntoControlVolume",
+          Double.valueOf(heatTransferIntoControlVolume));
+      result.put("heatTransferOutOfControlVolume",
+          Double.valueOf(heatTransferOutOfControlVolume));
+      result.put("shaftWorkIntoControlVolume", Double.valueOf(shaftWorkIntoControlVolume));
+      result.put("shaftWorkOutOfControlVolume",
+          Double.valueOf(shaftWorkOutOfControlVolume));
+      result.put("totalEnergyIn", Double.valueOf(totalEnergyIn));
+      result.put("totalEnergyOut", Double.valueOf(totalEnergyOut));
+      result.put("energyResidual", Double.valueOf(energyResidual));
+      result.put("relativeEnergyResidual", Double.valueOf(relativeEnergyResidual));
+      result.put("energyFlowUnit", "W");
+      result.put("complete", Boolean.valueOf(complete));
+      return result;
+    }
+  }
+
+  /** One structured energy-balance diagnostic. */
+  public static final class Diagnostic implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Severity severity;
+    private final String code;
+    private final String message;
+    private final String subjectId;
+
+    private Diagnostic(Severity severity, String code, String message, String subjectId) {
+      this.severity = severity;
+      this.code = code;
+      this.message = message;
+      this.subjectId = subjectId;
+    }
+
+    /** @return diagnostic severity */
+    public Severity getSeverity() {
+      return severity;
+    }
+
+    /** @return stable machine-readable diagnostic code */
+    public String getCode() {
+      return code;
+    }
+
+    /** @return human-readable diagnostic message */
+    public String getMessage() {
+      return message;
+    }
+
+    /** @return affected stable identity */
+    public String getSubjectId() {
+      return subjectId;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("severity", severity.name());
+      result.put("code", code);
+      result.put("message", message);
+      result.put("subjectId", subjectId);
+      return result;
+    }
+  }
+
+  private static final class Accumulator {
+    private int declaredPortCount;
+    private int suppliedFlowCount;
+    private double heatTransferIntoControlVolume;
+    private double heatTransferOutOfControlVolume;
+    private double shaftWorkIntoControlVolume;
+    private double shaftWorkOutOfControlVolume;
+    private boolean complete = true;
+  }
+
+  private final String documentSetId;
+  private final String sourceGraphFingerprint;
+  private final String designCaseId;
+  private final String sourceBalanceTableFingerprint;
+  private final List<EnergyPort> energyPorts;
+  private final List<EnergyFlow> energyFlows;
+  private final List<EnergyBalance> energyBalances;
+  private final List<Diagnostic> diagnostics;
+
+  private EngineeringDiagramEnergyBalanceTable(EngineeringDiagramBalanceTable balanceTable,
+      List<EnergyPort> energyPorts, List<EnergyFlow> energyFlows,
+      List<EnergyBalance> energyBalances, List<Diagnostic> diagnostics) {
+    this.documentSetId = balanceTable.getDocumentSetId();
+    this.sourceGraphFingerprint = balanceTable.getSourceGraphFingerprint();
+    this.designCaseId = balanceTable.getDesignCaseId();
+    this.sourceBalanceTableFingerprint = balanceTable.toMap().get("fingerprint").toString();
+    this.energyPorts = Collections.unmodifiableList(new ArrayList<EnergyPort>(energyPorts));
+    this.energyFlows = Collections.unmodifiableList(new ArrayList<EnergyFlow>(energyFlows));
+    this.energyBalances =
+        Collections.unmodifiableList(new ArrayList<EnergyBalance>(energyBalances));
+    this.diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+  }
+
+  /**
+   * Closes explicit heat-transfer and shaft-work terms against a source boundary balance table.
+   *
+   * @param balanceTable governed explicit-boundary balance table
+   * @param energyPorts explicit heat-transfer and shaft-work ports for every balance
+   * @param energyFlows one explicit energy-rate value for every declared port
+   * @return immutable energy-balance closure table with structured diagnostics
+   * @throws IllegalArgumentException if an argument is null or a list contains null
+   */
+  public static EngineeringDiagramEnergyBalanceTable fromBalanceTable(
+      EngineeringDiagramBalanceTable balanceTable, List<EnergyPort> energyPorts,
+      List<EnergyFlow> energyFlows) {
+    if (balanceTable == null) {
+      throw new IllegalArgumentException("balanceTable must not be null");
+    }
+    if (energyPorts == null) {
+      throw new IllegalArgumentException("energyPorts must not be null");
+    }
+    if (energyFlows == null) {
+      throw new IllegalArgumentException("energyFlows must not be null");
+    }
+    List<EnergyPort> sortedPorts = new ArrayList<EnergyPort>(energyPorts);
+    List<EnergyFlow> sortedFlows = new ArrayList<EnergyFlow>(energyFlows);
+    if (containsNull(sortedPorts)) {
+      throw new IllegalArgumentException("energyPorts must not contain null");
+    }
+    if (containsNull(sortedFlows)) {
+      throw new IllegalArgumentException("energyFlows must not contain null");
+    }
+    Collections.sort(sortedPorts, energyPortComparator());
+    Collections.sort(sortedFlows, energyFlowComparator());
+
+    List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
+    if (!balanceTable.isValid()) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "ENERGY_BALANCE_SOURCE_INVALID",
+          "The source explicit-boundary balance table contains error-severity diagnostics", ""));
+    }
+    if (sortedPorts.isEmpty()) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "ENERGY_PORT_NOT_DECLARED",
+          "At least one explicit heat-transfer or shaft-work port is required", ""));
+    }
+    if (sortedFlows.isEmpty()) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "ENERGY_FLOW_NOT_DECLARED",
+          "At least one explicit energy-rate value is required", ""));
+    }
+
+    Map<String, Balance> balancesById = new LinkedHashMap<String, Balance>();
+    for (Balance balance : balanceTable.getBalances()) {
+      balancesById.put(balance.getBalanceId(), balance);
+    }
+    Map<String, EnergyPort> portsByKey = new LinkedHashMap<String, EnergyPort>();
+    Map<String, List<EnergyPort>> portsByBalance =
+        new LinkedHashMap<String, List<EnergyPort>>();
+    Set<String> invalidBalances = new LinkedHashSet<String>();
+    for (EnergyPort port : sortedPorts) {
+      if (!balancesById.containsKey(port.getBalanceId())) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "ENERGY_PORT_UNKNOWN_BALANCE",
+            "An energy port references a balance absent from the source balance table",
+            port.getBalanceId()));
+        continue;
+      }
+      String key = portKey(port.getBalanceId(), port.getPortSemanticObjectId());
+      if (portsByKey.containsKey(key)) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "ENERGY_PORT_DUPLICATE",
+            "A stable energy port may be declared only once for the same balance", key));
+        invalidBalances.add(port.getBalanceId());
+        continue;
+      }
+      portsByKey.put(key, port);
+      List<EnergyPort> balancePorts = portsByBalance.get(port.getBalanceId());
+      if (balancePorts == null) {
+        balancePorts = new ArrayList<EnergyPort>();
+        portsByBalance.put(port.getBalanceId(), balancePorts);
+      }
+      balancePorts.add(port);
+    }
+
+    Map<String, EnergyFlow> flowsByPort = new LinkedHashMap<String, EnergyFlow>();
+    for (EnergyFlow flow : sortedFlows) {
+      String key = portKey(flow.getBalanceId(), flow.getPortSemanticObjectId());
+      if (!portsByKey.containsKey(key)) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "ENERGY_FLOW_UNKNOWN_PORT",
+            "An energy-rate value references a port absent from the named balance", key));
+        invalidBalances.add(flow.getBalanceId());
+        continue;
+      }
+      if (flowsByPort.containsKey(key)) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "ENERGY_FLOW_DUPLICATE",
+            "Only one energy-rate value may be supplied for a declared port", key));
+        invalidBalances.add(flow.getBalanceId());
+        continue;
+      }
+      if (!validFlow(flow)) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "ENERGY_FLOW_VALUE_INVALID",
+            "Energy flow must be finite, non-negative, in W, and on an ENERGY_RATE basis",
+            key));
+        invalidBalances.add(flow.getBalanceId());
+        continue;
+      }
+      flowsByPort.put(key, flow);
+    }
+
+    List<EnergyBalance> balances = new ArrayList<EnergyBalance>();
+    for (Balance source : balanceTable.getBalances()) {
+      Accumulator accumulator = new Accumulator();
+      accumulator.complete = balanceTable.isValid()
+          && !invalidBalances.contains(source.getBalanceId());
+      List<EnergyPort> balancePorts = portsByBalance.get(source.getBalanceId());
+      if (balancePorts == null || balancePorts.isEmpty()) {
+        accumulator.complete = false;
+        diagnostics.add(new Diagnostic(Severity.ERROR, "ENERGY_PORT_MISSING_FOR_BALANCE",
+            "Every source balance requires an explicit zero or non-zero energy-port declaration",
+            source.getBalanceId()));
+      } else {
+        accumulator.declaredPortCount = balancePorts.size();
+        for (EnergyPort port : balancePorts) {
+          String key = portKey(port.getBalanceId(), port.getPortSemanticObjectId());
+          EnergyFlow flow = flowsByPort.get(key);
+          if (flow == null) {
+            accumulator.complete = false;
+            diagnostics.add(new Diagnostic(Severity.ERROR, "ENERGY_FLOW_MISSING",
+                "Every declared energy port requires one explicit zero or non-zero flow value",
+                key));
+            continue;
+          }
+          accumulator.suppliedFlowCount++;
+          addEnergyFlow(port, flow, accumulator);
+        }
+      }
+      balances.add(new EnergyBalance(source, accumulator));
+    }
+    Collections.sort(diagnostics, diagnosticComparator());
+    return new EngineeringDiagramEnergyBalanceTable(balanceTable, sortedPorts, sortedFlows,
+        balances, diagnostics);
+  }
+
+  /** @return source controlled-document identity */
+  public String getDocumentSetId() {
+    return documentSetId;
+  }
+
+  /** @return canonical source-graph fingerprint */
+  public String getSourceGraphFingerprint() {
+    return sourceGraphFingerprint;
+  }
+
+  /** @return selected operating-case identity */
+  public String getDesignCaseId() {
+    return designCaseId;
+  }
+
+  /** @return deterministic fingerprint of the source balance-table representation */
+  public String getSourceBalanceTableFingerprint() {
+    return sourceBalanceTableFingerprint;
+  }
+
+  /** @return immutable explicit energy ports in deterministic order */
+  public List<EnergyPort> getEnergyPorts() {
+    return Collections.unmodifiableList(new ArrayList<EnergyPort>(energyPorts));
+  }
+
+  /** @return immutable explicit energy-rate values in deterministic order */
+  public List<EnergyFlow> getEnergyFlows() {
+    return Collections.unmodifiableList(new ArrayList<EnergyFlow>(energyFlows));
+  }
+
+  /** @return immutable energy-balance results in deterministic order */
+  public List<EnergyBalance> getEnergyBalances() {
+    return Collections.unmodifiableList(new ArrayList<EnergyBalance>(energyBalances));
+  }
+
+  /** @return immutable structured diagnostics */
+  public List<Diagnostic> getDiagnostics() {
+    return Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+  }
+
+  /** @return true when no error-severity diagnostic is present */
+  public boolean isValid() {
+    for (Diagnostic diagnostic : diagnostics) {
+      if (diagnostic.getSeverity() == Severity.ERROR) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** @return deterministic machine-readable representation */
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", SCHEMA_VERSION);
+    result.put("documentSetId", documentSetId);
+    result.put("sourceGraphFingerprint", sourceGraphFingerprint);
+    result.put("designCaseId", designCaseId);
+    result.put("sourceBalanceTableFingerprint", sourceBalanceTableFingerprint);
+    List<Map<String, Object>> portMaps = new ArrayList<Map<String, Object>>();
+    for (EnergyPort port : energyPorts) {
+      portMaps.add(port.toMap());
+    }
+    result.put("energyPorts", portMaps);
+    List<Map<String, Object>> flowMaps = new ArrayList<Map<String, Object>>();
+    for (EnergyFlow flow : energyFlows) {
+      flowMaps.add(flow.toMap());
+    }
+    result.put("energyFlows", flowMaps);
+    List<Map<String, Object>> balanceMaps = new ArrayList<Map<String, Object>>();
+    for (EnergyBalance balance : energyBalances) {
+      balanceMaps.add(balance.toMap());
+    }
+    result.put("energyBalances", balanceMaps);
+    List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
+    for (Diagnostic diagnostic : diagnostics) {
+      diagnosticMaps.add(diagnostic.toMap());
+    }
+    result.put("diagnostics", diagnosticMaps);
+    result.put("fingerprint", fingerprint(result));
+    return result;
+  }
+
+  /** @return deterministic pretty-printed JSON */
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+  }
+
+  private static void addEnergyFlow(EnergyPort port, EnergyFlow flow,
+      Accumulator accumulator) {
+    double value = flow.getResultValue();
+    if (port.getEnergyKind() == EnergyKind.HEAT_TRANSFER) {
+      if (port.getDirection() == EnergyDirection.INTO_CONTROL_VOLUME) {
+        accumulator.heatTransferIntoControlVolume += value;
+      } else {
+        accumulator.heatTransferOutOfControlVolume += value;
+      }
+    } else if (port.getDirection() == EnergyDirection.INTO_CONTROL_VOLUME) {
+      accumulator.shaftWorkIntoControlVolume += value;
+    } else {
+      accumulator.shaftWorkOutOfControlVolume += value;
+    }
+  }
+
+  private static boolean validFlow(EnergyFlow flow) {
+    return Double.isFinite(flow.getResultValue()) && flow.getResultValue() >= 0.0
+        && "W".equals(flow.getResultUnit())
+        && "ENERGY_RATE".equals(flow.getQuantityBasis());
+  }
+
+  private static String nonFiniteLabel(double value) {
+    if (Double.isNaN(value)) {
+      return "NaN";
+    }
+    return value > 0.0 ? "POSITIVE_INFINITY" : "NEGATIVE_INFINITY";
+  }
+
+  private static String portKey(String balanceId, String portId) {
+    return balanceId + "|" + portId;
+  }
+
+  private static Comparator<EnergyPort> energyPortComparator() {
+    return new Comparator<EnergyPort>() {
+      @Override
+      public int compare(EnergyPort left, EnergyPort right) {
+        int order = left.getBalanceId().compareTo(right.getBalanceId());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getPortSemanticObjectId().compareTo(right.getPortSemanticObjectId());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getEquipmentSemanticObjectId()
+            .compareTo(right.getEquipmentSemanticObjectId());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getEnergyKind().compareTo(right.getEnergyKind());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getDirection().compareTo(right.getDirection());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getSourceReference().compareTo(right.getSourceReference());
+        if (order != 0) {
+          return order;
+        }
+        return left.getEvidenceState().compareTo(right.getEvidenceState());
+      }
+    };
+  }
+
+  private static Comparator<EnergyFlow> energyFlowComparator() {
+    return new Comparator<EnergyFlow>() {
+      @Override
+      public int compare(EnergyFlow left, EnergyFlow right) {
+        int order = left.getBalanceId().compareTo(right.getBalanceId());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getPortSemanticObjectId().compareTo(right.getPortSemanticObjectId());
+        if (order != 0) {
+          return order;
+        }
+        order = Double.compare(left.getResultValue(), right.getResultValue());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getResultUnit().compareTo(right.getResultUnit());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getQuantityBasis().compareTo(right.getQuantityBasis());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getSourceReference().compareTo(right.getSourceReference());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getProvenance().compareTo(right.getProvenance());
+        if (order != 0) {
+          return order;
+        }
+        return left.getEvidenceState().compareTo(right.getEvidenceState());
+      }
+    };
+  }
+
+  private static Comparator<Diagnostic> diagnosticComparator() {
+    return new Comparator<Diagnostic>() {
+      @Override
+      public int compare(Diagnostic left, Diagnostic right) {
+        int order = left.getSubjectId().compareTo(right.getSubjectId());
+        if (order != 0) {
+          return order;
+        }
+        order = left.getCode().compareTo(right.getCode());
+        return order != 0 ? order : left.getMessage().compareTo(right.getMessage());
+      }
+    };
+  }
+
+  private static boolean containsNull(List<?> values) {
+    for (Object value : values) {
+      if (value == null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String requireText(String value, String field) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static String fingerprint(Map<String, Object> value) {
+    Map<String, Object> copy = new LinkedHashMap<String, Object>(value);
+    copy.remove("fingerprint");
+    byte[] bytes = new GsonBuilder().create().toJson(copy).getBytes(StandardCharsets.UTF_8);
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(bytes);
+      StringBuilder result = new StringBuilder();
+      for (byte element : hash) {
+        result.append(String.format("%02x", Integer.valueOf(element & 0xff)));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is unavailable", exception);
+    }
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramEnergyBalanceTableTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramEnergyBalanceTableTest.java
@@ -38,9 +38,8 @@ class EngineeringDiagramEnergyBalanceTableTest {
     List<EnergyPort> ports = completePorts();
     List<EnergyFlow> flows = completeFlows();
 
-    EngineeringDiagramEnergyBalanceTable table =
-        EngineeringDiagramEnergyBalanceTable.fromBalanceTable(
-            fixture.balanceTable, ports, flows);
+    EngineeringDiagramEnergyBalanceTable table = EngineeringDiagramEnergyBalanceTable
+        .fromBalanceTable(fixture.balanceTable, ports, flows);
 
     assertTrue(table.isValid());
     assertEquals(1, table.getEnergyBalances().size());
@@ -49,16 +48,13 @@ class EngineeringDiagramEnergyBalanceTableTest {
     assertEquals("BAL-SIMPLE-01", energy.getBalanceId());
     assertEquals(4, energy.getDeclaredPortCount());
     assertEquals(4, energy.getSuppliedFlowCount());
-    assertEquals(source.getInletStreamEnthalpyFlow(), energy.getInletStreamEnthalpyFlow(),
-        1.0e-12);
-    assertEquals(source.getOutletStreamEnthalpyFlow(), energy.getOutletStreamEnthalpyFlow(),
-        1.0e-12);
+    assertEquals(source.getInletStreamEnthalpyFlow(), energy.getInletStreamEnthalpyFlow(), 1.0e-12);
+    assertEquals(source.getOutletStreamEnthalpyFlow(), energy.getOutletStreamEnthalpyFlow(), 1.0e-12);
     assertEquals(1000.0, energy.getHeatTransferIntoControlVolume(), 1.0e-12);
     assertEquals(0.0, energy.getHeatTransferOutOfControlVolume(), 1.0e-12);
     assertEquals(0.0, energy.getShaftWorkIntoControlVolume(), 1.0e-12);
     assertEquals(500.0, energy.getShaftWorkOutOfControlVolume(), 1.0e-12);
-    assertEquals(source.getStreamEnthalpyResidual() + 500.0, energy.getEnergyResidual(),
-        1.0e-8);
+    assertEquals(source.getStreamEnthalpyResidual() + 500.0, energy.getEnergyResidual(), 1.0e-8);
     assertTrue(Double.isFinite(energy.getRelativeEnergyResidual()));
     assertTrue(energy.isComplete());
     assertFalse(table.getSourceBalanceTableFingerprint().isEmpty());
@@ -83,12 +79,10 @@ class EngineeringDiagramEnergyBalanceTableTest {
     Collections.reverse(secondPorts);
     Collections.reverse(secondFlows);
 
-    EngineeringDiagramEnergyBalanceTable first =
-        EngineeringDiagramEnergyBalanceTable.fromBalanceTable(
-            firstFixture.balanceTable, firstPorts, firstFlows);
-    EngineeringDiagramEnergyBalanceTable second =
-        EngineeringDiagramEnergyBalanceTable.fromBalanceTable(
-            secondFixture.balanceTable, secondPorts, secondFlows);
+    EngineeringDiagramEnergyBalanceTable first = EngineeringDiagramEnergyBalanceTable
+        .fromBalanceTable(firstFixture.balanceTable, firstPorts, firstFlows);
+    EngineeringDiagramEnergyBalanceTable second = EngineeringDiagramEnergyBalanceTable
+        .fromBalanceTable(secondFixture.balanceTable, secondPorts, secondFlows);
 
     assertEquals(first.toJson(), second.toJson());
   }
@@ -102,18 +96,15 @@ class EngineeringDiagramEnergyBalanceTableTest {
         EnergyDirection.INTO_CONTROL_VOLUME);
     EnergyFlow heatFlow = flow("energy:heat", 1000.0);
     List<EnergyPort> ports = new ArrayList<EnergyPort>(Arrays.asList(heat, heat, work,
-        new EnergyPort("BAL-MISSING", "equipment:unknown", "energy:unknown",
-            EnergyKind.HEAT_TRANSFER, EnergyDirection.OUT_OF_CONTROL_VOLUME,
-            "project-energy-register:test", EvidenceState.PROPOSED)));
-    List<EnergyFlow> flows = new ArrayList<EnergyFlow>(Arrays.asList(heatFlow, heatFlow,
-        new EnergyFlow("BAL-SIMPLE-01", "energy:work", Double.NaN, "kW", "ENERGY_RATE",
-            "project-energy-register:test", "simulation-case:NORMAL-01",
-            EvidenceState.PROPOSED),
+        new EnergyPort("BAL-MISSING", "equipment:unknown", "energy:unknown", EnergyKind.HEAT_TRANSFER,
+            EnergyDirection.OUT_OF_CONTROL_VOLUME, "project-energy-register:test", EvidenceState.PROPOSED)));
+    List<EnergyFlow> flows = new ArrayList<EnergyFlow>(Arrays.asList(
+        heatFlow, heatFlow, new EnergyFlow("BAL-SIMPLE-01", "energy:work", Double.NaN, "kW", "ENERGY_RATE",
+            "project-energy-register:test", "simulation-case:NORMAL-01", EvidenceState.PROPOSED),
         flow("energy:missing", 5.0)));
 
-    EngineeringDiagramEnergyBalanceTable table =
-        EngineeringDiagramEnergyBalanceTable.fromBalanceTable(
-            fixture.balanceTable, ports, flows);
+    EngineeringDiagramEnergyBalanceTable table = EngineeringDiagramEnergyBalanceTable
+        .fromBalanceTable(fixture.balanceTable, ports, flows);
 
     assertFalse(table.isValid());
     assertFalse(table.getEnergyBalances().get(0).isComplete());
@@ -130,42 +121,34 @@ class EngineeringDiagramEnergyBalanceTableTest {
   void requiresExplicitPortsFlowsAndValidArguments() {
     Fixture fixture = fixture();
 
-    EngineeringDiagramEnergyBalanceTable empty =
-        EngineeringDiagramEnergyBalanceTable.fromBalanceTable(fixture.balanceTable,
-            Collections.<EnergyPort>emptyList(), Collections.<EnergyFlow>emptyList());
+    EngineeringDiagramEnergyBalanceTable empty = EngineeringDiagramEnergyBalanceTable.fromBalanceTable(
+        fixture.balanceTable, Collections.<EnergyPort>emptyList(), Collections.<EnergyFlow>emptyList());
 
     assertFalse(empty.isValid());
     assertFalse(empty.getEnergyBalances().get(0).isComplete());
     assertTrue(hasDiagnostic(empty, "ENERGY_PORT_NOT_DECLARED"));
     assertTrue(hasDiagnostic(empty, "ENERGY_FLOW_NOT_DECLARED"));
     assertTrue(hasDiagnostic(empty, "ENERGY_PORT_MISSING_FOR_BALANCE"));
+    assertThrows(IllegalArgumentException.class, () -> EngineeringDiagramEnergyBalanceTable.fromBalanceTable(null,
+        Collections.<EnergyPort>emptyList(), Collections.<EnergyFlow>emptyList()));
+    assertThrows(IllegalArgumentException.class, () -> EngineeringDiagramEnergyBalanceTable
+        .fromBalanceTable(fixture.balanceTable, null, Collections.<EnergyFlow>emptyList()));
+    assertThrows(IllegalArgumentException.class, () -> EngineeringDiagramEnergyBalanceTable
+        .fromBalanceTable(fixture.balanceTable, Collections.<EnergyPort>emptyList(), null));
+    assertThrows(IllegalArgumentException.class, () -> new EnergyPort("BAL-SIMPLE-01", "equipment:heater",
+        "energy:heat", null, EnergyDirection.INTO_CONTROL_VOLUME, "source", EvidenceState.PROPOSED));
     assertThrows(IllegalArgumentException.class,
-        () -> EngineeringDiagramEnergyBalanceTable.fromBalanceTable(null,
-            Collections.<EnergyPort>emptyList(), Collections.<EnergyFlow>emptyList()));
-    assertThrows(IllegalArgumentException.class,
-        () -> EngineeringDiagramEnergyBalanceTable.fromBalanceTable(fixture.balanceTable,
-            null, Collections.<EnergyFlow>emptyList()));
-    assertThrows(IllegalArgumentException.class,
-        () -> EngineeringDiagramEnergyBalanceTable.fromBalanceTable(fixture.balanceTable,
-            Collections.<EnergyPort>emptyList(), null));
-    assertThrows(IllegalArgumentException.class,
-        () -> new EnergyPort("BAL-SIMPLE-01", "equipment:heater", "energy:heat",
-            null, EnergyDirection.INTO_CONTROL_VOLUME, "source", EvidenceState.PROPOSED));
-    assertThrows(IllegalArgumentException.class,
-        () -> new EnergyFlow("BAL-SIMPLE-01", "energy:heat", 0.0, "W", "ENERGY_RATE",
-            "source", "provenance", null));
+        () -> new EnergyFlow("BAL-SIMPLE-01", "energy:heat", 0.0, "W", "ENERGY_RATE", "source", "provenance", null));
   }
 
   @Test
   void propagatesInvalidSourceBalanceState() {
     Fixture fixture = fixture();
-    EngineeringDiagramBalanceTable invalidSource =
-        EngineeringDiagramBalanceTable.fromStreamTable(fixture.streamTable,
-            Collections.<Boundary>emptyList());
+    EngineeringDiagramBalanceTable invalidSource = EngineeringDiagramBalanceTable.fromStreamTable(fixture.streamTable,
+        Collections.<Boundary>emptyList());
 
-    EngineeringDiagramEnergyBalanceTable table =
-        EngineeringDiagramEnergyBalanceTable.fromBalanceTable(invalidSource, completePorts(),
-            completeFlows());
+    EngineeringDiagramEnergyBalanceTable table = EngineeringDiagramEnergyBalanceTable.fromBalanceTable(invalidSource,
+        completePorts(), completeFlows());
 
     assertFalse(table.isValid());
     assertTrue(hasDiagnostic(table, "ENERGY_BALANCE_SOURCE_INVALID"));
@@ -173,76 +156,62 @@ class EngineeringDiagramEnergyBalanceTableTest {
   }
 
   private static Fixture fixture() {
-    EngineeringDiagramReferenceFixtures.SystemCase reference =
-        EngineeringDiagramReferenceFixtures.simpleTrain();
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures.simpleTrain();
     for (StreamInterface product : reference.getProducts()) {
       reference.getProcessSystem().add(product);
     }
     reference.getProcessSystem().run();
-    EngineeringDiagramDocumentSet documents =
-        ProcessDiagramDocumentSetAdapter.fromProcessSystem(reference.getProcessSystem(),
-            reference.getCaseId(), "A", "PFD-HMB-007", "Energy balance",
-            ContentProfile.PFD, "NORMAL-01");
-    EngineeringDiagramStreamTable streamTable =
-        EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(
+        reference.getProcessSystem(), reference.getCaseId(), "A", "PFD-HMB-007", "Energy balance", ContentProfile.PFD,
+        "NORMAL-01");
+    EngineeringDiagramStreamTable streamTable = EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
     List<Boundary> boundaries = new ArrayList<Boundary>();
-    boundaries.add(new Boundary("BAL-SIMPLE-01",
-        completeRow(streamTable, reference.getFeed().getName()).getSemanticObjectId(),
-        Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED));
+    boundaries.add(
+        new Boundary("BAL-SIMPLE-01", completeRow(streamTable, reference.getFeed().getName()).getSemanticObjectId(),
+            Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED));
     for (StreamInterface product : reference.getProducts()) {
-      boundaries.add(new Boundary("BAL-SIMPLE-01",
-          completeRow(streamTable, product.getName()).getSemanticObjectId(), Direction.OUTLET,
-          "project-balance-register:test", EvidenceState.PROPOSED));
+      boundaries.add(new Boundary("BAL-SIMPLE-01", completeRow(streamTable, product.getName()).getSemanticObjectId(),
+          Direction.OUTLET, "project-balance-register:test", EvidenceState.PROPOSED));
     }
-    EngineeringDiagramBalanceTable balanceTable =
-        EngineeringDiagramBalanceTable.fromStreamTable(streamTable, boundaries);
+    EngineeringDiagramBalanceTable balanceTable = EngineeringDiagramBalanceTable.fromStreamTable(streamTable,
+        boundaries);
     return new Fixture(streamTable, balanceTable);
   }
 
   private static List<EnergyPort> completePorts() {
     return new ArrayList<EnergyPort>(Arrays.asList(
-        port("equipment:heater", "energy:heat-a", EnergyKind.HEAT_TRANSFER,
-            EnergyDirection.INTO_CONTROL_VOLUME),
-        port("equipment:heater", "energy:heat-b", EnergyKind.HEAT_TRANSFER,
-            EnergyDirection.INTO_CONTROL_VOLUME),
-        port("equipment:cooler", "energy:heat-out", EnergyKind.HEAT_TRANSFER,
-            EnergyDirection.OUT_OF_CONTROL_VOLUME),
-        port("equipment:turbine", "energy:shaft-out", EnergyKind.SHAFT_WORK,
-            EnergyDirection.OUT_OF_CONTROL_VOLUME)));
+        port("equipment:heater", "energy:heat-a", EnergyKind.HEAT_TRANSFER, EnergyDirection.INTO_CONTROL_VOLUME),
+        port("equipment:heater", "energy:heat-b", EnergyKind.HEAT_TRANSFER, EnergyDirection.INTO_CONTROL_VOLUME),
+        port("equipment:cooler", "energy:heat-out", EnergyKind.HEAT_TRANSFER, EnergyDirection.OUT_OF_CONTROL_VOLUME),
+        port("equipment:turbine", "energy:shaft-out", EnergyKind.SHAFT_WORK, EnergyDirection.OUT_OF_CONTROL_VOLUME)));
   }
 
   private static List<EnergyFlow> completeFlows() {
-    return new ArrayList<EnergyFlow>(Arrays.asList(flow("energy:heat-a", 700.0),
-        flow("energy:heat-b", 300.0), flow("energy:heat-out", 0.0),
-        flow("energy:shaft-out", 500.0)));
+    return new ArrayList<EnergyFlow>(Arrays.asList(flow("energy:heat-a", 700.0), flow("energy:heat-b", 300.0),
+        flow("energy:heat-out", 0.0), flow("energy:shaft-out", 500.0)));
   }
 
-  private static EnergyPort port(String equipmentId, String portId, EnergyKind kind,
-      EnergyDirection direction) {
-    return new EnergyPort("BAL-SIMPLE-01", equipmentId, portId, kind, direction,
-        "project-energy-register:test", EvidenceState.PROPOSED);
+  private static EnergyPort port(String equipmentId, String portId, EnergyKind kind, EnergyDirection direction) {
+    return new EnergyPort("BAL-SIMPLE-01", equipmentId, portId, kind, direction, "project-energy-register:test",
+        EvidenceState.PROPOSED);
   }
 
   private static EnergyFlow flow(String portId, double value) {
-    return new EnergyFlow("BAL-SIMPLE-01", portId, value, "W", "ENERGY_RATE",
-        "project-energy-register:test", "simulation-case:NORMAL-01",
-        EvidenceState.PROPOSED);
+    return new EnergyFlow("BAL-SIMPLE-01", portId, value, "W", "ENERGY_RATE", "project-energy-register:test",
+        "simulation-case:NORMAL-01", EvidenceState.PROPOSED);
   }
 
   private static Row completeRow(EngineeringDiagramStreamTable table, String sourceLabel) {
     for (Row row : table.getRows()) {
-      if (sourceLabel.equals(row.getSourceLabel())
-          && row.getValues().size() == Quantity.values().length) {
+      if (sourceLabel.equals(row.getSourceLabel()) && row.getValues().size() == Quantity.values().length) {
         return row;
       }
     }
     throw new AssertionError("No complete stream-table row for " + sourceLabel);
   }
 
-  private static boolean hasDiagnostic(EngineeringDiagramEnergyBalanceTable table,
-      String code) {
-    for (EngineeringDiagramEnergyBalanceTable.Diagnostic diagnostic :
-        table.getDiagnostics()) {
+  private static boolean hasDiagnostic(EngineeringDiagramEnergyBalanceTable table, String code) {
+    for (EngineeringDiagramEnergyBalanceTable.Diagnostic diagnostic : table.getDiagnostics()) {
       if (code.equals(diagnostic.getCode())) {
         return true;
       }
@@ -254,8 +223,7 @@ class EngineeringDiagramEnergyBalanceTableTest {
     private final EngineeringDiagramStreamTable streamTable;
     private final EngineeringDiagramBalanceTable balanceTable;
 
-    private Fixture(EngineeringDiagramStreamTable streamTable,
-        EngineeringDiagramBalanceTable balanceTable) {
+    private Fixture(EngineeringDiagramStreamTable streamTable, EngineeringDiagramBalanceTable balanceTable) {
       this.streamTable = streamTable;
       this.balanceTable = balanceTable;
     }

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramEnergyBalanceTableTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramEnergyBalanceTableTest.java
@@ -1,0 +1,263 @@
+package neqsim.process.processmodel.diagram;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Balance;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Boundary;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.Direction;
+import neqsim.process.engineering.model.EngineeringDiagramBalanceTable.EvidenceState;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
+import neqsim.process.engineering.model.EngineeringDiagramEnergyBalanceTable;
+import neqsim.process.engineering.model.EngineeringDiagramEnergyBalanceTable.EnergyBalance;
+import neqsim.process.engineering.model.EngineeringDiagramEnergyBalanceTable.EnergyDirection;
+import neqsim.process.engineering.model.EngineeringDiagramEnergyBalanceTable.EnergyFlow;
+import neqsim.process.engineering.model.EngineeringDiagramEnergyBalanceTable.EnergyKind;
+import neqsim.process.engineering.model.EngineeringDiagramEnergyBalanceTable.EnergyPort;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Quantity;
+import neqsim.process.engineering.model.EngineeringDiagramStreamTable.Row;
+import neqsim.process.equipment.stream.StreamInterface;
+import org.junit.jupiter.api.Test;
+
+/** Regression tests for explicit, deterministic heat/work energy-balance closure. */
+class EngineeringDiagramEnergyBalanceTableTest {
+
+  @Test
+  void closesExplicitParallelHeatAndShaftWorkPorts() {
+    Fixture fixture = fixture();
+    List<EnergyPort> ports = completePorts();
+    List<EnergyFlow> flows = completeFlows();
+
+    EngineeringDiagramEnergyBalanceTable table =
+        EngineeringDiagramEnergyBalanceTable.fromBalanceTable(
+            fixture.balanceTable, ports, flows);
+
+    assertTrue(table.isValid());
+    assertEquals(1, table.getEnergyBalances().size());
+    EnergyBalance energy = table.getEnergyBalances().get(0);
+    Balance source = fixture.balanceTable.getBalances().get(0);
+    assertEquals("BAL-SIMPLE-01", energy.getBalanceId());
+    assertEquals(4, energy.getDeclaredPortCount());
+    assertEquals(4, energy.getSuppliedFlowCount());
+    assertEquals(source.getInletStreamEnthalpyFlow(), energy.getInletStreamEnthalpyFlow(),
+        1.0e-12);
+    assertEquals(source.getOutletStreamEnthalpyFlow(), energy.getOutletStreamEnthalpyFlow(),
+        1.0e-12);
+    assertEquals(1000.0, energy.getHeatTransferIntoControlVolume(), 1.0e-12);
+    assertEquals(0.0, energy.getHeatTransferOutOfControlVolume(), 1.0e-12);
+    assertEquals(0.0, energy.getShaftWorkIntoControlVolume(), 1.0e-12);
+    assertEquals(500.0, energy.getShaftWorkOutOfControlVolume(), 1.0e-12);
+    assertEquals(source.getStreamEnthalpyResidual() + 500.0, energy.getEnergyResidual(),
+        1.0e-8);
+    assertTrue(Double.isFinite(energy.getRelativeEnergyResidual()));
+    assertTrue(energy.isComplete());
+    assertFalse(table.getSourceBalanceTableFingerprint().isEmpty());
+    assertNotSame(table.getEnergyPorts(), table.getEnergyPorts());
+    assertNotSame(table.getEnergyFlows(), table.getEnergyFlows());
+    assertNotSame(table.getEnergyBalances(), table.getEnergyBalances());
+    assertNotSame(table.getDiagnostics(), table.getDiagnostics());
+    assertThrows(UnsupportedOperationException.class, () -> table.getEnergyPorts().clear());
+    assertTrue(table.toJson().contains("\"energyFlowUnit\": \"W\""));
+    assertTrue(table.toJson().contains("\"quantityBasis\": \"ENERGY_RATE\""));
+    assertTrue(table.toJson().contains("\"provenance\": \"simulation-case:NORMAL-01\""));
+  }
+
+  @Test
+  void isDeterministicForFreshSystemsAndInputOrder() {
+    Fixture firstFixture = fixture();
+    Fixture secondFixture = fixture();
+    List<EnergyPort> firstPorts = completePorts();
+    List<EnergyFlow> firstFlows = completeFlows();
+    List<EnergyPort> secondPorts = completePorts();
+    List<EnergyFlow> secondFlows = completeFlows();
+    Collections.reverse(secondPorts);
+    Collections.reverse(secondFlows);
+
+    EngineeringDiagramEnergyBalanceTable first =
+        EngineeringDiagramEnergyBalanceTable.fromBalanceTable(
+            firstFixture.balanceTable, firstPorts, firstFlows);
+    EngineeringDiagramEnergyBalanceTable second =
+        EngineeringDiagramEnergyBalanceTable.fromBalanceTable(
+            secondFixture.balanceTable, secondPorts, secondFlows);
+
+    assertEquals(first.toJson(), second.toJson());
+  }
+
+  @Test
+  void diagnosesDuplicateUnknownInvalidAndMissingEnergyEvidence() {
+    Fixture fixture = fixture();
+    EnergyPort heat = port("equipment:heater", "energy:heat", EnergyKind.HEAT_TRANSFER,
+        EnergyDirection.INTO_CONTROL_VOLUME);
+    EnergyPort work = port("equipment:compressor", "energy:work", EnergyKind.SHAFT_WORK,
+        EnergyDirection.INTO_CONTROL_VOLUME);
+    EnergyFlow heatFlow = flow("energy:heat", 1000.0);
+    List<EnergyPort> ports = new ArrayList<EnergyPort>(Arrays.asList(heat, heat, work,
+        new EnergyPort("BAL-MISSING", "equipment:unknown", "energy:unknown",
+            EnergyKind.HEAT_TRANSFER, EnergyDirection.OUT_OF_CONTROL_VOLUME,
+            "project-energy-register:test", EvidenceState.PROPOSED)));
+    List<EnergyFlow> flows = new ArrayList<EnergyFlow>(Arrays.asList(heatFlow, heatFlow,
+        new EnergyFlow("BAL-SIMPLE-01", "energy:work", Double.NaN, "kW", "ENERGY_RATE",
+            "project-energy-register:test", "simulation-case:NORMAL-01",
+            EvidenceState.PROPOSED),
+        flow("energy:missing", 5.0)));
+
+    EngineeringDiagramEnergyBalanceTable table =
+        EngineeringDiagramEnergyBalanceTable.fromBalanceTable(
+            fixture.balanceTable, ports, flows);
+
+    assertFalse(table.isValid());
+    assertFalse(table.getEnergyBalances().get(0).isComplete());
+    assertTrue(hasDiagnostic(table, "ENERGY_PORT_DUPLICATE"));
+    assertTrue(hasDiagnostic(table, "ENERGY_PORT_UNKNOWN_BALANCE"));
+    assertTrue(hasDiagnostic(table, "ENERGY_FLOW_DUPLICATE"));
+    assertTrue(hasDiagnostic(table, "ENERGY_FLOW_UNKNOWN_PORT"));
+    assertTrue(hasDiagnostic(table, "ENERGY_FLOW_VALUE_INVALID"));
+    assertTrue(hasDiagnostic(table, "ENERGY_FLOW_MISSING"));
+    assertTrue(table.toJson().contains("\"nonFiniteResult\": \"NaN\""));
+  }
+
+  @Test
+  void requiresExplicitPortsFlowsAndValidArguments() {
+    Fixture fixture = fixture();
+
+    EngineeringDiagramEnergyBalanceTable empty =
+        EngineeringDiagramEnergyBalanceTable.fromBalanceTable(fixture.balanceTable,
+            Collections.<EnergyPort>emptyList(), Collections.<EnergyFlow>emptyList());
+
+    assertFalse(empty.isValid());
+    assertFalse(empty.getEnergyBalances().get(0).isComplete());
+    assertTrue(hasDiagnostic(empty, "ENERGY_PORT_NOT_DECLARED"));
+    assertTrue(hasDiagnostic(empty, "ENERGY_FLOW_NOT_DECLARED"));
+    assertTrue(hasDiagnostic(empty, "ENERGY_PORT_MISSING_FOR_BALANCE"));
+    assertThrows(IllegalArgumentException.class,
+        () -> EngineeringDiagramEnergyBalanceTable.fromBalanceTable(null,
+            Collections.<EnergyPort>emptyList(), Collections.<EnergyFlow>emptyList()));
+    assertThrows(IllegalArgumentException.class,
+        () -> EngineeringDiagramEnergyBalanceTable.fromBalanceTable(fixture.balanceTable,
+            null, Collections.<EnergyFlow>emptyList()));
+    assertThrows(IllegalArgumentException.class,
+        () -> EngineeringDiagramEnergyBalanceTable.fromBalanceTable(fixture.balanceTable,
+            Collections.<EnergyPort>emptyList(), null));
+    assertThrows(IllegalArgumentException.class,
+        () -> new EnergyPort("BAL-SIMPLE-01", "equipment:heater", "energy:heat",
+            null, EnergyDirection.INTO_CONTROL_VOLUME, "source", EvidenceState.PROPOSED));
+    assertThrows(IllegalArgumentException.class,
+        () -> new EnergyFlow("BAL-SIMPLE-01", "energy:heat", 0.0, "W", "ENERGY_RATE",
+            "source", "provenance", null));
+  }
+
+  @Test
+  void propagatesInvalidSourceBalanceState() {
+    Fixture fixture = fixture();
+    EngineeringDiagramBalanceTable invalidSource =
+        EngineeringDiagramBalanceTable.fromStreamTable(fixture.streamTable,
+            Collections.<Boundary>emptyList());
+
+    EngineeringDiagramEnergyBalanceTable table =
+        EngineeringDiagramEnergyBalanceTable.fromBalanceTable(invalidSource, completePorts(),
+            completeFlows());
+
+    assertFalse(table.isValid());
+    assertTrue(hasDiagnostic(table, "ENERGY_BALANCE_SOURCE_INVALID"));
+    assertTrue(hasDiagnostic(table, "ENERGY_PORT_UNKNOWN_BALANCE"));
+  }
+
+  private static Fixture fixture() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference =
+        EngineeringDiagramReferenceFixtures.simpleTrain();
+    for (StreamInterface product : reference.getProducts()) {
+      reference.getProcessSystem().add(product);
+    }
+    reference.getProcessSystem().run();
+    EngineeringDiagramDocumentSet documents =
+        ProcessDiagramDocumentSetAdapter.fromProcessSystem(reference.getProcessSystem(),
+            reference.getCaseId(), "A", "PFD-HMB-007", "Energy balance",
+            ContentProfile.PFD, "NORMAL-01");
+    EngineeringDiagramStreamTable streamTable =
+        EngineeringDiagramStreamTable.fromDocumentSet(documents, "NORMAL-01");
+    List<Boundary> boundaries = new ArrayList<Boundary>();
+    boundaries.add(new Boundary("BAL-SIMPLE-01",
+        completeRow(streamTable, reference.getFeed().getName()).getSemanticObjectId(),
+        Direction.INLET, "project-balance-register:test", EvidenceState.PROPOSED));
+    for (StreamInterface product : reference.getProducts()) {
+      boundaries.add(new Boundary("BAL-SIMPLE-01",
+          completeRow(streamTable, product.getName()).getSemanticObjectId(), Direction.OUTLET,
+          "project-balance-register:test", EvidenceState.PROPOSED));
+    }
+    EngineeringDiagramBalanceTable balanceTable =
+        EngineeringDiagramBalanceTable.fromStreamTable(streamTable, boundaries);
+    return new Fixture(streamTable, balanceTable);
+  }
+
+  private static List<EnergyPort> completePorts() {
+    return new ArrayList<EnergyPort>(Arrays.asList(
+        port("equipment:heater", "energy:heat-a", EnergyKind.HEAT_TRANSFER,
+            EnergyDirection.INTO_CONTROL_VOLUME),
+        port("equipment:heater", "energy:heat-b", EnergyKind.HEAT_TRANSFER,
+            EnergyDirection.INTO_CONTROL_VOLUME),
+        port("equipment:cooler", "energy:heat-out", EnergyKind.HEAT_TRANSFER,
+            EnergyDirection.OUT_OF_CONTROL_VOLUME),
+        port("equipment:turbine", "energy:shaft-out", EnergyKind.SHAFT_WORK,
+            EnergyDirection.OUT_OF_CONTROL_VOLUME)));
+  }
+
+  private static List<EnergyFlow> completeFlows() {
+    return new ArrayList<EnergyFlow>(Arrays.asList(flow("energy:heat-a", 700.0),
+        flow("energy:heat-b", 300.0), flow("energy:heat-out", 0.0),
+        flow("energy:shaft-out", 500.0)));
+  }
+
+  private static EnergyPort port(String equipmentId, String portId, EnergyKind kind,
+      EnergyDirection direction) {
+    return new EnergyPort("BAL-SIMPLE-01", equipmentId, portId, kind, direction,
+        "project-energy-register:test", EvidenceState.PROPOSED);
+  }
+
+  private static EnergyFlow flow(String portId, double value) {
+    return new EnergyFlow("BAL-SIMPLE-01", portId, value, "W", "ENERGY_RATE",
+        "project-energy-register:test", "simulation-case:NORMAL-01",
+        EvidenceState.PROPOSED);
+  }
+
+  private static Row completeRow(EngineeringDiagramStreamTable table, String sourceLabel) {
+    for (Row row : table.getRows()) {
+      if (sourceLabel.equals(row.getSourceLabel())
+          && row.getValues().size() == Quantity.values().length) {
+        return row;
+      }
+    }
+    throw new AssertionError("No complete stream-table row for " + sourceLabel);
+  }
+
+  private static boolean hasDiagnostic(EngineeringDiagramEnergyBalanceTable table,
+      String code) {
+    for (EngineeringDiagramEnergyBalanceTable.Diagnostic diagnostic :
+        table.getDiagnostics()) {
+      if (code.equals(diagnostic.getCode())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static final class Fixture {
+    private final EngineeringDiagramStreamTable streamTable;
+    private final EngineeringDiagramBalanceTable balanceTable;
+
+    private Fixture(EngineeringDiagramStreamTable streamTable,
+        EngineeringDiagramBalanceTable balanceTable) {
+      this.streamTable = streamTable;
+      this.balanceTable = balanceTable;
+    }
+  }
+}


### PR DESCRIPTION
## Roadmap

Coordinates #1332 and #2899 as one engineering-diagram implementation lane. This is the dependency-ready equipment heat/work closure tranche after merged component balances #3049.

Base: `360699de810894cd789d23a2d1e1c822616b58ed`
Publication head: `6021975e74224c5ec1d1d7fa1179cc6f5bfdaf84`
Branch: `agent/diagram-energy-balance-closure`

## Engineering question

Can the governed explicit-boundary balance model form a complete first-law residual without guessing equipment-duty signs, collapsing parallel energy connections, reading live equipment state, or changing any existing diagram/export API?

## Complete tranche

- adds immutable, serializable `EngineeringDiagramEnergyBalanceTable` as an opt-in companion to `EngineeringDiagramBalanceTable`
- declares stable balance, equipment/control-volume, and distinct energy-port identities
- distinguishes heat transfer from shaft work and requires explicit direction into or out of the control volume
- requires one explicit non-negative zero or non-zero `W` / `ENERGY_RATE` value per port
- retains source references, calculation provenance, and proposed/reviewed evidence state
- preserves parallel energy connections through distinct stable port IDs
- aggregates inlet/outlet stream enthalpy, heat transfer, shaft work, total energy input/output, absolute residual, and relative residual
- reports declared/supplied counts and an explicit completeness flag
- emits deterministic JSON and a source-balance fingerprint
- diagnoses invalid source balances, absent/unknown/duplicate ports, absent/unknown/duplicate flows, missing values, non-finite or negative values, and wrong unit/basis evidence
- adds fresh-system/input-order determinism, parallel-port aggregation, immutability, provenance, formula, completeness, and diagnostic regressions
- documents the public API, formula, compatibility boundary, and engineering limitations

## Balance convention

Every energy-flow value is non-negative. Its sign in the balance comes only from the port declaration.

`totalEnergyIn = inletStreamEnthalpyFlow + heatTransferIn + shaftWorkIn`

`totalEnergyOut = outletStreamEnthalpyFlow + heatTransferOut + shaftWorkOut`

`energyResidual = totalEnergyIn - totalEnergyOut`

The relative residual uses the larger absolute total and is zero when both totals are zero. A balance is complete only when the source stream-enthalpy terms are complete, at least one energy port is explicitly declared, and every declared port has one usable value.

## Semantics and limitations

This API does not read live heater, cooler, compressor, pump, or expander duties. It does not infer sign conventions, invent absent zeroes, apply project tolerances, reconcile measurements, or approve a balance. `REVIEWED` records evidence review only; it does not approve a PFD, P&ID, simulation result, duty, balance, or design data.

No standards-conformance claim is made. A P&ID remains an engineering proposal until accountable design data and review exist.

## Compatibility

This is an additive companion projection. Existing public APIs and controlled-document JSON remain unchanged. Classic DOT/Graphviz, native SVG/PDF PFD, DEXPI 2.0 Process exchange, and Proteus/DEXPI P&ID behavior are not modified.

## Documentation impact

Updated `docs/integration/engineering-diagram-document-model.md` with a complete public example, definitions, diagnostics, compatibility behavior, and the focused regression command. The test exercises the documented constructor and factory API. No notebook changed.

## Validation

**READY TO MERGE** at exact head `6021975e74224c5ec1d1d7fa1179cc6f5bfdaf84`.

Hosted exact-head evidence:

- dedicated Spotless format patch workflow passed with a verified zero-byte patch
- pre-commit checks and documentation search coverage passed
- PaperLab Replication Gate and CodeQL Security Analysis passed
- both engineering notebook workflows passed
- Java 21 Javadocs passed
- Java 21 Ubuntu and Windows fast tests passed
- all four Java 21 Ubuntu slow-test shards passed
- Java 8 Ubuntu and Windows tests passed

Additional local/connector evidence:

- `python devtools/check_documentation_search.py`: passed (653 Markdown pages and 1 standalone HTML page)
- trailing-whitespace and 120-column audits of the two new Java files and changed guide: clean
- final diff is exactly the intended production class, focused regression test, and documentation guide
- published blob SHAs match the reviewed source blobs
- mergeability, final diff, and all human/Copilot comments, reviews, and inline threads were rechecked at this head

Unavailable locally and not claimed as local passes:

- direct Spotless apply/check: Maven wrapper initialization was blocked by the runtime's read-only default Maven home
- focused/broader Maven tests and Javadocs: Maven/Javac unavailable
- local pre-commit/pre-push: `pre-commit` unavailable

The complete hosted matrix is authoritative for this exact head. The PR remains draft; this classification does not mark it ready, merge it, or enable auto-merge.

## Scope boundary and next dependency

No data reconciliation, tolerance inference, live equipment mapping, layout/rendering change, or downstream Huldra/public-dataset work is included. After merge, tolerance-based data reconciliation remains a distinct engineering dependency.