### PR TITLE
fix(twofluid): reconcile TwoFluidPipe steady state with OLGA 2025.1

### DIFF
--- a/.github/skills/neqsim-flow-assurance/SKILL.md
+++ b/.github/skills/neqsim-flow-assurance/SKILL.md
@@ -438,26 +438,41 @@ for (double qgMSm3d : gasRates) {
 > `setSteadyStateMaxWallClockTime(...)` (default 300 s) before blaming the model
 > if `isSteadyStateWallClockLimited()` is true.
 
-> **On a long undulating line, terrain used to prevent convergence — fixed, but
-> know the symptom.** The steady solve integrated `LiquidAccumulationTracker`
-> once per sweep with a nominal `dt`, and that tracker only ever adds liquid,
-> ratchets its volume up to what the sections already hold, then adds it back on
-> top of that holdup. It has no fixed point, so valley sections climbed to the
-> 0.85/0.95 cap and the profile never settled — measured on a 73.8 km export line
-> as a ΔP 43–219% above OLGA at 4/7/10/12 MSm3/d, none converged. The tracker is
-> no longer integrated during the steady solve (a steady state carries zero net
-> accumulation); terrain now acts only through the algebraic Froude-based
-> `applyTerrainAccumulation`, and it is still integrated in `runTransient` where
-> `dt` is physical time. If you ever see a `TwoFluidPipe` steady profile with a
-> section sitting exactly on a holdup cap, suspect this class of defect.
+> **Three defects that made this model disagree with OLGA — all fixed, but the
+> symptoms are generic and worth recognising elsewhere.**
+> (1) *A time integrator inside a fixed-point sweep.* The steady solve integrated
+> `LiquidAccumulationTracker` once per iteration with a nominal `dt`; that tracker
+> only ever adds liquid, ratchets its volume up to what the sections already hold,
+> then adds it back on top of that holdup, so it has no fixed point. Valley
+> sections climbed to the 0.85/0.95 cap and the profile never settled.
+> (2) *A correlation overriding a solved momentum balance.* The minimum-slip
+> constraint applied the Beggs and Brill horizontal holdup correlation as a lower
+> bound in every regime. It is fitted to 1–1.5 inch air-water loops at
+> near-atmospheric pressure with λ_L ≥ 0.01; the benchmark line runs λ_L ≈ 0.008
+> in a 14-inch pipe at 200 bara, and the floor was binding in EVERY section — so
+> the reported holdup was the correlation (≈3x OLGA), worth ≈+20% on ΔP through the
+> mixture density. Only the scale-free `lambdaL * minimumSlipFactor` bound remains.
+> (3) *Convergence declared without re-evaluating thermodynamics.* The flash runs
+> every `ssFlashInterval` sweeps but the "flash moved nothing" flag started false,
+> so a non-flash sweep read as settled. The solve could exit after ONE sweep on
+> densities it had never revisited.
+> If you see a steady profile with a section sitting exactly on a cap, or
+> `getSteadyStateIterationsUsed()` returning 1 on a long line, suspect these.
 
-> **Measured ΔP accuracy vs OLGA 2025.1** on that line at default settings:
-> a consistent **+19 to +23%** (12.15 vs 10.15 bar at 4 MSm3/d; 96.29 vs 78.50 at
-> 10), grid-converged (160 vs 320 sections within 0.4%), so it is a closure error,
-> not a mesh error. Arrival temperature is cold by the amount that extra expansion
-> implies (2.05 vs 8.38 C at 10 MSm3/d). 12 MSm3/d, which OLGA delivers, hits the
-> model's pressure floor — the same over-prediction expressed as lost
-> deliverability.
+> **Measured ΔP accuracy vs OLGA 2025.1** on that line at default settings, after
+> those fixes: **within 6% across a 3x rate range** — 10.73 vs 10.15 bar at
+> 4 MSm3/d, 35.49 vs 33.60 at 7, 79.58 vs 78.50 at 10, 138.70 vs 138.72 at 12.
+> Arrival temperature within 0.7–3.5 K. The rate exponent in ΔP ~ rate^n is
+> 2.14 / 2.26 / 3.06 against OLGA's 2.14 / 2.38 / 3.12, so the density feedback
+> along the line is reproduced, not just the level at one rate. 10 MW of DEH raises
+> arrival T by 17.4 K (OLGA 19.4) and ΔP by 15.0% (OLGA 12.3%). Grid-converged.
+> Still indicative: local holdup at low rate is dominated by single terrain trap
+> sections. And **the three-phase free-water case does not converge** — 15 m3/hr
+> of free water on the same line is wall-clock limited after 4078 iterations at a
+> 1200 s budget (88.6 bar vs OLGA 104.1). ΔP is identical between a 300 s and a
+> 1200 s budget, so the profile is stationary and the criterion is stalling on the
+> three-phase liquid split — but `isSteadyStateConverged()` is false, so the
+> number must not be quoted. ALWAYS check it on a water-bearing line.
 
 > **`TwoFluidPipe` also fails silently when a line has no deliverability.** The
 > marching solver clamps section pressure at a 1 bara floor; that clamp is a
@@ -468,15 +483,12 @@ for (double qgMSm3d : gasRates) {
 > reported. `PipeBeggsAndBrills` throws `Outlet pressure is negative` and OLGA
 > aborts with `PRESSURE ABOVE TABLE VALUES` on the same condition.
 
-> **`TwoFluidPipe` holdup runs 2–4x OLGA, and its ΔP can be blind to temperature.**
-> On a 73.8 km gas-condensate export line at matched inlet conditions: arrival
-> holdup 0.064 vs OLGA 0.023 dry, and 0.119 vs 0.034 with 15 m³/hr free water
-> (slip ratio ≈10 against OLGA's ≈3). The three-phase bookkeeping is sound —
-> gas/oil/water fractions sum to one and stay in range at every node — so the gap
-> is in the slip closure. Separately, adding 10 MW of DEH raised arrival
-> temperature 22 K but left ΔP unchanged to five figures, where OLGA moved +12.3%
-> and B&B +23.4%. Do not quote `TwoFluidPipe` holdup or inventory as a design
-> number, and treat ΔP from a case whose temperature field changes as indicative.
+> **`TwoFluidPipe` holdup at low rate is dominated by terrain trap sections.**
+> Mean holdup and ΔP agree with OLGA on the benchmarked line, but the MAXIMUM
+> holdup at 4 and 7 MSm3/d sits well above it (a single valley section), so do not
+> quote local `TwoFluidPipe` holdup or valley inventory as a design number. The
+> three-phase bookkeeping is sound — gas/oil/water fractions sum to one and stay in
+> range at every node.
 
 > **Direct electrical heating (DEH)** is available on both models with the same
 > convention — the power set is what reaches the fluid, so cable and coating

--- a/.github/skills/neqsim-flow-assurance/SKILL.md
+++ b/.github/skills/neqsim-flow-assurance/SKILL.md
@@ -466,8 +466,15 @@ for (double qgMSm3d : gasRates) {
 > 2.14 / 2.26 / 3.06 against OLGA's 2.14 / 2.38 / 3.12, so the density feedback
 > along the line is reproduced, not just the level at one rate. 10 MW of DEH raises
 > arrival T by 17.4 K (OLGA 19.4) and ΔP by 15.0% (OLGA 12.3%). Grid-converged.
-> Still indicative: local holdup at low rate is dominated by single terrain trap
-> sections. And **the three-phase free-water case does not converge** — 15 m3/hr
+> Still indicative: **low-point terrain accumulation is ~9x too strong.** A
+> section-by-section holdup comparison at 4 MSm3/d puts 316 of 320 sections within
+> 0.82-0.94 of OLGA (median 0.0201 vs 0.0235), but four terrain low points run
+> 4.6-8.8x OLGA. Scale-free: OLGA lifts its max holdup to 1.26x its own median,
+> this model to 11.0x. `applyTerrainAccumulation` multiplies three proxies for the
+> same effect (Froude up to 11, pooling up to 4, depth up to 6), compounding to
+> order 100 before an arbitrary 0.85 clip. ΔP is barely affected (1.2% of
+> sections) — but do NOT quote valley inventory, slug volume or cooldown from it.
+> And **the three-phase free-water case does not converge** — 15 m3/hr
 > of free water on the same line is wall-clock limited after 4078 iterations at a
 > 1200 s budget (88.6 bar vs OLGA 104.1). ΔP is identical between a 300 s and a
 > 1200 s budget, so the profile is stationary and the criterion is stalling on the

--- a/docs/cookbook/pipeline-recipes.md
+++ b/docs/cookbook/pipeline-recipes.md
@@ -454,11 +454,13 @@ for step in range(600):  # 5 minutes @ 0.5s steps
 | Direct electrical heating | ✅ | ✅ |
 
 **Accuracy caveats.** Benchmarked against OLGA 2025.1 on a 73.8 km subsea gas-condensate export
-line at matched inlet conditions over 4–12 MSm3/d, `TwoFluidPipe` predicts pressure drop **19–23%
-high** on a dry line and about 12% low with free water, with arrival temperature cold by the amount
-that extra expansion implies — and **liquid holdup runs 2–4x OLGA**. Pressure drop also did not
-respond to a 22 K temperature change from direct electrical heating. `PipeBeggsAndBrills` was
-31–75% high on pressure drop for the same cases.
+line at matched inlet conditions over 4–12 MSm3/d, `TwoFluidPipe` predicts pressure drop **within
+6%** and arrival temperature within 0.7 to 3.5 K, and reproduces the rate exponent.
+`PipeBeggsAndBrills` was 31–59% high on pressure drop for the same cases. Local liquid holdup at low
+rate is still dominated by single terrain trap sections, so valley inventory is indicative rather
+than a design number. **The three-phase free-water case does not converge** - with 15 m3/hr of free
+water the solve is wall-clock limited and reports 88.6 bar against OLGA's 104.1, so always check
+`isSteadyStateConverged()` on a water-bearing line.
 See [Known limitations](../wiki/two_fluid_model#known-limitations).
 
 **Always check the steady-state outcome** — `run()` does not throw when the solve fails:

--- a/docs/development/CODE_PATTERNS.md
+++ b/docs/development/CODE_PATTERNS.md
@@ -378,9 +378,10 @@ double[] holdups = pipe.getLiquidHoldupProfile();
 double inventory = pipe.getLiquidInventory("m3");
 ```
 
-> Holdup from `TwoFluidPipe` runs 2-4x OLGA on benchmarked gas-condensate lines, pressure drop runs
-> 19-23% high, and it does not always respond to a temperature change. See
-> [Known limitations](../wiki/two_fluid_model#known-limitations) before using either quantitatively.
+> `TwoFluidPipe` matches OLGA within 6% on pressure drop across a 3x rate range on the benchmarked
+> gas-condensate line, but local liquid holdup at low rate is still dominated by terrain trap
+> sections. See [Known limitations](../wiki/two_fluid_model#known-limitations) before quoting valley
+> inventory quantitatively.
 
 ### Two-Fluid Pipe Benchmark (Cross-Validate vs Beggs & Brill)
 

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -1041,30 +1041,30 @@ models were given. Pressure drop, in bar:
 
 | Case | OLGA | TwoFluidPipe | PipeBeggsAndBrills |
 |------|------|--------------|--------------------|
-| Dry line, 4 MSm3/d | 10.15 | 12.15 (+19.7%) | 13.59 (+34%) |
-| Dry line, 7 MSm3/d | 33.60 | 40.09 (+19.3%) | 43.87 (+31%) |
-| Dry line, 10 MSm3/d | 78.50 | 96.29 (+22.6%) | 125.00 (+59%) |
-| Dry line, 12 MSm3/d | 138.72 | pressure floor | throws |
-| 15 m3/hr free water, 10 MSm3/d | 104.06 | 91.31 (−12.3%) | 143.94 (+38%) |
+| Dry line, 4 MSm3/d | 10.15 | 10.73 (+5.7%) | 13.59 (+34%) |
+| Dry line, 7 MSm3/d | 33.60 | 35.49 (+5.6%) | 43.87 (+31%) |
+| Dry line, 10 MSm3/d | 78.50 | 79.58 (+1.4%) | 125.00 (+59%) |
+| Dry line, 12 MSm3/d | 138.72 | 138.70 (−0.0%) | throws |
 
-Three limitations are visible in that table and should be assumed until shown otherwise:
+Arrival temperature tracks to 0.7 to 3.5 K, maximum liquid holdup is 0.021 against OLGA's 0.023 at
+10 MSm3/d, and the rate exponent in $\Delta P \sim \dot m^{\,n}$ is 2.14 / 2.26 / 3.06 against
+2.14 / 2.38 / 3.12. Adding 10 MW of direct electrical heating raises the arrival temperature 17.4 K
+against OLGA's 19.4 K and the pressure drop 15.0 per cent against 12.3 per cent. Results are
+grid-converged, at default settings.
 
-- **Pressure drop is a consistent +19 to +23% high.** The offset is grid-converged (95.86 bar at 160
-  sections against 96.29 at 320 on the 10 MSm3/d case), so it is a closure error rather than a
-  discretisation error. Arrival temperature runs cold by the amount that extra expansion implies
-  (2.05 C against OLGA's 8.38 at 10 MSm3/d).
-- **Liquid holdup runs 2–4x higher than OLGA** across dry and water-bearing cases (0.064–0.072 vs
-  0.020–0.030 dry; 0.119 vs 0.034 with water). The slip closure, not the phase bookkeeping, is
-  responsible: gas/oil/water volume fractions sum correctly and stay in range in every case. The
-  inflated mixture density is the most likely driver of the pressure-drop offset above.
-- **Pressure drop does not always respond to temperature.** Adding 10 MW of heating raised the
-  arrival temperature by 22 K but left the computed pressure drop unchanged, where OLGA moved
-  +12.3% and Beggs–Brill +23.4%. Warmer gas at fixed mass rate is less dense and
-  $\Delta P \sim G^2/\rho$, so a response is expected. Treat pressure drop from a case whose
-  temperature field changes as indicative until this is resolved.
+Remaining limitations:
 
-All observations are model-to-model on one line. They are recorded here so the model is not assumed
-to be OLGA-equivalent.
+- **Holdup at low rate is dominated by single terrain trap sections.** The maximum holdup at 4 and
+  7 MSm3/d sits well above OLGA even though the mean and the pressure drop agree, so treat local
+  holdup and valley inventory as indicative rather than as design numbers.
+- **The three-phase free-water case does not converge.** With 15 m3/hr of free water on the same
+  line the solve is wall-clock limited after 4078 iterations at a 1200 s budget, reporting 88.64 bar
+  against OLGA's 104.06. The pressure drop is identical to the 300 s run to 0.01 bar, so the profile
+  is stationary and the convergence criterion is stalling on the three-phase liquid split rather
+  than the solution diverging - but `isSteadyStateConverged()` is correctly false and the number
+  must not be quoted.
+- All observations are model-to-model on one line. They are recorded here so the model is not
+  assumed to be OLGA-equivalent.
 
 ### Implemented regression tests
 

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -1054,9 +1054,16 @@ grid-converged, at default settings.
 
 Remaining limitations:
 
-- **Holdup at low rate is dominated by single terrain trap sections.** The maximum holdup at 4 and
-  7 MSm3/d sits well above OLGA even though the mean and the pressure drop agree, so treat local
-  holdup and valley inventory as indicative rather than as design numbers.
+- **Low-point terrain accumulation is far too strong.** A section-by-section comparison at
+  4 MSm3/d puts 316 of 320 sections within 0.82 to 0.94 of OLGA, with median holdup 0.0201 against
+  0.0235 - the bulk slip closure agrees. Four sections, all terrain low points, run 4.6 to 8.8 times
+  OLGA. Expressed scale-free, OLGA raises its maximum holdup to 1.26 times its own median on this
+  line while this model raises it to 11.0 times. The cause is visible in `applyTerrainAccumulation`:
+  the low-point branch multiplies three separate proxies for the same effect - a Froude factor up to
+  11, a pooling factor up to 4 and a depth factor up to 6 - so they compound to a factor of order
+  100 before an arbitrary 0.85 clip. Pressure drop is barely affected because only 1.2% of sections
+  are involved, but valley inventory, slug volume and cooldown are not design numbers until this is
+  recalibrated against a terrain-holdup dataset.
 - **The three-phase free-water case does not converge.** With 15 m3/hr of free water on the same
   line the solve is wall-clock limited after 4078 iterations at a 1200 s budget, reporting 88.64 bar
   against OLGA's 104.06. The pressure drop is identical to the 300 s run to 0.01 bar, so the profile

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -1460,16 +1460,20 @@ For applications where empirical accuracy is preferred over mechanistic modeling
 Measured against OLGA 2025.1 on a 73.8 km subsea gas-condensate export line at matched inlet
 conditions (see [TwoFluidPipe OLGA comparison](two_fluid_model_olga_comparison#measured-comparison-against-olga-20251)):
 
-- **Pressure drop** is a consistent 19–23% above OLGA (12.15 vs 10.15 bar at 4 MSm3/d, 96.29 vs
-  78.50 at 10), and about 12% low when free water is present (91.31 vs 104.06 bar). The offset is
-  grid-converged. Beggs–Brill is 31–75% high on the same cases.
-- **Arrival temperature** runs cold by the amount the extra expansion implies (2.05 vs 8.38 C at
-  10 MSm3/d), and tracks OLGA to about 1 K once a DEH load dominates the thermal balance
-  (28.9 vs 27.8 C with 10 MW).
-- **Liquid holdup runs 2–4x OLGA** (0.064 vs 0.023 dry, 0.119 vs 0.034 with free water). The
-  three-phase bookkeeping is sound — gas, oil and water fractions sum to one and stay in range at
-  every node — so the gap is in the slip closure, and the inflated mixture density is the most
-  likely driver of the pressure-drop offset.
+- **Pressure drop** is within 6% of OLGA across 4 to 12 MSm3/d on the benchmarked line (10.73 vs
+  10.15 bar at 4 MSm3/d, 79.58 vs 78.50 at 10, 138.70 vs 138.72 at 12), and the rate exponent is
+  reproduced. Beggs–Brill is 31–59% high on the same cases.
+- **Arrival temperature** tracks OLGA to between 0.7 and 3.5 K, and responds correctly to heating:
+  10 MW of DEH raises it 17.4 K against OLGA's 19.4 K while the pressure drop rises 15.0% against
+  12.3%.
+- **Local liquid holdup at low rate is dominated by terrain trap sections.** Mean holdup and
+  pressure drop agree with OLGA, but the maximum holdup at 4 and 7 MSm3/d sits well above it, so
+  valley inventory is indicative rather than a design number.
+- **The three-phase free-water case does not converge.** With 15 m3/hr of free water the solve is
+  wall-clock limited after 4078 iterations at a 1200 s budget (88.64 bar against OLGA's 104.06).
+  The pressure drop does not move between a 300 s and a 1200 s budget, so the criterion is stalling
+  on the three-phase liquid split rather than the solution diverging. Always check
+  `isSteadyStateConverged()` on a water-bearing line.
 - **Pressure drop does not always respond to a temperature change.** Adding 10 MW of heating raised
   the arrival temperature 22 K but left the computed pressure drop unchanged, where OLGA moved
   +12.3%. Treat pressure drop from a case whose temperature field changes as indicative.

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -1466,9 +1466,11 @@ conditions (see [TwoFluidPipe OLGA comparison](two_fluid_model_olga_comparison#m
 - **Arrival temperature** tracks OLGA to between 0.7 and 3.5 K, and responds correctly to heating:
   10 MW of DEH raises it 17.4 K against OLGA's 19.4 K while the pressure drop rises 15.0% against
   12.3%.
-- **Local liquid holdup at low rate is dominated by terrain trap sections.** Mean holdup and
-  pressure drop agree with OLGA, but the maximum holdup at 4 and 7 MSm3/d sits well above it, so
-  valley inventory is indicative rather than a design number.
+- **Low-point terrain accumulation is far too strong.** At 4 MSm3/d, 316 of 320 sections are within
+  0.82 to 0.94 of OLGA, but four terrain low points run 4.6 to 8.8 times OLGA. OLGA raises its
+  maximum holdup to 1.26 times its own median on this line; this model raises it to 11.0 times.
+  Pressure drop is barely affected, but valley inventory, slug volume and cooldown are not design
+  numbers until the low-point closure is recalibrated.
 - **The three-phase free-water case does not converge.** With 15 m3/hr of free water the solve is
   wall-clock limited after 4078 iterations at a 1200 s budget (88.64 bar against OLGA's 104.06).
   The pressure drop does not move between a 300 s and a 1200 s budget, so the criterion is stalling

--- a/docs/wiki/two_fluid_model_olga_comparison.md
+++ b/docs/wiki/two_fluid_model_olga_comparison.md
@@ -690,42 +690,57 @@ engine on a 73.8 km subsea gas-condensate export line (ID 0.355 m, U = 3 W/m2K, 
 the arrival pressure secant-iterated until its computed inlet equals the 200 bara the NeqSim models
 are given, so every case is compared at the same inlet state.
 
-A rate sweep was re-measured on this line, at 320 sections. Pressure drop, in bar:
+A rate sweep was measured on this line, at 320 sections and default settings. Pressure drop, in bar:
 
 | Rate | OLGA | TwoFluidPipe | Deviation |
 |------|------|--------------|-----------|
-| 4 MSm3/d | 10.15 | 12.15 | +19.7% |
-| 7 MSm3/d | 33.60 | 40.09 | +19.3% |
-| 10 MSm3/d | 78.50 | 96.29 | +22.6% |
-| 12 MSm3/d | 138.72 | pressure floor | not delivered |
+| 4 MSm3/d | 10.15 | 10.73 | +5.7% |
+| 7 MSm3/d | 33.60 | 35.49 | +5.6% |
+| 10 MSm3/d | 78.50 | 79.58 | +1.4% |
+| 12 MSm3/d | 138.72 | 138.70 | −0.0% |
 
-**ΔP is a consistent +19 to +23% against OLGA** across 4–10 MSm3/d. That offset is grid-converged:
-160 sections gives 95.86 bar against 96.29 bar at 320 on the 10 MSm3/d case, a 0.4% spread. It is a
-closure error, not a discretisation error. 12 MSm3/d is delivered by OLGA at 138.72 bar but hits the
-model's pressure floor, which is the same over-prediction expressed as an apparent loss of
-deliverability.
+Arrival temperature tracks to between 0.7 and 3.5 K (8.36 C against 9.06 at 4 MSm3/d, 7.00 against
+8.38 at 10). Maximum liquid holdup is 0.021 against OLGA's 0.023 at 10 MSm3/d and 0.021 against
+0.020 at 12; at the two lowest rates the maximum sits in a single terrain trap section and is higher.
+The rate exponent in $\Delta P \sim \dot m^{\,n}$ is 2.14 / 2.26 / 3.06 against OLGA's
+2.14 / 2.38 / 3.12, so the density feedback along the line is reproduced rather than merely the level
+at one rate. The result is grid-converged: 160 sections gives 79.31 bar against 79.58 at 320.
 
-**Arrival temperature runs cold by the amount the extra pressure drop implies** — 8.27 C against
-9.06 at 4 MSm3/d, 11.23 against 12.86 at 7, and 2.05 against 8.38 at 10, the error growing with the
-ΔP error through the extra Joule–Thomson expansion.
+Adding 10 MW of direct electrical heating raises the arrival temperature by 17.4 K against OLGA's
+19.4 K, and the pressure drop by 15.0 per cent against OLGA's 12.3 per cent, so the energy equation
+feeds the momentum balance as it should.
 
-**Liquid holdup is 2–4x OLGA.** Maximum holdup 0.064–0.072 against OLGA's 0.020–0.030 in the
-terrain-free sections of the sweep, and 0.119 against 0.034 with 15 m3/hr free water (water 0.074 vs
-0.020, oil 0.045 vs 0.013). The phase bookkeeping is sound — gas, oil and water volume fractions sum
-to one and stay in range at every node in both codes — so the discrepancy sits in the slip closure,
-not in the three-phase accounting. The slip ratio is roughly 10 against OLGA's 3, and it is the most
-likely driver of the ΔP offset through the mixture density.
+Three defects had to be fixed to reach this agreement, and each is worth knowing about because the
+symptoms are generic:
 
-Two earlier figures on this page are superseded. The 81.20 bar (+3.4%) dry-line result came from a
-steady-state exit after a single sweep, before the section densities had been fed back into the
-momentum balance; the convergence gate that now catches this also removes the agreement. A later
-revision reported that the default configuration could not converge on this line at all — that was
-the liquid accumulation tracker being integrated once per steady-state sweep, which has since been
-removed from the steady solve (a steady state carries no net accumulation). The table above is
-produced at default settings.
+1. **A time integrator inside a fixed-point sweep.** The steady solve integrated the liquid
+   accumulation tracker once per iteration with a nominal time step. That tracker only ever adds
+   liquid, ratchets its stored volume up to what the sections already hold, and then adds it back on
+   top of the holdup that already contains it, so it has no fixed point. Valley sections climbed to
+   the holdup cap and the solve never settled.
+2. **A correlation overriding a solved momentum balance.** The minimum-slip constraint applied the
+   Beggs and Brill horizontal holdup correlation as a lower bound in every regime. That correlation
+   was fitted to 1 to 1.5 inch air-water loops at near-atmospheric pressure with no-slip fractions at
+   or above 0.01. This line runs near 0.008 in a 14-inch pipe at 200 bara, where the correlation is
+   an extrapolation in diameter, pressure, fluid and liquid loading at once - and it was binding in
+   every section, so the reported holdup was the correlation, about three times OLGA, which carried
+   roughly twenty per cent onto the pressure drop through the mixture density.
+3. **Convergence declared without re-evaluating thermodynamics.** The flash runs every few sweeps,
+   but the flag recording that it had not moved the densities started false, so on a non-flash sweep
+   it read as "nothing moved" when in truth nothing had been checked. The solve could exit after a
+   single sweep on densities it had never revisited, which showed up as a step in pressure drop
+   against terrain amplitude.
 
-These are model-to-model comparisons on one line, and are recorded so the model is not assumed to be
-OLGA-equivalent despite sharing its modelling class.
+The remaining limitation is that liquid holdup and pressure drop are still model-to-model results on
+one line, recorded so the model is not assumed to be OLGA-equivalent despite sharing its modelling
+class. Two cases remain open: local holdup at low rate is dominated by single terrain trap sections,
+and the three-phase free-water case does not converge - with 15 m3/hr of free water the solve is
+wall-clock limited after 4078 iterations at a 1200 s budget and reports 88.64 bar against OLGA's
+104.06, with the pressure drop unchanged between a 300 s and a 1200 s budget, so the criterion is
+stalling on the three-phase liquid split rather than the solution diverging. An earlier revision of
+this page reported 81.20 bar (+3.4%) on the dry line together with a pressure drop that did not
+respond to temperature; that figure came from a steady-state exit after a single sweep and is
+superseded by the table above.
 
 ### Public severe-slugging benchmark
 

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -1445,7 +1445,9 @@ public class TwoFluidPipe extends Pipeline {
       // TP-flash for every section is the dominant expense; sparse updates are sufficient
       // because properties change slowly with small pressure changes between iterations.
       boolean thermodynamicsRefreshed = false;
+      boolean thermodynamicsEvaluated = referenceFluid == null;
       if (referenceFluid != null && (iter % ssFlashInterval == 0)) {
+        thermodynamicsEvaluated = true;
         double[] densityBefore = new double[numberOfSections];
         for (int i = 0; i < numberOfSections; i++) {
           densityBefore[i] = sections[i].getGasDensity();
@@ -1487,7 +1489,13 @@ public class TwoFluidPipe extends Pipeline {
           : Math.abs(totalDrop - previousTotalDrop) / Math.max(Math.abs(totalDrop), 1.0e3);
       previousTotalDrop = totalDrop;
 
-      boolean profileSettled = !densityCouplingMatters || (dropChange < tolerance && !thermodynamicsRefreshed);
+      // The flash runs only every ssFlashInterval sweeps, and thermodynamicsRefreshed starts false, so on a
+      // non-flash sweep it reports "the flash moved nothing" when in truth no flash was performed. Convergence
+      // was therefore reachable on a sweep whose densities had never been re-evaluated - observed as an exit at
+      // iteration 1 that returned a pressure drop several per cent away from the settled value. Require a sweep
+      // in which the thermodynamics was actually evaluated and found stationary.
+      boolean profileSettled = !densityCouplingMatters
+          || (dropChange < tolerance && thermodynamicsEvaluated && !thermodynamicsRefreshed);
       if (maxChange < tolerance && profileSettled) {
         // A section resting on the pressure floor is a fixed point of the clamp, not of the
         // momentum balance: marchPressure keeps returning the floor, the under-relaxed update
@@ -2574,26 +2582,15 @@ public class TwoFluidPipe extends Pipeline {
       // Apply terrain accumulation enhancement
       alphaL = applyTerrainAccumulation(sec, prev, alphaL);
 
-      // Apply minimum slip constraint based on physics-based correlation
-      // Use Beggs-Brill type correlation: αL = C × λL^a / Fr^b
-      // This gives physically reasonable holdup that increases with λL
-      // and decreases with velocity (Froude number)
+      // Apply minimum slip constraint. The bound is a multiple of the no-slip fraction, which is a
+      // statement that the slip ratio cannot fall below a given value and is therefore scale-free.
+      // It deliberately does NOT include a correlation-based term: see calculateAdaptiveMinimumHoldup.
       if (enforceMinimumSlip) {
-        double froudeNumber = vMix * vMix / (g * diameter);
-        double adaptiveMin = calculateAdaptiveMinimumHoldup(lambdaL, froudeNumber, regime);
-
-        // Clamp to physical bounds
-        // For lean gas systems (low lambdaL), use adaptive minimum based on no-slip holdup
-        // to avoid artificially high holdup floors
         double effectiveMin;
         if (useAdaptiveMinimumOnly) {
-          // No absolute floor - use only correlation-based minimum
-          // Scale with lambdaL to handle very lean systems
-          double lambdaBasedMin = lambdaL * minimumSlipFactor;
-          effectiveMin = Math.max(lambdaBasedMin, adaptiveMin);
+          effectiveMin = lambdaL * minimumSlipFactor;
         } else {
-          // Apply absolute floor (original behavior)
-          effectiveMin = Math.max(minimumLiquidHoldup, adaptiveMin);
+          effectiveMin = minimumLiquidHoldup;
         }
         effectiveMin = Math.min(0.9, effectiveMin);
 
@@ -2620,19 +2617,14 @@ public class TwoFluidPipe extends Pipeline {
         alphaL = applyTerrainAccumulation(sec, prev, alphaL);
       }
 
-      // Apply minimum slip constraint using Beggs-Brill type correlation
+      // Apply minimum slip constraint; see the parallel block above for why no correlation term
+      // is included.
       if (enforceMinimumSlip) {
-        double froudeNumber = vMix * vMix / (g * diameter);
-        double adaptiveMin = calculateAdaptiveMinimumHoldup(lambdaL, froudeNumber,
-            isStratified ? FlowRegime.STRATIFIED_SMOOTH : regime);
-
-        // Clamp to physical bounds - adaptive for lean gas systems
         double effectiveMin;
         if (useAdaptiveMinimumOnly) {
-          double lambdaBasedMin = lambdaL * minimumSlipFactor;
-          effectiveMin = Math.max(lambdaBasedMin, adaptiveMin);
+          effectiveMin = lambdaL * minimumSlipFactor;
         } else {
-          effectiveMin = Math.max(minimumLiquidHoldup, adaptiveMin);
+          effectiveMin = minimumLiquidHoldup;
         }
         effectiveMin = Math.min(0.9, effectiveMin);
 
@@ -2679,6 +2671,23 @@ public class TwoFluidPipe extends Pipeline {
 
   /**
    * Calculate a correlation-based minimum that vanishes continuously with liquid input.
+   *
+   * <p>
+   * This is the Beggs and Brill horizontal holdup correlation, fitted to 1 to 1.5 inch air-water loops at
+   * near-atmospheric pressure and no-slip liquid fractions at or above about 0.01. It is no longer used as a lower
+   * bound on the solved holdup. On a 73.8 km 14-inch high-pressure gas-condensate line at a no-slip fraction near 0.008
+   * it was binding in every section, so the reported holdup was the correlation rather than the momentum balance: about
+   * three times OLGA, which carried roughly twenty per cent onto the pressure drop through the mixture density.
+   * Restricting it to the regimes without a mechanistic closure is not a remedy either, because that makes the bound a
+   * discontinuous function of the flow map and a section flipping between annular and slug then steps between no floor
+   * and the full correlation. The remaining bound is the scale-free no-slip multiple
+   * {@code lambdaL * minimumSlipFactor}.
+   * </p>
+   *
+   * <p>
+   * The method is retained because the stratified closure uses it as the trace-liquid asymptote, where the momentum
+   * balance degenerates and a correlation is the only available value.
+   * </p>
    *
    * <p>
    * The epsilon regularizes only the Froude-number denominator. No lower bound is applied to {@code lambdaL}, so the

--- a/src/test/java/neqsim/fluidmechanics/flowsystem/twophaseflowsystem/twophasepipeflowsystem/TwoPhasePipeFlowSystemTest.java
+++ b/src/test/java/neqsim/fluidmechanics/flowsystem/twophaseflowsystem/twophasepipeflowsystem/TwoPhasePipeFlowSystemTest.java
@@ -906,19 +906,38 @@ public class TwoPhasePipeFlowSystemTest {
     assertTrue(twoFluidPipePressureDrop > 0, "TwoFluidPipe should give positive pressure drop");
     assertTrue(twoPhaseFlowSystemPressureDrop > 0, "TwoPhasePipeFlowSystem should give positive pressure drop");
 
-    // Note: These are fundamentally different physical models:
-    // - TwoFluidPipe uses a mixture/homogeneous model with average properties and mixture friction
-    // - TwoPhasePipeFlowSystem uses a separated flow model with individual phase friction factors
-    // and phase-specific hydraulic diameters
-    // The separated flow model typically predicts higher friction losses because:
-    // 1. Each phase has smaller hydraulic diameter than the full pipe diameter
-    // 2. Both phases have wall contact and contribute friction
-    // 3. Interphase friction adds additional losses
-    // Literature shows these models can differ by factor of 2-3 for high gas fraction flows.
-    // We accept up to a factor of 3.5 (250%) difference as reasonable for different
-    // modeling approaches, with margin for numerical precision and mesh discretization.
-    assertTrue(percentDiff < 250,
-        "Two-fluid models should give comparable results (< factor of 3.5). TwoFluidPipe: " + twoFluidPipePressureDrop
+    // Independent anchors were measured on this exact fixture (54 mass% gas, Re 8.5e5):
+    // a homogeneous no-slip Darcy-Weisbach integration gives 0.616 bar, which is a lower bound
+    // because it carries neither slip nor a two-phase multiplier, and PipeBeggsAndBrills gives
+    // 0.898 bar. TwoFluidPipe returns 0.845 bar - 1.37x the no-slip bound and within 6% of
+    // Beggs-Brill. TwoPhasePipeFlowSystem returns 3.489 bar, which is 5.7x the no-slip bound and
+    // 3.9x Beggs-Brill. The two anchors agree with each other and with TwoFluidPipe, so the
+    // separated-flow model in this package is the outlier rather than the process-equipment class.
+    // That is a pre-existing issue in this legacy model and is not asserted on here; what IS
+    // asserted is that TwoFluidPipe stays anchored to an independent correlation.
+    neqsim.process.equipment.stream.Stream anchorInlet = new neqsim.process.equipment.stream.Stream("anchor",
+        fluid.clone());
+    anchorInlet.setFlowRate(massFlowRate, "kg/sec");
+    anchorInlet.run();
+    neqsim.process.equipment.pipeline.PipeBeggsAndBrills anchorPipe = new neqsim.process.equipment.pipeline.PipeBeggsAndBrills(
+        "anchor-bb", anchorInlet);
+    anchorPipe.setLength(pipeLength);
+    anchorPipe.setDiameter(pipeDiameter);
+    anchorPipe.setElevation(0.0);
+    anchorPipe.setNumberOfIncrements(50);
+    anchorPipe.setRunIsothermal(true);
+    anchorPipe.run();
+    double anchorPressureDrop = anchorInlet.getPressure() - anchorPipe.getOutletStream().getPressure();
+
+    double anchorRatio = twoFluidPipePressureDrop / anchorPressureDrop;
+    assertTrue(anchorRatio > 0.5 && anchorRatio < 2.0,
+        "TwoFluidPipe must stay anchored to the Beggs-Brill correlation on a horizontal two-phase line. "
+            + "TwoFluidPipe: " + twoFluidPipePressureDrop + " bar, Beggs-Brill: " + anchorPressureDrop + " bar, ratio: "
+            + anchorRatio);
+
+    // The cross-model bound is kept only as a coarse guard against either model running away.
+    assertTrue(percentDiff < 500,
+        "Two-fluid models should stay within an order of magnitude. TwoFluidPipe: " + twoFluidPipePressureDrop
             + " bar, TwoPhasePipeFlowSystem: " + twoPhaseFlowSystemPressureDrop + " bar, diff: " + percentDiff + "%");
   }
 

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
@@ -652,8 +652,21 @@ class TwoFluidPipeBoundaryConditionTest {
         name + " liquid holdup changed across an unchanged near-zero-time handoff: RMS " + liquidHoldupRms);
     assertTrue(gasVelocityRms <= 0.10,
         name + " gas velocity changed across an unchanged near-zero-time handoff: RMS " + gasVelocityRms + " m/s");
-    assertTrue(liquidVelocityRms <= 0.05, name
-        + " liquid velocity changed across an unchanged near-zero-time handoff: RMS " + liquidVelocityRms + " m/s");
+    // Judged relative to the liquid velocity itself. An absolute bound is tied to the holdup of the
+    // particular fixture: a closure change that lowers holdup raises the liquid velocity for the same
+    // mass flux, which moves an absolute RMS without the handoff having become any less continuous.
+    // The scale-free ratio is the invariant, and an O(1) hydraulic jump - what this test guards - is
+    // order 100 per cent in it.
+    double meanLiquidSpeed = 0.0;
+    for (double velocity : liquidVelocityBefore) {
+      meanLiquidSpeed += Math.abs(velocity);
+    }
+    meanLiquidSpeed = Math.max(1.0e-12, meanLiquidSpeed / liquidVelocityBefore.length);
+    double liquidVelocityRelative = liquidVelocityRms / meanLiquidSpeed;
+    assertTrue(liquidVelocityRelative <= 0.06,
+        name + " liquid velocity changed across an unchanged near-zero-time handoff: RMS " + liquidVelocityRms
+            + " m/s, which is " + (100.0 * liquidVelocityRelative) + "% of the mean liquid speed " + meanLiquidSpeed
+            + " m/s");
     if (hasOilWaterSlip) {
       assertTrue(rmsDifferenceInterior(oilVelocityBefore, waterVelocityBefore) > 1.0e-3,
           "Three-phase regression case must exercise non-zero oil/water slip");

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeLeanGasHoldupTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeLeanGasHoldupTest.java
@@ -1,0 +1,185 @@
+package neqsim.process.equipment.pipeline;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Regression test for the holdup closure of a lean, high-pressure gas line in {@link TwoFluidPipe}.
+ *
+ * <p>
+ * The minimum-slip constraint used to apply the Beggs and Brill horizontal holdup correlation as a lower bound in every
+ * regime, including the stratified and annular regimes which already solve a mechanistic closure. That correlation was
+ * fitted to 1 to 1.5 inch air-water loops at near-atmospheric pressure with no-slip liquid fractions at or above about
+ * 0.01. On a 14-inch high-pressure gas-condensate export line running near a no-slip fraction of 0.008 it was binding
+ * in every section, so the reported holdup was the correlation rather than the solved momentum balance: roughly three
+ * times OLGA, which carried about twenty per cent onto the pressure drop through the mixture density.
+ * </p>
+ *
+ * <p>
+ * The correlation minimum is now skipped where a mechanistic closure exists. The no-slip multiple
+ * {@code lambdaL * minimumSlipFactor} still applies everywhere, since a bound on the slip ratio is dimensionally sound
+ * at any scale.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+class TwoFluidPipeLeanGasHoldupTest {
+  /** Inside diameter, in m. Large enough that the small-bore correlation is an extrapolation. */
+  private static final double DIAMETER = 0.355;
+
+  /** Pipe length, in m. */
+  private static final double LENGTH = 30000.0;
+
+  /** Wall roughness, in m. */
+  private static final double ROUGHNESS = 4.5e-5;
+
+  /** Inlet pressure, in bara. */
+  private static final double INLET_PRESSURE = 100.0;
+
+  /** Inlet temperature, in degrees Celsius. */
+  private static final double INLET_TEMPERATURE = 40.0;
+
+  /** Mass flow, in kg/hr. */
+  private static final double MASS_FLOW = 250000.0;
+
+  /** Number of finite volumes. */
+  private static final int SECTIONS = 100;
+
+  /**
+   * Builds a lean gas condensate that carries a small liquid fraction at pipeline conditions.
+   *
+   * @return a flashed fluid with its physical properties initialised
+   */
+  private SystemInterface buildFluid() {
+    SystemInterface fluid = new SystemSrkEos(273.15 + INLET_TEMPERATURE, INLET_PRESSURE);
+    fluid.addComponent("methane", 0.95);
+    fluid.addComponent("ethane", 0.03);
+    fluid.addComponent("n-heptane", 0.02);
+    fluid.setMixingRule("classic");
+    fluid.setPressure(INLET_PRESSURE, "bara");
+    fluid.setTemperature(INLET_TEMPERATURE, "C");
+    fluid.setTotalFlowRate(MASS_FLOW, "kg/hr");
+    new ThermodynamicOperations(fluid).TPflash();
+    fluid.initProperties();
+    return fluid;
+  }
+
+  /**
+   * Runs the lean gas line.
+   *
+   * @return the pipe after it has been run
+   */
+  private TwoFluidPipe runLeanGasLine() {
+    Stream stream = new Stream("feed", buildFluid());
+    stream.setFlowRate(MASS_FLOW, "kg/hr");
+    stream.setPressure(INLET_PRESSURE, "bara");
+    stream.setTemperature(INLET_TEMPERATURE, "C");
+    stream.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe("leangasline", stream);
+    pipe.setLength(LENGTH);
+    pipe.setDiameter(DIAMETER);
+    pipe.setRoughness(ROUGHNESS);
+    pipe.setNumberOfSections(SECTIONS);
+    pipe.setElevationProfile(new double[SECTIONS + 1]);
+    pipe.setIncludeEnergyEquation(true);
+    pipe.setHeatTransferCoefficient(3.0);
+    pipe.setSurfaceTemperature(4.0, "C");
+    pipe.run();
+    return pipe;
+  }
+
+  /**
+   * The slip ratio of a lean high-pressure gas line must come from the momentum balance.
+   *
+   * <p>
+   * The holdup is compared against the no-slip fraction reconstructed from the reported phase velocities, which makes
+   * the assertion independent of the absolute liquid loading of the fixture. With the correlation floor binding the
+   * ratio was near seven; the mechanistic closure gives about two and a half.
+   * </p>
+   */
+  @Test
+  @DisplayName("Lean gas holdup must follow the momentum balance, not the Beggs and Brill floor")
+  void testLeanGasHoldupIsNotSetByTheCorrelationFloor() {
+    TwoFluidPipe pipe = runLeanGasLine();
+    Assertions.assertTrue(pipe.isSteadyStateConverged(), "the lean gas line must converge");
+
+    double[] holdup = pipe.getLiquidHoldupProfile();
+    double[] gasVelocity = pipe.getGasVelocityProfile();
+    double[] liquidVelocity = pipe.getLiquidVelocityProfile();
+
+    double holdupSum = 0.0;
+    double noSlipSum = 0.0;
+    for (int i = 0; i < holdup.length; i++) {
+      double superficialGas = gasVelocity[i] * (1.0 - holdup[i]);
+      double superficialLiquid = liquidVelocity[i] * holdup[i];
+      double total = superficialGas + superficialLiquid;
+      if (total <= 0.0) {
+        continue;
+      }
+      holdupSum += holdup[i];
+      noSlipSum += superficialLiquid / total;
+    }
+
+    Assertions.assertTrue(noSlipSum > 0.0, "the fixture must carry some liquid");
+    double meanHoldup = holdupSum / holdup.length;
+    double meanNoSlip = noSlipSum / holdup.length;
+    double slipDrivenRatio = meanHoldup / meanNoSlip;
+
+    Assertions.assertTrue(slipDrivenRatio > 1.0,
+        "holdup must exceed the no-slip fraction because the gas is faster than the liquid");
+    Assertions.assertTrue(slipDrivenRatio < 4.0,
+        "holdup is " + slipDrivenRatio + " times the no-slip fraction, which indicates the small-bore "
+            + "correlation floor is overriding the mechanistic closure on a large-diameter line");
+  }
+
+  /**
+   * Releasing the minimum-slip constraint must no longer transform the answer.
+   *
+   * <p>
+   * When the correlation floor was binding in every section, switching the constraint off moved the mean holdup by a
+   * factor of five and the pressure drop by roughly twenty per cent. A closure that is actually solving the momentum
+   * balance must be far less sensitive to a bound that should only ever be a guard.
+   * </p>
+   */
+  @Test
+  @DisplayName("Releasing the minimum-slip guard must not transform a lean gas solution")
+  void testMinimumSlipGuardIsNotLoadBearing() {
+    TwoFluidPipe guarded = runLeanGasLine();
+
+    Stream stream = new Stream("feed", buildFluid());
+    stream.setFlowRate(MASS_FLOW, "kg/hr");
+    stream.setPressure(INLET_PRESSURE, "bara");
+    stream.setTemperature(INLET_TEMPERATURE, "C");
+    stream.run();
+    TwoFluidPipe released = new TwoFluidPipe("leangasline", stream);
+    released.setLength(LENGTH);
+    released.setDiameter(DIAMETER);
+    released.setRoughness(ROUGHNESS);
+    released.setNumberOfSections(SECTIONS);
+    released.setElevationProfile(new double[SECTIONS + 1]);
+    released.setIncludeEnergyEquation(true);
+    released.setHeatTransferCoefficient(3.0);
+    released.setSurfaceTemperature(4.0, "C");
+    released.setEnforceMinimumSlip(false);
+    released.run();
+
+    Assertions.assertTrue(guarded.isSteadyStateConverged(), "guarded case must converge");
+    Assertions.assertTrue(released.isSteadyStateConverged(), "released case must converge");
+
+    double[] guardedProfile = guarded.getPressureProfile();
+    double[] releasedProfile = released.getPressureProfile();
+    double guardedDrop = guardedProfile[0] - guardedProfile[guardedProfile.length - 1];
+    double releasedDrop = releasedProfile[0] - releasedProfile[releasedProfile.length - 1];
+
+    double relativeDifference = Math.abs(guardedDrop - releasedDrop) / releasedDrop;
+    Assertions.assertTrue(relativeDifference < 0.10, "the minimum-slip guard moved the pressure drop by "
+        + (100.0 * relativeDifference) + "%, so it is setting the solution rather than guarding it");
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeThermalPressureCouplingTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeThermalPressureCouplingTest.java
@@ -1,0 +1,148 @@
+package neqsim.process.equipment.pipeline;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Regression test for momentum-energy coupling in the {@link TwoFluidPipe} steady solve.
+ *
+ * <p>
+ * At fixed mass rate a gas line that is heated carries less dense gas, and the frictional gradient scales as
+ * {@code G^2 / rho}, so heating must raise the pressure drop. Earlier builds reported an arrival temperature rise of
+ * more than twenty kelvin from direct electrical heating while the computed pressure drop stayed unchanged to five
+ * figures, which meant the energy equation was not feeding the momentum balance. That symptom came from steady-state
+ * sweeps that terminated before the density field had been fed back into the pressure march.
+ * </p>
+ *
+ * <p>
+ * Measured against OLGA 2025.1 on a 73.8 km subsea gas-condensate export line at 10 MSm3/d, 10 MW of heating raises the
+ * arrival temperature by 19.4 K and the pressure drop by 12.3 per cent.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+class TwoFluidPipeThermalPressureCouplingTest {
+  /** Inside diameter, in m. */
+  private static final double DIAMETER = 0.30;
+
+  /** Pipe length, in m. */
+  private static final double LENGTH = 40000.0;
+
+  /** Wall roughness, in m. */
+  private static final double ROUGHNESS = 4.5e-5;
+
+  /** Inlet pressure, in bara. */
+  private static final double INLET_PRESSURE = 150.0;
+
+  /** Inlet temperature, in degrees Celsius. */
+  private static final double INLET_TEMPERATURE = 40.0;
+
+  /** Surrounding temperature, in degrees Celsius. */
+  private static final double SURFACE_TEMPERATURE = 4.0;
+
+  /** Overall heat transfer coefficient, in W/m2K. */
+  private static final double HEAT_TRANSFER_COEFFICIENT = 3.0;
+
+  /** Mass flow, in kg/hr. */
+  private static final double MASS_FLOW = 250000.0;
+
+  /** Number of finite volumes. */
+  private static final int SECTIONS = 120;
+
+  /** Uniform direct electrical heating, in W/m. */
+  private static final double HEATING_PER_METRE = 120.0;
+
+  /**
+   * Builds a lean gas at the inlet state.
+   *
+   * @return a flashed fluid with its physical properties initialised
+   */
+  private SystemInterface buildFluid() {
+    SystemInterface fluid = new SystemSrkEos(273.15 + INLET_TEMPERATURE, INLET_PRESSURE);
+    fluid.addComponent("methane", 0.90);
+    fluid.addComponent("ethane", 0.06);
+    fluid.addComponent("propane", 0.04);
+    fluid.setMixingRule("classic");
+    fluid.setPressure(INLET_PRESSURE, "bara");
+    fluid.setTemperature(INLET_TEMPERATURE, "C");
+    fluid.setTotalFlowRate(MASS_FLOW, "kg/hr");
+    new ThermodynamicOperations(fluid).TPflash();
+    fluid.initProperties();
+    return fluid;
+  }
+
+  /**
+   * Runs the line with the requested uniform heating.
+   *
+   * @param heatingPerMetre direct electrical heating in W/m, zero for the unheated reference
+   * @return the pipe after it has been run
+   */
+  private TwoFluidPipe runLine(double heatingPerMetre) {
+    Stream stream = new Stream("feed", buildFluid());
+    stream.setFlowRate(MASS_FLOW, "kg/hr");
+    stream.setPressure(INLET_PRESSURE, "bara");
+    stream.setTemperature(INLET_TEMPERATURE, "C");
+    stream.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe("heatedline", stream);
+    pipe.setLength(LENGTH);
+    pipe.setDiameter(DIAMETER);
+    pipe.setRoughness(ROUGHNESS);
+    pipe.setNumberOfSections(SECTIONS);
+    pipe.setElevationProfile(new double[SECTIONS + 1]);
+    pipe.setIncludeEnergyEquation(true);
+    pipe.setHeatTransferCoefficient(HEAT_TRANSFER_COEFFICIENT);
+    pipe.setSurfaceTemperature(SURFACE_TEMPERATURE, "C");
+    if (heatingPerMetre > 0.0) {
+      pipe.setDirectElectricalHeatingPowerPerMeter(heatingPerMetre);
+    }
+    pipe.run();
+    return pipe;
+  }
+
+  /**
+   * Returns the total pressure drop of a solved pipe.
+   *
+   * @param pipe a pipe that has been run
+   * @return pressure drop in Pa
+   */
+  private double pressureDrop(TwoFluidPipe pipe) {
+    double[] profile = pipe.getPressureProfile();
+    return profile[0] - profile[profile.length - 1];
+  }
+
+  /**
+   * Heating the line must raise both the arrival temperature and the pressure drop.
+   */
+  @Test
+  @DisplayName("Pressure drop must respond to a heating-driven density change")
+  void testHeatingRaisesPressureDrop() {
+    TwoFluidPipe cold = runLine(0.0);
+    TwoFluidPipe heated = runLine(HEATING_PER_METRE);
+
+    Assertions.assertTrue(cold.isSteadyStateConverged(), "unheated reference must converge");
+    Assertions.assertTrue(heated.isSteadyStateConverged(), "heated case must converge");
+
+    double coldArrival = cold.getOutletStream().getTemperature("C");
+    double heatedArrival = heated.getOutletStream().getTemperature("C");
+    Assertions.assertTrue(heatedArrival - coldArrival > 5.0,
+        "the heating load must raise the arrival temperature, but it moved only " + (heatedArrival - coldArrival)
+            + " K");
+
+    double coldDrop = pressureDrop(cold);
+    double heatedDrop = pressureDrop(heated);
+    double relativeChange = (heatedDrop - coldDrop) / coldDrop;
+
+    Assertions.assertTrue(relativeChange > 0.005,
+        "warmer gas is less dense and dP scales as G^2/rho, so the pressure drop must rise with "
+            + "heating, but it moved " + (100.0 * relativeChange) + "%");
+    Assertions.assertTrue(relativeChange < 0.60,
+        "the pressure-drop response to heating is implausibly large at " + (100.0 * relativeChange) + "%");
+  }
+}


### PR DESCRIPTION
fix(twofluid): reconcile TwoFluidPipe steady state with OLGA 2025.1

Three defects kept TwoFluidPipe from converging, or converging to the wrong
answer, on a 73.8 km subsea gas-condensate export line benchmarked against
OLGA 2025.1. Pressure drop moves from non-convergent / 43-219% high to within
6% of OLGA across a 3x rate range, and the rate exponent is reproduced.

1. A time integrator inside a fixed-point sweep. runSteadyState integrated
   LiquidAccumulationTracker once per iteration with a nominal time step. That
   tracker only ever adds liquid, ratchets its stored volume up to what the
   sections already hold, then adds it back on top of the holdup that already
   contains it, so it has no fixed point. Valley sections climbed to the holdup
   cap and the profile never settled. A steady state carries zero net
   accumulation, so the tracker is no longer integrated during the steady solve;
   zone identification is kept, and runTransient still integrates it where dt is
   physical time.

2. A correlation overriding a solved momentum balance. The minimum-slip
   constraint applied the Beggs and Brill horizontal holdup correlation as a
   lower bound in every regime. It is fitted to 1-1.5 inch air-water loops at
   near-atmospheric pressure with no-slip fractions at or above 0.01; the
   benchmark line runs near 0.008 in a 14-inch pipe at 200 bara, where it was
   binding in every section, so the reported holdup was the correlation - about
   three times OLGA, worth roughly twenty per cent on pressure drop through the
   mixture density. Only the scale-free lambdaL * minimumSlipFactor bound
   remains. The correlation is retained solely as the stratified trace-liquid
   asymptote. It must be removed uniformly: gating it by regime makes the bound
   a discontinuous function of the flow map.

3. Convergence declared without re-evaluating thermodynamics. The flash runs
   every ssFlashInterval sweeps, but the flag recording that it had not moved
   the densities starts false, so a non-flash sweep read as "nothing moved" when
   nothing had been checked. The solve could exit after one sweep on densities
   it had never revisited. Convergence now requires a sweep in which the
   thermodynamics was actually evaluated and found stationary.

Measured against OLGA at default settings, 320 sections:
   4 MSm3/d   10.73 vs  10.15 bar (+5.7%)
   7 MSm3/d   35.49 vs  33.60 bar (+5.6%)
  10 MSm3/d   79.58 vs  78.50 bar (+1.4%)
  12 MSm3/d  138.70 vs 138.72 bar (-0.0%), previously reported undeliverable

Rate exponent 2.14/2.26/3.06 vs OLGA 2.14/2.38/3.12. Arrival temperature within
0.7-3.5 K. 10 MW of direct electrical heating now raises arrival temperature
17.4 K and pressure drop 15.0%, against OLGA 19.4 K and 12.3%; the previously
documented temperature-blind pressure drop was an artefact of the premature
convergence and is gone.

Tests: TwoFluidPipeTerrainSteadyStateTest, TwoFluidPipeThermalPressureCouplingTest
and TwoFluidPipeLeanGasHoldupTest are new and were each verified to fail before
the corresponding fix.

TwoFluidPipeBoundaryConditionTest: the liquid-velocity handoff bound is made
scale-free. The correct lower holdup raises liquid velocity 1.048 -> 1.583 m/s,
so an absolute RMS bound moves without the handoff becoming less continuous;
measured against master the relative jump improved from 4.11% to 3.56%.

TwoPhasePipeFlowSystemTest: the cross-model bound is replaced by an anchor. On
that fixture a homogeneous no-slip Darcy integration gives 0.616 bar and
PipeBeggsAndBrills 0.898 bar; TwoFluidPipe now gives 0.845 bar while the legacy
separated-flow TwoPhasePipeFlowSystem gives 3.489 bar, which is 5.7x the no-slip
bound. The test now asserts that TwoFluidPipe stays anchored to Beggs-Brill and
keeps only a coarse runaway guard on the cross-model difference.

Known open items, documented rather than hidden: local holdup at low rate is
dominated by single terrain trap sections, and the three-phase free-water case
is wall-clock limited (88.6 bar vs OLGA 104.1) with the pressure drop unchanged
between a 300 s and a 1200 s budget, so the criterion stalls on the three-phase
liquid split.
