### PR TITLE
[AI-Assisted] fix(dexpi): stabilize Windows numeric export

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -284,7 +284,7 @@ Each piping connection carries operating line data and a NORSOK Z-003 line-ident
 - Operating pressure, temperature and flow generic attributes when available on the stream
 - A line-number text label (e.g. `PG-001`) composed by `NorsokLineNumber`
 
-The writer serializes numeric generic-attribute values with eleven significant digits. This
+The writer serializes numeric generic-attribute values with eight significant digits. This
 scale-aware canonical precision suppresses insignificant solver noise so repeated exports remain
 stable without rounding small, non-zero engineering values to zero.
 

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
@@ -95,7 +95,7 @@ public final class DexpiXmlWriter {
     format.setGroupingUsed(false);
     return format;
   });
-  private static final MathContext NUMERIC_ATTRIBUTE_PRECISION = new MathContext(11, RoundingMode.HALF_EVEN);
+  private static final MathContext NUMERIC_ATTRIBUTE_PRECISION = new MathContext(8, RoundingMode.HALF_EVEN);
 
   /**
    * Thread-local flag controlling whether the root {@code PlantModel} element declares the DEXPI default XML namespace.

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
@@ -331,19 +331,21 @@ public class DexpiXmlWriterTest extends NeqSimTest {
     process.add(sep);
     process.run();
 
-    sep.getGasOutStream().setTemperature(30.707918388829, "C");
+    sep.getGasOutStream().setTemperature(51.772939162, "C");
     ByteArrayOutputStream firstOut = new ByteArrayOutputStream();
     DexpiXmlWriter.write(process, firstOut);
     String firstXml = firstOut.toString(StandardCharsets.UTF_8.name());
 
-    sep.getGasOutStream().setTemperature(30.707918388769, "C");
+    sep.getGasOutStream().setTemperature(51.772939074, "C");
     ByteArrayOutputStream secondOut = new ByteArrayOutputStream();
     DexpiXmlWriter.write(process, secondOut);
     String secondXml = secondOut.toString(StandardCharsets.UTF_8.name());
 
-    assertTrue(firstXml.contains("Name=\"OperatingTemperatureValue\" Unit=\"C\" Value=\"30.707918389\""));
+    assertTrue(firstXml.contains("Name=\"OperatingTemperatureValue\" Unit=\"C\" Value=\"51.772939\""));
     assertEquals(normalizeEmissionMetadata(firstXml), normalizeEmissionMetadata(secondXml));
-    assertEquals("0.00000012345678901", DexpiXmlWriter.formatNumericAttribute(0.0000001234567890123));
+    assertEquals("30.707918", DexpiXmlWriter.formatNumericAttribute(30.707918388829));
+    assertEquals("30.707918", DexpiXmlWriter.formatNumericAttribute(30.707918388769));
+    assertEquals("0.00000012345679", DexpiXmlWriter.formatNumericAttribute(0.0000001234567890123));
   }
 
   private static String normalizeEmissionMetadata(String xml) {


### PR DESCRIPTION
## Summary

- canonicalize Proteus-compatible DEXPI numeric generic attributes to eight significant digits
- add the exact Windows Java 21 temperature pair from the failing run as a regression
- retain coverage for the earlier Windows jitter pair and for small non-zero values
- update the DEXPI integration documentation to match the serialization contract

## Root cause

[Workflow run 32126906125](https://github.com/equinor/neqsim/actions/runs/32126906125), job [95679803509](https://github.com/equinor/neqsim/actions/runs/32126906125/job/95679803509), ran 11,962 tests on Windows/Java 21 and failed only:

`EngineeringDiagramReferenceCasesTest.branchedReferenceCasePreservesDeterministicExchangeAndProposalBoundaries`

The two independently executed reference models produced otherwise byte-identical Proteus XML, but the compressor outlet temperature differed by `8.8e-8 °C`:

- `51.772939162 °C`
- `51.772939074 °C`

The existing eleven-significant-digit formatter retained that platform-level solver noise, so the exact determinism assertion failed. This is not a material thermodynamic discrepancy or a DEXPI topology difference.

Eight significant digits canonicalize both values to `51.772939 °C`. Around this operating point that still preserves approximately `1e-6 °C` resolution. The scale-aware `BigDecimal` path remains in place, so small values are retained rather than rounded to zero.

## Scope and compatibility

This is an export-boundary determinism repair. It does not change thermodynamic calculations, convergence, public APIs, topology, native DEXPI 2.0 exchange, drawing approval state, or standards-conformance claims.

## Validation

Base: exact failing master `d555280c1e2dd32f1bbfd3957b8c495c532f25a4`

Publication head: `fee5cfaed343cdfcc4b703826edc890108f0061a`

**EXACT-HEAD VALIDATION**

The failing Actions log was inspected through the connected GitHub integration. On exact publication head `fee5cfaed343cdfcc4b703826edc890108f0061a`:

- Windows Java 21: **PASS**, 11,962 tests, 0 failures, 0 errors, 215 skipped; the exact previously failing reference-case test passed
- Ubuntu Java 21: **PASS**
- Java 21 slow-test shards 1/4, 2/4, 3/4, and 4/4: **PASS**
- Java 21 Javadocs and agent-skill cross-references: **PASS**
- Spotless format patch, pre-commit, documentation search, CodeQL, PaperLab, and the process-to-engineering notebook: **PASS**
- Java 8 Ubuntu and Windows: **IN PROGRESS**

The environment has no local NeqSim checkout and no `gh` executable, so Maven, Spotless, pre-commit, and documentation-search commands were not run locally and are not claimed as local passes. Hosted GitHub CI is the authoritative validation.

## Documentation impact

Updated `docs/integration/dexpi-reader.md` to document the eight-significant-digit canonical precision.