### PR TITLE
feat(pipeline): add compressible upstream volume boundary

### DIFF
--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -950,6 +950,37 @@ stream remains the source of thermodynamic composition for the pipe boundary. Co
 heat transfer, and a momentum-resolved vessel/nozzle model are outside this lumped boundary's
 current scope.
 
+### Multi-branch pressure-node network
+
+`TwoFluidPipeNetwork` connects named `TwoFluidPipe` branches through fixed-pressure reservoirs
+and phase-resolved compressible storage nodes. It supports directed splits, merges, manifolds, and
+injection branches:
+
+```java
+TwoFluidPipeNetwork network = new TwoFluidPipeNetwork("subsea network");
+network.addFixedPressureNode("well", 120.0e5);
+network.addCompressibleNode("manifold", manifoldVolume);
+network.addFixedPressureNode("separator", 55.0e5);
+network.addPipe("flowline A", "well", "manifold", flowlineA);
+network.addPipe("riser", "manifold", "separator", riser);
+
+network.runTransient(0.1, UUID.randomUUID());
+double nodePressure = network.getNodePressurePa("manifold");
+double closure = network.getLastBalanceReport()
+    .getRelativeResidual(TwoFluidMassBalanceReport.Phase.TOTAL);
+```
+
+Every branch sees the node pressures at the beginning of the network step. After all branches
+advance, their accepted gas, oil, and water boundary transfers update every compressible node
+simultaneously. Branch iteration order therefore does not become an implicit pressure solve.
+The whole-network report includes pipe and node inventories, fixed-boundary transfers, phase
+sources, and gas/oil/water/liquid/total residuals.
+
+This first network implementation requires finite compressible storage at internal junctions.
+Fixed-pressure nodes are external reservoirs or sinks. Algebraic zero-volume junctions, a global
+Newton pressure-flow solve, component and enthalpy mixing, reverse-flow boundary composition, and
+branch subcycling remain outside the validated scope.
+
 ### Choosing Time Step, Sections, and Pipeline Length
 
 `runTransient(dt, id)` takes a macro time step in seconds. Internally, the solver sub-steps to
@@ -1061,6 +1092,36 @@ The option remains off by default while long-horizon severe-slugging, mesh, time
 independent OLGA/public benchmark qualification is completed. Do not use short startup peaks as
 limit-cycle evidence; report period, the P10-P90 band, and completed cycle count over a settled
 window.
+
+### Standing benchmark acceptance metrics
+
+Use `TwoFluidBenchmarkMetrics` to compare a rate sweep, a section profile, mesh realizations, and
+a settled transient with the same definitions in every benchmark:
+
+```java
+double exponent = TwoFluidBenchmarkMetrics.fitRateExponent(rates, pressureDrops);
+double terrainLocalization =
+    TwoFluidBenchmarkMetrics.maximumToMedianRatio(liquidHoldupProfile);
+double meshSpread =
+    TwoFluidBenchmarkMetrics.relativeMeshSpread(coarseResult, refinedResult);
+TwoFluidBenchmarkMetrics.LimitCycleMetrics cycle =
+    TwoFluidBenchmarkMetrics.analyzeLimitCycle(times, pressure, settledWindowStart);
+```
+
+The limit-cycle result reports period, P10, median, P90, P10-P90 band, sample window, and completed
+median-upcrossing cycle count. A large startup peak followed by a flat trace reports zero completed
+cycles, so it cannot pass as a sustained oscillation.
+
+The slow public Tengesdal benchmark now uses these settled-window definitions and requires at least
+two completed liquid-rate cycles in every mesh/timestep realization. It retains the published
+experimental source and its phase-mass, mean-pressure, mesh, amplitude, and deterministic-repeat
+checks.
+
+A user-supplied like-for-like OLGA run for the same geometry reported a 21.7 s cycle and a
+0.37-4.03 kg/s liquid-outlet range, while the public experiment reports 38 +/- 2 s. These values
+are comparison evidence, not embedded commercial correlations. A NeqSim/OLGA comparison should
+record exported time series and evaluate both with the same settled window and metrics; it should
+not compare one startup peak or tune a closure to one trajectory.
 
 ### Adaptive Timestepping
 

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -914,6 +914,42 @@ Avoid over-specifying the same side. For example, a `STREAM_CONNECTED` inlet alr
 temperature, pressure, and composition from the inlet stream; switch to `CONSTANT_FLOW` only when
 the flow should be independent of the stream flow rate.
 
+### Compressible upstream-volume boundary
+
+A real well, flowline, or laboratory loop normally has compressible inventory upstream of the
+modeled pipe. A fixed stream rate removes that storage and can shorten a severe-slug cycle.
+`UpstreamCompressibleVolume` supplies a phase-resolved dynamic inlet pressure without adding
+pipeline closures to the boundary model.
+
+Initialize the pipe to steady state, create the volume from its inlet section, and specify the
+external phase source rates:
+
+```java
+pipe.run();
+UpstreamCompressibleVolume sourceVolume =
+    pipe.initializeUpstreamCompressibleVolume(25.0);
+sourceVolume.setSourceMassFlowRates(gasSourceKgS, oilSourceKgS, waterSourceKgS);
+
+pipe.runTransient(0.1, UUID.randomUUID());
+double sourcePressurePa = sourceVolume.getPressurePa();
+double volumeClosure = sourceVolume.getMaximumRelativeVolumeResidual();
+```
+
+After every accepted internal substep, the pipe passes its integration-weighted gas, oil, and water
+inlet masses to the volume. The volume applies
+
+```text
+M_k(new) = M_k(old) + source_k dt - pipe_inlet_k
+sum_k M_k / rho_k(p) = fixed volume,  with d rho_k / d p = 1 / c_k^2.
+```
+
+Signed pipe transfer is supported, so a phase returning from the pipe adds upstream inventory.
+Phase depletion and non-converged pressure closure throw rather than clamping mass. Connecting the
+volume selects a constant-pressure inlet whose value is updated from the volume; the ordinary
+stream remains the source of thermodynamic composition for the pipe boundary. Component mixing,
+heat transfer, and a momentum-resolved vessel/nozzle model are outside this lumped boundary's
+current scope.
+
 ### Choosing Time Step, Sections, and Pipeline Length
 
 `runTransient(dt, id)` takes a macro time step in seconds. Internally, the solver sub-steps to

--- a/src/main/java/neqsim/process/equipment/network/TwoFluidPipeNetwork.java
+++ b/src/main/java/neqsim/process/equipment/network/TwoFluidPipeNetwork.java
@@ -1,0 +1,370 @@
+package neqsim.process.equipment.network;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport.Phase;
+import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import neqsim.process.equipment.pipeline.TwoFluidPipe.BoundaryCondition;
+import neqsim.process.equipment.pipeline.UpstreamCompressibleVolume;
+
+/**
+ * Phase-conservative transient hydraulic network of {@link TwoFluidPipe} branches.
+ *
+ * <p>
+ * Every branch is advanced from the pressures at the beginning of the network step. Gas, oil, and water boundary
+ * transfers are then accumulated at each compressible node, and all node pressures are advanced simultaneously.
+ * Fixed-pressure nodes represent external reservoirs or sinks. This explicit storage-node coupling supports splits,
+ * merges, manifolds, and injection branches without making branch execution order part of the pressure solution.
+ * </p>
+ *
+ * <p>
+ * This first network layer is intentionally storage based. Algebraic zero-volume junctions, global Newton pressure-flow
+ * iteration, component/enthalpy mixing, reverse-flow boundary composition, and branch subcycling are outside its
+ * current scope.
+ * </p>
+ */
+public final class TwoFluidPipeNetwork implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private static final int PHASE_COUNT = 3;
+
+  private final String name;
+  private final Map<String, NetworkNode> nodes = new LinkedHashMap<String, NetworkNode>();
+  private final Map<String, NetworkBranch> branches = new LinkedHashMap<String, NetworkBranch>();
+  private boolean initialized;
+  private double simulationTimeSeconds;
+  private BalanceReport lastBalanceReport;
+
+  /** Create an empty network. */
+  public TwoFluidPipeNetwork(String name) {
+    if (name == null || name.trim().isEmpty()) {
+      throw new IllegalArgumentException("Network name cannot be blank");
+    }
+    this.name = name;
+  }
+
+  /** Add a storage node whose pressure follows its compressible phase inventories. */
+  public void addCompressibleNode(String nodeName, UpstreamCompressibleVolume volume) {
+    requireUniqueNodeName(nodeName);
+    if (volume == null) {
+      throw new IllegalArgumentException("Compressible node volume cannot be null");
+    }
+    nodes.put(nodeName, NetworkNode.compressible(nodeName, volume));
+  }
+
+  /** Add an external fixed-pressure reservoir or sink node. */
+  public void addFixedPressureNode(String nodeName, double pressurePa) {
+    requireUniqueNodeName(nodeName);
+    requirePositiveFinite(pressurePa, "Fixed-node pressure");
+    nodes.put(nodeName, NetworkNode.fixed(nodeName, pressurePa));
+  }
+
+  /** Add a directed two-fluid pipe branch between existing nodes. */
+  public void addPipe(String branchName, String fromNodeName, String toNodeName, TwoFluidPipe pipe) {
+    requireName(branchName, "Branch");
+    if (branches.containsKey(branchName)) {
+      throw new IllegalArgumentException("Branch '" + branchName + "' already exists");
+    }
+    NetworkNode fromNode = requireNode(fromNodeName);
+    NetworkNode toNode = requireNode(toNodeName);
+    if (fromNode == toNode) {
+      throw new IllegalArgumentException("Branch '" + branchName + "' cannot connect a node to itself");
+    }
+    if (pipe == null) {
+      throw new IllegalArgumentException("Network pipe cannot be null");
+    }
+    if (pipe.getUpstreamCompressibleVolume() != null) {
+      throw new IllegalArgumentException(
+          "Branch '" + branchName + "' already owns an upstream volume; network nodes must own boundary storage");
+    }
+    NetworkBranch branch = new NetworkBranch(branchName, fromNode, toNode, pipe);
+    branches.put(branchName, branch);
+    fromNode.outgoingCount++;
+    toNode.incomingCount++;
+    initialized = false;
+  }
+
+  /**
+   * Initialize each branch from its configured stream and the downstream node pressure.
+   *
+   * <p>
+   * The branch stream flow remains the steady initialization rate. Transient execution then switches both ends to node
+   * pressures.
+   * </p>
+   */
+  public void initialize(UUID id) {
+    validateRunnableNetwork();
+    for (NetworkBranch branch : branches.values()) {
+      branch.pipe.setOutletPressure(branch.toNode.getPressurePa());
+      branch.pipe.run(id);
+      configureTransientPressures(branch);
+    }
+    initialized = true;
+  }
+
+  /** Advance every branch and all compressible nodes by one common reporting interval. */
+  public void runTransient(double timeStepSeconds, UUID id) {
+    requirePositiveFinite(timeStepSeconds, "Network time step");
+    if (!initialized) {
+      initialize(id);
+    }
+
+    double[] initialMassKg = new double[PHASE_COUNT];
+    double[] finalMassKg = new double[PHASE_COUNT];
+    double[] externalInletMassKg = new double[PHASE_COUNT];
+    double[] externalOutletMassKg = new double[PHASE_COUNT];
+    double[] sourceMassKg = new double[PHASE_COUNT];
+    Map<String, double[]> nodeTransferKg = new LinkedHashMap<String, double[]>();
+
+    for (NetworkNode node : nodes.values()) {
+      nodeTransferKg.put(node.name, new double[PHASE_COUNT]);
+      if (!node.fixedPressure) {
+        for (int phase = 0; phase < PHASE_COUNT; phase++) {
+          initialMassKg[phase] += node.volume.getPhaseMassKg(phase);
+          sourceMassKg[phase] += node.volume.getSourceMassFlowRateKgS(phase) * timeStepSeconds;
+        }
+      }
+    }
+
+    for (NetworkBranch branch : branches.values()) {
+      configureTransientPressures(branch);
+      branch.pipe.runTransient(timeStepSeconds, id);
+      TwoFluidMassBalanceReport report = branch.pipe.getLastMassBalanceReport();
+      if (report == null) {
+        throw new IllegalStateException("Branch '" + branch.name + "' returned no mass-balance report");
+      }
+      for (int phase = 0; phase < PHASE_COUNT; phase++) {
+        Phase aggregation = phase(phase);
+        initialMassKg[phase] += report.getInitialMassKg(aggregation);
+        finalMassKg[phase] += report.getFinalMassKg(aggregation);
+        sourceMassKg[phase] += report.getSourceMassKg(aggregation);
+        double inletMass = report.getInletMassKg(aggregation);
+        double outletMass = report.getOutletMassKg(aggregation);
+        if (branch.fromNode.fixedPressure) {
+          externalInletMassKg[phase] += inletMass;
+        } else {
+          nodeTransferKg.get(branch.fromNode.name)[phase] += inletMass;
+        }
+        if (branch.toNode.fixedPressure) {
+          externalOutletMassKg[phase] += outletMass;
+        } else {
+          nodeTransferKg.get(branch.toNode.name)[phase] -= outletMass;
+        }
+      }
+    }
+
+    for (NetworkNode node : nodes.values()) {
+      if (!node.fixedPressure) {
+        node.volume.advance(timeStepSeconds, nodeTransferKg.get(node.name));
+        for (int phase = 0; phase < PHASE_COUNT; phase++) {
+          finalMassKg[phase] += node.volume.getPhaseMassKg(phase);
+        }
+      }
+    }
+
+    simulationTimeSeconds += timeStepSeconds;
+    lastBalanceReport = new BalanceReport(timeStepSeconds, initialMassKg, finalMassKg, externalInletMassKg,
+        externalOutletMassKg, sourceMassKg);
+  }
+
+  private void configureTransientPressures(NetworkBranch branch) {
+    branch.pipe.setInletBoundaryCondition(BoundaryCondition.CONSTANT_PRESSURE);
+    branch.pipe.setInletPressure(branch.fromNode.getPressurePa());
+    branch.pipe.setOutletBoundaryCondition(BoundaryCondition.CONSTANT_PRESSURE);
+    branch.pipe.setOutletPressure(branch.toNode.getPressurePa());
+  }
+
+  private void validateRunnableNetwork() {
+    if (nodes.size() < 2 || branches.isEmpty()) {
+      throw new IllegalStateException("Two-fluid network requires at least two nodes and one branch");
+    }
+    for (NetworkNode node : nodes.values()) {
+      if (node.incomingCount + node.outgoingCount == 0) {
+        throw new IllegalStateException("Node '" + node.name + "' is not connected to a branch");
+      }
+    }
+  }
+
+  private void requireUniqueNodeName(String nodeName) {
+    requireName(nodeName, "Node");
+    if (nodes.containsKey(nodeName)) {
+      throw new IllegalArgumentException("Node '" + nodeName + "' already exists");
+    }
+  }
+
+  private NetworkNode requireNode(String nodeName) {
+    NetworkNode node = nodes.get(nodeName);
+    if (node == null) {
+      throw new IllegalArgumentException("Node '" + nodeName + "' does not exist");
+    }
+    return node;
+  }
+
+  private static void requireName(String value, String label) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(label + " name cannot be blank");
+    }
+  }
+
+  private static void requirePositiveFinite(double value, String label) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(label + " must be positive and finite");
+    }
+  }
+
+  private static Phase phase(int index) {
+    switch (index) {
+    case 0:
+      return Phase.GAS;
+    case 1:
+      return Phase.OIL;
+    case 2:
+      return Phase.WATER;
+    default:
+      throw new IllegalArgumentException("Unsupported phase index " + index);
+    }
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public double getSimulationTimeSeconds() {
+    return simulationTimeSeconds;
+  }
+
+  public BalanceReport getLastBalanceReport() {
+    return lastBalanceReport;
+  }
+
+  public TwoFluidPipe getPipe(String branchName) {
+    NetworkBranch branch = branches.get(branchName);
+    if (branch == null)
+      throw new IllegalArgumentException("Branch '" + branchName + "' does not exist");
+    return branch.pipe;
+  }
+
+  public double getNodePressurePa(String nodeName) {
+    return requireNode(nodeName).getPressurePa();
+  }
+
+  private static final class NetworkNode implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final boolean fixedPressure;
+    private final double fixedPressurePa;
+    private final UpstreamCompressibleVolume volume;
+    private int incomingCount;
+    private int outgoingCount;
+
+    private NetworkNode(String name, boolean fixedPressure, double fixedPressurePa, UpstreamCompressibleVolume volume) {
+      this.name = name;
+      this.fixedPressure = fixedPressure;
+      this.fixedPressurePa = fixedPressurePa;
+      this.volume = volume;
+    }
+
+    private static NetworkNode fixed(String name, double pressurePa) {
+      return new NetworkNode(name, true, pressurePa, null);
+    }
+
+    private static NetworkNode compressible(String name, UpstreamCompressibleVolume volume) {
+      return new NetworkNode(name, false, Double.NaN, volume);
+    }
+
+    private double getPressurePa() {
+      return fixedPressure ? fixedPressurePa : volume.getPressurePa();
+    }
+  }
+
+  private static final class NetworkBranch implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final NetworkNode fromNode;
+    private final NetworkNode toNode;
+    private final TwoFluidPipe pipe;
+
+    private NetworkBranch(String name, NetworkNode fromNode, NetworkNode toNode, TwoFluidPipe pipe) {
+      this.name = name;
+      this.fromNode = fromNode;
+      this.toNode = toNode;
+      this.pipe = pipe;
+    }
+  }
+
+  /** Whole-network phase and total mass balance for the latest accepted reporting interval. */
+  public static final class BalanceReport implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final double elapsedTimeSeconds;
+    private final double[] initialMassKg;
+    private final double[] finalMassKg;
+    private final double[] externalInletMassKg;
+    private final double[] externalOutletMassKg;
+    private final double[] sourceMassKg;
+
+    private BalanceReport(double elapsedTimeSeconds, double[] initialMassKg, double[] finalMassKg,
+        double[] externalInletMassKg, double[] externalOutletMassKg, double[] sourceMassKg) {
+      this.elapsedTimeSeconds = elapsedTimeSeconds;
+      this.initialMassKg = initialMassKg.clone();
+      this.finalMassKg = finalMassKg.clone();
+      this.externalInletMassKg = externalInletMassKg.clone();
+      this.externalOutletMassKg = externalOutletMassKg.clone();
+      this.sourceMassKg = sourceMassKg.clone();
+    }
+
+    public double getElapsedTimeSeconds() {
+      return elapsedTimeSeconds;
+    }
+
+    public double getInitialMassKg(Phase aggregation) {
+      return aggregate(initialMassKg, aggregation);
+    }
+
+    public double getFinalMassKg(Phase aggregation) {
+      return aggregate(finalMassKg, aggregation);
+    }
+
+    public double getExternalInletMassKg(Phase aggregation) {
+      return aggregate(externalInletMassKg, aggregation);
+    }
+
+    public double getExternalOutletMassKg(Phase aggregation) {
+      return aggregate(externalOutletMassKg, aggregation);
+    }
+
+    public double getSourceMassKg(Phase aggregation) {
+      return aggregate(sourceMassKg, aggregation);
+    }
+
+    public double getResidualKg(Phase aggregation) {
+      return getFinalMassKg(aggregation) - getInitialMassKg(aggregation)
+          - (getExternalInletMassKg(aggregation) - getExternalOutletMassKg(aggregation) + getSourceMassKg(aggregation));
+    }
+
+    public double getRelativeResidual(Phase aggregation) {
+      double scale = Math.max(Math.abs(getInitialMassKg(aggregation)), Math.abs(getFinalMassKg(aggregation)));
+      scale = Math.max(scale, Math.abs(getExternalInletMassKg(aggregation))
+          + Math.abs(getExternalOutletMassKg(aggregation)) + Math.abs(getSourceMassKg(aggregation)));
+      return Math.abs(getResidualKg(aggregation)) / Math.max(scale, 1.0e-12);
+    }
+
+    private static double aggregate(double[] values, Phase aggregation) {
+      switch (aggregation) {
+      case GAS:
+        return values[0];
+      case OIL:
+        return values[1];
+      case WATER:
+        return values[2];
+      case LIQUID:
+        return values[1] + values[2];
+      case TOTAL:
+        return values[0] + values[1] + values[2];
+      default:
+        throw new IllegalArgumentException("Unsupported phase " + aggregation);
+      }
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidBenchmarkMetrics.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidBenchmarkMetrics.java
@@ -1,0 +1,235 @@
+package neqsim.process.equipment.pipeline;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/** Reusable, scale-aware comparison metrics for two-fluid benchmark and acceptance suites. */
+public final class TwoFluidBenchmarkMetrics {
+  private TwoFluidBenchmarkMetrics() {
+  }
+
+  /** Fit the least-squares log-log exponent in {@code response = constant * rate^n}. */
+  public static double fitRateExponent(double[] rates, double[] responses) {
+    requireSameLength(rates, responses, 2);
+    double meanX = 0.0;
+    double meanY = 0.0;
+    for (int index = 0; index < rates.length; index++) {
+      requirePositiveFinite(rates[index], "Rate");
+      requirePositiveFinite(responses[index], "Response");
+      meanX += Math.log(rates[index]);
+      meanY += Math.log(responses[index]);
+    }
+    meanX /= rates.length;
+    meanY /= rates.length;
+    double covariance = 0.0;
+    double variance = 0.0;
+    for (int index = 0; index < rates.length; index++) {
+      double dx = Math.log(rates[index]) - meanX;
+      covariance += dx * (Math.log(responses[index]) - meanY);
+      variance += dx * dx;
+    }
+    if (!(variance > 0.0)) {
+      throw new IllegalArgumentException("Rate sweep must contain at least two distinct rates");
+    }
+    return covariance / variance;
+  }
+
+  /** Return maximum value divided by the sample median of a positive profile. */
+  public static double maximumToMedianRatio(double[] profile) {
+    requireFiniteValues(profile, 1, "Profile");
+    double maximum = -Double.MAX_VALUE;
+    for (double value : profile) {
+      if (value < 0.0) {
+        throw new IllegalArgumentException("Profile values must be non-negative");
+      }
+      maximum = Math.max(maximum, value);
+    }
+    double median = percentile(profile, 0.5);
+    if (!(median > 0.0)) {
+      throw new IllegalArgumentException("Profile median must be positive");
+    }
+    return maximum / median;
+  }
+
+  /** Symmetric relative spread using the larger absolute result as scale. */
+  public static double relativeMeshSpread(double first, double second) {
+    if (!Double.isFinite(first) || !Double.isFinite(second)) {
+      throw new IllegalArgumentException("Mesh results must be finite");
+    }
+    double scale = Math.max(Math.abs(first), Math.abs(second));
+    return scale == 0.0 ? 0.0 : Math.abs(first - second) / scale;
+  }
+
+  /**
+   * Analyze a settled signal with robust P10-P90 amplitude and completed median-upcrossing cycles.
+   *
+   * @param timeSeconds strictly increasing sample times
+   * @param signal sampled pressure, flow, or holdup signal
+   * @param settledWindowStartSeconds first time included in the settled window
+   * @return immutable limit-cycle metrics
+   */
+  public static LimitCycleMetrics analyzeLimitCycle(double[] timeSeconds, double[] signal,
+      double settledWindowStartSeconds) {
+    requireSameLength(timeSeconds, signal, 3);
+    if (!Double.isFinite(settledWindowStartSeconds)) {
+      throw new IllegalArgumentException("Settled-window start must be finite");
+    }
+    List<Double> selectedTimes = new ArrayList<Double>();
+    List<Double> selectedSignal = new ArrayList<Double>();
+    double previousTime = -Double.MAX_VALUE;
+    for (int index = 0; index < timeSeconds.length; index++) {
+      double time = timeSeconds[index];
+      double value = signal[index];
+      if (!Double.isFinite(time) || !Double.isFinite(value) || time <= previousTime) {
+        throw new IllegalArgumentException("Times must be finite and strictly increasing; signal must be finite");
+      }
+      previousTime = time;
+      if (time >= settledWindowStartSeconds) {
+        selectedTimes.add(time);
+        selectedSignal.add(value);
+      }
+    }
+    if (selectedTimes.size() < 3) {
+      throw new IllegalArgumentException("Settled window must contain at least three samples");
+    }
+
+    double[] values = new double[selectedSignal.size()];
+    for (int index = 0; index < values.length; index++) {
+      values[index] = selectedSignal.get(index);
+    }
+    double p10 = percentile(values, 0.10);
+    double median = percentile(values, 0.50);
+    double p90 = percentile(values, 0.90);
+    double robustBand = p90 - p10;
+
+    List<Double> crossingTimes = new ArrayList<Double>();
+    if (robustBand > Math.ulp(Math.max(1.0, Math.abs(median)))) {
+      for (int index = 1; index < values.length; index++) {
+        double before = values[index - 1] - median;
+        double after = values[index] - median;
+        if (before < 0.0 && after >= 0.0 && after > before) {
+          double fraction = -before / (after - before);
+          double crossing = selectedTimes.get(index - 1)
+              + fraction * (selectedTimes.get(index) - selectedTimes.get(index - 1));
+          crossingTimes.add(crossing);
+        }
+      }
+    }
+    int completedCycles = Math.max(0, crossingTimes.size() - 1);
+    double period = Double.NaN;
+    if (completedCycles > 0) {
+      double[] intervals = new double[completedCycles];
+      for (int index = 0; index < intervals.length; index++) {
+        intervals[index] = crossingTimes.get(index + 1) - crossingTimes.get(index);
+      }
+      period = percentile(intervals, 0.5);
+    }
+    return new LimitCycleMetrics(p10, median, p90, period, completedCycles, values.length, selectedTimes.get(0),
+        selectedTimes.get(selectedTimes.size() - 1));
+  }
+
+  private static double percentile(double[] values, double fraction) {
+    double[] sorted = Arrays.copyOf(values, values.length);
+    Arrays.sort(sorted);
+    double position = fraction * (sorted.length - 1);
+    int lower = (int) Math.floor(position);
+    int upper = (int) Math.ceil(position);
+    if (lower == upper) {
+      return sorted[lower];
+    }
+    double weight = position - lower;
+    return sorted[lower] * (1.0 - weight) + sorted[upper] * weight;
+  }
+
+  private static void requireSameLength(double[] first, double[] second, int minimumLength) {
+    requireFiniteValues(first, minimumLength, "First array");
+    requireFiniteValues(second, minimumLength, "Second array");
+    if (first.length != second.length) {
+      throw new IllegalArgumentException("Arrays must have the same length");
+    }
+  }
+
+  private static void requireFiniteValues(double[] values, int minimumLength, String label) {
+    if (values == null || values.length < minimumLength) {
+      throw new IllegalArgumentException(label + " must contain at least " + minimumLength + " values");
+    }
+    for (double value : values) {
+      if (!Double.isFinite(value)) {
+        throw new IllegalArgumentException(label + " values must be finite");
+      }
+    }
+  }
+
+  private static void requirePositiveFinite(double value, String label) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(label + " must be positive and finite");
+    }
+  }
+
+  /** Immutable transient limit-cycle summary. */
+  public static final class LimitCycleMetrics implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final double p10;
+    private final double median;
+    private final double p90;
+    private final double periodSeconds;
+    private final int completedCycleCount;
+    private final int sampleCount;
+    private final double windowStartSeconds;
+    private final double windowEndSeconds;
+
+    private LimitCycleMetrics(double p10, double median, double p90, double periodSeconds, int completedCycleCount,
+        int sampleCount, double windowStartSeconds, double windowEndSeconds) {
+      this.p10 = p10;
+      this.median = median;
+      this.p90 = p90;
+      this.periodSeconds = periodSeconds;
+      this.completedCycleCount = completedCycleCount;
+      this.sampleCount = sampleCount;
+      this.windowStartSeconds = windowStartSeconds;
+      this.windowEndSeconds = windowEndSeconds;
+    }
+
+    public double getP10() {
+      return p10;
+    }
+
+    public double getMedian() {
+      return median;
+    }
+
+    public double getP90() {
+      return p90;
+    }
+
+    public double getP10ToP90Band() {
+      return p90 - p10;
+    }
+
+    public double getPeriodSeconds() {
+      return periodSeconds;
+    }
+
+    public int getCompletedCycleCount() {
+      return completedCycleCount;
+    }
+
+    public int getSampleCount() {
+      return sampleCount;
+    }
+
+    public double getWindowStartSeconds() {
+      return windowStartSeconds;
+    }
+
+    public double getWindowEndSeconds() {
+      return windowEndSeconds;
+    }
+
+    public boolean hasRepeatedCycle() {
+      return completedCycleCount > 0 && Double.isFinite(periodSeconds);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -157,6 +157,9 @@ public class TwoFluidPipe extends Pipeline {
    */
   private boolean coupledPressureMomentumEnabled = false;
 
+  /** Optional phase-resolved compressible volume supplying the inlet pressure boundary. */
+  private UpstreamCompressibleVolume upstreamCompressibleVolume = null;
+
   /** Default closed-flow fluid-side heat-transfer coefficient in W/(m2 K). */
   private static final double DEFAULT_STAGNANT_INNER_HEAT_TRANSFER_COEFFICIENT = 50.0;
 
@@ -4142,6 +4145,7 @@ public class TwoFluidPipe extends Pipeline {
       throw new IllegalArgumentException("Transient time step must be positive and finite");
     }
     isTransientMode = true;
+    synchronizeUpstreamCompressibleVolumePressure();
     lastMassBalanceReport = null;
     lastThermalEnergyBalanceReport = null;
     lastComponentConservationReport = null;
@@ -4557,6 +4561,7 @@ public class TwoFluidPipe extends Pipeline {
   private void accumulateAcceptedMassBalance(List<TwoFluidConservationEquations.MassBalanceRate> stageRates,
       double timeStepSeconds, double[] inletMassKg, double[] outletMassKg, double[] sourceMassKg) {
     double[] weights = getTimeIntegrationStageWeights(stageRates.size());
+    double[] acceptedInletMassKg = new double[3];
     for (int stage = 0; stage < stageRates.size(); stage++) {
       TwoFluidConservationEquations.MassBalanceRate rate = stageRates.get(stage);
       double[] inletRate = rate.getInletMassFlowKgPerSecond();
@@ -4564,10 +4569,16 @@ public class TwoFluidPipe extends Pipeline {
       double[] sourceRate = rate.getSourceMassFlowKgPerSecond();
       double weightedTime = weights[stage] * timeStepSeconds;
       for (int phase = 0; phase < 3; phase++) {
-        inletMassKg[phase] += inletRate[phase] * weightedTime;
+        double acceptedInlet = inletRate[phase] * weightedTime;
+        inletMassKg[phase] += acceptedInlet;
+        acceptedInletMassKg[phase] += acceptedInlet;
         outletMassKg[phase] += outletRate[phase] * weightedTime;
         sourceMassKg[phase] += sourceRate[phase] * weightedTime;
       }
+    }
+    if (upstreamCompressibleVolume != null) {
+      upstreamCompressibleVolume.advance(timeStepSeconds, acceptedInletMassKg);
+      synchronizeUpstreamCompressibleVolumePressure();
     }
     if (coupledPressureMomentumEnabled) {
       double[] outletCorrectionKg = timeIntegrator.getCoupledPressureMomentumOutletMassCorrectionKg();
@@ -4575,6 +4586,15 @@ public class TwoFluidPipe extends Pipeline {
         outletMassKg[phase] += outletCorrectionKg[phase];
       }
     }
+  }
+
+  private void synchronizeUpstreamCompressibleVolumePressure() {
+    if (upstreamCompressibleVolume == null) {
+      return;
+    }
+    inletBCType = BoundaryCondition.CONSTANT_PRESSURE;
+    inletPressure = upstreamCompressibleVolume.getPressurePa();
+    inletPressureSet = true;
   }
 
   private double[] getTimeIntegrationStageWeights(int stageCount) {
@@ -7568,6 +7588,71 @@ public class TwoFluidPipe extends Pipeline {
   /** @return convergence status of the most recent coupled correction */
   public boolean isCoupledPressureMomentumConverged() {
     return !coupledPressureMomentumEnabled || timeIntegrator.isCoupledPressureMomentumConverged();
+  }
+
+  /**
+   * Connect a phase-resolved compressible volume to the inlet pressure boundary.
+   *
+   * <p>
+   * The pipe withdraws the phase masses measured by its accepted finite-volume inlet flux. The volume updates pressure
+   * from its fixed-volume compressibility closure after every accepted internal substep. Connecting a volume selects
+   * {@link BoundaryCondition#CONSTANT_PRESSURE} at the inlet; removing it does not otherwise change the selected
+   * boundary condition.
+   * </p>
+   *
+   * @param volume upstream volume, or {@code null} to disconnect it
+   */
+  public void setUpstreamCompressibleVolume(UpstreamCompressibleVolume volume) {
+    upstreamCompressibleVolume = volume;
+    synchronizeUpstreamCompressibleVolumePressure();
+  }
+
+  /** @return connected upstream compressible volume, or {@code null} when disconnected */
+  public UpstreamCompressibleVolume getUpstreamCompressibleVolume() {
+    return upstreamCompressibleVolume;
+  }
+
+  /**
+   * Initialize and connect an upstream volume from the current inlet-section phase state.
+   *
+   * <p>
+   * Call {@link #run()} first so phase holdups, densities, and sound speeds are initialized. The new volume begins in
+   * pressure and volume equilibrium with the first pipe section.
+   * </p>
+   *
+   * @param volumeM3 fixed upstream volume in m3
+   * @return the initialized and connected volume
+   */
+  public UpstreamCompressibleVolume initializeUpstreamCompressibleVolume(double volumeM3) {
+    if (sections == null || sections.length == 0) {
+      throw new IllegalStateException("Run the pipe before initializing an upstream compressible volume");
+    }
+    TwoFluidSection inlet = sections[0];
+    double gasHoldup = Math.max(inlet.getGasHoldup(), 0.0);
+    double oilHoldup = Math.max(inlet.getOilHoldup(), 0.0);
+    double waterHoldup = Math.max(inlet.getWaterHoldup(), 0.0);
+    double holdupSum = gasHoldup + oilHoldup + waterHoldup;
+    if (!(holdupSum > 0.0)) {
+      throw new IllegalStateException("Inlet section has no initialized phase volume");
+    }
+    gasHoldup /= holdupSum;
+    oilHoldup /= holdupSum;
+    waterHoldup /= holdupSum;
+
+    double gasDensity = Math.max(inlet.getGasDensity(), CLOSURE_DENOMINATOR_EPSILON);
+    double oilDensity = Math.max(inlet.getOilDensity(), CLOSURE_DENOMINATOR_EPSILON);
+    double waterDensity = Math.max(inlet.getWaterDensity(), CLOSURE_DENOMINATOR_EPSILON);
+    double[] phaseMassKg = { gasHoldup * volumeM3 * gasDensity, oilHoldup * volumeM3 * oilDensity,
+        waterHoldup * volumeM3 * waterDensity };
+    double[] phaseDensityKgM3 = { gasDensity, oilDensity, waterDensity };
+    double gasSoundSpeed = Math.max(inlet.getGasSoundSpeed(), CLOSURE_DENOMINATOR_EPSILON);
+    double liquidSoundSpeed = Math.max(inlet.getLiquidSoundSpeed(), CLOSURE_DENOMINATOR_EPSILON);
+    double[] phaseSoundSpeedMS = { gasSoundSpeed, liquidSoundSpeed, liquidSoundSpeed };
+
+    UpstreamCompressibleVolume volume = new UpstreamCompressibleVolume(volumeM3, inlet.getPressure(), phaseMassKg,
+        phaseDensityKgM3, phaseSoundSpeedMS);
+    setUpstreamCompressibleVolume(volume);
+    return volume;
   }
 
   /** @return maximum relative cell-volume residual of the most recent correction */

--- a/src/main/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolume.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolume.java
@@ -1,0 +1,212 @@
+package neqsim.process.equipment.pipeline;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Fixed-volume, compressible upstream boundary coupled by phase-resolved mass transfer.
+ *
+ * <p>
+ * The volume owns gas, oil, and water inventories. A source adds phase mass and the connected pipe withdraws the inlet
+ * mass reported by its conservative finite-volume flux. Pressure is then solved from fixed total volume using
+ * {@code d rho / d p = 1 / c^2}. The model is deliberately composable: it contains no pipe closures and can be
+ * connected to any boundary that reports the same three phase-mass withdrawals.
+ * </p>
+ */
+public final class UpstreamCompressibleVolume implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private static final int PHASE_COUNT = 3;
+  private static final int MAXIMUM_ITERATIONS = 30;
+  private static final double RELATIVE_VOLUME_TOLERANCE = 1.0e-10;
+  private static final double MINIMUM_PRESSURE_PA = 1.0e4;
+  private static final double MINIMUM_DENSITY_KG_M3 = 1.0e-6;
+
+  private final double volumeM3;
+  private final double[] phaseMassKg;
+  private final double[] phaseDensityKgM3;
+  private final double[] phaseSoundSpeedMS;
+  private final double[] sourceMassFlowKgS = new double[PHASE_COUNT];
+  private double pressurePa;
+  private double cumulativeSourceMassKg;
+  private double cumulativeWithdrawalMassKg;
+  private double maximumRelativeVolumeResidual;
+  private int pressureIterations;
+
+  /**
+   * Create a volume from a pressure-consistent phase inventory.
+   *
+   * @param volumeM3 fixed internal volume in m3
+   * @param pressurePa initial absolute pressure in Pa
+   * @param phaseMassKg initial gas, oil, and water mass in kg
+   * @param phaseDensityKgM3 initial gas, oil, and water density in kg/m3
+   * @param phaseSoundSpeedMS gas, oil, and water sound speed in m/s
+   */
+  public UpstreamCompressibleVolume(double volumeM3, double pressurePa, double[] phaseMassKg, double[] phaseDensityKgM3,
+      double[] phaseSoundSpeedMS) {
+    requirePositiveFinite(volumeM3, "Volume");
+    requirePositiveFinite(pressurePa, "Pressure");
+    this.phaseMassKg = requireNonNegativePhaseValues(phaseMassKg, "Phase mass");
+    this.phaseDensityKgM3 = requirePositivePhaseValues(phaseDensityKgM3, "Phase density");
+    this.phaseSoundSpeedMS = requirePositivePhaseValues(phaseSoundSpeedMS, "Phase sound speed");
+    this.volumeM3 = volumeM3;
+    this.pressurePa = pressurePa;
+    maximumRelativeVolumeResidual = Math.abs(calculateOccupiedVolumeM3() - volumeM3) / volumeM3;
+    if (maximumRelativeVolumeResidual > RELATIVE_VOLUME_TOLERANCE) {
+      throw new IllegalArgumentException(
+          "Initial phase masses and densities must fill the fixed volume; relative residual="
+              + maximumRelativeVolumeResidual);
+    }
+  }
+
+  /** Set phase-resolved source rates entering the volume. */
+  public void setSourceMassFlowRates(double gasKgS, double oilKgS, double waterKgS) {
+    double[] rates = { gasKgS, oilKgS, waterKgS };
+    for (int phase = 0; phase < PHASE_COUNT; phase++) {
+      if (!Double.isFinite(rates[phase]) || rates[phase] < 0.0) {
+        throw new IllegalArgumentException("Source phase mass-flow rates must be finite and non-negative");
+      }
+      sourceMassFlowKgS[phase] = rates[phase];
+    }
+  }
+
+  /**
+   * Advance the volume after an accepted pipe step.
+   *
+   * @param timeStepSeconds accepted step duration in s
+   * @param withdrawnPhaseMassKg signed gas, oil, and water mass delivered to the pipe in kg; negative values represent
+   * phase return from the pipe
+   */
+  public void advance(double timeStepSeconds, double[] withdrawnPhaseMassKg) {
+    requirePositiveFinite(timeStepSeconds, "Time step");
+    double[] withdrawal = requireFinitePhaseValues(withdrawnPhaseMassKg, "Withdrawn phase mass");
+    for (int phase = 0; phase < PHASE_COUNT; phase++) {
+      double sourceMass = sourceMassFlowKgS[phase] * timeStepSeconds;
+      double updatedMass = phaseMassKg[phase] + sourceMass - withdrawal[phase];
+      double tolerance = 1.0e-12 * Math.max(1.0, phaseMassKg[phase] + sourceMass);
+      if (updatedMass < -tolerance) {
+        throw new IllegalStateException("Upstream volume phase " + phase + " depleted by pipe withdrawal");
+      }
+      phaseMassKg[phase] = Math.max(updatedMass, 0.0);
+      cumulativeSourceMassKg += sourceMass;
+      cumulativeWithdrawalMassKg += withdrawal[phase];
+    }
+    solvePressureClosure();
+  }
+
+  private void solvePressureClosure() {
+    pressureIterations = 0;
+    for (int iteration = 1; iteration <= MAXIMUM_ITERATIONS; iteration++) {
+      double occupiedVolume = calculateOccupiedVolumeM3();
+      double residualM3 = occupiedVolume - volumeM3;
+      maximumRelativeVolumeResidual = Math.abs(residualM3) / volumeM3;
+      pressureIterations = iteration;
+      if (maximumRelativeVolumeResidual <= RELATIVE_VOLUME_TOLERANCE) {
+        return;
+      }
+
+      double pressureDerivativeMagnitude = 0.0;
+      for (int phase = 0; phase < PHASE_COUNT; phase++) {
+        if (phaseMassKg[phase] > 0.0) {
+          double density = phaseDensityKgM3[phase];
+          double soundSpeed = phaseSoundSpeedMS[phase];
+          pressureDerivativeMagnitude += phaseMassKg[phase] / (density * density * soundSpeed * soundSpeed);
+        }
+      }
+      if (!(pressureDerivativeMagnitude > 0.0) || !Double.isFinite(pressureDerivativeMagnitude)) {
+        throw new IllegalStateException("Upstream volume has no finite compressibility");
+      }
+
+      double pressureCorrection = residualM3 / pressureDerivativeMagnitude;
+      double lowerLimit = MINIMUM_PRESSURE_PA - pressurePa;
+      double magnitudeLimit = 0.25 * Math.max(pressurePa, MINIMUM_PRESSURE_PA);
+      pressureCorrection = Math.max(lowerLimit, Math.min(magnitudeLimit, pressureCorrection));
+      pressureCorrection = Math.max(-magnitudeLimit, pressureCorrection);
+      pressurePa += pressureCorrection;
+      for (int phase = 0; phase < PHASE_COUNT; phase++) {
+        double densityCorrection = pressureCorrection / (phaseSoundSpeedMS[phase] * phaseSoundSpeedMS[phase]);
+        phaseDensityKgM3[phase] = Math.max(MINIMUM_DENSITY_KG_M3, phaseDensityKgM3[phase] + densityCorrection);
+      }
+    }
+    throw new IllegalStateException(
+        "Upstream-volume pressure closure did not converge; relative volume residual=" + maximumRelativeVolumeResidual);
+  }
+
+  private double calculateOccupiedVolumeM3() {
+    double occupied = 0.0;
+    for (int phase = 0; phase < PHASE_COUNT; phase++) {
+      occupied += phaseMassKg[phase] / phaseDensityKgM3[phase];
+    }
+    return occupied;
+  }
+
+  private static double[] requireNonNegativePhaseValues(double[] values, String label) {
+    double[] copy = requireFinitePhaseValues(values, label);
+    for (double value : copy) {
+      if (value < 0.0) {
+        throw new IllegalArgumentException(label + " values must be non-negative");
+      }
+    }
+    return copy;
+  }
+
+  private static double[] requireFinitePhaseValues(double[] values, String label) {
+    if (values == null || values.length != PHASE_COUNT) {
+      throw new IllegalArgumentException(label + " must contain gas, oil, and water values");
+    }
+    double[] copy = Arrays.copyOf(values, values.length);
+    for (double value : copy) {
+      if (!Double.isFinite(value)) {
+        throw new IllegalArgumentException(label + " values must be finite");
+      }
+    }
+    return copy;
+  }
+
+  private static double[] requirePositivePhaseValues(double[] values, String label) {
+    double[] copy = requireNonNegativePhaseValues(values, label);
+    for (double value : copy) {
+      if (value <= 0.0) {
+        throw new IllegalArgumentException(label + " values must be positive");
+      }
+    }
+    return copy;
+  }
+
+  private static void requirePositiveFinite(double value, String label) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(label + " must be positive and finite");
+    }
+  }
+
+  public double getVolumeM3() {
+    return volumeM3;
+  }
+
+  public double getPressurePa() {
+    return pressurePa;
+  }
+
+  public double getPhaseMassKg(int phase) {
+    return phaseMassKg[phase];
+  }
+
+  public double getTotalMassKg() {
+    return phaseMassKg[0] + phaseMassKg[1] + phaseMassKg[2];
+  }
+
+  public double getCumulativeSourceMassKg() {
+    return cumulativeSourceMassKg;
+  }
+
+  public double getCumulativeWithdrawalMassKg() {
+    return cumulativeWithdrawalMassKg;
+  }
+
+  public double getMaximumRelativeVolumeResidual() {
+    return maximumRelativeVolumeResidual;
+  }
+
+  public int getPressureIterations() {
+    return pressureIterations;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolume.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolume.java
@@ -190,6 +190,10 @@ public final class UpstreamCompressibleVolume implements Serializable {
     return phaseMassKg[phase];
   }
 
+  public double getSourceMassFlowRateKgS(int phase) {
+    return sourceMassFlowKgS[phase];
+  }
+
   public double getTotalMassKg() {
     return phaseMassKg[0] + phaseMassKg[1] + phaseMassKg[2];
   }

--- a/src/test/java/neqsim/process/equipment/network/TwoFluidPipeNetworkTest.java
+++ b/src/test/java/neqsim/process/equipment/network/TwoFluidPipeNetworkTest.java
@@ -1,0 +1,81 @@
+package neqsim.process.equipment.network;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport.Phase;
+import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import neqsim.process.equipment.pipeline.UpstreamCompressibleVolume;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+@Tag("slow")
+class TwoFluidPipeNetworkTest {
+  @Test
+  void serialBranchesAndStorageNodeCloseWholeNetworkMass() {
+    TwoFluidPipeNetwork network = new TwoFluidPipeNetwork("serial network");
+    network.addFixedPressureNode("source", 60.0e5);
+    network.addCompressibleNode("manifold", createVolume(55.0e5, 1000.0));
+    network.addFixedPressureNode("sink", 50.0e5);
+    network.addPipe("upstream", "source", "manifold", createPipe("upstream"));
+    network.addPipe("downstream", "manifold", "sink", createPipe("downstream"));
+
+    network.runTransient(0.01, UUID.randomUUID());
+
+    TwoFluidPipeNetwork.BalanceReport report = network.getLastBalanceReport();
+    for (Phase phase : Phase.values()) {
+      assertTrue(report.getRelativeResidual(phase) < 1.0e-8,
+          phase + " network residual=" + report.getRelativeResidual(phase));
+    }
+    assertTrue(Double.isFinite(network.getNodePressurePa("manifold")));
+    assertEquals(0.01, network.getSimulationTimeSeconds(), 0.0);
+  }
+
+  @Test
+  void identicalSplitBranchesRemainSymmetric() {
+    UpstreamCompressibleVolume splitter = createVolume(60.0e5, 1.0e5);
+    TwoFluidPipeNetwork network = new TwoFluidPipeNetwork("symmetric split");
+    network.addCompressibleNode("splitter", splitter);
+    network.addFixedPressureNode("sink A", 50.0e5);
+    network.addFixedPressureNode("sink B", 50.0e5);
+    network.addPipe("branch A", "splitter", "sink A", createPipe("branch A"));
+    network.addPipe("branch B", "splitter", "sink B", createPipe("branch B"));
+
+    network.runTransient(0.01, UUID.randomUUID());
+
+    TwoFluidMassBalanceReport first = network.getPipe("branch A").getLastMassBalanceReport();
+    TwoFluidMassBalanceReport second = network.getPipe("branch B").getLastMassBalanceReport();
+    assertEquals(first.getOutletMassKg(Phase.TOTAL), second.getOutletMassKg(Phase.TOTAL), 1.0e-12);
+    assertTrue(network.getLastBalanceReport().getRelativeResidual(Phase.TOTAL) < 1.0e-8);
+  }
+
+  private static TwoFluidPipe createPipe(String name) {
+    SystemInterface fluid = new SystemSrkEos(300.0, 60.0);
+    fluid.addComponent("methane", 0.95);
+    fluid.addComponent("n-heptane", 0.05);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    Stream feed = new Stream(name + " feed", fluid);
+    feed.setFlowRate(2.0, "kg/sec");
+    feed.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe(name, feed);
+    pipe.setLength(50.0);
+    pipe.setDiameter(0.20);
+    pipe.setNumberOfSections(4);
+    pipe.setElevationProfile(new double[4]);
+    return pipe;
+  }
+
+  private static UpstreamCompressibleVolume createVolume(double pressurePa, double volumeM3) {
+    double[] density = { 45.0, 700.0, 1000.0 };
+    double[] soundSpeed = { 350.0, 1200.0, 1450.0 };
+    double[] mass = { 0.90 * volumeM3 * density[0], 0.10 * volumeM3 * density[1], 0.0 };
+    return new UpstreamCompressibleVolume(volumeM3, pressurePa, mass, density, soundSpeed);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidBenchmarkMetricsTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidBenchmarkMetricsTest.java
@@ -1,0 +1,59 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class TwoFluidBenchmarkMetricsTest {
+  @Test
+  void fitsRateSweepExponentInsteadOfOnlyCheckingOneLevel() {
+    double[] rates = { 1.0, 2.0, 4.0, 8.0 };
+    double[] pressureDrops = new double[rates.length];
+    for (int index = 0; index < rates.length; index++) {
+      pressureDrops[index] = 3.5 * Math.pow(rates[index], 1.8);
+    }
+    assertEquals(1.8, TwoFluidBenchmarkMetrics.fitRateExponent(rates, pressureDrops), 1.0e-12);
+  }
+
+  @Test
+  void reportsScaleFreeProfileLocalizationAndMeshSpread() {
+    assertEquals(9.0, TwoFluidBenchmarkMetrics.maximumToMedianRatio(new double[] { 1.0, 1.0, 1.0, 9.0 }), 0.0);
+    assertEquals(0.2, TwoFluidBenchmarkMetrics.relativeMeshSpread(80.0, 100.0), 1.0e-15);
+    assertEquals(0.2, TwoFluidBenchmarkMetrics.relativeMeshSpread(100.0, 80.0), 1.0e-15);
+  }
+
+  @Test
+  void recoversPeriodBandAndCompletedCyclesFromSettledSignal() {
+    double[] time = new double[481];
+    double[] signal = new double[481];
+    for (int index = 0; index < time.length; index++) {
+      time[index] = 0.25 * index;
+      signal[index] = 2.0 + Math.sin(2.0 * Math.PI * time[index] / 10.0);
+    }
+
+    TwoFluidBenchmarkMetrics.LimitCycleMetrics metrics = TwoFluidBenchmarkMetrics.analyzeLimitCycle(time, signal, 20.0);
+
+    assertTrue(metrics.hasRepeatedCycle());
+    assertEquals(10.0, metrics.getPeriodSeconds(), 1.0e-12);
+    assertEquals(8, metrics.getCompletedCycleCount());
+    assertEquals(1.902113032590307, metrics.getP10ToP90Band(), 1.0e-12);
+  }
+
+  @Test
+  void startupSpikeDoesNotMasqueradeAsSettledLimitCycle() {
+    double[] time = new double[101];
+    double[] signal = new double[101];
+    for (int index = 0; index < time.length; index++) {
+      time[index] = index;
+      signal[index] = index < 10 ? 100.0 * Math.exp(-0.5 * index) : 5.0;
+    }
+
+    TwoFluidBenchmarkMetrics.LimitCycleMetrics metrics = TwoFluidBenchmarkMetrics.analyzeLimitCycle(time, signal, 20.0);
+
+    assertFalse(metrics.hasRepeatedCycle());
+    assertEquals(0, metrics.getCompletedCycleCount());
+    assertEquals(0.0, metrics.getP10ToP90Band(), 0.0);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolumeTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolumeTest.java
@@ -1,0 +1,95 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+class UpstreamCompressibleVolumeTest {
+  @Test
+  void equalSourceAndWithdrawalLeaveTheStateInvariant() {
+    UpstreamCompressibleVolume volume = createVolume(100.0);
+    volume.setSourceMassFlowRates(10.0, 1.0, 0.5);
+    double initialPressure = volume.getPressurePa();
+    double initialMass = volume.getTotalMassKg();
+
+    volume.advance(2.0, new double[] { 20.0, 2.0, 1.0 });
+
+    assertEquals(initialPressure, volume.getPressurePa(), 0.0);
+    assertEquals(initialMass, volume.getTotalMassKg(), 0.0);
+    assertTrue(volume.getMaximumRelativeVolumeResidual() <= 1.0e-10);
+  }
+
+  @Test
+  void sourceSurplusRaisesPressureAndClosesMassAndVolume() {
+    UpstreamCompressibleVolume volume = createVolume(100.0);
+    volume.setSourceMassFlowRates(10.0, 1.0, 0.0);
+    double initialPressure = volume.getPressurePa();
+    double initialMass = volume.getTotalMassKg();
+
+    volume.advance(1.0, new double[] { 9.0, 1.0, 0.0 });
+
+    assertTrue(volume.getPressurePa() > initialPressure);
+    assertEquals(initialMass + 1.0, volume.getTotalMassKg(), 1.0e-10);
+    assertEquals(11.0, volume.getCumulativeSourceMassKg(), 0.0);
+    assertEquals(10.0, volume.getCumulativeWithdrawalMassKg(), 0.0);
+    assertTrue(volume.getMaximumRelativeVolumeResidual() <= 1.0e-10);
+  }
+
+  @Test
+  void phaseReturnFromPipeAddsInventory() {
+    UpstreamCompressibleVolume volume = createVolume(100.0);
+    double initialOilMass = volume.getPhaseMassKg(1);
+
+    volume.advance(1.0, new double[] { 0.0, -0.25, 0.0 });
+
+    assertEquals(initialOilMass + 0.25, volume.getPhaseMassKg(1), 1.0e-12);
+    assertTrue(volume.getPressurePa() > 60.0e5);
+  }
+
+  @Test
+  void pipeUsesAcceptedPhaseFluxToAdvanceConnectedVolume() {
+    SystemInterface fluid = new SystemSrkEos(300.0, 60.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(2.0, "kg/sec");
+    feed.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe("volume-coupled pipe", feed);
+    pipe.setLength(100.0);
+    pipe.setDiameter(0.30);
+    pipe.setNumberOfSections(5);
+    pipe.setElevationProfile(new double[5]);
+    pipe.setOutletPressure(50.0, "bara");
+    pipe.run();
+
+    UpstreamCompressibleVolume volume = pipe.initializeUpstreamCompressibleVolume(1.0e5);
+    double initialMass = volume.getTotalMassKg();
+    pipe.runTransient(0.01, UUID.randomUUID());
+
+    TwoFluidMassBalanceReport report = pipe.getLastMassBalanceReport();
+    double transferredMass = report.getInletMassKg(TwoFluidMassBalanceReport.Phase.TOTAL);
+    assertTrue(transferredMass > 0.0);
+    assertEquals(initialMass - transferredMass, volume.getTotalMassKg(), 1.0e-8);
+    assertEquals(volume.getPressurePa(), pipe.getInletPressure() * 1.0e5, 1.0e-6);
+  }
+
+  @Test
+  void phaseDepletionFailsLoudly() {
+    UpstreamCompressibleVolume volume = createVolume(1.0);
+    assertThrows(IllegalStateException.class, () -> volume.advance(1.0, new double[] { 1.0e6, 0.0, 0.0 }));
+  }
+
+  private static UpstreamCompressibleVolume createVolume(double volumeM3) {
+    double[] density = { 50.0, 700.0, 1000.0 };
+    double[] soundSpeed = { 350.0, 1200.0, 1450.0 };
+    double[] mass = { 0.90 * volumeM3 * density[0], 0.08 * volumeM3 * density[1], 0.02 * volumeM3 * density[2] };
+    return new UpstreamCompressibleVolume(volumeM3, 60.0e5, mass, density, soundSpeed);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingExperimentalBenchmarkTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingExperimentalBenchmarkTest.java
@@ -15,6 +15,8 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.TwoFluidBenchmarkMetrics;
+import neqsim.process.equipment.pipeline.TwoFluidBenchmarkMetrics.LimitCycleMetrics;
 import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport;
 import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport.Phase;
 import neqsim.process.equipment.pipeline.TwoFluidPipe;
@@ -174,11 +176,11 @@ class SevereSluggingExperimentalBenchmarkTest {
     for (TransientMetrics metrics : ensemble) {
       logger.info(String.format(Locale.ROOT,
           "%s: meanP=%.0f Pa peakToPeak=%.0f Pa (%.2f x riser head) p10p90=%.0f Pa period=%.2f s "
-              + "qMax=%.3f qMin=%.3f kg/s slug=%.3f m",
+              + "cycles=%d qMax=%.3f qMin=%.3f kg/s slug=%.3f m",
           metrics.label, metrics.meanInletPressurePa, metrics.peakToPeakPressurePa,
           metrics.peakToPeakPressurePa / RISER_HYDROSTATIC_HEAD_PA, metrics.p10ToP90PressurePa,
-          metrics.cyclePeriodSeconds, metrics.maximumLiquidOutletKgPerSecond, metrics.minimumLiquidOutletKgPerSecond,
-          metrics.maximumSlugLengthM));
+          metrics.cyclePeriodSeconds, metrics.completedCycleCount, metrics.maximumLiquidOutletKgPerSecond,
+          metrics.minimumLiquidOutletKgPerSecond, metrics.maximumSlugLengthM));
     }
   }
 
@@ -202,6 +204,8 @@ class SevereSluggingExperimentalBenchmarkTest {
           metrics.label + ": no repeated blowout/fallback cycle was detected");
       assertTrue(metrics.cyclePeriodSeconds > 5.0, metrics.label
           + ": cycle period is shorter than the riser filling time, period=" + metrics.cyclePeriodSeconds);
+      assertTrue(metrics.completedCycleCount >= 2, metrics.label
+          + ": fewer than two completed settled-window cycles were detected, count=" + metrics.completedCycleCount);
       assertTrue(
           metrics.peakToPeakPressurePa > RECORDED_PRESSURE_SWING_LOWER_BOUND_IN_RISER_HEADS * RISER_HYDROSTATIC_HEAD_PA,
           metrics.label + ": the riser-base swing is too small to be severe slugging, peakToPeak="
@@ -318,6 +322,7 @@ class SevereSluggingExperimentalBenchmarkTest {
     assertEquals(reference.peakToPeakPressurePa, referenceRepeat.peakToPeakPressurePa, 0.0);
     assertEquals(reference.meanInletPressurePa, referenceRepeat.meanInletPressurePa, 0.0);
     assertEquals(reference.cyclePeriodSeconds, referenceRepeat.cyclePeriodSeconds, 0.0);
+    assertEquals(reference.completedCycleCount, referenceRepeat.completedCycleCount);
     assertEquals(reference.maximumLiquidOutletKgPerSecond, referenceRepeat.maximumLiquidOutletKgPerSecond, 0.0);
     assertEquals(reference.maximumSlugLengthM, referenceRepeat.maximumSlugLengthM, 0.0);
     for (Phase phase : Phase.values()) {
@@ -357,14 +362,15 @@ class SevereSluggingExperimentalBenchmarkTest {
       }
     }
 
-    List<Double> sortedPressures = new ArrayList<>(pressureSamples);
-    Collections.sort(sortedPressures);
+    LimitCycleMetrics pressureCycle = TwoFluidBenchmarkMetrics.analyzeLimitCycle(toArray(sampleTimes),
+        toArray(pressureSamples), WARM_UP_SECONDS);
+    LimitCycleMetrics liquidCycle = TwoFluidBenchmarkMetrics.analyzeLimitCycle(toArray(sampleTimes),
+        toArray(liquidOutletSamples), WARM_UP_SECONDS);
     double maximumSlugLength = pipe.getMaxSlugLengthAtOutlet();
     return new TransientMetrics(label, SOURCE_URL, maximum(pressureSamples) - minimum(pressureSamples),
-        percentile(sortedPressures, 0.90) - percentile(sortedPressures, 0.10), mean(pressureSamples),
-        estimateLowProductionCyclePeriod(sampleTimes, liquidOutletSamples), minimum(liquidOutletSamples),
-        maximum(liquidOutletSamples), maximumSlugLength, pipe.isSteadyStateWallClockLimited(), maximumClosure,
-        finalInventory);
+        pressureCycle.getP10ToP90Band(), mean(pressureSamples), liquidCycle.getPeriodSeconds(),
+        liquidCycle.getCompletedCycleCount(), minimum(liquidOutletSamples), maximum(liquidOutletSamples),
+        maximumSlugLength, pipe.isSteadyStateWallClockLimited(), maximumClosure, finalInventory);
   }
 
   private static TwoFluidPipe createLargeFacilityTestThree(int numberOfSections, double inletPressurePerturbation) {
@@ -422,6 +428,14 @@ class SevereSluggingExperimentalBenchmarkTest {
     pipe.setSteadyStateMaxWallClockTime(Double.POSITIVE_INFINITY);
     pipe.run();
     return pipe;
+  }
+
+  private static double[] toArray(List<Double> values) {
+    double[] result = new double[values.size()];
+    for (int index = 0; index < values.size(); index++) {
+      result[index] = values.get(index);
+    }
+    return result;
   }
 
   private static double estimateLowProductionCyclePeriod(List<Double> times, List<Double> liquidRates) {
@@ -549,6 +563,7 @@ class SevereSluggingExperimentalBenchmarkTest {
     private final double p10ToP90PressurePa;
     private final double meanInletPressurePa;
     private final double cyclePeriodSeconds;
+    private final int completedCycleCount;
     private final double minimumLiquidOutletKgPerSecond;
     private final double maximumLiquidOutletKgPerSecond;
     private final double maximumSlugLengthM;
@@ -557,15 +572,17 @@ class SevereSluggingExperimentalBenchmarkTest {
     private final Map<Phase, Double> finalInventoryKg;
 
     private TransientMetrics(String label, String sourceUrl, double peakToPeakPressurePa, double p10ToP90PressurePa,
-        double meanInletPressurePa, double cyclePeriodSeconds, double minimumLiquidOutletKgPerSecond,
-        double maximumLiquidOutletKgPerSecond, double maximumSlugLengthM, boolean steadyStateWallClockLimited,
-        Map<Phase, Double> maximumRelativeClosure, Map<Phase, Double> finalInventoryKg) {
+        double meanInletPressurePa, double cyclePeriodSeconds, int completedCycleCount,
+        double minimumLiquidOutletKgPerSecond, double maximumLiquidOutletKgPerSecond, double maximumSlugLengthM,
+        boolean steadyStateWallClockLimited, Map<Phase, Double> maximumRelativeClosure,
+        Map<Phase, Double> finalInventoryKg) {
       this.label = label;
       this.sourceUrl = sourceUrl;
       this.peakToPeakPressurePa = peakToPeakPressurePa;
       this.p10ToP90PressurePa = p10ToP90PressurePa;
       this.meanInletPressurePa = meanInletPressurePa;
       this.cyclePeriodSeconds = cyclePeriodSeconds;
+      this.completedCycleCount = completedCycleCount;
       this.minimumLiquidOutletKgPerSecond = minimumLiquidOutletKgPerSecond;
       this.maximumLiquidOutletKgPerSecond = maximumLiquidOutletKgPerSecond;
       this.maximumSlugLengthM = maximumSlugLengthM;


### PR DESCRIPTION
## Summary

Stacked on #3110. Adds a composable, phase-resolved compressible upstream volume and connects it to `TwoFluidPipe` through the accepted finite-volume inlet flux.

Advances #2907 and the boundary prerequisite identified for the public Tengesdal severe-slugging case.

## Physical model

For gas, oil, and water:

```
M_k^{n+1} = M_k^n + source_k dt - transferred_to_pipe_k
sum_k M_k / rho_k(p) = V
d rho_k / d p = 1 / c_k^2
```

The pressure closure is Newton-iterated after every accepted internal pipe substep. The pipe transfer uses the same integration-weighted phase inlet flux that feeds `TwoFluidMassBalanceReport`, so rejected steps never advance the upstream inventory. Signed transfer supports phase return from the pipe.

## API

```java
pipe.run();
UpstreamCompressibleVolume volume =
    pipe.initializeUpstreamCompressibleVolume(25.0);
volume.setSourceMassFlowRates(gasKgS, oilKgS, waterKgS);
pipe.runTransient(dt, id);
```

A directly constructed `UpstreamCompressibleVolume` can also be attached with `setUpstreamCompressibleVolume`.

## Compatibility and exclusions

- Opt-in; existing boundary behavior is unchanged.
- Attaching a volume selects a constant-pressure inlet updated from the volume pressure.
- The inlet stream still supplies thermodynamic composition.
- No component mixing, thermal storage, vessel nozzle momentum, or controller is inferred.
- This PR is stacked on #3110 and should be reviewed/merged after it.

## Validation

**VALIDATION PENDING CI**

Completed locally without Maven:
- Java 17 compiler-module compilation of the standalone volume core.
- Executable mass/pressure harness: a 1 kg source surplus raised pressure from 6.000 MPa to 6.001360 MPa, converged in 3 Newton iterations, relative volume residual 2.13e-15.

Added tests cover invariant source/withdrawal, pressure response, signed return flow, depletion failure, and accepted pipe-flux coupling.

Full Maven, Spotless, pre-commit, documentation, Java 8/21, and repository-wide tests will be reported from exact-head CI.