### PR TITLE
[AI-Assisted] docs(wiki): repair onboarding and release links

### DIFF
--- a/docs/test_landing_page_documentation.py
+++ b/docs/test_landing_page_documentation.py
@@ -8,6 +8,8 @@ DOCS_DIR = Path(__file__).resolve().parent
 LANDING_PAGE = DOCS_DIR / "index.md"
 PACKAGE_INDEX = DOCS_DIR / "README.md"
 WIKI_INDEX = DOCS_DIR / "wiki" / "index.md"
+FAQ = DOCS_DIR / "wiki" / "faq.md"
+GITHUB_GUIDE = DOCS_DIR / "wiki" / "Getting-started-with-NeqSim-and-Github.md"
 POM = DOCS_DIR.parent / "pom.xml"
 
 
@@ -59,6 +61,8 @@ class LandingPageDocumentationContractTest(unittest.TestCase):
             LANDING_PAGE: LANDING_PAGE.read_text(encoding="utf-8"),
             PACKAGE_INDEX: PACKAGE_INDEX.read_text(encoding="utf-8"),
             WIKI_INDEX: WIKI_INDEX.read_text(encoding="utf-8"),
+            FAQ: FAQ.read_text(encoding="utf-8"),
+            GITHUB_GUIDE: GITHUB_GUIDE.read_text(encoding="utf-8"),
         }
 
     def test_front_matter_title_structure_and_fences(self):
@@ -94,32 +98,41 @@ class LandingPageDocumentationContractTest(unittest.TestCase):
                         )
 
     def test_wiki_uses_current_release_and_api_destinations(self):
-        wiki = self.documents[WIKI_INDEX]
         current_version = re.search(
             r"<revision>([^<]+)</revision>",
             POM.read_text(encoding="utf-8"),
         )
         self.assertIsNotNone(current_version)
+        version = current_version.group(1)
+
+        for source_path in (WIKI_INDEX, FAQ, GITHUB_GUIDE):
+            content = self.documents[source_path]
+            with self.subTest(source=source_path.name):
+                self.assertIn(f"<version>{version}</version>", content)
+                self.assertIn(
+                    "https://github.com/equinor/neqsim/releases",
+                    content,
+                )
+                self.assertNotIn("equinor/neqsimsource", content)
+                self.assertNotIn("htmlpreview.github.io", content)
+                self.assertNotIn("equinor/neqsimhome/blob", content)
+
         self.assertIn(
-            f"<version>{current_version.group(1)}</version>",
-            wiki,
+            f"com.equinor.neqsim:neqsim:{version}",
+            self.documents[FAQ],
         )
-        self.assertIn(
-            "https://github.com/equinor/neqsim/releases",
-            wiki,
-        )
-        self.assertIn(
-            "https://equinor.github.io/neqsim/javadoc/index.html",
-            wiki,
-        )
-        self.assertNotIn("equinor/neqsimsource", wiki)
-        self.assertNotIn("htmlpreview.github.io", wiki)
-        self.assertNotIn("equinor/neqsimhome/blob", wiki)
+        for source_path in (WIKI_INDEX, FAQ, GITHUB_GUIDE):
+            self.assertIn(
+                "https://equinor.github.io/neqsim/javadoc/index.html",
+                self.documents[source_path],
+            )
 
     def test_shared_java_example_is_complete_and_repository_safe(self):
         landing_example = extract_fence(self.documents[LANDING_PAGE], "java")
         package_example = extract_fence(self.documents[PACKAGE_INDEX], "java")
+        wiki_example = extract_fence(self.documents[WIKI_INDEX], "java")
         self.assertEqual(landing_example, package_example)
+        self.assertEqual(landing_example, wiki_example)
         self.assertIn("public final class NeqSimQuickStart", landing_example)
         self.assertIn("public static void main(String[] args)", landing_example)
         self.assertIn("LogManager.getLogger", landing_example)

--- a/docs/wiki/Getting-started-with-NeqSim-and-Github.md
+++ b/docs/wiki/Getting-started-with-NeqSim-and-Github.md
@@ -20,7 +20,7 @@ Add the current project version to a Maven build:
 
 Use [Maven Central](https://central.sonatype.com/artifact/com.equinor.neqsim/neqsim) to inspect
 published versions and [GitHub Releases](https://github.com/equinor/neqsim/releases) for release
-notes and downloadable assets. Do not use the retired `equinor/neqsimsource` repository.
+notes and downloadable assets. Older predecessor repositories are not authoritative.
 
 ## Build the current source
 

--- a/docs/wiki/Getting-started-with-NeqSim-and-Github.md
+++ b/docs/wiki/Getting-started-with-NeqSim-and-Github.md
@@ -1,159 +1,72 @@
 ---
-title: "Getting started with NeqSim and Github"
-description: "The NeqSim library as a jar files can be downloaded from the [NeqSim release pages](https://github.com/equinor/neqsimsource/releases). A shaded library is distributed including all dependent libraries..."
+title: "Getting started with NeqSim and GitHub"
+description: "Install NeqSim from Maven Central or build the current source, then navigate to the maintained Java, thermodynamics, process, pipeline, PVT, and engineering documentation."
 ---
 
-# Getting started with NeqSim and Github
+Use the published Maven artifact for applications. Clone the repository when you want to run the
+complete tests, change NeqSim, or contribute documentation and code.
 
-The NeqSim library as a jar files can be downloaded from the [NeqSim release pages](https://github.com/equinor/neqsimsource/releases). A shaded library is distributed including all dependent libraries used by NeqSim. Use of NeqSim in a Java program is done by adding NeqSim.jar to the classpath.
+## Install the released library
 
-Building NeqSim from source is done by cloning the project to a local directory on the developer computer. Building the code is done using JDK8+. NeqSim uses a number of libraries (jar files) for various calculations. These libraries must be available as part of the compilation process. The required libraries are listed in the [pom.xml](https://github.com/equinor/neqsimsource/blob/master/pom.xml) file. NeqSim can be built using the Maven build system ([https://maven.apache.org/](https://maven.apache.org/)). All NeqSim build dependencies are given in the pom.xml file.
+Add the current project version to a Maven build:
 
-An interactive demonstration of how to get started as a NeqSim developer is presented in this [NeqSim Colab demo](https://colab.research.google.com/drive/1JiszeCxfpcJZT2vejVWuNWGmd9SJdNC7).
+```xml
+<dependency>
+  <groupId>com.equinor.neqsim</groupId>
+  <artifactId>neqsim</artifactId>
+  <version>3.18.0</version>
+</dependency>
+```
 
-Also see [NeqSim JavaDoc](https://htmlpreview.github.io/?https://github.com/equinor/neqsimhome/blob/master/javadoc/site/apidocs/index.html).
+Use [Maven Central](https://central.sonatype.com/artifact/com.equinor.neqsim/neqsim) to inspect
+published versions and [GitHub Releases](https://github.com/equinor/neqsim/releases) for release
+notes and downloadable assets. Do not use the retired `equinor/neqsimsource` repository.
 
-And also see the [Java tests](https://github.com/equinor/neqsim/tree/master/src/test/java/neqsim) where a lot of the functionality is demonstrated.
+## Build the current source
 
----
+A Maven wrapper is included, so a separate Maven installation is not required:
 
-## 📚 NeqSim Java Documentation - Table of Contents
+```bash
+git clone https://github.com/equinor/neqsim.git
+cd neqsim
+./mvnw install
+```
 
-Navigate through the documentation organized from introductory concepts to advanced topics.
+On Windows, run `mvnw.cmd install`. NeqSim source remains compatible with Java 8; the continuous
+integration matrix also exercises newer supported JDKs. See the
+[developer setup guide](../development/DEVELOPER_SETUP.md) for platform-specific prerequisites,
+formatting, tests, and troubleshooting.
 
----
+## Choose a starting point
 
-### 🚀 Part I: Getting Started (Beginner)
+| Goal | Maintained documentation |
+| --- | --- |
+| Understand the documentation structure | [Documentation landing page](../index.md) |
+| Run a first Java calculation | [Java getting-started guide](../java-getting-started.md) |
+| Browse the package-level map | [Package documentation](../README.md) |
+| Find a specific topic | [Reference manual index](../REFERENCE_MANUAL_INDEX.md) |
+| Follow the wiki learning path | [Wiki getting-started guide](getting_started.md) |
+| Review common questions | [Frequently asked questions](faq.md) |
+| Explore worked examples | [Usage examples](usage_examples.md) |
 
-| # | Topic | Description |
-|---|-------|-------------|
-| 1 | [Getting started with NeqSim and GitHub](https://github.com/equinor/neqsimsource/wiki/Getting-started-with-NeqSim-and-Github) | Installation and quick start |
-| 2 | [Getting started as a NeqSim developer](https://github.com/equinor/neqsim/wiki/Getting-started-as-a-NeqSim-developer) | Development environment setup |
-| 3 | [The NeqSim parameter database](https://github.com/equinor/neqsimsource/wiki/The-NeqSim-parameter-database) | Component database and parameters |
+## Engineering topic map
 
----
+| Topic | Guide |
+| --- | --- |
+| Thermodynamic models and flashes | [Thermodynamics guide](thermodynamics_guide.md) |
+| Process flowsheets and equipment | [Process simulation guide](process_simulation.md) |
+| Pipelines and multiphase flow | [Pipeline documentation index](pipeline_index.md) |
+| PVT experiments and workflows | [PVT simulation workflows](pvt_simulation_workflows.md) |
+| Design cases and deliverables | [Engineering documentation](../engineering/index.md) |
 
-### 🧪 Part II: Fundamentals - Fluids & Thermodynamics (Beginner-Intermediate)
+## Authoritative project resources
 
-| # | Topic | Description |
-|---|-------|-------------|
-| 4 | [Example of setting up a fluid and running simple flash calculations](https://github.com/equinor/neqsimsource/wiki/Example-of-setting-up-a-fluid-and-running-simple-flash-calculations) | Basic fluid creation and flash |
-| 5 | [Select thermodynamic model and mixing rule](https://github.com/equinor/neqsim/wiki/Create-a-fluid-and-select-Equation-of-State-and-Mixing-Rule) | EOS selection and configuration |
-| 6 | [Flash calculations and phase envelope calculations using NeqSim](https://github.com/equinor/neqsimsource/wiki/Flash-calculations-and-phase-envelope-calculations-using-NeqSim) | Phase equilibria calculations |
-| 7 | [Calculation of thermodynamic and physical properties using NeqSim](https://github.com/equinor/neqsimsource/wiki/Calculation-of-thermodynamic-and-physical-properties-using-NeqSim) | Property calculation methods |
+- [Source repository](https://github.com/equinor/neqsim)
+- [JavaDoc API](https://equinor.github.io/neqsim/javadoc/index.html)
+- [GitHub Releases](https://github.com/equinor/neqsim/releases)
+- [Java regression examples](https://github.com/equinor/neqsim/tree/master/src/test/java/neqsim)
+- [Questions and discussions](https://github.com/equinor/neqsim/discussions)
+- [Bug reports and feature requests](https://github.com/equinor/neqsim/issues)
 
----
-
-### 🛢️ Part III: Fluid Characterization (Intermediate)
-
-| # | Topic | Description |
-|---|-------|-------------|
-| 8 | [Oil Characterization in NeqSim](https://github.com/equinor/neqsimsource/wiki/Oil-Characterization-in-NeqSim) | Crude oil and condensate characterization |
-| 9 | [Aqueous fluids and NeqSim](https://github.com/equinor/neqsimsource/wiki/Aqueous-fluids-and-NeqSim) | Water and brine systems |
-| 10 | [Electrolytes and NeqSim](https://github.com/equinor/neqsimsource/wiki/Electrolytes-and-NeqSim) | Electrolyte thermodynamics |
-
----
-
-### ⚙️ Part IV: Process Simulation (Intermediate)
-
-| # | Topic | Description |
-|---|-------|-------------|
-| 11 | [Process Calculations in NeqSim](https://github.com/equinor/neqsimsource/wiki/Process-Calculations-in-NeqSim) | Process simulation fundamentals |
-
-#### Equipment-Specific Guides
-
-| Topic | Description |
-|-------|-------------|
-| [Compressor calculations](https://github.com/equinor/neqsimsource/wiki/Compressor-Calc) | Compressor modeling |
-| [Compressor curves](https://github.com/equinor/neqsim/wiki/Compressor-curves) | Performance curves and maps |
-
----
-
-### 🔧 Part V: Extending NeqSim (Advanced)
-
-| # | Topic | Description |
-|---|-------|-------------|
-| 12 | [Adding a thermodynamic model in NeqSim](https://github.com/equinor/neqsimsource/wiki/Adding-a-thermodynamic-model-in-NeqSim) | Implement custom EOS models |
-| 13 | [Adding a viscosity model in NeqSim](https://github.com/equinor/neqsimsource/wiki/Adding-a-viscosity-model-in-NeqSim) | Implement custom viscosity correlations |
-| 14 | [Adding an unit operation in NeqSim](https://github.com/equinor/neqsimsource/wiki/Adding-an-unit-operation-in-NeqSim) | Create custom process equipment |
-
----
-
-### 🖥️ Part VI: Integration & Deployment (Advanced)
-
-| # | Topic | Description |
-|---|-------|-------------|
-| 15 | [How to make a NeqSim API](https://github.com/equinor/neqsim/wiki/How-to-make-a-NeqSim-API) | Building REST APIs with NeqSim |
-| 16 | [Create native image using GraalVM](https://github.com/equinor/neqsim/wiki/Create-native-image-using-GraalVM) | Native compilation for performance |
-
----
-
-### 📈 Part VII: Performance & Debugging (Advanced)
-
-| # | Topic | Description |
-|---|-------|-------------|
-| 17 | [Profiling calculations](https://github.com/equinor/neqsim/wiki/Profiling) | Performance analysis and optimization |
-| 18 | [Dynamic process simulations](https://github.com/equinor/neqsim/wiki/Dynamic-process-simulation) | Transient and dynamic modeling |
-
----
-
-## 📖 Additional Documentation Resources
-
-### In-Repository Documentation (docs/ folder)
-
-The repository contains extensive documentation organized by module:
-
-#### Core Modules
-- [Modules Overview](https://github.com/equinor/neqsim/blob/master/docs/modules) - Architecture and module structure
-- [Reference Manual Index](https://github.com/equinor/neqsim/blob/master/docs/REFERENCE_MANUAL_INDEX) - Complete documentation index
-
-#### Thermodynamics
-- [Thermodynamics Guide](https://github.com/equinor/neqsim/blob/master/docs/wiki/thermodynamics_guide) - Comprehensive thermodynamics overview
-- [Flash Equations and Tests](https://github.com/equinor/neqsim/blob/master/docs/wiki/flash_equations_and_tests) - Flash calculation methods
-- [Viscosity Models](https://github.com/equinor/neqsim/blob/master/docs/wiki/viscosity_models) - Viscosity calculation models
-- [Steam Tables IF97](https://github.com/equinor/neqsim/blob/master/docs/wiki/steam_tables_if97) - Steam table implementation
-
-#### Process Simulation
-- [Process Simulation Guide](https://github.com/equinor/neqsim/blob/master/docs/wiki/process_simulation) - Process modeling patterns
-- [Advanced Process Simulation](https://github.com/equinor/neqsim/blob/master/docs/wiki/advanced_process_simulation) - Advanced techniques
-- [Distillation Column](https://github.com/equinor/neqsim/blob/master/docs/wiki/distillation_column) - Column modeling
-- [Pump Usage Guide](https://github.com/equinor/neqsim/blob/master/docs/wiki/pump_usage_guide) - Pump calculations
-
-#### Pipeline & Multiphase Flow
-- [Pipeline Index](https://github.com/equinor/neqsim/blob/master/docs/wiki/pipeline_index) - Pipeline documentation hub
-- [Two-Fluid Model](https://github.com/equinor/neqsim/blob/master/docs/wiki/two_fluid_model) - Two-phase flow
-- [Beggs and Brill Correlation](https://github.com/equinor/neqsim/blob/master/docs/wiki/beggs_and_brill_correlation) - Pressure drop
-- [Pipeline Heat Transfer](https://github.com/equinor/neqsim/blob/master/docs/wiki/pipeline_heat_transfer) - Thermal modeling
-
-#### Safety & Dynamics
-- [PSV Dynamic Sizing](https://github.com/equinor/neqsim/blob/master/docs/wiki/psv_dynamic_sizing_example) - Relief valve sizing
-- [Process Transient Simulation Guide](https://github.com/equinor/neqsim/blob/master/docs/wiki/process_transient_simulation_guide) - Dynamic simulation
-- [ESD Fire Alarm System](https://github.com/equinor/neqsim/blob/master/docs/wiki/esd_fire_alarm_system) - Safety systems
-
-#### PVT & Characterization
-- [PVT Simulation Workflows](https://github.com/equinor/neqsim/blob/master/docs/wiki/pvt_simulation_workflows) - PVT studies
-- [Fluid Characterization](https://github.com/equinor/neqsim/blob/master/docs/wiki/fluid_characterization) - Fluid setup
-- [Black Oil Flash Playbook](https://github.com/equinor/neqsim/blob/master/docs/wiki/black_oil_flash_playbook) - Black oil models
-
-#### Integration
-- [AI Platform Integration](https://github.com/equinor/neqsim/blob/master/docs/integration/ai_platform_integration) - AI/ML integration
-- [MPC Integration](https://github.com/equinor/neqsim/blob/master/docs/integration/mpc_integration) - Model predictive control
-- [Real-Time Integration Guide](https://github.com/equinor/neqsim/blob/master/docs/integration/REAL_TIME_INTEGRATION_GUIDE) - Real-time systems
-
-#### Development
-- [Developer Setup](https://github.com/equinor/neqsim/blob/master/docs/development/DEVELOPER_SETUP) - Environment setup
-- [Test Overview](https://github.com/equinor/neqsim/blob/master/docs/wiki/test-overview) - Testing guidelines
-- [Usage Examples](https://github.com/equinor/neqsim/blob/master/docs/wiki/usage_examples) - Code examples
-
----
-
-## 🔗 Quick Links
-
-| Resource | Link |
-|----------|------|
-| **Source Code** | [github.com/equinor/neqsim](https://github.com/equinor/neqsim) |
-| **JavaDoc** | [NeqSim JavaDoc](https://htmlpreview.github.io/?https://github.com/equinor/neqsimhome/blob/master/javadoc/site/apidocs/index.html) |
-| **Java Tests** | [Test Examples](https://github.com/equinor/neqsim/tree/master/src/test/java/neqsim) |
-| **Colab Demo** | [Interactive Tutorial](https://colab.research.google.com/drive/1JiszeCxfpcJZT2vejVWuNWGmd9SJdNC7) |
-| **Releases** | [Download JAR](https://github.com/equinor/neqsimsource/releases) |
-| **Discussions** | [GitHub Discussions](https://github.com/equinor/neqsim/discussions) |
+Repository Java tests are valuable usage evidence, but user-facing examples should also be checked
+against the current public API and executed before publication.

--- a/docs/wiki/faq.md
+++ b/docs/wiki/faq.md
@@ -1,9 +1,8 @@
 ---
 title: "Frequently Asked Questions (FAQ)"
-description: "NeqSim (Non-Equilibrium Simulator) is a Java library for thermodynamic calculations and process simulation, specializing in oil and gas applications. It provides:"
+description: "Answers to common NeqSim installation, thermodynamics, process-simulation, physical-property, troubleshooting, and contribution questions."
 ---
 
-# Frequently Asked Questions (FAQ)
 
 ## Table of Contents
 - [General](#general)
@@ -22,14 +21,14 @@ description: "NeqSim (Non-Equilibrium Simulator) is a Java library for thermodyn
 
 NeqSim (Non-Equilibrium Simulator) is a Java library for thermodynamic calculations and process simulation, specializing in oil and gas applications. It provides:
 - Rigorous equations of state (SRK, PR, CPA, GERG-2008)
-- 50+ unit operations for process modeling
+- Process-equipment models for separation, compression, heat transfer, flow control, and pipelines
 - Physical property calculations (viscosity, density, thermal conductivity)
 - Pipeline and multiphase flow simulation
 - Dynamic simulation capabilities
 
 ### Where can I find the API documentation?
 
-The full JavaDoc is available at <https://htmlpreview.github.io/?https://github.com/equinor/neqsimhome/blob/master/javadoc/site/apidocs/index.html>.
+The full JavaDoc is available at <https://equinor.github.io/neqsim/javadoc/index.html>.
 
 ### Is NeqSim open source?
 
@@ -54,17 +53,17 @@ NeqSim requires Java 8 or higher. Java 11+ is recommended for best performance.
 <dependency>
     <groupId>com.equinor.neqsim</groupId>
     <artifactId>neqsim</artifactId>
-    <version>3.0.0</version>
+    <version>3.18.0</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation 'com.equinor.neqsim:neqsim:3.0.0'
+implementation 'com.equinor.neqsim:neqsim:3.18.0'
 ```
 
 **Direct Download:**
-Download the shaded JAR from [GitHub releases](https://github.com/equinor/neqsimsource/releases).
+Download the shaded JAR from [GitHub releases](https://github.com/equinor/neqsim/releases).
 
 ### How do I build NeqSim from source?
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -14,7 +14,7 @@ Welcome to the NeqSim documentation. This comprehensive wiki provides guides, tu
 
 - **Phase behavior** using rigorous equations of state (SRK, PR, CPA, GERG-2008)
 - **Physical properties** (viscosity, density, thermal conductivity, interfacial tension)
-- **Process equipment** (50+ unit operations including separators, compressors, heat exchangers)
+- **Process equipment** (separators, compressors, heat exchangers, columns, and other unit operations)
 - **Pipeline flow** (two-phase, multiphase, transient simulation)
 - **Flow assurance** (hydrates, wax, asphaltene, scaling)
 
@@ -25,23 +25,34 @@ Development was initiated at the [Norwegian University of Science and Technology
 ## Quick Start
 
 ```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
-// Create a fluid
-SystemSrkEos fluid = new SystemSrkEos(298.15, 10.0);  // T(K), P(bara)
-fluid.addComponent("methane", 0.9);
-fluid.addComponent("ethane", 0.07);
-fluid.addComponent("propane", 0.03);
-fluid.setMixingRule("classic");
+public final class NeqSimQuickStart {
+  private static final Logger logger = LogManager.getLogger(NeqSimQuickStart.class);
 
-// Run flash calculation
-ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-ops.TPflash();
+  private NeqSimQuickStart() {}
 
-// Get results
-System.out.println("Z-factor: " + fluid.getZ());
-System.out.println("Density: " + fluid.getDensity("kg/m3") + " kg/m3");
+  public static void main(String[] args) {
+    SystemInterface gas = new SystemSrkEos(298.15, 50.0);
+    gas.addComponent("methane", 0.90);
+    gas.addComponent("ethane", 0.05);
+    gas.addComponent("propane", 0.03);
+    gas.addComponent("CO2", 0.02);
+    gas.setMixingRule("classic");
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(gas);
+    operations.TPflash();
+    gas.initProperties();
+
+    logger.info("Density: {} kg/m3", gas.getDensity("kg/m3"));
+    logger.info("Compressibility: {}", gas.getZ());
+  }
+}
 ```
 
 ---
@@ -131,7 +142,7 @@ System.out.println("Density: " + fluid.getDensity("kg/m3") + " kg/m3");
 <dependency>
     <groupId>com.equinor.neqsim</groupId>
     <artifactId>neqsim</artifactId>
-    <version>3.17.0</version>
+    <version>3.18.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Refs #2499

## D070 frozen scope

Base: `master` at `2cec70c733164afaf2dc00ff9132f0cbc2d037ee`
Head: `docs/d070-wiki-onboarding` at `231fbe10005504a40a7a4cb5bab65992e20d5541`

This bounded documentation batch repairs the wiki landing, FAQ, onboarding map, and their focused contract:

- `docs/wiki/index.md`
- `docs/wiki/faq.md`
- `docs/wiki/Getting-started-with-NeqSim-and-Github.md`
- `docs/test_landing_page_documentation.py`

## Confirmed defects repaired

1. Synchronizes wiki Maven coordinates with release `3.18.0`.
2. Replaces FAQ Maven/Gradle `3.0.0` examples with current coordinates.
3. Removes retired `equinor/neqsimsource` destinations and terminology.
4. Replaces obsolete htmlpreview/neqsimhome JavaDoc links with the supported JavaDoc destination.
5. Removes duplicate H1 headings from FAQ/onboarding pages while retaining front-matter titles.
6. Replaces the incomplete `System.out` wiki snippet with the tested canonical complete Java example, including logging, flash, and property initialization.
7. Rebuilds the stale onboarding link catalog as a concise map to current repository documentation.
8. Extends the landing-page contract across these surfaces, current coordinates/destinations, canonical example parity, headings, fences, and internal links.

## Validation

Passed locally:

- `python -m py_compile docs/test_landing_page_documentation.py`
- Four focused contract tests: front matter/title/fences; current wiki release/API destinations; canonical Java example; supported Python gateway — 4/4 passed.
- Stale-pattern scan across the three changed wiki pages: no `neqsimsource`, obsolete JavaDoc hosts, stale `3.17.0`/`3.0.0`, duplicate H1, or `System.out`/`System.err`.
- Secret-pattern, trailing-whitespace, and Python contract line-length scans: clean.
- All 12 internal destinations newly exposed by the rewritten onboarding map were verified from the current GitHub repository.
- Remote compare immediately before publication: 5 commits ahead, 0 behind, exactly the four frozen files.

**VALIDATION CONFIRMED BY GITHUB CI** for exact head `231fbe10005504a40a7a4cb5bab65992e20d5541` on 2026-08-20:

- Run build, test and javadoc — passed ([run 10324](https://github.com/equinor/neqsim/actions/runs/32367912094))
- Spotless format patch — passed ([run 2739](https://github.com/equinor/neqsim/actions/runs/32367912170))
- Pre-commit checks — passed ([run 3186](https://github.com/equinor/neqsim/actions/runs/32367912055))
- Documentation search coverage — passed ([run 1860](https://github.com/equinor/neqsim/actions/runs/32367912162))
- CodeQL Security Analysis — passed ([run 6916](https://github.com/equinor/neqsim/actions/runs/32367912115))

The partial support checkout does not contain the repository's `devtools` scripts and does not have `pre-commit` installed, so these exact local invocations remained unavailable; the corresponding hosted workflows above passed:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- `pre-commit run --all-files --hook-stage pre-commit`
- `pre-commit run --all-files --hook-stage pre-push`

No browser-rendering claim is made beyond the passing hosted documentation/search workflow.

## Scope boundary

No production Java, notebooks, equations, images, DEXPI, pipeline, or Huldra work is included. The broader code-example audit of `docs/wiki/getting_started.md` and `docs/wiki/usage_examples.md` is deliberately left for a separate bounded scan.