### PR TITLE
[AI-Assisted] test(dexpi): pin external verifier baseline

### DIFF
--- a/devtools/test_validate_dexpi_interoperability.py
+++ b/devtools/test_validate_dexpi_interoperability.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import subprocess
 import tempfile
 import unittest
-from unittest import mock
+import unittest.mock
 
 
 SCRIPT = Path(__file__).with_name("validate_dexpi_interoperability.py")
@@ -103,7 +103,7 @@ class ValidateDexpiInteroperabilityTest(unittest.TestCase):
                     )
                 return subprocess.CompletedProcess(command, 1, stdout="issues", stderr="")
 
-            with mock.patch.object(MODULE.subprocess, "run", side_effect=fake_run):
+            with unittest.mock.patch.object(MODULE.subprocess, "run", side_effect=fake_run):
                 result = MODULE.run_dexpi_viewer(
                     native, root, MODULE.DEXPI_VIEWER_COMMIT
                 )

--- a/devtools/test_validate_dexpi_interoperability.py
+++ b/devtools/test_validate_dexpi_interoperability.py
@@ -1,0 +1,164 @@
+import csv
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPT = Path(__file__).with_name("validate_dexpi_interoperability.py")
+SPEC = importlib.util.spec_from_file_location("validate_dexpi_interoperability", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+CSV_HEADER = [
+    "Object ID",
+    "Line Number",
+    "Object Type",
+    "Rule ID",
+    "Severity",
+    "Severity Score",
+    "Rule Description",
+    "Location (XPath)",
+    "Profile Source",
+    "Suggested Correction",
+]
+
+
+class ValidateDexpiInteroperabilityTest(unittest.TestCase):
+    def test_csv_findings_are_typed_and_deterministically_sorted(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            report = Path(temporary) / "report.csv"
+            with report.open("w", encoding="utf-8", newline="") as stream:
+                writer = csv.writer(stream)
+                writer.writerow(CSV_HEADER)
+                writer.writerow(
+                    [
+                        "Pump1",
+                        "7",
+                        "Plant/ProcessEquipment.CentrifugalPump",
+                        "VAL-004",
+                        "Warning",
+                        "2",
+                        "Missing representation",
+                        "//*[@id='Pump1']",
+                        "Base",
+                        "Add reviewed representation data",
+                    ]
+                )
+                writer.writerow(
+                    [
+                        "",
+                        "3",
+                        "Core/EngineeringModel",
+                        "ERR-E07",
+                        "Error",
+                        "3",
+                        "Missing export provenance",
+                        "/Model/Object[1]",
+                        "Base",
+                        "Add controlled provenance",
+                    ]
+                )
+
+            findings = MODULE.parse_dexpi_viewer_csv(report)
+
+            self.assertEqual("ERR-E07", findings[0]["ruleId"])
+            self.assertEqual(3, findings[0]["lineNumber"])
+            self.assertEqual("VAL-004", findings[1]["ruleId"])
+
+    def test_run_requires_exact_checkout_and_retains_findings(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "validate-cli.js").write_text("// fake", encoding="utf-8")
+            native = root / "plant.dexpi.xml"
+            native.write_text("<Model/>", encoding="utf-8")
+
+            def fake_run(command, **kwargs):
+                if command[0] == "git":
+                    return subprocess.CompletedProcess(
+                        command, 0, stdout=MODULE.DEXPI_VIEWER_COMMIT + "\n", stderr=""
+                    )
+                output_directory = Path(command[command.index("--out") + 1])
+                csv_path = output_directory / "plant.dexpi.csv"
+                with csv_path.open("w", encoding="utf-8", newline="") as stream:
+                    writer = csv.writer(stream)
+                    writer.writerow(CSV_HEADER)
+                    writer.writerow(
+                        [
+                            "",
+                            "3",
+                            "Core/EngineeringModel",
+                            "ERR-E07",
+                            "Error",
+                            "3",
+                            "Missing export provenance",
+                            "/Model/Object[1]",
+                            "Base",
+                            "Add controlled provenance",
+                        ]
+                    )
+                return subprocess.CompletedProcess(command, 1, stdout="issues", stderr="")
+
+            with mock.patch.object(MODULE.subprocess, "run", side_effect=fake_run):
+                result = MODULE.run_dexpi_viewer(
+                    native, root, MODULE.DEXPI_VIEWER_COMMIT
+                )
+
+            self.assertEqual("ISSUES_FOUND", result["status"])
+            self.assertEqual({"errors": 1, "warnings": 0, "infos": 0}, result["issueCounts"])
+            self.assertEqual(MODULE.DEXPI_VIEWER_COMMIT, result["commit"])
+            self.assertEqual(1, len(result["findings"]))
+
+    def test_baseline_comparison_checks_provenance_and_counts(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            baseline = Path(temporary) / "baseline.json"
+            baseline.write_text(
+                json.dumps(
+                    {
+                        "repository": MODULE.DEXPI_VIEWER_REPOSITORY,
+                        "commit": MODULE.DEXPI_VIEWER_COMMIT,
+                        "inputSha256": "abc",
+                        "expectedIssueCounts": {"errors": 8, "warnings": 3},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = {
+                "repository": MODULE.DEXPI_VIEWER_REPOSITORY,
+                "commit": MODULE.DEXPI_VIEWER_COMMIT,
+                "inputSha256": "abc",
+                "issueCounts": {"errors": 8, "warnings": 3, "infos": 0},
+            }
+
+            matched = MODULE.compare_dexpi_viewer_baseline(result, baseline)
+            self.assertEqual("MATCHED", matched["status"])
+
+            result["issueCounts"]["errors"] = 7
+            changed = MODULE.compare_dexpi_viewer_baseline(result, baseline)
+            self.assertEqual("CHANGED", changed["status"])
+            self.assertEqual("issueCounts.errors", changed["differences"][0]["field"])
+
+    def test_native_file_can_be_validated_without_a_pydexpi_package(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            native = root / "fixture.xml"
+            native.write_text(
+                "<Model><Import prefix='Core' source='core'/>"
+                "<Import prefix='Plant' source='plant'/><Object type='Core/EngineeringModel'/>"
+                "</Model>",
+                encoding="utf-8",
+            )
+
+            report = MODULE.validate_package(root, None, native_file=native)
+
+            self.assertEqual("STRUCTURE_PASSED", report["nativeDexpi"]["status"])
+            self.assertEqual("NOT_AVAILABLE", report["pyDexpi"]["status"])
+            self.assertEqual("NOT_RUN", report["dexpiViewer"]["status"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/devtools/validate_dexpi_interoperability.py
+++ b/devtools/validate_dexpi_interoperability.py
@@ -4,44 +4,240 @@
 from __future__ import annotations
 
 import argparse
+import csv
+import hashlib
 import json
 from pathlib import Path
+import subprocess
 import sys
+import tempfile
 import xml.etree.ElementTree as ET
 
 
-def validate_package(package: Path, commercial_result: Path | None) -> dict:
-    native = package / "plant.dexpi.xml"
+DEXPI_VIEWER_REPOSITORY = "https://github.com/ToniaPedersen/DEXPIViewer"
+DEXPI_VIEWER_COMMIT = "18a17b1e38ba15a1a6ba49dd8265ddcff7c766ad"
+
+
+def sha256_file(path: Path) -> str:
+    """Return a lowercase SHA-256 digest for a file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_dexpi_viewer_csv(path: Path) -> list[dict]:
+    """Parse DEXPIViewer's documented CSV format into deterministic findings."""
+    findings = []
+    with path.open("r", encoding="utf-8-sig", newline="") as stream:
+        reader = csv.DictReader(stream)
+        required = {
+            "Object ID",
+            "Object Type",
+            "Rule ID",
+            "Severity",
+            "Rule Description",
+            "Location (XPath)",
+            "Profile Source",
+            "Suggested Correction",
+        }
+        missing = sorted(required.difference(reader.fieldnames or []))
+        if missing:
+            raise ValueError(f"DEXPIViewer CSV is missing columns: {', '.join(missing)}")
+        for row in reader:
+            finding = {
+                "objectId": row["Object ID"],
+                "objectType": row["Object Type"],
+                "ruleId": row["Rule ID"],
+                "severity": row["Severity"],
+                "description": row["Rule Description"],
+                "location": row["Location (XPath)"],
+                "profileSource": row["Profile Source"],
+                "suggestedCorrection": row["Suggested Correction"],
+            }
+            line_number = row.get("Line Number", "").strip()
+            if line_number:
+                try:
+                    finding["lineNumber"] = int(line_number)
+                except ValueError:
+                    finding["lineNumber"] = line_number
+            findings.append(finding)
+    severity_order = {"Error": 0, "Warning": 1, "Info": 2}
+    return sorted(
+        findings,
+        key=lambda item: (
+            severity_order.get(item["severity"], 3),
+            item["ruleId"],
+            item["objectId"],
+            item["location"],
+        ),
+    )
+
+
+def _checkout_head(repository: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repository), "rev-parse", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:
+        raise ValueError("git is required to verify the DEXPIViewer checkout") from exc
+    if result.returncode != 0:
+        raise ValueError("DEXPIViewer directory must be a Git checkout with a readable HEAD")
+    return result.stdout.strip().lower()
+
+
+def run_dexpi_viewer(native: Path, repository: Path, expected_commit: str) -> dict:
+    """Run the pinned DEXPIViewer CLI and retain its complete structured findings."""
+    repository = repository.resolve()
+    cli = repository / "validate-cli.js"
+    if not cli.is_file():
+        raise ValueError(f"DEXPIViewer CLI was not found: {cli}")
+    actual_commit = _checkout_head(repository)
+    expected_commit = expected_commit.lower()
+    if actual_commit != expected_commit:
+        raise ValueError(
+            "DEXPIViewer checkout mismatch: "
+            f"expected {expected_commit}, found {actual_commit}"
+        )
+    with tempfile.TemporaryDirectory(prefix="neqsim-dexpi-viewer-") as temporary:
+        output_directory = Path(temporary)
+        try:
+            completed = subprocess.run(
+                [
+                    "node",
+                    str(cli),
+                    str(native.resolve()),
+                    "--out",
+                    str(output_directory),
+                ],
+                cwd=repository,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except OSError as exc:
+            raise ValueError("Node.js is required to run DEXPIViewer") from exc
+        if completed.returncode not in (0, 1):
+            detail = (completed.stderr or completed.stdout).strip()
+            raise ValueError(
+                f"DEXPIViewer execution failed with exit code {completed.returncode}: {detail}"
+            )
+        csv_path = output_directory / f"{native.stem}.csv"
+        if not csv_path.is_file():
+            raise ValueError("DEXPIViewer did not produce its documented CSV report")
+        findings = parse_dexpi_viewer_csv(csv_path)
+        counts = {
+            severity.lower() + "s": sum(
+                1 for finding in findings if finding["severity"] == severity
+            )
+            for severity in ("Error", "Warning", "Info")
+        }
+        if completed.returncode == 0 and counts["errors"] != 0:
+            raise ValueError("DEXPIViewer exit code and CSV error count disagree")
+        if completed.returncode == 1 and counts["errors"] == 0:
+            raise ValueError("DEXPIViewer failed without reporting a validation error")
+        return {
+            "status": "PASSED" if counts["errors"] == 0 else "ISSUES_FOUND",
+            "repository": DEXPI_VIEWER_REPOSITORY,
+            "commit": actual_commit,
+            "inputSha256": sha256_file(native),
+            "csvSha256": sha256_file(csv_path),
+            "issueCounts": counts,
+            "findings": findings,
+        }
+
+
+def compare_dexpi_viewer_baseline(result: dict, baseline_path: Path) -> dict:
+    """Compare pinned-tool provenance and severity counts with a reviewed baseline."""
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    required = {"repository", "commit", "inputSha256", "expectedIssueCounts"}
+    missing = sorted(required.difference(baseline))
+    if missing:
+        raise ValueError(f"DEXPIViewer baseline is missing: {', '.join(missing)}")
+    differences = []
+    for key in ("repository", "commit", "inputSha256"):
+        if baseline[key] != result[key]:
+            differences.append(
+                {"field": key, "expected": baseline[key], "actual": result[key]}
+            )
+    for severity, expected in baseline["expectedIssueCounts"].items():
+        actual = result["issueCounts"].get(severity)
+        if actual != expected:
+            differences.append(
+                {
+                    "field": f"issueCounts.{severity}",
+                    "expected": expected,
+                    "actual": actual,
+                }
+            )
+    return {
+        "file": str(baseline_path),
+        "status": "MATCHED" if not differences else "CHANGED",
+        "differences": differences,
+    }
+
+
+def validate_package(
+    package: Path,
+    commercial_result: Path | None,
+    native_file: Path | None = None,
+    dexpi_viewer: Path | None = None,
+    dexpi_viewer_commit: str = DEXPI_VIEWER_COMMIT,
+    dexpi_viewer_baseline: Path | None = None,
+) -> dict:
+    native = native_file if native_file is not None else package / "plant.dexpi.xml"
     proteus = package / "plant-pydexpi.xml"
     report = {
-        "profile": "neqsim_dexpi_interoperability.v1",
-        "nativeDexpi": {"file": native.name, "status": "FAILED"},
+        "profile": "neqsim_dexpi_interoperability.v2",
+        "nativeDexpi": {"file": str(native), "status": "FAILED"},
+        "dexpiViewer": {
+            "status": "NOT_RUN",
+            "repository": DEXPI_VIEWER_REPOSITORY,
+            "commit": dexpi_viewer_commit,
+        },
         "pyDexpi": {"file": proteus.name, "status": "NOT_AVAILABLE"},
         "commercialCae": {"status": "QUALIFICATION_REQUIRED"},
     }
     root = ET.parse(native).getroot()
     if root.tag != "Model":
         raise ValueError(f"Unexpected native DEXPI root: {root.tag}")
-    imports = {item.attrib.get("prefix"): item.attrib.get("source") for item in root.findall("Import")}
+    imports = {
+        item.attrib.get("prefix"): item.attrib.get("source")
+        for item in root.findall("Import")
+    }
     if not imports.get("Core") or not imports.get("Plant"):
         raise ValueError("Native DEXPI document does not import Core and Plant models")
     report["nativeDexpi"] = {
-        "file": native.name,
+        "file": str(native),
         "status": "STRUCTURE_PASSED",
+        "sha256": sha256_file(native),
         "objectCount": len(root.findall(".//Object")),
     }
 
-    try:
-        from pydexpi.loaders import ProteusSerializer
-    except ImportError:
-        pass
-    else:
-        ProteusSerializer().load(str(package), proteus.name)
-        report["pyDexpi"] = {
-            "file": proteus.name,
-            "status": "IMPORT_PASSED",
-            "importer": "pyDEXPI ProteusSerializer",
-        }
+    if dexpi_viewer is not None:
+        viewer_result = run_dexpi_viewer(native, dexpi_viewer, dexpi_viewer_commit)
+        if dexpi_viewer_baseline is not None:
+            viewer_result["baseline"] = compare_dexpi_viewer_baseline(
+                viewer_result, dexpi_viewer_baseline
+            )
+        report["dexpiViewer"] = viewer_result
+
+    if proteus.is_file():
+        try:
+            from pydexpi.loaders import ProteusSerializer
+        except ImportError:
+            pass
+        else:
+            ProteusSerializer().load(str(package), proteus.name)
+            report["pyDexpi"] = {
+                "file": proteus.name,
+                "status": "IMPORT_PASSED",
+                "importer": "pyDEXPI ProteusSerializer",
+            }
 
     if commercial_result is not None:
         evidence = json.loads(commercial_result.read_text(encoding="utf-8"))
@@ -58,13 +254,43 @@ def validate_package(package: Path, commercial_result: Path | None) -> dict:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("package", type=Path)
+    parser.add_argument("--native-file", type=Path)
     parser.add_argument("--commercial-cae-result", type=Path)
+    parser.add_argument("--dexpi-viewer", type=Path)
+    parser.add_argument("--dexpi-viewer-commit", default=DEXPI_VIEWER_COMMIT)
+    parser.add_argument("--dexpi-viewer-baseline", type=Path)
+    parser.add_argument("--require-dexpi-viewer", action="store_true")
+    parser.add_argument("--require-dexpi-viewer-clean", action="store_true")
+    parser.add_argument("--require-dexpi-viewer-baseline", action="store_true")
     parser.add_argument("--require-pydexpi", action="store_true")
     parser.add_argument("--require-commercial-cae", action="store_true")
     parser.add_argument("--output", type=Path)
     args = parser.parse_args()
     try:
-        report = validate_package(args.package, args.commercial_cae_result)
+        if (args.require_dexpi_viewer or args.require_dexpi_viewer_clean) and not args.dexpi_viewer:
+            raise ValueError("DEXPIViewer is required; provide --dexpi-viewer")
+        if args.require_dexpi_viewer_baseline and not args.dexpi_viewer_baseline:
+            raise ValueError(
+                "DEXPIViewer baseline is required; provide --dexpi-viewer-baseline"
+            )
+        report = validate_package(
+            args.package,
+            args.commercial_cae_result,
+            native_file=args.native_file,
+            dexpi_viewer=args.dexpi_viewer,
+            dexpi_viewer_commit=args.dexpi_viewer_commit,
+            dexpi_viewer_baseline=args.dexpi_viewer_baseline,
+        )
+        viewer = report["dexpiViewer"]
+        if args.require_dexpi_viewer and viewer["status"] == "NOT_RUN":
+            raise ValueError("DEXPIViewer validation is required")
+        if args.require_dexpi_viewer_clean:
+            counts = viewer.get("issueCounts", {})
+            if counts.get("errors") != 0 or counts.get("warnings") != 0:
+                raise ValueError("DEXPIViewer clean validation requires zero errors and warnings")
+        if args.require_dexpi_viewer_baseline:
+            if viewer.get("baseline", {}).get("status") != "MATCHED":
+                raise ValueError("DEXPIViewer findings changed from the reviewed baseline")
         if args.require_pydexpi and report["pyDexpi"]["status"] != "IMPORT_PASSED":
             raise ValueError("pyDEXPI is required but is not installed")
         if args.require_commercial_cae and report["commercialCae"].get("status") != "PASSED":

--- a/docs/integration/dexpi-engineering-generation.md
+++ b/docs/integration/dexpi-engineering-generation.md
@@ -330,6 +330,28 @@ qualification. Commercial import and round-trip evidence must follow
 `docs/integration/dexpi-commercial-cae-evidence-template.json`; a missing vendor test remains
 `QUALIFICATION_REQUIRED` rather than being inferred from schema validity.
 
+The same helper can run the independent MIT-licensed DEXPIViewer validator without downloading or silently updating
+the tool. Supply a local checkout pinned to commit
+`18a17b1e38ba15a1a6ba49dd8265ddcff7c766ad` after installing that checkout's locked Node.js dependencies:
+
+```text
+python devtools/validate_dexpi_interoperability.py . \
+  --native-file src/test/resources/dexpi/2.0/golden/branching-process.dexpi.xml \
+  --dexpi-viewer /absolute/path/to/DEXPIViewer \
+  --dexpi-viewer-baseline src/test/resources/dexpi/2.0/golden/dexpi-viewer-baseline.json \
+  --require-dexpi-viewer \
+  --require-dexpi-viewer-baseline \
+  --output dexpi-viewer-report.json
+```
+
+The helper verifies the checkout's exact Git commit before execution, parses the validator's documented CSV into
+deterministically ordered JSON findings, and records the input and CSV SHA-256 digests. The reviewed golden baseline
+currently contains eight errors and three warnings; matching it is a regression gate, not a clean-validation claim.
+Use `--require-dexpi-viewer-clean` only when the selected native file is expected to have zero errors and zero warnings.
+The present findings identify required export provenance and plant metadata, absent native representation groups, and
+unconnected boundary piping nodes. They must be resolved through controlled metadata and genuine representation
+semantics, not placeholder timestamps or empty graphics.
+
 The DEXPI model contains explicit, graphically positioned process-instrumentation functions, signal-generating
 functions, instrumentation loops, information-flow relationships, control valves, shutdown valves, check valves,
 pressure-safety valves, and blowdown valves. Every generated object is associated with its protected equipment and

--- a/docs/integration/dexpi-pid-current-master-audit.md
+++ b/docs/integration/dexpi-pid-current-master-audit.md
@@ -47,7 +47,7 @@ reviewed public-API migration says otherwise.
 | Supported semantic profile | `Dexpi20SemanticValidator`, `Dexpi20ModelInspector`, `Dexpi20ConformanceAssessment` | Automated for NeqSim's declared supported subset; not full DEXPI coverage |
 | Proteus layout | `DexpiLayoutEngine`, `DexpiLayoutConfig`, `DexpiShapeCatalog` | Deterministic compatibility layout with routing, symbols, title fields, and off-page graphics |
 | Simulator/P&ID bridge | `diagram.DexpiDiagramBridge` and Python rendering helpers | Convenience import, export, and external rendering path; not canonical ownership |
-| pyDEXPI qualification helper | `devtools/validate_dexpi_interoperability.py` and `render_neqsim_dexpi_with_pydexpi.py` | Reproducible public-tool check when an exact environment is supplied |
+| Public-tool qualification helper | `devtools/validate_dexpi_interoperability.py`, pinned DEXPIViewer baseline, and `render_neqsim_dexpi_with_pydexpi.py` | Exact-checkout DEXPIViewer findings and pyDEXPI import are machine-readable and separate from clean/commercial qualification |
 | Commercial CAE evidence | `dexpi-commercial-cae-evidence-template.json`, `DexpiToolQualificationRunner`, `DexpiToolQualificationEvidence` | Template and evidence contract only; named product/version observation and accountable difference review are required |
 | Native professional SVG/PDF | No shared native renderer or controlled document-set model | Confirmed gap; Graphviz and external/tool-specific paths remain available |
 
@@ -100,7 +100,10 @@ study preparation, coordinated packages, and qualification evidence.
 
 The repository also contains deterministic native fixtures under
 `src/test/resources/dexpi/2.0/golden`, including the branching Plant fixture, manifest, semantic
-summary, and schema provenance. The coordinated
+summary, schema provenance, and a reviewed DEXPIViewer baseline pinned to commit
+`18a17b1e38ba15a1a6ba49dd8265ddcff7c766ad`. That external baseline has eight errors and three warnings; it detects
+drift while required provenance, plant metadata, genuine representation groups, and boundary-node handling remain
+open implementation work. The coordinated
 [engineering-diagram reference cases](dexpi-reference-cases.md) add executable, synthetic public
 simple, branched, and multi-area process fixtures. They check canonical topology, material balance,
 native Process/Plant exchange where supported, Proteus compatibility, legacy DOT, and governed P&ID
@@ -171,7 +174,7 @@ licensed standards, a named external tool, or accountable engineering review.
 | Simulation-backed engineering enrichment | Partial | Coordinated cases, registers, calculations, DEXPI packages and selected canonical stream values exist; governing envelopes and all equipment/design selections are not uniformly linked through the exchange |
 | DEXPI-centred study audits | Partial | Completeness, HAZOP preparation, SIS/HIPPS and qualification evidence exist; revision/MOC deltas and reusable selected-object study hooks are incomplete |
 | Java/Python engineer usability | Partial | Java writers/compilers and Python/Colab examples exist; one concise model-to-package-to-drawing-to-study API is not yet qualified |
-| Public DEXPI/pyDEXPI validation | Partial | Bundled schema, public helper and internal fixtures exist; exact-version external execution must be rerun per release/reference case |
+| Public DEXPI/pyDEXPI validation | Partial | Bundled schema, a pinned DEXPIViewer runner/baseline, pyDEXPI import helper, and internal fixtures exist; the reviewed external baseline is not clean and exact-version execution must be rerun per release/reference case |
 | Commercial CAE qualification | External | Evidence template exists; observed named-product/version import, export, semantic diff and accountable review are mandatory |
 | Executed reference workflows | Partial | Saved notebooks and CI workflows exist; the full realistic multi-area, recycle, isolation, relief, flare, cross-sheet, revision-delta acceptance workflow remains a gap |
 | Performance and completion release gate | Gap | Representative export/import/render/revision benchmarks and the final independent current-master audit are not complete |

--- a/src/test/resources/dexpi/2.0/golden/dexpi-viewer-baseline.json
+++ b/src/test/resources/dexpi/2.0/golden/dexpi-viewer-baseline.json
@@ -1,0 +1,18 @@
+{
+  "profile": "neqsim_dexpi_viewer_baseline.v1",
+  "repository": "https://github.com/ToniaPedersen/DEXPIViewer",
+  "commit": "18a17b1e38ba15a1a6ba49dd8265ddcff7c766ad",
+  "input": "branching-process.dexpi.xml",
+  "inputSha256": "64cdf0ac0e026e3b2cb79feef56a89488f29ecbcba5b1476cc976d82d618839b",
+  "expectedIssueCounts": {
+    "errors": 8,
+    "warnings": 3
+  },
+  "knownFindingClasses": [
+    "required Core/EngineeringModel export provenance",
+    "required Plant/Diagram.PlantMetaData",
+    "missing native equipment representation groups",
+    "unconnected boundary PipingNode objects"
+  ],
+  "approvalStatus": "REVIEWED_BASELINE_NOT_A_CLEAN_VALIDATION"
+}

--- a/src/test/resources/dexpi/2.0/golden/fixture-manifest.json
+++ b/src/test/resources/dexpi/2.0/golden/fixture-manifest.json
@@ -7,7 +7,13 @@
   "validation": {
     "officialDexpi20Xsd": "PASSED",
     "neqsimSemanticProfile": "PASSED",
-    "roundTripSummary": "PASSED"
+    "roundTripSummary": "PASSED",
+    "dexpiViewer": {
+      "repository": "https://github.com/ToniaPedersen/DEXPIViewer",
+      "commit": "18a17b1e38ba15a1a6ba49dd8265ddcff7c766ad",
+      "baseline": "dexpi-viewer-baseline.json",
+      "status": "REVIEWED_ISSUES_BASELINE"
+    }
   },
   "approvalStatus": "REGRESSION_FIXTURE_NOT_ENGINEERING_DELIVERABLE"
 }


### PR DESCRIPTION
## Summary

- extend `devtools/validate_dexpi_interoperability.py` with an opt-in DEXPIViewer runner pinned to `ToniaPedersen/DEXPIViewer@18a17b1e38ba15a1a6ba49dd8265ddcff7c766ad`
- verify the supplied checkout's exact Git head before execution, parse its documented CSV into deterministic structured findings, and record input/report SHA-256 provenance
- add separate gates for tool execution, a reviewed findings baseline, and genuinely clean zero-error/zero-warning validation
- record the branching native DEXPI fixture's reviewed 8-error/3-warning baseline without treating that baseline as conformance
- document the precise external workflow and the remaining controlled-metadata, representation, and boundary-node gaps

This advances the shared #1332/#2899 diagram lane without fabricating timestamps, plant metadata, or empty graphical representations. It does not alter Java APIs, generated DEXPI XML, legacy DOT/Graphviz, native SVG/PDF, Proteus compatibility, or Classic output.

## Validation

Local focused evidence on the exact published contents:

- `python -m unittest devtools/test_validate_dexpi_interoperability.py` — **PASSED** (4 tests)
- `python -m py_compile devtools/validate_dexpi_interoperability.py devtools/test_validate_dexpi_interoperability.py` — **PASSED**
- structural CLI run against `branching-process.dexpi.xml` — **PASSED**; SHA-256 `64cdf0ac0e026e3b2cb79feef56a89488f29ecbcba5b1476cc976d82d618839b`, 24 objects
- `python devtools/check_documentation_search.py` — **PASSED** for the locally available documentation subset (2 Markdown pages)
- JSON syntax checks for both fixture manifests — **PASSED**
- pre-commit — **NOT RUN** (not installed)
- direct Spotless — **NOT APPLICABLE** (no Java files changed)
- pinned DEXPIViewer execution — **VALIDATION PENDING CI / exact external checkout environment**; the committed counts come from the reviewed roadmap baseline and are not claimed as rerun locally

## Documentation impact

Updated the engineering-generation guide with exact pinning, invocation and gate semantics, and updated the current-master audit to distinguish baseline matching from clean validation and commercial qualification.

## Engineering boundary

A matching baseline detects drift but does not make the native Plant fixture clean or approved. The known findings remain required EngineeringModel provenance, PlantMetaData, genuine equipment representation groups, and unconnected boundary PipingNodes. P&ID output remains an engineering proposal requiring accountable design data and review; no ISO 10628 conformance or commercial CAE qualification is claimed.

Refs #1332
Refs #2899

**VALIDATION PENDING CI**