### PR TITLE
[AI-Assisted] feat(diagram): add fixed-port routing

### DIFF
--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -89,6 +89,34 @@ fixtures, accountable discipline review, and separate qualification evidence. Ex
 DOT/Graphviz, controlled-document JSON, DEXPI 2.0, and Proteus/P&ID outputs do not consume this
 register and remain unchanged.
 
+## Fixed-port orthogonal routing
+
+Native rendering retains `RoutingMode.LEGACY_CENTER` by default, so every existing constructor keeps
+the previous center-to-center SVG/PDF bytes and visual fingerprints. Select
+`RoutingMode.FIXED_PORT_ORTHOGONAL` through the additive renderer constructors when a controlled
+drawing view needs explicit canonical port geometry:
+
+```java
+NativeEngineeringDiagramRenderer renderer =
+    new NativeEngineeringDiagramRenderer(
+        documents, NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL);
+NativeEngineeringDiagramRenderer.Result result = renderer.render();
+```
+
+The opt-in mode resolves each connection's stable `sourceEndpointId` and `targetEndpointId`, anchors
+the corresponding port/nozzle at the left or right bound of its owner symbol, and exposes the endpoint
+identity on the SVG port marker. Port slots are sorted by stable identity. Branches therefore retain
+distinct anchors, connections between the same owner pair receive deterministic parallel lanes, and
+declared recycle or backward connections receive a deterministic orthogonal return path. Reciprocal
+off-page connectors remain the cross-sheet boundary, while a reviewed protected route remains
+authoritative and is never replaced by automatic routing.
+
+`DIAGRAM_RENDER_FIXED_PORT_UNRESOLVED` reports a malformed endpoint that cannot resolve to an owner.
+A valid peer owner absent from an off-page connection's current sheet is expected and does not create a
+false warning. Fixed-port routing is deterministic proposal geometry; it is not obstacle-optimal,
+standards-qualified, or drawing-approved. Projects should retain protected routes where accountable
+layout refinement is required.
+
 ## Java example
 
 ```java

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -407,9 +407,11 @@ public final class NativeEngineeringDiagramRenderer {
       }
     }
     Map<String, Point> endpointAnchors = routingMode == RoutingMode.FIXED_PORT_ORTHOGONAL
-        ? fixedPortAnchors(sheet, positions, objects, diagnostics) : Collections.<String, Point>emptyMap();
+        ? fixedPortAnchors(sheet, positions, objects, diagnostics)
+        : Collections.<String, Point>emptyMap();
     Map<String, Double> routeLanes = routingMode == RoutingMode.FIXED_PORT_ORTHOGONAL
-        ? parallelRouteLanes(sheet, objects) : Collections.<String, Double>emptyMap();
+        ? parallelRouteLanes(sheet, objects)
+        : Collections.<String, Double>emptyMap();
 
     List<String> ids = new ArrayList<String>(sheet.getObjectNodeIds());
     Collections.sort(ids);
@@ -619,8 +621,7 @@ public final class NativeEngineeringDiagramRenderer {
       }
       String sourceOwner = endpointOwnerId(connection, "sourceEndpointId", objects);
       String targetOwner = endpointOwnerId(connection, "targetEndpointId", objects);
-      String key = sourceOwner + "|" + targetOwner + "|"
-          + stringProperty(connection, "connectionType", "MATERIAL");
+      String key = sourceOwner + "|" + targetOwner + "|" + stringProperty(connection, "connectionType", "MATERIAL");
       List<String> ids = connectionIdsByOwnerPair.get(key);
       if (ids == null) {
         ids = new ArrayList<String>();
@@ -632,8 +633,7 @@ public final class NativeEngineeringDiagramRenderer {
     for (List<String> ids : connectionIdsByOwnerPair.values()) {
       Collections.sort(ids);
       for (int index = 0; index < ids.size(); index++) {
-        result.put(ids.get(index),
-            Double.valueOf((index - (ids.size() - 1) / 2.0) * PARALLEL_LANE_SPACING));
+        result.put(ids.get(index), Double.valueOf((index - (ids.size() - 1) / 2.0) * PARALLEL_LANE_SPACING));
       }
     }
     return result;

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -586,10 +586,14 @@ public final class NativeEngineeringDiagramRenderer {
     String endpointId = stringProperty(connection, property, "");
     SemanticObject endpoint = objects.get(endpointId);
     String ownerId = endpoint == null ? "" : stringProperty(endpoint, "ownerNodeId", "");
-    if (endpointId.isEmpty() || ownerId.isEmpty() || !positions.containsKey(ownerId)) {
+    if (endpointId.isEmpty() || ownerId.isEmpty()) {
       diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_FIXED_PORT_UNRESOLVED",
-          "Canonical endpoint cannot be anchored to a visible owner symbol; center routing fallback is retained",
+          "Canonical endpoint cannot be resolved to an owner symbol; center routing fallback is retained",
           endpointId.isEmpty() ? connection.getId() : endpointId));
+      return;
+    }
+    if (!positions.containsKey(ownerId)) {
+      // The peer owner of a valid off-page connection is intentionally absent from this sheet.
       return;
     }
     String role = source ? "source" : "target";

--- a/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRenderer.java
@@ -49,6 +49,9 @@ public final class NativeEngineeringDiagramRenderer {
   private static final double TITLE_BLOCK_HEIGHT = 30.0;
   private static final double OBJECT_WIDTH = 34.0;
   private static final double OBJECT_HEIGHT = 16.0;
+  private static final double PORT_MARKER_SIZE = 1.8;
+  private static final double PORT_SLOT_MARGIN = 2.0;
+  private static final double PARALLEL_LANE_SPACING = 4.0;
 
   /** Controlled paper sizes supported by the native renderer. */
   public enum SheetFormat {
@@ -74,6 +77,21 @@ public final class NativeEngineeringDiagramRenderer {
     public double getHeightMillimetres() {
       return heightMillimetres;
     }
+  }
+
+  /** Connection-routing behavior. */
+  public enum RoutingMode {
+    /** Byte-compatible center-to-center routing used by the original native renderer. */
+    LEGACY_CENTER,
+    /**
+     * Orthogonal routing from stable canonical port/nozzle identities at their owner-symbol bounds.
+     *
+     * <p>
+     * Parallel owner pairs receive deterministic lanes and recycle/backward connections receive a deterministic return
+     * path. Protected project routes remain authoritative.
+     * </p>
+     */
+    FIXED_PORT_ORTHOGONAL
   }
 
   /** Renderer diagnostic severity. */
@@ -180,6 +198,7 @@ public final class NativeEngineeringDiagramRenderer {
   private final EngineeringDiagramDocumentSet documentSet;
   private final SheetFormat format;
   private final EngineeringDiagramConventionRegister conventionRegister;
+  private final RoutingMode routingMode;
 
   /**
    * Creates an A3-landscape native renderer using byte-compatible legacy rectangle defaults.
@@ -187,7 +206,7 @@ public final class NativeEngineeringDiagramRenderer {
    * @param documentSet immutable controlled engineering-diagram document set
    */
   public NativeEngineeringDiagramRenderer(EngineeringDiagramDocumentSet documentSet) {
-    this(documentSet, SheetFormat.A3_LANDSCAPE, new EngineeringDiagramConventionRegister());
+    this(documentSet, SheetFormat.A3_LANDSCAPE, new EngineeringDiagramConventionRegister(), RoutingMode.LEGACY_CENTER);
   }
 
   /**
@@ -197,7 +216,29 @@ public final class NativeEngineeringDiagramRenderer {
    * @param format paper geometry
    */
   public NativeEngineeringDiagramRenderer(EngineeringDiagramDocumentSet documentSet, SheetFormat format) {
-    this(documentSet, format, new EngineeringDiagramConventionRegister());
+    this(documentSet, format, new EngineeringDiagramConventionRegister(), RoutingMode.LEGACY_CENTER);
+  }
+
+  /**
+   * Creates an A3-landscape renderer with explicit routing behavior and legacy symbol defaults.
+   *
+   * @param documentSet immutable controlled engineering-diagram document set
+   * @param routingMode connection-routing behavior
+   */
+  public NativeEngineeringDiagramRenderer(EngineeringDiagramDocumentSet documentSet, RoutingMode routingMode) {
+    this(documentSet, SheetFormat.A3_LANDSCAPE, new EngineeringDiagramConventionRegister(), routingMode);
+  }
+
+  /**
+   * Creates a renderer with explicit sheet geometry and routing behavior.
+   *
+   * @param documentSet immutable controlled engineering-diagram document set
+   * @param format paper geometry
+   * @param routingMode connection-routing behavior
+   */
+  public NativeEngineeringDiagramRenderer(EngineeringDiagramDocumentSet documentSet, SheetFormat format,
+      RoutingMode routingMode) {
+    this(documentSet, format, new EngineeringDiagramConventionRegister(), routingMode);
   }
 
   /**
@@ -208,7 +249,19 @@ public final class NativeEngineeringDiagramRenderer {
    */
   public NativeEngineeringDiagramRenderer(EngineeringDiagramDocumentSet documentSet,
       EngineeringDiagramConventionRegister conventionRegister) {
-    this(documentSet, SheetFormat.A3_LANDSCAPE, conventionRegister);
+    this(documentSet, SheetFormat.A3_LANDSCAPE, conventionRegister, RoutingMode.LEGACY_CENTER);
+  }
+
+  /**
+   * Creates an A3-landscape renderer with project symbol conventions and explicit routing behavior.
+   *
+   * @param documentSet immutable controlled engineering-diagram document set
+   * @param conventionRegister evidence-bearing project symbol conventions
+   * @param routingMode connection-routing behavior
+   */
+  public NativeEngineeringDiagramRenderer(EngineeringDiagramDocumentSet documentSet,
+      EngineeringDiagramConventionRegister conventionRegister, RoutingMode routingMode) {
+    this(documentSet, SheetFormat.A3_LANDSCAPE, conventionRegister, routingMode);
   }
 
   /**
@@ -226,6 +279,19 @@ public final class NativeEngineeringDiagramRenderer {
    */
   public NativeEngineeringDiagramRenderer(EngineeringDiagramDocumentSet documentSet, SheetFormat format,
       EngineeringDiagramConventionRegister conventionRegister) {
+    this(documentSet, format, conventionRegister, RoutingMode.LEGACY_CENTER);
+  }
+
+  /**
+   * Creates a renderer with explicit sheet geometry, project symbol conventions and routing behavior.
+   *
+   * @param documentSet immutable controlled engineering-diagram document set
+   * @param format paper geometry
+   * @param conventionRegister evidence-bearing project symbol conventions
+   * @param routingMode connection-routing behavior
+   */
+  public NativeEngineeringDiagramRenderer(EngineeringDiagramDocumentSet documentSet, SheetFormat format,
+      EngineeringDiagramConventionRegister conventionRegister, RoutingMode routingMode) {
     if (documentSet == null) {
       throw new IllegalArgumentException("documentSet must not be null");
     }
@@ -235,9 +301,13 @@ public final class NativeEngineeringDiagramRenderer {
     if (conventionRegister == null) {
       throw new IllegalArgumentException("conventionRegister must not be null");
     }
+    if (routingMode == null) {
+      throw new IllegalArgumentException("routingMode must not be null");
+    }
     this.documentSet = documentSet;
     this.format = format;
     this.conventionRegister = conventionRegister;
+    this.routingMode = routingMode;
   }
 
   /**
@@ -336,6 +406,10 @@ public final class NativeEngineeringDiagramRenderer {
             route.getSemanticConnectionId()));
       }
     }
+    Map<String, Point> endpointAnchors = routingMode == RoutingMode.FIXED_PORT_ORTHOGONAL
+        ? fixedPortAnchors(sheet, positions, objects, diagnostics) : Collections.<String, Point>emptyMap();
+    Map<String, Double> routeLanes = routingMode == RoutingMode.FIXED_PORT_ORTHOGONAL
+        ? parallelRouteLanes(sheet, objects) : Collections.<String, Double>emptyMap();
 
     List<String> ids = new ArrayList<String>(sheet.getObjectNodeIds());
     Collections.sort(ids);
@@ -345,8 +419,9 @@ public final class NativeEngineeringDiagramRenderer {
         diagnostics.add(diagnostic(Severity.ERROR, "DIAGRAM_RENDER_BROKEN_OBJECT_REFERENCE",
             "Controlled sheet references a semantic object that is absent from the document set", id));
       } else if (isConnection(object.getKind())) {
-        addConnection(page, object, positions, connectors.get(id), protectedRoutes.get(id), objects, contentRight,
-            contentBottom, diagnostics);
+        addConnection(page, object, positions, endpointAnchors, connectors.get(id), protectedRoutes.get(id), objects,
+            contentRight, contentBottom, routeLanes.containsKey(id) ? routeLanes.get(id).doubleValue() : 0.0,
+            diagnostics);
       }
     }
     addRouteQualityDiagnostics(page, positions, diagnostics);
@@ -360,6 +435,7 @@ public final class NativeEngineeringDiagramRenderer {
         addObject(page, object, position);
       }
     }
+    addPortMarkers(page, endpointAnchors);
     addTitleBlock(page, drawing, sheet);
     return page;
   }
@@ -473,9 +549,121 @@ public final class NativeEngineeringDiagramRenderer {
     return result;
   }
 
+  private Map<String, Point> fixedPortAnchors(Sheet sheet, Map<String, Point> positions,
+      Map<String, SemanticObject> objects, List<Diagnostic> diagnostics) {
+    Map<String, List<String>> anchorKeysByOwnerSide = new TreeMap<String, List<String>>();
+    List<String> connectionIds = new ArrayList<String>(sheet.getObjectNodeIds());
+    Collections.sort(connectionIds);
+    for (String connectionId : connectionIds) {
+      SemanticObject connection = objects.get(connectionId);
+      if (connection == null || !isConnection(connection.getKind())) {
+        continue;
+      }
+      collectPortAnchor(connection, "sourceEndpointId", true, positions, objects, anchorKeysByOwnerSide, diagnostics);
+      collectPortAnchor(connection, "targetEndpointId", false, positions, objects, anchorKeysByOwnerSide, diagnostics);
+    }
+    Map<String, Point> result = new TreeMap<String, Point>();
+    for (Map.Entry<String, List<String>> entry : anchorKeysByOwnerSide.entrySet()) {
+      List<String> keys = entry.getValue();
+      Collections.sort(keys);
+      String[] ownerAndSide = entry.getKey().split("\\|", 2);
+      Point owner = positions.get(ownerAndSide[0]);
+      boolean outlet = "OUTLET".equals(ownerAndSide[1]);
+      double spacing = keys.size() <= 1 ? 0.0
+          : Math.min(3.0, (OBJECT_HEIGHT - 2.0 * PORT_SLOT_MARGIN) / (keys.size() - 1));
+      for (int index = 0; index < keys.size(); index++) {
+        double offset = (index - (keys.size() - 1) / 2.0) * spacing;
+        result.put(keys.get(index),
+            new Point(owner.x + (outlet ? OBJECT_WIDTH / 2.0 : -OBJECT_WIDTH / 2.0), owner.y + offset));
+      }
+    }
+    return result;
+  }
+
+  private static void collectPortAnchor(SemanticObject connection, String property, boolean source,
+      Map<String, Point> positions, Map<String, SemanticObject> objects,
+      Map<String, List<String>> anchorKeysByOwnerSide, List<Diagnostic> diagnostics) {
+    String endpointId = stringProperty(connection, property, "");
+    SemanticObject endpoint = objects.get(endpointId);
+    String ownerId = endpoint == null ? "" : stringProperty(endpoint, "ownerNodeId", "");
+    if (endpointId.isEmpty() || ownerId.isEmpty() || !positions.containsKey(ownerId)) {
+      diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_FIXED_PORT_UNRESOLVED",
+          "Canonical endpoint cannot be anchored to a visible owner symbol; center routing fallback is retained",
+          endpointId.isEmpty() ? connection.getId() : endpointId));
+      return;
+    }
+    String role = source ? "source" : "target";
+    String anchorKey = endpointId + "|" + role;
+    String side = source ? "OUTLET" : "INLET";
+    String groupKey = ownerId + "|" + side;
+    List<String> keys = anchorKeysByOwnerSide.get(groupKey);
+    if (keys == null) {
+      keys = new ArrayList<String>();
+      anchorKeysByOwnerSide.put(groupKey, keys);
+    }
+    if (!keys.contains(anchorKey)) {
+      keys.add(anchorKey);
+    }
+  }
+
+  private static Map<String, Double> parallelRouteLanes(Sheet sheet, Map<String, SemanticObject> objects) {
+    Map<String, List<String>> connectionIdsByOwnerPair = new TreeMap<String, List<String>>();
+    for (String objectId : sheet.getObjectNodeIds()) {
+      SemanticObject connection = objects.get(objectId);
+      if (connection == null || !isConnection(connection.getKind())) {
+        continue;
+      }
+      String sourceOwner = endpointOwnerId(connection, "sourceEndpointId", objects);
+      String targetOwner = endpointOwnerId(connection, "targetEndpointId", objects);
+      String key = sourceOwner + "|" + targetOwner + "|"
+          + stringProperty(connection, "connectionType", "MATERIAL");
+      List<String> ids = connectionIdsByOwnerPair.get(key);
+      if (ids == null) {
+        ids = new ArrayList<String>();
+        connectionIdsByOwnerPair.put(key, ids);
+      }
+      ids.add(connection.getId());
+    }
+    Map<String, Double> result = new TreeMap<String, Double>();
+    for (List<String> ids : connectionIdsByOwnerPair.values()) {
+      Collections.sort(ids);
+      for (int index = 0; index < ids.size(); index++) {
+        result.put(ids.get(index),
+            Double.valueOf((index - (ids.size() - 1) / 2.0) * PARALLEL_LANE_SPACING));
+      }
+    }
+    return result;
+  }
+
+  private static void addPortMarkers(Page page, Map<String, Point> endpointAnchors) {
+    for (Map.Entry<String, Point> entry : endpointAnchors.entrySet()) {
+      Point point = entry.getValue();
+      String endpointId = entry.getKey().substring(0, entry.getKey().lastIndexOf('|'));
+      page.commands.add(Command.rect(point.x - PORT_MARKER_SIZE / 2.0, point.y - PORT_MARKER_SIZE / 2.0,
+          PORT_MARKER_SIZE, PORT_MARKER_SIZE, "#1f2937", "#ffffff", 0.5, endpointId, ""));
+    }
+  }
+
+  private static Point routedEndpointPosition(SemanticObject connection, String property, boolean source,
+      Map<String, Point> positions, Map<String, Point> endpointAnchors, Map<String, SemanticObject> objects) {
+    String endpointId = stringProperty(connection, property, "");
+    Point fixed = endpointAnchors.get(endpointId + "|" + (source ? "source" : "target"));
+    return fixed == null ? endpointPosition(connection, property, positions, objects) : fixed;
+  }
+
+  private static double recycleReturnY(Point source, Point target, double contentBottom, double laneOffset) {
+    double offset = 14.0 + Math.abs(laneOffset);
+    double above = Math.min(source.y, target.y) - offset;
+    if (above >= CONTENT_TOP + PORT_SLOT_MARGIN) {
+      return above;
+    }
+    return Math.min(contentBottom - PORT_SLOT_MARGIN, Math.max(source.y, target.y) + offset);
+  }
+
   private void addConnection(Page page, SemanticObject connection, Map<String, Point> positions,
-      OffPageConnector connector, ProtectedRoute protectedRoute, Map<String, SemanticObject> objects,
-      double contentRight, double contentBottom, List<Diagnostic> diagnostics) {
+      Map<String, Point> endpointAnchors, OffPageConnector connector, ProtectedRoute protectedRoute,
+      Map<String, SemanticObject> objects, double contentRight, double contentBottom, double laneOffset,
+      List<Diagnostic> diagnostics) {
     List<Point> points = new ArrayList<Point>();
     boolean protectedGeometry = protectedRoute != null;
     if (protectedGeometry) {
@@ -483,8 +671,8 @@ public final class NativeEngineeringDiagramRenderer {
         points.add(new Point(waypoint.getX(), waypoint.getY()));
       }
     } else {
-      Point source = endpointPosition(connection, "sourceEndpointId", positions, objects);
-      Point target = endpointPosition(connection, "targetEndpointId", positions, objects);
+      Point source = routedEndpointPosition(connection, "sourceEndpointId", true, positions, endpointAnchors, objects);
+      Point target = routedEndpointPosition(connection, "targetEndpointId", false, positions, endpointAnchors, objects);
       Point offPage = connector == null ? null : connectorPoint(connector, contentRight, contentBottom);
       if (connector != null && connector.getRole() == EngineeringDiagramDocumentSet.ConnectorRole.SOURCE) {
         target = offPage;
@@ -493,8 +681,20 @@ public final class NativeEngineeringDiagramRenderer {
       }
       if (source != null && target != null) {
         points.add(source);
-        points.add(new Point((source.x + target.x) / 2.0, source.y));
-        points.add(new Point((source.x + target.x) / 2.0, target.y));
+        if (routingMode == RoutingMode.FIXED_PORT_ORTHOGONAL
+            && (Boolean.TRUE.equals(connection.getProperties().get("recycle")) || source.x >= target.x)) {
+          double returnY = recycleReturnY(source, target, contentBottom, laneOffset);
+          double sourceTurnX = source.x + 10.0 + Math.abs(laneOffset);
+          double targetTurnX = target.x - 10.0 - Math.abs(laneOffset);
+          points.add(new Point(sourceTurnX, source.y));
+          points.add(new Point(sourceTurnX, returnY));
+          points.add(new Point(targetTurnX, returnY));
+          points.add(new Point(targetTurnX, target.y));
+        } else {
+          double middleX = (source.x + target.x) / 2.0 + laneOffset;
+          points.add(new Point(middleX, source.y));
+          points.add(new Point(middleX, target.y));
+        }
         points.add(target);
       } else {
         diagnostics.add(diagnostic(Severity.WARNING, "DIAGRAM_RENDER_CONNECTION_ENDPOINT_OMITTED",

--- a/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
@@ -3,6 +3,7 @@ package neqsim.process.processmodel.diagram;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
@@ -220,6 +221,48 @@ class NativeEngineeringDiagramRendererTest {
         assertArrayEquals(expectedPdf, result.getPdf());
       }
     }
+  }
+
+  @Test
+  void supportsOptInFixedPortOrthogonalRoutingForBranchesWithoutChangingLegacyDefault() {
+    EngineeringDiagramReferenceFixtures.SystemCase reference = EngineeringDiagramReferenceFixtures
+        .branchedSeparatorCompressionTrain();
+    ProcessSystem process = reference.getProcessSystem();
+    String classicDot = process.toDOT();
+    EngineeringDiagramDocumentSet documents = ProcessDiagramDocumentSetAdapter.fromProcessSystem(process,
+        reference.getCaseId(), "A", "PFD-NATIVE-008", "Fixed port routing reference", ContentProfile.PFD);
+
+    NativeEngineeringDiagramRenderer.Result defaultResult = new NativeEngineeringDiagramRenderer(documents).render();
+    NativeEngineeringDiagramRenderer.Result explicitLegacy = new NativeEngineeringDiagramRenderer(documents,
+        NativeEngineeringDiagramRenderer.RoutingMode.LEGACY_CENTER).render();
+    NativeEngineeringDiagramRenderer.Result first = new NativeEngineeringDiagramRenderer(documents,
+        NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL).render();
+    NativeEngineeringDiagramRenderer.Result second = new NativeEngineeringDiagramRenderer(documents,
+        NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL).render();
+    String svg = first.getSvgBySheetId().values().iterator().next();
+
+    List<String> separatorOutletIds = new ArrayList<String>();
+    for (SemanticObject object : documents.getSemanticObjects()) {
+      if (object.getKind() == EngineeringNode.Kind.PIPE_SEGMENT
+          && "20-VA-001".equals(object.getProperties().get("sourceEquipment"))) {
+        separatorOutletIds.add(String.valueOf(object.getProperties().get("sourceEndpointId")));
+      }
+    }
+
+    assertEquals(2, separatorOutletIds.size());
+    assertNotEquals(separatorOutletIds.get(0), separatorOutletIds.get(1));
+    for (String endpointId : separatorOutletIds) {
+      assertTrue(svg.contains("data-semantic-id=\"" + endpointId + "\""));
+    }
+    assertEquals(defaultResult.getSvgBySheetId(), explicitLegacy.getSvgBySheetId());
+    assertArrayEquals(defaultResult.getPdf(), explicitLegacy.getPdf());
+    assertEquals(defaultResult.getVisualFingerprintsBySheetId(), explicitLegacy.getVisualFingerprintsBySheetId());
+    assertEquals(first.getSvgBySheetId(), second.getSvgBySheetId());
+    assertArrayEquals(first.getPdf(), second.getPdf());
+    assertEquals(first.getVisualFingerprintsBySheetId(), second.getVisualFingerprintsBySheetId());
+    assertNotEquals(defaultResult.getVisualFingerprintsBySheetId(), first.getVisualFingerprintsBySheetId());
+    assertTrue(first.isComplete());
+    assertEquals(classicDot, process.toDOT());
   }
 
   private static PinnedPosition reviewedPosition(String semanticObjectId, String sheetKey, double x, double y) {

--- a/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
@@ -79,7 +79,8 @@ class NativeEngineeringDiagramRendererTest {
         "PFD-NATIVE-002", "Multi-area native drawing set", ContentProfile.PFD);
 
     NativeEngineeringDiagramRenderer.Result result = new NativeEngineeringDiagramRenderer(documents,
-        NativeEngineeringDiagramRenderer.SheetFormat.A1_LANDSCAPE).render();
+        NativeEngineeringDiagramRenderer.SheetFormat.A1_LANDSCAPE,
+        NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL).render();
     String pdf = new String(result.getPdf(), StandardCharsets.ISO_8859_1);
 
     assertEquals(4, result.getSvgBySheetId().size());
@@ -94,6 +95,7 @@ class NativeEngineeringDiagramRendererTest {
         assertTrue(svg.contains(connector.getZoneReference()));
       }
     }
+    assertFalse(hasDiagnostic(result, "DIAGRAM_RENDER_FIXED_PORT_UNRESOLVED"));
     assertTrue(result.isComplete());
   }
 
@@ -281,6 +283,7 @@ class NativeEngineeringDiagramRendererTest {
     String recycle = pointsForSemanticId(svg, "connection:recycle");
 
     assertNotEquals(firstParallel, secondParallel);
+    assertNotEquals(pointX(firstParallel, 1), pointX(secondParallel, 1));
     assertTrue(recycle.split(" ").length >= 6);
     assertEquals(first.getSvgBySheetId(), second.getSvgBySheetId());
     assertArrayEquals(first.getPdf(), second.getPdf());
@@ -330,6 +333,10 @@ class NativeEngineeringDiagramRendererTest {
     assertTrue(pointsStart >= "points=\"".length());
     assertTrue(pointsEnd > pointsStart);
     return svg.substring(pointsStart, pointsEnd);
+  }
+
+  private static String pointX(String points, int index) {
+    return points.split(" ")[index].split(",", 2)[0];
   }
 
   private static PinnedPosition reviewedPosition(String semanticObjectId, String sheetKey, double x, double y) {

--- a/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
@@ -313,10 +313,10 @@ class NativeEngineeringDiagramRendererTest {
 
   private static EngineeringNode connectionNode(String id, String sourceEndpointId, String targetEndpointId,
       String sourceEquipment, String targetEquipment, boolean recycle) {
-    return new EngineeringNode(id, EngineeringNode.Kind.PIPE_SEGMENT, id, id)
-        .putProperty("connectionType", "MATERIAL").putProperty("sourceEndpointId", sourceEndpointId)
-        .putProperty("targetEndpointId", targetEndpointId).putProperty("sourceEquipment", sourceEquipment)
-        .putProperty("targetEquipment", targetEquipment).putProperty("recycle", Boolean.valueOf(recycle));
+    return new EngineeringNode(id, EngineeringNode.Kind.PIPE_SEGMENT, id, id).putProperty("connectionType", "MATERIAL")
+        .putProperty("sourceEndpointId", sourceEndpointId).putProperty("targetEndpointId", targetEndpointId)
+        .putProperty("sourceEquipment", sourceEquipment).putProperty("targetEquipment", targetEquipment)
+        .putProperty("recycle", Boolean.valueOf(recycle));
   }
 
   private static String pointsForSemanticId(String svg, String semanticId) {

--- a/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/NativeEngineeringDiagramRendererTest.java
@@ -25,6 +25,7 @@ import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.Evidenc
 import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.PinnedPosition;
 import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.ProtectedRoute;
 import neqsim.process.engineering.model.EngineeringDiagramLayoutRegister.Waypoint;
+import neqsim.process.engineering.model.EngineeringGraph;
 import neqsim.process.engineering.model.EngineeringNode;
 import neqsim.process.processmodel.ProcessSystem;
 import org.junit.jupiter.api.Test;
@@ -263,6 +264,72 @@ class NativeEngineeringDiagramRendererTest {
     assertNotEquals(defaultResult.getVisualFingerprintsBySheetId(), first.getVisualFingerprintsBySheetId());
     assertTrue(first.isComplete());
     assertEquals(classicDot, process.toDOT());
+  }
+
+  @Test
+  void separatesParallelOwnerPairsAndReturnsRecycleRoutesDeterministically() {
+    EngineeringDiagramDocumentSet documents = EngineeringDiagramDocumentSet.fromGraph(fixedPortRoutingGraph(),
+        "PFD-NATIVE-009", "Parallel and recycle routing reference", ContentProfile.PFD);
+    NativeEngineeringDiagramRenderer.Result first = new NativeEngineeringDiagramRenderer(documents,
+        NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL).render();
+    NativeEngineeringDiagramRenderer.Result second = new NativeEngineeringDiagramRenderer(documents,
+        NativeEngineeringDiagramRenderer.RoutingMode.FIXED_PORT_ORTHOGONAL).render();
+    String svg = first.getSvgBySheetId().values().iterator().next();
+
+    String firstParallel = pointsForSemanticId(svg, "connection:parallel-1");
+    String secondParallel = pointsForSemanticId(svg, "connection:parallel-2");
+    String recycle = pointsForSemanticId(svg, "connection:recycle");
+
+    assertNotEquals(firstParallel, secondParallel);
+    assertTrue(recycle.split(" ").length >= 6);
+    assertEquals(first.getSvgBySheetId(), second.getSvgBySheetId());
+    assertArrayEquals(first.getPdf(), second.getPdf());
+    assertEquals(first.getVisualFingerprintsBySheetId(), second.getVisualFingerprintsBySheetId());
+    assertTrue(first.isComplete());
+  }
+
+  private static EngineeringGraph fixedPortRoutingGraph() {
+    EngineeringGraph graph = new EngineeringGraph("FIXED-PORT-ROUTING", "A");
+    graph.addNode(new EngineeringNode("equipment:a", EngineeringNode.Kind.EQUIPMENT, "a", "Equipment A")
+        .putProperty("equipmentName", "A"));
+    graph.addNode(new EngineeringNode("equipment:b", EngineeringNode.Kind.EQUIPMENT, "b", "Equipment B")
+        .putProperty("equipmentName", "B"));
+    graph.addNode(endpointNode("nozzle:a-out-1", "equipment:a", "OUTLET"));
+    graph.addNode(endpointNode("nozzle:a-out-2", "equipment:a", "OUTLET"));
+    graph.addNode(endpointNode("nozzle:a-in", "equipment:a", "INLET"));
+    graph.addNode(endpointNode("nozzle:b-in-1", "equipment:b", "INLET"));
+    graph.addNode(endpointNode("nozzle:b-in-2", "equipment:b", "INLET"));
+    graph.addNode(endpointNode("nozzle:b-out", "equipment:b", "OUTLET"));
+    graph.addNode(connectionNode("connection:parallel-1", "nozzle:a-out-1", "nozzle:b-in-1", "A", "B", false));
+    graph.addNode(connectionNode("connection:parallel-2", "nozzle:a-out-2", "nozzle:b-in-2", "A", "B", false));
+    graph.addNode(connectionNode("connection:recycle", "nozzle:b-out", "nozzle:a-in", "B", "A", true));
+    return graph;
+  }
+
+  private static EngineeringNode endpointNode(String id, String ownerId, String direction) {
+    return new EngineeringNode(id, EngineeringNode.Kind.NOZZLE, id, id).putProperty("ownerNodeId", ownerId)
+        .putProperty("direction", direction).putProperty("connectionType", "MATERIAL");
+  }
+
+  private static EngineeringNode connectionNode(String id, String sourceEndpointId, String targetEndpointId,
+      String sourceEquipment, String targetEquipment, boolean recycle) {
+    return new EngineeringNode(id, EngineeringNode.Kind.PIPE_SEGMENT, id, id)
+        .putProperty("connectionType", "MATERIAL").putProperty("sourceEndpointId", sourceEndpointId)
+        .putProperty("targetEndpointId", targetEndpointId).putProperty("sourceEquipment", sourceEquipment)
+        .putProperty("targetEquipment", targetEquipment).putProperty("recycle", Boolean.valueOf(recycle));
+  }
+
+  private static String pointsForSemanticId(String svg, String semanticId) {
+    String identity = "data-semantic-id=\"" + semanticId + "\"";
+    int identityIndex = svg.indexOf(identity);
+    int elementStart = svg.lastIndexOf("<polyline", identityIndex);
+    int pointsStart = svg.indexOf("points=\"", elementStart) + "points=\"".length();
+    int pointsEnd = svg.indexOf('"', pointsStart);
+    assertTrue(identityIndex >= 0);
+    assertTrue(elementStart >= 0);
+    assertTrue(pointsStart >= "points=\"".length());
+    assertTrue(pointsEnd > pointsStart);
+    return svg.substring(pointsStart, pointsEnd);
   }
 
   private static PinnedPosition reviewedPosition(String semanticObjectId, String sheetKey, double x, double y) {


### PR DESCRIPTION
## Roadmaps

Advances the next dependency-ready non-standards deterministic routing criterion shared by #1332 and #2899 after merged #3081.

Exact base: `b219f1f42a591afaa28cf89f358679cc8c42e090`
Exact current head: `2d8caa5997c60d3748fc302dd0fdf16c164030cd`
Branch: `campaign-1332-port-routing`

## Engineering question

Can the native SVG/PDF renderer use the canonical model's explicit stable port/nozzle identities for deterministic orthogonal connection geometry, including branches, parallel owner pairs and recycles, while preserving every existing constructor and byte-compatible legacy output by default?

## Complete tranche

- adds additive public `RoutingMode.LEGACY_CENTER` and `RoutingMode.FIXED_PORT_ORTHOGONAL`
- keeps every existing constructor delegated to `LEGACY_CENTER`
- adds explicit routing-mode constructor overloads, including composition with project symbol conventions and controlled sheet formats
- resolves `sourceEndpointId` / `targetEndpointId` through canonical port/nozzle owner identities
- anchors inlet/outlet markers at deterministic owner-symbol bounds with stable endpoint-slot ordering
- exposes each rendered endpoint through its stable `data-semantic-id` in SVG
- separates connections between the same owner pair into stable orthogonal lanes
- gives declared recycle or backward connections a deterministic return path
- retains reciprocal off-page connectors as cross-sheet boundaries without false unresolved-peer diagnostics
- preserves reviewed protected routes as authoritative
- reports malformed endpoint ownership through `DIAGRAM_RENDER_FIXED_PORT_UNRESOLVED`
- includes port geometry in normalized SVG/PDF visual fingerprints
- adds focused branched-process determinism, stable-port identity, legacy-byte and Classic-DOT regressions
- exercises reciprocal multi-area off-page peers in fixed mode without false unresolved-endpoint warnings
- adds synthetic canonical parallel-owner-pair lane-X and recycle-return geometry regressions
- documents the API, deterministic policy, diagnostics, compatibility and drawing-review limitations

## Compatibility and engineering boundary

Existing renderer constructors, Classic DOT/Graphviz, controlled-document JSON, DEXPI 2.0 Process, Proteus/P&ID, ProcessSystem and ProcessModel adapters are unchanged. `LEGACY_CENTER` is the default and the focused regression requires it to remain byte-identical to the previous constructor behavior.

Fixed-port routing is opt-in proposal geometry. It does not claim obstacle-optimal layout, ISO 10628/14617 conformance, project approval or accountable drawing review. Project protected routes remain the controlled refinement mechanism.

No thermodynamic calculation, physical equation, unit, process topology, stable-ID algorithm or simulation result changes.

## Validation

**VALIDATION PENDING CI**

On exact head `2d8caa5997c60d3748fc302dd0fdf16c164030cd`, PaperLab, the hosted Spotless patch gate, pre-commit, documentation search and CodeQL are green. The Java build/test/Javadoc workflow is still in progress; no result is claimed for its running platform jobs.

The previous exact head `9c483e1d4f882860d8c4b0bb614bd173801468f9` completed Javadocs and all four slow shards successfully. Its Windows fast job failed only in `TPflashHydrogenRichConsistencyTest` because the recently merged qualification matrix did not contain a stable one-phase endpoint on that platform. That test is outside this diagram diff and has a dedicated cross-platform test-matrix repair in #3102; the unrelated flash change is intentionally not duplicated here.

Local exact-head inspection used a clean checkout. `python devtools/check_documentation_search.py` passed for 654 Markdown pages and one standalone HTML page, and `git diff --check` reported no whitespace errors. Focused Maven execution could not resolve `maven-enforcer-plugin:3.6.3` because Maven Central DNS is unavailable in the sandbox, so no local compile, test or Spotless result is claimed. GitHub CI remains authoritative.

## Documentation/notebook impact

`docs/integration/engineering-diagram-document-model.md` documents selection, stable endpoint anchoring, branch/parallel/recycle behavior, protected-route/off-page precedence, diagnostics and limitations. Existing acceptance notebooks and their APIs are unchanged.

## Deliberate exclusions and stop boundary

No licensed-standard symbol catalog, standards traceability matrix, external layout-engine dependency, public API replacement, DEXPI graphical round trip, accountable P&ID approval, Huldra/public-dataset ingestion, OCR, 3D mapping or external drawing redistribution.

## Next dependency

After this tranche is merged and validated, select the next non-blocked deterministic layout/interoperability item. Qualified symbols and standards claims remain blocked on licensed/publicly distributable fixtures, traceability and accountable discipline review.