### PR TITLE
fix(process): order consumers after registered streams

### DIFF
--- a/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/graph/ProcessGraphBuilder.java
@@ -1068,6 +1068,11 @@ public final class ProcessGraphBuilder {
   private static void createEdgeFromProducer(ProcessGraph graph,
       Map<Object, ProcessEquipmentInterface> streamToProducer, Object stream, ProcessEquipmentInterface consumer) {
     ProcessEquipmentInterface producer = streamToProducer.get(stream);
+    // A registered stream is a mutable-state barrier between its equipment producer and consumers.
+    if (stream instanceof ProcessEquipmentInterface && stream != consumer
+        && graph.getNode((ProcessEquipmentInterface) stream) != null) {
+      producer = (ProcessEquipmentInterface) stream;
+    }
     if (producer != null && producer != consumer) {
       ProcessNode sourceNode = graph.getNode(producer);
       ProcessNode targetNode = graph.getNode(consumer);

--- a/src/test/java/neqsim/process/processmodel/MultiInputMixerPhaseRegressionTest.java
+++ b/src/test/java/neqsim/process/processmodel/MultiInputMixerPhaseRegressionTest.java
@@ -1,7 +1,11 @@
 package neqsim.process.processmodel;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.heatexchanger.Heater;
 import neqsim.process.equipment.mixer.StaticMixer;
 import neqsim.process.equipment.separator.ThreePhaseSeparator;
@@ -13,55 +17,72 @@ import neqsim.process.processmodel.graph.ProcessNode;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkCPAstatoil;
 
-/**
- * Regression coverage for reused multiphase state in a feed-forward process.
- *
- * @author NeqSim
- * @version 1.0
- */
+/** Regression coverage for reused multiphase state in a feed-forward process. */
 public class MultiInputMixerPhaseRegressionTest {
-  /** Verifies registered stream barriers preserve phase state without disabling parallel execution. */
   @Test
   public void reusedMultiInputProcessPreservesAqueousPhaseAfterFlowChange() {
-    ProcessSystem process = buildProcess();
-    assertTrue(process.isUseOptimizedExecution());
-    ProcessGraph.ParallelPartition partition = process.getParallelPartition();
-    assertTrue(partition.getMaxParallelism() >= 2);
-    assertTrue(findLevel(partition, "saturated gas stream") < findLevel(partition, "multiphase mixer"));
+    ProcessSystem sequential = buildProcess();
+    sequential.setUseOptimizedExecution(false);
+    runChangedInhibitorCase(sequential);
+
+    ProcessSystem optimized = buildProcess();
+    runChangedInhibitorCase(optimized);
+
+    assertEquivalentOutletState(sequential, optimized);
+    assertRegisteredStreamsAreExecutionBoundaries(optimized);
+  }
+
+  private void runChangedInhibitorCase(ProcessSystem process) {
     process.run();
 
     Stream inhibitor = (Stream) process.getUnit("inhibitor stream");
     inhibitor.setFlowRate(0.1, "kg/hr");
     process.run();
-
-    Stream outlet = (Stream) process.getUnit("downstream stream");
-    assertTrue(outlet.getFluid().hasPhaseType("gas"));
-    assertTrue(outlet.getFluid().hasPhaseType("aqueous"));
   }
 
-  /**
-   * Finds the parallel level assigned to a process unit.
-   *
-   * @param partition parallel execution partition
-   * @param unitName process unit name
-   * @return zero-based parallel level, or {@code -1} when absent
-   */
-  private int findLevel(ProcessGraph.ParallelPartition partition, String unitName) {
-    for (int levelIndex = 0; levelIndex < partition.getLevels().size(); levelIndex++) {
-      for (ProcessNode node : partition.getLevels().get(levelIndex)) {
-        if (node.getName().equals(unitName)) {
-          return levelIndex;
-        }
-      }
-    }
-    return -1;
+  private void assertEquivalentOutletState(ProcessSystem sequential, ProcessSystem optimized) {
+    SystemInterface expected = ((Stream) sequential.getUnit("downstream stream")).getFluid();
+    SystemInterface actual = ((Stream) optimized.getUnit("downstream stream")).getFluid();
+
+    assertTrue(actual.hasPhaseType("gas"));
+    assertTrue(actual.hasPhaseType("aqueous"));
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    assertEquals(expected.getTemperature("C"), actual.getTemperature("C"), 1.0e-8);
+    assertEquals(expected.getPressure("bara"), actual.getPressure("bara"), 1.0e-8);
+    assertEquals(expected.getFlowRate("kg/hr"), actual.getFlowRate("kg/hr"),
+        Math.abs(expected.getFlowRate("kg/hr")) * 1.0e-8);
+    assertEquals(expected.getPhase("gas").getFlowRate("kg/hr"), actual.getPhase("gas").getFlowRate("kg/hr"),
+        Math.abs(expected.getPhase("gas").getFlowRate("kg/hr")) * 1.0e-8);
+    assertEquals(expected.getPhase("aqueous").getFlowRate("kg/hr"), actual.getPhase("aqueous").getFlowRate("kg/hr"),
+        Math.abs(expected.getPhase("aqueous").getFlowRate("kg/hr")) * 1.0e-6);
+    assertArrayEquals(expected.getMolarComposition(), actual.getMolarComposition(), 1.0e-10);
   }
 
-  /**
-   * Builds a feed-forward process with a registered producer stream consumed by a multiphase mixer.
-   *
-   * @return configured process system
-   */
+  private void assertRegisteredStreamsAreExecutionBoundaries(ProcessSystem process) {
+    ProcessGraph graph = process.buildGraph();
+    ProcessGraph.ParallelPartition partition = graph.partitionForParallelExecution();
+
+    assertLevelBefore(process, graph, partition, "saturated gas stream", "multiphase mixer");
+    assertLevelBefore(process, graph, partition, "downstream stream", "separator heater");
+    assertTrue(partition.getMaxParallelism() > 1,
+        "Independent feed and downstream reader branches should remain parallel");
+  }
+
+  private void assertLevelBefore(ProcessSystem process, ProcessGraph graph, ProcessGraph.ParallelPartition partition,
+      String beforeName, String afterName) {
+    ProcessEquipmentInterface beforeUnit = process.getUnit(beforeName);
+    ProcessEquipmentInterface afterUnit = process.getUnit(afterName);
+    ProcessNode beforeNode = graph.getNode(beforeUnit);
+    ProcessNode afterNode = graph.getNode(afterUnit);
+    Integer beforeLevel = partition.getNodeToLevel().get(beforeNode);
+    Integer afterLevel = partition.getNodeToLevel().get(afterNode);
+
+    assertNotNull(beforeLevel);
+    assertNotNull(afterLevel);
+    assertTrue(beforeLevel < afterLevel,
+        beforeName + " must complete before " + afterName + " reads its mutable state");
+  }
+
   private ProcessSystem buildProcess() {
     SystemInterface feed = new SystemSrkCPAstatoil(298.15, 1.01325);
     String[] names = { "N2", "CO2", "methane", "ethane", "propane", "i-butane", "n-butane", "i-pentane", "n-pentane",

--- a/src/test/java/neqsim/process/processmodel/MultiInputMixerPhaseRegressionTest.java
+++ b/src/test/java/neqsim/process/processmodel/MultiInputMixerPhaseRegressionTest.java
@@ -1,0 +1,132 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.mixer.StaticMixer;
+import neqsim.process.equipment.separator.ThreePhaseSeparator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.util.StreamSaturatorUtil;
+import neqsim.process.measurementdevice.HydrateEquilibriumTemperatureAnalyser;
+import neqsim.process.processmodel.graph.ProcessGraph;
+import neqsim.process.processmodel.graph.ProcessNode;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+
+/**
+ * Regression coverage for reused multiphase state in a feed-forward process.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class MultiInputMixerPhaseRegressionTest {
+  /** Verifies registered stream barriers preserve phase state without disabling parallel execution. */
+  @Test
+  public void reusedMultiInputProcessPreservesAqueousPhaseAfterFlowChange() {
+    ProcessSystem process = buildProcess();
+    assertTrue(process.isUseOptimizedExecution());
+    ProcessGraph.ParallelPartition partition = process.getParallelPartition();
+    assertTrue(partition.getMaxParallelism() >= 2);
+    assertTrue(findLevel(partition, "saturated gas stream") < findLevel(partition, "multiphase mixer"));
+    process.run();
+
+    Stream inhibitor = (Stream) process.getUnit("inhibitor stream");
+    inhibitor.setFlowRate(0.1, "kg/hr");
+    process.run();
+
+    Stream outlet = (Stream) process.getUnit("downstream stream");
+    assertTrue(outlet.getFluid().hasPhaseType("gas"));
+    assertTrue(outlet.getFluid().hasPhaseType("aqueous"));
+  }
+
+  /**
+   * Finds the parallel level assigned to a process unit.
+   *
+   * @param partition parallel execution partition
+   * @param unitName process unit name
+   * @return zero-based parallel level, or {@code -1} when absent
+   */
+  private int findLevel(ProcessGraph.ParallelPartition partition, String unitName) {
+    for (int levelIndex = 0; levelIndex < partition.getLevels().size(); levelIndex++) {
+      for (ProcessNode node : partition.getLevels().get(levelIndex)) {
+        if (node.getName().equals(unitName)) {
+          return levelIndex;
+        }
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Builds a feed-forward process with a registered producer stream consumed by a multiphase mixer.
+   *
+   * @return configured process system
+   */
+  private ProcessSystem buildProcess() {
+    SystemInterface feed = new SystemSrkCPAstatoil(298.15, 1.01325);
+    String[] names = { "N2", "CO2", "methane", "ethane", "propane", "i-butane", "n-butane", "i-pentane", "n-pentane",
+        "c-C5", "22-dim-C3", "n-hexane", "n-heptane", "n-octane", "n-nonane" };
+    double[] amounts = { 0.41, 9.249, 73.263, 9.269, 4.75, 0.52, 1.34, 0.29, 0.36, 0.02, 0.02, 0.29, 0.25, 0.05, 0.02 };
+    for (int index = 0; index < names.length; index++) {
+      feed.addComponent(names[index], amounts[index]);
+    }
+    feed.addComponent("water", 0.0);
+    feed.addComponent("MEG", 0.0);
+    feed.setMixingRule(10);
+    feed.setMultiPhaseCheck(true);
+
+    ProcessSystem process = new ProcessSystem();
+    Stream gas = new Stream("gas stream", feed);
+    gas.setFlowRate(168958.0, "Sm3/hr");
+    gas.setTemperature(29.0, "C");
+    gas.setPressure(74.1, "barg");
+    process.add(gas);
+
+    StreamSaturatorUtil saturator = new StreamSaturatorUtil("water saturator", gas);
+    process.add(saturator);
+    Stream saturatedGas = (Stream) saturator.getOutStream();
+    saturatedGas.setName("saturated gas stream");
+    process.add(saturatedGas);
+
+    SystemInterface inhibitorFluid = feed.clone();
+    double inhibitorMoleFraction = (89.0 / 62.07) / ((89.0 / 62.07) + (11.0 / 18.01528));
+    double[] inhibitorComposition = new double[feed.getNumberOfComponents()];
+    for (int index = 0; index < feed.getNumberOfComponents(); index++) {
+      String componentName = feed.getComponent(index).getName();
+      if (componentName.equals("water")) {
+        inhibitorComposition[index] = 1.0 - inhibitorMoleFraction;
+      } else if (componentName.equals("MEG")) {
+        inhibitorComposition[index] = inhibitorMoleFraction;
+      }
+    }
+    inhibitorFluid.setMolarComposition(inhibitorComposition);
+
+    Stream inhibitor = new Stream("inhibitor stream", inhibitorFluid);
+    inhibitor.setFlowRate(0.01, "kg/hr");
+    inhibitor.setTemperature(29.0, "C");
+    inhibitor.setPressure(74.1, "barg");
+    process.add(inhibitor);
+
+    StaticMixer mixer = new StaticMixer("multiphase mixer");
+    mixer.addStream(inhibitor);
+    mixer.addStream(saturatedGas);
+    process.add(mixer);
+
+    Heater pipeline = new Heater("downstream heater", mixer.getOutletStream());
+    pipeline.setOutPressure(36.2, "barg");
+    pipeline.setOutTemperature(5.3, "C");
+    process.add(pipeline);
+
+    Stream outlet = (Stream) pipeline.getOutStream();
+    outlet.setName("downstream stream");
+    process.add(outlet);
+    process.add(new HydrateEquilibriumTemperatureAnalyser("hydrate analyser", outlet));
+
+    Heater separatorHeater = new Heater("separator heater", outlet);
+    separatorHeater.setOutPressure(35.0, "barg");
+    separatorHeater.setOutTemperature(19.0, "C");
+    process.add(separatorHeater);
+    process.add(new ThreePhaseSeparator("three phase separator", separatorHeater.getOutletStream()));
+    return process;
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramTopologyEquivalenceTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/ProcessDiagramTopologyEquivalenceTest.java
@@ -85,11 +85,10 @@ class ProcessDiagramTopologyEquivalenceTest {
 
     List<String> expected = sorted("branch feed->branch splitter|false", "branch splitter->branch mixer|false",
         "branch splitter->branch mixer|false", "branch mixer->loop mixer|false", "liquid recycle->tear seed|true",
-        "liquid recycle->loop mixer|true", "loop mixer->loop separator|false", "loop separator->liquid recycle|true");
+        "tear seed->loop mixer|false", "loop mixer->loop separator|false", "loop separator->liquid recycle|true");
 
-    // The legacy Graphviz view retains the tear stream as an explicit node, so its two-hop
-    // liquid recycle -> tear seed -> loop mixer projection is equivalent to the canonical
-    // physical connection liquid recycle -> loop mixer.
+    // The registered tear stream is an explicit mutable-state barrier in both execution and
+    // diagram projections: liquid recycle -> tear seed -> loop mixer.
     List<String> legacyExpected = sorted("branch feed->branch splitter|false", "branch splitter->branch mixer|false",
         "branch splitter->branch mixer|false", "branch mixer->loop mixer|false", "liquid recycle->tear seed|true",
         "tear seed->loop mixer|false", "loop mixer->loop separator|false", "loop separator->liquid recycle|true");


### PR DESCRIPTION
## Summary

- Treat an explicitly registered stream unit as a mutable-state dependency barrier between its equipment producer and downstream consumers.
- Preserve topological parallel execution for independent branches.
- Add a generic full-topology regression covering a reused multiphase mixer after an inhibitor-flow change.

## Root cause

The graph mapped a registered equipment output stream directly back to the equipment producer for every consumer edge. This allowed the registered stream unit and a downstream mixer consuming that same mutable stream to occupy the same parallel level and run concurrently.

The graph now keeps `producer -> registered stream -> consumer` ordering. Unregistered output streams retain the existing direct `producer -> consumer` edge.

## Performance

- No fallback to `runSequential`.
- No extra process or flash passes.
- Independent feed branches remain parallel (`maxParallelism >= 2` is asserted by the regression).
- Only the unsafe overlap between a registered mutable stream and its consumer is removed.

## Validation

Ran the new regression three consecutive times successfully.

Focused suite:

```text
MultiInputMixerPhaseRegressionTest: 1 passed
StaticMixerTest: 7 passed
ProcessGraphParallelConnectionsTest: 2 passed
ProcessSystemDataflowDispatchTest: 3 passed
Total: 13 passed
```

Spotless and `git diff --check` passed. No application-specific names are included.

## CI repair status

**VALIDATION PENDING CI**

Exact head: `105ed981bbda0e0f73edaeaf405e636aad229992`.

The previous exact head passed Spotless, pre-commit, CodeQL, Javadocs and all four Java 21 slow-test shards. Its Windows fast suite exposed one branch-attributable golden-topology mismatch: the new registered tear-stream barrier correctly changed `recycle -> mixer` into `recycle -> tear stream -> mixer`, while the canonical expectation still encoded the old direct edge.

This head updates that single existing expectation to the documented barrier topology. The repair is test-only; it does not add process passes, flashes, serialization, synchronization or sequential fallback. Fresh exact-head CI is pending.

Documentation impact: none — this repair only aligns an internal topology regression with the production behavior already described in this PR.
