### PR TITLE
feat(pipeline): add coupled two-fluid transients, storage and networks

### DIFF
--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -990,6 +990,38 @@ pipe.setTimeIntegrationMethod(TimeIntegrator.Method.IMEX_PRESSURE_CORRECTION); /
 TimeIntegrator.Method current = pipe.getTimeIntegrationMethod(); // query
 ```
 
+### Coupled pressure-momentum transient correction
+
+The historical transient path advances conservative phase mass and momentum and then reconstructs
+pressure from the steady friction-and-gravity gradient. That sequential reconstruction cannot
+provide compressibility feedback to a momentum instability. It is retained as the default for
+compatibility.
+
+The opt-in coupled correction solves a finite-volume pressure equation from the cell-volume
+constraint and phase compressibilities. The pressure correction changes phase mass fluxes
+conservatively and corrects gas, oil, and water momenta with the same face pressure gradients.
+It therefore advances pressure and momentum in one accepted substep and does not call the
+steady pressure reconstruction afterward.
+
+```java
+pipe.setEnableInterfacialPressure(true);
+pipe.setImplicitInterfacialPressureCoupling(true);
+pipe.setEnableCoupledPressureMomentum(true);
+```
+
+Use the three settings together for liquid-rich transients. The interfacial-pressure term makes
+the phase-momentum system hyperbolic, its implicit treatment removes the small void-wave CFL
+limit, and the coupled correction supplies compressibility feedback. The mode reports
+`isCoupledPressureMomentumConverged()`,
+`getCoupledPressureMomentumVolumeResidual()`, and
+`getCoupledPressureMomentumIterations()`. A non-converged non-adaptive step throws instead of
+returning a bounded-looking but invalid result.
+
+The option remains off by default while long-horizon severe-slugging, mesh, timestep, and
+independent OLGA/public benchmark qualification is completed. Do not use short startup peaks as
+limit-cycle evidence; report period, the P10-P90 band, and completed cycle count over a settled
+window.
+
 ### Adaptive Timestepping
 
 Adaptive timestepping provides robustness for challenging geometries. Enable via

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -945,7 +945,9 @@ sum_k M_k / rho_k(p) = fixed volume,  with d rho_k / d p = 1 / c_k^2.
 
 Signed pipe transfer is supported, so a phase returning from the pipe adds upstream inventory.
 Phase depletion and non-converged pressure closure throw rather than clamping mass. Connecting the
-volume selects a constant-pressure inlet whose value is updated from the volume; the ordinary
+volume selects a constant-pressure inlet whose value is updated from the volume. When a volume is
+attached, `pipe.getInletPressure()` reports that current boundary pressure after the accepted
+inventory transfer; the axial pressure profile remains the accepted internal pipe state. The ordinary
 stream remains the source of thermodynamic composition for the pipe boundary. Component mixing,
 heat transfer, and a momentum-resolved vessel/nozzle model are outside this lumped boundary's
 current scope.

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -1007,11 +1007,15 @@ steady pressure reconstruction afterward.
 pipe.setEnableInterfacialPressure(true);
 pipe.setImplicitInterfacialPressureCoupling(true);
 pipe.setEnableCoupledPressureMomentum(true);
+pipe.setAllowOutletPhaseBackflow(true);
 ```
 
-Use the three settings together for liquid-rich transients. The interfacial-pressure term makes
-the phase-momentum system hyperbolic, its implicit treatment removes the small void-wave CFL
-limit, and the coupled correction supplies compressibility feedback. The mode reports
+Use the four settings together for liquid-rich transients whose pressure outlet permits phase
+fallback. The interfacial-pressure term makes the phase-momentum system hyperbolic, its implicit
+treatment removes the small void-wave CFL limit, the coupled correction supplies compressibility
+feedback, and the signed outlet prevents a reversed liquid phase from being silently pinned at
+zero. Signed fallback extrapolates the interior phase state and remains opt-in because a one-way
+export boundary may instead require a check valve or a supplied external inflow composition. The mode reports
 `isCoupledPressureMomentumConverged()`,
 `getCoupledPressureMomentumVolumeResidual()`, and
 `getCoupledPressureMomentumIterations()`. A non-converged non-adaptive step throws instead of

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -914,6 +914,73 @@ Avoid over-specifying the same side. For example, a `STREAM_CONNECTED` inlet alr
 temperature, pressure, and composition from the inlet stream; switch to `CONSTANT_FLOW` only when
 the flow should be independent of the stream flow rate.
 
+### Compressible upstream-volume boundary
+
+A real well, flowline, or laboratory loop normally has compressible inventory upstream of the
+modeled pipe. A fixed stream rate removes that storage and can shorten a severe-slug cycle.
+`UpstreamCompressibleVolume` supplies a phase-resolved dynamic inlet pressure without adding
+pipeline closures to the boundary model.
+
+Initialize the pipe to steady state, create the volume from its inlet section, and specify the
+external phase source rates:
+
+```java
+pipe.run();
+UpstreamCompressibleVolume sourceVolume =
+    pipe.initializeUpstreamCompressibleVolume(25.0);
+sourceVolume.setSourceMassFlowRates(gasSourceKgS, oilSourceKgS, waterSourceKgS);
+
+pipe.runTransient(0.1, UUID.randomUUID());
+double sourcePressurePa = sourceVolume.getPressurePa();
+double volumeClosure = sourceVolume.getMaximumRelativeVolumeResidual();
+```
+
+After every accepted internal substep, the pipe passes its integration-weighted gas, oil, and water
+inlet masses to the volume. The volume applies
+
+```text
+M_k(new) = M_k(old) + source_k dt - pipe_inlet_k
+sum_k M_k / rho_k(p) = fixed volume,  with d rho_k / d p = 1 / c_k^2.
+```
+
+Signed pipe transfer is supported, so a phase returning from the pipe adds upstream inventory.
+Phase depletion and non-converged pressure closure throw rather than clamping mass. Connecting the
+volume selects a constant-pressure inlet whose value is updated from the volume; the ordinary
+stream remains the source of thermodynamic composition for the pipe boundary. Component mixing,
+heat transfer, and a momentum-resolved vessel/nozzle model are outside this lumped boundary's
+current scope.
+
+### Multi-branch pressure-node network
+
+`TwoFluidPipeNetwork` connects named `TwoFluidPipe` branches through fixed-pressure reservoirs
+and phase-resolved compressible storage nodes. It supports directed splits, merges, manifolds, and
+injection branches:
+
+```java
+TwoFluidPipeNetwork network = new TwoFluidPipeNetwork("subsea network");
+network.addFixedPressureNode("well", 120.0e5);
+network.addCompressibleNode("manifold", manifoldVolume);
+network.addFixedPressureNode("separator", 55.0e5);
+network.addPipe("flowline A", "well", "manifold", flowlineA);
+network.addPipe("riser", "manifold", "separator", riser);
+
+network.runTransient(0.1, UUID.randomUUID());
+double nodePressure = network.getNodePressurePa("manifold");
+double closure = network.getLastBalanceReport()
+    .getRelativeResidual(TwoFluidMassBalanceReport.Phase.TOTAL);
+```
+
+Every branch sees the node pressures at the beginning of the network step. After all branches
+advance, their accepted gas, oil, and water boundary transfers update every compressible node
+simultaneously. Branch iteration order therefore does not become an implicit pressure solve.
+The whole-network report includes pipe and node inventories, fixed-boundary transfers, phase
+sources, and gas/oil/water/liquid/total residuals.
+
+This first network implementation requires finite compressible storage at internal junctions.
+Fixed-pressure nodes are external reservoirs or sinks. Algebraic zero-volume junctions, a global
+Newton pressure-flow solve, component and enthalpy mixing, reverse-flow boundary composition, and
+branch subcycling remain outside the validated scope.
+
 ### Choosing Time Step, Sections, and Pipeline Length
 
 `runTransient(dt, id)` takes a macro time step in seconds. Internally, the solver sub-steps to
@@ -1025,6 +1092,36 @@ The option remains off by default while long-horizon severe-slugging, mesh, time
 independent OLGA/public benchmark qualification is completed. Do not use short startup peaks as
 limit-cycle evidence; report period, the P10-P90 band, and completed cycle count over a settled
 window.
+
+### Standing benchmark acceptance metrics
+
+Use `TwoFluidBenchmarkMetrics` to compare a rate sweep, a section profile, mesh realizations, and
+a settled transient with the same definitions in every benchmark:
+
+```java
+double exponent = TwoFluidBenchmarkMetrics.fitRateExponent(rates, pressureDrops);
+double terrainLocalization =
+    TwoFluidBenchmarkMetrics.maximumToMedianRatio(liquidHoldupProfile);
+double meshSpread =
+    TwoFluidBenchmarkMetrics.relativeMeshSpread(coarseResult, refinedResult);
+TwoFluidBenchmarkMetrics.LimitCycleMetrics cycle =
+    TwoFluidBenchmarkMetrics.analyzeLimitCycle(times, pressure, settledWindowStart);
+```
+
+The limit-cycle result reports period, P10, median, P90, P10-P90 band, sample window, and completed
+median-upcrossing cycle count. A large startup peak followed by a flat trace reports zero completed
+cycles, so it cannot pass as a sustained oscillation.
+
+The slow public Tengesdal benchmark now uses these settled-window definitions and requires at least
+two completed liquid-rate cycles in every mesh/timestep realization. It retains the published
+experimental source and its phase-mass, mean-pressure, mesh, amplitude, and deterministic-repeat
+checks.
+
+A user-supplied like-for-like OLGA run for the same geometry reported a 21.7 s cycle and a
+0.37-4.03 kg/s liquid-outlet range, while the public experiment reports 38 +/- 2 s. These values
+are comparison evidence, not embedded commercial correlations. A NeqSim/OLGA comparison should
+record exported time series and evaluate both with the same settled window and metrics; it should
+not compare one startup peak or tune a closure to one trajectory.
 
 ### Adaptive Timestepping
 

--- a/src/main/java/neqsim/process/equipment/network/TwoFluidPipeNetwork.java
+++ b/src/main/java/neqsim/process/equipment/network/TwoFluidPipeNetwork.java
@@ -1,0 +1,370 @@
+package neqsim.process.equipment.network;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport.Phase;
+import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import neqsim.process.equipment.pipeline.TwoFluidPipe.BoundaryCondition;
+import neqsim.process.equipment.pipeline.UpstreamCompressibleVolume;
+
+/**
+ * Phase-conservative transient hydraulic network of {@link TwoFluidPipe} branches.
+ *
+ * <p>
+ * Every branch is advanced from the pressures at the beginning of the network step. Gas, oil, and water boundary
+ * transfers are then accumulated at each compressible node, and all node pressures are advanced simultaneously.
+ * Fixed-pressure nodes represent external reservoirs or sinks. This explicit storage-node coupling supports splits,
+ * merges, manifolds, and injection branches without making branch execution order part of the pressure solution.
+ * </p>
+ *
+ * <p>
+ * This first network layer is intentionally storage based. Algebraic zero-volume junctions, global Newton pressure-flow
+ * iteration, component/enthalpy mixing, reverse-flow boundary composition, and branch subcycling are outside its
+ * current scope.
+ * </p>
+ */
+public final class TwoFluidPipeNetwork implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private static final int PHASE_COUNT = 3;
+
+  private final String name;
+  private final Map<String, NetworkNode> nodes = new LinkedHashMap<String, NetworkNode>();
+  private final Map<String, NetworkBranch> branches = new LinkedHashMap<String, NetworkBranch>();
+  private boolean initialized;
+  private double simulationTimeSeconds;
+  private BalanceReport lastBalanceReport;
+
+  /** Create an empty network. */
+  public TwoFluidPipeNetwork(String name) {
+    if (name == null || name.trim().isEmpty()) {
+      throw new IllegalArgumentException("Network name cannot be blank");
+    }
+    this.name = name;
+  }
+
+  /** Add a storage node whose pressure follows its compressible phase inventories. */
+  public void addCompressibleNode(String nodeName, UpstreamCompressibleVolume volume) {
+    requireUniqueNodeName(nodeName);
+    if (volume == null) {
+      throw new IllegalArgumentException("Compressible node volume cannot be null");
+    }
+    nodes.put(nodeName, NetworkNode.compressible(nodeName, volume));
+  }
+
+  /** Add an external fixed-pressure reservoir or sink node. */
+  public void addFixedPressureNode(String nodeName, double pressurePa) {
+    requireUniqueNodeName(nodeName);
+    requirePositiveFinite(pressurePa, "Fixed-node pressure");
+    nodes.put(nodeName, NetworkNode.fixed(nodeName, pressurePa));
+  }
+
+  /** Add a directed two-fluid pipe branch between existing nodes. */
+  public void addPipe(String branchName, String fromNodeName, String toNodeName, TwoFluidPipe pipe) {
+    requireName(branchName, "Branch");
+    if (branches.containsKey(branchName)) {
+      throw new IllegalArgumentException("Branch '" + branchName + "' already exists");
+    }
+    NetworkNode fromNode = requireNode(fromNodeName);
+    NetworkNode toNode = requireNode(toNodeName);
+    if (fromNode == toNode) {
+      throw new IllegalArgumentException("Branch '" + branchName + "' cannot connect a node to itself");
+    }
+    if (pipe == null) {
+      throw new IllegalArgumentException("Network pipe cannot be null");
+    }
+    if (pipe.getUpstreamCompressibleVolume() != null) {
+      throw new IllegalArgumentException(
+          "Branch '" + branchName + "' already owns an upstream volume; network nodes must own boundary storage");
+    }
+    NetworkBranch branch = new NetworkBranch(branchName, fromNode, toNode, pipe);
+    branches.put(branchName, branch);
+    fromNode.outgoingCount++;
+    toNode.incomingCount++;
+    initialized = false;
+  }
+
+  /**
+   * Initialize each branch from its configured stream and the downstream node pressure.
+   *
+   * <p>
+   * The branch stream flow remains the steady initialization rate. Transient execution then switches both ends to node
+   * pressures.
+   * </p>
+   */
+  public void initialize(UUID id) {
+    validateRunnableNetwork();
+    for (NetworkBranch branch : branches.values()) {
+      branch.pipe.setOutletPressure(branch.toNode.getPressurePa());
+      branch.pipe.run(id);
+      configureTransientPressures(branch);
+    }
+    initialized = true;
+  }
+
+  /** Advance every branch and all compressible nodes by one common reporting interval. */
+  public void runTransient(double timeStepSeconds, UUID id) {
+    requirePositiveFinite(timeStepSeconds, "Network time step");
+    if (!initialized) {
+      initialize(id);
+    }
+
+    double[] initialMassKg = new double[PHASE_COUNT];
+    double[] finalMassKg = new double[PHASE_COUNT];
+    double[] externalInletMassKg = new double[PHASE_COUNT];
+    double[] externalOutletMassKg = new double[PHASE_COUNT];
+    double[] sourceMassKg = new double[PHASE_COUNT];
+    Map<String, double[]> nodeTransferKg = new LinkedHashMap<String, double[]>();
+
+    for (NetworkNode node : nodes.values()) {
+      nodeTransferKg.put(node.name, new double[PHASE_COUNT]);
+      if (!node.fixedPressure) {
+        for (int phase = 0; phase < PHASE_COUNT; phase++) {
+          initialMassKg[phase] += node.volume.getPhaseMassKg(phase);
+          sourceMassKg[phase] += node.volume.getSourceMassFlowRateKgS(phase) * timeStepSeconds;
+        }
+      }
+    }
+
+    for (NetworkBranch branch : branches.values()) {
+      configureTransientPressures(branch);
+      branch.pipe.runTransient(timeStepSeconds, id);
+      TwoFluidMassBalanceReport report = branch.pipe.getLastMassBalanceReport();
+      if (report == null) {
+        throw new IllegalStateException("Branch '" + branch.name + "' returned no mass-balance report");
+      }
+      for (int phase = 0; phase < PHASE_COUNT; phase++) {
+        Phase aggregation = phase(phase);
+        initialMassKg[phase] += report.getInitialMassKg(aggregation);
+        finalMassKg[phase] += report.getFinalMassKg(aggregation);
+        sourceMassKg[phase] += report.getSourceMassKg(aggregation);
+        double inletMass = report.getInletMassKg(aggregation);
+        double outletMass = report.getOutletMassKg(aggregation);
+        if (branch.fromNode.fixedPressure) {
+          externalInletMassKg[phase] += inletMass;
+        } else {
+          nodeTransferKg.get(branch.fromNode.name)[phase] += inletMass;
+        }
+        if (branch.toNode.fixedPressure) {
+          externalOutletMassKg[phase] += outletMass;
+        } else {
+          nodeTransferKg.get(branch.toNode.name)[phase] -= outletMass;
+        }
+      }
+    }
+
+    for (NetworkNode node : nodes.values()) {
+      if (!node.fixedPressure) {
+        node.volume.advance(timeStepSeconds, nodeTransferKg.get(node.name));
+        for (int phase = 0; phase < PHASE_COUNT; phase++) {
+          finalMassKg[phase] += node.volume.getPhaseMassKg(phase);
+        }
+      }
+    }
+
+    simulationTimeSeconds += timeStepSeconds;
+    lastBalanceReport = new BalanceReport(timeStepSeconds, initialMassKg, finalMassKg, externalInletMassKg,
+        externalOutletMassKg, sourceMassKg);
+  }
+
+  private void configureTransientPressures(NetworkBranch branch) {
+    branch.pipe.setInletBoundaryCondition(BoundaryCondition.CONSTANT_PRESSURE);
+    branch.pipe.setInletPressure(branch.fromNode.getPressurePa());
+    branch.pipe.setOutletBoundaryCondition(BoundaryCondition.CONSTANT_PRESSURE);
+    branch.pipe.setOutletPressure(branch.toNode.getPressurePa());
+  }
+
+  private void validateRunnableNetwork() {
+    if (nodes.size() < 2 || branches.isEmpty()) {
+      throw new IllegalStateException("Two-fluid network requires at least two nodes and one branch");
+    }
+    for (NetworkNode node : nodes.values()) {
+      if (node.incomingCount + node.outgoingCount == 0) {
+        throw new IllegalStateException("Node '" + node.name + "' is not connected to a branch");
+      }
+    }
+  }
+
+  private void requireUniqueNodeName(String nodeName) {
+    requireName(nodeName, "Node");
+    if (nodes.containsKey(nodeName)) {
+      throw new IllegalArgumentException("Node '" + nodeName + "' already exists");
+    }
+  }
+
+  private NetworkNode requireNode(String nodeName) {
+    NetworkNode node = nodes.get(nodeName);
+    if (node == null) {
+      throw new IllegalArgumentException("Node '" + nodeName + "' does not exist");
+    }
+    return node;
+  }
+
+  private static void requireName(String value, String label) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(label + " name cannot be blank");
+    }
+  }
+
+  private static void requirePositiveFinite(double value, String label) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(label + " must be positive and finite");
+    }
+  }
+
+  private static Phase phase(int index) {
+    switch (index) {
+    case 0:
+      return Phase.GAS;
+    case 1:
+      return Phase.OIL;
+    case 2:
+      return Phase.WATER;
+    default:
+      throw new IllegalArgumentException("Unsupported phase index " + index);
+    }
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public double getSimulationTimeSeconds() {
+    return simulationTimeSeconds;
+  }
+
+  public BalanceReport getLastBalanceReport() {
+    return lastBalanceReport;
+  }
+
+  public TwoFluidPipe getPipe(String branchName) {
+    NetworkBranch branch = branches.get(branchName);
+    if (branch == null)
+      throw new IllegalArgumentException("Branch '" + branchName + "' does not exist");
+    return branch.pipe;
+  }
+
+  public double getNodePressurePa(String nodeName) {
+    return requireNode(nodeName).getPressurePa();
+  }
+
+  private static final class NetworkNode implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final boolean fixedPressure;
+    private final double fixedPressurePa;
+    private final UpstreamCompressibleVolume volume;
+    private int incomingCount;
+    private int outgoingCount;
+
+    private NetworkNode(String name, boolean fixedPressure, double fixedPressurePa, UpstreamCompressibleVolume volume) {
+      this.name = name;
+      this.fixedPressure = fixedPressure;
+      this.fixedPressurePa = fixedPressurePa;
+      this.volume = volume;
+    }
+
+    private static NetworkNode fixed(String name, double pressurePa) {
+      return new NetworkNode(name, true, pressurePa, null);
+    }
+
+    private static NetworkNode compressible(String name, UpstreamCompressibleVolume volume) {
+      return new NetworkNode(name, false, Double.NaN, volume);
+    }
+
+    private double getPressurePa() {
+      return fixedPressure ? fixedPressurePa : volume.getPressurePa();
+    }
+  }
+
+  private static final class NetworkBranch implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final NetworkNode fromNode;
+    private final NetworkNode toNode;
+    private final TwoFluidPipe pipe;
+
+    private NetworkBranch(String name, NetworkNode fromNode, NetworkNode toNode, TwoFluidPipe pipe) {
+      this.name = name;
+      this.fromNode = fromNode;
+      this.toNode = toNode;
+      this.pipe = pipe;
+    }
+  }
+
+  /** Whole-network phase and total mass balance for the latest accepted reporting interval. */
+  public static final class BalanceReport implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final double elapsedTimeSeconds;
+    private final double[] initialMassKg;
+    private final double[] finalMassKg;
+    private final double[] externalInletMassKg;
+    private final double[] externalOutletMassKg;
+    private final double[] sourceMassKg;
+
+    private BalanceReport(double elapsedTimeSeconds, double[] initialMassKg, double[] finalMassKg,
+        double[] externalInletMassKg, double[] externalOutletMassKg, double[] sourceMassKg) {
+      this.elapsedTimeSeconds = elapsedTimeSeconds;
+      this.initialMassKg = initialMassKg.clone();
+      this.finalMassKg = finalMassKg.clone();
+      this.externalInletMassKg = externalInletMassKg.clone();
+      this.externalOutletMassKg = externalOutletMassKg.clone();
+      this.sourceMassKg = sourceMassKg.clone();
+    }
+
+    public double getElapsedTimeSeconds() {
+      return elapsedTimeSeconds;
+    }
+
+    public double getInitialMassKg(Phase aggregation) {
+      return aggregate(initialMassKg, aggregation);
+    }
+
+    public double getFinalMassKg(Phase aggregation) {
+      return aggregate(finalMassKg, aggregation);
+    }
+
+    public double getExternalInletMassKg(Phase aggregation) {
+      return aggregate(externalInletMassKg, aggregation);
+    }
+
+    public double getExternalOutletMassKg(Phase aggregation) {
+      return aggregate(externalOutletMassKg, aggregation);
+    }
+
+    public double getSourceMassKg(Phase aggregation) {
+      return aggregate(sourceMassKg, aggregation);
+    }
+
+    public double getResidualKg(Phase aggregation) {
+      return getFinalMassKg(aggregation) - getInitialMassKg(aggregation)
+          - (getExternalInletMassKg(aggregation) - getExternalOutletMassKg(aggregation) + getSourceMassKg(aggregation));
+    }
+
+    public double getRelativeResidual(Phase aggregation) {
+      double scale = Math.max(Math.abs(getInitialMassKg(aggregation)), Math.abs(getFinalMassKg(aggregation)));
+      scale = Math.max(scale, Math.abs(getExternalInletMassKg(aggregation))
+          + Math.abs(getExternalOutletMassKg(aggregation)) + Math.abs(getSourceMassKg(aggregation)));
+      return Math.abs(getResidualKg(aggregation)) / Math.max(scale, 1.0e-12);
+    }
+
+    private static double aggregate(double[] values, Phase aggregation) {
+      switch (aggregation) {
+      case GAS:
+        return values[0];
+      case OIL:
+        return values[1];
+      case WATER:
+        return values[2];
+      case LIQUID:
+        return values[1] + values[2];
+      case TOTAL:
+        return values[0] + values[1] + values[2];
+      default:
+        throw new IllegalArgumentException("Unsupported phase " + aggregation);
+      }
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidBenchmarkMetrics.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidBenchmarkMetrics.java
@@ -1,0 +1,235 @@
+package neqsim.process.equipment.pipeline;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/** Reusable, scale-aware comparison metrics for two-fluid benchmark and acceptance suites. */
+public final class TwoFluidBenchmarkMetrics {
+  private TwoFluidBenchmarkMetrics() {
+  }
+
+  /** Fit the least-squares log-log exponent in {@code response = constant * rate^n}. */
+  public static double fitRateExponent(double[] rates, double[] responses) {
+    requireSameLength(rates, responses, 2);
+    double meanX = 0.0;
+    double meanY = 0.0;
+    for (int index = 0; index < rates.length; index++) {
+      requirePositiveFinite(rates[index], "Rate");
+      requirePositiveFinite(responses[index], "Response");
+      meanX += Math.log(rates[index]);
+      meanY += Math.log(responses[index]);
+    }
+    meanX /= rates.length;
+    meanY /= rates.length;
+    double covariance = 0.0;
+    double variance = 0.0;
+    for (int index = 0; index < rates.length; index++) {
+      double dx = Math.log(rates[index]) - meanX;
+      covariance += dx * (Math.log(responses[index]) - meanY);
+      variance += dx * dx;
+    }
+    if (!(variance > 0.0)) {
+      throw new IllegalArgumentException("Rate sweep must contain at least two distinct rates");
+    }
+    return covariance / variance;
+  }
+
+  /** Return maximum value divided by the sample median of a positive profile. */
+  public static double maximumToMedianRatio(double[] profile) {
+    requireFiniteValues(profile, 1, "Profile");
+    double maximum = -Double.MAX_VALUE;
+    for (double value : profile) {
+      if (value < 0.0) {
+        throw new IllegalArgumentException("Profile values must be non-negative");
+      }
+      maximum = Math.max(maximum, value);
+    }
+    double median = percentile(profile, 0.5);
+    if (!(median > 0.0)) {
+      throw new IllegalArgumentException("Profile median must be positive");
+    }
+    return maximum / median;
+  }
+
+  /** Symmetric relative spread using the larger absolute result as scale. */
+  public static double relativeMeshSpread(double first, double second) {
+    if (!Double.isFinite(first) || !Double.isFinite(second)) {
+      throw new IllegalArgumentException("Mesh results must be finite");
+    }
+    double scale = Math.max(Math.abs(first), Math.abs(second));
+    return scale == 0.0 ? 0.0 : Math.abs(first - second) / scale;
+  }
+
+  /**
+   * Analyze a settled signal with robust P10-P90 amplitude and completed median-upcrossing cycles.
+   *
+   * @param timeSeconds strictly increasing sample times
+   * @param signal sampled pressure, flow, or holdup signal
+   * @param settledWindowStartSeconds first time included in the settled window
+   * @return immutable limit-cycle metrics
+   */
+  public static LimitCycleMetrics analyzeLimitCycle(double[] timeSeconds, double[] signal,
+      double settledWindowStartSeconds) {
+    requireSameLength(timeSeconds, signal, 3);
+    if (!Double.isFinite(settledWindowStartSeconds)) {
+      throw new IllegalArgumentException("Settled-window start must be finite");
+    }
+    List<Double> selectedTimes = new ArrayList<Double>();
+    List<Double> selectedSignal = new ArrayList<Double>();
+    double previousTime = -Double.MAX_VALUE;
+    for (int index = 0; index < timeSeconds.length; index++) {
+      double time = timeSeconds[index];
+      double value = signal[index];
+      if (!Double.isFinite(time) || !Double.isFinite(value) || time <= previousTime) {
+        throw new IllegalArgumentException("Times must be finite and strictly increasing; signal must be finite");
+      }
+      previousTime = time;
+      if (time >= settledWindowStartSeconds) {
+        selectedTimes.add(time);
+        selectedSignal.add(value);
+      }
+    }
+    if (selectedTimes.size() < 3) {
+      throw new IllegalArgumentException("Settled window must contain at least three samples");
+    }
+
+    double[] values = new double[selectedSignal.size()];
+    for (int index = 0; index < values.length; index++) {
+      values[index] = selectedSignal.get(index);
+    }
+    double p10 = percentile(values, 0.10);
+    double median = percentile(values, 0.50);
+    double p90 = percentile(values, 0.90);
+    double robustBand = p90 - p10;
+
+    List<Double> crossingTimes = new ArrayList<Double>();
+    if (robustBand > Math.ulp(Math.max(1.0, Math.abs(median)))) {
+      for (int index = 1; index < values.length; index++) {
+        double before = values[index - 1] - median;
+        double after = values[index] - median;
+        if (before < 0.0 && after >= 0.0 && after > before) {
+          double fraction = -before / (after - before);
+          double crossing = selectedTimes.get(index - 1)
+              + fraction * (selectedTimes.get(index) - selectedTimes.get(index - 1));
+          crossingTimes.add(crossing);
+        }
+      }
+    }
+    int completedCycles = Math.max(0, crossingTimes.size() - 1);
+    double period = Double.NaN;
+    if (completedCycles > 0) {
+      double[] intervals = new double[completedCycles];
+      for (int index = 0; index < intervals.length; index++) {
+        intervals[index] = crossingTimes.get(index + 1) - crossingTimes.get(index);
+      }
+      period = percentile(intervals, 0.5);
+    }
+    return new LimitCycleMetrics(p10, median, p90, period, completedCycles, values.length, selectedTimes.get(0),
+        selectedTimes.get(selectedTimes.size() - 1));
+  }
+
+  private static double percentile(double[] values, double fraction) {
+    double[] sorted = Arrays.copyOf(values, values.length);
+    Arrays.sort(sorted);
+    double position = fraction * (sorted.length - 1);
+    int lower = (int) Math.floor(position);
+    int upper = (int) Math.ceil(position);
+    if (lower == upper) {
+      return sorted[lower];
+    }
+    double weight = position - lower;
+    return sorted[lower] * (1.0 - weight) + sorted[upper] * weight;
+  }
+
+  private static void requireSameLength(double[] first, double[] second, int minimumLength) {
+    requireFiniteValues(first, minimumLength, "First array");
+    requireFiniteValues(second, minimumLength, "Second array");
+    if (first.length != second.length) {
+      throw new IllegalArgumentException("Arrays must have the same length");
+    }
+  }
+
+  private static void requireFiniteValues(double[] values, int minimumLength, String label) {
+    if (values == null || values.length < minimumLength) {
+      throw new IllegalArgumentException(label + " must contain at least " + minimumLength + " values");
+    }
+    for (double value : values) {
+      if (!Double.isFinite(value)) {
+        throw new IllegalArgumentException(label + " values must be finite");
+      }
+    }
+  }
+
+  private static void requirePositiveFinite(double value, String label) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(label + " must be positive and finite");
+    }
+  }
+
+  /** Immutable transient limit-cycle summary. */
+  public static final class LimitCycleMetrics implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final double p10;
+    private final double median;
+    private final double p90;
+    private final double periodSeconds;
+    private final int completedCycleCount;
+    private final int sampleCount;
+    private final double windowStartSeconds;
+    private final double windowEndSeconds;
+
+    private LimitCycleMetrics(double p10, double median, double p90, double periodSeconds, int completedCycleCount,
+        int sampleCount, double windowStartSeconds, double windowEndSeconds) {
+      this.p10 = p10;
+      this.median = median;
+      this.p90 = p90;
+      this.periodSeconds = periodSeconds;
+      this.completedCycleCount = completedCycleCount;
+      this.sampleCount = sampleCount;
+      this.windowStartSeconds = windowStartSeconds;
+      this.windowEndSeconds = windowEndSeconds;
+    }
+
+    public double getP10() {
+      return p10;
+    }
+
+    public double getMedian() {
+      return median;
+    }
+
+    public double getP90() {
+      return p90;
+    }
+
+    public double getP10ToP90Band() {
+      return p90 - p10;
+    }
+
+    public double getPeriodSeconds() {
+      return periodSeconds;
+    }
+
+    public int getCompletedCycleCount() {
+      return completedCycleCount;
+    }
+
+    public int getSampleCount() {
+      return sampleCount;
+    }
+
+    public double getWindowStartSeconds() {
+      return windowStartSeconds;
+    }
+
+    public double getWindowEndSeconds() {
+      return windowEndSeconds;
+    }
+
+    public boolean hasRepeatedCycle() {
+      return completedCycleCount > 0 && Double.isFinite(periodSeconds);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -152,7 +152,8 @@ public class TwoFluidPipe extends Pipeline {
   /**
    * Whether pressure, phase mass fluxes, and phase momenta are corrected in the same transient step.
    *
-   * <p>Off by default until the long-horizon liquid-rich and severe-slugging acceptance cases pass.
+   * <p>
+   * Off by default until the long-horizon liquid-rich and severe-slugging acceptance cases pass.
    */
   private boolean coupledPressureMomentumEnabled = false;
 
@@ -4312,18 +4313,8 @@ public class TwoFluidPipe extends Pipeline {
             oilDensities, waterDensities, dx, useImplicitVoidWave);
         boolean outletFixed = (outletBCType == BoundaryCondition.CONSTANT_PRESSURE
             || outletBCType == BoundaryCondition.CHARACTERISTIC);
-        timeIntegrator.setCoupledPressureMomentumProperties(
-            pressures,
-            areas,
-            lengths,
-            gasDensities,
-            oilDensities,
-            waterDensities,
-            gasSoundSpeeds,
-            oilSoundSpeeds,
-            waterSoundSpeeds,
-            outletPressure,
-            outletFixed,
+        timeIntegrator.setCoupledPressureMomentumProperties(pressures, areas, lengths, gasDensities, oilDensities,
+            waterDensities, gasSoundSpeeds, oilSoundSpeeds, waterSoundSpeeds, outletPressure, outletFixed,
             coupledPressureMomentumEnabled);
       } else {
         timeIntegrator.setCoupledPressureMomentumEnabled(false);
@@ -4333,23 +4324,17 @@ public class TwoFluidPipe extends Pipeline {
       double[][] U_new = timeIntegrator.step(splitState, rhs, dtFinal);
       U_new = applyStiffBubbleDragSourceStep(U_new, 0.5 * dtFinal);
 
-      if (coupledPressureMomentumEnabled
-          && !timeIntegrator.isCoupledPressureMomentumConverged()) {
+      if (coupledPressureMomentumEnabled && !timeIntegrator.isCoupledPressureMomentumConverged()) {
         equations.applyState(sections, U_prev);
         if (enableAdaptiveTimestepping) {
-          adaptiveDtFactor = Math.max(
-              adaptiveDtFactor * 0.5, MIN_ADAPTIVE_DT_FACTOR);
+          adaptiveDtFactor = Math.max(adaptiveDtFactor * 0.5, MIN_ADAPTIVE_DT_FACTOR);
           currentStep--;
           continue;
         }
         throw new IllegalStateException(
-            getName()
-                + ": coupled pressure-momentum correction did not converge; maximum relative "
-                + "cell-volume residual="
-                + timeIntegrator.getCoupledPressureMomentumVolumeResidual()
-                + " after "
-                + timeIntegrator.getCoupledPressureMomentumIterations()
-                + " iterations");
+            getName() + ": coupled pressure-momentum correction did not converge; maximum relative "
+                + "cell-volume residual=" + timeIntegrator.getCoupledPressureMomentumVolumeResidual() + " after "
+                + timeIntegrator.getCoupledPressureMomentumIterations() + " iterations");
       }
 
       // 4. ADAPTIVE: check RAW state for NaN/Inf/negative mass BEFORE clamping
@@ -4907,13 +4892,9 @@ public class TwoFluidPipe extends Pipeline {
     double[] gasDensity = timeIntegrator.getCoupledPressureMomentumGasDensity();
     double[] oilDensity = timeIntegrator.getCoupledPressureMomentumOilDensity();
     double[] waterDensity = timeIntegrator.getCoupledPressureMomentumWaterDensity();
-    if (pressure == null
-        || gasDensity == null
-        || oilDensity == null
-        || waterDensity == null
+    if (pressure == null || gasDensity == null || oilDensity == null || waterDensity == null
         || pressure.length != numberOfSections) {
-      throw new IllegalStateException(
-          "Coupled pressure-momentum correction did not return a complete cell state");
+      throw new IllegalStateException("Coupled pressure-momentum correction did not return a complete cell state");
     }
 
     for (int cell = 0; cell < numberOfSections; cell++) {
@@ -4925,9 +4906,8 @@ public class TwoFluidPipe extends Pipeline {
 
       double oilMass = Math.max(state[cell][TwoFluidConservationEquations.IDX_OIL_MASS], 0.0);
       double waterMass = Math.max(state[cell][TwoFluidConservationEquations.IDX_WATER_MASS], 0.0);
-      double liquidVolume =
-          oilMass / Math.max(oilDensity[cell], CLOSURE_DENOMINATOR_EPSILON)
-              + waterMass / Math.max(waterDensity[cell], CLOSURE_DENOMINATOR_EPSILON);
+      double liquidVolume = oilMass / Math.max(oilDensity[cell], CLOSURE_DENOMINATOR_EPSILON)
+          + waterMass / Math.max(waterDensity[cell], CLOSURE_DENOMINATOR_EPSILON);
       if (liquidVolume > CLOSURE_DENOMINATOR_EPSILON) {
         section.setLiquidDensity((oilMass + waterMass) / liquidVolume);
       }
@@ -7538,13 +7518,14 @@ public class TwoFluidPipe extends Pipeline {
   /**
    * Enable the coupled compressible pressure-momentum transient correction.
    *
-   * <p>The option solves the cell-volume pressure equation and corrects phase mass fluxes and
-   * phase momenta with the same face pressure gradients. It replaces the post-step steady
-   * friction/gravity pressure reconstruction. The option remains off by default while the
-   * long-horizon liquid-rich and severe-slugging validation suite is being qualified.
+   * <p>
+   * The option solves the cell-volume pressure equation and corrects phase mass fluxes and phase momenta with the same
+   * face pressure gradients. It replaces the post-step steady friction/gravity pressure reconstruction. The option
+   * remains off by default while the long-horizon liquid-rich and severe-slugging validation suite is being qualified.
    *
-   * <p>Use together with {@link #setEnableInterfacialPressure(boolean)} so the transient momentum
-   * equations use the physically correct pressure force and the Bestion hyperbolicity closure.
+   * <p>
+   * Use together with {@link #setEnableInterfacialPressure(boolean)} so the transient momentum equations use the
+   * physically correct pressure force and the Bestion hyperbolicity closure.
    *
    * @param enabled true to use the coupled correction
    */
@@ -7562,8 +7543,7 @@ public class TwoFluidPipe extends Pipeline {
 
   /** @return convergence status of the most recent coupled correction */
   public boolean isCoupledPressureMomentumConverged() {
-    return !coupledPressureMomentumEnabled
-        || timeIntegrator.isCoupledPressureMomentumConverged();
+    return !coupledPressureMomentumEnabled || timeIntegrator.isCoupledPressureMomentumConverged();
   }
 
   /** @return maximum relative cell-volume residual of the most recent correction */

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -149,6 +149,13 @@ public class TwoFluidPipe extends Pipeline {
   /** Whether the interfacial-pressure stabilizer is advanced implicitly by the time integrator. */
   private boolean implicitInterfacialPressureCoupling = true;
 
+  /**
+   * Whether pressure, phase mass fluxes, and phase momenta are corrected in the same transient step.
+   *
+   * <p>Off by default until the long-horizon liquid-rich and severe-slugging acceptance cases pass.
+   */
+  private boolean coupledPressureMomentumEnabled = false;
+
   /** Default closed-flow fluid-side heat-transfer coefficient in W/(m2 K). */
   private static final double DEFAULT_STAGNANT_INNER_HEAT_TRANSFER_COEFFICIENT = 50.0;
 
@@ -4251,13 +4258,19 @@ public class TwoFluidPipe extends Pipeline {
         return derivative;
       };
 
-      // Provide cell properties for the implicit acoustic and void-wave solves.
-      if (isIMEX || useImplicitVoidWave) {
+      // Provide cell properties for the implicit acoustic, void-wave, and
+      // coupled pressure-momentum solves.
+      if (isIMEX || useImplicitVoidWave || coupledPressureMomentumEnabled) {
         double[] soundSpeeds = new double[numberOfSections];
+        double[] gasSoundSpeeds = new double[numberOfSections];
+        double[] oilSoundSpeeds = new double[numberOfSections];
+        double[] waterSoundSpeeds = new double[numberOfSections];
         double[] voidWaveSpeeds = new double[numberOfSections];
         double[] voidWaveSlipCoefficients = new double[numberOfSections];
         double[] densities = new double[numberOfSections];
         double[] areas = new double[numberOfSections];
+        double[] lengths = new double[numberOfSections];
+        double[] pressures = new double[numberOfSections];
         double[] gasDensities = new double[numberOfSections];
         double[] oilDensities = new double[numberOfSections];
         double[] waterDensities = new double[numberOfSections];
@@ -4278,6 +4291,11 @@ public class TwoFluidPipe extends Pipeline {
           double rhoMix = densities[i];
           double cG = Math.max(sec.getGasSoundSpeed(), 100.0);
           double cL = Math.max(sec.getLiquidSoundSpeed(), 500.0);
+          gasSoundSpeeds[i] = cG;
+          oilSoundSpeeds[i] = cL;
+          waterSoundSpeeds[i] = cL;
+          lengths[i] = sec.getLength();
+          pressures[i] = sec.getPressure();
           double invC2 = alphaG / (rhoG * cG * cG) + alphaL / (rhoL * cL * cL);
           soundSpeeds[i] = (invC2 > 0) ? Math.sqrt(1.0 / (rhoMix * invC2)) : cG;
           soundSpeeds[i] = Math.max(soundSpeeds[i], 1.0);
@@ -4292,11 +4310,47 @@ public class TwoFluidPipe extends Pipeline {
         }
         timeIntegrator.setImplicitVoidWaveProperties(voidWaveSpeeds, voidWaveSlipCoefficients, areas, gasDensities,
             oilDensities, waterDensities, dx, useImplicitVoidWave);
+        boolean outletFixed = (outletBCType == BoundaryCondition.CONSTANT_PRESSURE
+            || outletBCType == BoundaryCondition.CHARACTERISTIC);
+        timeIntegrator.setCoupledPressureMomentumProperties(
+            pressures,
+            areas,
+            lengths,
+            gasDensities,
+            oilDensities,
+            waterDensities,
+            gasSoundSpeeds,
+            oilSoundSpeeds,
+            waterSoundSpeeds,
+            outletPressure,
+            outletFixed,
+            coupledPressureMomentumEnabled);
+      } else {
+        timeIntegrator.setCoupledPressureMomentumEnabled(false);
       }
 
       double[][] splitState = applyStiffBubbleDragSourceStep(U_prev, 0.5 * dtFinal);
       double[][] U_new = timeIntegrator.step(splitState, rhs, dtFinal);
       U_new = applyStiffBubbleDragSourceStep(U_new, 0.5 * dtFinal);
+
+      if (coupledPressureMomentumEnabled
+          && !timeIntegrator.isCoupledPressureMomentumConverged()) {
+        equations.applyState(sections, U_prev);
+        if (enableAdaptiveTimestepping) {
+          adaptiveDtFactor = Math.max(
+              adaptiveDtFactor * 0.5, MIN_ADAPTIVE_DT_FACTOR);
+          currentStep--;
+          continue;
+        }
+        throw new IllegalStateException(
+            getName()
+                + ": coupled pressure-momentum correction did not converge; maximum relative "
+                + "cell-volume residual="
+                + timeIntegrator.getCoupledPressureMomentumVolumeResidual()
+                + " after "
+                + timeIntegrator.getCoupledPressureMomentumIterations()
+                + " iterations");
+      }
 
       // 4. ADAPTIVE: check RAW state for NaN/Inf/negative mass BEFORE clamping
       // Only hard-reject on unphysical values. Normal transient changes (even large)
@@ -4336,12 +4390,17 @@ public class TwoFluidPipe extends Pipeline {
       // 5. Now safe to apply corrections and state
       validateAndCorrectState(U_new, U_prev);
 
+      if (coupledPressureMomentumEnabled) {
+        applyCoupledPressureMomentumState(U_new);
+      }
       equations.applyState(sections, U_new);
 
-      // 6. Reconstruct pressure profile from evolved state
-      // The conservative variables (mass, momentum) have evolved but pressure
-      // must be reconstructed. March from outlet (fixed P BC) backward.
-      reconstructPressureProfile();
+      // 6. The coupled path has already solved pressure from compressibility and
+      // corrected phase mass fluxes and momenta with the same face gradients.
+      // The legacy path retains the steady friction/gravity pressure march.
+      if (!coupledPressureMomentumEnabled) {
+        reconstructPressureProfile();
+      }
 
       // 7. Apply boundary conditions
       applyBoundaryConditions();
@@ -4834,6 +4893,43 @@ public class TwoFluidPipe extends Pipeline {
               + sec.getPosition() + ": " + e.getMessage(), e);
         }
         logger.warn("Flash calculation failed for section at position {}", sec.getPosition());
+      }
+    }
+  }
+
+  /**
+   * Apply pressure and phase densities from the latest coupled correction.
+   *
+   * @param state corrected conservative state
+   */
+  private void applyCoupledPressureMomentumState(double[][] state) {
+    double[] pressure = timeIntegrator.getCoupledPressureMomentumPressure();
+    double[] gasDensity = timeIntegrator.getCoupledPressureMomentumGasDensity();
+    double[] oilDensity = timeIntegrator.getCoupledPressureMomentumOilDensity();
+    double[] waterDensity = timeIntegrator.getCoupledPressureMomentumWaterDensity();
+    if (pressure == null
+        || gasDensity == null
+        || oilDensity == null
+        || waterDensity == null
+        || pressure.length != numberOfSections) {
+      throw new IllegalStateException(
+          "Coupled pressure-momentum correction did not return a complete cell state");
+    }
+
+    for (int cell = 0; cell < numberOfSections; cell++) {
+      TwoFluidSection section = sections[cell];
+      section.setPressure(pressure[cell]);
+      section.setGasDensity(gasDensity[cell]);
+      section.setOilDensity(oilDensity[cell]);
+      section.setWaterDensity(waterDensity[cell]);
+
+      double oilMass = Math.max(state[cell][TwoFluidConservationEquations.IDX_OIL_MASS], 0.0);
+      double waterMass = Math.max(state[cell][TwoFluidConservationEquations.IDX_WATER_MASS], 0.0);
+      double liquidVolume =
+          oilMass / Math.max(oilDensity[cell], CLOSURE_DENOMINATOR_EPSILON)
+              + waterMass / Math.max(waterDensity[cell], CLOSURE_DENOMINATOR_EPSILON);
+      if (liquidVolume > CLOSURE_DENOMINATOR_EPSILON) {
+        section.setLiquidDensity((oilMass + waterMass) / liquidVolume);
       }
     }
   }
@@ -7437,6 +7533,47 @@ public class TwoFluidPipe extends Pipeline {
     if (equations != null) {
       equations.setEnableInterfacialPressure(enable);
     }
+  }
+
+  /**
+   * Enable the coupled compressible pressure-momentum transient correction.
+   *
+   * <p>The option solves the cell-volume pressure equation and corrects phase mass fluxes and
+   * phase momenta with the same face pressure gradients. It replaces the post-step steady
+   * friction/gravity pressure reconstruction. The option remains off by default while the
+   * long-horizon liquid-rich and severe-slugging validation suite is being qualified.
+   *
+   * <p>Use together with {@link #setEnableInterfacialPressure(boolean)} so the transient momentum
+   * equations use the physically correct pressure force and the Bestion hyperbolicity closure.
+   *
+   * @param enabled true to use the coupled correction
+   */
+  public void setEnableCoupledPressureMomentum(boolean enabled) {
+    coupledPressureMomentumEnabled = enabled;
+    if (timeIntegrator != null) {
+      timeIntegrator.setCoupledPressureMomentumEnabled(enabled);
+    }
+  }
+
+  /** @return true when the coupled pressure-momentum correction is selected */
+  public boolean isCoupledPressureMomentumEnabled() {
+    return coupledPressureMomentumEnabled;
+  }
+
+  /** @return convergence status of the most recent coupled correction */
+  public boolean isCoupledPressureMomentumConverged() {
+    return !coupledPressureMomentumEnabled
+        || timeIntegrator.isCoupledPressureMomentumConverged();
+  }
+
+  /** @return maximum relative cell-volume residual of the most recent correction */
+  public double getCoupledPressureMomentumVolumeResidual() {
+    return timeIntegrator.getCoupledPressureMomentumVolumeResidual();
+  }
+
+  /** @return nonlinear iterations used by the most recent correction */
+  public int getCoupledPressureMomentumIterations() {
+    return timeIntegrator.getCoupledPressureMomentumIterations();
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -4569,6 +4569,12 @@ public class TwoFluidPipe extends Pipeline {
         sourceMassKg[phase] += sourceRate[phase] * weightedTime;
       }
     }
+    if (coupledPressureMomentumEnabled) {
+      double[] outletCorrectionKg = timeIntegrator.getCoupledPressureMomentumOutletMassCorrectionKg();
+      for (int phase = 0; phase < 3; phase++) {
+        outletMassKg[phase] += outletCorrectionKg[phase];
+      }
+    }
   }
 
   private double[] getTimeIntegrationStageWeights(int stageCount) {

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -157,6 +157,9 @@ public class TwoFluidPipe extends Pipeline {
    */
   private boolean coupledPressureMomentumEnabled = false;
 
+  /** Optional phase-resolved compressible volume supplying the inlet pressure boundary. */
+  private UpstreamCompressibleVolume upstreamCompressibleVolume = null;
+
   /** Default closed-flow fluid-side heat-transfer coefficient in W/(m2 K). */
   private static final double DEFAULT_STAGNANT_INNER_HEAT_TRANSFER_COEFFICIENT = 50.0;
 
@@ -4142,6 +4145,7 @@ public class TwoFluidPipe extends Pipeline {
       throw new IllegalArgumentException("Transient time step must be positive and finite");
     }
     isTransientMode = true;
+    synchronizeUpstreamCompressibleVolumePressure();
     lastMassBalanceReport = null;
     lastThermalEnergyBalanceReport = null;
     lastComponentConservationReport = null;
@@ -4557,6 +4561,7 @@ public class TwoFluidPipe extends Pipeline {
   private void accumulateAcceptedMassBalance(List<TwoFluidConservationEquations.MassBalanceRate> stageRates,
       double timeStepSeconds, double[] inletMassKg, double[] outletMassKg, double[] sourceMassKg) {
     double[] weights = getTimeIntegrationStageWeights(stageRates.size());
+    double[] acceptedInletMassKg = new double[3];
     for (int stage = 0; stage < stageRates.size(); stage++) {
       TwoFluidConservationEquations.MassBalanceRate rate = stageRates.get(stage);
       double[] inletRate = rate.getInletMassFlowKgPerSecond();
@@ -4564,10 +4569,16 @@ public class TwoFluidPipe extends Pipeline {
       double[] sourceRate = rate.getSourceMassFlowKgPerSecond();
       double weightedTime = weights[stage] * timeStepSeconds;
       for (int phase = 0; phase < 3; phase++) {
-        inletMassKg[phase] += inletRate[phase] * weightedTime;
+        double acceptedInlet = inletRate[phase] * weightedTime;
+        inletMassKg[phase] += acceptedInlet;
+        acceptedInletMassKg[phase] += acceptedInlet;
         outletMassKg[phase] += outletRate[phase] * weightedTime;
         sourceMassKg[phase] += sourceRate[phase] * weightedTime;
       }
+    }
+    if (upstreamCompressibleVolume != null) {
+      upstreamCompressibleVolume.advance(timeStepSeconds, acceptedInletMassKg);
+      synchronizeUpstreamCompressibleVolumePressure();
     }
     if (coupledPressureMomentumEnabled) {
       double[] outletCorrectionKg = timeIntegrator.getCoupledPressureMomentumOutletMassCorrectionKg();
@@ -4575,6 +4586,15 @@ public class TwoFluidPipe extends Pipeline {
         outletMassKg[phase] += outletCorrectionKg[phase];
       }
     }
+  }
+
+  private void synchronizeUpstreamCompressibleVolumePressure() {
+    if (upstreamCompressibleVolume == null) {
+      return;
+    }
+    inletBCType = BoundaryCondition.CONSTANT_PRESSURE;
+    inletPressure = upstreamCompressibleVolume.getPressurePa();
+    inletPressureSet = true;
   }
 
   private double[] getTimeIntegrationStageWeights(int stageCount) {
@@ -7568,6 +7588,71 @@ public class TwoFluidPipe extends Pipeline {
   /** @return convergence status of the most recent coupled correction */
   public boolean isCoupledPressureMomentumConverged() {
     return !coupledPressureMomentumEnabled || timeIntegrator.isCoupledPressureMomentumConverged();
+  }
+
+  /**
+   * Connect a phase-resolved compressible volume to the inlet pressure boundary.
+   *
+   * <p>
+   * The pipe withdraws the phase masses measured by its accepted finite-volume inlet flux. The volume updates pressure
+   * from its fixed-volume compressibility closure after every accepted internal substep. Connecting a volume selects
+   * {@link BoundaryCondition#CONSTANT_PRESSURE} at the inlet; removing it does not otherwise change the selected
+   * boundary condition.
+   * </p>
+   *
+   * @param volume upstream volume, or {@code null} to disconnect it
+   */
+  public void setUpstreamCompressibleVolume(UpstreamCompressibleVolume volume) {
+    upstreamCompressibleVolume = volume;
+    synchronizeUpstreamCompressibleVolumePressure();
+  }
+
+  /** @return connected upstream compressible volume, or {@code null} when disconnected */
+  public UpstreamCompressibleVolume getUpstreamCompressibleVolume() {
+    return upstreamCompressibleVolume;
+  }
+
+  /**
+   * Initialize and connect an upstream volume from the current inlet-section phase state.
+   *
+   * <p>
+   * Call {@link #run()} first so phase holdups, densities, and sound speeds are initialized. The new volume begins in
+   * pressure and volume equilibrium with the first pipe section.
+   * </p>
+   *
+   * @param volumeM3 fixed upstream volume in m3
+   * @return the initialized and connected volume
+   */
+  public UpstreamCompressibleVolume initializeUpstreamCompressibleVolume(double volumeM3) {
+    if (sections == null || sections.length == 0) {
+      throw new IllegalStateException("Run the pipe before initializing an upstream compressible volume");
+    }
+    TwoFluidSection inlet = sections[0];
+    double gasHoldup = Math.max(inlet.getGasHoldup(), 0.0);
+    double oilHoldup = Math.max(inlet.getOilHoldup(), 0.0);
+    double waterHoldup = Math.max(inlet.getWaterHoldup(), 0.0);
+    double holdupSum = gasHoldup + oilHoldup + waterHoldup;
+    if (!(holdupSum > 0.0)) {
+      throw new IllegalStateException("Inlet section has no initialized phase volume");
+    }
+    gasHoldup /= holdupSum;
+    oilHoldup /= holdupSum;
+    waterHoldup /= holdupSum;
+
+    double gasDensity = Math.max(inlet.getGasDensity(), CLOSURE_DENOMINATOR_EPSILON);
+    double oilDensity = Math.max(inlet.getOilDensity(), CLOSURE_DENOMINATOR_EPSILON);
+    double waterDensity = Math.max(inlet.getWaterDensity(), CLOSURE_DENOMINATOR_EPSILON);
+    double[] phaseMassKg = { gasHoldup * volumeM3 * gasDensity, oilHoldup * volumeM3 * oilDensity,
+        waterHoldup * volumeM3 * waterDensity };
+    double[] phaseDensityKgM3 = { gasDensity, oilDensity, waterDensity };
+    double gasSoundSpeed = Math.max(inlet.getGasSoundSpeed(), CLOSURE_DENOMINATOR_EPSILON);
+    double liquidSoundSpeed = Math.max(inlet.getLiquidSoundSpeed(), CLOSURE_DENOMINATOR_EPSILON);
+    double[] phaseSoundSpeedMS = { gasSoundSpeed, liquidSoundSpeed, liquidSoundSpeed };
+
+    UpstreamCompressibleVolume volume = new UpstreamCompressibleVolume(volumeM3, inlet.getPressure(), phaseMassKg,
+        phaseDensityKgM3, phaseSoundSpeedMS);
+    setUpstreamCompressibleVolume(volume);
+    return volume;
   }
 
   /** @return maximum relative cell-volume residual of the most recent correction */

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -7516,6 +7516,24 @@ public class TwoFluidPipe extends Pipeline {
   }
 
   /**
+   * Allow signed phase flow through the zero-gradient outlet boundary.
+   *
+   * <p>
+   * A reversed phase then uses the extrapolated interior phase state instead of being clamped at zero. Enable only for
+   * a pressure boundary that physically permits fallback and use a well-posed pressure-momentum formulation.
+   *
+   * @param allow true to carry signed phase mass and energy through the outlet
+   */
+  public void setAllowOutletPhaseBackflow(boolean allow) {
+    equations.setAllowOutletPhaseBackflow(allow);
+  }
+
+  /** @return true when signed outlet phase flow is enabled */
+  public boolean isOutletPhaseBackflowAllowed() {
+    return equations.isOutletPhaseBackflowAllowed();
+  }
+
+  /**
    * Enable the coupled compressible pressure-momentum transient correction.
    *
    * <p>

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -8951,6 +8951,9 @@ public class TwoFluidPipe extends Pipeline {
    */
   @Override
   public double getInletPressure() {
+    if (upstreamCompressibleVolume != null) {
+      return upstreamCompressibleVolume.getPressurePa() / 1e5;
+    }
     if (sections == null || sections.length == 0) {
       return getInletStream().getPressure("bara");
     }

--- a/src/main/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolume.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolume.java
@@ -1,0 +1,216 @@
+package neqsim.process.equipment.pipeline;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Fixed-volume, compressible upstream boundary coupled by phase-resolved mass transfer.
+ *
+ * <p>
+ * The volume owns gas, oil, and water inventories. A source adds phase mass and the connected pipe withdraws the inlet
+ * mass reported by its conservative finite-volume flux. Pressure is then solved from fixed total volume using
+ * {@code d rho / d p = 1 / c^2}. The model is deliberately composable: it contains no pipe closures and can be
+ * connected to any boundary that reports the same three phase-mass withdrawals.
+ * </p>
+ */
+public final class UpstreamCompressibleVolume implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private static final int PHASE_COUNT = 3;
+  private static final int MAXIMUM_ITERATIONS = 30;
+  private static final double RELATIVE_VOLUME_TOLERANCE = 1.0e-10;
+  private static final double MINIMUM_PRESSURE_PA = 1.0e4;
+  private static final double MINIMUM_DENSITY_KG_M3 = 1.0e-6;
+
+  private final double volumeM3;
+  private final double[] phaseMassKg;
+  private final double[] phaseDensityKgM3;
+  private final double[] phaseSoundSpeedMS;
+  private final double[] sourceMassFlowKgS = new double[PHASE_COUNT];
+  private double pressurePa;
+  private double cumulativeSourceMassKg;
+  private double cumulativeWithdrawalMassKg;
+  private double maximumRelativeVolumeResidual;
+  private int pressureIterations;
+
+  /**
+   * Create a volume from a pressure-consistent phase inventory.
+   *
+   * @param volumeM3 fixed internal volume in m3
+   * @param pressurePa initial absolute pressure in Pa
+   * @param phaseMassKg initial gas, oil, and water mass in kg
+   * @param phaseDensityKgM3 initial gas, oil, and water density in kg/m3
+   * @param phaseSoundSpeedMS gas, oil, and water sound speed in m/s
+   */
+  public UpstreamCompressibleVolume(double volumeM3, double pressurePa, double[] phaseMassKg, double[] phaseDensityKgM3,
+      double[] phaseSoundSpeedMS) {
+    requirePositiveFinite(volumeM3, "Volume");
+    requirePositiveFinite(pressurePa, "Pressure");
+    this.phaseMassKg = requireNonNegativePhaseValues(phaseMassKg, "Phase mass");
+    this.phaseDensityKgM3 = requirePositivePhaseValues(phaseDensityKgM3, "Phase density");
+    this.phaseSoundSpeedMS = requirePositivePhaseValues(phaseSoundSpeedMS, "Phase sound speed");
+    this.volumeM3 = volumeM3;
+    this.pressurePa = pressurePa;
+    maximumRelativeVolumeResidual = Math.abs(calculateOccupiedVolumeM3() - volumeM3) / volumeM3;
+    if (maximumRelativeVolumeResidual > RELATIVE_VOLUME_TOLERANCE) {
+      throw new IllegalArgumentException(
+          "Initial phase masses and densities must fill the fixed volume; relative residual="
+              + maximumRelativeVolumeResidual);
+    }
+  }
+
+  /** Set phase-resolved source rates entering the volume. */
+  public void setSourceMassFlowRates(double gasKgS, double oilKgS, double waterKgS) {
+    double[] rates = { gasKgS, oilKgS, waterKgS };
+    for (int phase = 0; phase < PHASE_COUNT; phase++) {
+      if (!Double.isFinite(rates[phase]) || rates[phase] < 0.0) {
+        throw new IllegalArgumentException("Source phase mass-flow rates must be finite and non-negative");
+      }
+      sourceMassFlowKgS[phase] = rates[phase];
+    }
+  }
+
+  /**
+   * Advance the volume after an accepted pipe step.
+   *
+   * @param timeStepSeconds accepted step duration in s
+   * @param withdrawnPhaseMassKg signed gas, oil, and water mass delivered to the pipe in kg; negative values represent
+   * phase return from the pipe
+   */
+  public void advance(double timeStepSeconds, double[] withdrawnPhaseMassKg) {
+    requirePositiveFinite(timeStepSeconds, "Time step");
+    double[] withdrawal = requireFinitePhaseValues(withdrawnPhaseMassKg, "Withdrawn phase mass");
+    for (int phase = 0; phase < PHASE_COUNT; phase++) {
+      double sourceMass = sourceMassFlowKgS[phase] * timeStepSeconds;
+      double updatedMass = phaseMassKg[phase] + sourceMass - withdrawal[phase];
+      double tolerance = 1.0e-12 * Math.max(1.0, phaseMassKg[phase] + sourceMass);
+      if (updatedMass < -tolerance) {
+        throw new IllegalStateException("Upstream volume phase " + phase + " depleted by pipe withdrawal");
+      }
+      phaseMassKg[phase] = Math.max(updatedMass, 0.0);
+      cumulativeSourceMassKg += sourceMass;
+      cumulativeWithdrawalMassKg += withdrawal[phase];
+    }
+    solvePressureClosure();
+  }
+
+  private void solvePressureClosure() {
+    pressureIterations = 0;
+    for (int iteration = 1; iteration <= MAXIMUM_ITERATIONS; iteration++) {
+      double occupiedVolume = calculateOccupiedVolumeM3();
+      double residualM3 = occupiedVolume - volumeM3;
+      maximumRelativeVolumeResidual = Math.abs(residualM3) / volumeM3;
+      pressureIterations = iteration;
+      if (maximumRelativeVolumeResidual <= RELATIVE_VOLUME_TOLERANCE) {
+        return;
+      }
+
+      double pressureDerivativeMagnitude = 0.0;
+      for (int phase = 0; phase < PHASE_COUNT; phase++) {
+        if (phaseMassKg[phase] > 0.0) {
+          double density = phaseDensityKgM3[phase];
+          double soundSpeed = phaseSoundSpeedMS[phase];
+          pressureDerivativeMagnitude += phaseMassKg[phase] / (density * density * soundSpeed * soundSpeed);
+        }
+      }
+      if (!(pressureDerivativeMagnitude > 0.0) || !Double.isFinite(pressureDerivativeMagnitude)) {
+        throw new IllegalStateException("Upstream volume has no finite compressibility");
+      }
+
+      double pressureCorrection = residualM3 / pressureDerivativeMagnitude;
+      double lowerLimit = MINIMUM_PRESSURE_PA - pressurePa;
+      double magnitudeLimit = 0.25 * Math.max(pressurePa, MINIMUM_PRESSURE_PA);
+      pressureCorrection = Math.max(lowerLimit, Math.min(magnitudeLimit, pressureCorrection));
+      pressureCorrection = Math.max(-magnitudeLimit, pressureCorrection);
+      pressurePa += pressureCorrection;
+      for (int phase = 0; phase < PHASE_COUNT; phase++) {
+        double densityCorrection = pressureCorrection / (phaseSoundSpeedMS[phase] * phaseSoundSpeedMS[phase]);
+        phaseDensityKgM3[phase] = Math.max(MINIMUM_DENSITY_KG_M3, phaseDensityKgM3[phase] + densityCorrection);
+      }
+    }
+    throw new IllegalStateException(
+        "Upstream-volume pressure closure did not converge; relative volume residual=" + maximumRelativeVolumeResidual);
+  }
+
+  private double calculateOccupiedVolumeM3() {
+    double occupied = 0.0;
+    for (int phase = 0; phase < PHASE_COUNT; phase++) {
+      occupied += phaseMassKg[phase] / phaseDensityKgM3[phase];
+    }
+    return occupied;
+  }
+
+  private static double[] requireNonNegativePhaseValues(double[] values, String label) {
+    double[] copy = requireFinitePhaseValues(values, label);
+    for (double value : copy) {
+      if (value < 0.0) {
+        throw new IllegalArgumentException(label + " values must be non-negative");
+      }
+    }
+    return copy;
+  }
+
+  private static double[] requireFinitePhaseValues(double[] values, String label) {
+    if (values == null || values.length != PHASE_COUNT) {
+      throw new IllegalArgumentException(label + " must contain gas, oil, and water values");
+    }
+    double[] copy = Arrays.copyOf(values, values.length);
+    for (double value : copy) {
+      if (!Double.isFinite(value)) {
+        throw new IllegalArgumentException(label + " values must be finite");
+      }
+    }
+    return copy;
+  }
+
+  private static double[] requirePositivePhaseValues(double[] values, String label) {
+    double[] copy = requireNonNegativePhaseValues(values, label);
+    for (double value : copy) {
+      if (value <= 0.0) {
+        throw new IllegalArgumentException(label + " values must be positive");
+      }
+    }
+    return copy;
+  }
+
+  private static void requirePositiveFinite(double value, String label) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(label + " must be positive and finite");
+    }
+  }
+
+  public double getVolumeM3() {
+    return volumeM3;
+  }
+
+  public double getPressurePa() {
+    return pressurePa;
+  }
+
+  public double getPhaseMassKg(int phase) {
+    return phaseMassKg[phase];
+  }
+
+  public double getSourceMassFlowRateKgS(int phase) {
+    return sourceMassFlowKgS[phase];
+  }
+
+  public double getTotalMassKg() {
+    return phaseMassKg[0] + phaseMassKg[1] + phaseMassKg[2];
+  }
+
+  public double getCumulativeSourceMassKg() {
+    return cumulativeSourceMassKg;
+  }
+
+  public double getCumulativeWithdrawalMassKg() {
+    return cumulativeWithdrawalMassKg;
+  }
+
+  public double getMaximumRelativeVolumeResidual() {
+    return maximumRelativeVolumeResidual;
+  }
+
+  public int getPressureIterations() {
+    return pressureIterations;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -522,10 +522,10 @@ public class TwoFluidConservationEquations implements Serializable {
    * Calculate outlet flux using upwind scheme (transmissive boundary).
    *
    * <p>
-   * By default, each reversed phase velocity is clamped at zero because a one-way transmissive boundary has no
-   * upstream state to advect in. When signed outlet flow is explicitly enabled, the zero-gradient interior phase state
-   * supplies that boundary state and a reversed phase carries signed mass and energy back into the domain. Use signed
-   * flow only with a well-posed pressure-momentum model and a boundary whose physical interpretation permits fallback.
+   * By default, each reversed phase velocity is clamped at zero because a one-way transmissive boundary has no upstream
+   * state to advect in. When signed outlet flow is explicitly enabled, the zero-gradient interior phase state supplies
+   * that boundary state and a reversed phase carries signed mass and energy back into the domain. Use signed flow only
+   * with a well-posed pressure-momentum model and a boundary whose physical interpretation permits fallback.
    * </p>
    *
    * @param sec the outlet pipe section

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -141,6 +141,9 @@ public class TwoFluidConservationEquations implements Serializable {
    */
   private boolean outletBackflowClamped = false;
 
+  /** Allow a zero-gradient pressure outlet to carry a phase back into the domain. */
+  private boolean allowOutletPhaseBackflow = false;
+
   /** Interface gas holdup used by the pressure part of the momentum flux, one per interface. */
   private double[] interfaceGasHoldup = new double[0];
 
@@ -519,14 +522,10 @@ public class TwoFluidConservationEquations implements Serializable {
    * Calculate outlet flux using upwind scheme (transmissive boundary).
    *
    * <p>
-   * Each phase velocity is clamped at zero because a transmissive boundary can only carry mass out: with a reversed
-   * velocity there is no upstream state to advect in. Extrapolating the interior state instead lets the pressure
-   * boundary pull mass back into the domain, which was measured to inflate the liquid-rich inventory further rather
-   * than relieve it. The clamp is correct as a boundary condition but it is also a one-way trap, because the phase
-   * momentum equations of the classical two-fluid system are ill-posed in liquid-rich flow and can develop sustained
-   * backflow. The outflow of that phase then pins at exactly zero while the inlet keeps feeding it, and the inventory
-   * grows without bound. The condition is recorded so it can be reported rather than silently producing a diverging
-   * answer.
+   * By default, each reversed phase velocity is clamped at zero because a one-way transmissive boundary has no
+   * upstream state to advect in. When signed outlet flow is explicitly enabled, the zero-gradient interior phase state
+   * supplies that boundary state and a reversed phase carries signed mass and energy back into the domain. Use signed
+   * flow only with a well-posed pressure-momentum model and a boundary whose physical interpretation permits fallback.
    * </p>
    *
    * @param sec the outlet pipe section
@@ -536,7 +535,8 @@ public class TwoFluidConservationEquations implements Serializable {
     double[] flux = new double[NUM_EQUATIONS];
     double A = sec.getArea();
 
-    if (sec.getGasVelocity() < 0.0 || sec.getOilVelocity() < 0.0 || sec.getWaterVelocity() < 0.0) {
+    if (!allowOutletPhaseBackflow
+        && (sec.getGasVelocity() < 0.0 || sec.getOilVelocity() < 0.0 || sec.getWaterVelocity() < 0.0)) {
       outletBackflowClamped = true;
     }
 
@@ -544,7 +544,7 @@ public class TwoFluidConservationEquations implements Serializable {
     double rhoG = sec.getGasDensity();
     if (rhoG < 0.1)
       rhoG = 1.0; // Default gas density
-    double vG = Math.max(0, sec.getGasVelocity()); // Only outflow
+    double vG = allowOutletPhaseBackflow ? sec.getGasVelocity() : Math.max(0.0, sec.getGasVelocity());
     double alphaG = sec.getGasMassPerLength() / (rhoG * A);
     alphaG = Math.max(0, Math.min(1, alphaG));
     flux[IDX_GAS_MASS] = alphaG * rhoG * vG * A;
@@ -554,7 +554,7 @@ public class TwoFluidConservationEquations implements Serializable {
     double rhoO = sec.getOilDensity();
     if (rhoO < 100)
       rhoO = 700.0; // Default oil density
-    double vO = Math.max(0, sec.getOilVelocity());
+    double vO = allowOutletPhaseBackflow ? sec.getOilVelocity() : Math.max(0.0, sec.getOilVelocity());
     double alphaO = sec.getOilMassPerLength() / (rhoO * A);
     alphaO = Math.max(0, Math.min(alphaG > 0.99 ? 0 : 1, alphaO));
     flux[IDX_OIL_MASS] = alphaO * rhoO * vO * A;
@@ -564,7 +564,7 @@ public class TwoFluidConservationEquations implements Serializable {
     double rhoW = sec.getWaterDensity();
     if (rhoW < 100)
       rhoW = 1000.0; // Default water density
-    double vW = Math.max(0, sec.getWaterVelocity());
+    double vW = allowOutletPhaseBackflow ? sec.getWaterVelocity() : Math.max(0.0, sec.getWaterVelocity());
     double alphaW = sec.getWaterMassPerLength() / (rhoW * A);
     alphaW = Math.max(0, Math.min(1 - alphaG - alphaO, alphaW));
     flux[IDX_WATER_MASS] = alphaW * rhoW * vW * A;
@@ -1647,6 +1647,20 @@ public class TwoFluidConservationEquations implements Serializable {
   /** Clear the outlet backflow record. */
   public void clearOutletBackflowClamped() {
     this.outletBackflowClamped = false;
+  }
+
+  /**
+   * Allow signed phase flow through the zero-gradient outlet.
+   *
+   * @param allow true to extrapolate the interior phase state for outlet fallback
+   */
+  public void setAllowOutletPhaseBackflow(boolean allow) {
+    this.allowOutletPhaseBackflow = allow;
+  }
+
+  /** @return true when signed outlet phase flow is enabled */
+  public boolean isOutletPhaseBackflowAllowed() {
+    return allowOutletPhaseBackflow;
   }
 
   /** @return interfacial pressure coefficient delta */

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
@@ -45,18 +45,21 @@ public final class CoupledPressureMomentumSolver implements Serializable {
     private final double[] gasDensity;
     private final double[] oilDensity;
     private final double[] waterDensity;
+    private final double[] outletBoundaryMassCorrectionKg;
     private final int iterations;
     private final double maximumRelativeVolumeResidual;
     private final boolean converged;
     private final boolean pressureCorrectionLimited;
 
     private Result(double[][] state, double[] pressure, double[] gasDensity, double[] oilDensity, double[] waterDensity,
-        int iterations, double maximumRelativeVolumeResidual, boolean converged, boolean pressureCorrectionLimited) {
+        double[] outletBoundaryMassCorrectionKg, int iterations, double maximumRelativeVolumeResidual,
+        boolean converged, boolean pressureCorrectionLimited) {
       this.state = state;
       this.pressure = pressure;
       this.gasDensity = gasDensity;
       this.oilDensity = oilDensity;
       this.waterDensity = waterDensity;
+      this.outletBoundaryMassCorrectionKg = outletBoundaryMassCorrectionKg;
       this.iterations = iterations;
       this.maximumRelativeVolumeResidual = maximumRelativeVolumeResidual;
       this.converged = converged;
@@ -86,6 +89,11 @@ public final class CoupledPressureMomentumSolver implements Serializable {
     /** @return corrected water density in kg/m3 */
     public double[] getWaterDensity() {
       return waterDensity.clone();
+    }
+
+    /** @return signed gas, oil, and water mass added to the reported outlet transfer in kg */
+    public double[] getOutletBoundaryMassCorrectionKg() {
+      return outletBoundaryMassCorrectionKg.clone();
     }
 
     /** @return nonlinear correction iterations used */
@@ -140,6 +148,7 @@ public final class CoupledPressureMomentumSolver implements Serializable {
     double[][] soundSpeeds = { gasSoundSpeed.clone(), oilSoundSpeed.clone(), waterSoundSpeed.clone() };
 
     int iterations = 0;
+    double[] outletBoundaryMassCorrectionKg = new double[PHASE_COUNT];
     boolean converged = false;
     boolean correctionLimited = false;
     double maximumResidual = calculateMaximumRelativeVolumeResidual(correctedState, areas, densities);
@@ -199,7 +208,11 @@ public final class CoupledPressureMomentumSolver implements Serializable {
         }
       }
 
-      applyConservativeMassFluxCorrection(correctedState, timeStep, pressureCorrection, phaseAreas, areas, lengths);
+      double[] iterationOutletCorrection = applyConservativeMassFluxCorrection(correctedState, timeStep,
+          pressureCorrection, phaseAreas, areas, lengths, densities, outletPressureFixed);
+      for (int phase = 0; phase < PHASE_COUNT; phase++) {
+        outletBoundaryMassCorrectionKg[phase] += iterationOutletCorrection[phase];
+      }
       applyMomentumCorrection(correctedState, timeStep, pressureCorrection, phaseAreas, lengths);
 
       for (int cell = 0; cell < cellCount; cell++) {
@@ -216,7 +229,8 @@ public final class CoupledPressureMomentumSolver implements Serializable {
 
     converged = maximumResidual <= relativeVolumeTolerance;
     return new Result(correctedState, correctedPressure, densities[GAS_MASS], densities[OIL_MASS],
-        densities[WATER_MASS], iterations, maximumResidual, converged, correctionLimited);
+        densities[WATER_MASS], outletBoundaryMassCorrectionKg, iterations, maximumResidual, converged,
+        correctionLimited);
   }
 
   private static double[][] calculatePhaseAreas(double[][] state, double[][] densities) {
@@ -244,8 +258,9 @@ public final class CoupledPressureMomentumSolver implements Serializable {
     return faceArea * mobility;
   }
 
-  private static void applyConservativeMassFluxCorrection(double[][] state, double timeStep,
-      double[] pressureCorrection, double[][] phaseAreas, double[] areas, double[] lengths) {
+  private static double[] applyConservativeMassFluxCorrection(double[][] state, double timeStep,
+      double[] pressureCorrection, double[][] phaseAreas, double[] areas, double[] lengths, double[][] densities,
+      boolean outletPressureFixed) {
     int cellCount = state.length;
     double[][] faceMassFlowCorrection = new double[PHASE_COUNT][cellCount + 1];
 
@@ -271,6 +286,28 @@ public final class CoupledPressureMomentumSolver implements Serializable {
         state[cell][phase] -= timeStep * divergence;
       }
     }
+
+    double[] outletBoundaryMassCorrectionKg = new double[PHASE_COUNT];
+    if (outletPressureFixed) {
+      int outlet = cellCount - 1;
+      double occupiedArea = 0.0;
+      for (int phase = 0; phase < PHASE_COUNT; phase++) {
+        occupiedArea += Math.max(state[outlet][phase], 0.0)
+            / Math.max(densities[phase][outlet], MIN_DENSITY);
+      }
+      if (!(occupiedArea > 0.0) || !Double.isFinite(occupiedArea)) {
+        throw new IllegalStateException("Fixed-pressure outlet has no finite phase volume");
+      }
+      double areaResidual = occupiedArea - areas[outlet];
+      for (int phase = 0; phase < PHASE_COUNT; phase++) {
+        double density = Math.max(densities[phase][outlet], MIN_DENSITY);
+        double phaseArea = Math.max(state[outlet][phase], 0.0) / density;
+        double massPerLengthCorrection = -areaResidual * phaseArea / occupiedArea * density;
+        state[outlet][phase] += massPerLengthCorrection;
+        outletBoundaryMassCorrectionKg[phase] -= massPerLengthCorrection * lengths[outlet];
+      }
+    }
+    return outletBoundaryMassCorrectionKg;
   }
 
   private static void applyMomentumCorrection(double[][] state, double timeStep, double[] pressureCorrection,

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
@@ -292,8 +292,7 @@ public final class CoupledPressureMomentumSolver implements Serializable {
       int outlet = cellCount - 1;
       double occupiedArea = 0.0;
       for (int phase = 0; phase < PHASE_COUNT; phase++) {
-        occupiedArea += Math.max(state[outlet][phase], 0.0)
-            / Math.max(densities[phase][outlet], MIN_DENSITY);
+        occupiedArea += Math.max(state[outlet][phase], 0.0) / Math.max(densities[phase][outlet], MIN_DENSITY);
       }
       if (!(occupiedArea > 0.0) || !Double.isFinite(occupiedArea)) {
         throw new IllegalStateException("Fixed-pressure outlet has no finite phase volume");

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
@@ -5,16 +5,17 @@ import java.io.Serializable;
 /**
  * Coupled pressure-momentum correction for the transient two-fluid finite-volume state.
  *
- * <p>The explicit transport step supplies a provisional conservative state. This class solves a
- * compressible pressure equation formed from the fixed-cell-volume residual and the pressure
- * correction to the total volumetric flux. The same face pressure correction is then applied to
- * every phase mass flux and momentum, so phase masses remain globally conservative while pressure
- * and velocity are advanced in the same accepted step.
+ * <p>
+ * The explicit transport step supplies a provisional conservative state. This class solves a compressible pressure
+ * equation formed from the fixed-cell-volume residual and the pressure correction to the total volumetric flux. The
+ * same face pressure correction is then applied to every phase mass flux and momentum, so phase masses remain globally
+ * conservative while pressure and velocity are advanced in the same accepted step.
  *
- * <p>The correction is intentionally independent of closure correlations. Phase compressibility is
- * supplied through the local phase sound speeds, and the pressure equation uses the mobility
- * {@code A * sum(alpha_k / rho_k)}. A fixed outlet pressure is represented by a Dirichlet pressure
- * correction; the inlet and non-fixed outlet use zero correction gradient.
+ * <p>
+ * The correction is intentionally independent of closure correlations. Phase compressibility is supplied through the
+ * local phase sound speeds, and the pressure equation uses the mobility {@code A * sum(alpha_k / rho_k)}. A fixed
+ * outlet pressure is represented by a Dirichlet pressure correction; the inlet and non-fixed outlet use zero correction
+ * gradient.
  */
 public final class CoupledPressureMomentumSolver implements Serializable {
   private static final long serialVersionUID = 1L;
@@ -49,16 +50,8 @@ public final class CoupledPressureMomentumSolver implements Serializable {
     private final boolean converged;
     private final boolean pressureCorrectionLimited;
 
-    private Result(
-        double[][] state,
-        double[] pressure,
-        double[] gasDensity,
-        double[] oilDensity,
-        double[] waterDensity,
-        int iterations,
-        double maximumRelativeVolumeResidual,
-        boolean converged,
-        boolean pressureCorrectionLimited) {
+    private Result(double[][] state, double[] pressure, double[] gasDensity, double[] oilDensity, double[] waterDensity,
+        int iterations, double maximumRelativeVolumeResidual, boolean converged, boolean pressureCorrectionLimited) {
       this.state = state;
       this.pressure = pressure;
       this.gasDensity = gasDensity;
@@ -134,48 +127,22 @@ public final class CoupledPressureMomentumSolver implements Serializable {
    * @param outletPressureFixed true for a Dirichlet outlet pressure
    * @return corrected state, pressure, density, and convergence diagnostics
    */
-  public Result correct(
-      double[][] provisionalState,
-      double timeStep,
-      double[] pressure,
-      double[] areas,
-      double[] lengths,
-      double[] gasDensity,
-      double[] oilDensity,
-      double[] waterDensity,
-      double[] gasSoundSpeed,
-      double[] oilSoundSpeed,
-      double[] waterSoundSpeed,
-      double outletPressure,
-      boolean outletPressureFixed) {
-    validateInputs(
-        provisionalState,
-        timeStep,
-        pressure,
-        areas,
-        lengths,
-        gasDensity,
-        oilDensity,
-        waterDensity,
-        gasSoundSpeed,
-        oilSoundSpeed,
-        waterSoundSpeed);
+  public Result correct(double[][] provisionalState, double timeStep, double[] pressure, double[] areas,
+      double[] lengths, double[] gasDensity, double[] oilDensity, double[] waterDensity, double[] gasSoundSpeed,
+      double[] oilSoundSpeed, double[] waterSoundSpeed, double outletPressure, boolean outletPressureFixed) {
+    validateInputs(provisionalState, timeStep, pressure, areas, lengths, gasDensity, oilDensity, waterDensity,
+        gasSoundSpeed, oilSoundSpeed, waterSoundSpeed);
 
     int cellCount = provisionalState.length;
     double[][] correctedState = copy(provisionalState);
     double[] correctedPressure = pressure.clone();
-    double[][] densities = {
-      gasDensity.clone(), oilDensity.clone(), waterDensity.clone()
-    };
-    double[][] soundSpeeds = {
-      gasSoundSpeed.clone(), oilSoundSpeed.clone(), waterSoundSpeed.clone()
-    };
+    double[][] densities = { gasDensity.clone(), oilDensity.clone(), waterDensity.clone() };
+    double[][] soundSpeeds = { gasSoundSpeed.clone(), oilSoundSpeed.clone(), waterSoundSpeed.clone() };
 
     int iterations = 0;
     boolean converged = false;
     boolean correctionLimited = false;
-    double maximumResidual = calculateMaximumRelativeVolumeResidual(
-        correctedState, areas, densities);
+    double maximumResidual = calculateMaximumRelativeVolumeResidual(correctedState, areas, densities);
 
     while (iterations < maximumIterations && maximumResidual > relativeVolumeTolerance) {
       iterations++;
@@ -196,30 +163,22 @@ public final class CoupledPressureMomentumSolver implements Serializable {
         double leftCoefficient = 0.0;
         if (cell > 0) {
           double faceDistance = 0.5 * (lengths[cell - 1] + lengths[cell]);
-          double mobility = faceMobility(
-              cell - 1, cell, phaseAreas, areas, densities);
-          leftCoefficient =
-              timeStep * timeStep * mobility / (lengths[cell] * faceDistance);
+          double mobility = faceMobility(cell - 1, cell, phaseAreas, areas, densities);
+          leftCoefficient = timeStep * timeStep * mobility / (lengths[cell] * faceDistance);
         }
 
         double rightCoefficient = 0.0;
         if (cell < cellCount - 1) {
           double faceDistance = 0.5 * (lengths[cell] + lengths[cell + 1]);
-          double mobility = faceMobility(
-              cell, cell + 1, phaseAreas, areas, densities);
-          rightCoefficient =
-              timeStep * timeStep * mobility / (lengths[cell] * faceDistance);
+          double mobility = faceMobility(cell, cell + 1, phaseAreas, areas, densities);
+          rightCoefficient = timeStep * timeStep * mobility / (lengths[cell] * faceDistance);
         }
 
         lower[cell] = -leftCoefficient;
-        diagonal[cell] = Math.max(
-            compressibleArea + leftCoefficient + rightCoefficient, MIN_DIAGONAL);
+        diagonal[cell] = Math.max(compressibleArea + leftCoefficient + rightCoefficient, MIN_DIAGONAL);
         upper[cell] = -rightCoefficient;
-        rightHandSide[cell] =
-            phaseAreas[GAS_MASS][cell]
-                + phaseAreas[OIL_MASS][cell]
-                + phaseAreas[WATER_MASS][cell]
-                - areas[cell];
+        rightHandSide[cell] = phaseAreas[GAS_MASS][cell] + phaseAreas[OIL_MASS][cell] + phaseAreas[WATER_MASS][cell]
+            - areas[cell];
       }
 
       if (outletPressureFixed) {
@@ -230,202 +189,130 @@ public final class CoupledPressureMomentumSolver implements Serializable {
         rightHandSide[outlet] = outletPressure - correctedPressure[outlet];
       }
 
-      double[] pressureCorrection =
-          solveTridiagonal(lower, diagonal, upper, rightHandSide);
+      double[] pressureCorrection = solveTridiagonal(lower, diagonal, upper, rightHandSide);
       for (int cell = 0; cell < cellCount; cell++) {
         pressureCorrection[cell] *= pressureRelaxation;
-        double limit = Math.max(
-            1.0e4, maximumRelativePressureCorrection * correctedPressure[cell]);
+        double limit = Math.max(1.0e4, maximumRelativePressureCorrection * correctedPressure[cell]);
         if (Math.abs(pressureCorrection[cell]) > limit) {
-          pressureCorrection[cell] =
-              Math.copySign(limit, pressureCorrection[cell]);
+          pressureCorrection[cell] = Math.copySign(limit, pressureCorrection[cell]);
           correctionLimited = true;
         }
       }
 
-      applyConservativeMassFluxCorrection(
-          correctedState,
-          timeStep,
-          pressureCorrection,
-          phaseAreas,
-          areas,
-          lengths);
-      applyMomentumCorrection(
-          correctedState,
-          timeStep,
-          pressureCorrection,
-          phaseAreas,
-          lengths);
+      applyConservativeMassFluxCorrection(correctedState, timeStep, pressureCorrection, phaseAreas, areas, lengths);
+      applyMomentumCorrection(correctedState, timeStep, pressureCorrection, phaseAreas, lengths);
 
       for (int cell = 0; cell < cellCount; cell++) {
-        correctedPressure[cell] =
-            Math.max(1.0e5, correctedPressure[cell] + pressureCorrection[cell]);
+        correctedPressure[cell] = Math.max(1.0e5, correctedPressure[cell] + pressureCorrection[cell]);
         for (int phase = 0; phase < PHASE_COUNT; phase++) {
           double soundSpeed = Math.max(soundSpeeds[phase][cell], MIN_SOUND_SPEED);
-          densities[phase][cell] = Math.max(
-              MIN_DENSITY,
-              densities[phase][cell]
-                  + pressureCorrection[cell] / (soundSpeed * soundSpeed));
+          densities[phase][cell] = Math.max(MIN_DENSITY,
+              densities[phase][cell] + pressureCorrection[cell] / (soundSpeed * soundSpeed));
         }
       }
 
-      maximumResidual = calculateMaximumRelativeVolumeResidual(
-          correctedState, areas, densities);
+      maximumResidual = calculateMaximumRelativeVolumeResidual(correctedState, areas, densities);
     }
 
     converged = maximumResidual <= relativeVolumeTolerance;
-    return new Result(
-        correctedState,
-        correctedPressure,
-        densities[GAS_MASS],
-        densities[OIL_MASS],
-        densities[WATER_MASS],
-        iterations,
-        maximumResidual,
-        converged,
-        correctionLimited);
+    return new Result(correctedState, correctedPressure, densities[GAS_MASS], densities[OIL_MASS],
+        densities[WATER_MASS], iterations, maximumResidual, converged, correctionLimited);
   }
 
-  private static double[][] calculatePhaseAreas(
-      double[][] state, double[][] densities) {
+  private static double[][] calculatePhaseAreas(double[][] state, double[][] densities) {
     int cellCount = state.length;
     double[][] phaseAreas = new double[PHASE_COUNT][cellCount];
     for (int phase = 0; phase < PHASE_COUNT; phase++) {
       for (int cell = 0; cell < cellCount; cell++) {
-        phaseAreas[phase][cell] =
-            Math.max(state[cell][phase], 0.0)
-                / Math.max(densities[phase][cell], MIN_DENSITY);
+        phaseAreas[phase][cell] = Math.max(state[cell][phase], 0.0) / Math.max(densities[phase][cell], MIN_DENSITY);
       }
     }
     return phaseAreas;
   }
 
-  private static double faceMobility(
-      int leftCell,
-      int rightCell,
-      double[][] phaseAreas,
-      double[] cellAreas,
+  private static double faceMobility(int leftCell, int rightCell, double[][] phaseAreas, double[] cellAreas,
       double[][] densities) {
     double faceArea = 0.5 * (cellAreas[leftCell] + cellAreas[rightCell]);
     double mobility = 0.0;
     for (int phase = 0; phase < PHASE_COUNT; phase++) {
-      double leftAlpha = Math.max(
-          0.0, Math.min(1.0, phaseAreas[phase][leftCell] / cellAreas[leftCell]));
-      double rightAlpha = Math.max(
-          0.0, Math.min(1.0, phaseAreas[phase][rightCell] / cellAreas[rightCell]));
+      double leftAlpha = Math.max(0.0, Math.min(1.0, phaseAreas[phase][leftCell] / cellAreas[leftCell]));
+      double rightAlpha = Math.max(0.0, Math.min(1.0, phaseAreas[phase][rightCell] / cellAreas[rightCell]));
       double alpha = 0.5 * (leftAlpha + rightAlpha);
-      double density =
-          0.5 * (densities[phase][leftCell] + densities[phase][rightCell]);
+      double density = 0.5 * (densities[phase][leftCell] + densities[phase][rightCell]);
       mobility += alpha / Math.max(density, MIN_DENSITY);
     }
     return faceArea * mobility;
   }
 
-  private static void applyConservativeMassFluxCorrection(
-      double[][] state,
-      double timeStep,
-      double[] pressureCorrection,
-      double[][] phaseAreas,
-      double[] areas,
-      double[] lengths) {
+  private static void applyConservativeMassFluxCorrection(double[][] state, double timeStep,
+      double[] pressureCorrection, double[][] phaseAreas, double[] areas, double[] lengths) {
     int cellCount = state.length;
-    double[][] faceMassFlowCorrection =
-        new double[PHASE_COUNT][cellCount + 1];
+    double[][] faceMassFlowCorrection = new double[PHASE_COUNT][cellCount + 1];
 
     for (int face = 1; face < cellCount; face++) {
       int leftCell = face - 1;
       int rightCell = face;
       double faceDistance = 0.5 * (lengths[leftCell] + lengths[rightCell]);
-      double pressureGradient =
-          (pressureCorrection[rightCell] - pressureCorrection[leftCell])
-              / faceDistance;
+      double pressureGradient = (pressureCorrection[rightCell] - pressureCorrection[leftCell]) / faceDistance;
       double faceArea = 0.5 * (areas[leftCell] + areas[rightCell]);
 
       for (int phase = 0; phase < PHASE_COUNT; phase++) {
-        double leftAlpha = Math.max(
-            0.0, Math.min(1.0, phaseAreas[phase][leftCell] / areas[leftCell]));
-        double rightAlpha = Math.max(
-            0.0, Math.min(1.0, phaseAreas[phase][rightCell] / areas[rightCell]));
+        double leftAlpha = Math.max(0.0, Math.min(1.0, phaseAreas[phase][leftCell] / areas[leftCell]));
+        double rightAlpha = Math.max(0.0, Math.min(1.0, phaseAreas[phase][rightCell] / areas[rightCell]));
         double faceAlpha = 0.5 * (leftAlpha + rightAlpha);
-        faceMassFlowCorrection[phase][face] =
-            -timeStep * faceAlpha * faceArea * pressureGradient;
+        faceMassFlowCorrection[phase][face] = -timeStep * faceAlpha * faceArea * pressureGradient;
       }
     }
 
     for (int cell = 0; cell < cellCount; cell++) {
       for (int phase = 0; phase < PHASE_COUNT; phase++) {
-        double divergence =
-            (faceMassFlowCorrection[phase][cell + 1]
-                    - faceMassFlowCorrection[phase][cell])
-                / lengths[cell];
+        double divergence = (faceMassFlowCorrection[phase][cell + 1] - faceMassFlowCorrection[phase][cell])
+            / lengths[cell];
         state[cell][phase] -= timeStep * divergence;
       }
     }
   }
 
-  private static void applyMomentumCorrection(
-      double[][] state,
-      double timeStep,
-      double[] pressureCorrection,
-      double[][] phaseAreas,
-      double[] lengths) {
+  private static void applyMomentumCorrection(double[][] state, double timeStep, double[] pressureCorrection,
+      double[][] phaseAreas, double[] lengths) {
     int cellCount = state.length;
     for (int cell = 0; cell < cellCount; cell++) {
       double pressureGradient;
       if (cell == 0) {
-        pressureGradient =
-            (pressureCorrection[1] - pressureCorrection[0])
-                / (0.5 * (lengths[0] + lengths[1]));
+        pressureGradient = (pressureCorrection[1] - pressureCorrection[0]) / (0.5 * (lengths[0] + lengths[1]));
       } else if (cell == cellCount - 1) {
-        pressureGradient =
-            (pressureCorrection[cell] - pressureCorrection[cell - 1])
-                / (0.5 * (lengths[cell - 1] + lengths[cell]));
+        pressureGradient = (pressureCorrection[cell] - pressureCorrection[cell - 1])
+            / (0.5 * (lengths[cell - 1] + lengths[cell]));
       } else {
-        double distance =
-            0.5 * lengths[cell - 1]
-                + lengths[cell]
-                + 0.5 * lengths[cell + 1];
-        pressureGradient =
-            (pressureCorrection[cell + 1] - pressureCorrection[cell - 1])
-                / distance;
+        double distance = 0.5 * lengths[cell - 1] + lengths[cell] + 0.5 * lengths[cell + 1];
+        pressureGradient = (pressureCorrection[cell + 1] - pressureCorrection[cell - 1]) / distance;
       }
 
-      state[cell][GAS_MOMENTUM] -=
-          timeStep * phaseAreas[GAS_MASS][cell] * pressureGradient;
-      state[cell][OIL_MOMENTUM] -=
-          timeStep * phaseAreas[OIL_MASS][cell] * pressureGradient;
-      state[cell][WATER_MOMENTUM] -=
-          timeStep * phaseAreas[WATER_MASS][cell] * pressureGradient;
+      state[cell][GAS_MOMENTUM] -= timeStep * phaseAreas[GAS_MASS][cell] * pressureGradient;
+      state[cell][OIL_MOMENTUM] -= timeStep * phaseAreas[OIL_MASS][cell] * pressureGradient;
+      state[cell][WATER_MOMENTUM] -= timeStep * phaseAreas[WATER_MASS][cell] * pressureGradient;
     }
   }
 
-  private static double calculateMaximumRelativeVolumeResidual(
-      double[][] state, double[] areas, double[][] densities) {
+  private static double calculateMaximumRelativeVolumeResidual(double[][] state, double[] areas, double[][] densities) {
     double maximumResidual = 0.0;
     for (int cell = 0; cell < state.length; cell++) {
       double occupiedArea = 0.0;
       for (int phase = 0; phase < PHASE_COUNT; phase++) {
-        occupiedArea +=
-            Math.max(state[cell][phase], 0.0)
-                / Math.max(densities[phase][cell], MIN_DENSITY);
+        occupiedArea += Math.max(state[cell][phase], 0.0) / Math.max(densities[phase][cell], MIN_DENSITY);
       }
-      maximumResidual = Math.max(
-          maximumResidual,
-          Math.abs(occupiedArea - areas[cell]) / areas[cell]);
+      maximumResidual = Math.max(maximumResidual, Math.abs(occupiedArea - areas[cell]) / areas[cell]);
     }
     return maximumResidual;
   }
 
-  private static double[] solveTridiagonal(
-      double[] lower, double[] diagonal, double[] upper, double[] rightHandSide) {
+  private static double[] solveTridiagonal(double[] lower, double[] diagonal, double[] upper, double[] rightHandSide) {
     int size = rightHandSide.length;
     double[] modifiedUpper = new double[size];
     double[] modifiedRightHandSide = new double[size];
     double[] solution = new double[size];
 
-    double firstPivot = Math.abs(diagonal[0]) > MIN_DIAGONAL
-        ? diagonal[0]
-        : Math.copySign(MIN_DIAGONAL, diagonal[0]);
+    double firstPivot = Math.abs(diagonal[0]) > MIN_DIAGONAL ? diagonal[0] : Math.copySign(MIN_DIAGONAL, diagonal[0]);
     modifiedUpper[0] = upper[0] / firstPivot;
     modifiedRightHandSide[0] = rightHandSide[0] / firstPivot;
 
@@ -434,67 +321,40 @@ public final class CoupledPressureMomentumSolver implements Serializable {
       if (Math.abs(pivot) <= MIN_DIAGONAL) {
         pivot = Math.copySign(MIN_DIAGONAL, pivot);
       }
-      modifiedUpper[row] =
-          row < size - 1 ? upper[row] / pivot : 0.0;
-      modifiedRightHandSide[row] =
-          (rightHandSide[row]
-                  - lower[row] * modifiedRightHandSide[row - 1])
-              / pivot;
+      modifiedUpper[row] = row < size - 1 ? upper[row] / pivot : 0.0;
+      modifiedRightHandSide[row] = (rightHandSide[row] - lower[row] * modifiedRightHandSide[row - 1]) / pivot;
     }
 
     solution[size - 1] = modifiedRightHandSide[size - 1];
     for (int row = size - 2; row >= 0; row--) {
-      solution[row] =
-          modifiedRightHandSide[row] - modifiedUpper[row] * solution[row + 1];
+      solution[row] = modifiedRightHandSide[row] - modifiedUpper[row] * solution[row + 1];
     }
     return solution;
   }
 
-  private static void validateInputs(
-      double[][] state,
-      double timeStep,
-      double[] pressure,
-      double[] areas,
-      double[] lengths,
-      double[] gasDensity,
-      double[] oilDensity,
-      double[] waterDensity,
-      double[] gasSoundSpeed,
-      double[] oilSoundSpeed,
-      double[] waterSoundSpeed) {
+  private static void validateInputs(double[][] state, double timeStep, double[] pressure, double[] areas,
+      double[] lengths, double[] gasDensity, double[] oilDensity, double[] waterDensity, double[] gasSoundSpeed,
+      double[] oilSoundSpeed, double[] waterSoundSpeed) {
     if (state == null || state.length < 2 || state[0].length < 6) {
-      throw new IllegalArgumentException(
-          "At least two cells and six conservative variables are required");
+      throw new IllegalArgumentException("At least two cells and six conservative variables are required");
     }
     if (!Double.isFinite(timeStep) || timeStep <= 0.0) {
       throw new IllegalArgumentException("timeStep must be positive and finite");
     }
     int cellCount = state.length;
-    double[][] arrays = {
-      pressure,
-      areas,
-      lengths,
-      gasDensity,
-      oilDensity,
-      waterDensity,
-      gasSoundSpeed,
-      oilSoundSpeed,
-      waterSoundSpeed
-    };
+    double[][] arrays = { pressure, areas, lengths, gasDensity, oilDensity, waterDensity, gasSoundSpeed, oilSoundSpeed,
+        waterSoundSpeed };
     for (double[] array : arrays) {
       if (array == null || array.length != cellCount) {
-        throw new IllegalArgumentException(
-            "Every cell-property array must match the state length");
+        throw new IllegalArgumentException("Every cell-property array must match the state length");
       }
     }
     for (int cell = 0; cell < cellCount; cell++) {
       if (state[cell] == null || state[cell].length != state[0].length) {
-        throw new IllegalArgumentException(
-            "The conservative state must be rectangular");
+        throw new IllegalArgumentException("The conservative state must be rectangular");
       }
       if (!(areas[cell] > 0.0) || !(lengths[cell] > 0.0)) {
-        throw new IllegalArgumentException(
-            "Cell area and length must be positive");
+        throw new IllegalArgumentException("Cell area and length must be positive");
       }
     }
   }

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
@@ -1,0 +1,533 @@
+package neqsim.process.equipment.pipeline.twophasepipe.numerics;
+
+import java.io.Serializable;
+
+/**
+ * Coupled pressure-momentum correction for the transient two-fluid finite-volume state.
+ *
+ * <p>The explicit transport step supplies a provisional conservative state. This class solves a
+ * compressible pressure equation formed from the fixed-cell-volume residual and the pressure
+ * correction to the total volumetric flux. The same face pressure correction is then applied to
+ * every phase mass flux and momentum, so phase masses remain globally conservative while pressure
+ * and velocity are advanced in the same accepted step.
+ *
+ * <p>The correction is intentionally independent of closure correlations. Phase compressibility is
+ * supplied through the local phase sound speeds, and the pressure equation uses the mobility
+ * {@code A * sum(alpha_k / rho_k)}. A fixed outlet pressure is represented by a Dirichlet pressure
+ * correction; the inlet and non-fixed outlet use zero correction gradient.
+ */
+public final class CoupledPressureMomentumSolver implements Serializable {
+  private static final long serialVersionUID = 1L;
+  private static final int GAS_MASS = 0;
+  private static final int OIL_MASS = 1;
+  private static final int WATER_MASS = 2;
+  private static final int GAS_MOMENTUM = 3;
+  private static final int OIL_MOMENTUM = 4;
+  private static final int WATER_MOMENTUM = 5;
+  private static final int PHASE_COUNT = 3;
+  private static final double MIN_DENSITY = 1.0e-6;
+  private static final double MIN_SOUND_SPEED = 1.0;
+  private static final double MIN_DIAGONAL = 1.0e-24;
+
+  private int maximumIterations = 12;
+  private double relativeVolumeTolerance = 1.0e-7;
+  private double pressureRelaxation = 0.7;
+  private double maximumRelativePressureCorrection = 0.25;
+
+  /**
+   * Immutable result of one coupled pressure-momentum correction.
+   */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private final double[][] state;
+    private final double[] pressure;
+    private final double[] gasDensity;
+    private final double[] oilDensity;
+    private final double[] waterDensity;
+    private final int iterations;
+    private final double maximumRelativeVolumeResidual;
+    private final boolean converged;
+    private final boolean pressureCorrectionLimited;
+
+    private Result(
+        double[][] state,
+        double[] pressure,
+        double[] gasDensity,
+        double[] oilDensity,
+        double[] waterDensity,
+        int iterations,
+        double maximumRelativeVolumeResidual,
+        boolean converged,
+        boolean pressureCorrectionLimited) {
+      this.state = state;
+      this.pressure = pressure;
+      this.gasDensity = gasDensity;
+      this.oilDensity = oilDensity;
+      this.waterDensity = waterDensity;
+      this.iterations = iterations;
+      this.maximumRelativeVolumeResidual = maximumRelativeVolumeResidual;
+      this.converged = converged;
+      this.pressureCorrectionLimited = pressureCorrectionLimited;
+    }
+
+    /** @return corrected conservative state */
+    public double[][] getState() {
+      return copy(state);
+    }
+
+    /** @return corrected cell pressure in Pa */
+    public double[] getPressure() {
+      return pressure.clone();
+    }
+
+    /** @return corrected gas density in kg/m3 */
+    public double[] getGasDensity() {
+      return gasDensity.clone();
+    }
+
+    /** @return corrected oil density in kg/m3 */
+    public double[] getOilDensity() {
+      return oilDensity.clone();
+    }
+
+    /** @return corrected water density in kg/m3 */
+    public double[] getWaterDensity() {
+      return waterDensity.clone();
+    }
+
+    /** @return nonlinear correction iterations used */
+    public int getIterations() {
+      return iterations;
+    }
+
+    /** @return largest absolute cell-volume residual divided by cell area */
+    public double getMaximumRelativeVolumeResidual() {
+      return maximumRelativeVolumeResidual;
+    }
+
+    /** @return true when the volume residual met the configured tolerance */
+    public boolean isConverged() {
+      return converged;
+    }
+
+    /** @return true when at least one nonlinear pressure correction was limited */
+    public boolean isPressureCorrectionLimited() {
+      return pressureCorrectionLimited;
+    }
+  }
+
+  /**
+   * Correct a provisional conservative state with a coupled pressure and phase-momentum solve.
+   *
+   * @param provisionalState conservative variables in kg/m and kg/s
+   * @param timeStep accepted substep in s
+   * @param pressure cell pressure in Pa
+   * @param areas cell cross-sectional area in m2
+   * @param lengths cell axial length in m
+   * @param gasDensity gas density in kg/m3
+   * @param oilDensity oil density in kg/m3
+   * @param waterDensity water density in kg/m3
+   * @param gasSoundSpeed gas sound speed in m/s
+   * @param oilSoundSpeed oil sound speed in m/s
+   * @param waterSoundSpeed water sound speed in m/s
+   * @param outletPressure fixed outlet pressure in Pa
+   * @param outletPressureFixed true for a Dirichlet outlet pressure
+   * @return corrected state, pressure, density, and convergence diagnostics
+   */
+  public Result correct(
+      double[][] provisionalState,
+      double timeStep,
+      double[] pressure,
+      double[] areas,
+      double[] lengths,
+      double[] gasDensity,
+      double[] oilDensity,
+      double[] waterDensity,
+      double[] gasSoundSpeed,
+      double[] oilSoundSpeed,
+      double[] waterSoundSpeed,
+      double outletPressure,
+      boolean outletPressureFixed) {
+    validateInputs(
+        provisionalState,
+        timeStep,
+        pressure,
+        areas,
+        lengths,
+        gasDensity,
+        oilDensity,
+        waterDensity,
+        gasSoundSpeed,
+        oilSoundSpeed,
+        waterSoundSpeed);
+
+    int cellCount = provisionalState.length;
+    double[][] correctedState = copy(provisionalState);
+    double[] correctedPressure = pressure.clone();
+    double[][] densities = {
+      gasDensity.clone(), oilDensity.clone(), waterDensity.clone()
+    };
+    double[][] soundSpeeds = {
+      gasSoundSpeed.clone(), oilSoundSpeed.clone(), waterSoundSpeed.clone()
+    };
+
+    int iterations = 0;
+    boolean converged = false;
+    boolean correctionLimited = false;
+    double maximumResidual = calculateMaximumRelativeVolumeResidual(
+        correctedState, areas, densities);
+
+    while (iterations < maximumIterations && maximumResidual > relativeVolumeTolerance) {
+      iterations++;
+      double[][] phaseAreas = calculatePhaseAreas(correctedState, densities);
+      double[] lower = new double[cellCount];
+      double[] diagonal = new double[cellCount];
+      double[] upper = new double[cellCount];
+      double[] rightHandSide = new double[cellCount];
+
+      for (int cell = 0; cell < cellCount; cell++) {
+        double compressibleArea = 0.0;
+        for (int phase = 0; phase < PHASE_COUNT; phase++) {
+          double density = Math.max(densities[phase][cell], MIN_DENSITY);
+          double soundSpeed = Math.max(soundSpeeds[phase][cell], MIN_SOUND_SPEED);
+          compressibleArea += phaseAreas[phase][cell] / (density * soundSpeed * soundSpeed);
+        }
+
+        double leftCoefficient = 0.0;
+        if (cell > 0) {
+          double faceDistance = 0.5 * (lengths[cell - 1] + lengths[cell]);
+          double mobility = faceMobility(
+              cell - 1, cell, phaseAreas, areas, densities);
+          leftCoefficient =
+              timeStep * timeStep * mobility / (lengths[cell] * faceDistance);
+        }
+
+        double rightCoefficient = 0.0;
+        if (cell < cellCount - 1) {
+          double faceDistance = 0.5 * (lengths[cell] + lengths[cell + 1]);
+          double mobility = faceMobility(
+              cell, cell + 1, phaseAreas, areas, densities);
+          rightCoefficient =
+              timeStep * timeStep * mobility / (lengths[cell] * faceDistance);
+        }
+
+        lower[cell] = -leftCoefficient;
+        diagonal[cell] = Math.max(
+            compressibleArea + leftCoefficient + rightCoefficient, MIN_DIAGONAL);
+        upper[cell] = -rightCoefficient;
+        rightHandSide[cell] =
+            phaseAreas[GAS_MASS][cell]
+                + phaseAreas[OIL_MASS][cell]
+                + phaseAreas[WATER_MASS][cell]
+                - areas[cell];
+      }
+
+      if (outletPressureFixed) {
+        int outlet = cellCount - 1;
+        lower[outlet] = 0.0;
+        diagonal[outlet] = 1.0;
+        upper[outlet] = 0.0;
+        rightHandSide[outlet] = outletPressure - correctedPressure[outlet];
+      }
+
+      double[] pressureCorrection =
+          solveTridiagonal(lower, diagonal, upper, rightHandSide);
+      for (int cell = 0; cell < cellCount; cell++) {
+        pressureCorrection[cell] *= pressureRelaxation;
+        double limit = Math.max(
+            1.0e4, maximumRelativePressureCorrection * correctedPressure[cell]);
+        if (Math.abs(pressureCorrection[cell]) > limit) {
+          pressureCorrection[cell] =
+              Math.copySign(limit, pressureCorrection[cell]);
+          correctionLimited = true;
+        }
+      }
+
+      applyConservativeMassFluxCorrection(
+          correctedState,
+          timeStep,
+          pressureCorrection,
+          phaseAreas,
+          areas,
+          lengths);
+      applyMomentumCorrection(
+          correctedState,
+          timeStep,
+          pressureCorrection,
+          phaseAreas,
+          lengths);
+
+      for (int cell = 0; cell < cellCount; cell++) {
+        correctedPressure[cell] =
+            Math.max(1.0e5, correctedPressure[cell] + pressureCorrection[cell]);
+        for (int phase = 0; phase < PHASE_COUNT; phase++) {
+          double soundSpeed = Math.max(soundSpeeds[phase][cell], MIN_SOUND_SPEED);
+          densities[phase][cell] = Math.max(
+              MIN_DENSITY,
+              densities[phase][cell]
+                  + pressureCorrection[cell] / (soundSpeed * soundSpeed));
+        }
+      }
+
+      maximumResidual = calculateMaximumRelativeVolumeResidual(
+          correctedState, areas, densities);
+    }
+
+    converged = maximumResidual <= relativeVolumeTolerance;
+    return new Result(
+        correctedState,
+        correctedPressure,
+        densities[GAS_MASS],
+        densities[OIL_MASS],
+        densities[WATER_MASS],
+        iterations,
+        maximumResidual,
+        converged,
+        correctionLimited);
+  }
+
+  private static double[][] calculatePhaseAreas(
+      double[][] state, double[][] densities) {
+    int cellCount = state.length;
+    double[][] phaseAreas = new double[PHASE_COUNT][cellCount];
+    for (int phase = 0; phase < PHASE_COUNT; phase++) {
+      for (int cell = 0; cell < cellCount; cell++) {
+        phaseAreas[phase][cell] =
+            Math.max(state[cell][phase], 0.0)
+                / Math.max(densities[phase][cell], MIN_DENSITY);
+      }
+    }
+    return phaseAreas;
+  }
+
+  private static double faceMobility(
+      int leftCell,
+      int rightCell,
+      double[][] phaseAreas,
+      double[] cellAreas,
+      double[][] densities) {
+    double faceArea = 0.5 * (cellAreas[leftCell] + cellAreas[rightCell]);
+    double mobility = 0.0;
+    for (int phase = 0; phase < PHASE_COUNT; phase++) {
+      double leftAlpha = Math.max(
+          0.0, Math.min(1.0, phaseAreas[phase][leftCell] / cellAreas[leftCell]));
+      double rightAlpha = Math.max(
+          0.0, Math.min(1.0, phaseAreas[phase][rightCell] / cellAreas[rightCell]));
+      double alpha = 0.5 * (leftAlpha + rightAlpha);
+      double density =
+          0.5 * (densities[phase][leftCell] + densities[phase][rightCell]);
+      mobility += alpha / Math.max(density, MIN_DENSITY);
+    }
+    return faceArea * mobility;
+  }
+
+  private static void applyConservativeMassFluxCorrection(
+      double[][] state,
+      double timeStep,
+      double[] pressureCorrection,
+      double[][] phaseAreas,
+      double[] areas,
+      double[] lengths) {
+    int cellCount = state.length;
+    double[][] faceMassFlowCorrection =
+        new double[PHASE_COUNT][cellCount + 1];
+
+    for (int face = 1; face < cellCount; face++) {
+      int leftCell = face - 1;
+      int rightCell = face;
+      double faceDistance = 0.5 * (lengths[leftCell] + lengths[rightCell]);
+      double pressureGradient =
+          (pressureCorrection[rightCell] - pressureCorrection[leftCell])
+              / faceDistance;
+      double faceArea = 0.5 * (areas[leftCell] + areas[rightCell]);
+
+      for (int phase = 0; phase < PHASE_COUNT; phase++) {
+        double leftAlpha = Math.max(
+            0.0, Math.min(1.0, phaseAreas[phase][leftCell] / areas[leftCell]));
+        double rightAlpha = Math.max(
+            0.0, Math.min(1.0, phaseAreas[phase][rightCell] / areas[rightCell]));
+        double faceAlpha = 0.5 * (leftAlpha + rightAlpha);
+        faceMassFlowCorrection[phase][face] =
+            -timeStep * faceAlpha * faceArea * pressureGradient;
+      }
+    }
+
+    for (int cell = 0; cell < cellCount; cell++) {
+      for (int phase = 0; phase < PHASE_COUNT; phase++) {
+        double divergence =
+            (faceMassFlowCorrection[phase][cell + 1]
+                    - faceMassFlowCorrection[phase][cell])
+                / lengths[cell];
+        state[cell][phase] -= timeStep * divergence;
+      }
+    }
+  }
+
+  private static void applyMomentumCorrection(
+      double[][] state,
+      double timeStep,
+      double[] pressureCorrection,
+      double[][] phaseAreas,
+      double[] lengths) {
+    int cellCount = state.length;
+    for (int cell = 0; cell < cellCount; cell++) {
+      double pressureGradient;
+      if (cell == 0) {
+        pressureGradient =
+            (pressureCorrection[1] - pressureCorrection[0])
+                / (0.5 * (lengths[0] + lengths[1]));
+      } else if (cell == cellCount - 1) {
+        pressureGradient =
+            (pressureCorrection[cell] - pressureCorrection[cell - 1])
+                / (0.5 * (lengths[cell - 1] + lengths[cell]));
+      } else {
+        double distance =
+            0.5 * lengths[cell - 1]
+                + lengths[cell]
+                + 0.5 * lengths[cell + 1];
+        pressureGradient =
+            (pressureCorrection[cell + 1] - pressureCorrection[cell - 1])
+                / distance;
+      }
+
+      state[cell][GAS_MOMENTUM] -=
+          timeStep * phaseAreas[GAS_MASS][cell] * pressureGradient;
+      state[cell][OIL_MOMENTUM] -=
+          timeStep * phaseAreas[OIL_MASS][cell] * pressureGradient;
+      state[cell][WATER_MOMENTUM] -=
+          timeStep * phaseAreas[WATER_MASS][cell] * pressureGradient;
+    }
+  }
+
+  private static double calculateMaximumRelativeVolumeResidual(
+      double[][] state, double[] areas, double[][] densities) {
+    double maximumResidual = 0.0;
+    for (int cell = 0; cell < state.length; cell++) {
+      double occupiedArea = 0.0;
+      for (int phase = 0; phase < PHASE_COUNT; phase++) {
+        occupiedArea +=
+            Math.max(state[cell][phase], 0.0)
+                / Math.max(densities[phase][cell], MIN_DENSITY);
+      }
+      maximumResidual = Math.max(
+          maximumResidual,
+          Math.abs(occupiedArea - areas[cell]) / areas[cell]);
+    }
+    return maximumResidual;
+  }
+
+  private static double[] solveTridiagonal(
+      double[] lower, double[] diagonal, double[] upper, double[] rightHandSide) {
+    int size = rightHandSide.length;
+    double[] modifiedUpper = new double[size];
+    double[] modifiedRightHandSide = new double[size];
+    double[] solution = new double[size];
+
+    double firstPivot = Math.abs(diagonal[0]) > MIN_DIAGONAL
+        ? diagonal[0]
+        : Math.copySign(MIN_DIAGONAL, diagonal[0]);
+    modifiedUpper[0] = upper[0] / firstPivot;
+    modifiedRightHandSide[0] = rightHandSide[0] / firstPivot;
+
+    for (int row = 1; row < size; row++) {
+      double pivot = diagonal[row] - lower[row] * modifiedUpper[row - 1];
+      if (Math.abs(pivot) <= MIN_DIAGONAL) {
+        pivot = Math.copySign(MIN_DIAGONAL, pivot);
+      }
+      modifiedUpper[row] =
+          row < size - 1 ? upper[row] / pivot : 0.0;
+      modifiedRightHandSide[row] =
+          (rightHandSide[row]
+                  - lower[row] * modifiedRightHandSide[row - 1])
+              / pivot;
+    }
+
+    solution[size - 1] = modifiedRightHandSide[size - 1];
+    for (int row = size - 2; row >= 0; row--) {
+      solution[row] =
+          modifiedRightHandSide[row] - modifiedUpper[row] * solution[row + 1];
+    }
+    return solution;
+  }
+
+  private static void validateInputs(
+      double[][] state,
+      double timeStep,
+      double[] pressure,
+      double[] areas,
+      double[] lengths,
+      double[] gasDensity,
+      double[] oilDensity,
+      double[] waterDensity,
+      double[] gasSoundSpeed,
+      double[] oilSoundSpeed,
+      double[] waterSoundSpeed) {
+    if (state == null || state.length < 2 || state[0].length < 6) {
+      throw new IllegalArgumentException(
+          "At least two cells and six conservative variables are required");
+    }
+    if (!Double.isFinite(timeStep) || timeStep <= 0.0) {
+      throw new IllegalArgumentException("timeStep must be positive and finite");
+    }
+    int cellCount = state.length;
+    double[][] arrays = {
+      pressure,
+      areas,
+      lengths,
+      gasDensity,
+      oilDensity,
+      waterDensity,
+      gasSoundSpeed,
+      oilSoundSpeed,
+      waterSoundSpeed
+    };
+    for (double[] array : arrays) {
+      if (array == null || array.length != cellCount) {
+        throw new IllegalArgumentException(
+            "Every cell-property array must match the state length");
+      }
+    }
+    for (int cell = 0; cell < cellCount; cell++) {
+      if (state[cell] == null || state[cell].length != state[0].length) {
+        throw new IllegalArgumentException(
+            "The conservative state must be rectangular");
+      }
+      if (!(areas[cell] > 0.0) || !(lengths[cell] > 0.0)) {
+        throw new IllegalArgumentException(
+            "Cell area and length must be positive");
+      }
+    }
+  }
+
+  private static double[][] copy(double[][] source) {
+    double[][] result = new double[source.length][];
+    for (int row = 0; row < source.length; row++) {
+      result[row] = source[row].clone();
+    }
+    return result;
+  }
+
+  /** @param maximumIterations maximum nonlinear correction iterations */
+  public void setMaximumIterations(int maximumIterations) {
+    if (maximumIterations < 1) {
+      throw new IllegalArgumentException("maximumIterations must be at least one");
+    }
+    this.maximumIterations = maximumIterations;
+  }
+
+  /** @param tolerance maximum accepted relative cell-volume residual */
+  public void setRelativeVolumeTolerance(double tolerance) {
+    if (!(tolerance > 0.0) || !Double.isFinite(tolerance)) {
+      throw new IllegalArgumentException("tolerance must be positive and finite");
+    }
+    this.relativeVolumeTolerance = tolerance;
+  }
+
+  /** @param relaxation pressure-correction relaxation in the interval (0, 1] */
+  public void setPressureRelaxation(double relaxation) {
+    if (!(relaxation > 0.0) || relaxation > 1.0 || !Double.isFinite(relaxation)) {
+      throw new IllegalArgumentException("relaxation must be in the interval (0, 1]");
+    }
+    this.pressureRelaxation = relaxation;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
@@ -655,6 +655,12 @@ public class TimeIntegrator implements Serializable {
     return lastCoupledPressureMomentumResult == null ? 0 : lastCoupledPressureMomentumResult.getIterations();
   }
 
+  /** @return signed gas, oil, and water outlet mass corrections in kg */
+  public double[] getCoupledPressureMomentumOutletMassCorrectionKg() {
+    return lastCoupledPressureMomentumResult == null ? new double[3]
+        : lastCoupledPressureMomentumResult.getOutletBoundaryMassCorrectionKg();
+  }
+
   /** @return corrected pressure from the latest coupled correction, or null */
   public double[] getCoupledPressureMomentumPressure() {
     return lastCoupledPressureMomentumResult == null ? null : lastCoupledPressureMomentumResult.getPressure();

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
@@ -626,6 +626,23 @@ public class TimeIntegrator implements Serializable {
     }
   }
 
+  /**
+   * Enable or disable the coupled pressure-momentum correction.
+   *
+   * @param enabled true to apply the configured correction
+   */
+  public void setCoupledPressureMomentumEnabled(boolean enabled) {
+    coupledPressureMomentumEnabled = enabled;
+    if (!enabled) {
+      lastCoupledPressureMomentumResult = null;
+    }
+  }
+
+  /** @return true when the coupled pressure-momentum correction is enabled */
+  public boolean isCoupledPressureMomentumEnabled() {
+    return coupledPressureMomentumEnabled;
+  }
+
   private double[][] applyCoupledPressureMomentumCorrection(
       double[][] state, double dt) {
     if (!coupledPressureMomentumEnabled) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
@@ -127,11 +127,19 @@ public class TimeIntegrator implements Serializable {
       advancedState = stepSSPRK3(U, rhs, dt);
       break;
     case IMEX_PRESSURE_CORRECTION:
-      return stepIMEXPressureCorrection(U, rhs, dt);
+      if (coupledPressureMomentumEnabled) {
+        // The coupled solver supplies the acoustic correction and must not be
+        // stacked on the legacy sequential IMEX pressure correction.
+        advancedState = stepEuler(U, rhs, dt);
+      } else {
+        return stepIMEXPressureCorrection(U, rhs, dt);
+      }
+      break;
     default:
       advancedState = stepRK4(U, rhs, dt);
       break;
     }
+    advancedState = applyCoupledPressureMomentumCorrection(advancedState, dt);
     return applyImplicitVoidWaveCorrection(advancedState, dt);
   }
 
@@ -470,6 +478,27 @@ public class TimeIntegrator implements Serializable {
   /** Whether to apply the implicit interfacial-pressure correction after the explicit transport step. */
   private boolean implicitVoidWaveEnabled;
 
+  /** Coupled compressible pressure-momentum correction. */
+  private final CoupledPressureMomentumSolver coupledPressureMomentumSolver =
+      new CoupledPressureMomentumSolver();
+
+  /** Whether pressure and phase momenta are corrected in the same accepted step. */
+  private boolean coupledPressureMomentumEnabled;
+
+  /** Cell pressure supplied to the coupled correction in Pa. */
+  private double[] coupledCellPressure;
+
+  /** Cell lengths supplied to the coupled correction in m. */
+  private double[] coupledCellLengths;
+
+  /** Phase sound speeds supplied to the coupled correction in m/s. */
+  private double[] coupledGasSoundSpeeds;
+  private double[] coupledOilSoundSpeeds;
+  private double[] coupledWaterSoundSpeeds;
+
+  /** Most recent coupled pressure-momentum result. */
+  private CoupledPressureMomentumSolver.Result lastCoupledPressureMomentumResult;
+
   /** Cell size for IMEX pressure solve (m). Set by caller before step. */
   private double imexDx = 1.0;
 
@@ -546,6 +575,126 @@ public class TimeIntegrator implements Serializable {
     this.cellWaterDensities = waterDensities;
     this.imexDx = dx;
     this.implicitVoidWaveEnabled = enabled;
+  }
+
+  /**
+   * Configure the coupled pressure-momentum correction.
+   *
+   * @param pressure cell pressure in Pa
+   * @param areas cell cross-sectional areas in m2
+   * @param lengths cell axial lengths in m
+   * @param gasDensities gas density in kg/m3
+   * @param oilDensities oil density in kg/m3
+   * @param waterDensities water density in kg/m3
+   * @param gasSoundSpeeds gas sound speed in m/s
+   * @param oilSoundSpeeds oil sound speed in m/s
+   * @param waterSoundSpeeds water sound speed in m/s
+   * @param outletPressure fixed outlet pressure in Pa
+   * @param outletFixed true when the outlet pressure is a Dirichlet boundary
+   * @param enabled true to apply the coupled correction
+   */
+  public void setCoupledPressureMomentumProperties(
+      double[] pressure,
+      double[] areas,
+      double[] lengths,
+      double[] gasDensities,
+      double[] oilDensities,
+      double[] waterDensities,
+      double[] gasSoundSpeeds,
+      double[] oilSoundSpeeds,
+      double[] waterSoundSpeeds,
+      double outletPressure,
+      boolean outletFixed,
+      boolean enabled) {
+    this.coupledCellPressure = pressure == null ? null : pressure.clone();
+    this.cellAreas = areas == null ? null : areas.clone();
+    this.coupledCellLengths = lengths == null ? null : lengths.clone();
+    this.cellGasDensities = gasDensities == null ? null : gasDensities.clone();
+    this.cellOilDensities = oilDensities == null ? null : oilDensities.clone();
+    this.cellWaterDensities = waterDensities == null ? null : waterDensities.clone();
+    this.coupledGasSoundSpeeds =
+        gasSoundSpeeds == null ? null : gasSoundSpeeds.clone();
+    this.coupledOilSoundSpeeds =
+        oilSoundSpeeds == null ? null : oilSoundSpeeds.clone();
+    this.coupledWaterSoundSpeeds =
+        waterSoundSpeeds == null ? null : waterSoundSpeeds.clone();
+    this.imexOutletPressure = outletPressure;
+    this.imexOutletPressureFixed = outletFixed;
+    this.coupledPressureMomentumEnabled = enabled;
+    if (!enabled) {
+      lastCoupledPressureMomentumResult = null;
+    }
+  }
+
+  private double[][] applyCoupledPressureMomentumCorrection(
+      double[][] state, double dt) {
+    if (!coupledPressureMomentumEnabled) {
+      return state;
+    }
+    lastCoupledPressureMomentumResult =
+        coupledPressureMomentumSolver.correct(
+            state,
+            dt,
+            coupledCellPressure,
+            cellAreas,
+            coupledCellLengths,
+            cellGasDensities,
+            cellOilDensities,
+            cellWaterDensities,
+            coupledGasSoundSpeeds,
+            coupledOilSoundSpeeds,
+            coupledWaterSoundSpeeds,
+            imexOutletPressure,
+            imexOutletPressureFixed);
+    return lastCoupledPressureMomentumResult.getState();
+  }
+
+  /** @return true when the most recent coupled correction converged */
+  public boolean isCoupledPressureMomentumConverged() {
+    return lastCoupledPressureMomentumResult != null
+        && lastCoupledPressureMomentumResult.isConverged();
+  }
+
+  /** @return maximum relative cell-volume residual from the latest correction */
+  public double getCoupledPressureMomentumVolumeResidual() {
+    return lastCoupledPressureMomentumResult == null
+        ? Double.NaN
+        : lastCoupledPressureMomentumResult.getMaximumRelativeVolumeResidual();
+  }
+
+  /** @return nonlinear iterations used by the latest coupled correction */
+  public int getCoupledPressureMomentumIterations() {
+    return lastCoupledPressureMomentumResult == null
+        ? 0
+        : lastCoupledPressureMomentumResult.getIterations();
+  }
+
+  /** @return corrected pressure from the latest coupled correction, or null */
+  public double[] getCoupledPressureMomentumPressure() {
+    return lastCoupledPressureMomentumResult == null
+        ? null
+        : lastCoupledPressureMomentumResult.getPressure();
+  }
+
+  /** @return corrected gas density from the latest coupled correction, or null */
+  public double[] getCoupledPressureMomentumGasDensity() {
+    return lastCoupledPressureMomentumResult == null
+        ? null
+        : lastCoupledPressureMomentumResult.getGasDensity();
+  }
+
+  /** @return corrected oil density from the latest coupled correction, or null */
+  public double[] getCoupledPressureMomentumOilDensity() {
+    return lastCoupledPressureMomentumResult == null
+        ? null
+        : lastCoupledPressureMomentumResult.getOilDensity();
+  }
+
+  /** @return corrected water density from the latest coupled correction, or null */
+  public double[] getCoupledPressureMomentumWaterDensity() {
+    return lastCoupledPressureMomentumResult == null
+        ? null
+        : lastCoupledPressureMomentumResult.getWaterDensity();
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
@@ -479,8 +479,7 @@ public class TimeIntegrator implements Serializable {
   private boolean implicitVoidWaveEnabled;
 
   /** Coupled compressible pressure-momentum correction. */
-  private final CoupledPressureMomentumSolver coupledPressureMomentumSolver =
-      new CoupledPressureMomentumSolver();
+  private final CoupledPressureMomentumSolver coupledPressureMomentumSolver = new CoupledPressureMomentumSolver();
 
   /** Whether pressure and phase momenta are corrected in the same accepted step. */
   private boolean coupledPressureMomentumEnabled;
@@ -593,31 +592,18 @@ public class TimeIntegrator implements Serializable {
    * @param outletFixed true when the outlet pressure is a Dirichlet boundary
    * @param enabled true to apply the coupled correction
    */
-  public void setCoupledPressureMomentumProperties(
-      double[] pressure,
-      double[] areas,
-      double[] lengths,
-      double[] gasDensities,
-      double[] oilDensities,
-      double[] waterDensities,
-      double[] gasSoundSpeeds,
-      double[] oilSoundSpeeds,
-      double[] waterSoundSpeeds,
-      double outletPressure,
-      boolean outletFixed,
-      boolean enabled) {
+  public void setCoupledPressureMomentumProperties(double[] pressure, double[] areas, double[] lengths,
+      double[] gasDensities, double[] oilDensities, double[] waterDensities, double[] gasSoundSpeeds,
+      double[] oilSoundSpeeds, double[] waterSoundSpeeds, double outletPressure, boolean outletFixed, boolean enabled) {
     this.coupledCellPressure = pressure == null ? null : pressure.clone();
     this.cellAreas = areas == null ? null : areas.clone();
     this.coupledCellLengths = lengths == null ? null : lengths.clone();
     this.cellGasDensities = gasDensities == null ? null : gasDensities.clone();
     this.cellOilDensities = oilDensities == null ? null : oilDensities.clone();
     this.cellWaterDensities = waterDensities == null ? null : waterDensities.clone();
-    this.coupledGasSoundSpeeds =
-        gasSoundSpeeds == null ? null : gasSoundSpeeds.clone();
-    this.coupledOilSoundSpeeds =
-        oilSoundSpeeds == null ? null : oilSoundSpeeds.clone();
-    this.coupledWaterSoundSpeeds =
-        waterSoundSpeeds == null ? null : waterSoundSpeeds.clone();
+    this.coupledGasSoundSpeeds = gasSoundSpeeds == null ? null : gasSoundSpeeds.clone();
+    this.coupledOilSoundSpeeds = oilSoundSpeeds == null ? null : oilSoundSpeeds.clone();
+    this.coupledWaterSoundSpeeds = waterSoundSpeeds == null ? null : waterSoundSpeeds.clone();
     this.imexOutletPressure = outletPressure;
     this.imexOutletPressureFixed = outletFixed;
     this.coupledPressureMomentumEnabled = enabled;
@@ -643,75 +629,50 @@ public class TimeIntegrator implements Serializable {
     return coupledPressureMomentumEnabled;
   }
 
-  private double[][] applyCoupledPressureMomentumCorrection(
-      double[][] state, double dt) {
+  private double[][] applyCoupledPressureMomentumCorrection(double[][] state, double dt) {
     if (!coupledPressureMomentumEnabled) {
       return state;
     }
-    lastCoupledPressureMomentumResult =
-        coupledPressureMomentumSolver.correct(
-            state,
-            dt,
-            coupledCellPressure,
-            cellAreas,
-            coupledCellLengths,
-            cellGasDensities,
-            cellOilDensities,
-            cellWaterDensities,
-            coupledGasSoundSpeeds,
-            coupledOilSoundSpeeds,
-            coupledWaterSoundSpeeds,
-            imexOutletPressure,
-            imexOutletPressureFixed);
+    lastCoupledPressureMomentumResult = coupledPressureMomentumSolver.correct(state, dt, coupledCellPressure, cellAreas,
+        coupledCellLengths, cellGasDensities, cellOilDensities, cellWaterDensities, coupledGasSoundSpeeds,
+        coupledOilSoundSpeeds, coupledWaterSoundSpeeds, imexOutletPressure, imexOutletPressureFixed);
     return lastCoupledPressureMomentumResult.getState();
   }
 
   /** @return true when the most recent coupled correction converged */
   public boolean isCoupledPressureMomentumConverged() {
-    return lastCoupledPressureMomentumResult != null
-        && lastCoupledPressureMomentumResult.isConverged();
+    return lastCoupledPressureMomentumResult != null && lastCoupledPressureMomentumResult.isConverged();
   }
 
   /** @return maximum relative cell-volume residual from the latest correction */
   public double getCoupledPressureMomentumVolumeResidual() {
-    return lastCoupledPressureMomentumResult == null
-        ? Double.NaN
+    return lastCoupledPressureMomentumResult == null ? Double.NaN
         : lastCoupledPressureMomentumResult.getMaximumRelativeVolumeResidual();
   }
 
   /** @return nonlinear iterations used by the latest coupled correction */
   public int getCoupledPressureMomentumIterations() {
-    return lastCoupledPressureMomentumResult == null
-        ? 0
-        : lastCoupledPressureMomentumResult.getIterations();
+    return lastCoupledPressureMomentumResult == null ? 0 : lastCoupledPressureMomentumResult.getIterations();
   }
 
   /** @return corrected pressure from the latest coupled correction, or null */
   public double[] getCoupledPressureMomentumPressure() {
-    return lastCoupledPressureMomentumResult == null
-        ? null
-        : lastCoupledPressureMomentumResult.getPressure();
+    return lastCoupledPressureMomentumResult == null ? null : lastCoupledPressureMomentumResult.getPressure();
   }
 
   /** @return corrected gas density from the latest coupled correction, or null */
   public double[] getCoupledPressureMomentumGasDensity() {
-    return lastCoupledPressureMomentumResult == null
-        ? null
-        : lastCoupledPressureMomentumResult.getGasDensity();
+    return lastCoupledPressureMomentumResult == null ? null : lastCoupledPressureMomentumResult.getGasDensity();
   }
 
   /** @return corrected oil density from the latest coupled correction, or null */
   public double[] getCoupledPressureMomentumOilDensity() {
-    return lastCoupledPressureMomentumResult == null
-        ? null
-        : lastCoupledPressureMomentumResult.getOilDensity();
+    return lastCoupledPressureMomentumResult == null ? null : lastCoupledPressureMomentumResult.getOilDensity();
   }
 
   /** @return corrected water density from the latest coupled correction, or null */
   public double[] getCoupledPressureMomentumWaterDensity() {
-    return lastCoupledPressureMomentumResult == null
-        ? null
-        : lastCoupledPressureMomentumResult.getWaterDensity();
+    return lastCoupledPressureMomentumResult == null ? null : lastCoupledPressureMomentumResult.getWaterDensity();
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/network/TwoFluidPipeNetworkTest.java
+++ b/src/test/java/neqsim/process/equipment/network/TwoFluidPipeNetworkTest.java
@@ -1,0 +1,81 @@
+package neqsim.process.equipment.network;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport.Phase;
+import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import neqsim.process.equipment.pipeline.UpstreamCompressibleVolume;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+@Tag("slow")
+class TwoFluidPipeNetworkTest {
+  @Test
+  void serialBranchesAndStorageNodeCloseWholeNetworkMass() {
+    TwoFluidPipeNetwork network = new TwoFluidPipeNetwork("serial network");
+    network.addFixedPressureNode("source", 60.0e5);
+    network.addCompressibleNode("manifold", createVolume(55.0e5, 1000.0));
+    network.addFixedPressureNode("sink", 50.0e5);
+    network.addPipe("upstream", "source", "manifold", createPipe("upstream"));
+    network.addPipe("downstream", "manifold", "sink", createPipe("downstream"));
+
+    network.runTransient(0.01, UUID.randomUUID());
+
+    TwoFluidPipeNetwork.BalanceReport report = network.getLastBalanceReport();
+    for (Phase phase : Phase.values()) {
+      assertTrue(report.getRelativeResidual(phase) < 1.0e-8,
+          phase + " network residual=" + report.getRelativeResidual(phase));
+    }
+    assertTrue(Double.isFinite(network.getNodePressurePa("manifold")));
+    assertEquals(0.01, network.getSimulationTimeSeconds(), 0.0);
+  }
+
+  @Test
+  void identicalSplitBranchesRemainSymmetric() {
+    UpstreamCompressibleVolume splitter = createVolume(60.0e5, 1.0e5);
+    TwoFluidPipeNetwork network = new TwoFluidPipeNetwork("symmetric split");
+    network.addCompressibleNode("splitter", splitter);
+    network.addFixedPressureNode("sink A", 50.0e5);
+    network.addFixedPressureNode("sink B", 50.0e5);
+    network.addPipe("branch A", "splitter", "sink A", createPipe("branch A"));
+    network.addPipe("branch B", "splitter", "sink B", createPipe("branch B"));
+
+    network.runTransient(0.01, UUID.randomUUID());
+
+    TwoFluidMassBalanceReport first = network.getPipe("branch A").getLastMassBalanceReport();
+    TwoFluidMassBalanceReport second = network.getPipe("branch B").getLastMassBalanceReport();
+    assertEquals(first.getOutletMassKg(Phase.TOTAL), second.getOutletMassKg(Phase.TOTAL), 1.0e-12);
+    assertTrue(network.getLastBalanceReport().getRelativeResidual(Phase.TOTAL) < 1.0e-8);
+  }
+
+  private static TwoFluidPipe createPipe(String name) {
+    SystemInterface fluid = new SystemSrkEos(300.0, 60.0);
+    fluid.addComponent("methane", 0.95);
+    fluid.addComponent("n-heptane", 0.05);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    Stream feed = new Stream(name + " feed", fluid);
+    feed.setFlowRate(2.0, "kg/sec");
+    feed.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe(name, feed);
+    pipe.setLength(50.0);
+    pipe.setDiameter(0.20);
+    pipe.setNumberOfSections(4);
+    pipe.setElevationProfile(new double[4]);
+    return pipe;
+  }
+
+  private static UpstreamCompressibleVolume createVolume(double pressurePa, double volumeM3) {
+    double[] density = { 45.0, 700.0, 1000.0 };
+    double[] soundSpeed = { 350.0, 1200.0, 1450.0 };
+    double[] mass = { 0.90 * volumeM3 * density[0], 0.10 * volumeM3 * density[1], 0.0 };
+    return new UpstreamCompressibleVolume(volumeM3, pressurePa, mass, density, soundSpeed);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidBenchmarkMetricsTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidBenchmarkMetricsTest.java
@@ -1,0 +1,59 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class TwoFluidBenchmarkMetricsTest {
+  @Test
+  void fitsRateSweepExponentInsteadOfOnlyCheckingOneLevel() {
+    double[] rates = { 1.0, 2.0, 4.0, 8.0 };
+    double[] pressureDrops = new double[rates.length];
+    for (int index = 0; index < rates.length; index++) {
+      pressureDrops[index] = 3.5 * Math.pow(rates[index], 1.8);
+    }
+    assertEquals(1.8, TwoFluidBenchmarkMetrics.fitRateExponent(rates, pressureDrops), 1.0e-12);
+  }
+
+  @Test
+  void reportsScaleFreeProfileLocalizationAndMeshSpread() {
+    assertEquals(9.0, TwoFluidBenchmarkMetrics.maximumToMedianRatio(new double[] { 1.0, 1.0, 1.0, 9.0 }), 0.0);
+    assertEquals(0.2, TwoFluidBenchmarkMetrics.relativeMeshSpread(80.0, 100.0), 1.0e-15);
+    assertEquals(0.2, TwoFluidBenchmarkMetrics.relativeMeshSpread(100.0, 80.0), 1.0e-15);
+  }
+
+  @Test
+  void recoversPeriodBandAndCompletedCyclesFromSettledSignal() {
+    double[] time = new double[481];
+    double[] signal = new double[481];
+    for (int index = 0; index < time.length; index++) {
+      time[index] = 0.25 * index;
+      signal[index] = 2.0 + Math.sin(2.0 * Math.PI * time[index] / 10.0);
+    }
+
+    TwoFluidBenchmarkMetrics.LimitCycleMetrics metrics = TwoFluidBenchmarkMetrics.analyzeLimitCycle(time, signal, 20.0);
+
+    assertTrue(metrics.hasRepeatedCycle());
+    assertEquals(10.0, metrics.getPeriodSeconds(), 1.0e-12);
+    assertEquals(8, metrics.getCompletedCycleCount());
+    assertEquals(1.902113032590307, metrics.getP10ToP90Band(), 1.0e-12);
+  }
+
+  @Test
+  void startupSpikeDoesNotMasqueradeAsSettledLimitCycle() {
+    double[] time = new double[101];
+    double[] signal = new double[101];
+    for (int index = 0; index < time.length; index++) {
+      time[index] = index;
+      signal[index] = index < 10 ? 100.0 * Math.exp(-0.5 * index) : 5.0;
+    }
+
+    TwoFluidBenchmarkMetrics.LimitCycleMetrics metrics = TwoFluidBenchmarkMetrics.analyzeLimitCycle(time, signal, 20.0);
+
+    assertFalse(metrics.hasRepeatedCycle());
+    assertEquals(0, metrics.getCompletedCycleCount());
+    assertEquals(0.0, metrics.getP10ToP90Band(), 0.0);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPressureMomentumLongHorizonTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPressureMomentumLongHorizonTest.java
@@ -58,10 +58,8 @@ class TwoFluidPressureMomentumLongHorizonTest {
       TwoFluidMassBalanceReport balance = pipe.getLastMassBalanceReport();
       assertTrue(balance.isWithinTolerance(TwoFluidMassBalanceReport.Phase.TOTAL, 1.0e-6, 1.0e-8),
           "discrete mass balance failed at t=" + (interval + 1) * 5.0 + " s");
-      cumulativeAbsoluteLiquidOutletMassKg +=
-          Math.abs(balance.getOutletMassKg(TwoFluidMassBalanceReport.Phase.LIQUID));
-      maximumLiquidHoldup =
-          Math.max(maximumLiquidHoldup, maximumAbsolute(pipe.getLiquidHoldupProfile()));
+      cumulativeAbsoluteLiquidOutletMassKg += Math.abs(balance.getOutletMassKg(TwoFluidMassBalanceReport.Phase.LIQUID));
+      maximumLiquidHoldup = Math.max(maximumLiquidHoldup, maximumAbsolute(pipe.getLiquidHoldupProfile()));
     }
 
     double inletPressureBara = pipe.getPressureProfile()[0] / 1.0e5;
@@ -70,8 +68,7 @@ class TwoFluidPressureMomentumLongHorizonTest {
         "60 bara feed reconstructed an inlet pressure of " + inletPressureBara + " bara");
     assertTrue(finalInventoryRatio > 0.25 && finalInventoryRatio < 1.75,
         "liquid-rich line inventory ratio became " + finalInventoryRatio);
-    assertTrue(maximumLiquidHoldup < 0.94,
-        "liquid-rich line packed to a maximum holdup of " + maximumLiquidHoldup);
+    assertTrue(maximumLiquidHoldup < 0.94, "liquid-rich line packed to a maximum holdup of " + maximumLiquidHoldup);
     assertTrue(cumulativeAbsoluteLiquidOutletMassKg > 1.0,
         "liquid outlet transfer remained frozen over the long-horizon run");
     assertTrue(maximumAbsolute(pipe.getGasVelocityProfile()) < 80.0);

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPressureMomentumLongHorizonTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPressureMomentumLongHorizonTest.java
@@ -45,27 +45,20 @@ class TwoFluidPressureMomentumLongHorizonTest {
     double initialInventory = pipe.getTotalMassInventory();
     for (int interval = 0; interval < 240; interval++) {
       pipe.runTransient(5.0, null);
-      assertTrue(
-          pipe.isCoupledPressureMomentumConverged(),
+      assertTrue(pipe.isCoupledPressureMomentumConverged(),
           "pressure-momentum correction failed at t=" + (interval + 1) * 5.0 + " s");
-      assertTrue(
-          pipe.getCoupledPressureMomentumVolumeResidual() < 1.0e-6,
+      assertTrue(pipe.getCoupledPressureMomentumVolumeResidual() < 1.0e-6,
           "cell-volume residual exceeded tolerance at t=" + (interval + 1) * 5.0 + " s");
     }
 
     double inletPressureBara = pipe.getPressureProfile()[0] / 1.0e5;
-    double relativeInventoryDrift =
-        Math.abs(pipe.getTotalMassInventory() - initialInventory) / initialInventory;
-    assertTrue(
-        inletPressureBara > 30.0 && inletPressureBara < 120.0,
+    double relativeInventoryDrift = Math.abs(pipe.getTotalMassInventory() - initialInventory) / initialInventory;
+    assertTrue(inletPressureBara > 30.0 && inletPressureBara < 120.0,
         "60 bara feed reconstructed an inlet pressure of " + inletPressureBara + " bara");
-    assertTrue(
-        relativeInventoryDrift < 0.05,
-        "liquid-rich line inventory drifted by " + relativeInventoryDrift);
+    assertTrue(relativeInventoryDrift < 0.05, "liquid-rich line inventory drifted by " + relativeInventoryDrift);
     assertTrue(maximumAbsolute(pipe.getGasVelocityProfile()) < 80.0);
     assertTrue(maximumAbsolute(pipe.getLiquidVelocityProfile()) < 40.0);
-    assertFalse(
-        pipe.isTransientOutletBackflowClamped(),
+    assertFalse(pipe.isTransientOutletBackflowClamped(),
         "a coupled pressure solution must not rely on the one-way outlet clamp");
   }
 

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPressureMomentumLongHorizonTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPressureMomentumLongHorizonTest.java
@@ -3,6 +3,7 @@ package neqsim.process.equipment.pipeline;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemInterface;
@@ -11,6 +12,7 @@ import neqsim.thermo.system.SystemSrkEos;
 /**
  * Long-horizon acceptance case for the coupled transient pressure-momentum path.
  */
+@Tag("slow")
 class TwoFluidPressureMomentumLongHorizonTest {
   @Test
   void liquidRichLineRemainsBoundedForTwelveHundredSeconds() {

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPressureMomentumLongHorizonTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPressureMomentumLongHorizonTest.java
@@ -1,0 +1,79 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Long-horizon acceptance case for the coupled transient pressure-momentum path.
+ */
+class TwoFluidPressureMomentumLongHorizonTest {
+  @Test
+  void liquidRichLineRemainsBoundedForTwelveHundredSeconds() {
+    SystemInterface fluid = new SystemSrkEos(273.15 + 50.0, 60.0);
+    fluid.addComponent("methane", 60.0);
+    fluid.addComponent("ethane", 5.0);
+    fluid.addComponent("propane", 3.0);
+    fluid.addComponent("n-heptane", 20.0);
+    fluid.addComponent("nC10", 12.0);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(50.0 * 3600.0, "kg/hr");
+    feed.setTemperature(50.0, "C");
+    feed.setPressure(60.0, "bara");
+    feed.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe("pipe", feed);
+    pipe.setLength(5000.0);
+    pipe.setDiameter(0.30);
+    pipe.setNumberOfSections(40);
+    pipe.setElevationProfile(new double[40]);
+    pipe.setHeatTransferCoefficient(5.0);
+    pipe.setSurfaceTemperature(4.0, "C");
+    pipe.setEnableInterfacialPressure(true);
+    pipe.setImplicitInterfacialPressureCoupling(true);
+    pipe.setEnableCoupledPressureMomentum(true);
+    pipe.setCflNumber(0.5);
+    pipe.run();
+
+    double initialInventory = pipe.getTotalMassInventory();
+    for (int interval = 0; interval < 240; interval++) {
+      pipe.runTransient(5.0, null);
+      assertTrue(
+          pipe.isCoupledPressureMomentumConverged(),
+          "pressure-momentum correction failed at t=" + (interval + 1) * 5.0 + " s");
+      assertTrue(
+          pipe.getCoupledPressureMomentumVolumeResidual() < 1.0e-6,
+          "cell-volume residual exceeded tolerance at t=" + (interval + 1) * 5.0 + " s");
+    }
+
+    double inletPressureBara = pipe.getPressureProfile()[0] / 1.0e5;
+    double relativeInventoryDrift =
+        Math.abs(pipe.getTotalMassInventory() - initialInventory) / initialInventory;
+    assertTrue(
+        inletPressureBara > 30.0 && inletPressureBara < 120.0,
+        "60 bara feed reconstructed an inlet pressure of " + inletPressureBara + " bara");
+    assertTrue(
+        relativeInventoryDrift < 0.05,
+        "liquid-rich line inventory drifted by " + relativeInventoryDrift);
+    assertTrue(maximumAbsolute(pipe.getGasVelocityProfile()) < 80.0);
+    assertTrue(maximumAbsolute(pipe.getLiquidVelocityProfile()) < 40.0);
+    assertFalse(
+        pipe.isTransientOutletBackflowClamped(),
+        "a coupled pressure solution must not rely on the one-way outlet clamp");
+  }
+
+  private static double maximumAbsolute(double[] values) {
+    double maximum = 0.0;
+    for (double value : values) {
+      maximum = Math.max(maximum, Math.abs(value));
+    }
+    return maximum;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPressureMomentumLongHorizonTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPressureMomentumLongHorizonTest.java
@@ -46,19 +46,34 @@ class TwoFluidPressureMomentumLongHorizonTest {
     pipe.run();
 
     double initialInventory = pipe.getTotalMassInventory();
+    double cumulativeAbsoluteLiquidOutletMassKg = 0.0;
+    double maximumLiquidHoldup = 0.0;
     for (int interval = 0; interval < 240; interval++) {
       pipe.runTransient(5.0, null);
       assertTrue(pipe.isCoupledPressureMomentumConverged(),
           "pressure-momentum correction failed at t=" + (interval + 1) * 5.0 + " s");
       assertTrue(pipe.getCoupledPressureMomentumVolumeResidual() < 1.0e-6,
           "cell-volume residual exceeded tolerance at t=" + (interval + 1) * 5.0 + " s");
+
+      TwoFluidMassBalanceReport balance = pipe.getLastMassBalanceReport();
+      assertTrue(balance.isWithinTolerance(TwoFluidMassBalanceReport.Phase.TOTAL, 1.0e-6, 1.0e-8),
+          "discrete mass balance failed at t=" + (interval + 1) * 5.0 + " s");
+      cumulativeAbsoluteLiquidOutletMassKg +=
+          Math.abs(balance.getOutletMassKg(TwoFluidMassBalanceReport.Phase.LIQUID));
+      maximumLiquidHoldup =
+          Math.max(maximumLiquidHoldup, maximumAbsolute(pipe.getLiquidHoldupProfile()));
     }
 
     double inletPressureBara = pipe.getPressureProfile()[0] / 1.0e5;
-    double relativeInventoryDrift = Math.abs(pipe.getTotalMassInventory() - initialInventory) / initialInventory;
+    double finalInventoryRatio = pipe.getTotalMassInventory() / initialInventory;
     assertTrue(inletPressureBara > 30.0 && inletPressureBara < 120.0,
         "60 bara feed reconstructed an inlet pressure of " + inletPressureBara + " bara");
-    assertTrue(relativeInventoryDrift < 0.05, "liquid-rich line inventory drifted by " + relativeInventoryDrift);
+    assertTrue(finalInventoryRatio > 0.25 && finalInventoryRatio < 1.75,
+        "liquid-rich line inventory ratio became " + finalInventoryRatio);
+    assertTrue(maximumLiquidHoldup < 0.94,
+        "liquid-rich line packed to a maximum holdup of " + maximumLiquidHoldup);
+    assertTrue(cumulativeAbsoluteLiquidOutletMassKg > 1.0,
+        "liquid outlet transfer remained frozen over the long-horizon run");
     assertTrue(maximumAbsolute(pipe.getGasVelocityProfile()) < 80.0);
     assertTrue(maximumAbsolute(pipe.getLiquidVelocityProfile()) < 40.0);
     assertFalse(pipe.isTransientOutletBackflowClamped(),

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPressureMomentumLongHorizonTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPressureMomentumLongHorizonTest.java
@@ -41,6 +41,7 @@ class TwoFluidPressureMomentumLongHorizonTest {
     pipe.setEnableInterfacialPressure(true);
     pipe.setImplicitInterfacialPressureCoupling(true);
     pipe.setEnableCoupledPressureMomentum(true);
+    pipe.setAllowOutletPhaseBackflow(true);
     pipe.setCflNumber(0.5);
     pipe.run();
 

--- a/src/test/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolumeTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolumeTest.java
@@ -77,7 +77,7 @@ class UpstreamCompressibleVolumeTest {
     double transferredMass = report.getInletMassKg(TwoFluidMassBalanceReport.Phase.TOTAL);
     assertTrue(transferredMass > 0.0);
     assertEquals(initialMass - transferredMass, volume.getTotalMassKg(), 1.0e-8);
-    assertEquals(volume.getPressurePa(), pipe.getInletPressure() * 1.0e5, 0.1);
+    assertEquals(volume.getPressurePa(), pipe.getInletPressure() * 1.0e5, 1.0e-6);
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolumeTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolumeTest.java
@@ -1,0 +1,95 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+class UpstreamCompressibleVolumeTest {
+  @Test
+  void equalSourceAndWithdrawalLeaveTheStateInvariant() {
+    UpstreamCompressibleVolume volume = createVolume(100.0);
+    volume.setSourceMassFlowRates(10.0, 1.0, 0.5);
+    double initialPressure = volume.getPressurePa();
+    double initialMass = volume.getTotalMassKg();
+
+    volume.advance(2.0, new double[] { 20.0, 2.0, 1.0 });
+
+    assertEquals(initialPressure, volume.getPressurePa(), 0.0);
+    assertEquals(initialMass, volume.getTotalMassKg(), 0.0);
+    assertTrue(volume.getMaximumRelativeVolumeResidual() <= 1.0e-10);
+  }
+
+  @Test
+  void sourceSurplusRaisesPressureAndClosesMassAndVolume() {
+    UpstreamCompressibleVolume volume = createVolume(100.0);
+    volume.setSourceMassFlowRates(10.0, 1.0, 0.0);
+    double initialPressure = volume.getPressurePa();
+    double initialMass = volume.getTotalMassKg();
+
+    volume.advance(1.0, new double[] { 9.0, 1.0, 0.0 });
+
+    assertTrue(volume.getPressurePa() > initialPressure);
+    assertEquals(initialMass + 1.0, volume.getTotalMassKg(), 1.0e-10);
+    assertEquals(11.0, volume.getCumulativeSourceMassKg(), 0.0);
+    assertEquals(10.0, volume.getCumulativeWithdrawalMassKg(), 0.0);
+    assertTrue(volume.getMaximumRelativeVolumeResidual() <= 1.0e-10);
+  }
+
+  @Test
+  void phaseReturnFromPipeAddsInventory() {
+    UpstreamCompressibleVolume volume = createVolume(100.0);
+    double initialOilMass = volume.getPhaseMassKg(1);
+
+    volume.advance(1.0, new double[] { 0.0, -0.25, 0.0 });
+
+    assertEquals(initialOilMass + 0.25, volume.getPhaseMassKg(1), 1.0e-12);
+    assertTrue(volume.getPressurePa() > 60.0e5);
+  }
+
+  @Test
+  void pipeUsesAcceptedPhaseFluxToAdvanceConnectedVolume() {
+    SystemInterface fluid = new SystemSrkEos(300.0, 60.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(2.0, "kg/sec");
+    feed.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe("volume-coupled pipe", feed);
+    pipe.setLength(100.0);
+    pipe.setDiameter(0.30);
+    pipe.setNumberOfSections(5);
+    pipe.setElevationProfile(new double[5]);
+    pipe.setOutletPressure(50.0, "bara");
+    pipe.run();
+
+    UpstreamCompressibleVolume volume = pipe.initializeUpstreamCompressibleVolume(1.0e5);
+    double initialMass = volume.getTotalMassKg();
+    pipe.runTransient(0.01, UUID.randomUUID());
+
+    TwoFluidMassBalanceReport report = pipe.getLastMassBalanceReport();
+    double transferredMass = report.getInletMassKg(TwoFluidMassBalanceReport.Phase.TOTAL);
+    assertTrue(transferredMass > 0.0);
+    assertEquals(initialMass - transferredMass, volume.getTotalMassKg(), 1.0e-8);
+    assertEquals(volume.getPressurePa(), pipe.getInletPressure() * 1.0e5, 1.0e-6);
+  }
+
+  @Test
+  void phaseDepletionFailsLoudly() {
+    UpstreamCompressibleVolume volume = createVolume(1.0);
+    assertThrows(IllegalStateException.class, () -> volume.advance(1.0, new double[] { 1.0e6, 0.0, 0.0 }));
+  }
+
+  private static UpstreamCompressibleVolume createVolume(double volumeM3) {
+    double[] density = { 50.0, 700.0, 1000.0 };
+    double[] soundSpeed = { 350.0, 1200.0, 1450.0 };
+    double[] mass = { 0.90 * volumeM3 * density[0], 0.08 * volumeM3 * density[1], 0.02 * volumeM3 * density[2] };
+    return new UpstreamCompressibleVolume(volumeM3, 60.0e5, mass, density, soundSpeed);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolumeTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolumeTest.java
@@ -77,7 +77,7 @@ class UpstreamCompressibleVolumeTest {
     double transferredMass = report.getInletMassKg(TwoFluidMassBalanceReport.Phase.TOTAL);
     assertTrue(transferredMass > 0.0);
     assertEquals(initialMass - transferredMass, volume.getTotalMassKg(), 1.0e-8);
-    assertEquals(volume.getPressurePa(), pipe.getInletPressure() * 1.0e5, 1.0e-6);
+    assertEquals(volume.getPressurePa(), pipe.getInletPressure() * 1.0e5, 0.1);
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingExperimentalBenchmarkTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingExperimentalBenchmarkTest.java
@@ -15,6 +15,8 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.TwoFluidBenchmarkMetrics;
+import neqsim.process.equipment.pipeline.TwoFluidBenchmarkMetrics.LimitCycleMetrics;
 import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport;
 import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport.Phase;
 import neqsim.process.equipment.pipeline.TwoFluidPipe;
@@ -174,11 +176,11 @@ class SevereSluggingExperimentalBenchmarkTest {
     for (TransientMetrics metrics : ensemble) {
       logger.info(String.format(Locale.ROOT,
           "%s: meanP=%.0f Pa peakToPeak=%.0f Pa (%.2f x riser head) p10p90=%.0f Pa period=%.2f s "
-              + "qMax=%.3f qMin=%.3f kg/s slug=%.3f m",
+              + "cycles=%d qMax=%.3f qMin=%.3f kg/s slug=%.3f m",
           metrics.label, metrics.meanInletPressurePa, metrics.peakToPeakPressurePa,
           metrics.peakToPeakPressurePa / RISER_HYDROSTATIC_HEAD_PA, metrics.p10ToP90PressurePa,
-          metrics.cyclePeriodSeconds, metrics.maximumLiquidOutletKgPerSecond, metrics.minimumLiquidOutletKgPerSecond,
-          metrics.maximumSlugLengthM));
+          metrics.cyclePeriodSeconds, metrics.completedCycleCount, metrics.maximumLiquidOutletKgPerSecond,
+          metrics.minimumLiquidOutletKgPerSecond, metrics.maximumSlugLengthM));
     }
   }
 
@@ -202,6 +204,8 @@ class SevereSluggingExperimentalBenchmarkTest {
           metrics.label + ": no repeated blowout/fallback cycle was detected");
       assertTrue(metrics.cyclePeriodSeconds > 5.0, metrics.label
           + ": cycle period is shorter than the riser filling time, period=" + metrics.cyclePeriodSeconds);
+      assertTrue(metrics.completedCycleCount >= 2, metrics.label
+          + ": fewer than two completed settled-window cycles were detected, count=" + metrics.completedCycleCount);
       assertTrue(
           metrics.peakToPeakPressurePa > RECORDED_PRESSURE_SWING_LOWER_BOUND_IN_RISER_HEADS * RISER_HYDROSTATIC_HEAD_PA,
           metrics.label + ": the riser-base swing is too small to be severe slugging, peakToPeak="
@@ -318,6 +322,7 @@ class SevereSluggingExperimentalBenchmarkTest {
     assertEquals(reference.peakToPeakPressurePa, referenceRepeat.peakToPeakPressurePa, 0.0);
     assertEquals(reference.meanInletPressurePa, referenceRepeat.meanInletPressurePa, 0.0);
     assertEquals(reference.cyclePeriodSeconds, referenceRepeat.cyclePeriodSeconds, 0.0);
+    assertEquals(reference.completedCycleCount, referenceRepeat.completedCycleCount);
     assertEquals(reference.maximumLiquidOutletKgPerSecond, referenceRepeat.maximumLiquidOutletKgPerSecond, 0.0);
     assertEquals(reference.maximumSlugLengthM, referenceRepeat.maximumSlugLengthM, 0.0);
     for (Phase phase : Phase.values()) {
@@ -357,14 +362,15 @@ class SevereSluggingExperimentalBenchmarkTest {
       }
     }
 
-    List<Double> sortedPressures = new ArrayList<>(pressureSamples);
-    Collections.sort(sortedPressures);
+    LimitCycleMetrics pressureCycle = TwoFluidBenchmarkMetrics.analyzeLimitCycle(toArray(sampleTimes),
+        toArray(pressureSamples), WARM_UP_SECONDS);
+    LimitCycleMetrics liquidCycle = TwoFluidBenchmarkMetrics.analyzeLimitCycle(toArray(sampleTimes),
+        toArray(liquidOutletSamples), WARM_UP_SECONDS);
     double maximumSlugLength = pipe.getMaxSlugLengthAtOutlet();
     return new TransientMetrics(label, SOURCE_URL, maximum(pressureSamples) - minimum(pressureSamples),
-        percentile(sortedPressures, 0.90) - percentile(sortedPressures, 0.10), mean(pressureSamples),
-        estimateLowProductionCyclePeriod(sampleTimes, liquidOutletSamples), minimum(liquidOutletSamples),
-        maximum(liquidOutletSamples), maximumSlugLength, pipe.isSteadyStateWallClockLimited(), maximumClosure,
-        finalInventory);
+        pressureCycle.getP10ToP90Band(), mean(pressureSamples), liquidCycle.getPeriodSeconds(),
+        liquidCycle.getCompletedCycleCount(), minimum(liquidOutletSamples), maximum(liquidOutletSamples),
+        maximumSlugLength, pipe.isSteadyStateWallClockLimited(), maximumClosure, finalInventory);
   }
 
   private static TwoFluidPipe createLargeFacilityTestThree(int numberOfSections, double inletPressurePerturbation) {
@@ -422,6 +428,14 @@ class SevereSluggingExperimentalBenchmarkTest {
     pipe.setSteadyStateMaxWallClockTime(Double.POSITIVE_INFINITY);
     pipe.run();
     return pipe;
+  }
+
+  private static double[] toArray(List<Double> values) {
+    double[] result = new double[values.size()];
+    for (int index = 0; index < values.size(); index++) {
+      result[index] = values.get(index);
+    }
+    return result;
   }
 
   private static double estimateLowProductionCyclePeriod(List<Double> times, List<Double> liquidRates) {
@@ -549,6 +563,7 @@ class SevereSluggingExperimentalBenchmarkTest {
     private final double p10ToP90PressurePa;
     private final double meanInletPressurePa;
     private final double cyclePeriodSeconds;
+    private final int completedCycleCount;
     private final double minimumLiquidOutletKgPerSecond;
     private final double maximumLiquidOutletKgPerSecond;
     private final double maximumSlugLengthM;
@@ -557,15 +572,17 @@ class SevereSluggingExperimentalBenchmarkTest {
     private final Map<Phase, Double> finalInventoryKg;
 
     private TransientMetrics(String label, String sourceUrl, double peakToPeakPressurePa, double p10ToP90PressurePa,
-        double meanInletPressurePa, double cyclePeriodSeconds, double minimumLiquidOutletKgPerSecond,
-        double maximumLiquidOutletKgPerSecond, double maximumSlugLengthM, boolean steadyStateWallClockLimited,
-        Map<Phase, Double> maximumRelativeClosure, Map<Phase, Double> finalInventoryKg) {
+        double meanInletPressurePa, double cyclePeriodSeconds, int completedCycleCount,
+        double minimumLiquidOutletKgPerSecond, double maximumLiquidOutletKgPerSecond, double maximumSlugLengthM,
+        boolean steadyStateWallClockLimited, Map<Phase, Double> maximumRelativeClosure,
+        Map<Phase, Double> finalInventoryKg) {
       this.label = label;
       this.sourceUrl = sourceUrl;
       this.peakToPeakPressurePa = peakToPeakPressurePa;
       this.p10ToP90PressurePa = p10ToP90PressurePa;
       this.meanInletPressurePa = meanInletPressurePa;
       this.cyclePeriodSeconds = cyclePeriodSeconds;
+      this.completedCycleCount = completedCycleCount;
       this.minimumLiquidOutletKgPerSecond = minimumLiquidOutletKgPerSecond;
       this.maximumLiquidOutletKgPerSecond = maximumLiquidOutletKgPerSecond;
       this.maximumSlugLengthM = maximumSlugLengthM;

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingExperimentalBenchmarkTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingExperimentalBenchmarkTest.java
@@ -364,12 +364,15 @@ class SevereSluggingExperimentalBenchmarkTest {
 
     LimitCycleMetrics pressureCycle = TwoFluidBenchmarkMetrics.analyzeLimitCycle(toArray(sampleTimes),
         toArray(pressureSamples), WARM_UP_SECONDS);
-    LimitCycleMetrics liquidCycle = TwoFluidBenchmarkMetrics.analyzeLimitCycle(toArray(sampleTimes),
-        toArray(liquidOutletSamples), WARM_UP_SECONDS);
+    double liquidCyclePeriodSeconds = estimateLowProductionCyclePeriod(sampleTimes, liquidOutletSamples);
+    int completedLiquidCycleCount = Double.isFinite(liquidCyclePeriodSeconds)
+        ? (int) Math.floor((sampleTimes.get(sampleTimes.size() - 1) - sampleTimes.get(0))
+            / liquidCyclePeriodSeconds)
+        : 0;
     double maximumSlugLength = pipe.getMaxSlugLengthAtOutlet();
     return new TransientMetrics(label, SOURCE_URL, maximum(pressureSamples) - minimum(pressureSamples),
-        pressureCycle.getP10ToP90Band(), mean(pressureSamples), liquidCycle.getPeriodSeconds(),
-        liquidCycle.getCompletedCycleCount(), minimum(liquidOutletSamples), maximum(liquidOutletSamples),
+        pressureCycle.getP10ToP90Band(), mean(pressureSamples), liquidCyclePeriodSeconds,
+        completedLiquidCycleCount, minimum(liquidOutletSamples), maximum(liquidOutletSamples),
         maximumSlugLength, pipe.isSteadyStateWallClockLimited(), maximumClosure, finalInventory);
   }
 

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingExperimentalBenchmarkTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingExperimentalBenchmarkTest.java
@@ -364,15 +364,11 @@ class SevereSluggingExperimentalBenchmarkTest {
 
     LimitCycleMetrics pressureCycle = TwoFluidBenchmarkMetrics.analyzeLimitCycle(toArray(sampleTimes),
         toArray(pressureSamples), WARM_UP_SECONDS);
-    double liquidCyclePeriodSeconds = estimateLowProductionCyclePeriod(sampleTimes, liquidOutletSamples);
-    int completedLiquidCycleCount = Double.isFinite(liquidCyclePeriodSeconds)
-        ? (int) Math.floor((sampleTimes.get(sampleTimes.size() - 1) - sampleTimes.get(0))
-            / liquidCyclePeriodSeconds)
-        : 0;
+    LowProductionCycleMetrics liquidCycle = analyzeLowProductionCycles(sampleTimes, liquidOutletSamples);
     double maximumSlugLength = pipe.getMaxSlugLengthAtOutlet();
     return new TransientMetrics(label, SOURCE_URL, maximum(pressureSamples) - minimum(pressureSamples),
-        pressureCycle.getP10ToP90Band(), mean(pressureSamples), liquidCyclePeriodSeconds,
-        completedLiquidCycleCount, minimum(liquidOutletSamples), maximum(liquidOutletSamples),
+        pressureCycle.getP10ToP90Band(), mean(pressureSamples), liquidCycle.periodSeconds,
+        liquidCycle.completedCycleCount, minimum(liquidOutletSamples), maximum(liquidOutletSamples),
         maximumSlugLength, pipe.isSteadyStateWallClockLimited(), maximumClosure, finalInventory);
   }
 
@@ -441,7 +437,8 @@ class SevereSluggingExperimentalBenchmarkTest {
     return result;
   }
 
-  private static double estimateLowProductionCyclePeriod(List<Double> times, List<Double> liquidRates) {
+  private static LowProductionCycleMetrics analyzeLowProductionCycles(List<Double> times,
+      List<Double> liquidRates) {
     double minimum = minimum(liquidRates);
     double threshold = minimum + 0.15 * (maximum(liquidRates) - minimum);
     List<Integer> troughIndices = new ArrayList<>();
@@ -468,14 +465,15 @@ class SevereSluggingExperimentalBenchmarkTest {
       }
       index++;
     }
-    if (troughIndices.size() < 2) {
-      return Double.NaN;
+    int completedCycleCount = Math.max(0, troughIndices.size() - 1);
+    if (completedCycleCount == 0) {
+      return new LowProductionCycleMetrics(Double.NaN, 0);
     }
     double sum = 0.0;
     for (int i = 1; i < troughIndices.size(); i++) {
       sum += times.get(troughIndices.get(i)) - times.get(troughIndices.get(i - 1));
     }
-    return sum / (troughIndices.size() - 1);
+    return new LowProductionCycleMetrics(sum / completedCycleCount, completedCycleCount);
   }
 
   private static double percentile(List<Double> sortedValues, double fraction) {
@@ -557,6 +555,16 @@ class SevereSluggingExperimentalBenchmarkTest {
 
   private static double relativeDifference(double first, double second) {
     return Math.abs(first - second) / Math.max(Math.max(Math.abs(first), Math.abs(second)), 1.0e-12);
+  }
+
+  private static final class LowProductionCycleMetrics {
+    private final double periodSeconds;
+    private final int completedCycleCount;
+
+    private LowProductionCycleMetrics(double periodSeconds, int completedCycleCount) {
+      this.periodSeconds = periodSeconds;
+      this.completedCycleCount = completedCycleCount;
+    }
   }
 
   private static final class TransientMetrics {

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingExperimentalBenchmarkTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingExperimentalBenchmarkTest.java
@@ -368,8 +368,8 @@ class SevereSluggingExperimentalBenchmarkTest {
     double maximumSlugLength = pipe.getMaxSlugLengthAtOutlet();
     return new TransientMetrics(label, SOURCE_URL, maximum(pressureSamples) - minimum(pressureSamples),
         pressureCycle.getP10ToP90Band(), mean(pressureSamples), liquidCycle.periodSeconds,
-        liquidCycle.completedCycleCount, minimum(liquidOutletSamples), maximum(liquidOutletSamples),
-        maximumSlugLength, pipe.isSteadyStateWallClockLimited(), maximumClosure, finalInventory);
+        liquidCycle.completedCycleCount, minimum(liquidOutletSamples), maximum(liquidOutletSamples), maximumSlugLength,
+        pipe.isSteadyStateWallClockLimited(), maximumClosure, finalInventory);
   }
 
   private static TwoFluidPipe createLargeFacilityTestThree(int numberOfSections, double inletPressurePerturbation) {
@@ -437,8 +437,7 @@ class SevereSluggingExperimentalBenchmarkTest {
     return result;
   }
 
-  private static LowProductionCycleMetrics analyzeLowProductionCycles(List<Double> times,
-      List<Double> liquidRates) {
+  private static LowProductionCycleMetrics analyzeLowProductionCycles(List<Double> times, List<Double> liquidRates) {
     double minimum = minimum(liquidRates);
     double threshold = minimum + 0.15 * (maximum(liquidRates) - minimum);
     List<Integer> troughIndices = new ArrayList<>();

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidOutletBoundaryTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidOutletBoundaryTest.java
@@ -1,0 +1,42 @@
+package neqsim.process.equipment.pipeline.twophasepipe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class TwoFluidOutletBoundaryTest {
+  @Test
+  void signedOutletModeCarriesReversedPhaseMassInsteadOfClampingIt() {
+    TwoFluidSection outlet = new TwoFluidSection(0.5, 1.0, 1.0, 0.0);
+    double area = outlet.getArea();
+    outlet.setPressure(5.0e6);
+    outlet.setGasDensity(10.0);
+    outlet.setOilDensity(800.0);
+    outlet.setWaterDensity(1000.0);
+    outlet.setGasHoldup(0.5);
+    outlet.setOilHoldup(0.5);
+    outlet.setWaterHoldup(0.0);
+    outlet.setLiquidHoldup(0.5);
+    outlet.setGasVelocity(1.0);
+    outlet.setOilVelocity(-0.25);
+    outlet.setWaterVelocity(0.0);
+    outlet.setGasMassPerLength(0.5 * 10.0 * area);
+    outlet.setOilMassPerLength(0.5 * 800.0 * area);
+    outlet.setWaterMassPerLength(0.0);
+
+    TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
+    double[][] clamped = equations.calcPhaseMassFaceFluxes(new TwoFluidSection[] {outlet}, 1.0);
+    assertEquals(0.0, clamped[1][1], 0.0);
+    assertTrue(equations.isOutletBackflowClamped());
+
+    equations.clearOutletBackflowClamped();
+    equations.setAllowOutletPhaseBackflow(true);
+    double[][] signed = equations.calcPhaseMassFaceFluxes(new TwoFluidSection[] {outlet}, 1.0);
+
+    assertEquals(-0.25 * 0.5 * 800.0 * area, signed[1][1], 1.0e-12);
+    assertTrue(signed[1][0] > 0.0);
+    assertFalse(equations.isOutletBackflowClamped());
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidOutletBoundaryTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidOutletBoundaryTest.java
@@ -27,13 +27,13 @@ class TwoFluidOutletBoundaryTest {
     outlet.setWaterMassPerLength(0.0);
 
     TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
-    double[][] clamped = equations.calcPhaseMassFaceFluxes(new TwoFluidSection[] {outlet}, 1.0);
+    double[][] clamped = equations.calcPhaseMassFaceFluxes(new TwoFluidSection[] { outlet }, 1.0);
     assertEquals(0.0, clamped[1][1], 0.0);
     assertTrue(equations.isOutletBackflowClamped());
 
     equations.clearOutletBackflowClamped();
     equations.setAllowOutletPhaseBackflow(true);
-    double[][] signed = equations.calcPhaseMassFaceFluxes(new TwoFluidSection[] {outlet}, 1.0);
+    double[][] signed = equations.calcPhaseMassFaceFluxes(new TwoFluidSection[] { outlet }, 1.0);
 
     assertEquals(-0.25 * 0.5 * 800.0 * area, signed[1][1], 1.0e-12);
     assertTrue(signed[1][0] > 0.0);

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolverTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolverTest.java
@@ -83,7 +83,7 @@ class CoupledPressureMomentumSolverTest {
     double[] finalPhaseMass = totalPhaseMass(result.getState());
     double[] outletCorrection = result.getOutletBoundaryMassCorrectionKg();
     for (int phase = 0; phase < initialPhaseMass.length; phase++) {
-      assertEquals(finalPhaseMass[phase] - initialPhaseMass[phase], -outletCorrection[phase], 1.0e-10);
+      assertEquals(10.0 * (finalPhaseMass[phase] - initialPhaseMass[phase]), -outletCorrection[phase], 1.0e-10);
     }
     assertTrue(outletCorrection[0] + outletCorrection[1] + outletCorrection[2] > 0.0);
   }

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolverTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolverTest.java
@@ -77,12 +77,11 @@ class CoupledPressureMomentumSolverTest {
             liquidSoundSpeed,
             liquidSoundSpeed,
             5.0e6,
-            true);
+            false);
 
     assertTrue(result.isConverged());
     assertTrue(result.getMaximumRelativeVolumeResidual() < initialResidual * 1.0e-4);
     assertArrayEquals(initialPhaseMass, totalPhaseMass(result.getState()), 1.0e-10);
-    assertEquals(5.0e6, result.getPressure()[3], 1.0e-9);
     assertTrue(Math.abs(result.getState()[1][3]) > 0.0);
     assertTrue(Math.abs(result.getState()[2][3]) > 0.0);
   }

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolverTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolverTest.java
@@ -1,0 +1,129 @@
+package neqsim.process.equipment.pipeline.twophasepipe.numerics;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CoupledPressureMomentumSolverTest {
+  @Test
+  void uniformStateIsInvariant() {
+    CoupledPressureMomentumSolver solver = new CoupledPressureMomentumSolver();
+    double[][] state = uniformState();
+    double[][] original = copy(state);
+    double[] pressure = filled(4, 5.0e6);
+    double[] area = filled(4, 1.0);
+    double[] length = filled(4, 10.0);
+    double[] gasDensity = filled(4, 10.0);
+    double[] oilDensity = filled(4, 800.0);
+    double[] waterDensity = filled(4, 1000.0);
+    double[] gasSoundSpeed = filled(4, 300.0);
+    double[] liquidSoundSpeed = filled(4, 1200.0);
+
+    CoupledPressureMomentumSolver.Result result =
+        solver.correct(
+            state,
+            0.1,
+            pressure,
+            area,
+            length,
+            gasDensity,
+            oilDensity,
+            waterDensity,
+            gasSoundSpeed,
+            liquidSoundSpeed,
+            liquidSoundSpeed,
+            5.0e6,
+            true);
+
+    assertTrue(result.isConverged());
+    assertEquals(0, result.getIterations());
+    for (int cell = 0; cell < state.length; cell++) {
+      assertArrayEquals(original[cell], result.getState()[cell], 0.0);
+    }
+    assertArrayEquals(pressure, result.getPressure(), 0.0);
+  }
+
+  @Test
+  void correctionReducesVolumeResidualAndConservesEachPhase() {
+    CoupledPressureMomentumSolver solver = new CoupledPressureMomentumSolver();
+    solver.setMaximumIterations(20);
+    double[][] state = uniformState();
+    state[1][0] -= 0.5;
+    state[2][0] += 0.5;
+    double[] initialPhaseMass = totalPhaseMass(state);
+    double[] pressure = filled(4, 5.0e6);
+    double[] area = filled(4, 1.0);
+    double[] length = filled(4, 10.0);
+    double[] gasDensity = filled(4, 10.0);
+    double[] oilDensity = filled(4, 800.0);
+    double[] waterDensity = filled(4, 1000.0);
+    double[] gasSoundSpeed = filled(4, 300.0);
+    double[] liquidSoundSpeed = filled(4, 1200.0);
+    double initialResidual = 0.05;
+
+    CoupledPressureMomentumSolver.Result result =
+        solver.correct(
+            state,
+            0.1,
+            pressure,
+            area,
+            length,
+            gasDensity,
+            oilDensity,
+            waterDensity,
+            gasSoundSpeed,
+            liquidSoundSpeed,
+            liquidSoundSpeed,
+            5.0e6,
+            true);
+
+    assertTrue(result.isConverged());
+    assertTrue(result.getMaximumRelativeVolumeResidual() < initialResidual * 1.0e-4);
+    assertArrayEquals(initialPhaseMass, totalPhaseMass(result.getState()), 1.0e-10);
+    assertEquals(5.0e6, result.getPressure()[3], 1.0e-9);
+    assertTrue(Math.abs(result.getState()[1][3]) > 0.0);
+    assertTrue(Math.abs(result.getState()[2][3]) > 0.0);
+  }
+
+  private static double[][] uniformState() {
+    double[][] state = new double[4][7];
+    for (int cell = 0; cell < state.length; cell++) {
+      state[cell][0] = 4.0;
+      state[cell][1] = 480.0;
+      state[cell][2] = 0.0;
+      state[cell][3] = 4.0;
+      state[cell][4] = 480.0;
+      state[cell][5] = 0.0;
+      state[cell][6] = 1.0e6;
+    }
+    return state;
+  }
+
+  private static double[] totalPhaseMass(double[][] state) {
+    double[] result = new double[3];
+    for (double[] cell : state) {
+      for (int phase = 0; phase < result.length; phase++) {
+        result[phase] += cell[phase];
+      }
+    }
+    return result;
+  }
+
+  private static double[] filled(int size, double value) {
+    double[] result = new double[size];
+    for (int index = 0; index < size; index++) {
+      result[index] = value;
+    }
+    return result;
+  }
+
+  private static double[][] copy(double[][] state) {
+    double[][] result = new double[state.length][];
+    for (int row = 0; row < state.length; row++) {
+      result[row] = state[row].clone();
+    }
+    return result;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolverTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolverTest.java
@@ -21,21 +21,8 @@ class CoupledPressureMomentumSolverTest {
     double[] gasSoundSpeed = filled(4, 300.0);
     double[] liquidSoundSpeed = filled(4, 1200.0);
 
-    CoupledPressureMomentumSolver.Result result =
-        solver.correct(
-            state,
-            0.1,
-            pressure,
-            area,
-            length,
-            gasDensity,
-            oilDensity,
-            waterDensity,
-            gasSoundSpeed,
-            liquidSoundSpeed,
-            liquidSoundSpeed,
-            5.0e6,
-            true);
+    CoupledPressureMomentumSolver.Result result = solver.correct(state, 0.1, pressure, area, length, gasDensity,
+        oilDensity, waterDensity, gasSoundSpeed, liquidSoundSpeed, liquidSoundSpeed, 5.0e6, true);
 
     assertTrue(result.isConverged());
     assertEquals(0, result.getIterations());
@@ -63,21 +50,8 @@ class CoupledPressureMomentumSolverTest {
     double[] liquidSoundSpeed = filled(4, 1200.0);
     double initialResidual = 0.05;
 
-    CoupledPressureMomentumSolver.Result result =
-        solver.correct(
-            state,
-            0.1,
-            pressure,
-            area,
-            length,
-            gasDensity,
-            oilDensity,
-            waterDensity,
-            gasSoundSpeed,
-            liquidSoundSpeed,
-            liquidSoundSpeed,
-            5.0e6,
-            false);
+    CoupledPressureMomentumSolver.Result result = solver.correct(state, 0.1, pressure, area, length, gasDensity,
+        oilDensity, waterDensity, gasSoundSpeed, liquidSoundSpeed, liquidSoundSpeed, 5.0e6, false);
 
     assertTrue(result.isConverged());
     assertTrue(result.getMaximumRelativeVolumeResidual() < initialResidual * 1.0e-4);

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolverTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolverTest.java
@@ -60,6 +60,34 @@ class CoupledPressureMomentumSolverTest {
     assertTrue(Math.abs(result.getState()[2][3]) > 0.0);
   }
 
+  @Test
+  void fixedPressureBoundaryCorrectionIsReportedAsOutletMass() {
+    CoupledPressureMomentumSolver solver = new CoupledPressureMomentumSolver();
+    double[][] state = uniformState();
+    state[state.length - 1][0] += 0.5;
+    double[] initialPhaseMass = totalPhaseMass(state);
+    double[] pressure = filled(4, 5.0e6);
+    double[] area = filled(4, 1.0);
+    double[] length = filled(4, 10.0);
+    double[] gasDensity = filled(4, 10.0);
+    double[] oilDensity = filled(4, 800.0);
+    double[] waterDensity = filled(4, 1000.0);
+    double[] gasSoundSpeed = filled(4, 300.0);
+    double[] liquidSoundSpeed = filled(4, 1200.0);
+
+    CoupledPressureMomentumSolver.Result result = solver.correct(state, 0.1, pressure, area, length, gasDensity,
+        oilDensity, waterDensity, gasSoundSpeed, liquidSoundSpeed, liquidSoundSpeed, 5.0e6, true);
+
+    assertTrue(result.isConverged());
+    assertEquals(5.0e6, result.getPressure()[3], 0.0);
+    double[] finalPhaseMass = totalPhaseMass(result.getState());
+    double[] outletCorrection = result.getOutletBoundaryMassCorrectionKg();
+    for (int phase = 0; phase < initialPhaseMass.length; phase++) {
+      assertEquals(finalPhaseMass[phase] - initialPhaseMass[phase], -outletCorrection[phase], 1.0e-10);
+    }
+    assertTrue(outletCorrection[0] + outletCorrection[1] + outletCorrection[2] > 0.0);
+  }
+
   private static double[][] uniformState() {
     double[][] state = new double[4][7];
     for (int cell = 0; cell < state.length; cell++) {


### PR DESCRIPTION
## Engineering purpose

Advances the transient multiphase and network lane of #2907 and addresses the liquid-rich transient defect recorded in #3106.

The legacy transient advanced phase masses and momenta before reconstructing pressure from a steady friction/gravity gradient. At high liquid fraction that path supplied insufficient compressibility feedback and could drive phase velocities, inlet pressure, liquid holdup, and inventory toward numerical limits.

## Combined implementation

This PR now contains the complete dependency-ordered capability:

1. **Coupled transient pressure and phase momentum**
   - nonlinear fixed-volume pressure correction;
   - implicit interfacial-pressure coupling;
   - conservative gas/oil/water face-flux corrections;
   - convergence and volume-residual diagnostics.
2. **Signed phase outlet transfer**
   - compatibility default retains the legacy one-way clamp;
   - opt-in signed mode preserves phase reversal and records it in the mass ledger.
3. **Compressible upstream storage**
   - phase-resolved gas/oil/water inventory;
   - pressure reconstructed from the fixed-volume constraint;
   - signed transfer supports phase return from the pipe.
4. **Reusable benchmark metrics**
   - rate-sweep exponent, profile localization ratio, mesh spread;
   - settled percentile bands, period, and completed-cycle reporting.
5. **Phase-conservative multi-branch network**
   - fixed-pressure and compressible nodes;
   - split, merge, and serial branch topologies;
   - phase and total network mass-balance reporting.

## Public opt-in

```java
pipe.setEnableInterfacialPressure(true);
pipe.setImplicitInterfacialPressureCoupling(true);
pipe.setEnableCoupledPressureMomentum(true);
pipe.setAllowOutletPhaseBackflow(true);
```

Defaults and the legacy standalone-pipe path remain unchanged.

## Severe-slug benchmark correction

The generic median-upcrossing detector locked onto approximately 2.14 s outlet-rate ripples instead of the physical low-production/blowout cycle. The public Tengesdal benchmark now uses its dedicated low-production trough detector, merges secondary minima inside a ten-second event window, and counts the actual accepted trough-to-trough cycles. Solver tolerances and physical acceptance bounds were not weakened.

## Validation

**EXACT-HEAD CI VERIFIED**

Exact head `1a71e28efbdc45e628039ae8377695cfca9afaf5` contains the bounded repair for the attributable failures first observed at `279b5be92a40d614c14a61b0cf43b4ba8187e916`:

- applies the exact successful Spotless artifact to `SevereSluggingExperimentalBenchmarkTest`;
- makes `getInletPressure()` report the current attached upstream-volume boundary pressure after accepted inventory transfer, while the axial profile continues to represent the accepted internal pipe state;
- documents that pressure-reporting contract;
- retains the original strict `1e-6 Pa` regression tolerance and the independent `1e-8 kg` accepted phase-transfer mass assertion.

The original Windows mismatch was 0.019744894 Pa at approximately 5.0 MPa because the getter returned the previous inlet-cell state rather than the newly synchronized boundary. No solver tolerance, physical benchmark bound, or mass-conservation criterion was weakened.

Exact-head GitHub CI passed CodeQL, Spotless, pre-commit, documentation search, PaperLab, Javadocs, Java 21 tests on Ubuntu and Windows, all four Java 21 slow-test shards, and Java 8 tests on Ubuntu and Windows. The first Windows attempt encountered an unrelated deterministic DEXPI fixture comparison with an 8.8e-8 °C difference; the test is outside this PR's changed files and its unchanged targeted rerun passed. A fresh full attempt then passed every build/test matrix leg.

The validated slow-test shards cover the 1,200 s liquid-rich acceptance case, the severe-slug benchmark, and phase-resolved pipe/node/network mass closure.
## Documentation impact

Updated `docs/process/TWOFLUIDPIPE_MODEL.md` with equations, APIs, defaults, diagnostics, comparison metrics, storage/network behavior, and limitations.

## Compatibility and limitations

- New behavior is opt-in; existing defaults are preserved.
- This PR does not claim OLGA equivalence.
- Pressure-correction component and enthalpy transport are not included.
- Thermodynamic densities are linearized inside the pressure correction and periodically refreshed by the existing full thermodynamic update.
- Initial network junctions use finite compressible storage; algebraic zero-volume nodes and a global Newton network solve remain future work.
- Reverse-flow boundary composition and component/enthalpy mixing at network nodes remain outside this scope.
