### PR TITLE
docs: correct temperature-dependent mixing-rule equations

### DIFF
--- a/docs/test_mixing_rules_documentation.py
+++ b/docs/test_mixing_rules_documentation.py
@@ -1,0 +1,189 @@
+import re
+import unittest
+from pathlib import Path
+from urllib.parse import unquote
+
+
+DOCS_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = DOCS_DIR.parent
+MIXING_RULE_GUIDE = DOCS_DIR / "thermo" / "mixing_rules_guide.md"
+THERMODYNAMIC_MODELS = DOCS_DIR / "thermo" / "thermodynamic_models.md"
+MIXING_RULE_HANDLER = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/thermo/mixingrule/EosMixingRuleHandler.java"
+)
+
+CLASSIC_T_EQUATION = (
+    r"k_{ij}(T) = k_{ij,0} + k_{ij,T} "
+    r"\left(\frac{T}{273.15\ \mathrm{K}} - 1\right)"
+)
+CLASSIC_T2_EQUATION = (
+    r"k_{ij}(T) = k_{ij,0} + \frac{k_{ij,T}}{T}"
+)
+
+
+def heading_slugs(content):
+    content_without_fences = re.sub(
+        r"```.*?```",
+        "",
+        content,
+        flags=re.DOTALL,
+    )
+    return {
+        re.sub(r"[^a-z0-9 -]", "", heading.lower())
+        .strip()
+        .replace(" ", "-")
+        for heading in re.findall(
+            r"^#{1,6}\s+(.+)$",
+            content_without_fences,
+            flags=re.MULTILINE,
+        )
+    }
+
+
+def resolve_internal_target(source_path, destination):
+    target, _, fragment = unquote(destination).partition("#")
+    if not target:
+        return source_path, fragment
+
+    target_path = (source_path.parent / target).resolve()
+    if not target_path.is_file():
+        raise AssertionError(
+            "Unresolved link from {}: {}".format(source_path, destination)
+        )
+    return target_path, fragment
+
+
+class MixingRulesDocumentationContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.documents = {
+            MIXING_RULE_GUIDE: MIXING_RULE_GUIDE.read_text(encoding="utf-8"),
+            THERMODYNAMIC_MODELS: THERMODYNAMIC_MODELS.read_text(
+                encoding="utf-8"
+            ),
+        }
+        cls.mixing_rule_handler = MIXING_RULE_HANDLER.read_text(
+            encoding="utf-8"
+        )
+
+    def test_structure_and_internal_links_are_source_safe(self):
+        markdown_links = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+
+        for source_path, content in self.documents.items():
+            content_without_fences = re.sub(
+                r"```.*?```",
+                "",
+                content,
+                flags=re.DOTALL,
+            )
+            with self.subTest(source=source_path.name):
+                self.assertTrue(content.startswith("---\n"))
+                self.assertEqual(content.count("```") % 2, 0)
+                self.assertNotRegex(
+                    content_without_fences,
+                    re.compile(r"^# ", re.MULTILINE),
+                )
+
+            for destination in markdown_links.findall(content):
+                if destination.startswith(
+                    ("http://", "https://", "mailto:")
+                ):
+                    continue
+
+                target, _, fragment = destination.partition("#")
+                if target:
+                    with self.subTest(
+                        source=source_path.name,
+                        destination=destination,
+                    ):
+                        self.assertTrue(
+                            target.endswith(".md"),
+                            "Documentation source links must include .md",
+                        )
+
+                target_path, resolved_fragment = resolve_internal_target(
+                    source_path,
+                    destination,
+                )
+                if fragment:
+                    with self.subTest(
+                        source=source_path.name,
+                        destination=destination,
+                    ):
+                        self.assertEqual(fragment, resolved_fragment)
+                        self.assertIn(
+                            resolved_fragment,
+                            heading_slugs(
+                                target_path.read_text(encoding="utf-8")
+                            ),
+                        )
+
+    def test_temperature_dependent_equations_match_current_source(self):
+        source_contracts = (
+            "return new ClassicSRKT();",
+            "return new ClassicSRKT(1);",
+            (
+                "return intparam[i][j] + intparamT[i][j] "
+                "* (temperature / 273.15 - 1.0);"
+            ),
+            (
+                "return intparam[i][j] + intparamT[i][j] "
+                "/ temperature;"
+            ),
+        )
+        for source_contract in source_contracts:
+            with self.subTest(source_contract=source_contract):
+                self.assertIn(source_contract, self.mixing_rule_handler)
+
+        self.assertRegex(
+            self.mixing_rule_handler,
+            re.compile(
+                r"else if \(i == 8\).*?return new ClassicSRKT\(\);",
+                flags=re.DOTALL,
+            ),
+        )
+        self.assertRegex(
+            self.mixing_rule_handler,
+            re.compile(
+                r"else if \(i == 12\).*?return new ClassicSRKT\(1\);",
+                flags=re.DOTALL,
+            ),
+        )
+
+        for source_path, content in self.documents.items():
+            with self.subTest(source=source_path.name):
+                self.assertIn(CLASSIC_T_EQUATION, content)
+                self.assertIn(CLASSIC_T2_EQUATION, content)
+                self.assertNotIn(
+                    r"k_{ij,0} + k_{ij,T} \cdot T",
+                    content,
+                )
+
+    def test_parameter_units_and_custom_example_are_unambiguous(self):
+        guide = self.documents[MIXING_RULE_GUIDE]
+        models = self.documents[THERMODYNAMIC_MODELS]
+
+        for content in (guide, models):
+            with self.subTest(document="guide" if content is guide else "models"):
+                self.assertIn("273.15 K", content)
+                self.assertIn("dimensionless", content)
+                self.assertIn("units of kelvin", content)
+
+        for documented_call in (
+            "temperatureDependentFluid.setMixingRule("
+            "EosMixingRuleType.CLASSIC_T);",
+            "temperatureDependentRule.setBinaryInteractionParameter(",
+            "temperatureDependentRule.setBinaryInteractionParameterT1(",
+        ):
+            with self.subTest(documented_call=documented_call):
+                self.assertIn(documented_call, guide)
+
+        self.assertIn(
+            "fluid.setMixingRule(EosMixingRuleType.CLASSIC_T);",
+            models,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/thermo/mixing_rules_guide.md
+++ b/docs/thermo/mixing_rules_guide.md
@@ -3,8 +3,6 @@ title: "Mixing Rules in NeqSim"
 description: "This guide provides comprehensive documentation on mixing rules available in NeqSim, including mathematical formulations, usage patterns, and recommendations for different applications."
 ---
 
-# Mixing Rules in NeqSim
-
 This guide provides comprehensive documentation on mixing rules available in NeqSim, including mathematical formulations, usage patterns, and recommendations for different applications.
 
 ## Table of Contents
@@ -137,10 +135,12 @@ fluid.setMixingRule(2);  // or fluid.setMixingRule("classic");
 Classic mixing rule with temperature-dependent binary interaction parameters:
 
 $$
-k_{ij}(T) = k_{ij,0} + k_{ij,T} \cdot T
+k_{ij}(T) = k_{ij,0} + k_{ij,T} \left(\frac{T}{273.15\ \mathrm{K}} - 1\right)
 $$
 
-Where $k_{ij,0}$ is the reference value and $k_{ij,T}$ is the temperature coefficient.
+Here, $T$ is absolute temperature in kelvin, $k_{ij,0}$ is the interaction parameter at
+273.15 K, and $k_{ij,T}$ is a dimensionless coefficient for the normalized temperature
+shift.
 
 **Use case:** Systems where kij varies significantly with temperature.
 
@@ -158,6 +158,9 @@ Alternative temperature-dependent formulation:
 $$
 k_{ij}(T) = k_{ij,0} + \frac{k_{ij,T}}{T}
 $$
+
+Here, $T$ is absolute temperature in kelvin. Because $k_{ij}$ is dimensionless,
+$k_{ij,T}$ has units of kelvin in this inverse-temperature formulation.
 
 **Use case:** Systems requiring inverse temperature dependency.
 
@@ -457,12 +460,25 @@ mixRule.setBinaryInteractionParameterji(0, 1, 0.12);  // kji
 
 ### 8.4 Setting Temperature-Dependent kij
 
+Select the temperature-dependent rule before obtaining its mixing-rule interface. The coefficient
+meaning depends on the selected formulation.
+
 ```java
-// For mixing rules 8, 9, 12
-// kij(T) = kij0 + kijT * f(T)
-mixRule.setBinaryInteractionParameter(0, 1, 0.10);    // kij0
-mixRule.setBinaryInteractionParameterT1(0, 1, 0.001); // kijT
+SystemInterface temperatureDependentFluid = new SystemSrkEos(300.0, 50.0);
+temperatureDependentFluid.addComponent("methane", 0.9);
+temperatureDependentFluid.addComponent("CO2", 0.1);
+temperatureDependentFluid.setMixingRule(EosMixingRuleType.CLASSIC_T);
+
+EosMixingRulesInterface temperatureDependentRule =
+    temperatureDependentFluid.getPhase(0).getMixingRule();
+temperatureDependentRule.setBinaryInteractionParameter(0, 1, 0.10);
+temperatureDependentRule.setBinaryInteractionParameterT1(0, 1, 0.001);
 ```
+
+For `CLASSIC_T`, the values above mean $k_{ij}(273.15\ \mathrm{K}) = 0.10$ and a
+dimensionless normalized-temperature coefficient of 0.001. For `CLASSIC_T2`, the second
+parameter instead has units of kelvin because it is divided by $T$. CPA rules 9 and 10 use the
+temperature-dependence type supplied by the interaction-parameter database.
 
 ### 8.5 Displaying kij Matrix
 
@@ -590,7 +606,7 @@ ops.TPflash();
 
 ## See Also
 
-- [Fluid Creation Guide](fluid_creation_guide) - Complete guide to creating fluids
-- [Mathematical Models](mathematical_models) - EoS equations and derivations
-- [Thermodynamic Workflows](thermodynamic_workflows) - Flash calculations and operations
-- [PVT and Fluid Characterization](pvt_fluid_characterization) - Heavy fraction handling
+- [Fluid Creation Guide](fluid_creation_guide.md) - Complete guide to creating fluids
+- [Mathematical Models](mathematical_models.md) - EoS equations and derivations
+- [Thermodynamic Workflows](thermodynamic_workflows.md) - Flash calculations and operations
+- [PVT and Fluid Characterization](pvt_fluid_characterization.md) - Heavy fraction handling

--- a/docs/thermo/mixing_rules_guide.md
+++ b/docs/thermo/mixing_rules_guide.md
@@ -12,7 +12,7 @@ This guide provides comprehensive documentation on mixing rules available in Neq
 4. [Huron-Vidal Mixing Rules](#4-huron-vidal-mixing-rules)
 5. [Wong-Sandler Mixing Rule](#5-wong-sandler-mixing-rule)
 6. [CPA Mixing Rules](#6-cpa-mixing-rules)
-7. [Søreide-Whitson Mixing Rule](#7-søreide-whitson-mixing-rule)
+7. [Søreide-Whitson Mixing Rule](#7-sreide-whitson-mixing-rule)
 8. [Binary Interaction Parameters (kij)](#8-binary-interaction-parameters-kij)
 9. [Complete Reference Table](#9-complete-reference-table)
 10. [Examples by Application](#10-examples-by-application)

--- a/docs/thermo/thermodynamic_models.md
+++ b/docs/thermo/thermodynamic_models.md
@@ -4,8 +4,6 @@ description: "This document provides a comprehensive overview of the thermodynam
 keywords: "thermodynamic model, SRK, Peng-Robinson, CPA, UMR-CPA, SystemUMRCPAEoS, TEG dehydration, GERG-2008, EOS-CG, UMR-PRU, electrolyte, cubic EOS, activity coefficient, NRTL, UNIFAC"
 ---
 
-# Thermodynamic Models in NeqSim
-
 This document provides a comprehensive overview of the thermodynamic models available in NeqSim, their theoretical foundations, and practical guidance on when and how to use each model. Models are classified into categories based on their mathematical formulation and application domain.
 
 ## Table of Contents
@@ -564,7 +562,7 @@ ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
 ops.TPflash();
 ```
 
-> **📖 Detailed Documentation:** For complete mathematical formulation, salt type coefficients, validation data, and literature references, see [Søreide-Whitson Model Documentation](SoreideWhitsonModel).
+> **📖 Detailed Documentation:** For complete mathematical formulation, salt type coefficients, validation data, and literature references, see [Søreide-Whitson Model Documentation](SoreideWhitsonModel.md).
 >
 > **Reference:** Søreide, I. & Whitson, C.H. (1992). "Peng-Robinson predictions for hydrocarbons, CO₂, N₂, and H₂S with pure water and NaCl brine". *Fluid Phase Equilibria*, 77, 217-240.
 
@@ -611,8 +609,8 @@ $$
 |------|------|-------------|
 | 1 | `NO` | All $k_{ij} = 0$ (no interactions) |
 | 2 | `CLASSIC` | Classic with database $k_{ij}$ |
-| 8 | `CLASSIC_T` | Temperature-dependent: $k_{ij}(T) = k_{ij,0} + k_{ij,T} \cdot T$ |
-| 12 | `CLASSIC_T2` | Inverse T-dependency: $k_{ij}(T) = k_{ij,0} + k_{ij,T}/T$ |
+| 8 | `CLASSIC_T` | Normalized T-dependency: $k_{ij}(T) = k_{ij,0} + k_{ij,T} \left(\frac{T}{273.15\ \mathrm{K}} - 1\right)$ |
+| 12 | `CLASSIC_T2` | Inverse T-dependency: $k_{ij}(T) = k_{ij,0} + \frac{k_{ij,T}}{T}$ |
 
 ### 8.3 Huron-Vidal Mixing Rules
 
@@ -707,10 +705,17 @@ mixRule.setBinaryInteractionParameter(0, 1, 0.12);
 mixRule.setBinaryInteractionParameterij(0, 1, 0.08);  // kij
 mixRule.setBinaryInteractionParameterji(0, 1, 0.12);  // kji
 
-// Set temperature-dependent kij
-mixRule.setBinaryInteractionParameter(0, 1, 0.10);      // kij0
-mixRule.setBinaryInteractionParameterT1(0, 1, 0.001);   // kijT
+// Obtain the rule again after selecting CLASSIC_T
+fluid.setMixingRule(EosMixingRuleType.CLASSIC_T);
+EosMixingRulesInterface temperatureDependentRule =
+    fluid.getPhase(0).getMixingRule();
+temperatureDependentRule.setBinaryInteractionParameter(0, 1, 0.10);
+temperatureDependentRule.setBinaryInteractionParameterT1(0, 1, 0.001);
 ```
+
+For `CLASSIC_T`, `kij0` is the interaction parameter at 273.15 K and `kijT` is a
+dimensionless coefficient for the normalized temperature shift. For `CLASSIC_T2`, `kijT`
+has units of kelvin because the implementation divides it by absolute temperature in kelvin.
 
 ---
 
@@ -929,14 +934,14 @@ fluid.autoSelectMixingRule();  // Automatically sets appropriate mixing rule
 
 ## See Also
 
-- [Fluid Creation Guide](fluid_creation_guide) - Complete guide to creating fluids
-- [Mixing Rules Guide](mixing_rules_guide) - Detailed mixing rule documentation
-- [GERG-2008 and EOS-CG](gerg2008_eoscg) - Reference equation details
-- [Electrolyte CPA Model](ElectrolyteCPAModel) - Electrolyte model documentation
-- [Søreide-Whitson Model](SoreideWhitsonModel) - Gas solubility in brine, produced water emissions
-- [Flash Calculations Guide](flash_calculations_guide) - Thermodynamic operations
-- [Mathematical Models](mathematical_models) - Equation derivations
-- [Offshore Emission Reporting](../emissions/OFFSHORE_EMISSION_REPORTING) - Emission calculations using Søreide-Whitson
+- [Fluid Creation Guide](fluid_creation_guide.md) - Complete guide to creating fluids
+- [Mixing Rules Guide](mixing_rules_guide.md) - Detailed mixing rule documentation
+- [GERG-2008 and EOS-CG](gerg2008_eoscg.md) - Reference equation details
+- [Electrolyte CPA Model](ElectrolyteCPAModel.md) - Electrolyte model documentation
+- [Søreide-Whitson Model](SoreideWhitsonModel.md) - Gas solubility in brine, produced water emissions
+- [Flash Calculations Guide](flash_calculations_guide.md) - Thermodynamic operations
+- [Mathematical Models](mathematical_models.md) - Equation derivations
+- [Offshore Emission Reporting](../emissions/OFFSHORE_EMISSION_REPORTING.md) - Emission calculations using Søreide-Whitson
 
 ---
 


### PR DESCRIPTION
## Summary

Repairs D064 of the documentation-quality campaign in #2499: temperature-dependent EOS mixing-rule documentation.

The type-8 `CLASSIC_T` equation was repeated incorrectly in two reader-facing pages. The implementation selected by type 8 uses a 273.15 K-normalized temperature shift, not a direct `kijT*T` term. The pages also left coefficient units ambiguous, contained extensionless repository-relative links, and duplicated front-matter titles as body H1 headings.

## Frozen scope

- `docs/thermo/mixing_rules_guide.md`
- `docs/thermo/thermodynamic_models.md`
- `docs/test_mixing_rules_documentation.py`

Base: `6a6497bcde981a93f8fd4e294fff68fa81329e3c`

## Defects and root cause

- **High — technical accuracy:** both pages documented type 8 as `kij0 + kijT*T`. `EosMixingRuleHandler.getMixingRule(...)` selects `ClassicSRKT()` for type 8, whose implementation is `kij0 + kijT*(T/273.15 - 1)`.
- **Medium — units and provenance:** `kij0` and `kijT` were described generically even though type 8 makes `kij0` the 273.15 K value and `kijT` dimensionless, while type 12 divides a kelvin-valued coefficient by absolute temperature.
- **Medium — navigation:** source links omitted `.md`; the Søreide table-of-contents fragment also disagreed with the generated heading slug.
- **Low — structure:** both pages repeated their front-matter titles as body H1 headings.
- **Medium — example correctness:** the custom-temperature-coefficient snippet reused a generic mixing-rule object without first selecting and re-fetching a temperature-dependent rule.

## Changes

- Replaced the type-8 equation in both pages with
  `kij(T) = kij0 + kijT*(T/(273.15 K) - 1)`.
- Kept type 12 explicit as `kij0 + kijT/T` and documented the distinct coefficient units.
- Made the custom type-8 example select `EosMixingRuleType.CLASSIC_T` before obtaining its interface.
- Added explicit `.md` targets and corrected the Søreide fragment.
- Removed duplicate body H1 headings.
- Added a hermetic contract test tying both pages to the current Java factory paths and equations while checking front matter, headings, fences, internal files, and fragments.

## Validation performed on exact head

Head: `0f0633a98be124df6986dfcebf735422cfdc1bae`

- GitHub connector exact-content comparison: **PASS** — all three remote blobs match the intended contents.
- Scope comparison against the base: **PASS** — only the three frozen paths changed; branch is 0 commits behind its base.
- Source contract inspection: **PASS** — type 8 maps to `ClassicSRKT()`, type 12 maps to `ClassicSRKT(1)`, and both Java formulas are present.
- Markdown static contract: **PASS** — front matter, fence balance, absence of body H1, all 21 self fragments, all 10 repository-relative targets, canonical formulas, and stale-formula absence.
- `python -c <in-memory compile of docs/test_mixing_rules_documentation.py>`: **PASS (exit 0)**.
- Final diff: 3 files, no production Java, dependency, generated, notebook, or sensitive-material changes.

## CI validation on exact head

All GitHub workflows completed successfully on `0f0633a98be124df6986dfcebf735422cfdc1bae`:

- **Run build, test and javadoc** — success
- **Spotless format patch** — success
- **Pre-commit checks** — success
- **Documentation search coverage** — success; its job ran the documentation contract tests, built the Jekyll site, and verified generated search coverage
- **CodeQL Security Analysis** — success

A complete local checkout was not available in this connector-first run. The local forms of the
focused test, Spotless, documentation-search, pre-commit, pre-push, and Jekyll commands were not
run locally and are not claimed as local results; their repository CI workflows above passed on
the exact published head. No notebook or Python NeqSim execution is involved.

## Documentation impact

Direct and complete for the frozen mixing-rule pages. No public API or runtime behavior changes.

## Exclusions

No production-code changes, no interaction-database changes, no other thermodynamic pages, and no diagram, pipeline, notebook, or Huldra work.

D064 remains **in progress** until this PR is merged and audited on current `master`.

## Merge readiness

**READY TO MERGE** on exact head `0f0633a98be124df6986dfcebf735422cfdc1bae`.

- All applicable hosted workflows passed: documentation contracts and site/search coverage, pre-commit, Spotless, CodeQL, and the repository build workflow.
- The build workflow correctly skipped Java test/Javadoc matrix jobs because the final diff contains no Java or XML changes.
- Mergeable, 0 commits behind `master`, and limited to the three frozen documentation/test paths.
- No comments, reviews, requested changes, or unresolved review threads.
- Documentation impact is direct and complete; no runtime behavior, API, notebook, dependency, diagram, pipeline, or Huldra scope is changed.
