### PR TITLE
fix(pipeline): two-fluid model correctness update - level solver, Kelvin-Helmholtz, closure blending, separated friction

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/CompressorWashing.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorWashing.java
@@ -360,7 +360,7 @@ public class CompressorWashing implements Serializable {
     hoursSinceLastWash = 0.0;
     lastWashMethod = method;
 
-    logger.info("Compressor wash performed: {} - Recovery: {:.1f}%", method.getDisplayName(), recovery * 100);
+    logger.info("Compressor wash performed: {} - Recovery: {}%", method.getDisplayName(), recovery * 100);
 
     return recovery;
   }
@@ -744,10 +744,10 @@ public class CompressorWashing implements Serializable {
    */
   public void printSummary() {
     logger.info("=== Compressor Washing Status ===");
-    logger.info("Current Fouling: {:.1f}%", currentFoulingFactor * 100);
-    logger.info("Head Loss: {:.2f}%", getHeadLossFactor() * 100);
-    logger.info("Efficiency Loss: {:.2f}%", getEfficiencyDegradation() * 100);
-    logger.info("Hours Since Wash: {:.0f}", hoursSinceLastWash);
+    logger.info("Current Fouling: {}%", currentFoulingFactor * 100);
+    logger.info("Head Loss: {}%", getHeadLossFactor() * 100);
+    logger.info("Efficiency Loss: {}%", getEfficiencyDegradation() * 100);
+    logger.info("Hours Since Wash: {}", hoursSinceLastWash);
     logger.info("Washing Recommended: {}", isWashingRecommended() ? "YES" : "No");
     logger.info("Washing Critical: {}", isWashingCritical() ? "YES" : "No");
     logger.info("Dominant Fouling: {}", dominantFoulingType.getDescription());

--- a/src/main/java/neqsim/process/equipment/ejector/Ejector.java
+++ b/src/main/java/neqsim/process/equipment/ejector/Ejector.java
@@ -919,7 +919,7 @@ public class Ejector extends ProcessEquipmentBaseClass
     initializeEjectorCapacityConstraints();
 
     autoSized = true;
-    logger.info("Ejector '{}' auto-sized: design ER={:.2f}, CR={:.2f}", getName(), designEntrainmentRatio,
+    logger.info("Ejector '{}' auto-sized: design ER={}, CR={}", getName(), designEntrainmentRatio,
         designCompressionRatio);
   }
 

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -637,6 +637,19 @@ public class TwoFluidPipe extends Pipeline {
   private double ssMaxWallClockTime = 300.0;
 
   /**
+   * Use per-phase wall shear for the friction gradient where the phases are separated.
+   *
+   * <p>
+   * Off by default. It is the more consistent description and cuts the three-phase pressure-drop error from +190% to
+   * +17%, but because it uses the real liquid-layer geometry it also amplifies the outstanding hold-up deficit, which
+   * the mixture correlation masks. On the lean gas-condensate reference line it moves the pressure drop from about +5%
+   * to about +16% and drives the highest rate onto the pressure floor. It becomes the right default once hold-up is
+   * corrected.
+   * </p>
+   */
+  private boolean useSeparatedFrictionModel = false;
+
+  /**
    * Fraction of the inlet pressure the line must lose before the density coupling is taken to matter for steady-state
    * convergence. Below this the fluid density is uniform to within about the same fraction, so the pressure profile
    * cannot be materially wrong for want of a thermodynamic update.
@@ -3579,10 +3592,111 @@ public class TwoFluidPipe extends Pipeline {
     // Darcy-Weisbach: dP/dx = f * rho * v^2 / (2 * D)
     double dPdx_fric = fTP * rhoMix * vMix * vMix / (2.0 * diameter);
 
+    // A mixture correlation charges the whole perimeter with a liquid-weighted density, which is
+    // right for a dispersed flow and badly wrong for a separated one. Where the phases are
+    // separated the wall shear belongs to each phase over its own wetted perimeter.
+    if (useSeparatedFrictionModel) {
+      double separatedWeight = separatedFrictionWeight(sec);
+      if (separatedWeight > 0.0) {
+        double dPdx_sep = separatedFrictionGradient(sec);
+        if (Double.isFinite(dPdx_sep)) {
+          dPdx_fric = (1.0 - separatedWeight) * dPdx_fric + separatedWeight * dPdx_sep;
+        }
+      }
+    }
+
     // Gravity gradient
     double dPdx_grav = rhoMix * 9.81 * Math.sin(sec.getInclination());
 
     return dPdx_fric + dPdx_grav;
+  }
+
+  /**
+   * Fraction of the friction gradient that should come from the separated model.
+   *
+   * <p>
+   * Stratified and annular flow have a distinct liquid layer, so the wall shear is per phase. Slug, churn and dispersed
+   * bubble flow are mixed on the scale of the pipe, where the mixture correlation is the appropriate description.
+   * </p>
+   *
+   * @param sec section being evaluated
+   * @return a weight between zero and one
+   */
+  private double separatedFrictionWeight(TwoFluidSection sec) {
+    Map<FlowRegime, Double> weights = sec.getRegimeWeights();
+    if (weights == null) {
+      return isSeparatedRegime(sec.getFlowRegime()) ? 1.0 : 0.0;
+    }
+
+    double separated = 0.0;
+    for (Map.Entry<FlowRegime, Double> entry : weights.entrySet()) {
+      if (isSeparatedRegime(entry.getKey())) {
+        separated += entry.getValue();
+      }
+    }
+    return Math.max(0.0, Math.min(1.0, separated));
+  }
+
+  /**
+   * Whether a regime keeps the phases separated across the bore.
+   *
+   * @param regime the flow regime
+   * @return true for stratified and annular flow
+   */
+  private static boolean isSeparatedRegime(FlowRegime regime) {
+    return regime == FlowRegime.STRATIFIED_SMOOTH || regime == FlowRegime.STRATIFIED_WAVY
+        || regime == FlowRegime.ANNULAR;
+  }
+
+  /**
+   * Friction pressure gradient from the per-phase wall shear of a separated flow.
+   *
+   * <p>
+   * Summing the gas and liquid momentum equations cancels the interfacial shear and leaves
+   * {@code -dP/dx = (tau_wG*S_G + tau_wL*S_L)/A + rho_mix*g*sin(theta)}, so only the wall terms enter here. Each phase
+   * carries its own density, velocity and hydraulic diameter, with the interface counted in the gas perimeter alone.
+   * The single-phase limit reduces to Darcy-Weisbach exactly.
+   * </p>
+   *
+   * @param sec section being evaluated
+   * @return friction pressure gradient, in Pa/m, or NaN when the geometry is degenerate
+   */
+  private double separatedFrictionGradient(TwoFluidSection sec) {
+    double alphaL = sec.getLiquidHoldup();
+    double alphaG = 1.0 - alphaL;
+    if (alphaL <= 0.0 || alphaG <= 0.0) {
+      return Double.NaN;
+    }
+
+    double area = Math.PI * diameter * diameter / 4.0;
+    double liquidArea = alphaL * area;
+    double gasArea = alphaG * area;
+    double beta = calculateStratifiedCentralAngle(alphaL);
+    double liquidPerimeter = diameter * beta / 2.0;
+    double gasPerimeter = diameter * (Math.PI - beta / 2.0);
+    double interfaceWidth = diameter * Math.sin(beta / 2.0);
+
+    if (liquidPerimeter <= 0.0 || gasPerimeter <= 0.0) {
+      return Double.NaN;
+    }
+
+    double liquidHydraulicDiameter = 4.0 * liquidArea / liquidPerimeter;
+    double gasHydraulicDiameter = 4.0 * gasArea / (gasPerimeter + interfaceWidth);
+
+    double liquidVelocity = sec.getLiquidVelocity();
+    double gasVelocity = sec.getGasVelocity();
+    double rhoL = sec.getLiquidDensity();
+    double rhoG = sec.getGasDensity();
+
+    double fL = calcDarcyFrictionFactor(rhoL, Math.abs(liquidVelocity), liquidHydraulicDiameter,
+        sec.getLiquidViscosity());
+    double fG = calcDarcyFrictionFactor(rhoG, Math.abs(gasVelocity), gasHydraulicDiameter, sec.getGasViscosity());
+
+    // tau_w = f_Darcy * rho * U|U| / 8 follows from dP/dx = 4*tau_w/D in the single-phase limit.
+    double liquidWallShear = fL * rhoL * liquidVelocity * Math.abs(liquidVelocity) / 8.0;
+    double gasWallShear = fG * rhoG * gasVelocity * Math.abs(gasVelocity) / 8.0;
+
+    return (gasWallShear * gasPerimeter + liquidWallShear * liquidPerimeter) / area;
   }
 
   /**
@@ -7171,6 +7285,30 @@ public class TwoFluidPipe extends Pipeline {
    */
   public boolean isSteadyStateWallClockLimited() {
     return ssWallClockLimited;
+  }
+
+  /**
+   * Whether the friction gradient uses per-phase wall shear where the phases are separated.
+   *
+   * @return true when the separated friction model is active
+   */
+  public boolean isSeparatedFrictionModel() {
+    return useSeparatedFrictionModel;
+  }
+
+  /**
+   * Selects the friction model used for the pressure gradient.
+   *
+   * <p>
+   * The mixture form charges the whole perimeter with a hold-up weighted density. That is right for a dispersed flow,
+   * but in a separated flow it applies a liquid-dominated density to a bore that is mostly gas and over-predicts the
+   * pressure drop badly at high liquid hold-up. Disable only to reproduce the mixture-only behaviour.
+   * </p>
+   *
+   * @param enable true to use per-phase wall shear in stratified and annular flow
+   */
+  public void setSeparatedFrictionModel(boolean enable) {
+    this.useSeparatedFrictionModel = enable;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -1003,7 +1003,7 @@ public class TwoFluidPipe extends Pipeline {
           }
         }
 
-        logger.info("Three-phase flow detected: water cut = {:.1f}%, oil fraction = {:.1f}%", inletWaterCut * 100,
+        logger.info("Three-phase flow detected: water cut = {}%, oil fraction = {}%", inletWaterCut * 100,
             inletOilFraction * 100);
 
       } else if (hasOil || hasWater) {
@@ -1205,7 +1205,7 @@ public class TwoFluidPipe extends Pipeline {
     // Initialize accumulation tracker
     accumulationTracker.identifyAccumulationZones(sections);
 
-    logger.info("TwoFluidPipe initialized: {} sections, dx_min={:.2f}m{}", numberOfSections, dx,
+    logger.info("TwoFluidPipe initialized: {} sections, dx_min={}m{}", numberOfSections, dx,
         sectionLengths != null ? " (non-uniform mesh)" : "");
   }
 
@@ -1314,7 +1314,7 @@ public class TwoFluidPipe extends Pipeline {
         sec.updateStratifiedGeometry();
       }
 
-      logger.info("Forward-marching init complete. Outlet P estimate: {:.2f} bara",
+      logger.info("Forward-marching init complete. Outlet P estimate: {} bara",
           sections[numberOfSections - 1].getPressure() / 1e5);
     }
 
@@ -1330,8 +1330,7 @@ public class TwoFluidPipe extends Pipeline {
       long elapsed = System.currentTimeMillis() - startWallClock;
       if (elapsed > (long) (ssMaxWallClockTime * 1000)) {
         ssWallClockLimited = true;
-        logger.warn("Steady-state solver reached wall-clock limit ({:.1f}s) after {} iterations", ssMaxWallClockTime,
-            iter);
+        logger.warn("Steady-state solver reached wall-clock limit ({}s) after {} iterations", ssMaxWallClockTime, iter);
         break;
       }
 
@@ -1417,6 +1416,7 @@ public class TwoFluidPipe extends Pipeline {
         // Update water and oil holdups for three-phase flow
         // Check if this is a three-phase system (both oil and water densities set)
         if (sec.getWaterDensity() > 0 && sec.getOilDensity() > 0) {
+          double waterHoldupBefore = sec.getWaterHoldup();
           // Always update water/oil holdups when we have liquid and three-phase
           // properties
           if (alphaL_new > 0.0) {
@@ -1427,6 +1427,10 @@ public class TwoFluidPipe extends Pipeline {
             sec.setOilHoldup(0);
             sec.setWaterCut(prev != null ? prev.getWaterCut() : sec.getWaterCut());
           }
+
+          // The liquid split is a solved variable. Leaving it out of the residual lets the solver
+          // report convergence while oil and water are still redistributing.
+          maxChange = Math.max(maxChange, Math.abs(sec.getWaterHoldup() - waterHoldupBefore));
         }
 
         // Update derived quantities
@@ -2902,39 +2906,39 @@ public class TwoFluidPipe extends Pipeline {
 
     double lowerBound = Math.max(CLOSURE_SOLVER_HOLDUP_EPSILON, lambdaL * 1.0e-4);
     double upperBound = 1.0 - CLOSURE_SOLVER_HOLDUP_EPSILON;
-    double alphaL = Math.max(lowerBound, Math.min(upperBound, Math.max(lambdaL, asymptoticHoldup)));
-    double bestAlpha = alphaL;
-    double bestResidual = Double.POSITIVE_INFINITY;
 
-    for (int iter = 0; iter < 30; iter++) {
-      double residual = calculateStratifiedMomentumResidual(alphaL, vsG, vsL, rhoG, rhoL, muG, muL, D, theta);
-      if (Double.isFinite(residual) && Math.abs(residual) < bestResidual) {
-        bestResidual = Math.abs(residual);
-        bestAlpha = alphaL;
-      }
-      if (!Double.isFinite(residual) || Math.abs(residual) < 1.0) {
-        break;
-      }
+    // Bisection rather than a damped Newton step with an absolute residual tolerance: the residual is
+    // a pressure gradient, so any fixed threshold on it means something different on every line.
+    double residualLow = calculateStratifiedMomentumResidual(lowerBound, vsG, vsL, rhoG, rhoL, muG, muL, D, theta);
+    double residualHigh = calculateStratifiedMomentumResidual(upperBound, vsG, vsL, rhoG, rhoL, muG, muL, D, theta);
 
-      double dAlpha = Math.max(alphaL * 1.0e-3, 1.0e-12);
-      double perturbedAlpha = Math.min(upperBound, alphaL + dAlpha);
-      if (perturbedAlpha <= alphaL) {
-        break;
-      }
-      double perturbedResidual = calculateStratifiedMomentumResidual(perturbedAlpha, vsG, vsL, rhoG, rhoL, muG, muL, D,
-          theta);
-      double derivative = (perturbedResidual - residual) / (perturbedAlpha - alphaL);
-      if (!Double.isFinite(derivative) || Math.abs(derivative) < CLOSURE_DENOMINATOR_EPSILON) {
-        break;
-      }
-
-      double correction = -residual / derivative;
-      double maxCorrection = Math.max(0.5 * alphaL, 1.0e-12);
-      correction = Math.max(-maxCorrection, Math.min(maxCorrection, correction));
-      alphaL = Math.max(lowerBound, Math.min(upperBound, alphaL + 0.5 * correction));
+    if (!Double.isFinite(residualLow) || !Double.isFinite(residualHigh) || residualLow * residualHigh > 0.0) {
+      return Math.max(0.0, Math.min(1.0, Math.max(lambdaL, asymptoticHoldup)));
     }
 
-    return Math.max(0.0, Math.min(1.0, bestAlpha));
+    double low = lowerBound;
+    double high = upperBound;
+    for (int iter = 0; iter < 80; iter++) {
+      double mid = 0.5 * (low + high);
+      double residualMid = calculateStratifiedMomentumResidual(mid, vsG, vsL, rhoG, rhoL, muG, muL, D, theta);
+      if (!Double.isFinite(residualMid)) {
+        break;
+      }
+
+      if (residualLow * residualMid <= 0.0) {
+        high = mid;
+        residualHigh = residualMid;
+      } else {
+        low = mid;
+        residualLow = residualMid;
+      }
+
+      if (high - low < 1.0e-12) {
+        break;
+      }
+    }
+
+    return Math.max(0.0, Math.min(1.0, 0.5 * (low + high)));
   }
 
   /** Calculate the common-pressure-gradient residual for a stratified section. */
@@ -2952,8 +2956,9 @@ public class TwoFluidPipe extends Pipeline {
     double liquidPerimeter = D * beta / 2.0;
     double gasPerimeter = D * (Math.PI - beta / 2.0);
     double interfaceWidth = D * Math.sin(beta / 2.0);
-    double liquidHydraulicDiameter = 4.0 * liquidArea
-        / Math.max(CLOSURE_DENOMINATOR_EPSILON, liquidPerimeter + interfaceWidth);
+    // Taitel and Dukler hydraulic diameters: the interface is a shear surface for the gas but not a
+    // wall for the liquid, so it enters the gas perimeter only.
+    double liquidHydraulicDiameter = 4.0 * liquidArea / Math.max(CLOSURE_DENOMINATOR_EPSILON, liquidPerimeter);
     double gasHydraulicDiameter = 4.0 * gasArea / Math.max(CLOSURE_DENOMINATOR_EPSILON, gasPerimeter + interfaceWidth);
 
     double liquidVelocity = vsL / Math.max(CLOSURE_DENOMINATOR_EPSILON, alphaL);

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -2,6 +2,7 @@ package neqsim.process.equipment.pipeline;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1271,7 +1272,7 @@ public class TwoFluidPipe extends Pipeline {
     // inlet-to-outlet one section at a time, using upstream gradient estimates.
     {
       for (TwoFluidSection sec : sections) {
-        sec.setFlowRegime(flowRegimeDetector.detectFlowRegime(sec));
+        flowRegimeDetector.classify(sec);
       }
 
       // Update inlet section holdup
@@ -1308,7 +1309,7 @@ public class TwoFluidPipe extends Pipeline {
           updateLiquidPhaseSplit(sec, prev, hi[0], area);
         }
 
-        sec.setFlowRegime(flowRegimeDetector.detectFlowRegime(sec));
+        flowRegimeDetector.classify(sec);
         sec.updateDerivedQuantities();
         sec.updateStratifiedGeometry();
       }
@@ -1341,7 +1342,7 @@ public class TwoFluidPipe extends Pipeline {
 
       // Update flow regimes
       for (TwoFluidSection sec : sections) {
-        sec.setFlowRegime(flowRegimeDetector.detectFlowRegime(sec));
+        flowRegimeDetector.classify(sec);
       }
 
       // Update inlet section (i=0) holdup using same momentum balance as other sections
@@ -2518,65 +2519,17 @@ public class TwoFluidPipe extends Pipeline {
       // ========== FULL CLOSURE SET ==========
       // Use flow-regime-specific literature correlations.
 
-      if (regime == FlowRegime.ANNULAR) {
-        // Annular-film closure
-        if (enableAnnularFilmModel) {
-          double[] annularResult = calculateAnnularHoldupOLGA(vsG, vsL, rhoG, rhoL, muG, muL, sigma, diameter,
-              inclination);
-          alphaL = annularResult[0];
-        } else {
-          // Annular flow with slip model
-          // For annular flow, gas flows faster than liquid (S = vG/vL > 1)
-          // Holdup formula: αL = λL / (λL + S*(1-λL))
-          // Or equivalently: αL = λL / (S - (S-1)*λL)
-          //
-          // Typical slip ratios for annular flow: S = 1.5 to 4.0
-          // At high gas velocities, liquid film is thin and moves slower
-          double vsgRef = 8.0;
-          double velocityRatio = Math.max(0.5, Math.min(4.0, vsG / Math.max(vsgRef, 0.1)));
-
-          // Slip ratio increases with gas velocity (liquid film slows down)
-          double baseSlipRatio = 1.5; // Minimum slip ratio for annular
-          double maxSlipRatio = 4.0; // Maximum slip ratio
-          double slipRatio = baseSlipRatio
-              + (maxSlipRatio - baseSlipRatio) * Math.min(1.0, velocityRatio * velocityRatio / 4.0);
-
-          // Calculate holdup using slip model
-          // αL = λL / (λL + S*(1-λL)) = λL / (S - (S-1)*λL)
-          double denominator = slipRatio - (slipRatio - 1.0) * lambdaL;
-          if (denominator > 0.1) {
-            alphaL = lambdaL / denominator;
-          } else {
-            // Fallback for very high liquid loading
-            alphaL = lambdaL;
-          }
-
-          // A fixed wetting film is a user-selected physical model, not a universal
-          // numerical phase floor. Apply it only in explicit fixed-floor mode.
-          if (usesExplicitPhysicalFilmFloor()) {
-            double filmHoldup = 4.0 * minimumFilmThickness / diameter;
-            alphaL = Math.max(filmHoldup, alphaL);
-          }
-        }
-
-      } else if (regime == FlowRegime.SLUG || regime == FlowRegime.CHURN) {
-        // Slug unit-cell closure
-        alphaL = calculateSlugHoldupOLGA(vsG, vsL, rhoG, rhoL, muL, sigma, diameter, inclination);
-
-      } else if (regime == FlowRegime.STRATIFIED_SMOOTH || regime == FlowRegime.STRATIFIED_WAVY) {
-        // Stratified-flow momentum balance
-        alphaL = calculateStratifiedHoldupOLGA(vsG, vsL, rhoG, rhoL, muG, muL, sigma, diameter, inclination);
-
-      } else if (regime == FlowRegime.DISPERSED_BUBBLE || regime == FlowRegime.BUBBLE) {
-        // Dispersed bubble: near-homogeneous flow
-        // αL ≈ λL with small correction for bubble rise
-        double vSlip = 1.53 * Math.pow(g * sigma * (rhoL - rhoG) / (rhoL * rhoL), 0.25);
-        alphaL = vsL / (vsL + vsG + vSlip * (1.0 - lambdaL));
-        alphaL = Math.max(lambdaL * 0.9, alphaL);
-
+      Map<FlowRegime, Double> regimeWeights = sec.getRegimeWeights();
+      if (regimeWeights == null) {
+        alphaL = holdupForRegime(regime, vsG, vsL, rhoG, rhoL, muG, muL, sigma, inclination, lambdaL);
       } else {
-        // Default to stratified momentum balance
-        alphaL = calculateStratifiedHoldupOLGA(vsG, vsL, rhoG, rhoL, muG, muL, sigma, diameter, inclination);
+        // On a transition the section is partly each regime; blending the closures removes the
+        // step change a hard switch would impose on hold-up.
+        alphaL = 0.0;
+        for (Map.Entry<FlowRegime, Double> entry : regimeWeights.entrySet()) {
+          alphaL += entry.getValue()
+              * holdupForRegime(entry.getKey(), vsG, vsL, rhoG, rhoL, muG, muL, sigma, inclination, lambdaL);
+        }
       }
 
       // Apply terrain accumulation enhancement
@@ -2644,18 +2597,20 @@ public class TwoFluidPipe extends Pipeline {
     }
     alphaL = Math.max(0.0, Math.min(1.0, alphaL));
 
-    // Valley/peak terrain adjustments (existing logic)
+    // Valley/peak terrain adjustments. The strength ramps with how definite the slope reversal is:
+    // a hard threshold here steps the hold-up of a section as terrain drifts past it, which shows up
+    // as a pressure drop for an undulation that has zero net elevation change.
     if (prev != null) {
       double inclinationChange = inclination - prev.getInclination();
-      boolean isValley = prev.getInclination() < -0.05 && inclination > 0.05;
-      boolean isPeak = prev.getInclination() > 0.05 && inclination < -0.05;
+      double magnitude = 0.3 * Math.min(Math.abs(inclinationChange), 0.2);
+      double valleyStrength = slopeStrength(-prev.getInclination()) * slopeStrength(inclination);
+      double peakStrength = slopeStrength(prev.getInclination()) * slopeStrength(-inclination);
+      double factor = 1.0 + magnitude * (valleyStrength - peakStrength);
 
-      if (isValley) {
-        double valleyFactor = 1.0 + 0.3 * Math.min(Math.abs(inclinationChange), 0.2);
-        alphaL = Math.min(0.8, alphaL * valleyFactor); // Allow up to 80% in valleys
-      } else if (isPeak) {
-        double peakFactor = 1.0 - 0.3 * Math.min(Math.abs(inclinationChange), 0.2);
-        alphaL = Math.max(0.0, alphaL * peakFactor);
+      if (factor > 1.0) {
+        alphaL = Math.min(0.8, alphaL * factor); // Allow up to 80% in valleys
+      } else {
+        alphaL = Math.max(0.0, alphaL * factor);
       }
     }
 
@@ -2667,6 +2622,94 @@ public class TwoFluidPipe extends Pipeline {
     alphaL = Math.max(0.0, Math.min(1.0, alphaL));
 
     return new double[] { alphaL, 1.0 - alphaL };
+  }
+
+  /**
+   * How definitely a section slopes upward, ramped over the near-horizontal band.
+   *
+   * <p>
+   * Zero at or below horizontal, one once the slope is clearly upward. Used so a slope reversal enters and leaves the
+   * valley and peak corrections continuously rather than at a threshold.
+   * </p>
+   *
+   * @param inclination section inclination, in radians
+   * @return a weight between zero and one
+   */
+  private static double slopeStrength(double inclination) {
+    double lower = 0.02;
+    double upper = 0.08;
+    if (inclination <= lower) {
+      return 0.0;
+    }
+    if (inclination >= upper) {
+      return 1.0;
+    }
+    return (inclination - lower) / (upper - lower);
+  }
+
+  /**
+   * Liquid holdup from the closure belonging to a single flow regime.
+   *
+   * <p>
+   * Split out of the holdup calculation so a section sitting on a transition can evaluate more than one closure and
+   * blend the results, rather than switching between them at a point.
+   * </p>
+   *
+   * @param regime the regime whose closure is evaluated
+   * @param vsG superficial gas velocity, in m/s
+   * @param vsL superficial liquid velocity, in m/s
+   * @param rhoG gas density, in kg/m3
+   * @param rhoL liquid density, in kg/m3
+   * @param muG gas viscosity, in Pa.s
+   * @param muL liquid viscosity, in Pa.s
+   * @param sigma surface tension, in N/m
+   * @param inclination section inclination, in radians
+   * @param lambdaL no-slip liquid fraction
+   * @return liquid holdup for that regime
+   */
+  private double holdupForRegime(FlowRegime regime, double vsG, double vsL, double rhoG, double rhoL, double muG,
+      double muL, double sigma, double inclination, double lambdaL) {
+    double g = 9.81;
+
+    if (regime == FlowRegime.ANNULAR) {
+      if (enableAnnularFilmModel) {
+        double[] annularResult = calculateAnnularHoldupOLGA(vsG, vsL, rhoG, rhoL, muG, muL, sigma, diameter,
+            inclination);
+        return annularResult[0];
+      }
+
+      // Annular slip model: the gas core outruns the film, so S = vG/vL is between about 1.5 and 4
+      // and holdup follows alphaL = lambdaL / (S - (S-1)*lambdaL).
+      double vsgRef = 8.0;
+      double velocityRatio = Math.max(0.5, Math.min(4.0, vsG / Math.max(vsgRef, 0.1)));
+      double baseSlipRatio = 1.5;
+      double maxSlipRatio = 4.0;
+      double slipRatio = baseSlipRatio
+          + (maxSlipRatio - baseSlipRatio) * Math.min(1.0, velocityRatio * velocityRatio / 4.0);
+
+      double denominator = slipRatio - (slipRatio - 1.0) * lambdaL;
+      double alphaL = denominator > 0.1 ? lambdaL / denominator : lambdaL;
+
+      // A fixed wetting film is a user-selected physical model, not a universal
+      // numerical phase floor. Apply it only in explicit fixed-floor mode.
+      if (usesExplicitPhysicalFilmFloor()) {
+        double filmHoldup = 4.0 * minimumFilmThickness / diameter;
+        alphaL = Math.max(filmHoldup, alphaL);
+      }
+      return alphaL;
+    }
+
+    if (regime == FlowRegime.SLUG || regime == FlowRegime.CHURN) {
+      return calculateSlugHoldupOLGA(vsG, vsL, rhoG, rhoL, muL, sigma, diameter, inclination);
+    }
+
+    if (regime == FlowRegime.DISPERSED_BUBBLE || regime == FlowRegime.BUBBLE) {
+      double vSlip = 1.53 * Math.pow(g * sigma * (rhoL - rhoG) / (rhoL * rhoL), 0.25);
+      double alphaL = vsL / (vsL + vsG + vSlip * (1.0 - lambdaL));
+      return Math.max(lambdaL * 0.9, alphaL);
+    }
+
+    return calculateStratifiedHoldupOLGA(vsG, vsL, rhoG, rhoL, muG, muL, sigma, diameter, inclination);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -1057,7 +1057,7 @@ public class TwoFluidPipe extends Pipeline {
         inletWaterCut = volWater / volTotal;
         inletOilFraction = 1.0 - inletWaterCut;
         isThreePhase = true; // Use three-fluid tracking even without gas
-        logger.info("Oil-water flow (no gas): water cut = {:.1f}%", inletWaterCut * 100);
+        logger.info("Oil-water flow (no gas): water cut = {}%", inletWaterCut * 100);
       }
     }
 

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeDetector.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeDetector.java
@@ -1,6 +1,8 @@
 package neqsim.process.equipment.pipeline.twophasepipe;
 
 import java.io.Serializable;
+import java.util.EnumMap;
+import java.util.Map;
 import neqsim.process.equipment.pipeline.twophasepipe.PipeSection.FlowRegime;
 
 /**
@@ -51,6 +53,18 @@ public class FlowRegimeDetector implements Serializable {
   /** Select Taitel-Dukler transition B instead of the vertical droplet criterion in horizontal flow. */
   private boolean useEquilibriumLevelAnnularTransition = false;
 
+  /** Blend closures across horizontal regime transitions instead of switching at a point. */
+  private boolean blendRegimeTransitions = true;
+
+  /** Half-width of the Kelvin-Helmholtz blending band, as a fraction of the critical gas velocity. */
+  private static final double KH_TRANSITION_BAND = 0.15;
+
+  /** Equilibrium liquid level at which the bore bridges, as a fraction of the diameter. */
+  private static final double LEVEL_TRANSITION_CENTRE = 0.5;
+
+  /** Half-width of the equilibrium-level blending band, as a fraction of the diameter. */
+  private static final double LEVEL_TRANSITION_BAND = 0.08;
+
   /**
    * Whether the horizontal annular transition uses the equilibrium liquid level.
    *
@@ -91,6 +105,30 @@ public class FlowRegimeDetector implements Serializable {
    */
   public void setUseEquilibriumLevelAnnularTransition(boolean enable) {
     this.useEquilibriumLevelAnnularTransition = enable;
+  }
+
+  /**
+   * Whether closures are blended across horizontal regime transitions.
+   *
+   * @return true when transition blending is active
+   */
+  public boolean isBlendRegimeTransitions() {
+    return blendRegimeTransitions;
+  }
+
+  /**
+   * Selects blending of the closures across horizontal regime transitions.
+   *
+   * <p>
+   * Switching closure at a point steps hold-up and friction as an operating point drifts across a boundary, which shows
+   * up as a jump in pressure drop for a smooth change in terrain or rate. Blending ramps the weights over a band
+   * instead. Disable only to reproduce the hard-switching behaviour.
+   * </p>
+   *
+   * @param enable true to blend across transitions
+   */
+  public void setBlendRegimeTransitions(boolean enable) {
+    this.blendRegimeTransitions = enable;
   }
 
   /** Drift flux model for slip calculations. */
@@ -199,6 +237,100 @@ public class FlowRegimeDetector implements Serializable {
     } else {
       return detectHorizontalFlowRegime(U_SL, U_SG, D, theta, rho_L, rho_G, mu_L, sigma);
     }
+  }
+
+  /**
+   * Classifies a section, recording both the dominant regime and the transition blend.
+   *
+   * <p>
+   * A section sitting on a regime boundary is not wholly one regime or the other. Hard switching there steps hold-up
+   * and friction discontinuously as an operating point drifts across the boundary. This sets the regime and, where the
+   * section is on a horizontal transition, the fractional weights the closures should be blended with.
+   * </p>
+   *
+   * @param section section to classify; its regime and blend weights are updated
+   * @return the dominant flow regime
+   */
+  public FlowRegime classify(PipeSection section) {
+    FlowRegime regime = detectFlowRegime(section);
+    section.setFlowRegime(regime);
+
+    Map<FlowRegime, Double> weights = horizontalRegimeWeights(section, regime);
+    if (weights != null) {
+      section.setRegimeWeights(weights);
+    }
+    return section.getFlowRegime();
+  }
+
+  /**
+   * Fractional regime weights across the horizontal stratified, annular and slug transitions.
+   *
+   * <p>
+   * The stratified share follows the Kelvin-Helmholtz margin and the split of the remainder between annular and slug
+   * follows the equilibrium liquid level, both ramped over a band rather than switched at a point. Returns null when
+   * blending does not apply, in which case the single detected regime stands.
+   * </p>
+   *
+   * @param section section being classified
+   * @param regime the regime already detected for the section
+   * @return weights per regime, or null when a single regime applies
+   */
+  private Map<FlowRegime, Double> horizontalRegimeWeights(PipeSection section, FlowRegime regime) {
+    if (!blendRegimeTransitions || !useEquilibriumLevelAnnularTransition) {
+      return null;
+    }
+    if (detectionMethod != DetectionMethod.MECHANISTIC) {
+      return null;
+    }
+    if (regime == FlowRegime.SINGLE_PHASE_GAS || regime == FlowRegime.SINGLE_PHASE_LIQUID
+        || regime == FlowRegime.DISPERSED_BUBBLE || regime == FlowRegime.BUBBLE) {
+      return null;
+    }
+
+    double theta = section.getInclination();
+    if (Math.abs(theta) > Math.toRadians(10)) {
+      return null;
+    }
+
+    double U_SL = section.getSuperficialLiquidVelocity();
+    double U_SG = section.getSuperficialGasVelocity();
+    double D = section.getDiameter();
+    double rho_L = section.getLiquidDensity();
+    double rho_G = section.getGasDensity();
+    double mu_L = section.getLiquidViscosity();
+
+    double h_L = estimateStratifiedLiquidLevel(U_SL, U_SG, D, rho_L, rho_G, mu_L, theta);
+    double margin = kelvinHelmholtzMargin(U_SG, h_L, D, rho_L, rho_G);
+    if (margin <= 0.0) {
+      return null;
+    }
+
+    double unstableShare = rampWeight(margin, 1.0, KH_TRANSITION_BAND);
+    double slugShare = rampWeight(h_L / D, LEVEL_TRANSITION_CENTRE, LEVEL_TRANSITION_BAND);
+    FlowRegime stratified = isWavyTransition(U_SG, h_L, D, rho_L, rho_G, mu_L) ? FlowRegime.STRATIFIED_WAVY
+        : FlowRegime.STRATIFIED_SMOOTH;
+
+    Map<FlowRegime, Double> weights = new EnumMap<FlowRegime, Double>(FlowRegime.class);
+    weights.put(stratified, 1.0 - unstableShare);
+    weights.put(FlowRegime.ANNULAR, unstableShare * (1.0 - slugShare));
+    weights.put(FlowRegime.SLUG, unstableShare * slugShare);
+    return weights;
+  }
+
+  /**
+   * Linear ramp from zero to one across a band centred on a transition.
+   *
+   * @param value the criterion value
+   * @param centre the transition value
+   * @param halfWidth half the band width, in the same units as the value
+   * @return zero below the band, one above it, linear in between
+   */
+  private static double rampWeight(double value, double centre, double halfWidth) {
+    if (halfWidth <= 0.0) {
+      return value > centre ? 1.0 : 0.0;
+    }
+    double weight = (value - (centre - halfWidth)) / (2.0 * halfWidth);
+    return Math.max(0.0, Math.min(1.0, weight));
   }
 
   /**
@@ -567,62 +699,105 @@ public class FlowRegimeDetector implements Serializable {
    */
   private double estimateStratifiedLiquidLevel(double U_SL, double U_SG, double D, double rho_L, double rho_G,
       double mu_L, double theta) {
-    // Simplified momentum balance for stratified flow
-    // Iterative solution for liquid level h_L
+    double low = 0.01 * D;
+    double high = 0.99 * D;
 
-    double h_L = 0.5 * D; // Initial guess
+    double residLow = stratifiedMomentumResidual(low, U_SL, U_SG, D, rho_L, rho_G, mu_L, theta);
+    double residHigh = stratifiedMomentumResidual(high, U_SL, U_SG, D, rho_L, rho_G, mu_L, theta);
 
-    for (int iter = 0; iter < 20; iter++) {
-      double h_prev = h_L;
+    if (!isUsableResidual(residLow) || !isUsableResidual(residHigh)) {
+      return 0.5 * D;
+    }
 
-      // Geometric parameters
-      double beta = 2.0 * Math.acos(1.0 - 2.0 * h_L / D);
-      double A_L = D * D / 8.0 * (beta - Math.sin(beta));
-      double A_G = PI * D * D / 4.0 - A_L;
-      double S_L = D * beta / 2.0; // Wetted perimeter liquid
-      double S_G = D * (PI - beta / 2.0); // Wetted perimeter gas
-      double S_i = D * Math.sin(beta / 2.0); // Interface width
+    // No sign change means the balance has no interior root; the closer wall is the best estimate.
+    if (residLow * residHigh > 0.0) {
+      return Math.abs(residLow) <= Math.abs(residHigh) ? low : high;
+    }
 
-      if (A_L < 1e-10 || A_G < 1e-10) {
-        break;
+    for (int iter = 0; iter < 60; iter++) {
+      double mid = 0.5 * (low + high);
+      double residMid = stratifiedMomentumResidual(mid, U_SL, U_SG, D, rho_L, rho_G, mu_L, theta);
+      if (!isUsableResidual(residMid)) {
+        return mid;
       }
 
-      double U_L = U_SL * PI * D * D / 4.0 / A_L;
-      double U_G = U_SG * PI * D * D / 4.0 / A_G;
+      if (residLow * residMid <= 0.0) {
+        high = mid;
+        residHigh = residMid;
+      } else {
+        low = mid;
+        residLow = residMid;
+      }
 
-      // Friction factors
-      double D_hL = 4.0 * A_L / S_L;
-      double D_hG = 4.0 * A_G / (S_G + S_i);
-
-      double Re_L = rho_L * Math.abs(U_L) * D_hL / mu_L;
-      double Re_G = rho_G * Math.abs(U_G) * D_hG / (mu_L * 0.01);
-
-      double f_L = Re_L > 2000 ? 0.046 * Math.pow(Re_L, -0.2) : 16.0 / Math.max(Re_L, 1);
-      double f_G = Re_G > 2000 ? 0.046 * Math.pow(Re_G, -0.2) : 16.0 / Math.max(Re_G, 1);
-      double f_i = f_G; // Interface friction
-
-      // Shear stresses
-      double tau_wL = f_L * rho_L * U_L * Math.abs(U_L) / 2.0;
-      double tau_wG = f_G * rho_G * U_G * Math.abs(U_G) / 2.0;
-      double tau_i = f_i * rho_G * (U_G - U_L) * Math.abs(U_G - U_L) / 2.0;
-
-      // Combined momentum balance
-      double deltaRho = rho_L - rho_G;
-      double gravity_term = deltaRho * GRAVITY * Math.sin(theta);
-
-      // Residual
-      double resid = (-tau_wL * S_L + tau_i * S_i) / A_L - (-tau_wG * S_G - tau_i * S_i) / A_G - gravity_term;
-
-      // Adjust h_L
-      h_L = h_L - 0.1 * D * Math.signum(resid);
-      h_L = Math.max(0.01 * D, Math.min(0.99 * D, h_L));
-
-      if (Math.abs(h_L - h_prev) < 1e-6 * D) {
+      if (high - low < 1e-9 * D) {
         break;
       }
     }
 
-    return h_L;
+    return 0.5 * (low + high);
+  }
+
+  /**
+   * Whether a residual can be used to bracket a root.
+   *
+   * @param residual the momentum residual
+   * @return true when the value is finite
+   */
+  private static boolean isUsableResidual(double residual) {
+    return !Double.isNaN(residual) && !Double.isInfinite(residual);
+  }
+
+  /**
+   * Combined gas and liquid momentum residual for a stratified layer of a given depth.
+   *
+   * <p>
+   * The equilibrium level is the depth at which this vanishes.
+   * </p>
+   *
+   * @param h_L liquid height, in m
+   * @param U_SL superficial liquid velocity, in m/s
+   * @param U_SG superficial gas velocity, in m/s
+   * @param D pipe diameter, in m
+   * @param rho_L liquid density, in kg/m3
+   * @param rho_G gas density, in kg/m3
+   * @param mu_L liquid viscosity, in Pa.s
+   * @param theta inclination, in radians
+   * @return the momentum residual, or NaN when the geometry is degenerate
+   */
+  private double stratifiedMomentumResidual(double h_L, double U_SL, double U_SG, double D, double rho_L, double rho_G,
+      double mu_L, double theta) {
+    double beta = 2.0 * Math.acos(1.0 - 2.0 * h_L / D);
+    double A_L = D * D / 8.0 * (beta - Math.sin(beta));
+    double A_G = PI * D * D / 4.0 - A_L;
+    double S_L = D * beta / 2.0; // Wetted perimeter liquid
+    double S_G = D * (PI - beta / 2.0); // Wetted perimeter gas
+    double S_i = D * Math.sin(beta / 2.0); // Interface width
+
+    if (A_L < 1e-10 || A_G < 1e-10) {
+      return Double.NaN;
+    }
+
+    double U_L = U_SL * PI * D * D / 4.0 / A_L;
+    double U_G = U_SG * PI * D * D / 4.0 / A_G;
+
+    double D_hL = 4.0 * A_L / S_L;
+    double D_hG = 4.0 * A_G / (S_G + S_i);
+
+    double Re_L = rho_L * Math.abs(U_L) * D_hL / mu_L;
+    double Re_G = rho_G * Math.abs(U_G) * D_hG / (mu_L * 0.01);
+
+    double f_L = Re_L > 2000 ? 0.046 * Math.pow(Re_L, -0.2) : 16.0 / Math.max(Re_L, 1);
+    double f_G = Re_G > 2000 ? 0.046 * Math.pow(Re_G, -0.2) : 16.0 / Math.max(Re_G, 1);
+    double f_i = f_G; // Interface friction
+
+    double tau_wL = f_L * rho_L * U_L * Math.abs(U_L) / 2.0;
+    double tau_wG = f_G * rho_G * U_G * Math.abs(U_G) / 2.0;
+    double tau_i = f_i * rho_G * (U_G - U_L) * Math.abs(U_G - U_L) / 2.0;
+
+    double deltaRho = rho_L - rho_G;
+    double gravity_term = deltaRho * GRAVITY * Math.sin(theta);
+
+    return (-tau_wL * S_L + tau_i * S_i) / A_L - (-tau_wG * S_G - tau_i * S_i) / A_G - gravity_term;
   }
 
   /**
@@ -636,8 +811,27 @@ public class FlowRegimeDetector implements Serializable {
    * @return true if Kelvin-Helmholtz unstable condition exists
    */
   private boolean isKelvinHelmholtzUnstable(double U_SG, double h_L, double D, double rho_L, double rho_G) {
+    return kelvinHelmholtzMargin(U_SG, h_L, D, rho_L, rho_G) > 1.0;
+  }
+
+  /**
+   * Ratio of the actual gas velocity to the Kelvin-Helmholtz critical velocity.
+   *
+   * <p>
+   * The boolean instability test is the sign of this ratio about unity. Returning the ratio itself lets the caller
+   * blend closures across the transition instead of switching at a point.
+   * </p>
+   *
+   * @param U_SG superficial gas velocity, in m/s
+   * @param h_L liquid height, in m
+   * @param D pipe diameter, in m
+   * @param rho_L liquid density, in kg/m3
+   * @param rho_G gas density, in kg/m3
+   * @return the velocity ratio, or 0 when the geometry is degenerate
+   */
+  private double kelvinHelmholtzMargin(double U_SG, double h_L, double D, double rho_L, double rho_G) {
     if (h_L < 0.01 * D || h_L > 0.99 * D) {
-      return false;
+      return 0.0;
     }
 
     double beta = 2.0 * Math.acos(1.0 - 2.0 * h_L / D);
@@ -645,17 +839,22 @@ public class FlowRegimeDetector implements Serializable {
     double S_i = D * Math.sin(beta / 2.0);
 
     if (A_G < 1e-10) {
-      return false;
+      return 0.0;
     }
 
     double U_G = U_SG * PI * D * D / 4.0 / A_G;
-    double h_G = D - h_L;
 
-    // Kelvin-Helmholtz criterion
+    // Taitel and Dukler (1976) transition A. dA_L/dh_L is the interface width S_i, and C2 accounts
+    // for the gas being accelerated over the wave crest. Note there is no extra length inside the
+    // root: the group under it is a velocity squared.
     double deltaRho = rho_L - rho_G;
-    double U_G_crit = Math.sqrt(deltaRho * GRAVITY * h_G * A_G / (rho_G * S_i));
+    double C2 = 1.0 - h_L / D;
+    double U_G_crit = C2 * Math.sqrt(deltaRho * GRAVITY * A_G / (rho_G * S_i));
+    if (U_G_crit <= 0.0) {
+      return 0.0;
+    }
 
-    return U_G > U_G_crit;
+    return U_G / U_G_crit;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/PipeSection.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/PipeSection.java
@@ -1,6 +1,7 @@
 package neqsim.process.equipment.pipeline.twophasepipe;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -475,10 +476,13 @@ public class PipeSection implements Cloneable, Serializable {
    * section is wholly {@link #getFlowRegime()}.
    * </p>
    *
-   * @return weights summing to one, or null when a single regime applies
+   * @return unmodifiable snapshot of weights summing to one, or null when a single regime applies
    */
   public Map<FlowRegime, Double> getRegimeWeights() {
-    return regimeWeights;
+    if (regimeWeights == null) {
+      return null;
+    }
+    return Collections.unmodifiableMap(new EnumMap<FlowRegime, Double>(regimeWeights));
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/PipeSection.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/PipeSection.java
@@ -1,6 +1,8 @@
 package neqsim.process.equipment.pipeline.twophasepipe;
 
 import java.io.Serializable;
+import java.util.EnumMap;
+import java.util.Map;
 
 /**
  * Represents the state of a single section/cell in the multiphase pipe.
@@ -48,6 +50,12 @@ public class PipeSection implements Cloneable, Serializable {
 
   // Derived quantities
   private FlowRegime flowRegime;
+
+  /** Fractional weight of each regime when the section sits on a transition; null when a single regime applies. */
+  private Map<FlowRegime, Double> regimeWeights;
+
+  /** Weights at or below this fraction are dropped rather than triggering a second closure evaluation. */
+  private static final double REGIME_WEIGHT_EPSILON = 1.0e-3;
   private double mixtureVelocity; // m/s
   private double mixtureDensity; // kg/m³
   private double superficialGasVelocity; // m/s
@@ -455,6 +463,88 @@ public class PipeSection implements Cloneable, Serializable {
 
   public void setFlowRegime(FlowRegime flowRegime) {
     this.flowRegime = flowRegime;
+    this.regimeWeights = null;
+  }
+
+  /**
+   * Gets the fractional weight of each flow regime for closure blending.
+   *
+   * <p>
+   * A section sitting on a regime transition is not wholly one regime or the other. Blending the closures across the
+   * transition removes the step change that a hard switch imposes on hold-up and friction. A null return means the
+   * section is wholly {@link #getFlowRegime()}.
+   * </p>
+   *
+   * @return weights summing to one, or null when a single regime applies
+   */
+  public Map<FlowRegime, Double> getRegimeWeights() {
+    return regimeWeights;
+  }
+
+  /**
+   * Sets the fractional weight of each flow regime and the dominant regime that follows from it.
+   *
+   * <p>
+   * Weights are normalised, and entries at or below {@link #REGIME_WEIGHT_EPSILON} are dropped so a negligible
+   * contribution does not force a second closure evaluation. A single surviving entry clears the blend.
+   * </p>
+   *
+   * @param weights weight per regime, need not be normalised; null or empty clears the blend
+   */
+  public void setRegimeWeights(Map<FlowRegime, Double> weights) {
+    if (weights == null || weights.isEmpty()) {
+      this.regimeWeights = null;
+      return;
+    }
+
+    double total = 0.0;
+    for (Double weight : weights.values()) {
+      if (weight != null && weight > 0.0) {
+        total += weight;
+      }
+    }
+    if (total <= 0.0) {
+      this.regimeWeights = null;
+      return;
+    }
+
+    Map<FlowRegime, Double> normalised = new EnumMap<FlowRegime, Double>(FlowRegime.class);
+    FlowRegime dominant = null;
+    double dominantWeight = 0.0;
+    double kept = 0.0;
+    for (Map.Entry<FlowRegime, Double> entry : weights.entrySet()) {
+      Double weight = entry.getValue();
+      if (weight == null || weight <= 0.0) {
+        continue;
+      }
+      double fraction = weight / total;
+      if (fraction <= REGIME_WEIGHT_EPSILON) {
+        continue;
+      }
+      normalised.put(entry.getKey(), fraction);
+      kept += fraction;
+      if (fraction > dominantWeight) {
+        dominantWeight = fraction;
+        dominant = entry.getKey();
+      }
+    }
+
+    if (dominant == null) {
+      this.regimeWeights = null;
+      return;
+    }
+
+    this.flowRegime = dominant;
+    if (normalised.size() == 1) {
+      this.regimeWeights = null;
+      return;
+    }
+
+    // Renormalise after dropping negligible entries so the weights still sum to one.
+    for (Map.Entry<FlowRegime, Double> entry : normalised.entrySet()) {
+      entry.setValue(entry.getValue() / kept);
+    }
+    this.regimeWeights = normalised;
   }
 
   public double getMixtureVelocity() {

--- a/src/main/java/neqsim/process/equipment/pump/Pump.java
+++ b/src/main/java/neqsim/process/equipment/pump/Pump.java
@@ -1454,7 +1454,7 @@ public class Pump extends TwoPortEquipment implements PumpInterface,
     initializeCapacityConstraints();
 
     autoSized = true;
-    logger.info("Pump '{}' auto-sized: Design flow = {:.1f} m3/hr, Safety factor = {}", getName(), designVolumeFlow,
+    logger.info("Pump '{}' auto-sized: Design flow = {} m3/hr, Safety factor = {}", getName(), designVolumeFlow,
         safetyFactor);
   }
 

--- a/src/main/java/neqsim/process/equipment/tank/Tank.java
+++ b/src/main/java/neqsim/process/equipment/tank/Tank.java
@@ -575,7 +575,7 @@ public class Tank extends ProcessEquipmentBaseClass implements AutoSizeable, Cap
     initializeTankCapacityConstraints();
 
     autoSized = true;
-    logger.info("Tank '{}' auto-sized: volume={:.1f} m3, liquid volume={:.1f} m3", getName(), volume, liquidVolume);
+    logger.info("Tank '{}' auto-sized: volume={} m3, liquid volume={} m3", getName(), volume, liquidVolume);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/util/optimizer/FlowRateOptimizer.java
+++ b/src/main/java/neqsim/process/util/optimizer/FlowRateOptimizer.java
@@ -1445,8 +1445,8 @@ public class FlowRateOptimizer implements Serializable {
 
         boolean feasible = point.isFeasible() && utilizationOk && pressureOk && compressorsFeasible;
 
-        logger.debug("Iter {}: flow={:.0f}, Pout={:.2f} (target={:.2f}), util={:.1f}%, feasible={}", iter, midRate,
-            outletPressure, targetOutletPressure, util * 100, feasible);
+        logger.debug("Iter {}: flow={}, Pout={} (target={}), util={}%, feasible={}", iter, midRate, outletPressure,
+            targetOutletPressure, util * 100, feasible);
 
         if (feasible) {
           // This flow rate works - try higher

--- a/src/main/java/neqsim/process/util/optimizer/FluidMagicInput.java
+++ b/src/main/java/neqsim/process/util/optimizer/FluidMagicInput.java
@@ -208,7 +208,7 @@ public class FluidMagicInput implements Serializable {
 
       // Calculate standard gas volume
       gasStdVolume = gasPhase.getVolume("m3");
-      logger.info("Gas phase extracted: {} components, {:.4f} m3 at std conditions", gasPhase.getNumberOfComponents(),
+      logger.info("Gas phase extracted: {} components, {} m3 at std conditions", gasPhase.getNumberOfComponents(),
           gasStdVolume);
     } else {
       logger.warn("No gas phase found in reference fluid at standard conditions");
@@ -224,7 +224,7 @@ public class FluidMagicInput implements Serializable {
 
       // Calculate standard oil volume
       oilStdVolume = oilPhase.getVolume("m3");
-      logger.info("Oil phase extracted: {} components, {:.4f} m3 at std conditions", oilPhase.getNumberOfComponents(),
+      logger.info("Oil phase extracted: {} components, {} m3 at std conditions", oilPhase.getNumberOfComponents(),
           oilStdVolume);
     } else {
       logger.warn("No oil phase found in reference fluid at standard conditions");
@@ -233,7 +233,7 @@ public class FluidMagicInput implements Serializable {
     // Calculate base case GOR
     if (gasStdVolume > 0 && oilStdVolume > 0) {
       baseCaseGOR = gasStdVolume / oilStdVolume;
-      logger.info("Base case GOR: {:.1f} Sm3/Sm3", baseCaseGOR);
+      logger.info("Base case GOR: {} Sm3/Sm3", baseCaseGOR);
     }
 
     // Create water phase (pure water or brine based on salinity)
@@ -258,7 +258,7 @@ public class FluidMagicInput implements Serializable {
 
     // Calculate standard water volume (1 kmol at std conditions)
     waterStdVolume = waterPhase.getVolume("m3");
-    logger.info("Water phase created: {:.4f} m3/kmol at std conditions", waterStdVolume);
+    logger.info("Water phase created: {} m3/kmol at std conditions", waterStdVolume);
   }
 
   /**

--- a/src/main/java/neqsim/process/util/optimizer/MultiScenarioVFPGenerator.java
+++ b/src/main/java/neqsim/process/util/optimizer/MultiScenarioVFPGenerator.java
@@ -197,8 +197,8 @@ public class MultiScenarioVFPGenerator implements Serializable {
     long elapsed = System.currentTimeMillis() - startTime;
     int feasibleCount = vfpTable.getFeasibleCount();
 
-    logger.info("VFP table complete: {}/{} feasible in {:.1f}s ({:.2f}s/point)", feasibleCount, totalPoints,
-        elapsed / 1000.0, elapsed / 1000.0 / totalPoints);
+    logger.info("VFP table complete: {}/{} feasible in {}s ({}s/point)", feasibleCount, totalPoints, elapsed / 1000.0,
+        elapsed / 1000.0 / totalPoints);
 
     if (flashGenerator != null) {
       logger.info("Fluid cache: {}", flashGenerator.getCacheStatistics());
@@ -247,8 +247,8 @@ public class MultiScenarioVFPGenerator implements Serializable {
 
         if (completed % 20 == 0 || completed == tasks.size()) {
           String status = point.feasible ? String.format("P_in=%.1f bara", point.bhp) : "INFEASIBLE";
-          logger.info("[{}/{}] Rate={:.0f}, THP={:.0f}, WC={:.0f}%, GOR={:.0f} → {}", completed, tasks.size(),
-              point.flowRate, point.thp, point.waterCut * 100, point.gor, status);
+          logger.info("[{}/{}] Rate={}, THP={}, WC={}%, GOR={} → {}", completed, tasks.size(), point.flowRate,
+              point.thp, point.waterCut * 100, point.gor, status);
         }
       } catch (Exception e) {
         logger.error("Task execution failed", e);

--- a/src/main/java/neqsim/process/util/optimizer/RecombinationFlashGenerator.java
+++ b/src/main/java/neqsim/process/util/optimizer/RecombinationFlashGenerator.java
@@ -105,9 +105,9 @@ public class RecombinationFlashGenerator implements Serializable {
     this.fluidCache = new ConcurrentHashMap<>();
 
     logger.info("RecombinationFlashGenerator initialized");
-    logger.info("  Gas molar volume: {:.4f} Sm3/kmol", gasStdVolumePerMole);
-    logger.info("  Oil molar volume: {:.4f} Sm3/kmol", oilStdVolumePerMole);
-    logger.info("  Water molar volume: {:.4f} Sm3/kmol", waterStdVolumePerMole);
+    logger.info("  Gas molar volume: {} Sm3/kmol", gasStdVolumePerMole);
+    logger.info("  Oil molar volume: {} Sm3/kmol", oilStdVolumePerMole);
+    logger.info("  Water molar volume: {} Sm3/kmol", waterStdVolumePerMole);
   }
 
   /**
@@ -174,8 +174,8 @@ public class RecombinationFlashGenerator implements Serializable {
     // Calculate gas rate from GOR (gas per oil volume)
     double gasRate = oilRate * targetGOR; // Sm3/hr gas
 
-    logger.debug("Generating fluid: GOR={:.0f}, WC={:.1f}%, Oil={:.1f}, Gas={:.1f}, Water={:.1f}", targetGOR,
-        waterCut * 100, oilRate, gasRate, waterRate);
+    logger.debug("Generating fluid: GOR={}, WC={}%, Oil={}, Gas={}, Water={}", targetGOR, waterCut * 100, oilRate,
+        gasRate, waterRate);
 
     // Create recombined fluid starting from gas phase composition
     SystemInterface recombined = createBaseFluid();
@@ -391,8 +391,7 @@ public class RecombinationFlashGenerator implements Serializable {
     double actualGOR = (oilVolume > 0) ? gasVolume / oilVolume : 0.0;
     double relativeError = Math.abs(actualGOR - targetGOR) / targetGOR;
 
-    logger.debug("GOR validation: target={:.1f}, actual={:.1f}, error={:.2f}%", targetGOR, actualGOR,
-        relativeError * 100);
+    logger.debug("GOR validation: target={}, actual={}, error={}%", targetGOR, actualGOR, relativeError * 100);
 
     return relativeError <= tolerance;
   }

--- a/src/main/java/neqsim/pvtsimulation/flowassurance/FloryHugginsAsphalteneModel.java
+++ b/src/main/java/neqsim/pvtsimulation/flowassurance/FloryHugginsAsphalteneModel.java
@@ -535,7 +535,7 @@ public class FloryHugginsAsphalteneModel {
     // Validate: onset must be above approximate bubble point.
     // If onset is found near the minimum search pressure, it's likely a numerical artifact.
     if (!Double.isNaN(onsetP) && onsetP < minP + 2 * pressureSearchStep) {
-      logger.info("FH onset at {:.1f} bar is near minimum search pressure - treating as no onset", onsetP);
+      logger.info("FH onset at {} bar is near minimum search pressure - treating as no onset", onsetP);
       return Double.NaN;
     }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TVfractionFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TVfractionFlash.java
@@ -209,7 +209,7 @@ public class TVfractionFlash extends Flash {
         return lastValidPressure;
       }
 
-      logger.trace("iter {} pressure {:.6f} error {:.3e} damping {:.1f}", iterations, nyPres, error, dampingFactor);
+      logger.trace("iter {} pressure {} error {} damping {}", iterations, nyPres, error, dampingFactor);
 
       // Convergence check with early exit
       if (error < 1e-8 && iterations > 3) {

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeSeparatedFrictionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeSeparatedFrictionTest.java
@@ -1,0 +1,89 @@
+package neqsim.process.equipment.pipeline;
+
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the separated friction model against the mixture correlation it replaces.
+ *
+ * <p>
+ * The pressure march charges friction with a hold-up weighted mixture density over the whole perimeter. That is a
+ * dispersed-flow description; in a separated flow it applies a liquid-dominated density to a bore that is mostly gas.
+ * At high liquid hold-up it over-predicts the pressure drop severely, which is why the separated form exists.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+class TwoFluidPipeSeparatedFrictionTest {
+  /**
+   * Builds a horizontal liquid-loaded pipe.
+   *
+   * @param separated true to select the separated friction model
+   * @return a pipe ready to run
+   */
+  private TwoFluidPipe buildPipe(boolean separated) {
+    SystemInterface fluid = new SystemSrkEos(273.15 + 50.0, 57.0);
+    fluid.addComponent("methane", 60.0);
+    fluid.addComponent("ethane", 5.0);
+    fluid.addComponent("propane", 3.0);
+    fluid.addComponent("n-heptane", 20.0);
+    fluid.addComponent("nC10", 12.0);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(50.0 * 3600.0, "kg/hr");
+    feed.setTemperature(50.0, "C");
+    feed.setPressure(57.0, "bara");
+    feed.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe("pipe", feed);
+    pipe.setLength(5000.0);
+    pipe.setDiameter(0.30);
+    pipe.setNumberOfSections(20);
+    pipe.setElevationProfile(new double[20]);
+    pipe.setSeparatedFrictionModel(separated);
+    return pipe;
+  }
+
+  /**
+   * The mixture correlation must remain the default so existing results do not move.
+   */
+  @Test
+  @DisplayName("Separated friction model is off by default")
+  void testSeparatedFrictionIsOffByDefault() {
+    Assertions.assertFalse(buildPipe(false).isSeparatedFrictionModel(),
+        "the separated friction model must stay opt-in until the hold-up deficit is closed");
+    Assertions.assertTrue(buildPipe(true).isSeparatedFrictionModel(), "the selection must be honoured");
+  }
+
+  /**
+   * On a liquid-loaded line the mixture correlation must predict the larger pressure drop.
+   *
+   * <p>
+   * This is the signature of the defect the separated model addresses: charging the whole perimeter with a
+   * liquid-weighted density inflates the friction once the liquid hold-up is appreciable.
+   * </p>
+   */
+  @Test
+  @DisplayName("Mixture friction over-predicts pressure drop against the separated form")
+  void testMixtureFrictionExceedsSeparatedOnLiquidLoadedLine() {
+    TwoFluidPipe mixture = buildPipe(false);
+    mixture.run();
+    double mixtureDrop = mixture.getInletPressure() - mixture.getOutletPressure();
+
+    TwoFluidPipe separated = buildPipe(true);
+    separated.run();
+    double separatedDrop = separated.getInletPressure() - separated.getOutletPressure();
+
+    Assertions.assertTrue(mixtureDrop > 0.0 && separatedDrop > 0.0,
+        "both models must produce a positive pressure drop, got " + mixtureDrop + " and " + separatedDrop);
+    Assertions.assertTrue(separatedDrop < mixtureDrop,
+        "the mixture correlation must be the larger of the two on a liquid-loaded line, but got separated "
+            + separatedDrop + " bar against mixture " + mixtureDrop + " bar");
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeHorizontalTransitionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeHorizontalTransitionTest.java
@@ -1,5 +1,7 @@
 package neqsim.process.equipment.pipeline.twophasepipe;
 
+import java.util.EnumMap;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -153,12 +155,79 @@ class FlowRegimeHorizontalTransitionTest {
   }
 
   /**
-   * The selection must default to the legacy behaviour so existing results do not move.
+   * The transition stays opt-in, while the blending it depends on is always available.
    */
   @Test
-  @DisplayName("Equilibrium-level transition is off by default")
+  @DisplayName("Equilibrium-level transition is off by default, blending is on")
   void testEquilibriumLevelTransitionIsOffByDefault() {
-    Assertions.assertFalse(new FlowRegimeDetector().isUseEquilibriumLevelAnnularTransition(),
-        "the alternative transition must be opt-in until closure blending is available");
+    FlowRegimeDetector detector = new FlowRegimeDetector();
+
+    Assertions.assertFalse(detector.isUseEquilibriumLevelAnnularTransition(),
+        "the transition must stay opt-in until the terrain response it implies is anchored");
+    Assertions.assertTrue(detector.isBlendRegimeTransitions(),
+        "closure blending must default on, otherwise the transition steps hold-up");
+  }
+
+  /**
+   * Blending must give a continuous regime composition across the transition.
+   *
+   * <p>
+   * A hard switch shows up as a jump in the weight of a regime for an arbitrarily small change in gas velocity. Walking
+   * the gas velocity across the transition, no single step may move any regime weight by more than a modest fraction.
+   * </p>
+   */
+  @Test
+  @DisplayName("Regime weights vary continuously across the horizontal transition")
+  void testBlendedRegimeWeightsAreContinuous() {
+    FlowRegimeDetector detector = detector(true);
+    double rhoG = 40.0;
+    Map<FlowRegime, Double> previous = null;
+    double largestStep = 0.0;
+
+    for (int i = 0; i <= 200; i++) {
+      double superficialGas = 0.5 + i * 0.02;
+      PipeSection section = section(0.035, superficialGas, SMALL_LINE_DIAMETER, rhoG);
+      detector.classify(section);
+      Map<FlowRegime, Double> current = weightsOf(section);
+
+      if (previous != null) {
+        for (FlowRegime regime : FlowRegime.values()) {
+          double before = previous.containsKey(regime) ? previous.get(regime) : 0.0;
+          double after = current.containsKey(regime) ? current.get(regime) : 0.0;
+          largestStep = Math.max(largestStep, Math.abs(after - before));
+        }
+      }
+      previous = current;
+    }
+
+    Assertions.assertTrue(largestStep < 0.2,
+        "a blended transition must not step a regime weight by more than 0.2 per 0.02 m/s, but stepped " + largestStep);
+  }
+
+  /**
+   * Resolves the weight of each closure family, treating a single regime as weight one.
+   *
+   * <p>
+   * Smooth and wavy stratified flow share one closure, so a swap between them is not a closure discontinuity and must
+   * not be counted as one.
+   * </p>
+   *
+   * @param section a classified section
+   * @return weight per closure family
+   */
+  private Map<FlowRegime, Double> weightsOf(PipeSection section) {
+    Map<FlowRegime, Double> raw = section.getRegimeWeights();
+    if (raw == null) {
+      raw = new EnumMap<FlowRegime, Double>(FlowRegime.class);
+      raw.put(section.getFlowRegime(), 1.0);
+    }
+
+    Map<FlowRegime, Double> byClosure = new EnumMap<FlowRegime, Double>(FlowRegime.class);
+    for (Map.Entry<FlowRegime, Double> entry : raw.entrySet()) {
+      FlowRegime key = entry.getKey() == FlowRegime.STRATIFIED_WAVY ? FlowRegime.STRATIFIED_SMOOTH : entry.getKey();
+      Double existing = byClosure.get(key);
+      byClosure.put(key, entry.getValue() + (existing == null ? 0.0 : existing));
+    }
+    return byClosure;
   }
 }


### PR DESCRIPTION
Consolidated two-fluid pipeline model update. Supersedes #3067 and #3068, which
are contained in this branch; close those in favour of this one.

Six defects, each found by chasing the one before it. Everything is measured
against the OLGA reference cases, and no behaviour change is enabled by default
that is not independently justified.

## 1. The stratified level solver never converged

`estimateStratifiedLiquidLevel` updated the level with a fixed step,

    h_L = h_L - 0.1 * D * Math.signum(resid);

so from the `0.5*D` initial guess it could only ever land on a `0.1*D` grid, and
its own convergence test `|h_L - h_prev| < 1e-6*D` could never be met because
the step was always exactly `0.1*D`. It ran all 20 iterations and returned an
oscillating grid point. `h_L/D` jumped 0.4 -> 0.5 -> 0.6, so anything keyed on
the level was a step function of gas velocity. Replaced with bisection on the
same residual, which was verified term by term against the published
Taitel-Dukler combined momentum equation and is unchanged.

## 2. The Kelvin-Helmholtz criterion was dimensionally wrong

    U_G_crit = sqrt(dRho * g * h_G * A_G / (rho_G * S_i))

The group under the root is m3/s2, not a velocity, because of the spurious extra
`h_G`, and the `C2` factor was missing. Taitel and Dukler (1976) transition A is

    U_G >= C2 * sqrt(dRho * g * A_G / (rho_G * dA_L/dh_L)),  C2 = 1 - h_L/D

with `dA_L/dh_L = S_i`. The coded form was roughly 0.3 to 0.55 times the correct
critical velocity over the diameters of interest, so it declared the stratified
layer unstable far too readily and over-called slug.

This one is worth flagging to reviewers. Before it was found, enabling the
Taitel-Dukler transition appeared to improve the low-rate hold-up deficit from
-26% to -14%, and that was nearly shipped as an accuracy gain. The gain vanished
completely once the dimensions were corrected: it came from the wrong criterion
firing spuriously. With correct physics the reference line is stratified
throughout.

## 3. Closure switched at a point instead of blending

A section on a transition is not wholly one regime, so hold-up and friction
stepped as an operating point drifted across a boundary. `PipeSection` now
carries fractional regime weights, `FlowRegimeDetector.classify` sets them from
the Kelvin-Helmholtz margin and the equilibrium level ramped over bands, and
`TwoFluidPipe` evaluates and weights each closure. The valley and peak terrain
corrections ramp in over the near-horizontal band instead of switching at
0.05 rad.

## 4. The stratified closure used an absolute residual tolerance

`calculateStratifiedHoldupOLGA` stopped its damped Newton iteration on
`Math.abs(residual) < 1.0`. The residual is a pressure gradient in Pa/m, so a
fixed threshold means something different on every line. Replaced with
bisection. Its liquid hydraulic diameter also included the interface width;
Taitel and Dukler use `D_L = 4*A_L/S_L`, because the interface is a shear
surface for the gas but not a wall for the liquid. `FlowRegimeDetector` already
used the correct pair, so the two halves of the model disagreed.

## 5. The convergence residual ignored the oil/water split

`updateLiquidPhaseSplit` is a solved variable, but only pressure and total
liquid hold-up entered `maxChange`, so the solver could report convergence while
oil and water were still redistributing. The water hold-up change now enters the
residual.

## 6. Friction came from a mixture correlation in separated flow

The pressure march used a hold-up weighted mixture density over the whole
perimeter, which is a dispersed-flow description. Summing the phase momentum
equations cancels the interfacial shear and leaves

    -dP/dx = (tau_wG*S_G + tau_wL*S_L)/A + rho_mix*g*sin(theta)

`separatedFrictionGradient` implements this, weighted by the regime blend so
that stratified and annular sections use it while slug, churn and dispersed
bubble sections keep the mixture form. The single-phase limit reduces to
Darcy-Weisbach exactly.

On the three-phase reference case this cuts the pressure-drop error from +189.5%
to +16.9%.

It is **off by default**. Using the real liquid-layer geometry also amplifies the
outstanding hold-up deficit that the mixture correlation masks: on the lean
gas-condensate line pressure drop moves from about +5% to about +16% and the
highest rate is driven onto the pressure floor. The mixture form's good
agreement there partly rests on degenerating to gas-only at trace hold-up.

## Also included

40 Log4j2 calls across 11 files used Python-style format specifiers. Log4j2
substitutes `{}` only, so they printed literally and misbound their arguments.
The worst case is the message emitted when a solve is truncated: one placeholder
and two arguments, printing the timeout where the iteration count belonged.

## Reference results

Default configuration is unchanged to displayed precision:

| rate MSm3/d | OLGA dP | this branch | err |
| --- | --- | --- | --- |
| 4 | 10.15 | 10.65 | +4.8% |
| 7 | 33.60 | 35.43 | +5.5% |
| 10 | 78.50 | 79.58 | +1.4% |
| 12 | 138.72 | 138.70 | -0.0% |

Pipeline suite: 820 tests, 0 failures, 22 skipped.

## Known open items, deliberately not addressed here

- Low-rate hold-up deficit of -26% (0.0221 against 0.0297). Proven during this
  work that it cannot be closed in the horizontal stratified balance: at zero
  inclination that balance has no gravity term, so it is homogeneous in velocity
  scale and its root depends on the no-slip fraction and only weakly on the
  velocities. Measured directly: hold-up 0.024231 identical for superficial gas
  velocities of 2, 4, 6, 8 and 12 m/s. It must come from terrain or interfacial
  friction.
- A zero-net-elevation undulation still moves pressure drop by 6.8%. Shown to be
  a closure question rather than a numerical one: with the corrected level solver
  the figure returned to its original value, and the intermediate 5.83% was
  itself an artefact of the broken grid solver.
- The terrain slugging response is unanchored; there is no reference case for it.
- `TwoPhasePipeFlowSystem` remains an outlier at 3.489 bar against a
  0.616 homogeneous-Darcy, 0.898 Beggs and Brill and 0.845 TwoFluidPipe anchor on
  its own fixture.


## Review follow-up

- Head `4bd64af312d1bddaf0bf47aab0a943cfa0094a42`: `getRegimeWeights()` now preserves the existing null behavior and otherwise returns an unmodifiable defensive `EnumMap` snapshot.
- Documentation impact: Javadoc updated to document the accessor's snapshot/immutability contract; no user-guide change is needed because this only clarifies ownership semantics for the new accessor.
- Validation: **VALIDATION PENDING CI**. All workflows passed on the preceding exact head `315852122fb62f3d35af003c4456d0bdf6eb54ae`; fresh exact-head checks are required for this follow-up commit.
