### PR TITLE
fix(flash): replay cold water-rich seed after collapse

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1800,13 +1800,15 @@ Commercial process simulators do not publish all implementation details, but pub
   live system to rebuild the cubic/aqueous storage mapping; a recursion guard prevents fallback ping-pong. Genuine
   OIL+AQUEOUS liquid-liquid endpoints, already-feasible multiphase states, and dry systems do not run the additional
   flash.
-- For an ordinary neutral non-CPA water-rich asymmetric feed, the reciprocal multiphase calculation retains the cold
-  pre-iteration state instead of cloning the final endpoint. A post-flash clone can preserve collapsed phase-storage
-  and cubic-root history even after beta and compositions are reset, causing it to revisit a rejected three-phase
-  stationary point while the unchanged cold feed reaches a feasible OIL+AQUEOUS equilibrium. The cold seed is allocated
-  only when water feed is at least `0.01` and the existing critical-temperature/composition screen identifies an
-  asymmetric neutral mixture. Dry, CPA, chemical, ionic, solid, wax, and non-asymmetric water-bearing flashes remain on
-  their existing initialization paths. Seed provenance does not relax acceptance: exactly two distinct phases,
+- For a neutral non-CPA water-rich asymmetric feed, ordinary and explicit-multiphase calculations retain the cold
+  pre-iteration state instead of relying on a clone of a final endpoint. A post-flash clone can preserve collapsed
+  phase-storage and cubic-root history even after beta and compositions are reset, causing it to revisit a rejected
+  stationary point while the unchanged cold feed reaches a feasible OIL+AQUEOUS equilibrium. If the explicit
+  multiphase calculation collapses to one phase, water-bearing recovery consumes the cold state for one ordinary
+  TP flash; the retained K-value clone fallback remains available for other eligible collapses. The cold seed is
+  allocated only when water feed is at least `0.01` and the existing critical-temperature/composition screen identifies
+  an asymmetric neutral mixture. Dry, CPA, chemical, ionic, solid, wax, and non-asymmetric water-bearing flashes remain
+  on their existing initialization paths. Seed provenance does not relax acceptance: exactly two distinct phases,
   bounded and normalized beta/compositions, material balance and log-fugacity residuals below `1e-8`, and lower Gibbs
   energy are still required.
 - Multiphase stability cleanup merges two same-type liquid phases when their maximum component-composition difference

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -2886,12 +2886,14 @@ public class TPflash extends Flash {
    * retry consumes the cold pre-iteration state rather than cloning phase-storage and cubic-root history from the
    * collapsed endpoint. Other eligible collapses retain the post-removal K-value screen and clone fallback. The
    * ordinary result replaces the collapsed state only after it passes the existing phase-fraction,
-   * distinct-composition, material-balance, fugacity, and lower-Gibbs acceptance checks.
+   * distinct-composition, material-balance, fugacity, and lower-Gibbs acceptance checks. Reciprocal candidates observe
+   * the same thread-local guard, preventing fallback ping-pong.
    * </p>
    */
   private void rescueSinglePhaseWaterBearingEndpoint() {
-    boolean hasScreenedColdSeed = system.doMultiPhaseCheck() && system.getNumberOfPhases() == 1
-        && multiphaseEndpointRescueSeed != null && hasPotentialWaterRichColdSeedInstability();
+    boolean hasScreenedColdSeed = !MULTIPHASE_RESCUE_ACTIVE.get().booleanValue() && system.doMultiPhaseCheck()
+        && system.getNumberOfPhases() == 1 && multiphaseEndpointRescueSeed != null
+        && hasPotentialWaterRichColdSeedInstability();
     if (waterBearingRescueAttempted || (!hasScreenedColdSeed && !shouldRetryCollapsedWaterBearingEndpoint())) {
       return;
     }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -2333,8 +2333,8 @@ public class TPflash extends Flash {
    * <p>
    * This screen mirrors the existing neutral liquid-liquid composition/critical-temperature gate while permitting the
    * water component that defines this fallback. A substantial non-hydrocarbon fraction and a condensable hydrocarbon
-   * are both required, so hydrocarbon/water process flashes do not allocate a seed merely because water is present.
-   * The later reciprocal solve and strict feasibility, equilibrium, and Gibbs gates decide stability.
+   * are both required, so hydrocarbon/water process flashes do not allocate a seed merely because water is present. The
+   * later reciprocal solve and strict feasibility, equilibrium, and Gibbs gates decide stability.
    * </p>
    *
    * @return true when retaining one cold pre-iteration state is justified
@@ -2892,8 +2892,7 @@ public class TPflash extends Flash {
   private void rescueSinglePhaseWaterBearingEndpoint() {
     boolean hasScreenedColdSeed = system.doMultiPhaseCheck() && system.getNumberOfPhases() == 1
         && multiphaseEndpointRescueSeed != null && hasPotentialWaterRichColdSeedInstability();
-    if (waterBearingRescueAttempted
-        || (!hasScreenedColdSeed && !shouldRetryCollapsedWaterBearingEndpoint())) {
+    if (waterBearingRescueAttempted || (!hasScreenedColdSeed && !shouldRetryCollapsedWaterBearingEndpoint())) {
       return;
     }
     waterBearingRescueAttempted = true;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -2305,10 +2305,10 @@ public class TPflash extends Flash {
    * Once a stability trial has collapsed a phase, cloning that endpoint also copies its local cubic-root and
    * phase-storage history. A later retry can then reproduce the same homogeneous minimum even though a cold flash finds
    * a lower-Gibbs split. The seed is therefore captured before the two-phase iteration for multiphase flashes, ordinary
-   * sour-gas flashes whose deterministic asymmetric and Wilson endpoint screens justify a possible retry, and ordinary
+   * sour-gas flashes whose deterministic asymmetric and Wilson endpoint screens justify a possible retry, and neutral
    * non-CPA water-rich asymmetric feeds whose post-flash clone may otherwise retain a collapsed phase history. It is
-   * consumed at most once and cleared when the operation returns. Ordinary dry, CPA, chemical, ionic, solid, wax, and
-   * non-asymmetric water-bearing flashes remain outside the additional cold-seed allocation.
+   * consumed at most once and cleared when the operation returns. Dry, CPA, chemical, ionic, solid, wax, and
+   * non-asymmetric water-bearing flashes remain outside the additional water-rich cold-seed allocation.
    * </p>
    */
   private void prepareMultiphaseEndpointRescueSeed() {
@@ -2328,21 +2328,18 @@ public class TPflash extends Flash {
   }
 
   /**
-   * Screens an ordinary cubic-EOS water-rich asymmetric feed for a cold reciprocal-stability seed.
+   * Screens a cubic-EOS water-rich asymmetric feed for a cold reciprocal-stability seed.
    *
    * <p>
    * This screen mirrors the existing neutral liquid-liquid composition/critical-temperature gate while permitting the
    * water component that defines this fallback. A substantial non-hydrocarbon fraction and a condensable hydrocarbon
-   * are both required, so ordinary hydrocarbon/water process flashes do not allocate a seed merely because water is
-   * present. The later multiphase solve and strict feasibility, equilibrium, and Gibbs gates decide stability.
+   * are both required, so hydrocarbon/water process flashes do not allocate a seed merely because water is present.
+   * The later reciprocal solve and strict feasibility, equilibrium, and Gibbs gates decide stability.
    * </p>
    *
    * @return true when retaining one cold pre-iteration state is justified
    */
   private boolean hasPotentialWaterRichColdSeedInstability() {
-    if (system.doMultiPhaseCheck()) {
-      return false;
-    }
     String modelName = system.getModelName();
     if (modelName != null && modelName.contains("CPA")) {
       return false;
@@ -2885,23 +2882,31 @@ public class TPflash extends Flash {
    *
    * <p>
    * In some high-pressure CO2/water states the multiphase solver removes an aqueous phase even though the ordinary
-   * flash converges to a feasible lower-Gibbs oil/aqueous split. The stored post-removal K-values retain a strong phase
-   * preference: water has a very small K-value while at least one non-water component has a large K-value. Only this
-   * inexpensive screen triggers the retry. The ordinary result replaces the collapsed state only after it passes the
-   * existing phase-fraction, distinct-composition, and lower-Gibbs acceptance checks.
+   * flash converges to a feasible lower-Gibbs oil/aqueous split. For a screened neutral non-CPA water-rich feed, the
+   * retry consumes the cold pre-iteration state rather than cloning phase-storage and cubic-root history from the
+   * collapsed endpoint. Other eligible collapses retain the post-removal K-value screen and clone fallback. The
+   * ordinary result replaces the collapsed state only after it passes the existing phase-fraction,
+   * distinct-composition, material-balance, fugacity, and lower-Gibbs acceptance checks.
    * </p>
    */
   private void rescueSinglePhaseWaterBearingEndpoint() {
-    if (waterBearingRescueAttempted || !shouldRetryCollapsedWaterBearingEndpoint()) {
+    boolean hasScreenedColdSeed = system.doMultiPhaseCheck() && system.getNumberOfPhases() == 1
+        && multiphaseEndpointRescueSeed != null && hasPotentialWaterRichColdSeedInstability();
+    if (waterBearingRescueAttempted
+        || (!hasScreenedColdSeed && !shouldRetryCollapsedWaterBearingEndpoint())) {
       return;
     }
     waterBearingRescueAttempted = true;
     system.init(1);
     double referenceGibbsEnergy = system.getGibbsEnergy();
-    SystemInterface candidate = system.clone();
+    SystemInterface candidate = hasScreenedColdSeed ? multiphaseEndpointRescueSeed : system.clone();
+    if (hasScreenedColdSeed) {
+      multiphaseEndpointRescueSeed = null;
+    }
     MULTIPHASE_RESCUE_ACTIVE.set(Boolean.TRUE);
     try {
       candidate.setMultiPhaseCheck(false);
+      candidate.setEnhancedMultiPhaseCheck(false);
       new TPflash(candidate, candidate.doSolidPhaseCheck()).run();
       if (isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy)
           && isBalancedEquilibriumCandidate(candidate)) {

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterRichColdSeedConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashWaterRichColdSeedConsistencyTest.java
@@ -24,6 +24,8 @@ class TPflashWaterRichColdSeedConsistencyTest extends neqsim.NeqSimTest {
 
     SystemInterface poorGuess = flash(createSystem(230.0, 90.0, FEED, false), true);
     assertEquivalentOilAqueousState(ordinary, poorGuess);
+    SystemInterface poorMultiphaseGuess = flash(createSystem(230.0, 90.0, FEED, true), true);
+    assertEquivalentOilAqueousState(ordinary, poorMultiphaseGuess);
 
     double firstGibbsEnergy = ordinary.getGibbsEnergy();
     double firstOilBeta = ordinary.getPhase("oil").getBeta();
@@ -35,6 +37,17 @@ class TPflashWaterRichColdSeedConsistencyTest extends neqsim.NeqSimTest {
     assertEquals(firstOilBeta, ordinary.getPhase("oil").getBeta(), 1.0e-12);
     assertCompositionEquals(firstOilComposition, phaseComposition(ordinary, PhaseType.OIL), 1.0e-12);
     assertPhysicalEquilibrium(ordinary);
+
+    double firstMultiphaseGibbsEnergy = multiphase.getGibbsEnergy();
+    double firstMultiphaseOilBeta = multiphase.getPhase("oil").getBeta();
+    double[] firstMultiphaseOilComposition = phaseComposition(multiphase, PhaseType.OIL);
+    new ThermodynamicOperations(multiphase).TPflash();
+    multiphase.init(1);
+
+    assertEquals(firstMultiphaseGibbsEnergy, multiphase.getGibbsEnergy(), 1.0e-6);
+    assertEquals(firstMultiphaseOilBeta, multiphase.getPhase("oil").getBeta(), 1.0e-12);
+    assertCompositionEquals(firstMultiphaseOilComposition, phaseComposition(multiphase, PhaseType.OIL), 1.0e-12);
+    assertPhysicalEquilibrium(multiphase);
   }
 
   @Test


### PR DESCRIPTION
## Campaign

Advances #2937. This is the bounded repair tranche frozen in the [roadmap evidence comment](https://github.com/equinor/neqsim/issues/2937#issuecomment-5308451544).

Original base: `f420627b589286b9c9dd6ccd1659deb34b700ae5`  
Current base: `2e818a27d1fdd90017de41129ccdcd708bf49920`  
Initial head: `cd29e5e60834b89062983d3e2c583b9264f74eda`  
Final PR head: `03dc0f9cf0b55e3354792fb9cee229e6bd459029`  
Merge commit: `16e67be6bbbe40424eb7ebf878915305266d30a8`

## Reproduced problem

The final exact-head aggregate run for #3031 executed 11,848 tests and reported only two failures, both in `TPflashWaterRichColdSeedConsistencyTest`:

- `coldSeedRecoversBalancedOilAqueousEndpoint`: explicit multiphase expected 2 phases, returned 1
- `nearbyStatesAndChangedFeedRemainContinuousAndDeterministic`: explicit multiphase expected 2 phases, returned 1

Evidence: [workflow run 31931047567](https://github.com/equinor/neqsim/actions/runs/31931047567) on `e83c77b377c7ed8a1c5a6fac662f4da68406ac56`.

The ordinary TP flash still returns the balanced lower-Gibbs OIL+AQUEOUS state. The explicit-multiphase route can collapse to one phase after the Wilson admitted-phase initialization changes merged in #3036.

## Root cause

`TPflash` already captures a pre-iteration cold state because a clone of a collapsed endpoint can retain phase-storage and cubic-root history. Two guards prevented that state from repairing this regression:

1. the strict neutral non-CPA water-rich screen rejected explicit-multiphase calculations; and
2. `rescueSinglePhaseWaterBearingEndpoint()` always cloned the already-collapsed live state.

Reverting the Wilson initialization globally would also undo the UMR/Eclipse compatibility repair in #3036, so this PR does not change that initialization.

## Method

- Apply the existing deterministic water-rich asymmetric screen to ordinary and explicit-multiphase cubic-EOS calculations.
- When a screened explicit-multiphase calculation collapses to one phase, consume the pre-iteration seed once and run one ordinary TP flash with multiphase/enhanced-multiphase checks disabled.
- Retain the existing post-removal K-value clone fallback for other eligible water-bearing collapses.
- Accept a candidate only through the unchanged lower-Gibbs and balanced-equilibrium gates.

This is a state-provenance repair, not a new equilibrium formulation: it preserves the cold candidate for the existing stability/equilibrium calculation and leaves phase selection to the existing Gibbs, feasibility, material-balance, and fugacity tests.

## Numerical gates and tolerances

The regression continues to require:

- exactly two OIL+AQUEOUS phases;
- beta sum and phase-composition normalization within `1e-12`;
- component material-balance residual below `1e-10`;
- maximum log-fugacity residual below `1e-8`;
- phase fractions and compositions in `[0, 1]`;
- ordinary/multiphase beta, phase-Z, and composition agreement within `1e-10`;
- Gibbs-energy agreement within `1e-6 J`;
- strictly lower Gibbs energy before a recovered candidate replaces the collapsed endpoint.

No tolerance is weakened.

## Regression coverage

The existing matrix covers the CO2-rich water-bearing SRK/mixing-rule-2 case at 230 K and 90 bara, nine nearby temperature/pressure points, changed composition, changed state, phase duplicate removal, ordinary/multiphase cross-algorithm consistency, material balance, fugacity residuals, and deterministic ordinary repeat execution.

This PR adds:

- a poor-beta explicit-multiphase start (`1e-10` / `1 - 1e-10`);
- repeated explicit-multiphase execution with invariant Gibbs energy, oil beta, oil composition, material balance, and fugacity equilibrium.

## Solver-work and performance impact

The common path does not run an additional flash. The new work is bounded to the existing strict neutral non-CPA water-rich asymmetry screen. Only after such an explicit-multiphase calculation collapses to one phase is one ordinary TP flash performed. The seed clone is captured before iteration and consumed at most once. This PR makes no runtime-speed claim; post-change timing and aggregate failure-rate evidence are pending CI.

## Validation

**VALIDATION PENDING CI**

Implementation and publication were performed through the authoritative GitHub connector. No local checkout, Maven, Spotless, Python documentation gate, or pre-commit executable was available in this run, so none is claimed as passed.

CI must confirm:

- focused `TPflashWaterRichColdSeedConsistencyTest`;
- representative `TPflashTest` and `TPmultiflashTest`;
- repository formatting/Spotless and documentation-search gates;
- proportionate aggregate tests, especially UMR/Eclipse controls protected by #3036.

Pre-change evidence is the exact-head aggregate failure above (2 failures among 11,848 tests).

CI follow-up:

- Initial head `cd29e5e6` failed pre-commit only on two reported Spotless line wraps; the exact formatter diff was applied in `8a79b08b`.
- Head `8a79b08b` passed Spotless, pre-commit, documentation search, Javadocs, PaperLab, and CodeQL. Its slow-test shard 2/4 exposed a `StackOverflowError` in `NorwegianOilFieldLifecycleTest`: the new cold-seed branch did not yet observe the existing thread-local reciprocal-rescue guard.
- Head `822c3618` added that missing guard. Spotless, pre-commit, documentation search, Javadocs, PaperLab, CodeQL, and all four slow-test shards passed; in particular, slow-test shard 2/4 passed the lifecycle test that previously overflowed. Its Linux and Windows fast suites were still running when the branch baseline changed.
- Head `e21b200e` merged master `6d0512b0`; Spotless, pre-commit, documentation search, Javadocs, PaperLab, and CodeQL passed, while Linux/Windows fast suites and all slow shards were running without a failed step when master advanced again.
- Current head `03dc0f9c` is a second non-force merge of master `2e818a27`. The intervening commit changes ProcessEquipment/Recycle state transactions and does not overlap this tranche. The PR remains zero commits behind and its diff is still the same three TP-flash files.
- On `03dc0f9c`, Spotless, pre-commit, documentation search, Javadocs, PaperLab, CodeQL, both Java 21 fast suites, and all four Java 21 slow shards pass. Java 8 Linux and Windows suites remain in progress.
- While those long suites ran, master advanced through two CO2-tutorial/TwoFluid commits that did not overlap the TP-flash files.
- The PR was then merged externally as `16e67be6bbbe40424eb7ebf878915305266d30a8`; that merge commit is the verified current master head and contains the intended three TP-flash file changes.
- Final PR head `03dc0f9c` passes Java 8 and Java 21 on both Ubuntu and Windows, including all four Java 21 slow shards. No READY TO MERGE classification was issued before the external merge.

**MERGED AND VALIDATED.** The #2937 roadmap remains open because this tranche repairs one bounded water-rich collapse defect and does not complete the campaign's broader acceptance criteria.

## Compatibility and risk

Risk is localized to screened neutral, non-CPA, non-ionic, non-chemical water-rich asymmetric cubic-EOS feeds after an explicit-multiphase one-phase collapse. CPA, electrolyte/ionic, chemical, solid, wax, dry, and non-asymmetric water-bearing paths remain excluded. The Wilson admitted-phase beta behavior from #3036 is unchanged.

No public API, serialization format, notebook, process-model identity, unit, or provenance interface changes.

## Documentation impact

Updated `TPflash` Javadocs and `docs/thermodynamicoperations/TPflash_algorithm.md` to document cold-seed provenance, the one-shot ordinary replay, the retained K-value clone fallback, exclusions, and unchanged strict acceptance gates.
