### PR TITLE
[AI-Assisted] docs(serialization): repair persistence guidance

### DIFF
--- a/docs/process/processmodel/process_system.md
+++ b/docs/process/processmodel/process_system.md
@@ -1068,28 +1068,47 @@ System.out.println("Product rate: " + product.getFlowRate("kg/hr") + " kg/hr");
 
 ## Saving and Loading
 
-ProcessSystem supports saving and loading to/from compressed `.neqsim` files and JSON state files for version control.
+`ProcessSystem` supports compressed full-object `.neqsim` archives and selective lifecycle JSON
+state. These formats are not interchangeable.
 
 ```java
-// Save to compressed .neqsim file (recommended)
-process.saveToNeqsim("my_process.neqsim");
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.processmodel.lifecycle.ProcessSystemState;
 
-// Load (auto-runs after loading)
+// Full object graph. Check the boolean result.
+if (!process.saveToNeqsim("my_process.neqsim")) {
+    throw new IllegalStateException("Could not save process");
+}
+
+// The convenience loader runs a restored process and returns null on failure.
 ProcessSystem loaded = ProcessSystem.loadFromNeqsim("my_process.neqsim");
+if (loaded == null) {
+    throw new IllegalStateException("Could not load process");
+}
 
-// Auto-detect format by extension
-process.saveAuto("my_process.neqsim");  // Compressed XStream XML
-process.saveAuto("my_process.json");    // JSON state export
-
-// JSON state for version control
+// Selective JSON state for review, versioning, or a matching model definition.
 ProcessSystemState state = ProcessSystemState.fromProcessSystem(process);
 state.setVersion("1.0.0");
 state.saveToFile("my_process_v1.0.0.json");
 ```
 
-For full documentation on serialization options, see [Process Serialization Guide](../../simulation/process_serialization).
+`ProcessSystem.saveAuto()` writes `.neqsim` archives, `.json` lifecycle state, or legacy binary
+serialization for another extension. `ProcessSystem.loadAuto()` does not load lifecycle JSON: it
+loads `.neqsim` through `loadFromNeqsim()` and treats every other extension as legacy binary. Load
+JSON with `ProcessSystemState.loadFromFile()`, validate it, and apply it to a compatible pre-built
+process.
+
+Full-object XStream archives are a trusted-input format. A failed save can leave a partial file, so
+save to a temporary path, check the return value, reopen and run the temporary archive, and only
+then replace the last verified checkpoint. The embedded-host portability regression includes a
+recycle-bearing process; report any new `No converter available` failure with a minimal equipment
+graph instead of masking it with JVM `--add-opens` flags.
+
+For complete format selection, Python behavior, compatibility limits, and recovery steps, see the
+[Process Serialization Guide](../../simulation/process_serialization).
 
 ---
+
 
 ## Related Documentation
 

--- a/docs/simulation/process_serialization.md
+++ b/docs/simulation/process_serialization.md
@@ -1,1015 +1,279 @@
 ---
 title: "Saving and Loading Process Simulations in NeqSim"
-description: "This document describes how to save and load process simulations in NeqSim using JSON/XML serialization. NeqSim uses the **XStream** library for object serialization, supporting both uncompressed XML ..."
+description: "Choose and validate NeqSim process persistence formats in Java and Python."
 ---
 
 # Saving and Loading Process Simulations in NeqSim
 
-This document describes how to save and load process simulations in NeqSim using JSON/XML serialization. NeqSim uses the **XStream** library for object serialization, supporting both uncompressed XML and compressed `.neqsim` file formats.
+NeqSim has two different persistence models:
 
-## Table of Contents
+- a compressed `.neqsim` archive stores the Java object graph for a `ProcessSystem` or
+  `ProcessModel`; and
+- lifecycle JSON stores a portable, reviewable engineering-state representation.
 
-- [Overview](#overview)
-- [Serialization Options](#serialization-options)
-- [Java API](#java-api)
-  - [Quick Start - ProcessSystem Methods](#quick-start---processsystem-methods)
-  - [Saving Process Models](#saving-process-models)
-  - [Loading Process Models](#loading-process-models)
-  - [State-Based Serialization](#state-based-serialization)
-  - [Validation](#validation)
-- [Multi-Process Models (ProcessModel)](#multi-process-models-processmodel)
-  - [ProcessModel Overview](#processmodel-overview)
-  - [Saving and Loading ProcessModel](#saving-and-loading-processmodel)
-  - [ProcessModelState for JSON Export](#processmodelstate-for-json-export)
-  - [Inter-Process Connections](#inter-process-connections)
-- [Python API (neqsim-python)](#python-api-neqsim-python)
-  - [Quick Start](#quick-start)
-  - [Saving and Loading .neqsim Files](#saving-and-loading-neqsim-files)
-  - [Saving and Loading XML Files](#saving-and-loading-xml-files)
-  - [Direct Java API Access](#direct-java-api-access)
-- [Compressed Files (.neqsim format)](#compressed-files-neqsim-format)
-- [JSON State Export/Import](#json-state-exportimport)
-- [Best Practices](#best-practices)
-- [Troubleshooting](#troubleshooting)
+They serve different purposes. Use the full object graph when the same application needs to
+restart a model. Use lifecycle JSON for versioned state, comparison, interchange, or applying
+values to a compatible model definition.
 
----
+## Choose a format
 
-## Overview
+| Need | API | What is stored | Load behavior |
+| --- | --- | --- | --- |
+| Restart one process | `ProcessSystem.saveToNeqsim()` | Full XStream object graph in a ZIP archive | `ProcessSystem.loadFromNeqsim()` loads and runs it |
+| Restart several processes | `ProcessModel.saveToNeqsim()` | Full `ProcessModel` object graph in a ZIP archive | `ProcessModel.loadFromNeqsim()` loads and runs it |
+| Review or version state | `ProcessSystemState` / `ProcessModelState` | Selected equipment, stream, topology, metadata, and execution state | Validate, then reconstruct supported content or apply it to a matching model |
+| Inspect XML while debugging | `save_xml()` / `open_xml()` in neqsim-python | Uncompressed XStream XML | Low-level wrapper; the caller runs a restored process |
+| Read an older binary file | `saveAuto()` / `loadAuto()` with another extension | Legacy Java serialization | Compatibility path, not the preferred new format |
 
-NeqSim provides multiple ways to persist and restore process simulations:
+The `.neqsim` extension is used by both full-object archives and some compressed lifecycle-state
+helpers. The API that writes the file determines its contents; the extension alone does not.
 
-| Method | Format | Compression | Use Case |
-|--------|--------|-------------|----------|
-| `ProcessSystem.saveToNeqsim()` | XML in ZIP | ✅ Yes | **Recommended** - compact storage |
-| `ProcessSystem.saveAuto()` | Auto-detect | ✅ Auto | Convenience - format by extension |
-| `NeqSimXtream.saveNeqsim()` | XML in ZIP | ✅ Yes | Low-level API |
-| `ProcessSystemState` | JSON | ✅ Optional | Version control - Git-friendly |
-| `save_xml()` / `open_xml()` | Plain XML | ❌ No | Debugging - human-readable |
+> **Security boundary:** XStream deserialization can instantiate classes from the serialized
+> object graph. Load `.neqsim` and XML files only from trusted sources. Do not expose these load
+> methods directly to untrusted uploads.
 
-The underlying serialization technology is [XStream](https://x-stream.github.io/), a powerful Java library that converts objects to XML and back without requiring any modifications to the objects.
+## Java: `ProcessSystem` archives
 
----
+### Save and load
 
-## Serialization Options
-
-### 1. Compressed .neqsim Files (Recommended)
-
-The `.neqsim` file format stores the XML serialization inside a ZIP archive, significantly reducing file size for large process models. This is the recommended format for production use.
-
-**Advantages:**
-- Smaller file sizes (typically 5-20x compression)
-- Single file contains complete model state
-- Compatible with both Java and Python APIs
-
-### 2. Plain XML Files
-
-Uncompressed XML files are useful for debugging and manual inspection but can become very large for complex simulations.
-
-### 3. JSON State Files
-
-JSON-based state export provides a human-readable, Git-friendly format for version control and lifecycle management.
-
----
-
-## Java API
-
-### Quick Start - ProcessSystem Methods
-
-The simplest way to save and load process models is using the convenience methods directly on `ProcessSystem`:
+Check both failure signals. Saving returns `false`; the convenience loader logs a failure and
+returns `null`. The loader runs a successfully restored process before returning it.
 
 ```java
-import neqsim.process.processmodel.ProcessSystem;
 import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 
-// Create and configure a process
 SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
 fluid.addComponent("methane", 10.0);
 fluid.addComponent("ethane", 5.0);
 fluid.setMixingRule("classic");
 
-ProcessSystem process = new ProcessSystem("My Process");
-Stream feed = new Stream("Feed", fluid);
+ProcessSystem process = new ProcessSystem("my process");
+Stream feed = new Stream("feed", fluid);
 feed.setFlowRate(1000.0, "kg/hr");
 process.add(feed);
 process.run();
 
-// Save to compressed .neqsim file (recommended)
-process.saveToNeqsim("my_process.neqsim");
+if (!process.saveToNeqsim("my_process.neqsim")) {
+    throw new IllegalStateException("Could not save my_process.neqsim");
+}
 
-// Load from .neqsim file (auto-runs after loading)
 ProcessSystem loaded = ProcessSystem.loadFromNeqsim("my_process.neqsim");
-System.out.println("Loaded: " + loaded.getName());
-```
-
-#### Auto-Format Detection
-
-Use `saveAuto()` and `loadAuto()` to automatically detect format based on file extension:
-
-```java
-// Format detected by extension
-process.saveAuto("my_process.neqsim");  // → Compressed XStream XML
-process.saveAuto("my_process.json");    // → JSON state export
-process.saveAuto("my_process.ser");     // → Java binary serialization
-
-// Load with auto-detection
-ProcessSystem loaded = ProcessSystem.loadAuto("my_process.neqsim");
-```
-
-### Saving Process Models
-
-#### Using NeqSimXtream (Compressed Format)
-
-```java
-import neqsim.util.serialization.NeqSimXtream;
-import neqsim.process.processmodel.ProcessSystem;
-import neqsim.process.equipment.stream.Stream;
-import neqsim.thermo.system.SystemSrkEos;
-
-// Create and configure a process
-SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
-fluid.addComponent("methane", 10.0);
-fluid.addComponent("ethane", 5.0);
-fluid.setMixingRule(2);
-
-ProcessSystem process = new ProcessSystem("My Process");
-Stream feed = new Stream("Feed", fluid);
-feed.setFlowRate(1000.0, "kg/hr");
-process.add(feed);
-process.run();
-
-// Save to compressed .neqsim file
-boolean success = NeqSimXtream.saveNeqsim(process, "my_process.neqsim");
-if (success) {
-    System.out.println("Process saved successfully!");
+if (loaded == null) {
+    throw new IllegalStateException("Could not load my_process.neqsim");
 }
 ```
 
-#### Using XStream Directly (Uncompressed XML)
+The archive is a ZIP file containing one UTF-8 `process.xml` entry. Compression depends on the
+actual model graph, so measure representative files instead of assuming a fixed ratio.
 
-```java
-import com.thoughtworks.xstream.XStream;
-import com.thoughtworks.xstream.security.AnyTypePermission;
+### Exact `saveAuto()` and `loadAuto()` behavior
 
-// Create XStream instance
-XStream xstream = new XStream();
+`ProcessSystem.saveAuto()` selects the writer from the filename:
 
-// Serialize to XML string
-String xml = xstream.toXML(process);
+- `.neqsim` calls `saveToNeqsim()`;
+- `.json` calls `exportStateToFile()`; and
+- every other extension uses legacy Java binary serialization.
 
-// Save to file
-try (FileWriter writer = new FileWriter("my_process.xml")) {
-    writer.write(xml);
-}
-```
-
-### Loading Process Models
-
-#### Loading Compressed .neqsim Files
-
-```java
-import neqsim.util.serialization.NeqSimXtream;
-import neqsim.process.processmodel.ProcessSystem;
-
-try {
-    // Load from .neqsim file
-    Object loaded = NeqSimXtream.openNeqsim("my_process.neqsim");
-
-    if (loaded instanceof ProcessSystem) {
-        ProcessSystem process = (ProcessSystem) loaded;
-
-        // Run the restored process
-        process.run();
-
-        System.out.println("Process loaded: " + process.getName());
-        System.out.println("Number of units: " + process.getUnitOperations().size());
-    }
-} catch (IOException e) {
-    System.err.println("Failed to load process: " + e.getMessage());
-}
-```
-
-#### Loading Uncompressed XML
-
-```java
-import com.thoughtworks.xstream.XStream;
-import com.thoughtworks.xstream.security.AnyTypePermission;
-
-// Create XStream instance with security permissions
-XStream xstream = new XStream();
-xstream.addPermission(AnyTypePermission.ANY);
-
-// Read XML from file
-String xmlContent = new String(Files.readAllBytes(Paths.get("my_process.xml")));
-
-// Deserialize
-ProcessSystem process = (ProcessSystem) xstream.fromXML(xmlContent);
-process.run();
-```
-
-### State-Based Serialization
-
-NeqSim provides a `ProcessSystemState` class for JSON-based state management, ideal for version control and lifecycle tracking:
+`ProcessSystem.loadAuto()` does **not** load lifecycle JSON. It loads `.neqsim` with
+`loadFromNeqsim()` and routes every other extension to the legacy binary `open()` method. To read
+JSON, load a `ProcessSystemState` and apply it to a compatible, already-built process:
 
 ```java
 import neqsim.process.processmodel.lifecycle.ProcessSystemState;
+
+ProcessSystemState state = ProcessSystemState.loadFromFile("process_state.json");
+ProcessSystemState.ValidationResult validation = state.validate();
+if (!validation.isValid()) {
+    throw new IllegalArgumentException(validation.getErrors().toString());
+}
+state.applyTo(existingProcess);
+existingProcess.run();
+```
+
+`applyTo()` updates the matching process structure; it is not a promise that arbitrary equipment
+and connections will be recreated from JSON. `toProcessSystem()` reconstructs only the equipment
+types supported by the lifecycle implementation.
+
+### Low-level archive API
+
+Use `NeqSimXtream` when the object type is not known until runtime or when the caller needs the
+checked `IOException` from opening an archive:
+
+```java
+import java.io.IOException;
 import neqsim.process.processmodel.ProcessSystem;
-import java.io.File;
+import neqsim.util.serialization.NeqSimXtream;
 
-// Create a state snapshot from existing process
-ProcessSystemState state = ProcessSystemState.fromProcessSystem(process);
-
-// Add metadata
-state.setVersion("1.2.3");
-state.setDescription("Post-commissioning tuned model");
-
-// Save to JSON file (uncompressed) - using String path or File
-state.saveToFile("asset_model_v1.2.3.json");
-state.saveToFile(new File("asset_model_v1.2.3.json"));
-
-// Later: Load the state - using String path or File
-ProcessSystemState loadedState = ProcessSystemState.loadFromFile("asset_model_v1.2.3.json");
-ProcessSystemState loadedState = ProcessSystemState.loadFromFile(new File("asset_model_v1.2.3.json"));
-
-// Convert to ProcessSystem (limited reconstruction)
-ProcessSystem restoredProcess = loadedState.toProcessSystem();
-
-// Or apply state to existing process with matching structure
-loadedState.applyTo(existingProcess);
-```
-
-#### Compressed State Files
-
-For large process models, use GZIP compression to reduce file sizes (typically 5-20x reduction):
-
-```java
-// Save to compressed file (.neqsim) - using String path or File
-state.saveToCompressedFile("asset_model_v1.2.3.neqsim");
-state.saveToCompressedFile(new File("asset_model_v1.2.3.neqsim"));
-
-// Load from compressed file - using String path or File
-ProcessSystemState loadedState = ProcessSystemState.loadFromCompressedFile("asset_model_v1.2.3.neqsim");
-ProcessSystemState loadedState = ProcessSystemState.loadFromCompressedFile(new File("asset_model_v1.2.3.neqsim"));
-
-// Auto-detect compression based on file extension - using String path or File
-state.saveToFileAuto("asset_model.neqsim");  // Compressed
-state.saveToFileAuto("asset_model.json");    // Uncompressed
-state.saveToFileAuto(new File("asset_model.neqsim"));  // Also works with File
-
-ProcessSystemState loaded = ProcessSystemState.loadFromFileAuto("asset_model.neqsim");
-ProcessSystemState loaded = ProcessSystemState.loadFromFileAuto(new File("asset_model.neqsim"));
-```
-
-**When to use compressed state files (.neqsim):**
-- Large process models with many equipment units
-- Storage-constrained environments
-- Archiving historical model versions
-- Network transfer of state files
-
-**When to use plain JSON (.json):**
-- Version control (Git) - human-readable diffs
-- Debugging and manual inspection
-- Small to medium-sized models
-
-#### JSON State Export/Import
-
-```java
-// Export to JSON string
-String json = state.toJson();
-
-// Import from JSON string
-ProcessSystemState restored = ProcessSystemState.fromJson(json);
-```
-
-#### ProcessSystem Methods for State Management
-
-```java
-// Export current state to JSON file
-process.exportStateToFile("process_state.json");
-
-// Load and apply state from JSON file
-process.loadStateFromFile("process_state.json");
-```
-
-### Validation
-
-The `ProcessSystemState` class includes validation capabilities to verify loaded states:
-
-```java
-// Load a state file
-ProcessSystemState state = ProcessSystemState.loadFromFile("old_model.json");
-
-// Validate the state
-ProcessSystemState.ValidationResult result = state.validate();
-
-if (result.isValid()) {
-    System.out.println("State is valid!");
-} else {
-    System.out.println("Validation errors: " + result.getErrors());
+if (!NeqSimXtream.saveNeqsim(process, "my_process.neqsim")) {
+    throw new IllegalStateException("Serialization failed");
 }
 
-// Check for warnings even if valid
-if (!result.getWarnings().isEmpty()) {
-    System.out.println("Warnings: " + result.getWarnings());
+Object restored = NeqSimXtream.openNeqsim("my_process.neqsim");
+if (!(restored instanceof ProcessSystem)) {
+    throw new IOException("Archive does not contain a ProcessSystem");
 }
-
-// Check schema version
-System.out.println("Schema version: " + state.getSchemaVersion());
+ProcessSystem restoredProcess = (ProcessSystem) restored;
+restoredProcess.run();
 ```
 
-#### Schema Versioning
+Do not add unrestricted XStream permissions in application code as a substitute for the NeqSim
+helper. The helper configures reference handling and skips `ThreadLocal` fields, but its load path
+still assumes trusted input.
 
-ProcessSystemState includes automatic schema version tracking for backward compatibility:
+## Java: `ProcessModel` archives and state
 
-```java
-// Current schema version is embedded automatically
-ProcessSystemState state = ProcessSystemState.fromProcessSystem(process);
-System.out.println("Schema: " + state.getSchemaVersion()); // e.g., "1.1"
-
-// Older files without schema version are automatically migrated on load
-ProcessSystemState old = ProcessSystemState.loadFromFile("legacy_model.json");
-// Migration is automatic - connectionStates initialized if missing
-```
-
-#### Connection State Capture
-
-ProcessSystemState captures stream connections between equipment for topology analysis:
-
-```java
-ProcessSystemState state = ProcessSystemState.fromProcessSystem(process);
-
-// View captured connections
-for (ProcessSystemState.ConnectionState conn : state.getConnectionStates()) {
-    System.out.println(conn.getSourceEquipmentName() + "." + conn.getSourcePortName()
-        + " -> " + conn.getTargetEquipmentName() + "." + conn.getTargetPortName());
-}
-// Example output: separator.gasOutStream -> compressor.inlet
-```
-
----
-
-## Multi-Process Models (ProcessModel)
-
-When your simulation requires multiple interconnected ProcessSystem instances (e.g., upstream production + downstream processing), use the `ProcessModel` class for coordinated execution and serialization.
-
-### ProcessModel Overview
-
-`ProcessModel` manages a collection of `ProcessSystem` instances with:
-- **Unified execution:** Run all processes with convergence checking
-- **Cross-process tracking:** Track streams shared between ProcessSystems
-- **Single-file serialization:** Save/load entire multi-process model
-
-| Class | Purpose | Scope |
-|-------|---------|-------|
-| `ProcessSystem` | Single process flowsheet | Individual equipment + streams |
-| `ProcessModel` | Multi-process container | Multiple ProcessSystems |
-| `ProcessSystemState` | JSON state for single process | Equipment states + connections |
-| `ProcessModelState` | JSON state for multi-process | All ProcessSystemStates + inter-process links |
-
-### Saving and Loading ProcessModel
-
-#### Quick Start
+The same full-object pattern applies to a multi-process model:
 
 ```java
 import neqsim.process.processmodel.ProcessModel;
-import neqsim.process.processmodel.ProcessSystem;
 
-// Create a multi-process model
 ProcessModel model = new ProcessModel();
-model.add("upstream", createUpstreamProcess());
-model.add("downstream", createDownstreamProcess());
-model.setMaxIterations(50);
-model.setFlowTolerance(1e-5);
+model.add("upstream", upstreamProcess);
+model.add("downstream", downstreamProcess);
 model.run();
 
-// Save to compressed .neqsim file (recommended)
-model.saveToNeqsim("field_model.neqsim");
-
-// Load later (auto-runs after loading)
-ProcessModel loaded = ProcessModel.loadFromNeqsim("field_model.neqsim");
-ProcessSystem upstream = loaded.get("upstream");
-System.out.println("Upstream solved: " + upstream.solved());
-```
-
-#### Auto-Format Detection
-
-```java
-// Save with auto-format detection by extension
-model.saveAuto("field_model.neqsim");  // → Compressed XStream XML
-model.saveAuto("field_model.json");    // → JSON state export
-model.saveAuto("field_model.ser");     // → Java binary serialization
-
-// Load with auto-detection
-ProcessModel loaded = ProcessModel.loadAuto("field_model.neqsim");
-```
-
-#### Low-Level API with NeqSimXtream
-
-```java
-import neqsim.util.serialization.NeqSimXtream;
-
-// Save ProcessModel directly
-NeqSimXtream.saveNeqsim(model, "field_model.neqsim");
-
-// Load (returns Object, requires cast)
-ProcessModel loaded = (ProcessModel) NeqSimXtream.openNeqsim("field_model.neqsim");
-loaded.run();
-```
-
-### ProcessModelState for JSON Export
-
-For Git-friendly version control, use `ProcessModelState` to export multi-process models to JSON:
-
-```java
-import neqsim.process.processmodel.lifecycle.ProcessModelState;
-
-// Export state from model
-ProcessModelState state = model.exportState();
-state.setVersion("1.0.0");
-state.setDescription("Full field development model");
-state.setCreatedBy("engineering-team");
-
-// Save to JSON (human-readable)
-state.saveToFile("field_model_v1.0.0.json");
-
-// Save to compressed JSON
-state.saveToFile("field_model_v1.0.0.json.gz");
-
-// Load later
-ProcessModelState loadedState = ProcessModelState.loadFromFile("field_model_v1.0.0.json");
-ProcessModel restoredModel = loadedState.toProcessModel();
-```
-
-#### Execution Configuration Preservation
-
-ProcessModelState preserves execution settings:
-
-```java
-ProcessModelState state = model.exportState();
-
-// Access execution config
-ProcessModelState.ExecutionConfig config = state.getExecutionConfig();
-System.out.println("Max iterations: " + config.getMaxIterations());
-System.out.println("Flow tolerance: " + config.getFlowTolerance());
-System.out.println("Optimized execution: " + config.isUseOptimizedExecution());
-```
-
-### Inter-Process Connections
-
-ProcessModelState automatically captures streams shared between different ProcessSystems:
-
-```java
-ProcessModelState state = model.exportState();
-
-// View inter-process connections
-for (ProcessModelState.InterProcessConnection conn : state.getInterProcessConnections()) {
-    System.out.println(conn.getSourceProcess() + "/" + conn.getStreamName()
-        + " -> " + conn.getTargetProcess() + ":" + conn.getTargetPort());
+if (!model.saveToNeqsim("field_model.neqsim")) {
+    throw new IllegalStateException("Could not save field model");
 }
-// Example output: upstream/gas_export -> downstream:inlet
-```
-
-#### Validation
-
-Validate multi-process model state before loading:
-
-```java
-ProcessModelState state = ProcessModelState.loadFromFile("field_model.json");
-ProcessModelState.ValidationResult result = state.validate();
-
-if (!result.isValid()) {
-    for (String error : result.getErrors()) {
-        System.err.println("ERROR: " + error);
-    }
-    for (String warning : result.getWarnings()) {
-        System.out.println("WARNING: " + warning);
-    }
-} else {
-    ProcessModel model = state.toProcessModel();
-    model.run();
+ProcessModel restoredModel = ProcessModel.loadFromNeqsim("field_model.neqsim");
+if (restoredModel == null) {
+    throw new IllegalStateException("Could not load field model");
 }
 ```
 
-### Python API for ProcessModel
+Unlike `ProcessSystem.loadAuto()`, `ProcessModel.loadAuto()` recognizes `.json` and calls
+`loadStateFromFile()`. The lifecycle representation captures model metadata, per-process state,
+execution configuration, and inter-process connection records. See
+[Process Model Lifecycle Management](../process/lifecycle/process_model_lifecycle) for its schema,
+validation, comparison, and migration APIs.
 
-From Python, use the direct Java API access pattern:
+## Python: neqsim-python archives
 
-```python
-import jpype
-from neqsim import jneqsim
-
-# Access ProcessModel class
-ProcessModel = jneqsim.process.processmodel.ProcessModel
-ProcessSystem = jneqsim.process.processmodel.ProcessSystem
-NeqSimXtream = jneqsim.util.serialization.NeqSimXtream
-
-# Load a ProcessModel
-loaded = NeqSimXtream.openNeqsim("field_model.neqsim")
-model = jpype.JObject(loaded, ProcessModel)
-model.run()
-
-# Access individual ProcessSystems
-upstream = model.get("upstream")
-print(f"Upstream solved: {upstream.solved()}")
-
-# Save ProcessModel
-model.saveToNeqsim("field_model_updated.neqsim")
-```
-
----
-
-## Python API (neqsim-python)
-
-The [neqsim-python](https://github.com/equinor/neqsim-python) package provides Python wrappers for saving and loading NeqSim objects.
-
-### Quick Start
+The Python wrappers return `False` from `save_neqsim()` and `None` from `open_neqsim()` when the
+underlying operation fails. Check those values before publishing or using a file. The low-level
+Python loader does not run a restored process automatically.
 
 ```python
 import neqsim
+from neqsim.process import clearProcess, getProcess, runProcess, separator, stream
 from neqsim.thermo import fluid
-from neqsim.process import stream, separator, runProcess, clearProcess, getProcess
 
-# Build and run a process
 clearProcess()
-feed_fluid = fluid('srk')
-feed_fluid.addComponent('methane', 0.9)
-feed_fluid.addComponent('ethane', 0.1)
-feed_fluid.setTemperature(30.0, 'C')
-feed_fluid.setPressure(50.0, 'bara')
-feed_fluid.setTotalFlowRate(10.0, 'MSm3/day')
+feed_fluid = fluid("srk")
+feed_fluid.addComponent("methane", 0.9)
+feed_fluid.addComponent("ethane", 0.1)
+feed_fluid.setTemperature(30.0, "C")
+feed_fluid.setPressure(50.0, "bara")
+feed_fluid.setTotalFlowRate(10.0, "MSm3/day")
 
-inlet = stream('inlet', feed_fluid)
-sep = separator('separator', inlet)
+feed = stream("feed", feed_fluid)
+separator("separator", feed)
 runProcess()
 process = getProcess()
 
-# Save to compressed .neqsim file
-neqsim.save_neqsim(process, "my_process.neqsim")
+if not neqsim.save_neqsim(process, "my_process.neqsim"):
+    raise OSError("Could not save my_process.neqsim")
 
-# Load from .neqsim file
-loaded = neqsim.open_neqsim("my_process.neqsim")
-loaded.run()
-print(f"Loaded: {loaded.getName()}")
-```
-
-### Saving and Loading .neqsim Files
-
-The `.neqsim` format stores compressed XML, making it efficient for large process models:
-
-```python
-import neqsim
-from neqsim.thermo import fluid
-from neqsim.process import stream, separator, runProcess, clearProcess, getProcess
-
-# Build a process
-clearProcess()
-feed_fluid = fluid('srk')
-feed_fluid.addComponent('methane', 0.9)
-feed_fluid.addComponent('ethane', 0.1)
-feed_fluid.setTemperature(30.0, 'C')
-feed_fluid.setPressure(50.0, 'bara')
-feed_fluid.setTotalFlowRate(10.0, 'MSm3/day')
-
-inlet = stream('inlet', feed_fluid)
-sep = separator('separator', inlet)
-runProcess()
-
-# Get the process object
-process = getProcess()
-
-# Save to compressed .neqsim file
-neqsim.save_neqsim(process, "my_process.neqsim")
-print("Process saved!")
-```
-
-```python
-# Load the process from .neqsim file
 loaded_process = neqsim.open_neqsim("my_process.neqsim")
-
-# Run the loaded process
+if loaded_process is None:
+    raise OSError("Could not load my_process.neqsim")
 loaded_process.run()
-
-print(f"Loaded process: {loaded_process.getName()}")
-print(f"Number of units: {loaded_process.getUnitOperations().size()}")
 ```
 
-### Saving and Loading XML Files
+`save_xml()` and `open_xml()` provide uncompressed XML for debugging. They have the same trusted-
+input boundary as `.neqsim` archives and are not a safe interchange parser for arbitrary XML.
 
-For debugging or when human-readable output is needed:
+## Publish files transactionally
 
-```python
-import neqsim
-from neqsim.thermo import createfluid
+`saveToNeqsim()` and `save_neqsim()` open the destination before serializing. If serialization
+fails, they report failure but a partial or truncated destination can remain. Do not treat file
+existence as proof of success.
 
-# Create a fluid
-fluid1 = createfluid("dry gas")
+For durable checkpoints:
 
-# Save to uncompressed XML
-neqsim.save_xml(fluid1, "my_fluid.xml")
+1. save to a temporary path in the destination directory;
+2. require a successful return value;
+3. reopen the temporary archive and verify its expected Java type;
+4. run the restored process and check the engineering acceptance criteria; and
+5. replace the published checkpoint with the verified temporary file using an atomic move when
+   the filesystem supports it.
 
-# Load from XML
-fluid2 = neqsim.open_xml("my_fluid.xml")
+Delete a failed temporary file. Preserve the previous verified checkpoint until the replacement
+has passed the round trip.
 
-# Verify the data was preserved
-assert fluid1.getTemperature() == fluid2.getTemperature()
-```
+## Portability and compatibility
 
-### Direct Java API Access
+### Embedded JVM hosts
 
-For full control, you can use the Java API directly from Python via JPype:
+XStream cannot reflect into several JDK collection implementations when the JVM does not open
+`java.util`. This matters in embedded hosts such as neqsim-python, which normally run without
+Surefire's `--add-opens` options. A reachable unsupported collection can produce a
+`No converter available` error and a truncated output file.
 
-```python
-import jpype
-import jpype.imports
-from jpype.types import *
+NeqSim regression coverage now checks that empty and recycle-bearing `ProcessSystem` graphs do not
+retain the known unsupported JDK collection types, and it round-trips a process containing a
+`Recycle`. If the error recurs for another equipment graph, record the failing equipment and full
+exception, remove the partial file, and report a minimal model that reproduces the graph.
 
-# Start the JVM (if not already started by neqsim)
-if not jpype.isJVMStarted():
-    jpype.startJVM(classpath=['path/to/neqsim.jar'])
+Do not add JVM-wide `--add-opens` flags merely to make a process serializable. That can hide a
+non-portable stored field and behave differently between Maven tests and embedded applications.
 
-# Import Java classes directly
-from neqsim.process.processmodel import ProcessSystem
-from neqsim.process.processmodel.lifecycle import ProcessSystemState
-from neqsim.thermo.system import SystemSrkEos
-from neqsim.process.equipment.stream import Stream
+### Version compatibility
 
-# Create a process using Java API
-fluid = SystemSrkEos(298.15, 50.0)
-fluid.addComponent("methane", 10.0)
-fluid.addComponent("ethane", 5.0)
-fluid.setMixingRule("classic")
+Full-object archives contain Java class and field names. Test a representative archive before a
+NeqSim upgrade, keep the creating NeqSim version with the artifact, and retain a previous verified
+checkpoint. Unknown fields may be ignored by the configured reader, but renamed or removed classes,
+changed equipment graphs, and changed solver behavior can still prevent loading or change results.
 
-process = ProcessSystem("MyProcess")
-feed = Stream("feed", fluid)
-feed.setFlowRate(1000.0, "kg/hr")
-process.add(feed)
-process.run()
-
-# Use the convenience methods
-process.saveToNeqsim("model.neqsim")
-
-# Load back
-loaded = ProcessSystem.loadFromNeqsim("model.neqsim")
-print(f"Loaded: {loaded.getName()}")
-
-# Use ProcessSystemState for JSON export
-state = ProcessSystemState.fromProcessSystem(process)
-state.setVersion("1.0.0")
-state.setDescription("Initial model")
-state.saveToFile("model_state.json")
-
-# Validate loaded state
-loaded_state = ProcessSystemState.loadFromFile("model_state.json")
-result = loaded_state.validate()
-if result.isValid():
-    print("State is valid")
-else:
-    print(f"Errors: {list(result.getErrors())}")
-```
-
-#### ProcessSystemState from Python
-
-```python
-from neqsim.process.processmodel.lifecycle import ProcessSystemState
-
-# Create state from process
-state = ProcessSystemState.fromProcessSystem(process)
-
-# Add metadata
-state.setVersion("2.1.0")
-state.setDescription("Updated heat exchanger configuration")
-state.setCreatedBy("engineer@company.com")
-
-# Save with auto-format detection
-state.saveToFileAuto("model.neqsim")  # Compressed
-state.saveToFileAuto("model.json")    # JSON (Git-friendly)
-
-# Load and validate
-loaded = ProcessSystemState.loadFromFileAuto("model.neqsim")
-print(f"Schema version: {loaded.getSchemaVersion()}")
-print(f"Equipment count: {loaded.getEquipmentStates().size()}")
-
-# Check connections
-for conn in loaded.getConnectionStates():
-    print(f"  {conn.getSourceEquipmentName()} -> {conn.getTargetEquipmentName()}")
-```
-
-### Using ProcessBuilder with Configuration Files
-
-neqsim-python also supports JSON/YAML-based process configuration:
-
-```python
-from neqsim.thermo import fluid
-from neqsim.process import ProcessBuilder
-
-# Create fluid
-feed = fluid('srk')
-feed.addComponent('methane', 0.9)
-feed.addComponent('ethane', 0.1)
-feed.setTemperature(30.0, 'C')
-feed.setPressure(50.0, 'bara')
-
-# Load process from JSON configuration
-process = ProcessBuilder.from_json('process_config.json',
-                                   fluids={'feed': feed}).run()
-
-# Get results as JSON
-results = process.results_json()
-
-# Save results to file
-process.save_results('results.json', format='json')
-```
-
-#### Example JSON Configuration File
-
-```json
-{
-  "name": "Compression Train",
-  "equipment": [
-    {
-      "type": "stream",
-      "name": "inlet",
-      "fluid": "feed",
-      "flow_rate": 10.0,
-      "flow_unit": "MSm3/day"
-    },
-    {
-      "type": "separator",
-      "name": "inlet_separator",
-      "inlet": "inlet"
-    },
-    {
-      "type": "compressor",
-      "name": "stage1_compressor",
-      "inlet": "inlet_separator",
-      "outlet_pressure": 80.0
-    }
-  ]
-}
-```
-
----
-
-## Compressed Files (.neqsim format)
-
-### Internal Structure
-
-A `.neqsim` file is a standard ZIP archive containing a single XML file:
-
-```
-my_process.neqsim (ZIP archive)
-└── process.xml    (XStream-serialized XML)
-```
-
-### File Size Comparison
-
-| Process Complexity | XML Size | .neqsim Size | Compression Ratio |
-|-------------------|----------|--------------|-------------------|
-| Simple (5 units)  | ~500 KB  | ~30 KB       | ~17:1             |
-| Medium (20 units) | ~2 MB    | ~120 KB      | ~17:1             |
-| Complex (50+ units) | ~10 MB | ~600 KB      | ~17:1             |
-
-### Manual Inspection
-
-You can manually inspect `.neqsim` files using any ZIP tool:
-
-```bash
-# Linux/Mac
-unzip -l my_process.neqsim
-unzip -p my_process.neqsim process.xml | head -100
-
-# Windows PowerShell
-Expand-Archive -Path my_process.neqsim -DestinationPath extracted
-Get-Content extracted\process.xml | Select-Object -First 100
-```
-
----
-
-## Best Practices
-
-### 1. Use Compressed Format for Production
-
-Always use `.neqsim` format for production deployments to minimize storage and transfer costs:
-
-```java
-// Good - compressed
-NeqSimXtream.saveNeqsim(process, "production_model.neqsim");
-
-// Avoid for large models - uncompressed
-// xstream.toXML(process, new FileWriter("production_model.xml"));
-```
-
-### 2. Version Your Models
-
-Use `ProcessSystemState` with version metadata for proper model lifecycle management:
-
-```java
-ProcessSystemState state = ProcessSystemState.fromProcessSystem(process);
-state.setVersion("2.1.0");
-state.setDescription("Updated valve Cv values based on commissioning data");
-state.setCreatedBy("process_engineer@company.com");
-state.saveToFile("model_v2.1.0.json");
-```
-
-### 3. Run After Loading
-
-Always run the process after loading to ensure the internal state is consistent:
-
-```java
-ProcessSystem loaded = (ProcessSystem) NeqSimXtream.openNeqsim("model.neqsim");
-loaded.run();  // Important: reinitialize calculations
-```
-
-### 4. Handle Security Permissions
-
-When using XStream directly, explicitly set permissions:
-
-```java
-XStream xstream = new XStream();
-xstream.addPermission(AnyTypePermission.ANY);  // Required for deserialization
-xstream.allowTypesByWildcard(new String[]{"neqsim.**"});
-```
-
-### 5. Use JSON for Version Control
-
-JSON state files are ideal for Git-based version control:
-
-```bash
-# Track model changes in Git
-git add asset_model_v1.2.3.json
-git commit -m "Updated model with new heat exchanger configuration"
-```
-
----
+Lifecycle JSON is easier to inspect and migrate, but it is a selective state model rather than a
+lossless copy of every Java object. Record schema version, model version, provenance, units, and the
+base model definition used for `applyTo()`.
 
 ## Troubleshooting
 
-### Common Issues
+### Save returned `false`
 
-#### 1. FileNotFoundException: process.xml not found in zip file
+- Read the logged root exception; do not continue with the destination file.
+- Remove the partial temporary file.
+- For `No converter available` or module-access errors, reduce the model to the equipment that
+  introduces the stored collection and report it as a portability defect.
+- Confirm the parent directory is writable and has enough free space.
 
-The `.neqsim` file is corrupted or not a valid ZIP archive.
+### Load returned `null` or `None`
 
-**Solution:** Verify the file is a valid ZIP and contains `process.xml`:
-```bash
-unzip -l my_process.neqsim
-```
+- Confirm the file is a ZIP archive with a `process.xml` entry.
+- Confirm it was created with a compatible NeqSim version.
+- Confirm the expected root type (`ProcessSystem` versus `ProcessModel`).
+- Do not retry an untrusted or visibly truncated file with broader XStream permissions.
 
-#### 2. ClassNotFoundException during deserialization
+### Loaded values differ
 
-The serialized object references a class that doesn't exist in the current NeqSim version.
+- Remember that the Java convenience loaders run the model after deserialization.
+- Compare inputs, solver settings, NeqSim version, and convergence diagnostics, not only stored
+  outlet values.
+- For lifecycle JSON, verify that `validate()` succeeds and that `applyTo()` targets the same
+  equipment names and topology.
 
-**Solution:** Ensure you're using the same (or compatible) NeqSim version that created the file.
+## API summary
 
-#### 3. Large file sizes
+| API | Failure signal | Runs after load? |
+| --- | --- | --- |
+| `ProcessSystem.saveToNeqsim(path)` | `false` | Not applicable |
+| `ProcessSystem.loadFromNeqsim(path)` | `null` | Yes |
+| `ProcessModel.saveToNeqsim(path)` | `false` | Not applicable |
+| `ProcessModel.loadFromNeqsim(path)` | `null` | Yes |
+| `NeqSimXtream.saveNeqsim(object, path)` | `false` | Not applicable |
+| `NeqSimXtream.openNeqsim(path)` | `IOException` or incompatible object | No |
+| `neqsim.save_neqsim(object, path)` | `False` | Not applicable |
+| `neqsim.open_neqsim(path)` | `None` | No |
 
-Complex processes with many components can create large files.
+## See also
 
-**Solution:**
-- Use compressed `.neqsim` format
-- Consider saving only the process state (JSON) instead of the full object
-
-#### 4. ThreadLocal serialization error
-
-XStream cannot serialize ThreadLocal fields.
-
-**Solution:** The `NeqSimXtream` class automatically handles this by skipping ThreadLocal fields. Use `NeqSimXtream` instead of raw XStream.
-
-### Debugging Serialization Issues
-
-Enable detailed logging to diagnose problems:
-
-```java
-// Check what's being serialized
-String xml = xstream.toXML(process);
-System.out.println("XML length: " + xml.length());
-System.out.println("First 1000 chars: " + xml.substring(0, Math.min(1000, xml.length())));
-```
-
----
-
-## API Reference
-
-### Java Classes
-
-| Class | Description |
-|-------|-------------|
-| `neqsim.process.processmodel.ProcessSystem` | Main process container with `saveToNeqsim()`, `loadFromNeqsim()`, `saveAuto()`, `loadAuto()` methods |
-| `neqsim.process.processmodel.ProcessModel` | Multi-process container with save/load methods for multiple ProcessSystems |
-| `neqsim.util.serialization.NeqSimXtream` | Low-level compressed XML serialization to `.neqsim` files |
-| `neqsim.process.processmodel.lifecycle.ProcessSystemState` | JSON-based state snapshots for single ProcessSystem |
-| `neqsim.process.processmodel.lifecycle.ProcessModelState` | JSON-based state snapshots for multi-process models |
-| `neqsim.process.processmodel.lifecycle.ProcessSystemState.ValidationResult` | Validation result with errors and warnings |
-| `neqsim.process.processmodel.lifecycle.ProcessSystemState.ConnectionState` | Stream connection between equipment |
-| `neqsim.process.processmodel.lifecycle.ProcessSystemState.EquipmentState` | Captured state of a single equipment unit |
-| `neqsim.process.processmodel.lifecycle.ProcessModelState.InterProcessConnection` | Connection between ProcessSystems |
-| `neqsim.process.processmodel.lifecycle.ProcessModelState.ExecutionConfig` | Execution configuration for ProcessModel |
-
-### ProcessSystem Methods
-
-| Method | Description |
-|--------|-------------|
-| `saveToNeqsim(String filename)` | Save to compressed .neqsim file |
-| `loadFromNeqsim(String filename)` | Load from .neqsim file (static, auto-runs) |
-| `saveAuto(String filename)` | Save with auto-format detection by extension |
-| `loadAuto(String filename)` | Load with auto-format detection (static) |
-| `exportStateToFile(String filename)` | Export JSON state to file |
-| `loadStateFromFile(String filename)` | Load and apply JSON state |
-| `exportState()` | Get ProcessSystemState snapshot |
-
-### ProcessModel Methods
-
-| Method | Description |
-|--------|-------------|
-| `saveToNeqsim(String filename)` | Save entire model to compressed .neqsim file |
-| `loadFromNeqsim(String filename)` | Load from .neqsim file (static, auto-runs) |
-| `saveAuto(String filename)` | Save with auto-format detection by extension |
-| `loadAuto(String filename)` | Load with auto-format detection (static) |
-| `saveStateToFile(String filename)` | Export JSON state to file |
-| `loadStateFromFile(String filename)` | Load JSON state (static) |
-| `exportState()` | Get ProcessModelState snapshot |
-| `add(String name, ProcessSystem)` | Add a ProcessSystem to the model |
-| `get(String name)` | Get a ProcessSystem by name |
-| `getAllProcesses()` | Get all ProcessSystems |
-| `validateSetup()` | Validate all processes |
-
-### ProcessSystemState Methods
-
-| Method | Description |
-|--------|-------------|
-| `fromProcessSystem(ProcessSystem)` | Create state snapshot (static) |
-| `saveToFile(String)` / `saveToFile(File)` | Save as JSON |
-| `loadFromFile(String)` / `loadFromFile(File)` | Load JSON (static) |
-| `saveToCompressedFile(String)` | Save as GZIP-compressed JSON |
-| `loadFromCompressedFile(String)` | Load compressed JSON (static) |
-| `saveToFileAuto(String)` | Auto-detect format by extension |
-| `loadFromFileAuto(String)` | Auto-detect format on load (static) |
-| `validate()` | Validate state, returns ValidationResult |
-| `applyTo(ProcessSystem)` | Apply state to existing process |
-| `toJson()` / `fromJson(String)` | JSON string conversion |
-| `getSchemaVersion()` | Get schema version string |
-| `getConnectionStates()` | Get list of stream connections |
-| `getEquipmentStates()` | Get list of equipment states |
-
-### ProcessModelState Methods
-
-| Method | Description |
-|--------|-------------|
-| `fromProcessModel(ProcessModel)` | Create state snapshot (static) |
-| `saveToFile(String)` | Save as JSON (or .gz for compressed) |
-| `loadFromFile(String)` | Load JSON (static) |
-| `saveToCompressedFile(String)` | Save as GZIP-compressed file |
-| `loadFromCompressedFile(String)` | Load compressed file (static) |
-| `toProcessModel()` | Reconstruct ProcessModel from state |
-| `validate()` | Validate state, returns ValidationResult |
-| `toJson()` / `fromJson(String)` | JSON string conversion |
-| `toJson(SerializationOptions)` | JSON with formatting options |
-| `toCompressedBytes()` | GZIP-compressed byte array |
-| `fromCompressedBytes(byte[])` | Load from compressed bytes (static) |
-| `compare(old, new)` | Compare two states, returns ModelDiff (static) |
-| `migrate(state, version)` | Migrate state to target schema (static) |
-| `getProcessStates()` | Get map of ProcessSystemStates |
-| `getInterProcessConnections()` | Get inter-process connections |
-| `addInterProcessConnection(InterProcessConnection)` | Add manual inter-process connection |
-| `getConnectionsTo(String)` | Get connections targeting a process |
-| `getExecutionConfig()` | Get execution configuration |
-| `getProcessCount()` | Get number of ProcessSystems |
-| `setVersion(String)` | Set version metadata |
-| `setDescription(String)` | Set description metadata |
-| `setCreatedBy(String)` | Set creator metadata |
-| `setCustomProperty(String, Object)` | Set custom property |
-| `getCustomProperty(String)` | Get single custom property |
-| `getCustomProperties()` | Get all custom properties map |
-
-### Python Functions
-
-| Function | Description |
-|----------|-------------|
-| `neqsim.save_neqsim(obj, filename)` | Save object to compressed `.neqsim` file |
-| `neqsim.open_neqsim(filename)` | Load object from compressed `.neqsim` file |
-| `neqsim.save_xml(obj, filename)` | Save object to uncompressed XML file |
-| `neqsim.open_xml(filename)` | Load object from uncompressed XML file |
-
-### Python Direct Java API
-
-| Class (via JPype) | Description |
-|-------------------|-------------|
-| `ProcessSystem.saveToNeqsim(filename)` | Save process to .neqsim |
-| `ProcessSystem.loadFromNeqsim(filename)` | Load process from .neqsim |
-| `ProcessModel.saveToNeqsim(filename)` | Save multi-process model to .neqsim |
-| `ProcessModel.loadFromNeqsim(filename)` | Load multi-process model from .neqsim |
-| `ProcessSystemState.fromProcessSystem(process)` | Create state snapshot |
-| `ProcessModelState.fromProcessModel(model)` | Create multi-process state snapshot |
-| `ProcessSystemState.loadFromFileAuto(filename)` | Load state with format detection |
-| `state.validate()` | Validate loaded state |
-
----
-
-## See Also
-
-- [Process Model Lifecycle Management](../process/lifecycle/process_model_lifecycle) - State management, versioning, and lifecycle tracking
-- [Process Automation API](process_automation) - String-addressable automation for reading/writing simulation variables
-- [NeqSim Java Documentation](https://equinor.github.io/neqsim/)
-- [NeqSim Python Documentation](https://github.com/equinor/neqsim-python)
-- [XStream Library](https://x-stream.github.io/)
-- [Process Simulation Guide](../process/)
+- [ProcessSystem](../process/processmodel/process_system)
+- [ProcessModel](../process/processmodel/process_model)
+- [Process Model Lifecycle Management](../process/lifecycle/process_model_lifecycle)
+- [NeqSim Python](https://github.com/equinor/neqsim-python)
+- [XStream security](https://x-stream.github.io/security.html)

--- a/docs/test_process_serialization_documentation.py
+++ b/docs/test_process_serialization_documentation.py
@@ -1,0 +1,104 @@
+"""Regression contracts for the process serialization documentation."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDE = ROOT / "docs" / "simulation" / "process_serialization.md"
+PROCESS_GUIDE = ROOT / "docs" / "process" / "processmodel" / "process_system.md"
+PROCESS_SOURCE = (
+    ROOT / "src" / "main" / "java" / "neqsim" / "process" / "processmodel" / "ProcessSystem.java"
+)
+XSTREAM_SOURCE = (
+    ROOT / "src" / "main" / "java" / "neqsim" / "util" / "serialization" / "NeqSimXtream.java"
+)
+PORTABILITY_TEST = (
+    ROOT
+    / "src"
+    / "test"
+    / "java"
+    / "neqsim"
+    / "process"
+    / "processmodel"
+    / "ProcessSystemXStreamPortabilityTest.java"
+)
+
+
+def read(path: Path) -> str:
+    """Read one repository text file."""
+
+    return path.read_text(encoding="utf-8")
+
+
+def test_java_quick_start_checks_archive_failures() -> None:
+    """The primary recipe must compile conceptually and check both documented failure signals."""
+
+    guide = read(GUIDE)
+
+    assert "import neqsim.thermo.system.SystemInterface;" in guide
+    assert 'if (!process.saveToNeqsim("my_process.neqsim"))' in guide
+    assert "if (loaded == null)" in guide
+    assert "ProcessSystem.loadFromNeqsim() loads and runs it" in guide
+
+
+def test_process_system_auto_load_semantics_match_source() -> None:
+    """Do not imply that ProcessSystem.loadAuto can consume lifecycle JSON."""
+
+    guide = read(GUIDE)
+    source = read(PROCESS_SOURCE)
+
+    assert "ProcessSystem.loadAuto() does **not** load lifecycle JSON" in guide
+    assert 'if (lowerName.endsWith(".neqsim"))' in source
+    assert "return loadFromNeqsim(filename);" in source
+    assert "return open(filename);" in source
+
+
+def test_python_recipe_checks_wrapper_failure_values() -> None:
+    """Python users must not run a missing or partially written process."""
+
+    guide = read(GUIDE)
+
+    assert "if not neqsim.save_neqsim" in guide
+    assert "if loaded_process is None:" in guide
+    assert "loaded_process.run()" in guide
+
+
+def test_failed_save_and_trust_boundaries_are_explicit() -> None:
+    """Document partial-file behavior without teaching unrestricted XStream setup."""
+
+    guide = read(GUIDE)
+    source = read(XSTREAM_SOURCE)
+
+    assert "partial or truncated destination can remain" in guide
+    assert "Load `.neqsim` and XML files only from trusted sources" in guide
+    assert "AnyTypePermission.ANY" not in guide
+    assert "new FileOutputStream(filename)" in source
+    assert "return false;" in source
+
+
+def test_embedded_host_portability_guidance_is_source_anchored() -> None:
+    """Keep the recent recycle portability fix discoverable and diagnostically useful."""
+
+    guide = read(GUIDE)
+    regression = read(PORTABILITY_TEST)
+
+    assert "embedded hosts such as neqsim-python" in guide
+    assert "`No converter available` error" in guide
+    assert "recycle-bearing `ProcessSystem`" in guide
+    assert "save_neqsim" in regression
+    assert "No converter available" in regression
+    assert "testProcessWithRecycleRoundTripsThroughXStream" in regression
+
+
+def test_format_boundaries_and_process_entry_point_remain_discoverable() -> None:
+    """Keep full-object archives distinct from selective lifecycle state at both entry points."""
+
+    guide = read(GUIDE)
+    process_guide = read(PROCESS_GUIDE)
+
+    assert "selective state model rather than a lossless copy" in guide
+    assert "Compression depends on the actual model graph" in guide
+    assert "~500 KB" not in guide
+    assert "Process Serialization Guide" in process_guide
+    assert "does not load lifecycle JSON" in process_guide
+    assert "saveToNeqsim" in process_guide

--- a/docs/test_process_serialization_documentation.py
+++ b/docs/test_process_serialization_documentation.py
@@ -47,7 +47,7 @@ def test_process_system_auto_load_semantics_match_source() -> None:
     guide = read(GUIDE)
     source = read(PROCESS_SOURCE)
 
-    assert "ProcessSystem.loadAuto() does **not** load lifecycle JSON" in guide
+    assert "does **not** load lifecycle JSON" in guide
     assert 'if (lowerName.endsWith(".neqsim"))' in source
     assert "return loadFromNeqsim(filename);" in source
     assert "return open(filename);" in source
@@ -96,7 +96,8 @@ def test_format_boundaries_and_process_entry_point_remain_discoverable() -> None
     guide = read(GUIDE)
     process_guide = read(PROCESS_GUIDE)
 
-    assert "selective state model rather than a lossless copy" in guide
+    assert "selective state model rather than a" in guide
+    assert "lossless copy of every Java object" in guide
     assert "Compression depends on the actual model graph" in guide
     assert "~500 KB" not in guide
     assert "Process Serialization Guide" in process_guide


### PR DESCRIPTION
## Summary

Repairs D073 of documentation-quality campaign #2499 by aligning process-persistence guidance with the current Java and neqsim-python behavior, including the embedded-host portability fix merged in #3126.

- distinguishes full-object `.neqsim` archives from selective lifecycle JSON state;
- corrects the asymmetric `ProcessSystem.saveAuto()` / `loadAuto()` extension behavior;
- makes Java and Python recipes check their documented failure signals;
- documents trusted-input, version-compatibility, partial-file, and transactional-publication boundaries;
- removes unsupported fixed compression claims and unsafe raw-XStream guidance;
- exposes the recycle-bearing embedded-host portability regression and diagnostic path;
- updates the `ProcessSystem` entry point and adds six source-anchored documentation contracts.

Advances #2499.

## Frozen scope

- Base: `06bd37614d4e74a044662fe56fb6b123b7cbfaee`.
- Exact head: `02f90e29b10658e67bb4a649a2ce53e61cc93226`.
- Files:
  - `docs/simulation/process_serialization.md`
  - `docs/process/processmodel/process_system.md`
  - `docs/test_process_serialization_documentation.py`
- Stop boundary: no production serialization API, object graph, lifecycle schema, neqsim-python, notebook, or Huldra changes.

## Documentation impact

This PR is documentation-first. It corrects user-visible persistence choices, exact load/run behavior, failure handling, trust boundaries, compatibility expectations, and embedded-host diagnostics. No API or runtime behavior changes.

## Validation

**READY TO MERGE** at exact head `02f90e29b10658e67bb4a649a2ce53e61cc93226`.

All exact-head GitHub workflows passed:

- [build, tests, and Javadocs](https://github.com/equinor/neqsim/actions/runs/32453284981);
- [documentation search coverage](https://github.com/equinor/neqsim/actions/runs/32453284936);
- [pre-commit checks](https://github.com/equinor/neqsim/actions/runs/32453284935);
- [Spotless format patch](https://github.com/equinor/neqsim/actions/runs/32453284995);
- [CodeQL security analysis](https://github.com/equinor/neqsim/actions/runs/32453284915).

Additional evidence:

- connector-backed exact-source audit against `ProcessSystem`, `ProcessModel`, `NeqSimXtream`, `ProcessSystemXStreamPortabilityTest`, and current neqsim-python wrappers;
- all six committed documentation-contract tests passed in the hosted build;
- `python -m py_compile docs/test_process_serialization_documentation.py` passed for the staged test content;
- final compare is four commits ahead, zero behind, with exactly the three frozen files changed;
- no comments, review findings, or unresolved threads at this head.

Local Maven, pre-commit, Spotless, and full documentation search were unavailable because this environment has no full repository checkout; the equivalent GitHub workflows are the authoritative validation.
