### PR TITLE
fix(pipeline): real gas viscosity in the stratified level solver, Bendiksen drift velocity, reachable annular criterion

### DIFF
--- a/.github/agents/unisim.reader.agent.md
+++ b/.github/agents/unisim.reader.agent.md
@@ -70,8 +70,9 @@ main flowsheet) become separate `ProcessSystem` areas composed into a
 Tc, Pc, omega, MW, and BIPs from UniSim COM and writes E300 files. Use the
 skill guidance for robust COM extraction: critical temperature and boiling point
 are requested in Celsius and converted to Kelvin, critical pressure is requested
-in kPa and converted to bara, and missing `AcentricFactor` is handled with
-package vectors or Edmister fallback. The generated code loads the fluid via
+in kPa and converted to bara, and the acentric factor is read from the UniSim COM
+attribute `Acentricity` (NOT `AcentricFactor`), with package vectors and an
+Edmister estimate only as fallbacks. The generated code loads the fluid via
 `EclipseFluidReadWrite.read()` for lossless transfer of hypothetical/pseudo
 component properties.
 
@@ -257,7 +258,11 @@ If deviations exceed acceptable ranges, investigate:
 1. Check E300 export/use — were all expected fluid packages exported and loaded
   with `EclipseFluidReadWrite.read(...)`?
 2. Check component/property sanity — methane Tc/Pc and water Tc/Pc should be in
-  expected Kelvin/bara ranges; acentric factors should not be missing.
+  expected Kelvin/bara ranges; acentric factors should not be missing. Compare
+  the exported `ACF` block against `comp.AcentricityValue` from COM: any `0.0`
+  or Edmister-looking value means the acentric factor was estimated rather than
+  transferred, which biases every bubble point / TVP by ~10-15 %. The exporter
+  logs a warning when it has to default an acentric factor to 0.0.
 3. Check component mapping — missing components or wrong fluid package per area?
 4. Check EOS — PR vs SRK differences?
 5. Check equipment specs — efficiency, pressure, temperature set correctly?

--- a/.github/skills/neqsim-flow-assurance/SKILL.md
+++ b/.github/skills/neqsim-flow-assurance/SKILL.md
@@ -497,6 +497,31 @@ for (double qgMSm3d : gasRates) {
 > three-phase bookkeeping is sound — gas/oil/water fractions sum to one and stay in
 > range at every node.
 
+> **On an undulating profile the holdup is often the minimum-slip bound, not the
+> solved balance.** `alphaL >= lambdaL * minimumSlipFactor` (default 2.0) is applied
+> after the regime closures and has no inclination dependence. On a 5 km, 200 mm
+> fixture undulating by +/-30 m, 85 of 100 sections sit exactly on it, including 41
+> of 41 uphill sections, so the terrain response is replaced by a constant there.
+> It is inert on a near-horizontal transmission line: on the 73.8 km export line at
+> 4 MSm3/d, `setMinimumSlipFactor(1.0)` leaves ΔP and the holdup profile unchanged.
+> Check `holdup / (lambdaL * factor)` before attributing a terrain result to
+> physics, and lower the factor if you need the solved inclination response.
+
+> **The horizontal annular criterion is a selection, and the default over-calls
+> annular.** By default the regime map uses the vertical droplet-entrainment
+> threshold `U_SG > 3.1*(sigma*g*drho/rhoG^2)^0.25` ahead of the stratified/slug
+> transition; that is about 0.75 m/s on a 14-inch export line, so essentially any
+> horizontal gas pipeline is classified annular and a shallow stratified layer is
+> solved with a thin-film closure. `pipe.setUseEquilibriumLevelAnnularTransition(true)`
+> selects the Taitel-Dukler equilibrium-level branch instead. The two agree wherever
+> the Kelvin-Helmholtz margin exceeds one — identical at 10 MSm3/d on the export
+> line — and differ at 4 MSm3/d, where the option reclassifies 272 of 320 sections
+> as stratified-wavy and moves median holdup from 0.0198 to 0.0232 against a
+> reference near 0.0235. It is opt-in because the slug closure it then selects on
+> uphill sections returns less liquid than the stratified closure returns on
+> downhill ones, which flattens the terrain signature. Use it for a near-horizontal
+> line at low gas velocity; leave it off on an undulating profile.
+
 > **Direct electrical heating (DEH)** is available on both models with the same
 > convention — the power set is what reaches the fluid, so cable and coating
 > losses must already be deducted:

--- a/.github/skills/neqsim-unisim-reader/SKILL.md
+++ b/.github/skills/neqsim-unisim-reader/SKILL.md
@@ -235,8 +235,9 @@ for i in range(n):
     pc = comp.CriticalPressure.GetValue("kPa") * 0.01      # bara
     nbp = comp.NormalBoilingPt.GetValue("C") + 273.15      # K
     vc = comp.CriticalVolume.GetValue("m3/kgmole") # m3/kmol
-    # Acentric factor — not directly available via .AcentricFactor
-    # Use Edmister correlation: w = (3/7) * log10(Pc/1.01325) / (Tc/Tbp - 1) - 1
+    # Acentric factor: the UniSim COM attribute is `Acentricity` (NOT
+    # `AcentricFactor`). Only fall back to Edmister if it is absent.
+    omega = comp.AcentricityValue
 ```
 
 **Notes:**
@@ -247,13 +248,57 @@ for i in range(n):
    `NormalBoilingPoint` in `C` first and convert to K; request `CriticalPressure`
    in `kPa` first and convert to bara. Sanity-check known components after export:
    methane Tc ≈ 190.7 K and Pc ≈ 46.4 bara; water Tc ≈ 647.3 K and Pc ≈ 221 bara.
-- Acentric factor is NOT directly accessible via COM for all property packages.
-   `comp.AcentricFactor` may not exist. Try property-package vectors
-   (`AcentricFactor`, `AcentricFactors`, `Omega`, `ACF`) first, then use the
-   Edmister correlation as fallback when Tc, Pc, and normal boiling point exist.
+- **Acentric factor: read `comp.Acentricity` / `comp.AcentricityValue`.** This is
+   the attribute UniSim actually exposes; `AcentricFactor` / `Omega` do NOT exist on
+   the component COM surface. Reading the Edmister estimate instead silently changes
+   the EOS alpha function and shifts every bubble point / TVP of the converted fluid
+   (measured: 12–15 % low on a 23-component SRK-Peneloux oil, and `0.0` for the
+   heaviest pseudos where the Edmister value exceeded the `omega > 2` sanity guard).
+   With `Acentricity` read correctly, a NeqSim E300 round-trip reproduces UniSim
+   bubble points to < 0.5 %. Keep the property-package vectors
+   (`Acentricity`, `AcentricFactor`, `Omega`, `ACF`) and Edmister only as fallbacks.
 - Parachor can sometimes be read via `pp.Parachor.Values` (same pattern as Kij).
 - Volume shift: `pp.VolumShift.Values` (note the UniSim spelling: "VolumShift",
   not "VolumeShift").
+
+### 1.2.1 Reading TVP / RVP (Cold Properties) off a stream
+
+Vapour-pressure results live on the **material stream**, in **kPa** (temperatures
+in **°C**). Missing values return the sentinel `-32767`.
+
+```python
+s = case.Flowsheet.MaterialStreams.Item(0)
+s.TrueVPValue                 # TVP, evaluated at 37.8 C
+s.RVP_37_8_DegCValue          # Reid VP at 37.8 C
+s.RVPASTM_D323_73_79Value     # ASTM / API RVP correlations
+s.RVPAPI_5B_1_1Value, s.RVPAPI_5B_1_2Value
+cp = s.ColdProperty           # Cold Properties utility
+cp.TrueVapourPressureValue, cp.ReidVapourPressureValue
+cp.FlashPointValue, cp.PourPointValue, cp.D86CurveValue
+```
+
+For TVP at **any other temperature** (e.g. a 30 °C export spec), flash a duplicate —
+this never touches the case:
+
+```python
+f = s.DuplicateFluid()
+f.TVFlash(30.0, 0.0)          # (T [C], vapour fraction) -> bubble point
+tvp_bara = f.PressureValue * 0.01
+```
+
+Water-free basis: assign a renormalised `f.MolarFractionsValue` with H2O zeroed
+*before* the flash (the setter works); `f.MassFractionsValue` gives water wt%
+directly. Free water only adds its own saturation pressure (~0.04 bara at 30 °C).
+
+> **NeqSim comparison gotcha:** `bubblePointPressureFlash` is not three-phase aware.
+> With free water in the feed it returns a grossly inflated TVP (measured 5–6.5 bara
+> instead of 2.2) because water is treated as dissolved in the oil, and
+> `getPhase("oil")` then returns the aqueous phase. Strip water first, or use
+> `Standard_ASTM_D6377`'s `VPCR4_no_water` / `RVP_ASTM_D323_73_79` variants.
+>
+> A TVP/RVP ratio far above ~1.3 is usually **physical**, not an error: a bubble
+> point is hypersensitive to trace dissolved light ends (N2/C1/CO2) while the
+> V/L = 4, 80 vol %-vaporised RVP test is not. It signals incompletely stabilised oil.
 
 ### 1.3 Generating E300 Fluid Files from UniSim Data
 
@@ -891,6 +936,10 @@ comparator.print_report(comparisons)
    +70% water flow error at secondary stages is structurally expected if recycles are missing.
 5. **Hypothetical components**: Pseudo-component property estimation differs between simulators.
    Critical properties and acentric factor estimation methods vary.
+   **First check the acentric factor was transferred, not estimated** — compare the exported
+   `ACF` block against `comp.AcentricityValue`. Estimated (or `0.0`) values biased a
+   23-component SRK-Peneloux oil's bubble point / TVP by 12–15 %; reading `Acentricity`
+   brought it to < 0.5 % (Section 1.2).
 6. **Compressor efficiency**: UniSim COM sometimes returns `None` for `AdiabaticEfficiency`.
    Always check extracted efficiency values; default to 75% isentropic with a warning.
 7. **Mixing rules**: UniSim may use advanced mixing rules not available in NeqSim.

--- a/devtools/test_unisim_outputs.py
+++ b/devtools/test_unisim_outputs.py
@@ -189,6 +189,23 @@ class _FakeComponentWithoutAcentricFactor:
         raise AttributeError(attribute_name)
 
 
+class _FakeComponentWithAcentricity:
+    """Component exposing the real UniSim COM name for the acentric factor."""
+
+    name = 'C29-C35*'
+    Name = 'C29-C35*'
+    Acentricity = _FakeQuantity({None: 1.277})
+    CriticalTemperature = _FakeQuantity({'K': 829.84})
+    CriticalPressure = _FakeQuantity({'bar': 13.632})
+    MolecularWeight = _FakeQuantity({None: 438.573})
+    NormalBoilingPt = _FakeQuantity({'K': 733.32})
+    CriticalVolume = _FakeQuantity({'m3/kgmole': 1.6})
+
+    def __getattr__(self, attribute_name):
+        """Raise the same style of missing-property error seen in COM."""
+        raise AttributeError(attribute_name)
+
+
 def _build_e300_test_model(tmpdir):
     """Create a model with an exported PR-LK E300 fluid package."""
     components = [
@@ -634,6 +651,48 @@ def test_missing_acentric_factor_uses_edmister_fallback():
     print("  PASS")
 
 
+def test_acentricity_attribute_is_preferred_over_edmister_estimate():
+    """UniSim exposes the acentric factor as 'Acentricity'; use it verbatim.
+
+    Reading the Edmister estimate instead silently changes the EOS alpha
+    function and shifts every bubble point / TVP of the converted fluid.
+    """
+    reader = UniSimReader()
+    extracted_component = UniSimComponent('C29-C35*', 0)
+    reader._populate_component_properties(
+        _FakeComponentWithAcentricity(), extracted_component)
+
+    assert extracted_component.acentric_factor == 1.277
+    print("  PASS")
+
+
+def test_package_vector_does_not_overwrite_component_acentricity():
+    """A property-package acentricity vector must not clobber the COM value."""
+
+    class _FakePropertyPackage:
+        Acentricity = _FakeQuantity({None: None})
+        Acentricities = (0.11, 0.22)
+
+        def __getattr__(self, attribute_name):
+            raise AttributeError(attribute_name)
+
+    class _FakeFluidPackage:
+        PropertyPackage = _FakePropertyPackage()
+
+    reader = UniSimReader()
+    pkg = UniSimFluidPackage(
+        name='Common PVT',
+        property_package='SRK',
+        components=[UniSimComponent('C29-C35*', 0, acentric_factor=1.277),
+                    UniSimComponent('C36-C43*', 1)],
+    )
+    reader._populate_property_package_vectors(_FakeFluidPackage(), pkg)
+
+    assert pkg.components[0].acentric_factor == 1.277
+    assert pkg.components[1].acentric_factor == 0.22
+    print("  PASS")
+
+
 def test_e300_fluid_package_export_and_usage():
     """Verify UniSim fluid packages export to E300 and are consumed as E300."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -1045,6 +1104,10 @@ if __name__ == "__main__":
          test_operation_handler_registry_documents_mapping_strategy),
         ("missing_acentric_factor_uses_edmister_fallback",
          test_missing_acentric_factor_uses_edmister_fallback),
+        ("acentricity_attribute_is_preferred_over_edmister_estimate",
+         test_acentricity_attribute_is_preferred_over_edmister_estimate),
+        ("package_vector_does_not_overwrite_component_acentricity",
+         test_package_vector_does_not_overwrite_component_acentricity),
         ("e300_fluid_package_export_and_usage", test_e300_fluid_package_export_and_usage),
         ("all_fluid_packages_are_exposed_as_e300", test_all_fluid_packages_are_exposed_as_e300),
         ("compressor_discharge_temperature_when_efficiency_missing",

--- a/devtools/unisim_reader.py
+++ b/devtools/unisim_reader.py
@@ -263,7 +263,16 @@ class UniSimFluidPackage:
         _write_section(lines, 'PCRIT', pc_vals, '   {:.4f}', 'Pc (Bar)')
         lines.append('')
 
-        # ACF (acentric factor)
+        # ACF (acentric factor). A silent 0.0 here changes the EOS alpha
+        # function and shifts every bubble point of the exported fluid, so a
+        # missing value is reported instead of being quietly defaulted.
+        missing_acf = [c.name for c in self.components
+                       if c.acentric_factor is None]
+        if missing_acf:
+            logger.warning(
+                "E300 export of fluid package '%s': acentric factor missing for "
+                "%s - writing 0.0, which will bias VLE. Check the UniSim COM "
+                "attribute 'Acentricity'.", self.name, ', '.join(missing_acf))
         acf_vals = [c.acentric_factor if c.acentric_factor is not None else 0.0
                     for c in self.components]
         _write_section(lines, 'ACF', acf_vals, '   {:.6f}', 'Omega')
@@ -1087,8 +1096,11 @@ class UniSimReader:
         extracted_component.pc_bara = self._extract_quantity(
             comp, ['CriticalPressure'], [('kPa', 0.01, 0.0), ('bar', 1.0, 0.0),
                                         ('bara', 1.0, 0.0), (None, 0.01, 0.0)])
+        # 'Acentricity' is the attribute UniSim actually exposes; the other
+        # aliases are kept for other UniSim/HYSYS builds.
         extracted_component.acentric_factor = self._extract_quantity(
-            comp, ['AcentricFactor', 'AcentricityFactor', 'Omega'], [(None, 1.0, 0.0)])
+            comp, ['Acentricity', 'AcentricFactor', 'AcentricityFactor', 'Omega'],
+            [(None, 1.0, 0.0)])
         extracted_component.mw = self._extract_quantity(
             comp, ['MolecularWeight'], [(None, 1.0, 0.0), ('kg/kmol', 1.0, 0.0)])
         extracted_component.tboil_K = self._extract_quantity(
@@ -1229,7 +1241,8 @@ class UniSimReader:
         except Exception:
             return
         vector_specs = [
-            ('acentric_factor', ['AcentricFactor', 'AcentricFactors',
+            ('acentric_factor', ['Acentricity', 'Acentricities',
+                                 'AcentricFactor', 'AcentricFactors',
                                  'AcentricityFactor', 'AcentricityFactors',
                                  'Omega', 'Omegas', 'ACF']),
             ('volume_shift', ['VolumShift', 'VolumeShift', 'VolumeShifts', 'SSHIFT']),
@@ -1238,14 +1251,22 @@ class UniSimReader:
             ('omegab', ['OmegaB', 'OMEGAB']),
             ('sshifts', ['VolumShiftSurface', 'VolumeShiftSurface', 'SSHIFTS']),
         ]
+        # The per-component `Acentricity` read is authoritative; the package
+        # vector (often an estimate) must not overwrite it.
+        gap_fill_only = {'acentric_factor'}
         for attribute_name, candidate_names in vector_specs:
             values = self._extract_package_vector(property_package, candidate_names,
                                                   len(pkg.components))
             if values is None:
                 continue
             for component_index, value in enumerate(values):
-                if value is not None:
-                    setattr(pkg.components[component_index], attribute_name, value)
+                if value is None:
+                    continue
+                if (attribute_name in gap_fill_only
+                        and getattr(pkg.components[component_index],
+                                    attribute_name) is not None):
+                    continue
+                setattr(pkg.components[component_index], attribute_name, value)
         for component_index, extracted_component in enumerate(pkg.components):
             if extracted_component.volume_shift is not None:
                 continue

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -325,6 +325,36 @@ The default **adaptive minimum** is a closure relation that scales with no-slip 
 | `setMinimumSlipFactor(double)` | 2.0 | Multiplier for no-slip holdup |
 | `setEnforceMinimumSlip(boolean)` | `true` | Enable/disable minimum constraint |
 
+> **Known limitation — the minimum is binding on inclined sections.** The bound
+> `alphaL >= lambdaL * minimumSlipFactor` is applied after the regime closures and carries no
+> inclination dependence. On a 5 km, 200 mm fixture undulating by +/-30 m, 85 of 100 sections
+> sit exactly on it, including 41 of 41 uphill sections, so the terrain response of the
+> momentum balance is overwritten by a constant there. It is inert on a near-horizontal
+> transmission line: on a 73.8 km export line at 4 MSm3/d, lowering the factor from 2.0 to 1.0
+> leaves both the pressure drop and the holdup profile unchanged. Lower the factor if you need
+> the solved inclination response on an undulating profile.
+
+### Horizontal Annular Criterion
+
+| Method | Default | Description |
+|--------|---------|-------------|
+| `setUseEquilibriumLevelAnnularTransition(boolean)` | `false` | Branch on the equilibrium liquid level instead of the droplet-entrainment criterion |
+
+The default horizontal path decides annular flow with the vertical droplet-entrainment
+criterion `U_SG > 3.1 * (sigma * g * drho / rhoG^2)^0.25`, checked ahead of the stratified/slug
+transition. That threshold is around 0.75 m/s for a 14-inch high-pressure export line, so a
+horizontal gas pipeline is classified annular on gas velocity alone and a shallow stratified
+layer is then solved with a thin-film closure. Enabling the option selects the horizontal
+criterion of Taitel and Dukler (1976) instead.
+
+The two paths differ only where the gas velocity clears the droplet threshold while the
+Kelvin-Helmholtz margin is still below one. On the export line above they are identical at
+10 MSm3/d; at 4 MSm3/d the option reclassifies 272 of 320 sections as stratified-wavy and moves
+the median holdup from 0.0198 to 0.0232 against a reference value near 0.0235. It stays opt-in
+because the slug closure it then selects on uphill sections returns less liquid than the
+stratified closure returns on downhill ones, so an undulating profile loses its terrain
+signature.
+
 #### Lean Gas Systems
 
 For lean wet gas (< 1% liquid loading), use adaptive-only mode:

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -243,6 +243,21 @@ Fixed-floor mode is opt-in and should be supported by fluid, wall-wetting, and f
 | `setMinimumLiquidHoldup(double)` | 0.001 | Absolute minimum holdup floor (when adaptive-only is false) |
 | `setMinimumSlipFactor(double)` | 2.0 | Multiplier for no-slip holdup in adaptive mode |
 | `setEnforceMinimumSlip(boolean)` | `true` | Enable/disable minimum slip constraint entirely |
+| `setUseEquilibriumLevelAnnularTransition(boolean)` | `false` | Branch on the equilibrium liquid level instead of the droplet-entrainment criterion |
+
+The minimum slip constraint carries no inclination dependence, and on an undulating profile it
+is what binds: on a 5 km, 200 mm fixture with +/-30 m undulation, 85 of 100 sections sit exactly
+on `lambdaL * minimumSlipFactor`, so the terrain response of the momentum balance is replaced by
+a constant. It is inert on a near-horizontal transmission line, where lowering the factor from
+2.0 to 1.0 leaves the pressure drop and holdup profile unchanged.
+
+The horizontal annular criterion is a separate selection. The default uses the vertical
+droplet-entrainment threshold, which classifies effectively any horizontal gas pipeline as
+annular; the option selects the Taitel-Dukler equilibrium-level branch. The two differ only
+below the Kelvin-Helmholtz threshold, which on a 73.8 km export line means they agree at
+10 MSm3/d and differ at 4 MSm3/d, where the option moves the median holdup from 0.0198 to 0.0232
+against a reference value near 0.0235. It remains opt-in because the slug closure it selects on
+uphill sections returns less liquid than the stratified closure returns on downhill ones.
 
 ### Example: Lean Gas vs Rich Condensate
 

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -122,6 +122,12 @@ public class TwoFluidPipe extends Pipeline {
   /** Upper no-slip fraction for the trace-liquid asymptote of the stratified closure. */
   private static final double STRATIFIED_TRACE_LIQUID_TRANSITION = 1.0e-6;
 
+  /** Bendiksen (1984) horizontal Taylor bubble drift coefficient. */
+  private static final double SLUG_DRIFT_HORIZONTAL_COEFFICIENT = 0.54;
+
+  /** Bendiksen (1984) vertical Taylor bubble drift coefficient. */
+  private static final double SLUG_DRIFT_VERTICAL_COEFFICIENT = 0.35;
+
   /** Default closed-flow fluid-side heat-transfer coefficient in W/(m2 K). */
   private static final double DEFAULT_STAGNANT_INNER_HEAT_TRANSFER_COEFFICIENT = 50.0;
 
@@ -3193,13 +3199,29 @@ public class TwoFluidPipe extends Pipeline {
    *
    * <p>
    * Slug flow is represented as a sequence of liquid slugs separated by Taylor bubbles. The average holdup is
-   * determined by:
+   * determined by the slug body holdup, the film holdup under the Taylor bubble, and the slug length ratio.
    * </p>
-   * <ul>
-   * <li>Slug body holdup (typically 0.7-1.0)</li>
-   * <li>Film holdup under Taylor bubble</li>
-   * <li>Slug frequency and length</li>
-   * </ul>
+   *
+   * <p>
+   * KNOWN DEFECT, not fixed here: the inclination response is inverted. The drift velocity grows with upward
+   * inclination and enters the DENOMINATOR of the slug length ratio, so the average holdup decreases uphill. Measured
+   * on a 5 km, 200 mm profile undulating by +/-30 m, uphill sections return 0.0328 against 0.0493 downhill, the
+   * opposite of the accumulation a pipeline shows. It is masked wherever the flow map returns annular rather than slug,
+   * which is the case on the near-horizontal reference lines.
+   * </p>
+   *
+   * <p>
+   * Replacing the unit cell by the drift-flux form {@code alpha_G = v_sG / (C0*v_m + v_d)} corrects the direction and
+   * restores the terrain signature - the undulating fixture goes from a maximum-to-minimum holdup ratio of 1.45 to
+   * 10.22 with valley above peak - but it breaks the trace-liquid degeneracy pinned by
+   * {@code TwoFluidPipePhaseDegeneracyTest}: with {@code C0 > 1} and a finite drift velocity the gas fraction stays
+   * below one even at zero liquid input, so the closure invents inventory. Weighting the drift by
+   * {@code (1 - alpha_G)^n} in the Zuber-Findlay manner restores the degeneracy but suppresses the drift by more than
+   * an order of magnitude at the liquid fractions of interest, removing the inclination response again. The fix is to
+   * keep the unit cell, whose slug length ratio vanishes with the liquid supply, and give the film holdup under the
+   * Taylor bubble the inclination dependence it lacks - it is a constant multiple of the no-slip fraction here -
+   * through a film balance of the same form as the annular closure.
+   * </p>
    *
    * @param vsG Gas superficial velocity [m/s]
    * @param vsL Liquid superficial velocity [m/s]
@@ -3222,22 +3244,15 @@ public class TwoFluidPipe extends Pipeline {
     double slugBodyHoldup = 1.0 / (1.0 + Math.pow(vMix / 8.66, 1.39));
     slugBodyHoldup = Math.max(0.5, Math.min(0.98, slugBodyHoldup));
 
-    // Taylor bubble rise velocity using Bendiksen (1984)
     double dRho = rhoL - rhoG;
     double C0 = 1.2; // Distribution coefficient
 
-    // Drift velocity for inclined pipes
-    double vD0 = 0.35 * Math.sqrt(g * D * dRho / rhoL);
-    double sinTheta = Math.sin(theta);
-    double cosTheta = Math.cos(theta);
-
-    // Inclination correction
-    double vD;
-    if (theta >= 0) {
-      vD = vD0 * (cosTheta + 1.2 * sinTheta);
-    } else {
-      vD = vD0 * (cosTheta + 0.3 * Math.abs(sinTheta));
-    }
+    // Bendiksen (1984) drift velocity: one expression over the whole inclination range, the
+    // horizontal and vertical coefficients projected onto the pipe axis, so a negative inclination
+    // reduces the drift through sin(theta) instead of through a separate down-flow branch.
+    double driftScale = Math.sqrt(g * D * Math.max(0.0, dRho) / Math.max(CLOSURE_DENOMINATOR_EPSILON, rhoL));
+    double vD = driftScale
+        * (SLUG_DRIFT_HORIZONTAL_COEFFICIENT * Math.cos(theta) + SLUG_DRIFT_VERTICAL_COEFFICIENT * Math.sin(theta));
 
     // Taylor bubble velocity
     double vTB = C0 * vMix + vD;
@@ -7584,6 +7599,30 @@ public class TwoFluidPipe extends Pipeline {
    */
   public boolean isEnableAnnularFilmModel() {
     return enableAnnularFilmModel;
+  }
+
+  /**
+   * Select how the horizontal branch of the flow map decides annular flow.
+   *
+   * <p>
+   * Delegates to the flow regime detector owned by this pipe. See
+   * {@link FlowRegimeDetector#setUseEquilibriumLevelAnnularTransition(boolean)} for the two criteria and why the
+   * equilibrium-level branch of Taitel and Dukler (1976) is the horizontal one.
+   * </p>
+   *
+   * @param enable true to branch on the equilibrium liquid level, false to use the droplet-entrainment criterion
+   */
+  public void setUseEquilibriumLevelAnnularTransition(boolean enable) {
+    flowRegimeDetector.setUseEquilibriumLevelAnnularTransition(enable);
+  }
+
+  /**
+   * Which horizontal annular criterion this pipe is using.
+   *
+   * @return true when the equilibrium-level transition is active
+   */
+  public boolean isUseEquilibriumLevelAnnularTransition() {
+    return flowRegimeDetector.isUseEquilibriumLevelAnnularTransition();
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeDetector.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeDetector.java
@@ -65,6 +65,9 @@ public class FlowRegimeDetector implements Serializable {
   /** Half-width of the equilibrium-level blending band, as a fraction of the diameter. */
   private static final double LEVEL_TRANSITION_BAND = 0.08;
 
+  /** Gas viscosity as a fraction of the liquid viscosity, used only when the section carries none. */
+  private static final double DEGENERATE_GAS_VISCOSITY_FRACTION = 0.01;
+
   /**
    * Whether the horizontal annular transition uses the equilibrium liquid level.
    *
@@ -95,10 +98,23 @@ public class FlowRegimeDetector implements Serializable {
    * </p>
    *
    * <p>
-   * It is off by default because regime selection switches closures discontinuously: on a line that changes
-   * inclination, sections reclassify and the mean holdup steps by roughly 20 per cent as soon as mild terrain is
-   * introduced. Blending across the transition is required before this can become the default, so the option is
-   * provided for evaluation rather than for design work.
+   * This is off by default, and the reason is not the one originally recorded here. Closure blending, which used to be
+   * named as the prerequisite, has been available and on by default since the transition work landed, and with it the
+   * condensation fixture that used to fail now passes. The remaining blocker is that the hold-up closures this
+   * transition routes to do not respond to inclination. On a 5 km 200 mm undulating fixture the equilibrium level
+   * itself swings from {@code h_L/D = 0.058} on a 4 degree downhill section to {@code 0.793} on a 4 degree uphill one,
+   * a factor of 47 in liquid area, while the hold-up returned for those same sections is 0.04303 and 0.04305 -
+   * identical to five figures. Selecting this transition therefore replaces the only inclination-sensitive closure in
+   * the model, the annular film balance with its gravity term, by closures that carry no terrain response at all: the
+   * fixture's maximum-to-minimum hold-up ratio falls from 11.3 to 1.45 and the valley and peak ordering becomes
+   * arbitrary. The bulk gain and the terrain loss are both real, so this stays selectable rather than default until the
+   * stratified and slug hold-up closures respond to the section inclination that the level solver already sees.
+   * </p>
+   *
+   * <p>
+   * The two paths differ only in the shallow-layer, sub-critical Kelvin-Helmholtz corner. On the export line above they
+   * return identical profiles at 10 MSm3/d, where the margin exceeds one in every section and both branch to annular;
+   * they differ at 4 MSm3/d, where the margin is below one in 85 per cent of sections.
    * </p>
    *
    * @param enable true to use the equilibrium-level transition
@@ -229,13 +245,14 @@ public class FlowRegimeDetector implements Serializable {
     double rho_L = section.getLiquidDensity();
     double rho_G = section.getGasDensity();
     double mu_L = section.getLiquidViscosity();
+    double mu_G = section.getGasViscosity();
     double sigma = section.getSurfaceTension();
 
     // Use Barnea's unified model for inclined pipes
     if (Math.abs(theta) > Math.toRadians(10)) {
-      return detectInclinedFlowRegime(U_SL, U_SG, D, theta, rho_L, rho_G, mu_L, sigma);
+      return detectInclinedFlowRegime(U_SL, U_SG, D, theta, rho_L, rho_G, mu_L, mu_G, sigma);
     } else {
-      return detectHorizontalFlowRegime(U_SL, U_SG, D, theta, rho_L, rho_G, mu_L, sigma);
+      return detectHorizontalFlowRegime(U_SL, U_SG, D, theta, rho_L, rho_G, mu_L, mu_G, sigma);
     }
   }
 
@@ -298,8 +315,9 @@ public class FlowRegimeDetector implements Serializable {
     double rho_L = section.getLiquidDensity();
     double rho_G = section.getGasDensity();
     double mu_L = section.getLiquidViscosity();
+    double mu_G = section.getGasViscosity();
 
-    double h_L = estimateStratifiedLiquidLevel(U_SL, U_SG, D, rho_L, rho_G, mu_L, theta);
+    double h_L = estimateStratifiedLiquidLevel(U_SL, U_SG, D, rho_L, rho_G, mu_L, mu_G, theta);
     double margin = kelvinHelmholtzMargin(U_SG, h_L, D, rho_L, rho_G);
     if (margin <= 0.0) {
       return null;
@@ -400,11 +418,12 @@ public class FlowRegimeDetector implements Serializable {
    * @param rho_L Liquid density (kg/m³)
    * @param rho_G Gas density (kg/m³)
    * @param mu_L Liquid viscosity (Pa·s)
+   * @param mu_G Gas viscosity (Pa·s)
    * @param sigma Surface tension (N/m)
    * @return Flow regime
    */
   private FlowRegime detectHorizontalFlowRegime(double U_SL, double U_SG, double D, double theta, double rho_L,
-      double rho_G, double mu_L, double sigma) {
+      double rho_G, double mu_L, double mu_G, double sigma) {
     double U_M = U_SL + U_SG;
 
     // Dimensionless parameters
@@ -424,7 +443,7 @@ public class FlowRegimeDetector implements Serializable {
       return FlowRegime.DISPERSED_BUBBLE;
     }
 
-    double h_L = estimateStratifiedLiquidLevel(U_SL, U_SG, D, rho_L, rho_G, mu_L, theta);
+    double h_L = estimateStratifiedLiquidLevel(U_SL, U_SG, D, rho_L, rho_G, mu_L, mu_G, theta);
 
     if (useEquilibriumLevelAnnularTransition) {
       // Taitel-Dukler transition B. Once the Kelvin-Helmholtz instability has lifted the stratified
@@ -467,11 +486,12 @@ public class FlowRegimeDetector implements Serializable {
    * @param rho_L Liquid density (kg/m³)
    * @param rho_G Gas density (kg/m³)
    * @param mu_L Liquid viscosity (Pa·s)
+   * @param mu_G Gas viscosity (Pa·s)
    * @param sigma Surface tension (N/m)
    * @return Flow regime
    */
   private FlowRegime detectInclinedFlowRegime(double U_SL, double U_SG, double D, double theta, double rho_L,
-      double rho_G, double mu_L, double sigma) {
+      double rho_G, double mu_L, double mu_G, double sigma) {
     boolean isUpward = theta > 0;
 
     // Check for dispersed bubble
@@ -503,7 +523,7 @@ public class FlowRegimeDetector implements Serializable {
 
     } else {
       // Downward flow: stratified, slug, annular
-      double h_L = estimateStratifiedLiquidLevel(U_SL, U_SG, D, rho_L, rho_G, mu_L, theta);
+      double h_L = estimateStratifiedLiquidLevel(U_SL, U_SG, D, rho_L, rho_G, mu_L, mu_G, theta);
 
       if (isKelvinHelmholtzUnstable(U_SG, h_L, D, rho_L, rho_G)) {
         return FlowRegime.SLUG;
@@ -694,16 +714,17 @@ public class FlowRegimeDetector implements Serializable {
    * @param rho_L liquid density [kg/m3]
    * @param rho_G gas density [kg/m3]
    * @param mu_L liquid viscosity [Pa.s]
+   * @param mu_G gas viscosity [Pa.s]
    * @param theta pipe inclination angle [rad]
    * @return estimated liquid level [m]
    */
   private double estimateStratifiedLiquidLevel(double U_SL, double U_SG, double D, double rho_L, double rho_G,
-      double mu_L, double theta) {
+      double mu_L, double mu_G, double theta) {
     double low = 0.01 * D;
     double high = 0.99 * D;
 
-    double residLow = stratifiedMomentumResidual(low, U_SL, U_SG, D, rho_L, rho_G, mu_L, theta);
-    double residHigh = stratifiedMomentumResidual(high, U_SL, U_SG, D, rho_L, rho_G, mu_L, theta);
+    double residLow = stratifiedMomentumResidual(low, U_SL, U_SG, D, rho_L, rho_G, mu_L, mu_G, theta);
+    double residHigh = stratifiedMomentumResidual(high, U_SL, U_SG, D, rho_L, rho_G, mu_L, mu_G, theta);
 
     if (!isUsableResidual(residLow) || !isUsableResidual(residHigh)) {
       return 0.5 * D;
@@ -716,7 +737,7 @@ public class FlowRegimeDetector implements Serializable {
 
     for (int iter = 0; iter < 60; iter++) {
       double mid = 0.5 * (low + high);
-      double residMid = stratifiedMomentumResidual(mid, U_SL, U_SG, D, rho_L, rho_G, mu_L, theta);
+      double residMid = stratifiedMomentumResidual(mid, U_SL, U_SG, D, rho_L, rho_G, mu_L, mu_G, theta);
       if (!isUsableResidual(residMid)) {
         return mid;
       }
@@ -761,11 +782,12 @@ public class FlowRegimeDetector implements Serializable {
    * @param rho_L liquid density, in kg/m3
    * @param rho_G gas density, in kg/m3
    * @param mu_L liquid viscosity, in Pa.s
+   * @param mu_G gas viscosity, in Pa.s
    * @param theta inclination, in radians
    * @return the momentum residual, or NaN when the geometry is degenerate
    */
   private double stratifiedMomentumResidual(double h_L, double U_SL, double U_SG, double D, double rho_L, double rho_G,
-      double mu_L, double theta) {
+      double mu_L, double mu_G, double theta) {
     double beta = 2.0 * Math.acos(1.0 - 2.0 * h_L / D);
     double A_L = D * D / 8.0 * (beta - Math.sin(beta));
     double A_G = PI * D * D / 4.0 - A_L;
@@ -784,7 +806,9 @@ public class FlowRegimeDetector implements Serializable {
     double D_hG = 4.0 * A_G / (S_G + S_i);
 
     double Re_L = rho_L * Math.abs(U_L) * D_hL / mu_L;
-    double Re_G = rho_G * Math.abs(U_G) * D_hG / (mu_L * 0.01);
+    // Only reached when the section carries no gas-viscosity value, as in a hand-built fixture.
+    double gasViscosity = mu_G > 0.0 ? mu_G : mu_L * DEGENERATE_GAS_VISCOSITY_FRACTION;
+    double Re_G = rho_G * Math.abs(U_G) * D_hG / gasViscosity;
 
     double f_L = Re_L > 2000 ? 0.046 * Math.pow(Re_L, -0.2) : 16.0 / Math.max(Re_L, 1);
     double f_G = Re_G > 2000 ? 0.046 * Math.pow(Re_G, -0.2) : 16.0 / Math.max(Re_G, 1);

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeHorizontalTransitionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeHorizontalTransitionTest.java
@@ -163,9 +163,36 @@ class FlowRegimeHorizontalTransitionTest {
     FlowRegimeDetector detector = new FlowRegimeDetector();
 
     Assertions.assertFalse(detector.isUseEquilibriumLevelAnnularTransition(),
-        "the transition must stay opt-in until the terrain response it implies is anchored");
+        "the transition must stay opt-in until the hold-up closures it selects respond to inclination");
     Assertions.assertTrue(detector.isBlendRegimeTransitions(),
         "closure blending must default on, otherwise the transition steps hold-up");
+  }
+
+  /**
+   * A pipe must be able to select the criterion its own detector uses.
+   *
+   * <p>
+   * {@link neqsim.process.equipment.pipeline.TwoFluidPipe} owns a private detector with no accessor, so before the
+   * delegating setter the choice of horizontal criterion was unreachable from the equipment class and could only be
+   * exercised by reflection.
+   * </p>
+   */
+  @Test
+  @DisplayName("TwoFluidPipe exposes the horizontal annular criterion")
+  void testPipeDelegatesTheTransitionSetting() {
+    neqsim.process.equipment.pipeline.TwoFluidPipe pipe = new neqsim.process.equipment.pipeline.TwoFluidPipe(
+        "criterion-delegation");
+
+    Assertions.assertFalse(pipe.isUseEquilibriumLevelAnnularTransition(),
+        "a new pipe must start on the same criterion as a new detector");
+
+    pipe.setUseEquilibriumLevelAnnularTransition(true);
+    Assertions.assertTrue(pipe.isUseEquilibriumLevelAnnularTransition(),
+        "the pipe must delegate the criterion to the detector it owns");
+
+    pipe.setUseEquilibriumLevelAnnularTransition(false);
+    Assertions.assertFalse(pipe.isUseEquilibriumLevelAnnularTransition(),
+        "the criterion must be selectable in both directions");
   }
 
   /**


### PR DESCRIPTION
## Summary

Two independent fixes, each found while tracing why `TwoFluidPipe` under-predicts liquid hold-up on a lean gas-condensate line at low rate.

### 1. Real gas viscosity in the stratified level solver

`FlowRegimeDetector.stratifiedMomentumResidual` computed the gas Reynolds number from `mu_L * 0.01`, although the section already carries a gas viscosity and `detectFlowRegime` already reads the liquid one beside it. The equilibrium level it returns feeds the Kelvin-Helmholtz margin and the annular/slug branch, so the substitution reached the regime map itself.

The real property is threaded through `detectFlowRegime` -> the horizontal and inclined branches -> `estimateStratifiedLiquidLevel` -> `stratifiedMomentumResidual`, and through `horizontalRegimeWeights`. The old fraction is kept only for a section that carries no gas viscosity, as hand-built fixtures do.

| case | `h_L/D` as coded | with the real value |
|---|---|---|
| 73.8 km export line, 4 MSm3/d | 0.0783 | 0.0726 |
| 5 km undulating fixture, uphill | 0.793 | 0.768 |

The default regime path is **bit-identical** on both fixtures.

### 2. Bendiksen (1984) Taylor bubble drift velocity

The slug closure branched on the sign of `theta` and its down-flow branch still **added** drift, so a downhill section was given a larger translational velocity than a horizontal one. Replaced by the single expression `sqrt(g*D*drho/rhoL) * (0.54*cos(theta) + 0.35*sin(theta))`, in which a negative inclination reduces the drift.

### 3. The horizontal annular criterion becomes reachable

`TwoFluidPipe` owns a private `FlowRegimeDetector` with no getter, so the choice between the droplet-entrainment criterion and the Taitel-Dukler equilibrium level could only be exercised by reflection. Added delegating `set`/`isUseEquilibriumLevelAnnularTransition`, with a test.

## Two limitations documented rather than left to be rediscovered

**The minimum-slip bound is what binds on an undulating profile.** `alphaL >= lambdaL * minimumSlipFactor` is applied after the regime closures and carries no inclination dependence. On a 5 km, 200 mm fixture undulating by +/-30 m, **85 of 100 sections sit exactly on it**, including 41 of 41 uphill sections, so the terrain response of the momentum balance is replaced by a constant there. It is inert on a near-horizontal line: on the export line at 4 MSm3/d, lowering the factor from 2.0 to 1.0 leaves pressure drop and hold-up unchanged.

**The slug closure's inclination response is inverted.** The drift velocity enters the denominator of the Dukler-Hubbard slug length ratio, so hold-up decreases uphill: 0.0328 uphill against 0.0493 downhill. Replacing the unit cell by the drift-flux form corrects the direction and restores the terrain signature (max/min 1.45 -> 10.22, valley above peak) but breaks the trace-liquid degeneracy pinned by `TwoFluidPipePhaseDegeneracyTest`; weighting the drift by `(1 - alpha_G)^n` restores the degeneracy and removes the response again. The fix belongs in the Taylor bubble film hold-up, which is currently a constant multiple of the no-slip fraction. Left for a follow-up rather than patched.

## Also in this PR: UniSim acentric factor

Unrelated, from parallel work on the UniSim reader. The E300 fluid export looked up the acentric factor under `AcentricFactor`, `AcentricityFactor` and `Omega`; UniSim exposes it as `Acentricity`, so none resolved and every component was written with **0.0**, silently changing the EOS alpha function and shifting every bubble point of the exported fluid. `Acentricity` is now tried first, a component still without a value is reported rather than quietly defaulted, and the fluid-package vector no longer overwrites resolved per-component values. Covered by `devtools/test_unisim_outputs.py`, which needs no COM connection.

## Verification

`neqsim.process.equipment.pipeline.**` : **821 tests, 0 failures, 0 errors, 22 pre-existing skips**. `spotless:check` clean.
