### PR TITLE
docs(valve): define negative differential pressure semantics

### DIFF
--- a/docs/process/equipment/valves.md
+++ b/docs/process/equipment/valves.md
@@ -1,9 +1,10 @@
 ---
 title: Valve Equipment
 description: >-
-  Verified NeqSim examples for throttling valves, valve flow coefficients,
-  characteristics, mechanical design, and dynamic travel.
-keywords: "valve, throttling valve, control valve, Joule-Thomson, Cv, Kv, pressure drop, choke, mechanical design"
+  Verified NeqSim examples for throttling valves, negative differential
+  pressure handling, valve flow coefficients, characteristics, mechanical
+  design, and dynamic travel.
+keywords: "valve, throttling valve, control valve, Joule-Thomson, Cv, Kv, pressure drop, negative differential pressure, choke, mechanical design"
 ---
 
 NeqSim represents pressure letdown and control-valve calculations with classes in
@@ -78,6 +79,37 @@ public final class ValveLetdownExample {
 The outlet temperature is calculated by an isenthalpic flash. The sign and
 magnitude of the Joule–Thomson temperature change depend on the fluid,
 temperature, pressure, and thermodynamic model.
+
+## Requested outlet pressure above the inlet
+
+A throttling valve is a pressure-letdown device: it does not add shaft work or
+compress the fluid. `ThrottlingValve` nevertheless accepts a specified outlet
+pressure above the inlet by default. The `acceptNegativeDP` flag controls how
+that requested **thermodynamic pressure state** is handled; it does not enable a
+reverse-flow calculation.
+
+| Requested pressure | `acceptNegativeDP` | Outlet thermodynamic pressure | Hydraulic driving differential |
+|---|---:|---|---|
+| `Pout <= Pin` | either value | Requested `Pout` | `Pin - Pout` |
+| `Pout > Pin` | `false` | Clamped to `Pin` | Zero |
+| `Pout > Pin` | `true` (default) | Requested `Pout` is retained | Zero |
+
+Use `setAcceptNegativeDP(false)` for a one-way pressure-letdown model that
+must not report an outlet pressure above its inlet:
+
+```java
+ThrottlingValve valve = new ThrottlingValve("PV-100", inlet);
+valve.setOutletPressure(85.0, "bara");
+valve.setAcceptNegativeDP(false);
+valve.run();
+```
+
+With the flag set to `true`, a higher requested outlet pressure can represent
+a boundary condition owned by another model. NeqSim retains that pressure for
+the outlet thermodynamic state, but the valve hydraulic calculation clips the
+driving differential to zero. This setting does **not** calculate compressor
+work, valve reverse flow, or a bidirectional network solution. Model those
+effects with the appropriate equipment or network formulation.
 
 ## Cv, Kv, and valve opening
 
@@ -175,7 +207,7 @@ For blowdown activation logic, use `BlowdownValve`.
 
 For every valve calculation, verify:
 
-- inlet pressure exceeds outlet pressure unless reverse flow is intentionally allowed;
+- the requested outlet pressure and `acceptNegativeDP` setting match the intended pressure-boundary model;
 - mass flow is conserved;
 - a normal throttling calculation preserves specific enthalpy within numerical tolerance;
 - temperature and phase changes are physically plausible for the selected fluid model;

--- a/docs/test_valve_equipment_documentation.py
+++ b/docs/test_valve_equipment_documentation.py
@@ -1,0 +1,64 @@
+"""Regression checks for the throttling-valve equipment documentation."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDE = ROOT / "docs/process/equipment/valves.md"
+SOURCE = (
+    ROOT
+    / "src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java"
+)
+JAVA_TEST = (
+    ROOT
+    / "src/test/java/neqsim/process/equipment/valve/ThrottlingValveTest.java"
+)
+
+
+def test_valve_guide_metadata_and_navigation() -> None:
+    """The guide remains discoverable as the valve equipment reference."""
+    text = GUIDE.read_text(encoding="utf-8")
+
+    assert text.startswith("---\ntitle: Valve Equipment\n")
+    assert "negative differential pressure" in text
+    assert "[Process equipment overview](README.md)" in text
+
+
+def test_valve_guide_defines_the_pressure_state_truth_table() -> None:
+    """Document all requested-pressure and acceptance-flag combinations."""
+    text = GUIDE.read_text(encoding="utf-8")
+
+    assert "## Requested outlet pressure above the inlet" in text
+    assert "| `Pout <= Pin` | either value |" in text
+    assert "| `Pout > Pin` | `false` |" in text
+    assert "| `Pout > Pin` | `true` (default) |" in text
+    assert "setAcceptNegativeDP(false)" in text
+
+
+def test_valve_guide_does_not_promise_pressure_adding_or_reverse_flow() -> None:
+    """Keep the accepted pressure state distinct from unsupported hydraulics."""
+    text = GUIDE.read_text(encoding="utf-8")
+
+    assert "does not add shaft work" in text
+    assert "does not enable a reverse-flow calculation" in text
+    assert "does **not** calculate compressor" in text
+    assert "bidirectional network solution" in text
+
+
+def test_source_contract_matches_the_documented_default_and_clamp() -> None:
+    """Pin the source default, Javadocs, and pressure-clamping branch."""
+    text = SOURCE.read_text(encoding="utf-8")
+
+    assert "private boolean acceptNegativeDP = true;" in text
+    assert "the valve hydraulic driving differential is limited to zero" in text
+    assert "if (!acceptNegativeDP)" in text
+    assert "outThermoSystem.setPressure(inThermoSystem.getPressure())" in text
+
+
+def test_focused_java_regression_covers_default_clamp_and_acceptance() -> None:
+    """Ensure executable coverage exists for all higher-outlet-pressure modes."""
+    text = JAVA_TEST.read_text(encoding="utf-8")
+
+    assert "assertTrue(defaultValve.isAcceptNegativeDP()" in text
+    assert "defaultValve.setOutletPressure(15.0, \"bara\")" in text
+    assert "clampingValve.setAcceptNegativeDP(false)" in text
+    assert "acceptingValve.setAcceptNegativeDP(true)" in text

--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -1135,11 +1135,12 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
   /**
    * Returns whether a requested outlet pressure above the inlet is retained.
    *
-   * <p>The default is {@code true}. This flag controls the outlet thermodynamic pressure state;
-   * it does not enable reverse flow, compressor work, or a bidirectional network calculation.
+   * <p>
+   * The default is {@code true}. This flag controls the outlet thermodynamic pressure state; it does not enable reverse
+   * flow, compressor work, or a bidirectional network calculation.
    *
-   * @return {@code true} when a requested outlet pressure above the inlet is retained, or
-   *         {@code false} when it is clamped to the inlet pressure
+   * @return {@code true} when a requested outlet pressure above the inlet is retained, or {@code false} when it is
+   *         clamped to the inlet pressure
    */
   public boolean isAcceptNegativeDP() {
     return acceptNegativeDP;
@@ -1148,13 +1149,14 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
   /**
    * Sets whether a requested outlet pressure above the inlet is retained.
    *
-   * <p>Set to {@code false} for a one-way pressure-letdown model that must clamp the outlet
-   * thermodynamic pressure to the inlet pressure. When {@code true}, the requested outlet
-   * pressure is retained, while the valve hydraulic driving differential is limited to zero.
-   * This setting does not calculate reverse flow, compressor work, or a bidirectional network.
+   * <p>
+   * Set to {@code false} for a one-way pressure-letdown model that must clamp the outlet thermodynamic pressure to the
+   * inlet pressure. When {@code true}, the requested outlet pressure is retained, while the valve hydraulic driving
+   * differential is limited to zero. This setting does not calculate reverse flow, compressor work, or a bidirectional
+   * network.
    *
-   * @param acceptNegativeDP {@code true} to retain the requested outlet pressure, or
-   *        {@code false} to clamp it to the inlet pressure
+   * @param acceptNegativeDP {@code true} to retain the requested outlet pressure, or {@code false} to clamp it to the
+   *        inlet pressure
    */
   public void setAcceptNegativeDP(boolean acceptNegativeDP) {
     this.acceptNegativeDP = acceptNegativeDP;

--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -1133,18 +1133,28 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
   }
 
   /**
-   * isAcceptNegativeDP.
+   * Returns whether a requested outlet pressure above the inlet is retained.
    *
-   * @return a boolean
+   * <p>The default is {@code true}. This flag controls the outlet thermodynamic pressure state;
+   * it does not enable reverse flow, compressor work, or a bidirectional network calculation.
+   *
+   * @return {@code true} when a requested outlet pressure above the inlet is retained, or
+   *         {@code false} when it is clamped to the inlet pressure
    */
   public boolean isAcceptNegativeDP() {
     return acceptNegativeDP;
   }
 
   /**
-   * Setter for the field <code>acceptNegativeDP</code>.
+   * Sets whether a requested outlet pressure above the inlet is retained.
    *
-   * @param acceptNegativeDP a boolean
+   * <p>Set to {@code false} for a one-way pressure-letdown model that must clamp the outlet
+   * thermodynamic pressure to the inlet pressure. When {@code true}, the requested outlet
+   * pressure is retained, while the valve hydraulic driving differential is limited to zero.
+   * This setting does not calculate reverse flow, compressor work, or a bidirectional network.
+   *
+   * @param acceptNegativeDP {@code true} to retain the requested outlet pressure, or
+   *        {@code false} to clamp it to the inlet pressure
    */
   public void setAcceptNegativeDP(boolean acceptNegativeDP) {
     this.acceptNegativeDP = acceptNegativeDP;

--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -1140,7 +1140,7 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
    * flow, compressor work, or a bidirectional network calculation.
    *
    * @return {@code true} when a requested outlet pressure above the inlet is retained, or {@code false} when it is
-   *         clamped to the inlet pressure
+   * clamped to the inlet pressure
    */
   public boolean isAcceptNegativeDP() {
     return acceptNegativeDP;
@@ -1156,7 +1156,7 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
    * network.
    *
    * @param acceptNegativeDP {@code true} to retain the requested outlet pressure, or {@code false} to clamp it to the
-   *        inlet pressure
+   * inlet pressure
    */
   public void setAcceptNegativeDP(boolean acceptNegativeDP) {
     this.acceptNegativeDP = acceptNegativeDP;

--- a/src/test/java/neqsim/process/equipment/valve/ThrottlingValveTest.java
+++ b/src/test/java/neqsim/process/equipment/valve/ThrottlingValveTest.java
@@ -691,18 +691,25 @@ public class ThrottlingValveTest {
     stream1.setPressure(10.0, "bara");
     stream1.run();
 
-    ThrottlingValve valve1 = new ThrottlingValve("valve1", stream1);
-    valve1.setOutletPressure(15.0, "bara");
-    valve1.setAcceptNegativeDP(false);
-    valve1.run();
-    assertEquals(10.0, valve1.getOutletStream().getPressure("bara"), 1e-4,
-        "When isAcceptNegativeDP is false, pressure must be clamped to inlet pressure");
+    ThrottlingValve defaultValve = new ThrottlingValve("default valve", stream1);
+    assertTrue(defaultValve.isAcceptNegativeDP(), "Requested higher outlet pressure is accepted by default");
+    defaultValve.setOutletPressure(15.0, "bara");
+    defaultValve.run();
+    assertEquals(15.0, defaultValve.getOutletStream().getPressure("bara"), 1e-4,
+        "The default retains the requested outlet thermodynamic pressure state");
 
-    ThrottlingValve valve2 = new ThrottlingValve("valve2", stream1);
-    valve2.setOutletPressure(15.0, "bara");
-    valve2.setAcceptNegativeDP(true);
-    valve2.run();
-    assertEquals(15.0, valve2.getOutletStream().getPressure("bara"), 1e-4,
-        "When isAcceptNegativeDP is true, negative DP (higher pressure) should be accepted");
+    ThrottlingValve clampingValve = new ThrottlingValve("clamping valve", stream1);
+    clampingValve.setOutletPressure(15.0, "bara");
+    clampingValve.setAcceptNegativeDP(false);
+    clampingValve.run();
+    assertEquals(10.0, clampingValve.getOutletStream().getPressure("bara"), 1e-4,
+        "Disabling acceptance clamps the outlet thermodynamic pressure to the inlet");
+
+    ThrottlingValve acceptingValve = new ThrottlingValve("accepting valve", stream1);
+    acceptingValve.setOutletPressure(15.0, "bara");
+    acceptingValve.setAcceptNegativeDP(true);
+    acceptingValve.run();
+    assertEquals(15.0, acceptingValve.getOutletStream().getPressure("bara"), 1e-4,
+        "Enabling acceptance retains the requested outlet thermodynamic pressure state");
   }
 }


### PR DESCRIPTION
## Campaign

Advances #2499, batch D062. The bounded scope and validation plan were frozen in [the D062 evidence comment](https://github.com/equinor/neqsim/issues/2499#issuecomment-5307338930).

Base: `2e818a27d1fdd90017de41129ccdcd708bf49920`  
Initial head: `64db29f8f02de6f1066f1567e05f113fef285810`
Current head: `4ac81789504033d9ebd149e12be3e4002320cc78`

## Confirmed defects and root cause

The current valve guide and API surface leave four coupled documentation defects:

1. **High — misleading reverse-flow guidance.** The guide says an inlet pressure below the outlet is acceptable when reverse flow is intended, but `ThrottlingValve` clips the hydraulic driving differential to zero; it does not solve reverse flow.
2. **High — undocumented default pressure-state behavior.** `acceptNegativeDP` defaults to `true`, so a requested outlet pressure above the inlet is retained as the outlet thermodynamic pressure state.
3. **Medium — ambiguous API contract.** The getter and setter Javadocs describe only “a boolean” and do not explain retention versus clamping or the hydraulic boundary.
4. **Medium — incomplete regression coverage.** The focused test covered explicit `true` and `false`, but did not pin the public default or distinguish thermodynamic pressure state from hydraulic direction.

The root cause is terminology: “accept negative DP” governs the accepted outlet pressure state, not a reverse-flow or pressure-adding calculation.

## Fix

- Add a truth table for `Pout <= Pin` and `Pout > Pin` under both flag states.
- State that `true` is the default, retains the requested outlet thermodynamic pressure, and still clips hydraulic driving differential to zero.
- State that the flag does not calculate shaft work, compressor duty, reverse flow, or a bidirectional network solution.
- Replace the misleading physical-check bullet.
- Give the getter/setter precise Javadocs without changing the API or runtime behavior.
- Extend the Java regression to cover the default, explicit clamp, and explicit acceptance.
- Add a hermetic documentation/source contract test.

## Frozen paths

- `docs/process/equipment/valves.md`
- `docs/test_valve_equipment_documentation.py`
- `src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java` (Javadocs only)
- `src/test/java/neqsim/process/equipment/valve/ThrottlingValveTest.java`

No notebook, generated artifact, public default, serialization format, or production calculation changed.

## Validation

**VALIDATION PENDING CI**

Completed through exact GitHub source and connector objects:

- exact-base review against `master` at `2e818a27d1fdd90017de41129ccdcd708bf49920`;
- source inspection confirming `acceptNegativeDP = true`, the `!acceptNegativeDP` pressure clamp, and zero-clipped hydraulic differential;
- one-commit comparison: 1 ahead, 0 behind;
- final scope review: exactly the four frozen paths;
- text integrity checks: final newlines, no CR characters, no trailing whitespace;
- static contract checks for metadata, truth-table markers, source default/clamp markers, and all three Java regression modes.

The GitHub connector was authoritative for this run; a local checkout and repository toolchain were not used. Therefore the following are not claimed as passed and must be verified by CI:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- pre-commit pre-commit and pre-push stages
- `docs/test_valve_equipment_documentation.py`
- focused `ThrottlingValveTest`
- proportionate Maven build/Javadocs/documentation checks

No Python NeqSim or notebook execution is required by this batch.

CI follow-up:

- Initial head `64db29f8`: documentation-search hook passed and the dedicated Spotless patch workflow succeeded. Pre-commit failed only because the valve Javadocs did not yet have Spotless's canonical paragraph and wrapping layout.
- Intermediate head `dc9eff4f`: applied the paragraph wrapping from the reported formatter diff; pre-commit then identified two remaining continuation-line indentation changes.
- Current head `4ac81789`: applies those exact final alignments. On this exact head, pre-commit, the Spotless patch workflow, documentation search, PaperLab, Java 21 Javadocs, and CodeQL pass. Linux/Windows fast tests and all four slow-test shards remain in progress. The standalone Python documentation contract has not been separately executed and is not claimed as passed.

## Risk and boundaries

Risk is documentation/Javadocs plus focused regression coverage. The default remains `true`; the valve equations and pressure-clamping branch are unchanged. This PR does not design reverse-flow architecture or pressure-adding equipment.

No Huldra data or integration work is included. The clarified pressure-boundary contract is reusable by later process-model composition, but this batch adds no downstream interface.

Draft only. This PR does not authorize merge, auto-merge, or a direct change to `master`.