### PR TITLE
[AI-Assisted] feat(optimization): rank debottleneck alternatives

### DIFF
--- a/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
+++ b/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
@@ -1091,7 +1091,8 @@ policy = Ranking.RankingPolicy(
     "NeqSim stream result",
     "single steady state",
     Ranking.RankingDirection.MAXIMIZE,
-    0.0,
+    1.0e-8,
+    1.0e-8,
     0.5,
     0.9,
 )
@@ -1335,7 +1336,7 @@ on `ProcessSimulationEvaluator`.
 
 | Method | Description |
 |--------|-------------|
-| `RankingPolicy(...)` | Exact single-metric identity, unit, basis, provenance, period, direction, tie tolerance, and optional confidence floors |
+| `RankingPolicy(...)` | Exact single-metric identity, unit, basis, provenance, period and direction; in-unit tie tolerance; dimensionless repeated-baseline relative tolerance; optional confidence floors |
 | `rank(List<StudyResult>)` | Fail-closed qualification, exact-baseline comparison, deterministic ordering, and competition ranks |
 | `RankingResult.getRankedCandidates()` | Compatible candidates in deterministic rank order with their complete paired-study evidence |
 | `RankingResult.getRejectedCandidates()` | Incompatible studies with status and diagnostics; no synthetic normalized score |
@@ -1363,4 +1364,3 @@ on `ProcessSimulationEvaluator`.
 - [flow-rate-optimization.md](../process/optimization/flow-rate-optimization.md) - FlowRateOptimizer for lift curve generation
 - [pressure_boundary_optimization.md](../process/pressure_boundary_optimization.md) - Simplified pressure boundary optimizer
 - [PRODUCTION_OPTIMIZATION_GUIDE.md](../examples/PRODUCTION_OPTIMIZATION_GUIDE.md) - Complete production optimization examples
-

--- a/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
+++ b/docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md
@@ -1070,6 +1070,74 @@ retains no process model, equipment, live capacity constraint, or Python callbac
 Java-serialized for restartable records. Screening economics and emissions remain caller-supplied
 metrics with explicit basis and provenance; NeqSim does not certify them.
 
+### Rank compatible paired studies from Python
+
+`ProcessModelDebottleneckRanking` consumes completed immutable study results. It ranks one exact
+metric definition and rejects changed units, bases, provenance, periods, confidence, searches, or
+baseline evidence instead of constructing a normalized score.
+
+```python
+Ranking = jneqsim.process.util.optimizer.ProcessModelDebottleneckRanking
+
+policy = Ranking.RankingPolicy(
+    "production-delta",
+    "Production delta ranking",
+    "screening portfolio rev A",
+    "production",
+    "Feed production",
+    Study.MetricKind.PRODUCTION,
+    "kg/hr",
+    "wet feed mass rate",
+    "NeqSim stream result",
+    "single steady state",
+    Ranking.RankingDirection.MAXIMIZE,
+    0.0,
+    0.5,
+    0.9,
+)
+
+ranking = Ranking(
+    "separator-portfolio",
+    "Separator alternatives portfolio",
+    "brownfield screening alternatives rev A",
+    policy,
+)
+
+study_results = ArrayList()
+study_results.add(result_1100)
+study_results.add(result_1150)
+study_results.add(result_1200)
+portfolio = ranking.rank(study_results)
+
+best = portfolio.getBestCandidate()
+best_alternative_id = best.getAlternativeDefinition().getId()
+best_delta = best.getDelta()
+best_unit = portfolio.getPolicy().getUnit()
+
+ranked_rows = [
+    {
+        "rank": row.getRank(),
+        "alternative_id": row.getAlternativeDefinition().getId(),
+        "delta": row.getDelta(),
+    }
+    for row in portfolio.getRankedCandidates()
+]
+rejected_rows = [
+    {
+        "alternative_id": row.getAlternativeDefinition().getId(),
+        "status": str(row.getStatus()),
+        "diagnostics": list(row.getDiagnostics()),
+    }
+    for row in portfolio.getRejectedCandidates()
+]
+```
+
+The same deterministic baseline must be reproduced by every rankable study. A different candidate
+grid that selects another installed-case point is rejected even when its alternative delta is
+finite. The returned Java lists are unmodifiable and every `CandidateEvidence` retains its complete
+serializable `StudyResult`. Run separate policies for production, power, emissions, and screening
+economics; never sum their raw deltas or compare unlike units.
+
 ### Export Problem Definition
 
 ```python
@@ -1262,6 +1330,17 @@ on `ProcessSimulationEvaluator`.
 | `StudyResult.getBaseline()` / `getAlternative()` | Immutable scenario evidence with selected parameters, objectives, margins, installed/boundary evidence, metrics, and diagnostics |
 | `StudyResult.getMetricComparisons()` | Identically defined metric rows with `alternative - baseline` deltas |
 | `StudyResult.isCapacityRestored()` / `isProcessStateRestored()` | Explicit transaction-recovery evidence |
+
+### ProcessModelDebottleneckRanking
+
+| Method | Description |
+|--------|-------------|
+| `RankingPolicy(...)` | Exact single-metric identity, unit, basis, provenance, period, direction, tie tolerance, and optional confidence floors |
+| `rank(List<StudyResult>)` | Fail-closed qualification, exact-baseline comparison, deterministic ordering, and competition ranks |
+| `RankingResult.getRankedCandidates()` | Compatible candidates in deterministic rank order with their complete paired-study evidence |
+| `RankingResult.getRejectedCandidates()` | Incompatible studies with status and diagnostics; no synthetic normalized score |
+| `RankingResult.getCandidatesInInputOrder()` | Complete audit trail in caller submission order |
+| `RankingResult.getBestCandidate()` | Highest-ranked compatible candidate, or `null` when none qualifies |
 
 ### EvaluationResult
 

--- a/docs/process/optimization/OPTIMIZATION_AND_CONSTRAINTS.md
+++ b/docs/process/optimization/OPTIMIZATION_AND_CONSTRAINTS.md
@@ -828,6 +828,83 @@ or investment approval.
 
 ---
 
+## Ranking Independent Debottleneck Alternatives
+
+Use `ProcessModelDebottleneckRanking` after two or more independent
+`ProcessModelDebottleneckStudy` runs have completed. It ranks one explicitly declared metric at a
+time and rejects evidence that is not directly comparable. It does not normalize, weight, or add
+production, power, energy, emissions, and screening economics.
+
+```java
+ProcessModelDebottleneckRanking.RankingPolicy productionPolicy =
+    new ProcessModelDebottleneckRanking.RankingPolicy(
+        "production-delta",
+        "Production delta ranking",
+        "screening portfolio rev A",
+        "production",
+        "Feed production",
+        ProcessModelDebottleneckStudy.MetricKind.PRODUCTION,
+        "kg/hr",
+        "wet feed mass rate",
+        "NeqSim stream result",
+        "single steady state",
+        ProcessModelDebottleneckRanking.RankingDirection.MAXIMIZE,
+        0.0,
+        0.5,
+        0.9);
+
+ProcessModelDebottleneckRanking ranking =
+    new ProcessModelDebottleneckRanking(
+        "separator-portfolio",
+        "Separator alternatives portfolio",
+        "brownfield screening alternatives rev A",
+        productionPolicy);
+
+ProcessModelDebottleneckRanking.RankingResult ranked =
+    ranking.rank(Arrays.asList(study1100, study1150, study1200));
+
+ProcessModelDebottleneckRanking.CandidateEvidence best = ranked.getBestCandidate();
+List<ProcessModelDebottleneckRanking.CandidateEvidence> rejected =
+    ranked.getRejectedCandidates();
+```
+
+The policy above requires exact metric id, name, kind, unit, basis, provenance, and effective
+period. The two confidence floors apply separately to the documented capacity alternative and the
+baseline/alternative metric evidence; use `Double.NaN` only when a confidence floor is deliberately
+unset. A submitted study is rankable only when it:
+
+- completed both scenarios and independently verified convergence and feasibility;
+- restored the complete installed-capacity state and reconverged the pre-study process state;
+- supplies a finite `alternative - baseline` delta for the declared metric; and
+- reproduces the reference baseline's search identity/provenance, selected parameter vector,
+  ranking metric, objective rows, and constraint rows exactly.
+
+The first otherwise-qualified submission establishes the baseline reference. This deliberately
+strict comparison prevents alternatives based on a changed candidate set, process configuration,
+constraint registration, objective definition, data period, emission factor, or price basis from
+being silently mixed into one list. Rejected rows remain available through
+`getRejectedCandidates()` and `getCandidatesInInputOrder()` with a `CandidateStatus` and explicit
+diagnostics.
+
+Ranking values are always the declared metric's paired delta in its stated unit. Candidates are
+ordered by the policy direction. The tie tolerance is in that same unit; ties receive competition
+ranks and retain deterministic input order. Run separate rankings for production, power, emissions,
+or screening value. A screening-economic ranking is only comparable when currency/time basis,
+factor provenance, effective period, and confidence match exactly; it is not an NPV calculation or
+investment decision.
+
+For weighted field-concept decisions across economics, risk, emissions, strategic fit, and other
+normalized criteria, use the field-development `DevelopmentOptionRanker`. That is a separate MCDA
+layer with accountable weights. `ProcessModelDebottleneckRanking` deliberately stays at the
+simulator-evidence layer and never invents those weights.
+
+`RankingPolicy`, `CandidateEvidence`, and `RankingResult` are immutable and Java-serializable. The
+result retains each complete immutable `StudyResult`, so JPype callers can inspect the original and
+applied capacity states, selected operating points, physical constraint margins, boundary evidence,
+all registered metrics, restoration flags, and diagnostics after ranking.
+
+---
+
 ## References
 
 ### Related Documentation

--- a/docs/process/optimization/OPTIMIZATION_AND_CONSTRAINTS.md
+++ b/docs/process/optimization/OPTIMIZATION_AND_CONSTRAINTS.md
@@ -849,7 +849,8 @@ ProcessModelDebottleneckRanking.RankingPolicy productionPolicy =
         "NeqSim stream result",
         "single steady state",
         ProcessModelDebottleneckRanking.RankingDirection.MAXIMIZE,
-        0.0,
+        1.0e-8,
+        1.0e-8,
         0.5,
         0.9);
 
@@ -869,15 +870,18 @@ List<ProcessModelDebottleneckRanking.CandidateEvidence> rejected =
 ```
 
 The policy above requires exact metric id, name, kind, unit, basis, provenance, and effective
-period. The two confidence floors apply separately to the documented capacity alternative and the
-baseline/alternative metric evidence; use `Double.NaN` only when a confidence floor is deliberately
-unset. A submitted study is rankable only when it:
+period. The first tolerance is in `kg/hr` for ranking ties. The second is dimensionless and applies
+only to repeated finite simulator values from an otherwise identical baseline; metadata and selected
+parameter values still match exactly. The two confidence floors apply separately to the documented
+capacity alternative and the baseline/alternative metric evidence; use `Double.NaN` only when a
+confidence floor is deliberately unset. A submitted study is rankable only when it:
 
 - completed both scenarios and independently verified convergence and feasibility;
 - restored the complete installed-capacity state and reconverged the pre-study process state;
 - supplies a finite `alternative - baseline` delta for the declared metric; and
-- reproduces the reference baseline's search identity/provenance, selected parameter vector,
-  ranking metric, objective rows, and constraint rows exactly.
+- reproduces the reference baseline's search identity/provenance, selected parameter vector and
+  evidence schema exactly, with finite metric/objective/constraint values inside the declared
+  dimensionless relative tolerance.
 
 The first otherwise-qualified submission establishes the baseline reference. This deliberately
 strict comparison prevents alternatives based on a changed candidate set, process configuration,

--- a/docs/process/optimization/OPTIMIZATION_OVERVIEW.md
+++ b/docs/process/optimization/OPTIMIZATION_OVERVIEW.md
@@ -37,6 +37,7 @@ This document provides a high-level introduction to the process optimization cap
 | Optimize full multi-area process models | `ProcessModelSimulationEvaluator` | Use area-qualified `ProcessAutomation` addresses and installed `CapacityConstraint` limits |
 | Ramp producers until a full facility reaches a bottleneck | `ProcessModelThroughputOptimizer` | Use producer mappings, installed capacity tables, and exported case traces |
 | Compare one installed capacity alternative with the same search policy | `ProcessModelDebottleneckStudy` | [Optimization & Constraints Guide](OPTIMIZATION_AND_CONSTRAINTS.md#paired-installed-capacity-alternatives) |
+| Rank independently documented capacity alternatives on one compatible metric | `ProcessModelDebottleneckRanking` | [Optimization & Constraints Guide](OPTIMIZATION_AND_CONSTRAINTS.md#ranking-independent-debottleneck-alternatives) |
 | Solve constrained NLP (equality + inequality) | `SQPoptimizer` | [SQP Optimizer](sqp_optimizer.md) |
 | Calibrate model parameters to data | `BatchParameterEstimator` | [Data Reconciliation and Steady-State Detection](data-reconciliation.md) |
 | Load optimization config from YAML/JSON | `ProductionOptimizationSpecLoader` | [YAML Spec Format](#yaml-specification-files) |
@@ -216,6 +217,7 @@ System.out.println("Optimal rate: " + result.getOptimalRate() + " kg/hr");
 | "Trade off throughput vs power consumption" | `ProductionOptimizer.optimizePareto()` | Pareto multi-objective |
 | "Increase several producers until the full facility reaches a bottleneck" | `ProcessModelThroughputOptimizer` | Maps producers, loads installed capacities, and records the active bottleneck per case |
 | "Quantify one documented equipment expansion against the installed case" | `ProcessModelDebottleneckStudy` | Pairs identical searches, metrics, evidence, and state recovery |
+| "Rank several independently evaluated equipment alternatives" | `ProcessModelDebottleneckRanking` | Requires one exact metric definition and one identical deterministic baseline; rejects unlike evidence |
 | "Evaluate 100 scenarios in parallel" | `ProductionOptimizer` | Has parallel evaluation |
 | "Calibrate model to match field data" | `BatchParameterEstimator` | Levenberg-Marquardt for data fitting |
 
@@ -228,6 +230,11 @@ Use `ProcessModelThroughputOptimizer` for large fixed-equipment studies such as 
 Use `ProcessModelSimulationEvaluator` directly when you need a lower-level black-box bridge to SciPy, NLopt, SQP, Pyomo, or another external optimizer.
 
 Use `ProcessModelDebottleneckStudy` after the evaluator and direct installed constraints are configured when one documented capacity replacement or expansion must be compared with the installed baseline. It uses the same search policy for both scenarios, freezes immutable objective/constraint/metric evidence, and restores the installed limit plus pre-study operating point. This is a paired screening study, not an equipment-sizing algorithm or economic approval.
+
+Use `ProcessModelDebottleneckRanking` after independent paired studies complete when alternatives
+must be ordered by one comparable production, power, energy, emissions, or screening-economic
+delta. The policy requires exact units and provenance plus an identical deterministic baseline. It
+does not combine unlike metrics, infer a shadow price, or provide investment approval.
 
 The evaluator is deliberately a black-box bridge. It keeps the full plant model intact, lets external optimizers pass a vector of decision variables, runs `ProcessModel.run()`, and returns objective values, constraint margins, feasibility, and the active bottleneck.
 

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelDebottleneckRanking.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelDebottleneckRanking.java
@@ -22,18 +22,17 @@ import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.StudyResult;
  * Ranks independently completed paired debottleneck studies on one explicitly compatible metric.
  *
  * <p>
- * The ranking consumes immutable {@link StudyResult} objects and never reruns or mutates a process
- * model. A candidate is rankable only when its paired study completed with verified state recovery,
- * its declared metric identity and engineering basis match the ranking policy exactly, and its
- * baseline is identical to the first qualified baseline. Unlike units, bases, provenance, effective
- * periods, search policies, parameter vectors, objective evidence, or constraint evidence are never
- * normalized or compared.
+ * The ranking consumes immutable {@link StudyResult} objects and never reruns or mutates a process model. A candidate
+ * is rankable only when its paired study completed with verified state recovery, its declared metric identity and
+ * engineering basis match the ranking policy exactly, and its baseline is identical to the first qualified baseline.
+ * Unlike units, bases, provenance, effective periods, search policies, parameter vectors, objective evidence, or
+ * constraint evidence are never normalized or compared.
  * </p>
  *
  * <p>
- * One ranking uses one physical or screening metric. Production, power, energy, emissions, and
- * economics remain separate. Results are sampled screening evidence, not causal production loss,
- * global optimality, a KKT multiplier, design approval, certified emissions, or investment approval.
+ * One ranking uses one physical or screening metric. Production, power, energy, emissions, and economics remain
+ * separate. Results are sampled screening evidence, not causal production loss, global optimality, a KKT multiplier,
+ * design approval, certified emissions, or investment approval.
  * </p>
  *
  * @author NeqSim Development Team
@@ -123,10 +122,10 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
      * @param minimumAlternativeConfidence confidence floor in [0, 1], or NaN when unset
      * @param minimumMetricConfidence confidence floor in [0, 1], or NaN when unset
      */
-    public RankingPolicy(String id, String name, String provenance, String metricId,
-        String metricName, MetricKind metricKind, String unit, String basis,
-        String metricProvenance, String effectivePeriod, RankingDirection direction,
-        double tieTolerance, double minimumAlternativeConfidence, double minimumMetricConfidence) {
+    public RankingPolicy(String id, String name, String provenance, String metricId, String metricName,
+        MetricKind metricKind, String unit, String basis, String metricProvenance, String effectivePeriod,
+        RankingDirection direction, double tieTolerance, double minimumAlternativeConfidence,
+        double minimumMetricConfidence) {
       this.id = requireText(id, "Ranking policy identifier");
       this.name = requireText(name, "Ranking policy name");
       this.provenance = requireText(provenance, "Ranking policy provenance");
@@ -152,8 +151,7 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
       this.minimumAlternativeConfidence = validateConfidence(minimumAlternativeConfidence,
           "Minimum alternative confidence");
       metricConfidenceFloorSet = !Double.isNaN(minimumMetricConfidence);
-      this.minimumMetricConfidence = validateConfidence(minimumMetricConfidence,
-          "Minimum metric confidence");
+      this.minimumMetricConfidence = validateConfidence(minimumMetricConfidence, "Minimum metric confidence");
     }
 
     /** @return stable ranking-policy identifier */
@@ -326,10 +324,9 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
     private final List<CandidateEvidence> candidatesInInputOrder;
     private final List<String> diagnostics;
 
-    private RankingResult(String id, String name, String provenance, RankingPolicy policy,
-        RankingOutcome outcome, List<CandidateEvidence> rankedCandidates,
-        List<CandidateEvidence> rejectedCandidates, List<CandidateEvidence> candidatesInInputOrder,
-        List<String> diagnostics) {
+    private RankingResult(String id, String name, String provenance, RankingPolicy policy, RankingOutcome outcome,
+        List<CandidateEvidence> rankedCandidates, List<CandidateEvidence> rejectedCandidates,
+        List<CandidateEvidence> candidatesInInputOrder, List<String> diagnostics) {
       this.id = id;
       this.name = name;
       this.provenance = provenance;
@@ -433,8 +430,7 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
    * @param provenance source and assumptions for the portfolio
    * @param policy exact single-metric comparison policy
    */
-  public ProcessModelDebottleneckRanking(String id, String name, String provenance,
-      RankingPolicy policy) {
+  public ProcessModelDebottleneckRanking(String id, String name, String provenance, RankingPolicy policy) {
     this.id = requireText(id, "Portfolio identifier");
     this.name = requireText(name, "Portfolio name");
     this.provenance = requireText(provenance, "Portfolio provenance");
@@ -523,12 +519,12 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
     List<String> diagnostics = new ArrayList<String>();
     diagnostics.add("Ranked " + rankedEvidence.size() + " compatible alternatives and rejected "
         + rejectedEvidence.size() + " alternatives");
-    diagnostics.add("Ranking uses one declared metric and does not aggregate unlike physical, emission, or "
-        + "economic units");
+    diagnostics.add(
+        "Ranking uses one declared metric and does not aggregate unlike physical, emission, or " + "economic units");
     diagnostics.add("Results are sampled screening evidence, not causal value, global optimality, design approval, "
         + "certified emissions, or investment approval");
-    return new RankingResult(id, name, provenance, policy, outcome, rankedEvidence, rejectedEvidence,
-        inputEvidence, diagnostics);
+    return new RankingResult(id, name, provenance, policy, outcome, rankedEvidence, rejectedEvidence, inputEvidence,
+        diagnostics);
   }
 
   /**
@@ -551,14 +547,13 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
       draft.diagnostics.add("Study outcome is " + study.getOutcome());
       return draft;
     }
-    if (!study.isCapacityRestored() || !study.isProcessStateRestored()
-        || !study.isRecoverySimulationConverged()) {
+    if (!study.isCapacityRestored() || !study.isProcessStateRestored() || !study.isRecoverySimulationConverged()) {
       draft.status = CandidateStatus.RECOVERY_NOT_VERIFIED;
       draft.diagnostics.add("Installed-capacity and process-state recovery must all be verified");
       return draft;
     }
-    if (study.getBaseline() == null || study.getAlternative() == null
-        || !study.getBaseline().isQualified() || !study.getAlternative().isQualified()) {
+    if (study.getBaseline() == null || study.getAlternative() == null || !study.getBaseline().isQualified()
+        || !study.getAlternative().isQualified()) {
       draft.status = CandidateStatus.SCENARIO_NOT_QUALIFIED;
       draft.diagnostics.add("Both baseline and alternative scenarios must be qualified");
       return draft;
@@ -584,8 +579,7 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
     }
     CapacityAlternative alternative = study.getAlternativeDefinition();
     if (policy.hasMinimumAlternativeConfidence()
-        && (!alternative.hasConfidence()
-            || alternative.getConfidence() < policy.getMinimumAlternativeConfidence())) {
+        && (!alternative.hasConfidence() || alternative.getConfidence() < policy.getMinimumAlternativeConfidence())) {
       draft.status = CandidateStatus.ALTERNATIVE_CONFIDENCE_TOO_LOW;
       draft.diagnostics.add("Alternative confidence is absent or below the declared floor");
       return draft;
@@ -609,8 +603,7 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
       MetricEvidence baseline = comparison.getBaseline();
       if (baseline != null && policy.getMetricId().equals(baseline.getId())) {
         if (found != null) {
-          throw new IllegalArgumentException(
-              "Study contains duplicate ranking metric identifiers: " + study.getId());
+          throw new IllegalArgumentException("Study contains duplicate ranking metric identifiers: " + study.getId());
         }
         found = comparison;
       }
@@ -620,15 +613,13 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
 
   private boolean metadataMatches(MetricEvidence evidence) {
     return evidence != null && policy.getMetricId().equals(evidence.getId())
-        && policy.getMetricName().equals(evidence.getName())
-        && policy.getMetricKind() == evidence.getKind() && policy.getUnit().equals(evidence.getUnit())
-        && policy.getBasis().equals(evidence.getBasis())
+        && policy.getMetricName().equals(evidence.getName()) && policy.getMetricKind() == evidence.getKind()
+        && policy.getUnit().equals(evidence.getUnit()) && policy.getBasis().equals(evidence.getBasis())
         && policy.getMetricProvenance().equals(evidence.getProvenance())
         && policy.getEffectivePeriod().equals(evidence.getEffectivePeriod());
   }
 
-  private boolean baselineMatches(BaselineReference reference, ScenarioEvidence baseline,
-      MetricEvidence metric) {
+  private boolean baselineMatches(BaselineReference reference, ScenarioEvidence baseline, MetricEvidence metric) {
     ScenarioEvidence expected = reference.baseline;
     return expected.getSearchId().equals(baseline.getSearchId())
         && expected.getSearchName().equals(baseline.getSearchName())
@@ -653,10 +644,9 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
     for (int index = 0; index < left.size(); index++) {
       ObjectiveEvidence a = left.get(index);
       ObjectiveEvidence b = right.get(index);
-      if (a.getIndex() != b.getIndex() || !a.getName().equals(b.getName())
-          || a.getDirection() != b.getDirection() || !a.getUnit().equals(b.getUnit())
-          || !bitsEqual(a.getWeight(), b.getWeight()) || !bitsEqual(a.getRawValue(), b.getRawValue())
-          || !bitsEqual(a.getMinimizerValue(), b.getMinimizerValue())) {
+      if (a.getIndex() != b.getIndex() || !a.getName().equals(b.getName()) || a.getDirection() != b.getDirection()
+          || !a.getUnit().equals(b.getUnit()) || !bitsEqual(a.getWeight(), b.getWeight())
+          || !bitsEqual(a.getRawValue(), b.getRawValue()) || !bitsEqual(a.getMinimizerValue(), b.getMinimizerValue())) {
         return false;
       }
     }
@@ -670,9 +660,8 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
     for (int index = 0; index < left.size(); index++) {
       ConstraintEvidence a = left.get(index);
       ConstraintEvidence b = right.get(index);
-      if (a.getIndex() != b.getIndex() || !a.getName().equals(b.getName())
-          || a.getType() != b.getType() || !a.getUnit().equals(b.getUnit())
-          || a.isHard() != b.isHard() || !bitsEqual(a.getValue(), b.getValue())
+      if (a.getIndex() != b.getIndex() || !a.getName().equals(b.getName()) || a.getType() != b.getType()
+          || !a.getUnit().equals(b.getUnit()) || a.isHard() != b.isHard() || !bitsEqual(a.getValue(), b.getValue())
           || !bitsEqual(a.getMargin(), b.getMargin())) {
         return false;
       }
@@ -696,8 +685,7 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
     while (start < qualified.size()) {
       double groupLeader = qualified.get(start).delta;
       int end = start + 1;
-      while (end < qualified.size()
-          && Math.abs(qualified.get(end).delta - groupLeader) <= policy.getTieTolerance()) {
+      while (end < qualified.size() && Math.abs(qualified.get(end).delta - groupLeader) <= policy.getTieTolerance()) {
         end++;
       }
       List<CandidateDraft> tieGroup = qualified.subList(start, end);
@@ -710,8 +698,8 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
       int rank = start + 1;
       for (CandidateDraft draft : tieGroup) {
         draft.rank = rank;
-        draft.diagnostics.add("Assigned competition rank " + rank + " using tie tolerance "
-            + policy.getTieTolerance() + " " + policy.getUnit());
+        draft.diagnostics.add("Assigned competition rank " + rank + " using tie tolerance " + policy.getTieTolerance()
+            + " " + policy.getUnit());
       }
       start = end;
     }

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelDebottleneckRanking.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelDebottleneckRanking.java
@@ -1,0 +1,806 @@
+package neqsim.process.util.optimizer;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.CapacityAlternative;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.ConstraintEvidence;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.MetricComparison;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.MetricEvidence;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.MetricKind;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.ObjectiveEvidence;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.ScenarioEvidence;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.StudyOutcome;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.StudyResult;
+
+/**
+ * Ranks independently completed paired debottleneck studies on one explicitly compatible metric.
+ *
+ * <p>
+ * The ranking consumes immutable {@link StudyResult} objects and never reruns or mutates a process
+ * model. A candidate is rankable only when its paired study completed with verified state recovery,
+ * its declared metric identity and engineering basis match the ranking policy exactly, and its
+ * baseline is identical to the first qualified baseline. Unlike units, bases, provenance, effective
+ * periods, search policies, parameter vectors, objective evidence, or constraint evidence are never
+ * normalized or compared.
+ * </p>
+ *
+ * <p>
+ * One ranking uses one physical or screening metric. Production, power, energy, emissions, and
+ * economics remain separate. Results are sampled screening evidence, not causal production loss,
+ * global optimality, a KKT multiplier, design approval, certified emissions, or investment approval.
+ * </p>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public final class ProcessModelDebottleneckRanking implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  /** Direction in which the declared ranking-metric delta improves. */
+  public enum RankingDirection {
+    /** Larger alternative-minus-baseline deltas rank first. */
+    MAXIMIZE,
+    /** Smaller alternative-minus-baseline deltas rank first. */
+    MINIMIZE
+  }
+
+  /** Qualification state of one submitted paired study. */
+  public enum CandidateStatus {
+    /** The study and metric are comparable and included in the ranking. */
+    QUALIFIED,
+    /** The paired study did not complete successfully. */
+    STUDY_NOT_COMPLETED,
+    /** Installed-capacity or process-state recovery was not verified. */
+    RECOVERY_NOT_VERIFIED,
+    /** Baseline or alternative scenario evidence is absent or unqualified. */
+    SCENARIO_NOT_QUALIFIED,
+    /** The declared ranking metric is absent. */
+    RANKING_METRIC_MISSING,
+    /** The declared ranking metric is unavailable or non-finite. */
+    RANKING_METRIC_NOT_CALCULABLE,
+    /** Metric identity, unit, kind, basis, provenance, or period differs from the policy. */
+    METRIC_METADATA_MISMATCH,
+    /** Alternative evidence confidence is absent or below the declared floor. */
+    ALTERNATIVE_CONFIDENCE_TOO_LOW,
+    /** Metric evidence confidence is absent or below the declared floor. */
+    METRIC_CONFIDENCE_TOO_LOW,
+    /** The deterministic baseline differs from the reference baseline. */
+    BASELINE_INCOMPATIBLE
+  }
+
+  /** Outcome of the complete ranking operation. */
+  public enum RankingOutcome {
+    /** Every submitted study was qualified and ranked. */
+    COMPLETED,
+    /** At least one study was ranked and at least one was rejected. */
+    PARTIAL,
+    /** No submitted study satisfied the fail-closed comparison policy. */
+    NO_QUALIFIED_ALTERNATIVE
+  }
+
+  /** Immutable single-metric comparison policy. */
+  public static final class RankingPolicy implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String id;
+    private final String name;
+    private final String provenance;
+    private final String metricId;
+    private final String metricName;
+    private final MetricKind metricKind;
+    private final String unit;
+    private final String basis;
+    private final String metricProvenance;
+    private final String effectivePeriod;
+    private final RankingDirection direction;
+    private final double tieTolerance;
+    private final boolean alternativeConfidenceFloorSet;
+    private final double minimumAlternativeConfidence;
+    private final boolean metricConfidenceFloorSet;
+    private final double minimumMetricConfidence;
+
+    /**
+     * Creates a fully qualified single-metric ranking policy.
+     *
+     * @param id stable policy identifier
+     * @param name human-readable policy name
+     * @param provenance source and assumptions for the ranking policy
+     * @param metricId exact registered metric identifier
+     * @param metricName exact registered metric name
+     * @param metricKind engineering role of the metric
+     * @param unit exact engineering unit of the metric and its deltas
+     * @param basis exact physical or commercial metric basis
+     * @param metricProvenance exact metric source or factor provenance
+     * @param effectivePeriod exact metric effective period
+     * @param direction direction in which the paired delta improves
+     * @param tieTolerance non-negative tie tolerance in the metric unit
+     * @param minimumAlternativeConfidence confidence floor in [0, 1], or NaN when unset
+     * @param minimumMetricConfidence confidence floor in [0, 1], or NaN when unset
+     */
+    public RankingPolicy(String id, String name, String provenance, String metricId,
+        String metricName, MetricKind metricKind, String unit, String basis,
+        String metricProvenance, String effectivePeriod, RankingDirection direction,
+        double tieTolerance, double minimumAlternativeConfidence, double minimumMetricConfidence) {
+      this.id = requireText(id, "Ranking policy identifier");
+      this.name = requireText(name, "Ranking policy name");
+      this.provenance = requireText(provenance, "Ranking policy provenance");
+      this.metricId = requireText(metricId, "Ranking metric identifier");
+      this.metricName = requireText(metricName, "Ranking metric name");
+      if (metricKind == null) {
+        throw new IllegalArgumentException("Ranking metric kind is required");
+      }
+      this.metricKind = metricKind;
+      this.unit = requireText(unit, "Ranking metric unit");
+      this.basis = requireText(basis, "Ranking metric basis");
+      this.metricProvenance = requireText(metricProvenance, "Ranking metric provenance");
+      this.effectivePeriod = requireText(effectivePeriod, "Ranking metric effective period");
+      if (direction == null) {
+        throw new IllegalArgumentException("Ranking direction is required");
+      }
+      this.direction = direction;
+      if (!isFinite(tieTolerance) || tieTolerance < 0.0) {
+        throw new IllegalArgumentException("Ranking tie tolerance must be finite and non-negative");
+      }
+      this.tieTolerance = tieTolerance;
+      alternativeConfidenceFloorSet = !Double.isNaN(minimumAlternativeConfidence);
+      this.minimumAlternativeConfidence = validateConfidence(minimumAlternativeConfidence,
+          "Minimum alternative confidence");
+      metricConfidenceFloorSet = !Double.isNaN(minimumMetricConfidence);
+      this.minimumMetricConfidence = validateConfidence(minimumMetricConfidence,
+          "Minimum metric confidence");
+    }
+
+    /** @return stable ranking-policy identifier */
+    public String getId() {
+      return id;
+    }
+
+    /** @return human-readable ranking-policy name */
+    public String getName() {
+      return name;
+    }
+
+    /** @return policy source and assumptions */
+    public String getProvenance() {
+      return provenance;
+    }
+
+    /** @return exact registered ranking-metric identifier */
+    public String getMetricId() {
+      return metricId;
+    }
+
+    /** @return exact registered ranking-metric name */
+    public String getMetricName() {
+      return metricName;
+    }
+
+    /** @return engineering role of the ranking metric */
+    public MetricKind getMetricKind() {
+      return metricKind;
+    }
+
+    /** @return engineering unit of ranking values and deltas */
+    public String getUnit() {
+      return unit;
+    }
+
+    /** @return exact physical or commercial metric basis */
+    public String getBasis() {
+      return basis;
+    }
+
+    /** @return exact metric source or factor provenance */
+    public String getMetricProvenance() {
+      return metricProvenance;
+    }
+
+    /** @return exact metric effective period */
+    public String getEffectivePeriod() {
+      return effectivePeriod;
+    }
+
+    /** @return direction in which the paired delta improves */
+    public RankingDirection getDirection() {
+      return direction;
+    }
+
+    /** @return tie tolerance in the ranking metric unit */
+    public double getTieTolerance() {
+      return tieTolerance;
+    }
+
+    /** @return true when an alternative-confidence floor is enforced */
+    public boolean hasMinimumAlternativeConfidence() {
+      return alternativeConfidenceFloorSet;
+    }
+
+    /** @return alternative-confidence floor, or NaN when unset */
+    public double getMinimumAlternativeConfidence() {
+      return alternativeConfidenceFloorSet ? minimumAlternativeConfidence : Double.NaN;
+    }
+
+    /** @return true when a metric-confidence floor is enforced */
+    public boolean hasMinimumMetricConfidence() {
+      return metricConfidenceFloorSet;
+    }
+
+    /** @return metric-confidence floor, or NaN when unset */
+    public double getMinimumMetricConfidence() {
+      return metricConfidenceFloorSet ? minimumMetricConfidence : Double.NaN;
+    }
+  }
+
+  /** Immutable qualification and ranking evidence for one submitted study. */
+  public static final class CandidateEvidence implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final int inputIndex;
+    private final int rank;
+    private final CandidateStatus status;
+    private final StudyResult studyResult;
+    private final MetricEvidence baselineMetric;
+    private final MetricEvidence alternativeMetric;
+    private final double delta;
+    private final List<String> diagnostics;
+
+    private CandidateEvidence(CandidateDraft draft) {
+      inputIndex = draft.inputIndex;
+      rank = draft.rank;
+      status = draft.status;
+      studyResult = draft.studyResult;
+      baselineMetric = draft.baselineMetric;
+      alternativeMetric = draft.alternativeMetric;
+      delta = draft.delta;
+      diagnostics = immutableStrings(draft.diagnostics);
+    }
+
+    /** @return zero-based submission order */
+    public int getInputIndex() {
+      return inputIndex;
+    }
+
+    /** @return one-based competition rank, or zero when rejected */
+    public int getRank() {
+      return rank;
+    }
+
+    /** @return qualification or rejection status */
+    public CandidateStatus getStatus() {
+      return status;
+    }
+
+    /** @return true when the candidate is included in the ranking */
+    public boolean isQualified() {
+      return status == CandidateStatus.QUALIFIED;
+    }
+
+    /** @return complete immutable paired-study evidence */
+    public StudyResult getStudyResult() {
+      return studyResult;
+    }
+
+    /** @return immutable installed-capacity alternative definition */
+    public CapacityAlternative getAlternativeDefinition() {
+      return studyResult.getAlternativeDefinition();
+    }
+
+    /** @return declared metric evidence at the installed baseline */
+    public MetricEvidence getBaselineMetric() {
+      return baselineMetric;
+    }
+
+    /** @return declared metric evidence for the alternative */
+    public MetricEvidence getAlternativeMetric() {
+      return alternativeMetric;
+    }
+
+    /** @return alternative-minus-baseline metric delta, or NaN when unavailable */
+    public double getDelta() {
+      return delta;
+    }
+
+    /** @return unmodifiable qualification and ranking diagnostics */
+    public List<String> getDiagnostics() {
+      return immutableStrings(diagnostics);
+    }
+  }
+
+  /** Immutable result of one portfolio ranking. */
+  public static final class RankingResult implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String id;
+    private final String name;
+    private final String provenance;
+    private final RankingPolicy policy;
+    private final RankingOutcome outcome;
+    private final List<CandidateEvidence> rankedCandidates;
+    private final List<CandidateEvidence> rejectedCandidates;
+    private final List<CandidateEvidence> candidatesInInputOrder;
+    private final List<String> diagnostics;
+
+    private RankingResult(String id, String name, String provenance, RankingPolicy policy,
+        RankingOutcome outcome, List<CandidateEvidence> rankedCandidates,
+        List<CandidateEvidence> rejectedCandidates, List<CandidateEvidence> candidatesInInputOrder,
+        List<String> diagnostics) {
+      this.id = id;
+      this.name = name;
+      this.provenance = provenance;
+      this.policy = policy;
+      this.outcome = outcome;
+      this.rankedCandidates = immutableList(rankedCandidates);
+      this.rejectedCandidates = immutableList(rejectedCandidates);
+      this.candidatesInInputOrder = immutableList(candidatesInInputOrder);
+      this.diagnostics = immutableStrings(diagnostics);
+    }
+
+    /** @return stable portfolio identifier */
+    public String getId() {
+      return id;
+    }
+
+    /** @return human-readable portfolio name */
+    public String getName() {
+      return name;
+    }
+
+    /** @return portfolio source and assumptions */
+    public String getProvenance() {
+      return provenance;
+    }
+
+    /** @return immutable single-metric ranking policy */
+    public RankingPolicy getPolicy() {
+      return policy;
+    }
+
+    /** @return complete, partial, or no-qualified-alternative outcome */
+    public RankingOutcome getOutcome() {
+      return outcome;
+    }
+
+    /** @return unmodifiable candidates in deterministic rank order */
+    public List<CandidateEvidence> getRankedCandidates() {
+      return immutableList(rankedCandidates);
+    }
+
+    /** @return unmodifiable rejected candidates in submission order */
+    public List<CandidateEvidence> getRejectedCandidates() {
+      return immutableList(rejectedCandidates);
+    }
+
+    /** @return complete unmodifiable audit trail in submission order */
+    public List<CandidateEvidence> getCandidatesInInputOrder() {
+      return immutableList(candidatesInInputOrder);
+    }
+
+    /** @return highest-ranked candidate, or null when none qualified */
+    public CandidateEvidence getBestCandidate() {
+      return rankedCandidates.isEmpty() ? null : rankedCandidates.get(0);
+    }
+
+    /** @return unmodifiable portfolio-level diagnostics */
+    public List<String> getDiagnostics() {
+      return immutableStrings(diagnostics);
+    }
+  }
+
+  /** Mutable internal row used only while assigning qualification and ranks. */
+  private static final class CandidateDraft {
+    private final int inputIndex;
+    private final StudyResult studyResult;
+    private int rank;
+    private CandidateStatus status;
+    private MetricEvidence baselineMetric;
+    private MetricEvidence alternativeMetric;
+    private double delta = Double.NaN;
+    private final List<String> diagnostics = new ArrayList<String>();
+
+    private CandidateDraft(int inputIndex, StudyResult studyResult) {
+      this.inputIndex = inputIndex;
+      this.studyResult = studyResult;
+    }
+  }
+
+  /** Frozen reference evidence that all later qualified baselines must reproduce exactly. */
+  private static final class BaselineReference {
+    private final ScenarioEvidence baseline;
+    private final MetricEvidence metric;
+
+    private BaselineReference(ScenarioEvidence baseline, MetricEvidence metric) {
+      this.baseline = baseline;
+      this.metric = metric;
+    }
+  }
+
+  private final String id;
+  private final String name;
+  private final String provenance;
+  private final RankingPolicy policy;
+
+  /**
+   * Creates an immutable portfolio-ranking configuration.
+   *
+   * @param id stable portfolio identifier
+   * @param name human-readable portfolio name
+   * @param provenance source and assumptions for the portfolio
+   * @param policy exact single-metric comparison policy
+   */
+  public ProcessModelDebottleneckRanking(String id, String name, String provenance,
+      RankingPolicy policy) {
+    this.id = requireText(id, "Portfolio identifier");
+    this.name = requireText(name, "Portfolio name");
+    this.provenance = requireText(provenance, "Portfolio provenance");
+    if (policy == null) {
+      throw new IllegalArgumentException("Ranking policy is required");
+    }
+    this.policy = policy;
+  }
+
+  /** @return stable portfolio identifier */
+  public String getId() {
+    return id;
+  }
+
+  /** @return human-readable portfolio name */
+  public String getName() {
+    return name;
+  }
+
+  /** @return portfolio source and assumptions */
+  public String getProvenance() {
+    return provenance;
+  }
+
+  /** @return immutable single-metric ranking policy */
+  public RankingPolicy getPolicy() {
+    return policy;
+  }
+
+  /**
+   * Qualifies and ranks immutable paired-study results.
+   *
+   * @param studies completed paired studies in deterministic submission order
+   * @return immutable ranking and rejection evidence
+   */
+  public RankingResult rank(List<StudyResult> studies) {
+    if (studies == null || studies.isEmpty()) {
+      throw new IllegalArgumentException("At least one paired study result is required");
+    }
+    validateIdentities(studies);
+
+    List<CandidateDraft> drafts = new ArrayList<CandidateDraft>();
+    BaselineReference reference = null;
+    for (int index = 0; index < studies.size(); index++) {
+      CandidateDraft draft = assess(index, studies.get(index));
+      if (draft.status == CandidateStatus.QUALIFIED) {
+        if (reference == null) {
+          reference = new BaselineReference(draft.studyResult.getBaseline(), draft.baselineMetric);
+          draft.diagnostics.add("Established the exact deterministic portfolio baseline");
+        } else if (!baselineMatches(reference, draft.studyResult.getBaseline(), draft.baselineMetric)) {
+          draft.status = CandidateStatus.BASELINE_INCOMPATIBLE;
+          draft.delta = Double.NaN;
+          draft.diagnostics.add("Baseline search, parameters, metric, objectives, or constraints differ from the "
+              + "portfolio reference baseline");
+        }
+      }
+      drafts.add(draft);
+    }
+
+    List<CandidateDraft> qualified = new ArrayList<CandidateDraft>();
+    List<CandidateDraft> rejected = new ArrayList<CandidateDraft>();
+    for (CandidateDraft draft : drafts) {
+      if (draft.status == CandidateStatus.QUALIFIED) {
+        qualified.add(draft);
+      } else {
+        rejected.add(draft);
+      }
+    }
+    assignRanks(qualified);
+
+    List<CandidateEvidence> rankedEvidence = new ArrayList<CandidateEvidence>();
+    for (CandidateDraft draft : qualified) {
+      rankedEvidence.add(new CandidateEvidence(draft));
+    }
+    List<CandidateEvidence> rejectedEvidence = new ArrayList<CandidateEvidence>();
+    for (CandidateDraft draft : rejected) {
+      rejectedEvidence.add(new CandidateEvidence(draft));
+    }
+    List<CandidateEvidence> inputEvidence = new ArrayList<CandidateEvidence>();
+    for (CandidateDraft draft : drafts) {
+      inputEvidence.add(findEvidence(draft.inputIndex, rankedEvidence, rejectedEvidence));
+    }
+
+    RankingOutcome outcome = rankedEvidence.isEmpty() ? RankingOutcome.NO_QUALIFIED_ALTERNATIVE
+        : rejectedEvidence.isEmpty() ? RankingOutcome.COMPLETED : RankingOutcome.PARTIAL;
+    List<String> diagnostics = new ArrayList<String>();
+    diagnostics.add("Ranked " + rankedEvidence.size() + " compatible alternatives and rejected "
+        + rejectedEvidence.size() + " alternatives");
+    diagnostics.add("Ranking uses one declared metric and does not aggregate unlike physical, emission, or "
+        + "economic units");
+    diagnostics.add("Results are sampled screening evidence, not causal value, global optimality, design approval, "
+        + "certified emissions, or investment approval");
+    return new RankingResult(id, name, provenance, policy, outcome, rankedEvidence, rejectedEvidence,
+        inputEvidence, diagnostics);
+  }
+
+  /**
+   * Convenience overload for Java arrays and JPype callers.
+   *
+   * @param studies completed paired-study result array
+   * @return immutable ranking and rejection evidence
+   */
+  public RankingResult rank(StudyResult[] studies) {
+    if (studies == null) {
+      throw new IllegalArgumentException("Paired study result array must not be null");
+    }
+    return rank(Arrays.asList(Arrays.copyOf(studies, studies.length)));
+  }
+
+  private CandidateDraft assess(int index, StudyResult study) {
+    CandidateDraft draft = new CandidateDraft(index, study);
+    if (study.getOutcome() != StudyOutcome.COMPLETED) {
+      draft.status = CandidateStatus.STUDY_NOT_COMPLETED;
+      draft.diagnostics.add("Study outcome is " + study.getOutcome());
+      return draft;
+    }
+    if (!study.isCapacityRestored() || !study.isProcessStateRestored()
+        || !study.isRecoverySimulationConverged()) {
+      draft.status = CandidateStatus.RECOVERY_NOT_VERIFIED;
+      draft.diagnostics.add("Installed-capacity and process-state recovery must all be verified");
+      return draft;
+    }
+    if (study.getBaseline() == null || study.getAlternative() == null
+        || !study.getBaseline().isQualified() || !study.getAlternative().isQualified()) {
+      draft.status = CandidateStatus.SCENARIO_NOT_QUALIFIED;
+      draft.diagnostics.add("Both baseline and alternative scenarios must be qualified");
+      return draft;
+    }
+
+    MetricComparison comparison = findRankingMetric(study);
+    if (comparison == null) {
+      draft.status = CandidateStatus.RANKING_METRIC_MISSING;
+      draft.diagnostics.add("Ranking metric was not found: " + policy.getMetricId());
+      return draft;
+    }
+    draft.baselineMetric = comparison.getBaseline();
+    draft.alternativeMetric = comparison.getAlternative();
+    if (!metadataMatches(draft.baselineMetric) || !metadataMatches(draft.alternativeMetric)) {
+      draft.status = CandidateStatus.METRIC_METADATA_MISMATCH;
+      draft.diagnostics.add("Ranking metric metadata does not exactly match the declared policy");
+      return draft;
+    }
+    if (!comparison.isCalculable() || !isFinite(comparison.getDelta())) {
+      draft.status = CandidateStatus.RANKING_METRIC_NOT_CALCULABLE;
+      draft.diagnostics.add("Ranking metric comparison is unavailable or non-finite");
+      return draft;
+    }
+    CapacityAlternative alternative = study.getAlternativeDefinition();
+    if (policy.hasMinimumAlternativeConfidence()
+        && (!alternative.hasConfidence()
+            || alternative.getConfidence() < policy.getMinimumAlternativeConfidence())) {
+      draft.status = CandidateStatus.ALTERNATIVE_CONFIDENCE_TOO_LOW;
+      draft.diagnostics.add("Alternative confidence is absent or below the declared floor");
+      return draft;
+    }
+    if (policy.hasMinimumMetricConfidence()
+        && (!meetsConfidence(draft.baselineMetric, policy.getMinimumMetricConfidence())
+            || !meetsConfidence(draft.alternativeMetric, policy.getMinimumMetricConfidence()))) {
+      draft.status = CandidateStatus.METRIC_CONFIDENCE_TOO_LOW;
+      draft.diagnostics.add("Metric confidence is absent or below the declared floor");
+      return draft;
+    }
+    draft.status = CandidateStatus.QUALIFIED;
+    draft.delta = comparison.getDelta();
+    draft.diagnostics.add("Paired metric delta is compatible and finite in " + policy.getUnit());
+    return draft;
+  }
+
+  private MetricComparison findRankingMetric(StudyResult study) {
+    MetricComparison found = null;
+    for (MetricComparison comparison : study.getMetricComparisons()) {
+      MetricEvidence baseline = comparison.getBaseline();
+      if (baseline != null && policy.getMetricId().equals(baseline.getId())) {
+        if (found != null) {
+          throw new IllegalArgumentException(
+              "Study contains duplicate ranking metric identifiers: " + study.getId());
+        }
+        found = comparison;
+      }
+    }
+    return found;
+  }
+
+  private boolean metadataMatches(MetricEvidence evidence) {
+    return evidence != null && policy.getMetricId().equals(evidence.getId())
+        && policy.getMetricName().equals(evidence.getName())
+        && policy.getMetricKind() == evidence.getKind() && policy.getUnit().equals(evidence.getUnit())
+        && policy.getBasis().equals(evidence.getBasis())
+        && policy.getMetricProvenance().equals(evidence.getProvenance())
+        && policy.getEffectivePeriod().equals(evidence.getEffectivePeriod());
+  }
+
+  private boolean baselineMatches(BaselineReference reference, ScenarioEvidence baseline,
+      MetricEvidence metric) {
+    ScenarioEvidence expected = reference.baseline;
+    return expected.getSearchId().equals(baseline.getSearchId())
+        && expected.getSearchName().equals(baseline.getSearchName())
+        && expected.getSearchProvenance().equals(baseline.getSearchProvenance())
+        && arraysEqual(expected.getSelectedParameters(), baseline.getSelectedParameters())
+        && metricEvidenceEqual(reference.metric, metric)
+        && objectivesEqual(expected.getObjectives(), baseline.getObjectives())
+        && constraintsEqual(expected.getConstraints(), baseline.getConstraints());
+  }
+
+  private boolean metricEvidenceEqual(MetricEvidence left, MetricEvidence right) {
+    return metadataMatches(left) && metadataMatches(right) && left.getStatus() == right.getStatus()
+        && left.isRequired() == right.isRequired() && left.hasConfidence() == right.hasConfidence()
+        && (!left.hasConfidence() || bitsEqual(left.getConfidence(), right.getConfidence()))
+        && bitsEqual(left.getValue(), right.getValue());
+  }
+
+  private boolean objectivesEqual(List<ObjectiveEvidence> left, List<ObjectiveEvidence> right) {
+    if (left.size() != right.size()) {
+      return false;
+    }
+    for (int index = 0; index < left.size(); index++) {
+      ObjectiveEvidence a = left.get(index);
+      ObjectiveEvidence b = right.get(index);
+      if (a.getIndex() != b.getIndex() || !a.getName().equals(b.getName())
+          || a.getDirection() != b.getDirection() || !a.getUnit().equals(b.getUnit())
+          || !bitsEqual(a.getWeight(), b.getWeight()) || !bitsEqual(a.getRawValue(), b.getRawValue())
+          || !bitsEqual(a.getMinimizerValue(), b.getMinimizerValue())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean constraintsEqual(List<ConstraintEvidence> left, List<ConstraintEvidence> right) {
+    if (left.size() != right.size()) {
+      return false;
+    }
+    for (int index = 0; index < left.size(); index++) {
+      ConstraintEvidence a = left.get(index);
+      ConstraintEvidence b = right.get(index);
+      if (a.getIndex() != b.getIndex() || !a.getName().equals(b.getName())
+          || a.getType() != b.getType() || !a.getUnit().equals(b.getUnit())
+          || a.isHard() != b.isHard() || !bitsEqual(a.getValue(), b.getValue())
+          || !bitsEqual(a.getMargin(), b.getMargin())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private void assignRanks(List<CandidateDraft> qualified) {
+    Collections.sort(qualified, new Comparator<CandidateDraft>() {
+      @Override
+      public int compare(CandidateDraft left, CandidateDraft right) {
+        int comparison = Double.compare(left.delta, right.delta);
+        if (policy.getDirection() == RankingDirection.MAXIMIZE) {
+          comparison = -comparison;
+        }
+        return comparison != 0 ? comparison : Integer.compare(left.inputIndex, right.inputIndex);
+      }
+    });
+
+    int start = 0;
+    while (start < qualified.size()) {
+      double groupLeader = qualified.get(start).delta;
+      int end = start + 1;
+      while (end < qualified.size()
+          && Math.abs(qualified.get(end).delta - groupLeader) <= policy.getTieTolerance()) {
+        end++;
+      }
+      List<CandidateDraft> tieGroup = qualified.subList(start, end);
+      Collections.sort(tieGroup, new Comparator<CandidateDraft>() {
+        @Override
+        public int compare(CandidateDraft left, CandidateDraft right) {
+          return Integer.compare(left.inputIndex, right.inputIndex);
+        }
+      });
+      int rank = start + 1;
+      for (CandidateDraft draft : tieGroup) {
+        draft.rank = rank;
+        draft.diagnostics.add("Assigned competition rank " + rank + " using tie tolerance "
+            + policy.getTieTolerance() + " " + policy.getUnit());
+      }
+      start = end;
+    }
+  }
+
+  private void validateIdentities(List<StudyResult> studies) {
+    Set<String> studyIds = new HashSet<String>();
+    Set<String> alternativeIds = new HashSet<String>();
+    for (StudyResult study : studies) {
+      if (study == null || study.getAlternativeDefinition() == null) {
+        throw new IllegalArgumentException("Every submitted study and alternative definition is required");
+      }
+      if (!studyIds.add(study.getId())) {
+        throw new IllegalArgumentException("Duplicate study identifier: " + study.getId());
+      }
+      String alternativeId = study.getAlternativeDefinition().getId();
+      if (!alternativeIds.add(alternativeId)) {
+        throw new IllegalArgumentException("Duplicate alternative identifier: " + alternativeId);
+      }
+    }
+  }
+
+  private CandidateEvidence findEvidence(int inputIndex, List<CandidateEvidence> ranked,
+      List<CandidateEvidence> rejected) {
+    for (CandidateEvidence evidence : ranked) {
+      if (evidence.getInputIndex() == inputIndex) {
+        return evidence;
+      }
+    }
+    for (CandidateEvidence evidence : rejected) {
+      if (evidence.getInputIndex() == inputIndex) {
+        return evidence;
+      }
+    }
+    throw new IllegalStateException("Portfolio candidate evidence was lost");
+  }
+
+  private static boolean meetsConfidence(MetricEvidence evidence, double minimum) {
+    return evidence.hasConfidence() && evidence.getConfidence() >= minimum;
+  }
+
+  private static double validateConfidence(double value, String label) {
+    if (Double.isNaN(value)) {
+      return Double.NaN;
+    }
+    if (!isFinite(value) || value < 0.0 || value > 1.0) {
+      throw new IllegalArgumentException(label + " must be in [0, 1] or NaN");
+    }
+    return value;
+  }
+
+  private static boolean arraysEqual(double[] left, double[] right) {
+    if (left.length != right.length) {
+      return false;
+    }
+    for (int index = 0; index < left.length; index++) {
+      if (!bitsEqual(left[index], right[index])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean bitsEqual(double left, double right) {
+    return Double.doubleToLongBits(left) == Double.doubleToLongBits(right);
+  }
+
+  private static boolean isFinite(double value) {
+    return !Double.isNaN(value) && !Double.isInfinite(value);
+  }
+
+  private static String requireText(String value, String label) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(label + " must not be blank");
+    }
+    return value;
+  }
+
+  private static <T> List<T> immutableList(List<T> values) {
+    if (values == null || values.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return Collections.unmodifiableList(new ArrayList<T>(values));
+  }
+
+  private static List<String> immutableStrings(List<String> values) {
+    if (values == null || values.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return Collections.unmodifiableList(new ArrayList<String>(values));
+  }
+}

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelDebottleneckRanking.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelDebottleneckRanking.java
@@ -99,6 +99,7 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
     private final String effectivePeriod;
     private final RankingDirection direction;
     private final double tieTolerance;
+    private final double baselineRelativeTolerance;
     private final boolean alternativeConfidenceFloorSet;
     private final double minimumAlternativeConfidence;
     private final boolean metricConfidenceFloorSet;
@@ -119,13 +120,15 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
      * @param effectivePeriod exact metric effective period
      * @param direction direction in which the paired delta improves
      * @param tieTolerance non-negative tie tolerance in the metric unit
+     * @param baselineRelativeTolerance dimensionless relative tolerance in [0, 1] for repeated
+     *        simulator values in an otherwise identical baseline
      * @param minimumAlternativeConfidence confidence floor in [0, 1], or NaN when unset
      * @param minimumMetricConfidence confidence floor in [0, 1], or NaN when unset
      */
     public RankingPolicy(String id, String name, String provenance, String metricId, String metricName,
         MetricKind metricKind, String unit, String basis, String metricProvenance, String effectivePeriod,
-        RankingDirection direction, double tieTolerance, double minimumAlternativeConfidence,
-        double minimumMetricConfidence) {
+        RankingDirection direction, double tieTolerance, double baselineRelativeTolerance,
+        double minimumAlternativeConfidence, double minimumMetricConfidence) {
       this.id = requireText(id, "Ranking policy identifier");
       this.name = requireText(name, "Ranking policy name");
       this.provenance = requireText(provenance, "Ranking policy provenance");
@@ -147,6 +150,11 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
         throw new IllegalArgumentException("Ranking tie tolerance must be finite and non-negative");
       }
       this.tieTolerance = tieTolerance;
+      if (!isFinite(baselineRelativeTolerance) || baselineRelativeTolerance < 0.0
+          || baselineRelativeTolerance > 1.0) {
+        throw new IllegalArgumentException("Baseline relative tolerance must be finite and in [0, 1]");
+      }
+      this.baselineRelativeTolerance = baselineRelativeTolerance;
       alternativeConfidenceFloorSet = !Double.isNaN(minimumAlternativeConfidence);
       this.minimumAlternativeConfidence = validateConfidence(minimumAlternativeConfidence,
           "Minimum alternative confidence");
@@ -212,6 +220,11 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
     /** @return tie tolerance in the ranking metric unit */
     public double getTieTolerance() {
       return tieTolerance;
+    }
+
+    /** @return dimensionless relative tolerance for repeated baseline simulator values */
+    public double getBaselineRelativeTolerance() {
+      return baselineRelativeTolerance;
     }
 
     /** @return true when an alternative-confidence floor is enforced */
@@ -479,12 +492,13 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
       if (draft.status == CandidateStatus.QUALIFIED) {
         if (reference == null) {
           reference = new BaselineReference(draft.studyResult.getBaseline(), draft.baselineMetric);
-          draft.diagnostics.add("Established the exact deterministic portfolio baseline");
+          draft.diagnostics.add("Established the deterministic portfolio baseline with relative numeric tolerance "
+              + policy.getBaselineRelativeTolerance());
         } else if (!baselineMatches(reference, draft.studyResult.getBaseline(), draft.baselineMetric)) {
           draft.status = CandidateStatus.BASELINE_INCOMPATIBLE;
           draft.delta = Double.NaN;
-          draft.diagnostics.add("Baseline search, parameters, metric, objectives, or constraints differ from the "
-              + "portfolio reference baseline");
+          draft.diagnostics.add("Baseline search, parameters, metric metadata, or simulator values differ from the "
+              + "portfolio reference baseline beyond relative tolerance " + policy.getBaselineRelativeTolerance());
         }
       }
       drafts.add(draft);
@@ -634,7 +648,7 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
     return metadataMatches(left) && metadataMatches(right) && left.getStatus() == right.getStatus()
         && left.isRequired() == right.isRequired() && left.hasConfidence() == right.hasConfidence()
         && (!left.hasConfidence() || bitsEqual(left.getConfidence(), right.getConfidence()))
-        && bitsEqual(left.getValue(), right.getValue());
+        && relativeEqual(left.getValue(), right.getValue());
   }
 
   private boolean objectivesEqual(List<ObjectiveEvidence> left, List<ObjectiveEvidence> right) {
@@ -646,7 +660,8 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
       ObjectiveEvidence b = right.get(index);
       if (a.getIndex() != b.getIndex() || !a.getName().equals(b.getName()) || a.getDirection() != b.getDirection()
           || !a.getUnit().equals(b.getUnit()) || !bitsEqual(a.getWeight(), b.getWeight())
-          || !bitsEqual(a.getRawValue(), b.getRawValue()) || !bitsEqual(a.getMinimizerValue(), b.getMinimizerValue())) {
+          || !relativeEqual(a.getRawValue(), b.getRawValue())
+          || !relativeEqual(a.getMinimizerValue(), b.getMinimizerValue())) {
         return false;
       }
     }
@@ -661,8 +676,8 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
       ConstraintEvidence a = left.get(index);
       ConstraintEvidence b = right.get(index);
       if (a.getIndex() != b.getIndex() || !a.getName().equals(b.getName()) || a.getType() != b.getType()
-          || !a.getUnit().equals(b.getUnit()) || a.isHard() != b.isHard() || !bitsEqual(a.getValue(), b.getValue())
-          || !bitsEqual(a.getMargin(), b.getMargin())) {
+          || !a.getUnit().equals(b.getUnit()) || a.isHard() != b.isHard()
+          || !relativeEqual(a.getValue(), b.getValue()) || !relativeEqual(a.getMargin(), b.getMargin())) {
         return false;
       }
     }
@@ -765,6 +780,17 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
 
   private static boolean bitsEqual(double left, double right) {
     return Double.doubleToLongBits(left) == Double.doubleToLongBits(right);
+  }
+
+  private boolean relativeEqual(double left, double right) {
+    if (bitsEqual(left, right)) {
+      return true;
+    }
+    if (!isFinite(left) || !isFinite(right)) {
+      return false;
+    }
+    double scale = Math.max(Math.abs(left), Math.abs(right));
+    return scale > 0.0 && Math.abs(left - right) <= policy.getBaselineRelativeTolerance() * scale;
   }
 
   private static boolean isFinite(double value) {

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelDebottleneckRanking.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelDebottleneckRanking.java
@@ -120,8 +120,8 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
      * @param effectivePeriod exact metric effective period
      * @param direction direction in which the paired delta improves
      * @param tieTolerance non-negative tie tolerance in the metric unit
-     * @param baselineRelativeTolerance dimensionless relative tolerance in [0, 1] for repeated
-     *        simulator values in an otherwise identical baseline
+     * @param baselineRelativeTolerance dimensionless relative tolerance in [0, 1] for repeated simulator values in an
+     * otherwise identical baseline
      * @param minimumAlternativeConfidence confidence floor in [0, 1], or NaN when unset
      * @param minimumMetricConfidence confidence floor in [0, 1], or NaN when unset
      */
@@ -150,8 +150,7 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
         throw new IllegalArgumentException("Ranking tie tolerance must be finite and non-negative");
       }
       this.tieTolerance = tieTolerance;
-      if (!isFinite(baselineRelativeTolerance) || baselineRelativeTolerance < 0.0
-          || baselineRelativeTolerance > 1.0) {
+      if (!isFinite(baselineRelativeTolerance) || baselineRelativeTolerance < 0.0 || baselineRelativeTolerance > 1.0) {
         throw new IllegalArgumentException("Baseline relative tolerance must be finite and in [0, 1]");
       }
       this.baselineRelativeTolerance = baselineRelativeTolerance;
@@ -676,8 +675,8 @@ public final class ProcessModelDebottleneckRanking implements Serializable {
       ConstraintEvidence a = left.get(index);
       ConstraintEvidence b = right.get(index);
       if (a.getIndex() != b.getIndex() || !a.getName().equals(b.getName()) || a.getType() != b.getType()
-          || !a.getUnit().equals(b.getUnit()) || a.isHard() != b.isHard()
-          || !relativeEqual(a.getValue(), b.getValue()) || !relativeEqual(a.getMargin(), b.getMargin())) {
+          || !a.getUnit().equals(b.getUnit()) || a.isHard() != b.isHard() || !relativeEqual(a.getValue(), b.getValue())
+          || !relativeEqual(a.getMargin(), b.getMargin())) {
         return false;
       }
     }

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelDebottleneckRankingTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelDebottleneckRankingTest.java
@@ -50,8 +50,7 @@ class ProcessModelDebottleneckRankingTest {
     private final CapacityConstraint installedCapacity;
     private final ProcessModelSimulationEvaluator evaluator;
 
-    private Fixture(Stream feed, CapacityConstraint installedCapacity,
-        ProcessModelSimulationEvaluator evaluator) {
+    private Fixture(Stream feed, CapacityConstraint installedCapacity, ProcessModelSimulationEvaluator evaluator) {
       this.feed = feed;
       this.installedCapacity = installedCapacity;
       this.evaluator = evaluator;
@@ -59,25 +58,25 @@ class ProcessModelDebottleneckRankingTest {
   }
 
   /**
-   * Three independently executed studies must rank 200, 100 and 100 kg/hr production deltas with
-   * deterministic competition ranks while retaining the submitted order inside the tie.
+   * Three independently executed studies must rank 200, 100 and 100 kg/hr production deltas with deterministic
+   * competition ranks while retaining the submitted order inside the tie.
    *
    * @throws Exception when Java serialization fails
    */
   @Test
   void ranksCompatibleAlternativesDeterministicallyAndSerializes() throws Exception {
     Fixture fixture = createFixture();
-    fixture.evaluator.evaluate(new double[] {800.0});
+    fixture.evaluator.evaluate(new double[] { 800.0 });
     List<double[]> candidates = commonCandidates();
 
-    StudyResult result1100 = createStudy(fixture, "study-1100", 1100.0, 0.90, "kg/hr",
-        "wet feed mass rate", candidates).evaluate();
+    StudyResult result1100 = createStudy(fixture, "study-1100", 1100.0, 0.90, "kg/hr", "wet feed mass rate", candidates)
+        .evaluate();
     assertOriginalStateRestored(fixture);
-    StudyResult result1150 = createStudy(fixture, "study-1150", 1150.0, 0.80, "kg/hr",
-        "wet feed mass rate", candidates).evaluate();
+    StudyResult result1150 = createStudy(fixture, "study-1150", 1150.0, 0.80, "kg/hr", "wet feed mass rate", candidates)
+        .evaluate();
     assertOriginalStateRestored(fixture);
-    StudyResult result1200 = createStudy(fixture, "study-1200", 1200.0, 0.95, "kg/hr",
-        "wet feed mass rate", candidates).evaluate();
+    StudyResult result1200 = createStudy(fixture, "study-1200", 1200.0, 0.95, "kg/hr", "wet feed mass rate", candidates)
+        .evaluate();
     assertOriginalStateRestored(fixture);
 
     ProcessModelDebottleneckRanking ranking = createProductionRanking(0.0, 0.50, 0.90);
@@ -86,21 +85,16 @@ class ProcessModelDebottleneckRankingTest {
     assertEquals(RankingOutcome.COMPLETED, first.getOutcome());
     assertEquals(3, first.getRankedCandidates().size());
     assertEquals(0, first.getRejectedCandidates().size());
-    assertEquals("separator-gas-1200",
-        first.getBestCandidate().getAlternativeDefinition().getId());
+    assertEquals("separator-gas-1200", first.getBestCandidate().getAlternativeDefinition().getId());
     assertEquals(200.0, first.getBestCandidate().getDelta(), 1.0e-8);
     assertEquals(1, first.getBestCandidate().getRank());
-    assertEquals("separator-gas-1100",
-        first.getRankedCandidates().get(1).getAlternativeDefinition().getId());
+    assertEquals("separator-gas-1100", first.getRankedCandidates().get(1).getAlternativeDefinition().getId());
     assertEquals(2, first.getRankedCandidates().get(1).getRank());
-    assertEquals("separator-gas-1150",
-        first.getRankedCandidates().get(2).getAlternativeDefinition().getId());
+    assertEquals("separator-gas-1150", first.getRankedCandidates().get(2).getAlternativeDefinition().getId());
     assertEquals(2, first.getRankedCandidates().get(2).getRank());
-    assertEquals("separator-gas-1100",
-        first.getCandidatesInInputOrder().get(0).getAlternativeDefinition().getId());
+    assertEquals("separator-gas-1100", first.getCandidatesInInputOrder().get(0).getAlternativeDefinition().getId());
     assertEquals("kg/hr", first.getBestCandidate().getBaselineMetric().getUnit());
-    assertEquals("NeqSim stream result",
-        first.getBestCandidate().getAlternativeMetric().getProvenance());
+    assertEquals("NeqSim stream result", first.getBestCandidate().getAlternativeMetric().getProvenance());
     assertThrows(UnsupportedOperationException.class, () -> first.getRankedCandidates().clear());
 
     RankingResult restored = roundTrip(first);
@@ -108,15 +102,13 @@ class ProcessModelDebottleneckRankingTest {
     assertEquals(first.getBestCandidate().getAlternativeDefinition().getQualifiedConstraintName(),
         restored.getBestCandidate().getAlternativeDefinition().getQualifiedConstraintName());
     assertEquals(first.getBestCandidate().getDelta(), restored.getBestCandidate().getDelta(), 0.0);
-    assertEquals(first.getPolicy().getMetricProvenance(),
-        restored.getPolicy().getMetricProvenance());
+    assertEquals(first.getPolicy().getMetricProvenance(), restored.getPolicy().getMetricProvenance());
 
-    RankingResult second = ranking.rank(new StudyResult[] {result1100, result1150, result1200});
+    RankingResult second = ranking.rank(new StudyResult[] { result1100, result1150, result1200 });
     for (int index = 0; index < first.getRankedCandidates().size(); index++) {
       CandidateEvidence expected = first.getRankedCandidates().get(index);
       CandidateEvidence actual = second.getRankedCandidates().get(index);
-      assertEquals(expected.getAlternativeDefinition().getId(),
-          actual.getAlternativeDefinition().getId());
+      assertEquals(expected.getAlternativeDefinition().getId(), actual.getAlternativeDefinition().getId());
       assertEquals(expected.getRank(), actual.getRank());
       assertEquals(expected.getDelta(), actual.getDelta(), 0.0);
     }
@@ -126,22 +118,22 @@ class ProcessModelDebottleneckRankingTest {
   @Test
   void rejectsIncompatibleEvidenceWithoutComparingUnlikeMetrics() {
     Fixture fixture = createFixture();
-    fixture.evaluator.evaluate(new double[] {800.0});
+    fixture.evaluator.evaluate(new double[] { 800.0 });
 
-    StudyResult reference = createStudy(fixture, "reference", 1100.0, 0.90, "kg/hr",
-        "wet feed mass rate", commonCandidates()).evaluate();
-    StudyResult wrongUnit = createStudy(fixture, "wrong-unit", 1150.0, 0.90, "t/day",
-        "wet feed mass rate", commonCandidates()).evaluate();
+    StudyResult reference = createStudy(fixture, "reference", 1100.0, 0.90, "kg/hr", "wet feed mass rate",
+        commonCandidates()).evaluate();
+    StudyResult wrongUnit = createStudy(fixture, "wrong-unit", 1150.0, 0.90, "t/day", "wet feed mass rate",
+        commonCandidates()).evaluate();
     List<double[]> differentBaselineCandidates = new ArrayList<double[]>();
-    differentBaselineCandidates.add(new double[] {800.0});
-    differentBaselineCandidates.add(new double[] {899.0});
-    differentBaselineCandidates.add(new double[] {1099.0});
-    differentBaselineCandidates.add(new double[] {1199.0});
-    differentBaselineCandidates.add(new double[] {1400.0});
-    StudyResult wrongBaseline = createStudy(fixture, "wrong-baseline", 1200.0, 0.90,
-        "kg/hr", "wet feed mass rate", differentBaselineCandidates).evaluate();
-    StudyResult lowConfidence = createStudy(fixture, "low-confidence", 1250.0, 0.40,
-        "kg/hr", "wet feed mass rate", commonCandidates()).evaluate();
+    differentBaselineCandidates.add(new double[] { 800.0 });
+    differentBaselineCandidates.add(new double[] { 899.0 });
+    differentBaselineCandidates.add(new double[] { 1099.0 });
+    differentBaselineCandidates.add(new double[] { 1199.0 });
+    differentBaselineCandidates.add(new double[] { 1400.0 });
+    StudyResult wrongBaseline = createStudy(fixture, "wrong-baseline", 1200.0, 0.90, "kg/hr", "wet feed mass rate",
+        differentBaselineCandidates).evaluate();
+    StudyResult lowConfidence = createStudy(fixture, "low-confidence", 1250.0, 0.40, "kg/hr", "wet feed mass rate",
+        commonCandidates()).evaluate();
 
     RankingResult result = createProductionRanking(0.0, 0.50, 0.90)
         .rank(Arrays.asList(reference, wrongUnit, wrongBaseline, lowConfidence));
@@ -149,12 +141,9 @@ class ProcessModelDebottleneckRankingTest {
     assertEquals(RankingOutcome.PARTIAL, result.getOutcome());
     assertEquals(1, result.getRankedCandidates().size());
     assertEquals(3, result.getRejectedCandidates().size());
-    assertEquals(CandidateStatus.METRIC_METADATA_MISMATCH,
-        result.getCandidatesInInputOrder().get(1).getStatus());
-    assertEquals(CandidateStatus.BASELINE_INCOMPATIBLE,
-        result.getCandidatesInInputOrder().get(2).getStatus());
-    assertEquals(CandidateStatus.ALTERNATIVE_CONFIDENCE_TOO_LOW,
-        result.getCandidatesInInputOrder().get(3).getStatus());
+    assertEquals(CandidateStatus.METRIC_METADATA_MISMATCH, result.getCandidatesInInputOrder().get(1).getStatus());
+    assertEquals(CandidateStatus.BASELINE_INCOMPATIBLE, result.getCandidatesInInputOrder().get(2).getStatus());
+    assertEquals(CandidateStatus.ALTERNATIVE_CONFIDENCE_TOO_LOW, result.getCandidatesInInputOrder().get(3).getStatus());
     assertTrue(Double.isNaN(result.getCandidatesInInputOrder().get(1).getDelta()));
     assertTrue(Double.isNaN(result.getCandidatesInInputOrder().get(2).getDelta()));
     assertTrue(Double.isNaN(result.getCandidatesInInputOrder().get(3).getDelta()));
@@ -165,44 +154,38 @@ class ProcessModelDebottleneckRankingTest {
   @Test
   void duplicateIdentityFailsClosed() {
     Fixture fixture = createFixture();
-    fixture.evaluator.evaluate(new double[] {800.0});
-    StudyResult result = createStudy(fixture, "duplicate", 1100.0, 0.90, "kg/hr",
-        "wet feed mass rate", commonCandidates()).evaluate();
+    fixture.evaluator.evaluate(new double[] { 800.0 });
+    StudyResult result = createStudy(fixture, "duplicate", 1100.0, 0.90, "kg/hr", "wet feed mass rate",
+        commonCandidates()).evaluate();
 
     assertThrows(IllegalArgumentException.class,
-        () -> createProductionRanking(0.0, Double.NaN, Double.NaN)
-            .rank(Arrays.asList(result, result)));
+        () -> createProductionRanking(0.0, Double.NaN, Double.NaN).rank(Arrays.asList(result, result)));
   }
 
   /** Creates the exact production-delta policy used by the focused regressions. */
   private ProcessModelDebottleneckRanking createProductionRanking(double tieTolerance,
       double minimumAlternativeConfidence, double minimumMetricConfidence) {
     RankingPolicy policy = new RankingPolicy("production-delta", "Production delta ranking",
-        "synthetic deterministic portfolio policy", "production", "Feed production",
-        MetricKind.PRODUCTION, "kg/hr", "wet feed mass rate", "NeqSim stream result",
-        "single steady state", RankingDirection.MAXIMIZE, tieTolerance,
+        "synthetic deterministic portfolio policy", "production", "Feed production", MetricKind.PRODUCTION, "kg/hr",
+        "wet feed mass rate", "NeqSim stream result", "single steady state", RankingDirection.MAXIMIZE, tieTolerance,
         minimumAlternativeConfidence, minimumMetricConfidence);
-    return new ProcessModelDebottleneckRanking("separator-portfolio",
-        "Separator alternatives portfolio", "synthetic deterministic portfolio", policy);
+    return new ProcessModelDebottleneckRanking("separator-portfolio", "Separator alternatives portfolio",
+        "synthetic deterministic portfolio", policy);
   }
 
   /** Creates one independent paired study over a declared candidate set. */
-  private ProcessModelDebottleneckStudy createStudy(Fixture fixture, String studyId,
-      double proposedLimit, double alternativeConfidence, String metricUnit, String metricBasis,
-      List<double[]> candidates) {
-    CandidateListSearch search = new CandidateListSearch("ordered-throughput-grid",
-        "Ordered throughput grid", "synthetic portfolio candidate set", candidates, 0, 0.0);
-    CapacityAlternative alternative = new CapacityAlternative(
-        "separator-gas-" + Integer.toString((int) proposedLimit),
-        "Raise separator installed gas capacity to " + proposedLimit + " kg/hr",
-        "synthetic brownfield screening case", "separation", "separator",
-        "installed gas rate", proposedLimit, "kg/hr", LimitDirection.MAXIMUM,
+  private ProcessModelDebottleneckStudy createStudy(Fixture fixture, String studyId, double proposedLimit,
+      double alternativeConfidence, String metricUnit, String metricBasis, List<double[]> candidates) {
+    CandidateListSearch search = new CandidateListSearch("ordered-throughput-grid", "Ordered throughput grid",
+        "synthetic portfolio candidate set", candidates, 0, 0.0);
+    CapacityAlternative alternative = new CapacityAlternative("separator-gas-" + Integer.toString((int) proposedLimit),
+        "Raise separator installed gas capacity to " + proposedLimit + " kg/hr", "synthetic brownfield screening case",
+        "separation", "separator", "installed gas rate", proposedLimit, "kg/hr", LimitDirection.MAXIMUM,
         "synthetic replacement equipment basis", alternativeConfidence, 900.0, 1300.0);
-    ProcessModelDebottleneckStudy study = new ProcessModelDebottleneckStudy(studyId,
-        "Paired separator capacity study", "synthetic deterministic regression",
-        fixture.evaluator, alternative, search, 0);
-    study.addMetric(new MetricDefinition("production", "Feed production", MetricKind.PRODUCTION,
-        metricUnit, metricBasis, "NeqSim stream result", "single steady state", 1.0, true,
+    ProcessModelDebottleneckStudy study = new ProcessModelDebottleneckStudy(studyId, "Paired separator capacity study",
+        "synthetic deterministic regression", fixture.evaluator, alternative, search, 0);
+    study.addMetric(new MetricDefinition("production", "Feed production", MetricKind.PRODUCTION, metricUnit,
+        metricBasis, "NeqSim stream result", "single steady state", 1.0, true,
         model -> model.getVariableValue("wells::feed.flowRate", "kg/hr")));
     return study;
   }
@@ -210,11 +193,11 @@ class ProcessModelDebottleneckRankingTest {
   /** @return common deterministic candidate set with exact baseline and alternative incumbents */
   private List<double[]> commonCandidates() {
     List<double[]> candidates = new ArrayList<double[]>();
-    candidates.add(new double[] {800.0});
-    candidates.add(new double[] {999.0});
-    candidates.add(new double[] {1099.0});
-    candidates.add(new double[] {1199.0});
-    candidates.add(new double[] {1400.0});
+    candidates.add(new double[] { 800.0 });
+    candidates.add(new double[] { 999.0 });
+    candidates.add(new double[] { 1099.0 });
+    candidates.add(new double[] { 1199.0 });
+    candidates.add(new double[] { 1400.0 });
     return candidates;
   }
 
@@ -226,12 +209,10 @@ class ProcessModelDebottleneckRankingTest {
     fluid.setMixingRule("classic");
     fluid.setTotalFlowRate(800.0, "kg/hr");
     final Stream feed = new Stream("feed", fluid);
-    final CapacityConstraint installed = new CapacityConstraint("installed gas rate", "kg/hr",
-        ConstraintType.HARD).setDesignValue(1000.0).setMaxValue(1300.0)
-        .setWarningThreshold(0.90).setSeverity(ConstraintSeverity.HARD)
-        .setDataSource("synthetic installed basis").setConfidence(0.95)
-        .setValidityRange(500.0, 1400.0).setShadowPrice(12.3)
-        .setValueSupplier(new DoubleSupplier() {
+    final CapacityConstraint installed = new CapacityConstraint("installed gas rate", "kg/hr", ConstraintType.HARD)
+        .setDesignValue(1000.0).setMaxValue(1300.0).setWarningThreshold(0.90).setSeverity(ConstraintSeverity.HARD)
+        .setDataSource("synthetic installed basis").setConfidence(0.95).setValidityRange(500.0, 1400.0)
+        .setShadowPrice(12.3).setValueSupplier(new DoubleSupplier() {
           @Override
           public double getAsDouble() {
             return feed.getFlowRate("kg/hr");
@@ -257,8 +238,7 @@ class ProcessModelDebottleneckRankingTest {
           public double applyAsDouble(ProcessModel completedModel) {
             return completedModel.getVariableValue("wells::feed.flowRate", "kg/hr");
           }
-        }, ProcessModelSimulationEvaluator.ObjectiveDefinition.Direction.MAXIMIZE)
-        .addEquipmentCapacityConstraints();
+        }, ProcessModelSimulationEvaluator.ObjectiveDefinition.Direction.MAXIMIZE).addEquipmentCapacityConstraints();
     evaluator.getObjectives().get(0).setUnit("kg/hr");
     return new Fixture(feed, installed, evaluator);
   }

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelDebottleneckRankingTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelDebottleneckRankingTest.java
@@ -79,7 +79,7 @@ class ProcessModelDebottleneckRankingTest {
         .evaluate();
     assertOriginalStateRestored(fixture);
 
-    ProcessModelDebottleneckRanking ranking = createProductionRanking(0.0, 0.50, 0.90);
+    ProcessModelDebottleneckRanking ranking = createProductionRanking(1.0e-8, 0.50, 0.90);
     RankingResult first = ranking.rank(Arrays.asList(result1100, result1150, result1200));
 
     assertEquals(RankingOutcome.COMPLETED, first.getOutcome());
@@ -168,7 +168,7 @@ class ProcessModelDebottleneckRankingTest {
     RankingPolicy policy = new RankingPolicy("production-delta", "Production delta ranking",
         "synthetic deterministic portfolio policy", "production", "Feed production", MetricKind.PRODUCTION, "kg/hr",
         "wet feed mass rate", "NeqSim stream result", "single steady state", RankingDirection.MAXIMIZE, tieTolerance,
-        minimumAlternativeConfidence, minimumMetricConfidence);
+        1.0e-8, minimumAlternativeConfidence, minimumMetricConfidence);
     return new ProcessModelDebottleneckRanking("separator-portfolio", "Separator alternatives portfolio",
         "synthetic deterministic portfolio", policy);
   }

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelDebottleneckRankingTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelDebottleneckRankingTest.java
@@ -1,0 +1,286 @@
+package neqsim.process.util.optimizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.DoubleSupplier;
+import java.util.function.ToDoubleFunction;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.capacity.CapacityConstraint;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintSeverity;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintType;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckRanking.CandidateEvidence;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckRanking.CandidateStatus;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckRanking.RankingDirection;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckRanking.RankingOutcome;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckRanking.RankingPolicy;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckRanking.RankingResult;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.CandidateListSearch;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.CapacityAlternative;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.LimitDirection;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.MetricDefinition;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.MetricKind;
+import neqsim.process.util.optimizer.ProcessModelDebottleneckStudy.StudyResult;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Tests for {@link ProcessModelDebottleneckRanking}.
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+class ProcessModelDebottleneckRankingTest {
+
+  /** Shared process-model fixture proving that each paired study restores the same live state. */
+  private static final class Fixture {
+    private final Stream feed;
+    private final CapacityConstraint installedCapacity;
+    private final ProcessModelSimulationEvaluator evaluator;
+
+    private Fixture(Stream feed, CapacityConstraint installedCapacity,
+        ProcessModelSimulationEvaluator evaluator) {
+      this.feed = feed;
+      this.installedCapacity = installedCapacity;
+      this.evaluator = evaluator;
+    }
+  }
+
+  /**
+   * Three independently executed studies must rank 200, 100 and 100 kg/hr production deltas with
+   * deterministic competition ranks while retaining the submitted order inside the tie.
+   *
+   * @throws Exception when Java serialization fails
+   */
+  @Test
+  void ranksCompatibleAlternativesDeterministicallyAndSerializes() throws Exception {
+    Fixture fixture = createFixture();
+    fixture.evaluator.evaluate(new double[] {800.0});
+    List<double[]> candidates = commonCandidates();
+
+    StudyResult result1100 = createStudy(fixture, "study-1100", 1100.0, 0.90, "kg/hr",
+        "wet feed mass rate", candidates).evaluate();
+    assertOriginalStateRestored(fixture);
+    StudyResult result1150 = createStudy(fixture, "study-1150", 1150.0, 0.80, "kg/hr",
+        "wet feed mass rate", candidates).evaluate();
+    assertOriginalStateRestored(fixture);
+    StudyResult result1200 = createStudy(fixture, "study-1200", 1200.0, 0.95, "kg/hr",
+        "wet feed mass rate", candidates).evaluate();
+    assertOriginalStateRestored(fixture);
+
+    ProcessModelDebottleneckRanking ranking = createProductionRanking(0.0, 0.50, 0.90);
+    RankingResult first = ranking.rank(Arrays.asList(result1100, result1150, result1200));
+
+    assertEquals(RankingOutcome.COMPLETED, first.getOutcome());
+    assertEquals(3, first.getRankedCandidates().size());
+    assertEquals(0, first.getRejectedCandidates().size());
+    assertEquals("separator-gas-1200",
+        first.getBestCandidate().getAlternativeDefinition().getId());
+    assertEquals(200.0, first.getBestCandidate().getDelta(), 1.0e-8);
+    assertEquals(1, first.getBestCandidate().getRank());
+    assertEquals("separator-gas-1100",
+        first.getRankedCandidates().get(1).getAlternativeDefinition().getId());
+    assertEquals(2, first.getRankedCandidates().get(1).getRank());
+    assertEquals("separator-gas-1150",
+        first.getRankedCandidates().get(2).getAlternativeDefinition().getId());
+    assertEquals(2, first.getRankedCandidates().get(2).getRank());
+    assertEquals("separator-gas-1100",
+        first.getCandidatesInInputOrder().get(0).getAlternativeDefinition().getId());
+    assertEquals("kg/hr", first.getBestCandidate().getBaselineMetric().getUnit());
+    assertEquals("NeqSim stream result",
+        first.getBestCandidate().getAlternativeMetric().getProvenance());
+    assertThrows(UnsupportedOperationException.class, () -> first.getRankedCandidates().clear());
+
+    RankingResult restored = roundTrip(first);
+    assertEquals(first.getOutcome(), restored.getOutcome());
+    assertEquals(first.getBestCandidate().getAlternativeDefinition().getQualifiedConstraintName(),
+        restored.getBestCandidate().getAlternativeDefinition().getQualifiedConstraintName());
+    assertEquals(first.getBestCandidate().getDelta(), restored.getBestCandidate().getDelta(), 0.0);
+    assertEquals(first.getPolicy().getMetricProvenance(),
+        restored.getPolicy().getMetricProvenance());
+
+    RankingResult second = ranking.rank(new StudyResult[] {result1100, result1150, result1200});
+    for (int index = 0; index < first.getRankedCandidates().size(); index++) {
+      CandidateEvidence expected = first.getRankedCandidates().get(index);
+      CandidateEvidence actual = second.getRankedCandidates().get(index);
+      assertEquals(expected.getAlternativeDefinition().getId(),
+          actual.getAlternativeDefinition().getId());
+      assertEquals(expected.getRank(), actual.getRank());
+      assertEquals(expected.getDelta(), actual.getDelta(), 0.0);
+    }
+  }
+
+  /** Incompatible units, baselines and confidence must be rejected without a synthetic score. */
+  @Test
+  void rejectsIncompatibleEvidenceWithoutComparingUnlikeMetrics() {
+    Fixture fixture = createFixture();
+    fixture.evaluator.evaluate(new double[] {800.0});
+
+    StudyResult reference = createStudy(fixture, "reference", 1100.0, 0.90, "kg/hr",
+        "wet feed mass rate", commonCandidates()).evaluate();
+    StudyResult wrongUnit = createStudy(fixture, "wrong-unit", 1150.0, 0.90, "t/day",
+        "wet feed mass rate", commonCandidates()).evaluate();
+    List<double[]> differentBaselineCandidates = new ArrayList<double[]>();
+    differentBaselineCandidates.add(new double[] {800.0});
+    differentBaselineCandidates.add(new double[] {899.0});
+    differentBaselineCandidates.add(new double[] {1099.0});
+    differentBaselineCandidates.add(new double[] {1199.0});
+    differentBaselineCandidates.add(new double[] {1400.0});
+    StudyResult wrongBaseline = createStudy(fixture, "wrong-baseline", 1200.0, 0.90,
+        "kg/hr", "wet feed mass rate", differentBaselineCandidates).evaluate();
+    StudyResult lowConfidence = createStudy(fixture, "low-confidence", 1250.0, 0.40,
+        "kg/hr", "wet feed mass rate", commonCandidates()).evaluate();
+
+    RankingResult result = createProductionRanking(0.0, 0.50, 0.90)
+        .rank(Arrays.asList(reference, wrongUnit, wrongBaseline, lowConfidence));
+
+    assertEquals(RankingOutcome.PARTIAL, result.getOutcome());
+    assertEquals(1, result.getRankedCandidates().size());
+    assertEquals(3, result.getRejectedCandidates().size());
+    assertEquals(CandidateStatus.METRIC_METADATA_MISMATCH,
+        result.getCandidatesInInputOrder().get(1).getStatus());
+    assertEquals(CandidateStatus.BASELINE_INCOMPATIBLE,
+        result.getCandidatesInInputOrder().get(2).getStatus());
+    assertEquals(CandidateStatus.ALTERNATIVE_CONFIDENCE_TOO_LOW,
+        result.getCandidatesInInputOrder().get(3).getStatus());
+    assertTrue(Double.isNaN(result.getCandidatesInInputOrder().get(1).getDelta()));
+    assertTrue(Double.isNaN(result.getCandidatesInInputOrder().get(2).getDelta()));
+    assertTrue(Double.isNaN(result.getCandidatesInInputOrder().get(3).getDelta()));
+    assertOriginalStateRestored(fixture);
+  }
+
+  /** Duplicate study or alternative identities must fail before a ranking is constructed. */
+  @Test
+  void duplicateIdentityFailsClosed() {
+    Fixture fixture = createFixture();
+    fixture.evaluator.evaluate(new double[] {800.0});
+    StudyResult result = createStudy(fixture, "duplicate", 1100.0, 0.90, "kg/hr",
+        "wet feed mass rate", commonCandidates()).evaluate();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> createProductionRanking(0.0, Double.NaN, Double.NaN)
+            .rank(Arrays.asList(result, result)));
+  }
+
+  /** Creates the exact production-delta policy used by the focused regressions. */
+  private ProcessModelDebottleneckRanking createProductionRanking(double tieTolerance,
+      double minimumAlternativeConfidence, double minimumMetricConfidence) {
+    RankingPolicy policy = new RankingPolicy("production-delta", "Production delta ranking",
+        "synthetic deterministic portfolio policy", "production", "Feed production",
+        MetricKind.PRODUCTION, "kg/hr", "wet feed mass rate", "NeqSim stream result",
+        "single steady state", RankingDirection.MAXIMIZE, tieTolerance,
+        minimumAlternativeConfidence, minimumMetricConfidence);
+    return new ProcessModelDebottleneckRanking("separator-portfolio",
+        "Separator alternatives portfolio", "synthetic deterministic portfolio", policy);
+  }
+
+  /** Creates one independent paired study over a declared candidate set. */
+  private ProcessModelDebottleneckStudy createStudy(Fixture fixture, String studyId,
+      double proposedLimit, double alternativeConfidence, String metricUnit, String metricBasis,
+      List<double[]> candidates) {
+    CandidateListSearch search = new CandidateListSearch("ordered-throughput-grid",
+        "Ordered throughput grid", "synthetic portfolio candidate set", candidates, 0, 0.0);
+    CapacityAlternative alternative = new CapacityAlternative(
+        "separator-gas-" + Integer.toString((int) proposedLimit),
+        "Raise separator installed gas capacity to " + proposedLimit + " kg/hr",
+        "synthetic brownfield screening case", "separation", "separator",
+        "installed gas rate", proposedLimit, "kg/hr", LimitDirection.MAXIMUM,
+        "synthetic replacement equipment basis", alternativeConfidence, 900.0, 1300.0);
+    ProcessModelDebottleneckStudy study = new ProcessModelDebottleneckStudy(studyId,
+        "Paired separator capacity study", "synthetic deterministic regression",
+        fixture.evaluator, alternative, search, 0);
+    study.addMetric(new MetricDefinition("production", "Feed production", MetricKind.PRODUCTION,
+        metricUnit, metricBasis, "NeqSim stream result", "single steady state", 1.0, true,
+        model -> model.getVariableValue("wells::feed.flowRate", "kg/hr")));
+    return study;
+  }
+
+  /** @return common deterministic candidate set with exact baseline and alternative incumbents */
+  private List<double[]> commonCandidates() {
+    List<double[]> candidates = new ArrayList<double[]>();
+    candidates.add(new double[] {800.0});
+    candidates.add(new double[] {999.0});
+    candidates.add(new double[] {1099.0});
+    candidates.add(new double[] {1199.0});
+    candidates.add(new double[] {1400.0});
+    return candidates;
+  }
+
+  /** Creates a two-area process model with one reversible direct installed capacity limit. */
+  private Fixture createFixture() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.90);
+    fluid.addComponent("ethane", 0.10);
+    fluid.setMixingRule("classic");
+    fluid.setTotalFlowRate(800.0, "kg/hr");
+    final Stream feed = new Stream("feed", fluid);
+    final CapacityConstraint installed = new CapacityConstraint("installed gas rate", "kg/hr",
+        ConstraintType.HARD).setDesignValue(1000.0).setMaxValue(1300.0)
+        .setWarningThreshold(0.90).setSeverity(ConstraintSeverity.HARD)
+        .setDataSource("synthetic installed basis").setConfidence(0.95)
+        .setValidityRange(500.0, 1400.0).setShadowPrice(12.3)
+        .setValueSupplier(new DoubleSupplier() {
+          @Override
+          public double getAsDouble() {
+            return feed.getFlowRate("kg/hr");
+          }
+        });
+    Separator separator = new Separator("separator", feed);
+    separator.clearCapacityConstraints();
+    separator.addCapacityConstraint(installed);
+
+    ProcessSystem wells = new ProcessSystem("wells");
+    wells.add(feed);
+    ProcessSystem separation = new ProcessSystem("separation");
+    separation.add(separator);
+    ProcessModel model = new ProcessModel();
+    model.add("wells", wells);
+    model.add("separation", separation);
+
+    ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(model);
+    evaluator.setIncludeStrategyCapacityConstraints(false);
+    evaluator.addParameter("wells::feed.flowRate", 800.0, 1400.0, "kg/hr")
+        .addObjective("feed production", new ToDoubleFunction<ProcessModel>() {
+          @Override
+          public double applyAsDouble(ProcessModel completedModel) {
+            return completedModel.getVariableValue("wells::feed.flowRate", "kg/hr");
+          }
+        }, ProcessModelSimulationEvaluator.ObjectiveDefinition.Direction.MAXIMIZE)
+        .addEquipmentCapacityConstraints();
+    evaluator.getObjectives().get(0).setUnit("kg/hr");
+    return new Fixture(feed, installed, evaluator);
+  }
+
+  /** Confirms that every sequential study returned the shared live fixture to its original state. */
+  private void assertOriginalStateRestored(Fixture fixture) {
+    assertEquals(1000.0, fixture.installedCapacity.getDesignValue(), 0.0);
+    assertEquals(1300.0, fixture.installedCapacity.getMaxValue(), 0.0);
+    assertEquals("synthetic installed basis", fixture.installedCapacity.getDataSource());
+    assertEquals(0.95, fixture.installedCapacity.getConfidence(), 0.0);
+    assertEquals(800.0, fixture.feed.getFlowRate("kg/hr"), 1.0e-8);
+  }
+
+  /** Java-serializes one immutable result and returns its detached copy. */
+  private RankingResult roundTrip(RankingResult result) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream output = new ObjectOutputStream(bytes);
+    output.writeObject(result);
+    output.close();
+    ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    RankingResult restored = (RankingResult) input.readObject();
+    input.close();
+    return restored;
+  }
+}


### PR DESCRIPTION
## READY TO MERGE at exact head `7c81dcb5849a8bb59cce79b4312a46e94ed4e468`

Advances dependency 12 of #2941 with one reviewable capability: fail-closed, deterministic ranking of independently completed debottleneck studies by one declared, physically comparable metric.

## Production-engineering value

`ProcessModelDebottleneckStudy` already preserves paired installed-versus-proposed capacity evidence for one alternative. This PR makes several completed studies comparable without silently normalizing unlike units or promoting screening evidence to a design, causal, shadow-price, NPV, or investment claim.

Callers retain the complete study evidence for every alternative while receiving a deterministic qualified ranking and explicit rejection diagnostics for studies that cannot be compared.

## Baseline and engineering question

Base: `06bd37614d4e74a044662fe56fb6b123b7cbfaee`.

Question: can Java and JPype/Python callers rank independently evaluated capacity alternatives by one declared production, energy, emissions, or screening-economic metric only when the studies share the exact simulator baseline and metric metadata?

Current `master` has no optimization-layer API for that comparison. The field-development `DevelopmentOptionRanker` performs weighted MCDA and is intentionally not reused here because this capability must preserve one physical metric, its unit, basis, provenance, and effective period without weights or normalization.

## Implementation

Adds immutable, serializable `ProcessModelDebottleneckRanking` evidence with:

- ranking policy identity, declared metric metadata, direction, in-unit tie tolerance, optional alternative/metric confidence floors, and explicit provenance;
- exact common-baseline metadata and parameter qualification, with a caller-declared dimensionless relative tolerance for repeated finite simulator values;
- fail-closed statuses for incomplete/unrecovered studies, unqualified scenarios, missing/not-calculable metrics, metadata mismatches, low confidence, and incompatible baselines;
- deterministic ordering, competition ranks, and input-order preservation inside tolerance-qualified ties;
- complete retained `StudyResult` evidence for qualified and rejected candidates;
- defensive collections, array/list entry points, Java serialization, and JPype-friendly getters.

It does not execute simulations, mutate a `ProcessModel`, aggregate unlike units, assign economic weights, claim global optimality, or replace field-development MCDA.

## Acceptance evidence

The focused synthetic regression defines three independently restored separator-capacity studies:

- installed capacity: 1,000 kg/hr;
- proposed alternatives: 1,100, 1,150, and 1,200 kg/hr;
- feasible throughput gains: 100, 100, and 200 kg/hr.

Expected ranking is 1,200 first and the 1,100/1,150 alternatives tied at competition rank 2 in input order. Tests also cover repeat determinism, exact shared-state restoration, approximately 10⁻¹³ repeated-solve noise, incompatible units and materially changed baselines, confidence rejection, duplicate identities, serialization, defensive collections, and complete evidence retention.

## Validation

Locally executed on OpenJDK 17.0.19 using Java 8 source/target compatibility:

- source-slice compile of the new production API and focused test: **passed**;
- `-Xdoclint:all` for the new public API: **passed**;
- conflict-marker, TODO/FIXME, and common secret-pattern scan: **passed**.

A focused runtime was reproduced against a recent real NeqSim runtime artifact. The three compatible alternatives, failure diagnostics, serialization, rejection, restoration, and repeatability regressions now **pass locally**. The first hosted matrix exposed bitwise baseline comparison of repeated converged values differing by about 10⁻¹³; this was corrected with an explicit 1.0e-8 dimensionless relative tolerance while metadata and selected parameters remain exact. On current head `7c81dcb5849a8bb59cce79b4312a46e94ed4e468`, the complete hosted Java 8/21 Ubuntu/Windows matrix, all four slow-test shards, Javadocs, Spotless, pre-commit, documentation search, PaperLab, and CodeQL **pass**. The connector-first repair lane treats these exact-head hosted results as authoritative; an isolated local Maven cache could not resolve the Spotless plugin, so no local Spotless result is claimed.

## Documentation impact

Updated the optimization/constraint guide, external-optimizer guide with a JPype/Python example, and optimization overview/API selection tables. No notebook changes are included; canonical executed notebooks remain a later dependency after this API is reviewed and merged.

## Compatibility and performance

Additive public API; no existing signature or solver behavior changes. Ranking is in-memory over completed immutable results, performs no simulator evaluations, and is dominated by deterministic candidate sorting.

## Risks and limitations

- evidence matching is intentionally conservative: identity, units, provenance, period and selected parameters are exact, while repeated finite simulator values use only the declared relative tolerance;
- tolerance applies only in the declared metric unit;
- ranking quality remains bounded by completed study/search evidence;
- screening economics remain screening evidence, not investment approval.

## Scope exclusions

No changes to thermodynamics, equipment solvers, dynamics, TP flash, two-fluid, columns, generic process performance, mechanical sizing, field-development MCDA, notebooks, or Huldra data/models.