### PR TITLE
[AI-Assisted] feat(optimization): add paired debottleneck studies

### DIFF
--- a/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
+++ b/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
@@ -1028,8 +1028,8 @@ Study = jneqsim.process.util.optimizer.ProcessModelDebottleneckStudy
 
 candidates = ArrayList()
 candidates.add(JArray(JDouble)([800.0]))
-candidates.add(JArray(JDouble)([1000.0]))
-candidates.add(JArray(JDouble)([1200.0]))
+candidates.add(JArray(JDouble)([999.0]))
+candidates.add(JArray(JDouble)([1199.0]))
 
 search = Study.CandidateListSearch(
     "throughput-grid",
@@ -1053,6 +1053,10 @@ metric_deltas = {
 }
 diagnostics = list(result.getDiagnostics())
 ```
+
+Here the 999 and 1199 kg/hr candidates retain 1 kg/hr of declared headroom below nominal
+1000 and 1200 kg/hr installed limits. Do not rely on a unit conversion or floating-point process
+reconstruction to land exactly on a hard constraint boundary.
 
 The study independently re-evaluates the selected point after the search callback returns. A
 custom external search therefore supplies a candidate vector, not trusted convergence or

--- a/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
+++ b/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
@@ -1008,6 +1008,64 @@ The ranking is over the common selected-objective unit and finite sampled points
 non-causal evidence, not a capacity-sizing answer, global optimum, KKT multiplier, shadow price,
 production-loss estimate, economic value, or operating approval.
 
+### Paired debottleneck studies from Python
+
+\`ProcessModelDebottleneckStudy\` evaluates one documented direct installed-capacity alternative
+with the same \`ScenarioSearch\` in both cases. The built-in \`CandidateListSearch\` is useful when
+Python has already generated a bounded candidate design and NeqSim must remain the physical
+feasibility authority.
+
+JPype callers should pass an ordered Java \`List<double[]>\`. Result arrays are defensive copies,
+and result lists are unmodifiable Java lists. Convert them explicitly when native Python containers
+are needed:
+
+\`\`\`python
+import jpype
+from jpype.types import JArray, JDouble
+
+ArrayList = jpype.JClass("java.util.ArrayList")
+Study = jneqsim.process.util.optimizer.ProcessModelDebottleneckStudy
+
+candidates = ArrayList()
+candidates.add(JArray(JDouble)([800.0]))
+candidates.add(JArray(JDouble)([1000.0]))
+candidates.add(JArray(JDouble)([1200.0]))
+
+search = Study.CandidateListSearch(
+    "throughput-grid",
+    "Ordered throughput grid",
+    "screening candidate set rev A",
+    candidates,
+    0,
+    0.0,
+)
+
+# Configure CapacityAlternative, ProcessModelDebottleneckStudy, and metric
+# definitions with explicit units/provenance as shown in the optimization guide.
+result = study.evaluate()
+
+baseline_parameters = list(result.getBaseline().getSelectedParameters())
+alternative_parameters = list(result.getAlternative().getSelectedParameters())
+metric_deltas = {
+    row.getBaseline().getId(): row.getDelta()
+    for row in result.getMetricComparisons()
+    if row.isCalculable()
+}
+diagnostics = list(result.getDiagnostics())
+\`\`\`
+
+The study independently re-evaluates the selected point after the search callback returns. A
+custom external search therefore supplies a candidate vector, not trusted convergence or
+feasibility flags. Do not mutate the same evaluator or process model concurrently. The study
+restores and reconverges the pre-study parameter vector before returning.
+
+The immutable \`StudyResult\` retains the alternative identity and provenance, original and applied
+capacity state, paired objectives and constraint residuals, installed-capacity and process-boundary
+evidence, physical/screening metrics, evaluation counts, recovery flags, and diagnostics. It
+retains no process model, equipment, live capacity constraint, or Python callback and can be
+Java-serialized for restartable records. Screening economics and emissions remain caller-supplied
+metrics with explicit basis and provenance; NeqSim does not certify them.
+
 ### Export Problem Definition
 
 ```python
@@ -1188,6 +1246,18 @@ on `ProcessSimulationEvaluator`.
 | `getRankedHydraulicConstraintsAtBestSampledObjective()` | Stable descending-utilization evidence at the best sampled objective |
 | `getInstalledCapacityEvidenceAtBestFeasible()` | Complete immutable installed-capacity evidence at the feasible incumbent |
 | `getInstalledCapacityEvidenceAtBestSampledObjective()` | Complete immutable installed-capacity evidence at the best sampled objective |
+
+### ProcessModelDebottleneckStudy
+
+| Method | Description |
+|--------|-------------|
+| \`evaluate()\` | Run the common search for baseline and alternative, independently verify each selected point, sample metrics, and recover state |
+| \`CandidateListSearch(...)\` | Deterministic direction-aware search over an ordered bounded candidate list; equal objective values retain the first candidate |
+| \`CapacityAlternative(...)\` | Stable direct-constraint identity plus proposed applicable limit, unit, direction, source, confidence, and validity range |
+| \`addMetric(MetricDefinition)\` | Register one production, power, energy, emissions, screening-economic, or other metric with unit, basis, provenance, period, confidence, and required status |
+| \`StudyResult.getBaseline()\` / \`getAlternative()\` | Immutable scenario evidence with selected parameters, objectives, margins, installed/boundary evidence, metrics, and diagnostics |
+| \`StudyResult.getMetricComparisons()\` | Identically defined metric rows with \`alternative - baseline\` deltas |
+| \`StudyResult.isCapacityRestored()\` / \`isProcessStateRestored()\` | Explicit transaction-recovery evidence |
 
 ### EvaluationResult
 

--- a/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
+++ b/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
@@ -1010,16 +1010,16 @@ production-loss estimate, economic value, or operating approval.
 
 ### Paired debottleneck studies from Python
 
-\`ProcessModelDebottleneckStudy\` evaluates one documented direct installed-capacity alternative
-with the same \`ScenarioSearch\` in both cases. The built-in \`CandidateListSearch\` is useful when
+`ProcessModelDebottleneckStudy` evaluates one documented direct installed-capacity alternative
+with the same `ScenarioSearch` in both cases. The built-in `CandidateListSearch` is useful when
 Python has already generated a bounded candidate design and NeqSim must remain the physical
 feasibility authority.
 
-JPype callers should pass an ordered Java \`List<double[]>\`. Result arrays are defensive copies,
+JPype callers should pass an ordered Java `List<double[]>`. Result arrays are defensive copies,
 and result lists are unmodifiable Java lists. Convert them explicitly when native Python containers
 are needed:
 
-\`\`\`python
+```python
 import jpype
 from jpype.types import JArray, JDouble
 
@@ -1052,14 +1052,14 @@ metric_deltas = {
     if row.isCalculable()
 }
 diagnostics = list(result.getDiagnostics())
-\`\`\`
+```
 
 The study independently re-evaluates the selected point after the search callback returns. A
 custom external search therefore supplies a candidate vector, not trusted convergence or
 feasibility flags. Do not mutate the same evaluator or process model concurrently. The study
 restores and reconverges the pre-study parameter vector before returning.
 
-The immutable \`StudyResult\` retains the alternative identity and provenance, original and applied
+The immutable `StudyResult` retains the alternative identity and provenance, original and applied
 capacity state, paired objectives and constraint residuals, installed-capacity and process-boundary
 evidence, physical/screening metrics, evaluation counts, recovery flags, and diagnostics. It
 retains no process model, equipment, live capacity constraint, or Python callback and can be
@@ -1251,13 +1251,13 @@ on `ProcessSimulationEvaluator`.
 
 | Method | Description |
 |--------|-------------|
-| \`evaluate()\` | Run the common search for baseline and alternative, independently verify each selected point, sample metrics, and recover state |
-| \`CandidateListSearch(...)\` | Deterministic direction-aware search over an ordered bounded candidate list; equal objective values retain the first candidate |
-| \`CapacityAlternative(...)\` | Stable direct-constraint identity plus proposed applicable limit, unit, direction, source, confidence, and validity range |
-| \`addMetric(MetricDefinition)\` | Register one production, power, energy, emissions, screening-economic, or other metric with unit, basis, provenance, period, confidence, and required status |
-| \`StudyResult.getBaseline()\` / \`getAlternative()\` | Immutable scenario evidence with selected parameters, objectives, margins, installed/boundary evidence, metrics, and diagnostics |
-| \`StudyResult.getMetricComparisons()\` | Identically defined metric rows with \`alternative - baseline\` deltas |
-| \`StudyResult.isCapacityRestored()\` / \`isProcessStateRestored()\` | Explicit transaction-recovery evidence |
+| `evaluate()` | Run the common search for baseline and alternative, independently verify each selected point, sample metrics, and recover state |
+| `CandidateListSearch(...)` | Deterministic direction-aware search over an ordered bounded candidate list; equal objective values retain the first candidate |
+| `CapacityAlternative(...)` | Stable direct-constraint identity plus proposed applicable limit, unit, direction, source, confidence, and validity range |
+| `addMetric(MetricDefinition)` | Register one production, power, energy, emissions, screening-economic, or other metric with unit, basis, provenance, period, confidence, and required status |
+| `StudyResult.getBaseline()` / `getAlternative()` | Immutable scenario evidence with selected parameters, objectives, margins, installed/boundary evidence, metrics, and diagnostics |
+| `StudyResult.getMetricComparisons()` | Identically defined metric rows with `alternative - baseline` deltas |
+| `StudyResult.isCapacityRestored()` / `isProcessStateRestored()` | Explicit transaction-recovery evidence |
 
 ### EvaluationResult
 

--- a/docs/process/optimization/OPTIMIZATION_AND_CONSTRAINTS.md
+++ b/docs/process/optimization/OPTIMIZATION_AND_CONSTRAINTS.md
@@ -729,6 +729,99 @@ OptimizationResult result = new ProductionOptimizer().optimize(process, feed, co
 | `getIterations()` | Number of iterations used |
 | `getInfeasibilityDiagnosis()` | Detailed constraint violation report |
 
+
+---
+
+## Paired Installed-Capacity Alternatives
+
+Use \`ProcessModelDebottleneckStudy\` when an installed direct \`CapacityConstraint\` has
+one documented replacement or expansion basis and both the existing and proposed cases must be
+searched with the same deterministic policy. The study:
+
+1. resolves the exact \`area::equipment/constraint\` identity;
+2. freezes the installed limit, direction, unit, severity, provenance, confidence, validity range,
+   and shadow-price field;
+3. searches and independently verifies the baseline;
+4. applies the proposed limit and its evidence metadata, then searches and verifies the alternative;
+5. samples registered production, power, energy, emissions, or screening-economic metrics once at
+   each selected operating point; and
+6. restores the installed constraint and pre-study parameter vector and reconverges the model.
+
+Only direct equipment constraints are eligible. Strategy-generated defaults are deliberately
+excluded because they are not a stable installed asset transaction.
+
+\`\`\`java
+List<double[]> candidates = Arrays.asList(
+    new double[] {800.0},
+    new double[] {1000.0},
+    new double[] {1200.0});
+
+ProcessModelDebottleneckStudy.CandidateListSearch search =
+    new ProcessModelDebottleneckStudy.CandidateListSearch(
+        "throughput-grid",
+        "Ordered throughput grid",
+        "screening candidate set rev A",
+        candidates,
+        0,
+        0.0);
+
+ProcessModelDebottleneckStudy.CapacityAlternative alternative =
+    new ProcessModelDebottleneckStudy.CapacityAlternative(
+        "separator-gas-1200",
+        "Raise separator gas capacity",
+        "brownfield screening case rev A",
+        "separation",
+        "separator",
+        "installed gas rate",
+        1200.0,
+        "kg/hr",
+        ProcessModelDebottleneckStudy.LimitDirection.MAXIMUM,
+        "vendor budget curve rev A",
+        0.8,
+        900.0,
+        1300.0);
+
+ProcessModelDebottleneckStudy study = new ProcessModelDebottleneckStudy(
+    "separator-study",
+    "Paired separator capacity study",
+    "2026 screening basis",
+    evaluator,
+    alternative,
+    search,
+    0);
+
+study.addMetric(new ProcessModelDebottleneckStudy.MetricDefinition(
+    "production",
+    "Feed production",
+    ProcessModelDebottleneckStudy.MetricKind.PRODUCTION,
+    "kg/hr",
+    "wet feed mass rate",
+    "NeqSim stream result",
+    "single steady state",
+    1.0,
+    true,
+    model -> model.getVariableValue("wells::feed.flowRate", "kg/hr")));
+
+ProcessModelDebottleneckStudy.StudyResult result = study.evaluate();
+\`\`\`
+
+A \`COMPLETED\` outcome requires two converged, feasible verification runs, all required metrics,
+and successful state recovery. Inspect \`getOriginalCapacityState()\`,
+\`getAppliedCapacityState()\`, both scenario evidence objects, \`getMetricComparisons()\`, and
+\`getDiagnostics()\`. Scenario evidence retains objective values, physical constraint margins,
+installed-equipment evidence, and boundary evidence. Arrays and lists returned by the result are
+defensive copies or unmodifiable views, and the result is Java-serializable for Python/JPype and
+restartable study records.
+
+Metric deltas are always \`alternative - baseline\`. Units, physical or commercial basis,
+provenance, effective period, confidence, and required/optional status are explicit. Economic
+metrics are screening indicators only; no price, discount rate, emissions factor, or cost is
+implied by NeqSim.
+
+The paired result is sampled simulator evidence over the declared candidates. It is not proof of
+causality, a global optimum, a KKT shadow price, certified emissions, mechanical design adequacy,
+or investment approval.
+
 ---
 
 ## References

--- a/docs/process/optimization/OPTIMIZATION_AND_CONSTRAINTS.md
+++ b/docs/process/optimization/OPTIMIZATION_AND_CONSTRAINTS.md
@@ -753,8 +753,8 @@ excluded because they are not a stable installed asset transaction.
 ```java
 List<double[]> candidates = Arrays.asList(
     new double[] {800.0},
-    new double[] {1000.0},
-    new double[] {1200.0});
+    new double[] {999.0},
+    new double[] {1199.0});
 
 ProcessModelDebottleneckStudy.CandidateListSearch search =
     new ProcessModelDebottleneckStudy.CandidateListSearch(
@@ -804,6 +804,10 @@ study.addMetric(new ProcessModelDebottleneckStudy.MetricDefinition(
 
 ProcessModelDebottleneckStudy.StudyResult result = study.evaluate();
 ```
+
+The 999 and 1199 kg/hr candidates deliberately retain 1 kg/hr below the documented
+1000 and 1200 kg/hr installed limits. Keep a declared engineering/numerical feasibility margin
+instead of depending on floating-point reconstruction of stream flow to equal a hard limit exactly.
 
 A `COMPLETED` outcome requires two converged, feasible verification runs, all required metrics,
 and successful state recovery. Inspect `getOriginalCapacityState()`,

--- a/docs/process/optimization/OPTIMIZATION_AND_CONSTRAINTS.md
+++ b/docs/process/optimization/OPTIMIZATION_AND_CONSTRAINTS.md
@@ -734,11 +734,11 @@ OptimizationResult result = new ProductionOptimizer().optimize(process, feed, co
 
 ## Paired Installed-Capacity Alternatives
 
-Use \`ProcessModelDebottleneckStudy\` when an installed direct \`CapacityConstraint\` has
+Use `ProcessModelDebottleneckStudy` when an installed direct `CapacityConstraint` has
 one documented replacement or expansion basis and both the existing and proposed cases must be
 searched with the same deterministic policy. The study:
 
-1. resolves the exact \`area::equipment/constraint\` identity;
+1. resolves the exact `area::equipment/constraint` identity;
 2. freezes the installed limit, direction, unit, severity, provenance, confidence, validity range,
    and shadow-price field;
 3. searches and independently verifies the baseline;
@@ -750,7 +750,7 @@ searched with the same deterministic policy. The study:
 Only direct equipment constraints are eligible. Strategy-generated defaults are deliberately
 excluded because they are not a stable installed asset transaction.
 
-\`\`\`java
+```java
 List<double[]> candidates = Arrays.asList(
     new double[] {800.0},
     new double[] {1000.0},
@@ -803,17 +803,17 @@ study.addMetric(new ProcessModelDebottleneckStudy.MetricDefinition(
     model -> model.getVariableValue("wells::feed.flowRate", "kg/hr")));
 
 ProcessModelDebottleneckStudy.StudyResult result = study.evaluate();
-\`\`\`
+```
 
-A \`COMPLETED\` outcome requires two converged, feasible verification runs, all required metrics,
-and successful state recovery. Inspect \`getOriginalCapacityState()\`,
-\`getAppliedCapacityState()\`, both scenario evidence objects, \`getMetricComparisons()\`, and
-\`getDiagnostics()\`. Scenario evidence retains objective values, physical constraint margins,
+A `COMPLETED` outcome requires two converged, feasible verification runs, all required metrics,
+and successful state recovery. Inspect `getOriginalCapacityState()`,
+`getAppliedCapacityState()`, both scenario evidence objects, `getMetricComparisons()`, and
+`getDiagnostics()`. Scenario evidence retains objective values, physical constraint margins,
 installed-equipment evidence, and boundary evidence. Arrays and lists returned by the result are
 defensive copies or unmodifiable views, and the result is Java-serializable for Python/JPype and
 restartable study records.
 
-Metric deltas are always \`alternative - baseline\`. Units, physical or commercial basis,
+Metric deltas are always `alternative - baseline`. Units, physical or commercial basis,
 provenance, effective period, confidence, and required/optional status are explicit. Economic
 metrics are screening indicators only; no price, discount rate, emissions factor, or cost is
 implied by NeqSim.

--- a/docs/process/optimization/OPTIMIZATION_OVERVIEW.md
+++ b/docs/process/optimization/OPTIMIZATION_OVERVIEW.md
@@ -36,6 +36,7 @@ This document provides a high-level introduction to the process optimization cap
 | Integrate with external optimizers (SciPy, NLopt) | `ProcessSimulationEvaluator` | [External Optimizer Integration](../../integration/EXTERNAL_OPTIMIZER_INTEGRATION.md) |
 | Optimize full multi-area process models | `ProcessModelSimulationEvaluator` | Use area-qualified `ProcessAutomation` addresses and installed `CapacityConstraint` limits |
 | Ramp producers until a full facility reaches a bottleneck | `ProcessModelThroughputOptimizer` | Use producer mappings, installed capacity tables, and exported case traces |
+| Compare one installed capacity alternative with the same search policy | `ProcessModelDebottleneckStudy` | [Optimization & Constraints Guide](OPTIMIZATION_AND_CONSTRAINTS.md#paired-installed-capacity-alternatives) |
 | Solve constrained NLP (equality + inequality) | `SQPoptimizer` | [SQP Optimizer](sqp_optimizer.md) |
 | Calibrate model parameters to data | `BatchParameterEstimator` | [Data Reconciliation and Steady-State Detection](data-reconciliation.md) |
 | Load optimization config from YAML/JSON | `ProductionOptimizationSpecLoader` | [YAML Spec Format](#yaml-specification-files) |
@@ -214,6 +215,7 @@ System.out.println("Optimal rate: " + result.getOptimalRate() + " kg/hr");
 | "Optimize pressure AND flow rate together" | `ProductionOptimizer` | Multi-variable support |
 | "Trade off throughput vs power consumption" | `ProductionOptimizer.optimizePareto()` | Pareto multi-objective |
 | "Increase several producers until the full facility reaches a bottleneck" | `ProcessModelThroughputOptimizer` | Maps producers, loads installed capacities, and records the active bottleneck per case |
+| "Quantify one documented equipment expansion against the installed case" | `ProcessModelDebottleneckStudy` | Pairs identical searches, metrics, evidence, and state recovery |
 | "Evaluate 100 scenarios in parallel" | `ProductionOptimizer` | Has parallel evaluation |
 | "Calibrate model to match field data" | `BatchParameterEstimator` | Levenberg-Marquardt for data fitting |
 
@@ -224,6 +226,8 @@ System.out.println("Optimal rate: " + result.getOptimalRate() + " kg/hr");
 Use `ProcessModelThroughputOptimizer` for large fixed-equipment studies such as increasing one or more producer feed rates until a separator, compressor, valve, heat exchanger, or export train reaches its installed capacity. It is the ergonomic layer for the common full-facility throughput-to-bottleneck task.
 
 Use `ProcessModelSimulationEvaluator` directly when you need a lower-level black-box bridge to SciPy, NLopt, SQP, Pyomo, or another external optimizer.
+
+Use `ProcessModelDebottleneckStudy` after the evaluator and direct installed constraints are configured when one documented capacity replacement or expansion must be compared with the installed baseline. It uses the same search policy for both scenarios, freezes immutable objective/constraint/metric evidence, and restores the installed limit plus pre-study operating point. This is a paired screening study, not an equipment-sizing algorithm or economic approval.
 
 The evaluator is deliberately a black-box bridge. It keeps the full plant model intact, lets external optimizers pass a vector of decision variables, runs `ProcessModel.run()`, and returns objective values, constraint margins, feasibility, and the active bottleneck.
 

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelDebottleneckStudy.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelDebottleneckStudy.java
@@ -1,0 +1,1559 @@
+package neqsim.process.util.optimizer;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import neqsim.process.automation.ProcessAutomation;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.capacity.CapacityConstraint;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.util.optimizer.ProcessModelSimulationEvaluator.ConstraintDefinition;
+import neqsim.process.util.optimizer.ProcessModelSimulationEvaluator.EvaluationResult;
+import neqsim.process.util.optimizer.ProcessModelSimulationEvaluator.ObjectiveDefinition;
+import neqsim.process.util.optimizer.ProcessModelSimulationEvaluator.ParameterDefinition;
+
+/**
+ * Evaluates one installed-capacity alternative against a common deterministic production-search
+ * policy.
+ *
+ * <p>
+ * The study resolves one direct {@link CapacityConstraint} by its stable
+ * {@code area::equipment/constraint} address, freezes its complete observable state, evaluates the
+ * baseline, applies and verifies the proposed applicable limit, evaluates the alternative, and
+ * finally restores both the installed constraint and the pre-study process operating point. Every
+ * result is immutable and serializable; no live model, equipment, constraint, search callback, or
+ * metric callback is retained.
+ * </p>
+ *
+ * <p>
+ * A result is paired simulator evidence for the declared candidate set. It is not proof of causal
+ * production loss, global optimality, a KKT multiplier, design adequacy, certified emissions, or
+ * investment approval. Physical, energy, emission, and economic metrics remain separate and are
+ * compared only through identical metric definitions and units.
+ * </p>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public final class ProcessModelDebottleneckStudy {
+  /** Direction of the installed applicable limit. */
+  public enum LimitDirection {
+    /** Values above the installed limit are worse. */
+    MAXIMUM,
+    /** Values below the installed limit are worse. */
+    MINIMUM
+  }
+
+  /** Outcome of the complete paired study. */
+  public enum StudyOutcome {
+    /** Both scenarios and all required metrics are qualified and state was recovered. */
+    COMPLETED,
+    /** The named installed constraint could not be safely resolved or changed. */
+    ALTERNATIVE_NOT_APPLICABLE,
+    /** No qualified baseline operating point was selected. */
+    BASELINE_FAILED,
+    /** The alternative scenario did not produce a qualified operating point. */
+    ALTERNATIVE_FAILED,
+    /** Physical scenarios completed but at least one required metric was unavailable. */
+    REQUIRED_METRIC_UNAVAILABLE,
+    /** The installed constraint or pre-study process state was not exactly recovered. */
+    RESTORATION_FAILED
+  }
+
+  /** Status of one completed scenario. */
+  public enum ScenarioStatus {
+    /** Search and verification produced a converged, feasible operating point. */
+    QUALIFIED,
+    /** Search threw or did not select a candidate. */
+    SEARCH_FAILED,
+    /** The selected candidate failed deterministic verification. */
+    VERIFICATION_FAILED
+  }
+
+  /** Engineering role of a registered scenario metric. */
+  public enum MetricKind {
+    PRODUCTION,
+    POWER,
+    ENERGY,
+    DIRECT_EMISSIONS,
+    INDIRECT_EMISSIONS,
+    SCREENING_ECONOMIC,
+    OTHER
+  }
+
+  /** Availability of one sampled metric. */
+  public enum MetricStatus {
+    AVAILABLE,
+    NON_FINITE,
+    SAMPLING_FAILED,
+    NOT_SAMPLED
+  }
+
+  /** Serializable callback implementing the same search policy for both scenarios. */
+  public interface ScenarioSearch extends Serializable {
+    /** @return stable search-policy identifier */
+    String getId();
+
+    /** @return human-readable search-policy name */
+    String getName();
+
+    /** @return source and assumptions for the search policy */
+    String getProvenance();
+
+    /**
+     * Selects one parameter vector. The study independently verifies the selected vector.
+     *
+     * @param evaluator live process-model evaluator
+     * @return immutable search selection
+     */
+    SearchSelection search(ProcessModelSimulationEvaluator evaluator);
+  }
+
+  /** Serializable metric callback sampled once at each verified scenario point. */
+  public interface MetricSampler extends Serializable {
+    /**
+     * Samples the completed process model.
+     *
+     * @param model completed scenario model
+     * @return metric value in the definition's unit
+     */
+    double sample(ProcessModel model);
+  }
+
+  /** Immutable definition of one installed-capacity alternative. */
+  public static final class CapacityAlternative implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String id;
+    private final String name;
+    private final String provenance;
+    private final String areaName;
+    private final String equipmentName;
+    private final String constraintName;
+    private final double proposedLimit;
+    private final String unit;
+    private final LimitDirection limitDirection;
+    private final String proposalSource;
+    private final boolean confidenceSet;
+    private final double confidence;
+    private final boolean validityRangeSet;
+    private final double validityMinimum;
+    private final double validityMaximum;
+
+    /**
+     * Creates a fully qualified installed-capacity alternative.
+     *
+     * @param id stable alternative identifier
+     * @param name human-readable alternative name
+     * @param provenance engineering provenance for the study definition
+     * @param areaName exact process-area name
+     * @param equipmentName exact equipment name
+     * @param constraintName exact direct capacity-constraint name
+     * @param proposedLimit proposed applicable limit
+     * @param unit engineering unit of the existing and proposed limit
+     * @param limitDirection expected installed-limit direction
+     * @param proposalSource source of the proposed limit
+     * @param confidence evidence-quality confidence, or NaN when unset
+     * @param validityMinimum inclusive proposal validity minimum, or NaN when unset
+     * @param validityMaximum inclusive proposal validity maximum, or NaN when unset
+     */
+    public CapacityAlternative(String id, String name, String provenance, String areaName,
+        String equipmentName, String constraintName, double proposedLimit, String unit,
+        LimitDirection limitDirection, String proposalSource, double confidence,
+        double validityMinimum, double validityMaximum) {
+      this.id = requireText(id, "Alternative identifier");
+      this.name = requireText(name, "Alternative name");
+      this.provenance = requireText(provenance, "Alternative provenance");
+      this.areaName = requireText(areaName, "Process area name");
+      this.equipmentName = requireText(equipmentName, "Equipment name");
+      this.constraintName = requireText(constraintName, "Capacity constraint name");
+      if (!isFinite(proposedLimit) || proposedLimit <= 0.0) {
+        throw new IllegalArgumentException("Proposed capacity limit must be finite and positive");
+      }
+      this.proposedLimit = proposedLimit;
+      this.unit = requireText(unit, "Capacity limit unit");
+      if (limitDirection == null) {
+        throw new IllegalArgumentException("Capacity limit direction is required");
+      }
+      this.limitDirection = limitDirection;
+      this.proposalSource = requireText(proposalSource, "Capacity proposal source");
+      if (Double.isNaN(confidence)) {
+        this.confidenceSet = false;
+        this.confidence = Double.NaN;
+      } else {
+        if (!isFinite(confidence) || confidence < 0.0 || confidence > 1.0) {
+          throw new IllegalArgumentException("Alternative confidence must be in [0, 1] or NaN");
+        }
+        this.confidenceSet = true;
+        this.confidence = confidence;
+      }
+      boolean minimumSet = isFinite(validityMinimum);
+      boolean maximumSet = isFinite(validityMaximum);
+      if (minimumSet != maximumSet) {
+        throw new IllegalArgumentException("Both alternative validity bounds must be set together");
+      }
+      if (minimumSet && validityMinimum > validityMaximum) {
+        throw new IllegalArgumentException("Alternative validity minimum must not exceed maximum");
+      }
+      this.validityRangeSet = minimumSet;
+      this.validityMinimum = minimumSet ? validityMinimum : Double.NaN;
+      this.validityMaximum = maximumSet ? validityMaximum : Double.NaN;
+      if (validityRangeSet
+          && (proposedLimit < validityMinimum || proposedLimit > validityMaximum)) {
+        throw new IllegalArgumentException("Proposed limit lies outside its declared validity range");
+      }
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getProvenance() {
+      return provenance;
+    }
+
+    public String getAreaName() {
+      return areaName;
+    }
+
+    public String getEquipmentName() {
+      return equipmentName;
+    }
+
+    public String getConstraintName() {
+      return constraintName;
+    }
+
+    public String getQualifiedConstraintName() {
+      return areaName + ProcessAutomation.AREA_SEPARATOR + equipmentName + "/" + constraintName;
+    }
+
+    public double getProposedLimit() {
+      return proposedLimit;
+    }
+
+    public String getUnit() {
+      return unit;
+    }
+
+    public LimitDirection getLimitDirection() {
+      return limitDirection;
+    }
+
+    public String getProposalSource() {
+      return proposalSource;
+    }
+
+    public boolean hasConfidence() {
+      return confidenceSet;
+    }
+
+    public double getConfidence() {
+      return confidenceSet ? confidence : Double.NaN;
+    }
+
+    public boolean hasValidityRange() {
+      return validityRangeSet;
+    }
+
+    public double getValidityMinimum() {
+      return validityRangeSet ? validityMinimum : Double.NaN;
+    }
+
+    public double getValidityMaximum() {
+      return validityRangeSet ? validityMaximum : Double.NaN;
+    }
+  }
+
+  /** Frozen observable state of one installed capacity constraint. */
+  public static final class CapacityState implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final double designValue;
+    private final double maximumValue;
+    private final double minimumValue;
+    private final double warningThreshold;
+    private final String unit;
+    private final CapacityConstraint.ConstraintSeverity severity;
+    private final boolean enabled;
+    private final String dataSource;
+    private final boolean confidenceSet;
+    private final double confidence;
+    private final boolean validityRangeSet;
+    private final double validityMinimum;
+    private final double validityMaximum;
+    private final double shadowPrice;
+
+    private CapacityState(CapacityConstraint constraint) {
+      designValue = constraint.getDesignValue();
+      maximumValue = constraint.getMaxValue();
+      minimumValue = constraint.getMinValue();
+      warningThreshold = constraint.getWarningThreshold();
+      unit = safeText(constraint.getUnit());
+      severity = constraint.getSeverity();
+      enabled = constraint.isEnabled();
+      dataSource = safeText(constraint.getDataSource());
+      confidenceSet = constraint.hasConfidence();
+      confidence = confidenceSet ? constraint.getConfidence() : Double.NaN;
+      validityRangeSet = constraint.hasValidityRange();
+      validityMinimum = validityRangeSet ? constraint.getValidityMinimum() : Double.NaN;
+      validityMaximum = validityRangeSet ? constraint.getValidityMaximum() : Double.NaN;
+      shadowPrice = constraint.getShadowPrice();
+    }
+
+    public double getDesignValue() {
+      return designValue;
+    }
+
+    public double getMaximumValue() {
+      return maximumValue;
+    }
+
+    public double getMinimumValue() {
+      return minimumValue;
+    }
+
+    public double getApplicableLimit() {
+      return minimumValue > 0.0 && designValue == Double.MAX_VALUE ? minimumValue : designValue;
+    }
+
+    public double getWarningThreshold() {
+      return warningThreshold;
+    }
+
+    public String getUnit() {
+      return unit;
+    }
+
+    public CapacityConstraint.ConstraintSeverity getSeverity() {
+      return severity;
+    }
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public String getDataSource() {
+      return dataSource;
+    }
+
+    public boolean hasConfidence() {
+      return confidenceSet;
+    }
+
+    public double getConfidence() {
+      return confidenceSet ? confidence : Double.NaN;
+    }
+
+    public boolean hasValidityRange() {
+      return validityRangeSet;
+    }
+
+    public double getValidityMinimum() {
+      return validityRangeSet ? validityMinimum : Double.NaN;
+    }
+
+    public double getValidityMaximum() {
+      return validityRangeSet ? validityMaximum : Double.NaN;
+    }
+
+    public double getShadowPrice() {
+      return shadowPrice;
+    }
+  }
+
+  /** Immutable search-policy selection. */
+  public static final class SearchSelection implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final boolean selected;
+    private final double[] parameters;
+    private final List<String> diagnostics;
+
+    private SearchSelection(boolean selected, double[] parameters, List<String> diagnostics) {
+      this.selected = selected;
+      this.parameters = parameters == null ? new double[0] : Arrays.copyOf(parameters, parameters.length);
+      this.diagnostics = immutableStrings(diagnostics);
+    }
+
+    public static SearchSelection selected(double[] parameters, String diagnostic) {
+      return new SearchSelection(true, parameters, Collections.singletonList(safeText(diagnostic)));
+    }
+
+    public static SearchSelection failed(String diagnostic) {
+      return new SearchSelection(false, null, Collections.singletonList(safeText(diagnostic)));
+    }
+
+    public boolean isSelected() {
+      return selected;
+    }
+
+    public double[] getParameters() {
+      return Arrays.copyOf(parameters, parameters.length);
+    }
+
+    public List<String> getDiagnostics() {
+      return immutableStrings(diagnostics);
+    }
+  }
+
+  /**
+   * Deterministic derivative-free search over an explicit ordered list of parameter vectors.
+   *
+   * <p>
+   * Only converged feasible candidates with finite selected-objective values are eligible. Ties
+   * inside the declared absolute tolerance retain the earliest candidate, making repeated Java and
+   * JPype execution deterministic.
+   * </p>
+   */
+  public static final class CandidateListSearch implements ScenarioSearch {
+    private static final long serialVersionUID = 1L;
+
+    private final String id;
+    private final String name;
+    private final String provenance;
+    private final List<double[]> candidates;
+    private final int objectiveIndex;
+    private final double objectiveTolerance;
+
+    public CandidateListSearch(String id, String name, String provenance, List<double[]> candidates,
+        int objectiveIndex, double objectiveTolerance) {
+      this.id = requireText(id, "Search identifier");
+      this.name = requireText(name, "Search name");
+      this.provenance = requireText(provenance, "Search provenance");
+      if (candidates == null || candidates.isEmpty()) {
+        throw new IllegalArgumentException("Candidate-list search requires at least one candidate");
+      }
+      List<double[]> copied = new ArrayList<double[]>();
+      for (double[] candidate : candidates) {
+        if (candidate == null) {
+          throw new IllegalArgumentException("Search candidates must not be null");
+        }
+        copied.add(Arrays.copyOf(candidate, candidate.length));
+      }
+      this.candidates = Collections.unmodifiableList(copied);
+      if (objectiveIndex < 0) {
+        throw new IllegalArgumentException("Objective index must be non-negative");
+      }
+      this.objectiveIndex = objectiveIndex;
+      if (!isFinite(objectiveTolerance) || objectiveTolerance < 0.0) {
+        throw new IllegalArgumentException("Objective tolerance must be finite and non-negative");
+      }
+      this.objectiveTolerance = objectiveTolerance;
+    }
+
+    @Override
+    public String getId() {
+      return id;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public String getProvenance() {
+      return provenance;
+    }
+
+    public List<double[]> getCandidates() {
+      List<double[]> copy = new ArrayList<double[]>();
+      for (double[] candidate : candidates) {
+        copy.add(Arrays.copyOf(candidate, candidate.length));
+      }
+      return Collections.unmodifiableList(copy);
+    }
+
+    public int getObjectiveIndex() {
+      return objectiveIndex;
+    }
+
+    public double getObjectiveTolerance() {
+      return objectiveTolerance;
+    }
+
+    @Override
+    public SearchSelection search(ProcessModelSimulationEvaluator evaluator) {
+      if (evaluator == null) {
+        return SearchSelection.failed("Process-model evaluator was null");
+      }
+      if (objectiveIndex >= evaluator.getObjectiveCount()) {
+        return SearchSelection.failed("Search objective index is not registered");
+      }
+      ObjectiveDefinition objective = evaluator.getObjectives().get(objectiveIndex);
+      double[] selected = null;
+      double selectedValue = Double.NaN;
+      int candidateIndex = 0;
+      for (double[] candidate : candidates) {
+        String invalid = validateCandidate(evaluator, candidate, candidateIndex);
+        if (invalid != null) {
+          return SearchSelection.failed(invalid);
+        }
+        EvaluationResult result = evaluator.evaluate(candidate);
+        double[] rawObjectives = result.getObjectivesRaw();
+        if (result.isSimulationConverged() && result.isFeasible()
+            && rawObjectives != null && objectiveIndex < rawObjectives.length
+            && isFinite(rawObjectives[objectiveIndex])) {
+          double value = rawObjectives[objectiveIndex];
+          if (selected == null || improves(value, selectedValue, objective.getDirection())) {
+            selected = Arrays.copyOf(candidate, candidate.length);
+            selectedValue = value;
+          }
+        }
+        candidateIndex++;
+      }
+      if (selected == null) {
+        return SearchSelection.failed("No converged feasible candidate with a finite objective was found");
+      }
+      return SearchSelection.selected(selected,
+          "Selected the first direction-aware best feasible candidate from the ordered candidate list");
+    }
+
+    private String validateCandidate(ProcessModelSimulationEvaluator evaluator, double[] candidate,
+        int candidateIndex) {
+      if (candidate.length != evaluator.getParameterCount()) {
+        return "Candidate " + candidateIndex + " length does not match evaluator parameter count";
+      }
+      List<ParameterDefinition> parameters = evaluator.getParameters();
+      for (int index = 0; index < candidate.length; index++) {
+        if (!isFinite(candidate[index])) {
+          return "Candidate " + candidateIndex + " contains a non-finite parameter";
+        }
+        if (!parameters.get(index).isWithinBounds(candidate[index])) {
+          return "Candidate " + candidateIndex + " lies outside declared parameter bounds";
+        }
+      }
+      return null;
+    }
+
+    private boolean improves(double candidate, double incumbent,
+        ObjectiveDefinition.Direction direction) {
+      if (direction == ObjectiveDefinition.Direction.MAXIMIZE) {
+        return candidate > incumbent + objectiveTolerance;
+      }
+      return candidate < incumbent - objectiveTolerance;
+    }
+  }
+
+  /** Immutable metric definition. */
+  public static final class MetricDefinition {
+    private final String id;
+    private final String name;
+    private final MetricKind kind;
+    private final String unit;
+    private final String basis;
+    private final String provenance;
+    private final String effectivePeriod;
+    private final boolean confidenceSet;
+    private final double confidence;
+    private final boolean required;
+    private final MetricSampler sampler;
+
+    public MetricDefinition(String id, String name, MetricKind kind, String unit, String basis,
+        String provenance, String effectivePeriod, double confidence, boolean required,
+        MetricSampler sampler) {
+      this.id = requireText(id, "Metric identifier");
+      this.name = requireText(name, "Metric name");
+      if (kind == null) {
+        throw new IllegalArgumentException("Metric kind is required");
+      }
+      this.kind = kind;
+      this.unit = requireText(unit, "Metric unit");
+      this.basis = requireText(basis, "Metric basis");
+      this.provenance = requireText(provenance, "Metric provenance");
+      this.effectivePeriod = requireText(effectivePeriod, "Metric effective period");
+      if (Double.isNaN(confidence)) {
+        confidenceSet = false;
+        this.confidence = Double.NaN;
+      } else {
+        if (!isFinite(confidence) || confidence < 0.0 || confidence > 1.0) {
+          throw new IllegalArgumentException("Metric confidence must be in [0, 1] or NaN");
+        }
+        confidenceSet = true;
+        this.confidence = confidence;
+      }
+      this.required = required;
+      if (sampler == null) {
+        throw new IllegalArgumentException("Metric sampler is required");
+      }
+      this.sampler = sampler;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public MetricKind getKind() {
+      return kind;
+    }
+
+    public String getUnit() {
+      return unit;
+    }
+
+    public String getBasis() {
+      return basis;
+    }
+
+    public String getProvenance() {
+      return provenance;
+    }
+
+    public String getEffectivePeriod() {
+      return effectivePeriod;
+    }
+
+    public boolean hasConfidence() {
+      return confidenceSet;
+    }
+
+    public double getConfidence() {
+      return confidenceSet ? confidence : Double.NaN;
+    }
+
+    public boolean isRequired() {
+      return required;
+    }
+  }
+
+  /** Immutable evidence from one metric sample. */
+  public static final class MetricEvidence implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String id;
+    private final String name;
+    private final MetricKind kind;
+    private final String unit;
+    private final String basis;
+    private final String provenance;
+    private final String effectivePeriod;
+    private final boolean confidenceSet;
+    private final double confidence;
+    private final boolean required;
+    private final MetricStatus status;
+    private final double value;
+    private final String diagnostic;
+
+    private MetricEvidence(MetricDefinition definition, MetricStatus status, double value,
+        String diagnostic) {
+      id = definition.id;
+      name = definition.name;
+      kind = definition.kind;
+      unit = definition.unit;
+      basis = definition.basis;
+      provenance = definition.provenance;
+      effectivePeriod = definition.effectivePeriod;
+      confidenceSet = definition.confidenceSet;
+      confidence = definition.confidence;
+      required = definition.required;
+      this.status = status;
+      this.value = value;
+      this.diagnostic = safeText(diagnostic);
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public MetricKind getKind() {
+      return kind;
+    }
+
+    public String getUnit() {
+      return unit;
+    }
+
+    public String getBasis() {
+      return basis;
+    }
+
+    public String getProvenance() {
+      return provenance;
+    }
+
+    public String getEffectivePeriod() {
+      return effectivePeriod;
+    }
+
+    public boolean hasConfidence() {
+      return confidenceSet;
+    }
+
+    public double getConfidence() {
+      return confidenceSet ? confidence : Double.NaN;
+    }
+
+    public boolean isRequired() {
+      return required;
+    }
+
+    public MetricStatus getStatus() {
+      return status;
+    }
+
+    public double getValue() {
+      return value;
+    }
+
+    public String getDiagnostic() {
+      return diagnostic;
+    }
+
+    public boolean isAvailable() {
+      return status == MetricStatus.AVAILABLE;
+    }
+  }
+
+  /** Immutable comparison of one identically defined metric. */
+  public static final class MetricComparison implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final MetricEvidence baseline;
+    private final MetricEvidence alternative;
+    private final boolean calculable;
+    private final double delta;
+
+    private MetricComparison(MetricEvidence baseline, MetricEvidence alternative) {
+      this.baseline = baseline;
+      this.alternative = alternative;
+      calculable = baseline != null && alternative != null && baseline.isAvailable()
+          && alternative.isAvailable() && baseline.getId().equals(alternative.getId())
+          && baseline.getUnit().equals(alternative.getUnit());
+      delta = calculable ? alternative.getValue() - baseline.getValue() : Double.NaN;
+    }
+
+    public MetricEvidence getBaseline() {
+      return baseline;
+    }
+
+    public MetricEvidence getAlternative() {
+      return alternative;
+    }
+
+    public boolean isCalculable() {
+      return calculable;
+    }
+
+    public double getDelta() {
+      return delta;
+    }
+  }
+
+  /** Frozen objective row for one scenario. */
+  public static final class ObjectiveEvidence implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final int index;
+    private final String name;
+    private final ObjectiveDefinition.Direction direction;
+    private final String unit;
+    private final double weight;
+    private final double rawValue;
+    private final double minimizerValue;
+
+    private ObjectiveEvidence(int index, ObjectiveDefinition definition, double rawValue,
+        double minimizerValue) {
+      this.index = index;
+      name = safeText(definition.getName());
+      direction = definition.getDirection();
+      unit = safeText(definition.getUnit());
+      weight = definition.getWeight();
+      this.rawValue = rawValue;
+      this.minimizerValue = minimizerValue;
+    }
+
+    public int getIndex() {
+      return index;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public ObjectiveDefinition.Direction getDirection() {
+      return direction;
+    }
+
+    public String getUnit() {
+      return unit;
+    }
+
+    public double getWeight() {
+      return weight;
+    }
+
+    public double getRawValue() {
+      return rawValue;
+    }
+
+    public double getMinimizerValue() {
+      return minimizerValue;
+    }
+  }
+
+  /** Frozen constraint row for one scenario. */
+  public static final class ConstraintEvidence implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final int index;
+    private final String name;
+    private final ConstraintDefinition.Type type;
+    private final String unit;
+    private final boolean hard;
+    private final double value;
+    private final double margin;
+
+    private ConstraintEvidence(int index, ConstraintDefinition definition, double value,
+        double margin) {
+      this.index = index;
+      name = safeText(definition.getName());
+      type = definition.getType();
+      unit = safeText(definition.getUnit());
+      hard = definition.isHard();
+      this.value = value;
+      this.margin = margin;
+    }
+
+    public int getIndex() {
+      return index;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public ConstraintDefinition.Type getType() {
+      return type;
+    }
+
+    public String getUnit() {
+      return unit;
+    }
+
+    public boolean isHard() {
+      return hard;
+    }
+
+    public double getValue() {
+      return value;
+    }
+
+    public double getMargin() {
+      return margin;
+    }
+  }
+
+  /** Immutable evidence for one baseline or alternative scenario. */
+  public static final class ScenarioEvidence implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String label;
+    private final String searchId;
+    private final String searchName;
+    private final String searchProvenance;
+    private final ScenarioStatus status;
+    private final double[] selectedParameters;
+    private final boolean simulationConverged;
+    private final boolean feasible;
+    private final int evaluationCount;
+    private final List<ObjectiveEvidence> objectives;
+    private final List<ConstraintEvidence> constraints;
+    private final List<InstalledEquipmentCapacityEvidence> installedCapacityEvidence;
+    private final List<ProcessBoundaryConstraintEvidence> boundaryEvidence;
+    private final List<MetricEvidence> metrics;
+    private final List<String> diagnostics;
+
+    private ScenarioEvidence(String label, ScenarioSearch search, ScenarioStatus status,
+        double[] selectedParameters, EvaluationResult result, int evaluationCount,
+        List<ObjectiveEvidence> objectives, List<ConstraintEvidence> constraints,
+        List<MetricEvidence> metrics, List<String> diagnostics) {
+      this.label = label;
+      searchId = search.getId();
+      searchName = search.getName();
+      searchProvenance = search.getProvenance();
+      this.status = status;
+      this.selectedParameters = selectedParameters == null ? new double[0]
+          : Arrays.copyOf(selectedParameters, selectedParameters.length);
+      simulationConverged = result != null && result.isSimulationConverged();
+      feasible = result != null && result.isFeasible();
+      this.evaluationCount = evaluationCount;
+      this.objectives = immutableList(objectives);
+      this.constraints = immutableList(constraints);
+      installedCapacityEvidence = result == null ? Collections.<InstalledEquipmentCapacityEvidence>emptyList()
+          : immutableList(result.getInstalledEquipmentCapacityEvidence());
+      boundaryEvidence = result == null ? Collections.<ProcessBoundaryConstraintEvidence>emptyList()
+          : immutableList(result.getProcessBoundaryConstraintEvidence());
+      this.metrics = immutableList(metrics);
+      this.diagnostics = immutableStrings(diagnostics);
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    public String getSearchId() {
+      return searchId;
+    }
+
+    public String getSearchName() {
+      return searchName;
+    }
+
+    public String getSearchProvenance() {
+      return searchProvenance;
+    }
+
+    public ScenarioStatus getStatus() {
+      return status;
+    }
+
+    public double[] getSelectedParameters() {
+      return Arrays.copyOf(selectedParameters, selectedParameters.length);
+    }
+
+    public boolean isSimulationConverged() {
+      return simulationConverged;
+    }
+
+    public boolean isFeasible() {
+      return feasible;
+    }
+
+    public boolean isQualified() {
+      return status == ScenarioStatus.QUALIFIED && simulationConverged && feasible;
+    }
+
+    public int getEvaluationCount() {
+      return evaluationCount;
+    }
+
+    public List<ObjectiveEvidence> getObjectives() {
+      return immutableList(objectives);
+    }
+
+    public List<ConstraintEvidence> getConstraints() {
+      return immutableList(constraints);
+    }
+
+    public List<InstalledEquipmentCapacityEvidence> getInstalledCapacityEvidence() {
+      return immutableList(installedCapacityEvidence);
+    }
+
+    public List<ProcessBoundaryConstraintEvidence> getBoundaryEvidence() {
+      return immutableList(boundaryEvidence);
+    }
+
+    public List<MetricEvidence> getMetrics() {
+      return immutableList(metrics);
+    }
+
+    public List<String> getDiagnostics() {
+      return immutableStrings(diagnostics);
+    }
+  }
+
+  /** Immutable paired study result. */
+  public static final class StudyResult implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String id;
+    private final String name;
+    private final String provenance;
+    private final CapacityAlternative alternativeDefinition;
+    private final CapacityState originalCapacityState;
+    private final CapacityState appliedCapacityState;
+    private final StudyOutcome outcome;
+    private final ScenarioEvidence baseline;
+    private final ScenarioEvidence alternative;
+    private final boolean capacityRestored;
+    private final boolean processStateRestored;
+    private final boolean recoverySimulationConverged;
+    private final List<MetricComparison> metricComparisons;
+    private final boolean objectiveDeltaCalculable;
+    private final double objectiveDelta;
+    private final List<String> diagnostics;
+
+    private StudyResult(String id, String name, String provenance,
+        CapacityAlternative alternativeDefinition, CapacityState originalCapacityState,
+        CapacityState appliedCapacityState, StudyOutcome outcome, ScenarioEvidence baseline,
+        ScenarioEvidence alternative, boolean capacityRestored, boolean processStateRestored,
+        boolean recoverySimulationConverged, List<MetricComparison> metricComparisons,
+        boolean objectiveDeltaCalculable, double objectiveDelta, List<String> diagnostics) {
+      this.id = id;
+      this.name = name;
+      this.provenance = provenance;
+      this.alternativeDefinition = alternativeDefinition;
+      this.originalCapacityState = originalCapacityState;
+      this.appliedCapacityState = appliedCapacityState;
+      this.outcome = outcome;
+      this.baseline = baseline;
+      this.alternative = alternative;
+      this.capacityRestored = capacityRestored;
+      this.processStateRestored = processStateRestored;
+      this.recoverySimulationConverged = recoverySimulationConverged;
+      this.metricComparisons = immutableList(metricComparisons);
+      this.objectiveDeltaCalculable = objectiveDeltaCalculable;
+      this.objectiveDelta = objectiveDelta;
+      this.diagnostics = immutableStrings(diagnostics);
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getProvenance() {
+      return provenance;
+    }
+
+    public CapacityAlternative getAlternativeDefinition() {
+      return alternativeDefinition;
+    }
+
+    public CapacityState getOriginalCapacityState() {
+      return originalCapacityState;
+    }
+
+    public CapacityState getAppliedCapacityState() {
+      return appliedCapacityState;
+    }
+
+    public StudyOutcome getOutcome() {
+      return outcome;
+    }
+
+    public ScenarioEvidence getBaseline() {
+      return baseline;
+    }
+
+    public ScenarioEvidence getAlternative() {
+      return alternative;
+    }
+
+    public boolean isCapacityRestored() {
+      return capacityRestored;
+    }
+
+    public boolean isProcessStateRestored() {
+      return processStateRestored;
+    }
+
+    public boolean isRecoverySimulationConverged() {
+      return recoverySimulationConverged;
+    }
+
+    public List<MetricComparison> getMetricComparisons() {
+      return immutableList(metricComparisons);
+    }
+
+    public boolean isObjectiveDeltaCalculable() {
+      return objectiveDeltaCalculable;
+    }
+
+    public double getObjectiveDelta() {
+      return objectiveDelta;
+    }
+
+    public List<String> getDiagnostics() {
+      return immutableStrings(diagnostics);
+    }
+  }
+
+  /** Internal resolved direct installed constraint. */
+  private static final class CapacityTarget {
+    private final CapacityConstraint constraint;
+
+    private CapacityTarget(CapacityConstraint constraint) {
+      this.constraint = constraint;
+    }
+  }
+
+  private final String id;
+  private final String name;
+  private final String provenance;
+  private final ProcessModelSimulationEvaluator evaluator;
+  private final CapacityAlternative alternative;
+  private final ScenarioSearch search;
+  private final int objectiveIndex;
+  private final List<MetricDefinition> metrics = new ArrayList<MetricDefinition>();
+
+  /**
+   * Creates a paired debottleneck study.
+   *
+   * @param id stable study identifier
+   * @param name human-readable study name
+   * @param provenance engineering provenance for the study configuration
+   * @param evaluator configured process-model evaluator
+   * @param alternative installed-capacity alternative
+   * @param search common search policy used for baseline and alternative
+   * @param objectiveIndex objective used for the paired delta
+   */
+  public ProcessModelDebottleneckStudy(String id, String name, String provenance,
+      ProcessModelSimulationEvaluator evaluator, CapacityAlternative alternative,
+      ScenarioSearch search, int objectiveIndex) {
+    this.id = requireText(id, "Study identifier");
+    this.name = requireText(name, "Study name");
+    this.provenance = requireText(provenance, "Study provenance");
+    if (evaluator == null || alternative == null || search == null) {
+      throw new IllegalArgumentException("Evaluator, capacity alternative, and search are required");
+    }
+    if (objectiveIndex < 0 || objectiveIndex >= evaluator.getObjectiveCount()) {
+      throw new IllegalArgumentException("Study objective index is not registered");
+    }
+    this.evaluator = evaluator;
+    this.alternative = alternative;
+    this.search = search;
+    this.objectiveIndex = objectiveIndex;
+    if (search instanceof CandidateListSearch
+        && ((CandidateListSearch) search).getObjectiveIndex() != objectiveIndex) {
+      throw new IllegalArgumentException(
+          "Candidate-list search and study must use the same objective index");
+    }
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getProvenance() {
+    return provenance;
+  }
+
+  public ProcessModelSimulationEvaluator getEvaluator() {
+    return evaluator;
+  }
+
+  public CapacityAlternative getAlternative() {
+    return alternative;
+  }
+
+  public ScenarioSearch getSearch() {
+    return search;
+  }
+
+  public int getObjectiveIndex() {
+    return objectiveIndex;
+  }
+
+  /** Adds one physical or screening metric sampled at both selected operating points. */
+  public ProcessModelDebottleneckStudy addMetric(MetricDefinition metric) {
+    if (metric == null) {
+      throw new IllegalArgumentException("Metric definition must not be null");
+    }
+    for (MetricDefinition existing : metrics) {
+      if (existing.id.equals(metric.id)) {
+        throw new IllegalArgumentException("Metric identifier is already registered: " + metric.id);
+      }
+    }
+    metrics.add(metric);
+    return this;
+  }
+
+  /** @return fresh immutable metric definitions in registration order */
+  public List<MetricDefinition> getMetrics() {
+    return Collections.unmodifiableList(new ArrayList<MetricDefinition>(metrics));
+  }
+
+  /** Executes the paired study and always attempts exact installed/process-state recovery. */
+  public StudyResult evaluate() {
+    ProcessModel model = evaluator.getProcessModel();
+    double[] recoveryParameters = evaluator.getLastParameters();
+    if (recoveryParameters == null) {
+      recoveryParameters = evaluator.getInitialValues();
+    }
+    List<String> diagnostics = new ArrayList<String>();
+    diagnostics.add("Results are paired sampled evidence, not causal production loss, global "
+        + "optimality, a shadow price, certified emissions, design approval, or investment approval");
+
+    CapacityTarget target;
+    try {
+      target = resolveTarget(model);
+    } catch (RuntimeException exception) {
+      diagnostics.add(exception.getMessage());
+      return result(StudyOutcome.ALTERNATIVE_NOT_APPLICABLE, null, null, null, null,
+          false, false, false, diagnostics);
+    }
+
+    CapacityState originalState = new CapacityState(target.constraint);
+    CapacityState appliedState = null;
+    ScenarioEvidence baseline = null;
+    ScenarioEvidence alternativeScenario = null;
+    boolean capacityRestored = false;
+    boolean processStateRestored = false;
+    boolean recoveryConverged = false;
+    boolean alternativeApplied = false;
+    StudyOutcome provisionalOutcome = StudyOutcome.BASELINE_FAILED;
+
+    try {
+      baseline = runScenario("baseline");
+      if (!baseline.isQualified()) {
+        diagnostics.add("Baseline search or verification did not produce a qualified point");
+        provisionalOutcome = StudyOutcome.BASELINE_FAILED;
+      } else {
+        applyAlternative(target.constraint);
+        alternativeApplied = true;
+        appliedState = new CapacityState(target.constraint);
+        alternativeScenario = runScenario("alternative");
+        if (!alternativeScenario.isQualified()) {
+          diagnostics.add("Alternative search or verification did not produce a qualified point");
+          provisionalOutcome = StudyOutcome.ALTERNATIVE_FAILED;
+        } else if (hasUnavailableRequiredMetric(baseline)
+            || hasUnavailableRequiredMetric(alternativeScenario)) {
+          diagnostics.add("At least one required scenario metric was unavailable");
+          provisionalOutcome = StudyOutcome.REQUIRED_METRIC_UNAVAILABLE;
+        } else {
+          provisionalOutcome = StudyOutcome.COMPLETED;
+        }
+      }
+    } catch (RuntimeException exception) {
+      diagnostics.add("Study execution failed: " + safeText(exception.getMessage()));
+      provisionalOutcome = baseline == null || !baseline.isQualified()
+          ? StudyOutcome.BASELINE_FAILED : StudyOutcome.ALTERNATIVE_FAILED;
+    } finally {
+      try {
+        restoreConstraint(target.constraint, originalState);
+        capacityRestored = statesEqual(originalState, new CapacityState(target.constraint));
+      } catch (RuntimeException exception) {
+        diagnostics.add("Installed-capacity restoration failed: " + safeText(exception.getMessage()));
+        capacityRestored = false;
+      }
+      try {
+        EvaluationResult recovery = evaluator.evaluate(recoveryParameters);
+        recoveryConverged = recovery.isSimulationConverged();
+        processStateRestored = recoveryConverged
+            && arraysEqual(recoveryParameters, recovery.getParameters(), 0.0);
+      } catch (RuntimeException exception) {
+        diagnostics.add("Pre-study process-state recovery failed: " + safeText(exception.getMessage()));
+      }
+    }
+
+    if (!alternativeApplied && appliedState != null) {
+      diagnostics.add("Internal diagnostic: applied capacity state was retained without an applied alternative");
+    }
+    StudyOutcome outcome = capacityRestored && processStateRestored && recoveryConverged
+        ? provisionalOutcome : StudyOutcome.RESTORATION_FAILED;
+    if (capacityRestored) {
+      diagnostics.add("The complete installed-capacity state was restored and verified");
+    }
+    if (processStateRestored && recoveryConverged) {
+      diagnostics.add("The pre-study parameter vector was restored and the process model reconverged");
+    }
+    return result(outcome, originalState, appliedState, baseline, alternativeScenario,
+        capacityRestored, processStateRestored, recoveryConverged, diagnostics);
+  }
+
+  private CapacityTarget resolveTarget(ProcessModel model) {
+    ProcessSystem area = model.get(alternative.getAreaName());
+    if (area == null) {
+      throw new IllegalArgumentException("Alternative process area was not found: "
+          + alternative.getAreaName());
+    }
+    ProcessEquipmentInterface equipment = area.getUnit(alternative.getEquipmentName());
+    if (equipment == null) {
+      throw new IllegalArgumentException("Alternative equipment was not found: "
+          + alternative.getQualifiedConstraintName());
+    }
+    Map<String, CapacityConstraint> direct = equipment.getCapacityConstraints();
+    CapacityConstraint constraint = direct == null ? null : direct.get(alternative.getConstraintName());
+    if (constraint == null) {
+      throw new IllegalArgumentException("A direct installed capacity constraint was not found: "
+          + alternative.getQualifiedConstraintName());
+    }
+    if (!constraint.isEnabled()) {
+      throw new IllegalArgumentException("The installed capacity constraint is disabled");
+    }
+    if (!alternative.getUnit().equals(constraint.getUnit())) {
+      throw new IllegalArgumentException("Alternative unit does not match the installed constraint unit");
+    }
+    LimitDirection actual = constraint.isMinimumConstraint()
+        ? LimitDirection.MINIMUM : LimitDirection.MAXIMUM;
+    if (actual != alternative.getLimitDirection()) {
+      throw new IllegalArgumentException("Alternative direction does not match the installed constraint");
+    }
+    if (!isFinite(constraint.getDisplayDesignValue())
+        || constraint.getDisplayDesignValue() == Double.MAX_VALUE
+        || constraint.getDisplayDesignValue() <= 0.0) {
+      throw new IllegalArgumentException("Installed applicable limit must be finite and positive");
+    }
+    return new CapacityTarget(constraint);
+  }
+
+  private void applyAlternative(CapacityConstraint constraint) {
+    if (alternative.getLimitDirection() == LimitDirection.MINIMUM) {
+      constraint.setMinValue(alternative.getProposedLimit());
+    } else {
+      constraint.setDesignValue(alternative.getProposedLimit());
+    }
+    constraint.setDataSource(alternative.getProposalSource());
+    if (alternative.hasConfidence()) {
+      constraint.setConfidence(alternative.getConfidence());
+    } else {
+      constraint.clearConfidence();
+    }
+    if (alternative.hasValidityRange()) {
+      constraint.setValidityRange(alternative.getValidityMinimum(),
+          alternative.getValidityMaximum());
+    } else {
+      constraint.clearValidityRange();
+    }
+    if (Double.doubleToLongBits(constraint.getDisplayDesignValue())
+        != Double.doubleToLongBits(alternative.getProposedLimit())) {
+      throw new IllegalStateException("Proposed installed limit failed exact read-back verification");
+    }
+  }
+
+  private ScenarioEvidence runScenario(String label) {
+    int before = evaluator.getEvaluationCount();
+    List<String> diagnostics = new ArrayList<String>();
+    SearchSelection selection;
+    try {
+      selection = search.search(evaluator);
+    } catch (RuntimeException exception) {
+      diagnostics.add("Search failed: " + safeText(exception.getMessage()));
+      return new ScenarioEvidence(label, search, ScenarioStatus.SEARCH_FAILED, null, null,
+          evaluator.getEvaluationCount() - before, Collections.<ObjectiveEvidence>emptyList(),
+          Collections.<ConstraintEvidence>emptyList(), notSampledMetrics(), diagnostics);
+    }
+    diagnostics.addAll(selection.getDiagnostics());
+    if (!selection.isSelected()) {
+      return new ScenarioEvidence(label, search, ScenarioStatus.SEARCH_FAILED, null, null,
+          evaluator.getEvaluationCount() - before, Collections.<ObjectiveEvidence>emptyList(),
+          Collections.<ConstraintEvidence>emptyList(), notSampledMetrics(), diagnostics);
+    }
+    double[] parameters = selection.getParameters();
+    String invalid = validateSelectedParameters(parameters);
+    if (invalid != null) {
+      diagnostics.add(invalid);
+      return new ScenarioEvidence(label, search, ScenarioStatus.VERIFICATION_FAILED, parameters,
+          null, evaluator.getEvaluationCount() - before,
+          Collections.<ObjectiveEvidence>emptyList(), Collections.<ConstraintEvidence>emptyList(),
+          notSampledMetrics(), diagnostics);
+    }
+    EvaluationResult result = evaluator.evaluate(parameters);
+    List<ObjectiveEvidence> objectives = snapshotObjectives(result);
+    List<ConstraintEvidence> constraints = snapshotConstraints(result);
+    ScenarioStatus status = result.isSimulationConverged() && result.isFeasible()
+        ? ScenarioStatus.QUALIFIED : ScenarioStatus.VERIFICATION_FAILED;
+    if (status != ScenarioStatus.QUALIFIED) {
+      diagnostics.add("Selected point did not pass independent convergence and feasibility verification");
+    }
+    List<MetricEvidence> metricEvidence = status == ScenarioStatus.QUALIFIED
+        ? sampleMetrics(evaluator.getProcessModel()) : notSampledMetrics();
+    return new ScenarioEvidence(label, search, status, parameters, result,
+        evaluator.getEvaluationCount() - before, objectives, constraints, metricEvidence, diagnostics);
+  }
+
+  private String validateSelectedParameters(double[] parameters) {
+    if (parameters == null || parameters.length != evaluator.getParameterCount()) {
+      return "Selected parameter vector does not match evaluator parameter count";
+    }
+    List<ParameterDefinition> definitions = evaluator.getParameters();
+    for (int index = 0; index < parameters.length; index++) {
+      if (!isFinite(parameters[index]) || !definitions.get(index).isWithinBounds(parameters[index])) {
+        return "Selected parameter vector contains a non-finite or out-of-bounds value";
+      }
+    }
+    return null;
+  }
+
+  private List<ObjectiveEvidence> snapshotObjectives(EvaluationResult result) {
+    List<ObjectiveEvidence> evidence = new ArrayList<ObjectiveEvidence>();
+    double[] raw = result.getObjectivesRaw();
+    double[] adjusted = result.getObjectives();
+    for (int index = 0; index < evaluator.getObjectives().size(); index++) {
+      evidence.add(new ObjectiveEvidence(index, evaluator.getObjectives().get(index), raw[index],
+          adjusted[index]));
+    }
+    return evidence;
+  }
+
+  private List<ConstraintEvidence> snapshotConstraints(EvaluationResult result) {
+    List<ConstraintEvidence> evidence = new ArrayList<ConstraintEvidence>();
+    double[] values = result.getConstraintValues();
+    double[] margins = result.getConstraintMargins();
+    for (int index = 0; index < evaluator.getConstraints().size(); index++) {
+      evidence.add(new ConstraintEvidence(index, evaluator.getConstraints().get(index), values[index],
+          margins[index]));
+    }
+    return evidence;
+  }
+
+  private List<MetricEvidence> sampleMetrics(ProcessModel model) {
+    List<MetricEvidence> evidence = new ArrayList<MetricEvidence>();
+    for (MetricDefinition metric : metrics) {
+      try {
+        double value = metric.sampler.sample(model);
+        if (isFinite(value)) {
+          evidence.add(new MetricEvidence(metric, MetricStatus.AVAILABLE, value,
+              "Sampled once at the verified completed operating point"));
+        } else {
+          evidence.add(new MetricEvidence(metric, MetricStatus.NON_FINITE, Double.NaN,
+              "Metric sampler returned a non-finite value"));
+        }
+      } catch (RuntimeException exception) {
+        evidence.add(new MetricEvidence(metric, MetricStatus.SAMPLING_FAILED, Double.NaN,
+            safeText(exception.getMessage())));
+      }
+    }
+    return evidence;
+  }
+
+  private List<MetricEvidence> notSampledMetrics() {
+    List<MetricEvidence> evidence = new ArrayList<MetricEvidence>();
+    for (MetricDefinition metric : metrics) {
+      evidence.add(new MetricEvidence(metric, MetricStatus.NOT_SAMPLED, Double.NaN,
+          "Scenario was not qualified for metric sampling"));
+    }
+    return evidence;
+  }
+
+  private boolean hasUnavailableRequiredMetric(ScenarioEvidence scenario) {
+    for (MetricEvidence metric : scenario.getMetrics()) {
+      if (metric.isRequired() && !metric.isAvailable()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private StudyResult result(StudyOutcome outcome, CapacityState originalState,
+      CapacityState appliedState, ScenarioEvidence baseline, ScenarioEvidence alternativeScenario,
+      boolean capacityRestored, boolean processStateRestored, boolean recoveryConverged,
+      List<String> diagnostics) {
+    List<MetricComparison> comparisons = compareMetrics(baseline, alternativeScenario);
+    boolean deltaCalculable = baseline != null && alternativeScenario != null
+        && baseline.getObjectives().size() > objectiveIndex
+        && alternativeScenario.getObjectives().size() > objectiveIndex
+        && isFinite(baseline.getObjectives().get(objectiveIndex).getRawValue())
+        && isFinite(alternativeScenario.getObjectives().get(objectiveIndex).getRawValue());
+    double delta = deltaCalculable
+        ? alternativeScenario.getObjectives().get(objectiveIndex).getRawValue()
+            - baseline.getObjectives().get(objectiveIndex).getRawValue()
+        : Double.NaN;
+    return new StudyResult(id, name, provenance, alternative, originalState, appliedState, outcome,
+        baseline, alternativeScenario, capacityRestored, processStateRestored,
+        recoveryConverged, comparisons, deltaCalculable, delta, diagnostics);
+  }
+
+  private List<MetricComparison> compareMetrics(ScenarioEvidence baseline,
+      ScenarioEvidence alternativeScenario) {
+    if (baseline == null || alternativeScenario == null) {
+      return Collections.emptyList();
+    }
+    List<MetricEvidence> baselineMetrics = baseline.getMetrics();
+    List<MetricEvidence> alternativeMetrics = alternativeScenario.getMetrics();
+    List<MetricComparison> comparisons = new ArrayList<MetricComparison>();
+    int count = Math.min(baselineMetrics.size(), alternativeMetrics.size());
+    for (int index = 0; index < count; index++) {
+      comparisons.add(new MetricComparison(baselineMetrics.get(index),
+          alternativeMetrics.get(index)));
+    }
+    return comparisons;
+  }
+
+  private static void restoreConstraint(CapacityConstraint constraint, CapacityState state) {
+    constraint.setDesignValue(state.getDesignValue());
+    constraint.setMaxValue(state.getMaximumValue());
+    constraint.setMinValue(state.getMinimumValue());
+    constraint.setWarningThreshold(state.getWarningThreshold());
+    constraint.setSeverity(state.getSeverity());
+    constraint.setEnabled(state.isEnabled());
+    constraint.setDataSource(state.getDataSource());
+    if (state.hasConfidence()) {
+      constraint.setConfidence(state.getConfidence());
+    } else {
+      constraint.clearConfidence();
+    }
+    if (state.hasValidityRange()) {
+      constraint.setValidityRange(state.getValidityMinimum(), state.getValidityMaximum());
+    } else {
+      constraint.clearValidityRange();
+    }
+    constraint.setShadowPrice(state.getShadowPrice());
+  }
+
+  private static boolean statesEqual(CapacityState first, CapacityState second) {
+    return bitsEqual(first.designValue, second.designValue)
+        && bitsEqual(first.maximumValue, second.maximumValue)
+        && bitsEqual(first.minimumValue, second.minimumValue)
+        && bitsEqual(first.warningThreshold, second.warningThreshold)
+        && first.unit.equals(second.unit) && first.severity == second.severity
+        && first.enabled == second.enabled && first.dataSource.equals(second.dataSource)
+        && first.confidenceSet == second.confidenceSet
+        && (!first.confidenceSet || bitsEqual(first.confidence, second.confidence))
+        && first.validityRangeSet == second.validityRangeSet
+        && (!first.validityRangeSet
+            || bitsEqual(first.validityMinimum, second.validityMinimum)
+                && bitsEqual(first.validityMaximum, second.validityMaximum))
+        && bitsEqual(first.shadowPrice, second.shadowPrice);
+  }
+
+  private static boolean arraysEqual(double[] first, double[] second, double tolerance) {
+    if (first == null || second == null || first.length != second.length) {
+      return false;
+    }
+    for (int index = 0; index < first.length; index++) {
+      if (Math.abs(first[index] - second[index]) > tolerance) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean bitsEqual(double first, double second) {
+    return Double.doubleToLongBits(first) == Double.doubleToLongBits(second);
+  }
+
+  private static boolean isFinite(double value) {
+    return !Double.isNaN(value) && !Double.isInfinite(value);
+  }
+
+  private static String requireText(String value, String label) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(label + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static String safeText(String value) {
+    return value == null ? "" : value;
+  }
+
+  private static List<String> immutableStrings(List<String> values) {
+    if (values == null || values.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return Collections.unmodifiableList(new ArrayList<String>(values));
+  }
+
+  private static <T> List<T> immutableList(List<T> values) {
+    if (values == null || values.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return Collections.unmodifiableList(new ArrayList<T>(values));
+  }
+}

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelDebottleneckStudy.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelDebottleneckStudy.java
@@ -17,23 +17,20 @@ import neqsim.process.util.optimizer.ProcessModelSimulationEvaluator.ObjectiveDe
 import neqsim.process.util.optimizer.ProcessModelSimulationEvaluator.ParameterDefinition;
 
 /**
- * Evaluates one installed-capacity alternative against a common deterministic production-search
- * policy.
+ * Evaluates one installed-capacity alternative against a common deterministic production-search policy.
  *
  * <p>
- * The study resolves one direct {@link CapacityConstraint} by its stable
- * {@code area::equipment/constraint} address, freezes its complete observable state, evaluates the
- * baseline, applies and verifies the proposed applicable limit, evaluates the alternative, and
- * finally restores both the installed constraint and the pre-study process operating point. Every
- * result is immutable and serializable; no live model, equipment, constraint, search callback, or
- * metric callback is retained.
+ * The study resolves one direct {@link CapacityConstraint} by its stable {@code area::equipment/constraint} address,
+ * freezes its complete observable state, evaluates the baseline, applies and verifies the proposed applicable limit,
+ * evaluates the alternative, and finally restores both the installed constraint and the pre-study process operating
+ * point. Every result is immutable and serializable; no live model, equipment, constraint, search callback, or metric
+ * callback is retained.
  * </p>
  *
  * <p>
- * A result is paired simulator evidence for the declared candidate set. It is not proof of causal
- * production loss, global optimality, a KKT multiplier, design adequacy, certified emissions, or
- * investment approval. Physical, energy, emission, and economic metrics remain separate and are
- * compared only through identical metric definitions and units.
+ * A result is paired simulator evidence for the declared candidate set. It is not proof of causal production loss,
+ * global optimality, a KKT multiplier, design adequacy, certified emissions, or investment approval. Physical, energy,
+ * emission, and economic metrics remain separate and are compared only through identical metric definitions and units.
  * </p>
  *
  * @author NeqSim Development Team
@@ -76,21 +73,12 @@ public final class ProcessModelDebottleneckStudy {
 
   /** Engineering role of a registered scenario metric. */
   public enum MetricKind {
-    PRODUCTION,
-    POWER,
-    ENERGY,
-    DIRECT_EMISSIONS,
-    INDIRECT_EMISSIONS,
-    SCREENING_ECONOMIC,
-    OTHER
+    PRODUCTION, POWER, ENERGY, DIRECT_EMISSIONS, INDIRECT_EMISSIONS, SCREENING_ECONOMIC, OTHER
   }
 
   /** Availability of one sampled metric. */
   public enum MetricStatus {
-    AVAILABLE,
-    NON_FINITE,
-    SAMPLING_FAILED,
-    NOT_SAMPLED
+    AVAILABLE, NON_FINITE, SAMPLING_FAILED, NOT_SAMPLED
   }
 
   /** Serializable callback implementing the same search policy for both scenarios. */
@@ -161,10 +149,9 @@ public final class ProcessModelDebottleneckStudy {
      * @param validityMinimum inclusive proposal validity minimum, or NaN when unset
      * @param validityMaximum inclusive proposal validity maximum, or NaN when unset
      */
-    public CapacityAlternative(String id, String name, String provenance, String areaName,
-        String equipmentName, String constraintName, double proposedLimit, String unit,
-        LimitDirection limitDirection, String proposalSource, double confidence,
-        double validityMinimum, double validityMaximum) {
+    public CapacityAlternative(String id, String name, String provenance, String areaName, String equipmentName,
+        String constraintName, double proposedLimit, String unit, LimitDirection limitDirection, String proposalSource,
+        double confidence, double validityMinimum, double validityMaximum) {
       this.id = requireText(id, "Alternative identifier");
       this.name = requireText(name, "Alternative name");
       this.provenance = requireText(provenance, "Alternative provenance");
@@ -202,8 +189,7 @@ public final class ProcessModelDebottleneckStudy {
       this.validityRangeSet = minimumSet;
       this.validityMinimum = minimumSet ? validityMinimum : Double.NaN;
       this.validityMaximum = maximumSet ? validityMaximum : Double.NaN;
-      if (validityRangeSet
-          && (proposedLimit < validityMinimum || proposedLimit > validityMaximum)) {
+      if (validityRangeSet && (proposedLimit < validityMinimum || proposedLimit > validityMaximum)) {
         throw new IllegalArgumentException("Proposed limit lies outside its declared validity range");
       }
     }
@@ -409,9 +395,8 @@ public final class ProcessModelDebottleneckStudy {
    * Deterministic derivative-free search over an explicit ordered list of parameter vectors.
    *
    * <p>
-   * Only converged feasible candidates with finite selected-objective values are eligible. Ties
-   * inside the declared absolute tolerance retain the earliest candidate, making repeated Java and
-   * JPype execution deterministic.
+   * Only converged feasible candidates with finite selected-objective values are eligible. Ties inside the declared
+   * absolute tolerance retain the earliest candidate, making repeated Java and JPype execution deterministic.
    * </p>
    */
   public static final class CandidateListSearch implements ScenarioSearch {
@@ -424,8 +409,8 @@ public final class ProcessModelDebottleneckStudy {
     private final int objectiveIndex;
     private final double objectiveTolerance;
 
-    public CandidateListSearch(String id, String name, String provenance, List<double[]> candidates,
-        int objectiveIndex, double objectiveTolerance) {
+    public CandidateListSearch(String id, String name, String provenance, List<double[]> candidates, int objectiveIndex,
+        double objectiveTolerance) {
       this.id = requireText(id, "Search identifier");
       this.name = requireText(name, "Search name");
       this.provenance = requireText(provenance, "Search provenance");
@@ -500,9 +485,8 @@ public final class ProcessModelDebottleneckStudy {
         }
         EvaluationResult result = evaluator.evaluate(candidate);
         double[] rawObjectives = result.getObjectivesRaw();
-        if (result.isSimulationConverged() && result.isFeasible()
-            && rawObjectives != null && objectiveIndex < rawObjectives.length
-            && isFinite(rawObjectives[objectiveIndex])) {
+        if (result.isSimulationConverged() && result.isFeasible() && rawObjectives != null
+            && objectiveIndex < rawObjectives.length && isFinite(rawObjectives[objectiveIndex])) {
           double value = rawObjectives[objectiveIndex];
           if (selected == null || improves(value, selectedValue, objective.getDirection())) {
             selected = Arrays.copyOf(candidate, candidate.length);
@@ -535,8 +519,7 @@ public final class ProcessModelDebottleneckStudy {
       return null;
     }
 
-    private boolean improves(double candidate, double incumbent,
-        ObjectiveDefinition.Direction direction) {
+    private boolean improves(double candidate, double incumbent, ObjectiveDefinition.Direction direction) {
       if (direction == ObjectiveDefinition.Direction.MAXIMIZE) {
         return candidate > incumbent + objectiveTolerance;
       }
@@ -558,9 +541,8 @@ public final class ProcessModelDebottleneckStudy {
     private final boolean required;
     private final MetricSampler sampler;
 
-    public MetricDefinition(String id, String name, MetricKind kind, String unit, String basis,
-        String provenance, String effectivePeriod, double confidence, boolean required,
-        MetricSampler sampler) {
+    public MetricDefinition(String id, String name, MetricKind kind, String unit, String basis, String provenance,
+        String effectivePeriod, double confidence, boolean required, MetricSampler sampler) {
       this.id = requireText(id, "Metric identifier");
       this.name = requireText(name, "Metric name");
       if (kind == null) {
@@ -647,8 +629,7 @@ public final class ProcessModelDebottleneckStudy {
     private final double value;
     private final String diagnostic;
 
-    private MetricEvidence(MetricDefinition definition, MetricStatus status, double value,
-        String diagnostic) {
+    private MetricEvidence(MetricDefinition definition, MetricStatus status, double value, String diagnostic) {
       id = definition.id;
       name = definition.name;
       kind = definition.kind;
@@ -733,9 +714,8 @@ public final class ProcessModelDebottleneckStudy {
     private MetricComparison(MetricEvidence baseline, MetricEvidence alternative) {
       this.baseline = baseline;
       this.alternative = alternative;
-      calculable = baseline != null && alternative != null && baseline.isAvailable()
-          && alternative.isAvailable() && baseline.getId().equals(alternative.getId())
-          && baseline.getUnit().equals(alternative.getUnit());
+      calculable = baseline != null && alternative != null && baseline.isAvailable() && alternative.isAvailable()
+          && baseline.getId().equals(alternative.getId()) && baseline.getUnit().equals(alternative.getUnit());
       delta = calculable ? alternative.getValue() - baseline.getValue() : Double.NaN;
     }
 
@@ -768,8 +748,7 @@ public final class ProcessModelDebottleneckStudy {
     private final double rawValue;
     private final double minimizerValue;
 
-    private ObjectiveEvidence(int index, ObjectiveDefinition definition, double rawValue,
-        double minimizerValue) {
+    private ObjectiveEvidence(int index, ObjectiveDefinition definition, double rawValue, double minimizerValue) {
       this.index = index;
       name = safeText(definition.getName());
       direction = definition.getDirection();
@@ -820,8 +799,7 @@ public final class ProcessModelDebottleneckStudy {
     private final double value;
     private final double margin;
 
-    private ConstraintEvidence(int index, ConstraintDefinition definition, double value,
-        double margin) {
+    private ConstraintEvidence(int index, ConstraintDefinition definition, double value, double margin) {
       this.index = index;
       name = safeText(definition.getName());
       type = definition.getType();
@@ -880,10 +858,9 @@ public final class ProcessModelDebottleneckStudy {
     private final List<MetricEvidence> metrics;
     private final List<String> diagnostics;
 
-    private ScenarioEvidence(String label, ScenarioSearch search, ScenarioStatus status,
-        double[] selectedParameters, EvaluationResult result, int evaluationCount,
-        List<ObjectiveEvidence> objectives, List<ConstraintEvidence> constraints,
-        List<MetricEvidence> metrics, List<String> diagnostics) {
+    private ScenarioEvidence(String label, ScenarioSearch search, ScenarioStatus status, double[] selectedParameters,
+        EvaluationResult result, int evaluationCount, List<ObjectiveEvidence> objectives,
+        List<ConstraintEvidence> constraints, List<MetricEvidence> metrics, List<String> diagnostics) {
       this.label = label;
       searchId = search.getId();
       searchName = search.getName();
@@ -990,12 +967,11 @@ public final class ProcessModelDebottleneckStudy {
     private final double objectiveDelta;
     private final List<String> diagnostics;
 
-    private StudyResult(String id, String name, String provenance,
-        CapacityAlternative alternativeDefinition, CapacityState originalCapacityState,
-        CapacityState appliedCapacityState, StudyOutcome outcome, ScenarioEvidence baseline,
-        ScenarioEvidence alternative, boolean capacityRestored, boolean processStateRestored,
-        boolean recoverySimulationConverged, List<MetricComparison> metricComparisons,
-        boolean objectiveDeltaCalculable, double objectiveDelta, List<String> diagnostics) {
+    private StudyResult(String id, String name, String provenance, CapacityAlternative alternativeDefinition,
+        CapacityState originalCapacityState, CapacityState appliedCapacityState, StudyOutcome outcome,
+        ScenarioEvidence baseline, ScenarioEvidence alternative, boolean capacityRestored, boolean processStateRestored,
+        boolean recoverySimulationConverged, List<MetricComparison> metricComparisons, boolean objectiveDeltaCalculable,
+        double objectiveDelta, List<String> diagnostics) {
       this.id = id;
       this.name = name;
       this.provenance = provenance;
@@ -1109,8 +1085,8 @@ public final class ProcessModelDebottleneckStudy {
    * @param objectiveIndex objective used for the paired delta
    */
   public ProcessModelDebottleneckStudy(String id, String name, String provenance,
-      ProcessModelSimulationEvaluator evaluator, CapacityAlternative alternative,
-      ScenarioSearch search, int objectiveIndex) {
+      ProcessModelSimulationEvaluator evaluator, CapacityAlternative alternative, ScenarioSearch search,
+      int objectiveIndex) {
     this.id = requireText(id, "Study identifier");
     this.name = requireText(name, "Study name");
     this.provenance = requireText(provenance, "Study provenance");
@@ -1124,10 +1100,8 @@ public final class ProcessModelDebottleneckStudy {
     this.alternative = alternative;
     this.search = search;
     this.objectiveIndex = objectiveIndex;
-    if (search instanceof CandidateListSearch
-        && ((CandidateListSearch) search).getObjectiveIndex() != objectiveIndex) {
-      throw new IllegalArgumentException(
-          "Candidate-list search and study must use the same objective index");
+    if (search instanceof CandidateListSearch && ((CandidateListSearch) search).getObjectiveIndex() != objectiveIndex) {
+      throw new IllegalArgumentException("Candidate-list search and study must use the same objective index");
     }
   }
 
@@ -1194,8 +1168,7 @@ public final class ProcessModelDebottleneckStudy {
       target = resolveTarget(model);
     } catch (RuntimeException exception) {
       diagnostics.add(exception.getMessage());
-      return result(StudyOutcome.ALTERNATIVE_NOT_APPLICABLE, null, null, null, null,
-          false, false, false, diagnostics);
+      return result(StudyOutcome.ALTERNATIVE_NOT_APPLICABLE, null, null, null, null, false, false, false, diagnostics);
     }
 
     CapacityState originalState = new CapacityState(target.constraint);
@@ -1221,8 +1194,7 @@ public final class ProcessModelDebottleneckStudy {
         if (!alternativeScenario.isQualified()) {
           diagnostics.add("Alternative search or verification did not produce a qualified point");
           provisionalOutcome = StudyOutcome.ALTERNATIVE_FAILED;
-        } else if (hasUnavailableRequiredMetric(baseline)
-            || hasUnavailableRequiredMetric(alternativeScenario)) {
+        } else if (hasUnavailableRequiredMetric(baseline) || hasUnavailableRequiredMetric(alternativeScenario)) {
           diagnostics.add("At least one required scenario metric was unavailable");
           provisionalOutcome = StudyOutcome.REQUIRED_METRIC_UNAVAILABLE;
         } else {
@@ -1231,8 +1203,8 @@ public final class ProcessModelDebottleneckStudy {
       }
     } catch (RuntimeException exception) {
       diagnostics.add("Study execution failed: " + safeText(exception.getMessage()));
-      provisionalOutcome = baseline == null || !baseline.isQualified()
-          ? StudyOutcome.BASELINE_FAILED : StudyOutcome.ALTERNATIVE_FAILED;
+      provisionalOutcome = baseline == null || !baseline.isQualified() ? StudyOutcome.BASELINE_FAILED
+          : StudyOutcome.ALTERNATIVE_FAILED;
     } finally {
       try {
         restoreConstraint(target.constraint, originalState);
@@ -1244,8 +1216,7 @@ public final class ProcessModelDebottleneckStudy {
       try {
         EvaluationResult recovery = evaluator.evaluate(recoveryParameters);
         recoveryConverged = recovery.isSimulationConverged();
-        processStateRestored = recoveryConverged
-            && arraysEqual(recoveryParameters, recovery.getParameters(), 0.0);
+        processStateRestored = recoveryConverged && arraysEqual(recoveryParameters, recovery.getParameters(), 0.0);
       } catch (RuntimeException exception) {
         diagnostics.add("Pre-study process-state recovery failed: " + safeText(exception.getMessage()));
       }
@@ -1254,34 +1225,33 @@ public final class ProcessModelDebottleneckStudy {
     if (!alternativeApplied && appliedState != null) {
       diagnostics.add("Internal diagnostic: applied capacity state was retained without an applied alternative");
     }
-    StudyOutcome outcome = capacityRestored && processStateRestored && recoveryConverged
-        ? provisionalOutcome : StudyOutcome.RESTORATION_FAILED;
+    StudyOutcome outcome = capacityRestored && processStateRestored && recoveryConverged ? provisionalOutcome
+        : StudyOutcome.RESTORATION_FAILED;
     if (capacityRestored) {
       diagnostics.add("The complete installed-capacity state was restored and verified");
     }
     if (processStateRestored && recoveryConverged) {
       diagnostics.add("The pre-study parameter vector was restored and the process model reconverged");
     }
-    return result(outcome, originalState, appliedState, baseline, alternativeScenario,
-        capacityRestored, processStateRestored, recoveryConverged, diagnostics);
+    return result(outcome, originalState, appliedState, baseline, alternativeScenario, capacityRestored,
+        processStateRestored, recoveryConverged, diagnostics);
   }
 
   private CapacityTarget resolveTarget(ProcessModel model) {
     ProcessSystem area = model.get(alternative.getAreaName());
     if (area == null) {
-      throw new IllegalArgumentException("Alternative process area was not found: "
-          + alternative.getAreaName());
+      throw new IllegalArgumentException("Alternative process area was not found: " + alternative.getAreaName());
     }
     ProcessEquipmentInterface equipment = area.getUnit(alternative.getEquipmentName());
     if (equipment == null) {
-      throw new IllegalArgumentException("Alternative equipment was not found: "
-          + alternative.getQualifiedConstraintName());
+      throw new IllegalArgumentException(
+          "Alternative equipment was not found: " + alternative.getQualifiedConstraintName());
     }
     Map<String, CapacityConstraint> direct = equipment.getCapacityConstraints();
     CapacityConstraint constraint = direct == null ? null : direct.get(alternative.getConstraintName());
     if (constraint == null) {
-      throw new IllegalArgumentException("A direct installed capacity constraint was not found: "
-          + alternative.getQualifiedConstraintName());
+      throw new IllegalArgumentException(
+          "A direct installed capacity constraint was not found: " + alternative.getQualifiedConstraintName());
     }
     if (!constraint.isEnabled()) {
       throw new IllegalArgumentException("The installed capacity constraint is disabled");
@@ -1289,13 +1259,11 @@ public final class ProcessModelDebottleneckStudy {
     if (!alternative.getUnit().equals(constraint.getUnit())) {
       throw new IllegalArgumentException("Alternative unit does not match the installed constraint unit");
     }
-    LimitDirection actual = constraint.isMinimumConstraint()
-        ? LimitDirection.MINIMUM : LimitDirection.MAXIMUM;
+    LimitDirection actual = constraint.isMinimumConstraint() ? LimitDirection.MINIMUM : LimitDirection.MAXIMUM;
     if (actual != alternative.getLimitDirection()) {
       throw new IllegalArgumentException("Alternative direction does not match the installed constraint");
     }
-    if (!isFinite(constraint.getDisplayDesignValue())
-        || constraint.getDisplayDesignValue() == Double.MAX_VALUE
+    if (!isFinite(constraint.getDisplayDesignValue()) || constraint.getDisplayDesignValue() == Double.MAX_VALUE
         || constraint.getDisplayDesignValue() <= 0.0) {
       throw new IllegalArgumentException("Installed applicable limit must be finite and positive");
     }
@@ -1315,13 +1283,12 @@ public final class ProcessModelDebottleneckStudy {
       constraint.clearConfidence();
     }
     if (alternative.hasValidityRange()) {
-      constraint.setValidityRange(alternative.getValidityMinimum(),
-          alternative.getValidityMaximum());
+      constraint.setValidityRange(alternative.getValidityMinimum(), alternative.getValidityMaximum());
     } else {
       constraint.clearValidityRange();
     }
-    if (Double.doubleToLongBits(constraint.getDisplayDesignValue())
-        != Double.doubleToLongBits(alternative.getProposedLimit())) {
+    if (Double.doubleToLongBits(constraint.getDisplayDesignValue()) != Double
+        .doubleToLongBits(alternative.getProposedLimit())) {
       throw new IllegalStateException("Proposed installed limit failed exact read-back verification");
     }
   }
@@ -1348,23 +1315,23 @@ public final class ProcessModelDebottleneckStudy {
     String invalid = validateSelectedParameters(parameters);
     if (invalid != null) {
       diagnostics.add(invalid);
-      return new ScenarioEvidence(label, search, ScenarioStatus.VERIFICATION_FAILED, parameters,
-          null, evaluator.getEvaluationCount() - before,
-          Collections.<ObjectiveEvidence>emptyList(), Collections.<ConstraintEvidence>emptyList(),
-          notSampledMetrics(), diagnostics);
+      return new ScenarioEvidence(label, search, ScenarioStatus.VERIFICATION_FAILED, parameters, null,
+          evaluator.getEvaluationCount() - before, Collections.<ObjectiveEvidence>emptyList(),
+          Collections.<ConstraintEvidence>emptyList(), notSampledMetrics(), diagnostics);
     }
     EvaluationResult result = evaluator.evaluate(parameters);
     List<ObjectiveEvidence> objectives = snapshotObjectives(result);
     List<ConstraintEvidence> constraints = snapshotConstraints(result);
-    ScenarioStatus status = result.isSimulationConverged() && result.isFeasible()
-        ? ScenarioStatus.QUALIFIED : ScenarioStatus.VERIFICATION_FAILED;
+    ScenarioStatus status = result.isSimulationConverged() && result.isFeasible() ? ScenarioStatus.QUALIFIED
+        : ScenarioStatus.VERIFICATION_FAILED;
     if (status != ScenarioStatus.QUALIFIED) {
       diagnostics.add("Selected point did not pass independent convergence and feasibility verification");
     }
     List<MetricEvidence> metricEvidence = status == ScenarioStatus.QUALIFIED
-        ? sampleMetrics(evaluator.getProcessModel()) : notSampledMetrics();
-    return new ScenarioEvidence(label, search, status, parameters, result,
-        evaluator.getEvaluationCount() - before, objectives, constraints, metricEvidence, diagnostics);
+        ? sampleMetrics(evaluator.getProcessModel())
+        : notSampledMetrics();
+    return new ScenarioEvidence(label, search, status, parameters, result, evaluator.getEvaluationCount() - before,
+        objectives, constraints, metricEvidence, diagnostics);
   }
 
   private String validateSelectedParameters(double[] parameters) {
@@ -1385,8 +1352,7 @@ public final class ProcessModelDebottleneckStudy {
     double[] raw = result.getObjectivesRaw();
     double[] adjusted = result.getObjectives();
     for (int index = 0; index < evaluator.getObjectives().size(); index++) {
-      evidence.add(new ObjectiveEvidence(index, evaluator.getObjectives().get(index), raw[index],
-          adjusted[index]));
+      evidence.add(new ObjectiveEvidence(index, evaluator.getObjectives().get(index), raw[index], adjusted[index]));
     }
     return evidence;
   }
@@ -1396,8 +1362,7 @@ public final class ProcessModelDebottleneckStudy {
     double[] values = result.getConstraintValues();
     double[] margins = result.getConstraintMargins();
     for (int index = 0; index < evaluator.getConstraints().size(); index++) {
-      evidence.add(new ConstraintEvidence(index, evaluator.getConstraints().get(index), values[index],
-          margins[index]));
+      evidence.add(new ConstraintEvidence(index, evaluator.getConstraints().get(index), values[index], margins[index]));
     }
     return evidence;
   }
@@ -1415,8 +1380,8 @@ public final class ProcessModelDebottleneckStudy {
               "Metric sampler returned a non-finite value"));
         }
       } catch (RuntimeException exception) {
-        evidence.add(new MetricEvidence(metric, MetricStatus.SAMPLING_FAILED, Double.NaN,
-            safeText(exception.getMessage())));
+        evidence.add(
+            new MetricEvidence(metric, MetricStatus.SAMPLING_FAILED, Double.NaN, safeText(exception.getMessage())));
       }
     }
     return evidence;
@@ -1440,10 +1405,9 @@ public final class ProcessModelDebottleneckStudy {
     return false;
   }
 
-  private StudyResult result(StudyOutcome outcome, CapacityState originalState,
-      CapacityState appliedState, ScenarioEvidence baseline, ScenarioEvidence alternativeScenario,
-      boolean capacityRestored, boolean processStateRestored, boolean recoveryConverged,
-      List<String> diagnostics) {
+  private StudyResult result(StudyOutcome outcome, CapacityState originalState, CapacityState appliedState,
+      ScenarioEvidence baseline, ScenarioEvidence alternativeScenario, boolean capacityRestored,
+      boolean processStateRestored, boolean recoveryConverged, List<String> diagnostics) {
     List<MetricComparison> comparisons = compareMetrics(baseline, alternativeScenario);
     boolean deltaCalculable = baseline != null && alternativeScenario != null
         && baseline.getObjectives().size() > objectiveIndex
@@ -1454,13 +1418,12 @@ public final class ProcessModelDebottleneckStudy {
         ? alternativeScenario.getObjectives().get(objectiveIndex).getRawValue()
             - baseline.getObjectives().get(objectiveIndex).getRawValue()
         : Double.NaN;
-    return new StudyResult(id, name, provenance, alternative, originalState, appliedState, outcome,
-        baseline, alternativeScenario, capacityRestored, processStateRestored,
-        recoveryConverged, comparisons, deltaCalculable, delta, diagnostics);
+    return new StudyResult(id, name, provenance, alternative, originalState, appliedState, outcome, baseline,
+        alternativeScenario, capacityRestored, processStateRestored, recoveryConverged, comparisons, deltaCalculable,
+        delta, diagnostics);
   }
 
-  private List<MetricComparison> compareMetrics(ScenarioEvidence baseline,
-      ScenarioEvidence alternativeScenario) {
+  private List<MetricComparison> compareMetrics(ScenarioEvidence baseline, ScenarioEvidence alternativeScenario) {
     if (baseline == null || alternativeScenario == null) {
       return Collections.emptyList();
     }
@@ -1469,8 +1432,7 @@ public final class ProcessModelDebottleneckStudy {
     List<MetricComparison> comparisons = new ArrayList<MetricComparison>();
     int count = Math.min(baselineMetrics.size(), alternativeMetrics.size());
     for (int index = 0; index < count; index++) {
-      comparisons.add(new MetricComparison(baselineMetrics.get(index),
-          alternativeMetrics.get(index)));
+      comparisons.add(new MetricComparison(baselineMetrics.get(index), alternativeMetrics.get(index)));
     }
     return comparisons;
   }
@@ -1497,18 +1459,15 @@ public final class ProcessModelDebottleneckStudy {
   }
 
   private static boolean statesEqual(CapacityState first, CapacityState second) {
-    return bitsEqual(first.designValue, second.designValue)
-        && bitsEqual(first.maximumValue, second.maximumValue)
+    return bitsEqual(first.designValue, second.designValue) && bitsEqual(first.maximumValue, second.maximumValue)
         && bitsEqual(first.minimumValue, second.minimumValue)
-        && bitsEqual(first.warningThreshold, second.warningThreshold)
-        && first.unit.equals(second.unit) && first.severity == second.severity
-        && first.enabled == second.enabled && first.dataSource.equals(second.dataSource)
-        && first.confidenceSet == second.confidenceSet
+        && bitsEqual(first.warningThreshold, second.warningThreshold) && first.unit.equals(second.unit)
+        && first.severity == second.severity && first.enabled == second.enabled
+        && first.dataSource.equals(second.dataSource) && first.confidenceSet == second.confidenceSet
         && (!first.confidenceSet || bitsEqual(first.confidence, second.confidence))
         && first.validityRangeSet == second.validityRangeSet
-        && (!first.validityRangeSet
-            || bitsEqual(first.validityMinimum, second.validityMinimum)
-                && bitsEqual(first.validityMaximum, second.validityMaximum))
+        && (!first.validityRangeSet || bitsEqual(first.validityMinimum, second.validityMinimum)
+            && bitsEqual(first.validityMaximum, second.validityMaximum))
         && bitsEqual(first.shadowPrice, second.shadowPrice);
   }
 

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelDebottleneckStudyTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelDebottleneckStudyTest.java
@@ -1,0 +1,289 @@
+package neqsim.process.util.optimizer;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.DoubleSupplier;
+import java.util.function.ToDoubleFunction;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.capacity.CapacityConstraint;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintSeverity;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintType;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.CandidateListSearch;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.CapacityAlternative;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.LimitDirection;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.MetricDefinition;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.MetricKind;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.MetricSampler;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.StudyOutcome;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.StudyResult;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Tests for {@link ProcessModelDebottleneckStudy}.
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+class ProcessModelDebottleneckStudyTest {
+
+  /** Small process-model fixture with one direct installed gas-capacity limit. */
+  private static final class Fixture {
+    private final Stream feed;
+    private final CapacityConstraint installedCapacity;
+    private final ProcessModel model;
+    private final ProcessModelSimulationEvaluator evaluator;
+
+    private Fixture(Stream feed, CapacityConstraint installedCapacity, ProcessModel model,
+        ProcessModelSimulationEvaluator evaluator) {
+      this.feed = feed;
+      this.installedCapacity = installedCapacity;
+      this.model = model;
+      this.evaluator = evaluator;
+    }
+  }
+
+  /**
+   * A 20% installed-capacity increase must produce a paired 20% throughput increase while every
+   * original mutable limit field and the pre-study operating point are restored exactly.
+   *
+   * @throws Exception when result serialization fails
+   */
+  @Test
+  void pairedCapacityAlternativeIsDeterministicSerializableAndReversible() throws Exception {
+    Fixture fixture = createFixture();
+    fixture.evaluator.evaluate(new double[] {800.0});
+    int evaluationCountBeforeStudy = fixture.evaluator.getEvaluationCount();
+
+    ProcessModelDebottleneckStudy study = createStudy(fixture, "kg/hr");
+    StudyResult first = study.evaluate();
+
+    assertEquals(StudyOutcome.COMPLETED, first.getOutcome());
+    assertTrue(first.isCapacityRestored());
+    assertTrue(first.isProcessStateRestored());
+    assertTrue(first.isRecoverySimulationConverged());
+    assertArrayEquals(new double[] {1000.0}, first.getBaseline().getSelectedParameters(), 0.0);
+    assertArrayEquals(new double[] {1200.0}, first.getAlternative().getSelectedParameters(), 0.0);
+    assertEquals(200.0, first.getObjectiveDelta(), 1.0e-8);
+    assertEquals(5, first.getBaseline().getEvaluationCount());
+    assertEquals(5, first.getAlternative().getEvaluationCount());
+    assertEquals(evaluationCountBeforeStudy + 11, fixture.evaluator.getEvaluationCount());
+
+    assertEquals(4, first.getMetricComparisons().size());
+    assertEquals(200.0, first.getMetricComparisons().get(0).getDelta(), 1.0e-8);
+    assertEquals(2.0, first.getMetricComparisons().get(1).getDelta(), 1.0e-8);
+    assertEquals(0.8, first.getMetricComparisons().get(2).getDelta(), 1.0e-8);
+    assertEquals(1000.0, first.getMetricComparisons().get(3).getDelta(), 1.0e-8);
+    assertEquals("kg/hr", first.getMetricComparisons().get(0).getBaseline().getUnit());
+    assertEquals("synthetic linear power relationship",
+        first.getMetricComparisons().get(1).getBaseline().getProvenance());
+    assertEquals(MetricKind.SCREENING_ECONOMIC,
+        first.getMetricComparisons().get(3).getBaseline().getKind());
+
+    assertEquals(1000.0, first.getOriginalCapacityState().getApplicableLimit(), 0.0);
+    assertEquals(1200.0, first.getAppliedCapacityState().getApplicableLimit(), 0.0);
+    assertEquals(1000.0,
+        first.getBaseline().getInstalledCapacityEvidence().get(0).getApplicableLimit(), 0.0);
+    assertEquals(1200.0,
+        first.getAlternative().getInstalledCapacityEvidence().get(0).getApplicableLimit(), 0.0);
+    assertEquals("synthetic replacement equipment basis",
+        first.getAlternative().getInstalledCapacityEvidence().get(0).getDataSource());
+    assertEquals(0.90,
+        first.getAlternative().getInstalledCapacityEvidence().get(0).getConfidence(), 0.0);
+    assertOriginalStateRestored(fixture);
+
+    double[] exposed = first.getAlternative().getSelectedParameters();
+    exposed[0] = -1.0;
+    assertArrayEquals(new double[] {1200.0}, first.getAlternative().getSelectedParameters(), 0.0);
+    assertThrows(UnsupportedOperationException.class,
+        () -> first.getMetricComparisons().clear());
+
+    StudyResult serialized = roundTrip(first);
+    assertEquals(first.getOutcome(), serialized.getOutcome());
+    assertEquals(first.getAlternativeDefinition().getQualifiedConstraintName(),
+        serialized.getAlternativeDefinition().getQualifiedConstraintName());
+    assertEquals(first.getObjectiveDelta(), serialized.getObjectiveDelta(), 0.0);
+    assertEquals(first.getMetricComparisons().get(2).getAlternative().getProvenance(),
+        serialized.getMetricComparisons().get(2).getAlternative().getProvenance());
+
+    StudyResult second = study.evaluate();
+    assertEquals(first.getOutcome(), second.getOutcome());
+    assertArrayEquals(first.getBaseline().getSelectedParameters(),
+        second.getBaseline().getSelectedParameters(), 0.0);
+    assertArrayEquals(first.getAlternative().getSelectedParameters(),
+        second.getAlternative().getSelectedParameters(), 0.0);
+    assertEquals(first.getObjectiveDelta(), second.getObjectiveDelta(), 0.0);
+    assertNotSame(first.getMetricComparisons(), second.getMetricComparisons());
+    assertOriginalStateRestored(fixture);
+  }
+
+  /** A unit mismatch must fail closed before any simulator evaluation or model mutation. */
+  @Test
+  void incompatibleCapacityAlternativeFailsClosedWithoutEvaluation() {
+    Fixture fixture = createFixture();
+    fixture.evaluator.evaluate(new double[] {800.0});
+    int evaluationCountBeforeStudy = fixture.evaluator.getEvaluationCount();
+
+    StudyResult result = createStudy(fixture, "t/day").evaluate();
+
+    assertEquals(StudyOutcome.ALTERNATIVE_NOT_APPLICABLE, result.getOutcome());
+    assertEquals(evaluationCountBeforeStudy, fixture.evaluator.getEvaluationCount());
+    assertFalse(result.isObjectiveDeltaCalculable());
+    assertTrue(result.getBaseline() == null);
+    assertTrue(result.getAlternative() == null);
+    assertOriginalStateRestored(fixture);
+  }
+
+  /** A non-finite required metric must be diagnosed without discarding valid physical scenarios. */
+  @Test
+  void unavailableRequiredMetricRetainsPhysicalEvidenceAndRestoresState() {
+    Fixture fixture = createFixture();
+    fixture.evaluator.evaluate(new double[] {800.0});
+    ProcessModelDebottleneckStudy study = createStudy(fixture, "kg/hr");
+    study.addMetric(new MetricDefinition("required-quality", "Required quality", MetricKind.OTHER,
+        "mol/mol", "dry product basis", "synthetic unavailable analyzer", "single steady state",
+        0.5, true, new MetricSampler() {
+          private static final long serialVersionUID = 1L;
+
+          @Override
+          public double sample(ProcessModel model) {
+            return Double.NaN;
+          }
+        }));
+
+    StudyResult result = study.evaluate();
+
+    assertEquals(StudyOutcome.REQUIRED_METRIC_UNAVAILABLE, result.getOutcome());
+    assertTrue(result.getBaseline().isQualified());
+    assertTrue(result.getAlternative().isQualified());
+    assertTrue(result.isObjectiveDeltaCalculable());
+    assertFalse(result.getMetricComparisons().get(4).isCalculable());
+    assertTrue(result.isCapacityRestored());
+    assertTrue(result.isProcessStateRestored());
+    assertOriginalStateRestored(fixture);
+  }
+
+  /** Creates the deterministic paired study used by the focused tests. */
+  private ProcessModelDebottleneckStudy createStudy(Fixture fixture, String alternativeUnit) {
+    List<double[]> candidates = new ArrayList<double[]>();
+    candidates.add(new double[] {800.0});
+    candidates.add(new double[] {1000.0});
+    candidates.add(new double[] {1200.0});
+    candidates.add(new double[] {1400.0});
+    CandidateListSearch search = new CandidateListSearch("ordered-throughput-grid",
+        "Ordered throughput grid", "synthetic acceptance candidate set", candidates, 0, 0.0);
+    CapacityAlternative alternative = new CapacityAlternative("separator-gas-1200",
+        "Raise separator installed gas capacity", "synthetic brownfield screening case",
+        "separation", "separator", "installed gas rate", 1200.0, alternativeUnit,
+        LimitDirection.MAXIMUM, "synthetic replacement equipment basis", 0.90, 900.0, 1300.0);
+    ProcessModelDebottleneckStudy study = new ProcessModelDebottleneckStudy("paired-separator-study",
+        "Paired separator capacity study", "synthetic deterministic regression", fixture.evaluator,
+        alternative, search, 0);
+    study.addMetric(new MetricDefinition("production", "Feed production", MetricKind.PRODUCTION,
+        "kg/hr", "wet feed mass rate", "NeqSim stream result", "single steady state", 1.0,
+        true, model -> model.getVariableValue("wells::feed.flowRate", "kg/hr")));
+    study.addMetric(new MetricDefinition("power", "Synthetic power", MetricKind.POWER, "kW",
+        "shaft power", "synthetic linear power relationship", "single steady state", 0.8,
+        true, model -> 0.01 * model.getVariableValue("wells::feed.flowRate", "kg/hr")));
+    study.addMetric(new MetricDefinition("indirect-emissions", "Synthetic indirect emissions",
+        MetricKind.INDIRECT_EMISSIONS, "kgCO2e/hr", "location-based electricity",
+        "synthetic 0.4 kgCO2e/kWh factor", "single steady state", 0.5, false,
+        model -> 0.004 * model.getVariableValue("wells::feed.flowRate", "kg/hr")));
+    study.addMetric(new MetricDefinition("screening-value", "Synthetic screening value",
+        MetricKind.SCREENING_ECONOMIC, "NOK/hr", "gross value before costs",
+        "synthetic educational 5 NOK/kg factor", "single steady state", 0.2, false,
+        model -> 5.0 * model.getVariableValue("wells::feed.flowRate", "kg/hr")));
+    return study;
+  }
+
+  /** Creates a two-area process model with one mutable direct capacity constraint. */
+  private Fixture createFixture() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.90);
+    fluid.addComponent("ethane", 0.10);
+    fluid.setMixingRule("classic");
+    fluid.setTotalFlowRate(800.0, "kg/hr");
+    final Stream feed = new Stream("feed", fluid);
+    final CapacityConstraint installed = new CapacityConstraint("installed gas rate", "kg/hr",
+        ConstraintType.HARD).setDesignValue(1000.0).setMaxValue(1100.0)
+            .setWarningThreshold(0.90).setSeverity(ConstraintSeverity.HARD)
+            .setDataSource("synthetic installed basis").setConfidence(0.95)
+            .setValidityRange(500.0, 1400.0).setShadowPrice(12.3)
+            .setValueSupplier(new DoubleSupplier() {
+              @Override
+              public double getAsDouble() {
+                return feed.getFlowRate("kg/hr");
+              }
+            });
+    Separator separator = new Separator("separator", feed);
+    separator.clearCapacityConstraints();
+    separator.addCapacityConstraint(installed);
+
+    ProcessSystem wells = new ProcessSystem("wells");
+    wells.add(feed);
+    ProcessSystem separation = new ProcessSystem("separation");
+    separation.add(separator);
+    ProcessModel model = new ProcessModel();
+    model.add("wells", wells);
+    model.add("separation", separation);
+
+    ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(model);
+    evaluator.setIncludeStrategyCapacityConstraints(false);
+    evaluator.addParameter("wells::feed.flowRate", 800.0, 1400.0, "kg/hr")
+        .addObjective("feed production", new ToDoubleFunction<ProcessModel>() {
+          @Override
+          public double applyAsDouble(ProcessModel completedModel) {
+            return completedModel.getVariableValue("wells::feed.flowRate", "kg/hr");
+          }
+        }, ProcessModelSimulationEvaluator.ObjectiveDefinition.Direction.MAXIMIZE)
+        .addEquipmentCapacityConstraints();
+    evaluator.getObjectives().get(0).setUnit("kg/hr");
+    return new Fixture(feed, installed, model, evaluator);
+  }
+
+  /** Confirms exact recovery of every mutable installed-capacity field and the process set point. */
+  private void assertOriginalStateRestored(Fixture fixture) {
+    assertEquals(1000.0, fixture.installedCapacity.getDesignValue(), 0.0);
+    assertEquals(1100.0, fixture.installedCapacity.getMaxValue(), 0.0);
+    assertEquals(0.0, fixture.installedCapacity.getMinValue(), 0.0);
+    assertEquals(0.90, fixture.installedCapacity.getWarningThreshold(), 0.0);
+    assertEquals("kg/hr", fixture.installedCapacity.getUnit());
+    assertEquals(ConstraintSeverity.HARD, fixture.installedCapacity.getSeverity());
+    assertTrue(fixture.installedCapacity.isEnabled());
+    assertEquals("synthetic installed basis", fixture.installedCapacity.getDataSource());
+    assertTrue(fixture.installedCapacity.hasConfidence());
+    assertEquals(0.95, fixture.installedCapacity.getConfidence(), 0.0);
+    assertTrue(fixture.installedCapacity.hasValidityRange());
+    assertEquals(500.0, fixture.installedCapacity.getValidityMinimum(), 0.0);
+    assertEquals(1400.0, fixture.installedCapacity.getValidityMaximum(), 0.0);
+    assertEquals(12.3, fixture.installedCapacity.getShadowPrice(), 0.0);
+    assertEquals(800.0, fixture.feed.getFlowRate("kg/hr"), 1.0e-8);
+  }
+
+  /** Java-serializes one immutable result and returns the deserialized copy. */
+  private StudyResult roundTrip(StudyResult result) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream output = new ObjectOutputStream(bytes);
+    output.writeObject(result);
+    output.close();
+    ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    StudyResult restored = (StudyResult) input.readObject();
+    input.close();
+    return restored;
+  }
+}

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelDebottleneckStudyTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelDebottleneckStudyTest.java
@@ -211,7 +211,7 @@ class ProcessModelDebottleneckStudyTest {
     fluid.setTotalFlowRate(800.0, "kg/hr");
     final Stream feed = new Stream("feed", fluid);
     final CapacityConstraint installed = new CapacityConstraint("installed gas rate", "kg/hr", ConstraintType.HARD)
-        .setDesignValue(1000.0).setMaxValue(1100.0).setWarningThreshold(0.90).setSeverity(ConstraintSeverity.HARD)
+        .setDesignValue(1000.0).setMaxValue(1300.0).setWarningThreshold(0.90).setSeverity(ConstraintSeverity.HARD)
         .setDataSource("synthetic installed basis").setConfidence(0.95).setValidityRange(500.0, 1400.0)
         .setShadowPrice(12.3).setValueSupplier(new DoubleSupplier() {
           @Override
@@ -247,7 +247,7 @@ class ProcessModelDebottleneckStudyTest {
   /** Confirms exact recovery of every mutable installed-capacity field and the process set point. */
   private void assertOriginalStateRestored(Fixture fixture) {
     assertEquals(1000.0, fixture.installedCapacity.getDesignValue(), 0.0);
-    assertEquals(1100.0, fixture.installedCapacity.getMaxValue(), 0.0);
+    assertEquals(1300.0, fixture.installedCapacity.getMaxValue(), 0.0);
     assertEquals(0.0, fixture.installedCapacity.getMinValue(), 0.0);
     assertEquals(0.90, fixture.installedCapacity.getWarningThreshold(), 0.0);
     assertEquals("kg/hr", fixture.installedCapacity.getUnit());

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelDebottleneckStudyTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelDebottleneckStudyTest.java
@@ -59,8 +59,9 @@ class ProcessModelDebottleneckStudyTest {
   }
 
   /**
-   * A 20% installed-capacity increase must produce a paired 20% throughput increase while every original mutable limit
-   * field and the pre-study operating point are restored exactly.
+   * A 20% installed-capacity increase must produce a paired 200 kg/hr throughput gain using candidates 1 kg/hr below
+   * each installed limit, while every original mutable limit field and the pre-study operating point are restored
+   * exactly.
    *
    * @throws Exception when result serialization fails
    */
@@ -77,8 +78,8 @@ class ProcessModelDebottleneckStudyTest {
     assertTrue(first.isCapacityRestored());
     assertTrue(first.isProcessStateRestored());
     assertTrue(first.isRecoverySimulationConverged());
-    assertArrayEquals(new double[] { 1000.0 }, first.getBaseline().getSelectedParameters(), 0.0);
-    assertArrayEquals(new double[] { 1200.0 }, first.getAlternative().getSelectedParameters(), 0.0);
+    assertArrayEquals(new double[] { 999.0 }, first.getBaseline().getSelectedParameters(), 0.0);
+    assertArrayEquals(new double[] { 1199.0 }, first.getAlternative().getSelectedParameters(), 0.0);
     assertEquals(200.0, first.getObjectiveDelta(), 1.0e-8);
     assertEquals(5, first.getBaseline().getEvaluationCount());
     assertEquals(5, first.getAlternative().getEvaluationCount());
@@ -105,7 +106,7 @@ class ProcessModelDebottleneckStudyTest {
 
     double[] exposed = first.getAlternative().getSelectedParameters();
     exposed[0] = -1.0;
-    assertArrayEquals(new double[] { 1200.0 }, first.getAlternative().getSelectedParameters(), 0.0);
+    assertArrayEquals(new double[] { 1199.0 }, first.getAlternative().getSelectedParameters(), 0.0);
     assertThrows(UnsupportedOperationException.class, () -> first.getMetricComparisons().clear());
 
     StudyResult serialized = roundTrip(first);
@@ -175,8 +176,9 @@ class ProcessModelDebottleneckStudyTest {
   private ProcessModelDebottleneckStudy createStudy(Fixture fixture, String alternativeUnit) {
     List<double[]> candidates = new ArrayList<double[]>();
     candidates.add(new double[] { 800.0 });
-    candidates.add(new double[] { 1000.0 });
-    candidates.add(new double[] { 1200.0 });
+    // Keep selected points 1 kg/hr inside each limit so unit-conversion roundoff cannot make equality infeasible.
+    candidates.add(new double[] { 999.0 });
+    candidates.add(new double[] { 1199.0 });
     candidates.add(new double[] { 1400.0 });
     CandidateListSearch search = new CandidateListSearch("ordered-throughput-grid", "Ordered throughput grid",
         "synthetic acceptance candidate set", candidates, 0, 0.0);

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelDebottleneckStudyTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelDebottleneckStudyTest.java
@@ -59,15 +59,15 @@ class ProcessModelDebottleneckStudyTest {
   }
 
   /**
-   * A 20% installed-capacity increase must produce a paired 20% throughput increase while every
-   * original mutable limit field and the pre-study operating point are restored exactly.
+   * A 20% installed-capacity increase must produce a paired 20% throughput increase while every original mutable limit
+   * field and the pre-study operating point are restored exactly.
    *
    * @throws Exception when result serialization fails
    */
   @Test
   void pairedCapacityAlternativeIsDeterministicSerializableAndReversible() throws Exception {
     Fixture fixture = createFixture();
-    fixture.evaluator.evaluate(new double[] {800.0});
+    fixture.evaluator.evaluate(new double[] { 800.0 });
     int evaluationCountBeforeStudy = fixture.evaluator.getEvaluationCount();
 
     ProcessModelDebottleneckStudy study = createStudy(fixture, "kg/hr");
@@ -77,8 +77,8 @@ class ProcessModelDebottleneckStudyTest {
     assertTrue(first.isCapacityRestored());
     assertTrue(first.isProcessStateRestored());
     assertTrue(first.isRecoverySimulationConverged());
-    assertArrayEquals(new double[] {1000.0}, first.getBaseline().getSelectedParameters(), 0.0);
-    assertArrayEquals(new double[] {1200.0}, first.getAlternative().getSelectedParameters(), 0.0);
+    assertArrayEquals(new double[] { 1000.0 }, first.getBaseline().getSelectedParameters(), 0.0);
+    assertArrayEquals(new double[] { 1200.0 }, first.getAlternative().getSelectedParameters(), 0.0);
     assertEquals(200.0, first.getObjectiveDelta(), 1.0e-8);
     assertEquals(5, first.getBaseline().getEvaluationCount());
     assertEquals(5, first.getAlternative().getEvaluationCount());
@@ -92,26 +92,21 @@ class ProcessModelDebottleneckStudyTest {
     assertEquals("kg/hr", first.getMetricComparisons().get(0).getBaseline().getUnit());
     assertEquals("synthetic linear power relationship",
         first.getMetricComparisons().get(1).getBaseline().getProvenance());
-    assertEquals(MetricKind.SCREENING_ECONOMIC,
-        first.getMetricComparisons().get(3).getBaseline().getKind());
+    assertEquals(MetricKind.SCREENING_ECONOMIC, first.getMetricComparisons().get(3).getBaseline().getKind());
 
     assertEquals(1000.0, first.getOriginalCapacityState().getApplicableLimit(), 0.0);
     assertEquals(1200.0, first.getAppliedCapacityState().getApplicableLimit(), 0.0);
-    assertEquals(1000.0,
-        first.getBaseline().getInstalledCapacityEvidence().get(0).getApplicableLimit(), 0.0);
-    assertEquals(1200.0,
-        first.getAlternative().getInstalledCapacityEvidence().get(0).getApplicableLimit(), 0.0);
+    assertEquals(1000.0, first.getBaseline().getInstalledCapacityEvidence().get(0).getApplicableLimit(), 0.0);
+    assertEquals(1200.0, first.getAlternative().getInstalledCapacityEvidence().get(0).getApplicableLimit(), 0.0);
     assertEquals("synthetic replacement equipment basis",
         first.getAlternative().getInstalledCapacityEvidence().get(0).getDataSource());
-    assertEquals(0.90,
-        first.getAlternative().getInstalledCapacityEvidence().get(0).getConfidence(), 0.0);
+    assertEquals(0.90, first.getAlternative().getInstalledCapacityEvidence().get(0).getConfidence(), 0.0);
     assertOriginalStateRestored(fixture);
 
     double[] exposed = first.getAlternative().getSelectedParameters();
     exposed[0] = -1.0;
-    assertArrayEquals(new double[] {1200.0}, first.getAlternative().getSelectedParameters(), 0.0);
-    assertThrows(UnsupportedOperationException.class,
-        () -> first.getMetricComparisons().clear());
+    assertArrayEquals(new double[] { 1200.0 }, first.getAlternative().getSelectedParameters(), 0.0);
+    assertThrows(UnsupportedOperationException.class, () -> first.getMetricComparisons().clear());
 
     StudyResult serialized = roundTrip(first);
     assertEquals(first.getOutcome(), serialized.getOutcome());
@@ -123,10 +118,9 @@ class ProcessModelDebottleneckStudyTest {
 
     StudyResult second = study.evaluate();
     assertEquals(first.getOutcome(), second.getOutcome());
-    assertArrayEquals(first.getBaseline().getSelectedParameters(),
-        second.getBaseline().getSelectedParameters(), 0.0);
-    assertArrayEquals(first.getAlternative().getSelectedParameters(),
-        second.getAlternative().getSelectedParameters(), 0.0);
+    assertArrayEquals(first.getBaseline().getSelectedParameters(), second.getBaseline().getSelectedParameters(), 0.0);
+    assertArrayEquals(first.getAlternative().getSelectedParameters(), second.getAlternative().getSelectedParameters(),
+        0.0);
     assertEquals(first.getObjectiveDelta(), second.getObjectiveDelta(), 0.0);
     assertNotSame(first.getMetricComparisons(), second.getMetricComparisons());
     assertOriginalStateRestored(fixture);
@@ -136,7 +130,7 @@ class ProcessModelDebottleneckStudyTest {
   @Test
   void incompatibleCapacityAlternativeFailsClosedWithoutEvaluation() {
     Fixture fixture = createFixture();
-    fixture.evaluator.evaluate(new double[] {800.0});
+    fixture.evaluator.evaluate(new double[] { 800.0 });
     int evaluationCountBeforeStudy = fixture.evaluator.getEvaluationCount();
 
     StudyResult result = createStudy(fixture, "t/day").evaluate();
@@ -153,11 +147,10 @@ class ProcessModelDebottleneckStudyTest {
   @Test
   void unavailableRequiredMetricRetainsPhysicalEvidenceAndRestoresState() {
     Fixture fixture = createFixture();
-    fixture.evaluator.evaluate(new double[] {800.0});
+    fixture.evaluator.evaluate(new double[] { 800.0 });
     ProcessModelDebottleneckStudy study = createStudy(fixture, "kg/hr");
-    study.addMetric(new MetricDefinition("required-quality", "Required quality", MetricKind.OTHER,
-        "mol/mol", "dry product basis", "synthetic unavailable analyzer", "single steady state",
-        0.5, true, new MetricSampler() {
+    study.addMetric(new MetricDefinition("required-quality", "Required quality", MetricKind.OTHER, "mol/mol",
+        "dry product basis", "synthetic unavailable analyzer", "single steady state", 0.5, true, new MetricSampler() {
           private static final long serialVersionUID = 1L;
 
           @Override
@@ -181,33 +174,31 @@ class ProcessModelDebottleneckStudyTest {
   /** Creates the deterministic paired study used by the focused tests. */
   private ProcessModelDebottleneckStudy createStudy(Fixture fixture, String alternativeUnit) {
     List<double[]> candidates = new ArrayList<double[]>();
-    candidates.add(new double[] {800.0});
-    candidates.add(new double[] {1000.0});
-    candidates.add(new double[] {1200.0});
-    candidates.add(new double[] {1400.0});
-    CandidateListSearch search = new CandidateListSearch("ordered-throughput-grid",
-        "Ordered throughput grid", "synthetic acceptance candidate set", candidates, 0, 0.0);
+    candidates.add(new double[] { 800.0 });
+    candidates.add(new double[] { 1000.0 });
+    candidates.add(new double[] { 1200.0 });
+    candidates.add(new double[] { 1400.0 });
+    CandidateListSearch search = new CandidateListSearch("ordered-throughput-grid", "Ordered throughput grid",
+        "synthetic acceptance candidate set", candidates, 0, 0.0);
     CapacityAlternative alternative = new CapacityAlternative("separator-gas-1200",
-        "Raise separator installed gas capacity", "synthetic brownfield screening case",
-        "separation", "separator", "installed gas rate", 1200.0, alternativeUnit,
-        LimitDirection.MAXIMUM, "synthetic replacement equipment basis", 0.90, 900.0, 1300.0);
+        "Raise separator installed gas capacity", "synthetic brownfield screening case", "separation", "separator",
+        "installed gas rate", 1200.0, alternativeUnit, LimitDirection.MAXIMUM, "synthetic replacement equipment basis",
+        0.90, 900.0, 1300.0);
     ProcessModelDebottleneckStudy study = new ProcessModelDebottleneckStudy("paired-separator-study",
-        "Paired separator capacity study", "synthetic deterministic regression", fixture.evaluator,
-        alternative, search, 0);
-    study.addMetric(new MetricDefinition("production", "Feed production", MetricKind.PRODUCTION,
-        "kg/hr", "wet feed mass rate", "NeqSim stream result", "single steady state", 1.0,
-        true, model -> model.getVariableValue("wells::feed.flowRate", "kg/hr")));
-    study.addMetric(new MetricDefinition("power", "Synthetic power", MetricKind.POWER, "kW",
-        "shaft power", "synthetic linear power relationship", "single steady state", 0.8,
-        true, model -> 0.01 * model.getVariableValue("wells::feed.flowRate", "kg/hr")));
+        "Paired separator capacity study", "synthetic deterministic regression", fixture.evaluator, alternative, search,
+        0);
+    study.addMetric(new MetricDefinition("production", "Feed production", MetricKind.PRODUCTION, "kg/hr",
+        "wet feed mass rate", "NeqSim stream result", "single steady state", 1.0, true,
+        model -> model.getVariableValue("wells::feed.flowRate", "kg/hr")));
+    study.addMetric(new MetricDefinition("power", "Synthetic power", MetricKind.POWER, "kW", "shaft power",
+        "synthetic linear power relationship", "single steady state", 0.8, true,
+        model -> 0.01 * model.getVariableValue("wells::feed.flowRate", "kg/hr")));
     study.addMetric(new MetricDefinition("indirect-emissions", "Synthetic indirect emissions",
-        MetricKind.INDIRECT_EMISSIONS, "kgCO2e/hr", "location-based electricity",
-        "synthetic 0.4 kgCO2e/kWh factor", "single steady state", 0.5, false,
-        model -> 0.004 * model.getVariableValue("wells::feed.flowRate", "kg/hr")));
-    study.addMetric(new MetricDefinition("screening-value", "Synthetic screening value",
-        MetricKind.SCREENING_ECONOMIC, "NOK/hr", "gross value before costs",
-        "synthetic educational 5 NOK/kg factor", "single steady state", 0.2, false,
-        model -> 5.0 * model.getVariableValue("wells::feed.flowRate", "kg/hr")));
+        MetricKind.INDIRECT_EMISSIONS, "kgCO2e/hr", "location-based electricity", "synthetic 0.4 kgCO2e/kWh factor",
+        "single steady state", 0.5, false, model -> 0.004 * model.getVariableValue("wells::feed.flowRate", "kg/hr")));
+    study.addMetric(new MetricDefinition("screening-value", "Synthetic screening value", MetricKind.SCREENING_ECONOMIC,
+        "NOK/hr", "gross value before costs", "synthetic educational 5 NOK/kg factor", "single steady state", 0.2,
+        false, model -> 5.0 * model.getVariableValue("wells::feed.flowRate", "kg/hr")));
     return study;
   }
 
@@ -219,17 +210,15 @@ class ProcessModelDebottleneckStudyTest {
     fluid.setMixingRule("classic");
     fluid.setTotalFlowRate(800.0, "kg/hr");
     final Stream feed = new Stream("feed", fluid);
-    final CapacityConstraint installed = new CapacityConstraint("installed gas rate", "kg/hr",
-        ConstraintType.HARD).setDesignValue(1000.0).setMaxValue(1100.0)
-            .setWarningThreshold(0.90).setSeverity(ConstraintSeverity.HARD)
-            .setDataSource("synthetic installed basis").setConfidence(0.95)
-            .setValidityRange(500.0, 1400.0).setShadowPrice(12.3)
-            .setValueSupplier(new DoubleSupplier() {
-              @Override
-              public double getAsDouble() {
-                return feed.getFlowRate("kg/hr");
-              }
-            });
+    final CapacityConstraint installed = new CapacityConstraint("installed gas rate", "kg/hr", ConstraintType.HARD)
+        .setDesignValue(1000.0).setMaxValue(1100.0).setWarningThreshold(0.90).setSeverity(ConstraintSeverity.HARD)
+        .setDataSource("synthetic installed basis").setConfidence(0.95).setValidityRange(500.0, 1400.0)
+        .setShadowPrice(12.3).setValueSupplier(new DoubleSupplier() {
+          @Override
+          public double getAsDouble() {
+            return feed.getFlowRate("kg/hr");
+          }
+        });
     Separator separator = new Separator("separator", feed);
     separator.clearCapacityConstraints();
     separator.addCapacityConstraint(installed);
@@ -250,8 +239,7 @@ class ProcessModelDebottleneckStudyTest {
           public double applyAsDouble(ProcessModel completedModel) {
             return completedModel.getVariableValue("wells::feed.flowRate", "kg/hr");
           }
-        }, ProcessModelSimulationEvaluator.ObjectiveDefinition.Direction.MAXIMIZE)
-        .addEquipmentCapacityConstraints();
+        }, ProcessModelSimulationEvaluator.ObjectiveDefinition.Direction.MAXIMIZE).addEquipmentCapacityConstraints();
     evaluator.getObjectives().get(0).setUnit("kg/hr");
     return new Fixture(feed, installed, model, evaluator);
   }


### PR DESCRIPTION
## READY TO MERGE

Advances #2941 dependency 11: reversible installed-capacity alternatives and paired debottleneck evidence.

### Engineering question

For one documented brownfield equipment-capacity replacement or expansion, can NeqSim compare the installed and proposed cases with the same deterministic production search, preserve constraint/objective/metric evidence with explicit units and provenance, and return the live `ProcessModel` plus installed constraint to their pre-study state?

### Baseline

At base `564a1d2cf92729d422471b99fa59328382e0cea2`, `ProcessModelSimulationEvaluator` exposes direct and strategy-generated capacity residuals and immutable installed/boundary evidence, but there is no transaction that:

- applies one installed-capacity alternative;
- uses one frozen search policy for both cases;
- independently verifies both selected points;
- compares production, energy, emissions, or screening-economic metrics; and
- restores and verifies installed-capacity and process operating state.

Callers must currently mutate live constraints and assemble unlike or state-dependent results themselves.

### Implementation

Adds `ProcessModelDebottleneckStudy` as one coherent optimization-facing capability:

- stable `area::equipment/constraint` targeting for direct installed constraints only;
- immutable alternative identity, limit direction, unit, proposal source, confidence, and validity range;
- complete observable capacity-state capture and exact read-back after apply/restore;
- identical `ScenarioSearch` execution for baseline and alternative;
- a deterministic direction-aware `CandidateListSearch` over ordered bounded parameter vectors;
- independent evaluator verification of each selected point;
- immutable objective values, signed constraint margins, installed-capacity evidence, process-boundary evidence, evaluation counts, and diagnostics;
- once-per-scenario physical and screening metrics with kind, unit, basis, provenance, period, confidence, and required/optional status;
- `alternative - baseline` metric and selected-objective deltas;
- Java-serializable results with defensive arrays/unmodifiable lists for JPype;
- unconditional installed-capacity restoration and pre-study parameter-vector reconvergence.

The proposed limit's data source, confidence, and validity range are applied to the live constraint for the alternative evidence and then restored with the installed basis.

### Measured acceptance case

The focused regression defines a synthetic two-area gas case with a direct separator limit:

| Evidence | Installed case | Alternative case |
|---|---:|---:|
| Applicable gas-rate limit | 1000 kg/hr | 1200 kg/hr |
| Selected feasible production | 999 kg/hr | 1199 kg/hr |
| Production delta |  | +200 kg/hr |
| Synthetic power delta |  | +2 kW |
| Synthetic indirect-emissions delta |  | +0.8 kgCO2e/hr |
| Synthetic gross screening-value delta |  | +1000 NOK/hr |

The candidate policy is the same ordered set in both cases: 800, 999, 1199, and 1400 kg/hr. The selected points retain 1 kg/hr headroom below each installed limit so platform-specific mass-flow conversion roundoff cannot turn exact equality into a false violation. Each scenario uses four search evaluations plus one independent verification. A final recovery evaluation is required.

Focused tests cover:

- deterministic repeated selection and deltas;
- direct installed-evidence limit/provenance read-back;
- all mutable capacity fields and the 800 kg/hr pre-study point restored;
- Java serialization and defensive result containers;
- unit mismatch failing closed before evaluation;
- a non-finite required metric retaining valid physical evidence but producing `REQUIRED_METRIC_UNAVAILABLE`.

### Validation

Current exact head: `bb8ebfdd2087d96cce7aa358ed5cc7eb704536f3`.

The branch was updated without force-push using a normal two-parent merge of the previously validated feature head `d2389a05500945d67f32c5491991c6904eb21dfe` and current `master` `4a8eb2ae725acd6727098e62b07abaadb74ddeeb`. The incorporated baseline contains the unrelated absorber-documentation change and the repository-wide wiki/version repair. GitHub reports the branch conflict-free, 14 commits ahead and 0 behind `master`; the final comparison still contains exactly the five intended optimizer paths.

**READY TO MERGE** at exact head `bb8ebfdd2087d96cce7aa358ed5cc7eb704536f3`.

Fresh exact-head validation passed:

- Run build, test and javadoc: Java 21 Ubuntu and Windows, all four Java 21 slow-test shards, Java 8 Ubuntu and Windows, Javadoc, and agent-skill cross-reference validation;
- Pre-commit checks;
- Spotless format patch;
- Documentation search coverage;
- PaperLab Replication Gate; and
- CodeQL Security Analysis.

The PR is mergeable, 0 commits behind current `master`, limited to the five intended optimizer and documentation paths, and has no conversation comments, reviews, Copilot feedback, or unresolved inline threads. The PR remains draft; this classification does not mark it ready or authorize merge.

Prior feature-head evidence at `d2389a05500945d67f32c5491991c6904eb21dfe`:

- production and focused test sources compiled with the JDK compiler module using `-source 8 -target 8` against task-local API-compatible stubs (exit 0, with only the expected bootstrap-class-path warning);
- GitHub Run build, test and javadoc passed the Java 8/21 fast-test matrix, all Java 21 slow-test shards, Javadoc, and agent-skill cross-reference validation;
- GitHub Pre-commit checks, Spotless format patch, PaperLab Replication Gate, and CodeQL Security Analysis passed;
- the documentation workflow's changed-source contracts passed, while its former repository-wide 3.17.0/3.18.0 baseline mismatch is repaired by current `master`;
- the PR has no review, inline-review, or conversation comments;
- no notebook changes and no Huldra dataset or model work.

The first Windows Java 21 run at `ebeb4c90` correctly exposed exact-boundary floating-point reconstruction. The accepted regression and both user-guide examples use 999 and 1199 kg/hr, preserving 1 kg/hr below the 1000 and 1200 kg/hr installed limits while retaining the measured +200 kg/hr paired production delta.

Local infrastructure did not contain a full repository checkout or `devtools` tree. The missing local Spotless, documentation-search, pre-commit, and direct-`javac` commands are not claimed as local passes. The PR remains draft.

### Documentation impact

Updated:

- the optimization/constraints guide with the transaction lifecycle, Java example, evidence semantics, metric rules, and limitations;
- the external-optimizer guide with JPype candidate/result handling and API tables;
- the optimization overview with workflow selection and discoverability.

No release-note claim is included because the capability is unmerged.

### Compatibility, performance, and stop boundary

- Additive Java API; no existing behavior or solver internals are changed.
- Java 8 source compatibility is retained.
- Search cost is explicit: baseline and alternative each run the same policy, each selected point is verified once, and recovery runs once.
- One study instance is mutable configuration over one live evaluator and is not thread-safe; immutable returned evidence is safe to retain and serialize.
- Strategy-generated defaults are intentionally ineligible because they are not stable installed-asset transactions.
- No dynamic engine, TP-flash, two-fluid, column, generic performance, mechanical sizing, certified emissions, or economic optimizer internals are changed.
- Results are paired sampled evidence, not causal production loss, global optimality, a KKT multiplier, mechanical-design approval, certified emissions, or investment approval.

### Next dependency

After this tranche is validated and merged, #2941 can add ranking across multiple independently documented alternatives without embedding an unreviewed economic model or conflating unlike units.
