### PR TITLE
fix(process): make Mixer fully inlet-order invariant

### DIFF
--- a/docs/process/equipment/mixers_splitters.md
+++ b/docs/process/equipment/mixers_splitters.md
@@ -12,7 +12,7 @@ thermodynamic state or composition. The public classes are in
 | Class | Use |
 | --- | --- |
 | `Mixer` | Combine two or more streams and calculate an outlet state |
-| `StaticMixer` | Use the alternative static-mixing implementation |
+| `StaticMixer` | Backward-compatible class name for the standard `Mixer` implementation |
 | `Splitter` | Divide one stream by relative factors or specified outlet flow rates |
 
 The stream accessors return `StreamInterface`. Keep that interface type unless a downstream API
@@ -81,6 +81,12 @@ double mixedTemperatureC = mixedGas.getTemperature("C");
 
 The example produces $8000\ \mathrm{kg/h}$. A focused documentation test verifies the flow,
 enthalpy closure, component result, and pressure diagnostics.
+
+The mixed result is independent of the order in which inlets are added. NeqSim uses the active
+inlet with the largest mass flow as the thermodynamic template and resolves equal-flow ties from
+the streams' thermodynamic configuration rather than their insertion position. Multiphase
+checking is retained when any active inlet requests it, unless it is explicitly disabled on the
+mixer with `setMultiPhaseCheck(false)`.
 
 ### Pressure behavior and diagnostics
 

--- a/src/main/java/neqsim/process/equipment/mixer/Mixer.java
+++ b/src/main/java/neqsim/process/equipment/mixer/Mixer.java
@@ -6,6 +6,7 @@ import java.text.DecimalFormat;
 import java.text.FieldPosition;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import javax.swing.JDialog;
@@ -59,6 +60,8 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface, 
   protected ArrayList<StreamInterface> streams = new ArrayList<StreamInterface>(0);
   private int numberOfInputStreams = 0;
   protected StreamInterface mixedStream;
+  /** Inlet cloned as the thermodynamic template for the current run. */
+  private int templateStreamIndex = 0;
   private boolean isSetOutTemperature = false;
   private double outTemperature = Double.NaN;
   double lowestPressure = Double.NEGATIVE_INFINITY;
@@ -222,9 +225,13 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface, 
       }
     }
 
-    // Process ALL streams starting from k=1 (k=0 is already cloned into mixedStream)
-    // but ensure first stream's components are also explicitly added if needed
-    for (int k = 1; k < streams.size(); k++) {
+    // The selected thermodynamic template is already cloned into mixedStream. Add every
+    // other active inlet in canonical order so permuting addStream calls cannot change the
+    // inventory accumulation order.
+    for (int k : getCanonicalStreamIndices(true)) {
+      if (k == templateStreamIndex) {
+        continue;
+      }
       // Skip streams with negligible flow to avoid mixing in zero/negative moles
       if (streams.get(k).getFlowRate("kg/hr") <= getMinimumFlow()) {
         continue;
@@ -296,6 +303,86 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface, 
   }
 
   /**
+   * Return inlet indices in a deterministic thermodynamic order.
+   *
+   * <p>
+   * The active inlet with the largest mass flow is ranked first because it normally provides the most representative
+   * thermodynamic model and component slate for the mixture. Equal-flow candidates are ranked by a stable fingerprint
+   * of their thermodynamic configuration and stream name instead of their insertion position.
+   * </p>
+   *
+   * @param activeOnly whether to exclude streams at or below the minimum flow threshold
+   * @return canonically ordered inlet indices
+   */
+  private List<Integer> getCanonicalStreamIndices(boolean activeOnly) {
+    List<Integer> indices = new ArrayList<Integer>();
+    for (int streamIndex = 0; streamIndex < streams.size(); streamIndex++) {
+      if (!activeOnly || streams.get(streamIndex).getFlowRate("kg/hr") > getMinimumFlow()) {
+        indices.add(streamIndex);
+      }
+    }
+    Collections.sort(indices, new Comparator<Integer>() {
+      @Override
+      public int compare(Integer firstIndex, Integer secondIndex) {
+        return compareTemplateCandidates(secondIndex, firstIndex);
+      }
+    });
+    return indices;
+  }
+
+  /**
+   * Compare two candidate thermodynamic templates without using inlet position.
+   *
+   * @param firstIndex first inlet index
+   * @param secondIndex second inlet index
+   * @return positive when the first candidate is preferred
+   */
+  private int compareTemplateCandidates(int firstIndex, int secondIndex) {
+    StreamInterface firstStream = streams.get(firstIndex);
+    StreamInterface secondStream = streams.get(secondIndex);
+    int comparison = Double.compare(firstStream.getFlowRate("kg/hr"), secondStream.getFlowRate("kg/hr"));
+    if (comparison != 0) {
+      return comparison;
+    }
+
+    SystemInterface firstSystem = firstStream.getThermoSystem();
+    SystemInterface secondSystem = secondStream.getThermoSystem();
+    comparison = Integer.compare(firstSystem.getNumberOfComponents(), secondSystem.getNumberOfComponents());
+    if (comparison != 0) {
+      return comparison;
+    }
+    return getTemplateFingerprint(firstStream).compareTo(getTemplateFingerprint(secondStream));
+  }
+
+  /**
+   * Build a stable tie-break fingerprint for otherwise equally ranked inlet templates.
+   *
+   * @param stream inlet stream
+   * @return fingerprint based on public thermodynamic configuration and state
+   */
+  private String getTemplateFingerprint(StreamInterface stream) {
+    SystemInterface system = stream.getThermoSystem();
+    StringBuilder fingerprint = new StringBuilder();
+    fingerprint.append(system.getClass().getName()).append('|');
+    fingerprint.append(system.getModelName()).append('|');
+    fingerprint.append(system.getMixingRule()).append('|');
+    fingerprint.append(system.doMultiPhaseCheck()).append('|');
+    fingerprint.append(system.getTemperature()).append('|');
+    fingerprint.append(system.getPressure()).append('|');
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      fingerprint.append(component.getName()).append(':');
+      fingerprint.append(component.getz()).append(':');
+      fingerprint.append(component.getMolarMass()).append(':');
+      fingerprint.append(component.getNormalLiquidDensity()).append(':');
+      fingerprint.append(component.isIsTBPfraction()).append(':');
+      fingerprint.append(component.isIsPlusFraction()).append('|');
+    }
+    fingerprint.append(stream.getName());
+    return fingerprint.toString();
+  }
+
+  /**
    * Whether the last mix collapsed active inlets of materially different pressure to the lowest one. Correct physics,
    * but usually a sign that an upstream unit (e.g. a compressor) did not reach its target discharge pressure.
    *
@@ -361,7 +448,7 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface, 
    */
   public double guessTemperature() {
     double gtemp = 0;
-    for (int k = 0; k < streams.size(); k++) {
+    for (int k : getCanonicalStreamIndices(true)) {
       gtemp += streams.get(k).getThermoSystem().getTemperature() * streams.get(k).getThermoSystem().getNumberOfMoles()
           / mixedStream.getThermoSystem().getNumberOfMoles();
     }
@@ -375,11 +462,9 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface, 
    */
   public double calcMixStreamEnthalpy() {
     double enthalpy = 0;
-    for (int k = 0; k < streams.size(); k++) {
-      if (streams.get(k).getFlowRate("kg/hr") > getMinimumFlow()) {
-        streams.get(k).getThermoSystem().init(2);
-        enthalpy += streams.get(k).getThermoSystem().getEnthalpy();
-      }
+    for (int k : getCanonicalStreamIndices(true)) {
+      streams.get(k).getThermoSystem().init(2);
+      enthalpy += streams.get(k).getThermoSystem().getEnthalpy();
     }
     return enthalpy;
   }
@@ -483,17 +568,15 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface, 
     // ((Stream) streams.get(0)).getThermoSystem().display();
 
     // Check if all streams have zero/negligible flow
-    boolean hasFlow = false;
-    for (int k = 0; k < streams.size(); k++) {
-      if (streams.get(k).getFlowRate("kg/hr") > getMinimumFlow()) {
-        hasFlow = true;
-        break;
-      }
-    }
+    List<Integer> activeStreamIndices = getCanonicalStreamIndices(true);
+    boolean hasFlow = !activeStreamIndices.isEmpty();
 
     if (!hasFlow) {
-      // All streams have zero flow - set mixer inactive and use first stream as template
-      SystemInterface thermoSystem2 = streams.get(0).getThermoSystem().clone();
+      // All streams have zero flow. Use the same deterministic template ranking as an active
+      // mix so inlet insertion order does not leak into the inactive outlet state.
+      List<Integer> allStreamIndices = getCanonicalStreamIndices(false);
+      templateStreamIndex = allStreamIndices.get(0);
+      SystemInterface thermoSystem2 = streams.get(templateStreamIndex).getThermoSystem().clone();
       // Set all component moles to zero to reflect no flow
       for (int i = 0; i < thermoSystem2.getPhase(0).getNumberOfComponents(); i++) {
         thermoSystem2.getPhase(0).getComponent(i).setNumberOfmoles(0.0);
@@ -504,11 +587,13 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface, 
       return;
     }
 
-    boolean inletMultiPhaseCheck = streams.get(0).getThermoSystem().doMultiPhaseCheck();
-    SystemInterface thermoSystem2 = streams.get(0).getThermoSystem().clone();
-    if (!doMultiPhaseCheck) {
-      thermoSystem2.setMultiPhaseCheck(false);
+    templateStreamIndex = activeStreamIndices.get(0);
+    boolean inletMultiPhaseCheck = false;
+    for (int streamIndex : activeStreamIndices) {
+      inletMultiPhaseCheck |= streams.get(streamIndex).getThermoSystem().doMultiPhaseCheck();
     }
+    SystemInterface thermoSystem2 = streams.get(templateStreamIndex).getThermoSystem().clone();
+    thermoSystem2.setMultiPhaseCheck(doMultiPhaseCheck && inletMultiPhaseCheck);
     isActive(true);
     // System.out.println("total number of moles " +
     // thermoSystem2.getTotalNumberOfMoles());
@@ -562,10 +647,6 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface, 
         mixedStream.getThermoSystem().initProperties();
         isActive(false);
       }
-    }
-
-    if (inletMultiPhaseCheck) {
-      mixedStream.getThermoSystem().setMultiPhaseCheck(true);
     }
 
     finishRun(id);

--- a/src/test/java/neqsim/process/equipment/mixer/MixerTest.java
+++ b/src/test/java/neqsim/process/equipment/mixer/MixerTest.java
@@ -3,12 +3,16 @@ package neqsim.process.equipment.mixer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
 import neqsim.thermo.system.SystemSrkEos;
 
 /**
@@ -345,5 +349,132 @@ class MixerTest {
     double[] molarComposition = testMixer.getThermoSystem().getMolarComposition();
     assertEquals(0.5, molarComposition[0], 1e-6);
     assertEquals(0.5, molarComposition[1], 1e-6);
+  }
+
+  @Test
+  void testInletOrderPermutationsProduceEquivalentMultiphaseState() {
+    List<int[]> permutations = Arrays.asList(new int[] { 0, 1, 2 }, new int[] { 0, 2, 1 }, new int[] { 1, 0, 2 },
+        new int[] { 1, 2, 0 }, new int[] { 2, 0, 1 }, new int[] { 2, 1, 0 });
+    SystemInterface reference = null;
+
+    for (int mixerType = 0; mixerType < 2; mixerType++) {
+      for (int[] permutation : permutations) {
+        Stream[] inlets = createMultiphasePermutationInlets();
+        Mixer mixer = mixerType == 0 ? new Mixer("permuted mixer") : new StaticMixer("permuted static mixer");
+        for (int inletIndex : permutation) {
+          mixer.addStream(inlets[inletIndex]);
+        }
+
+        mixer.run();
+        inlets[1].setFlowRate(0.1, "kg/hr");
+        inlets[1].run();
+        mixer.run();
+
+        SystemInterface actual = mixer.getOutletStream().getFluid();
+        assertTrue(actual.doMultiPhaseCheck(),
+            "the mixed system must retain multiphase checking requested by any active inlet");
+        assertTrue(actual.hasPhaseType("gas"));
+        assertEquals(0.0, mixer.getMassBalance("kg/hr"), 1.0e-6);
+
+        if (reference == null) {
+          reference = actual.clone();
+        } else {
+          assertEquivalentThermodynamicState(reference, actual);
+        }
+      }
+    }
+  }
+
+  @Test
+  void testEqualFlowTemplateTieDoesNotUseInsertionOrder() {
+    SystemSrkEos richFluid = new SystemSrkEos(310.15, 40.0);
+    richFluid.addComponent("methane", 0.7);
+    richFluid.addComponent("ethane", 0.3);
+    richFluid.setMixingRule(1);
+
+    SystemSrkEos leanFluid = new SystemSrkEos(310.15, 40.0);
+    leanFluid.addComponent("methane", 0.9);
+    leanFluid.addComponent("ethane", 0.1);
+    leanFluid.setMixingRule(2);
+
+    Stream rich = new Stream("equal-flow rich gas", richFluid);
+    rich.setFlowRate(100.0, "kg/hr");
+    rich.run();
+    Stream lean = new Stream("equal-flow lean gas", leanFluid);
+    lean.setFlowRate(100.0, "kg/hr");
+    lean.run();
+
+    Mixer forward = new Mixer("forward equal-flow mixer");
+    forward.addStream(rich);
+    forward.addStream(lean);
+    forward.run();
+
+    Mixer reverse = new Mixer("reverse equal-flow mixer");
+    reverse.addStream(lean);
+    reverse.addStream(rich);
+    reverse.run();
+
+    assertEquals(forward.getThermoSystem().getMixingRule(), reverse.getThermoSystem().getMixingRule());
+    assertEquivalentThermodynamicState(forward.getThermoSystem(), reverse.getThermoSystem());
+  }
+
+  private static Stream[] createMultiphasePermutationInlets() {
+    SystemInterface gasFluid = new SystemSrkCPAstatoil(278.45, 37.21325);
+    gasFluid.addComponent("methane", 5.0);
+    gasFluid.addComponent("water", 0.11833608283886514);
+    gasFluid.addComponent("MEG", 0.0);
+    gasFluid.setMixingRule(10);
+    gasFluid.setMultiPhaseCheck(true);
+
+    SystemInterface megFluid = gasFluid.clone();
+    megFluid.setMolarComposition(new double[] { 0.0, 0.1099744114900417, 0.8900255885099583 });
+    megFluid.setMultiPhaseCheck(false);
+
+    SystemInterface waterFluid = gasFluid.clone();
+    waterFluid.setMolarComposition(new double[] { 0.0, 1.0, 0.0 });
+    waterFluid.setMultiPhaseCheck(false);
+
+    Stream gas = new Stream("bulk gas", gasFluid);
+    gas.setFlowRate(168958.0, "Sm3/hr");
+    gas.setTemperature(29.0, "C");
+    gas.setPressure(74.1, "barg");
+    gas.run();
+
+    Stream meg = new Stream("lean MEG", megFluid);
+    meg.setFlowRate(0.01, "kg/hr");
+    meg.setTemperature(29.0, "C");
+    meg.setPressure(74.1, "barg");
+    meg.run();
+
+    Stream water = new Stream("trim water", waterFluid);
+    water.setFlowRate(0.02, "kg/hr");
+    water.setTemperature(29.0, "C");
+    water.setPressure(74.1, "barg");
+    water.run();
+    return new Stream[] { gas, meg, water };
+  }
+
+  private static void assertEquivalentThermodynamicState(SystemInterface expected, SystemInterface actual) {
+    assertEquals(expected.getTemperature("K"), actual.getTemperature("K"), 1.0e-8);
+    assertEquals(expected.getPressure("bara"), actual.getPressure("bara"), 1.0e-10);
+    assertEquals(expected.getFlowRate("kg/hr"), actual.getFlowRate("kg/hr"),
+        Math.abs(expected.getFlowRate("kg/hr")) * 1.0e-10);
+    assertEquals(expected.getTotalNumberOfMoles(), actual.getTotalNumberOfMoles(),
+        Math.abs(expected.getTotalNumberOfMoles()) * 1.0e-10);
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    assertEquals(expected.getNumberOfComponents(), actual.getNumberOfComponents());
+    for (int componentIndex = 0; componentIndex < expected.getNumberOfComponents(); componentIndex++) {
+      String componentName = expected.getComponent(componentIndex).getName();
+      assertEquals(expected.getComponent(componentName).getz(), actual.getComponent(componentName).getz(), 1.0e-12,
+          componentName + " overall composition must be inlet-order invariant");
+      assertEquals(expected.getComponent(componentName).getNumberOfmoles(),
+          actual.getComponent(componentName).getNumberOfmoles(),
+          Math.abs(expected.getComponent(componentName).getNumberOfmoles()) * 1.0e-10,
+          componentName + " inventory must be inlet-order invariant");
+    }
+    for (int phaseIndex = 0; phaseIndex < expected.getNumberOfPhases(); phaseIndex++) {
+      assertEquals(expected.getPhase(phaseIndex).getType(), actual.getPhase(phaseIndex).getType());
+      assertEquals(expected.getPhase(phaseIndex).getBeta(), actual.getPhase(phaseIndex).getBeta(), 1.0e-10);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- choose the thermodynamic template from a canonical active-inlet order: highest mass flow first, with thermodynamic fingerprint and stream name resolving equal-flow ties
- add every non-template inlet in the same canonical order and use the canonical template for zero-flow states
- retain multiphase checking when any active inlet requests it, while preserving the explicit `Mixer.setMultiPhaseCheck(false)` override
- document the template and multiphase behavior and correct the stale `StaticMixer` capability description

This keeps optimized/parallel `ProcessSystem` execution unchanged. It adds only small inlet-ordering work and does not add a TP/PH flash.

Compared with #3092, this also covers three-inlet permutations, repeated execution after changing MEG flow, equal-flow template ties, component inventory, phase state, and the all-inactive path. It avoids enabling expensive multiphase checks when every active inlet has disabled them.

Closes #3085.

## Regression evidence

The new regressions fail on current `master`:

- MEG/water/gas permutation: the mixed system inherits `false` multiphase checking from inlet 0
- equal-flow tie: reversed inlets select different mixing rules (`NO` versus `CLASSIC`)

With this change, all six permutations of three inlets produce equivalent results for both `Mixer` and `StaticMixer`, including a second solve after the MEG flow changes.

## Validation

- Java 8-target compilation of changed production and test classes with Eclipse compiler 3.41.0: passed
- mixer package: 25 tests passed, 0 failed
- `python devtools/run_spotless.py apply`: passed
- `python devtools/run_spotless.py check`: passed
- `pre-commit run --all-files --hook-stage pre-commit`: passed
- `pre-commit run --all-files --hook-stage pre-push`: passed
- `python devtools/check_documentation_search.py`: passed (654 Markdown pages and one standalone HTML page)
- full repository Maven suite: pending GitHub CI

## Documentation impact

Updated `docs/process/equipment/mixers_splitters.md` for deterministic template selection, multiphase propagation, and `StaticMixer` compatibility semantics.
