### PR TITLE
[AI-Assisted] docs(safety): repair relief-valve sizing guide

### DIFF
--- a/docs/safety/README.md
+++ b/docs/safety/README.md
@@ -90,3 +90,4 @@ This folder contains guides for implementing safety systems in process simulatio
 - [Process Package](../process/) - Process simulation overview
 - [Process Safety](../process/safety/) - Safety equipment classes
 - [Controllers](../process/controllers.md) - Controller devices
+

--- a/docs/safety/README.md
+++ b/docs/safety/README.md
@@ -68,6 +68,7 @@ This folder contains guides for implementing safety systems in process simulatio
 
 | Document | Description |
 |----------|-------------|
+| [Relief-Valve Sizing Screening](relief_valve_sizing_api.md) | Static gas, liquid, two-phase, and wetted-surface fire screening APIs with explicit SI units and qualification limits |
 | [Trapped Inventory Calculator](trapped_inventory_calculator.md) | Evidence-linked trapped inventory for isolation, blowdown, flare-load, and MDMT screening |
 | [Trapped Liquid Fire Rupture](trapped_liquid_fire_rupture.md) | Fire exposure, thermal expansion, pipe/flange failure screening, PFP demand, and source-term handoff |
 | [Blocked-In Liquid Thermal Expansion](blocked_in_liquid_thermal_expansion.md) | Isochoric pressure-rise screening and simplified beta/kappa relation for blocked-in liquid thermal relief screening |
@@ -89,4 +90,3 @@ This folder contains guides for implementing safety systems in process simulatio
 - [Process Package](../process/) - Process simulation overview
 - [Process Safety](../process/safety/) - Safety equipment classes
 - [Controllers](../process/controllers.md) - Controller devices
-

--- a/docs/safety/relief_valve_sizing_api.md
+++ b/docs/safety/relief_valve_sizing_api.md
@@ -1,187 +1,210 @@
 ---
-title: "Relief Valve Sizing - API 520/521"
-description: "PSV sizing for gas, liquid, and two-phase relief per API 520 and API 521, including fire heat input calculations."
+title: "Relief-Valve Sizing Screening"
+description: "Static NeqSim screening APIs for gas, liquid, two-phase, and fire-case relief calculations, with explicit SI units and engineering limitations."
 ---
 
-# Relief Valve Sizing - API 520 / 521
+`ReliefValveSizing` is a static screening utility for preliminary pressure-relief calculations. It does not hold a
+thermodynamic system or relief-valve state: the constructor is private, and callers supply the required relieving
+properties directly to each static method.
 
-The `ReliefValveSizing` class calculates required orifice area and mass flow capacity for pressure safety valves (PSVs) using API 520 / 521 methods. It supports gas, liquid, and two-phase service.
+The calculations support transparent comparisons and early design studies. They do not establish scenario
+completeness, certified valve capacity, installation acceptability, conformity with a purchased standard edition, or
+approval for design or construction. Confirm the governing edition, certified coefficients, applicable correction
+factors, inlet and outlet hydraulics, reaction forces, disposal-system back pressure, and independent review before
+using a result for an engineered relief system.
 
-**Class**: `neqsim.process.util.fire.ReliefValveSizing`
+**Class:** `neqsim.process.util.fire.ReliefValveSizing`
 
----
+## Unit contract
 
-## Capabilities
+The public methods do not accept unit strings. Convert all inputs before calling them.
 
-| Scenario | Method | Standard |
-|----------|--------|----------|
-| Gas / vapour relief | `calculateRequiredArea()` | API 520 Section 5 |
-| Liquid relief | `calculateLiquidReliefArea()` | API 520 Section 5.8 |
-| Two-phase relief | `calculateTwoPhaseReliefArea()` | API 520 Appendix D (Leung omega) |
-| Fire heat input | `calculateAPI521FireHeatInput()` | API 521 Table 4 |
-| Cv rating | `calculateCv()` | ISA/IEC |
-| Mass flow capacity | `calculateMassFlowCapacity()` | API 520 |
-| Blowdown pressure | `calculateBlowdownPressure()` | API 520/526 |
+| Quantity | Required unit or basis |
+| --- | --- |
+| Mass flow | kg/s |
+| Volumetric flow | m³/s at relieving conditions |
+| Set and back pressure | Pa absolute |
+| Temperature | K |
+| Molecular weight | kg/mol |
+| Density | kg/m³ at relieving conditions |
+| Dynamic viscosity | Pa·s |
+| Latent heat | J/kg |
+| Heat capacity | J/(kg·K) |
+| Orifice and wetted area | m² |
+| Gas fraction, overpressure, $Z$, and $C_p/C_v$ | dimensionless |
 
----
+## Current API
 
-## Gas Relief Sizing
+| Screening task | Static method | Result |
+| --- | --- | --- |
+| Gas or vapour required area | `calculateRequiredArea(...)` | `PSVSizingResult`, including required and selected areas |
+| Gas or vapour capacity | `calculateMassFlowCapacity(...)` | Capacity in kg/s |
+| Liquid required area | `calculateLiquidReliefArea(...)` | `LiquidPSVSizingResult` |
+| Two-phase required area | `calculateTwoPhaseReliefArea(...)` | Area in m² |
+| Wetted-surface fire heat input | `calculateAPI521FireHeatInput(...)` | Heat input in W |
+| Reseat pressure screening | `calculateBlowdownPressure(...)` | Pressure in Pa |
+| Approximate valve coefficient | `calculateCv(...)` | Approximate $C_v$ |
 
-The standard gas PSV sizing determines the required orifice area for critical (choked) or subcritical flow.
+## Complete Java 8 example
 
-### Java Example
+The following program exercises the gas, liquid, two-phase, and fire helpers with explicit SI conversions.
 
 ```java
+import java.util.Locale;
+import java.util.logging.Logger;
 import neqsim.process.util.fire.ReliefValveSizing;
-import neqsim.thermo.system.SystemSrkEos;
 
-SystemSrkEos fluid = new SystemSrkEos(273.15 + 60, 100.0);
-fluid.addComponent("methane", 0.85);
-fluid.addComponent("ethane", 0.10);
-fluid.addComponent("propane", 0.05);
-fluid.setMixingRule("classic");
+public final class ReliefValveSizingExample {
+  private static final Logger LOGGER =
+      Logger.getLogger(ReliefValveSizingExample.class.getName());
 
-ReliefValveSizing psv = new ReliefValveSizing(fluid);
-psv.setReliefPressure(110.0);              // bara
-psv.setBackPressure(1.013);                // bara
-psv.setReliefTemperature(273.15 + 60.0);   // K
-psv.setReliefMassRate(5000.0);             // kg/hr
+  private ReliefValveSizingExample() {
+  }
 
-double area = psv.calculateRequiredArea();
-double capacity = psv.calculateMassFlowCapacity();
-System.out.println("Required area: " + area + " m2");
-System.out.println("Mass flow capacity: " + capacity + " kg/hr");
+  public static void main(String[] args) {
+    ReliefValveSizing.PSVSizingResult gasResult =
+        ReliefValveSizing.calculateRequiredArea(
+            5000.0 / 3600.0,
+            110.0e5,
+            0.10,
+            1.013e5,
+            333.15,
+            0.018,
+            0.95,
+            1.30,
+            false,
+            false);
+
+    ReliefValveSizing.LiquidPSVSizingResult liquidResult =
+        ReliefValveSizing.calculateLiquidReliefArea(
+            50.0 / 3600.0,
+            850.0,
+            25.0e5,
+            0.10,
+            1.013e5,
+            0.004,
+            false);
+
+    double twoPhaseArea =
+        ReliefValveSizing.calculateTwoPhaseReliefArea(
+            30000.0 / 3600.0,
+            80.0e5,
+            0.10,
+            5.0e5,
+            373.15,
+            0.30,
+            50.0,
+            700.0,
+            250000.0,
+            2500.0);
+
+    double fireHeatInput =
+        ReliefValveSizing.calculateAPI521FireHeatInput(80.0, true, true);
+
+    if (gasResult.getRequiredArea() <= 0.0
+        || liquidResult.getRequiredAreaM2() <= 0.0
+        || twoPhaseArea <= 0.0
+        || fireHeatInput <= 0.0) {
+      throw new IllegalStateException("Relief screening produced a non-positive result");
+    }
+
+    LOGGER.info(
+        String.format(
+            Locale.ROOT,
+            "gas=%.6g m2 (%s), liquid=%.6g m2 (%s), two-phase=%.6g m2, fire=%.1f kW",
+            gasResult.getRequiredArea(),
+            gasResult.getRecommendedOrifice(),
+            liquidResult.getRequiredAreaM2(),
+            liquidResult.getRecommendedOrifice(),
+            twoPhaseArea,
+            fireHeatInput / 1000.0));
+  }
+}
 ```
 
----
+The current implementation gives approximately:
 
-## Liquid Relief Sizing
+| Result | Screening value |
+| --- | ---: |
+| Gas required area and selected standard orifice | $6.74\times10^{-5}$ m²; D |
+| Liquid required area and selected standard orifice | $2.71\times10^{-4}$ m²; G |
+| Two-phase required area | $5.88\times10^{-5}$ m² |
+| Fire heat input for 80 m² with drainage | 1570 kW |
 
-For liquid-filled equipment (pumps, blocked-in liquid lines), API 520 Section 5.8 applies.
+These values are regression examples for the stated inputs, not recommended design cases.
 
-### Java Example
+## Gas and vapour screening
 
-```java
-ReliefValveSizing psv = new ReliefValveSizing(liquidFluid);
-psv.setReliefPressure(25.0);
-psv.setBackPressure(1.013);
-psv.setReliefTemperature(273.15 + 40.0);
-psv.setReliefMassRate(50000.0);   // kg/hr
+`calculateRequiredArea(...)` uses the source implementation's gas/vapour screening equation and returns both the
+required area and the first standard D-through-T area that is not smaller. The method uses $K_d=0.975$, $K_c=0.9$
+when an upstream rupture disk is declared and $K_c=1.0$ otherwise, plus the implemented simplified back-pressure
+correction. It does not obtain molecular weight, compressibility, or heat-capacity ratio from a NeqSim fluid; the
+caller must supply properties that are consistent at the relieving state.
 
-ReliefValveSizing.LiquidPSVSizingResult result = psv.calculateLiquidReliefArea();
-System.out.println("Required area (liquid): " + result.getRequiredArea() + " m2");
-System.out.println("Kd (liquid): " + result.getKd());
-System.out.println("Kw (back-pressure): " + result.getKw());
-System.out.println("Kc (combination): " + result.getKc());
-System.out.println("Kv (viscosity): " + result.getKv());
-```
+Use these explicit result getters:
 
-### Key Correction Factors
+- `getRequiredArea()` and `getRequiredAreaIn2()`;
+- `getRecommendedOrifice()`, `getSelectedArea()`, and `getSelectedAreaIn2()`;
+- `getMassFlowCapacity()` in kg/s; and
+- `getDischargeCoefficient()`, `getBackPressureCorrectionFactor()`, and
+  `getCombinationCorrectionFactor()`.
 
-| Factor | Symbol | Description | Default |
-|--------|--------|-------------|---------|
-| Discharge coefficient | $K_d$ | API 520 liquid discharge | 0.65 |
-| Back-pressure | $K_w$ | Balanced bellows correction | 1.0 |
-| Combination | $K_c$ | Rupture disk + PSV | 1.0 |
-| Viscosity | $K_v$ | Re-based viscosity correction | 1.0 |
+## Liquid screening
 
----
+`calculateLiquidReliefArea(...)` requires volumetric flow at relieving conditions, density, absolute pressures,
+viscosity, and the balanced-bellows selection. The current implementation applies its simplified $K_d$, $K_w$,
+$K_v$, and overpressure correction before selecting a standard orifice.
 
-## Two-Phase Relief Sizing
+`LiquidPSVSizingResult` exposes `getRequiredAreaM2()`, `getRequiredAreaIn2()`, `getMassFlowRate()`,
+`getVolumeFlowRate()`, `getRecommendedOrifice()`, `getSelectedAreaIn2()`, `getDischargeCoefficient()`,
+`getBackPressureCorrectionFactor()`, and `getViscosityCorrectionFactor()`. It does not contain a $K_c$ field.
 
-Uses the Leung omega method (API 520 Appendix D) for flashing and non-flashing two-phase mixtures.
+## Two-phase omega-method screening
 
-### Java Example
+The source defines the inlet mixture specific volume as
 
-```java
-ReliefValveSizing psv = new ReliefValveSizing(twoPhaseFluid);
-psv.setReliefPressure(80.0);
-psv.setBackPressure(5.0);
-psv.setReliefTemperature(273.15 + 100.0);
-psv.setReliefMassRate(30000.0);
-psv.setInletVapourMassFraction(0.3);  // quality at inlet
+$$v_{\mathrm{mix}}=xv_g+(1-x)v_l$$
 
-double area = psv.calculateTwoPhaseReliefArea();
-System.out.println("Two-phase required area: " + area + " m2");
-```
+and evaluates
 
-### Method
+$$\omega=\frac{xv_g}{v_{\mathrm{mix}}}+\frac{c_{p,l}TP_0(v_g-v_l)^2}{h_{fg}^2v_{\mathrm{mix}}}$$
 
-The Leung omega parameter characterises the compressibility of the two-phase mixture:
+where $x$ is inlet gas mass fraction, $v_g$ and $v_l$ are gas and liquid specific volumes, $c_{p,l}$ is liquid heat
+capacity, $T$ is inlet temperature, $P_0$ is relieving pressure, and $h_{fg}$ is latent heat. The method then applies
+the implemented critical-ratio expression, back-pressure floor, mass-flux expression, and $K_d=0.85$.
 
-$$
-\omega = \frac{x \cdot v_g + (1-x) \cdot v_l}{v_{mix}} \cdot \frac{c_p \cdot T \cdot P}{h_{fg}^2}
-$$
+The method returns only required area. It does not select an orifice, calculate fluid properties, establish the
+applicable two-phase scenario, or qualify homogeneous-equilibrium assumptions.
 
-The critical pressure ratio and mass flux are then calculated from $\omega$ to obtain the required area.
+## Wetted-surface fire heat input
 
----
+Call `calculateAPI521FireHeatInput(wettedAreaM2, hasDrainage, hasFireFighting)` with all three arguments. The current
+implementation uses a fixed environmental factor of 1.0 and branches on `hasDrainage`, giving approximately
 
-## API 521 Fire Heat Input
+$$Q=43192A_w^{0.82}\ \mathrm{W}$$
 
-Calculates the total heat absorption rate for fire-exposed equipment per API 521 Table 4. Used to determine thermal relief requirements.
+with drainage, and
 
-### Java Example
+$$Q=70959A_w^{0.82}\ \mathrm{W}$$
 
-```java
-double wettedArea = 80.0;  // m2
-boolean drainage = true;    // adequate drainage and firefighting
+without drainage, for $A_w$ in m². The `hasFireFighting` argument is currently retained in the public signature but
+does not change the numerical factor. Do not infer a firefighting credit from that boolean.
 
-double Q = ReliefValveSizing.calculateAPI521FireHeatInput(wettedArea, drainage);
-System.out.println("Fire heat input: " + Q + " W");
-System.out.println("Fire heat input: " + (Q / 1000.0) + " kW");
-```
+## Engineering limits
 
-### Correlations
+- Select the relieving scenario and accumulation basis from the governing project requirements; do not reuse the
+  example's 10% overpressure automatically.
+- Obtain fluid properties at a consistent relieving state and document their source and uncertainty.
+- Check certified capacity data and the actual valve, rupture-disk, inlet-line, tailpipe, header, and flare-system
+  configuration independently.
+- Treat the built-in standard-orifice selection as a screening convenience; it does not select a vendor valve or
+  certify a purchased device.
+- Use a dynamic pressure/inventory model when the transient source, heat input, phase change, disposal-system
+  interaction, or valve dynamics control the case.
 
-For adequate drainage and firefighting facilities:
+## Related documentation
 
-$$
-Q = 43200 \cdot F \cdot A_{wetted}^{0.82} \quad \text{(W)}
-$$
-
-where $F$ is the environmental factor (default 1.0) and $A_{wetted}$ is in m$^2$.
-
-For inadequate drainage:
-
-$$
-Q = 70900 \cdot F \cdot A_{wetted}^{0.82} \quad \text{(W)}
-$$
-
----
-
-## Python Example
-
-```python
-from neqsim import jneqsim
-
-SystemSrkEos = jneqsim.thermo.system.SystemSrkEos
-ReliefValveSizing = jneqsim.process.util.fire.ReliefValveSizing
-
-fluid = SystemSrkEos(273.15 + 60.0, 100.0)
-fluid.addComponent("methane", 0.85)
-fluid.addComponent("ethane", 0.10)
-fluid.addComponent("propane", 0.05)
-fluid.setMixingRule("classic")
-
-psv = ReliefValveSizing(fluid)
-psv.setReliefPressure(110.0)
-psv.setBackPressure(1.013)
-psv.setReliefTemperature(273.15 + 60.0)
-psv.setReliefMassRate(5000.0)
-
-area = psv.calculateRequiredArea()
-print(f"Required orifice area: {area:.6f} m2")
-
-# Fire heat input
-Q = ReliefValveSizing.calculateAPI521FireHeatInput(80.0, True)
-print(f"Fire heat input: {Q/1000:.0f} kW")
-```
-
----
-
-## Related Documentation
-
-- [PSV Dynamic Sizing](psv_dynamic_sizing_example.md) - Dynamic relief valve simulation
-- [Fire and Blowdown Capabilities](fire_blowdown_capabilities.md) - Blowdown and fire scenario simulation
-- [Safety Engineering Overview](index.md) - Full safety tools overview
+- [Dynamic PSV sizing example](psv_dynamic_sizing_example.md)
+- [Fire and blowdown capabilities](fire_blowdown_capabilities.md)
+- [Blocked-in liquid thermal expansion](blocked_in_liquid_thermal_expansion.md)
+- [Safety systems documentation](README.md)

--- a/docs/test_relief_valve_sizing_documentation.py
+++ b/docs/test_relief_valve_sizing_documentation.py
@@ -1,0 +1,136 @@
+import re
+import unittest
+from pathlib import Path
+from urllib.parse import unquote
+
+
+DOCS_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = DOCS_DIR.parent
+GUIDE = DOCS_DIR / "safety" / "relief_valve_sizing_api.md"
+SAFETY_INDEX = DOCS_DIR / "safety" / "README.md"
+SOURCE = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/process/util/fire/ReliefValveSizing.java"
+)
+
+
+def java_fences(content):
+    return re.findall(r"\x60\x60\x60java\n(.*?)\x60\x60\x60", content, re.DOTALL)
+
+
+def heading_slugs(content):
+    content_without_fences = re.sub(
+        r"\x60\x60\x60.*?\x60\x60\x60", "", content, flags=re.DOTALL
+    )
+    return {
+        re.sub(r"[^a-z0-9 -]", "", heading.lower())
+        .strip()
+        .replace(" ", "-")
+        for heading in re.findall(
+            r"^#{1,6}\s+(.+)$", content_without_fences, flags=re.MULTILINE
+        )
+    }
+
+
+class ReliefValveSizingDocumentationContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+        cls.safety_index = SAFETY_INDEX.read_text(encoding="utf-8")
+        cls.source = SOURCE.read_text(encoding="utf-8")
+
+    def test_structure_math_fences_and_internal_links(self):
+        self.assertTrue(self.guide.startswith("---\n"))
+        self.assertEqual(self.guide.count("\x60\x60\x60") % 2, 0)
+        self.assertEqual(self.guide.count("$$") % 2, 0)
+        without_fences = re.sub(
+            r"\x60\x60\x60.*?\x60\x60\x60",
+            "",
+            self.guide,
+            flags=re.DOTALL,
+        )
+        self.assertNotRegex(without_fences, re.compile(r"^# ", re.MULTILINE))
+        self.assertNotIn(r"\[", without_fences)
+        self.assertNotIn(r"\(", without_fences)
+
+        link_pattern = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+        for destination in link_pattern.findall(self.guide):
+            if destination.startswith(("http://", "https://", "mailto:")):
+                continue
+            target, _, fragment = unquote(destination).partition("#")
+            target_path = (GUIDE.parent / target).resolve()
+            with self.subTest(destination=destination):
+                self.assertTrue(target.endswith(".md"))
+                self.assertTrue(target_path.is_file())
+                if fragment:
+                    self.assertIn(
+                        fragment,
+                        heading_slugs(target_path.read_text(encoding="utf-8")),
+                    )
+
+    def test_documented_static_signatures_match_source(self):
+        contracts = (
+            "private ReliefValveSizing()",
+            "public static PSVSizingResult calculateRequiredArea(",
+            "public static double calculateMassFlowCapacity(",
+            "public static LiquidPSVSizingResult calculateLiquidReliefArea(",
+            "public static double calculateTwoPhaseReliefArea(",
+            "public static double calculateAPI521FireHeatInput(",
+            "double wettedAreaM2, boolean hasDrainage, boolean hasFireFighting",
+        )
+        for contract in contracts:
+            with self.subTest(contract=contract):
+                self.assertIn(contract, self.source)
+
+        self.assertIn("static screening utility", self.guide)
+        self.assertIn("does not change the numerical factor", self.guide)
+
+    def test_stale_object_api_and_result_getters_are_absent(self):
+        stale_calls = (
+            "new ReliefValveSizing(",
+            ".setReliefPressure(",
+            ".setBackPressure(",
+            ".setReliefTemperature(",
+            ".setReliefMassRate(",
+            ".setInletVapourMassFraction(",
+            ".getRequiredArea() + \" m2\"",
+            ".getKd(",
+            ".getKw(",
+            ".getKc(",
+            ".getKv(",
+        )
+        for block in java_fences(self.guide):
+            for stale_call in stale_calls:
+                with self.subTest(stale_call=stale_call):
+                    self.assertNotIn(stale_call, block)
+
+        self.assertIn("getRequiredAreaM2()", self.guide)
+        self.assertIn("getViscosityCorrectionFactor()", self.guide)
+        self.assertIn("does not contain a $K_c$ field", self.guide)
+
+    def test_complete_java_example_exercises_every_primary_helper(self):
+        blocks = java_fences(self.guide)
+        self.assertEqual(1, len(blocks))
+        example = blocks[0]
+        for contract in (
+            "public final class ReliefValveSizingExample",
+            "public static void main(String[] args)",
+            "ReliefValveSizing.calculateRequiredArea(",
+            "ReliefValveSizing.calculateLiquidReliefArea(",
+            "ReliefValveSizing.calculateTwoPhaseReliefArea(",
+            "ReliefValveSizing.calculateAPI521FireHeatInput(80.0, true, true)",
+        ):
+            with self.subTest(contract=contract):
+                self.assertIn(contract, example)
+
+        self.assertNotIn("System.out", example)
+
+    def test_safety_index_discovers_the_guide(self):
+        self.assertIn(
+            "[Relief-Valve Sizing Screening](relief_valve_sizing_api.md)",
+            self.safety_index,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test/java/neqsim/process/util/fire/ReliefValveSizingDocumentationTest.java
+++ b/src/test/java/neqsim/process/util/fire/ReliefValveSizingDocumentationTest.java
@@ -15,8 +15,8 @@ public class ReliefValveSizingDocumentationTest {
     ReliefValveSizing.LiquidPSVSizingResult liquidResult = ReliefValveSizing.calculateLiquidReliefArea(50.0 / 3600.0,
         850.0, 25.0e5, 0.10, 1.013e5, 0.004, false);
 
-    double twoPhaseArea = ReliefValveSizing.calculateTwoPhaseReliefArea(30000.0 / 3600.0, 80.0e5, 0.10, 5.0e5,
-        373.15, 0.30, 50.0, 700.0, 250000.0, 2500.0);
+    double twoPhaseArea = ReliefValveSizing.calculateTwoPhaseReliefArea(30000.0 / 3600.0, 80.0e5, 0.10, 5.0e5, 373.15,
+        0.30, 50.0, 700.0, 250000.0, 2500.0);
     double fireHeatInput = ReliefValveSizing.calculateAPI521FireHeatInput(80.0, true, true);
 
     assertEquals(6.7388e-5, gasResult.getRequiredArea(), 1.0e-9);
@@ -34,8 +34,7 @@ public class ReliefValveSizingDocumentationTest {
     double withoutFireFighting = ReliefValveSizing.calculateAPI521FireHeatInput(80.0, true, false);
     double withoutDrainage = ReliefValveSizing.calculateAPI521FireHeatInput(80.0, false, true);
 
-    assertEquals(withFireFighting, withoutFireFighting, 0.0,
-        "The current helper does not apply a firefighting credit");
+    assertEquals(withFireFighting, withoutFireFighting, 0.0, "The current helper does not apply a firefighting credit");
     assertTrue(withoutDrainage > withFireFighting);
   }
 }

--- a/src/test/java/neqsim/process/util/fire/ReliefValveSizingDocumentationTest.java
+++ b/src/test/java/neqsim/process/util/fire/ReliefValveSizingDocumentationTest.java
@@ -1,0 +1,41 @@
+package neqsim.process.util.fire;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Executes the relief-valve sizing workflow documented in the safety guide. */
+public class ReliefValveSizingDocumentationTest {
+  @Test
+  void executesDocumentedGasLiquidTwoPhaseAndFireScreening() {
+    ReliefValveSizing.PSVSizingResult gasResult = ReliefValveSizing.calculateRequiredArea(5000.0 / 3600.0, 110.0e5,
+        0.10, 1.013e5, 333.15, 0.018, 0.95, 1.30, false, false);
+
+    ReliefValveSizing.LiquidPSVSizingResult liquidResult = ReliefValveSizing.calculateLiquidReliefArea(50.0 / 3600.0,
+        850.0, 25.0e5, 0.10, 1.013e5, 0.004, false);
+
+    double twoPhaseArea = ReliefValveSizing.calculateTwoPhaseReliefArea(30000.0 / 3600.0, 80.0e5, 0.10, 5.0e5,
+        373.15, 0.30, 50.0, 700.0, 250000.0, 2500.0);
+    double fireHeatInput = ReliefValveSizing.calculateAPI521FireHeatInput(80.0, true, true);
+
+    assertEquals(6.7388e-5, gasResult.getRequiredArea(), 1.0e-9);
+    assertEquals("D", gasResult.getRecommendedOrifice());
+    assertTrue(gasResult.getSelectedArea() >= gasResult.getRequiredArea());
+    assertEquals(2.7061e-4, liquidResult.getRequiredAreaM2(), 1.0e-8);
+    assertEquals("G", liquidResult.getRecommendedOrifice());
+    assertEquals(5.8836e-5, twoPhaseArea, 1.0e-9);
+    assertEquals(1.57015e6, fireHeatInput, 10.0);
+  }
+
+  @Test
+  void preservesDocumentedFireHelperBoundary() {
+    double withFireFighting = ReliefValveSizing.calculateAPI521FireHeatInput(80.0, true, true);
+    double withoutFireFighting = ReliefValveSizing.calculateAPI521FireHeatInput(80.0, true, false);
+    double withoutDrainage = ReliefValveSizing.calculateAPI521FireHeatInput(80.0, false, true);
+
+    assertEquals(withFireFighting, withoutFireFighting, 0.0,
+        "The current helper does not apply a firefighting credit");
+    assertTrue(withoutDrainage > withFireFighting);
+  }
+}


### PR DESCRIPTION
## Summary

Progresses #2499 scan D066 (rotation scope 4: engineering design and safety).

This repairs the relief-valve sizing guide against the exact current static `ReliefValveSizing` API:

- replaces impossible object construction, nonexistent setters, and nonexistent no-argument overloads;
- documents the required SI input contract and real gas, liquid, two-phase, and fire signatures;
- corrects result getters and the implemented two-phase omega equation;
- records that the current fire helper branches on drainage and does not numerically apply its firefighting boolean;
- distinguishes source-code screening from certified capacity, purchased-standard conformity, installation acceptance, and engineering approval;
- replaces incomplete fragments with one complete Java 8 example and expected regression values;
- adds the missing safety-index entry; and
- adds focused executable and hermetic source/document/navigation contracts.

## Frozen scope

Exact base: `0c1f895e4b3dca001af70444500b9403841839f4`

Changed files:

- `docs/safety/relief_valve_sizing_api.md`
- `docs/safety/README.md`
- `docs/test_relief_valve_sizing_documentation.py`
- `src/test/java/neqsim/process/util/fire/ReliefValveSizingDocumentationTest.java`

`docs/REFERENCE_MANUAL_INDEX.md` already contains the correct page entry and is intentionally unchanged. No production algorithm, coefficient, standard policy, dynamic blowdown/flare model, DEXPI implementation, notebook, image, external qualification, or Huldra work is included.

## Validation

Passed locally:

- `python -m unittest d066/docs/test_relief_valve_sizing_documentation.py` — 5 tests, 0 failures/errors, using the exact master `ReliefValveSizing.java` blob `d40b2b3ceec750ea1d39f3c9e735aecadaa98dea`
- front matter, duplicate-H1, fence, display-math delimiter, internal-link, API-signature, stale-call, complete-example, and safety-index contracts
- independent source-equation cross-check of the documented expected values:
  - gas area `6.7388e-5 m2`, orifice D
  - liquid area `2.7061e-4 m2`, orifice G
  - two-phase area `5.8836e-5 m2`
  - fire heat input `1.57015e6 W`

## READY TO MERGE

Exact-head hosted validation passed on `ad89a0630a435e33ee1f2fdce0304644daf20726`:

- Pre-commit checks
- Spotless format patch/check
- Documentation search coverage
- CodeQL Security Analysis
- complete build, test, and Javadoc workflow:
  - Java 21 fast tests on Ubuntu and Windows
  - all four Java 21 slow-test shards
  - Java 8 tests on Ubuntu and Windows
  - Java 21 Javadocs
  - Java/XML change detection and agent-skill cross-reference verification
- focused Java documentation example and hermetic Python documentation contracts
- final scope audit: exactly the four frozen documentation/test files; no production Java, notebook, image, generated output, external URL, or Huldra change
- final review audit: mergeable, with no human/Copilot comments, submitted reviews, requested changes, or unresolved inline threads

Documentation impact: the user-facing relief-valve screening guide and safety documentation index are updated and executable contracts keep them aligned with the current static API.

No browser-render artifact was produced, so browser visual inspection is not claimed. The changed guide is source-validated for front matter, headings, fences, display-math delimiters, internal links, API signatures, and complete example structure. The PR remains a draft; this is a merge-readiness classification only.

## Review boundary

The guide deliberately documents the current implementation, including simplified corrections and the unused firefighting credit input, rather than silently changing safety calculations in a documentation PR. Any algorithm or standards-edition correction requires a separate, independently validated engineering change.