### PR TITLE
feat: transact local stream state

### DIFF
--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -588,3 +588,23 @@ base-equipment, convergence and local acceleration state; stable object identity
 copies; foreign/null snapshot rejection; recycle-registration restoration; and Java-serialization continuation. It does
 not qualify thermodynamic model accuracy, convergence of every recycle topology, strongly coupled DAE behaviour, timestep
 independence, external side effects, safety action, virtual commissioning or OTS use.
+
+## Local stream-source transaction coverage
+
+Concrete local `Stream` objects participate in the same identity-preserving transaction. A stream checkpoint captures
+its thermodynamic system defensively, run/cache inputs, property-initialization mode, gas-quality
+configuration and reusable base-equipment state. Rollback retains the registered stream object and restores an independent
+thermodynamic clone; property-derived criconden and vapour-pressure caches are invalidated so a rejected trial cannot leak
+a stale result. Stream clones receive a distinct transaction identity, while Java serialization retains the original
+identity and restart state.
+
+A fully connected registered `Stream` plus classic `Recycle` reports quantitative 2/2 participant coverage and rolls both
+objects back together.
+
+Wrapper `Stream` objects remain fail-closed because their run path delegates fluid mutation to a separately owned stream.
+`VirtualStream` also remains fail-closed: every run constructs a new output `Stream` and increments legacy process-global
+stream-numbering state, which cannot be safely rewound across concurrent models. Stream subclasses, attached controllers,
+energy ports, failure state, design conditions and runtime capacity constraints remain blocked until their additional
+ownership is composed explicitly. This coverage establishes transaction and restart mechanics only; it does not qualify
+source-boundary physics, stream flash accuracy, property-package accuracy, adaptive full-step/two-half-step rejection,
+external I/O, safety action, virtual commissioning or OTS use.

--- a/src/main/java/neqsim/process/equipment/stream/Stream.java
+++ b/src/main/java/neqsim/process/equipment/stream/Stream.java
@@ -6,12 +6,15 @@
 
 package neqsim.process.equipment.stream;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import com.google.gson.GsonBuilder;
+import neqsim.process.dynamics.TransientStateParticipant;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
 import neqsim.process.measurementdevice.HydrocarbonDewPointAnalyser;
 import neqsim.process.util.monitor.StreamResponse;
@@ -33,7 +36,8 @@ import neqsim.util.exception.InvalidInputException;
  * @author Even Solbraa
  * @version $Id: $Id
  */
-public class Stream extends ProcessEquipmentBaseClass implements StreamInterface, Cloneable {
+public class Stream extends ProcessEquipmentBaseClass
+    implements StreamInterface, Cloneable, TransientStateParticipant<Stream.TransientState> {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
   /** Logger object for class. */
@@ -45,6 +49,9 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
   private static final double CRICONDEN_ECHO_TOLERANCE = 1.0e-6;
   /** Initial value for the deterministic criconden-envelope input fingerprint. */
   private static final long CRICONDEN_SIGNATURE_SEED = 1125899906842597L;
+
+  /** Stable transaction identity retained by Java serialization. */
+  private String transientStateIdentity = UUID.randomUUID().toString();
 
   /** Fingerprint of the fluid state used for the cached criconden envelope. */
   private transient long cachedCricondenInputSignature = Long.MIN_VALUE;
@@ -284,8 +291,114 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
     if (thermoSystem != null) {
       clonedSystem.thermoSystem = thermoSystem.clone();
     }
+    clonedSystem.transientStateIdentity = UUID.randomUUID().toString();
+    clonedSystem.lastComposition = lastComposition == null ? null : lastComposition.clone();
+    clonedSystem.invalidateDerivedTransientCaches();
 
     return clonedSystem;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateIdentity() {
+    if (transientStateIdentity == null || transientStateIdentity.trim().isEmpty()) {
+      transientStateIdentity = UUID.randomUUID().toString();
+    }
+    return "equipment:stream:" + transientStateIdentity;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getTransientStateCoverageIssue() {
+    if (getClass() != Stream.class) {
+      return "stream subclass " + getClass().getName() + " must extend the snapshot for subclass-owned mutable state";
+    }
+    String baseIssue = getBaseTransientStateCoverageIssue();
+    if (baseIssue != null) {
+      return baseIssue;
+    }
+    if (stream != null) {
+      return "wrapper streams delegate mutations to another stream and require coordinated state ownership";
+    }
+    if (thermoSystem == null) {
+      return "stream has no thermodynamic system to capture";
+    }
+    return null;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public TransientState captureTransientState() {
+    String coverageIssue = getTransientStateCoverageIssue();
+    if (coverageIssue != null) {
+      throw new IllegalStateException("Cannot capture stream '" + getName() + "': " + coverageIssue);
+    }
+    return new TransientState(this);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void restoreTransientState(TransientState snapshot) {
+    Objects.requireNonNull(snapshot, "stream transient snapshot cannot be null");
+    if (!getTransientStateIdentity().equals(snapshot.stateIdentity)) {
+      throw new IllegalArgumentException("Transient snapshot belongs to another stream");
+    }
+
+    restoreBaseTransientState(snapshot.baseState);
+    thermoSystem = snapshot.thermoSystem.clone();
+    stream = null;
+    streamNumber = snapshot.streamNumber;
+    gasQuality = snapshot.gasQuality;
+    lastTemperature = snapshot.lastTemperature;
+    lastPressure = snapshot.lastPressure;
+    lastFlowRate = snapshot.lastFlowRate;
+    lastComposition = snapshot.lastComposition == null ? null : snapshot.lastComposition.clone();
+    lastSpecification = snapshot.lastSpecification;
+    propertyInitLevel = snapshot.propertyInitLevel;
+    invalidateDerivedTransientCaches();
+  }
+
+  /** Clears derived property caches so rejected trials cannot leak cached results. */
+  private void invalidateDerivedTransientCaches() {
+    cachedCricondenInputSignature = Long.MIN_VALUE;
+    hasCachedCricondenEnvelope = false;
+    cachedCricondenTherm = null;
+    cachedCricondenBar = null;
+    cachedRvpStandard = null;
+    cachedRvpFluid = null;
+    cachedRvpComposition = null;
+    cachedRvpReferenceTemperature = Double.NaN;
+    cachedRvpReferenceTemperatureUnit = null;
+  }
+
+  /** Immutable serializable checkpoint for a concrete local stream. */
+  public static final class TransientState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String stateIdentity;
+    private final ProcessEquipmentTransientState baseState;
+    private final SystemInterface thermoSystem;
+    private final int streamNumber;
+    private final double gasQuality;
+    private final double lastTemperature;
+    private final double lastPressure;
+    private final double lastFlowRate;
+    private final double[] lastComposition;
+    private final String lastSpecification;
+    private final PropertyInitLevel propertyInitLevel;
+
+    private TransientState(Stream source) {
+      stateIdentity = source.getTransientStateIdentity();
+      baseState = source.captureBaseTransientState();
+      thermoSystem = source.thermoSystem.clone();
+      streamNumber = source.streamNumber;
+      gasQuality = source.gasQuality;
+      lastTemperature = source.lastTemperature;
+      lastPressure = source.lastPressure;
+      lastFlowRate = source.lastFlowRate;
+      lastComposition = source.lastComposition == null ? null : source.lastComposition.clone();
+      lastSpecification = source.lastSpecification;
+      propertyInitLevel = source.propertyInitLevel;
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/stream/Stream.java
+++ b/src/main/java/neqsim/process/equipment/stream/Stream.java
@@ -279,11 +279,12 @@ public class Stream extends ProcessEquipmentBaseClass
   /** {@inheritDoc} */
   @Override
   public Stream clone() {
-    Stream clonedSystem = null;
+    Stream clonedSystem;
     try {
       clonedSystem = (Stream) super.clone();
     } catch (Exception ex) {
-      logger.error(ex.getMessage());
+      logger.error("Failed to clone stream {}", getName(), ex);
+      throw new IllegalStateException("Unable to clone stream '" + getName() + "'", ex);
     }
     if (stream != null) {
       clonedSystem.setStream(stream.clone());

--- a/src/test/java/neqsim/process/equipment/stream/StreamTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/StreamTransientStateTransactionTest.java
@@ -1,0 +1,163 @@
+package neqsim.process.equipment.stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.dynamics.TransientStepTransaction;
+import neqsim.process.dynamics.TransientTransactionCoverage;
+import neqsim.process.equipment.util.Recycle;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Quantitative transaction and restart evidence for local stream-source equipment. */
+class StreamTransientStateTransactionTest extends neqsim.NeqSimTest {
+  private static final double TOLERANCE = 1.0e-12;
+
+  @Test
+  void streamRollbackRestoresThermodynamicsConfigurationAndBaseState() {
+    Stream stream = stream("feed");
+    stream.setGasQuality(0.3);
+    stream.setPropertyInitLevel(Stream.PropertyInitLevel.DENSITY_ONLY);
+    stream.setSpecification("TP");
+    stream.run();
+    stream.setTime(4.0);
+    UUID capturedIdentifier = stream.getCalculationIdentifier();
+    ProcessSystem process = new ProcessSystem("stream transaction");
+    process.add(stream);
+
+    TransientTransactionCoverage coverage = process.getTransientTransactionCoverage();
+    assertTrue(coverage.isComplete());
+    assertEquals(1, coverage.getProcessElementCount());
+    assertEquals(1, coverage.getParticipantCount());
+    assertFalse(stream.needRecalculation());
+
+    TransientStepTransaction transaction = process.beginTransientStepTransaction();
+    stream.setTemperature(340.0, "K");
+    stream.setPressure(8.0, "bara");
+    stream.setFlowRate(250.0, "kg/hr");
+    stream.setGasQuality(0.9);
+    stream.setPropertyInitLevel(Stream.PropertyInitLevel.FULL);
+    stream.setSpecification("PH");
+    process.runTransient(0.5, UUID.randomUUID());
+    transaction.rollback();
+
+    assertSame(stream, process.getUnitOperations().get(0));
+    assertEquals(298.15, stream.getTemperature("K"), TOLERANCE);
+    assertEquals(30.0, stream.getPressure("bara"), TOLERANCE);
+    assertEquals(100.0, stream.getFlowRate("kg/hr"), 1.0e-9);
+    assertEquals(0.3, stream.getGasQuality(), TOLERANCE);
+    assertEquals(Stream.PropertyInitLevel.DENSITY_ONLY, stream.getPropertyInitLevel());
+    assertEquals("TP", stream.getSpecification());
+    assertEquals(4.0, stream.getTime(), TOLERANCE);
+    assertEquals(0.0, process.getTime(), TOLERANCE);
+    assertEquals(capturedIdentifier, stream.getCalculationIdentifier());
+    assertFalse(stream.needRecalculation());
+  }
+
+  @Test
+  void registeredStreamAndRecycleRollbackTogetherWithCompleteCoverage() {
+    Stream feed = stream("registered feed");
+    Stream recycleOutlet = stream("recycle outlet");
+    Recycle recycle = new Recycle("recycle");
+    recycle.addStream(feed);
+    recycle.setOutletStream(recycleOutlet);
+    ProcessSystem process = new ProcessSystem("stream recycle transaction");
+    process.add(feed);
+    process.add(recycle);
+
+    TransientTransactionCoverage coverage = process.getTransientTransactionCoverage();
+    assertTrue(coverage.isComplete());
+    assertEquals(2, coverage.getProcessElementCount());
+    assertEquals(2, coverage.getParticipantCount());
+    StreamInterface capturedRecycleInput = recycle.getStream(0);
+    StreamInterface capturedRecycleOutput = recycle.getOutletStream();
+    double capturedFeedFlow = feed.getFlowRate("kg/hr");
+    double capturedRecycleFlow = recycleOutlet.getFlowRate("kg/hr");
+
+    TransientStepTransaction transaction = process.beginTransientStepTransaction();
+    feed.setFlowRate(180.0, "kg/hr");
+    process.runTransient(0.25, UUID.randomUUID());
+    transaction.rollback();
+
+    assertSame(feed, process.getUnitOperations().get(0));
+    assertSame(capturedRecycleInput, recycle.getStream(0));
+    assertSame(capturedRecycleOutput, recycle.getOutletStream());
+    assertEquals(capturedFeedFlow, feed.getFlowRate("kg/hr"), 1.0e-9);
+    assertEquals(capturedRecycleFlow, recycleOutlet.getFlowRate("kg/hr"), 1.0e-9);
+    assertEquals(0.0, process.getTime(), TOLERANCE);
+    assertEquals(0.0, feed.getTime(), TOLERANCE);
+    assertEquals(0.0, recycle.getTime(), TOLERANCE);
+  }
+
+  @Test
+  void serializationForeignSnapshotsAndUnsupportedOwnershipFailClosed() throws Exception {
+    Stream original = stream("original");
+    String identity = original.getTransientStateIdentity();
+    Stream restarted = roundTrip(original);
+    assertEquals(identity, restarted.getTransientStateIdentity());
+    assertNotEquals(identity, original.clone("clone").getTransientStateIdentity());
+
+    Stream.TransientState checkpoint = restarted.captureTransientState();
+    restarted.setTemperature(330.0, "K");
+    restarted.restoreTransientState(checkpoint);
+    assertEquals(298.15, restarted.getTemperature("K"), TOLERANCE);
+    assertThrows(IllegalArgumentException.class, () -> original.restoreTransientState(checkpoint));
+    assertThrows(NullPointerException.class, () -> original.restoreTransientState(null));
+
+    Stream wrapper = new Stream("wrapper", original);
+    assertTrue(wrapper.getTransientStateCoverageIssue().contains("wrapper"));
+    assertThrows(IllegalStateException.class, wrapper::captureTransientState);
+
+    DerivedStream derived = new DerivedStream("derived", original.getFluid().clone());
+    assertTrue(derived.getTransientStateCoverageIssue().contains("subclass"));
+    assertThrows(IllegalStateException.class, derived::captureTransientState);
+
+    VirtualStream virtual = new VirtualStream("virtual", original);
+    ProcessSystem virtualProcess = new ProcessSystem("unsupported virtual stream");
+    virtualProcess.add(virtual);
+    TransientTransactionCoverage virtualCoverage = virtualProcess.getTransientTransactionCoverage();
+    assertEquals(1, virtualCoverage.getProcessElementCount());
+    assertEquals(0, virtualCoverage.getParticipantCount());
+    assertTrue(virtualCoverage.getBlockingIssues().get(0).contains("does not implement"));
+    assertThrows(IllegalStateException.class, virtualProcess::beginTransientStepTransaction);
+  }
+
+  private static Stream stream(String name) {
+    SystemInterface fluid = new SystemSrkEos(298.15, 30.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("ethane", 0.2);
+    fluid.setMixingRule("classic");
+    Stream stream = new Stream(name, fluid);
+    stream.setFlowRate(100.0, "kg/hr");
+    return stream;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T roundTrip(T value) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(value);
+    }
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (T) input.readObject();
+    }
+  }
+
+  private static final class DerivedStream extends Stream {
+    private static final long serialVersionUID = 1000L;
+
+    private DerivedStream(String name, SystemInterface fluid) {
+      super(name, fluid);
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/stream/StreamTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/StreamTransientStateTransactionTest.java
@@ -141,14 +141,18 @@ class StreamTransientStateTransactionTest extends neqsim.NeqSimTest {
     Stream original = stream("original");
     String identity = original.getTransientStateIdentity();
     Stream restarted = roundTrip(original);
+    Stream clone = original.clone("clone");
     assertEquals(identity, restarted.getTransientStateIdentity());
-    assertNotEquals(identity, original.clone("clone").getTransientStateIdentity());
+    assertNotEquals(identity, clone.getTransientStateIdentity());
 
     Stream.TransientState checkpoint = restarted.captureTransientState();
     restarted.setTemperature(330.0, "K");
     restarted.restoreTransientState(checkpoint);
     assertEquals(298.15, restarted.getTemperature("K"), TOLERANCE);
-    assertThrows(IllegalArgumentException.class, () -> original.restoreTransientState(checkpoint));
+    original.setTemperature(320.0, "K");
+    original.restoreTransientState(checkpoint);
+    assertEquals(298.15, original.getTemperature("K"), TOLERANCE);
+    assertThrows(IllegalArgumentException.class, () -> clone.restoreTransientState(checkpoint));
     assertThrows(NullPointerException.class, () -> original.restoreTransientState(null));
 
     Stream wrapper = new Stream("wrapper", original);

--- a/src/test/java/neqsim/process/equipment/stream/StreamTransientStateTransactionTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/StreamTransientStateTransactionTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import neqsim.process.dynamics.TransientStepTransaction;
 import neqsim.process.dynamics.TransientTransactionCoverage;
 import neqsim.process.equipment.util.Recycle;
+import neqsim.process.processmodel.ProcessModel;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
@@ -97,6 +98,42 @@ class StreamTransientStateTransactionTest extends neqsim.NeqSimTest {
     assertEquals(0.0, process.getTime(), TOLERANCE);
     assertEquals(0.0, feed.getTime(), TOLERANCE);
     assertEquals(0.0, recycle.getTime(), TOLERANCE);
+  }
+
+  @Test
+  void processModelCoordinatesStreamAndRecycleAreaRollback() {
+    Stream boundary = stream("boundary");
+    ProcessSystem boundaryArea = new ProcessSystem("boundary area");
+    boundaryArea.add(boundary);
+
+    Stream recycleInput = stream("area recycle input");
+    Stream recycleOutput = stream("area recycle output");
+    Recycle recycle = new Recycle("area recycle");
+    recycle.addStream(recycleInput);
+    recycle.setOutletStream(recycleOutput);
+    ProcessSystem recycleArea = new ProcessSystem("recycle area");
+    recycleArea.add(recycle);
+
+    ProcessModel model = new ProcessModel();
+    model.add("boundary", boundaryArea);
+    model.add("recycle", recycleArea);
+    TransientTransactionCoverage coverage = model.getTransientTransactionCoverage();
+    assertTrue(coverage.isComplete());
+    assertEquals(2, coverage.getProcessElementCount());
+    assertEquals(2, coverage.getParticipantCount());
+
+    TransientStepTransaction transaction = model.beginTransientStepTransaction();
+    boundary.setFlowRate(150.0, "kg/hr");
+    recycle.setPriority(99);
+    model.runTransient(0.5, UUID.randomUUID());
+    transaction.rollback();
+
+    assertSame(boundaryArea, model.get("boundary"));
+    assertSame(recycleArea, model.get("recycle"));
+    assertEquals(100.0, boundary.getFlowRate("kg/hr"), 1.0e-9);
+    assertEquals(100, recycle.getPriority());
+    assertEquals(0.0, boundaryArea.getTime(), TOLERANCE);
+    assertEquals(0.0, recycleArea.getTime(), TOLERANCE);
   }
 
   @Test


### PR DESCRIPTION
## Roadmap

Advances #2911 as **DYN-C018** after merged DYN-C017. This is the next dependency-ready shared transaction tranche; it does not close the campaign.

## Engineering question

Can a registered concrete local `Stream` participate in an identity-preserving whole-step transaction, including a realistic `Stream + Recycle` composition, without claiming wrapper, subclass or virtual-source ownership that cannot be restored safely?

Baseline: `master` at `1d9206dfb2a87cc67103468d8a5ff766ca01bbad`.

## Implementation

- makes exact concrete local `Stream` implement `TransientStateParticipant<Stream.TransientState>` with a serialization-stable identity;
- captures a defensive thermodynamic clone, base-equipment state, gas-quality and property-initialization configuration, and run/recalculation caches;
- restores the same registered stream object and invalidates derived criconden/RVP caches after rollback;
- gives clones a distinct transaction identity and defensively copies last-composition state;
- fails closed for wrapper streams, subclasses, missing fluids, attached controllers, energy ports, failure state, design conditions and runtime capacity constraints;
- deliberately leaves `VirtualStream` unsupported because each run creates a new stream and mutates legacy process-global stream numbering, which cannot be rewound safely across concurrent models.

## Quantitative regression evidence

`StreamTransientStateTransactionTest` adds four focused tests:

1. 1/1 `ProcessSystem` coverage and rollback of thermodynamics, configuration, caches, identifiers and clocks at 1e-12;
2. a registered `Stream + Recycle` transaction with 2/2 coverage, original object identities and coordinated rollback;
3. coordinated two-area `ProcessModel` rollback with aggregate 2/2 coverage and aligned clocks;
4. Java-serialization restart, clone identity separation, foreign/null rejection, wrapper/subclass blockers and explicit `VirtualStream` fail-closed coverage.

## Documentation

Updates `docs/process/dynamic-capability-contract.md` with the covered state, ownership boundary and remaining limitations.

## Validation

**READY TO MERGE**

Exact head: `2469458db0193c0ccf6d827d73a72ab54883f587`.

- `git diff --check`: passed locally; the two review/CI repairs are whitespace-neutral.
- Local focused Maven/Spotless execution was unavailable because the environment could not resolve `repo.maven.apache.org` and its default `/root/.m2` was read-only; no local Maven result is claimed.
- GitHub CI on this exact head passes: Spotless, pre-commit, documentation search, PaperLab, CodeQL and Javadoc.
- Java 21 fast tests pass on Ubuntu and Windows; all four Java 21 slow-test shards pass.
- Java 8 fast tests pass on Ubuntu and Windows.
- The prior serialization-test contradiction is repaired: the original and serialized restart retain one logical identity and accept the same checkpoint, while a clone with a new identity rejects it.
- The nullable-clone review finding is repaired fail-fast; its inline thread is answered and resolved.
- The final diff remains the declared three-file stream transaction tranche, is mergeable and is zero commits behind `master`.

## Stop boundary

This PR establishes transaction/restart mechanics for exact local streams only. It does not qualify stream/property-package accuracy, wrapper or virtual-source side effects, adaptive full-step/two-half-step rejection, global DAE/pressure-flow solving, external I/O, safety action, virtual commissioning, OTS, #2935 species transport, #2907 multiphase closures/slugging or Huldra integration.