### PR TITLE
feat: transact recycle equipment state

### DIFF
--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -137,7 +137,7 @@ Coverage is quantitative: `getProcessElementCount()`, `getParticipantCount()`, a
 complete participation from API presence. Equipment-attached controllers are included even when they are not registered
 as standalone process controllers. Duplicate registration of the same object is counted once; duplicate or changing
 state identities are rejected. Systems containing a mutable process element without the participant contract, or a
-configured recycle whose shared `RecycleController` state cannot yet be restored in place, fail before opening a trial.
+configured recycle whose equipment or shared `RecycleController` state cannot be restored in place, fail before opening a trial.
 
 Concrete `TransferFunctionBlock` and `LogicBlock` instances are covered participants. Transfer-function snapshots
 include both lag states, the complete circular dead-time buffer and index, output, physical-step identifier, tuning,
@@ -571,13 +571,20 @@ controller and accelerator instances. Java serialization also retains coordinate
 instead of silently restarting those solver memories.
 
 The controller snapshot is orchestration state, so it is intentionally outside the quantitative process-element and
-participant counts reported by `TransientTransactionCoverage`. Every `Recycle` unit remains a separate
-registered process element and does not yet implement `TransientStateParticipant`; a realistic flowsheet that
-contains a recycle therefore still fails closed on that equipment state. This tranche removes only the additional shared
-controller blocker and establishes the reusable boundary needed before recycle equipment inventory, internal streams and
-acceleration state can be qualified.
+participant counts reported by `TransientTransactionCoverage`. Every configured `Recycle` remains a separate
+participant: its checkpoint preserves the same inlet, mixed, last-iteration and outlet stream identities while restoring
+independent thermodynamic clones, calculation identifiers, clocks, activation flags, convergence residuals and tolerances,
+adaptive/Wegstein memory, local Broyden continuation, priority and low-flow tuning. Java serialization retains the stable
+recycle identity and Broyden continuation rather than silently cold-starting the solver.
 
-Coverage includes exact in-memory rollback of priority and coordinated Broyden state, stable object identity, defensive
-matrix/vector copies, foreign/null snapshot rejection, recycle-registration restoration and exact Java-serialization
-continuation. It does not qualify recycle thermodynamics, convergence tolerances, strongly coupled DAE behaviour,
-timestep independence, external side effects, safety action, virtual commissioning or OTS use.
+`ProcessEquipmentBaseClass` supplies a protected reusable checkpoint for simulation identity/clock, activation,
+low-flow ownership, specification, report/properties, capacity-analysis enablement and IEC 81346 designation. It remains
+fail-closed when a concrete equipment snapshot would omit independently mutable attached controllers, active energy ports,
+failure state, design conditions or runtime capacity constraints. `Recycle` also fails closed for subclasses and
+incompletely connected streams. These diagnostics prevent a nominal participant count from overstating rollback coverage.
+
+Coverage includes exact in-memory rollback of controller priority and coordinated Broyden state plus recycle-owned stream,
+base-equipment, convergence and local acceleration state; stable object identity; defensive thermodynamic/matrix/vector
+copies; foreign/null snapshot rejection; recycle-registration restoration; and Java-serialization continuation. It does
+not qualify thermodynamic model accuracy, convergence of every recycle topology, strongly coupled DAE behaviour, timestep
+independence, external side effects, safety action, virtual commissioning or OTS use.

--- a/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
+++ b/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
@@ -10,6 +10,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1303,4 +1304,166 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
     }
     return sb.toString();
   }
+
+  /**
+   * Reports whether base-equipment state can be captured without losing attached mutable objects.
+   *
+   * <p>
+   * The reusable base snapshot covers simulation clock/identifier state, activation and low-flow state, specification,
+   * reports, properties, capacity-analysis enablement and IEC 81346 designation. Equipment with attached controllers,
+   * active energy ports, failure state, design conditions or runtime capacity constraints remains fail-closed until the
+   * concrete participant explicitly composes those independently owned objects into its transaction.
+   * </p>
+   *
+   * @return {@code null} when the reusable base snapshot is complete, otherwise a deterministic blocking diagnostic
+   */
+  protected final String getBaseTransientStateCoverageIssue() {
+    if (controller != null || flowValveController != null || hasController || !controllerMap.isEmpty()) {
+      return "attached controller state must participate independently";
+    }
+    if (isSetEnergyStream || !energyPorts.isEmpty() || !externallyConnectedEnergyPorts.isEmpty()) {
+      return "connected energy-stream and energy-port state is not covered by the equipment snapshot";
+    }
+    if (failureMode != null || isFailed) {
+      return "equipment failure state is not covered by the reusable base snapshot";
+    }
+    if (designConditions != null) {
+      return "mutable design-condition state is not covered by the reusable base snapshot";
+    }
+    if (capacityConstraints != null && !capacityConstraints.isEmpty()) {
+      return "runtime capacity-constraint state is not covered by the reusable base snapshot";
+    }
+    return null;
+  }
+
+  /**
+   * Captures mutable state owned directly by {@code ProcessEquipmentBaseClass}.
+   *
+   * @return immutable, serializable base-equipment checkpoint
+   */
+  protected final ProcessEquipmentTransientState captureBaseTransientState() {
+    return new ProcessEquipmentTransientState(getName(), calcIdentifier, calculateSteadyState, time, isRunInSteps(),
+        specification, copyTransientReport(report),
+        properties == null ? null : new HashMap<String, String>(properties), isSolved, isActive,
+        lockedInactive, minimumFlow, minimumFlowExplicitlyConfigured, minimumFlowAutoManaged,
+        minimumFlowRecalculationPending, capacityAnalysisEnabled, referenceDesignation,
+        copyTransientReferenceDesignation(referenceDesignation));
+  }
+
+  /**
+   * Restores a checkpoint captured by {@link #captureBaseTransientState()} without replacing this equipment instance.
+   *
+   * @param snapshot base-equipment checkpoint
+   */
+  protected final void restoreBaseTransientState(ProcessEquipmentTransientState snapshot) {
+    Objects.requireNonNull(snapshot, "base-equipment transient snapshot cannot be null");
+    setName(snapshot.name);
+    calcIdentifier = snapshot.calculationIdentifier;
+    calculateSteadyState = snapshot.calculateSteadyState;
+    time = snapshot.time;
+    setRunInSteps(snapshot.runInSteps);
+    specification = snapshot.specification;
+    report = copyTransientReport(snapshot.report);
+    properties = snapshot.properties == null ? null : new HashMap<String, String>(snapshot.properties);
+    isSolved = snapshot.solved;
+    isActive = snapshot.active;
+    lockedInactive = snapshot.lockedInactive;
+    minimumFlow = snapshot.minimumFlow;
+    minimumFlowExplicitlyConfigured = snapshot.minimumFlowExplicitlyConfigured;
+    minimumFlowAutoManaged = snapshot.minimumFlowAutoManaged;
+    minimumFlowRecalculationPending = snapshot.minimumFlowRecalculationPending;
+    assigningAutoMinimumFlow = false;
+    capacityAnalysisEnabled = snapshot.capacityAnalysisEnabled;
+    referenceDesignation = snapshot.referenceDesignationReference;
+    restoreTransientReferenceDesignation(referenceDesignation, snapshot.referenceDesignationState);
+  }
+
+  private static String[][] copyTransientReport(String[][] source) {
+    if (source == null) {
+      return null;
+    }
+    String[][] copy = new String[source.length][];
+    for (int i = 0; i < source.length; i++) {
+      copy[i] = source[i] == null ? null : source[i].clone();
+    }
+    return copy;
+  }
+
+  private static ReferenceDesignation copyTransientReferenceDesignation(ReferenceDesignation source) {
+    if (source == null) {
+      return null;
+    }
+    ReferenceDesignation copy = new ReferenceDesignation();
+    copy.setFunctionDesignation(source.getFunctionDesignation());
+    copy.setProductDesignation(source.getProductDesignation());
+    copy.setLocationDesignation(source.getLocationDesignation());
+    copy.setLetterCode(source.getLetterCode());
+    copy.setSequenceNumber(source.getSequenceNumber());
+    return copy;
+  }
+
+  private static void restoreTransientReferenceDesignation(ReferenceDesignation target,
+      ReferenceDesignation source) {
+    if (target == null || source == null) {
+      if (target != source) {
+        throw new IllegalArgumentException("Reference-designation snapshot structure changed");
+      }
+      return;
+    }
+    target.setFunctionDesignation(source.getFunctionDesignation());
+    target.setProductDesignation(source.getProductDesignation());
+    target.setLocationDesignation(source.getLocationDesignation());
+    target.setLetterCode(source.getLetterCode());
+    target.setSequenceNumber(source.getSequenceNumber());
+  }
+
+  /** Serializable state owned directly by {@code ProcessEquipmentBaseClass}. */
+  protected static final class ProcessEquipmentTransientState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final UUID calculationIdentifier;
+    private final boolean calculateSteadyState;
+    private final double time;
+    private final boolean runInSteps;
+    private final String specification;
+    private final String[][] report;
+    private final HashMap<String, String> properties;
+    private final boolean solved;
+    private final boolean active;
+    private final boolean lockedInactive;
+    private final double minimumFlow;
+    private final boolean minimumFlowExplicitlyConfigured;
+    private final boolean minimumFlowAutoManaged;
+    private final boolean minimumFlowRecalculationPending;
+    private final boolean capacityAnalysisEnabled;
+    private final ReferenceDesignation referenceDesignationReference;
+    private final ReferenceDesignation referenceDesignationState;
+
+    private ProcessEquipmentTransientState(String name, UUID calculationIdentifier, boolean calculateSteadyState,
+        double time, boolean runInSteps, String specification, String[][] report,
+        HashMap<String, String> properties, boolean solved, boolean active, boolean lockedInactive,
+        double minimumFlow, boolean minimumFlowExplicitlyConfigured, boolean minimumFlowAutoManaged,
+        boolean minimumFlowRecalculationPending, boolean capacityAnalysisEnabled,
+        ReferenceDesignation referenceDesignationReference, ReferenceDesignation referenceDesignationState) {
+      this.name = name;
+      this.calculationIdentifier = calculationIdentifier;
+      this.calculateSteadyState = calculateSteadyState;
+      this.time = time;
+      this.runInSteps = runInSteps;
+      this.specification = specification;
+      this.report = report;
+      this.properties = properties;
+      this.solved = solved;
+      this.active = active;
+      this.lockedInactive = lockedInactive;
+      this.minimumFlow = minimumFlow;
+      this.minimumFlowExplicitlyConfigured = minimumFlowExplicitlyConfigured;
+      this.minimumFlowAutoManaged = minimumFlowAutoManaged;
+      this.minimumFlowRecalculationPending = minimumFlowRecalculationPending;
+      this.capacityAnalysisEnabled = capacityAnalysisEnabled;
+      this.referenceDesignationReference = referenceDesignationReference;
+      this.referenceDesignationState = referenceDesignationState;
+    }
+  }
+
 }

--- a/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
+++ b/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
@@ -1343,9 +1343,8 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
    */
   protected final ProcessEquipmentTransientState captureBaseTransientState() {
     return new ProcessEquipmentTransientState(getName(), calcIdentifier, calculateSteadyState, time, isRunInSteps(),
-        specification, copyTransientReport(report),
-        properties == null ? null : new HashMap<String, String>(properties), isSolved, isActive,
-        lockedInactive, minimumFlow, minimumFlowExplicitlyConfigured, minimumFlowAutoManaged,
+        specification, copyTransientReport(report), properties == null ? null : new HashMap<String, String>(properties),
+        isSolved, isActive, lockedInactive, minimumFlow, minimumFlowExplicitlyConfigured, minimumFlowAutoManaged,
         minimumFlowRecalculationPending, capacityAnalysisEnabled, referenceDesignation,
         copyTransientReferenceDesignation(referenceDesignation));
   }
@@ -1402,8 +1401,7 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
     return copy;
   }
 
-  private static void restoreTransientReferenceDesignation(ReferenceDesignation target,
-      ReferenceDesignation source) {
+  private static void restoreTransientReferenceDesignation(ReferenceDesignation target, ReferenceDesignation source) {
     if (target == null || source == null) {
       if (target != source) {
         throw new IllegalArgumentException("Reference-designation snapshot structure changed");
@@ -1440,9 +1438,9 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass impl
     private final ReferenceDesignation referenceDesignationState;
 
     private ProcessEquipmentTransientState(String name, UUID calculationIdentifier, boolean calculateSteadyState,
-        double time, boolean runInSteps, String specification, String[][] report,
-        HashMap<String, String> properties, boolean solved, boolean active, boolean lockedInactive,
-        double minimumFlow, boolean minimumFlowExplicitlyConfigured, boolean minimumFlowAutoManaged,
+        double time, boolean runInSteps, String specification, String[][] report, HashMap<String, String> properties,
+        boolean solved, boolean active, boolean lockedInactive, double minimumFlow,
+        boolean minimumFlowExplicitlyConfigured, boolean minimumFlowAutoManaged,
         boolean minimumFlowRecalculationPending, boolean capacityAnalysisEnabled,
         ReferenceDesignation referenceDesignationReference, ReferenceDesignation referenceDesignationState) {
       this.name = name;

--- a/src/main/java/neqsim/process/equipment/util/Recycle.java
+++ b/src/main/java/neqsim/process/equipment/util/Recycle.java
@@ -1316,8 +1316,6 @@ public class Recycle extends ProcessEquipmentBaseClass
     super.setMinimumFlow(minimumFlow);
   }
 
-
-
   /** {@inheritDoc} */
   @Override
   public String getTransientStateIdentity() {
@@ -1331,8 +1329,7 @@ public class Recycle extends ProcessEquipmentBaseClass
   @Override
   public String getTransientStateCoverageIssue() {
     if (getClass() != Recycle.class) {
-      return "recycle subclass " + getClass().getName()
-          + " must extend the snapshot for subclass-owned mutable state";
+      return "recycle subclass " + getClass().getName() + " must extend the snapshot for subclass-owned mutable state";
     }
     String baseIssue = getBaseTransientStateCoverageIssue();
     if (baseIssue != null) {

--- a/src/main/java/neqsim/process/equipment/util/Recycle.java
+++ b/src/main/java/neqsim/process/equipment/util/Recycle.java
@@ -1,12 +1,17 @@
 package neqsim.process.equipment.util;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import com.google.gson.GsonBuilder;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
 import neqsim.process.equipment.mixer.MixerInterface;
 import neqsim.process.equipment.stream.StreamInterface;
@@ -27,9 +32,13 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * @author Even Solbraa
  * @version $Id: $Id
  */
-public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface {
+public class Recycle extends ProcessEquipmentBaseClass
+    implements MixerInterface, TransientStateParticipant<Recycle.TransientState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+
+  /** Stable identity used for transaction provenance and foreign-snapshot rejection. */
+  private String transientStateIdentity = UUID.randomUUID().toString();
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(Recycle.class);
 
@@ -111,7 +120,7 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
 
   // Broyden acceleration
   /** Broyden accelerator instance for multi-variable acceleration. */
-  private transient BroydenAccelerator broydenAccelerator = null;
+  private BroydenAccelerator broydenAccelerator = null;
 
   /**
    * Constructor for Recycle.
@@ -1305,6 +1314,267 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
   public void setMinimumFlow(double minimumFlow) {
     this.minimumFlow = minimumFlow;
     super.setMinimumFlow(minimumFlow);
+  }
+
+
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateIdentity == null || transientStateIdentity.trim().isEmpty()) {
+      transientStateIdentity = UUID.randomUUID().toString();
+    }
+    return "equipment:recycle:" + transientStateIdentity;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != Recycle.class) {
+      return "recycle subclass " + getClass().getName()
+          + " must extend the snapshot for subclass-owned mutable state";
+    }
+    String baseIssue = getBaseTransientStateCoverageIssue();
+    if (baseIssue != null) {
+      return baseIssue;
+    }
+    if (numberOfInputStreams != streams.size()) {
+      return "input-stream count does not match the registered stream identities";
+    }
+    if (streams.isEmpty() || mixedStream == null || lastIterationStream == null || outletStream == null) {
+      return "recycle streams must be fully connected before transient state can be captured";
+    }
+    for (StreamInterface stream : streams) {
+      if (stream == null || stream.getThermoSystem() == null) {
+        return "recycle contains a null stream or thermodynamic system";
+      }
+    }
+    if (mixedStream.getThermoSystem() == null || lastIterationStream.getThermoSystem() == null
+        || outletStream.getThermoSystem() == null) {
+      return "recycle-owned stream thermodynamic state is incomplete";
+    }
+    return null;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public TransientState captureTransientState() {
+    String coverageIssue = getTransientStateCoverageIssue();
+    if (coverageIssue != null) {
+      throw new IllegalStateException("Cannot capture recycle '" + getName() + "': " + coverageIssue);
+    }
+    return new TransientState(this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(TransientState snapshot) {
+    Objects.requireNonNull(snapshot, "recycle transient snapshot cannot be null");
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException("Transient snapshot belongs to another recycle");
+    }
+
+    restoreBaseTransientState(snapshot.baseState);
+    streams.clear();
+    streams.addAll(snapshot.streams);
+    downstreamProperty = new ArrayList<String>(snapshot.downstreamProperty);
+    numberOfInputStreams = snapshot.numberOfInputStreams;
+    mixedStream = snapshot.mixedStream;
+    lastIterationStream = snapshot.lastIterationStream;
+    outletStream = snapshot.outletStream;
+    for (StreamTransientState streamState : snapshot.streamStates) {
+      streamState.restore();
+    }
+
+    priority = snapshot.priority;
+    firstTime = snapshot.firstTime;
+    iterations = snapshot.iterations;
+    maxIterations = snapshot.maxIterations;
+    errorComposition = snapshot.errorComposition;
+    errorFlow = snapshot.errorFlow;
+    errorTemperature = snapshot.errorTemperature;
+    errorPressure = snapshot.errorPressure;
+    flowTolerance = snapshot.flowTolerance;
+    compositionTolerance = snapshot.compositionTolerance;
+    temperatureTolerance = snapshot.temperatureTolerance;
+    pressureTolerance = snapshot.pressureTolerance;
+    absoluteFlowChange = snapshot.absoluteFlowChange;
+    absoluteFlowTolerance = snapshot.absoluteFlowTolerance;
+    absoluteFlowToleranceExplicit = snapshot.absoluteFlowToleranceExplicit;
+    minimumFlow = snapshot.minimumFlow;
+    accelerationMethod = snapshot.accelerationMethod;
+    accelerationMethodExplicit = snapshot.accelerationMethodExplicit;
+    adaptiveAcceleration = snapshot.adaptiveAcceleration;
+    adaptiveAccelerationExplicit = snapshot.adaptiveAccelerationExplicit;
+    adaptiveAccelerationAutoManaged = snapshot.adaptiveAccelerationAutoManaged;
+    accelerationAutoUpgraded = snapshot.accelerationAutoUpgraded;
+    previousErrorFlow = snapshot.previousErrorFlow;
+    stallingPasses = snapshot.stallingPasses;
+    wegsteinQMaxExplicit = snapshot.wegsteinQMaxExplicit;
+    wegsteinQMin = snapshot.wegsteinQMin;
+    wegsteinQMax = snapshot.wegsteinQMax;
+    wegsteinDelayIterations = snapshot.wegsteinDelayIterations;
+    previousInputValues = copyTransientArray(snapshot.previousInputValues);
+    previousOutputValues = copyTransientArray(snapshot.previousOutputValues);
+    wegsteinQFactors = copyTransientArray(snapshot.wegsteinQFactors);
+    if (snapshot.broydenState == null) {
+      broydenAccelerator = null;
+    } else {
+      if (broydenAccelerator == null) {
+        broydenAccelerator = new BroydenAccelerator();
+      }
+      broydenAccelerator.restoreState(snapshot.broydenState);
+    }
+  }
+
+  private static double[] copyTransientArray(double[] source) {
+    return source == null ? null : source.clone();
+  }
+
+  private static ArrayList<StreamTransientState> captureStreamStates(Recycle source) {
+    ArrayList<StreamTransientState> states = new ArrayList<StreamTransientState>();
+    Map<StreamInterface, Boolean> captured = new IdentityHashMap<StreamInterface, Boolean>();
+    for (StreamInterface stream : source.streams) {
+      captureStreamState(stream, captured, states);
+    }
+    captureStreamState(source.mixedStream, captured, states);
+    captureStreamState(source.lastIterationStream, captured, states);
+    captureStreamState(source.outletStream, captured, states);
+    return states;
+  }
+
+  private static void captureStreamState(StreamInterface stream, Map<StreamInterface, Boolean> captured,
+      ArrayList<StreamTransientState> states) {
+    if (stream != null && captured.put(stream, Boolean.TRUE) == null) {
+      states.add(new StreamTransientState(stream));
+    }
+  }
+
+  /** Immutable serializable state for one configured recycle. */
+  public static final class TransientState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final ProcessEquipmentTransientState baseState;
+    private final ArrayList<StreamInterface> streams;
+    private final ArrayList<String> downstreamProperty;
+    private final int numberOfInputStreams;
+    private final StreamInterface mixedStream;
+    private final StreamInterface lastIterationStream;
+    private final StreamInterface outletStream;
+    private final ArrayList<StreamTransientState> streamStates;
+    private final int priority;
+    private final boolean firstTime;
+    private final int iterations;
+    private final int maxIterations;
+    private final double errorComposition;
+    private final double errorFlow;
+    private final double errorTemperature;
+    private final double errorPressure;
+    private final double flowTolerance;
+    private final double compositionTolerance;
+    private final double temperatureTolerance;
+    private final double pressureTolerance;
+    private final double absoluteFlowChange;
+    private final double absoluteFlowTolerance;
+    private final boolean absoluteFlowToleranceExplicit;
+    private final double minimumFlow;
+    private final AccelerationMethod accelerationMethod;
+    private final boolean accelerationMethodExplicit;
+    private final boolean adaptiveAcceleration;
+    private final boolean adaptiveAccelerationExplicit;
+    private final boolean adaptiveAccelerationAutoManaged;
+    private final boolean accelerationAutoUpgraded;
+    private final double previousErrorFlow;
+    private final int stallingPasses;
+    private final boolean wegsteinQMaxExplicit;
+    private final double wegsteinQMin;
+    private final double wegsteinQMax;
+    private final int wegsteinDelayIterations;
+    private final double[] previousInputValues;
+    private final double[] previousOutputValues;
+    private final double[] wegsteinQFactors;
+    private final BroydenAccelerator.Snapshot broydenState;
+
+    private TransientState(Recycle source) {
+      stateIdentity = source.getTransientStateIdentity();
+      baseState = source.captureBaseTransientState();
+      streams = new ArrayList<StreamInterface>(source.streams);
+      downstreamProperty = new ArrayList<String>(source.downstreamProperty);
+      numberOfInputStreams = source.numberOfInputStreams;
+      mixedStream = source.mixedStream;
+      lastIterationStream = source.lastIterationStream;
+      outletStream = source.outletStream;
+      streamStates = captureStreamStates(source);
+      priority = source.priority;
+      firstTime = source.firstTime;
+      iterations = source.iterations;
+      maxIterations = source.maxIterations;
+      errorComposition = source.errorComposition;
+      errorFlow = source.errorFlow;
+      errorTemperature = source.errorTemperature;
+      errorPressure = source.errorPressure;
+      flowTolerance = source.flowTolerance;
+      compositionTolerance = source.compositionTolerance;
+      temperatureTolerance = source.temperatureTolerance;
+      pressureTolerance = source.pressureTolerance;
+      absoluteFlowChange = source.absoluteFlowChange;
+      absoluteFlowTolerance = source.absoluteFlowTolerance;
+      absoluteFlowToleranceExplicit = source.absoluteFlowToleranceExplicit;
+      minimumFlow = source.minimumFlow;
+      accelerationMethod = source.accelerationMethod;
+      accelerationMethodExplicit = source.accelerationMethodExplicit;
+      adaptiveAcceleration = source.adaptiveAcceleration;
+      adaptiveAccelerationExplicit = source.adaptiveAccelerationExplicit;
+      adaptiveAccelerationAutoManaged = source.adaptiveAccelerationAutoManaged;
+      accelerationAutoUpgraded = source.accelerationAutoUpgraded;
+      previousErrorFlow = source.previousErrorFlow;
+      stallingPasses = source.stallingPasses;
+      wegsteinQMaxExplicit = source.wegsteinQMaxExplicit;
+      wegsteinQMin = source.wegsteinQMin;
+      wegsteinQMax = source.wegsteinQMax;
+      wegsteinDelayIterations = source.wegsteinDelayIterations;
+      previousInputValues = copyTransientArray(source.previousInputValues);
+      previousOutputValues = copyTransientArray(source.previousOutputValues);
+      wegsteinQFactors = copyTransientArray(source.wegsteinQFactors);
+      broydenState = source.broydenAccelerator == null ? null : source.broydenAccelerator.captureState();
+    }
+  }
+
+  /** Identity-preserving checkpoint for one stream owned or referenced by the recycle. */
+  private static final class StreamTransientState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final StreamInterface stream;
+    private final String name;
+    private final SystemInterface thermoSystem;
+    private final UUID calculationIdentifier;
+    private final boolean calculateSteadyState;
+    private final double time;
+    private final boolean runInSteps;
+    private final boolean active;
+    private final boolean lockedInactive;
+
+    private StreamTransientState(StreamInterface stream) {
+      this.stream = stream;
+      name = stream.getName();
+      thermoSystem = stream.getThermoSystem().clone();
+      calculationIdentifier = stream.getCalculationIdentifier();
+      calculateSteadyState = stream.getCalculateSteadyState();
+      time = stream.getTime();
+      runInSteps = stream.isRunInSteps();
+      active = stream.isActive();
+      lockedInactive = stream.isLockedInactive();
+    }
+
+    private void restore() {
+      stream.setName(name);
+      stream.setThermoSystem(thermoSystem.clone());
+      stream.setCalculationIdentifier(calculationIdentifier);
+      stream.setCalculateSteadyState(calculateSteadyState);
+      stream.setTime(time);
+      stream.setRunInSteps(runInSteps);
+      stream.setLockedInactive(lockedInactive);
+      stream.isActive(active);
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/test/java/neqsim/process/equipment/util/RecycleTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/equipment/util/RecycleTransientStateTransactionTest.java
@@ -75,7 +75,7 @@ class RecycleTransientStateTransactionTest extends neqsim.NeqSimTest {
     capturedLastIteration.setPressure(5.0, "bara");
     capturedOutlet.setFlowRate(888.0, "kg/hr");
     accelerator.setRelaxationFactor(0.25);
-    accelerator.accelerate(new double[] {1.4, 2.3}, new double[] {1.6, 2.5});
+    accelerator.accelerate(new double[] { 1.4, 2.3 }, new double[] { 1.6, 2.5 });
 
     transaction.rollback();
 
@@ -129,7 +129,7 @@ class RecycleTransientStateTransactionTest extends neqsim.NeqSimTest {
     Recycle.TransientState checkpoint = restarted.captureTransientState();
     double capturedFlow = restarted.getStream(0).getFlowRate("kg/hr");
     restarted.getStream(0).setFlowRate(capturedFlow + 50.0, "kg/hr");
-    restarted.getBroydenAccelerator().accelerate(new double[] {1.4, 2.3}, new double[] {1.6, 2.5});
+    restarted.getBroydenAccelerator().accelerate(new double[] { 1.4, 2.3 }, new double[] { 1.6, 2.5 });
     restarted.restoreTransientState(checkpoint);
 
     assertEquals(capturedFlow, restarted.getStream(0).getFlowRate("kg/hr"), TOLERANCE);
@@ -170,9 +170,9 @@ class RecycleTransientStateTransactionTest extends neqsim.NeqSimTest {
   }
 
   private static void accelerateThreeTimes(BroydenAccelerator accelerator) {
-    accelerator.accelerate(new double[] {1.0, 2.0}, new double[] {1.2, 2.2});
-    accelerator.accelerate(new double[] {1.2, 2.2}, new double[] {1.3, 2.25});
-    accelerator.accelerate(new double[] {1.3, 2.25}, new double[] {1.35, 2.28});
+    accelerator.accelerate(new double[] { 1.0, 2.0 }, new double[] { 1.2, 2.2 });
+    accelerator.accelerate(new double[] { 1.2, 2.2 }, new double[] { 1.3, 2.25 });
+    accelerator.accelerate(new double[] { 1.3, 2.25 }, new double[] { 1.35, 2.28 });
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/neqsim/process/equipment/util/RecycleTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/equipment/util/RecycleTransientStateTransactionTest.java
@@ -1,0 +1,200 @@
+package neqsim.process.equipment.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.dynamics.TransientStepTransaction;
+import neqsim.process.dynamics.TransientTransactionCoverage;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.mechanicaldesign.DesignConditions;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Quantitative transaction and restart evidence for recycle-equipment state. */
+class RecycleTransientStateTransactionTest extends neqsim.NeqSimTest {
+  private static final double TOLERANCE = 1.0e-12;
+
+  @Test
+  void processTransactionRestoresRecycleStreamsSolverAndBaseStateInPlace() {
+    Fixture fixture = fixture();
+    Recycle recycle = fixture.recycle;
+    recycle.applyAutoMinimumFlow(2.0);
+    recycle.setPriority(25);
+    recycle.setAdaptiveAcceleration(true);
+    recycle.setAbsoluteFlowTolerance(3.0);
+    recycle.setTime(12.0);
+    recycle.setCalculationIdentifier(UUID.randomUUID());
+    recycle.properties.put("mode", "captured");
+    recycle.getReferenceDesignation().setProductDesignation("RC-101");
+    BroydenAccelerator accelerator = recycle.getBroydenAccelerator();
+    accelerator.setDelayIterations(0);
+    accelerateThreeTimes(accelerator);
+
+    StreamInterface capturedInput = recycle.getStream(0);
+    StreamInterface capturedMixed = recycle.getOutStream();
+    StreamInterface capturedLastIteration = recycle.lastIterationStream;
+    StreamInterface capturedOutlet = recycle.getOutletStream();
+    UUID capturedCalculationIdentifier = recycle.getCalculationIdentifier();
+    int capturedBroydenIterations = accelerator.getIterationCount();
+    double capturedInputFlow = capturedInput.getFlowRate("kg/hr");
+    double capturedMixedTemperature = capturedMixed.getTemperature("K");
+    double capturedLastPressure = capturedLastIteration.getPressure("bara");
+    double capturedOutletFlow = capturedOutlet.getFlowRate("kg/hr");
+
+    TransientTransactionCoverage coverage = fixture.process.getTransientTransactionCoverage();
+    assertTrue(coverage.isComplete());
+    assertEquals(1, coverage.getProcessElementCount());
+    assertEquals(1, coverage.getParticipantCount());
+
+    TransientStepTransaction transaction = fixture.process.beginTransientStepTransaction();
+    Stream replacement = new Stream("replacement", fixture.fluid.clone());
+    replacement.setFlowRate(900.0, "kg/hr");
+    recycle.replaceStream(0, replacement);
+    recycle.setOutletStream(replacement);
+    recycle.setPriority(999);
+    recycle.setAdaptiveAcceleration(false);
+    recycle.setAbsoluteFlowTolerance(33.0);
+    recycle.setMinimumFlow(9.0);
+    recycle.setTime(99.0);
+    recycle.setCalculationIdentifier(UUID.randomUUID());
+    recycle.properties.put("mode", "trial");
+    recycle.getReferenceDesignation().setProductDesignation("TRIAL");
+    capturedInput.setFlowRate(777.0, "kg/hr");
+    capturedMixed.setTemperature(350.0, "K");
+    capturedLastIteration.setPressure(5.0, "bara");
+    capturedOutlet.setFlowRate(888.0, "kg/hr");
+    accelerator.setRelaxationFactor(0.25);
+    accelerator.accelerate(new double[] {1.4, 2.3}, new double[] {1.6, 2.5});
+
+    transaction.rollback();
+
+    assertEquals(TransientStepTransaction.Status.ROLLED_BACK, transaction.getStatus());
+    assertSame(capturedInput, recycle.getStream(0));
+    assertSame(capturedMixed, recycle.getOutStream());
+    assertSame(capturedLastIteration, recycle.lastIterationStream);
+    assertSame(capturedOutlet, recycle.getOutletStream());
+    assertEquals(capturedInputFlow, capturedInput.getFlowRate("kg/hr"), TOLERANCE);
+    assertEquals(capturedMixedTemperature, capturedMixed.getTemperature("K"), TOLERANCE);
+    assertEquals(capturedLastPressure, capturedLastIteration.getPressure("bara"), TOLERANCE);
+    assertEquals(capturedOutletFlow, capturedOutlet.getFlowRate("kg/hr"), TOLERANCE);
+    assertEquals(25, recycle.getPriority());
+    assertTrue(recycle.isAdaptiveAcceleration());
+    assertEquals(3.0, recycle.getAbsoluteFlowTolerance(), TOLERANCE);
+    assertEquals(2.0, recycle.getMinimumFlow(), TOLERANCE);
+    assertTrue(recycle.isMinimumFlowAutoManaged());
+    assertFalse(recycle.isMinimumFlowExplicitlyConfigured());
+    assertEquals(12.0, recycle.getTime(), TOLERANCE);
+    assertEquals(capturedCalculationIdentifier, recycle.getCalculationIdentifier());
+    assertEquals("captured", recycle.properties.get("mode"));
+    assertEquals("RC-101", recycle.getReferenceDesignation().getProductDesignation());
+    assertSame(accelerator, recycle.getBroydenAccelerator());
+    assertEquals(capturedBroydenIterations, accelerator.getIterationCount());
+    assertEquals(1.0, accelerator.getRelaxationFactor(), TOLERANCE);
+  }
+
+  @Test
+  void directSnapshotRejectsForeignAndNullState() {
+    Recycle first = fixture().recycle;
+    Recycle second = fixture().recycle;
+    Recycle.TransientState snapshot = first.captureTransientState();
+
+    assertThrows(IllegalArgumentException.class, () -> second.restoreTransientState(snapshot));
+    assertThrows(NullPointerException.class, () -> first.restoreTransientState(null));
+  }
+
+  @Test
+  void javaSerializationPreservesIdentityAndBroydenContinuation() throws Exception {
+    Recycle original = fixture().recycle;
+    original.getBroydenAccelerator().setDelayIterations(0);
+    accelerateThreeTimes(original.getBroydenAccelerator());
+    Recycle restarted = roundTrip(original);
+
+    assertEquals(original.getTransientStateIdentity(), restarted.getTransientStateIdentity());
+    assertEquals(original.getBroydenAccelerator().getIterationCount(),
+        restarted.getBroydenAccelerator().getIterationCount());
+    assertEquals(original.getBroydenAccelerator().getResidualNorm(),
+        restarted.getBroydenAccelerator().getResidualNorm(), TOLERANCE);
+
+    Recycle.TransientState checkpoint = restarted.captureTransientState();
+    double capturedFlow = restarted.getStream(0).getFlowRate("kg/hr");
+    restarted.getStream(0).setFlowRate(capturedFlow + 50.0, "kg/hr");
+    restarted.getBroydenAccelerator().accelerate(new double[] {1.4, 2.3}, new double[] {1.6, 2.5});
+    restarted.restoreTransientState(checkpoint);
+
+    assertEquals(capturedFlow, restarted.getStream(0).getFlowRate("kg/hr"), TOLERANCE);
+    assertEquals(original.getBroydenAccelerator().getIterationCount(),
+        restarted.getBroydenAccelerator().getIterationCount());
+  }
+
+  @Test
+  void unsupportedBaseAttachmentsRemainFailClosed() {
+    Recycle recycle = fixture().recycle;
+    recycle.setDesignConditions(new DesignConditions());
+
+    String issue = recycle.getTransientStateCoverageIssue();
+    assertNotNull(issue);
+    assertTrue(issue.contains("design-condition"));
+    assertThrows(IllegalStateException.class, recycle::captureTransientState);
+  }
+
+  private static Fixture fixture() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 30.0);
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.1);
+    fluid.setMixingRule("classic");
+
+    Stream inlet = new Stream("recycle inlet", fluid.clone());
+    inlet.setFlowRate(100.0, "kg/hr");
+    inlet.run();
+    Stream outlet = new Stream("recycle outlet", fluid.clone());
+    outlet.setFlowRate(100.0, "kg/hr");
+    outlet.run();
+
+    Recycle recycle = new Recycle("recycle");
+    recycle.addStream(inlet);
+    recycle.setOutletStream(outlet);
+    ProcessSystem process = new ProcessSystem("recycle transaction");
+    process.add(recycle);
+    return new Fixture(process, recycle, fluid);
+  }
+
+  private static void accelerateThreeTimes(BroydenAccelerator accelerator) {
+    accelerator.accelerate(new double[] {1.0, 2.0}, new double[] {1.2, 2.2});
+    accelerator.accelerate(new double[] {1.2, 2.2}, new double[] {1.3, 2.25});
+    accelerator.accelerate(new double[] {1.3, 2.25}, new double[] {1.35, 2.28});
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T roundTrip(T value) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(value);
+    }
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (T) input.readObject();
+    }
+  }
+
+  private static final class Fixture {
+    private final ProcessSystem process;
+    private final Recycle recycle;
+    private final SystemInterface fluid;
+
+    private Fixture(ProcessSystem process, Recycle recycle, SystemInterface fluid) {
+      this.process = process;
+      this.recycle = recycle;
+      this.fluid = fluid;
+    }
+  }
+}


### PR DESCRIPTION
## Roadmap

Advances #2911 after merged DYN-C016. This is the next dependency-ready shared-engine tranche; it does not close the campaign.

## Engineering question

Can one fully connected `Recycle` participate in an identity-preserving transient-step transaction without replacing its stream or solver objects, while failing closed for state owned by unsupported attachments or subclasses?

Baseline: `master` at `f420627b589286b9c9dd6ccd1659deb34b700ae5`. Shared `RecycleController` state is already transactional, but `Recycle` itself does not implement `TransientStateParticipant`, so any realistic recycle flowsheet fails quantitative coverage.

## Implementation

- adds a protected reusable `ProcessEquipmentBaseClass` checkpoint for calculation identity/clock, activation, low-flow ownership, specification, report/properties, capacity-analysis enablement and IEC 81346 designation;
- keeps unsupported attached controllers, active energy ports, failure state, design conditions and runtime capacity constraints fail-closed;
- makes `Recycle` a stable-identity participant;
- restores the original inlet, mixed, last-iteration and outlet stream identities with defensive thermodynamic clones;
- captures convergence residuals/tolerances, priority, adaptive and Wegstein memory, local Broyden continuation, low-flow tuning and base-equipment state;
- retains local Broyden continuation across Java serialization;
- rejects null/foreign snapshots, subclasses and incomplete stream configurations.

## Evidence

`RecycleTransientStateTransactionTest` adds four focused tests:

1. quantitative ProcessSystem coverage (1 process element / 1 participant) and exact rollback at 1e-12;
2. original stream and accelerator object identities after rollback;
3. foreign/null rejection and fail-closed design-condition diagnostics;
4. Java-serialization restart with stable identity and Broyden continuation.

## Documentation impact

Updated `docs/process/dynamic-capability-contract.md` with the new equipment/base checkpoint boundary, covered state, fail-closed cases and remaining numerical/engineering limitations.

## Validation

**VALIDATION PENDING CI**

Exact head: `cfc69a0583c0dd0fb4c7ad416690a001497978d5`.

The exact GitHub-generated Spotless patch was applied after the first formatting-only failure. On this head, Spotless, pre-commit, documentation search, Javadocs, PaperLab and CodeQL pass. The Java 21 fast and four-way slow test matrix is still running; Java 8 follows only after Java 21 succeeds. No uncompleted test is claimed as passed.

No local checkout or Maven execution was available in this runtime; validation statements above come from exact-head GitHub CI.

## Stop boundary

This PR covers shared transaction/orchestration mechanics for classic `Recycle`. It does not qualify every recycle topology, thermodynamic accuracy, strongly coupled DAE stability, timestep independence, #2935 one-phase species transport, #2907 multiphase closures/slugging, safety action, virtual commissioning, OTS, or Huldra data.