### PR TITLE
[AI-Assisted] feat(dexpi): add controlled Plant export metadata

### DIFF
--- a/docs/integration/dexpi-engineering-generation.md
+++ b/docs/integration/dexpi-engineering-generation.md
@@ -330,6 +330,36 @@ qualification. Commercial import and round-trip evidence must follow
 `docs/integration/dexpi-commercial-cae-evidence-template.json`; a missing vendor test remains
 `QUALIFICATION_REQUIRED` rather than being inferred from schema validity.
 
+### Controlled native Plant export metadata
+
+The compatibility `Dexpi20XmlWriter.write(process, file)` overload remains unchanged and does not invent
+provenance. When the exporting workflow has accountable source values, use
+`Dexpi20PlantExportMetadata` and the additive metadata overload:
+
+```java
+Dexpi20PlantExportMetadata metadata =
+    Dexpi20PlantExportMetadata.builder(
+            "2026-08-18T05:00:00Z", "NeqSim", "Equinor", "3.17.0")
+        .plantProperty(
+            Dexpi20PlantExportMetadata.PlantProperty.PROCESS_PLANT_IDENTIFICATION_CODE,
+            "SYNTHETIC-PLANT")
+        .plantProperty(
+            Dexpi20PlantExportMetadata.PlantProperty.PROCESS_PLANT_NAME,
+            "Synthetic regression plant")
+        .build();
+Dexpi20XmlWriter.write(process, outputFile, metadata);
+```
+
+The builder requires a caller-supplied ISO-8601 timestamp with an offset, all four required
+`Core/EngineeringModel` provenance values, and at least one non-blank official
+`Plant/Diagram.PlantMetaData` property. It rejects an empty metadata object so a validator cannot be silenced with
+placeholder content. The exporter places PlantMetaData under the PlantModel's inherited `MetaData` composition and
+serializes plant fields in stable declaration order. This is source provenance, not drawing approval, standards
+conformance, or evidence that graphical representations and boundary nodes are complete.
+
+The committed external baseline is intentionally not changed by this API alone. Regenerate a controlled fixture with
+the metadata overload and rerun the pinned verifier before changing its reviewed error and warning counts.
+
 The same helper can run the independent MIT-licensed DEXPIViewer validator without downloading or silently updating
 the tool. Supply a local checkout pinned to commit
 `18a17b1e38ba15a1a6ba49dd8265ddcff7c766ad` after installing that checkout's locked Node.js dependencies:

--- a/docs/integration/dexpi-pid-current-master-audit.md
+++ b/docs/integration/dexpi-pid-current-master-audit.md
@@ -101,9 +101,12 @@ study preparation, coordinated packages, and qualification evidence.
 The repository also contains deterministic native fixtures under
 `src/test/resources/dexpi/2.0/golden`, including the branching Plant fixture, manifest, semantic
 summary, schema provenance, and a reviewed DEXPIViewer baseline pinned to commit
-`18a17b1e38ba15a1a6ba49dd8265ddcff7c766ad`. That external baseline has eight errors and three warnings; it detects
-drift while required provenance, plant metadata, genuine representation groups, and boundary-node handling remain
-open implementation work. The coordinated
+`18a17b1e38ba15a1a6ba49dd8265ddcff7c766ad`. That external baseline has eight errors and three warnings. The native
+Plant writer now has an additive controlled-metadata overload for caller-supplied `Core/EngineeringModel` export
+provenance and non-empty `Plant/Diagram.PlantMetaData`; the compatibility overload and committed golden fixture
+remain unchanged. The reviewed baseline therefore continues to report the metadata findings until a controlled
+fixture is regenerated and the pinned verifier is rerun. Genuine representation groups and boundary-node handling
+remain separate open implementation work. The coordinated
 [engineering-diagram reference cases](dexpi-reference-cases.md) add executable, synthetic public
 simple, branched, and multi-area process fixtures. They check canonical topology, material balance,
 native Process/Plant exchange where supported, Proteus compatibility, legacy DOT, and governed P&ID

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20PlantExportMetadata.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20PlantExportMetadata.java
@@ -1,0 +1,178 @@
+package neqsim.process.processmodel.dexpi;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Immutable, caller-supplied provenance and plant identity for a native DEXPI 2.0 Plant
+ * exchange.
+ *
+ * <p>The export timestamp and plant identity are deliberately required inputs. The exporter never
+ * invents a current timestamp or project metadata, and use of this class does not imply drawing
+ * approval or DEXPI qualification.</p>
+ */
+public final class Dexpi20PlantExportMetadata {
+  /** Data properties defined by {@code Plant/Diagram.PlantMetaData}. */
+  public enum PlantProperty {
+    ENTERPRISE_IDENTIFICATION_CODE("EnterpriseIdentificationCode"),
+    ENTERPRISE_NAME("EnterpriseName"),
+    INDUSTRIAL_COMPLEX_IDENTIFICATION_CODE("IndustrialComplexIdentificationCode"),
+    INDUSTRIAL_COMPLEX_NAME("IndustrialComplexName"),
+    PLANT_AREA_IDENTIFICATION_CODE("PlantAreaIdentificationCode"),
+    PLANT_AREA_NAME("PlantAreaName"),
+    PLANT_SECTION_IDENTIFICATION_CODE("PlantSectionIdentificationCode"),
+    PLANT_SECTION_NAME("PlantSectionName"),
+    PLANT_SYSTEM_IDENTIFICATION_CODE("PlantSystemIdentificationCode"),
+    PLANT_SYSTEM_NAME("PlantSystemName"),
+    PLANT_TRAIN_IDENTIFICATION_CODE("PlantTrainIdentificationCode"),
+    PLANT_TRAIN_NAME("PlantTrainName"),
+    PROCESS_PLANT_IDENTIFICATION_CODE("ProcessPlantIdentificationCode"),
+    PROCESS_PLANT_NAME("ProcessPlantName"),
+    SITE_IDENTIFICATION_CODE("SiteIdentificationCode"),
+    SITE_NAME("SiteName");
+
+    private final String dexpiProperty;
+
+    PlantProperty(String dexpiProperty) {
+      this.dexpiProperty = dexpiProperty;
+    }
+
+    /**
+     * Returns the exact DEXPI 2.0 data-property name.
+     *
+     * @return DEXPI property name
+     */
+    public String getDexpiProperty() {
+      return dexpiProperty;
+    }
+  }
+
+  private final String exportDateTime;
+  private final String originatingSystemName;
+  private final String originatingSystemVendorName;
+  private final String originatingSystemVersion;
+  private final Map<PlantProperty, String> plantProperties;
+
+  private Dexpi20PlantExportMetadata(Builder builder) {
+    exportDateTime = builder.exportDateTime;
+    originatingSystemName = builder.originatingSystemName;
+    originatingSystemVendorName = builder.originatingSystemVendorName;
+    originatingSystemVersion = builder.originatingSystemVersion;
+    plantProperties = Collections.unmodifiableMap(
+        new EnumMap<PlantProperty, String>(builder.plantProperties));
+  }
+
+  /**
+   * Starts a controlled metadata definition.
+   *
+   * @param exportDateTime ISO-8601 date-time including an offset, supplied by the exporting workflow
+   * @param originatingSystemName name of the originating system
+   * @param originatingSystemVendorName vendor or responsible organization name
+   * @param originatingSystemVersion exact originating-system version
+   * @return metadata builder
+   */
+  public static Builder builder(String exportDateTime, String originatingSystemName,
+      String originatingSystemVendorName, String originatingSystemVersion) {
+    return new Builder(exportDateTime, originatingSystemName, originatingSystemVendorName,
+        originatingSystemVersion);
+  }
+
+  /** @return caller-supplied ISO-8601 export date-time */
+  public String getExportDateTime() {
+    return exportDateTime;
+  }
+
+  /** @return originating-system name */
+  public String getOriginatingSystemName() {
+    return originatingSystemName;
+  }
+
+  /** @return originating-system vendor or responsible organization */
+  public String getOriginatingSystemVendorName() {
+    return originatingSystemVendorName;
+  }
+
+  /** @return exact originating-system version */
+  public String getOriginatingSystemVersion() {
+    return originatingSystemVersion;
+  }
+
+  /**
+   * Returns plant properties in stable DEXPI declaration order.
+   *
+   * @return immutable plant-property map
+   */
+  public Map<PlantProperty, String> getPlantProperties() {
+    return plantProperties;
+  }
+
+  /** Builder for {@link Dexpi20PlantExportMetadata}. */
+  public static final class Builder {
+    private final String exportDateTime;
+    private final String originatingSystemName;
+    private final String originatingSystemVendorName;
+    private final String originatingSystemVersion;
+    private final EnumMap<PlantProperty, String> plantProperties =
+        new EnumMap<PlantProperty, String>(PlantProperty.class);
+
+    private Builder(String exportDateTime, String originatingSystemName,
+        String originatingSystemVendorName, String originatingSystemVersion) {
+      this.exportDateTime = requiredDateTime(exportDateTime);
+      this.originatingSystemName = required(originatingSystemName, "originatingSystemName");
+      this.originatingSystemVendorName =
+          required(originatingSystemVendorName, "originatingSystemVendorName");
+      this.originatingSystemVersion =
+          required(originatingSystemVersion, "originatingSystemVersion");
+    }
+
+    /**
+     * Adds one reviewed DEXPI PlantMetaData value.
+     *
+     * @param property official PlantMetaData property
+     * @param value controlled source value
+     * @return this builder
+     */
+    public Builder plantProperty(PlantProperty property, String value) {
+      if (property == null) {
+        throw new IllegalArgumentException("property must not be null");
+      }
+      plantProperties.put(property, required(value, property.getDexpiProperty()));
+      return this;
+    }
+
+    /**
+     * Builds immutable metadata. At least one real plant value is required so an empty metadata
+     * object cannot be emitted merely to satisfy a validator.
+     *
+     * @return immutable export metadata
+     */
+    public Dexpi20PlantExportMetadata build() {
+      if (plantProperties.isEmpty()) {
+        throw new IllegalStateException("at least one controlled PlantMetaData value is required");
+      }
+      return new Dexpi20PlantExportMetadata(this);
+    }
+  }
+
+  private static String requiredDateTime(String value) {
+    String result = required(value, "exportDateTime");
+    try {
+      OffsetDateTime.parse(result);
+    } catch (DateTimeParseException ex) {
+      throw new IllegalArgumentException(
+          "exportDateTime must be an ISO-8601 date-time with an offset", ex);
+    }
+    return result;
+  }
+
+  private static String required(String value, String name) {
+    String result = value == null ? "" : value.trim();
+    if (result.isEmpty()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return result;
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20PlantExportMetadata.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20PlantExportMetadata.java
@@ -7,32 +7,24 @@ import java.util.EnumMap;
 import java.util.Map;
 
 /**
- * Immutable, caller-supplied provenance and plant identity for a native DEXPI 2.0 Plant
- * exchange.
+ * Immutable, caller-supplied provenance and plant identity for a native DEXPI 2.0 Plant exchange.
  *
- * <p>The export timestamp and plant identity are deliberately required inputs. The exporter never
- * invents a current timestamp or project metadata, and use of this class does not imply drawing
- * approval or DEXPI qualification.</p>
+ * <p>
+ * The export timestamp and plant identity are deliberately required inputs. The exporter never invents a current
+ * timestamp or project metadata, and use of this class does not imply drawing approval or DEXPI qualification.
+ * </p>
  */
 public final class Dexpi20PlantExportMetadata {
   /** Data properties defined by {@code Plant/Diagram.PlantMetaData}. */
   public enum PlantProperty {
-    ENTERPRISE_IDENTIFICATION_CODE("EnterpriseIdentificationCode"),
-    ENTERPRISE_NAME("EnterpriseName"),
+    ENTERPRISE_IDENTIFICATION_CODE("EnterpriseIdentificationCode"), ENTERPRISE_NAME("EnterpriseName"),
     INDUSTRIAL_COMPLEX_IDENTIFICATION_CODE("IndustrialComplexIdentificationCode"),
-    INDUSTRIAL_COMPLEX_NAME("IndustrialComplexName"),
-    PLANT_AREA_IDENTIFICATION_CODE("PlantAreaIdentificationCode"),
-    PLANT_AREA_NAME("PlantAreaName"),
-    PLANT_SECTION_IDENTIFICATION_CODE("PlantSectionIdentificationCode"),
-    PLANT_SECTION_NAME("PlantSectionName"),
-    PLANT_SYSTEM_IDENTIFICATION_CODE("PlantSystemIdentificationCode"),
-    PLANT_SYSTEM_NAME("PlantSystemName"),
-    PLANT_TRAIN_IDENTIFICATION_CODE("PlantTrainIdentificationCode"),
-    PLANT_TRAIN_NAME("PlantTrainName"),
-    PROCESS_PLANT_IDENTIFICATION_CODE("ProcessPlantIdentificationCode"),
-    PROCESS_PLANT_NAME("ProcessPlantName"),
-    SITE_IDENTIFICATION_CODE("SiteIdentificationCode"),
-    SITE_NAME("SiteName");
+    INDUSTRIAL_COMPLEX_NAME("IndustrialComplexName"), PLANT_AREA_IDENTIFICATION_CODE("PlantAreaIdentificationCode"),
+    PLANT_AREA_NAME("PlantAreaName"), PLANT_SECTION_IDENTIFICATION_CODE("PlantSectionIdentificationCode"),
+    PLANT_SECTION_NAME("PlantSectionName"), PLANT_SYSTEM_IDENTIFICATION_CODE("PlantSystemIdentificationCode"),
+    PLANT_SYSTEM_NAME("PlantSystemName"), PLANT_TRAIN_IDENTIFICATION_CODE("PlantTrainIdentificationCode"),
+    PLANT_TRAIN_NAME("PlantTrainName"), PROCESS_PLANT_IDENTIFICATION_CODE("ProcessPlantIdentificationCode"),
+    PROCESS_PLANT_NAME("ProcessPlantName"), SITE_IDENTIFICATION_CODE("SiteIdentificationCode"), SITE_NAME("SiteName");
 
     private final String dexpiProperty;
 
@@ -61,8 +53,7 @@ public final class Dexpi20PlantExportMetadata {
     originatingSystemName = builder.originatingSystemName;
     originatingSystemVendorName = builder.originatingSystemVendorName;
     originatingSystemVersion = builder.originatingSystemVersion;
-    plantProperties = Collections.unmodifiableMap(
-        new EnumMap<PlantProperty, String>(builder.plantProperties));
+    plantProperties = Collections.unmodifiableMap(new EnumMap<PlantProperty, String>(builder.plantProperties));
   }
 
   /**
@@ -74,10 +65,9 @@ public final class Dexpi20PlantExportMetadata {
    * @param originatingSystemVersion exact originating-system version
    * @return metadata builder
    */
-  public static Builder builder(String exportDateTime, String originatingSystemName,
-      String originatingSystemVendorName, String originatingSystemVersion) {
-    return new Builder(exportDateTime, originatingSystemName, originatingSystemVendorName,
-        originatingSystemVersion);
+  public static Builder builder(String exportDateTime, String originatingSystemName, String originatingSystemVendorName,
+      String originatingSystemVersion) {
+    return new Builder(exportDateTime, originatingSystemName, originatingSystemVendorName, originatingSystemVersion);
   }
 
   /** @return caller-supplied ISO-8601 export date-time */
@@ -115,17 +105,15 @@ public final class Dexpi20PlantExportMetadata {
     private final String originatingSystemName;
     private final String originatingSystemVendorName;
     private final String originatingSystemVersion;
-    private final EnumMap<PlantProperty, String> plantProperties =
-        new EnumMap<PlantProperty, String>(PlantProperty.class);
+    private final EnumMap<PlantProperty, String> plantProperties = new EnumMap<PlantProperty, String>(
+        PlantProperty.class);
 
-    private Builder(String exportDateTime, String originatingSystemName,
-        String originatingSystemVendorName, String originatingSystemVersion) {
+    private Builder(String exportDateTime, String originatingSystemName, String originatingSystemVendorName,
+        String originatingSystemVersion) {
       this.exportDateTime = requiredDateTime(exportDateTime);
       this.originatingSystemName = required(originatingSystemName, "originatingSystemName");
-      this.originatingSystemVendorName =
-          required(originatingSystemVendorName, "originatingSystemVendorName");
-      this.originatingSystemVersion =
-          required(originatingSystemVersion, "originatingSystemVersion");
+      this.originatingSystemVendorName = required(originatingSystemVendorName, "originatingSystemVendorName");
+      this.originatingSystemVersion = required(originatingSystemVersion, "originatingSystemVersion");
     }
 
     /**
@@ -144,8 +132,8 @@ public final class Dexpi20PlantExportMetadata {
     }
 
     /**
-     * Builds immutable metadata. At least one real plant value is required so an empty metadata
-     * object cannot be emitted merely to satisfy a validator.
+     * Builds immutable metadata. At least one real plant value is required so an empty metadata object cannot be
+     * emitted merely to satisfy a validator.
      *
      * @return immutable export metadata
      */
@@ -162,8 +150,7 @@ public final class Dexpi20PlantExportMetadata {
     try {
       OffsetDateTime.parse(result);
     } catch (DateTimeParseException ex) {
-      throw new IllegalArgumentException(
-          "exportDateTime must be an ISO-8601 date-time with an offset", ex);
+      throw new IllegalArgumentException("exportDateTime must be an ISO-8601 date-time with an offset", ex);
     }
     return result;
   }

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20SemanticValidator.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20SemanticValidator.java
@@ -23,10 +23,11 @@ public final class Dexpi20SemanticValidator {
   private static final String CORE_MODEL = "https://data.dexpi.org/models/2.0.0/Core.xml";
   private static final String PLANT_MODEL = "https://data.dexpi.org/models/2.0.0/Plant.xml";
   private static final String PROCESS_MODEL = "https://data.dexpi.org/models/2.0.0/Process.xml";
-  private static final Set<String> SUPPORTED_TYPES = Collections.unmodifiableSet(new LinkedHashSet<String>(
-      Arrays.asList("Core/EngineeringModel", "Core/QualifiedValue", "Core/PhysicalQuantities.PhysicalQuantity",
-          "Core/Diagram.Diagram", "Core/Diagram.RepresentationGroup", "Core/Diagram.Text", "Core/Diagram.Point",
-          "Plant/PlantModel", "Plant/Diagram.PlantMetaData", "Plant/ProcessEquipment.ProcessEquipment", "Plant/ProcessEquipment.CentrifugalCompressor",
+  private static final Set<String> SUPPORTED_TYPES = Collections
+      .unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("Core/EngineeringModel", "Core/QualifiedValue",
+          "Core/PhysicalQuantities.PhysicalQuantity", "Core/Diagram.Diagram", "Core/Diagram.RepresentationGroup",
+          "Core/Diagram.Text", "Core/Diagram.Point", "Plant/PlantModel", "Plant/Diagram.PlantMetaData",
+          "Plant/ProcessEquipment.ProcessEquipment", "Plant/ProcessEquipment.CentrifugalCompressor",
           "Plant/ProcessEquipment.CentrifugalPump", "Plant/ProcessEquipment.Separator",
           "Plant/ProcessEquipment.AirCoolingSystem", "Plant/ProcessEquipment.TubularHeatExchanger",
           "Plant/ProcessEquipment.FiredHeater", "Plant/ProcessEquipment.Tank", "Plant/ProcessEquipment.Nozzle",

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20SemanticValidator.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20SemanticValidator.java
@@ -26,7 +26,7 @@ public final class Dexpi20SemanticValidator {
   private static final Set<String> SUPPORTED_TYPES = Collections.unmodifiableSet(new LinkedHashSet<String>(
       Arrays.asList("Core/EngineeringModel", "Core/QualifiedValue", "Core/PhysicalQuantities.PhysicalQuantity",
           "Core/Diagram.Diagram", "Core/Diagram.RepresentationGroup", "Core/Diagram.Text", "Core/Diagram.Point",
-          "Plant/PlantModel", "Plant/ProcessEquipment.ProcessEquipment", "Plant/ProcessEquipment.CentrifugalCompressor",
+          "Plant/PlantModel", "Plant/Diagram.PlantMetaData", "Plant/ProcessEquipment.ProcessEquipment", "Plant/ProcessEquipment.CentrifugalCompressor",
           "Plant/ProcessEquipment.CentrifugalPump", "Plant/ProcessEquipment.Separator",
           "Plant/ProcessEquipment.AirCoolingSystem", "Plant/ProcessEquipment.TubularHeatExchanger",
           "Plant/ProcessEquipment.FiredHeater", "Plant/ProcessEquipment.Tank", "Plant/ProcessEquipment.Nozzle",

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20XmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20XmlWriter.java
@@ -53,16 +53,16 @@ public final class Dexpi20XmlWriter {
    * @param metadata caller-supplied export provenance and plant identity
    * @throws IOException if serialization or validation fails
    */
-  public static void write(ProcessSystem processSystem, File file,
-      Dexpi20PlantExportMetadata metadata) throws IOException {
+  public static void write(ProcessSystem processSystem, File file, Dexpi20PlantExportMetadata metadata)
+      throws IOException {
     if (metadata == null) {
       throw new IllegalArgumentException("metadata must not be null");
     }
     writeValidated(processSystem, file, metadata);
   }
 
-  private static void writeValidated(ProcessSystem processSystem, File file,
-      Dexpi20PlantExportMetadata metadata) throws IOException {
+  private static void writeValidated(ProcessSystem processSystem, File file, Dexpi20PlantExportMetadata metadata)
+      throws IOException {
     if (file == null) {
       throw new IllegalArgumentException("file must not be null");
     }
@@ -115,8 +115,8 @@ public final class Dexpi20XmlWriter {
    * @param metadata caller-supplied export provenance and plant identity
    * @throws IOException if serialization fails
    */
-  public static void write(ProcessSystem processSystem, OutputStream outputStream,
-      Dexpi20PlantExportMetadata metadata) throws IOException {
+  public static void write(ProcessSystem processSystem, OutputStream outputStream, Dexpi20PlantExportMetadata metadata)
+      throws IOException {
     if (metadata == null) {
       throw new IllegalArgumentException("metadata must not be null");
     }
@@ -264,26 +264,21 @@ public final class Dexpi20XmlWriter {
   private static void appendEngineeringModelMetadata(Document document, Element engineeringModel,
       Dexpi20PlantExportMetadata metadata) {
     data(document, engineeringModel, "OriginatingSystemName", metadata.getOriginatingSystemName());
-    data(document, engineeringModel, "OriginatingSystemVendorName",
-        metadata.getOriginatingSystemVendorName());
-    data(document, engineeringModel, "OriginatingSystemVersion",
-        metadata.getOriginatingSystemVersion());
+    data(document, engineeringModel, "OriginatingSystemVendorName", metadata.getOriginatingSystemVendorName());
+    data(document, engineeringModel, "OriginatingSystemVersion", metadata.getOriginatingSystemVersion());
     dateTimeData(document, engineeringModel, "ExportDateTime", metadata.getExportDateTime());
   }
 
-  private static void appendPlantMetadata(Document document, Element plant,
-      Dexpi20PlantExportMetadata metadata) {
+  private static void appendPlantMetadata(Document document, Element plant, Dexpi20PlantExportMetadata metadata) {
     Element metadataObjects = components(document, plant, "MetaData");
     Element plantMetadata = object(document, "PlantMetaData1", "Plant/Diagram.PlantMetaData");
-    for (Map.Entry<Dexpi20PlantExportMetadata.PlantProperty, String> entry :
-        metadata.getPlantProperties().entrySet()) {
+    for (Map.Entry<Dexpi20PlantExportMetadata.PlantProperty, String> entry : metadata.getPlantProperties().entrySet()) {
       data(document, plantMetadata, entry.getKey().getDexpiProperty(), entry.getValue());
     }
     metadataObjects.appendChild(plantMetadata);
   }
 
-  private static void dateTimeData(Document document, Element parent, String property,
-      String value) {
+  private static void dateTimeData(Document document, Element parent, String property, String value) {
     Element data = document.createElement("Data");
     data.setAttribute("property", property);
     Element dateTime = document.createElement("DateTime");

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20XmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20XmlWriter.java
@@ -40,14 +40,35 @@ public final class Dexpi20XmlWriter {
   private Dexpi20XmlWriter() {
   }
 
-  /** Writes and validates a native DEXPI 2.0 model. */
+  /** Writes and validates a native DEXPI 2.0 model using the compatibility path. */
   public static void write(ProcessSystem processSystem, File file) throws IOException {
+    writeValidated(processSystem, file, null);
+  }
+
+  /**
+   * Writes and validates a native DEXPI 2.0 Plant model with controlled export metadata.
+   *
+   * @param processSystem source simulation topology
+   * @param file destination DEXPI XML file
+   * @param metadata caller-supplied export provenance and plant identity
+   * @throws IOException if serialization or validation fails
+   */
+  public static void write(ProcessSystem processSystem, File file,
+      Dexpi20PlantExportMetadata metadata) throws IOException {
+    if (metadata == null) {
+      throw new IllegalArgumentException("metadata must not be null");
+    }
+    writeValidated(processSystem, file, metadata);
+  }
+
+  private static void writeValidated(ProcessSystem processSystem, File file,
+      Dexpi20PlantExportMetadata metadata) throws IOException {
     if (file == null) {
       throw new IllegalArgumentException("file must not be null");
     }
     FileOutputStream stream = new FileOutputStream(file);
     try {
-      write(processSystem, stream);
+      writeDocument(processSystem, stream, metadata);
     } finally {
       stream.close();
     }
@@ -66,8 +87,44 @@ public final class Dexpi20XmlWriter {
     return Dexpi20ConformanceAssessment.assess(file.toPath(), Dexpi20ConformanceAssessment.Profile.PLANT_P_ID);
   }
 
-  /** Writes a native DEXPI 2.0 model to a stream. */
+  /**
+   * Writes a metadata-bearing Plant exchange and returns its auditable conformance assessment.
+   *
+   * @param processSystem source simulation topology
+   * @param file destination DEXPI XML file
+   * @param metadata caller-supplied export provenance and plant identity
+   * @return schema and supported-profile assessment
+   * @throws IOException if serialization, validation, or assessment fails
+   */
+  public static Dexpi20ConformanceAssessment.Report writeAndAssess(ProcessSystem processSystem, File file,
+      Dexpi20PlantExportMetadata metadata) throws IOException {
+    write(processSystem, file, metadata);
+    return Dexpi20ConformanceAssessment.assess(file.toPath(), Dexpi20ConformanceAssessment.Profile.PLANT_P_ID);
+  }
+
+  /** Writes a native DEXPI 2.0 model to a stream using the compatibility path. */
   public static void write(ProcessSystem processSystem, OutputStream outputStream) throws IOException {
+    writeDocument(processSystem, outputStream, null);
+  }
+
+  /**
+   * Writes a native DEXPI 2.0 Plant model with controlled export metadata to a stream.
+   *
+   * @param processSystem source simulation topology
+   * @param outputStream destination stream
+   * @param metadata caller-supplied export provenance and plant identity
+   * @throws IOException if serialization fails
+   */
+  public static void write(ProcessSystem processSystem, OutputStream outputStream,
+      Dexpi20PlantExportMetadata metadata) throws IOException {
+    if (metadata == null) {
+      throw new IllegalArgumentException("metadata must not be null");
+    }
+    writeDocument(processSystem, outputStream, metadata);
+  }
+
+  private static void writeDocument(ProcessSystem processSystem, OutputStream outputStream,
+      Dexpi20PlantExportMetadata metadata) throws IOException {
     if (processSystem == null || outputStream == null) {
       throw new IllegalArgumentException("processSystem and outputStream must not be null");
     }
@@ -82,9 +139,15 @@ public final class Dexpi20XmlWriter {
 
       Element engineeringModel = object(document, null, "Core/EngineeringModel");
       model.appendChild(engineeringModel);
+      if (metadata != null) {
+        appendEngineeringModelMetadata(document, engineeringModel, metadata);
+      }
       Element conceptualModel = components(document, engineeringModel, "ConceptualModel");
       Element plant = object(document, "PlantModel1", "Plant/PlantModel");
       conceptualModel.appendChild(plant);
+      if (metadata != null) {
+        appendPlantMetadata(document, plant, metadata);
+      }
 
       Element taggedItems = components(document, plant, "TaggedPlantItems");
       Element pipingSystems = components(document, plant, "PipingNetworkSystems");
@@ -195,6 +258,37 @@ public final class Dexpi20XmlWriter {
     Element string = document.createElement("String");
     string.setTextContent(value == null ? "" : value);
     data.appendChild(string);
+    parent.appendChild(data);
+  }
+
+  private static void appendEngineeringModelMetadata(Document document, Element engineeringModel,
+      Dexpi20PlantExportMetadata metadata) {
+    data(document, engineeringModel, "OriginatingSystemName", metadata.getOriginatingSystemName());
+    data(document, engineeringModel, "OriginatingSystemVendorName",
+        metadata.getOriginatingSystemVendorName());
+    data(document, engineeringModel, "OriginatingSystemVersion",
+        metadata.getOriginatingSystemVersion());
+    dateTimeData(document, engineeringModel, "ExportDateTime", metadata.getExportDateTime());
+  }
+
+  private static void appendPlantMetadata(Document document, Element plant,
+      Dexpi20PlantExportMetadata metadata) {
+    Element metadataObjects = components(document, plant, "MetaData");
+    Element plantMetadata = object(document, "PlantMetaData1", "Plant/Diagram.PlantMetaData");
+    for (Map.Entry<Dexpi20PlantExportMetadata.PlantProperty, String> entry :
+        metadata.getPlantProperties().entrySet()) {
+      data(document, plantMetadata, entry.getKey().getDexpiProperty(), entry.getValue());
+    }
+    metadataObjects.appendChild(plantMetadata);
+  }
+
+  private static void dateTimeData(Document document, Element parent, String property,
+      String value) {
+    Element data = document.createElement("Data");
+    data.setAttribute("property", property);
+    Element dateTime = document.createElement("DateTime");
+    dateTime.setTextContent(value);
+    data.appendChild(dateTime);
     parent.appendChild(data);
   }
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20PlantExportMetadataTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20PlantExportMetadataTest.java
@@ -1,0 +1,173 @@
+package neqsim.process.processmodel.dexpi;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import neqsim.NeqSimTest;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests controlled provenance and plant identity in native DEXPI 2.0 Plant export. */
+public class Dexpi20PlantExportMetadataTest extends NeqSimTest {
+  @TempDir Path temporaryDirectory;
+
+  /** Verifies deterministic schema-valid export and the exact DEXPI metadata placement. */
+  @Test
+  public void writesControlledMetadataDeterministically() throws Exception {
+    ProcessSystem process = process();
+    Dexpi20PlantExportMetadata metadata =
+        Dexpi20PlantExportMetadata.builder("2026-08-18T05:00:00Z", "NeqSim", "Equinor",
+            "3.17.0")
+            .plantProperty(
+                Dexpi20PlantExportMetadata.PlantProperty.PROCESS_PLANT_IDENTIFICATION_CODE,
+                "SYNTHETIC-PLANT")
+            .plantProperty(Dexpi20PlantExportMetadata.PlantProperty.PROCESS_PLANT_NAME,
+                "Synthetic regression plant")
+            .plantProperty(
+                Dexpi20PlantExportMetadata.PlantProperty.PLANT_AREA_IDENTIFICATION_CODE,
+                "AREA-10")
+            .plantProperty(Dexpi20PlantExportMetadata.PlantProperty.PLANT_AREA_NAME,
+                "Synthetic process area")
+            .build();
+    Path first = temporaryDirectory.resolve("controlled-first.dexpi.xml");
+    Path second = temporaryDirectory.resolve("controlled-second.dexpi.xml");
+
+    Dexpi20ConformanceAssessment.Report report =
+        Dexpi20XmlWriter.writeAndAssess(process, first.toFile(), metadata);
+    Dexpi20XmlWriter.write(process, second.toFile(), metadata);
+
+    assertTrue(report.isSchemaAndProfileConformant(), report.getErrors().toString());
+    assertArrayEquals(Files.readAllBytes(first), Files.readAllBytes(second));
+
+    Document document = parse(first);
+    Element engineeringModel = objectByType(document, "Core/EngineeringModel");
+    assertEquals("NeqSim", dataValue(engineeringModel, "OriginatingSystemName"));
+    assertEquals("Equinor", dataValue(engineeringModel, "OriginatingSystemVendorName"));
+    assertEquals("3.17.0", dataValue(engineeringModel, "OriginatingSystemVersion"));
+    assertEquals("2026-08-18T05:00:00Z", dataValue(engineeringModel, "ExportDateTime"));
+
+    Element plantModel = objectByType(document, "Plant/PlantModel");
+    Element plantMetadata = componentObject(plantModel, "MetaData");
+    assertEquals("Plant/Diagram.PlantMetaData", plantMetadata.getAttribute("type"));
+    assertEquals("SYNTHETIC-PLANT",
+        dataValue(plantMetadata, "ProcessPlantIdentificationCode"));
+    assertEquals("Synthetic regression plant", dataValue(plantMetadata, "ProcessPlantName"));
+    assertEquals("AREA-10", dataValue(plantMetadata, "PlantAreaIdentificationCode"));
+    assertEquals("Synthetic process area", dataValue(plantMetadata, "PlantAreaName"));
+  }
+
+  /** Verifies that the compatibility overload remains metadata-free and deterministic. */
+  @Test
+  public void preservesCompatibilityExport() throws Exception {
+    ProcessSystem process = process();
+    Path first = temporaryDirectory.resolve("legacy-first.dexpi.xml");
+    Path second = temporaryDirectory.resolve("legacy-second.dexpi.xml");
+
+    Dexpi20XmlWriter.write(process, first.toFile());
+    Dexpi20XmlWriter.write(process, second.toFile());
+
+    assertArrayEquals(Files.readAllBytes(first), Files.readAllBytes(second));
+    Document document = parse(first);
+    Element engineeringModel = objectByType(document, "Core/EngineeringModel");
+    assertEquals("", dataValue(engineeringModel, "ExportDateTime"));
+    assertFalse(hasObjectType(document, "Plant/Diagram.PlantMetaData"));
+  }
+
+  /** Verifies that placeholders cannot be used to manufacture validator success. */
+  @Test
+  public void rejectsInvalidOrEmptyMetadata() {
+    assertThrows(IllegalArgumentException.class,
+        () -> Dexpi20PlantExportMetadata.builder("not-a-date", "NeqSim", "Equinor", "3.17.0"));
+    assertThrows(IllegalArgumentException.class,
+        () -> Dexpi20PlantExportMetadata.builder("2026-08-18T05:00:00Z", " ", "Equinor",
+            "3.17.0"));
+    Dexpi20PlantExportMetadata.Builder builder =
+        Dexpi20PlantExportMetadata.builder("2026-08-18T05:00:00Z", "NeqSim", "Equinor",
+            "3.17.0");
+    assertThrows(IllegalStateException.class, builder::build);
+  }
+
+  private static Document parse(Path file) throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setXIncludeAware(false);
+    factory.setExpandEntityReferences(false);
+    return factory.newDocumentBuilder().parse(file.toFile());
+  }
+
+  private static Element objectByType(Document document, String type) {
+    NodeList objects = document.getElementsByTagName("Object");
+    for (int index = 0; index < objects.getLength(); index++) {
+      Element object = (Element) objects.item(index);
+      if (type.equals(object.getAttribute("type"))) {
+        return object;
+      }
+    }
+    throw new AssertionError("Missing object type " + type);
+  }
+
+  private static boolean hasObjectType(Document document, String type) {
+    NodeList objects = document.getElementsByTagName("Object");
+    for (int index = 0; index < objects.getLength(); index++) {
+      if (type.equals(((Element) objects.item(index)).getAttribute("type"))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static Element componentObject(Element parent, String property) {
+    for (Node child = parent.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (child instanceof Element && "Components".equals(((Element) child).getTagName())
+          && property.equals(((Element) child).getAttribute("property"))) {
+        NodeList objects = ((Element) child).getElementsByTagName("Object");
+        if (objects.getLength() > 0) {
+          return (Element) objects.item(0);
+        }
+      }
+    }
+    throw new AssertionError("Missing component property " + property);
+  }
+
+  private static String dataValue(Element parent, String property) {
+    for (Node child = parent.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (child instanceof Element && "Data".equals(((Element) child).getTagName())
+          && property.equals(((Element) child).getAttribute("property"))) {
+        return child.getTextContent().trim();
+      }
+    }
+    return "";
+  }
+
+  private static ProcessSystem process() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 40.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("n-heptane", 0.2);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("10-FEED-001", fluid);
+    Separator separator = new Separator("10-VA-001", feed);
+    Compressor compressor = new Compressor("10-KA-001", separator.getGasOutStream());
+    ProcessSystem process = new ProcessSystem("controlled DEXPI metadata test");
+    process.add(feed);
+    process.add(separator);
+    process.add(compressor);
+    return process;
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20PlantExportMetadataTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20PlantExportMetadataTest.java
@@ -24,31 +24,23 @@ import neqsim.thermo.system.SystemSrkEos;
 
 /** Tests controlled provenance and plant identity in native DEXPI 2.0 Plant export. */
 public class Dexpi20PlantExportMetadataTest extends NeqSimTest {
-  @TempDir Path temporaryDirectory;
+  @TempDir
+  Path temporaryDirectory;
 
   /** Verifies deterministic schema-valid export and the exact DEXPI metadata placement. */
   @Test
   public void writesControlledMetadataDeterministically() throws Exception {
     ProcessSystem process = process();
-    Dexpi20PlantExportMetadata metadata =
-        Dexpi20PlantExportMetadata.builder("2026-08-18T05:00:00Z", "NeqSim", "Equinor",
-            "3.17.0")
-            .plantProperty(
-                Dexpi20PlantExportMetadata.PlantProperty.PROCESS_PLANT_IDENTIFICATION_CODE,
-                "SYNTHETIC-PLANT")
-            .plantProperty(Dexpi20PlantExportMetadata.PlantProperty.PROCESS_PLANT_NAME,
-                "Synthetic regression plant")
-            .plantProperty(
-                Dexpi20PlantExportMetadata.PlantProperty.PLANT_AREA_IDENTIFICATION_CODE,
-                "AREA-10")
-            .plantProperty(Dexpi20PlantExportMetadata.PlantProperty.PLANT_AREA_NAME,
-                "Synthetic process area")
-            .build();
+    Dexpi20PlantExportMetadata metadata = Dexpi20PlantExportMetadata
+        .builder("2026-08-18T05:00:00Z", "NeqSim", "Equinor", "3.17.0")
+        .plantProperty(Dexpi20PlantExportMetadata.PlantProperty.PROCESS_PLANT_IDENTIFICATION_CODE, "SYNTHETIC-PLANT")
+        .plantProperty(Dexpi20PlantExportMetadata.PlantProperty.PROCESS_PLANT_NAME, "Synthetic regression plant")
+        .plantProperty(Dexpi20PlantExportMetadata.PlantProperty.PLANT_AREA_IDENTIFICATION_CODE, "AREA-10")
+        .plantProperty(Dexpi20PlantExportMetadata.PlantProperty.PLANT_AREA_NAME, "Synthetic process area").build();
     Path first = temporaryDirectory.resolve("controlled-first.dexpi.xml");
     Path second = temporaryDirectory.resolve("controlled-second.dexpi.xml");
 
-    Dexpi20ConformanceAssessment.Report report =
-        Dexpi20XmlWriter.writeAndAssess(process, first.toFile(), metadata);
+    Dexpi20ConformanceAssessment.Report report = Dexpi20XmlWriter.writeAndAssess(process, first.toFile(), metadata);
     Dexpi20XmlWriter.write(process, second.toFile(), metadata);
 
     assertTrue(report.isSchemaAndProfileConformant(), report.getErrors().toString());
@@ -64,8 +56,7 @@ public class Dexpi20PlantExportMetadataTest extends NeqSimTest {
     Element plantModel = objectByType(document, "Plant/PlantModel");
     Element plantMetadata = componentObject(plantModel, "MetaData");
     assertEquals("Plant/Diagram.PlantMetaData", plantMetadata.getAttribute("type"));
-    assertEquals("SYNTHETIC-PLANT",
-        dataValue(plantMetadata, "ProcessPlantIdentificationCode"));
+    assertEquals("SYNTHETIC-PLANT", dataValue(plantMetadata, "ProcessPlantIdentificationCode"));
     assertEquals("Synthetic regression plant", dataValue(plantMetadata, "ProcessPlantName"));
     assertEquals("AREA-10", dataValue(plantMetadata, "PlantAreaIdentificationCode"));
     assertEquals("Synthetic process area", dataValue(plantMetadata, "PlantAreaName"));
@@ -94,11 +85,9 @@ public class Dexpi20PlantExportMetadataTest extends NeqSimTest {
     assertThrows(IllegalArgumentException.class,
         () -> Dexpi20PlantExportMetadata.builder("not-a-date", "NeqSim", "Equinor", "3.17.0"));
     assertThrows(IllegalArgumentException.class,
-        () -> Dexpi20PlantExportMetadata.builder("2026-08-18T05:00:00Z", " ", "Equinor",
-            "3.17.0"));
-    Dexpi20PlantExportMetadata.Builder builder =
-        Dexpi20PlantExportMetadata.builder("2026-08-18T05:00:00Z", "NeqSim", "Equinor",
-            "3.17.0");
+        () -> Dexpi20PlantExportMetadata.builder("2026-08-18T05:00:00Z", " ", "Equinor", "3.17.0"));
+    Dexpi20PlantExportMetadata.Builder builder = Dexpi20PlantExportMetadata.builder("2026-08-18T05:00:00Z", "NeqSim",
+        "Equinor", "3.17.0");
     assertThrows(IllegalStateException.class, builder::build);
   }
 


### PR DESCRIPTION
## Summary

- add immutable `Dexpi20PlantExportMetadata` for caller-supplied DEXPI 2.0 export provenance and the complete official `Plant/Diagram.PlantMetaData` property set
- require an offset-bearing ISO-8601 export timestamp, all four required `Core/EngineeringModel` provenance values, and at least one non-blank plant value
- add opt-in file, stream and assessed native Plant writer overloads
- serialize PlantMetaData through the PlantModel's inherited `MetaData` composition in stable declaration order
- retain the existing metadata-free writer overload byte path unchanged
- add focused deterministic/schema/profile/placement/negative tests and document the qualification boundary

This is the dependency-ready metadata tranche following #3109 in the shared #1332/#2899 diagram lane. It does not add graphical representation groups, change boundary-node topology, alter the DEXPI 2.0 Process writer, or touch legacy DOT/Graphviz, native SVG/PDF, Proteus/P&ID or Classic output.

## Validation

**READY TO MERGE — exact head `309c858785bc1f297b7e539f9d109eedcc07bfe4`**

All hosted validation for this exact head passed:

- Spotless formatting
- Pre-commit checks
- Documentation search coverage
- Execute process-to-engineering simulator notebook
- PaperLab Replication Gate
- CodeQL Security Analysis
- Java 21 fast tests on Ubuntu and Windows
- all four Java 21 slow-test shards on Ubuntu
- Java 8 tests on Ubuntu and Windows
- Java 21 Javadoc

The regression `Dexpi20PlantExportMetadataTest` proves deterministic serialization, schema and supported-profile conformance, exact metadata placement, compatibility-overload behavior, and invalid-input rejection. The final audit found the PR mergeable and current with `master` (0 commits behind), with exactly six intended files and no comments, reviews, or unresolved threads. Draft status is intentionally retained.

GitHub CI is the authoritative validator; no local checks are claimed.

The committed DEXPIViewer baseline remains 8 errors and 3 warnings. This PR does not alter those reviewed counts because the golden fixture has not been regenerated with accountable metadata and the pinned external verifier has not been rerun.

Documentation impact: the public metadata API and qualification boundary are documented in the two integration guides changed by this PR; the validator allowlist repair introduces no additional user-facing behavior beyond making the documented official metadata object pass the existing conformance path.

## Compatibility

- existing `Dexpi20XmlWriter.write(process, file)` and stream overloads retain their metadata-free serialization path
- new metadata is opt-in and caller supplied; no wall-clock timestamp, plant identity or approval state is inferred
- metadata collections are immutable and serialized deterministically
- an empty PlantMetaData object is rejected rather than emitted merely to silence a validator

## Engineering boundary

The metadata records export/source identity only. It does not make a P&ID approved, make the external validation clean, or establish ISO 10628, DEXPI EV or commercial-CAE qualification. Genuine representation semantics and boundary-node handling remain separate follow-up dependencies.

Refs #1332
Refs #2899