### PR TITLE
Improve dataflow dispatch for wide multi-input processes

### DIFF
--- a/docs/process/processmodel/graph_simulation.md
+++ b/docs/process/processmodel/graph_simulation.md
@@ -58,26 +58,35 @@ process.runOptimized(calcId);
 ```
 
 The method inspects the process for:
-- **Recycle units** → Sequential execution for convergence
-- **Multi-input equipment** (Mixer, Manifold, HeatExchanger, etc.) → Sequential for correct mass balance
-- **Adjuster units** → Hybrid execution (parallel feed-forward + iteration)
-- **Feed-forward only** → Full parallel execution for maximum speed
+- **Adjuster units** → Sequential execution for implicit feedback
+- **Recycle units** → Hybrid execution (parallel feed-forward + iterative recycle section)
+- **Wide feed-forward topology** → Dependency-aware dataflow execution
+- **Small or narrow feed-forward topology** → Level-based parallel execution
+
+Mixers, manifolds, heat exchangers, and other multi-input equipment are supported by both feed-forward strategies. The
+graph places each task after all direct predecessors, while equipment sharing a mutable input is grouped into one
+sequential task.
 
 ### Execution Strategy Comparison
 
 | Strategy | Method | Best For | When Used by runOptimized() |
 |----------|--------|----------|----------------------------|
-| Sequential | `run()` or `runSequential()` | Recycles, multi-input equipment | Has Recycle units or Mixer/HeatExchanger/etc. |
+| Sequential | `runSequential()` | Adjusters and legacy insertion-order execution | Has Adjuster or MultiVariableAdjuster units |
 | Graph-based | `setUseGraphBasedExecution(true)` | Complex ordering | Manual configuration only |
-| Parallel | `runParallel()` | Feed-forward (no recycles) | No recycles, no multi-input, no adjusters |
-| Hybrid | `runHybrid()` | Processes with adjusters | Has adjusters but no recycles/multi-input |
+| Parallel | `runParallel()` | Small or narrow feed-forward graphs | Dataflow threshold or useful-width test is not met |
+| Dataflow | `runDataflow()` | Wide or asymmetric feed-forward graphs | At least eight units and independent tasks |
+| Hybrid | `runHybrid()` | Processes with recycles | Has recycle units and no adjusters |
 | **Optimized** | `runOptimized()` | **All processes** | **Auto-selects from above** |
 
-### Sequential Execution (Default)
+### Sequential Execution (Explicit Legacy Mode)
 
-Standard execution in insertion order:
+Explicit insertion-order execution:
 
 ```java
+process.runSequential(UUID.randomUUID());
+
+// Or retain sequential behavior for subsequent process.run() calls
+process.setUseOptimizedExecution(false);
 process.run();
 ```
 
@@ -110,6 +119,22 @@ try {
 3. Runs units at each level in parallel
 4. Waits for level completion before next level
 
+### Dataflow Execution
+
+Executes each unit or shared-input group as soon as its direct predecessors finish:
+
+```java
+try {
+    process.runDataflow();
+} catch (InterruptedException e) {
+    Thread.currentThread().interrupt();
+}
+```
+
+`runOptimized()` selects dataflow only for a feed-forward graph with at least eight units and useful independent tasks.
+Unlike level-based execution, a slow unit on one branch does not hold unrelated downstream work behind a global level
+barrier. Multi-input equipment retains deterministic predecessor ordering and shared-input grouping.
+
 ### Hybrid Execution
 
 Combines parallel and iterative execution for processes with recycles:
@@ -140,10 +165,10 @@ process.runOptimized();
 
 | Condition | Strategy | Reason |
 |-----------|----------|--------|
-| Has `Recycle` units | `runSequential()` | Recycles require full iterative convergence |
-| Has multi-input equipment | `runSequential()` | Mixer, Manifold, etc. need correct stream ordering |
-| Has `Adjuster` units | `runHybrid()` | Adjusters need iteration but feed-forward can parallelize |
-| Feed-forward only | `runParallel()` | Maximum speed with no dependencies |
+| Has `Adjuster`/`MultiVariableAdjuster` units | `runSequential()` | Implicit feedback is not represented by stream dependencies |
+| Has `Recycle` units | `runHybrid()` | Feed-forward levels can run in parallel; the recycle section iterates |
+| Feed-forward, at least eight units, useful independent tasks | `runDataflow()` | Direct predecessor scheduling avoids unnecessary level barriers |
+| Other feed-forward topology | `runParallel()` | Small or serial graphs do not amortize dataflow futures |
 
 **Multi-input equipment includes:**
 - `Mixer`, `Manifold`
@@ -166,7 +191,7 @@ boolean hasRecycles = process.hasRecycles();
 // Check if process has Adjuster units (requires iteration)
 boolean hasAdjusters = process.hasAdjusters();
 
-// Check if process has multi-input equipment (requires sequential)
+// Check if process has multi-input equipment (supported by parallel and dataflow execution)
 // Includes: Mixer, Manifold, HeatExchanger, TurboExpanderCompressor, etc.
 boolean hasMultiInput = process.hasMultiInputEquipment();
 
@@ -181,14 +206,12 @@ System.out.println(process.getExecutionPartitionInfo());
 
 ```java
 // What will runOptimized() do for my process?
-if (process.hasRecycles()) {
-    System.out.println("Will use: runSequential() - Recycle units detected");
-} else if (process.hasMultiInputEquipment()) {
-    System.out.println("Will use: runSequential() - Multi-input equipment detected");
-} else if (process.hasAdjusters()) {
-    System.out.println("Will use: runHybrid() - Adjusters with parallel feed-forward");
+if (process.hasAdjusters()) {
+    System.out.println("Will use: runSequential() - Adjuster feedback detected");
+} else if (process.hasRecycles()) {
+    System.out.println("Will use: runHybrid() - Recycle units detected");
 } else {
-    System.out.println("Will use: runParallel() - Full parallel execution");
+    System.out.println(process.getExecutionStrategyExplanation());
 }
 ```
 

--- a/docs/process/processmodel/process_system.md
+++ b/docs/process/processmodel/process_system.md
@@ -279,9 +279,10 @@ process.runTransient(1.0, calcId);
 
 | Method | Best For | Description |
 |--------|----------|-------------|
-| `run()` | General use | Sequential execution in insertion order |
+| `run()` | General use | Optimized execution by default; sequential when explicitly disabled |
 | `runOptimized()` | **Recommended** | Auto-selects best strategy based on topology |
 | `runParallel()` | Feed-forward processes | Maximum parallelism for no-recycle processes |
+| `runDataflow()` | Wide feed-forward processes | Direct predecessor scheduling without level barriers |
 | `runHybrid()` | Complex processes | Parallel feed-forward + iterative recycle |
 
 ### Recommended: runOptimized()
@@ -298,8 +299,13 @@ process.runOptimized(calcId);
 ```
 
 **How it works:**
-- **No recycles detected**: Uses `runParallel()` for maximum speed
+- **Adjusters detected**: Uses `runSequential()` because implicit feedback is not represented by stream dependencies
 - **Recycles detected**: Uses `runHybrid()` which runs feed-forward sections in parallel, then iterates on recycle sections
+- **Wide feed-forward topology**: Uses `runDataflow()` so each task starts after its direct predecessors
+- **Small or narrow feed-forward topology**: Uses `runParallel()` to avoid unnecessary future scheduling
+
+Multi-input equipment is supported in both feed-forward strategies. Dependency ordering and shared-input grouping keep
+mixers, manifolds, and heat exchangers from running before their inlet producers or racing another mutable consumer.
 
 **Performance gains** (typical separation train with 40 units, 3 recycles):
 | Mode | Time | Speedup |
@@ -311,7 +317,7 @@ process.runOptimized(calcId);
 ### Steady-State Simulation
 
 ```java
-// Basic sequential execution
+// General execution (optimized by default)
 process.run();
 
 // Run with calculation ID for tracking
@@ -333,6 +339,9 @@ try {
 ```
 
 **Note:** `runParallel()` does not handle recycles or adjusters. Use `runOptimized()` for processes with recycles.
+
+For a sufficiently wide feed-forward graph, `runOptimized()` selects `runDataflow()` instead. Dataflow removes global
+level barriers while retaining the same predecessor dependencies and shared-input groups as `runParallel()`.
 
 ### Thread Safety: Shared Stream Handling
 
@@ -373,13 +382,15 @@ Stream sharedInput = valve.getOutletStream();
 Heater heater1 = new Heater("heater1", sharedInput);  // Same stream object
 Heater heater2 = new Heater("heater2", sharedInput);  // Same stream object
 
-// NeqSim detects shared input and runs heater1 and heater2 sequentially
-// Other independent units at this level still run in parallel
+// These single-input units only read/clone the shared stream and may run in parallel.
+// If either consumer were multi-input, NeqSim would group the consumers into one
+// sequential task to protect mutable mixing behavior.
 process.runParallel();
 ```
 
 **Applies to:**
 - `runParallel()` - Groups by shared input streams
+- `runDataflow()` - Uses the same groups plus direct predecessor dependencies
 - `runHybrid()` - Groups in Phase 1 (feed-forward section)
 - `runTransient()` - Groups at each time step
 
@@ -637,8 +648,8 @@ process.runOptimized();  // Auto-selects best strategy
 
 // Or manually choose strategy:
 
-// 1. Sequential (default)
-process.run();
+// 1. Sequential (explicit legacy mode)
+process.runSequential(UUID.randomUUID());
 
 // 2. Graph-based ordering
 process.setUseGraphBasedExecution(true);
@@ -647,7 +658,10 @@ process.run();
 // 3. Parallel execution (no recycles)
 process.runParallel();
 
-// 4. Hybrid execution (recycle processes)
+// 4. Dependency-aware dataflow (wide feed-forward processes)
+process.runDataflow();
+
+// 5. Hybrid execution (recycle processes)
 process.runHybrid();
 ```
 

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -257,8 +257,8 @@ public class ProcessSystem extends SimulationBaseClass {
    * Whether to use optimized execution (parallel/hybrid) by default when run() is called. When true, run() delegates to
    * runOptimized() which automatically selects the best strategy. When false, run() uses sequential execution in
    * insertion order (legacy behavior). Default is true for optimal performance - runOptimized() automatically falls
-   * back to sequential execution for processes with multi-input equipment (mixers, heat exchangers, etc.) to preserve
-   * correct mass balance.
+   * back to level-based execution when a feed-forward topology is too small or too narrow to amortize dataflow
+   * scheduling.
    */
   private boolean useOptimizedExecution = true;
 
@@ -1483,10 +1483,9 @@ public class ProcessSystem extends SimulationBaseClass {
    * <ul>
    * <li>For processes with adjusters: sequential execution (adjusters modify upstream variables and read downstream
    * targets, creating implicit feedback loops)</li>
-   * <li>For processes with recycles (no adjusters): sequential execution for full convergence</li>
-   * <li>For processes with multi-input equipment (Mixer, Manifold, HeatExchanger, etc.): sequential execution to ensure
-   * correct mass balance</li>
-   * <li>For simple feed-forward processes: parallel execution for maximum speed</li>
+   * <li>For processes with recycles (no adjusters): hybrid feed-forward parallelism and iterative convergence</li>
+   * <li>For feed-forward processes, including multi-input equipment: dependency-aware dataflow for sufficiently wide
+   * topologies, otherwise level-based parallel execution</li>
    * </ul>
    *
    * @param id calculation identifier for tracking
@@ -1517,26 +1516,15 @@ public class ProcessSystem extends SimulationBaseClass {
           logger.warn("Hybrid execution interrupted, falling back to sequential");
           runSequential(id);
         }
-      } else if (hasMultiInputEquipment()) {
-        // Process has multi-input equipment (Mixer, HeatExchanger, etc.) but no
-        // recycles or adjusters. The graph correctly places multi-input equipment
-        // at levels after all their input producers, so parallel execution of
-        // independent units at earlier levels is safe. Use runParallel which
-        // respects the topological order and Union-Find grouping.
-        try {
-          runParallel(id);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          logger.warn("Parallel execution interrupted, falling back to sequential");
-          runSequential(id);
-        }
       } else {
-        // Feed-forward process with single-input equipment only. For larger,
-        // genuinely wide flowsheets use dataflow scheduling (no level barriers,
-        // units fire as soon as predecessors complete). Serial plans cannot
-        // benefit from futures, and small trees do not amortize their overhead.
+        // Feed-forward process. For larger, genuinely wide flowsheets use dataflow
+        // scheduling (no level barriers, units fire as soon as predecessors
+        // complete). Multi-input equipment is safe because the dataflow plan uses
+        // the same predecessor graph and shared-input grouping as runParallel().
+        // Serial plans cannot benefit from futures, and small trees do not
+        // amortize their overhead.
         try {
-          if (unitOperations.size() >= DATAFLOW_UNIT_THRESHOLD && getCachedDataflowPlan().hasParallelTasks) {
+          if (shouldUseDataflowExecution()) {
             runDataflow(id);
           } else {
             runParallel(id);
@@ -1550,6 +1538,15 @@ public class ProcessSystem extends SimulationBaseClass {
     } finally {
       exitRunScope();
     }
+  }
+
+  /**
+   * Returns whether this feed-forward process is wide enough to amortize dataflow scheduling.
+   *
+   * @return true when the cached plan contains useful parallel tasks and meets the size threshold
+   */
+  private boolean shouldUseDataflowExecution() {
+    return unitOperations.size() >= DATAFLOW_UNIT_THRESHOLD && getCachedDataflowPlan().hasParallelTasks;
   }
 
   /**
@@ -2232,12 +2229,15 @@ public class ProcessSystem extends SimulationBaseClass {
     } else if (!recycles.isEmpty()) {
       strategy = "hybrid (parallel feed-forward then iterative recycle section)";
       reason = "process contains Recycle units - iterative convergence required";
-    } else if (!multiInput.isEmpty()) {
-      strategy = "parallel (topological levels with union-find grouping)";
-      reason = "process contains multi-input equipment - level-based parallelism applied";
+    } else if (shouldUseDataflowExecution()) {
+      strategy = "dataflow (dependency-aware parallel tasks)";
+      reason = multiInput.isEmpty()
+          ? "wide feed-forward process has independent tasks that can run without level barriers"
+          : "wide feed-forward process includes multi-input equipment protected by predecessor dependencies and "
+              + "shared-input grouping";
     } else {
-      strategy = "parallel (fully data-parallel)";
-      reason = "feed-forward process with single-input equipment only";
+      strategy = "parallel (topological levels with union-find grouping)";
+      reason = "feed-forward plan is too small or too narrow to amortize dataflow scheduling";
     }
     sb.append("Strategy: ").append(strategy).append("\n");
     sb.append("Reason: ").append(reason).append("\n");

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemDataflowBenchmark.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemDataflowBenchmark.java
@@ -1,0 +1,165 @@
+package neqsim.process.processmodel;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import neqsim.process.equipment.heatexchanger.Cooler;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.mixer.Mixer;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Compares ProcessSystem automatic, level-parallel, and dataflow dispatch on independent trains. */
+public final class ProcessSystemDataflowBenchmark {
+  private static final int TRAIN_COUNT = 4;
+
+  private static final class Fixture {
+    final ProcessSystem process;
+    final List<Stream> feeds;
+    final List<Separator> products;
+
+    Fixture(ProcessSystem process, List<Stream> feeds, List<Separator> products) {
+      this.process = process;
+      this.feeds = feeds;
+      this.products = products;
+    }
+  }
+
+  private static SystemInterface createFluid(boolean cpa) {
+    SystemInterface fluid = cpa ? new SystemSrkCPAstatoil(303.15, 60.0) : new SystemSrkEos(303.15, 60.0);
+    fluid.addComponent("methane", 0.82);
+    fluid.addComponent("ethane", 0.08);
+    fluid.addComponent("propane", 0.05);
+    fluid.addComponent("n-heptane", 0.04);
+    fluid.addComponent(cpa ? "water" : "nC10", 0.01);
+    fluid.setMixingRule(cpa ? 10 : 2);
+    fluid.setMultiPhaseCheck(true);
+    return fluid;
+  }
+
+  private static Fixture createFixture(boolean cpa, boolean imbalanced, boolean multiInput)
+      throws InterruptedException {
+    ProcessSystem process = new ProcessSystem("wide independent process");
+    List<Stream> feeds = new ArrayList<>();
+    List<Separator> products = new ArrayList<>();
+    for (int train = 0; train < TRAIN_COUNT; train++) {
+      String prefix = "train-" + train + " ";
+      Stream feed = new Stream(prefix + "feed", createFluid(cpa));
+      feed.setFlowRate(12000.0 + 1000.0 * train, "kg/hr");
+      process.add(feed);
+      feeds.add(feed);
+
+      StreamInterface current = feed;
+      if (multiInput) {
+        Stream secondFeed = new Stream(prefix + "second feed", createFluid(cpa));
+        secondFeed.setTemperature(295.15 + train, "K");
+        secondFeed.setFlowRate(3000.0 + 250.0 * train, "kg/hr");
+        process.add(secondFeed);
+        feeds.add(secondFeed);
+        Mixer mixer = new Mixer(prefix + "mixer");
+        mixer.addStream(feed);
+        mixer.addStream(secondFeed);
+        process.add(mixer);
+        current = mixer.getOutletStream();
+      }
+      int thermalPairs = imbalanced ? train + 1 : 3;
+      for (int stage = 0; stage < thermalPairs; stage++) {
+        Heater heater = new Heater(prefix + "heater-" + stage, current);
+        heater.setOutTemperature(308.15 + 2.0 * stage);
+        process.add(heater);
+        Cooler cooler = new Cooler(prefix + "cooler-" + stage, heater.getOutletStream());
+        cooler.setOutTemperature(300.15 + stage);
+        process.add(cooler);
+        current = cooler.getOutletStream();
+      }
+
+      ThrottlingValve valve = new ThrottlingValve(prefix + "valve", current);
+      valve.setOutletPressure(45.0 - train, "bara");
+      process.add(valve);
+      Separator separator = new Separator(prefix + "separator", valve.getOutletStream());
+      process.add(separator);
+      products.add(separator);
+    }
+    process.runParallel(new UUID(0L, 1L));
+    return new Fixture(process, feeds, products);
+  }
+
+  private static void run(Fixture fixture, String strategy, UUID id) throws Exception {
+    if ("parallel".equals(strategy)) {
+      fixture.process.runParallel(id);
+    } else if ("dataflow".equals(strategy)) {
+      fixture.process.runDataflow(id);
+    } else {
+      fixture.process.runOptimized(id);
+    }
+  }
+
+  private static double checksum(Fixture fixture) {
+    double checksum = 0.0;
+    for (Separator product : fixture.products) {
+      StreamInterface gas = product.getGasOutStream();
+      StreamInterface liquid = product.getLiquidOutStream();
+      checksum += gas.getFlowRate("kg/hr") + liquid.getFlowRate("kg/hr");
+      checksum += gas.getTemperature("K") + gas.getPressure("bara");
+      checksum += 1000.0 * gas.getThermoSystem().getNumberOfPhases();
+    }
+    return checksum;
+  }
+
+  /**
+   * Runs one warmed benchmark fork. Alternate fresh JVMs for representative comparisons.
+   *
+   * @param args warmups, measured runs, strategy, topology, fluid, and optional mixer flag
+   * @throws Exception if process execution fails
+   */
+  public static void main(String[] args) throws Exception {
+    int warmups = args.length > 0 ? Integer.parseInt(args[0]) : 40;
+    int measured = args.length > 1 ? Integer.parseInt(args[1]) : 160;
+    String strategy = args.length > 2 ? args[2] : "optimized";
+    boolean imbalanced = args.length > 3 && "imbalanced".equals(args[3]);
+    boolean cpa = args.length > 4 && "cpa".equals(args[4]);
+    boolean multiInput = args.length > 5 && "mixer".equals(args[5]);
+    Fixture fixture = createFixture(cpa, imbalanced, multiInput);
+
+    for (int i = 0; i < warmups; i++) {
+      for (int feedIndex = 0; feedIndex < fixture.feeds.size(); feedIndex++) {
+        double baseFlow = fixture.feeds.get(feedIndex).getName().contains("second feed")
+            ? 3000.0 + 250.0 * (feedIndex / (multiInput ? 2 : 1))
+            : 12000.0 + 1000.0 * (feedIndex / (multiInput ? 2 : 1));
+        fixture.feeds.get(feedIndex).setFlowRate(baseFlow + ((i & 1) == 0 ? 0.0 : 50.0), "kg/hr");
+      }
+      run(fixture, strategy, new UUID(1L, i + 2L));
+    }
+
+    com.sun.management.ThreadMXBean threadBean =
+        (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+    long allocatedBefore = threadBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+    long start = System.nanoTime();
+    double checksum = 0.0;
+    for (int i = 0; i < measured; i++) {
+      for (int feedIndex = 0; feedIndex < fixture.feeds.size(); feedIndex++) {
+        double baseFlow = fixture.feeds.get(feedIndex).getName().contains("second feed")
+            ? 3000.0 + 250.0 * (feedIndex / (multiInput ? 2 : 1))
+            : 12000.0 + 1000.0 * (feedIndex / (multiInput ? 2 : 1));
+        fixture.feeds.get(feedIndex).setFlowRate(baseFlow + ((i & 1) == 0 ? 0.0 : 50.0), "kg/hr");
+      }
+      run(fixture, strategy, new UUID(2L, i + 2L));
+      checksum += checksum(fixture);
+    }
+    long elapsed = System.nanoTime() - start;
+    long allocatedAfter = threadBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+    System.out.printf(Locale.US,
+        "strategy=%s topology=%s fluid=%s units=%d nsPerRun=%.3f bytesPerRun=%.3f checksum=%.12f solved=%s%n",
+        strategy, (imbalanced ? "imbalanced" : "balanced") + (multiInput ? "-mixer" : ""),
+        cpa ? "cpa" : "srk",
+        fixture.process.getUnitOperations().size(), elapsed / (double) measured,
+        (allocatedAfter - allocatedBefore) / (double) measured, checksum, fixture.process.solved());
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemDataflowBenchmark.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemDataflowBenchmark.java
@@ -138,8 +138,7 @@ public final class ProcessSystemDataflowBenchmark {
       run(fixture, strategy, new UUID(1L, i + 2L));
     }
 
-    com.sun.management.ThreadMXBean threadBean =
-        (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+    com.sun.management.ThreadMXBean threadBean = (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
     long allocatedBefore = threadBean.getThreadAllocatedBytes(Thread.currentThread().getId());
     long start = System.nanoTime();
     double checksum = 0.0;
@@ -156,9 +155,8 @@ public final class ProcessSystemDataflowBenchmark {
     long elapsed = System.nanoTime() - start;
     long allocatedAfter = threadBean.getThreadAllocatedBytes(Thread.currentThread().getId());
     System.out.printf(Locale.US,
-        "strategy=%s topology=%s fluid=%s units=%d nsPerRun=%.3f bytesPerRun=%.3f checksum=%.12f solved=%s%n",
-        strategy, (imbalanced ? "imbalanced" : "balanced") + (multiInput ? "-mixer" : ""),
-        cpa ? "cpa" : "srk",
+        "strategy=%s topology=%s fluid=%s units=%d nsPerRun=%.3f bytesPerRun=%.3f checksum=%.12f solved=%s%n", strategy,
+        (imbalanced ? "imbalanced" : "balanced") + (multiInput ? "-mixer" : ""), cpa ? "cpa" : "srk",
         fixture.process.getUnitOperations().size(), elapsed / (double) measured,
         (allocatedAfter - allocatedBefore) / (double) measured, checksum, fixture.process.solved());
   }

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemMultiInputDataflowTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemMultiInputDataflowTest.java
@@ -1,0 +1,195 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.mixer.Mixer;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression coverage for dependency-aware dataflow dispatch with multi-input equipment. */
+class ProcessSystemMultiInputDataflowTest {
+  private static final class Fixture {
+    private final ProcessSystem process;
+    private final List<Stream> feeds;
+    private final List<Heater> products;
+
+    private Fixture(ProcessSystem process, List<Stream> feeds, List<Heater> products) {
+      this.process = process;
+      this.feeds = feeds;
+      this.products = products;
+    }
+  }
+
+  private static final class RecordingProcessSystem extends ProcessSystem {
+    private static final long serialVersionUID = 1000L;
+    private int parallelRuns;
+    private int dataflowRuns;
+
+    private RecordingProcessSystem() {
+      super("recording process");
+    }
+
+    @Override
+    public synchronized void runParallel(UUID id) {
+      parallelRuns++;
+      setCalculationIdentifier(id);
+    }
+
+    @Override
+    public synchronized void runDataflow(UUID id) {
+      dataflowRuns++;
+      setCalculationIdentifier(id);
+    }
+  }
+
+  private static SystemInterface createFluid(boolean cpa) {
+    SystemInterface fluid = cpa ? new SystemSrkCPAstatoil(303.15, 60.0) : new SystemSrkEos(303.15, 60.0);
+    fluid.addComponent("methane", 0.82);
+    fluid.addComponent("ethane", 0.08);
+    fluid.addComponent("propane", 0.05);
+    fluid.addComponent("n-heptane", 0.04);
+    fluid.addComponent(cpa ? "water" : "nC10", 0.01);
+    fluid.setMixingRule(cpa ? 10 : 2);
+    fluid.setMultiPhaseCheck(true);
+    return fluid;
+  }
+
+  private static Fixture createFixture(boolean cpa) {
+    ProcessSystem process = new ProcessSystem("wide mixer process");
+    List<Stream> feeds = new ArrayList<>();
+    List<Heater> products = new ArrayList<>();
+    for (int branch = 0; branch < 2; branch++) {
+      Stream first = new Stream("first feed " + branch, createFluid(cpa));
+      first.setFlowRate(12000.0 + 1000.0 * branch, "kg/hr");
+      Stream second = new Stream("second feed " + branch, createFluid(cpa));
+      second.setTemperature(295.15 + branch, "K");
+      second.setFlowRate(3000.0 + 250.0 * branch, "kg/hr");
+      Mixer mixer = new Mixer("mixer " + branch);
+      mixer.addStream(first);
+      mixer.addStream(second);
+      Heater firstHeater = new Heater("first heater " + branch, mixer.getOutletStream());
+      firstHeater.setOutTemperature(308.15 + branch);
+      Heater product = new Heater("product heater " + branch, firstHeater.getOutletStream());
+      product.setOutTemperature(312.15 + branch);
+      process.add(first);
+      process.add(second);
+      process.add(mixer);
+      process.add(firstHeater);
+      process.add(product);
+      feeds.add(first);
+      feeds.add(second);
+      products.add(product);
+    }
+    return new Fixture(process, feeds, products);
+  }
+
+  private static void compare(Fixture expected, Fixture actual) {
+    double expectedFeedFlow = 0.0;
+    double actualFeedFlow = 0.0;
+    double expectedProductFlow = 0.0;
+    double actualProductFlow = 0.0;
+    for (int i = 0; i < expected.feeds.size(); i++) {
+      expectedFeedFlow += expected.feeds.get(i).getFlowRate("kg/hr");
+      actualFeedFlow += actual.feeds.get(i).getFlowRate("kg/hr");
+    }
+    for (int i = 0; i < expected.products.size(); i++) {
+      StreamInterface expectedProduct = expected.products.get(i).getOutletStream();
+      StreamInterface actualProduct = actual.products.get(i).getOutletStream();
+      expectedProductFlow += expectedProduct.getFlowRate("kg/hr");
+      actualProductFlow += actualProduct.getFlowRate("kg/hr");
+      assertEquals(expectedProduct.getTemperature("K"), actualProduct.getTemperature("K"), 1.0e-10);
+      assertEquals(expectedProduct.getPressure("bara"), actualProduct.getPressure("bara"), 1.0e-10);
+      assertEquals(expectedProduct.getFluid().getEnthalpy(), actualProduct.getFluid().getEnthalpy(), 1.0e-7);
+      assertEquals(expectedProduct.getThermoSystem().getNumberOfPhases(),
+          actualProduct.getThermoSystem().getNumberOfPhases());
+      assertArrayEquals(expectedProduct.getThermoSystem().getMolarComposition(),
+          actualProduct.getThermoSystem().getMolarComposition(), 1.0e-12);
+    }
+    assertEquals(expectedFeedFlow, actualFeedFlow, 1.0e-8);
+    assertEquals(expectedProductFlow, actualProductFlow, 1.0e-8);
+    assertEquals(expectedFeedFlow, expectedProductFlow, 1.0e-6);
+    assertEquals(actualFeedFlow, actualProductFlow, 1.0e-6);
+  }
+
+  private static void verifyExecutionParity(boolean cpa) throws Exception {
+    Fixture levelParallel = createFixture(cpa);
+    Fixture dataflow = createFixture(cpa);
+
+    levelParallel.process.runParallel(new UUID(1L, 1L));
+    dataflow.process.runOptimized(new UUID(1L, 1L));
+    compare(levelParallel, dataflow);
+    assertTrue(dataflow.process.getExecutionStrategyExplanation().contains("dataflow"));
+
+    levelParallel.feeds.get(0).setFlowRate(12500.0, "kg/hr");
+    dataflow.feeds.get(0).setFlowRate(12500.0, "kg/hr");
+    levelParallel.feeds.get(1).setTemperature(296.15, "K");
+    dataflow.feeds.get(1).setTemperature(296.15, "K");
+    levelParallel.process.runParallel(new UUID(2L, 2L));
+    dataflow.process.runOptimized(new UUID(2L, 2L));
+    compare(levelParallel, dataflow);
+
+    levelParallel.process.runParallel(new UUID(3L, 3L));
+    dataflow.process.runOptimized(new UUID(3L, 3L));
+    compare(levelParallel, dataflow);
+  }
+
+  @Test
+  void wideMultiInputProcessUsesDataflow() {
+    RecordingProcessSystem process = new RecordingProcessSystem();
+    Fixture fixture = createFixture(false);
+    for (neqsim.process.equipment.ProcessEquipmentInterface unit : fixture.process.getUnitOperations()) {
+      process.add(unit);
+    }
+
+    process.runOptimized(new UUID(4L, 4L));
+
+    assertEquals(0, process.parallelRuns);
+    assertEquals(1, process.dataflowRuns);
+  }
+
+  @Test
+  void srkDataflowMatchesLevelParallelAcrossNearbyAndRepeatedRuns() throws Exception {
+    verifyExecutionParity(false);
+  }
+
+  @Test
+  void cpaDataflowMatchesLevelParallelAcrossNearbyAndRepeatedRuns() throws Exception {
+    verifyExecutionParity(true);
+  }
+
+  @Test
+  void independentWideMixerProcessesRemainThreadSafe() throws Exception {
+    Fixture reference = createFixture(false);
+    reference.process.runOptimized(new UUID(5L, 5L));
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      List<Future<Fixture>> futures = new ArrayList<>();
+      for (int scenario = 0; scenario < 4; scenario++) {
+        final int scenarioIndex = scenario;
+        futures.add(executor.submit(() -> {
+          Fixture fixture = createFixture(false);
+          fixture.process.runOptimized(new UUID(6L, scenarioIndex + 1L));
+          return fixture;
+        }));
+      }
+      for (Future<Fixture> future : futures) {
+        compare(reference, future.get());
+      }
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Roadmap: #2939

Wide feed-forward `ProcessSystem` graphs already use dependency-aware dataflow execution, but `runOptimized()` unconditionally forces every graph containing multi-input equipment onto level-parallel execution. The cached dataflow plan already models every direct predecessor and reuses the same shared-input groups as `runParallel()`, so the guard creates unnecessary global level barriers for mixers, manifolds, and heat exchangers.

This change:

- applies the existing eight-unit/useful-width dataflow threshold to all feed-forward graphs, including multi-input equipment;
- keeps adjuster, recycle, small-graph, and narrow-graph behavior unchanged;
- makes `getExecutionStrategyExplanation()` report the concrete strategy selected;
- adds SRK/CPA, nearby-state, repeated-run, mass/enthalpy/phase/composition, and concurrent-instance regressions;
- adds a reproducible standalone benchmark harness for automatic, level-parallel, and dataflow execution;
- corrects the affected ProcessSystem execution documentation.

No public API, serialized field, numerical tolerance, thermodynamic model, convergence algorithm, or unit-operation implementation changes.

## Measured bottleneck

Exact base: [`564a1d2cf92729d422471b99fa59328382e0cea2`](https://github.com/equinor/neqsim/commit/564a1d2cf92729d422471b99fa59328382e0cea2)

Environment: OpenJDK 17.0.19, Linux x86_64, G1, `-Xms768m -Xmx768m -XX:ActiveProcessorCount=2`. Each comparison alternated fresh JVMs. Workloads contain four independent rich-gas trains with alternating nearby feed rates. Every train has two feeds, a Mixer, thermal stages, a valve, and a separator.

| Workload | Runs | Current automatic median | Candidate automatic median | Gain | Paired wins |
|---|---:|---:|---:|---:|---:|
| Balanced SRK, 44 units | 40 warmup + 160 measured, 5 pairs | 19.706 ms/run | 12.671 ms/run | **35.7%** | 5/5 |
| Imbalanced SRK, 40 units | 40 warmup + 160 measured, 5 pairs | 14.317 ms/run | 13.175 ms/run | **8.0%** | 4/5 |
| Imbalanced SRK-CPA, 40 units | 10 warmup + 20 measured, 3 pairs | 457.550 ms/run | 297.263 ms/run | **35.0%** | 3/3 |

The exact checksum was unchanged in every fork:

- SRK balanced: `11689198.838691873000`
- SRK imbalanced: `11688866.591375664000`
- SRK-CPA imbalanced: `1461093.440937069000`
- all runs reported `solved=true`.

A preceding unmodified-master screen comparing current automatic dispatch with direct `runDataflow()` isolated the same selection bottleneck: 25.0% faster on imbalanced SRK (7/7) and 36.3% faster on imbalanced CPA (5/5), with exact checksums.

`ThreadMXBean` allocation numbers are intentionally not presented as whole-process allocation results because work moves between the caller and worker threads; elapsed time is the acceptance metric.

## Scientific and compatibility validation

`ProcessSystemMultiInputDataflowTest` compares current level-parallel execution with automatic dataflow execution for both SRK and SRK-CPA across:

- cold execution;
- nearby feed-flow and feed-temperature changes;
- repeated unchanged execution;
- feed/product mass closure;
- outlet flow, temperature, pressure, enthalpy, phase count, and molar composition;
- four independent processes executed concurrently.

The selection regression also proves a wide multi-input graph dispatches to dataflow. Existing dataflow-threshold, execution-preparation, and parallel-clone regressions are included in the focused suite.

The change is deterministic at the observable process boundary, remains instance-local/thread-safe, does not alter phase behavior or convergence logic, and adds no serialized state.

## Validation

**READY TO MERGE** at exact head `ea42f43575319ee5a92505ea0a5bd1799a891b9d`.

Current exact head: `ea42f43575319ee5a92505ea0a5bd1799a891b9d`.

The branch was updated without force-push using a normal two-parent merge of the previously validated feature head `4a27eafe0b3b271fc4c43a4c83e09876ba671bdc` and current `master` `4a8eb2ae725acd6727098e62b07abaadb74ddeeb`. GitHub reports the branch conflict-free, 7 commits ahead and 0 behind `master`; the final comparison still contains exactly the five intended ProcessSystem implementation, benchmark, regression, and documentation paths.

All applicable GitHub Actions workflows on the exact head passed: Run build, test and javadoc (Java 8/21 on Ubuntu and Windows, four Java 21 slow-test shards, Javadoc, and agent-skill cross-reference validation), Pre-commit checks, Spotless format patch, Documentation search coverage, PaperLab Replication Gate, and CodeQL Security Analysis.

Final exact-head audit: GitHub reports the branch mergeable and 0 commits behind current `master`; the final diff contains exactly the five intended ProcessSystem implementation, benchmark, regression, and documentation paths; and there are no human or Copilot reviews or unresolved inline threads. This readiness classification does not mark the draft ready for review and does not merge it.

Prior feature-head evidence at `4a27eafe0b3b271fc4c43a4c83e09876ba671bdc`:

- Run build, test and javadoc passed the Java 8/21 Ubuntu/Windows matrix, all four Java 21 slow-test shards, Javadoc, and agent-skill cross-reference validation;
- Pre-commit checks, Spotless format patch, PaperLab Replication Gate, and CodeQL Security Analysis passed;
- the changed ProcessSystem documentation contracts passed; the former repository-wide 3.17.0/3.18.0 mismatch is repaired by current `master`;
- local Java 8 source compilation passed and the focused JUnit suite passed 14/14 tests;
- no human or Copilot review, unresolved inline thread, or conversation blocker was present.

The connector-first scratch environment did not contain the full repository formatter/documentation scripts, pre-commit executable, or a full Maven checkout. Those local commands are not claimed as passes. The PR remains draft.

## Documentation impact

Documentation impact: **updated**. The default/optimized execution behavior is user-visible. `graph_simulation.md` and `process_system.md` now describe the actual adjuster/recycle/feed-forward dispatch order, `runDataflow()`, the threshold, and multi-input predecessor/shared-stream safety.

## Limitations and stop boundary

This PR changes only automatic strategy selection for feed-forward `ProcessSystem` graphs. It does not modify TPflash, physical-property kernels, column solvers, dynamics, two-fluid flow, recycles, or production optimization. It deliberately retains the existing threshold and cached plan rather than introducing a new planner or public tuning API.
