### PR TITLE
[AI-Assisted] docs: repair wiki release and API navigation

### DIFF
--- a/docs/test_landing_page_documentation.py
+++ b/docs/test_landing_page_documentation.py
@@ -7,6 +7,8 @@ from urllib.parse import unquote
 DOCS_DIR = Path(__file__).resolve().parent
 LANDING_PAGE = DOCS_DIR / "index.md"
 PACKAGE_INDEX = DOCS_DIR / "README.md"
+WIKI_INDEX = DOCS_DIR / "wiki" / "index.md"
+POM = DOCS_DIR.parent / "pom.xml"
 
 
 def extract_fence(content, language):
@@ -39,8 +41,10 @@ def resolve_internal_target(source_path, destination):
         candidates.append(raw_target.with_suffix(".md"))
     elif target.endswith("/"):
         candidates.extend((raw_target / "README.md", raw_target / "index.md"))
-    else:
+    elif raw_target.suffix:
         candidates.append(raw_target)
+    else:
+        candidates.extend((raw_target, raw_target.with_suffix(".md")))
 
     for candidate in candidates:
         if candidate.is_file():
@@ -54,6 +58,7 @@ class LandingPageDocumentationContractTest(unittest.TestCase):
         cls.documents = {
             LANDING_PAGE: LANDING_PAGE.read_text(encoding="utf-8"),
             PACKAGE_INDEX: PACKAGE_INDEX.read_text(encoding="utf-8"),
+            WIKI_INDEX: WIKI_INDEX.read_text(encoding="utf-8"),
         }
 
     def test_front_matter_title_structure_and_fences(self):
@@ -87,6 +92,29 @@ class LandingPageDocumentationContractTest(unittest.TestCase):
                             fragment,
                             heading_slugs(target_path.read_text(encoding="utf-8")),
                         )
+
+    def test_wiki_uses_current_release_and_api_destinations(self):
+        wiki = self.documents[WIKI_INDEX]
+        current_version = re.search(
+            r"<revision>([^<]+)</revision>",
+            POM.read_text(encoding="utf-8"),
+        )
+        self.assertIsNotNone(current_version)
+        self.assertIn(
+            f"<version>{current_version.group(1)}</version>",
+            wiki,
+        )
+        self.assertIn(
+            "https://github.com/equinor/neqsim/releases",
+            wiki,
+        )
+        self.assertIn(
+            "https://equinor.github.io/neqsim/javadoc/index.html",
+            wiki,
+        )
+        self.assertNotIn("equinor/neqsimsource", wiki)
+        self.assertNotIn("htmlpreview.github.io", wiki)
+        self.assertNotIn("equinor/neqsimhome/blob", wiki)
 
     def test_shared_java_example_is_complete_and_repository_safe(self):
         landing_example = extract_fence(self.documents[LANDING_PAGE], "java")

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -131,17 +131,17 @@ System.out.println("Density: " + fluid.getDensity("kg/m3") + " kg/m3");
 <dependency>
     <groupId>com.equinor.neqsim</groupId>
     <artifactId>neqsim</artifactId>
-    <version>3.0.0</version>
+    <version>3.17.0</version>
 </dependency>
 ```
 
-**Download:** [GitHub Releases](https://github.com/equinor/neqsimsource/releases)
+**Download:** [GitHub Releases](https://github.com/equinor/neqsim/releases)
 
 ---
 
 ## Resources
 
-- **JavaDoc**: [API Documentation](https://htmlpreview.github.io/?https://github.com/equinor/neqsimhome/blob/master/javadoc/site/apidocs/index.html)
+- **JavaDoc**: [API Documentation](https://equinor.github.io/neqsim/javadoc/index.html)
 - **Source Code**: [github.com/equinor/neqsim](https://github.com/equinor/neqsim)
 - **Issues**: [Report bugs or request features](https://github.com/equinor/neqsim/issues)
 - **Discussions**: [Ask questions](https://github.com/equinor/neqsim/discussions)


### PR DESCRIPTION
## Campaign

Advances documentation-quality campaign #2499, frozen batch D063 (scope 1: landing pages, navigation, indexes, and internal links).

Exact base: `0ef7b4c2ccc11546406cbd547ed4879243f230e9`  
Exact publication head: `2686e4fb8730e663c95fa70d1ce32a70e2216224`  
Branch: `docs-2499-d063-top-level-navigation`

## Confirmed defects and root cause

The legacy wiki landing page retained destinations and installation text from earlier repository/release infrastructure:

- **Medium:** Download linked to nonexistent `equinor/neqsimsource/releases`.
- **Medium:** JavaDoc linked through htmlpreview to a NeqSim 3.9.1 snapshot in `neqsimhome`, while the current documentation landing page uses the generated main-repository JavaDoc destination.
- **Medium:** the Maven example pinned NeqSim 3.0.0 although the exact-base POM revision is 3.17.0.

The broader scan found no missing internal target or fragment: 173 extracted links normalized to 129 unique internal destination/fragment entries and 131 candidate source paths; 131/131 targets and all six explicit fragments resolved.

## Fix

- routes Releases to `https://github.com/equinor/neqsim/releases`
- routes JavaDoc to `https://equinor.github.io/neqsim/javadoc/index.html`, matching `docs/index.md`
- updates the Maven example to 3.17.0
- extends the existing landing-page contract to include `docs/wiki/index.md`
- teaches its hermetic resolver to validate extensionless wiki links
- pins canonical release/API destinations and derives the expected Maven version from `pom.xml`

## Frozen paths

- `docs/wiki/index.md`
- `docs/test_landing_page_documentation.py`

No `REFERENCE_MANUAL_INDEX.md` change was required because no page or topic was added.

## Documentation impact

The user-visible wiki installation and resource destinations are corrected. No runtime Java/Python API, thermodynamics, process calculation, default, notebook, or generated artifact changes.

## Validation

**VALIDATION PENDING CI**

Completed through exact-source connector inspection:

- all 131 internal target candidates exist
- all six explicit fragments resolve
- all three landing pages have Jekyll front matter
- code fences and display-math delimiters are balanced
- final compare is exactly two files, 36 changed lines, two commits, two ahead / zero behind
- branch head and current `master` were re-read immediately before publication
- no active #2499 implementation PR existed

Not run locally because this run did not have a complete connector-matched checkout:

- `python -m unittest docs/test_landing_page_documentation.py`
- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- pre-commit/pre-push stages
- Jekyll rendering and visual inspection

Hosted CI must verify the focused contract, documentation search/build, formatting, pre-commit, and rendered site. No unrun check is claimed as passed.

## External-link evidence

Connector repository search found no `equinor/neqsimsource` repository. The canonical `equinor/neqsim` Releases endpoint is active and publishes NeqSim 3.17.0. The old fetched JavaDoc identifies itself as NeqSim 3.9.1; the current landing page declares the replacement JavaDoc destination used here.

## Exclusions

No external-link cleanup outside the frozen page, Java example behavior change, package/API work, notebooks, production code, broad index reorganization, or Huldra dataset/digital-twin work.

## Huldra coordination

No Huldra work was started. This navigation-only repair exposes no new identity, unit, provenance, restart, diagnostic, ProcessSystem/ProcessModel, or diagram/control mapping interface.

## Next D063 scope

After this PR is merged and recorded, scan the next bounded landing/index group for orphaned pages, duplicated navigation, and source-accurate discoverability.