### PR TITLE
fix: re-evaluate calculators during recycle convergence

### DIFF
--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -1498,11 +1498,10 @@ public class ProcessSystem extends SimulationBaseClass {
       // performs the active-state reset when runOptimized() is called directly.
       // When run() delegates here, its outer run scope already performed the
       // active-state reset, so repeating preparation in this dispatcher is wasteful.
-      if (hasAdjusters()) {
-        // Adjusters create implicit feedback loops via signal connections and
-        // iterate on a target variable. The graph partitioner cannot represent
-        // that iterative coupling, so adjuster-containing systems must run
-        // sequentially to ensure correct evaluation order.
+      if (hasAdjusters() || (hasRecycles() && hasCalculators())) {
+        // Adjusters and calculators create implicit feedback loops via signal
+        // connections. A calculator coupled to a recycle must be evaluated on
+        // every recycle pass, which requires insertion-order sequential execution.
         runSequential(id);
       } else if (hasRecycles()) {
         // Process has Recycle units. runHybrid() parallelises feed-forward levels

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
@@ -47,6 +47,49 @@ public class ProcessSystemTest extends neqsim.NeqSimTest {
   ProcessSystem p;
   String _name = "TestProcess";
 
+  @Test
+  public void calculatorReevaluatesDuringRecycleConvergence() {
+    neqsim.thermo.system.SystemInterface methane = new neqsim.thermo.system.SystemSrkEos(298.15, 10.0);
+    methane.addComponent("methane", 1.0);
+
+    Stream recycleFeed = new Stream("recycle feed", methane);
+    recycleFeed.setFlowRate(1.0e-6, "kg/hr");
+    Stream makeup = new Stream("makeup", methane.clone());
+    makeup.setFlowRate(0.0, "kg/hr");
+
+    final int[] calculationCount = new int[] { 0 };
+    Calculator calculator = new Calculator("makeup calculator");
+    calculator.addInputVariable(recycleFeed);
+    calculator.setOutputVariable(makeup);
+    calculator.setCalculationMethod((inputs, output) -> {
+      calculationCount[0]++;
+      double requiredMakeup = 100.0 - ((Stream) inputs.get(0)).getFlowRate("kg/hr");
+      ((Stream) output).setFlowRate(Math.max(0.0, requiredMakeup), "kg/hr");
+    });
+
+    StaticMixer mixer = new StaticMixer("makeup mixer");
+    mixer.addStream(recycleFeed);
+    mixer.addStream(makeup);
+
+    Recycle recycle = new Recycle("makeup recycle");
+    recycle.addStream(mixer.getOutletStream());
+    recycle.setOutletStream(recycleFeed);
+    recycle.setTolerance(1.0e-4);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(recycleFeed);
+    process.add(makeup);
+    process.add(calculator);
+    process.add(mixer);
+    process.add(recycle);
+    process.run();
+
+    assertTrue(recycle.solved());
+    assertTrue(calculationCount[0] > 1);
+    assertEquals(100.0, recycleFeed.getFlowRate("kg/hr"), 1.0e-3);
+    assertEquals(0.0, makeup.getFlowRate("kg/hr"), 1.0e-3);
+  }
+
   private static class FailingProcessUnit extends ProcessEquipmentBaseClass {
     private static final long serialVersionUID = 1000L;
 


### PR DESCRIPTION
## Summary
- route recycle flowsheets containing `Calculator` units through sequential execution so the calculator runs on every recycle pass
- retain hybrid execution for recycle flowsheets without calculators
- add a focused regression test that verifies a calculator callback is invoked more than once and reaches the recycle fixed point without `setDownstreamProperty("flow rate")`

Fixes #3083

## Verification
- `./mvnw test -Dtest=ProcessSystemTest#calculatorReevaluatesDuringRecycleConvergence`
- `./mvnw spotless:check`