### PR TITLE
fix(pipeline): stop the two-fluid transient from failing silently

### DIFF
--- a/.github/skills/neqsim-flow-assurance/SKILL.md
+++ b/.github/skills/neqsim-flow-assurance/SKILL.md
@@ -561,6 +561,15 @@ for (double qgMSm3d : gasRates) {
 > yet validated, so it is not a drop-in replacement. Finishing it means folding
 > the term into the IMEX implicit pressure solve.
 >
+> **The transient now tells you when it has failed — always check it.** As of
+> PR #3080, `pipe.isTransientOutletBackflowClamped()` returns true once any phase
+> has reversed at the outlet, which is the first event in the runaway above. This
+> is the transient counterpart of `isSteadyStatePressureFloorLimited()`: ALWAYS
+> read it after `runTransient` and discard the profile when it is true, exactly
+> as with the steady-state flags. The mass-balance report will NOT warn you — it
+> closes to 1e-16 throughout, because it is computed from the same clamped flux.
+> The flag is sticky for the run and is cleared by the next `run()`.
+>
 > **Three-phase (gas/oil/water) steady state is fixed.** The oil/water slip
 > ratio uses `S = 1 + 1.75·max(0, 1 − (Fr/3)²)`, a stratified plateau that rolls
 > off to no slip once the liquid disperses above a liquid Froude number of about

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -1028,6 +1028,31 @@ rate. `isSteadyStatePressureFloorLimited()` makes that case visible, and `isStea
 is withheld. `PipeBeggsAndBrills` throws `Outlet pressure is negative` on the same condition, so
 both codes agree that such a case has no solution.
 
+### Always check the transient outcome too
+
+`runTransient(dt, id)` has the same property: it does not throw when the answer stops being a
+solution, so the outcome has to be read back.
+
+| Query | Meaning when true |
+|-------|-------------------|
+| `isTransientOutletBackflowClamped()` | A phase reversed at the outlet and its outflow is pinned at zero |
+
+```java
+pipe.runTransient(dt, null);
+if (pipe.isTransientOutletBackflowClamped()) {
+  throw new IllegalStateException("Transient liquid inventory is running away");
+}
+```
+
+**Why outlet backflow matters.** The outlet is transmissive: it can carry mass out but not in, so a
+reversed phase velocity is clamped to zero. That is correct as a boundary condition and is also a
+one-way trap. The phase momentum equations of the classical two-fluid system are ill-posed at high
+liquid fraction and can develop sustained backflow, after which the outflow of that phase pins at
+exactly 0 kg/s while the inlet keeps feeding the line and the inventory grows without bound. The
+finite-volume balance still closes to machine precision throughout, so nothing else reports a
+problem — this flag is the only warning. Gas-dominated lines do not show it.
+`setEnableInterfacialPressure(true)` removes it, at the cost of a much smaller stable time step.
+
 ### Direct electrical heating (DEH)
 
 A uniform electrical heat input can be added to the energy equation, in steady state and in

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -131,6 +131,9 @@ public class TwoFluidPipe extends Pipeline {
   /** Bound on the Taylor bubble film holdup as a fraction of the slug body it separates. */
   private static final double SLUG_FILM_HOLDUP_FRACTION_OF_BODY = 0.9;
 
+  /** Whether a phase reversed at the transmissive outlet during the transient run. */
+  private boolean transientOutletBackflowClamped = false;
+
   /** Default closed-flow fluid-side heat-transfer coefficient in W/(m2 K). */
   private static final double DEFAULT_STAGNANT_INNER_HEAT_TRANSFER_COEFFICIENT = 50.0;
 
@@ -1258,6 +1261,8 @@ public class TwoFluidPipe extends Pipeline {
     ssConverged = false;
     ssPressureFloorLimited = false;
     ssIterationsUsed = 0;
+    transientOutletBackflowClamped = false;
+    equations.clearOutletBackflowClamped();
 
     // Get total mass flow rate (conserved)
     double massFlow = getInletStream().getFlowRate("kg/sec");
@@ -4352,6 +4357,14 @@ public class TwoFluidPipe extends Pipeline {
     updateOutletStream();
     updateResultArrays();
 
+    if (equations.isOutletBackflowClamped() && !transientOutletBackflowClamped) {
+      transientOutletBackflowClamped = true;
+      logger.warn("{}: a phase reversed at the outlet, where the transmissive boundary can only carry mass out, so its "
+          + "outflow is clamped at zero while the inlet keeps feeding it. Liquid inventory will grow without "
+          + "bound and the transient result must not be used. This is the ill-posedness of the classical "
+          + "two-fluid system in liquid-rich flow; see setEnableInterfacialPressure(boolean).", getName());
+    }
+
     setCalculationIdentifier(id);
   }
 
@@ -7417,6 +7430,25 @@ public class TwoFluidPipe extends Pipeline {
    */
   public boolean isSteadyStatePressureFloorLimited() {
     return ssPressureFloorLimited;
+  }
+
+  /**
+   * Whether a phase reversed at the outlet during the transient run.
+   *
+   * <p>
+   * The transmissive outlet can only carry mass out, so a reversed phase velocity is clamped to zero. That clamp is
+   * correct as a boundary condition and is also a one-way trap: the phase momentum equations of the classical two-fluid
+   * system are ill-posed in liquid-rich flow and can develop sustained backflow, after which the outflow of that phase
+   * pins at exactly zero while the inlet keeps feeding it and the inventory grows without bound. When this is true the
+   * transient profile is not a solution and must be discarded, in the same way as
+   * {@link #isSteadyStatePressureFloorLimited()} for the steady solve. Gas-dominated lines do not show it;
+   * {@link #setEnableInterfacialPressure(boolean)} removes it at the cost of a much smaller CFL number.
+   * </p>
+   *
+   * @return true when at least one phase reversed at the outlet since the last steady-state solve
+   */
+  public boolean isTransientOutletBackflowClamped() {
+    return transientOutletBackflowClamped;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -129,6 +129,15 @@ public class TwoFluidConservationEquations implements Serializable {
    */
   private double interfacialPressureCoefficient = 1.2;
 
+  /**
+   * Whether the transmissive outlet has had to suppress a reversed phase velocity.
+   *
+   * <p>
+   * Sticky once set, so a caller can ask after a sequence of steps. Cleared with {@link #clearOutletBackflowClamped()}.
+   * </p>
+   */
+  private boolean outletBackflowClamped = false;
+
   /** Interface gas holdup used by the pressure part of the momentum flux, one per interface. */
   private double[] interfaceGasHoldup = new double[0];
 
@@ -506,12 +515,25 @@ public class TwoFluidConservationEquations implements Serializable {
   /**
    * Calculate outlet flux using upwind scheme (transmissive boundary).
    *
+   * <p>
+   * Each phase velocity is clamped at zero because a transmissive boundary can only carry mass out: with a reversed
+   * velocity there is no upstream state to advect in. That clamp is correct as a boundary condition but it is also a
+   * one-way trap, because the phase momentum equations of the classical two-fluid system are ill-posed in liquid-rich
+   * flow and can develop sustained backflow. The outflow of that phase then pins at exactly zero while the inlet keeps
+   * feeding it, and the inventory grows without bound. The condition is recorded so it can be reported rather than
+   * silently producing a diverging answer.
+   * </p>
+   *
    * @param sec the outlet pipe section
    * @return array of flux values for each conserved variable
    */
   private double[] calcOutletFlux(TwoFluidSection sec) {
     double[] flux = new double[NUM_EQUATIONS];
     double A = sec.getArea();
+
+    if (sec.getGasVelocity() < 0.0 || sec.getOilVelocity() < 0.0 || sec.getWaterVelocity() < 0.0) {
+      outletBackflowClamped = true;
+    }
 
     // Gas flux (positive velocity means outflow) - use default density if not set
     double rhoG = sec.getGasDensity();
@@ -1572,6 +1594,20 @@ public class TwoFluidConservationEquations implements Serializable {
    */
   public void setEnableInterfacialPressure(boolean enableInterfacialPressure) {
     this.enableInterfacialPressure = enableInterfacialPressure;
+  }
+
+  /**
+   * Whether the transmissive outlet has had to suppress a reversed phase velocity.
+   *
+   * @return true when at least one phase reversed at the outlet since the flag was last cleared
+   */
+  public boolean isOutletBackflowClamped() {
+    return outletBackflowClamped;
+  }
+
+  /** Clear the outlet backflow record. */
+  public void clearOutletBackflowClamped() {
+    this.outletBackflowClamped = false;
   }
 
   /** @return interfacial pressure coefficient delta */

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeTransientNullTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeTransientNullTest.java
@@ -123,4 +123,45 @@ public class TwoFluidPipeTransientNullTest {
     Assertions.assertTrue(pipe.getLiquidInventory("m3") < 0.9 * PIPE_VOLUME,
         "liquid must not fill the line under steady inflow");
   }
+
+  /**
+   * The outlet trap that drives the two defects above must not be silent.
+   *
+   * <p>
+   * Until the closure is fixed the liquid-rich transient is not a solution, so the caller has to be able to find that
+   * out. Both disabled tests above are the same trap seen from two sides, and both start with a phase reversing at the
+   * transmissive outlet, so that reversal is what gets reported.
+   * </p>
+   */
+  @Test
+  void testLiquidRichOutletBackflowIsReportedAndClearedByANewSteadySolve() {
+    TwoFluidPipe pipe = buildPipe(true, 50.0);
+    Assertions.assertFalse(pipe.isTransientOutletBackflowClamped(),
+        "a freshly solved steady state must not report outlet backflow");
+
+    int firstTrip = -1;
+    for (int i = 0; i < 120 && firstTrip < 0; i++) {
+      pipe.runTransient(5.0, null);
+      if (pipe.isTransientOutletBackflowClamped()) {
+        firstTrip = i;
+      }
+    }
+    Assertions.assertTrue(firstTrip >= 0,
+        "the liquid-rich runaway must announce itself, but 120 steps passed without a backflow report");
+
+    pipe.run();
+    Assertions.assertFalse(pipe.isTransientOutletBackflowClamped(),
+        "a new steady solve must clear the transient diagnostic");
+  }
+
+  /** A healthy line must not raise the diagnostic, or it is worthless as a gate. */
+  @Test
+  void testGasDominatedTransientDoesNotReportOutletBackflow() {
+    TwoFluidPipe pipe = buildPipe(false, 40.0);
+    for (int i = 0; i < 120; i++) {
+      pipe.runTransient(5.0, null);
+    }
+    Assertions.assertFalse(pipe.isTransientOutletBackflowClamped(),
+        "a gas-dominated line holding its own steady state must not report outlet backflow");
+  }
 }


### PR DESCRIPTION
## What this changes

`runTransient` could return a result that is not a solution and say nothing about it. This makes that case detectable.

## The defect

The outlet is transmissive: it carries mass out but not in, so `calcOutletFlux` clamps a reversed phase velocity to zero. That is correct as a boundary condition and it is also a **one-way trap**. The phase momentum equations of the classical two-fluid system are ill-posed at high liquid fraction and can develop sustained backflow; once they do, the outflow of that phase pins at exactly 0 kg/s while the inlet keeps feeding the line.

On the liquid-rich null-test case:

| | start | after 30 min |
|---|---|---|
| inventory | 114.7 t | **192.7 t** (still climbing) |
| liquid holdup | 0.45 | **0.77** (still climbing) |
| liquid outflow | — | **exactly 0.000 kg/s** |

## Why nothing caught it

The finite-volume mass balance closes to machine precision the whole way — it is computed from the same clamped flux, so the accounting is perfectly self-consistent *about a state that is physically wrong*. Two tests in `TwoFluidPipeTransientNullTest` are `@Disabled` against exactly this, and a caller integrating the model had no way to find out at runtime.

## What is added

`TwoFluidPipe.isTransientOutletBackflowClamped()`, plus a warning on first occurrence.

This mirrors the existing `isSteadyStatePressureFloorLimited()`, which already withholds convergence rather than silently returning a clamped steady state — same failure mode, same treatment. The flag is sticky for the run and is cleared by the next steady solve.

## What this is not

**This does not fix the closure.** It makes the defect detectable, which is the prerequisite both for using the model on liquid-rich lines at all and for measuring whether a future fix worked.

`setEnableInterfacialPressure(true)` already removes the underlying ill-posedness, at the cost of a much smaller stable time step. Folding that term into the implicit pressure solve so it is affordable by default is the real fix: it requires coupling phase momentum to the void-fraction wave in `stepIMEXPressureCorrection`, which today solves a scalar pressure equation. That is not attempted here.

## Verification

Two new **enabled** tests:

- the liquid-rich case raises the flag, and a new steady solve clears it;
- the gas-dominated case never raises it over the same 120 steps — so it is not a blanket alarm.

Full pipeline suite: **823 tests, 0 failures, 22 skipped** (skip count unchanged; the two `@Disabled` runaway tests stay disabled because the closure is unchanged).
