### PR TITLE
fix(pipeline): validate the horizontal flow map and stop calling annular flow at 45% liquid

### DIFF
--- a/.github/skills/neqsim-flow-assurance/SKILL.md
+++ b/.github/skills/neqsim-flow-assurance/SKILL.md
@@ -561,6 +561,22 @@ for (double qgMSm3d : gasRates) {
 > yet validated, so it is not a drop-in replacement. Finishing it means folding
 > the term into the IMEX implicit pressure solve.
 >
+> **Re-measured (PR #3086): the interfacial-pressure term does NOT rescue this
+> case.** Sweeping CFL 0.05/0.1/0.2/0.35/0.5/0.8 with and without the term, using
+> `isTransientOutletBackflowClamped()` as the objective detector, every one of the
+> twelve combinations is unstable — with the term ON, backflow trips at *every*
+> CFL including 0.05. So do not reach for `setEnableInterfacialPressure(true)`
+> expecting a stable liquid-rich transient, and note that folding the term into
+> the IMEX solve would only buy step-size relief for a term that does not deliver
+> stability here. `calcVoidWaveSpeed` already feeds the CFL limit, so the small
+> step it needs is a genuine stability limit, not a controller oversight.
+>
+> **What did help: fixing the regime.** The same case classified SLUG rather than
+> ANNULAR (PR #3086, Barnea bridging limit) cuts the 30-minute inventory runaway
+> from **+56.3% to +20.1%** at default settings. Still unusable, still gated by
+> the flag, but the regime branch is a bigger lever on the runaway than the
+> interfacial-pressure term is.
+>
 > **The transient now tells you when it has failed — always check it.** As of
 > PR #3080, `pipe.isTransientOutletBackflowClamped()` returns true once any phase
 > has reversed at the outlet, which is the first event in the runaway above. This

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeDetector.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeDetector.java
@@ -59,14 +59,24 @@ public class FlowRegimeDetector implements Serializable {
   /** Half-width of the Kelvin-Helmholtz blending band, as a fraction of the critical gas velocity. */
   private static final double KH_TRANSITION_BAND = 0.15;
 
-  /** Equilibrium liquid level at which the bore bridges, as a fraction of the diameter. */
-  private static final double LEVEL_TRANSITION_CENTRE = 0.5;
-
-  /** Half-width of the equilibrium-level blending band, as a fraction of the diameter. */
+  /** Half-width of the blending band around the bridging limit, as a liquid-fraction difference. */
   private static final double LEVEL_TRANSITION_BAND = 0.08;
 
   /** Gas viscosity as a fraction of the liquid viscosity, used only when the section carries none. */
   private static final double DEGENERATE_GAS_VISCOSITY_FRACTION = 0.01;
+
+  /** Jeffreys sheltering coefficient used by Taitel-Dukler transition D. */
+  private static final double SHELTERING_COEFFICIENT = 0.01;
+
+  /**
+   * Liquid fraction above which the liquid can bridge the bore, so annular flow cannot be sustained.
+   *
+   * <p>
+   * Barnea (1987) blockage criterion. A stable liquid slug needs a liquid fraction of about 0.48 in its body; bridging
+   * becomes possible once the film holds half of that, so annular flow requires an in-situ liquid fraction below 0.24.
+   * </p>
+   */
+  private static final double ANNULAR_BRIDGING_HOLDUP = 0.24;
 
   /**
    * Whether the horizontal annular transition uses the equilibrium liquid level.
@@ -323,8 +333,8 @@ public class FlowRegimeDetector implements Serializable {
     }
 
     double unstableShare = rampWeight(margin, 1.0, KH_TRANSITION_BAND);
-    double slugShare = rampWeight(h_L / D, LEVEL_TRANSITION_CENTRE, LEVEL_TRANSITION_BAND);
-    FlowRegime stratified = isWavyTransition(U_SG, h_L, D, rho_L, rho_G, mu_L) ? FlowRegime.STRATIFIED_WAVY
+    double slugShare = rampWeight(liquidAreaFraction(h_L, D), ANNULAR_BRIDGING_HOLDUP, LEVEL_TRANSITION_BAND);
+    FlowRegime stratified = isWavyTransition(U_SL, U_SG, h_L, D, theta, rho_L, rho_G, mu_L) ? FlowRegime.STRATIFIED_WAVY
         : FlowRegime.STRATIFIED_SMOOTH;
 
     Map<FlowRegime, Double> weights = new EnumMap<FlowRegime, Double>(FlowRegime.class);
@@ -445,11 +455,13 @@ public class FlowRegimeDetector implements Serializable {
     double h_L = estimateStratifiedLiquidLevel(U_SL, U_SG, D, rho_L, rho_G, mu_L, mu_G, theta);
 
     if (useEquilibriumLevelAnnularTransition) {
-      // Taitel-Dukler transition B. Once the Kelvin-Helmholtz instability has lifted the stratified
-      // layer, the horizontal branch is decided by the equilibrium liquid level: below half a
-      // diameter the liquid cannot bridge the bore and the flow goes annular, above it a slug forms.
+      // Taitel-Dukler transition B, with the Barnea (1987) blockage criterion. Once the
+      // Kelvin-Helmholtz instability has lifted the stratified layer the branch is annular only if
+      // the liquid is too thin to bridge the bore; otherwise it forms a slug. The level criterion
+      // alone allows anything below half a diameter, which admits annular flow at liquid fractions
+      // no gas stream could hold as a film.
       if (isKelvinHelmholtzUnstable(U_SG, h_L, D, rho_L, rho_G)) {
-        return (h_L / D < 0.5) ? FlowRegime.ANNULAR : FlowRegime.SLUG;
+        return bridgesTheBore(h_L, D) ? FlowRegime.SLUG : FlowRegime.ANNULAR;
       }
     } else {
       // Legacy path: the vertical droplet-entrainment criterion, checked ahead of the
@@ -464,7 +476,7 @@ public class FlowRegimeDetector implements Serializable {
     }
 
     // Stratified flow - check smooth vs wavy transition
-    if (isWavyTransition(U_SG, h_L, D, rho_L, rho_G, mu_L)) {
+    if (isWavyTransition(U_SL, U_SG, h_L, D, theta, rho_L, rho_G, mu_L)) {
       return FlowRegime.STRATIFIED_WAVY;
     }
 
@@ -528,7 +540,7 @@ public class FlowRegimeDetector implements Serializable {
         return FlowRegime.SLUG;
       }
 
-      if (isWavyTransition(U_SG, h_L, D, rho_L, rho_G, mu_L)) {
+      if (isWavyTransition(U_SL, U_SG, h_L, D, theta, rho_L, rho_G, mu_L)) {
         return FlowRegime.STRATIFIED_WAVY;
       }
 
@@ -883,33 +895,90 @@ public class FlowRegimeDetector implements Serializable {
   /**
    * Check transition from smooth to wavy stratified.
    *
-   * @param U_SG superficial gas velocity
-   * @param h_L liquid height
-   * @param D pipe diameter
-   * @param rho_L liquid density
-   * @param rho_G gas density
-   * @param mu_L liquid viscosity
+   * <p>
+   * Taitel and Dukler (1976) transition D, from Jeffreys' sheltering theory: waves grow when the gas can feed energy to
+   * the interface faster than viscous dissipation in the liquid removes it,
+   * {@code U_G > sqrt(4 nu_L (rho_L - rho_G) g cos(theta) / (s rho_G U_L))}. The group is a velocity squared only when
+   * the viscosity is kinematic and the divisor carries the liquid velocity; both were wrong here, which put the
+   * threshold near 52 m/s for air and water and left an ordinary wavy line reported as smooth.
+   * </p>
+   *
+   * @param U_SL superficial liquid velocity, in m/s
+   * @param U_SG superficial gas velocity, in m/s
+   * @param h_L liquid height, in m
+   * @param D pipe diameter, in m
+   * @param theta inclination, in radians
+   * @param rho_L liquid density, in kg/m3
+   * @param rho_G gas density, in kg/m3
+   * @param mu_L liquid dynamic viscosity, in Pa.s
    * @return true if transition from smooth to wavy stratified occurs
    */
-  private boolean isWavyTransition(double U_SG, double h_L, double D, double rho_L, double rho_G, double mu_L) {
+  private boolean isWavyTransition(double U_SL, double U_SG, double h_L, double D, double theta, double rho_L,
+      double rho_G, double mu_L) {
     if (h_L < 0.01 * D || h_L > 0.99 * D) {
       return false;
     }
 
-    // Jeffreys' sheltering criterion for wave generation
-    double s = 0.01; // Sheltering coefficient
-
     double beta = 2.0 * Math.acos(1.0 - 2.0 * h_L / D);
-    double A_G = PI * D * D / 4.0 - D * D / 8.0 * (beta - Math.sin(beta));
-    double U_G = U_SG * PI * D * D / 4.0 / A_G;
+    double A = PI * D * D / 4.0;
+    double A_L = D * D / 8.0 * (beta - Math.sin(beta));
+    double A_G = A - A_L;
+    if (A_L < 1e-12 || A_G < 1e-12) {
+      return false;
+    }
+
+    double U_G = U_SG * A / A_G;
+    double U_L = U_SL * A / A_L;
+    if (U_L <= 0.0) {
+      return false;
+    }
 
     double deltaRho = rho_L - rho_G;
-    double mu_G = mu_L * 0.01;
+    double cosTheta = Math.cos(theta);
+    if (deltaRho <= 0.0 || cosTheta <= 0.0) {
+      return false;
+    }
 
-    // Wave speed and critical velocity
-    double U_G_crit = Math.sqrt(4.0 * mu_L * deltaRho * GRAVITY / (s * rho_G * rho_G));
+    double nu_L = mu_L / rho_L;
+    double U_G_crit = Math.sqrt(4.0 * nu_L * deltaRho * GRAVITY * cosTheta / (SHELTERING_COEFFICIENT * rho_G * U_L));
 
     return U_G > U_G_crit;
+  }
+
+  /**
+   * Whether the liquid at this level can bridge the bore, so annular flow cannot be sustained.
+   *
+   * <p>
+   * Barnea (1987) blockage criterion, evaluated on the same stratified equilibrium level that transition B uses — the
+   * approximation already made there. Annular flow is impossible once the in-situ liquid fraction reaches
+   * {@value #ANNULAR_BRIDGING_HOLDUP}. This is strictly stronger than the {@code h_L/D < 0.5} level test, which
+   * corresponds to a liquid fraction of 0.5.
+   * </p>
+   *
+   * @param h_L liquid height, in m
+   * @param D pipe diameter, in m
+   * @return true when the liquid fraction is at or above the bridging limit
+   */
+  private boolean bridgesTheBore(double h_L, double D) {
+    return liquidAreaFraction(h_L, D) >= ANNULAR_BRIDGING_HOLDUP;
+  }
+
+  /**
+   * In-situ liquid area fraction of a circular segment filled to {@code h_L}.
+   *
+   * @param h_L liquid height, in m
+   * @param D pipe diameter, in m
+   * @return the liquid area fraction, between 0 and 1
+   */
+  private double liquidAreaFraction(double h_L, double D) {
+    if (h_L <= 0.0 || D <= 0.0) {
+      return 0.0;
+    }
+    if (h_L >= D) {
+      return 1.0;
+    }
+    double beta = 2.0 * Math.acos(1.0 - 2.0 * h_L / D);
+    return (beta - Math.sin(beta)) / (2.0 * PI);
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPipeBoundaryConditionTest.java
@@ -438,7 +438,7 @@ class TwoFluidPipeBoundaryConditionTest {
     gasPipe.run();
 
     assertOutletPressure(gasPipe, 55.0);
-    assertPressureProfilePhysical(gasPipe);
+    assertSteadyPressureProfilePhysical(gasPipe);
     assertTrue(averageArray(gasPipe.getLiquidHoldupProfile()) < 1e-6,
         "One-phase gas should not build artificial liquid holdup");
   }
@@ -451,7 +451,7 @@ class TwoFluidPipeBoundaryConditionTest {
     twoPhasePipe.run();
 
     assertOutletPressure(twoPhasePipe, 58.0);
-    assertPressureProfilePhysical(twoPhasePipe);
+    assertSteadyPressureProfilePhysical(twoPhasePipe);
     assertTrue(averageArray(twoPhasePipe.getLiquidHoldupProfile()) > 1e-6,
         "Gas-liquid flow should keep a positive liquid holdup");
     assertTrue(averageArray(twoPhasePipe.getWaterHoldupProfile()) < 1e-6,
@@ -466,7 +466,7 @@ class TwoFluidPipeBoundaryConditionTest {
     threePhasePipe.run();
 
     assertOutletPressure(threePhasePipe, 60.0);
-    assertPressureProfilePhysical(threePhasePipe);
+    assertSteadyPressureProfilePhysical(threePhasePipe);
     assertTrue(averageArray(threePhasePipe.getWaterHoldupProfile()) > 1e-7,
         "Three-phase flow should keep water holdup");
     assertTrue(averageArray(threePhasePipe.getOilHoldupProfile()) > 1e-7, "Three-phase flow should keep oil holdup");
@@ -945,7 +945,7 @@ class TwoFluidPipeBoundaryConditionTest {
   }
 
   /**
-   * Assert finite pressures that decrease in the flow direction.
+   * Assert finite, positive pressures everywhere in the profile.
    *
    * @param checkedPipe pipe to inspect
    */
@@ -955,6 +955,25 @@ class TwoFluidPipeBoundaryConditionTest {
       assertTrue(Double.isFinite(pressureProfile[i]), "Pressure should be finite at index " + i);
       assertTrue(pressureProfile[i] > 0.0, "Pressure should be positive at index " + i);
     }
+  }
+
+  /**
+   * Assert finite, positive pressures that also fall in the flow direction.
+   *
+   * <p>
+   * Only a settled profile has to be monotone. An instantaneous transient profile does not: a decompression wave
+   * travelling up the line is a non-monotone pressure profile, and that is what it is meant to be. On this 300 m case
+   * the acoustic transit time is about 0.75 s against a 2 s step, so the response rings rather than settles — measured
+   * over 60 s the total drop swings between +92 kPa and -11 kPa about a steady drop of 1.4 kPa, and the sign of the
+   * local gradient changes on most steps. That behaviour predates the flow-map work and is unchanged by it; asserting
+   * monotonicity at whichever instant the settling detector stops on was measuring the phase of the ringing.
+   * </p>
+   *
+   * @param checkedPipe pipe to inspect
+   */
+  private void assertSteadyPressureProfilePhysical(TwoFluidPipe checkedPipe) {
+    assertPressureProfilePhysical(checkedPipe);
+    double[] pressureProfile = checkedPipe.getPressureProfile();
     assertTrue(pressureProfile[0] >= pressureProfile[pressureProfile.length - 1],
         "Pressure should not increase from inlet to outlet");
   }

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeMapValidationTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeMapValidationTest.java
@@ -1,0 +1,197 @@
+package neqsim.process.equipment.pipeline.twophasepipe;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.twophasepipe.PipeSection.FlowRegime;
+
+/**
+ * Validates {@link FlowRegimeDetector} against the published horizontal flow map.
+ *
+ * <p>
+ * The detector had been changed several times against a single hydrocarbon fixture, which is how it came to report
+ * annular flow at a liquid fraction of 0.45 with a superficial gas velocity of 1.7 m/s. This class supplies the
+ * measurement that was missing: the canonical air-water case of Mandhane, Gregory and Aziz (1974), 25 mm horizontal
+ * pipe at ambient conditions, which every horizontal flow-map study since is reported against.
+ * </p>
+ *
+ * <p>
+ * Anchors are placed well inside each published region, never on a boundary. Published maps disagree with each other
+ * near the transitions — the slug/annular boundary at a superficial liquid velocity of 0.3 m/s is quoted anywhere
+ * between 20 and 30 m/s of gas — so a boundary-adjacent anchor measures the disagreement between sources rather than
+ * the correctness of the code.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+class FlowRegimeMapValidationTest {
+  /** Inside diameter of the canonical air-water case, in m. */
+  private static final double AIR_WATER_DIAMETER = 0.025;
+
+  /** Water density at ambient conditions, in kg/m3. */
+  private static final double RHO_WATER = 998.0;
+
+  /** Air density at ambient conditions, in kg/m3. */
+  private static final double RHO_AIR = 1.2;
+
+  /** Water dynamic viscosity, in Pa.s. */
+  private static final double MU_WATER = 1.0e-3;
+
+  /** Air dynamic viscosity, in Pa.s. */
+  private static final double MU_AIR = 1.8e-5;
+
+  /** Air-water interfacial tension, in N/m. */
+  private static final double SIGMA_AIR_WATER = 0.072;
+
+  /** Holdup used only to convert superficial velocities into phase velocities. */
+  private static final double ALPHA_G = 0.90;
+
+  /** Liquid counterpart of {@link #ALPHA_G}. */
+  private static final double ALPHA_L = 0.10;
+
+  /**
+   * Builds a horizontal section carrying the requested superficial velocities.
+   *
+   * @param superficialLiquid superficial liquid velocity, in m/s
+   * @param superficialGas superficial gas velocity, in m/s
+   * @param diameter inside diameter, in m
+   * @param liquidDensity liquid density, in kg/m3
+   * @param gasDensity gas density, in kg/m3
+   * @param liquidViscosity liquid dynamic viscosity, in Pa.s
+   * @param surfaceTension interfacial tension, in N/m
+   * @return a section ready for regime detection
+   */
+  private PipeSection section(double superficialLiquid, double superficialGas, double diameter, double liquidDensity,
+      double gasDensity, double liquidViscosity, double surfaceTension) {
+    PipeSection sec = new PipeSection(0.0, 100.0, diameter, 0.0);
+    sec.setGasHoldup(ALPHA_G);
+    sec.setLiquidHoldup(ALPHA_L);
+    sec.setGasVelocity(superficialGas / ALPHA_G);
+    sec.setLiquidVelocity(superficialLiquid / ALPHA_L);
+    sec.setGasDensity(gasDensity);
+    sec.setLiquidDensity(liquidDensity);
+    sec.setLiquidViscosity(liquidViscosity);
+    sec.setGasViscosity(MU_AIR);
+    sec.setSurfaceTension(surfaceTension);
+    sec.updateDerivedQuantities();
+    return sec;
+  }
+
+  /**
+   * Classifies a point on the canonical air-water map.
+   *
+   * @param superficialLiquid superficial liquid velocity, in m/s
+   * @param superficialGas superficial gas velocity, in m/s
+   * @return the detected regime
+   */
+  private FlowRegime airWater(double superficialLiquid, double superficialGas) {
+    return new FlowRegimeDetector().detectFlowRegime(
+        section(superficialLiquid, superficialGas, AIR_WATER_DIAMETER, RHO_WATER, RHO_AIR, MU_WATER, SIGMA_AIR_WATER));
+  }
+
+  /**
+   * Asserts one map anchor.
+   *
+   * @param superficialLiquid superficial liquid velocity, in m/s
+   * @param superficialGas superficial gas velocity, in m/s
+   * @param expected the published regime for this point
+   */
+  private void assertAnchor(double superficialLiquid, double superficialGas, FlowRegime expected) {
+    FlowRegime actual = airWater(superficialLiquid, superficialGas);
+    Assertions.assertEquals(expected, actual, "air-water 25 mm horizontal at vsl = " + superficialLiquid
+        + " m/s and vsg = " + superficialGas + " m/s is " + expected + " on the published map, but was " + actual);
+  }
+
+  @Test
+  @DisplayName("the canonical air-water horizontal map is reproduced away from the transitions")
+  void testCanonicalAirWaterMapAnchors() {
+    assertAnchor(0.005, 0.5, FlowRegime.STRATIFIED_SMOOTH);
+    assertAnchor(0.02, 5.0, FlowRegime.STRATIFIED_WAVY);
+    assertAnchor(0.02, 40.0, FlowRegime.ANNULAR);
+    assertAnchor(0.05, 60.0, FlowRegime.ANNULAR);
+    assertAnchor(0.3, 80.0, FlowRegime.ANNULAR);
+    assertAnchor(0.5, 0.3, FlowRegime.SLUG);
+    assertAnchor(1.0, 2.0, FlowRegime.SLUG);
+    assertAnchor(5.0, 0.5, FlowRegime.DISPERSED_BUBBLE);
+  }
+
+  /**
+   * The annular region must retreat as the line carries more liquid.
+   *
+   * <p>
+   * A criterion that decides annular flow on gas velocity alone gets the anchors above right and this wrong, because
+   * its boundary is a vertical line on the map.
+   * </p>
+   *
+   * <p>
+   * Only the liquid-rich side is checked. Below a superficial liquid velocity of about 0.05 m/s the boundary is not
+   * monotonic and should not be: the layer is then so thin that it is Kelvin-Helmholtz stable, which delays annular
+   * flow to a higher gas velocity again. That dip belongs to the Taitel-Dukler construction and is not a defect.
+   * </p>
+   */
+  @Test
+  @DisplayName("the annular boundary moves to higher gas velocity as the liquid rate rises")
+  void testAnnularBoundaryRetreatsWithLiquidRate() {
+    double[] liquidRates = new double[] { 0.05, 0.3, 1.0 };
+    double previousBoundary = 0.0;
+    for (int i = 0; i < liquidRates.length; i++) {
+      double boundary = Double.NaN;
+      for (double vsg = 1.0; vsg <= 400.0; vsg *= 1.15) {
+        if (airWater(liquidRates[i], vsg) == FlowRegime.ANNULAR) {
+          boundary = vsg;
+          break;
+        }
+      }
+      Assertions.assertTrue(!Double.isNaN(boundary),
+          "no annular flow was found at any gas rate for vsl = " + liquidRates[i] + " m/s");
+      Assertions.assertTrue(boundary > previousBoundary,
+          "the annular boundary must move up with liquid rate, but at vsl = " + liquidRates[i] + " m/s it sat at vsg = "
+              + boundary + " m/s against " + previousBoundary + " m/s at the rate below");
+      previousBoundary = boundary;
+    }
+  }
+
+  /**
+   * Annular flow cannot be reported when the liquid would bridge the bore.
+   *
+   * <p>
+   * This is the invariant the detector previously violated: on a liquid-rich hydrocarbon line it returned annular at a
+   * liquid fraction near 0.45 with only 1.7 m/s of gas, a film no gas stream could hold up. Barnea (1987) puts the
+   * limit at a liquid fraction of 0.24, half the 0.48 a slug body needs before it can bridge. The case is swept across
+   * diameters because the defect only appeared at some of them.
+   * </p>
+   */
+  @Test
+  @DisplayName("a liquid-rich line at low gas velocity is never called annular")
+  void testNoAnnularFlowWhenTheLiquidCanBridgeTheBore() {
+    double[] diameters = new double[] { 0.20, 0.30, 0.40, 0.50 };
+    for (int i = 0; i < diameters.length; i++) {
+      for (double vsg = 0.5; vsg <= 4.0; vsg += 0.5) {
+        FlowRegime regime = new FlowRegimeDetector()
+            .detectFlowRegime(section(0.9, vsg, diameters[i], 700.0, 45.0, 5.0e-4, 0.015));
+        Assertions.assertNotEquals(FlowRegime.ANNULAR, regime,
+            "a liquid-rich line cannot be annular at vsg = " + vsg + " m/s in a " + diameters[i] + " m bore");
+      }
+    }
+  }
+
+  /**
+   * The smooth-to-wavy threshold must respond to the liquid rate.
+   *
+   * <p>
+   * Taitel and Dukler (1976) transition D carries the liquid velocity in the divisor, so a faster liquid needs less gas
+   * to raise waves. The form previously coded here had a second gas density there instead, which both removed that
+   * dependence and left the group dimensionally inconsistent, putting the threshold near 52 m/s for air and water and
+   * reporting an ordinary wavy line as smooth.
+   * </p>
+   */
+  @Test
+  @DisplayName("more liquid makes waves easier, as Taitel-Dukler transition D requires")
+  void testWavyTransitionRespondsToLiquidRate() {
+    Assertions.assertEquals(FlowRegime.STRATIFIED_SMOOTH, airWater(0.002, 2.0),
+        "a slow thin liquid layer under 2 m/s of gas should still be smooth");
+    Assertions.assertEquals(FlowRegime.STRATIFIED_WAVY, airWater(0.02, 5.0),
+        "a faster liquid layer under 5 m/s of gas should be wavy");
+  }
+}


### PR DESCRIPTION
## What this changes

The flow-regime detector had been tuned repeatedly against a single hydrocarbon fixture. That is how it came to report **ANNULAR at a liquid fraction of 0.45 with a superficial gas velocity of 1.7 m/s** — a film no gas stream could hold against gravity.

This adds the measurement that was missing, then fixes what it found.

## 1. The harness (the part that was actually missing)

`FlowRegimeMapValidationTest` scores the detector against the canonical air–water horizontal case of **Mandhane, Gregory & Aziz (1974)** — 25 mm pipe at ambient — which every horizontal flow-map study since is reported against.

Anchors sit **well inside** each published region, never on a boundary. Published maps disagree with each other near the transitions (the slug/annular boundary at 0.3 m/s liquid is quoted anywhere from 20 to 30 m/s gas), so a boundary-adjacent anchor measures disagreement between sources rather than correctness of the code. My first draft had exactly that mistake and I moved the anchor rather than adjust the model to it.

Three further tests pin behaviour a single-point anchor set cannot:
- the annular boundary must retreat as liquid rate rises (a gas-velocity-only criterion has a vertical boundary and fails this);
- a liquid-rich line at low gas velocity is never annular — the invariant that was violated;
- the smooth→wavy threshold must respond to liquid rate.

## 2. Two defects the map exposed

**Taitel–Dukler transition D was dimensionally wrong.** It read `sqrt(4·μ_L·Δρ·g/(s·ρ_G·ρ_G))`, which has units of m^1.5/s^1.5. The published criterion uses the *kinematic* viscosity and carries the *liquid velocity* in the divisor:

$$U_{G,crit} = \sqrt{\frac{4\,\nu_L\,\Delta\rho\,g\cos\theta}{s\,\rho_G\,U_L}}$$

The coded form put the threshold near **52 m/s** for air–water, so an ordinary wavy line was reported as smooth, and the dependence on liquid rate was absent entirely. Corrected, the threshold is **3.6 m/s**.

**The annular branch had no bridging limit.** It used only `h_L/D < 0.5`, which admits annular flow at liquid fractions approaching one half. Barnea (1987) adds the blockage criterion: a stable slug body needs a liquid fraction of ~0.48, so bridging becomes possible once the film holds half of that — annular requires an in-situ liquid fraction below **0.24**. It is evaluated on the same stratified equilibrium level transition B already uses. The `setBlendRegimeTransitions` blend now ramps about the same limit so the smooth and hard classifiers agree.

## 3. Measured effect

| | before | after |
|---|---|---|
| canonical map anchors | 7/8 | **8/8** |
| liquid-rich fixture, D = 0.30 / 0.40 m | ANNULAR | **SLUG** |
| gas-dominated export line | SW / SW / AN | unchanged |
| 73.8 km reference line ΔP | +1.5 / +1.6 / +0.1 / −2.7 % | unchanged |

## Honest limit — this does not move the pressure drop

The fixture reports the **same 5.520 bar and 0.426 hold-up before and after**, because ANNULAR and SLUG currently route to the same mixture-friction closure (separated friction is stratified-only). My earlier framing of this as "likely the largest remaining accuracy gain" was wrong and the measurement says so.

What it does deliver: the regime a user reads back is now physically possible, and a future slug closure has a correct branch to attach to.

## Test change

`TwoFluidPipeBoundaryConditionTest` applied its monotonicity check to *instantaneous transient* profiles. That is not a physical requirement — a decompression wave travelling up the line **is** a non-monotone pressure profile.

On that 300 m case the acoustic transit time is ~0.75 s against a 2 s step, so the response rings rather than settles: over 60 s the total drop swings between **+92 kPa and −11 kPa** about a steady drop of **1.4 kPa**, and the local gradient changes sign on most steps. I verified this ringing is **unchanged by this work** by reverting only the detector and re-running — master rings identically. The check was recording the phase of the ringing at whichever instant the settling detector stopped.

Monotonicity now applies to settled profiles, where it belongs. The transient keeps the finite / positive / outlet-boundary assertions, and **all 28 cases pass including every settling assertion** — so nothing real was hiding behind it.

## Verification

Full pipeline suite: **827 tests, 0 failures, 22 skipped**.
