### PR TITLE
test(pipeline): standardize multiphase benchmark acceptance metrics

### DIFF
--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -1062,6 +1062,36 @@ independent OLGA/public benchmark qualification is completed. Do not use short s
 limit-cycle evidence; report period, the P10-P90 band, and completed cycle count over a settled
 window.
 
+### Standing benchmark acceptance metrics
+
+Use `TwoFluidBenchmarkMetrics` to compare a rate sweep, a section profile, mesh realizations, and
+a settled transient with the same definitions in every benchmark:
+
+```java
+double exponent = TwoFluidBenchmarkMetrics.fitRateExponent(rates, pressureDrops);
+double terrainLocalization =
+    TwoFluidBenchmarkMetrics.maximumToMedianRatio(liquidHoldupProfile);
+double meshSpread =
+    TwoFluidBenchmarkMetrics.relativeMeshSpread(coarseResult, refinedResult);
+TwoFluidBenchmarkMetrics.LimitCycleMetrics cycle =
+    TwoFluidBenchmarkMetrics.analyzeLimitCycle(times, pressure, settledWindowStart);
+```
+
+The limit-cycle result reports period, P10, median, P90, P10-P90 band, sample window, and completed
+median-upcrossing cycle count. A large startup peak followed by a flat trace reports zero completed
+cycles, so it cannot pass as a sustained oscillation.
+
+The slow public Tengesdal benchmark now uses these settled-window definitions and requires at least
+two completed liquid-rate cycles in every mesh/timestep realization. It retains the published
+experimental source and its phase-mass, mean-pressure, mesh, amplitude, and deterministic-repeat
+checks.
+
+A user-supplied like-for-like OLGA run for the same geometry reported a 21.7 s cycle and a
+0.37-4.03 kg/s liquid-outlet range, while the public experiment reports 38 +/- 2 s. These values
+are comparison evidence, not embedded commercial correlations. A NeqSim/OLGA comparison should
+record exported time series and evaluate both with the same settled window and metrics; it should
+not compare one startup peak or tune a closure to one trajectory.
+
 ### Adaptive Timestepping
 
 Adaptive timestepping provides robustness for challenging geometries. Enable via

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -950,6 +950,37 @@ stream remains the source of thermodynamic composition for the pipe boundary. Co
 heat transfer, and a momentum-resolved vessel/nozzle model are outside this lumped boundary's
 current scope.
 
+### Multi-branch pressure-node network
+
+`TwoFluidPipeNetwork` connects named `TwoFluidPipe` branches through fixed-pressure reservoirs
+and phase-resolved compressible storage nodes. It supports directed splits, merges, manifolds, and
+injection branches:
+
+```java
+TwoFluidPipeNetwork network = new TwoFluidPipeNetwork("subsea network");
+network.addFixedPressureNode("well", 120.0e5);
+network.addCompressibleNode("manifold", manifoldVolume);
+network.addFixedPressureNode("separator", 55.0e5);
+network.addPipe("flowline A", "well", "manifold", flowlineA);
+network.addPipe("riser", "manifold", "separator", riser);
+
+network.runTransient(0.1, UUID.randomUUID());
+double nodePressure = network.getNodePressurePa("manifold");
+double closure = network.getLastBalanceReport()
+    .getRelativeResidual(TwoFluidMassBalanceReport.Phase.TOTAL);
+```
+
+Every branch sees the node pressures at the beginning of the network step. After all branches
+advance, their accepted gas, oil, and water boundary transfers update every compressible node
+simultaneously. Branch iteration order therefore does not become an implicit pressure solve.
+The whole-network report includes pipe and node inventories, fixed-boundary transfers, phase
+sources, and gas/oil/water/liquid/total residuals.
+
+This first network implementation requires finite compressible storage at internal junctions.
+Fixed-pressure nodes are external reservoirs or sinks. Algebraic zero-volume junctions, a global
+Newton pressure-flow solve, component and enthalpy mixing, reverse-flow boundary composition, and
+branch subcycling remain outside the validated scope.
+
 ### Choosing Time Step, Sections, and Pipeline Length
 
 `runTransient(dt, id)` takes a macro time step in seconds. Internally, the solver sub-steps to

--- a/src/main/java/neqsim/process/equipment/network/TwoFluidPipeNetwork.java
+++ b/src/main/java/neqsim/process/equipment/network/TwoFluidPipeNetwork.java
@@ -1,0 +1,370 @@
+package neqsim.process.equipment.network;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport.Phase;
+import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import neqsim.process.equipment.pipeline.TwoFluidPipe.BoundaryCondition;
+import neqsim.process.equipment.pipeline.UpstreamCompressibleVolume;
+
+/**
+ * Phase-conservative transient hydraulic network of {@link TwoFluidPipe} branches.
+ *
+ * <p>
+ * Every branch is advanced from the pressures at the beginning of the network step. Gas, oil, and water boundary
+ * transfers are then accumulated at each compressible node, and all node pressures are advanced simultaneously.
+ * Fixed-pressure nodes represent external reservoirs or sinks. This explicit storage-node coupling supports splits,
+ * merges, manifolds, and injection branches without making branch execution order part of the pressure solution.
+ * </p>
+ *
+ * <p>
+ * This first network layer is intentionally storage based. Algebraic zero-volume junctions, global Newton pressure-flow
+ * iteration, component/enthalpy mixing, reverse-flow boundary composition, and branch subcycling are outside its
+ * current scope.
+ * </p>
+ */
+public final class TwoFluidPipeNetwork implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private static final int PHASE_COUNT = 3;
+
+  private final String name;
+  private final Map<String, NetworkNode> nodes = new LinkedHashMap<String, NetworkNode>();
+  private final Map<String, NetworkBranch> branches = new LinkedHashMap<String, NetworkBranch>();
+  private boolean initialized;
+  private double simulationTimeSeconds;
+  private BalanceReport lastBalanceReport;
+
+  /** Create an empty network. */
+  public TwoFluidPipeNetwork(String name) {
+    if (name == null || name.trim().isEmpty()) {
+      throw new IllegalArgumentException("Network name cannot be blank");
+    }
+    this.name = name;
+  }
+
+  /** Add a storage node whose pressure follows its compressible phase inventories. */
+  public void addCompressibleNode(String nodeName, UpstreamCompressibleVolume volume) {
+    requireUniqueNodeName(nodeName);
+    if (volume == null) {
+      throw new IllegalArgumentException("Compressible node volume cannot be null");
+    }
+    nodes.put(nodeName, NetworkNode.compressible(nodeName, volume));
+  }
+
+  /** Add an external fixed-pressure reservoir or sink node. */
+  public void addFixedPressureNode(String nodeName, double pressurePa) {
+    requireUniqueNodeName(nodeName);
+    requirePositiveFinite(pressurePa, "Fixed-node pressure");
+    nodes.put(nodeName, NetworkNode.fixed(nodeName, pressurePa));
+  }
+
+  /** Add a directed two-fluid pipe branch between existing nodes. */
+  public void addPipe(String branchName, String fromNodeName, String toNodeName, TwoFluidPipe pipe) {
+    requireName(branchName, "Branch");
+    if (branches.containsKey(branchName)) {
+      throw new IllegalArgumentException("Branch '" + branchName + "' already exists");
+    }
+    NetworkNode fromNode = requireNode(fromNodeName);
+    NetworkNode toNode = requireNode(toNodeName);
+    if (fromNode == toNode) {
+      throw new IllegalArgumentException("Branch '" + branchName + "' cannot connect a node to itself");
+    }
+    if (pipe == null) {
+      throw new IllegalArgumentException("Network pipe cannot be null");
+    }
+    if (pipe.getUpstreamCompressibleVolume() != null) {
+      throw new IllegalArgumentException(
+          "Branch '" + branchName + "' already owns an upstream volume; network nodes must own boundary storage");
+    }
+    NetworkBranch branch = new NetworkBranch(branchName, fromNode, toNode, pipe);
+    branches.put(branchName, branch);
+    fromNode.outgoingCount++;
+    toNode.incomingCount++;
+    initialized = false;
+  }
+
+  /**
+   * Initialize each branch from its configured stream and the downstream node pressure.
+   *
+   * <p>
+   * The branch stream flow remains the steady initialization rate. Transient execution then switches both ends to node
+   * pressures.
+   * </p>
+   */
+  public void initialize(UUID id) {
+    validateRunnableNetwork();
+    for (NetworkBranch branch : branches.values()) {
+      branch.pipe.setOutletPressure(branch.toNode.getPressurePa());
+      branch.pipe.run(id);
+      configureTransientPressures(branch);
+    }
+    initialized = true;
+  }
+
+  /** Advance every branch and all compressible nodes by one common reporting interval. */
+  public void runTransient(double timeStepSeconds, UUID id) {
+    requirePositiveFinite(timeStepSeconds, "Network time step");
+    if (!initialized) {
+      initialize(id);
+    }
+
+    double[] initialMassKg = new double[PHASE_COUNT];
+    double[] finalMassKg = new double[PHASE_COUNT];
+    double[] externalInletMassKg = new double[PHASE_COUNT];
+    double[] externalOutletMassKg = new double[PHASE_COUNT];
+    double[] sourceMassKg = new double[PHASE_COUNT];
+    Map<String, double[]> nodeTransferKg = new LinkedHashMap<String, double[]>();
+
+    for (NetworkNode node : nodes.values()) {
+      nodeTransferKg.put(node.name, new double[PHASE_COUNT]);
+      if (!node.fixedPressure) {
+        for (int phase = 0; phase < PHASE_COUNT; phase++) {
+          initialMassKg[phase] += node.volume.getPhaseMassKg(phase);
+          sourceMassKg[phase] += node.volume.getSourceMassFlowRateKgS(phase) * timeStepSeconds;
+        }
+      }
+    }
+
+    for (NetworkBranch branch : branches.values()) {
+      configureTransientPressures(branch);
+      branch.pipe.runTransient(timeStepSeconds, id);
+      TwoFluidMassBalanceReport report = branch.pipe.getLastMassBalanceReport();
+      if (report == null) {
+        throw new IllegalStateException("Branch '" + branch.name + "' returned no mass-balance report");
+      }
+      for (int phase = 0; phase < PHASE_COUNT; phase++) {
+        Phase aggregation = phase(phase);
+        initialMassKg[phase] += report.getInitialMassKg(aggregation);
+        finalMassKg[phase] += report.getFinalMassKg(aggregation);
+        sourceMassKg[phase] += report.getSourceMassKg(aggregation);
+        double inletMass = report.getInletMassKg(aggregation);
+        double outletMass = report.getOutletMassKg(aggregation);
+        if (branch.fromNode.fixedPressure) {
+          externalInletMassKg[phase] += inletMass;
+        } else {
+          nodeTransferKg.get(branch.fromNode.name)[phase] += inletMass;
+        }
+        if (branch.toNode.fixedPressure) {
+          externalOutletMassKg[phase] += outletMass;
+        } else {
+          nodeTransferKg.get(branch.toNode.name)[phase] -= outletMass;
+        }
+      }
+    }
+
+    for (NetworkNode node : nodes.values()) {
+      if (!node.fixedPressure) {
+        node.volume.advance(timeStepSeconds, nodeTransferKg.get(node.name));
+        for (int phase = 0; phase < PHASE_COUNT; phase++) {
+          finalMassKg[phase] += node.volume.getPhaseMassKg(phase);
+        }
+      }
+    }
+
+    simulationTimeSeconds += timeStepSeconds;
+    lastBalanceReport = new BalanceReport(timeStepSeconds, initialMassKg, finalMassKg, externalInletMassKg,
+        externalOutletMassKg, sourceMassKg);
+  }
+
+  private void configureTransientPressures(NetworkBranch branch) {
+    branch.pipe.setInletBoundaryCondition(BoundaryCondition.CONSTANT_PRESSURE);
+    branch.pipe.setInletPressure(branch.fromNode.getPressurePa());
+    branch.pipe.setOutletBoundaryCondition(BoundaryCondition.CONSTANT_PRESSURE);
+    branch.pipe.setOutletPressure(branch.toNode.getPressurePa());
+  }
+
+  private void validateRunnableNetwork() {
+    if (nodes.size() < 2 || branches.isEmpty()) {
+      throw new IllegalStateException("Two-fluid network requires at least two nodes and one branch");
+    }
+    for (NetworkNode node : nodes.values()) {
+      if (node.incomingCount + node.outgoingCount == 0) {
+        throw new IllegalStateException("Node '" + node.name + "' is not connected to a branch");
+      }
+    }
+  }
+
+  private void requireUniqueNodeName(String nodeName) {
+    requireName(nodeName, "Node");
+    if (nodes.containsKey(nodeName)) {
+      throw new IllegalArgumentException("Node '" + nodeName + "' already exists");
+    }
+  }
+
+  private NetworkNode requireNode(String nodeName) {
+    NetworkNode node = nodes.get(nodeName);
+    if (node == null) {
+      throw new IllegalArgumentException("Node '" + nodeName + "' does not exist");
+    }
+    return node;
+  }
+
+  private static void requireName(String value, String label) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(label + " name cannot be blank");
+    }
+  }
+
+  private static void requirePositiveFinite(double value, String label) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(label + " must be positive and finite");
+    }
+  }
+
+  private static Phase phase(int index) {
+    switch (index) {
+    case 0:
+      return Phase.GAS;
+    case 1:
+      return Phase.OIL;
+    case 2:
+      return Phase.WATER;
+    default:
+      throw new IllegalArgumentException("Unsupported phase index " + index);
+    }
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public double getSimulationTimeSeconds() {
+    return simulationTimeSeconds;
+  }
+
+  public BalanceReport getLastBalanceReport() {
+    return lastBalanceReport;
+  }
+
+  public TwoFluidPipe getPipe(String branchName) {
+    NetworkBranch branch = branches.get(branchName);
+    if (branch == null)
+      throw new IllegalArgumentException("Branch '" + branchName + "' does not exist");
+    return branch.pipe;
+  }
+
+  public double getNodePressurePa(String nodeName) {
+    return requireNode(nodeName).getPressurePa();
+  }
+
+  private static final class NetworkNode implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final boolean fixedPressure;
+    private final double fixedPressurePa;
+    private final UpstreamCompressibleVolume volume;
+    private int incomingCount;
+    private int outgoingCount;
+
+    private NetworkNode(String name, boolean fixedPressure, double fixedPressurePa, UpstreamCompressibleVolume volume) {
+      this.name = name;
+      this.fixedPressure = fixedPressure;
+      this.fixedPressurePa = fixedPressurePa;
+      this.volume = volume;
+    }
+
+    private static NetworkNode fixed(String name, double pressurePa) {
+      return new NetworkNode(name, true, pressurePa, null);
+    }
+
+    private static NetworkNode compressible(String name, UpstreamCompressibleVolume volume) {
+      return new NetworkNode(name, false, Double.NaN, volume);
+    }
+
+    private double getPressurePa() {
+      return fixedPressure ? fixedPressurePa : volume.getPressurePa();
+    }
+  }
+
+  private static final class NetworkBranch implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final NetworkNode fromNode;
+    private final NetworkNode toNode;
+    private final TwoFluidPipe pipe;
+
+    private NetworkBranch(String name, NetworkNode fromNode, NetworkNode toNode, TwoFluidPipe pipe) {
+      this.name = name;
+      this.fromNode = fromNode;
+      this.toNode = toNode;
+      this.pipe = pipe;
+    }
+  }
+
+  /** Whole-network phase and total mass balance for the latest accepted reporting interval. */
+  public static final class BalanceReport implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final double elapsedTimeSeconds;
+    private final double[] initialMassKg;
+    private final double[] finalMassKg;
+    private final double[] externalInletMassKg;
+    private final double[] externalOutletMassKg;
+    private final double[] sourceMassKg;
+
+    private BalanceReport(double elapsedTimeSeconds, double[] initialMassKg, double[] finalMassKg,
+        double[] externalInletMassKg, double[] externalOutletMassKg, double[] sourceMassKg) {
+      this.elapsedTimeSeconds = elapsedTimeSeconds;
+      this.initialMassKg = initialMassKg.clone();
+      this.finalMassKg = finalMassKg.clone();
+      this.externalInletMassKg = externalInletMassKg.clone();
+      this.externalOutletMassKg = externalOutletMassKg.clone();
+      this.sourceMassKg = sourceMassKg.clone();
+    }
+
+    public double getElapsedTimeSeconds() {
+      return elapsedTimeSeconds;
+    }
+
+    public double getInitialMassKg(Phase aggregation) {
+      return aggregate(initialMassKg, aggregation);
+    }
+
+    public double getFinalMassKg(Phase aggregation) {
+      return aggregate(finalMassKg, aggregation);
+    }
+
+    public double getExternalInletMassKg(Phase aggregation) {
+      return aggregate(externalInletMassKg, aggregation);
+    }
+
+    public double getExternalOutletMassKg(Phase aggregation) {
+      return aggregate(externalOutletMassKg, aggregation);
+    }
+
+    public double getSourceMassKg(Phase aggregation) {
+      return aggregate(sourceMassKg, aggregation);
+    }
+
+    public double getResidualKg(Phase aggregation) {
+      return getFinalMassKg(aggregation) - getInitialMassKg(aggregation)
+          - (getExternalInletMassKg(aggregation) - getExternalOutletMassKg(aggregation) + getSourceMassKg(aggregation));
+    }
+
+    public double getRelativeResidual(Phase aggregation) {
+      double scale = Math.max(Math.abs(getInitialMassKg(aggregation)), Math.abs(getFinalMassKg(aggregation)));
+      scale = Math.max(scale, Math.abs(getExternalInletMassKg(aggregation))
+          + Math.abs(getExternalOutletMassKg(aggregation)) + Math.abs(getSourceMassKg(aggregation)));
+      return Math.abs(getResidualKg(aggregation)) / Math.max(scale, 1.0e-12);
+    }
+
+    private static double aggregate(double[] values, Phase aggregation) {
+      switch (aggregation) {
+      case GAS:
+        return values[0];
+      case OIL:
+        return values[1];
+      case WATER:
+        return values[2];
+      case LIQUID:
+        return values[1] + values[2];
+      case TOTAL:
+        return values[0] + values[1] + values[2];
+      default:
+        throw new IllegalArgumentException("Unsupported phase " + aggregation);
+      }
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidBenchmarkMetrics.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidBenchmarkMetrics.java
@@ -1,0 +1,235 @@
+package neqsim.process.equipment.pipeline;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/** Reusable, scale-aware comparison metrics for two-fluid benchmark and acceptance suites. */
+public final class TwoFluidBenchmarkMetrics {
+  private TwoFluidBenchmarkMetrics() {
+  }
+
+  /** Fit the least-squares log-log exponent in {@code response = constant * rate^n}. */
+  public static double fitRateExponent(double[] rates, double[] responses) {
+    requireSameLength(rates, responses, 2);
+    double meanX = 0.0;
+    double meanY = 0.0;
+    for (int index = 0; index < rates.length; index++) {
+      requirePositiveFinite(rates[index], "Rate");
+      requirePositiveFinite(responses[index], "Response");
+      meanX += Math.log(rates[index]);
+      meanY += Math.log(responses[index]);
+    }
+    meanX /= rates.length;
+    meanY /= rates.length;
+    double covariance = 0.0;
+    double variance = 0.0;
+    for (int index = 0; index < rates.length; index++) {
+      double dx = Math.log(rates[index]) - meanX;
+      covariance += dx * (Math.log(responses[index]) - meanY);
+      variance += dx * dx;
+    }
+    if (!(variance > 0.0)) {
+      throw new IllegalArgumentException("Rate sweep must contain at least two distinct rates");
+    }
+    return covariance / variance;
+  }
+
+  /** Return maximum value divided by the sample median of a positive profile. */
+  public static double maximumToMedianRatio(double[] profile) {
+    requireFiniteValues(profile, 1, "Profile");
+    double maximum = -Double.MAX_VALUE;
+    for (double value : profile) {
+      if (value < 0.0) {
+        throw new IllegalArgumentException("Profile values must be non-negative");
+      }
+      maximum = Math.max(maximum, value);
+    }
+    double median = percentile(profile, 0.5);
+    if (!(median > 0.0)) {
+      throw new IllegalArgumentException("Profile median must be positive");
+    }
+    return maximum / median;
+  }
+
+  /** Symmetric relative spread using the larger absolute result as scale. */
+  public static double relativeMeshSpread(double first, double second) {
+    if (!Double.isFinite(first) || !Double.isFinite(second)) {
+      throw new IllegalArgumentException("Mesh results must be finite");
+    }
+    double scale = Math.max(Math.abs(first), Math.abs(second));
+    return scale == 0.0 ? 0.0 : Math.abs(first - second) / scale;
+  }
+
+  /**
+   * Analyze a settled signal with robust P10-P90 amplitude and completed median-upcrossing cycles.
+   *
+   * @param timeSeconds strictly increasing sample times
+   * @param signal sampled pressure, flow, or holdup signal
+   * @param settledWindowStartSeconds first time included in the settled window
+   * @return immutable limit-cycle metrics
+   */
+  public static LimitCycleMetrics analyzeLimitCycle(double[] timeSeconds, double[] signal,
+      double settledWindowStartSeconds) {
+    requireSameLength(timeSeconds, signal, 3);
+    if (!Double.isFinite(settledWindowStartSeconds)) {
+      throw new IllegalArgumentException("Settled-window start must be finite");
+    }
+    List<Double> selectedTimes = new ArrayList<Double>();
+    List<Double> selectedSignal = new ArrayList<Double>();
+    double previousTime = -Double.MAX_VALUE;
+    for (int index = 0; index < timeSeconds.length; index++) {
+      double time = timeSeconds[index];
+      double value = signal[index];
+      if (!Double.isFinite(time) || !Double.isFinite(value) || time <= previousTime) {
+        throw new IllegalArgumentException("Times must be finite and strictly increasing; signal must be finite");
+      }
+      previousTime = time;
+      if (time >= settledWindowStartSeconds) {
+        selectedTimes.add(time);
+        selectedSignal.add(value);
+      }
+    }
+    if (selectedTimes.size() < 3) {
+      throw new IllegalArgumentException("Settled window must contain at least three samples");
+    }
+
+    double[] values = new double[selectedSignal.size()];
+    for (int index = 0; index < values.length; index++) {
+      values[index] = selectedSignal.get(index);
+    }
+    double p10 = percentile(values, 0.10);
+    double median = percentile(values, 0.50);
+    double p90 = percentile(values, 0.90);
+    double robustBand = p90 - p10;
+
+    List<Double> crossingTimes = new ArrayList<Double>();
+    if (robustBand > Math.ulp(Math.max(1.0, Math.abs(median)))) {
+      for (int index = 1; index < values.length; index++) {
+        double before = values[index - 1] - median;
+        double after = values[index] - median;
+        if (before < 0.0 && after >= 0.0 && after > before) {
+          double fraction = -before / (after - before);
+          double crossing = selectedTimes.get(index - 1)
+              + fraction * (selectedTimes.get(index) - selectedTimes.get(index - 1));
+          crossingTimes.add(crossing);
+        }
+      }
+    }
+    int completedCycles = Math.max(0, crossingTimes.size() - 1);
+    double period = Double.NaN;
+    if (completedCycles > 0) {
+      double[] intervals = new double[completedCycles];
+      for (int index = 0; index < intervals.length; index++) {
+        intervals[index] = crossingTimes.get(index + 1) - crossingTimes.get(index);
+      }
+      period = percentile(intervals, 0.5);
+    }
+    return new LimitCycleMetrics(p10, median, p90, period, completedCycles, values.length, selectedTimes.get(0),
+        selectedTimes.get(selectedTimes.size() - 1));
+  }
+
+  private static double percentile(double[] values, double fraction) {
+    double[] sorted = Arrays.copyOf(values, values.length);
+    Arrays.sort(sorted);
+    double position = fraction * (sorted.length - 1);
+    int lower = (int) Math.floor(position);
+    int upper = (int) Math.ceil(position);
+    if (lower == upper) {
+      return sorted[lower];
+    }
+    double weight = position - lower;
+    return sorted[lower] * (1.0 - weight) + sorted[upper] * weight;
+  }
+
+  private static void requireSameLength(double[] first, double[] second, int minimumLength) {
+    requireFiniteValues(first, minimumLength, "First array");
+    requireFiniteValues(second, minimumLength, "Second array");
+    if (first.length != second.length) {
+      throw new IllegalArgumentException("Arrays must have the same length");
+    }
+  }
+
+  private static void requireFiniteValues(double[] values, int minimumLength, String label) {
+    if (values == null || values.length < minimumLength) {
+      throw new IllegalArgumentException(label + " must contain at least " + minimumLength + " values");
+    }
+    for (double value : values) {
+      if (!Double.isFinite(value)) {
+        throw new IllegalArgumentException(label + " values must be finite");
+      }
+    }
+  }
+
+  private static void requirePositiveFinite(double value, String label) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(label + " must be positive and finite");
+    }
+  }
+
+  /** Immutable transient limit-cycle summary. */
+  public static final class LimitCycleMetrics implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final double p10;
+    private final double median;
+    private final double p90;
+    private final double periodSeconds;
+    private final int completedCycleCount;
+    private final int sampleCount;
+    private final double windowStartSeconds;
+    private final double windowEndSeconds;
+
+    private LimitCycleMetrics(double p10, double median, double p90, double periodSeconds, int completedCycleCount,
+        int sampleCount, double windowStartSeconds, double windowEndSeconds) {
+      this.p10 = p10;
+      this.median = median;
+      this.p90 = p90;
+      this.periodSeconds = periodSeconds;
+      this.completedCycleCount = completedCycleCount;
+      this.sampleCount = sampleCount;
+      this.windowStartSeconds = windowStartSeconds;
+      this.windowEndSeconds = windowEndSeconds;
+    }
+
+    public double getP10() {
+      return p10;
+    }
+
+    public double getMedian() {
+      return median;
+    }
+
+    public double getP90() {
+      return p90;
+    }
+
+    public double getP10ToP90Band() {
+      return p90 - p10;
+    }
+
+    public double getPeriodSeconds() {
+      return periodSeconds;
+    }
+
+    public int getCompletedCycleCount() {
+      return completedCycleCount;
+    }
+
+    public int getSampleCount() {
+      return sampleCount;
+    }
+
+    public double getWindowStartSeconds() {
+      return windowStartSeconds;
+    }
+
+    public double getWindowEndSeconds() {
+      return windowEndSeconds;
+    }
+
+    public boolean hasRepeatedCycle() {
+      return completedCycleCount > 0 && Double.isFinite(periodSeconds);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolume.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/UpstreamCompressibleVolume.java
@@ -190,6 +190,10 @@ public final class UpstreamCompressibleVolume implements Serializable {
     return phaseMassKg[phase];
   }
 
+  public double getSourceMassFlowRateKgS(int phase) {
+    return sourceMassFlowKgS[phase];
+  }
+
   public double getTotalMassKg() {
     return phaseMassKg[0] + phaseMassKg[1] + phaseMassKg[2];
   }

--- a/src/test/java/neqsim/process/equipment/network/TwoFluidPipeNetworkTest.java
+++ b/src/test/java/neqsim/process/equipment/network/TwoFluidPipeNetworkTest.java
@@ -1,0 +1,81 @@
+package neqsim.process.equipment.network;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport.Phase;
+import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import neqsim.process.equipment.pipeline.UpstreamCompressibleVolume;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+@Tag("slow")
+class TwoFluidPipeNetworkTest {
+  @Test
+  void serialBranchesAndStorageNodeCloseWholeNetworkMass() {
+    TwoFluidPipeNetwork network = new TwoFluidPipeNetwork("serial network");
+    network.addFixedPressureNode("source", 60.0e5);
+    network.addCompressibleNode("manifold", createVolume(55.0e5, 1000.0));
+    network.addFixedPressureNode("sink", 50.0e5);
+    network.addPipe("upstream", "source", "manifold", createPipe("upstream"));
+    network.addPipe("downstream", "manifold", "sink", createPipe("downstream"));
+
+    network.runTransient(0.01, UUID.randomUUID());
+
+    TwoFluidPipeNetwork.BalanceReport report = network.getLastBalanceReport();
+    for (Phase phase : Phase.values()) {
+      assertTrue(report.getRelativeResidual(phase) < 1.0e-8,
+          phase + " network residual=" + report.getRelativeResidual(phase));
+    }
+    assertTrue(Double.isFinite(network.getNodePressurePa("manifold")));
+    assertEquals(0.01, network.getSimulationTimeSeconds(), 0.0);
+  }
+
+  @Test
+  void identicalSplitBranchesRemainSymmetric() {
+    UpstreamCompressibleVolume splitter = createVolume(60.0e5, 1.0e5);
+    TwoFluidPipeNetwork network = new TwoFluidPipeNetwork("symmetric split");
+    network.addCompressibleNode("splitter", splitter);
+    network.addFixedPressureNode("sink A", 50.0e5);
+    network.addFixedPressureNode("sink B", 50.0e5);
+    network.addPipe("branch A", "splitter", "sink A", createPipe("branch A"));
+    network.addPipe("branch B", "splitter", "sink B", createPipe("branch B"));
+
+    network.runTransient(0.01, UUID.randomUUID());
+
+    TwoFluidMassBalanceReport first = network.getPipe("branch A").getLastMassBalanceReport();
+    TwoFluidMassBalanceReport second = network.getPipe("branch B").getLastMassBalanceReport();
+    assertEquals(first.getOutletMassKg(Phase.TOTAL), second.getOutletMassKg(Phase.TOTAL), 1.0e-12);
+    assertTrue(network.getLastBalanceReport().getRelativeResidual(Phase.TOTAL) < 1.0e-8);
+  }
+
+  private static TwoFluidPipe createPipe(String name) {
+    SystemInterface fluid = new SystemSrkEos(300.0, 60.0);
+    fluid.addComponent("methane", 0.95);
+    fluid.addComponent("n-heptane", 0.05);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+    Stream feed = new Stream(name + " feed", fluid);
+    feed.setFlowRate(2.0, "kg/sec");
+    feed.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe(name, feed);
+    pipe.setLength(50.0);
+    pipe.setDiameter(0.20);
+    pipe.setNumberOfSections(4);
+    pipe.setElevationProfile(new double[4]);
+    return pipe;
+  }
+
+  private static UpstreamCompressibleVolume createVolume(double pressurePa, double volumeM3) {
+    double[] density = { 45.0, 700.0, 1000.0 };
+    double[] soundSpeed = { 350.0, 1200.0, 1450.0 };
+    double[] mass = { 0.90 * volumeM3 * density[0], 0.10 * volumeM3 * density[1], 0.0 };
+    return new UpstreamCompressibleVolume(volumeM3, pressurePa, mass, density, soundSpeed);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidBenchmarkMetricsTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidBenchmarkMetricsTest.java
@@ -1,0 +1,59 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class TwoFluidBenchmarkMetricsTest {
+  @Test
+  void fitsRateSweepExponentInsteadOfOnlyCheckingOneLevel() {
+    double[] rates = { 1.0, 2.0, 4.0, 8.0 };
+    double[] pressureDrops = new double[rates.length];
+    for (int index = 0; index < rates.length; index++) {
+      pressureDrops[index] = 3.5 * Math.pow(rates[index], 1.8);
+    }
+    assertEquals(1.8, TwoFluidBenchmarkMetrics.fitRateExponent(rates, pressureDrops), 1.0e-12);
+  }
+
+  @Test
+  void reportsScaleFreeProfileLocalizationAndMeshSpread() {
+    assertEquals(9.0, TwoFluidBenchmarkMetrics.maximumToMedianRatio(new double[] { 1.0, 1.0, 1.0, 9.0 }), 0.0);
+    assertEquals(0.2, TwoFluidBenchmarkMetrics.relativeMeshSpread(80.0, 100.0), 1.0e-15);
+    assertEquals(0.2, TwoFluidBenchmarkMetrics.relativeMeshSpread(100.0, 80.0), 1.0e-15);
+  }
+
+  @Test
+  void recoversPeriodBandAndCompletedCyclesFromSettledSignal() {
+    double[] time = new double[481];
+    double[] signal = new double[481];
+    for (int index = 0; index < time.length; index++) {
+      time[index] = 0.25 * index;
+      signal[index] = 2.0 + Math.sin(2.0 * Math.PI * time[index] / 10.0);
+    }
+
+    TwoFluidBenchmarkMetrics.LimitCycleMetrics metrics = TwoFluidBenchmarkMetrics.analyzeLimitCycle(time, signal, 20.0);
+
+    assertTrue(metrics.hasRepeatedCycle());
+    assertEquals(10.0, metrics.getPeriodSeconds(), 1.0e-12);
+    assertEquals(8, metrics.getCompletedCycleCount());
+    assertEquals(1.902113032590307, metrics.getP10ToP90Band(), 1.0e-12);
+  }
+
+  @Test
+  void startupSpikeDoesNotMasqueradeAsSettledLimitCycle() {
+    double[] time = new double[101];
+    double[] signal = new double[101];
+    for (int index = 0; index < time.length; index++) {
+      time[index] = index;
+      signal[index] = index < 10 ? 100.0 * Math.exp(-0.5 * index) : 5.0;
+    }
+
+    TwoFluidBenchmarkMetrics.LimitCycleMetrics metrics = TwoFluidBenchmarkMetrics.analyzeLimitCycle(time, signal, 20.0);
+
+    assertFalse(metrics.hasRepeatedCycle());
+    assertEquals(0, metrics.getCompletedCycleCount());
+    assertEquals(0.0, metrics.getP10ToP90Band(), 0.0);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingExperimentalBenchmarkTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/SevereSluggingExperimentalBenchmarkTest.java
@@ -15,6 +15,8 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.TwoFluidBenchmarkMetrics;
+import neqsim.process.equipment.pipeline.TwoFluidBenchmarkMetrics.LimitCycleMetrics;
 import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport;
 import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport.Phase;
 import neqsim.process.equipment.pipeline.TwoFluidPipe;
@@ -174,11 +176,11 @@ class SevereSluggingExperimentalBenchmarkTest {
     for (TransientMetrics metrics : ensemble) {
       logger.info(String.format(Locale.ROOT,
           "%s: meanP=%.0f Pa peakToPeak=%.0f Pa (%.2f x riser head) p10p90=%.0f Pa period=%.2f s "
-              + "qMax=%.3f qMin=%.3f kg/s slug=%.3f m",
+              + "cycles=%d qMax=%.3f qMin=%.3f kg/s slug=%.3f m",
           metrics.label, metrics.meanInletPressurePa, metrics.peakToPeakPressurePa,
           metrics.peakToPeakPressurePa / RISER_HYDROSTATIC_HEAD_PA, metrics.p10ToP90PressurePa,
-          metrics.cyclePeriodSeconds, metrics.maximumLiquidOutletKgPerSecond, metrics.minimumLiquidOutletKgPerSecond,
-          metrics.maximumSlugLengthM));
+          metrics.cyclePeriodSeconds, metrics.completedCycleCount, metrics.maximumLiquidOutletKgPerSecond,
+          metrics.minimumLiquidOutletKgPerSecond, metrics.maximumSlugLengthM));
     }
   }
 
@@ -202,6 +204,8 @@ class SevereSluggingExperimentalBenchmarkTest {
           metrics.label + ": no repeated blowout/fallback cycle was detected");
       assertTrue(metrics.cyclePeriodSeconds > 5.0, metrics.label
           + ": cycle period is shorter than the riser filling time, period=" + metrics.cyclePeriodSeconds);
+      assertTrue(metrics.completedCycleCount >= 2, metrics.label
+          + ": fewer than two completed settled-window cycles were detected, count=" + metrics.completedCycleCount);
       assertTrue(
           metrics.peakToPeakPressurePa > RECORDED_PRESSURE_SWING_LOWER_BOUND_IN_RISER_HEADS * RISER_HYDROSTATIC_HEAD_PA,
           metrics.label + ": the riser-base swing is too small to be severe slugging, peakToPeak="
@@ -318,6 +322,7 @@ class SevereSluggingExperimentalBenchmarkTest {
     assertEquals(reference.peakToPeakPressurePa, referenceRepeat.peakToPeakPressurePa, 0.0);
     assertEquals(reference.meanInletPressurePa, referenceRepeat.meanInletPressurePa, 0.0);
     assertEquals(reference.cyclePeriodSeconds, referenceRepeat.cyclePeriodSeconds, 0.0);
+    assertEquals(reference.completedCycleCount, referenceRepeat.completedCycleCount);
     assertEquals(reference.maximumLiquidOutletKgPerSecond, referenceRepeat.maximumLiquidOutletKgPerSecond, 0.0);
     assertEquals(reference.maximumSlugLengthM, referenceRepeat.maximumSlugLengthM, 0.0);
     for (Phase phase : Phase.values()) {
@@ -357,14 +362,15 @@ class SevereSluggingExperimentalBenchmarkTest {
       }
     }
 
-    List<Double> sortedPressures = new ArrayList<>(pressureSamples);
-    Collections.sort(sortedPressures);
+    LimitCycleMetrics pressureCycle = TwoFluidBenchmarkMetrics.analyzeLimitCycle(toArray(sampleTimes),
+        toArray(pressureSamples), WARM_UP_SECONDS);
+    LimitCycleMetrics liquidCycle = TwoFluidBenchmarkMetrics.analyzeLimitCycle(toArray(sampleTimes),
+        toArray(liquidOutletSamples), WARM_UP_SECONDS);
     double maximumSlugLength = pipe.getMaxSlugLengthAtOutlet();
     return new TransientMetrics(label, SOURCE_URL, maximum(pressureSamples) - minimum(pressureSamples),
-        percentile(sortedPressures, 0.90) - percentile(sortedPressures, 0.10), mean(pressureSamples),
-        estimateLowProductionCyclePeriod(sampleTimes, liquidOutletSamples), minimum(liquidOutletSamples),
-        maximum(liquidOutletSamples), maximumSlugLength, pipe.isSteadyStateWallClockLimited(), maximumClosure,
-        finalInventory);
+        pressureCycle.getP10ToP90Band(), mean(pressureSamples), liquidCycle.getPeriodSeconds(),
+        liquidCycle.getCompletedCycleCount(), minimum(liquidOutletSamples), maximum(liquidOutletSamples),
+        maximumSlugLength, pipe.isSteadyStateWallClockLimited(), maximumClosure, finalInventory);
   }
 
   private static TwoFluidPipe createLargeFacilityTestThree(int numberOfSections, double inletPressurePerturbation) {
@@ -422,6 +428,14 @@ class SevereSluggingExperimentalBenchmarkTest {
     pipe.setSteadyStateMaxWallClockTime(Double.POSITIVE_INFINITY);
     pipe.run();
     return pipe;
+  }
+
+  private static double[] toArray(List<Double> values) {
+    double[] result = new double[values.size()];
+    for (int index = 0; index < values.size(); index++) {
+      result[index] = values.get(index);
+    }
+    return result;
   }
 
   private static double estimateLowProductionCyclePeriod(List<Double> times, List<Double> liquidRates) {
@@ -549,6 +563,7 @@ class SevereSluggingExperimentalBenchmarkTest {
     private final double p10ToP90PressurePa;
     private final double meanInletPressurePa;
     private final double cyclePeriodSeconds;
+    private final int completedCycleCount;
     private final double minimumLiquidOutletKgPerSecond;
     private final double maximumLiquidOutletKgPerSecond;
     private final double maximumSlugLengthM;
@@ -557,15 +572,17 @@ class SevereSluggingExperimentalBenchmarkTest {
     private final Map<Phase, Double> finalInventoryKg;
 
     private TransientMetrics(String label, String sourceUrl, double peakToPeakPressurePa, double p10ToP90PressurePa,
-        double meanInletPressurePa, double cyclePeriodSeconds, double minimumLiquidOutletKgPerSecond,
-        double maximumLiquidOutletKgPerSecond, double maximumSlugLengthM, boolean steadyStateWallClockLimited,
-        Map<Phase, Double> maximumRelativeClosure, Map<Phase, Double> finalInventoryKg) {
+        double meanInletPressurePa, double cyclePeriodSeconds, int completedCycleCount,
+        double minimumLiquidOutletKgPerSecond, double maximumLiquidOutletKgPerSecond, double maximumSlugLengthM,
+        boolean steadyStateWallClockLimited, Map<Phase, Double> maximumRelativeClosure,
+        Map<Phase, Double> finalInventoryKg) {
       this.label = label;
       this.sourceUrl = sourceUrl;
       this.peakToPeakPressurePa = peakToPeakPressurePa;
       this.p10ToP90PressurePa = p10ToP90PressurePa;
       this.meanInletPressurePa = meanInletPressurePa;
       this.cyclePeriodSeconds = cyclePeriodSeconds;
+      this.completedCycleCount = completedCycleCount;
       this.minimumLiquidOutletKgPerSecond = minimumLiquidOutletKgPerSecond;
       this.maximumLiquidOutletKgPerSecond = maximumLiquidOutletKgPerSecond;
       this.maximumSlugLengthM = maximumSlugLengthM;


### PR DESCRIPTION
## Summary

Stacked on #3111 (which is stacked on #3110). Converts the session's comparison rules into reusable code and applies them to the public Tengesdal severe-slug benchmark.

Advances #2907 validation items.

## Metrics

`TwoFluidBenchmarkMetrics` provides deterministic definitions for:

- least-squares rate exponent in `deltaP ~ rate^n`;
- section-profile maximum/median localization ratio;
- symmetric relative mesh spread;
- settled-window P10, median, P90, P10-P90 band, median-upcrossing period, and completed cycle count.

A decaying startup spike followed by a flat result reports zero completed cycles.

## Benchmark integration

The public Tengesdal benchmark now:
- computes the pressure P10-P90 band and liquid-rate period through the reusable metric;
- records completed settled-window cycles;
- requires at least two completed cycles in every mesh/timestep/trajectory realization;
- retains the existing public experimental, phase-mass, amplitude, mean-pressure, mesh, and deterministic-repeat checks.

Documentation records the user-supplied like-for-like OLGA comparison (21.7 s period, 0.37–4.03 kg/s liquid outlet) separately from the public experiment (38 +/- 2 s). No proprietary closure or internal data is included.

## Compatibility

This adds metrics and tightens benchmark observability; it does not change solver defaults or closures.

## Validation

**VALIDATION PENDING CI**

Completed locally without Maven:
- Java 17 compiler-module compilation of the metrics class.
- Executable synthetic harness recovered a 10.0 s period, 8 completed settled-window cycles, P10-P90 band 1.902113, and log-log exponent 1.8 exactly within floating-point error.

Full severe-slug execution, Maven, Spotless, pre-commit, documentation, Java 8/21, and repository-wide tests will be reported from exact-head CI.

---

Supersedes #3112, which GitHub auto-closed while the stacked branches were being restacked.