### PR TITLE
[AI-Assisted] docs(standards): repair core oil-quality guide

### DIFF
--- a/docs/standards/oil_quality_standards.md
+++ b/docs/standards/oil_quality_standards.md
@@ -3,8 +3,6 @@ title: "Oil Quality Standards"
 description: "Comprehensive guide to oil quality standards in NeqSim including ASTM D86 distillation, D445 viscosity, D4052 density/API gravity, D4294 sulfur, D2500 cloud point, D97 pour point, TVP (true vapor pressure), D4737 cetane index, and BS&W."
 ---
 
-# Oil Quality Standards
-
 NeqSim provides thermodynamics-based implementations of key ASTM standards used for crude oil and petroleum product quality characterization.
 
 ## Available Standards
@@ -15,7 +13,7 @@ NeqSim provides thermodynamics-based implementations of key ASTM standards used 
 | ASTM D445 | `Standard_ASTM_D445` | Kinematic viscosity | KV40, KV100, Viscosity Index |
 | ASTM D4052 | `Standard_ASTM_D4052` | Density / API gravity | Density, SG, API, classification |
 | ASTM D4294 | `Standard_ASTM_D4294` | Total sulfur content | Sulfur wt%, sweet/sour class |
-| ASTM D6377 | `Standard_ASTM_D6377` | Reid vapor pressure (RVP) | RVP at 37.8 &deg;C |
+| ASTM D6377 | `Standard_ASTM_D6377` | Simulated vapour pressure | Selected RVP/VPCR4 route and TVP at 37.8 &deg;C |
 | TVP (API MPMS 19) | `Standard_TVP` | True vapor pressure | Bubble-point pressure at any reference temperature |
 | ASTM D4737 | `Standard_ASTM_D4737` | Calculated cetane index | CCI (4-variable) + D976 (2-variable) |
 | ASTM D611 | `Standard_ASTM_D611` | Aniline point (estimate) | Estimated aniline point from Watson K + MeABP |
@@ -41,16 +39,17 @@ SystemSrkEos oil = new SystemSrkEos(273.15 + 15.0, 1.01325);
 oil.addComponent("methane", 0.01);
 oil.addComponent("ethane", 0.02);
 oil.addComponent("propane", 0.03);
-oil.addTBPfraction("C7", 0.15, 95.0, 0.72);
-oil.addTBPfraction("C10", 0.20, 135.0, 0.78);
-oil.addTBPfraction("C20", 0.30, 280.0, 0.85);
-oil.addTBPfraction("C30", 0.29, 450.0, 0.91);
+// TBP molar mass is kg/mol; density is specific gravity (g/cm3 numerically).
+oil.addTBPfraction("C7", 0.15, 0.095, 0.72);
+oil.addTBPfraction("C10", 0.20, 0.135, 0.78);
+oil.addTBPfraction("C20", 0.30, 0.280, 0.85);
+oil.addTBPfraction("C30", 0.29, 0.450, 0.91);
 oil.setMixingRule(2);
 
 // API gravity
 Standard_ASTM_D4052 apiStd = new Standard_ASTM_D4052(oil);
 apiStd.calculate();
-double apiGravity = apiStd.getValue("API gravity");
+double apiGravity = apiStd.getValue("API");
 String classification = apiStd.getOilClassification();
 System.out.println("API gravity: " + apiGravity + " (" + classification + ")");
 
@@ -87,9 +86,7 @@ Available via `getValue(param)` (or `getValue(param, unit)` for temperatures):
 | `WatsonK` (or `UOPK`) | Watson (UOP) characterization factor |
 | `recovery`, `loss`, `residue` | Recovery/loss/residue volume fractions |
 
-> Average boiling points, the Watson factor, the slope, `residue` and `loss`
-> are dimensionless or fixed-basis values and are returned unconverted by
-> `getValue(param, unit)`.
+> `IBP`, `Txx`, `FBP`, `VABP`, `MABP`, `WABP`, `CABP`, and `MeABP` are temperatures and honor the requested temperature unit. `WatsonK`, `UOPK`, `slope`, `residue`, and `loss` are returned unchanged when a unit argument is supplied.
 
 ### Temperature Units
 
@@ -213,7 +210,7 @@ Determines density at 15.556 °C (60 °F), specific gravity, API gravity, and cl
 |-----------|-------------|------|
 | `density` | Density at 60 °F | kg/m3 |
 | `specificGravity` | SG relative to water at 60 °F | dimensionless |
-| `API gravity` | API gravity | °API |
+| `API` / `apiGravity` | API gravity | °API |
 
 ### Density Unit Conversion
 
@@ -236,12 +233,14 @@ String classification = d4052.getOilClassification();
 | 10.0 - 22.3 | Heavy |
 | < 10.0 | Extra-Heavy |
 
-### Spec Checking
+### Result validity and explicit limits
+
+`isOnSpec()` currently means only that API gravity was calculated to a finite value; the class does not store minimum or maximum product limits. Apply the governing limit explicitly and retain its source and edition:
 
 ```java
-d4052.setMinAPIGravity(20.0);
-d4052.setMaxAPIGravity(45.0);
-boolean onSpec = d4052.isOnSpec();
+double api = d4052.getValue("API");
+boolean calculationValid = d4052.isOnSpec();
+boolean withinProjectLimit = calculationValid && api >= 20.0 && api <= 45.0;
 ```
 
 ---
@@ -254,8 +253,8 @@ Calculates total sulfur from sulfur-bearing components in the fluid (H2S, mercap
 
 | Parameter | Description | Unit |
 |-----------|-------------|------|
-| `sulfurContent` | Total sulfur | wt% |
-| `sulfurContent` (unit `"ppmw"`) | Total sulfur | ppmw |
+| `sulfur` / `totalSulfur` | Total sulfur derived from represented components | wt% |
+| `sulfur` / `totalSulfur` (unit `"ppmw"`) | Total sulfur derived from represented components | ppmw |
 
 ### Sulfur Classification
 
@@ -276,14 +275,14 @@ String classification = d4294.getSulfurClassification();
 SystemSrkEos sourOil = new SystemSrkEos(273.15 + 15.0, 1.01325);
 sourOil.addComponent("methane", 0.10);
 sourOil.addComponent("H2S", 0.02);
-sourOil.addTBPfraction("C10", 0.50, 135.0, 0.78);
-sourOil.addTBPfraction("C20", 0.38, 280.0, 0.85);
+sourOil.addTBPfraction("C10", 0.50, 0.135, 0.78);
+sourOil.addTBPfraction("C20", 0.38, 0.280, 0.85);
 sourOil.setMixingRule(2);
 
 Standard_ASTM_D4294 d4294 = new Standard_ASTM_D4294(sourOil);
 d4294.calculate();
 
-double sulfurWtPct = d4294.getValue("sulfurContent");
+double sulfurWtPct = d4294.getValue("sulfur");
 double sulfurPpmw = d4294.getValue("sulfurContent", "ppmw");
 String sweetSour = d4294.getSulfurClassification();
 
@@ -354,11 +353,7 @@ The required inputs are obtained internally from `Standard_ASTM_D86` (distillati
 
 ### Formula (ASTM D4737)
 
-$$
-\mathrm{CCI} = 45.2 + 0.0892\,T_{10N} + (0.131 + 0.901\,B)\,T_{50N}
-            + (0.0523 - 0.420\,B)\,T_{90N}
-            + 0.00049\,(T_{10N}^2 - T_{90N}^2) + 107\,B + 60\,B^2
-$$
+$$\mathrm{CCI} = 45.2 + 0.0892\,T_{10N} + (0.131 + 0.901\,B)\,T_{50N} + (0.0523 - 0.420\,B)\,T_{90N} + 0.00049\,(T_{10N}^2 - T_{90N}^2) + 107\,B + 60\,B^2$$
 
 where $T_{10N} = T_{10} - 215$, $T_{50N} = T_{50} - 260$, $T_{90N} = T_{90} - 310$ (temperatures in &deg;C), $B = e^{-3.5\,(D - 0.85)} - 1$, and $D$ is the density at 15 &deg;C in g/mL.
 
@@ -395,9 +390,7 @@ The **aniline point** is the lowest temperature at which equal volumes of the oi
 
 ### Formula
 
-$$
-\mathrm{AP}[^{\circ}\mathrm{C}] = c_0 + c_1\,(K_w - 12.0) + c_2\,(\mathrm{MeABP}[^{\circ}\mathrm{C}] - 190.0)
-$$
+$$\mathrm{AP}[^{\circ}\mathrm{C}] = c_0 + c_1\,(K_w - 12.0) + c_2\,(\mathrm{MeABP}[^{\circ}\mathrm{C}] - 190.0)$$
 
 with defaults $c_0 = 60.0$, $c_1 = 35.0$, $c_2 = 0.083$.
 
@@ -430,9 +423,7 @@ The **smoke point** is the maximum flame height in millimetres at which a kerose
 
 ### Formula
 
-$$
-\mathrm{SmokePoint}[\mathrm{mm}] = sp_0 + sp_1\,\mathrm{AP}[^{\circ}\mathrm{C}]
-$$
+$$\mathrm{SmokePoint}[\mathrm{mm}] = sp_0 + sp_1\,\mathrm{AP}[^{\circ}\mathrm{C}]$$
 
 with defaults $sp_0 = 8.5$, $sp_1 = 0.325$.
 
@@ -465,9 +456,7 @@ The **cold filter plugging point (CFPP)** is the highest temperature at which a 
 
 ### Formula
 
-$$
-\mathrm{CFPP}[^{\circ}\mathrm{C}] = \mathrm{cloudPoint}[^{\circ}\mathrm{C}] + \mathrm{offset}
-$$
+$$\mathrm{CFPP}[^{\circ}\mathrm{C}] = \mathrm{cloudPoint}[^{\circ}\mathrm{C}] + \mathrm{offset}$$
 
 ### Example
 
@@ -501,13 +490,9 @@ The **salt content** of crude oil is reported as PTB (pounds of NaCl-equivalent 
 
 ### Formula
 
-$$
-\mathrm{PTB} = w_{\mathrm{water}} \cdot S_{\mathrm{brine}}[\mathrm{kg/m^3}] \cdot 350.51
-$$
+$$\mathrm{PTB} = w_{\mathrm{water}} \cdot S_{\mathrm{brine}}[\mathrm{kg/m^3}] \cdot 350.51$$
 
-$$
-\mathrm{ppmw} = \frac{w_{\mathrm{water}} \cdot S_{\mathrm{brine}}[\mathrm{kg/m^3}]}{\rho_{\mathrm{crude}}[\mathrm{kg/m^3}]} \cdot 10^6
-$$
+$$\mathrm{ppmw} = \frac{w_{\mathrm{water}} \cdot S_{\mathrm{brine}}[\mathrm{kg/m^3}]}{\rho_{\mathrm{crude}}[\mathrm{kg/m^3}]} \cdot 10^6$$
 
 where the PTB factor $350.51 = 158.987\ \mathrm{m^3/1000\,bbl} \cdot 2.20462\ \mathrm{lb/kg}$, and the crude density is obtained internally from `Standard_ASTM_D4052`.
 
@@ -617,8 +602,9 @@ Determines the water and sediment volume fraction in crude oil per ASTM D4007 / 
 | Parameter | Description | Unit |
 |-----------|-------------|------|
 | `BSW` | Basic sediment & water | vol% |
-| `waterVolumeFraction` | Water volume fraction | fraction |
-| `oilVolumeFraction` | Oil volume fraction | fraction |
+| `waterCut` | Thermodynamic aqueous share of aqueous + oil liquid volume | vol% |
+
+The implementation has no sediment model and exposes no separate oil-volume getter; `BSW` and `waterCut` are the same thermodynamic water-cut result in vol%.
 
 ### Spec Checking
 
@@ -646,24 +632,26 @@ Generate a comprehensive quality report for a crude oil:
 SystemSrkEos oil = new SystemSrkEos(273.15 + 15.0, 1.01325);
 oil.addComponent("methane", 0.01);
 oil.addComponent("H2S", 0.005);
-oil.addTBPfraction("C7", 0.10, 95.0, 0.72);
-oil.addTBPfraction("C10", 0.20, 135.0, 0.78);
-oil.addTBPfraction("C20", 0.35, 280.0, 0.85);
-oil.addTBPfraction("C30", 0.295, 450.0, 0.91);
+oil.addTBPfraction("C7", 0.10, 0.095, 0.72);
+oil.addTBPfraction("C10", 0.20, 0.135, 0.78);
+oil.addTBPfraction("C20", 0.35, 0.280, 0.85);
+oil.addTBPfraction("C30", 0.295, 0.450, 0.91);
 oil.addComponent("water", 0.01);
 oil.setMixingRule(2);
+oil.setMultiPhaseCheck(true);
+oil.init(0);
 
 // API Gravity & Density
 Standard_ASTM_D4052 d4052 = new Standard_ASTM_D4052(oil);
 d4052.calculate();
 System.out.printf("API Gravity: %.1f (%s)%n",
-    d4052.getValue("API gravity"), d4052.getOilClassification());
+    d4052.getValue("API"), d4052.getOilClassification());
 
 // Sulfur Content
 Standard_ASTM_D4294 d4294 = new Standard_ASTM_D4294(oil);
 d4294.calculate();
 System.out.printf("Sulfur: %.3f wt%% (%s)%n",
-    d4294.getValue("sulfurContent"), d4294.getSulfurClassification());
+    d4294.getValue("sulfur"), d4294.getSulfurClassification());
 
 // BS&W
 Standard_BSW bsw = new Standard_BSW(oil);
@@ -697,15 +685,16 @@ Standard_ASTM_D445 = jneqsim.standards.oilquality.Standard_ASTM_D445
 
 oil = SystemSrkEos(273.15 + 15.0, 1.01325)
 oil.addComponent("methane", 0.01)
-oil.addTBPfraction("C7", 0.15, 95.0, 0.72)
-oil.addTBPfraction("C10", 0.25, 135.0, 0.78)
-oil.addTBPfraction("C20", 0.30, 280.0, 0.85)
-oil.addTBPfraction("C30", 0.29, 450.0, 0.91)
+# TBP molar mass is kg/mol; density is specific gravity (g/cm3 numerically).
+oil.addTBPfraction("C7", 0.15, 0.095, 0.72)
+oil.addTBPfraction("C10", 0.25, 0.135, 0.78)
+oil.addTBPfraction("C20", 0.30, 0.280, 0.85)
+oil.addTBPfraction("C30", 0.29, 0.450, 0.91)
 oil.setMixingRule(2)
 
 d4052 = Standard_ASTM_D4052(oil)
 d4052.calculate()
-print(f"API gravity: {d4052.getValue('API gravity'):.1f}")
+print(f"API gravity: {d4052.getValue('API'):.1f}")
 print(f"Classification: {d4052.getOilClassification()}")
 ```
 
@@ -713,6 +702,6 @@ print(f"Classification: {d4052.getOilClassification()}")
 
 ## Related Documentation
 
-- [ASTM D6377 - Reid Vapor Pressure](astm_d6377_rvp)
-- [Sales Contracts](sales_contracts)
-- [ISO 6976 - Calorific Values](iso6976_calorific_values)
+- [ASTM D6377 - simulated vapour pressure](astm_d6377_rvp.md)
+- [Sales Contracts](sales_contracts.md)
+- [ISO 6976 - Calorific Values](iso6976_calorific_values.md)

--- a/docs/standards/oil_quality_standards.md
+++ b/docs/standards/oil_quality_standards.md
@@ -283,7 +283,7 @@ Standard_ASTM_D4294 d4294 = new Standard_ASTM_D4294(sourOil);
 d4294.calculate();
 
 double sulfurWtPct = d4294.getValue("sulfur");
-double sulfurPpmw = d4294.getValue("sulfurContent", "ppmw");
+double sulfurPpmw = d4294.getValue("sulfur", "ppmw");
 String sweetSour = d4294.getSulfurClassification();
 
 System.out.printf("Sulfur: %.3f wt%% (%.0f ppmw) - %s%n",

--- a/docs/test_oil_quality_standards_documentation.py
+++ b/docs/test_oil_quality_standards_documentation.py
@@ -168,7 +168,7 @@ class OilQualityStandardsDocumentationContractTest(unittest.TestCase):
         bsw_source = self.sources["Standard_BSW"]
         self.assertNotIn("setMinAPIGravity", d4052_source)
         self.assertNotIn("setMaxAPIGravity", d4052_source)
-        self.assertIn("isOnSpec() currently means only", self.guide)
+        self.assertIn("`isOnSpec()` currently means only", self.guide)
         self.assertIn(
             "the class does not store minimum or maximum product limits",
             self.guide,

--- a/docs/test_oil_quality_standards_documentation.py
+++ b/docs/test_oil_quality_standards_documentation.py
@@ -153,7 +153,7 @@ class OilQualityStandardsDocumentationContractTest(unittest.TestCase):
         stale_contracts = (
             'getValue("API gravity")',
             "getValue('API gravity')",
-            'getValue("sulfurContent")',
+            '"sulfurContent"',
             "setMinAPIGravity(",
             "setMaxAPIGravity(",
             "`waterVolumeFraction`",

--- a/docs/test_oil_quality_standards_documentation.py
+++ b/docs/test_oil_quality_standards_documentation.py
@@ -1,0 +1,193 @@
+import re
+import unittest
+from pathlib import Path
+from urllib.parse import unquote
+
+
+DOCS_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = DOCS_DIR.parent
+GUIDE = DOCS_DIR / "standards" / "oil_quality_standards.md"
+STANDARDS_INDEX = DOCS_DIR / "standards" / "README.md"
+REFERENCE_INDEX = DOCS_DIR / "REFERENCE_MANUAL_INDEX.md"
+SYSTEM_INTERFACE = (
+    REPOSITORY_ROOT / "src/main/java/neqsim/thermo/system/SystemInterface.java"
+)
+OIL_QUALITY_SOURCE_DIR = (
+    REPOSITORY_ROOT / "src/main/java/neqsim/standards/oilquality"
+)
+
+
+def fenced_blocks(content, language):
+    pattern = rf"\x60\x60\x60{language}\n(.*?)\x60\x60\x60"
+    return re.findall(pattern, content, re.DOTALL)
+
+
+def heading_slugs(content):
+    content_without_fences = re.sub(
+        r"\x60\x60\x60.*?\x60\x60\x60",
+        "",
+        content,
+        flags=re.DOTALL,
+    )
+    return {
+        re.sub(r"[^a-z0-9 -]", "", heading.lower())
+        .strip()
+        .replace(" ", "-")
+        for heading in re.findall(
+            r"^#{1,6}\s+(.+)$",
+            content_without_fences,
+            flags=re.MULTILINE,
+        )
+    }
+
+
+class OilQualityStandardsDocumentationContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+        cls.standards_index = STANDARDS_INDEX.read_text(encoding="utf-8")
+        cls.reference_index = REFERENCE_INDEX.read_text(encoding="utf-8")
+        cls.system_interface = SYSTEM_INTERFACE.read_text(encoding="utf-8")
+        cls.sources = {
+            path.stem: path.read_text(encoding="utf-8")
+            for path in OIL_QUALITY_SOURCE_DIR.glob("Standard_*.java")
+        }
+
+    def test_structure_compact_math_fences_and_internal_links(self):
+        self.assertTrue(self.guide.startswith("---\n"))
+        self.assertEqual(self.guide.count("\x60\x60\x60") % 2, 0)
+        self.assertEqual(self.guide.count("$$") % 2, 0)
+
+        without_fences = re.sub(
+            r"\x60\x60\x60.*?\x60\x60\x60",
+            "",
+            self.guide,
+            flags=re.DOTALL,
+        )
+        self.assertNotRegex(without_fences, re.compile(r"^# ", re.MULTILINE))
+        self.assertNotIn(r"\[", without_fences)
+        self.assertNotIn(r"\(", without_fences)
+        for line in without_fences.splitlines():
+            if "$$" in line:
+                self.assertEqual(2, line.count("$$"))
+                self.assertNotIn("$$ ", line)
+                self.assertNotIn(" $$", line)
+
+        link_pattern = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+        for destination in link_pattern.findall(self.guide):
+            if destination.startswith(("http://", "https://", "mailto:")):
+                continue
+            target, _, fragment = unquote(destination).partition("#")
+            target_path = (GUIDE.parent / target).resolve()
+            with self.subTest(destination=destination):
+                self.assertTrue(target.endswith(".md"))
+                self.assertTrue(target_path.is_file())
+                if fragment:
+                    self.assertIn(
+                        fragment,
+                        heading_slugs(target_path.read_text(encoding="utf-8")),
+                    )
+
+    def test_tbp_fraction_units_and_complete_examples_are_copyable(self):
+        calls = re.findall(
+            r'addTBPfraction\("[^"]+",\s*[0-9.]+,\s*([0-9.]+),\s*([0-9.]+)\)',
+            self.guide,
+        )
+        self.assertEqual(14, len(calls))
+        for molar_mass, density in calls:
+            with self.subTest(molar_mass=molar_mass, density=density):
+                self.assertGreater(float(molar_mass), 0.05)
+                self.assertLessEqual(float(molar_mass), 0.65)
+                self.assertGreaterEqual(float(density), 0.65)
+                self.assertLessEqual(float(density), 1.1)
+
+        self.assertIn(
+            "@param molarMass molar mass of the component in kg/mol",
+            self.system_interface,
+        )
+        self.assertIn("TBP molar mass is kg/mol", self.guide)
+
+        java_blocks = fenced_blocks(self.guide, "java")
+        python_blocks = fenced_blocks(self.guide, "python")
+        self.assertGreaterEqual(len(java_blocks), 10)
+        self.assertEqual(1, len(python_blocks))
+        self.assertIn('oil.addTBPfraction("C7", 0.15, 0.095, 0.72)', java_blocks[0])
+        self.assertIn('apiStd.getValue("API")', java_blocks[0])
+        self.assertIn('distStd.getValue("T50", "C")', java_blocks[0])
+        self.assertIn('oil.addTBPfraction("C7", 0.15, 0.095, 0.72)', python_blocks[0])
+        self.assertIn("d4052.getValue('API')", python_blocks[0])
+
+    def test_documented_parameter_keys_match_current_sources(self):
+        contracts = {
+            "Standard_ASTM_D86": (
+                'case "IBP":',
+                'case "T50":',
+                'case "FBP":',
+                'case "WatsonK":',
+            ),
+            "Standard_ASTM_D4052": (
+                'case "density":',
+                'case "SG":',
+                'case "API":',
+            ),
+            "Standard_ASTM_D445": (
+                'case "KV40":',
+                'case "KV100":',
+                'case "VI":',
+            ),
+            "Standard_ASTM_D4294": (
+                'case "sulfur":',
+                'case "totalSulfur":',
+            ),
+            "Standard_BSW": (
+                'case "BSW":',
+                'case "waterCut":',
+            ),
+        }
+        for class_name, signatures in contracts.items():
+            source = self.sources[class_name]
+            for signature in signatures:
+                with self.subTest(class_name=class_name, signature=signature):
+                    self.assertIn(signature, source)
+
+        stale_contracts = (
+            'getValue("API gravity")',
+            "getValue('API gravity')",
+            'getValue("sulfurContent")',
+            "setMinAPIGravity(",
+            "setMaxAPIGravity(",
+            "`waterVolumeFraction`",
+            "`oilVolumeFraction`",
+        )
+        for stale_contract in stale_contracts:
+            with self.subTest(stale_contract=stale_contract):
+                self.assertNotIn(stale_contract, self.guide)
+
+    def test_result_and_specification_boundaries_are_explicit(self):
+        d4052_source = self.sources["Standard_ASTM_D4052"]
+        bsw_source = self.sources["Standard_BSW"]
+        self.assertNotIn("setMinAPIGravity", d4052_source)
+        self.assertNotIn("setMaxAPIGravity", d4052_source)
+        self.assertIn("isOnSpec() currently means only", self.guide)
+        self.assertIn(
+            "the class does not store minimum or maximum product limits",
+            self.guide,
+        )
+        self.assertIn("no sediment model", self.guide)
+        self.assertIn("exposes no separate oil-volume getter", self.guide)
+        self.assertIn('case "waterCut":', bsw_source)
+        self.assertIn(
+            "`IBP`, `Txx`, `FBP`, `VABP`, "
+            "`MABP`, `WABP`, `CABP`, and `MeABP` "
+            "are temperatures",
+            self.guide,
+        )
+
+    def test_standards_indexes_discover_the_guide(self):
+        link = "[Oil-quality methods](oil_quality_standards.md)"
+        self.assertIn(link, self.standards_index)
+        self.assertIn("standards/oil_quality_standards.md", self.reference_index)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test/java/neqsim/standards/oilquality/OilQualityStandardsDocumentationTest.java
+++ b/src/test/java/neqsim/standards/oilquality/OilQualityStandardsDocumentationTest.java
@@ -1,0 +1,101 @@
+package neqsim.standards.oilquality;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Executes the core oil-quality workflows documented in the standards guide. */
+public class OilQualityStandardsDocumentationTest {
+  private SystemInterface createDocumentedOil() {
+    SystemInterface oil = new SystemSrkEos(273.15 + 15.0, 1.01325);
+    oil.addComponent("methane", 0.01);
+    oil.addComponent("ethane", 0.02);
+    oil.addComponent("propane", 0.03);
+    oil.addTBPfraction("C7", 0.15, 0.095, 0.72);
+    oil.addTBPfraction("C10", 0.20, 0.135, 0.78);
+    oil.addTBPfraction("C20", 0.30, 0.280, 0.85);
+    oil.addTBPfraction("C30", 0.29, 0.450, 0.91);
+    oil.setMixingRule(2);
+    oil.init(0);
+    return oil;
+  }
+
+  @Test
+  void executesDocumentedDensityViscosityAndDistillationWorkflow() {
+    SystemInterface oil = createDocumentedOil();
+
+    Standard_ASTM_D4052 density = new Standard_ASTM_D4052(oil);
+    density.calculate();
+    double densityKgPerM3 = density.getValue("density");
+    double specificGravity = density.getValue("SG");
+    double apiGravity = density.getValue("API");
+
+    assertTrue(densityKgPerM3 > 600.0 && densityKgPerM3 < 1100.0);
+    assertTrue(specificGravity > 0.6 && specificGravity < 1.1);
+    assertEquals(141.5 / specificGravity - 131.5, apiGravity, 1.0e-10);
+    assertTrue(density.isOnSpec(), "D4052 isOnSpec reports a finite calculation");
+
+    Standard_ASTM_D86 distillation = new Standard_ASTM_D86(oil);
+    distillation.calculate();
+    double initialBoilingPointC = distillation.getValue("IBP", "C");
+    double midpointC = distillation.getValue("T50", "C");
+    double finalBoilingPointC = distillation.getValue("FBP", "C");
+
+    assertFalse(Double.isNaN(initialBoilingPointC));
+    assertTrue(initialBoilingPointC < midpointC);
+    assertTrue(midpointC < finalBoilingPointC);
+    assertEquals(distillation.getValue("WatsonK"),
+        distillation.getValue("WatsonK", "K"), 0.0);
+
+    Standard_ASTM_D445 viscosity = new Standard_ASTM_D445(oil);
+    viscosity.calculate();
+    assertTrue(viscosity.getValue("KV40") > 0.0);
+    assertTrue(viscosity.getValue("KV100") > 0.0);
+  }
+
+  @Test
+  void executesDocumentedSulfurKeysAndUnits() {
+    SystemInterface sourOil = new SystemSrkEos(273.15 + 15.0, 1.01325);
+    sourOil.addComponent("n-hexane", 0.40);
+    sourOil.addComponent("nC10", 0.40);
+    sourOil.addComponent("H2S", 0.05);
+    sourOil.addTBPfraction("C15", 0.15, 0.206, 0.83);
+    sourOil.setMixingRule(2);
+    sourOil.init(0);
+
+    Standard_ASTM_D4294 sulfur = new Standard_ASTM_D4294(sourOil);
+    sulfur.calculate();
+    double sulfurWtPct = sulfur.getValue("sulfur");
+    double sulfurPpmw = sulfur.getValue("sulfur", "ppmw");
+
+    assertTrue(sulfurWtPct > 0.0);
+    assertEquals(sulfurWtPct, sulfur.getValue("totalSulfur"), 0.0);
+    assertEquals(sulfurWtPct * 10000.0, sulfurPpmw, 1.0e-8);
+    assertFalse("Unknown".equals(sulfur.getSulfurClassification()));
+  }
+
+  @Test
+  void executesDocumentedThermodynamicBswBoundary() {
+    SystemInterface wetOil = new SystemSrkEos(273.15 + 60.0, 1.01325);
+    wetOil.addComponent("n-hexane", 0.30);
+    wetOil.addComponent("nC10", 0.50);
+    wetOil.addComponent("water", 0.02);
+    wetOil.addTBPfraction("C15", 0.18, 0.206, 0.83);
+    wetOil.setMixingRule(2);
+    wetOil.setMultiPhaseCheck(true);
+    wetOil.init(0);
+
+    Standard_BSW bsw = new Standard_BSW(wetOil);
+    bsw.setMaxBSW(100.0);
+    bsw.calculate();
+
+    double bswVolPct = bsw.getValue("BSW");
+    assertTrue(bswVolPct >= 0.0 && bswVolPct <= 100.0);
+    assertEquals(bswVolPct, bsw.getValue("waterCut"), 0.0);
+    assertTrue(bsw.isOnSpec());
+  }
+}

--- a/src/test/java/neqsim/standards/oilquality/OilQualityStandardsDocumentationTest.java
+++ b/src/test/java/neqsim/standards/oilquality/OilQualityStandardsDocumentationTest.java
@@ -48,8 +48,7 @@ public class OilQualityStandardsDocumentationTest {
     assertFalse(Double.isNaN(initialBoilingPointC));
     assertTrue(initialBoilingPointC < midpointC);
     assertTrue(midpointC < finalBoilingPointC);
-    assertEquals(distillation.getValue("WatsonK"),
-        distillation.getValue("WatsonK", "K"), 0.0);
+    assertEquals(distillation.getValue("WatsonK"), distillation.getValue("WatsonK", "K"), 0.0);
 
     Standard_ASTM_D445 viscosity = new Standard_ASTM_D445(oil);
     viscosity.calculate();


### PR DESCRIPTION
## Summary

Progresses #2499 scan D067 (rotation scope 5: PVT, flow assurance, standards, and gas/oil quality).

This repairs the core oil-quality guide against the exact current oil-quality APIs:

- corrects all 14 documented TBP fraction molar masses from g/mol-like values to the required kg/mol inputs while retaining specific-gravity density inputs;
- replaces unsupported D4052, D4294, and BS&W parameter keys with the actual source keys;
- removes nonexistent D4052 product-limit setters and explains that its current `isOnSpec()` only reports a finite calculation;
- distinguishes the selected simulated D6377 RVP/VPCR4 route from a generic laboratory RVP claim;
- corrects D86 temperature versus dimensionless/fixed-basis unit behavior;
- records the thermodynamic BS&W boundary: water cut only, no sediment model and no separate oil-volume getter;
- converts all six display equations to compact Colab/Jekyll-safe delimiters;
- makes the three related internal targets explicit `.md` links; and
- adds focused Java execution coverage plus five hermetic documentation/source/navigation contracts.

## Frozen scope

Exact base: `44f705a903590749b9d150b865dd53a46d1d78a5`

Changed files:

- `docs/standards/oil_quality_standards.md`
- `docs/test_oil_quality_standards_documentation.py`
- `src/test/java/neqsim/standards/oilquality/OilQualityStandardsDocumentationTest.java`

The standards index and `docs/REFERENCE_MANUAL_INDEX.md` already contain the correct guide link and are intentionally unchanged. The D4737/D611/D1322/EN116/D3230/D2500/D97 advanced-method sections were not independently requalified; their display delimiters were normalized because the shared page contract covers all equations.

Stop boundary: no standards algorithm or coefficient change, contract policy, pipeline/flow-assurance implementation, notebook, image, external qualification, or Huldra work. Open PRs #3110, #3111, #3114, #3115, and #3116 do not overlap these paths.

## Defects and root cause

1. **High — invalid TBP units:** every complete Java/Python fixture supplied molar masses such as `95.0` and `450.0`; `SystemInterface.addTBPfraction` requires kg/mol. The examples now use `0.095` through `0.450`.
2. **High — unsupported result keys:** `API gravity`, `sulfurContent`, `waterVolumeFraction`, and `oilVolumeFraction` are not supported by the corresponding source switches. The guide now uses `API`, `sulfur`/`totalSulfur`, `BSW`, and `waterCut`.
3. **High — nonexistent D4052 setters:** `setMinAPIGravity` and `setMaxAPIGravity` do not exist. The guide now performs explicit project-limit comparisons after verifying a finite result.
4. **Medium — incomplete method boundaries:** D6377 route selection, D86 unit behavior, and the BS&W water-only thermodynamic approximation were not stated accurately.
5. **Medium — no executable guide regression:** the stale fixtures and keys had no focused documentation test.
6. **Low — page structure/rendering/navigation:** duplicate H1, multiline display delimiters, and extensionless internal links weakened Jekyll/Colab robustness.

## Validation

Passed through exact GitHub source inspection on the branch:

- front matter present; duplicate H1 removed; all 38 fence markers balanced;
- six display equations use compact `$$equation$$` delimiters;
- 14/14 `addTBPfraction` calls use plausible kg/mol and specific-gravity ranges;
- no stale result keys or nonexistent D4052 setters remain;
- all three internal `.md` targets exist;
- standards and reference-manual indexes discover the guide;
- documentation contracts are anchored to current `SystemInterface`, `Standard_ASTM_D86`, `Standard_ASTM_D4052`, `Standard_ASTM_D445`, `Standard_ASTM_D4294`, and `Standard_BSW` source signatures;
- final scope audit: exactly the three frozen documentation/test files, zero commits behind the frozen master.

## READY TO MERGE — exact head `864f86c2c826b6ad77198030b247e42f3dc2f4c8`

All hosted validation passed on the exact head:

- **Spotless format patch** — success;
- **Pre-commit checks** — success;
- **Documentation search coverage** — success, including the Jekyll/search and hermetic Python documentation contracts;
- **CodeQL Security Analysis** — success;
- **Run build, test and javadoc** — success, including Javadocs, Java 21 fast tests on Ubuntu and Windows, all four Java 21 slow-test shards, and Java 8 tests on Ubuntu and Windows.

Final review/scope audit:

- PR is mergeable and zero commits behind current `master`;
- exactly the three frozen documentation/test files changed;
- no human or GitHub Copilot comments, suggested changes, reviews, or unresolved threads;
- no visual browser render was produced, so visual inspection is not claimed;
- no external URL, notebook, image, generated output, production algorithm, or Huldra content changed.

Documentation impact: the user-facing oil-quality guide now matches the current public API, units, result semantics, and engineering-screening boundaries.

## Review boundary

The guide documents current calculations as engineering screening. It does not imply that a NeqSim result replaces representative sampling, certified laboratory execution, a governing standards edition, contractual acceptance, or accountable engineering approval.
