### PR TITLE
[AI-Assisted] test(docs): fix calculator graph source contract

### DIFF
--- a/docs/test_calculator_documentation.py
+++ b/docs/test_calculator_documentation.py
@@ -202,7 +202,8 @@ class CalculatorDocumentationContractTest(unittest.TestCase):
         for contract in (
             "if (unit instanceof Calculator)",
             "((Calculator) unit).getOutputVariable()",
-            "collectCalculatorInputsAndCreateEdges",
+            "for (ProcessEquipmentInterface inputEquip : calc.getInputVariable())",
+            "addSignalEdgeIfAbsent(graph, signalSource, calc",
         ):
             with self.subTest(contract=contract):
                 self.assertIn(contract, self.graph_builder)


### PR DESCRIPTION
## D065 follow-up

Repairs the single attributable documentation-contract failure introduced by merged #3097.

Exact base: `9cd315bb6ca977661c97be98ee9f2df4a072cb0a`  
Head: `30dfc6bc5988f83e04ea58bf3356d64d697056d1`

The new test asserted an invented helper name, `collectCalculatorInputsAndCreateEdges`. Current `ProcessGraphBuilder` creates the dependency inline. This replaces that one brittle assertion with the two exact implementation contracts: the `calc.getInputVariable()` loop and `addSignalEdgeIfAbsent(graph, signalSource, calc`.

The failed #3097 workflow ran 66 documentation contracts with exactly one failure; the other 65 passed. Pre-commit and Spotless passed. The documented behavior is independently covered by `CalculatorRecycleHybridExecutionTest`.

**VALIDATION PENDING CI:** exact-head documentation contracts/search/Jekyll and all other hosted checks must complete. No local result is claimed. No documentation prose, Java source, runtime behavior, dependencies, outputs, or Huldra integration changes. Advances #2499 D065; the ledger remains in progress until merged and audited.