### PR TITLE
[AI-Assisted] docs(wiki): curate getting-started examples

### DIFF
--- a/docs/test_landing_page_documentation.py
+++ b/docs/test_landing_page_documentation.py
@@ -10,6 +10,8 @@ PACKAGE_INDEX = DOCS_DIR / "README.md"
 WIKI_INDEX = DOCS_DIR / "wiki" / "index.md"
 FAQ = DOCS_DIR / "wiki" / "faq.md"
 GITHUB_GUIDE = DOCS_DIR / "wiki" / "Getting-started-with-NeqSim-and-Github.md"
+GETTING_STARTED = DOCS_DIR / "wiki" / "getting_started.md"
+USAGE_EXAMPLES = DOCS_DIR / "wiki" / "usage_examples.md"
 POM = DOCS_DIR.parent / "pom.xml"
 
 
@@ -63,6 +65,8 @@ class LandingPageDocumentationContractTest(unittest.TestCase):
             WIKI_INDEX: WIKI_INDEX.read_text(encoding="utf-8"),
             FAQ: FAQ.read_text(encoding="utf-8"),
             GITHUB_GUIDE: GITHUB_GUIDE.read_text(encoding="utf-8"),
+            GETTING_STARTED: GETTING_STARTED.read_text(encoding="utf-8"),
+            USAGE_EXAMPLES: USAGE_EXAMPLES.read_text(encoding="utf-8"),
         }
 
     def test_front_matter_title_structure_and_fences(self):
@@ -105,7 +109,7 @@ class LandingPageDocumentationContractTest(unittest.TestCase):
         self.assertIsNotNone(current_version)
         version = current_version.group(1)
 
-        for source_path in (WIKI_INDEX, FAQ, GITHUB_GUIDE):
+        for source_path in (WIKI_INDEX, FAQ, GITHUB_GUIDE, GETTING_STARTED):
             content = self.documents[source_path]
             with self.subTest(source=source_path.name):
                 self.assertIn(f"<version>{version}</version>", content)
@@ -131,13 +135,43 @@ class LandingPageDocumentationContractTest(unittest.TestCase):
         landing_example = extract_fence(self.documents[LANDING_PAGE], "java")
         package_example = extract_fence(self.documents[PACKAGE_INDEX], "java")
         wiki_example = extract_fence(self.documents[WIKI_INDEX], "java")
+        getting_started_example = extract_fence(
+            self.documents[GETTING_STARTED],
+            "java",
+        )
         self.assertEqual(landing_example, package_example)
         self.assertEqual(landing_example, wiki_example)
+        self.assertEqual(landing_example, getting_started_example)
         self.assertIn("public final class NeqSimQuickStart", landing_example)
         self.assertIn("public static void main(String[] args)", landing_example)
         self.assertIn("LogManager.getLogger", landing_example)
         self.assertNotIn("System.out", landing_example)
         self.assertNotIn("System.err", landing_example)
+
+    def test_wiki_tutorials_are_curated_and_repository_safe(self):
+        for source_path in (GETTING_STARTED, USAGE_EXAMPLES):
+            content = self.documents[source_path]
+            with self.subTest(source=source_path.name):
+                self.assertNotIn("System.out", content)
+                self.assertNotIn("System.err", content)
+                self.assertNotIn("equinor/neqsimsource", content)
+                self.assertNotIn("htmlpreview.github.io", content)
+                self.assertNotIn("50+", content)
+                self.assertNotRegex(content, re.compile(r"\b\d{2}-\d{2}%\b"))
+
+        usage = self.documents[USAGE_EXAMPLES]
+        self.assertNotIn("```java", usage)
+        for destination in (
+            "../cookbook/thermodynamics-recipes.md",
+            "../cookbook/process-recipes.md",
+            "../process/processmodel/process_system.md",
+            "../process/equipment/absorbers.md",
+            "pipeline_index.md",
+            "../examples/index.md",
+            "../troubleshooting/index.md",
+        ):
+            with self.subTest(destination=destination):
+                self.assertIn(f"]({destination})", usage)
 
     def test_python_example_uses_public_gateway(self):
         example = extract_fence(self.documents[LANDING_PAGE], "python")

--- a/docs/wiki/getting_started.md
+++ b/docs/wiki/getting_started.md
@@ -1,50 +1,32 @@
 ---
 title: "Getting Started with NeqSim"
-description: "Use this page as a launchpad into the NeqSim documentation. It mirrors the high-level structure from the Colab introduction notebook and links directly to reference guides and examples."
+description: "Install the current NeqSim release, run the repository-tested Java quick start, and choose a maintained thermodynamics, process, PVT, pipeline, or engineering guide."
 ---
 
-# Getting Started with NeqSim
+Use this page to install NeqSim, run one complete thermodynamic calculation, and choose the
+maintained guide that matches your task. NeqSim uses kelvin for constructor temperatures and bara
+for constructor pressures unless an API explicitly accepts a unit string.
 
-Use this page as a launchpad into the NeqSim documentation. It mirrors the high-level structure from the Colab introduction notebook and links directly to reference guides and examples.
+## Install the released library
 
-## Table of Contents
-- [Quick Start](#quick-start)
-- [Set up NeqSim locally](#set-up-neqsim-locally)
-- [Your First Calculation](#your-first-calculation)
-- [Fundamentals and thermodynamics](#fundamentals-and-thermodynamics)
-- [Fluid characterization and PVT workflows](#fluid-characterization-and-pvt-workflows)
-- [Process simulation](#process-simulation)
-- [Pipeline and multiphase flow](#pipeline-and-multiphase-flow)
-- [Dynamic behavior and process safety](#dynamic-behavior-and-process-safety)
-- [Unit operations and equipment models](#unit-operations-and-equipment-models)
-- [Integration, control, and automation](#integration-control-and-automation)
-- [Examples and tutorials](#examples-and-tutorials)
-
----
-
-## Quick Start
-
-### Using Maven (Recommended)
-
-Add NeqSim as a dependency in your `pom.xml`:
+Add the current release to a Maven project:
 
 ```xml
 <dependency>
-    <groupId>com.equinor.neqsim</groupId>
-    <artifactId>neqsim</artifactId>
-    <version>3.0.0</version>
+  <groupId>com.equinor.neqsim</groupId>
+  <artifactId>neqsim</artifactId>
+  <version>3.18.0</version>
 </dependency>
 ```
 
-### Direct JAR Download
+Use [Maven Central](https://central.sonatype.com/artifact/com.equinor.neqsim/neqsim) to inspect
+published artifacts and [GitHub Releases](https://github.com/equinor/neqsim/releases) for release
+notes and downloadable assets. Application builds should pin a released version rather than track
+the changing `master` branch.
 
-Download the shaded JAR from the [releases page](https://github.com/equinor/neqsimsource/releases) and add to your classpath.
+## Build the current source
 
----
-
-## Set up NeqSim locally
-
-Clone the repository and build with the Maven wrapper:
+Clone the repository when contributing to NeqSim or validating changes against current source:
 
 ```bash
 git clone https://github.com/equinor/neqsim.git
@@ -52,307 +34,86 @@ cd neqsim
 ./mvnw install
 ```
 
-On Windows:
-```cmd
-mvnw.cmd install
-```
+On Windows, run `mvnw.cmd install`. The Maven wrapper supplies the repository's Maven version.
+NeqSim source remains Java 8 compatible; continuous integration also tests newer supported JDKs.
+See the [developer setup guide](../development/DEVELOPER_SETUP.md) for prerequisites, formatting,
+tests, and platform-specific troubleshooting.
 
-The command downloads dependencies, compiles the project, and runs the test suite. For environment notes and troubleshooting tips, see the [README](../../) and [developer setup guide](../development/DEVELOPER_SETUP).
+## Run the canonical Java quick start
 
-### Requirements
-- Java 8 or higher (Java 11+ recommended)
-- Maven 3.6+ (included via wrapper)
-
----
-
-## Your First Calculation
-
-### Simple Flash Calculation
+The following complete program is shared with the documentation landing pages and protected by
+the landing-page regression contract:
 
 ```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
-public class FirstCalculation {
-    public static void main(String[] args) {
-        // 1. Create a natural gas system at 25°C and 50 bar
-        SystemSrkEos gas = new SystemSrkEos(298.15, 50.0);
-        gas.addComponent("methane", 0.90);
-        gas.addComponent("ethane", 0.06);
-        gas.addComponent("propane", 0.03);
-        gas.addComponent("n-butane", 0.01);
-        gas.setMixingRule("classic");
+public final class NeqSimQuickStart {
+  private static final Logger logger = LogManager.getLogger(NeqSimQuickStart.class);
 
-        // 2. Perform flash calculation
-        ThermodynamicOperations ops = new ThermodynamicOperations(gas);
-        ops.TPflash();
+  private NeqSimQuickStart() {}
 
-        // 3. Initialize properties — REQUIRED before reading physical properties.
-        // TPflash only solves phase equilibrium (compositions, phase fractions).
-        // Physical and transport properties (density, viscosity, thermal conductivity)
-        // are NOT calculated automatically by TPflash — this is by design to improve
-        // performance, since many workflows only need equilibrium results.
-        // Call initProperties() to compute both thermodynamic and transport properties.
-        gas.initProperties();
+  public static void main(String[] args) {
+    SystemInterface gas = new SystemSrkEos(298.15, 50.0);
+    gas.addComponent("methane", 0.90);
+    gas.addComponent("ethane", 0.05);
+    gas.addComponent("propane", 0.03);
+    gas.addComponent("CO2", 0.02);
+    gas.setMixingRule("classic");
 
-        // 4. Print results
-        System.out.println("Number of phases: " + gas.getNumberOfPhases());
-        System.out.println("Density: " + gas.getDensity("kg/m3") + " kg/m³");
-        System.out.println("Z-factor: " + gas.getPhase("gas").getZ());
-        System.out.println("Molecular weight: " + gas.getMolarMass() * 1000 + " g/mol");
-    }
+    ThermodynamicOperations operations = new ThermodynamicOperations(gas);
+    operations.TPflash();
+    gas.initProperties();
+
+    logger.info("Density: {} kg/m3", gas.getDensity("kg/m3"));
+    logger.info("Compressibility: {}", gas.getZ());
+  }
 }
 ```
 
-### Simple Process Simulation
+`TPflash()` solves phase equilibrium at the system temperature and pressure. The explicit
+`initProperties()` call prepares physical-property results before the example reads density. The
+example logs values instead of writing directly to standard output, in line with repository rules.
 
-```java
-import neqsim.process.equipment.stream.Stream;
-import neqsim.process.equipment.valve.ThrottlingValve;
-import neqsim.process.equipment.separator.Separator;
-import neqsim.process.processmodel.ProcessSystem;
-import neqsim.thermo.system.SystemSrkEos;
+For compilation and dependency details, continue with the
+[Java getting-started guide](../java-getting-started.md). Python users should start from the
+[Python integration on the documentation landing page](../index.md#python-integration), which uses
+the supported `jneqsim` gateway.
 
-public class FirstProcess {
-    public static void main(String[] args) {
-        // 1. Create fluid
-        SystemSrkEos fluid = new SystemSrkEos(320.0, 100.0);
-        fluid.addComponent("methane", 0.80);
-        fluid.addComponent("ethane", 0.10);
-        fluid.addComponent("propane", 0.05);
-        fluid.addComponent("n-pentane", 0.05);
-        fluid.setMixingRule("classic");
+## Choose a maintained workflow
 
-        // 2. Create stream
-        Stream feed = new Stream("Feed", fluid);
-        feed.setFlowRate(10000.0, "kg/hr");
-        feed.setTemperature(50.0, "C");
-        feed.setPressure(100.0, "bara");
+| Goal | Recommended guide |
+| --- | --- |
+| Create fluids, run flashes, and read properties | [Thermodynamics recipes](../cookbook/thermodynamics-recipes.md) |
+| Understand models and phase-equilibrium methods | [Thermodynamics guide](thermodynamics_guide.md) |
+| Inspect flash equations and validation | [Flash equations and tests](flash_equations_and_tests.md) |
+| Characterize oils and heavy fractions | [Fluid characterization](fluid_characterization.md) |
+| Run laboratory-style PVT studies | [PVT simulation workflows](pvt_simulation_workflows.md) |
+| Build a steady-state process | [Process recipes](../cookbook/process-recipes.md) |
+| Understand process execution and reporting | [ProcessSystem guide](../process/processmodel/process_system.md) |
+| Model absorbers and strippers | [Absorber and stripper guide](../process/equipment/absorbers.md) |
+| Select a pipeline workflow | [Pipeline documentation index](pipeline_index.md) |
+| Build dynamic cases | [Process transient simulation guide](process_transient_simulation_guide.md) |
+| Screen oil-quality methods | [Oil-quality standards](../standards/oil_quality_standards.md) |
+| Find runnable tutorials and notebooks | [Examples index](../examples/index.md) |
+| Diagnose setup or runtime problems | [Troubleshooting guide](../troubleshooting/index.md) |
 
-        // 3. Add equipment
-        ThrottlingValve valve = new ThrottlingValve("Valve", feed);
-        valve.setOutletPressure(20.0, "bara");
+The [curated usage-example catalog](usage_examples.md) groups these guides by engineering task and
+records the validation expectations for complete programs and notebooks.
 
-        Separator separator = new Separator("Separator", valve.getOutletStream());
+## Interpret results responsibly
 
-        // 4. Build and run process
-        ProcessSystem process = new ProcessSystem();
-        process.add(feed);
-        process.add(valve);
-        process.add(separator);
+- Keep temperature, pressure, flow, composition, and property units explicit.
+- Select the thermodynamic model and mixing rule for the fluid and property of interest.
+- Check phase count before requesting a named phase from a result that may be single phase.
+- Initialize the state required by each property API and verify mass or component closure where
+  the workflow changes streams.
+- Treat examples as reproducible screening workflows, not mechanical design, safety approval, or
+  standards certification.
 
-        // Use runOptimized() for best performance (auto-selects strategy)
-        process.runOptimized();
-
-        // 5. Results
-        System.out.println("Gas rate: " + separator.getGasOutStream().getFlowRate("kg/hr") + " kg/hr");
-        System.out.println("Liquid rate: " + separator.getLiquidOutStream().getFlowRate("kg/hr") + " kg/hr");
-    }
-}
-```
-
-### Execution Strategies
-
-NeqSim provides optimized execution strategies for complex process simulations:
-
-| Method | Best For | Speedup |
-|--------|----------|---------|
-| `run()` | Simple processes | baseline |
-| `runOptimized()` | **Recommended** | 28-40% |
-| `runParallel()` | Feed-forward (no recycles) | 40-57% |
-| `runHybrid()` | Complex recycle processes | 38% |
-
-```java
-// Recommended - auto-selects best strategy based on process topology
-process.runOptimized();
-
-// Analyze process structure
-System.out.println(process.getExecutionPartitionInfo());
-```
-
-See [ProcessSystem documentation](../process/processmodel/process_system) for details.
-
----
-
-## Fundamentals and thermodynamics
-
-### Equations of State
-NeqSim supports multiple equations of state for different applications:
-
-| EOS | Class | Best For |
-|-----|-------|----------|
-| SRK | `SystemSrkEos` | General hydrocarbon systems |
-| Peng-Robinson | `SystemPrEos` | Reservoir/liquid density |
-| SRK-CPA | `SystemSrkCPAstatoil` | Water, glycols, alcohols |
-| GERG-2008 | `SystemGERG2008Eos` | Natural gas custody transfer |
-
-### Documentation Links
-- Read the [Thermodynamics Guide](thermodynamics_guide) for an overview of models, correlations, and implementation notes.
-- Explore validated calculations in [Flash equations and tests](flash_equations_and_tests) and the [Thermodynamics of gas processing](process_simulation#thermodynamics).
-- Review property-focused workflows in [Property flash workflows](property_flash_workflows) and viscosity models in [Viscosity models](viscosity_models).
-- See [Steam Tables IF97](steam_tables_if97) for water/steam calculations.
-
----
-
-## Fluid characterization and PVT workflows
-
-### Heavy Fraction Handling
-For oils with C7+ fractions:
-
-```java
-SystemSrkEos oil = new SystemSrkEos(350.0, 100.0);
-oil.addComponent("methane", 10.0);
-oil.addComponent("ethane", 5.0);
-// ... light components ...
-
-// Add TBP fractions
-oil.addTBPfraction("C7", 5.0, 0.092, 730.0);
-oil.addTBPfraction("C8", 4.0, 0.104, 750.0);
-oil.addPlusFraction("C10+", 20.0, 0.200, 820.0);
-
-// Characterize
-oil.getCharacterization().setTBPModel("PedersenSRK");
-oil.getCharacterization().characterisePlusFraction();
-```
-
-### Documentation Links
-- Follow [Fluid Characterization](fluid_characterization) for setting up equations of state and component data.
-- Use the [PVT simulation workflows](pvt_simulation_workflows) and [Black-oil flash playbook](black_oil_flash_playbook) for reservoir-focused setups.
-- See [TBP Fraction Models](tbp_fraction_models) for detailed characterization methods.
-- See [Gas quality standards from tests](gas_quality_standards_from_tests) for handling analytical measurements.
-
----
-
-## Process simulation
-
-### Available Equipment
-NeqSim includes 50+ unit operations:
-
-| Category | Equipment |
-|----------|-----------|
-| **Separation** | Separator, ThreePhaseSeparator, DistillationColumn, MembraneSeparator |
-| **Compression** | Compressor, Pump, Expander, Ejector |
-| **Heat Transfer** | Heater, Cooler, HeatExchanger |
-| **Flow Control** | ThrottlingValve, FlowRateController |
-| **Pipelines** | PipeBeggsAndBrills, AdiabaticPipe, WaterHammerPipe |
-| **Specialty** | Electrolyzer, WindTurbine, SolarPanel, Battery |
-
-### Documentation Links
-- Start with the [Process Simulation Guide](process_simulation) for steady-state modeling patterns.
-- Dive deeper into [Advanced process simulation](advanced_process_simulation) and [Logical unit operations](logical_unit_operations) for custom flowsheets.
-- Consult the [Modules overview](../modules) and [Process calculator](../simulation/process_calculator) when wiring NeqSim into larger systems.
-
----
-
-## Pipeline and multiphase flow
-
-### Pipeline Models
-
-```java
-PipeBeggsAndBrills pipeline = new PipeBeggsAndBrills("Pipeline", inletStream);
-pipeline.setLength(10000.0);           // 10 km
-pipeline.setDiameter(0.2);             // 8 inch
-pipeline.setElevation(50.0);           // 50m elevation gain
-pipeline.setPipeWallRoughness(4.5e-5); // Steel
-pipeline.run();
-```
-
-### Documentation Links
-- See the [Pipeline Index](pipeline_index) for all pipeline documentation
-- [Beggs and Brill Correlation](beggs_and_brill_correlation) for multiphase pressure drop
-- [Pipeline Heat Transfer](pipeline_heat_transfer) for non-adiabatic flow
-- [Multiphase Transient Model](multiphase_transient_model) for dynamic simulation
-- [Water Hammer Implementation](water_hammer_implementation) for fast transients
-
----
-
-## Dynamic behavior and process safety
-
-### Safety Systems
-NeqSim provides comprehensive safety simulation:
-
-```java
-// PSV sizing example
-ValveController psv = new ValveController("PSV-001");
-psv.setMaxPressure(50.0, "bara");
-psv.setReliefPressure(55.0, "bara");
-```
-
-### Documentation Links
-- Study dynamic blowdown and protection behavior in [ESD blowdown systems](../safety/ESD_BLOWDOWN_SYSTEM), [PSV dynamic sizing](psv_dynamic_sizing_example), and [HIPPS implementation](../safety/hipps_implementation).
-- Review layered safety topics in [Integrated safety systems](../safety/INTEGRATED_SAFETY_SYSTEMS), [HIPPS summary](../safety/HIPPS_SUMMARY), and [Layered safety architecture](../safety/layered_safety_architecture).
-- For alarm logic and shutdown sequencing, see [Alarm system guide](../safety/alarm_system_guide), [SIS logic implementation](../safety/sis_logic_implementation), and [Integration safety chain tests](../safety/integration_safety_chain_tests).
-- See [Process Transient Simulation Guide](process_transient_simulation_guide) for dynamic simulations.
-
----
-
-## Unit operations and equipment models
-
-### Equipment Categories
-- **Compressors**: [Compressor calculations](../process/equipment/compressors), performance curves, staging
-- **Pumps**: [Pump usage guide](pump_usage_guide), [Pump theory](pump_theory_and_implementation)
-- **Separation**: [Distillation column](distillation_column), [Membrane separation](membrane_separation)
-- **Heat Exchange**: [Air cooler](air_cooler), [Water cooler](water_cooler), [Steam heater](steam_heater)
-- **Metering**: [Flow meter models](flow_meter_models), [Venturi calculation](venturi_calculation)
-- **Specialty**: [Battery storage](battery_storage), [Solar panel](solar_panel), [Gibbs reactor](gibbs_reactor)
-
-### Documentation Links
-- Browse individual equipment pages such as [Distillation column](distillation_column), [Air cooler](air_cooler), [Water cooler](water_cooler), and [Heat exchanger mechanical design](heat_exchanger_mechanical_design).
-- For specialized models, see [Flow meter models](flow_meter_models), [Battery storage unit](battery_storage), [Solar panel](solar_panel), and [Pump usage guide](pump_usage_guide).
-- Additional unit operations and mechanical details are covered in the [Process logic enhancements](../simulation/ProcessLogicEnhancements) series.
-
----
-
-## Integration, control, and automation
-
-### PID Control Example
-
-```java
-ControllerDeviceBaseClass controller = new ControllerDeviceBaseClass();
-controller.setControllerSetPoint(50.0);
-controller.setControllerParameters(0.5, 100.0, 0.0); // Kp, Ti, Td
-valve.setController(controller);
-```
-
-### Documentation Links
-- Connect NeqSim to control systems using the [Process control framework](process_control) and [Real-time integration guide](../integration/REAL_TIME_INTEGRATION_GUIDE).
-- Learn about runtime flexibility in [Runtime logic flexibility](../simulation/RuntimeLogicFlexibility) and alarm handling in [Alarm triggered logic example](../safety/alarm_triggered_logic_example).
-- For AI/ML integration, see [AI Platform Integration](../integration/ai_platform_integration) and [ML Integration](../integration/ml_integration).
-- For MPC, see [MPC Integration](../integration/mpc_integration) and [Industrial MPC Integration](../integration/neqsim_industrial_mpc_integration).
-- For scripting and hybrid workflows, see [Java simulations from Colab notebooks](java_simulation_from_colab_notebooks) and [Java/Python usage examples](usage_examples).
-
----
-
-## Examples and tutorials
-
-### Jupyter Notebooks
-
-GitHub Pages publishes the rendered tutorial pages, while the source notebooks remain
-available on GitHub and can be opened directly in Google Colab.
-
-- [ESP Pump Tutorial](../examples/ESP_Pump_Tutorial.html)
-  ([Jupyter notebook](https://github.com/equinor/neqsim/blob/master/docs/examples/ESP_Pump_Tutorial.ipynb)
-  | [Open in Colab](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/ESP_Pump_Tutorial.ipynb))
-- [PVT Simulation and Tuning](../examples/PVT_Simulation_and_Tuning.html)
-  ([Jupyter notebook](https://github.com/equinor/neqsim/blob/master/docs/examples/PVT_Simulation_and_Tuning.ipynb)
-  | [Open in Colab](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/PVT_Simulation_and_Tuning.ipynb))
-- [MPC Integration Tutorial](../examples/MPC_Integration_Tutorial.html)
-  ([Jupyter notebook](https://github.com/equinor/neqsim/blob/master/docs/examples/MPC_Integration_Tutorial.ipynb)
-  | [Open in Colab](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/MPC_Integration_Tutorial.ipynb))
-- [AI Platform Integration](../examples/AIPlatformIntegration.html)
-  ([Jupyter notebook](https://github.com/equinor/neqsim/blob/master/docs/examples/AIPlatformIntegration.ipynb)
-  | [Open in Colab](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/AIPlatformIntegration.ipynb))
-- [Graph-Based Simulation](../examples/GraphBasedProcessSimulation.html)
-  ([Jupyter notebook](https://github.com/equinor/neqsim/blob/master/docs/examples/GraphBasedProcessSimulation.ipynb)
-  | [Open in Colab](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/GraphBasedProcessSimulation.ipynb))
-
-### Documentation Links
-- Work through the [Usage examples](usage_examples) for end-to-end flows in both Java and Python.
-- Try the [Process transient simulation guide](process_transient_simulation_guide) and [Process simulation using NeqSim](process_simulation) for hands-on modeling patterns.
-- Explore extended topics such as [Process automation and logic implementation summary](../simulation/process_logic_implementation_summary) and integration tests in [Test overview](test-overview).
-
-### External Resources
-- [NeqSim Colab Demo](https://colab.research.google.com/drive/1JiszeCxfpcJZT2vejVWuNWGmd9SJdNC7)
-- [Java Test Examples](https://github.com/equinor/neqsim/tree/master/src/test/java/neqsim)
-- [NeqSim Python](https://github.com/equinor/neqsimpython)
-- [NeqSim Matlab](https://github.com/equinor/neqsimmatlab)
+Use current source, focused tests, published benchmarks, and accountable engineering review before
+using a result for design or operational decisions.

--- a/docs/wiki/usage_examples.md
+++ b/docs/wiki/usage_examples.md
@@ -1,402 +1,76 @@
 ---
 title: "Usage Examples"
-description: "Comprehensive examples demonstrating NeqSim capabilities for thermodynamic calculations and process simulation."
+description: "A curated catalog of maintained NeqSim examples for thermodynamics, PVT, process simulation, pipelines, dynamics, standards, and troubleshooting."
 ---
 
-# Usage Examples
-
-Comprehensive examples demonstrating NeqSim capabilities for thermodynamic calculations and process simulation.
-
-## Table of Contents
-- [Thermodynamic Calculations](#thermodynamic-calculations)
-  - [Basic TP Flash](#basic-tp-flash)
-  - [Phase Envelope](#phase-envelope)
-  - [Dew Point Calculations](#dew-point-calculations)
-  - [Physical Properties](#physical-properties)
-- [Fluid Creation](#fluid-creation)
-  - [Simple Gas Mixture](#simple-gas-mixture)
-  - [Oil with Heavy Fractions](#oil-with-heavy-fractions)
-  - [Aqueous Systems with CPA](#aqueous-systems-with-cpa)
-- [Process Simulation](#process-simulation)
-  - [Simple Separation](#simple-separation)
-  - [Compression System](#compression-system)
-  - [Heat Exchanger](#heat-exchanger)
-  - [Complete Gas Processing Plant](#complete-gas-processing-plant)
-- [Pipeline Calculations](#pipeline-calculations)
-- [Specialized Equipment](#specialized-equipment)
-
----
-
-## Thermodynamic Calculations
-
-### Basic TP Flash
-
-The most common thermodynamic calculation - determining phase equilibrium at fixed temperature and pressure.
-
-```java
-import neqsim.thermo.system.SystemSrkEos;
-import neqsim.thermodynamicoperations.ThermodynamicOperations;
-
-// Create a natural gas system
-SystemSrkEos gas = new SystemSrkEos(298.15, 50.0);  // 25°C, 50 bar
-gas.addComponent("methane", 0.85);
-gas.addComponent("ethane", 0.08);
-gas.addComponent("propane", 0.04);
-gas.addComponent("n-butane", 0.02);
-gas.addComponent("n-pentane", 0.01);
-gas.setMixingRule("classic");
-
-// Perform TP flash
-ThermodynamicOperations ops = new ThermodynamicOperations(gas);
-ops.TPflash();
-
-// Print results
-System.out.println("Number of phases: " + gas.getNumberOfPhases());
-System.out.println("Gas fraction: " + gas.getPhaseFraction("gas", "mole"));
-System.out.println("Liquid fraction: " + gas.getPhaseFraction("oil", "mole"));
-System.out.println("Gas density: " + gas.getPhase("gas").getDensity("kg/m3") + " kg/m³");
-```
-
-### Phase Envelope
-
-Calculate the complete phase envelope (bubble and dew point curves).
-
-```java
-import neqsim.thermo.system.SystemSrkEos;
-import neqsim.thermodynamicoperations.ThermodynamicOperations;
-
-SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
-fluid.addComponent("methane", 0.80);
-fluid.addComponent("ethane", 0.10);
-fluid.addComponent("propane", 0.07);
-fluid.addComponent("n-heptane", 0.03);
-fluid.setMixingRule("classic");
-
-ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-ops.calcPTphaseEnvelope();
-
-// Get cricondenbar (maximum pressure point)
-double cricondenbarP = ops.get("cricondenbar")[0];
-double cricondenbarT = ops.get("cricondenbar")[1];
-System.out.println("Cricondenbar: " + cricondenbarP + " bar at " + cricondenbarT + " K");
-
-// Get cricondentherm (maximum temperature point)
-double cricondentT = ops.get("cricondentherm")[1];
-double cricondentP = ops.get("cricondentherm")[0];
-System.out.println("Cricondentherm: " + cricondentT + " K at " + cricondentP + " bar");
-```
-
-### Dew Point Calculations
-
-Calculate hydrocarbon and water dew points.
-
-```java
-import neqsim.thermo.system.SystemSrkCPAstatoil;
-import neqsim.thermodynamicoperations.ThermodynamicOperations;
-
-// Use CPA for accurate water modeling
-SystemSrkCPAstatoil gas = new SystemSrkCPAstatoil(298.15, 70.0);
-gas.addComponent("methane", 0.90);
-gas.addComponent("ethane", 0.05);
-gas.addComponent("propane", 0.03);
-gas.addComponent("water", 0.02);
-gas.setMixingRule(10);  // CPA mixing rule
-
-ThermodynamicOperations ops = new ThermodynamicOperations(gas);
-
-// Hydrocarbon dew point at fixed pressure
-ops.dewPointTemperatureFlash();
-System.out.println("HC Dew Point at 70 bar: " + (gas.getTemperature() - 273.15) + " °C");
-
-// Water dew point
-ops.waterDewPointTemperatureFlash();
-System.out.println("Water Dew Point: " + (gas.getTemperature() - 273.15) + " °C");
-```
-
-### Physical Properties
-
-Calculate comprehensive physical properties after flash.
-
-```java
-import neqsim.thermo.system.SystemSrkEos;
-import neqsim.thermodynamicoperations.ThermodynamicOperations;
-
-SystemSrkEos fluid = new SystemSrkEos(300.0, 30.0);
-fluid.addComponent("methane", 0.95);
-fluid.addComponent("CO2", 0.05);
-fluid.setMixingRule("classic");
-
-ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-ops.TPflash();
-
-// Gas phase properties
-System.out.println("=== Gas Phase Properties ===");
-System.out.println("Density: " + fluid.getPhase("gas").getDensity("kg/m3") + " kg/m³");
-System.out.println("Viscosity: " + fluid.getPhase("gas").getViscosity("cP") + " cP");
-System.out.println("Thermal Conductivity: " + fluid.getPhase("gas").getThermalConductivity("W/mK") + " W/m·K");
-System.out.println("Cp: " + fluid.getPhase("gas").getCp("kJ/kgK") + " kJ/kg·K");
-System.out.println("Cv: " + fluid.getPhase("gas").getCv("kJ/kgK") + " kJ/kg·K");
-System.out.println("Z-factor: " + fluid.getPhase("gas").getZ());
-System.out.println("Speed of Sound: " + fluid.getPhase("gas").getSoundSpeed() + " m/s");
-System.out.println("Molecular Weight: " + fluid.getPhase("gas").getMolarMass() * 1000 + " g/mol");
-System.out.println("Enthalpy: " + fluid.getPhase("gas").getEnthalpy("kJ/kg") + " kJ/kg");
-System.out.println("Entropy: " + fluid.getPhase("gas").getEntropy("kJ/kgK") + " kJ/kg·K");
-```
-
----
-
-## Fluid Creation
-
-### Simple Gas Mixture
-
-```java
-import neqsim.thermo.system.SystemSrkEos;
-
-// Standard SRK for natural gas
-SystemSrkEos gas = new SystemSrkEos(298.15, 50.0);
-gas.addComponent("nitrogen", 0.02);
-gas.addComponent("CO2", 0.03);
-gas.addComponent("methane", 0.85);
-gas.addComponent("ethane", 0.06);
-gas.addComponent("propane", 0.03);
-gas.addComponent("i-butane", 0.005);
-gas.addComponent("n-butane", 0.005);
-gas.setMixingRule("classic");
-```
-
-### Oil with Heavy Fractions
-
-```java
-import neqsim.thermo.system.SystemSrkEos;
-
-SystemSrkEos oil = new SystemSrkEos(350.0, 100.0);
-
-// Light components
-oil.addComponent("methane", 10.0);
-oil.addComponent("ethane", 5.0);
-oil.addComponent("propane", 4.0);
-oil.addComponent("n-butane", 3.0);
-oil.addComponent("n-pentane", 2.0);
-oil.addComponent("n-hexane", 2.0);
-
-// Heavy fractions (TBP cuts)
-// addTBPfraction(name, moles, molarMass_kg/mol, density_kg/m3)
-oil.addTBPfraction("C7", 5.0, 0.092, 730.0);
-oil.addTBPfraction("C8", 4.0, 0.104, 750.0);
-oil.addTBPfraction("C9", 3.0, 0.117, 770.0);
-
-// Plus fraction
-oil.addPlusFraction("C10+", 20.0, 0.200, 820.0);
-
-// Set mixing rule and characterize
-oil.setMixingRule("classic");
-
-// Run characterization to split plus fraction
-oil.getCharacterization().setTBPModel("PedersenSRK");
-oil.getCharacterization().setPlusFractionModel("Pedersen");
-oil.getCharacterization().characterisePlusFraction();
-```
-
-### Aqueous Systems with CPA
-
-For systems with water, glycols, or alcohols, use CPA equation of state.
-
-```java
-import neqsim.thermo.system.SystemSrkCPAstatoil;
-
-// Gas with MEG injection for hydrate inhibition
-SystemSrkCPAstatoil fluid = new SystemSrkCPAstatoil(280.0, 100.0);
-fluid.addComponent("methane", 0.85);
-fluid.addComponent("ethane", 0.08);
-fluid.addComponent("propane", 0.04);
-fluid.addComponent("water", 0.02);
-fluid.addComponent("MEG", 0.01);
-fluid.setMixingRule(10);  // CPA mixing rule
-
-// Calculate hydrate equilibrium
-ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-ops.hydrateFormationTemperature();
-System.out.println("Hydrate formation temperature: " + (fluid.getTemperature() - 273.15) + " °C");
-```
-
----
-
-## Process Simulation
-
-### Simple Separation
-
-Two-stage separation with pressure reduction.
-
-```java
-import neqsim.process.equipment.stream.Stream;
-import neqsim.process.equipment.valve.ThrottlingValve;
-import neqsim.process.equipment.separator.Separator;
-import neqsim.process.processmodel.ProcessSystem;
-import neqsim.thermo.system.SystemSrkEos;
-
-// Create feed fluid
-SystemSrkEos fluid = new SystemSrkEos(350.0, 150.0);
-fluid.addComponent("methane", 70.0);
-fluid.addComponent("ethane", 10.0);
-fluid.addComponent("propane", 8.0);
-fluid.addComponent("n-butane", 5.0);
-fluid.addComponent("n-pentane", 4.0);
-fluid.addComponent("n-heptane", 3.0);
-fluid.setMixingRule("classic");
-
-// Create feed stream
-Stream wellStream = new Stream("Well Stream", fluid);
-wellStream.setFlowRate(10000.0, "kg/hr");
-wellStream.setTemperature(80.0, "C");
-wellStream.setPressure(150.0, "bara");
-
-// First stage separation
-ThrottlingValve chokeValve = new ThrottlingValve("Choke Valve", wellStream);
-chokeValve.setOutletPressure(50.0, "bara");
-
-Separator hpSeparator = new Separator("HP Separator", chokeValve.getOutletStream());
-
-// Second stage separation
-ThrottlingValve lpValve = new ThrottlingValve("LP Valve", hpSeparator.getLiquidOutStream());
-lpValve.setOutletPressure(5.0, "bara");
-
-Separator lpSeparator = new Separator("LP Separator", lpValve.getOutletStream());
-
-// Build and run process
-ProcessSystem process = new ProcessSystem();
-process.add(wellStream);
-process.add(chokeValve);
-process.add(hpSeparator);
-process.add(lpValve);
-process.add(lpSeparator);
-process.run();
-
-// Results
-System.out.println("=== HP Separator ===");
-System.out.println("Gas rate: " + hpSeparator.getGasOutStream().getFlowRate("kg/hr") + " kg/hr");
-System.out.println("Oil rate: " + hpSeparator.getLiquidOutStream().getFlowRate("kg/hr") + " kg/hr");
-
-System.out.println("=== LP Separator ===");
-System.out.println("Flash gas: " + lpSeparator.getGasOutStream().getFlowRate("kg/hr") + " kg/hr");
-System.out.println("Stabilized oil: " + lpSeparator.getLiquidOutStream().getFlowRate("kg/hr") + " kg/hr");
-```
-
-### Compression System
-
-## Distillation column
-
-Simulate a deethanizer column with six available solver algorithms. See
-[distillation column docs](distillation_column.md) for full mathematical details.
-
-```java
-import neqsim.process.equipment.distillation.DistillationColumn;
-import neqsim.process.equipment.stream.Stream;
-import neqsim.thermo.system.SystemSrkEos;
-
-SystemSrkEos feed = new SystemSrkEos(216.0, 30.0);
-feed.addComponent("methane", 0.5);
-feed.addComponent("ethane", 0.2);
-feed.addComponent("propane", 0.15);
-feed.addComponent("n-butane", 0.05);
-feed.addComponent("n-pentane", 0.05);
-feed.addComponent("n-hexane", 0.03);
-feed.addComponent("n-heptane", 0.02);
-feed.setMixingRule("classic");
-
-Stream feedStream = new Stream("feed", feed);
-feedStream.setFlowRate(100.0, "kg/hr");
-feedStream.run();
-
-DistillationColumn column = new DistillationColumn("Deethanizer", 5, true, false);
-column.addFeedStream(feedStream, 5);
-column.getReboiler().setOutTemperature(378.15);
-column.setTopPressure(30.0);
-column.setBottomPressure(32.0);
-column.setSolverType(DistillationColumn.SolverType.INSIDE_OUT);
-column.run();
-
-System.out.println("Gas:    " + column.getGasOutStream().getFlowRate("kg/hr") + " kg/hr");
-System.out.println("Liquid: " + column.getLiquidOutStream().getFlowRate("kg/hr") + " kg/hr");
-```
-
-## Wind turbine
-
-The `WindTurbine` unit converts kinetic energy in wind into electrical power using a simple
-actuator-disk formulation. Air density is assumed constant at 1.225 kg/m³ and all inefficiencies
-are lumped into the power coefficient.
-
-```java
-import neqsim.process.equipment.powergeneration.WindTurbine;
-
-WindTurbine turbine = new WindTurbine("turbine");
-turbine.setWindSpeed(12.0);    // m/s
-turbine.setRotorArea(50.0);    // m²
-turbine.setPowerCoefficient(0.4);
-turbine.run();
-
-System.out.println("Power produced: " + turbine.getPower() + " W");
-```
-
-### Electrolyzer
-
-Water electrolysis for hydrogen production.
-
-```java
-import neqsim.process.equipment.electrolyzer.Electrolyzer;
-import neqsim.process.equipment.stream.Stream;
-import neqsim.thermo.system.SystemSrkEos;
-
-// Water feed
-SystemSrkEos water = new SystemSrkEos(298.15, 1.0);
-water.addComponent("water", 1.0);
-water.setMixingRule("classic");
-
-Stream waterFeed = new Stream("Water Feed", water);
-waterFeed.setFlowRate(100.0, "kg/hr");
-
-Electrolyzer electrolyzer = new Electrolyzer("PEM Electrolyzer", waterFeed);
-electrolyzer.setEfficiency(0.70);
-electrolyzer.run();
-
-System.out.println("H2 production rate: " + electrolyzer.getHydrogenOutStream().getFlowRate("kg/hr") + " kg/hr");
-System.out.println("O2 production rate: " + electrolyzer.getOxygenOutStream().getFlowRate("kg/hr") + " kg/hr");
-System.out.println("Power consumption: " + electrolyzer.getPower("kW") + " kW");
-```
-
-### Membrane Separator
-
-Gas separation using membrane technology.
-
-```java
-import neqsim.process.equipment.separator.MembraneSeparator;
-import neqsim.process.equipment.stream.Stream;
-import neqsim.thermo.system.SystemSrkEos;
-
-SystemSrkEos gas = new SystemSrkEos(298.15, 50.0);
-gas.addComponent("CO2", 0.30);
-gas.addComponent("methane", 0.70);
-gas.setMixingRule("classic");
-
-Stream feed = new Stream("Feed", gas);
-feed.setFlowRate(1000.0, "Sm3/hr");
-
-MembraneSeparator membrane = new MembraneSeparator("CO2 Membrane", feed);
-membrane.setRelativePermability("CO2", 20.0);
-membrane.setRelativePermability("methane", 1.0);
-membrane.setMembranePressureDrop(30.0, "bara");
-membrane.run();
-
-System.out.println("Permeate CO2: " + membrane.getPermeateStream().getFluid().getComponent("CO2").getx() * 100 + " mol%");
-System.out.println("Retentate CO2: " + membrane.getRetentateStream().getFluid().getComponent("CO2").getx() * 100 + " mol%");
-```
-
----
-
-## Additional Resources
-
-For more examples, see:
-- [Java Test Suite](https://github.com/equinor/neqsim/tree/master/src/test/java/neqsim) - Extensive test cases demonstrating functionality
-- [Process Simulation Guide](process_simulation) - Detailed process simulation documentation
-- [Thermodynamics Guide](thermodynamics_guide) - Complete thermodynamic modeling guide
-- [Pipeline Index](pipeline_index) - Pipeline modeling documentation
-- [Example Notebooks](https://github.com/equinor/neqsim/tree/master/docs/examples) - Jupyter notebook examples
+This catalog points to maintained, task-oriented examples instead of repeating short Java
+fragments that can drift away from the public API. Start with the
+[canonical quick start](getting_started.md#run-the-canonical-java-quick-start), then choose the
+workflow closest to your engineering question.
+
+## Thermodynamics and physical properties
+
+| Task | Maintained example | What to verify |
+| --- | --- | --- |
+| Create a fluid and run TP, PH, and dew-point flashes | [Thermodynamics recipes](../cookbook/thermodynamics-recipes.md) | Model, mixing rule, state units, phase result |
+| Understand flash algorithms and validation cases | [Flash equations and tests](flash_equations_and_tests.md) | Convergence, phase stability, material balance |
+| Read density, viscosity, conductivity, and interfacial properties | [Property-flash workflows](property_flash_workflows.md) | Required initialization and property units |
+| Select an equation of state | [Thermodynamics guide](thermodynamics_guide.md) | Fluid range, association, electrolyte limitations |
+
+## Fluid characterization and PVT
+
+| Task | Maintained example | What to verify |
+| --- | --- | --- |
+| Add TBP and plus fractions | [Fluid characterization](fluid_characterization.md) | Molar-mass and density basis, characterization model |
+| Run CCE, CVD, separator, and viscosity studies | [PVT simulation workflows](pvt_simulation_workflows.md) | Laboratory conditions, basis, observed-data comparison |
+| Screen crude-oil quality | [Oil-quality standards](../standards/oil_quality_standards.md) | Method boundary, sample basis, units, expert review |
+
+## Process simulation and equipment
+
+| Task | Maintained example | What to verify |
+| --- | --- | --- |
+| Connect streams, separators, valves, heaters, and compressors | [Process recipes](../cookbook/process-recipes.md) | Feed initialization, equipment units, balances |
+| Select execution and inspect process results | [ProcessSystem guide](../process/processmodel/process_system.md) | Topology, convergence, calculation identity, reporting |
+| Model tray absorbers and strippers | [Absorber and stripper guide](../process/equipment/absorbers.md) | Solver status, tray setup, transfer and balance checks |
+| Explore broader process patterns | [Process simulation guide](process_simulation.md) | Model ownership, recycles, operating assumptions |
+
+## Pipelines and dynamics
+
+| Task | Maintained example | What to verify |
+| --- | --- | --- |
+| Choose a steady-state or transient pipeline model | [Pipeline documentation index](pipeline_index.md) | Geometry, elevation sign, roughness, heat transfer, flow regime |
+| Build a dynamic process case | [Process transient simulation guide](process_transient_simulation_guide.md) | Initial steady state, time step, controller topology, inventories |
+
+## Tutorials and notebooks
+
+The [examples index](../examples/index.md) links to complete tutorials and source notebooks. A
+published notebook should have been executed from a clean runtime and saved with its calculated
+tables, plots, diagnostics, and validation checks. Interactive outputs need a stored static
+fallback when they cannot render reliably outside their original environment.
+
+Use the [Java getting-started guide](../java-getting-started.md) for a complete application layout.
+For short copyable recipes, prefer the maintained cookbook pages over isolated fragments copied
+from old issues or tests.
+
+## Validation checklist
+
+Before adapting an example:
+
+1. Pin the NeqSim version or record the tested `master` commit.
+2. Define composition basis, thermodynamic model, mixing rule, temperature, pressure, and flow
+   units.
+3. Run flashes and property initialization in the order required by the API.
+4. Check phase availability before reading a named phase.
+5. Verify material, component, and energy balances appropriate to the workflow.
+6. Compare important results with a nearby operating point and an independent reference or
+   defensible physical bound.
+7. Preserve convergence diagnostics and warnings that affect validity.
+
+For common setup, convergence, units, and dependency problems, use the
+[troubleshooting guide](../troubleshooting/index.md).
+
+## Engineering boundary
+
+Examples demonstrate reproducible NeqSim calculations. They do not replace fluid-model
+qualification, equipment design, relief or safety verification, standards interpretation, vendor
+review, or accountable engineering approval.


### PR DESCRIPTION
Refs #2499

## D071 frozen scope

Base: `master` at `4a8eb2ae725acd6727098e62b07abaadb74ddeeb`  
Head: `docs/d071-wiki-examples` at `516df18e3e52f8acd35fd746dbfdd7277c6d8d0d`

Rotation: tutorials, cookbook, troubleshooting, and examples, bounded to:

- `docs/wiki/getting_started.md`
- `docs/wiki/usage_examples.md`
- `docs/test_landing_page_documentation.py`

## Confirmed defects repaired

1. Removes duplicate H1 headings from both front-matter-titled pages.
2. Synchronizes the getting-started Maven example with release `3.18.0`.
3. Replaces the retired `equinor/neqsimsource` release destination.
4. Removes repository-prohibited `System.out` output.
5. Replaces incomplete, unverified Java fragments with the existing repository-tested canonical quick start.
6. Removes unsupported fixed execution-speed percentages and the brittle “50+” equipment inventory.
7. Replaces the usage page's missing/empty advertised sections and unrelated pseudo-cookbook fragments with a task-oriented catalog of maintained executable guides.
8. Extends the landing-page contract across both surfaces, their current coordinates, canonical-example identity, prohibited patterns, curated targets, headings, fences, and internal links.

## Documentation behavior

The getting-started page now provides current install/build guidance, the exact canonical Java program already shared by the root landing pages, explicit flash/property initialization semantics, a maintained workflow map, and engineering-use boundaries.

The usage page is now a curated catalog for thermodynamics, properties, PVT, process simulation, absorbers, pipelines, dynamics, standards, notebooks, and troubleshooting. It states the evidence users should verify instead of presenting drifting standalone fragments.

## Validation

Passed locally:

- `python -m py_compile docs/test_landing_page_documentation.py`
- Five focused landing contracts — 5/5 passed:
  - front matter/title/fence structure;
  - current release/API destinations;
  - canonical Java example identity and repository-safe logging;
  - curated tutorial surfaces and required targets;
  - supported Python gateway.
- Stale-pattern scan: no retired repository/JavaDoc hosts, stale `3.0.0`/`3.17.0`, duplicate H1, `System.out`/`System.err`, “50+”, or fixed speedup ranges.
- Secret-pattern, trailing-whitespace, and Python contract line-length scans: clean.
- All 18 distinct internal target files resolve from current GitHub source; both changed fragments resolve.
- Maven Central artifact and current GitHub Releases destinations were reachable on 2026-08-20.
- Local Git blob hashes exactly match the three published branch blobs.
- Remote compare immediately before publication: 3 commits ahead, 0 behind, exactly the three frozen files.
- Portfolio check: this is autonomous slot 5 of 10 and the only open #2499 implementation PR.

**VALIDATION CONFIRMED BY GITHUB CI** for exact head `516df18e3e52f8acd35fd746dbfdd7277c6d8d0d` on 2026-08-20:

- [Run build, test and javadoc](https://github.com/equinor/neqsim/actions/runs/32401687743) — passed
- [Spotless format patch](https://github.com/equinor/neqsim/actions/runs/32401687695) — passed
- [Pre-commit checks](https://github.com/equinor/neqsim/actions/runs/32401687696) — passed
- [Documentation search coverage](https://github.com/equinor/neqsim/actions/runs/32401687819) — passed
- [CodeQL Security Analysis](https://github.com/equinor/neqsim/actions/runs/32401687758) — passed

The partial support checkout does not contain repository `devtools` and does not have `pre-commit` installed. These exact local invocations remained unavailable; the corresponding hosted workflows above passed:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- `pre-commit run --all-files --hook-stage pre-commit`
- `pre-commit run --all-files --hook-stage pre-push`

No rendered-browser claim is made beyond the passing hosted documentation/search workflow.

## Documentation impact

Documentation impact: **updated**. Installation, example selection, property initialization, validation expectations, and engineering boundaries are user-visible.

## Stop boundary

No production Java, target-guide rewrites, notebook changes or execution, phase-envelope API changes, process scheduling changes, DEXPI, pipeline-model implementation, or Huldra work is included.