### PR TITLE
[AI-Assisted] feat(dexpi): connect explicit Plant boundaries

### DIFF
--- a/docs/integration/dexpi-engineering-generation.md
+++ b/docs/integration/dexpi-engineering-generation.md
@@ -360,6 +360,31 @@ conformance, or evidence that graphical representations and boundary nodes are c
 The committed external baseline is intentionally not changed by this API alone. Regenerate a controlled fixture with
 the metadata overload and rerun the pinned verifier before changing its reviewed error and warning counts.
 
+### Explicit process-boundary connectors
+
+A controlled export can opt in to directional boundary semantics without changing either established byte path:
+
+```java
+Dexpi20PlantExportOptions options =
+    Dexpi20PlantExportOptions.builder(metadata)
+        .boundaryConnectionMode(
+            Dexpi20PlantExportOptions.BoundaryConnectionMode.EXPLICIT_OFF_PAGE_CONNECTORS)
+        .build();
+Dexpi20XmlWriter.write(process, outputFile, options);
+```
+
+For each detected feed crossing into the exported `ProcessSystem`, the writer adds a
+`Plant/Piping.FlowInPipeOffPageConnector`; for every unconsumed product it adds a
+`Plant/Piping.FlowOutPipeOffPageConnector`. Each connector owns a stable piping node, and its boundary segment carries
+explicit source/target item and node references. Ordering follows the process-system and outlet ordering, so repeated
+exports are byte-deterministic. `BoundaryConnectionMode.NONE` is the default and is byte-identical to the metadata-only
+overload.
+
+These objects record a simulation/export boundary proposal. They are not reciprocal controlled-document connector
+pairs, sheet or grid references, graphical representation groups, line-design evidence, or accountable P&ID approval.
+Use the canonical document-set APIs for reviewed cross-sheet intent, and verify the selected Plant artifact with the
+target tool before controlled issue.
+
 The same helper can run the independent MIT-licensed DEXPIViewer validator without downloading or silently updating
 the tool. Supply a local checkout pinned to commit
 `18a17b1e38ba15a1a6ba49dd8265ddcff7c766ad` after installing that checkout's locked Node.js dependencies:

--- a/docs/integration/dexpi-pid-current-master-audit.md
+++ b/docs/integration/dexpi-pid-current-master-audit.md
@@ -102,11 +102,13 @@ The repository also contains deterministic native fixtures under
 `src/test/resources/dexpi/2.0/golden`, including the branching Plant fixture, manifest, semantic
 summary, schema provenance, and a reviewed DEXPIViewer baseline pinned to commit
 `18a17b1e38ba15a1a6ba49dd8265ddcff7c766ad`. That external baseline has eight errors and three warnings. The native
-Plant writer now has an additive controlled-metadata overload for caller-supplied `Core/EngineeringModel` export
-provenance and non-empty `Plant/Diagram.PlantMetaData`; the compatibility overload and committed golden fixture
-remain unchanged. The reviewed baseline therefore continues to report the metadata findings until a controlled
-fixture is regenerated and the pinned verifier is rerun. Genuine representation groups and boundary-node handling
-remain separate open implementation work. The coordinated
+Plant writer now has additive controlled metadata and export-options overloads. The options path can explicitly
+connect detected feed and product boundaries through directional `FlowInPipeOffPageConnector` and
+`FlowOutPipeOffPageConnector` objects with owned piping nodes and complete segment item/node references. The
+compatibility and metadata-only overloads plus the committed golden fixture remain byte-unchanged. The reviewed
+baseline therefore remains an 8-error/3-warning drift gate until a controlled fixture is regenerated and the pinned
+verifier is rerun; no clean result is inferred. Genuine graphical representation groups remain separate open work,
+and reciprocal controlled-sheet connector pairs remain owned by the document-set layer. The coordinated
 [engineering-diagram reference cases](dexpi-reference-cases.md) add executable, synthetic public
 simple, branched, and multi-area process fixtures. They check canonical topology, material balance,
 native Process/Plant exchange where supported, Proteus compatibility, legacy DOT, and governed P&ID

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20PlantExportOptions.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20PlantExportOptions.java
@@ -4,8 +4,8 @@ package neqsim.process.processmodel.dexpi;
  * Immutable options for the opt-in native DEXPI 2.0 Plant export path.
  *
  * <p>
- * The default keeps the metadata-only output introduced for controlled provenance. Boundary connectors are emitted
- * only when explicitly requested, so the legacy metadata-free and metadata-only byte paths remain unchanged.
+ * The default keeps the metadata-only output introduced for controlled provenance. Boundary connectors are emitted only
+ * when explicitly requested, so the legacy metadata-free and metadata-only byte paths remain unchanged.
  * </p>
  */
 public final class Dexpi20PlantExportOptions {

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20PlantExportOptions.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20PlantExportOptions.java
@@ -1,0 +1,83 @@
+package neqsim.process.processmodel.dexpi;
+
+/**
+ * Immutable options for the opt-in native DEXPI 2.0 Plant export path.
+ *
+ * <p>
+ * The default keeps the metadata-only output introduced for controlled provenance. Boundary connectors are emitted
+ * only when explicitly requested, so the legacy metadata-free and metadata-only byte paths remain unchanged.
+ * </p>
+ */
+public final class Dexpi20PlantExportOptions {
+  /** Supported handling for material streams that cross the exported process boundary. */
+  public enum BoundaryConnectionMode {
+    /** Preserve the existing writer output without synthesized boundary objects. */
+    NONE,
+    /** Connect every detected feed and product boundary through a directional off-page connector. */
+    EXPLICIT_OFF_PAGE_CONNECTORS
+  }
+
+  private final Dexpi20PlantExportMetadata metadata;
+  private final BoundaryConnectionMode boundaryConnectionMode;
+
+  private Dexpi20PlantExportOptions(Builder builder) {
+    metadata = builder.metadata;
+    boundaryConnectionMode = builder.boundaryConnectionMode;
+  }
+
+  /**
+   * Starts an export-options definition using controlled DEXPI Plant metadata.
+   *
+   * @param metadata caller-supplied export provenance and plant identity
+   * @return options builder
+   */
+  public static Builder builder(Dexpi20PlantExportMetadata metadata) {
+    return new Builder(metadata);
+  }
+
+  /** @return controlled export metadata */
+  public Dexpi20PlantExportMetadata getMetadata() {
+    return metadata;
+  }
+
+  /** @return selected process-boundary handling */
+  public BoundaryConnectionMode getBoundaryConnectionMode() {
+    return boundaryConnectionMode;
+  }
+
+  /** Builder for {@link Dexpi20PlantExportOptions}. */
+  public static final class Builder {
+    private final Dexpi20PlantExportMetadata metadata;
+    private BoundaryConnectionMode boundaryConnectionMode = BoundaryConnectionMode.NONE;
+
+    private Builder(Dexpi20PlantExportMetadata metadata) {
+      if (metadata == null) {
+        throw new IllegalArgumentException("metadata must not be null");
+      }
+      this.metadata = metadata;
+    }
+
+    /**
+     * Selects how feeds and products crossing the exported process boundary are represented.
+     *
+     * @param mode boundary handling; never {@code null}
+     * @return this builder
+     */
+    public Builder boundaryConnectionMode(BoundaryConnectionMode mode) {
+      if (mode == null) {
+        throw new IllegalArgumentException("boundaryConnectionMode must not be null");
+      }
+      boundaryConnectionMode = mode;
+      return this;
+    }
+
+    /**
+     * Builds immutable export options.
+     *
+     * @return immutable options
+     */
+    public Dexpi20PlantExportOptions build() {
+      return new Dexpi20PlantExportOptions(this);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20XmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20XmlWriter.java
@@ -6,8 +6,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -58,17 +60,33 @@ public final class Dexpi20XmlWriter {
     if (metadata == null) {
       throw new IllegalArgumentException("metadata must not be null");
     }
-    writeValidated(processSystem, file, metadata);
+    writeValidated(processSystem, file, Dexpi20PlantExportOptions.builder(metadata).build());
   }
 
-  private static void writeValidated(ProcessSystem processSystem, File file, Dexpi20PlantExportMetadata metadata)
+  /**
+   * Writes and validates a native DEXPI 2.0 Plant model using explicit export options.
+   *
+   * @param processSystem source simulation topology
+   * @param file destination DEXPI XML file
+   * @param options controlled metadata and opt-in boundary handling
+   * @throws IOException if serialization or validation fails
+   */
+  public static void write(ProcessSystem processSystem, File file, Dexpi20PlantExportOptions options)
+      throws IOException {
+    if (options == null) {
+      throw new IllegalArgumentException("options must not be null");
+    }
+    writeValidated(processSystem, file, options);
+  }
+
+  private static void writeValidated(ProcessSystem processSystem, File file, Dexpi20PlantExportOptions options)
       throws IOException {
     if (file == null) {
       throw new IllegalArgumentException("file must not be null");
     }
     FileOutputStream stream = new FileOutputStream(file);
     try {
-      writeDocument(processSystem, stream, metadata);
+      writeDocument(processSystem, stream, options);
     } finally {
       stream.close();
     }
@@ -102,6 +120,21 @@ public final class Dexpi20XmlWriter {
     return Dexpi20ConformanceAssessment.assess(file.toPath(), Dexpi20ConformanceAssessment.Profile.PLANT_P_ID);
   }
 
+  /**
+   * Writes an option-controlled Plant exchange and returns its auditable conformance assessment.
+   *
+   * @param processSystem source simulation topology
+   * @param file destination DEXPI XML file
+   * @param options controlled metadata and opt-in boundary handling
+   * @return schema and supported-profile assessment
+   * @throws IOException if serialization, validation, or assessment fails
+   */
+  public static Dexpi20ConformanceAssessment.Report writeAndAssess(ProcessSystem processSystem, File file,
+      Dexpi20PlantExportOptions options) throws IOException {
+    write(processSystem, file, options);
+    return Dexpi20ConformanceAssessment.assess(file.toPath(), Dexpi20ConformanceAssessment.Profile.PLANT_P_ID);
+  }
+
   /** Writes a native DEXPI 2.0 model to a stream using the compatibility path. */
   public static void write(ProcessSystem processSystem, OutputStream outputStream) throws IOException {
     writeDocument(processSystem, outputStream, null);
@@ -120,14 +153,33 @@ public final class Dexpi20XmlWriter {
     if (metadata == null) {
       throw new IllegalArgumentException("metadata must not be null");
     }
-    writeDocument(processSystem, outputStream, metadata);
+    writeDocument(processSystem, outputStream, Dexpi20PlantExportOptions.builder(metadata).build());
+  }
+
+  /**
+   * Writes a native DEXPI 2.0 Plant model using explicit export options to a stream.
+   *
+   * @param processSystem source simulation topology
+   * @param outputStream destination stream
+   * @param options controlled metadata and opt-in boundary handling
+   * @throws IOException if serialization fails
+   */
+  public static void write(ProcessSystem processSystem, OutputStream outputStream, Dexpi20PlantExportOptions options)
+      throws IOException {
+    if (options == null) {
+      throw new IllegalArgumentException("options must not be null");
+    }
+    writeDocument(processSystem, outputStream, options);
   }
 
   private static void writeDocument(ProcessSystem processSystem, OutputStream outputStream,
-      Dexpi20PlantExportMetadata metadata) throws IOException {
+      Dexpi20PlantExportOptions options) throws IOException {
     if (processSystem == null || outputStream == null) {
       throw new IllegalArgumentException("processSystem and outputStream must not be null");
     }
+    Dexpi20PlantExportMetadata metadata = options == null ? null : options.getMetadata();
+    boolean explicitBoundaryConnectors = options != null && options
+        .getBoundaryConnectionMode() == Dexpi20PlantExportOptions.BoundaryConnectionMode.EXPLICIT_OFF_PAGE_CONNECTORS;
     try {
       Document document = createDocument();
       Element model = document.createElement("Model");
@@ -158,6 +210,8 @@ public final class Dexpi20XmlWriter {
 
       Map<StreamInterface, String> outletNodes = new IdentityHashMap<StreamInterface, String>();
       Map<String, String> inletNodes = new LinkedHashMap<String, String>();
+      Map<String, String> nodeOwners = new LinkedHashMap<String, String>();
+      Map<String, String> boundaryOutletNodes = new LinkedHashMap<String, String>();
       int equipmentNumber = 1;
       int nodeNumber = 1;
       for (ProcessEquipmentInterface unit : processSystem.getUnitOperations()) {
@@ -170,19 +224,30 @@ public final class Dexpi20XmlWriter {
         Element nozzles = components(document, equipment, "Nozzles");
 
         String inletNode = "PipingNode" + nodeNumber++;
-        appendNozzle(document, nozzles, equipmentId + "Inlet", inletNode, "INLET");
+        String inletNozzleId = equipmentId + "Inlet";
+        appendNozzle(document, nozzles, inletNozzleId, inletNode, "INLET");
         inletNodes.put(unit.getName(), inletNode);
+        nodeOwners.put(inletNode, inletNozzleId);
 
         List<StreamInterface> outlets = unit.getOutletStreams();
         if (outlets == null || outlets.isEmpty()) {
           String outletNode = "PipingNode" + nodeNumber++;
-          appendNozzle(document, nozzles, equipmentId + "Outlet", outletNode, "OUTLET");
+          String outletNozzleId = equipmentId + "Outlet";
+          appendNozzle(document, nozzles, outletNozzleId, outletNode, "OUTLET");
+          nodeOwners.put(outletNode, outletNozzleId);
+          boundaryOutletNodes.put(outletNode, unit.getName() + " product");
         } else {
           for (int i = 0; i < outlets.size(); i++) {
             String outletNode = "PipingNode" + nodeNumber++;
-            appendNozzle(document, nozzles, equipmentId + "Outlet" + (i + 1), outletNode, "OUTLET_" + (i + 1));
+            String outletNozzleId = equipmentId + "Outlet" + (i + 1);
+            appendNozzle(document, nozzles, outletNozzleId, outletNode, "OUTLET_" + (i + 1));
+            nodeOwners.put(outletNode, outletNozzleId);
             if (outlets.get(i) != null) {
               outletNodes.put(outlets.get(i), outletNode);
+              boundaryOutletNodes.put(outletNode,
+                  boundaryLabel(outlets.get(i), unit.getName() + " product " + (i + 1)));
+            } else {
+              boundaryOutletNodes.put(outletNode, unit.getName() + " product " + (i + 1));
             }
           }
         }
@@ -190,17 +255,37 @@ public final class Dexpi20XmlWriter {
       }
 
       int segmentNumber = 1;
+      Set<String> connectedOutletNodes = new LinkedHashSet<String>();
       for (ProcessEquipmentInterface unit : processSystem.getUnitOperations()) {
         if (unit == null || unit instanceof Stream) {
           continue;
         }
         String targetNode = inletNodes.get(unit.getName());
-        for (StreamInterface inlet : unit.getInletStreams()) {
-          String sourceNode = outletNodes.get(inlet);
-          if (sourceNode == null || targetNode == null) {
-            continue;
+        List<StreamInterface> inlets = unit.getInletStreams();
+        if ((inlets == null || inlets.isEmpty()) && explicitBoundaryConnectors && targetNode != null) {
+          appendBoundarySegment(document, segments, segmentNumber++, true, targetNode, nodeOwners.get(targetNode),
+              unit.getName() + " feed");
+        } else if (inlets != null) {
+          for (StreamInterface inlet : inlets) {
+            String sourceNode = outletNodes.get(inlet);
+            if (sourceNode == null || targetNode == null) {
+              if (explicitBoundaryConnectors && targetNode != null) {
+                appendBoundarySegment(document, segments, segmentNumber++, true, targetNode,
+                    nodeOwners.get(targetNode), boundaryLabel(inlet, unit.getName() + " feed"));
+              }
+              continue;
+            }
+            appendSegment(document, segments, segmentNumber++, sourceNode, targetNode);
+            connectedOutletNodes.add(sourceNode);
           }
-          appendSegment(document, segments, segmentNumber++, sourceNode, targetNode);
+        }
+      }
+      if (explicitBoundaryConnectors) {
+        for (Map.Entry<String, String> boundary : boundaryOutletNodes.entrySet()) {
+          if (!connectedOutletNodes.contains(boundary.getKey())) {
+            appendBoundarySegment(document, segments, segmentNumber++, false, boundary.getKey(),
+                nodeOwners.get(boundary.getKey()), boundary.getValue());
+          }
         }
       }
 
@@ -295,6 +380,39 @@ public final class Dexpi20XmlWriter {
     nozzles.appendChild(nozzle);
   }
 
+  private static void appendBoundarySegment(Document document, Element segments, int number, boolean inbound,
+      String equipmentNode, String equipmentItem, String label) {
+    Element segment = object(document, "PipingNetworkSegment" + number, "Plant/Piping.PipingNetworkSegment");
+    Element items = components(document, segment, "Items");
+    String connectorId = "BoundaryConnector" + number;
+    String boundaryNode = "BoundaryPipingNode" + number;
+    String connectorType = inbound ? "Plant/Piping.FlowInPipeOffPageConnector"
+        : "Plant/Piping.FlowOutPipeOffPageConnector";
+    Element connector = object(document, connectorId, connectorType);
+    Element nodes = components(document, connector, "Nodes");
+    nodes.appendChild(object(document, boundaryNode, "Plant/Piping.PipingNode"));
+    data(document, connector, "PipeConnectorNumber", label);
+    items.appendChild(connector);
+
+    String sourceNode = inbound ? boundaryNode : equipmentNode;
+    String targetNode = inbound ? equipmentNode : boundaryNode;
+    String sourceItem = inbound ? connectorId : equipmentItem;
+    String targetItem = inbound ? equipmentItem : connectorId;
+    Element connections = components(document, segment, "Connections");
+    Element pipe = object(document, "Pipe" + number, "Plant/Piping.Pipe");
+    references(document, pipe, "SourceItem", sourceItem);
+    references(document, pipe, "SourceNode", sourceNode);
+    references(document, pipe, "TargetItem", targetItem);
+    references(document, pipe, "TargetNode", targetNode);
+    connections.appendChild(pipe);
+    references(document, segment, "SourceItem", sourceItem);
+    references(document, segment, "SourceNode", sourceNode);
+    references(document, segment, "TargetItem", targetItem);
+    references(document, segment, "TargetNode", targetNode);
+    data(document, segment, "SegmentNumber", Integer.toString(number));
+    segments.appendChild(segment);
+  }
+
   private static void appendSegment(Document document, Element segments, int number, String sourceNode,
       String targetNode) {
     Element segment = object(document, "PipingNetworkSegment" + number, "Plant/Piping.PipingNetworkSegment");
@@ -314,6 +432,15 @@ public final class Dexpi20XmlWriter {
     reference.setAttribute("property", property);
     reference.setAttribute("objects", "#" + identifier(id, "Object"));
     parent.appendChild(reference);
+  }
+
+  private static String boundaryLabel(StreamInterface stream, String fallback) {
+    try {
+      return stream == null || stream.getName() == null || stream.getName().trim().isEmpty() ? fallback
+          : stream.getName();
+    } catch (RuntimeException ex) {
+      return fallback;
+    }
   }
 
   private static String dexpiType(ProcessEquipmentInterface unit) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20XmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20XmlWriter.java
@@ -270,8 +270,8 @@ public final class Dexpi20XmlWriter {
             String sourceNode = outletNodes.get(inlet);
             if (sourceNode == null || targetNode == null) {
               if (explicitBoundaryConnectors && targetNode != null) {
-                appendBoundarySegment(document, segments, segmentNumber++, true, targetNode,
-                    nodeOwners.get(targetNode), boundaryLabel(inlet, unit.getName() + " feed"));
+                appendBoundarySegment(document, segments, segmentNumber++, true, targetNode, nodeOwners.get(targetNode),
+                    boundaryLabel(inlet, unit.getName() + " feed"));
               }
               continue;
             }

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20PlantBoundaryExportTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20PlantBoundaryExportTest.java
@@ -1,0 +1,161 @@
+package neqsim.process.processmodel.dexpi;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.xml.parsers.DocumentBuilderFactory;
+import neqsim.NeqSimTest;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/** Tests explicit material-boundary handling in native DEXPI 2.0 Plant export. */
+public class Dexpi20PlantBoundaryExportTest extends NeqSimTest {
+  @TempDir
+  Path temporaryDirectory;
+
+  /** Verifies directional boundary objects, connected nodes, conformance, and deterministic output. */
+  @Test
+  public void writesExplicitBoundaryConnectorsDeterministically() throws Exception {
+    ProcessSystem process = process();
+    Dexpi20PlantExportOptions options = Dexpi20PlantExportOptions.builder(metadata())
+        .boundaryConnectionMode(Dexpi20PlantExportOptions.BoundaryConnectionMode.EXPLICIT_OFF_PAGE_CONNECTORS).build();
+    Path output = temporaryDirectory.resolve("explicit-boundaries.dexpi.xml");
+
+    Dexpi20ConformanceAssessment.Report report = Dexpi20XmlWriter.writeAndAssess(process, output.toFile(), options);
+    ByteArrayOutputStream repeated = new ByteArrayOutputStream();
+    Dexpi20XmlWriter.write(process, repeated, options);
+
+    assertTrue(report.isSchemaAndProfileConformant(), report.getErrors().toString());
+    assertArrayEquals(Files.readAllBytes(output), repeated.toByteArray());
+
+    Document document = parse(output);
+    assertEquals(1, countObjects(document, "Plant/Piping.FlowInPipeOffPageConnector"));
+    assertEquals(2, countObjects(document, "Plant/Piping.FlowOutPipeOffPageConnector"));
+    assertEquals(3, Dexpi20ModelInspector.inspect(output).getOffPageConnectorCount());
+
+    Set<String> nodeIds = objectIds(document, "Plant/Piping.PipingNode");
+    Set<String> connectedNodeIds = referencedNodeIds(document);
+    assertEquals(8, nodeIds.size());
+    assertEquals(nodeIds, connectedNodeIds);
+  }
+
+  /** Verifies that boundary generation is opt-in and the metadata-only byte path is unchanged. */
+  @Test
+  public void preservesMetadataOnlyExportByDefault() throws Exception {
+    ProcessSystem process = process();
+    Dexpi20PlantExportMetadata metadata = metadata();
+    Path established = temporaryDirectory.resolve("established-metadata.dexpi.xml");
+    Path defaultOptions = temporaryDirectory.resolve("default-options.dexpi.xml");
+    Path explicit = temporaryDirectory.resolve("explicit-options.dexpi.xml");
+
+    Dexpi20XmlWriter.write(process, established.toFile(), metadata);
+    Dexpi20XmlWriter.write(process, defaultOptions.toFile(), Dexpi20PlantExportOptions.builder(metadata).build());
+    Dexpi20XmlWriter.write(process, explicit.toFile(),
+        Dexpi20PlantExportOptions.builder(metadata)
+            .boundaryConnectionMode(Dexpi20PlantExportOptions.BoundaryConnectionMode.EXPLICIT_OFF_PAGE_CONNECTORS)
+            .build());
+
+    assertArrayEquals(Files.readAllBytes(established), Files.readAllBytes(defaultOptions));
+    assertNotEquals(new String(Files.readAllBytes(established), "UTF-8"),
+        new String(Files.readAllBytes(explicit), "UTF-8"));
+  }
+
+  /** Verifies that incomplete option definitions fail before serialization. */
+  @Test
+  public void rejectsInvalidOptions() {
+    assertThrows(IllegalArgumentException.class, () -> Dexpi20PlantExportOptions.builder(null));
+    Dexpi20PlantExportOptions.Builder builder = Dexpi20PlantExportOptions.builder(metadata());
+    assertThrows(IllegalArgumentException.class, () -> builder.boundaryConnectionMode(null));
+    assertThrows(IllegalArgumentException.class,
+        () -> Dexpi20XmlWriter.write(process(), new ByteArrayOutputStream(), (Dexpi20PlantExportOptions) null));
+  }
+
+  private static Document parse(Path file) throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setXIncludeAware(false);
+    factory.setExpandEntityReferences(false);
+    return factory.newDocumentBuilder().parse(file.toFile());
+  }
+
+  private static int countObjects(Document document, String type) {
+    int count = 0;
+    NodeList objects = document.getElementsByTagName("Object");
+    for (int index = 0; index < objects.getLength(); index++) {
+      if (type.equals(((Element) objects.item(index)).getAttribute("type"))) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static Set<String> objectIds(Document document, String type) {
+    Set<String> result = new LinkedHashSet<String>();
+    NodeList objects = document.getElementsByTagName("Object");
+    for (int index = 0; index < objects.getLength(); index++) {
+      Element object = (Element) objects.item(index);
+      if (type.equals(object.getAttribute("type"))) {
+        result.add(object.getAttribute("id"));
+      }
+    }
+    return result;
+  }
+
+  private static Set<String> referencedNodeIds(Document document) {
+    Set<String> result = new LinkedHashSet<String>();
+    NodeList references = document.getElementsByTagName("References");
+    for (int index = 0; index < references.getLength(); index++) {
+      Element reference = (Element) references.item(index);
+      String property = reference.getAttribute("property");
+      if (!"SourceNode".equals(property) && !"TargetNode".equals(property)) {
+        continue;
+      }
+      for (String value : reference.getAttribute("objects").trim().split("\\s+")) {
+        if (value.startsWith("#")) {
+          result.add(value.substring(1));
+        }
+      }
+    }
+    return result;
+  }
+
+  private static Dexpi20PlantExportMetadata metadata() {
+    return Dexpi20PlantExportMetadata.builder("2026-08-18T11:00:00Z", "NeqSim", "Equinor", "3.17.0")
+        .plantProperty(Dexpi20PlantExportMetadata.PlantProperty.PROCESS_PLANT_IDENTIFICATION_CODE,
+            "SYNTHETIC-BOUNDARY-PLANT")
+        .build();
+  }
+
+  private static ProcessSystem process() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 40.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("n-heptane", 0.2);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("10-FEED-001", fluid);
+    Separator separator = new Separator("10-VA-001", feed);
+    Compressor compressor = new Compressor("10-KA-001", separator.getGasOutStream());
+    ProcessSystem process = new ProcessSystem("controlled DEXPI boundary test");
+    process.add(feed);
+    process.add(separator);
+    process.add(compressor);
+    return process;
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20PlantBoundaryExportTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20PlantBoundaryExportTest.java
@@ -66,10 +66,8 @@ public class Dexpi20PlantBoundaryExportTest extends NeqSimTest {
 
     Dexpi20XmlWriter.write(process, established.toFile(), metadata);
     Dexpi20XmlWriter.write(process, defaultOptions.toFile(), Dexpi20PlantExportOptions.builder(metadata).build());
-    Dexpi20XmlWriter.write(process, explicit.toFile(),
-        Dexpi20PlantExportOptions.builder(metadata)
-            .boundaryConnectionMode(Dexpi20PlantExportOptions.BoundaryConnectionMode.EXPLICIT_OFF_PAGE_CONNECTORS)
-            .build());
+    Dexpi20XmlWriter.write(process, explicit.toFile(), Dexpi20PlantExportOptions.builder(metadata)
+        .boundaryConnectionMode(Dexpi20PlantExportOptions.BoundaryConnectionMode.EXPLICIT_OFF_PAGE_CONNECTORS).build());
 
     assertArrayEquals(Files.readAllBytes(established), Files.readAllBytes(defaultOptions));
     assertNotEquals(new String(Files.readAllBytes(established), "UTF-8"),
@@ -138,10 +136,8 @@ public class Dexpi20PlantBoundaryExportTest extends NeqSimTest {
   }
 
   private static Dexpi20PlantExportMetadata metadata() {
-    return Dexpi20PlantExportMetadata.builder("2026-08-18T11:00:00Z", "NeqSim", "Equinor", "3.17.0")
-        .plantProperty(Dexpi20PlantExportMetadata.PlantProperty.PROCESS_PLANT_IDENTIFICATION_CODE,
-            "SYNTHETIC-BOUNDARY-PLANT")
-        .build();
+    return Dexpi20PlantExportMetadata.builder("2026-08-18T11:00:00Z", "NeqSim", "Equinor", "3.17.0").plantProperty(
+        Dexpi20PlantExportMetadata.PlantProperty.PROCESS_PLANT_IDENTIFICATION_CODE, "SYNTHETIC-BOUNDARY-PLANT").build();
   }
 
   private static ProcessSystem process() {


### PR DESCRIPTION
## Summary

- add immutable `Dexpi20PlantExportOptions` with an explicit process-boundary policy
- preserve the legacy metadata-free and metadata-only byte paths by default
- opt in to directional `FlowInPipeOffPageConnector` and `FlowOutPipeOffPageConnector` objects for detected feeds and unconsumed products
- give every boundary connector a stable owned `PipingNode` and complete segment/pipe source-item, source-node, target-item, and target-node references
- retain deterministic process/outlet ordering and add focused schema/profile/connectivity/byte-compatibility tests
- document the semantic and engineering boundary

This is the next dependency-ready boundary-node tranche after merged #3114 in the coordinated #1332/#2899 engineering-diagram lane. Genuine graphical representation groups, reciprocal controlled-sheet connector pairs, line-design data, and accountable P&ID approval remain separate dependencies.

## Compatibility

- `Dexpi20XmlWriter.write(process, file)` is unchanged.
- `Dexpi20XmlWriter.write(process, file, metadata)` delegates to options with `BoundaryConnectionMode.NONE` and is regression-tested byte-identical.
- The new objects appear only when a caller selects `EXPLICIT_OFF_PAGE_CONNECTORS`.
- Classic DOT/Graphviz, native SVG/PDF, DEXPI 2.0 Process, Proteus/P&ID, and controlled-document APIs are untouched.

## Validation

Merged exact head `7df148ab17a478ac7fd19805821154ed30b120ed` as [`1320f847177603858522d246cc52d5ad44119352`](https://github.com/equinor/neqsim/commit/1320f847177603858522d246cc52d5ad44119352) on 18 August 2026.

All seven exact-head workflows completed successfully. The build matrix passed Java 8 tests on Ubuntu and Windows, Java 21 fast tests on Ubuntu and Windows, all four Java 21 slow-test shards, and Java 21 Javadocs. Spotless, pre-commit, documentation search, CodeQL, PaperLab, and the process-to-engineering acceptance notebook also passed. There were no reviews or unresolved review threads.

The first pre-commit run had failed only because Spotless would reflow three changed Java files. The successful hosted formatter artifact (`spotless-format-patch`, artifact 9322672524) was inspected and applied exactly before the green final head; its resulting blob SHAs are `70db8453`, `21f742c0`, and `03599b3f`.

Post-merge verification against current `master` `564a1d2cf92729d422471b99fa59328382e0cea2` confirms the merge commit is an ancestor and all five delivered files remain byte-identical to the exact PR head.

Local JDK, Maven, Spotless, pre-commit, and documentation-search commands were unavailable in the publication runtime and are not claimed as locally executed. GitHub CI is the authoritative validation evidence.

Documentation impact: the DEXPI engineering-generation guide and current-master audit now document the additive options API, compatibility defaults, explicit boundary semantics, and proposal/approval boundary.

## External and engineering boundary

The pinned DEXPIViewer was not rerun, and the committed golden fixture/baseline remains unchanged at the reviewed 8-error/3-warning drift gate. This PR does not claim a clean external result, DEXPI EV certification, ISO 10628 conformance, commercial-CAE interoperability, approved drawing status, or accountable engineering approval. A P&ID remains a proposal until controlled design data and review exist.

Refs #1332
Refs #2899