### PR TITLE
fix(process): order registered stream aliases

### DIFF
--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
@@ -107,6 +107,10 @@ public final class ProcessGraphBuilder {
 
     // Build a map from stream objects to units that produce them (as outputs)
     Map<Object, ProcessEquipmentInterface> streamToProducer = new IdentityHashMap<>();
+    // Preserve the equipment source of streams that are also registered as explicit
+    // ProcessSystem units. The registered Stream becomes the producer seen by downstream
+    // consumers, while this map retains the preceding producer -> Stream dependency.
+    Map<Object, ProcessEquipmentInterface> registeredStreamSources = new IdentityHashMap<>();
 
     // First pass: identify stream producers.
     // We process non-Stream equipment FIRST so that streams produced by real
@@ -310,11 +314,17 @@ public final class ProcessGraphBuilder {
       }
     }
 
-    // Pass 1b: Stream units default to producing themselves, but only if no
-    // real producer has already claimed them (e.g., a Recycle's outlet).
+    // Pass 1b: a registered Stream is an executable alias boundary. Downstream consumers must
+    // depend on that Stream unit, not run beside it after only waiting for the equipment that
+    // originally created the same object. Preserve the original producer separately so pass 2
+    // can create producer -> Stream -> consumer edges.
     for (ProcessEquipmentInterface unit : units) {
       if (unit instanceof StreamInterface) {
-        streamToProducer.putIfAbsent(unit, unit);
+        ProcessEquipmentInterface source = streamToProducer.get(unit);
+        if (source != null && source != unit) {
+          registeredStreamSources.put(unit, source);
+        }
+        streamToProducer.put(unit, unit);
       }
     }
 
@@ -328,9 +338,9 @@ public final class ProcessGraphBuilder {
       // when the outlet stream of a Recycle is registered as its own unit.
       if (unit instanceof StreamInterface) {
         // Case 1: this stream is registered as an outlet of another equipment.
-        ProcessEquipmentInterface producer = streamToProducer.get(unit);
-        if (producer != null && producer != unit) {
-          createEdgeFromProducer(graph, streamToProducer, unit, unit);
+        ProcessEquipmentInterface producer = registeredStreamSources.get(unit);
+        if (producer != null) {
+          createEdgeFromKnownProducer(graph, producer, unit, unit);
         }
         // Case 2: Stream wraps another upstream Stream via the `stream` field.
         try {
@@ -1068,6 +1078,19 @@ public final class ProcessGraphBuilder {
   private static void createEdgeFromProducer(ProcessGraph graph,
       Map<Object, ProcessEquipmentInterface> streamToProducer, Object stream, ProcessEquipmentInterface consumer) {
     ProcessEquipmentInterface producer = streamToProducer.get(stream);
+    createEdgeFromKnownProducer(graph, producer, stream, consumer);
+  }
+
+  /**
+   * Creates an edge from a known producer to a consumer, preserving stream identity.
+   *
+   * @param graph process graph to add the edge to
+   * @param producer equipment producing the stream, or {@code null}
+   * @param stream stream object connecting producer and consumer
+   * @param consumer consuming process equipment
+   */
+  private static void createEdgeFromKnownProducer(ProcessGraph graph, ProcessEquipmentInterface producer, Object stream,
+      ProcessEquipmentInterface consumer) {
     if (producer != null && producer != consumer) {
       ProcessNode sourceNode = graph.getNode(producer);
       ProcessNode targetNode = graph.getNode(consumer);

--- a/src/test/java/neqsim/process/processmodel/MultiInputMixerPhaseRegressionTest.java
+++ b/src/test/java/neqsim/process/processmodel/MultiInputMixerPhaseRegressionTest.java
@@ -1,0 +1,152 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.mixer.StaticMixer;
+import neqsim.process.equipment.separator.ThreePhaseSeparator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.util.StreamSaturatorUtil;
+import neqsim.process.measurementdevice.HydrateEquilibriumTemperatureAnalyser;
+import neqsim.process.processmodel.graph.ProcessGraph;
+import neqsim.process.processmodel.graph.ProcessNode;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+
+/** Regression coverage for reused multiphase state in a feed-forward process. */
+public class MultiInputMixerPhaseRegressionTest {
+  @Test
+  public void reusedMultiInputProcessPreservesAqueousPhaseAfterFlowChange() {
+    ProcessSystem sequential = buildProcess();
+    sequential.setUseOptimizedExecution(false);
+    runChangedInhibitorCase(sequential);
+
+    ProcessSystem optimized = buildProcess();
+    runChangedInhibitorCase(optimized);
+
+    assertEquivalentOutletState(sequential, optimized);
+    assertRegisteredStreamsAreExecutionBoundaries(optimized);
+  }
+
+  private void runChangedInhibitorCase(ProcessSystem process) {
+    process.run();
+    Stream inhibitor = (Stream) process.getUnit("inhibitor stream");
+    inhibitor.setFlowRate(0.1, "kg/hr");
+    process.run();
+  }
+
+  private void assertEquivalentOutletState(ProcessSystem sequential, ProcessSystem optimized) {
+    SystemInterface expected = ((Stream) sequential.getUnit("downstream stream")).getFluid();
+    SystemInterface actual = ((Stream) optimized.getUnit("downstream stream")).getFluid();
+
+    assertTrue(actual.hasPhaseType("gas"));
+    assertTrue(actual.hasPhaseType("aqueous"));
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    assertEquals(expected.getTemperature("C"), actual.getTemperature("C"), 1.0e-8);
+    assertEquals(expected.getPressure("bara"), actual.getPressure("bara"), 1.0e-8);
+    assertEquals(expected.getFlowRate("kg/hr"), actual.getFlowRate("kg/hr"),
+        Math.abs(expected.getFlowRate("kg/hr")) * 1.0e-8);
+    assertEquals(expected.getPhase("gas").getFlowRate("kg/hr"), actual.getPhase("gas").getFlowRate("kg/hr"),
+        Math.abs(expected.getPhase("gas").getFlowRate("kg/hr")) * 1.0e-8);
+    assertEquals(expected.getPhase("aqueous").getFlowRate("kg/hr"), actual.getPhase("aqueous").getFlowRate("kg/hr"),
+        Math.abs(expected.getPhase("aqueous").getFlowRate("kg/hr")) * 1.0e-6);
+    assertArrayEquals(expected.getMolarComposition(), actual.getMolarComposition(), 1.0e-10);
+  }
+
+  private void assertRegisteredStreamsAreExecutionBoundaries(ProcessSystem process) {
+    ProcessGraph graph = process.buildGraph();
+    ProcessGraph.ParallelPartition partition = graph.partitionForParallelExecution();
+
+    assertLevelBefore(process, graph, partition, "saturated gas stream", "multiphase mixer");
+    assertLevelBefore(process, graph, partition, "downstream stream", "separator heater");
+    assertTrue(partition.getMaxParallelism() > 1,
+        "Independent feed and downstream reader branches should remain parallel");
+  }
+
+  private void assertLevelBefore(ProcessSystem process, ProcessGraph graph, ProcessGraph.ParallelPartition partition,
+      String beforeName, String afterName) {
+    ProcessEquipmentInterface beforeUnit = process.getUnit(beforeName);
+    ProcessEquipmentInterface afterUnit = process.getUnit(afterName);
+    ProcessNode beforeNode = graph.getNode(beforeUnit);
+    ProcessNode afterNode = graph.getNode(afterUnit);
+    Integer beforeLevel = partition.getNodeToLevel().get(beforeNode);
+    Integer afterLevel = partition.getNodeToLevel().get(afterNode);
+
+    assertNotNull(beforeLevel);
+    assertNotNull(afterLevel);
+    assertTrue(beforeLevel < afterLevel,
+        beforeName + " must complete before " + afterName + " reads its mutable state");
+  }
+
+  private ProcessSystem buildProcess() {
+    SystemInterface feed = new SystemSrkCPAstatoil(298.15, 1.01325);
+    String[] names = { "N2", "CO2", "methane", "ethane", "propane", "i-butane", "n-butane", "i-pentane", "n-pentane",
+        "c-C5", "22-dim-C3", "n-hexane", "n-heptane", "n-octane", "n-nonane" };
+    double[] amounts = { 0.41, 9.249, 73.263, 9.269, 4.75, 0.52, 1.34, 0.29, 0.36, 0.02, 0.02, 0.29, 0.25, 0.05, 0.02 };
+    for (int index = 0; index < names.length; index++) {
+      feed.addComponent(names[index], amounts[index]);
+    }
+    feed.addComponent("water", 0.0);
+    feed.addComponent("MEG", 0.0);
+    feed.setMixingRule(10);
+    feed.setMultiPhaseCheck(true);
+
+    ProcessSystem process = new ProcessSystem();
+    Stream gas = new Stream("gas stream", feed);
+    gas.setFlowRate(168958.0, "Sm3/hr");
+    gas.setTemperature(29.0, "C");
+    gas.setPressure(74.1, "barg");
+    process.add(gas);
+
+    StreamSaturatorUtil saturator = new StreamSaturatorUtil("water saturator", gas);
+    process.add(saturator);
+    Stream saturatedGas = (Stream) saturator.getOutStream();
+    saturatedGas.setName("saturated gas stream");
+    process.add(saturatedGas);
+
+    SystemInterface inhibitorFluid = feed.clone();
+    double inhibitorMoleFraction = (89.0 / 62.07) / ((89.0 / 62.07) + (11.0 / 18.01528));
+    double[] inhibitorComposition = new double[feed.getNumberOfComponents()];
+    for (int index = 0; index < feed.getNumberOfComponents(); index++) {
+      String componentName = feed.getComponent(index).getName();
+      if (componentName.equals("water")) {
+        inhibitorComposition[index] = 1.0 - inhibitorMoleFraction;
+      } else if (componentName.equals("MEG")) {
+        inhibitorComposition[index] = inhibitorMoleFraction;
+      }
+    }
+    inhibitorFluid.setMolarComposition(inhibitorComposition);
+
+    Stream inhibitor = new Stream("inhibitor stream", inhibitorFluid);
+    inhibitor.setFlowRate(0.01, "kg/hr");
+    inhibitor.setTemperature(29.0, "C");
+    inhibitor.setPressure(74.1, "barg");
+    process.add(inhibitor);
+
+    StaticMixer mixer = new StaticMixer("multiphase mixer");
+    mixer.addStream(inhibitor);
+    mixer.addStream(saturatedGas);
+    process.add(mixer);
+
+    Heater pipeline = new Heater("downstream heater", mixer.getOutletStream());
+    pipeline.setOutPressure(36.2, "barg");
+    pipeline.setOutTemperature(5.3, "C");
+    process.add(pipeline);
+
+    Stream outlet = (Stream) pipeline.getOutStream();
+    outlet.setName("downstream stream");
+    process.add(outlet);
+    process.add(new HydrateEquilibriumTemperatureAnalyser("hydrate analyser", outlet));
+
+    Heater separatorHeater = new Heater("separator heater", outlet);
+    separatorHeater.setOutPressure(35.0, "barg");
+    separatorHeater.setOutTemperature(19.0, "C");
+    process.add(separatorHeater);
+    process.add(new ThreePhaseSeparator("three phase separator", separatorHeater.getOutletStream()));
+    return process;
+  }
+}


### PR DESCRIPTION
## Summary

- Treat a registered `Stream` that is also an equipment outlet as an executable alias boundary in the process graph.
- Build the required `producer -> registered Stream -> consumer` dependency chain.
- Include and strengthen the multiphase MEG regression from #3063.

## Root cause

The same mutable `Stream` object can be:

1. an equipment outlet,
2. an explicit unit in `ProcessSystem`, and
3. an inlet to downstream equipment.

The producer map retained only the original equipment as producer for downstream consumers. Parallel partitioning therefore placed the explicit `Stream.run()` beside its downstream consumers. Those units concurrently replaced, flashed, cloned, or initialized the same mutable `ThermoSystem`.

On current `master`, the reproducer failed during optimized execution in CPA initialization with:

`Unexpected number of rows in B based on shape of A. Found=10 Expected=2`

Sequential insertion-order execution worked because it happened to serialize the aliases.

## Fix

`ProcessGraphBuilder` now retains the original equipment source separately, then makes an explicitly registered `Stream` the producer seen by downstream consumers. This adds only the missing alias edges; it does not disable optimized execution or call `runSequential()`.

Independent branches remain parallel. The regression requires `maxParallelism > 1`, while enforcing the necessary ordering around the saturated-gas and downstream outlet stream aliases.

## Regression coverage

`MultiInputMixerPhaseRegressionTest`:

- runs the low-MEG case, changes inhibitor flow, and reuses the process;
- compares optimized execution with an independently built sequential reference;
- verifies gas and aqueous phases;
- compares phase count, gas/aqueous flow, total flow, pressure, temperature, and composition;
- verifies registered streams precede consumers in parallel execution levels;
- verifies useful parallelism remains available.

This includes and supersedes the test-only change in #3063; #3063 does not need to be merged separately.

## Validation

- Original regression reproduced before the fix: failed with concurrent CPA state corruption.
- Focused process/graph suite: **83 tests passed**.
- Broader `ProcessSystemTest` and `ProcessModelExecutionOptimizationTest`: **74 tests passed**.
- Total local test invocations: **157 passed, 0 failed**.
- `python devtools/run_spotless.py apply`: passed.
- `python devtools/run_spotless.py check`: passed.
- `python devtools/check_documentation_search.py`: passed.
- `git diff --check`: passed.
- Java 8 and Checkstyle matrix: **VALIDATION PENDING CI** because the isolated local cache lacks the Java 8 flatten/checkstyle plugin artifacts and Maven Central DNS is unavailable.

## Documentation impact

Documentation impact: none. This corrects internal dependency-graph ordering for existing process models without changing public APIs, model inputs, units, configuration, or recommended usage.
