### PR TITLE
fix: make mixer inlet order invariant

### DIFF
--- a/src/main/java/neqsim/process/equipment/mixer/Mixer.java
+++ b/src/main/java/neqsim/process/equipment/mixer/Mixer.java
@@ -180,6 +180,15 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface, 
    * mixStream.
    */
   public void mixStream() {
+    mixStream(streams.get(0));
+  }
+
+  /**
+   * Mixes every inlet except the stream already represented by the mixed-stream template.
+   *
+   * @param templateStream inlet stream cloned as the mixed-stream template
+   */
+  private void mixStream(StreamInterface templateStream) {
     int index = 0;
     // Determine outlet pressure from the lowest pressure across ACTIVE inlet streams only.
     // Streams with negligible flow (bypassed / deactivated) must not influence the mixer
@@ -222,9 +231,11 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface, 
       }
     }
 
-    // Process ALL streams starting from k=1 (k=0 is already cloned into mixedStream)
-    // but ensure first stream's components are also explicitly added if needed
-    for (int k = 1; k < streams.size(); k++) {
+    // The template stream is already present in mixedStream; add every other inlet exactly once.
+    for (int k = 0; k < streams.size(); k++) {
+      if (streams.get(k) == templateStream) {
+        continue;
+      }
       // Skip streams with negligible flow to avoid mixing in zero/negative moles
       if (streams.get(k).getFlowRate("kg/hr") <= getMinimumFlow()) {
         continue;
@@ -293,6 +304,33 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface, 
     if (hasAddedNewComponent) {
       mixedStream.getThermoSystem().setMixingRule(mixedStream.getThermoSystem().getMixingRule());
     }
+  }
+
+  /**
+   * Selects a stable thermodynamic template from the active inlet streams.
+   *
+   * <p>
+   * The largest active mass-flow stream is used so a small injection stream cannot control the outlet's thermodynamic
+   * configuration merely because it was registered first. Equal-flow ties are resolved by stream name, making the
+   * selection independent of registration order.
+   * </p>
+   *
+   * @return the selected thermodynamic template stream
+   */
+  private StreamInterface selectTemplateStream() {
+    StreamInterface templateStream = streams.get(0);
+    double maximumFlow = Double.NEGATIVE_INFINITY;
+    for (StreamInterface stream : streams) {
+      double flow = stream.getFlowRate("kg/hr");
+      if (flow <= getMinimumFlow()) {
+        continue;
+      }
+      if (flow > maximumFlow || (flow == maximumFlow && stream.getName().compareTo(templateStream.getName()) < 0)) {
+        templateStream = stream;
+        maximumFlow = flow;
+      }
+    }
+    return templateStream;
   }
 
   /**
@@ -504,18 +542,16 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface, 
       return;
     }
 
-    boolean inletMultiPhaseCheck = streams.get(0).getThermoSystem().doMultiPhaseCheck();
-    SystemInterface thermoSystem2 = streams.get(0).getThermoSystem().clone();
-    if (!doMultiPhaseCheck) {
-      thermoSystem2.setMultiPhaseCheck(false);
-    }
+    StreamInterface templateStream = selectTemplateStream();
+    SystemInterface thermoSystem2 = templateStream.getThermoSystem().clone();
+    thermoSystem2.setMultiPhaseCheck(doMultiPhaseCheck);
     isActive(true);
     // System.out.println("total number of moles " +
     // thermoSystem2.getTotalNumberOfMoles());
     mixedStream.setThermoSystem(thermoSystem2);
     // thermoSystem2.display();
     if (streams.size() >= 2) {
-      mixStream();
+      mixStream(templateStream);
       if (mixedStream.getFlowRate("kg/hr") > getMinimumFlow()) {
         mixedStream.setPressure(lowestPressure);
         enthalpy = calcMixStreamEnthalpy();
@@ -562,10 +598,6 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface, 
         mixedStream.getThermoSystem().initProperties();
         isActive(false);
       }
-    }
-
-    if (inletMultiPhaseCheck) {
-      mixedStream.getThermoSystem().setMultiPhaseCheck(true);
     }
 
     finishRun(id);

--- a/src/test/java/neqsim/process/equipment/mixer/StaticMixerTest.java
+++ b/src/test/java/neqsim/process/equipment/mixer/StaticMixerTest.java
@@ -1,6 +1,7 @@
 package neqsim.process.equipment.mixer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
@@ -10,6 +11,42 @@ import neqsim.thermo.system.SystemSrkCPAstatoil;
 import neqsim.thermo.system.SystemSrkEos;
 
 class StaticMixerTest {
+
+  private StaticMixer runGasMegMixer(boolean megFirst) {
+    neqsim.thermo.system.SystemInterface gasFluid = new SystemSrkCPAstatoil(302.15, 74.1);
+    gasFluid.addComponent("methane", 5.0);
+    gasFluid.addComponent("water", 0.11833608283886514);
+    gasFluid.addComponent("MEG", 0.0);
+    gasFluid.setMixingRule(10);
+    gasFluid.setMultiPhaseCheck(true);
+
+    neqsim.thermo.system.SystemInterface megFluid = gasFluid.clone();
+    megFluid.setMolarComposition(new double[] { 0.0, 0.1099744114900417, 0.8900255885099583 });
+    megFluid.setMultiPhaseCheck(false);
+
+    Stream gasStream = new Stream("bulk wet gas", gasFluid);
+    gasStream.setFlowRate(168958.0, "Sm3/hr");
+    gasStream.setTemperature(29.0, "C");
+    gasStream.setPressure(74.1, "barg");
+    gasStream.run();
+
+    Stream megStream = new Stream("lean MEG", megFluid);
+    megStream.setFlowRate(0.01, "kg/hr");
+    megStream.setTemperature(29.0, "C");
+    megStream.setPressure(74.1, "barg");
+    megStream.run();
+
+    StaticMixer mixer = new StaticMixer("gas/MEG mixer");
+    if (megFirst) {
+      mixer.addStream(megStream);
+      mixer.addStream(gasStream);
+    } else {
+      mixer.addStream(gasStream);
+      mixer.addStream(megStream);
+    }
+    mixer.run();
+    return mixer;
+  }
 
   @Test
   void testMixTwoStreamsEqualFlow() {
@@ -83,6 +120,23 @@ class StaticMixerTest {
     process.run();
 
     assertTrue(mixer.getOutletStream().getFluid().hasPhaseType("gas"));
+  }
+
+  @Test
+  void testInletOrderDoesNotChangeDominantTemplateOrMultiphaseConfiguration() {
+    StaticMixer megFirstMixer = runGasMegMixer(true);
+    StaticMixer gasFirstMixer = runGasMegMixer(false);
+
+    assertTrue(megFirstMixer.getThermoSystem().doMultiPhaseCheck());
+    assertTrue(gasFirstMixer.getThermoSystem().doMultiPhaseCheck());
+    assertEquals(gasFirstMixer.getOutletStream().getFlowRate("kg/hr"),
+        megFirstMixer.getOutletStream().getFlowRate("kg/hr"), 1.0e-6);
+    assertEquals(gasFirstMixer.getOutletStream().getTemperature("K"),
+        megFirstMixer.getOutletStream().getTemperature("K"), 1.0e-6);
+    assertEquals(gasFirstMixer.getOutletStream().getFluid().getNumberOfPhases(),
+        megFirstMixer.getOutletStream().getFluid().getNumberOfPhases());
+    assertTrue(megFirstMixer.getOutletStream().getFluid().hasPhaseType("gas"));
+    assertFalse(Double.isNaN(megFirstMixer.getOutletStream().getFlowRate("kg/hr")));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- select the largest active inlet as the `Mixer` thermodynamic template instead of inheriting setup from registration index 0
- add every non-template stream exactly once during mixing, retaining mass conservation for the selected template
- apply `Mixer.setMultiPhaseCheck(...)` as the explicit outlet configuration rather than inheriting it from an arbitrary inlet
- add a `StaticMixer` permutation regression with a low-flow MEG stream and bulk wet gas registered in both orders

Fixes #3085

## Verification
- `./mvnw test -Dtest=StaticMixerTest#testInletOrderDoesNotChangeDominantTemplateOrMultiphaseConfiguration`
- `./mvnw test -Dtest=StaticMixerTest`
- `./mvnw spotless:check`