### PR TITLE
[AI-Assisted] docs(process): correct equipment API boundaries

### DIFF
--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -9,14 +9,17 @@ For controlled design cases, equipment and discipline sizing, safety verificatio
 handover, use the separate [Engineering documentation](../engineering/).
 
 ## Table of Contents
+
 - [Overview](#overview)
 - [Documentation Structure](#documentation-structure)
-- [Package Structure](#package-structure)
+- [Package Architecture](#package-architecture)
 - [ProcessSystem](#processsystem)
-- [Equipment Categories](#equipment-categories)
-- [Controllers and Logic](#controllers-and-logic)
-- [Safety Systems](#safety-systems)
-- [Basic Usage](#basic-usage)
+- [Choosing Equipment](#choosing-equipment)
+- [Specifications, Recycles, and Calculators](#specifications-recycles-and-calculators)
+- [Transient and Safety Boundaries](#transient-and-safety-boundaries)
+- [Result Handling](#result-handling)
+- [Best Practices](#best-practices)
+
 
 ---
 
@@ -226,161 +229,28 @@ This documentation is organized into the following sections:
 
 ---
 
-## Package Structure
+## Package Architecture
 
-```
-process/
-├── SimulationBaseClass.java         # Base class for simulations
-├── SimulationInterface.java         # Simulation interface
-│
-├── equipment/                        # Process equipment
-│   ├── ProcessEquipmentBaseClass.java
-│   ├── ProcessEquipmentInterface.java
-│   ├── TwoPortEquipment.java         # Equipment with inlet/outlet
-│   ├── EquipmentFactory.java         # Factory for creating equipment
-│   │
-│   ├── stream/                       # Streams
-│   │   ├── Stream.java
-│   │   ├── StreamInterface.java
-│   │   ├── EnergyStream.java
-│   │   └── VirtualStream.java
-│   │
-│   ├── separator/                    # Separators
-│   │   ├── Separator.java
-│   │   ├── ThreePhaseSeparator.java
-│   │   ├── GasScrubber.java
-│   │   └── SeparatorInterface.java
-│   │
-│   ├── heatexchanger/               # Heat transfer
-│   │   ├── Heater.java
-│   │   ├── Cooler.java
-│   │   ├── HeatExchanger.java
-│   │   ├── NeqHeater.java
-│   │   └── Condenser.java
-│   │
-│   ├── compressor/                  # Compression
-│   │   ├── Compressor.java
-│   │   ├── CompressorInterface.java
-│   │   └── CompressorChartInterface.java
-│   │
-│   ├── pump/                        # Pumps
-│   │   ├── Pump.java
-│   │   └── PumpInterface.java
-│   │
-│   ├── expander/                    # Expanders
-│   │   ├── Expander.java
-│   │   └── ExpanderInterface.java
-│   │
-│   ├── valve/                       # Valves
-│   │   ├── ThrottlingValve.java
-│   │   ├── ValveInterface.java
-│   │   └── SafetyValve.java
-│   │
-│   ├── mixer/                       # Mixers
-│   │   ├── Mixer.java
-│   │   ├── StaticMixer.java
-│   │   └── MixerInterface.java
-│   │
-│   ├── splitter/                    # Splitters
-│   │   ├── Splitter.java
-│   │   └── SplitterInterface.java
-│   │
-│   ├── distillation/                # Distillation
-│   │   ├── DistillationColumn.java
-│   │   ├── SimpleTray.java
-│   │   ├── Condenser.java
-│   │   └── Reboiler.java
-│   │
-│   ├── reactor/                     # Reactors
-│   │   ├── Reactor.java
-│   │   └── PFReactor.java
-│   │
-│   ├── absorber/                    # Absorption
-│   │   ├── Absorber.java
-│   │   └── SimpleTEGAbsorber.java
-│   │
-│   ├── pipeline/                    # Pipelines
-│   │   ├── Pipeline.java
-│   │   └── PipelineInterface.java
-│   │
-│   ├── well/                        # Wells
-│   │   ├── SimpleWell.java
-│   │   └── WellFlow.java
-│   │
-│   ├── tank/                        # Tanks and vessels
-│   │   ├── Tank.java
-│   │   └── ProcessVessel.java
-│   │
-│   ├── filter/                      # Filters
-│   │   └── Filter.java
-│   │
-│   ├── membrane/                    # Membranes
-│   │   └── Membrane.java
-│   │
-│   ├── ejector/                     # Ejectors
-│   │   └── Ejector.java
-│   │
-│   ├── electrolyzer/                # Electrolyzers
-│   │   └── PEM_Electrolyzer.java
-│   │
-│   └── util/                        # Utility equipment
-│       ├── Adjuster.java
-│       ├── Recycle.java
-│       ├── Calculator.java
-│       ├── Setter.java
-│       └── MoleFractionSetter.java
-│
-├── processmodel/                    # Process system
-│   ├── ProcessSystem.java
-│   ├── ProcessModule.java
-│   └── graph/                       # Graph-based execution
-│       ├── ProcessGraph.java
-│       └── ProcessGraphBuilder.java
-│
-├── controllerdevice/                # Controllers
-│   ├── ControllerDevice.java
-│   └── PIDController.java
-│
-├── measurementdevice/               # Measurements
-│   ├── MeasurementDevice.java
-│   ├── TemperatureMeasurement.java
-│   ├── PressureMeasurement.java
-│   └── FlowMeasurement.java
-│
-├── logic/                           # Process logic
-│   ├── ProcessLogicController.java
-│   └── ConditionalLogic.java
-│
-├── alarm/                           # Alarm system
-│   └── ProcessAlarmManager.java
-│
-├── safety/                          # Safety systems
-│   ├── PSV/
-│   ├── ESD/
-│   └── Blowdown/
-│
-├── calibration/                     # Equipment calibration
-├── conditionmonitor/                # Condition monitoring
-├── costestimation/                  # Cost estimation
-├── mechanicaldesign/                # Mechanical design calculations
-│   ├── separator/                   # Separator vessel design
-│   ├── compressor/                  # Compressor design (API 617)
-│   ├── valve/                       # Valve body, sizing, actuator
-│   └── designstandards/             # ASME, API, IEC standards
-├── mpc/                             # Model predictive control
-├── ml/                              # Machine learning
-└── streaming/                       # Data streaming
-```
+The process package separates common simulation behavior from equipment-specific stream topology.
+Use the narrowest API that represents the operation being modeled.
 
-### Mechanical Design Documentation
+| Responsibility | Current API | Boundary |
+|---|---|---|
+| Simulation lifecycle | `SimulationInterface`, `SimulationBaseClass` | Execution identity, run state, and common simulation behavior |
+| Equipment contract | `ProcessEquipmentInterface` | Reporting, mechanical design, validation, fluid access, capacity, and common operating properties |
+| Shared equipment implementation | `ProcessEquipmentBaseClass` | Common state and default implementations; it does not imply one inlet and one outlet |
+| One-inlet/one-outlet equipment | `TwoPortInterface`, `TwoPortEquipment` | Single-stream inlet/outlet methods used by heaters, compressors, pumps, and throttling valves |
+| Multiport equipment | Equipment-specific classes | Separators, mixers, splitters, and columns expose topology-specific stream methods |
+| Flowsheet orchestration | `ProcessSystem` | Named units, topology, execution strategy, convergence, reporting, and transient time |
+| Controls and measurements | `controllerdevice`, `measurementdevice`, `logic` | Controllers, sensors, alarms, and process logic |
 
-| Equipment | Documentation | Standards |
-|-----------|--------------|-----------|
-| Separators | See SeparatorMechanicalDesign | ASME, BS 5500 |
-| Compressors | [CompressorMechanicalDesign.md](CompressorMechanicalDesign.md) | API 617, API 672 |
+See the [equipment index](equipment/README.md) for the current category map and
+[ProcessSystem guide](processmodel/process_system.md) for orchestration details.
+API 672 |
 | Valves | [ValveMechanicalDesign.md](ValveMechanicalDesign.md) | IEC 60534, ANSI/ISA-75, ASME B16.34 |
 
 ---
+
 
 ## ProcessSystem
 
@@ -491,211 +361,80 @@ topology-derived execution plan. The complete quick start above executes both ca
 
 ---
 
-## Equipment Categories
+## Choosing Equipment
 
-### Streams
+The [equipment index](equipment/README.md) is the authoritative navigation page for individual
+unit-operation guides. The complete quick start above is the canonical package example; individual
+guides add equipment-specific constructors, specifications, units, and validation.
 
-```java
-// Material stream
-Stream gas = new Stream("Natural Gas", fluid);
-gas.setFlowRate(5000.0, "Sm3/hr");
-gas.setTemperature(25.0, "C");
-gas.setPressure(100.0, "bara");
-gas.run();
+Stream topology determines which accessor is valid:
 
-// Energy stream
-EnergyStream heat = new EnergyStream("Heating Duty");
-heat.setEnergyFlow(1000.0, "kW");
-```
+| Topology | Examples | Access pattern |
+|---|---|---|
+| One inlet, one outlet | Heater, compressor, pump, throttling valve | `TwoPortEquipment.getInletStream()` and `getOutletStream()` |
+| Multiple outlets | Separator, splitter | Equipment-specific getters such as `Separator.getGasOutStream()` and `getLiquidOutStream()` |
+| Multiple inlets | Mixer, separator | Equipment-specific `addStream(...)` or inlet-list APIs |
+| Staged equipment | Distillation column, absorber | Stage/feed APIs plus equipment-specific product streams |
+| Utility graph node | Recycle, adjuster, calculator | Declared input/output dependencies rather than a universal material outlet |
 
-### Separators
+Do not cast the result of `ProcessSystem.getUnit(name)` until the expected equipment type has
+been established. Prefer retaining a typed reference when constructing the flowsheet.
 
-```java
-// Two-phase separator
-Separator sep2p = new Separator("V-100", inletStream);
-sep2p.run();
-Stream gas = sep2p.getGasOutStream();
-Stream liquid = sep2p.getLiquidOutStream();
+## Specifications, Recycles, and Calculators
 
-// Three-phase separator
-ThreePhaseSeparator sep3p = new ThreePhaseSeparator("V-200", inletStream);
-sep3p.run();
-Stream gas = sep3p.getGasOutStream();
-Stream oil = sep3p.getOilOutStream();
-Stream water = sep3p.getWaterOutStream();
-```
+- Use [adjusters](equipment/util/adjusters.md) for a bounded variable-to-target solve.
+- Use [recycles](equipment/util/recycles.md) to close material loops and document the convergence
+  variable, tolerance, and maximum iterations.
+- Use [calculators and setters](equipment/util/calculators.md) for explicit Java callbacks and
+  supported setter targets. `Calculator` does not parse expression strings.
+- Add each utility object to the same `ProcessSystem` as its dependencies so topology and
+  convergence logic can account for it.
 
-### Heat Exchangers
+## Transient and Safety Boundaries
 
-```java
-// Heater (duty specified)
-Heater heater = new Heater("E-100", inletStream);
-heater.setOutTemperature(80.0, "C");
-heater.run();
-System.out.println("Duty: " + heater.getDuty() + " W");
+A steady-state flowsheet is not automatically a valid dynamic model. Before advancing time:
 
-// Cooler
-Cooler cooler = new Cooler("E-200", inletStream);
-cooler.setOutTemperature(30.0, "C");
-cooler.run();
+1. converge and validate the steady-state case;
+2. confirm that each participating unit implements the required transient state and holdup;
+3. choose a time step appropriate for the fastest modeled response;
+4. configure controllers, events, and boundary conditions explicitly;
+5. call `runTransient(double, UUID)` when the caller needs explicit step duration and calculation
+   identity, or the configured no-argument helper when that behavior is intentional;
+6. capture results through reports, monitors, or callbacks rather than console printing.
 
-// Shell-tube heat exchanger
-HeatExchanger hx = new HeatExchanger("E-300", hotStream, coldStream);
-hx.setUAvalue(5000.0);  // W/K
-hx.run();
-```
+See [dynamic simulation](dynamic-simulation.md) for instrumentation and controller setup.
 
-### Compressors
+A `SafetyValve` is constructed from a `StreamInterface`, not a vessel object, and its current
+set-pressure method is `setPressureSpec(double)`; there is no `setSetPressure(...)` API.
+Pressure-relief simulation is not design certification. Use the [valve guide](equipment/valves.md)
+and [safety roadmap](../safety/SAFETY_SIMULATION_ROADMAP.md), record units and scenarios explicitly,
+and obtain the required engineering review.
 
-```java
-// Compressor with polytropic efficiency
-Compressor comp = new Compressor("K-100", inletStream);
-comp.setOutletPressure(80.0, "bara");
-comp.setPolytropicEfficiency(0.75);
-comp.setUsePolytropicCalc(true);
-comp.run();
+## Result Handling
 
-System.out.println("Power: " + comp.getPower("kW") + " kW");
-System.out.println("Outlet T: " + comp.getOutletStream().getTemperature("C") + " °C");
-```
+After a successful run:
 
-### Valves
+- use `getReport_json()` for a structured process report;
+- use `getStreamSummaryTable()` for a formatted stream-property table;
+- use equipment-specific getters for engineering quantities and always supply units where the API
+  accepts them;
+- check conservation and operating constraints before interpreting results.
 
-```java
-// Throttling valve (Joule-Thomson)
-ThrottlingValve valve = new ThrottlingValve("FV-100", inletStream);
-valve.setOutletPressure(50.0, "bara");
-valve.run();
-
-// Valve with Cv
-valve.setCv(100.0, "US");
-valve.setPercentValveOpening(50.0);
-```
-
-### Distillation
-
-```java
-// Simple distillation column
-DistillationColumn column = new DistillationColumn("T-100", 10, true, true);
-column.addFeedStream(feedStream, 5);
-column.setCondenserTemperature(40.0, "C");
-column.setReboilerTemperature(120.0, "C");
-column.run();
-
-Stream overhead = column.getGasOutStream();
-Stream bottoms = column.getLiquidOutStream();
-```
-
----
-
-## Controllers and Logic
-
-### Adjusters
-
-Adjust a parameter to meet a specification.
-
-```java
-// Adjust heater duty to achieve target temperature
-Adjuster tempAdjuster = new Adjuster("TC-100");
-tempAdjuster.setAdjustedVariable(heater, "duty");
-tempAdjuster.setTargetVariable(heater.getOutletStream(), "temperature", 80.0, "C");
-process.add(tempAdjuster);
-```
-
-### Recycles
-
-Handle recycle loops in the process.
-
-```java
-Recycle recycle = new Recycle("Recycle");
-recycle.addStream(recycleStream);
-recycle.setOutletStream(recycleInletStream);
-recycle.setTolerance(1e-6);
-process.add(recycle);
-```
-
-### Calculators
-
-Use an explicit Java callback; `Calculator` does not parse expression strings. Register the
-equipment objects themselves so optimized process execution can derive graph dependencies.
-
-```java
-Calculator calc = new Calculator("heater target calculator");
-calc.addInputVariable(stream);
-calc.setOutputVariable(heater);
-calc.setCalculationMethod((inputs, output) -> {
-    Stream feed = (Stream) inputs.get(0);
-    Heater target = (Heater) output;
-    target.setOutTemperature(feed.getTemperature("K") + 10.0, "K");
-});
-process.add(calc);
-```
-
-See [Calculators and setters](equipment/util/calculators.md) for a complete executable example,
-preset calculations, recycle-coupling behavior, supported setter targets, and validation
-boundaries.
-
----
-
-## Safety Systems
-
-### Pressure Safety Valves
-
-```java
-SafetyValve psv = new SafetyValve("PSV-100", vessel);
-psv.setSetPressure(120.0, "bara");
-psv.setBlowdownPressure(0.1);  // 10% blowdown
-process.add(psv);
-```
-
-### Blowdown Systems
-
-See [Safety Simulation Roadmap](../safety/SAFETY_SIMULATION_ROADMAP.md) for detailed safety system documentation.
-
----
-
-## Dynamic Simulation
-
-```java
-// Run transient simulation
-double simulationTime = 3600.0;  // 1 hour
-double timeStep = 1.0;           // 1 second
-
-process.setTimeStep(timeStep);
-for (double t = 0; t < simulationTime; t += timeStep) {
-    process.runTransient();
-
-    // Log data
-    System.out.println(t + ", " +
-        separator.getPressure() + ", " +
-        separator.getGasOutStream().getFlowRate("kg/hr"));
-}
-```
-
----
-
-## Process Reports
-
-After a successful run, use `getReport_json()` for the structured process report and
-`getStreamSummaryTable()` for a formatted stream summary. The legacy `reportResults()` aggregator
-assumes that every equipment type supplies a non-null row array and is not safe as a general
-flowsheet reporting contract. The complete quick start executes both supported APIs. Treat
-`display()` as an interactive console helper rather than a machine-readable result contract.
-
----
-
----
+The legacy `reportResults()` aggregator assumes every equipment type supplies a non-null row
+array and is not a general flowsheet reporting contract. Treat interactive display helpers as
+diagnostic UI, not serialized evidence.
 
 ## Best Practices
 
-1. **Use unique names** for all equipment
-2. **Set flow rate and conditions** before running
-3. **Add equipment in flow order** for clarity
-4. **Use Recycle** for recycle loops
-5. **Check mass balance** after simulation
-6. **Clone streams** before branching to avoid shared state
+1. Give every stream, equipment object, controller, and measurement a stable unique name.
+2. Set feed composition, flow basis, temperature, and pressure with explicit units.
+3. Retain typed object references and add units to the `ProcessSystem` in readable flow order.
+4. Use graph-aware recycle, adjuster, and calculator objects instead of manual outer loops.
+5. Validate mass and energy balances, convergence, phase behavior, and operating constraints.
+6. Clone a stream before intentional branching when downstream cases must not share mutable state.
+7. Preserve the `ProcessSystem`, named streams, calculation identity, and structured reports when
+   the model will be serialized, restarted, or embedded in a larger workflow.
 
----
 
 ## Future Infrastructure
 

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -246,11 +246,6 @@ Use the narrowest API that represents the operation being modeled.
 
 See the [equipment index](equipment/README.md) for the current category map and
 [ProcessSystem guide](processmodel/process_system.md) for orchestration details.
-API 672 |
-| Valves | [ValveMechanicalDesign.md](ValveMechanicalDesign.md) | IEC 60534, ANSI/ISA-75, ASME B16.34 |
-
----
-
 
 ## ProcessSystem
 
@@ -389,6 +384,24 @@ been established. Prefer retaining a typed reference when constructing the flows
   supported setter targets. `Calculator` does not parse expression strings.
 - Add each utility object to the same `ProcessSystem` as its dependencies so topology and
   convergence logic can account for it.
+
+A focused calculator callback looks like this when `stream` and `heater` are already typed
+objects in the same running flowsheet:
+
+```java
+Calculator calc = new Calculator("heater target calculator");
+calc.addInputVariable(stream);
+calc.setOutputVariable(heater);
+calc.setCalculationMethod((inputs, output) -> {
+    Stream feed = (Stream) inputs.get(0);
+    Heater target = (Heater) output;
+    target.setOutTemperature(feed.getTemperature("K") + 10.0, "K");
+});
+process.add(calc);
+```
+
+The [calculator guide](equipment/util/calculators.md) supplies the imports, complete executable
+context, supported presets, setter targets, and recycle-coupling boundaries.
 
 ## Transient and Safety Boundaries
 

--- a/docs/process/equipment/README.md
+++ b/docs/process/equipment/README.md
@@ -1,11 +1,11 @@
 ---
 title: Process Equipment Documentation
-description: This folder contains detailed documentation for all process equipment in NeqSim.
+description: Source-safe navigation and API ownership for process equipment in NeqSim.
 ---
 
-# Process Equipment Documentation
-
-This folder contains detailed documentation for all process equipment in NeqSim.
+Use this index to choose an equipment-specific guide. For an executable, end-to-end flowsheet,
+start with the [process-package quick start](../README.md); it is compiled and run by the
+documentation regression suite.
 
 ## Equipment Categories
 
@@ -13,219 +13,192 @@ This folder contains detailed documentation for all process equipment in NeqSim.
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Streams | [streams.md](streams) | Material and energy streams |
-| Mixers & Splitters | [mixers_splitters.md](mixers_splitters) | Stream mixing and splitting |
+| Streams | [streams.md](streams.md) | Material and energy streams |
+| Mixers & Splitters | [mixers_splitters.md](mixers_splitters.md) | Stream mixing and splitting |
 
 ### Separation Equipment
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Separators | [separators.md](separators) | 2-phase and 3-phase separators, scrubbers |
-| Distillation | [distillation.md](distillation) | Distillation columns |
-| Absorbers | [absorbers.md](absorbers) | Absorption/stripping columns |
-| Membranes | [membranes.md](membranes) | Membrane separation units |
-| Filters | [filters.md](filters) | Particulate and charcoal filters |
+| Separators | [separators.md](separators.md) | 2-phase and 3-phase separators, scrubbers |
+| Distillation | [distillation.md](distillation.md) | Distillation columns |
+| Absorbers | [absorbers.md](absorbers.md) | Absorption/stripping columns |
+| Membranes | [membranes.md](membranes.md) | Membrane separation units |
+| Filters | [filters.md](filters.md) | Particulate and charcoal filters |
 
 ### Heat Transfer Equipment
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Heat Exchangers | [heat_exchangers.md](heat_exchangers) | Heaters, coolers, condensers, reboilers |
+| Heat Exchangers | [heat_exchangers.md](heat_exchangers.md) | Heaters, coolers, condensers, reboilers |
 
 ### Rotating Equipment
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Compressors | [compressors.md](compressors) | Gas compression, mechanical losses, seal gas |
-| Compressor Anti-Surge Control | [compressor_antisurge_control.md](compressor_antisurge_control) | Dynamic anti-surge recycle, speed/load control, and coordinated pressure-speed-recycle control philosophy |
-| Pumps | [pumps.md](pumps) | Liquid pumping |
-| Expanders | [expanders.md](expanders) | Power recovery, turboexpanders |
+| Compressors | [compressors.md](compressors.md) | Gas compression, mechanical losses, seal gas |
+| Compressor Anti-Surge Control | [compressor_antisurge_control.md](compressor_antisurge_control.md) | Dynamic anti-surge recycle, speed/load control, and coordinated pressure-speed-recycle control philosophy |
+| Pumps | [pumps.md](pumps.md) | Liquid pumping |
+| Expanders | [expanders.md](expanders.md) | Power recovery, turboexpanders |
 
 ### Flow Control
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Valves | [valves.md](valves) | Throttling valves, chokes, safety valves |
+| Valves | [valves.md](valves.md) | Throttling valves, chokes, safety valves |
 
 ### Reactors
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Reactors (Overview) | [reactors.md](reactors) | All reactor types: PFR, CSTR, Gibbs, stoichiometric, ammonia, sulfur, bio-processing |
-| Iron-Sulfide Wall Source | [iron_sulfide_wall_source.md](iron_sulfide_wall_source) | Stateful FeS/FeCO3 scale, oxygen ingress, S8 generation, and compressor deposition coupling |
-| Plug Flow Reactor | [plug_flow_reactor.md](plug_flow_reactor) | Kinetic PFR with power-law/LHHW/reversible kinetics, catalyst bed, Ergun ΔP, energy modes |
-| Electrolyzers | [electrolyzers.md](electrolyzers) | Water and CO₂ electrolysis |
+| Reactors (Overview) | [reactors.md](reactors.md) | All reactor types: PFR, CSTR, Gibbs, stoichiometric, ammonia, sulfur, bio-processing |
+| Iron-Sulfide Wall Source | [iron_sulfide_wall_source.md](iron_sulfide_wall_source.md) | Stateful FeS/FeCO3 scale, oxygen ingress, S8 generation, and compressor deposition coupling |
+| Plug Flow Reactor | [plug_flow_reactor.md](plug_flow_reactor.md) | Kinetic PFR with power-law/LHHW/reversible kinetics, catalyst bed, Ergun ΔP, energy modes |
+| Electrolyzers | [electrolyzers.md](electrolyzers.md) | Water and CO₂ electrolysis |
 
 ### Ejectors
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Ejectors | [ejectors.md](ejectors) | Steam and gas ejectors |
+| Ejectors | [ejectors.md](ejectors.md) | Steam and gas ejectors |
 
 ### Safety Equipment
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Flares | [flares.md](flares) | Flare systems and combustion |
+| Flares | [flares.md](flares.md) | Flare systems and combustion |
 
 ### Well/Reservoir
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Wells | [wells.md](wells) | Production wells, chokes |
-| Reservoirs | [reservoirs.md](reservoirs) | Material balance reservoir modeling |
-| Subsea Systems | [subsea_systems.md](subsea_systems) | Subsea wells and flowlines |
+| Wells | [wells.md](wells.md) | Production wells, chokes |
+| Reservoirs | [reservoirs.md](reservoirs.md) | Material balance reservoir modeling |
+| Subsea Systems | [subsea_systems.md](subsea_systems.md) | Subsea wells and flowlines |
 
 ### Subsea Equipment
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Subsea Trees | [subsea_trees.md](subsea_trees) | Christmas trees, valve control |
-| Subsea Manifolds | [subsea_manifolds.md](subsea_manifolds) | Multi-slot production manifolds |
-| Subsea Boosters | [subsea_boosters.md](subsea_boosters) | Multiphase pumps, compressors |
-| Umbilicals | [umbilicals.md](umbilicals) | Hydraulic, chemical, electrical supply |
+| Subsea Trees | [subsea_trees.md](subsea_trees.md) | Christmas trees, valve control |
+| Subsea Manifolds | [subsea_manifolds.md](subsea_manifolds.md) | Multi-slot production manifolds |
+| Subsea Boosters | [subsea_boosters.md](subsea_boosters.md) | Multiphase pumps, compressors |
+| Umbilicals | [umbilicals.md](umbilicals.md) | Hydraulic, chemical, electrical supply |
 
 ### Pipeline/Network
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Pipelines | [pipelines.md](pipelines) | Pipe flow, pressure drop |
-| **Risers** | [pipelines.md#risers](pipelines#risers) | **SCR, TTR, Flexible, Lazy-Wave risers** |
-| Networks | [networks.md](networks) | Pipeline network modeling |
-| Looped Networks | [looped_networks.md](looped_networks) | Hardy Cross solver for loops |
-| Gas Network Operations | [../gas_network_operations.md](../gas_network_operations) | Coupled gas quality, optimization, and linepack |
-| Oil Network Operations | [../oil_network_operations.md](../oil_network_operations) | Oil pumps, terminal tanks, parcels, and cargo schedules |
-| Manifolds | [manifolds.md](manifolds) | Multi-stream routing |
+| Pipelines | [pipelines.md](pipelines.md) | Pipe flow, pressure drop |
+| **Risers** | [pipelines.md#risers](pipelines.md#risers) | **SCR, TTR, Flexible, Lazy-Wave risers** |
+| Networks | [networks.md](networks.md) | Pipeline network modeling |
+| Looped Networks | [looped_networks.md](looped_networks.md) | Hardy Cross solver for loops |
+| Gas Network Operations | [../gas_network_operations.md](../gas_network_operations.md) | Coupled gas quality, optimization, and linepack |
+| Oil Network Operations | [../oil_network_operations.md](../oil_network_operations.md) | Oil pumps, terminal tanks, parcels, and cargo schedules |
+| Manifolds | [manifolds.md](manifolds.md) | Multi-stream routing |
 
 ### Flow Measurement
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Differential Pressure | [differential_pressure.md](differential_pressure) | Orifice plates, flow measurement |
+| Differential Pressure | [differential_pressure.md](differential_pressure.md) | Orifice plates, flow measurement |
 
 ### Storage
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Tanks | [tanks.md](tanks) | Storage tanks, LNG boil-off |
-| Vessel Depressurization | [vessel_depressurization.md](vessel_depressurization) | Filling, blowdown, fire cases, CNG/H2 tanks, heat transfer models |
+| Tanks | [tanks.md](tanks.md) | Storage tanks, LNG boil-off |
+| Vessel Depressurization | [vessel_depressurization.md](vessel_depressurization.md) | Filling, blowdown, fire cases, CNG/H2 tanks, heat transfer models |
 
 ### Gas Treatment
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Adsorbers | [adsorbers.md](adsorbers) | CO₂ and gas adsorption |
+| Adsorbers | [adsorbers.md](adsorbers.md) | CO₂ and gas adsorption |
 
 ### Power Generation
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Power Equipment | [power_generation.md](power_generation) | Gas turbines, fuel cells, renewables |
-| Battery Storage | [battery_storage.md](battery_storage) | Energy storage systems |
+| Power Equipment | [power_generation.md](power_generation.md) | Gas turbines, fuel cells, renewables |
+| Battery Storage | [battery_storage.md](battery_storage.md) | Energy storage systems |
 
 ### Utility Equipment
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Adjusters | [util/adjusters.md](util/adjusters) | Variable adjustment to meet specs |
-| Recycles | [util/recycles.md](util/recycles) | Recycle stream handling |
-| Calculators | [util/calculators.md](util/calculators) | Custom calculations and setters |
+| Adjusters | [util/adjusters.md](util/adjusters.md) | Variable adjustment to meet specs |
+| Recycles | [util/recycles.md](util/recycles.md) | Recycle stream handling |
+| Calculators | [util/calculators.md](util/calculators.md) | Custom calculations and setters |
 
 ### Reliability & Failure
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Failure Modes | [failure_modes.md](failure_modes) | Equipment failure modeling for risk analysis |
+| Failure Modes | [failure_modes.md](failure_modes.md) | Equipment failure modeling for risk analysis |
 
----
 
-## Quick Reference
+## API Ownership
 
-### Creating Equipment
+All process equipment implements `ProcessEquipmentInterface`, normally through
+`ProcessEquipmentBaseClass`. That common contract covers lifecycle, reporting, validation,
+mechanical design, capacity, fluid access, and common operating properties. It does **not** give
+every unit a single material inlet and outlet.
 
-```java
-// All equipment follows similar pattern
-EquipmentType equipment = new EquipmentType("Name", inletStream);
-equipment.setParameter(value);
-equipment.run();
-Stream outlet = equipment.getOutletStream();
-```
+| API owner | Use it for | Representative equipment |
+|---|---|---|
+| `ProcessEquipmentInterface` | Common execution, reporting, design, validation, capacity, and fluid access | All process equipment |
+| `TwoPortInterface` / `TwoPortEquipment` | One material inlet and one material outlet | Heater, cooler, compressor, pump, expander, throttling valve |
+| Equipment-specific multiport API | Multiple feeds, products, or stages | Separator, mixer, splitter, distillation column, absorber |
+| Utility equipment API | Graph dependencies, targets, and convergence | Recycle, adjuster, calculator |
 
-### Adding to ProcessSystem
+For example, `TwoPortEquipment` owns `getInletStream()` and `getOutletStream()`.
+`Separator` instead exposes gas and liquid product streams and can accept multiple feeds.
+A mixer, splitter, or staged column likewise needs its own guide; do not assume the two-port
+constructor or accessors.
 
-```java
-ProcessSystem process = new ProcessSystem();
-process.add(stream);
-process.add(equipment1);
-process.add(equipment2);
-process.run();
-```
+## Constructing and Running Equipment
 
-### Getting Equipment by Name
+There is no universal `EquipmentType(name, inletStream)` constructor or `setParameter(value)`
+method. Follow the selected guide and current Java source for that equipment's:
 
-```java
-Compressor comp = (Compressor) process.getUnit("K-100");
-```
+1. constructor and stream topology;
+2. specification methods and units;
+3. required thermodynamic or physical-property initialization;
+4. steady-state or transient execution boundary;
+5. equipment-specific results and validation.
 
----
+Add streams and equipment to one `ProcessSystem`, retain typed references, run the process, and
+check conservation plus equipment constraints. The
+[canonical process-package example](../README.md#processsystem) demonstrates this sequence with a
+feed, throttling valve, separator, mass-balance assertion, topology diagnostics, and structured
+reports.
 
-## Common Methods
+`ProcessSystem.getUnit(name)` returns the common equipment interface. Cast only after verifying
+the expected type, or retain the typed reference created while building the process.
 
-All equipment inherits from `ProcessEquipmentBaseClass`:
+## Equipment Hierarchy
 
-| Method | Description |
-|--------|-------------|
-| `run()` | Execute calculation |
-| `runTransient()` | Execute transient step |
-| `getName()` | Get equipment name |
-| `getInletStream()` | Get inlet stream |
-| `getOutletStream()` | Get outlet stream |
-| `getPressure()` | Get operating pressure |
-| `getTemperature()` | Get operating temperature |
-| `getMechanicalDesign()` | Get mechanical design object |
-| `needRecalculation()` | Check if recalculation needed |
-
-### Compressor-Specific Methods
-
-| Method | Description |
-|--------|-------------|
-| `initMechanicalLosses(shaftDiameter)` | Initialize seal gas and bearing loss model |
-| `getSealGasConsumption()` | Get total seal gas consumption (Nm³/hr) |
-| `getBearingLoss()` | Get total bearing power loss (kW) |
-| `getMechanicalEfficiency()` | Get mechanical efficiency (0-1) |
-
----
-
-## Equipment Inheritance
-
-```
+```text
 ProcessEquipmentInterface
-    │
     └── ProcessEquipmentBaseClass
-            │
-            ├── TwoPortEquipment (inlet/outlet pattern)
-            │       ├── Heater, Cooler
-            │       ├── Compressor, Pump, Expander
-            │       ├── ThrottlingValve
-            │       └── ...
-            │
-            ├── Separator (multi-outlet)
-            │       ├── ThreePhaseSeparator
-            │       ├── GasScrubber
-            │       └── ...
-            │
-            ├── Mixer (multi-inlet)
-            ├── Splitter (multi-outlet)
-            │
-            └── DistillationColumn
+        ├── TwoPortEquipment implements TwoPortInterface
+        │   ├── Heater / Cooler
+        │   ├── Compressor / Pump / Expander
+        │   └── ThrottlingValve
+        ├── Separator and ThreePhaseSeparator (multi-inlet, multi-outlet)
+        ├── Mixer (multi-inlet)
+        ├── Splitter (multi-outlet)
+        └── DistillationColumn and absorbers (staged, equipment-specific ports)
 ```
 
----
+The diagram shows API ownership, not every concrete subtype.
 
 ## Related Documentation
 
-- [Process Package](../) - Package overview
-- [ProcessSystem](../processmodel/process_system) - Process system guide
-- [ProcessModule](../processmodel/process_module) - Modular process units
-- [Controllers](../controllers) - Control equipment
-- [Safety Systems](../safety/) - Safety equipment
+- [Process package](../README.md) — architecture, execution, reports, and the executable quick start
+- [ProcessSystem](../processmodel/process_system.md) — flowsheet orchestration and execution
+- [ProcessModule](../processmodel/process_module.md) — modular process units
+- [Controllers](../controllers.md) — control equipment
+- [Safety systems](../safety/README.md) — safety simulation
+- [Engineering documentation](../../engineering/) — controlled design cases and discipline workflows

--- a/docs/test_process_overview_documentation.py
+++ b/docs/test_process_overview_documentation.py
@@ -7,9 +7,34 @@ from urllib.parse import unquote
 DOCS_DIR = Path(__file__).resolve().parent
 REPOSITORY_ROOT = DOCS_DIR.parent
 PROCESS_OVERVIEW = DOCS_DIR / "process" / "README.md"
+EQUIPMENT_OVERVIEW = DOCS_DIR / "process" / "equipment" / "README.md"
 PROCESS_SYSTEM = (
     REPOSITORY_ROOT
     / "src/main/java/neqsim/process/processmodel/ProcessSystem.java"
+)
+PROCESS_EQUIPMENT_INTERFACE = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/process/equipment/ProcessEquipmentInterface.java"
+)
+PROCESS_EQUIPMENT_BASE = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java"
+)
+TWO_PORT_INTERFACE = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/process/equipment/TwoPortInterface.java"
+)
+TWO_PORT_EQUIPMENT = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/process/equipment/TwoPortEquipment.java"
+)
+SEPARATOR = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/process/equipment/separator/Separator.java"
+)
+SAFETY_VALVE = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/process/equipment/valve/SafetyValve.java"
 )
 
 
@@ -53,50 +78,79 @@ def resolve_internal_target(source_path, destination):
 class ProcessOverviewDocumentationContractTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.overview = PROCESS_OVERVIEW.read_text(encoding="utf-8")
+        cls.pages = {
+            PROCESS_OVERVIEW: PROCESS_OVERVIEW.read_text(encoding="utf-8"),
+            EQUIPMENT_OVERVIEW: EQUIPMENT_OVERVIEW.read_text(
+                encoding="utf-8"
+            ),
+        }
+        cls.overview = cls.pages[PROCESS_OVERVIEW]
+        cls.equipment_overview = cls.pages[EQUIPMENT_OVERVIEW]
         cls.process_system = PROCESS_SYSTEM.read_text(encoding="utf-8")
+        cls.process_equipment_interface = (
+            PROCESS_EQUIPMENT_INTERFACE.read_text(encoding="utf-8")
+        )
+        cls.process_equipment_base = PROCESS_EQUIPMENT_BASE.read_text(
+            encoding="utf-8"
+        )
+        cls.two_port_interface = TWO_PORT_INTERFACE.read_text(
+            encoding="utf-8"
+        )
+        cls.two_port_equipment = TWO_PORT_EQUIPMENT.read_text(
+            encoding="utf-8"
+        )
+        cls.separator = SEPARATOR.read_text(encoding="utf-8")
+        cls.safety_valve = SAFETY_VALVE.read_text(encoding="utf-8")
 
     def test_structure_and_internal_links_are_source_safe(self):
-        self.assertTrue(self.overview.startswith("---\n"))
-        self.assertEqual(self.overview.count("```") % 2, 0)
-
-        content_without_fences = re.sub(
-            r"```.*?```",
-            "",
-            self.overview,
-            flags=re.DOTALL,
-        )
-        self.assertNotRegex(
-            content_without_fences,
-            re.compile(r"^# ", re.MULTILINE),
-        )
-
         markdown_links = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
-        for destination in markdown_links.findall(self.overview):
-            if destination.startswith(("http://", "https://", "mailto:")):
-                continue
 
-            target, _, fragment = destination.partition("#")
-            with self.subTest(destination=destination):
-                if target and not target.endswith("/"):
-                    self.assertTrue(
-                        target.endswith(".md"),
-                        "Documentation source links must include .md",
-                    )
+        for source_path, content in self.pages.items():
+            with self.subTest(source_path=source_path):
+                self.assertTrue(content.startswith("---\n"))
+                self.assertEqual(content.count("```") % 2, 0)
 
-                target_path, resolved_fragment = resolve_internal_target(
-                    PROCESS_OVERVIEW,
-                    destination,
+                content_without_fences = re.sub(
+                    r"```.*?```",
+                    "",
+                    content,
+                    flags=re.DOTALL,
                 )
-                self.assertTrue(target_path.is_file())
-                if fragment:
-                    self.assertEqual(fragment, resolved_fragment)
-                    self.assertIn(
-                        resolved_fragment,
-                        heading_slugs(
-                            target_path.read_text(encoding="utf-8")
-                        ),
+                self.assertNotRegex(
+                    content_without_fences,
+                    re.compile(r"^# ", re.MULTILINE),
+                )
+
+            for destination in markdown_links.findall(content):
+                if destination.startswith(
+                    ("http://", "https://", "mailto:")
+                ):
+                    continue
+
+                target, _, fragment = destination.partition("#")
+                with self.subTest(
+                    source_path=source_path,
+                    destination=destination,
+                ):
+                    if target and not target.endswith("/"):
+                        self.assertTrue(
+                            target.endswith(".md"),
+                            "Documentation source links must include .md",
+                        )
+
+                    target_path, resolved_fragment = resolve_internal_target(
+                        source_path,
+                        destination,
                     )
+                    self.assertTrue(target_path.is_file())
+                    if fragment:
+                        self.assertEqual(fragment, resolved_fragment)
+                        self.assertIn(
+                            resolved_fragment,
+                            heading_slugs(
+                                target_path.read_text(encoding="utf-8")
+                            ),
+                        )
 
     def test_process_system_claims_match_current_source(self):
         for signature in (
@@ -107,6 +161,7 @@ class ProcessOverviewDocumentationContractTest(unittest.TestCase):
             "public String getExecutionPartitionInfo()",
             "public String getStreamSummaryTable()",
             "public String getReport_json()",
+            "public synchronized void runTransient(double dt, UUID id)",
         ):
             with self.subTest(signature=signature):
                 self.assertIn(signature, self.process_system)
@@ -121,25 +176,86 @@ class ProcessOverviewDocumentationContractTest(unittest.TestCase):
             with self.subTest(documented_call=documented_call):
                 self.assertIn(documented_call, self.overview)
 
-    def test_stale_execution_and_report_patterns_do_not_return(self):
+    def test_equipment_api_ownership_matches_current_source(self):
+        self.assertIn(
+            "implements ProcessEquipmentInterface",
+            self.process_equipment_base,
+        )
+        self.assertIn(
+            "implements TwoPortInterface",
+            self.two_port_equipment,
+        )
+        for signature in (
+            "StreamInterface getInletStream();",
+            "StreamInterface getOutletStream();",
+        ):
+            with self.subTest(signature=signature):
+                self.assertIn(signature, self.two_port_interface)
+
+        for signature in (
+            "public StreamInterface getInletStream()",
+            "public StreamInterface getOutletStream()",
+        ):
+            with self.subTest(signature=signature):
+                self.assertIn(signature, self.two_port_equipment)
+
+        for signature in (
+            "public StreamInterface getGasOutStream()",
+            "public StreamInterface getLiquidOutStream()",
+            "public void addStream(StreamInterface newStream)",
+        ):
+            with self.subTest(signature=signature):
+                self.assertIn(signature, self.separator)
+
+        for signature in (
+            "public SafetyValve(String name, StreamInterface inletStream)",
+            "public void setPressureSpec(double pressureSpec)",
+            "public void setBlowdown(double blowdownPercent)",
+        ):
+            with self.subTest(signature=signature):
+                self.assertIn(signature, self.safety_valve)
+
+        for claim in (
+            "`ProcessEquipmentInterface`",
+            "`ProcessEquipmentBaseClass`",
+            "`TwoPortInterface`",
+            "`TwoPortEquipment`",
+            "`Separator`",
+        ):
+            with self.subTest(claim=claim):
+                self.assertIn(claim, self.equipment_overview)
+
+    def test_stale_fragments_and_pseudo_code_do_not_return(self):
+        combined = self.overview + self.equipment_overview
         for stale_pattern in (
             "process.runHybrid();",
             "getUnitOperationsAsTable()",
             "process.reportResults()",
             "runTransient(time, dt)",
-            "28-40%",
-            "40-57%",
-            "`getReport()`",
+            "EquipmentType equipment =",
+            "equipment.setParameter(value)",
+            "System.out.println",
+            "psv.setSetPressure(",
+            "new SafetyValve(\"PSV-100\", vessel)",
+            "All equipment follows similar pattern",
         ):
             with self.subTest(stale_pattern=stale_pattern):
-                self.assertNotIn(stale_pattern, self.overview)
+                self.assertNotIn(stale_pattern, combined)
 
-        self.assertIn("public final class ProcessSystemQuickStart", self.overview)
-        self.assertIn("public static void main(String[] args)", self.overview)
-        quick_start = self.overview.split(
-            "public final class ProcessSystemQuickStart", 1
-        )[1].split("```", 1)[0]
-        self.assertNotIn("System.out.println", quick_start)
+        self.assertEqual(
+            self.overview.count(
+                "public final class ProcessSystemQuickStart"
+            ),
+            1,
+        )
+        self.assertIn(
+            "public static void main(String[] args)",
+            self.overview,
+        )
+        self.assertIn(
+            "[process-package quick start](../README.md)",
+            self.equipment_overview,
+        )
 
 
 if __name__ == "__main__":

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemDocumentationTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemDocumentationTest.java
@@ -41,14 +41,9 @@ class ProcessSystemDocumentationTest {
 
     double inletMassFlowKgPerHr = feed.getFlowRate("kg/hr");
     double gasMassFlowKgPerHr = separator.getGasOutStream().getFlowRate("kg/hr");
-    double liquidMassFlowKgPerHr =
-        separator.getLiquidOutStream().getFlowRate("kg/hr");
-    double relativeMassBalanceError =
-        Math.abs(
-                inletMassFlowKgPerHr
-                    - gasMassFlowKgPerHr
-                    - liquidMassFlowKgPerHr)
-            / inletMassFlowKgPerHr;
+    double liquidMassFlowKgPerHr = separator.getLiquidOutStream().getFlowRate("kg/hr");
+    double relativeMassBalanceError = Math.abs(inletMassFlowKgPerHr - gasMassFlowKgPerHr - liquidMassFlowKgPerHr)
+        / inletMassFlowKgPerHr;
 
     assertTrue(gasMassFlowKgPerHr > 0.0);
     assertTrue(relativeMassBalanceError < 1.0e-6);
@@ -60,32 +55,15 @@ class ProcessSystemDocumentationTest {
   }
 
   @Test
-  void equipmentIndexDocumentsStreamTopologyOwnership()
-      throws NoSuchMethodException {
-    assertTrue(
-        ProcessEquipmentInterface.class.isAssignableFrom(
-            ProcessEquipmentBaseClass.class));
-    assertTrue(
-        ProcessEquipmentBaseClass.class.isAssignableFrom(
-            TwoPortEquipment.class));
+  void equipmentIndexDocumentsStreamTopologyOwnership() throws NoSuchMethodException {
+    assertTrue(ProcessEquipmentInterface.class.isAssignableFrom(ProcessEquipmentBaseClass.class));
+    assertTrue(ProcessEquipmentBaseClass.class.isAssignableFrom(TwoPortEquipment.class));
     assertTrue(TwoPortEquipment.class.isAssignableFrom(ThrottlingValve.class));
     assertFalse(TwoPortEquipment.class.isAssignableFrom(Separator.class));
 
-    assertSame(
-        StreamInterface.class,
-        TwoPortEquipment.class
-            .getMethod("getInletStream")
-            .getReturnType());
-    assertSame(
-        StreamInterface.class,
-        TwoPortEquipment.class
-            .getMethod("getOutletStream")
-            .getReturnType());
-    assertSame(
-        StreamInterface.class,
-        Separator.class.getMethod("getGasOutStream").getReturnType());
-    assertSame(
-        StreamInterface.class,
-        Separator.class.getMethod("getLiquidOutStream").getReturnType());
+    assertSame(StreamInterface.class, TwoPortEquipment.class.getMethod("getInletStream").getReturnType());
+    assertSame(StreamInterface.class, TwoPortEquipment.class.getMethod("getOutletStream").getReturnType());
+    assertSame(StreamInterface.class, Separator.class.getMethod("getGasOutStream").getReturnType());
+    assertSame(StreamInterface.class, Separator.class.getMethod("getLiquidOutStream").getReturnType());
   }
 }

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemDocumentationTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemDocumentationTest.java
@@ -5,8 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.TwoPortEquipment;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.equipment.valve.ThrottlingValve;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
@@ -37,9 +41,14 @@ class ProcessSystemDocumentationTest {
 
     double inletMassFlowKgPerHr = feed.getFlowRate("kg/hr");
     double gasMassFlowKgPerHr = separator.getGasOutStream().getFlowRate("kg/hr");
-    double liquidMassFlowKgPerHr = separator.getLiquidOutStream().getFlowRate("kg/hr");
-    double relativeMassBalanceError = Math.abs(inletMassFlowKgPerHr - gasMassFlowKgPerHr - liquidMassFlowKgPerHr)
-        / inletMassFlowKgPerHr;
+    double liquidMassFlowKgPerHr =
+        separator.getLiquidOutStream().getFlowRate("kg/hr");
+    double relativeMassBalanceError =
+        Math.abs(
+                inletMassFlowKgPerHr
+                    - gasMassFlowKgPerHr
+                    - liquidMassFlowKgPerHr)
+            / inletMassFlowKgPerHr;
 
     assertTrue(gasMassFlowKgPerHr > 0.0);
     assertTrue(relativeMassBalanceError < 1.0e-6);
@@ -48,5 +57,35 @@ class ProcessSystemDocumentationTest {
     assertFalse(process.getExecutionPartitionInfo().isEmpty());
     assertFalse(process.getReport_json().isEmpty());
     assertFalse(process.getStreamSummaryTable().isEmpty());
+  }
+
+  @Test
+  void equipmentIndexDocumentsStreamTopologyOwnership()
+      throws NoSuchMethodException {
+    assertTrue(
+        ProcessEquipmentInterface.class.isAssignableFrom(
+            ProcessEquipmentBaseClass.class));
+    assertTrue(
+        ProcessEquipmentBaseClass.class.isAssignableFrom(
+            TwoPortEquipment.class));
+    assertTrue(TwoPortEquipment.class.isAssignableFrom(ThrottlingValve.class));
+    assertFalse(TwoPortEquipment.class.isAssignableFrom(Separator.class));
+
+    assertSame(
+        StreamInterface.class,
+        TwoPortEquipment.class
+            .getMethod("getInletStream")
+            .getReturnType());
+    assertSame(
+        StreamInterface.class,
+        TwoPortEquipment.class
+            .getMethod("getOutletStream")
+            .getReturnType());
+    assertSame(
+        StreamInterface.class,
+        Separator.class.getMethod("getGasOutStream").getReturnType());
+    assertSame(
+        StreamInterface.class,
+        Separator.class.getMethod("getLiquidOutStream").getReturnType());
   }
 }


### PR DESCRIPTION
## Summary

Repairs the D076 process-equipment documentation batch for #2499.

The two landing pages now distinguish common equipment lifecycle/reporting APIs from single-port and multiport stream topology, keep one executable process quick start, use source-safe links, and document steady-state, transient, reporting, and safety boundaries without pseudo-code or console-output fragments.

## Frozen scan scope

Base: `884810a814f918aea948f6bb05a37f92b8077394`

- `docs/process/README.md`
- `docs/process/equipment/README.md`
- `docs/test_process_overview_documentation.py`
- `src/test/java/neqsim/process/processmodel/ProcessSystemDocumentationTest.java`

Rotation scope: process equipment and process simulation.

## Defects and evidence

1. Duplicate H1 on the equipment index.
2. Forty-plus equipment-index source links omitted `.md`.
3. Non-compilable `EquipmentType` pseudo-code implied a universal constructor and outlet.
4. The common-method table assigned two-port methods to every equipment type.
5. The hierarchy omitted `TwoPortInterface` and blurred multiport ownership.
6. The package page duplicated the tested quick start with incomplete fragments.
7. Heater, compressor, and dynamic fragments used prohibited `System.out.println`.
8. Dynamic guidance omitted state, time-step, identity, controller/event, and result-capture boundaries.
9. The PSV fragment called nonexistent `setSetPressure` and used an ambiguous vessel argument.
10. Existing documentation contracts covered only the package page and did not protect equipment link/API ownership.

Current-source evidence was read from `ProcessSystem`, `ProcessEquipmentInterface`,
`ProcessEquipmentBaseClass`, `TwoPortInterface`, `TwoPortEquipment`, `Separator`, and
`SafetyValve`.

## Changes

- replaces the drifting package tree/fragments with a current API-ownership map;
- makes the valve-and-separator program the single canonical package/equipment example;
- preserves equipment discoverability while making all file links explicit;
- documents two-port, multiport, utility, transient, safety, reporting, units, and serialization boundaries;
- extends Python contracts across both landing pages and their source APIs;
- extends executable Java coverage for hierarchy/return-type ownership while retaining mass-balance and diagnostics coverage.

Documentation impact: **updated**. This PR is itself the required documentation correction; no production API or runtime behavior changes.

## Validation

### Exact-head passes

At `2205aaeb785e9db1ed03424090bdfeeeb952ec4f`:

- hosted Spotless patch is empty / Spotless passes;
- pre-commit passes;
- CodeQL passes;
- all four D076 Python documentation contracts pass;
- the existing calculator overview contract passes after preserving its maintained callback;
- agent-skill cross-reference validation and Java 21 Javadocs pass;
- 48 equipment-index targets resolve (47 files plus the engineering directory's `index.md`);
- all four remote blobs were re-read and the diff remains limited to the frozen files.

### VALIDATION BLOCKED BY EXISTING MASTER REGRESSION

The documentation-search workflow reaches 98 source contracts. Every D076 contract passes, but the
workflow ends with the pre-existing
`ExamplesIndexDocumentationTest.setUpClass` error. On base `master`
`884810a814f918aea948f6bb05a37f92b8077394`, `docs/examples/index.md` blob
`e9850137e16d4f87b601ea843c28b0bfbb90bcd0` lacks all three headings that unchanged test blob
`9dda70d1c0d153b8d80fb6542de3721c26708207` splits on:
`Maintained workflow notebooks`, `Local notebook catalog`, and
`Standalone Java source examples`. None of those examples files is in this PR.

The build/test/Javadoc workflow remains in progress for Java 21 Ubuntu/Windows fast tests and four
slow shards. Do not treat this PR as ready until those reach terminal success.

No browser-rendered visual inspection is claimed; the changed pages contain no equations, plots,
images, or notebook outputs.

## Exclusions

No production implementation, individual equipment-guide rewrite, notebook, optimization, hydrate,
architecture, merge/auto-merge, ready-for-review, or Huldra work.

Next rotation scope after merged-master verification: engineering design, safety, DEXPI, and field
development.
