### PR TITLE
[AI-Assisted] feat(diagram): separate BFD, PFD and P&ID content

### DIFF
--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -29,11 +29,42 @@ The initial model provides:
   affected drawing and sheet; and
 - opt-in manual sheet definitions, stable object-to-sheet assignments, pinned coordinates, and
   protected connection routes with explicit review evidence; and
+- distinct conservative BFD, PFD, and P&ID drawing views over the same complete canonical semantic
+  object snapshot, with structured diagnostics for every profile omission; and
 - byte-deterministic JSON for equivalent fresh process models.
 
 The automatic partition remains deliberately conservative. It does not choose sheet sizes, grids,
 symbols, legends, or title-block geometry. Manual layout intent is supplied separately through an
 `EngineeringDiagramLayoutRegister`; it is never hidden in the process execution graph.
+
+## Content profiles
+
+`ContentProfile` controls only drawing and sheet membership. `getSemanticObjects()` always retains
+the complete canonical model with the same stable identities, properties, units, provenance, and
+connections, regardless of the selected profile.
+
+| Profile | Drawing-view content | Deliberate omissions |
+| --- | --- | --- |
+| `BFD` | Areas, equipment blocks, boundaries, material ports/nozzles, and material connections | Controlled line detail, energy connections, instrumentation, and signal connections |
+| `PFD` | Areas, equipment, boundaries, controlled lines, material and energy ports/connections | Instrumentation and signal ports/connections |
+| `PID` | Every visual semantic object currently represented by the canonical model | None at the content-policy layer; source-adapter losses remain diagnostic |
+
+Parallel material connections remain distinct in all three profiles. Multi-area off-page connector
+pairs are created only for connections visible in the selected profile, so a BFD does not acquire
+energy or signal cross-sheet references and a PFD does not acquire signal references. Manual sheet,
+pinned-position, or protected-route evidence targeting an omitted object is retained in its source
+register but reported as `DIAGRAM_CONTENT_PROFILE_LAYOUT_OMITTED` rather than silently changing the
+profile.
+
+Every document set records `DIAGRAM_CONTENT_PROFILE_PROPOSAL_ONLY`, and each omitted visual object
+records `DIAGRAM_CONTENT_PROFILE_OBJECT_OMITTED`. These are loss/projection diagnostics, not errors;
+the omitted objects remain available in the canonical semantic snapshot and to other drawing or
+exchange projections.
+
+The BFD policy treats current unit operations as conservative functional blocks; it does not infer
+or aggregate licensed-standard process blocks. The PFD and P&ID policies likewise do not qualify
+symbols, content, layout, measurement/control conventions, or drawing practice. None of the three
+profiles claims ISO 10628, ISO 14617, ISA, or project-standard conformance or engineering approval.
 
 ## Java example
 
@@ -529,3 +560,4 @@ coordinates and protected routes, reciprocal off-page references, deterministic 
 route/object and route-label obstacle diagnostics, collision, clipping, label-overflow and
 broken-reference diagnostics, normalized visual fingerprints, multi-page drawing sets, fresh-model
 determinism, and unchanged Classic DOT and controlled-document JSON.
+

--- a/src/main/java/neqsim/process/engineering/model/EngineeringDiagramDocumentSet.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringDiagramDocumentSet.java
@@ -27,11 +27,21 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
 
   /** Drawing content profiles. */
   public enum ContentProfile {
-    /** Block flow diagram. */
+    /**
+     * Conservative functional-block view containing equipment, boundaries, and material connections.
+     *
+     * <p>
+     * This profile does not aggregate unit operations into licensed-standard process blocks and does not assert BFD
+     * conformance.
+     * </p>
+     */
     BFD,
-    /** Process flow diagram. */
+    /**
+     * Process-flow view containing equipment plus material and energy connections while omitting instrumentation and
+     * signal connections.
+     */
     PFD,
-    /** Piping and instrumentation diagram proposal. */
+    /** Piping and instrumentation proposal retaining every visual semantic object. */
     PID
   }
 
@@ -773,7 +783,7 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
     Map<String, MutableSheet> sheetsByAreaName = new LinkedHashMap<String, MutableSheet>();
     if (areas.isEmpty()) {
       MutableSheet sheet = new MutableSheet("plant", sheetId(normalizedNumber, "plant"), "1", title, null);
-      sheet.objectNodeIds.addAll(visualNodeIds(graph));
+      sheet.objectNodeIds.addAll(visualNodeIds(graph, profile));
       mutableSheets.add(sheet);
     } else {
       int index = 1;
@@ -783,7 +793,7 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
             String.valueOf(index), areaName, null);
         sheet.areaNodeIds.add(area.getId());
         for (EngineeringNode node : graph.getNodes().values()) {
-          if (belongsToArea(node, areaName) && isVisual(node.getKind())) {
+          if (belongsToArea(node, areaName) && isVisible(profile, node)) {
             sheet.objectNodeIds.add(node.getId());
           }
         }
@@ -794,9 +804,10 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
     }
     Map<String, MutableSheet> sheetsByKey = sheetsByKey(mutableSheets);
     addManualSheets(normalizedNumber, layoutRegister, mutableSheets, sheetsByKey, diagnostics);
-    applyManualAssignments(graph, layoutRegister, mutableSheets, sheetsByKey, diagnostics);
-    addCrossSheetReferences(graph, mutableSheets, sheetsByAreaName, diagnostics);
-    applyLayoutOverrides(graph, layoutRegister, sheetsByKey, diagnostics);
+    applyManualAssignments(graph, profile, layoutRegister, mutableSheets, sheetsByKey, diagnostics);
+    addCrossSheetReferences(graph, profile, mutableSheets, sheetsByAreaName, diagnostics);
+    applyLayoutOverrides(graph, profile, layoutRegister, sheetsByKey, diagnostics);
+    addContentProfileDiagnostics(graph, profile, normalizedNumber, diagnostics);
     List<Sheet> sheets = new ArrayList<Sheet>();
     for (MutableSheet mutable : mutableSheets) {
       sheets.add(mutable.toSheet());
@@ -967,8 +978,9 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
     }
   }
 
-  private static void applyManualAssignments(EngineeringGraph graph, EngineeringDiagramLayoutRegister layoutRegister,
-      List<MutableSheet> allSheets, Map<String, MutableSheet> sheetsByKey, List<Diagnostic> diagnostics) {
+  private static void applyManualAssignments(EngineeringGraph graph, ContentProfile profile,
+      EngineeringDiagramLayoutRegister layoutRegister, List<MutableSheet> allSheets,
+      Map<String, MutableSheet> sheetsByKey, List<Diagnostic> diagnostics) {
     Map<String, EngineeringDiagramLayoutRegister.SheetAssignment> assignmentsByObject = new LinkedHashMap<String, EngineeringDiagramLayoutRegister.SheetAssignment>();
     for (EngineeringDiagramLayoutRegister.SheetAssignment assignment : layoutRegister.getAssignments()) {
       EngineeringNode node = graph.getNode(assignment.getSemanticObjectId());
@@ -988,6 +1000,11 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
             "Manual sheet assignment targets an object that has no drawing view", node.getId()));
         continue;
       }
+      if (!isVisible(profile, node)) {
+        diagnostics.add(new Diagnostic(Severity.WARNING, "DIAGRAM_CONTENT_PROFILE_LAYOUT_OMITTED",
+            "Manual sheet assignment targets an object omitted by the selected content profile", node.getId()));
+        continue;
+      }
       if (isConnection(node.getKind())) {
         diagnostics.add(new Diagnostic(Severity.ERROR, "DIAGRAM_DOCUMENT_LAYOUT_CONNECTION_ASSIGNMENT_DERIVED",
             "Connection sheet projection is derived from its endpoint assignments; use protected routes for each view",
@@ -1000,6 +1017,9 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
     }
     for (EngineeringNode endpoint : graph.getNodes().values()) {
       if (endpoint.getKind() != EngineeringNode.Kind.PORT && endpoint.getKind() != EngineeringNode.Kind.NOZZLE) {
+        continue;
+      }
+      if (!isVisible(profile, endpoint)) {
         continue;
       }
       String ownerNodeId = stringProperty(endpoint, "ownerNodeId", "");
@@ -1019,10 +1039,10 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
     }
   }
 
-  private static void addCrossSheetReferences(EngineeringGraph graph, List<MutableSheet> allSheets,
-      Map<String, MutableSheet> sheetsByAreaName, List<Diagnostic> diagnostics) {
+  private static void addCrossSheetReferences(EngineeringGraph graph, ContentProfile profile,
+      List<MutableSheet> allSheets, Map<String, MutableSheet> sheetsByAreaName, List<Diagnostic> diagnostics) {
     for (EngineeringNode node : graph.getNodes().values()) {
-      if (!isConnection(node.getKind())) {
+      if (!isConnection(node.getKind()) || !isVisible(profile, node)) {
         continue;
       }
       MutableSheet sourceSheet = sheetContaining(allSheets, stringProperty(node, "sourceEndpointId", ""));
@@ -1085,8 +1105,9 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
     }
   }
 
-  private static void applyLayoutOverrides(EngineeringGraph graph, EngineeringDiagramLayoutRegister layoutRegister,
-      Map<String, MutableSheet> sheetsByKey, List<Diagnostic> diagnostics) {
+  private static void applyLayoutOverrides(EngineeringGraph graph, ContentProfile profile,
+      EngineeringDiagramLayoutRegister layoutRegister, Map<String, MutableSheet> sheetsByKey,
+      List<Diagnostic> diagnostics) {
     for (EngineeringDiagramLayoutRegister.PinnedPosition position : layoutRegister.getPinnedPositions()) {
       EngineeringNode node = graph.getNode(position.getSemanticObjectId());
       MutableSheet sheet = sheetsByKey.get(position.getSheetKey());
@@ -1096,6 +1117,9 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
       } else if (sheet == null) {
         diagnostics.add(new Diagnostic(Severity.ERROR, "DIAGRAM_DOCUMENT_LAYOUT_UNKNOWN_SHEET",
             "Pinned position references an unknown sheet key", position.getSheetKey()));
+      } else if (!isVisible(profile, node)) {
+        diagnostics.add(new Diagnostic(Severity.WARNING, "DIAGRAM_CONTENT_PROFILE_LAYOUT_OMITTED",
+            "Pinned position targets an object omitted by the selected content profile", node.getId()));
       } else if (!sheet.objectNodeIds.contains(node.getId())) {
         diagnostics.add(new Diagnostic(Severity.ERROR, "DIAGRAM_DOCUMENT_LAYOUT_OBJECT_NOT_ON_SHEET",
             "Pinned position must target a sheet containing the semantic object", node.getId()));
@@ -1112,6 +1136,9 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
       } else if (sheet == null) {
         diagnostics.add(new Diagnostic(Severity.ERROR, "DIAGRAM_DOCUMENT_LAYOUT_UNKNOWN_SHEET",
             "Protected route references an unknown sheet key", route.getSheetKey()));
+      } else if (!isVisible(profile, node)) {
+        diagnostics.add(new Diagnostic(Severity.WARNING, "DIAGRAM_CONTENT_PROFILE_LAYOUT_OMITTED",
+            "Protected route targets a connection omitted by the selected content profile", node.getId()));
       } else if (!sheet.objectNodeIds.contains(node.getId())) {
         diagnostics.add(new Diagnostic(Severity.ERROR, "DIAGRAM_DOCUMENT_LAYOUT_CONNECTION_NOT_ON_SHEET",
             "Protected route must target a sheet containing the semantic connection view", node.getId()));
@@ -1274,14 +1301,47 @@ public final class EngineeringDiagramDocumentSet implements Serializable {
     return result;
   }
 
-  private static List<String> visualNodeIds(EngineeringGraph graph) {
+  private static List<String> visualNodeIds(EngineeringGraph graph, ContentProfile profile) {
     List<String> result = new ArrayList<String>();
     for (EngineeringNode node : graph.getNodes().values()) {
-      if (isVisual(node.getKind())) {
+      if (isVisible(profile, node)) {
         result.add(node.getId());
       }
     }
     return result;
+  }
+
+  private static boolean isVisible(ContentProfile profile, EngineeringNode node) {
+    if (!isVisual(node.getKind())) {
+      return false;
+    }
+    if (profile == ContentProfile.PID) {
+      return true;
+    }
+    String connectionType = stringProperty(node, "connectionType", "MATERIAL");
+    if (profile == ContentProfile.PFD) {
+      return node.getKind() != EngineeringNode.Kind.INSTRUMENT
+          && node.getKind() != EngineeringNode.Kind.SIGNAL_CONNECTION && !"SIGNAL".equals(connectionType);
+    }
+    return node.getKind() == EngineeringNode.Kind.AREA || node.getKind() == EngineeringNode.Kind.EQUIPMENT
+        || node.getKind() == EngineeringNode.Kind.BOUNDARY || node.getKind() == EngineeringNode.Kind.PIPE_SEGMENT
+        || ((node.getKind() == EngineeringNode.Kind.PORT || node.getKind() == EngineeringNode.Kind.NOZZLE)
+            && "MATERIAL".equals(connectionType));
+  }
+
+  private static void addContentProfileDiagnostics(EngineeringGraph graph, ContentProfile profile, String drawingNumber,
+      List<Diagnostic> diagnostics) {
+    diagnostics.add(new Diagnostic(Severity.INFO, "DIAGRAM_CONTENT_PROFILE_PROPOSAL_ONLY", profile.name()
+        + " is a conservative NeqSim content projection and does not claim standards conformance or engineering approval",
+        drawingNumber));
+    for (EngineeringNode node : graph.getNodes().values()) {
+      if (isVisual(node.getKind()) && !isVisible(profile, node)) {
+        diagnostics.add(new Diagnostic(Severity.INFO, "DIAGRAM_CONTENT_PROFILE_OBJECT_OMITTED",
+            "Object is retained in the canonical semantic model but omitted from the " + profile.name()
+                + " drawing view",
+            node.getId()));
+      }
+    }
   }
 
   private static boolean isVisual(EngineeringNode.Kind kind) {

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramContentProfileTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramContentProfileTest.java
@@ -6,16 +6,26 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import neqsim.process.engineering.model.EngineeringDiagramDesignationRegister;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Diagnostic;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Drawing;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.SemanticObject;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Sheet;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.CoordinateUnit;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.EvidenceState;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.PinnedPosition;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.ProtectedRoute;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.SheetAssignment;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.SheetDefinition;
+import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.Waypoint;
 import neqsim.process.engineering.model.EngineeringGraph;
 import neqsim.process.engineering.model.EngineeringNode;
 
@@ -86,6 +96,30 @@ class EngineeringDiagramContentProfileTest {
     assertThrows(UnsupportedOperationException.class,
         () -> first.getDrawings().get(0).getSheets().get(0).getObjectNodeIds().add("equipment:extra"));
     assertTrue(hasDiagnostic(first, "DIAGRAM_CONTENT_PROFILE_PROPOSAL_ONLY", "PFD-PROFILE-001"));
+  }
+
+  @Test
+  void reportsManualLayoutEvidenceThatTheProfileCannotDisplay() {
+    EngineeringDiagramLayoutRegister layout = new EngineeringDiagramLayoutRegister()
+        .withSheet(new SheetDefinition("instrument-detail", "2", "Instrument detail", "layout:profile",
+            EvidenceState.REVIEWED, "Process discipline", "2026-08-17T05:00:00Z", "A"))
+        .withAssignment(new SheetAssignment("instrument:temperature", "instrument-detail", "layout:profile",
+            EvidenceState.REVIEWED, "Process discipline", "2026-08-17T05:00:00Z", "A"))
+        .withPinnedPosition(
+            new PinnedPosition("instrument:temperature", "instrument-detail", 50.0, 60.0, CoordinateUnit.MILLIMETRE,
+                "layout:profile", EvidenceState.REVIEWED, "Process discipline", "2026-08-17T05:00:00Z", "A"))
+        .withProtectedRoute(new ProtectedRoute("energy-connection:heater-duty", "plant",
+            Arrays.asList(new Waypoint(10.0, 20.0), new Waypoint(30.0, 20.0)), CoordinateUnit.MILLIMETRE,
+            "layout:profile", EvidenceState.REVIEWED, "Process discipline", "2026-08-17T05:00:00Z", "A"));
+
+    EngineeringDiagramDocumentSet documents = EngineeringDiagramDocumentSet.fromGraph(profileGraph(), "PFD-PROFILE-001",
+        "Content profile reference", ContentProfile.BFD, new EngineeringDiagramDesignationRegister(), layout);
+
+    assertTrue(documents.isValid());
+    assertEquals(3, diagnosticCount(documents, "DIAGRAM_CONTENT_PROFILE_LAYOUT_OMITTED"));
+    assertTrue(findSheet(documents, "instrument-detail").getManualAssignments().isEmpty());
+    assertTrue(findSheet(documents, "instrument-detail").getPinnedPositions().isEmpty());
+    assertTrue(findSheet(documents, "plant").getProtectedRoutes().isEmpty());
   }
 
   private static EngineeringDiagramDocumentSet documents(EngineeringGraph graph, ContentProfile profile) {
@@ -192,5 +226,24 @@ class EngineeringDiagramContentProfileTest {
       }
     }
     return false;
+  }
+
+  private static int diagnosticCount(EngineeringDiagramDocumentSet documents, String code) {
+    int result = 0;
+    for (Diagnostic diagnostic : documents.getDiagnostics()) {
+      if (code.equals(diagnostic.getCode())) {
+        result++;
+      }
+    }
+    return result;
+  }
+
+  private static Sheet findSheet(EngineeringDiagramDocumentSet documents, String key) {
+    for (Sheet sheet : documents.getDrawings().get(0).getSheets()) {
+      if (key.equals(sheet.getKey())) {
+        return sheet;
+      }
+    }
+    throw new AssertionError("Missing sheet " + key);
   }
 }

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramContentProfileTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramContentProfileTest.java
@@ -1,0 +1,196 @@
+package neqsim.process.processmodel.diagram;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Diagnostic;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Drawing;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.SemanticObject;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.Sheet;
+import neqsim.process.engineering.model.EngineeringGraph;
+import neqsim.process.engineering.model.EngineeringNode;
+
+class EngineeringDiagramContentProfileTest {
+  @Test
+  void separatesDrawingViewsWithoutDiscardingCanonicalSemantics() {
+    EngineeringDiagramDocumentSet bfd = documents(profileGraph(), ContentProfile.BFD);
+    EngineeringDiagramDocumentSet pfd = documents(profileGraph(), ContentProfile.PFD);
+    EngineeringDiagramDocumentSet pid = documents(profileGraph(), ContentProfile.PID);
+
+    assertEquals(semanticIds(pid), semanticIds(pfd));
+    assertEquals(semanticIds(pid), semanticIds(bfd));
+
+    Set<String> bfdIds = visibleIds(bfd);
+    Set<String> pfdIds = visibleIds(pfd);
+    Set<String> pidIds = visibleIds(pid);
+    assertTrue(pfdIds.containsAll(bfdIds));
+    assertTrue(pidIds.containsAll(pfdIds));
+
+    assertTrue(bfdIds.contains("equipment:feed"));
+    assertTrue(bfdIds.contains("pipe-segment:feed-a"));
+    assertTrue(bfdIds.contains("pipe-segment:feed-b"));
+    assertFalse(bfdIds.contains("line:feed"));
+    assertFalse(bfdIds.contains("energy-connection:heater-duty"));
+    assertFalse(bfdIds.contains("instrument:temperature"));
+    assertFalse(bfdIds.contains("signal-connection:temperature"));
+
+    assertTrue(pfdIds.contains("line:feed"));
+    assertTrue(pfdIds.contains("energy-connection:heater-duty"));
+    assertFalse(pfdIds.contains("instrument:temperature"));
+    assertFalse(pfdIds.contains("port:signal-source"));
+    assertFalse(pfdIds.contains("signal-connection:temperature"));
+
+    assertTrue(pidIds.contains("instrument:temperature"));
+    assertTrue(pidIds.contains("port:signal-source"));
+    assertTrue(pidIds.contains("signal-connection:temperature"));
+    assertTrue(hasDiagnostic(bfd, "DIAGRAM_CONTENT_PROFILE_OBJECT_OMITTED", "energy-connection:heater-duty"));
+    assertTrue(hasDiagnostic(pfd, "DIAGRAM_CONTENT_PROFILE_OBJECT_OMITTED", "instrument:temperature"));
+    assertFalse(hasDiagnostic(pid, "DIAGRAM_CONTENT_PROFILE_OBJECT_OMITTED", "instrument:temperature"));
+  }
+
+  @Test
+  void filtersCrossSheetReferencesAndPreservesParallelMaterialConnections() {
+    EngineeringDiagramDocumentSet bfd = documents(multiAreaGraph(), ContentProfile.BFD);
+    EngineeringDiagramDocumentSet pfd = documents(multiAreaGraph(), ContentProfile.PFD);
+    EngineeringDiagramDocumentSet pid = documents(multiAreaGraph(), ContentProfile.PID);
+
+    assertEquals(4, connectorCount(bfd));
+    assertEquals(6, connectorCount(pfd));
+    assertEquals(8, connectorCount(pid));
+    assertEquals(2, connectorCount(bfd, "pipe-segment:parallel-a"));
+    assertEquals(2, connectorCount(bfd, "pipe-segment:parallel-b"));
+    assertEquals(0, connectorCount(bfd, "energy-connection:duty"));
+    assertEquals(2, connectorCount(pfd, "energy-connection:duty"));
+    assertEquals(0, connectorCount(pfd, "signal-connection:control"));
+    assertEquals(2, connectorCount(pid, "signal-connection:control"));
+    assertTrue(bfd.isValid());
+    assertTrue(pfd.isValid());
+    assertTrue(pid.isValid());
+  }
+
+  @Test
+  void remainsDeterministicAndReturnsImmutableProfileViews() {
+    EngineeringDiagramDocumentSet first = documents(profileGraph(), ContentProfile.PFD);
+    EngineeringDiagramDocumentSet second = documents(profileGraph(), ContentProfile.PFD);
+
+    assertEquals(first.toJson(), second.toJson());
+    assertThrows(UnsupportedOperationException.class,
+        () -> first.getDrawings().get(0).getSheets().get(0).getObjectNodeIds().add("equipment:extra"));
+    assertTrue(hasDiagnostic(first, "DIAGRAM_CONTENT_PROFILE_PROPOSAL_ONLY", "PFD-PROFILE-001"));
+  }
+
+  private static EngineeringDiagramDocumentSet documents(EngineeringGraph graph, ContentProfile profile) {
+    return EngineeringDiagramDocumentSet.fromGraph(graph, "PFD-PROFILE-001", "Content profile reference", profile);
+  }
+
+  private static EngineeringGraph profileGraph() {
+    EngineeringGraph graph = new EngineeringGraph("PROFILE-PLANT", "A");
+    graph.addNode(node("equipment:feed", EngineeringNode.Kind.EQUIPMENT, "Feed block"));
+    graph.addNode(node("equipment:product", EngineeringNode.Kind.EQUIPMENT, "Product block"));
+    graph.addNode(node("boundary:feed", EngineeringNode.Kind.BOUNDARY, "Feed boundary"));
+    graph.addNode(node("line:feed", EngineeringNode.Kind.LINE, "L-001"));
+    graph.addNode(endpoint("nozzle:feed-out", EngineeringNode.Kind.NOZZLE, "equipment:feed", "MATERIAL"));
+    graph.addNode(endpoint("nozzle:product-in", EngineeringNode.Kind.NOZZLE, "equipment:product", "MATERIAL"));
+    graph.addNode(connection("pipe-segment:feed-a", EngineeringNode.Kind.PIPE_SEGMENT, "MATERIAL", "nozzle:feed-out",
+        "nozzle:product-in"));
+    graph.addNode(connection("pipe-segment:feed-b", EngineeringNode.Kind.PIPE_SEGMENT, "MATERIAL", "nozzle:feed-out",
+        "nozzle:product-in"));
+    graph.addNode(endpoint("port:energy-source", EngineeringNode.Kind.PORT, "equipment:feed", "ENERGY"));
+    graph.addNode(endpoint("port:energy-target", EngineeringNode.Kind.PORT, "equipment:product", "ENERGY"));
+    graph.addNode(connection("energy-connection:heater-duty", EngineeringNode.Kind.ENERGY_CONNECTION, "ENERGY",
+        "port:energy-source", "port:energy-target"));
+    graph.addNode(node("instrument:temperature", EngineeringNode.Kind.INSTRUMENT, "TIT-001"));
+    graph.addNode(endpoint("port:signal-source", EngineeringNode.Kind.PORT, "instrument:temperature", "SIGNAL"));
+    graph.addNode(endpoint("port:signal-target", EngineeringNode.Kind.PORT, "equipment:product", "SIGNAL"));
+    graph.addNode(connection("signal-connection:temperature", EngineeringNode.Kind.SIGNAL_CONNECTION, "SIGNAL",
+        "port:signal-source", "port:signal-target"));
+    return graph;
+  }
+
+  private static EngineeringGraph multiAreaGraph() {
+    EngineeringGraph graph = new EngineeringGraph("PROFILE-MULTI-AREA", "A");
+    graph.addNode(
+        new EngineeringNode("area:a", EngineeringNode.Kind.AREA, "area-a", "Area A").putProperty("areaName", "Area A"));
+    graph.addNode(
+        new EngineeringNode("area:b", EngineeringNode.Kind.AREA, "area-b", "Area B").putProperty("areaName", "Area B"));
+    graph.addNode(crossAreaConnection("pipe-segment:parallel-a", EngineeringNode.Kind.PIPE_SEGMENT, "MATERIAL"));
+    graph.addNode(crossAreaConnection("pipe-segment:parallel-b", EngineeringNode.Kind.PIPE_SEGMENT, "MATERIAL"));
+    graph.addNode(crossAreaConnection("energy-connection:duty", EngineeringNode.Kind.ENERGY_CONNECTION, "ENERGY"));
+    graph.addNode(crossAreaConnection("signal-connection:control", EngineeringNode.Kind.SIGNAL_CONNECTION, "SIGNAL"));
+    return graph;
+  }
+
+  private static EngineeringNode node(String id, EngineeringNode.Kind kind, String label) {
+    return new EngineeringNode(id, kind, id, label);
+  }
+
+  private static EngineeringNode endpoint(String id, EngineeringNode.Kind kind, String ownerId, String connectionType) {
+    return node(id, kind, id).putProperty("ownerNodeId", ownerId).putProperty("connectionType", connectionType);
+  }
+
+  private static EngineeringNode connection(String id, EngineeringNode.Kind kind, String connectionType,
+      String sourceEndpointId, String targetEndpointId) {
+    return node(id, kind, id).putProperty("connectionType", connectionType)
+        .putProperty("sourceEndpointId", sourceEndpointId).putProperty("targetEndpointId", targetEndpointId);
+  }
+
+  private static EngineeringNode crossAreaConnection(String id, EngineeringNode.Kind kind, String connectionType) {
+    return node(id, kind, id).putProperty("connectionType", connectionType).putProperty("crossArea", Boolean.TRUE)
+        .putProperty("sourceArea", "Area A").putProperty("targetArea", "Area B");
+  }
+
+  private static Set<String> visibleIds(EngineeringDiagramDocumentSet documents) {
+    Set<String> result = new LinkedHashSet<String>();
+    for (Sheet sheet : documents.getDrawings().get(0).getSheets()) {
+      result.addAll(sheet.getObjectNodeIds());
+    }
+    return result;
+  }
+
+  private static List<String> semanticIds(EngineeringDiagramDocumentSet documents) {
+    List<String> result = new ArrayList<String>();
+    for (SemanticObject object : documents.getSemanticObjects()) {
+      result.add(object.getId());
+    }
+    return result;
+  }
+
+  private static int connectorCount(EngineeringDiagramDocumentSet documents) {
+    int result = 0;
+    for (Sheet sheet : documents.getDrawings().get(0).getSheets()) {
+      result += sheet.getOffPageConnectors().size();
+    }
+    return result;
+  }
+
+  private static int connectorCount(EngineeringDiagramDocumentSet documents, String connectionId) {
+    int result = 0;
+    Drawing drawing = documents.getDrawings().get(0);
+    for (Sheet sheet : drawing.getSheets()) {
+      for (EngineeringDiagramDocumentSet.OffPageConnector connector : sheet.getOffPageConnectors()) {
+        if (connectionId.equals(connector.getSemanticConnectionId())) {
+          result++;
+        }
+      }
+    }
+    return result;
+  }
+
+  private static boolean hasDiagnostic(EngineeringDiagramDocumentSet documents, String code, String subjectId) {
+    for (Diagnostic diagnostic : documents.getDiagnostics()) {
+      if (code.equals(diagnostic.getCode()) && subjectId.equals(diagnostic.getSubjectId())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## Roadmaps

Advances the first unfinished Phase 2 item in #1332 and the shared canonical-model/document-view boundary coordinated with #2899.

Exact base: `0ef7b4c2ccc11546406cbd547ed4879243f230e9`
Exact publication head: `ae172306b4e0953b3d324bd385df7ac4444d18cd`
Branch: `campaign-1332-2899-content-profile-projection`

## Engineering question

Can one complete canonical engineering semantic model produce genuinely distinct BFD, PFD and P&ID drawing views without changing stable identities, parallel connections, legacy DOT/Graphviz, DEXPI 2.0 Process exchange or the existing Proteus/DEXPI P&ID path?

Before this change, `ContentProfile` was title-block metadata only: all profiles projected the same visual objects and cross-sheet references.

## Complete tranche

- keeps `getSemanticObjects()` complete and identical across BFD, PFD and PID projections
- projects BFD sheets to areas, functional equipment blocks, boundaries and material ports/connections
- projects PFD sheets to areas, equipment, boundaries, controlled lines, and material/energy ports/connections
- projects PID sheets to all currently visual canonical objects, including instruments and signals
- preserves distinct parallel material connections in all profiles
- creates multi-area off-page pairs only for connection types visible in the selected profile
- retains omitted objects in the canonical semantic snapshot and reports each deliberate omission
- reports profile-incompatible manual assignments, pins and protected routes as structured warnings instead of silently widening the view or invalidating the canonical model
- records an explicit proposal-only diagnostic for every profile
- documents the exact policies and limitations

## Compatibility and engineering boundary

No public signature, schema field, stable ID algorithm, ProcessSystem/ProcessModel adapter call, legacy DOT/Graphviz output, native renderer API, DEXPI writer, or Proteus/P&ID workflow changes. Existing PFD callers now receive the content separation their selected profile declares; full canonical semantic data remains available unchanged.

The BFD policy treats existing unit operations as conservative functional blocks. It does not aggregate licensed-standard blocks. No profile claims ISO 10628, ISO 14617, ISA, project-standard conformance, design approval or construction approval.

No physical equations, units, thermodynamic calculations or simulation results change.

## Focused evidence

- profile views are nested BFD ⊆ PFD ⊆ PID while canonical semantic identities remain equal
- parallel material connections remain distinct
- multi-area connector counts exclude energy from BFD and signals from BFD/PFD
- deliberate omissions and proposal boundaries are structured and deterministic
- repeated fresh projections are byte-deterministic
- exposed view lists remain immutable
- profile-incompatible layout evidence is omitted with deterministic warnings while the document remains valid

## Documentation impact

`docs/integration/engineering-diagram-document-model.md` now defines profile content, omissions, canonical retention, off-page behavior, layout-diagnostic behavior and standards/approval limitations.

## Validation

**READY TO MERGE** at exact head `ae172306b4e0953b3d324bd385df7ac4444d18cd`.

Passed locally against diagram source blobs byte-matched to exact base:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py` — 654 Markdown pages and one standalone HTML page
- `./mvnw -DskipTests compile`
- all 13 `neqsim.process.processmodel.diagram` test classes — 114 tests, 0 failures, 0 errors, one existing skip

All eight exact-head GitHub workflows passed:

- Java 8/21 Ubuntu/Windows fast tests, all four Java 21 slow shards, and Java 21 Javadocs
- verified-zero-delta Spotless and hosted pre-commit
- documentation search coverage
- CodeQL security analysis
- PaperLab replication gate
- process-to-engineering and complete offshore engineering notebooks

The local Maven cache used the immediate pre-dependency-bump JUnit 6.1.2 artifacts; exact-head hosted CI passed with the current JUnit 6.1.3 dependency. Local Javadocs were attempted but blocked by unavailable cached Maven reporting dependencies and are not claimed; hosted Java 21 Javadocs passed. The local `pre-commit` executable was unavailable; direct repository Spotless and documentation gates passed, and hosted pre-commit passed.

Final audit: the diff remains exactly the intended three files; the draft is mergeable with no reviews or unresolved threads. Current master `0dbc0fc3a4e64552387e501401e7a0b0304f7e16` is two commits ahead of the exact base, but those commits touch only dynamic-event and landing-page documentation/test files and do not overlap this diagram tranche.

## Deliberate exclusions and stop boundary

No ISO symbol qualification, project convention registry, layout engine, DEXPI graphical round trip, P&ID accountable design data, Huldra/public-dataset ingestion, OCR, 3D mapping or external drawing redistribution.

## Next dependency

After merge, the next bounded shared step is project-configurable content/symbol conventions with explicit fallback diagnostics. Any ISO-aligned or conformant profile remains blocked on licensed standards traceability and accountable engineering review.
