### PR TITLE
fix(logging): use Log4j2 placeholders instead of Python format specifiers

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/CompressorWashing.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorWashing.java
@@ -360,7 +360,7 @@ public class CompressorWashing implements Serializable {
     hoursSinceLastWash = 0.0;
     lastWashMethod = method;
 
-    logger.info("Compressor wash performed: {} - Recovery: {:.1f}%", method.getDisplayName(), recovery * 100);
+    logger.info("Compressor wash performed: {} - Recovery: {}%", method.getDisplayName(), recovery * 100);
 
     return recovery;
   }
@@ -744,10 +744,10 @@ public class CompressorWashing implements Serializable {
    */
   public void printSummary() {
     logger.info("=== Compressor Washing Status ===");
-    logger.info("Current Fouling: {:.1f}%", currentFoulingFactor * 100);
-    logger.info("Head Loss: {:.2f}%", getHeadLossFactor() * 100);
-    logger.info("Efficiency Loss: {:.2f}%", getEfficiencyDegradation() * 100);
-    logger.info("Hours Since Wash: {:.0f}", hoursSinceLastWash);
+    logger.info("Current Fouling: {}%", currentFoulingFactor * 100);
+    logger.info("Head Loss: {}%", getHeadLossFactor() * 100);
+    logger.info("Efficiency Loss: {}%", getEfficiencyDegradation() * 100);
+    logger.info("Hours Since Wash: {}", hoursSinceLastWash);
     logger.info("Washing Recommended: {}", isWashingRecommended() ? "YES" : "No");
     logger.info("Washing Critical: {}", isWashingCritical() ? "YES" : "No");
     logger.info("Dominant Fouling: {}", dominantFoulingType.getDescription());

--- a/src/main/java/neqsim/process/equipment/ejector/Ejector.java
+++ b/src/main/java/neqsim/process/equipment/ejector/Ejector.java
@@ -919,7 +919,7 @@ public class Ejector extends ProcessEquipmentBaseClass
     initializeEjectorCapacityConstraints();
 
     autoSized = true;
-    logger.info("Ejector '{}' auto-sized: design ER={:.2f}, CR={:.2f}", getName(), designEntrainmentRatio,
+    logger.info("Ejector '{}' auto-sized: design ER={}, CR={}", getName(), designEntrainmentRatio,
         designCompressionRatio);
   }
 

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -1057,7 +1057,7 @@ public class TwoFluidPipe extends Pipeline {
         inletWaterCut = volWater / volTotal;
         inletOilFraction = 1.0 - inletWaterCut;
         isThreePhase = true; // Use three-fluid tracking even without gas
-        logger.info("Oil-water flow (no gas): water cut = {:.1f}%", inletWaterCut * 100);
+        logger.info("Oil-water flow (no gas): water cut = {}%", inletWaterCut * 100);
       }
     }
 

--- a/src/main/java/neqsim/process/equipment/pump/Pump.java
+++ b/src/main/java/neqsim/process/equipment/pump/Pump.java
@@ -1454,7 +1454,7 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
     initializeCapacityConstraints();
 
     autoSized = true;
-    logger.info("Pump '{}' auto-sized: Design flow = {:.1f} m3/hr, Safety factor = {}", getName(), designVolumeFlow,
+    logger.info("Pump '{}' auto-sized: Design flow = {} m3/hr, Safety factor = {}", getName(), designVolumeFlow,
         safetyFactor);
   }
 

--- a/src/main/java/neqsim/process/equipment/tank/Tank.java
+++ b/src/main/java/neqsim/process/equipment/tank/Tank.java
@@ -575,7 +575,7 @@ public class Tank extends ProcessEquipmentBaseClass implements AutoSizeable, Cap
     initializeTankCapacityConstraints();
 
     autoSized = true;
-    logger.info("Tank '{}' auto-sized: volume={:.1f} m3, liquid volume={:.1f} m3", getName(), volume, liquidVolume);
+    logger.info("Tank '{}' auto-sized: volume={} m3, liquid volume={} m3", getName(), volume, liquidVolume);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/util/optimizer/FlowRateOptimizer.java
+++ b/src/main/java/neqsim/process/util/optimizer/FlowRateOptimizer.java
@@ -1445,8 +1445,8 @@ public class FlowRateOptimizer implements Serializable {
 
         boolean feasible = point.isFeasible() && utilizationOk && pressureOk && compressorsFeasible;
 
-        logger.debug("Iter {}: flow={:.0f}, Pout={:.2f} (target={:.2f}), util={:.1f}%, feasible={}", iter, midRate,
-            outletPressure, targetOutletPressure, util * 100, feasible);
+        logger.debug("Iter {}: flow={}, Pout={} (target={}), util={}%, feasible={}", iter, midRate, outletPressure,
+            targetOutletPressure, util * 100, feasible);
 
         if (feasible) {
           // This flow rate works - try higher

--- a/src/main/java/neqsim/process/util/optimizer/FluidMagicInput.java
+++ b/src/main/java/neqsim/process/util/optimizer/FluidMagicInput.java
@@ -208,7 +208,7 @@ public class FluidMagicInput implements Serializable {
 
       // Calculate standard gas volume
       gasStdVolume = gasPhase.getVolume("m3");
-      logger.info("Gas phase extracted: {} components, {:.4f} m3 at std conditions", gasPhase.getNumberOfComponents(),
+      logger.info("Gas phase extracted: {} components, {} m3 at std conditions", gasPhase.getNumberOfComponents(),
           gasStdVolume);
     } else {
       logger.warn("No gas phase found in reference fluid at standard conditions");
@@ -224,7 +224,7 @@ public class FluidMagicInput implements Serializable {
 
       // Calculate standard oil volume
       oilStdVolume = oilPhase.getVolume("m3");
-      logger.info("Oil phase extracted: {} components, {:.4f} m3 at std conditions", oilPhase.getNumberOfComponents(),
+      logger.info("Oil phase extracted: {} components, {} m3 at std conditions", oilPhase.getNumberOfComponents(),
           oilStdVolume);
     } else {
       logger.warn("No oil phase found in reference fluid at standard conditions");
@@ -233,7 +233,7 @@ public class FluidMagicInput implements Serializable {
     // Calculate base case GOR
     if (gasStdVolume > 0 && oilStdVolume > 0) {
       baseCaseGOR = gasStdVolume / oilStdVolume;
-      logger.info("Base case GOR: {:.1f} Sm3/Sm3", baseCaseGOR);
+      logger.info("Base case GOR: {} Sm3/Sm3", baseCaseGOR);
     }
 
     // Create water phase (pure water or brine based on salinity)
@@ -258,7 +258,7 @@ public class FluidMagicInput implements Serializable {
 
     // Calculate standard water volume (1 kmol at std conditions)
     waterStdVolume = waterPhase.getVolume("m3");
-    logger.info("Water phase created: {:.4f} m3/kmol at std conditions", waterStdVolume);
+    logger.info("Water phase created: {} m3/kmol at std conditions", waterStdVolume);
   }
 
   /**

--- a/src/main/java/neqsim/process/util/optimizer/MultiScenarioVFPGenerator.java
+++ b/src/main/java/neqsim/process/util/optimizer/MultiScenarioVFPGenerator.java
@@ -197,8 +197,8 @@ public class MultiScenarioVFPGenerator implements Serializable {
     long elapsed = System.currentTimeMillis() - startTime;
     int feasibleCount = vfpTable.getFeasibleCount();
 
-    logger.info("VFP table complete: {}/{} feasible in {:.1f}s ({:.2f}s/point)", feasibleCount, totalPoints,
-        elapsed / 1000.0, elapsed / 1000.0 / totalPoints);
+    logger.info("VFP table complete: {}/{} feasible in {}s ({}s/point)", feasibleCount, totalPoints, elapsed / 1000.0,
+        elapsed / 1000.0 / totalPoints);
 
     if (flashGenerator != null) {
       logger.info("Fluid cache: {}", flashGenerator.getCacheStatistics());
@@ -247,8 +247,8 @@ public class MultiScenarioVFPGenerator implements Serializable {
 
         if (completed % 20 == 0 || completed == tasks.size()) {
           String status = point.feasible ? String.format("P_in=%.1f bara", point.bhp) : "INFEASIBLE";
-          logger.info("[{}/{}] Rate={:.0f}, THP={:.0f}, WC={:.0f}%, GOR={:.0f} → {}", completed, tasks.size(),
-              point.flowRate, point.thp, point.waterCut * 100, point.gor, status);
+          logger.info("[{}/{}] Rate={}, THP={}, WC={}%, GOR={} → {}", completed, tasks.size(), point.flowRate,
+              point.thp, point.waterCut * 100, point.gor, status);
         }
       } catch (Exception e) {
         logger.error("Task execution failed", e);

--- a/src/main/java/neqsim/process/util/optimizer/RecombinationFlashGenerator.java
+++ b/src/main/java/neqsim/process/util/optimizer/RecombinationFlashGenerator.java
@@ -105,9 +105,9 @@ public class RecombinationFlashGenerator implements Serializable {
     this.fluidCache = new ConcurrentHashMap<>();
 
     logger.info("RecombinationFlashGenerator initialized");
-    logger.info("  Gas molar volume: {:.4f} Sm3/kmol", gasStdVolumePerMole);
-    logger.info("  Oil molar volume: {:.4f} Sm3/kmol", oilStdVolumePerMole);
-    logger.info("  Water molar volume: {:.4f} Sm3/kmol", waterStdVolumePerMole);
+    logger.info("  Gas molar volume: {} Sm3/kmol", gasStdVolumePerMole);
+    logger.info("  Oil molar volume: {} Sm3/kmol", oilStdVolumePerMole);
+    logger.info("  Water molar volume: {} Sm3/kmol", waterStdVolumePerMole);
   }
 
   /**
@@ -174,8 +174,8 @@ public class RecombinationFlashGenerator implements Serializable {
     // Calculate gas rate from GOR (gas per oil volume)
     double gasRate = oilRate * targetGOR; // Sm3/hr gas
 
-    logger.debug("Generating fluid: GOR={:.0f}, WC={:.1f}%, Oil={:.1f}, Gas={:.1f}, Water={:.1f}", targetGOR,
-        waterCut * 100, oilRate, gasRate, waterRate);
+    logger.debug("Generating fluid: GOR={}, WC={}%, Oil={}, Gas={}, Water={}", targetGOR, waterCut * 100, oilRate,
+        gasRate, waterRate);
 
     // Create recombined fluid starting from gas phase composition
     SystemInterface recombined = createBaseFluid();
@@ -391,8 +391,7 @@ public class RecombinationFlashGenerator implements Serializable {
     double actualGOR = (oilVolume > 0) ? gasVolume / oilVolume : 0.0;
     double relativeError = Math.abs(actualGOR - targetGOR) / targetGOR;
 
-    logger.debug("GOR validation: target={:.1f}, actual={:.1f}, error={:.2f}%", targetGOR, actualGOR,
-        relativeError * 100);
+    logger.debug("GOR validation: target={}, actual={}, error={}%", targetGOR, actualGOR, relativeError * 100);
 
     return relativeError <= tolerance;
   }

--- a/src/main/java/neqsim/pvtsimulation/flowassurance/FloryHugginsAsphalteneModel.java
+++ b/src/main/java/neqsim/pvtsimulation/flowassurance/FloryHugginsAsphalteneModel.java
@@ -535,7 +535,7 @@ public class FloryHugginsAsphalteneModel {
     // Validate: onset must be above approximate bubble point.
     // If onset is found near the minimum search pressure, it's likely a numerical artifact.
     if (!Double.isNaN(onsetP) && onsetP < minP + 2 * pressureSearchStep) {
-      logger.info("FH onset at {:.1f} bar is near minimum search pressure - treating as no onset", onsetP);
+      logger.info("FH onset at {} bar is near minimum search pressure - treating as no onset", onsetP);
       return Double.NaN;
     }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TVfractionFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TVfractionFlash.java
@@ -209,7 +209,7 @@ public class TVfractionFlash extends Flash {
         return lastValidPressure;
       }
 
-      logger.trace("iter {} pressure {:.6f} error {:.3e} damping {:.1f}", iterations, nyPres, error, dampingFactor);
+      logger.trace("iter {} pressure {} error {} damping {}", iterations, nyPres, error, dampingFactor);
 
       // Convergence check with early exit
       if (error < 1e-8 && iterations > 3) {


### PR DESCRIPTION
fix(logging): use Log4j2 placeholders instead of Python format specifiers

40 logger calls across 11 files used Python-style format specifiers such as
{:.1f}, {:.2f} and {:.0f}. Log4j2 substitutes {} only, so these were emitted
literally and, wherever the specifier count differed from the argument count,
the remaining arguments bound to the wrong placeholders or were dropped.

The clearest example, in TwoFluidPipe:

    logger.warn("Steady-state solver reached wall-clock limit ({:.1f}s) after {} iterations",
        ssMaxWallClockTime, iter);

One real placeholder, two arguments: the message printed the configured timeout
where the iteration count belonged and discarded the iteration count. That
message is emitted exactly when a solve is truncated, so it misreported the one
case it exists to diagnose.

Replacing the specifiers with {} loses the intended decimal precision in the log
text, which is a fair trade for messages that substitute at all and bind their
arguments in the right order.

Found while investigating a truncated steady-state solve. No behaviour outside
logging is affected.
