### PR TITLE
feat(optimizer): qualify process boundary constraints

### DIFF
--- a/docs/process/optimization/OPTIMIZATION_AND_CONSTRAINTS.md
+++ b/docs/process/optimization/OPTIMIZATION_AND_CONSTRAINTS.md
@@ -16,6 +16,7 @@ This document provides an integrated view of NeqSim's optimization and constrain
 - [Overview](#overview)
 - [Constraint Framework Architecture](#constraint-framework-architecture)
   - [Core Constraint Classes](#core-constraint-classes)
+  - [Process-Boundary Constraint Evidence](#process-boundary-constraint-evidence)
   - [Equipment Capacity Strategies](#equipment-capacity-strategies)
   - [Constraint Types and Severity](#constraint-types-and-severity)
 - [Optimization Framework](#optimization-framework)
@@ -144,6 +145,38 @@ CapacityConstraint speedConstraint = new CapacityConstraint("speed", "RPM", Cons
 | `isNearLimit()` | `boolean` | True if above warning threshold (default 90%) |
 | `getMargin()` | `double` | Remaining headroom (1.0 - utilization) |
 | `isEnabled()` | `boolean` | True if constraint participates in capacity analysis |
+
+### Process-Boundary Constraint Evidence
+
+`ProcessModelSimulationEvaluator` can register injection, receiving-capacity, export-capacity,
+product-quality, and nomination limits as qualified process-boundary constraints. Each completed
+operating point returns immutable `ProcessBoundaryConstraintEvidence` containing:
+
+- stable area/point/constraint identity and boundary kind;
+- flow direction and an explicit mass, molar, standard-volume, actual-volume, or energy basis;
+- physical unit, fixed bounds or target/tolerance, sampled value, and signed physical margin;
+- non-negative physical violation plus a separately scaled dimensionless violation;
+- provenance, confidence, effective-period labels, applicability, calculation status, and diagnostics.
+
+Missing, non-finite, not-calculable, or explicitly out-of-validity evidence fails a hard boundary
+constraint closed. A boundary callback is sampled exactly once after the `ProcessModel` run, and
+the resulting evidence is propagated to single-action and coupled action-set evaluations. The
+`NetworkNomination` and `NetworkQualityResult` adapters retain their existing rate-basis, quality
+method, reference-condition, margin, and provenance metadata without changing the underlying
+network or thermodynamic calculation.
+
+```java
+evaluator.addNominationConstraint(
+    "sales nomination", "export", nomination, periodIndex,
+    ProcessBoundaryConstraintEvidence.FlowDirection.OUT_OF_PROCESS,
+    model -> model.getVariableValue("export::sales gas.flowRate", "kg/hr"),
+    true, 1000.0, 1000.0, "shipper nomination");
+```
+
+The residual scale is expressed in the same physical unit as the constraint. It is used only to
+form the dimensionless optimization penalty; it never changes the reported engineering value,
+limit, or margin. These APIs qualify optimization-facing evidence and do not implement nominations,
+market settlement, gas-quality physics, injection physics, or equipment solvers.
 
 ### Equipment Capacity Strategies
 

--- a/src/main/java/neqsim/process/util/optimizer/ProcessBoundaryConstraintEvidence.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessBoundaryConstraintEvidence.java
@@ -8,8 +8,8 @@ import neqsim.process.equipment.network.NetworkQualityResult;
  * Immutable, unit-safe evidence for one process-boundary constraint at one completed operating point.
  *
  * <p>
- * Physical values and margins retain their engineering unit. {@link #getScaledViolation()} is the only
- * dimensionless quantity and is formed with the explicit positive {@link #getResidualScale()}.
+ * Physical values and margins retain their engineering unit. {@link #getScaledViolation()} is the only dimensionless
+ * quantity and is formed with the explicit positive {@link #getResidualScale()}.
  * </p>
  */
 public final class ProcessBoundaryConstraintEvidence implements Serializable {
@@ -17,36 +17,22 @@ public final class ProcessBoundaryConstraintEvidence implements Serializable {
 
   /** Boundary role. */
   public enum Kind {
-    INJECTION,
-    RECEIVING_CAPACITY,
-    EXPORT_CAPACITY,
-    PRODUCT_QUALITY,
-    NOMINATION
+    INJECTION, RECEIVING_CAPACITY, EXPORT_CAPACITY, PRODUCT_QUALITY, NOMINATION
   }
 
   /** Positive-flow direction relative to the modeled process. */
   public enum FlowDirection {
-    INTO_PROCESS,
-    OUT_OF_PROCESS,
-    BIDIRECTIONAL,
-    NOT_APPLICABLE
+    INTO_PROCESS, OUT_OF_PROCESS, BIDIRECTIONAL, NOT_APPLICABLE
   }
 
   /** Applicability of the registered validity period to this evaluation. */
   public enum ApplicabilityStatus {
-    APPLICABLE,
-    OUTSIDE_VALIDITY,
-    NOT_ASSESSED
+    APPLICABLE, OUTSIDE_VALIDITY, NOT_ASSESSED
   }
 
   /** Availability of the runtime sample used to calculate the residual. */
   public enum CalculationStatus {
-    AVAILABLE,
-    MISSING_VALUE,
-    NON_FINITE_VALUE,
-    NOT_CALCULABLE,
-    METADATA_MISMATCH,
-    OUTSIDE_VALIDITY
+    AVAILABLE, MISSING_VALUE, NON_FINITE_VALUE, NOT_CALCULABLE, METADATA_MISMATCH, OUTSIDE_VALIDITY
   }
 
   /** Immutable registration metadata, safe to retain independently of evaluator callbacks. */
@@ -203,8 +189,7 @@ public final class ProcessBoundaryConstraintEvidence implements Serializable {
     private final String diagnostic;
 
     /** Creates one immutable sample. */
-    public Sample(Double value, CalculationStatus status, Double sourceMargin, String provenance,
-        String diagnostic) {
+    public Sample(Double value, CalculationStatus status, Double sourceMargin, String provenance, String diagnostic) {
       this.value = value;
       this.status = status == null ? CalculationStatus.NOT_CALCULABLE : status;
       this.sourceMargin = sourceMargin;
@@ -220,11 +205,11 @@ public final class ProcessBoundaryConstraintEvidence implements Serializable {
     /** Adapts a network-quality result without retaining its mutable reference object. */
     public static Sample fromNetworkQualityResult(NetworkQualityResult result) {
       if (result == null) {
-        return new Sample(null, CalculationStatus.NOT_CALCULABLE, null, null,
-            "Network quality result was null");
+        return new Sample(null, CalculationStatus.NOT_CALCULABLE, null, null, "Network quality result was null");
       }
       CalculationStatus calculationStatus = result.getStatus() == NetworkQualityResult.Status.NOT_CALCULABLE
-          ? CalculationStatus.NOT_CALCULABLE : CalculationStatus.AVAILABLE;
+          ? CalculationStatus.NOT_CALCULABLE
+          : CalculationStatus.AVAILABLE;
       return new Sample(result.getValue(), calculationStatus, result.getMargin(), result.getProvenance(),
           result.getMessage());
     }
@@ -274,8 +259,8 @@ public final class ProcessBoundaryConstraintEvidence implements Serializable {
   private final String diagnostic;
 
   /** Creates one evaluated evidence row. */
-  ProcessBoundaryConstraintEvidence(Metadata metadata,
-      ProcessModelSimulationEvaluator.ConstraintDefinition definition, Sample sample, double residualScale) {
+  ProcessBoundaryConstraintEvidence(Metadata metadata, ProcessModelSimulationEvaluator.ConstraintDefinition definition,
+      Sample sample, double residualScale) {
     if (metadata == null || definition == null) {
       throw new IllegalArgumentException("Boundary metadata and constraint definition are required");
     }
@@ -283,8 +268,7 @@ public final class ProcessBoundaryConstraintEvidence implements Serializable {
       throw new IllegalArgumentException("Residual scale must be finite and positive");
     }
     this.metadata = metadata;
-    this.qualifiedConstraintName = metadata.getAreaName() + "::" + metadata.getPointName() + "/"
-        + definition.getName();
+    this.qualifiedConstraintName = metadata.getAreaName() + "::" + metadata.getPointName() + "/" + definition.getName();
     this.constraintType = definition.getType();
     this.hard = definition.isHard();
     this.unit = definition.getUnit();
@@ -293,7 +277,8 @@ public final class ProcessBoundaryConstraintEvidence implements Serializable {
     this.equalityTolerance = definition.getEqualityTolerance();
     this.residualScale = residualScale;
     Sample safeSample = sample == null
-        ? new Sample(null, CalculationStatus.MISSING_VALUE, null, null, "Boundary sampler returned null") : sample;
+        ? new Sample(null, CalculationStatus.MISSING_VALUE, null, null, "Boundary sampler returned null")
+        : sample;
     CalculationStatus status = safeSample.getStatus();
     Double value = safeSample.getValue();
     if (metadata.getApplicabilityStatus() == ApplicabilityStatus.OUTSIDE_VALIDITY) {

--- a/src/main/java/neqsim/process/util/optimizer/ProcessBoundaryConstraintEvidence.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessBoundaryConstraintEvidence.java
@@ -1,0 +1,417 @@
+package neqsim.process.util.optimizer;
+
+import java.io.Serializable;
+import neqsim.process.equipment.network.NetworkDecisionVariable;
+import neqsim.process.equipment.network.NetworkQualityResult;
+
+/**
+ * Immutable, unit-safe evidence for one process-boundary constraint at one completed operating point.
+ *
+ * <p>
+ * Physical values and margins retain their engineering unit. {@link #getScaledViolation()} is the only
+ * dimensionless quantity and is formed with the explicit positive {@link #getResidualScale()}.
+ * </p>
+ */
+public final class ProcessBoundaryConstraintEvidence implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  /** Boundary role. */
+  public enum Kind {
+    INJECTION,
+    RECEIVING_CAPACITY,
+    EXPORT_CAPACITY,
+    PRODUCT_QUALITY,
+    NOMINATION
+  }
+
+  /** Positive-flow direction relative to the modeled process. */
+  public enum FlowDirection {
+    INTO_PROCESS,
+    OUT_OF_PROCESS,
+    BIDIRECTIONAL,
+    NOT_APPLICABLE
+  }
+
+  /** Applicability of the registered validity period to this evaluation. */
+  public enum ApplicabilityStatus {
+    APPLICABLE,
+    OUTSIDE_VALIDITY,
+    NOT_ASSESSED
+  }
+
+  /** Availability of the runtime sample used to calculate the residual. */
+  public enum CalculationStatus {
+    AVAILABLE,
+    MISSING_VALUE,
+    NON_FINITE_VALUE,
+    NOT_CALCULABLE,
+    METADATA_MISMATCH,
+    OUTSIDE_VALIDITY
+  }
+
+  /** Immutable registration metadata, safe to retain independently of evaluator callbacks. */
+  public static final class Metadata implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private final String id;
+    private final String areaName;
+    private final String pointName;
+    private final Kind kind;
+    private final FlowDirection flowDirection;
+    private final NetworkDecisionVariable.RateBasis rateBasis;
+    private final String provenance;
+    private final double confidence;
+    private final String effectiveFrom;
+    private final String effectiveTo;
+    private final ApplicabilityStatus applicabilityStatus;
+    private final String observableName;
+    private final String method;
+    private final String referenceJson;
+    private final int periodIndex;
+
+    /**
+     * Creates complete immutable boundary metadata.
+     *
+     * @param id stable caller-owned identifier
+     * @param areaName process-model area name
+     * @param pointName named boundary point
+     * @param kind boundary role
+     * @param flowDirection positive-flow direction
+     * @param rateBasis rate basis, or {@code NONE} for non-flow constraints
+     * @param provenance source of the limit or nomination
+     * @param confidence confidence in [0, 1], or NaN when not quantified
+     * @param effectiveFrom inclusive effective-period label, or null
+     * @param effectiveTo inclusive effective-period label, or null
+     * @param applicabilityStatus validity assessment for this evaluation context
+     * @param observableName measured attribute or metric key, or null
+     * @param method calculation, test, or standard name, or null
+     * @param referenceJson serialized reference conditions, or null
+     * @param periodIndex zero-based nomination period, or -1 when not applicable
+     */
+    public Metadata(String id, String areaName, String pointName, Kind kind, FlowDirection flowDirection,
+        NetworkDecisionVariable.RateBasis rateBasis, String provenance, double confidence, String effectiveFrom,
+        String effectiveTo, ApplicabilityStatus applicabilityStatus, String observableName, String method,
+        String referenceJson, int periodIndex) {
+      this.id = requireText(id, "Boundary id");
+      this.areaName = requireText(areaName, "Area name");
+      this.pointName = requireText(pointName, "Point name");
+      if (kind == null || flowDirection == null || rateBasis == null || applicabilityStatus == null) {
+        throw new IllegalArgumentException("Boundary kind, direction, rate basis, and applicability are required");
+      }
+      if (Double.isFinite(confidence) && (confidence < 0.0 || confidence > 1.0)) {
+        throw new IllegalArgumentException("Confidence must be in [0, 1] or NaN");
+      }
+      if (periodIndex < -1) {
+        throw new IllegalArgumentException("Period index must be -1 or non-negative");
+      }
+      this.kind = kind;
+      this.flowDirection = flowDirection;
+      this.rateBasis = rateBasis;
+      this.provenance = provenance;
+      this.confidence = confidence;
+      this.effectiveFrom = effectiveFrom;
+      this.effectiveTo = effectiveTo;
+      this.applicabilityStatus = applicabilityStatus;
+      this.observableName = observableName;
+      this.method = method;
+      this.referenceJson = referenceJson;
+      this.periodIndex = periodIndex;
+    }
+
+    /** @return stable caller-owned identifier */
+    public String getId() {
+      return id;
+    }
+
+    /** @return process-model area name */
+    public String getAreaName() {
+      return areaName;
+    }
+
+    /** @return named boundary point */
+    public String getPointName() {
+      return pointName;
+    }
+
+    /** @return boundary role */
+    public Kind getKind() {
+      return kind;
+    }
+
+    /** @return positive-flow direction */
+    public FlowDirection getFlowDirection() {
+      return flowDirection;
+    }
+
+    /** @return explicit rate basis */
+    public NetworkDecisionVariable.RateBasis getRateBasis() {
+      return rateBasis;
+    }
+
+    /** @return source of the registered limit or nomination */
+    public String getProvenance() {
+      return provenance;
+    }
+
+    /** @return confidence in [0, 1], or NaN */
+    public double getConfidence() {
+      return confidence;
+    }
+
+    /** @return inclusive effective-period start label, or null */
+    public String getEffectiveFrom() {
+      return effectiveFrom;
+    }
+
+    /** @return inclusive effective-period end label, or null */
+    public String getEffectiveTo() {
+      return effectiveTo;
+    }
+
+    /** @return validity assessment for this evaluation context */
+    public ApplicabilityStatus getApplicabilityStatus() {
+      return applicabilityStatus;
+    }
+
+    /** @return measured attribute or metric key, or null */
+    public String getObservableName() {
+      return observableName;
+    }
+
+    /** @return calculation, test, or standard name, or null */
+    public String getMethod() {
+      return method;
+    }
+
+    /** @return serialized reference conditions, or null */
+    public String getReferenceJson() {
+      return referenceJson;
+    }
+
+    /** @return zero-based nomination period, or -1 */
+    public int getPeriodIndex() {
+      return periodIndex;
+    }
+  }
+
+  /** Immutable result of sampling one boundary observable exactly once. */
+  public static final class Sample implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private final Double value;
+    private final CalculationStatus status;
+    private final Double sourceMargin;
+    private final String provenance;
+    private final String diagnostic;
+
+    /** Creates one immutable sample. */
+    public Sample(Double value, CalculationStatus status, Double sourceMargin, String provenance,
+        String diagnostic) {
+      this.value = value;
+      this.status = status == null ? CalculationStatus.NOT_CALCULABLE : status;
+      this.sourceMargin = sourceMargin;
+      this.provenance = provenance;
+      this.diagnostic = diagnostic;
+    }
+
+    /** Creates an available scalar sample. */
+    public static Sample available(double value) {
+      return new Sample(Double.valueOf(value), CalculationStatus.AVAILABLE, null, null, null);
+    }
+
+    /** Adapts a network-quality result without retaining its mutable reference object. */
+    public static Sample fromNetworkQualityResult(NetworkQualityResult result) {
+      if (result == null) {
+        return new Sample(null, CalculationStatus.NOT_CALCULABLE, null, null,
+            "Network quality result was null");
+      }
+      CalculationStatus calculationStatus = result.getStatus() == NetworkQualityResult.Status.NOT_CALCULABLE
+          ? CalculationStatus.NOT_CALCULABLE : CalculationStatus.AVAILABLE;
+      return new Sample(result.getValue(), calculationStatus, result.getMargin(), result.getProvenance(),
+          result.getMessage());
+    }
+
+    /** @return sampled value, or null */
+    public Double getValue() {
+      return value;
+    }
+
+    /** @return calculation status reported by the sampler */
+    public CalculationStatus getStatus() {
+      return status;
+    }
+
+    /** @return source-reported signed margin, or null */
+    public Double getSourceMargin() {
+      return sourceMargin;
+    }
+
+    /** @return sample-specific provenance, or null */
+    public String getProvenance() {
+      return provenance;
+    }
+
+    /** @return sample diagnostic, or null */
+    public String getDiagnostic() {
+      return diagnostic;
+    }
+  }
+
+  private final Metadata metadata;
+  private final String qualifiedConstraintName;
+  private final ProcessModelSimulationEvaluator.ConstraintDefinition.Type constraintType;
+  private final boolean hard;
+  private final String unit;
+  private final double lowerBound;
+  private final double upperBound;
+  private final double equalityTolerance;
+  private final double sampledValue;
+  private final double signedMargin;
+  private final double violation;
+  private final double residualScale;
+  private final double scaledViolation;
+  private final CalculationStatus calculationStatus;
+  private final Double sourceMargin;
+  private final String sampleProvenance;
+  private final String diagnostic;
+
+  /** Creates one evaluated evidence row. */
+  ProcessBoundaryConstraintEvidence(Metadata metadata,
+      ProcessModelSimulationEvaluator.ConstraintDefinition definition, Sample sample, double residualScale) {
+    if (metadata == null || definition == null) {
+      throw new IllegalArgumentException("Boundary metadata and constraint definition are required");
+    }
+    if (!Double.isFinite(residualScale) || residualScale <= 0.0) {
+      throw new IllegalArgumentException("Residual scale must be finite and positive");
+    }
+    this.metadata = metadata;
+    this.qualifiedConstraintName = metadata.getAreaName() + "::" + metadata.getPointName() + "/"
+        + definition.getName();
+    this.constraintType = definition.getType();
+    this.hard = definition.isHard();
+    this.unit = definition.getUnit();
+    this.lowerBound = definition.getLowerBound();
+    this.upperBound = definition.getUpperBound();
+    this.equalityTolerance = definition.getEqualityTolerance();
+    this.residualScale = residualScale;
+    Sample safeSample = sample == null
+        ? new Sample(null, CalculationStatus.MISSING_VALUE, null, null, "Boundary sampler returned null") : sample;
+    CalculationStatus status = safeSample.getStatus();
+    Double value = safeSample.getValue();
+    if (metadata.getApplicabilityStatus() == ApplicabilityStatus.OUTSIDE_VALIDITY) {
+      status = CalculationStatus.OUTSIDE_VALIDITY;
+    } else if (status == CalculationStatus.AVAILABLE && value == null) {
+      status = CalculationStatus.MISSING_VALUE;
+    } else if (status == CalculationStatus.AVAILABLE && !Double.isFinite(value.doubleValue())) {
+      status = CalculationStatus.NON_FINITE_VALUE;
+    }
+    this.calculationStatus = status;
+    this.sampledValue = status == CalculationStatus.AVAILABLE ? value.doubleValue() : Double.NaN;
+    this.signedMargin = status == CalculationStatus.AVAILABLE ? definition.marginFromValue(sampledValue) : Double.NaN;
+    this.violation = Double.isFinite(signedMargin) ? Math.max(0.0, -signedMargin) : Double.NaN;
+    this.scaledViolation = Double.isFinite(violation) ? violation / residualScale : Double.NaN;
+    this.sourceMargin = safeSample.getSourceMargin();
+    this.sampleProvenance = safeSample.getProvenance();
+    this.diagnostic = safeSample.getDiagnostic();
+  }
+
+  /** @return immutable registration metadata */
+  public Metadata getMetadata() {
+    return metadata;
+  }
+
+  /** @return stable {@code area::point/constraint} identity */
+  public String getQualifiedConstraintName() {
+    return qualifiedConstraintName;
+  }
+
+  /** @return lower, upper, range, or equality type */
+  public ProcessModelSimulationEvaluator.ConstraintDefinition.Type getConstraintType() {
+    return constraintType;
+  }
+
+  /** @return true when unavailable or violated evidence is infeasible */
+  public boolean isHard() {
+    return hard;
+  }
+
+  /** @return physical engineering unit */
+  public String getUnit() {
+    return unit;
+  }
+
+  /** @return physical lower bound or equality target */
+  public double getLowerBound() {
+    return lowerBound;
+  }
+
+  /** @return physical upper bound */
+  public double getUpperBound() {
+    return upperBound;
+  }
+
+  /** @return absolute equality tolerance */
+  public double getEqualityTolerance() {
+    return equalityTolerance;
+  }
+
+  /** @return sampled physical value, or NaN when unavailable */
+  public double getSampledValue() {
+    return sampledValue;
+  }
+
+  /** @return positive satisfied margin, negative violation, or NaN */
+  public double getSignedMargin() {
+    return signedMargin;
+  }
+
+  /** @return non-negative physical violation, or NaN */
+  public double getViolation() {
+    return violation;
+  }
+
+  /** @return positive physical scale used only for normalization */
+  public double getResidualScale() {
+    return residualScale;
+  }
+
+  /** @return non-negative dimensionless violation, or NaN */
+  public double getScaledViolation() {
+    return scaledViolation;
+  }
+
+  /** @return resolved evidence calculation status */
+  public CalculationStatus getCalculationStatus() {
+    return calculationStatus;
+  }
+
+  /** @return source-reported signed margin, or null */
+  public Double getSourceMargin() {
+    return sourceMargin;
+  }
+
+  /** @return runtime-sample provenance, or null */
+  public String getSampleProvenance() {
+    return sampleProvenance;
+  }
+
+  /** @return runtime diagnostic, or null */
+  public String getDiagnostic() {
+    return diagnostic;
+  }
+
+  /** @return true when a finite, applicable value was available */
+  public boolean isCalculable() {
+    return calculationStatus == CalculationStatus.AVAILABLE;
+  }
+
+  /** @return true when evidence is calculable and the physical margin is non-negative */
+  public boolean isFeasible() {
+    return isCalculable() && signedMargin >= 0.0;
+  }
+
+  private static String requireText(String value, String label) {
+    if (value == null || value.trim().length() == 0) {
+      throw new IllegalArgumentException(label + " is required");
+    }
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelOperatingActionEvaluator.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelOperatingActionEvaluator.java
@@ -638,8 +638,8 @@ public final class ProcessModelOperatingActionEvaluator {
       this.constraintMargins = Arrays.copyOf(constraintMargins, constraintMargins.length);
       this.hydraulicConstraints = Collections
           .unmodifiableList(new ArrayList<HydraulicConstraintSnapshot>(hydraulicConstraints));
-      this.processBoundaryConstraintEvidence = Collections.unmodifiableList(
-          new ArrayList<ProcessBoundaryConstraintEvidence>(processBoundaryConstraintEvidence));
+      this.processBoundaryConstraintEvidence = Collections
+          .unmodifiableList(new ArrayList<ProcessBoundaryConstraintEvidence>(processBoundaryConstraintEvidence));
       this.diagnostics = Collections.unmodifiableList(new ArrayList<String>(diagnostics));
     }
 
@@ -746,8 +746,8 @@ public final class ProcessModelOperatingActionEvaluator {
 
     /** @return fresh immutable qualified boundary evidence in constraint registration order */
     public List<ProcessBoundaryConstraintEvidence> getProcessBoundaryConstraintEvidence() {
-      return Collections.unmodifiableList(
-          new ArrayList<ProcessBoundaryConstraintEvidence>(processBoundaryConstraintEvidence));
+      return Collections
+          .unmodifiableList(new ArrayList<ProcessBoundaryConstraintEvidence>(processBoundaryConstraintEvidence));
     }
 
     /** @return fresh immutable snapshot of diagnostics */

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelOperatingActionEvaluator.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelOperatingActionEvaluator.java
@@ -612,6 +612,9 @@ public final class ProcessModelOperatingActionEvaluator {
     /** Required hydraulic snapshots in binding order. */
     private final List<HydraulicConstraintSnapshot> hydraulicConstraints;
 
+    /** Qualified boundary evidence from the candidate operating point. */
+    private final List<ProcessBoundaryConstraintEvidence> processBoundaryConstraintEvidence;
+
     /** Immutable diagnostics. */
     private final List<String> diagnostics;
 
@@ -620,7 +623,7 @@ public final class ProcessModelOperatingActionEvaluator {
         Outcome outcome, boolean candidateSimulationConverged, boolean candidateEvaluatorFeasible,
         boolean baselineRestored, boolean baselineSimulationConverged, double[] rawObjectives, double[] objectives,
         double[] constraintValues, double[] constraintMargins, List<HydraulicConstraintSnapshot> hydraulicConstraints,
-        List<String> diagnostics) {
+        List<ProcessBoundaryConstraintEvidence> processBoundaryConstraintEvidence, List<String> diagnostics) {
       this.action = action;
       this.baselineValue = baselineValue;
       this.candidateValue = candidateValue;
@@ -635,6 +638,8 @@ public final class ProcessModelOperatingActionEvaluator {
       this.constraintMargins = Arrays.copyOf(constraintMargins, constraintMargins.length);
       this.hydraulicConstraints = Collections
           .unmodifiableList(new ArrayList<HydraulicConstraintSnapshot>(hydraulicConstraints));
+      this.processBoundaryConstraintEvidence = Collections.unmodifiableList(
+          new ArrayList<ProcessBoundaryConstraintEvidence>(processBoundaryConstraintEvidence));
       this.diagnostics = Collections.unmodifiableList(new ArrayList<String>(diagnostics));
     }
 
@@ -643,7 +648,8 @@ public final class ProcessModelOperatingActionEvaluator {
         Outcome outcome, List<String> diagnostics) {
       return new CandidateEvaluationResult(action, Double.NaN, candidateValue, outcome, false, false, false, false,
           new double[0], new double[0], new double[0], new double[0],
-          Collections.<HydraulicConstraintSnapshot>emptyList(), diagnostics);
+          Collections.<HydraulicConstraintSnapshot>emptyList(),
+          Collections.<ProcessBoundaryConstraintEvidence>emptyList(), diagnostics);
     }
 
     /** Creates a result from one optional candidate simulation. */
@@ -654,12 +660,13 @@ public final class ProcessModelOperatingActionEvaluator {
       if (evaluation == null) {
         return new CandidateEvaluationResult(action, baselineValue, candidateValue, outcome, false, false,
             baselineRestored, baselineSimulationConverged, new double[0], new double[0], new double[0], new double[0],
-            hydraulicConstraints, diagnostics);
+            hydraulicConstraints, Collections.<ProcessBoundaryConstraintEvidence>emptyList(), diagnostics);
       }
       return new CandidateEvaluationResult(action, baselineValue, candidateValue, outcome,
           evaluation.isSimulationConverged(), evaluation.isFeasible(), baselineRestored, baselineSimulationConverged,
           copy(evaluation.getObjectivesRaw()), copy(evaluation.getObjectives()), copy(evaluation.getConstraintValues()),
-          copy(evaluation.getConstraintMargins()), hydraulicConstraints, diagnostics);
+          copy(evaluation.getConstraintMargins()), hydraulicConstraints,
+          evaluation.getProcessBoundaryConstraintEvidence(), diagnostics);
     }
 
     /** Returns a defensive array or an empty array for null. */
@@ -735,6 +742,12 @@ public final class ProcessModelOperatingActionEvaluator {
     /** @return fresh immutable snapshot of hydraulic evidence in binding order */
     public List<HydraulicConstraintSnapshot> getHydraulicConstraints() {
       return Collections.unmodifiableList(new ArrayList<HydraulicConstraintSnapshot>(hydraulicConstraints));
+    }
+
+    /** @return fresh immutable qualified boundary evidence in constraint registration order */
+    public List<ProcessBoundaryConstraintEvidence> getProcessBoundaryConstraintEvidence() {
+      return Collections.unmodifiableList(
+          new ArrayList<ProcessBoundaryConstraintEvidence>(processBoundaryConstraintEvidence));
     }
 
     /** @return fresh immutable snapshot of diagnostics */

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelOperatingActionSetEvaluator.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelOperatingActionSetEvaluator.java
@@ -862,6 +862,9 @@ public final class ProcessModelOperatingActionSetEvaluator {
     /** Complete unit-safe installed-capacity evidence from the candidate operating point. */
     private final List<InstalledEquipmentCapacityEvidence> installedEquipmentCapacityEvidence;
 
+    /** Complete qualified boundary evidence from the candidate operating point. */
+    private final List<ProcessBoundaryConstraintEvidence> processBoundaryConstraintEvidence;
+
     /** Immutable diagnostics. */
     private final List<String> diagnostics;
 
@@ -873,7 +876,8 @@ public final class ProcessModelOperatingActionSetEvaluator {
         double[] rawObjectives, double[] objectives, List<CandidateObjectiveEvidence> objectiveEvidence,
         double[] constraintValues, double[] constraintMargins, List<CandidateConstraintEvidence> constraintEvidence,
         List<HydraulicConstraintSnapshot> hydraulicConstraints,
-        List<InstalledEquipmentCapacityEvidence> installedEquipmentCapacityEvidence, List<String> diagnostics) {
+        List<InstalledEquipmentCapacityEvidence> installedEquipmentCapacityEvidence,
+        List<ProcessBoundaryConstraintEvidence> processBoundaryConstraintEvidence, List<String> diagnostics) {
       this.id = id;
       this.name = name;
       this.provenance = provenance;
@@ -897,6 +901,8 @@ public final class ProcessModelOperatingActionSetEvaluator {
           .unmodifiableList(new ArrayList<HydraulicConstraintSnapshot>(hydraulicConstraints));
       this.installedEquipmentCapacityEvidence = Collections
           .unmodifiableList(new ArrayList<InstalledEquipmentCapacityEvidence>(installedEquipmentCapacityEvidence));
+      this.processBoundaryConstraintEvidence = Collections.unmodifiableList(
+          new ArrayList<ProcessBoundaryConstraintEvidence>(processBoundaryConstraintEvidence));
       this.diagnostics = Collections.unmodifiableList(new ArrayList<String>(diagnostics));
     }
 
@@ -908,7 +914,8 @@ public final class ProcessModelOperatingActionSetEvaluator {
           Collections.<ActionCandidateEvidence>emptyList(), outcome, false, false, false, false, new double[0],
           new double[0], Collections.<CandidateObjectiveEvidence>emptyList(), new double[0], new double[0],
           Collections.<CandidateConstraintEvidence>emptyList(), Collections.<HydraulicConstraintSnapshot>emptyList(),
-          Collections.<InstalledEquipmentCapacityEvidence>emptyList(), diagnostics);
+          Collections.<InstalledEquipmentCapacityEvidence>emptyList(),
+          Collections.<ProcessBoundaryConstraintEvidence>emptyList(), diagnostics);
     }
 
     /** Creates a result from an optional candidate simulation. */
@@ -923,13 +930,15 @@ public final class ProcessModelOperatingActionSetEvaluator {
             false, false, baselineRestored, baselineSimulationConverged, new double[0], new double[0],
             Collections.<CandidateObjectiveEvidence>emptyList(), new double[0], new double[0],
             Collections.<CandidateConstraintEvidence>emptyList(), hydraulicConstraints,
-            Collections.<InstalledEquipmentCapacityEvidence>emptyList(), diagnostics);
+            Collections.<InstalledEquipmentCapacityEvidence>emptyList(),
+            Collections.<ProcessBoundaryConstraintEvidence>emptyList(), diagnostics);
       }
       return new CandidateSetEvaluationResult(id, name, provenance, actions, candidateValues, actionEvidence, outcome,
           evaluation.isSimulationConverged(), evaluation.isFeasible(), baselineRestored, baselineSimulationConverged,
           copy(evaluation.getObjectivesRaw()), copy(evaluation.getObjectives()), objectiveEvidence,
           copy(evaluation.getConstraintValues()), copy(evaluation.getConstraintMargins()), constraintEvidence,
-          hydraulicConstraints, evaluation.getInstalledEquipmentCapacityEvidence(), diagnostics);
+          hydraulicConstraints, evaluation.getInstalledEquipmentCapacityEvidence(),
+          evaluation.getProcessBoundaryConstraintEvidence(), diagnostics);
     }
 
     /** Snapshots objective definitions and sampled values without retaining evaluator callbacks. */
@@ -1086,6 +1095,12 @@ public final class ProcessModelOperatingActionSetEvaluator {
     public List<InstalledEquipmentCapacityEvidence> getInstalledEquipmentCapacityEvidence() {
       return Collections
           .unmodifiableList(new ArrayList<InstalledEquipmentCapacityEvidence>(installedEquipmentCapacityEvidence));
+    }
+
+    /** @return fresh immutable qualified boundary evidence in constraint registration order */
+    public List<ProcessBoundaryConstraintEvidence> getProcessBoundaryConstraintEvidence() {
+      return Collections.unmodifiableList(
+          new ArrayList<ProcessBoundaryConstraintEvidence>(processBoundaryConstraintEvidence));
     }
 
     /** @return fresh immutable diagnostics */

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelOperatingActionSetEvaluator.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelOperatingActionSetEvaluator.java
@@ -901,8 +901,8 @@ public final class ProcessModelOperatingActionSetEvaluator {
           .unmodifiableList(new ArrayList<HydraulicConstraintSnapshot>(hydraulicConstraints));
       this.installedEquipmentCapacityEvidence = Collections
           .unmodifiableList(new ArrayList<InstalledEquipmentCapacityEvidence>(installedEquipmentCapacityEvidence));
-      this.processBoundaryConstraintEvidence = Collections.unmodifiableList(
-          new ArrayList<ProcessBoundaryConstraintEvidence>(processBoundaryConstraintEvidence));
+      this.processBoundaryConstraintEvidence = Collections
+          .unmodifiableList(new ArrayList<ProcessBoundaryConstraintEvidence>(processBoundaryConstraintEvidence));
       this.diagnostics = Collections.unmodifiableList(new ArrayList<String>(diagnostics));
     }
 
@@ -1099,8 +1099,8 @@ public final class ProcessModelOperatingActionSetEvaluator {
 
     /** @return fresh immutable qualified boundary evidence in constraint registration order */
     public List<ProcessBoundaryConstraintEvidence> getProcessBoundaryConstraintEvidence() {
-      return Collections.unmodifiableList(
-          new ArrayList<ProcessBoundaryConstraintEvidence>(processBoundaryConstraintEvidence));
+      return Collections
+          .unmodifiableList(new ArrayList<ProcessBoundaryConstraintEvidence>(processBoundaryConstraintEvidence));
     }
 
     /** @return fresh immutable diagnostics */

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluator.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluator.java
@@ -18,6 +18,9 @@ import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.capacity.CapacityConstraint;
 import neqsim.process.equipment.capacity.EquipmentCapacityStrategy;
 import neqsim.process.equipment.capacity.EquipmentCapacityStrategyRegistry;
+import neqsim.process.equipment.network.NetworkDecisionVariable;
+import neqsim.process.equipment.network.NetworkNomination;
+import neqsim.process.equipment.network.NetworkQualityResult;
 import neqsim.process.processmodel.ProcessModel;
 import neqsim.process.processmodel.ProcessSystem;
 
@@ -47,6 +50,17 @@ public class ProcessModelSimulationEvaluator implements Serializable {
 
   /** Logger. */
   private static final Logger logger = LogManager.getLogger(ProcessModelSimulationEvaluator.class);
+
+  /** Serializable callback that returns one structured boundary sample after a model run. */
+  public interface BoundarySampleEvaluator extends Serializable {
+    /**
+     * Samples one boundary observable.
+     *
+     * @param model completed process-model operating point
+     * @return structured sample, or null to report missing evidence
+     */
+    ProcessBoundaryConstraintEvidence.Sample evaluate(ProcessModel model);
+  }
 
   /** Finite-difference stencil used for objective gradients and constraint Jacobians. */
   public enum FiniteDifferenceMethod {
@@ -1942,6 +1956,15 @@ public class ProcessModelSimulationEvaluator implements Serializable {
     /** Model-level constraint evaluator. */
     private transient ToDoubleFunction<ProcessModel> evaluator;
 
+    /** Structured boundary sampler, mutually exclusive with the scalar evaluator. */
+    private transient BoundarySampleEvaluator boundarySampleEvaluator;
+
+    /** Frozen boundary identity and provenance, or null for a general constraint. */
+    private ProcessBoundaryConstraintEvidence.Metadata boundaryMetadata;
+
+    /** Physical scale used only for the dimensionless boundary violation. */
+    private double boundaryResidualScale = 1.0;
+
     /** Whether this constraint represents equipment capacity utilization. */
     private boolean capacityConstraint = false;
 
@@ -2166,6 +2189,56 @@ public class ProcessModelSimulationEvaluator implements Serializable {
       this.evaluator = evaluator;
     }
 
+    /** @return structured boundary sampler, or null for a scalar constraint */
+    public BoundarySampleEvaluator getBoundarySampleEvaluator() {
+      return boundarySampleEvaluator;
+    }
+
+    /**
+     * Sets structured boundary sampling metadata.
+     *
+     * @param metadata immutable boundary identity and provenance
+     * @param sampleEvaluator runtime sampler
+     * @param residualScale finite positive scale in {@link #getUnit()}
+     */
+    public void setBoundaryMetadata(ProcessBoundaryConstraintEvidence.Metadata metadata,
+        BoundarySampleEvaluator sampleEvaluator, double residualScale) {
+      if (metadata == null || sampleEvaluator == null) {
+        throw new IllegalArgumentException("Boundary metadata and sampler are required");
+      }
+      if (!Double.isFinite(residualScale) || residualScale <= 0.0) {
+        throw new IllegalArgumentException("Boundary residual scale must be finite and positive");
+      }
+      this.boundaryMetadata = metadata;
+      this.boundarySampleEvaluator = sampleEvaluator;
+      this.boundaryResidualScale = residualScale;
+    }
+
+    /** @return true when this definition represents a qualified process boundary */
+    public boolean isBoundaryConstraint() {
+      return boundaryMetadata != null;
+    }
+
+    /** @return immutable boundary metadata, or null for a general constraint */
+    public ProcessBoundaryConstraintEvidence.Metadata getBoundaryMetadata() {
+      return boundaryMetadata;
+    }
+
+    /** @return positive physical residual scale */
+    public double getBoundaryResidualScale() {
+      return boundaryResidualScale;
+    }
+
+    /** Samples a structured boundary observable exactly once. */
+    private ProcessBoundaryConstraintEvidence.Sample evaluateBoundarySample(ProcessModel model) {
+      if (boundarySampleEvaluator == null) {
+        return new ProcessBoundaryConstraintEvidence.Sample(null,
+            ProcessBoundaryConstraintEvidence.CalculationStatus.NOT_CALCULABLE, null, null,
+            "Boundary sampler is unavailable after serialization");
+      }
+      return boundarySampleEvaluator.evaluate(model);
+    }
+
     /**
      * Checks whether this is an equipment capacity constraint.
      *
@@ -2309,7 +2382,7 @@ public class ProcessModelSimulationEvaluator implements Serializable {
      * @param value sampled constraint value
      * @return positive margin when satisfied and negative margin when violated
      */
-    private double marginFromValue(double value) {
+    double marginFromValue(double value) {
       switch (type) {
       case LOWER_BOUND:
         return value - lowerBound;
@@ -2784,6 +2857,9 @@ public class ProcessModelSimulationEvaluator implements Serializable {
     /** Immutable unit-safe installed-capacity evidence for this evaluated model state. */
     private List<InstalledEquipmentCapacityEvidence> installedEquipmentCapacityEvidence = Collections.emptyList();
 
+    /** Immutable qualified process-boundary evidence for this evaluated model state. */
+    private List<ProcessBoundaryConstraintEvidence> processBoundaryConstraintEvidence = Collections.emptyList();
+
     /** Additional scalar outputs. */
     private Map<String, Double> additionalOutputs = new LinkedHashMap<String, Double>();
 
@@ -3023,6 +3099,29 @@ public class ProcessModelSimulationEvaluator implements Serializable {
       }
       installedEquipmentCapacityEvidence = Collections
           .unmodifiableList(new ArrayList<InstalledEquipmentCapacityEvidence>(evidence));
+    }
+
+    /**
+     * Gets process-boundary evidence sampled at this completed operating point.
+     *
+     * @return fresh immutable evidence in constraint registration order
+     */
+    public List<ProcessBoundaryConstraintEvidence> getProcessBoundaryConstraintEvidence() {
+      if (processBoundaryConstraintEvidence == null || processBoundaryConstraintEvidence.isEmpty()) {
+        return Collections.emptyList();
+      }
+      return Collections.unmodifiableList(
+          new ArrayList<ProcessBoundaryConstraintEvidence>(processBoundaryConstraintEvidence));
+    }
+
+    /** Sets boundary evidence using a defensive immutable copy. */
+    public void setProcessBoundaryConstraintEvidence(List<ProcessBoundaryConstraintEvidence> evidence) {
+      if (evidence == null || evidence.isEmpty()) {
+        processBoundaryConstraintEvidence = Collections.emptyList();
+        return;
+      }
+      processBoundaryConstraintEvidence = Collections.unmodifiableList(
+          new ArrayList<ProcessBoundaryConstraintEvidence>(evidence));
     }
 
     /**
@@ -3331,6 +3430,156 @@ public class ProcessModelSimulationEvaluator implements Serializable {
   }
 
   /**
+   * Adds a fully qualified process-boundary constraint.
+   *
+   * <p>
+   * Bounds and units are frozen at registration. The structured sampler is invoked once after each completed model
+   * run; missing, non-finite, not-calculable, or out-of-validity evidence fails a hard constraint closed.
+   * </p>
+   *
+   * @param name human-readable constraint name
+   * @param metadata immutable boundary identity and provenance
+   * @param sampleEvaluator structured runtime sampler
+   * @param type lower, upper, range, or equality constraint
+   * @param lowerBound lower bound or equality target
+   * @param upperBound upper bound
+   * @param equalityTolerance absolute equality tolerance
+   * @param unit physical engineering unit
+   * @param hard whether unavailable or violated evidence makes the point infeasible
+   * @param penaltyWeight penalty multiplier
+   * @param residualScale positive physical scale used for dimensionless violation only
+   * @return this evaluator for chaining
+   */
+  public ProcessModelSimulationEvaluator addBoundaryConstraint(String name,
+      ProcessBoundaryConstraintEvidence.Metadata metadata, BoundarySampleEvaluator sampleEvaluator,
+      ConstraintDefinition.Type type, double lowerBound, double upperBound, double equalityTolerance, String unit,
+      boolean hard, double penaltyWeight, double residualScale) {
+    if (name == null || name.trim().length() == 0 || type == null) {
+      throw new IllegalArgumentException("Boundary constraint name and type are required");
+    }
+    if (unit == null || unit.trim().length() == 0) {
+      throw new IllegalArgumentException("Boundary constraint unit is required");
+    }
+    if (!Double.isFinite(penaltyWeight) || penaltyWeight < 0.0) {
+      throw new IllegalArgumentException("Penalty weight must be finite and non-negative");
+    }
+    if (type == ConstraintDefinition.Type.LOWER_BOUND && !Double.isFinite(lowerBound)
+        || type == ConstraintDefinition.Type.UPPER_BOUND && !Double.isFinite(upperBound)
+        || type == ConstraintDefinition.Type.RANGE
+            && (!Double.isFinite(lowerBound) || !Double.isFinite(upperBound) || lowerBound > upperBound)
+        || type == ConstraintDefinition.Type.EQUALITY
+            && (!Double.isFinite(lowerBound) || !Double.isFinite(equalityTolerance) || equalityTolerance < 0.0)) {
+      throw new IllegalArgumentException("Boundary bounds and tolerance must be finite and ordered for the type");
+    }
+    ConstraintDefinition definition = new ConstraintDefinition();
+    definition.setName(name);
+    definition.setType(type);
+    definition.setLowerBound(lowerBound);
+    definition.setUpperBound(upperBound);
+    definition.setEqualityTolerance(equalityTolerance);
+    definition.setUnit(unit);
+    definition.setHard(hard);
+    definition.setPenaltyWeight(penaltyWeight);
+    definition.setBoundaryMetadata(metadata, sampleEvaluator, residualScale);
+    constraints.add(definition);
+    return this;
+  }
+
+  /**
+   * Adds an equality constraint from one period of a {@link NetworkNomination}.
+   *
+   * @param name constraint name
+   * @param areaName process area containing the nominated point
+   * @param nomination immutable nomination series
+   * @param periodIndex zero-based nomination period
+   * @param flowDirection positive-flow direction
+   * @param evaluator actual boundary rate sampler
+   * @param hard whether unavailable or off-nomination evidence is infeasible
+   * @param penaltyWeight penalty multiplier
+   * @param residualScale positive scale in the nomination unit
+   * @param provenance source of the nomination
+   * @return this evaluator for chaining
+   */
+  public ProcessModelSimulationEvaluator addNominationConstraint(String name, String areaName,
+      NetworkNomination nomination, int periodIndex, ProcessBoundaryConstraintEvidence.FlowDirection flowDirection,
+      final ToDoubleFunction<ProcessModel> evaluator, boolean hard, double penaltyWeight, double residualScale,
+      String provenance) {
+    if (nomination == null || periodIndex < 0 || periodIndex >= nomination.size() || evaluator == null) {
+      throw new IllegalArgumentException("Nomination, valid period index, and evaluator are required");
+    }
+    double target = nomination.getValue(periodIndex);
+    double tolerance = Math.abs(target) * Math.abs(nomination.getToleranceFraction());
+    ProcessBoundaryConstraintEvidence.Metadata metadata = new ProcessBoundaryConstraintEvidence.Metadata(
+        areaName + "::" + nomination.getPointName() + "/nomination/" + periodIndex, areaName,
+        nomination.getPointName(), ProcessBoundaryConstraintEvidence.Kind.NOMINATION, flowDirection,
+        nomination.getBasis(), provenance, Double.NaN, Integer.toString(periodIndex), Integer.toString(periodIndex),
+        ProcessBoundaryConstraintEvidence.ApplicabilityStatus.APPLICABLE, "nominated rate", null, null, periodIndex);
+    BoundarySampleEvaluator sampler = new BoundarySampleEvaluator() {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public ProcessBoundaryConstraintEvidence.Sample evaluate(ProcessModel model) {
+        return ProcessBoundaryConstraintEvidence.Sample.available(evaluator.applyAsDouble(model));
+      }
+    };
+    return addBoundaryConstraint(name, metadata, sampler, ConstraintDefinition.Type.EQUALITY, target,
+        Double.POSITIVE_INFINITY, tolerance, nomination.getUnit(), hard, penaltyWeight, residualScale);
+  }
+
+  /**
+   * Adds a product-quality boundary using fixed limits from a network-quality specification.
+   *
+   * @param name constraint name
+   * @param areaName process area containing the quality point
+   * @param pointName named quality point
+   * @param specification fixed metric, unit, limits, method, and reference basis
+   * @param sampleEvaluator runtime quality sampler
+   * @param hard whether unavailable or off-spec evidence is infeasible
+   * @param penaltyWeight penalty multiplier
+   * @param residualScale positive scale in the specification unit
+   * @return this evaluator for chaining
+   */
+  public ProcessModelSimulationEvaluator addNetworkQualityConstraint(String name, String areaName, String pointName,
+      NetworkQualityResult specification, BoundarySampleEvaluator sampleEvaluator, boolean hard,
+      double penaltyWeight, double residualScale) {
+    if (specification == null || sampleEvaluator == null) {
+      throw new IllegalArgumentException("Quality specification and sampler are required");
+    }
+    Double lower = specification.getLowerLimit();
+    Double upper = specification.getUpperLimit();
+    ConstraintDefinition.Type type;
+    double lowerValue = Double.NEGATIVE_INFINITY;
+    double upperValue = Double.POSITIVE_INFINITY;
+    if (lower != null && upper != null) {
+      type = ConstraintDefinition.Type.RANGE;
+      lowerValue = lower.doubleValue();
+      upperValue = upper.doubleValue();
+    } else if (lower != null) {
+      type = ConstraintDefinition.Type.LOWER_BOUND;
+      lowerValue = lower.doubleValue();
+    } else if (upper != null) {
+      type = ConstraintDefinition.Type.UPPER_BOUND;
+      upperValue = upper.doubleValue();
+    } else {
+      throw new IllegalArgumentException("Quality specification must declare at least one limit");
+    }
+    String observable = specification.getMetricKey();
+    if (specification.getAttributeName() != null && specification.getAttributeName().length() > 0) {
+      observable += ":" + specification.getAttributeName();
+    }
+    String referenceJson = specification.getReference() == null ? null : specification.getReference().toJson();
+    ProcessBoundaryConstraintEvidence.Metadata metadata = new ProcessBoundaryConstraintEvidence.Metadata(
+        areaName + "::" + pointName + "/quality/" + observable, areaName, pointName,
+        ProcessBoundaryConstraintEvidence.Kind.PRODUCT_QUALITY,
+        ProcessBoundaryConstraintEvidence.FlowDirection.NOT_APPLICABLE, NetworkDecisionVariable.RateBasis.NONE,
+        specification.getProvenance(), Double.NaN, null, null,
+        ProcessBoundaryConstraintEvidence.ApplicabilityStatus.NOT_ASSESSED, observable, specification.getMethod(),
+        referenceJson, -1);
+    return addBoundaryConstraint(name, metadata, sampleEvaluator, type, lowerValue, upperValue, 0.0,
+        specification.getUnit(), hard, penaltyWeight, residualScale);
+  }
+
+  /**
    * Gets all constraints.
    *
    * @return constraint definitions
@@ -3616,6 +3865,7 @@ public class ProcessModelSimulationEvaluator implements Serializable {
 
       double[] constraintValues = new double[constraints.size()];
       double[] margins = new double[constraints.size()];
+      List<ProcessBoundaryConstraintEvidence> boundaryEvidence = new ArrayList<ProcessBoundaryConstraintEvidence>();
       List<InstalledEquipmentCapacityEvidence> installedCapacityEvidence = new ArrayList<InstalledEquipmentCapacityEvidence>(
           snapshotInstalledEquipmentCapacityEvidence(processModel));
       Map<String, InstalledEquipmentCapacityEvidence> installedCapacityByIdentity = new LinkedHashMap<String, InstalledEquipmentCapacityEvidence>();
@@ -3626,6 +3876,22 @@ public class ProcessModelSimulationEvaluator implements Serializable {
       boolean feasible = processModel.isModelConverged();
       for (int constraintIndex = 0; constraintIndex < constraints.size(); constraintIndex++) {
         ConstraintDefinition constraint = constraints.get(constraintIndex);
+        ProcessBoundaryConstraintEvidence evaluatedBoundary = null;
+        if (constraint.isBoundaryConstraint()) {
+          ProcessBoundaryConstraintEvidence.Sample sample = constraint.evaluateBoundarySample(processModel);
+          evaluatedBoundary = new ProcessBoundaryConstraintEvidence(constraint.getBoundaryMetadata(), constraint,
+              sample, constraint.getBoundaryResidualScale());
+          boundaryEvidence.add(evaluatedBoundary);
+          constraintValues[constraintIndex] = evaluatedBoundary.getSampledValue();
+          margins[constraintIndex] = evaluatedBoundary.getSignedMargin();
+          if (!evaluatedBoundary.isCalculable()) {
+            penaltySum += constraint.getPenaltyWeight();
+            if (constraint.isHard()) {
+              feasible = false;
+            }
+            continue;
+          }
+        }
         InstalledEquipmentCapacityEvidence capacityEvidence = null;
         if (constraint.isCapacityConstraint() && "1".equals(constraint.getUnit())) {
           capacityEvidence = installedCapacityByIdentity.get(constraint.getName());
@@ -3637,14 +3903,23 @@ public class ProcessModelSimulationEvaluator implements Serializable {
             }
           }
         }
-        if (capacityEvidence == null) {
+        if (evaluatedBoundary != null) {
+          // Value and margin were derived from the single structured sample above.
+        } else if (capacityEvidence == null) {
           constraintValues[constraintIndex] = constraint.evaluate(processModel);
         } else {
           constraintValues[constraintIndex] = capacityEvidence.getNormalizedUtilization();
         }
-        margins[constraintIndex] = constraint.marginFromValue(constraintValues[constraintIndex]);
+        if (evaluatedBoundary == null) {
+          margins[constraintIndex] = constraint.marginFromValue(constraintValues[constraintIndex]);
+        }
         if (margins[constraintIndex] < 0.0) {
-          penaltySum += constraint.penaltyFromMargin(margins[constraintIndex]);
+          if (evaluatedBoundary == null) {
+            penaltySum += constraint.penaltyFromMargin(margins[constraintIndex]);
+          } else {
+            double scaledViolation = evaluatedBoundary.getScaledViolation();
+            penaltySum += constraint.getPenaltyWeight() * scaledViolation * scaledViolation;
+          }
           if (constraint.isHard()) {
             feasible = false;
           }
@@ -3655,6 +3930,7 @@ public class ProcessModelSimulationEvaluator implements Serializable {
       result.setConstraintMargins(margins);
       result.setPenaltySum(penaltySum);
       result.setInstalledEquipmentCapacityEvidence(installedCapacityEvidence);
+      result.setProcessBoundaryConstraintEvidence(boundaryEvidence);
       List<BottleneckStatus> rankedCapacityConstraints = toBottleneckStatuses(installedCapacityEvidence);
       result.setRankedCapacityConstraints(rankedCapacityConstraints);
       result.setActiveBottleneck(selectActiveBottleneck(rankedCapacityConstraints));

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluator.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluator.java
@@ -3110,8 +3110,8 @@ public class ProcessModelSimulationEvaluator implements Serializable {
       if (processBoundaryConstraintEvidence == null || processBoundaryConstraintEvidence.isEmpty()) {
         return Collections.emptyList();
       }
-      return Collections.unmodifiableList(
-          new ArrayList<ProcessBoundaryConstraintEvidence>(processBoundaryConstraintEvidence));
+      return Collections
+          .unmodifiableList(new ArrayList<ProcessBoundaryConstraintEvidence>(processBoundaryConstraintEvidence));
     }
 
     /** Sets boundary evidence using a defensive immutable copy. */
@@ -3120,8 +3120,8 @@ public class ProcessModelSimulationEvaluator implements Serializable {
         processBoundaryConstraintEvidence = Collections.emptyList();
         return;
       }
-      processBoundaryConstraintEvidence = Collections.unmodifiableList(
-          new ArrayList<ProcessBoundaryConstraintEvidence>(evidence));
+      processBoundaryConstraintEvidence = Collections
+          .unmodifiableList(new ArrayList<ProcessBoundaryConstraintEvidence>(evidence));
     }
 
     /**
@@ -3433,8 +3433,8 @@ public class ProcessModelSimulationEvaluator implements Serializable {
    * Adds a fully qualified process-boundary constraint.
    *
    * <p>
-   * Bounds and units are frozen at registration. The structured sampler is invoked once after each completed model
-   * run; missing, non-finite, not-calculable, or out-of-validity evidence fails a hard constraint closed.
+   * Bounds and units are frozen at registration. The structured sampler is invoked once after each completed model run;
+   * missing, non-finite, not-calculable, or out-of-validity evidence fails a hard constraint closed.
    * </p>
    *
    * @param name human-readable constraint name
@@ -3510,9 +3510,9 @@ public class ProcessModelSimulationEvaluator implements Serializable {
     double target = nomination.getValue(periodIndex);
     double tolerance = Math.abs(target) * Math.abs(nomination.getToleranceFraction());
     ProcessBoundaryConstraintEvidence.Metadata metadata = new ProcessBoundaryConstraintEvidence.Metadata(
-        areaName + "::" + nomination.getPointName() + "/nomination/" + periodIndex, areaName,
-        nomination.getPointName(), ProcessBoundaryConstraintEvidence.Kind.NOMINATION, flowDirection,
-        nomination.getBasis(), provenance, Double.NaN, Integer.toString(periodIndex), Integer.toString(periodIndex),
+        areaName + "::" + nomination.getPointName() + "/nomination/" + periodIndex, areaName, nomination.getPointName(),
+        ProcessBoundaryConstraintEvidence.Kind.NOMINATION, flowDirection, nomination.getBasis(), provenance, Double.NaN,
+        Integer.toString(periodIndex), Integer.toString(periodIndex),
         ProcessBoundaryConstraintEvidence.ApplicabilityStatus.APPLICABLE, "nominated rate", null, null, periodIndex);
     BoundarySampleEvaluator sampler = new BoundarySampleEvaluator() {
       private static final long serialVersionUID = 1L;
@@ -3540,8 +3540,8 @@ public class ProcessModelSimulationEvaluator implements Serializable {
    * @return this evaluator for chaining
    */
   public ProcessModelSimulationEvaluator addNetworkQualityConstraint(String name, String areaName, String pointName,
-      NetworkQualityResult specification, BoundarySampleEvaluator sampleEvaluator, boolean hard,
-      double penaltyWeight, double residualScale) {
+      NetworkQualityResult specification, BoundarySampleEvaluator sampleEvaluator, boolean hard, double penaltyWeight,
+      double residualScale) {
     if (specification == null || sampleEvaluator == null) {
       throw new IllegalArgumentException("Quality specification and sampler are required");
     }

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelOperatingActionSetEvaluatorTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelOperatingActionSetEvaluatorTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.capacity.CapacityConstraint;
 import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintSeverity;
 import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintType;
+import neqsim.process.equipment.network.NetworkDecisionVariable;
 import neqsim.process.equipment.reservoir.SimpleReservoir;
 import neqsim.process.equipment.reservoir.WellFlow;
 import neqsim.process.equipment.separator.Separator;
@@ -97,6 +98,16 @@ class ProcessModelOperatingActionSetEvaluatorTest {
     simulation.addObjective("total production",
         model -> fixture.producerA.getFlowRate("kg/hr") + fixture.producerB.getFlowRate("kg/hr"),
         ProcessModelSimulationEvaluator.ObjectiveDefinition.Direction.MAXIMIZE);
+    ProcessBoundaryConstraintEvidence.Metadata boundary = new ProcessBoundaryConstraintEvidence.Metadata(
+        "host-receiving", "gathering", "host inlet", ProcessBoundaryConstraintEvidence.Kind.RECEIVING_CAPACITY,
+        ProcessBoundaryConstraintEvidence.FlowDirection.INTO_PROCESS, NetworkDecisionVariable.RateBasis.MASS,
+        "synthetic host receiving basis", 1.0, null, null,
+        ProcessBoundaryConstraintEvidence.ApplicabilityStatus.NOT_ASSESSED, "total rate", null, null, -1);
+    simulation.addBoundaryConstraint("host receiving rate", boundary,
+        model -> ProcessBoundaryConstraintEvidence.Sample.available(
+            fixture.producerA.getFlowRate("kg/hr") + fixture.producerB.getFlowRate("kg/hr")),
+        ProcessModelSimulationEvaluator.ConstraintDefinition.Type.UPPER_BOUND, Double.NEGATIVE_INFINITY, 2000.0,
+        0.0, "kg/hr", true, 10.0, 1000.0);
     ProcessModelOperatingAction actionA = ProcessModelOperatingAction.continuous("producer-a-rate", "Producer A rate",
         "wells::producer A.flowRate", 200.0, 1000.0, "kg/hr", "synthetic producer A envelope");
     ProcessModelOperatingAction actionB = ProcessModelOperatingAction.continuous("producer-b-rate", "Producer B rate",
@@ -123,6 +134,8 @@ class ProcessModelOperatingActionSetEvaluatorTest {
     assertArrayEquals(new double[] { 600.0, 400.0 }, redistributed.getBaselineValues(), 1.0e-8);
     assertArrayEquals(new double[] { 700.0, 300.0 }, redistributed.getCandidateValues(), 0.0);
     assertEquals(1000.0, redistributed.getRawObjectives()[0], 1.0e-8);
+    assertEquals(1, redistributed.getProcessBoundaryConstraintEvidence().size());
+    assertEquals(1000.0, redistributed.getProcessBoundaryConstraintEvidence().get(0).getSampledValue(), 1.0e-8);
     assertEquals(1000.0 / 1200.0, redistributed.getHydraulicConstraints().get(0).getUtilization(), 1.0e-12);
     assertEquals(1.0 - 1000.0 / 1200.0, redistributed.getHydraulicConstraints().get(0).getMargin(), 1.0e-12);
     assertEquals(600.0, fixture.producerA.getFlowRate("kg/hr"), 1.0e-8);
@@ -210,10 +223,13 @@ class ProcessModelOperatingActionSetEvaluatorTest {
     assertNotSame(restored.getActions(), restored.getActions());
     assertNotSame(restored.getActionEvidence(), restored.getActionEvidence());
     assertNotSame(restored.getHydraulicConstraints(), restored.getHydraulicConstraints());
+    assertNotSame(restored.getProcessBoundaryConstraintEvidence(), restored.getProcessBoundaryConstraintEvidence());
     assertNotSame(restored.getDiagnostics(), restored.getDiagnostics());
     assertThrows(UnsupportedOperationException.class, () -> restored.getActions().clear());
     assertThrows(UnsupportedOperationException.class, () -> restored.getActionEvidence().clear());
     assertThrows(UnsupportedOperationException.class, () -> restored.getHydraulicConstraints().clear());
+    assertThrows(UnsupportedOperationException.class,
+        () -> restored.getProcessBoundaryConstraintEvidence().clear());
     assertThrows(UnsupportedOperationException.class, () -> restored.getDiagnostics().clear());
   }
 

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelOperatingActionSetEvaluatorTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelOperatingActionSetEvaluatorTest.java
@@ -104,10 +104,10 @@ class ProcessModelOperatingActionSetEvaluatorTest {
         "synthetic host receiving basis", 1.0, null, null,
         ProcessBoundaryConstraintEvidence.ApplicabilityStatus.NOT_ASSESSED, "total rate", null, null, -1);
     simulation.addBoundaryConstraint("host receiving rate", boundary,
-        model -> ProcessBoundaryConstraintEvidence.Sample.available(
-            fixture.producerA.getFlowRate("kg/hr") + fixture.producerB.getFlowRate("kg/hr")),
-        ProcessModelSimulationEvaluator.ConstraintDefinition.Type.UPPER_BOUND, Double.NEGATIVE_INFINITY, 2000.0,
-        0.0, "kg/hr", true, 10.0, 1000.0);
+        model -> ProcessBoundaryConstraintEvidence.Sample
+            .available(fixture.producerA.getFlowRate("kg/hr") + fixture.producerB.getFlowRate("kg/hr")),
+        ProcessModelSimulationEvaluator.ConstraintDefinition.Type.UPPER_BOUND, Double.NEGATIVE_INFINITY, 2000.0, 0.0,
+        "kg/hr", true, 10.0, 1000.0);
     ProcessModelOperatingAction actionA = ProcessModelOperatingAction.continuous("producer-a-rate", "Producer A rate",
         "wells::producer A.flowRate", 200.0, 1000.0, "kg/hr", "synthetic producer A envelope");
     ProcessModelOperatingAction actionB = ProcessModelOperatingAction.continuous("producer-b-rate", "Producer B rate",
@@ -228,8 +228,7 @@ class ProcessModelOperatingActionSetEvaluatorTest {
     assertThrows(UnsupportedOperationException.class, () -> restored.getActions().clear());
     assertThrows(UnsupportedOperationException.class, () -> restored.getActionEvidence().clear());
     assertThrows(UnsupportedOperationException.class, () -> restored.getHydraulicConstraints().clear());
-    assertThrows(UnsupportedOperationException.class,
-        () -> restored.getProcessBoundaryConstraintEvidence().clear());
+    assertThrows(UnsupportedOperationException.class, () -> restored.getProcessBoundaryConstraintEvidence().clear());
     assertThrows(UnsupportedOperationException.class, () -> restored.getDiagnostics().clear());
   }
 

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
@@ -21,6 +21,10 @@ import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintSeverity;
 import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintType;
 import neqsim.process.equipment.capacity.ValveCapacityStrategy;
 import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.network.NetworkDecisionVariable;
+import neqsim.process.equipment.network.NetworkNomination;
+import neqsim.process.equipment.network.NetworkQualityResult;
+import neqsim.process.equipment.network.QualityReference;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.valve.ThrottlingValve;
@@ -36,6 +40,165 @@ import neqsim.thermo.system.SystemSrkEos;
  * @version 1.0
  */
 class ProcessModelSimulationEvaluatorTest {
+
+  /** Verifies physical margins, dimensionless residuals, stable identity, and fail-closed status. */
+  @Test
+  void boundaryEvidenceRetainsQualifiedMetadataAndFailsClosed() {
+    ModelFixture fixture = createModelFixture();
+    ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(fixture.model);
+    ProcessBoundaryConstraintEvidence.Metadata metadata = new ProcessBoundaryConstraintEvidence.Metadata(
+        "export-gas", "separation", "gas export", ProcessBoundaryConstraintEvidence.Kind.EXPORT_CAPACITY,
+        ProcessBoundaryConstraintEvidence.FlowDirection.OUT_OF_PROCESS,
+        NetworkDecisionVariable.RateBasis.MASS, "installed export contract", 0.9, "2026-01", "2026-12",
+        ProcessBoundaryConstraintEvidence.ApplicabilityStatus.APPLICABLE, "gas rate", "metered", null, -1);
+    AtomicInteger samples = new AtomicInteger();
+    evaluator.addBoundaryConstraint("maximum export", metadata, model -> {
+      samples.incrementAndGet();
+      return ProcessBoundaryConstraintEvidence.Sample.available(10500.0);
+    }, ProcessModelSimulationEvaluator.ConstraintDefinition.Type.UPPER_BOUND, Double.NEGATIVE_INFINITY, 10000.0,
+        0.0, "kg/hr", true, 25.0, 500.0);
+
+    ProcessModelSimulationEvaluator.EvaluationResult result = evaluator.evaluate(new double[0]);
+    ProcessBoundaryConstraintEvidence evidence = result.getProcessBoundaryConstraintEvidence().get(0);
+
+    assertEquals(1, samples.get());
+    assertFalse(result.isFeasible());
+    assertEquals("separation::gas export/maximum export", evidence.getQualifiedConstraintName());
+    assertEquals(10500.0, evidence.getSampledValue(), 0.0);
+    assertEquals(-500.0, evidence.getSignedMargin(), 0.0);
+    assertEquals(500.0, evidence.getViolation(), 0.0);
+    assertEquals(1.0, evidence.getScaledViolation(), 0.0);
+    assertEquals(25.0, result.getPenaltySum(), 0.0);
+    assertEquals("kg/hr", evidence.getUnit());
+    assertEquals(NetworkDecisionVariable.RateBasis.MASS, evidence.getMetadata().getRateBasis());
+    assertThrows(UnsupportedOperationException.class, () -> result.getProcessBoundaryConstraintEvidence().clear());
+
+    ProcessModelSimulationEvaluator missingEvaluator = new ProcessModelSimulationEvaluator(fixture.model);
+    missingEvaluator.addBoundaryConstraint("required injection", metadata,
+        model -> new ProcessBoundaryConstraintEvidence.Sample(null,
+            ProcessBoundaryConstraintEvidence.CalculationStatus.NOT_CALCULABLE, null, "meter historian",
+            "sample unavailable"), ProcessModelSimulationEvaluator.ConstraintDefinition.Type.LOWER_BOUND, 100.0,
+        Double.POSITIVE_INFINITY, 0.0, "kg/hr", true, 7.0, 100.0);
+    ProcessModelSimulationEvaluator.EvaluationResult missing = missingEvaluator.evaluate(new double[0]);
+    assertFalse(missing.isFeasible());
+    assertEquals(7.0, missing.getPenaltySum(), 0.0);
+    assertTrue(Double.isNaN(missing.getConstraintValues()[0]));
+    assertEquals(ProcessBoundaryConstraintEvidence.CalculationStatus.NOT_CALCULABLE,
+        missing.getProcessBoundaryConstraintEvidence().get(0).getCalculationStatus());
+
+    ProcessModelSimulationEvaluator lowerEvaluator = new ProcessModelSimulationEvaluator(fixture.model);
+    ProcessBoundaryConstraintEvidence.Metadata injection = new ProcessBoundaryConstraintEvidence.Metadata(
+        "water-injection", "wells", "injection header", ProcessBoundaryConstraintEvidence.Kind.INJECTION,
+        ProcessBoundaryConstraintEvidence.FlowDirection.INTO_PROCESS, NetworkDecisionVariable.RateBasis.MASS,
+        "injection operating envelope", Double.NaN, null, null,
+        ProcessBoundaryConstraintEvidence.ApplicabilityStatus.APPLICABLE, "water rate", null, null, -1);
+    lowerEvaluator.addBoundaryConstraint("minimum injection", injection,
+        model -> ProcessBoundaryConstraintEvidence.Sample.available(50.0),
+        ProcessModelSimulationEvaluator.ConstraintDefinition.Type.LOWER_BOUND, 100.0,
+        Double.POSITIVE_INFINITY, 0.0, "kg/hr", true, 1.0, 25.0);
+    ProcessModelSimulationEvaluator.EvaluationResult lower = lowerEvaluator.evaluate(new double[0]);
+    assertFalse(lower.isFeasible());
+    assertEquals(-50.0, lower.getConstraintMargins()[0], 0.0);
+    assertEquals(2.0, lower.getProcessBoundaryConstraintEvidence().get(0).getScaledViolation(), 0.0);
+  }
+
+  /** Verifies nomination and network-quality adapters retain their source metadata and sample once. */
+  @Test
+  void nominationAndQualityAdaptersProduceFreshDeterministicEvidence() {
+    ModelFixture fixture = createModelFixture();
+    ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(fixture.model);
+    NetworkNomination nomination = new NetworkNomination("sales meter", new double[] {10000.0, 12000.0},
+        "kg/hr", NetworkDecisionVariable.RateBasis.MASS, 0.02);
+    AtomicInteger nominationSamples = new AtomicInteger();
+    evaluator.addNominationConstraint("sales nomination", "separation", nomination, 0,
+        ProcessBoundaryConstraintEvidence.FlowDirection.OUT_OF_PROCESS, model -> {
+          nominationSamples.incrementAndGet();
+          return 10150.0;
+        }, true, 10.0, 200.0, "daily shipper nomination");
+
+    QualityReference reference = QualityReference.atPressureAndTemperature(70.0, "bara", 15.0, "C")
+        .withBasis("synthetic sales-gas specification");
+    NetworkQualityResult specification = new NetworkQualityResult("water_dew_point", null, null, "C", reference,
+        null, -8.0, null, NetworkQualityResult.Status.NOT_CALCULABLE, "ISO synthetic", "sales contract", null);
+    AtomicInteger qualitySamples = new AtomicInteger();
+    evaluator.addNetworkQualityConstraint("water dew point", "separation", "sales meter", specification,
+        model -> {
+          qualitySamples.incrementAndGet();
+          return ProcessBoundaryConstraintEvidence.Sample.fromNetworkQualityResult(new NetworkQualityResult(
+              "water_dew_point", null, -10.0, "C", reference, null, -8.0, 2.0,
+              NetworkQualityResult.Status.PASS, "ISO synthetic", "online analyzer", "within limit"));
+        }, true, 10.0, 1.0);
+
+    ProcessModelSimulationEvaluator.EvaluationResult first = evaluator.evaluate(new double[0]);
+    ProcessModelSimulationEvaluator.EvaluationResult second = evaluator.evaluate(new double[0]);
+
+    assertTrue(first.isFeasible());
+    assertTrue(second.isFeasible());
+    assertEquals(2, nominationSamples.get());
+    assertEquals(2, qualitySamples.get());
+    assertEquals(150.0, first.getConstraintMargins()[0], 0.0);
+    assertEquals(2.0, first.getConstraintMargins()[1], 0.0);
+    assertEquals(0, first.getProcessBoundaryConstraintEvidence().get(0).getMetadata().getPeriodIndex());
+    assertEquals("water_dew_point",
+        first.getProcessBoundaryConstraintEvidence().get(1).getMetadata().getObservableName());
+    assertTrue(first.getProcessBoundaryConstraintEvidence().get(1).getMetadata().getReferenceJson()
+        .contains("synthetic sales-gas specification"));
+    assertEquals(Double.valueOf(2.0), first.getProcessBoundaryConstraintEvidence().get(1).getSourceMargin());
+    assertNotSame(first.getProcessBoundaryConstraintEvidence(), second.getProcessBoundaryConstraintEvidence());
+
+    ProcessModelSimulationEvaluator failingQuality = new ProcessModelSimulationEvaluator(fixture.model);
+    failingQuality.addNetworkQualityConstraint("water dew point", "separation", "sales meter", specification,
+        model -> ProcessBoundaryConstraintEvidence.Sample.fromNetworkQualityResult(new NetworkQualityResult(
+            "water_dew_point", null, -6.0, "C", reference, null, -8.0, -2.0,
+            NetworkQualityResult.Status.FAIL, "ISO synthetic", "online analyzer", "above limit")),
+        true, 10.0, 1.0);
+    ProcessModelSimulationEvaluator.EvaluationResult failed = failingQuality.evaluate(new double[0]);
+    assertFalse(failed.isFeasible());
+    assertEquals(-2.0, failed.getConstraintMargins()[0], 0.0);
+    assertEquals(ProcessBoundaryConstraintEvidence.CalculationStatus.AVAILABLE,
+        failed.getProcessBoundaryConstraintEvidence().get(0).getCalculationStatus());
+
+    ProcessModelSimulationEvaluator unavailableQuality = new ProcessModelSimulationEvaluator(fixture.model);
+    unavailableQuality.addNetworkQualityConstraint("water dew point", "separation", "sales meter", specification,
+        model -> ProcessBoundaryConstraintEvidence.Sample.fromNetworkQualityResult(new NetworkQualityResult(
+            "water_dew_point", null, null, "C", reference, null, -8.0, null,
+            NetworkQualityResult.Status.NOT_CALCULABLE, "ISO synthetic", "online analyzer", "sample missing")),
+        true, 10.0, 1.0);
+    ProcessModelSimulationEvaluator.EvaluationResult unavailable = unavailableQuality.evaluate(new double[0]);
+    assertFalse(unavailable.isFeasible());
+    assertEquals(ProcessBoundaryConstraintEvidence.CalculationStatus.NOT_CALCULABLE,
+        unavailable.getProcessBoundaryConstraintEvidence().get(0).getCalculationStatus());
+  }
+
+  /** Verifies evaluated evidence remains serializable without retaining simulator callbacks. */
+  @Test
+  void boundaryEvidenceRoundTripsThroughJavaSerialization() throws Exception {
+    ModelFixture fixture = createModelFixture();
+    ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(fixture.model);
+    ProcessBoundaryConstraintEvidence.Metadata metadata = new ProcessBoundaryConstraintEvidence.Metadata(
+        "receiving", "wells", "host inlet", ProcessBoundaryConstraintEvidence.Kind.RECEIVING_CAPACITY,
+        ProcessBoundaryConstraintEvidence.FlowDirection.INTO_PROCESS, NetworkDecisionVariable.RateBasis.MASS,
+        "host design basis", Double.NaN, null, null,
+        ProcessBoundaryConstraintEvidence.ApplicabilityStatus.NOT_ASSESSED, "rate", null, null, -1);
+    evaluator.addBoundaryConstraint("host capacity", metadata,
+        model -> ProcessBoundaryConstraintEvidence.Sample.available(9000.0),
+        ProcessModelSimulationEvaluator.ConstraintDefinition.Type.RANGE, 1000.0, 10000.0, 0.0, "kg/hr", true,
+        1.0, 1000.0);
+    ProcessBoundaryConstraintEvidence original = evaluator.evaluate(new double[0])
+        .getProcessBoundaryConstraintEvidence().get(0);
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream output = new ObjectOutputStream(bytes);
+    output.writeObject(original);
+    output.close();
+    ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    ProcessBoundaryConstraintEvidence restored = (ProcessBoundaryConstraintEvidence) input.readObject();
+    input.close();
+
+    assertEquals(original.getQualifiedConstraintName(), restored.getQualifiedConstraintName());
+    assertEquals(original.getSignedMargin(), restored.getSignedMargin(), 0.0);
+    assertEquals("host design basis", restored.getMetadata().getProvenance());
+  }
 
   /**
    * Test fixture holding a small two-area process model.

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
@@ -136,7 +136,7 @@ class ProcessModelSimulationEvaluatorTest {
     assertTrue(second.isFeasible());
     assertEquals(2, nominationSamples.get());
     assertEquals(2, qualitySamples.get());
-    assertEquals(150.0, first.getConstraintMargins()[0], 0.0);
+    assertEquals(50.0, first.getConstraintMargins()[0], 0.0);
     assertEquals(2.0, first.getConstraintMargins()[1], 0.0);
     assertEquals(0, first.getProcessBoundaryConstraintEvidence().get(0).getMetadata().getPeriodIndex());
     assertEquals("water_dew_point",

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
@@ -46,17 +46,17 @@ class ProcessModelSimulationEvaluatorTest {
   void boundaryEvidenceRetainsQualifiedMetadataAndFailsClosed() {
     ModelFixture fixture = createModelFixture();
     ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(fixture.model);
-    ProcessBoundaryConstraintEvidence.Metadata metadata = new ProcessBoundaryConstraintEvidence.Metadata(
-        "export-gas", "separation", "gas export", ProcessBoundaryConstraintEvidence.Kind.EXPORT_CAPACITY,
-        ProcessBoundaryConstraintEvidence.FlowDirection.OUT_OF_PROCESS,
-        NetworkDecisionVariable.RateBasis.MASS, "installed export contract", 0.9, "2026-01", "2026-12",
+    ProcessBoundaryConstraintEvidence.Metadata metadata = new ProcessBoundaryConstraintEvidence.Metadata("export-gas",
+        "separation", "gas export", ProcessBoundaryConstraintEvidence.Kind.EXPORT_CAPACITY,
+        ProcessBoundaryConstraintEvidence.FlowDirection.OUT_OF_PROCESS, NetworkDecisionVariable.RateBasis.MASS,
+        "installed export contract", 0.9, "2026-01", "2026-12",
         ProcessBoundaryConstraintEvidence.ApplicabilityStatus.APPLICABLE, "gas rate", "metered", null, -1);
     AtomicInteger samples = new AtomicInteger();
     evaluator.addBoundaryConstraint("maximum export", metadata, model -> {
       samples.incrementAndGet();
       return ProcessBoundaryConstraintEvidence.Sample.available(10500.0);
-    }, ProcessModelSimulationEvaluator.ConstraintDefinition.Type.UPPER_BOUND, Double.NEGATIVE_INFINITY, 10000.0,
-        0.0, "kg/hr", true, 25.0, 500.0);
+    }, ProcessModelSimulationEvaluator.ConstraintDefinition.Type.UPPER_BOUND, Double.NEGATIVE_INFINITY, 10000.0, 0.0,
+        "kg/hr", true, 25.0, 500.0);
 
     ProcessModelSimulationEvaluator.EvaluationResult result = evaluator.evaluate(new double[0]);
     ProcessBoundaryConstraintEvidence evidence = result.getProcessBoundaryConstraintEvidence().get(0);
@@ -77,8 +77,9 @@ class ProcessModelSimulationEvaluatorTest {
     missingEvaluator.addBoundaryConstraint("required injection", metadata,
         model -> new ProcessBoundaryConstraintEvidence.Sample(null,
             ProcessBoundaryConstraintEvidence.CalculationStatus.NOT_CALCULABLE, null, "meter historian",
-            "sample unavailable"), ProcessModelSimulationEvaluator.ConstraintDefinition.Type.LOWER_BOUND, 100.0,
-        Double.POSITIVE_INFINITY, 0.0, "kg/hr", true, 7.0, 100.0);
+            "sample unavailable"),
+        ProcessModelSimulationEvaluator.ConstraintDefinition.Type.LOWER_BOUND, 100.0, Double.POSITIVE_INFINITY, 0.0,
+        "kg/hr", true, 7.0, 100.0);
     ProcessModelSimulationEvaluator.EvaluationResult missing = missingEvaluator.evaluate(new double[0]);
     assertFalse(missing.isFeasible());
     assertEquals(7.0, missing.getPenaltySum(), 0.0);
@@ -94,8 +95,8 @@ class ProcessModelSimulationEvaluatorTest {
         ProcessBoundaryConstraintEvidence.ApplicabilityStatus.APPLICABLE, "water rate", null, null, -1);
     lowerEvaluator.addBoundaryConstraint("minimum injection", injection,
         model -> ProcessBoundaryConstraintEvidence.Sample.available(50.0),
-        ProcessModelSimulationEvaluator.ConstraintDefinition.Type.LOWER_BOUND, 100.0,
-        Double.POSITIVE_INFINITY, 0.0, "kg/hr", true, 1.0, 25.0);
+        ProcessModelSimulationEvaluator.ConstraintDefinition.Type.LOWER_BOUND, 100.0, Double.POSITIVE_INFINITY, 0.0,
+        "kg/hr", true, 1.0, 25.0);
     ProcessModelSimulationEvaluator.EvaluationResult lower = lowerEvaluator.evaluate(new double[0]);
     assertFalse(lower.isFeasible());
     assertEquals(-50.0, lower.getConstraintMargins()[0], 0.0);
@@ -107,8 +108,8 @@ class ProcessModelSimulationEvaluatorTest {
   void nominationAndQualityAdaptersProduceFreshDeterministicEvidence() {
     ModelFixture fixture = createModelFixture();
     ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(fixture.model);
-    NetworkNomination nomination = new NetworkNomination("sales meter", new double[] {10000.0, 12000.0},
-        "kg/hr", NetworkDecisionVariable.RateBasis.MASS, 0.02);
+    NetworkNomination nomination = new NetworkNomination("sales meter", new double[] { 10000.0, 12000.0 }, "kg/hr",
+        NetworkDecisionVariable.RateBasis.MASS, 0.02);
     AtomicInteger nominationSamples = new AtomicInteger();
     evaluator.addNominationConstraint("sales nomination", "separation", nomination, 0,
         ProcessBoundaryConstraintEvidence.FlowDirection.OUT_OF_PROCESS, model -> {
@@ -118,16 +119,15 @@ class ProcessModelSimulationEvaluatorTest {
 
     QualityReference reference = QualityReference.atPressureAndTemperature(70.0, "bara", 15.0, "C")
         .withBasis("synthetic sales-gas specification");
-    NetworkQualityResult specification = new NetworkQualityResult("water_dew_point", null, null, "C", reference,
-        null, -8.0, null, NetworkQualityResult.Status.NOT_CALCULABLE, "ISO synthetic", "sales contract", null);
+    NetworkQualityResult specification = new NetworkQualityResult("water_dew_point", null, null, "C", reference, null,
+        -8.0, null, NetworkQualityResult.Status.NOT_CALCULABLE, "ISO synthetic", "sales contract", null);
     AtomicInteger qualitySamples = new AtomicInteger();
-    evaluator.addNetworkQualityConstraint("water dew point", "separation", "sales meter", specification,
-        model -> {
-          qualitySamples.incrementAndGet();
-          return ProcessBoundaryConstraintEvidence.Sample.fromNetworkQualityResult(new NetworkQualityResult(
-              "water_dew_point", null, -10.0, "C", reference, null, -8.0, 2.0,
-              NetworkQualityResult.Status.PASS, "ISO synthetic", "online analyzer", "within limit"));
-        }, true, 10.0, 1.0);
+    evaluator.addNetworkQualityConstraint("water dew point", "separation", "sales meter", specification, model -> {
+      qualitySamples.incrementAndGet();
+      return ProcessBoundaryConstraintEvidence.Sample
+          .fromNetworkQualityResult(new NetworkQualityResult("water_dew_point", null, -10.0, "C", reference, null, -8.0,
+              2.0, NetworkQualityResult.Status.PASS, "ISO synthetic", "online analyzer", "within limit"));
+    }, true, 10.0, 1.0);
 
     ProcessModelSimulationEvaluator.EvaluationResult first = evaluator.evaluate(new double[0]);
     ProcessModelSimulationEvaluator.EvaluationResult second = evaluator.evaluate(new double[0]);
@@ -148,9 +148,9 @@ class ProcessModelSimulationEvaluatorTest {
 
     ProcessModelSimulationEvaluator failingQuality = new ProcessModelSimulationEvaluator(fixture.model);
     failingQuality.addNetworkQualityConstraint("water dew point", "separation", "sales meter", specification,
-        model -> ProcessBoundaryConstraintEvidence.Sample.fromNetworkQualityResult(new NetworkQualityResult(
-            "water_dew_point", null, -6.0, "C", reference, null, -8.0, -2.0,
-            NetworkQualityResult.Status.FAIL, "ISO synthetic", "online analyzer", "above limit")),
+        model -> ProcessBoundaryConstraintEvidence.Sample
+            .fromNetworkQualityResult(new NetworkQualityResult("water_dew_point", null, -6.0, "C", reference, null,
+                -8.0, -2.0, NetworkQualityResult.Status.FAIL, "ISO synthetic", "online analyzer", "above limit")),
         true, 10.0, 1.0);
     ProcessModelSimulationEvaluator.EvaluationResult failed = failingQuality.evaluate(new double[0]);
     assertFalse(failed.isFeasible());
@@ -160,9 +160,9 @@ class ProcessModelSimulationEvaluatorTest {
 
     ProcessModelSimulationEvaluator unavailableQuality = new ProcessModelSimulationEvaluator(fixture.model);
     unavailableQuality.addNetworkQualityConstraint("water dew point", "separation", "sales meter", specification,
-        model -> ProcessBoundaryConstraintEvidence.Sample.fromNetworkQualityResult(new NetworkQualityResult(
-            "water_dew_point", null, null, "C", reference, null, -8.0, null,
-            NetworkQualityResult.Status.NOT_CALCULABLE, "ISO synthetic", "online analyzer", "sample missing")),
+        model -> ProcessBoundaryConstraintEvidence.Sample.fromNetworkQualityResult(
+            new NetworkQualityResult("water_dew_point", null, null, "C", reference, null, -8.0, null,
+                NetworkQualityResult.Status.NOT_CALCULABLE, "ISO synthetic", "online analyzer", "sample missing")),
         true, 10.0, 1.0);
     ProcessModelSimulationEvaluator.EvaluationResult unavailable = unavailableQuality.evaluate(new double[0]);
     assertFalse(unavailable.isFeasible());
@@ -175,15 +175,15 @@ class ProcessModelSimulationEvaluatorTest {
   void boundaryEvidenceRoundTripsThroughJavaSerialization() throws Exception {
     ModelFixture fixture = createModelFixture();
     ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(fixture.model);
-    ProcessBoundaryConstraintEvidence.Metadata metadata = new ProcessBoundaryConstraintEvidence.Metadata(
-        "receiving", "wells", "host inlet", ProcessBoundaryConstraintEvidence.Kind.RECEIVING_CAPACITY,
+    ProcessBoundaryConstraintEvidence.Metadata metadata = new ProcessBoundaryConstraintEvidence.Metadata("receiving",
+        "wells", "host inlet", ProcessBoundaryConstraintEvidence.Kind.RECEIVING_CAPACITY,
         ProcessBoundaryConstraintEvidence.FlowDirection.INTO_PROCESS, NetworkDecisionVariable.RateBasis.MASS,
-        "host design basis", Double.NaN, null, null,
-        ProcessBoundaryConstraintEvidence.ApplicabilityStatus.NOT_ASSESSED, "rate", null, null, -1);
+        "host design basis", Double.NaN, null, null, ProcessBoundaryConstraintEvidence.ApplicabilityStatus.NOT_ASSESSED,
+        "rate", null, null, -1);
     evaluator.addBoundaryConstraint("host capacity", metadata,
         model -> ProcessBoundaryConstraintEvidence.Sample.available(9000.0),
-        ProcessModelSimulationEvaluator.ConstraintDefinition.Type.RANGE, 1000.0, 10000.0, 0.0, "kg/hr", true,
-        1.0, 1000.0);
+        ProcessModelSimulationEvaluator.ConstraintDefinition.Type.RANGE, 1000.0, 10000.0, 0.0, "kg/hr", true, 1.0,
+        1000.0);
     ProcessBoundaryConstraintEvidence original = evaluator.evaluate(new double[0])
         .getProcessBoundaryConstraintEvidence().get(0);
 


### PR DESCRIPTION
## Production-engineering value

Advances dependency 10 of #2941 with a complete optimization-facing process-boundary constraint slice. Existing `ProcessModel` candidates can now expose deterministic, unit-safe evidence for injection, receiving, export, product-quality, and nomination limits without changing any underlying hydraulic, thermodynamic, network, or market solver.

## Baseline

At `master` eb284675a0295fac97a60c2c40517fd5ccc71b24, `ProcessModelSimulationEvaluator` could evaluate generic scalar constraints and installed equipment capacity, but it did not retain qualified boundary identity/provenance, rate basis, validity, calculation status, physical residuals, or network nomination/quality metadata. Operating-action results consequently could not carry this evidence to optimization/allocation callers.

## Implementation

- adds immutable, Java-serializable `ProcessBoundaryConstraintEvidence` with stable `area::point/constraint` identity
- separates physical value/margin/violation from explicitly scaled dimensionless violation
- retains kind, direction, rate basis, constraint type/severity, unit, bounds/target/tolerance, provenance, confidence, effective period, applicability, calculation status, source margin, and diagnostics
- samples each structured boundary callback once per completed operating point
- fails hard constraints closed for missing, non-finite, not-calculable, or outside-validity evidence
- adds fixed-limit adapters for `NetworkNomination` and `NetworkQualityResult`
- propagates fresh immutable evidence through simulation, single operating-action, coupled action-set, and downstream allocation candidate records
- keeps legacy generic constraints and installed-capacity behavior compatible

## Acceptance evidence in tests

Focused regressions cover:

- lower, upper, range, and equality residuals
- injection, export, receiving, nomination, and product-quality identities
- quality pass, fail, and not-calculable outcomes
- single-sample invocation and deterministic repeated evaluation
- physical versus dimensionless residual scaling
- fail-closed unavailable evidence
- defensive immutable lists
- Java serialization/JPype-oriented getters
- coupled action-set propagation and serialization

The fixture uses synthetic deterministic process data. No empirical correlation or proprietary data is introduced. Conservation and convergence remain governed by the unchanged `ProcessModel` run.

## Validation

**VALIDATION PENDING CI — local Maven blocked; repository formatter artifact applied**

Executed on the exact published checkout:

- `git diff --check` — passed
- `python devtools/check_documentation_search.py` — passed (654 Markdown pages, 1 standalone HTML page)
- `python devtools/run_spotless.py apply` — blocked: Maven could not resolve the Spotless plugin prefix
- `python devtools/run_spotless.py check` — blocked by the same plugin-resolution failure
- `./mvnw -q -DskipITs -Dtest=ProcessModelSimulationEvaluatorTest test` — blocked before compilation: DNS could not resolve `repo.maven.apache.org` for `maven-enforcer-plugin:3.6.3`
- pre-commit — unavailable in the task environment
- initial GitHub pre-commit run — identified only Spotless differences
- repository `Spotless format patch` artifact — applied exactly in `a889f13d98b98a4888e3d008cdc402f66a34f992`; replacement CI is pending

No blocked command is claimed as passing. The draft should remain unmerged until CI compiles on Java 8/21, runs focused/broader tests, and passes Spotless/documentation gates.

## Documentation impact

Updated `OPTIMIZATION_AND_CONSTRAINTS.md` with the evidence contract, fail-closed semantics, nomination example, residual scaling, and explicit scope boundary.

## Compatibility, performance, and risk

- additive public API; existing scalar and equipment-capacity registrations are unchanged
- boundary callbacks are transient like existing evaluator callbacks; evaluated evidence itself is immutable and serializable
- one boundary sample per registered boundary per model point; no additional process run
- fixed registration limits prevent candidate-to-candidate specification drift
- main residual risk is unverified compilation because local Maven dependency resolution was unavailable; formatting now matches the repository-produced artifact and replacement CI is the required validator

## Exclusions / next dependency

This PR does not implement injection physics, gas-quality calculations, network solvers, nominations/settlement economics, market optimization, controls, dynamics, TP flash, two-fluid, columns, or generic process-performance internals. After this tranche is validated, the next #2941 step is optimization diagnostics/ranking over the qualified evidence rather than another boundary DTO.