### PR TITLE
[AI-Assisted] test(flash): qualify hydrogen-rich VLE against literature

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1898,6 +1898,41 @@ Recommended regression coverage should include both numerical convergence and ph
 | Multiphase cleanup | Cases with small beta phases and duplicate aqueous candidates | Removed phases preserve total composition and final mass balance |
 | Documentation drift | Algorithm doc parameter table versus source constants | Stale thresholds are detected during review |
 
+#### 6.4.1 Hydrogen-Rich Cubic-EOS Qualification
+
+The hydrogen-rich binary regression uses five experimental vapor-liquid tie lines reported by Sagara, Arai, and
+Saito [10]. Pressure is absolute and is converted from atmospheres to bar with `1 atm = 1.01325 bar`. No binary
+interaction parameters were fitted: both SRK and PR use the classic mixing rule and the database parameters available
+to a normal NeqSim calculation.
+
+| System | Temperature (K) | Pressure (atm) | Experimental x(H2) | Experimental y(H2) | SRK x/y(H2) | PR x/y(H2) |
+|--------|----------------:|---------------:|-------------------:|-------------------:|-------------:|------------:|
+| H2 + methane | 123.15 | 20.0 | 0.01920 | 0.818 | 0.019225 / 0.849073 | 0.022707 / 0.842951 |
+| H2 + methane | 143.05 | 40.2 | 0.04770 | 0.721 | 0.049051 / 0.725721 | 0.055217 / 0.717073 |
+| H2 + methane | 173.65 | 59.9 | 0.07090 | 0.362 | 0.090427 / 0.349538 | 0.096174 / 0.339973 |
+| H2 + ethane | 148.15 | 20.0 | 0.00618 | 0.986 | 0.006841 / 0.994840 | 0.008724 / 0.994161 |
+| H2 + ethane | 173.15 | 40.0 | 0.01680 | 0.977 | 0.019465 / 0.981041 | 0.023502 / 0.979088 |
+
+The experimental authors report temperature and pressure accuracies of `0.1 K` and `0.1 atm`, respectively, and
+composition uncertainty normally within `0.01` mole fraction. The regression's `0.04` absolute composition envelope
+is deliberately a separate model-qualification tolerance. The observed maximum absolute deviation is `0.031073` for
+SRK and `0.025274` for PR; these values do not imply parameter fitting or universal hydrogen-mixture accuracy.
+
+For each experimental tie line, the regression verifies the following:
+
+- the overall composition halfway between the liquid and vapor endpoints returns GAS+OIL equilibrium;
+- a liquid-side composition at half the experimental liquid endpoint and a vapor-side composition `0.05` above the
+  experimental vapor endpoint (capped at `0.999`) return the adjacent one-phase states;
+- ordinary and explicit-multiphase calculations agree within `1e-10` for beta and phase composition, `1e-8` for
+  compressibility factor, and a relative `1e-8` extensive-Gibbs tolerance;
+- phase fractions and compositions are finite, bounded, and normalized within `1e-12`, component material balance
+  closes below `1e-10`, and two-phase log-fugacity residuals remain below `1e-8`; and
+- poor phase-fraction initialization, an exact repeated flash, and a changed temperature-pressure-composition state
+  recover the same equilibrium as a fresh calculation.
+
+This is an evidence-level-1 literature qualification of phase topology and numerical consistency. It does not claim
+that classic cubic EOS models reproduce every hydrogen-rich VLE dataset within experimental uncertainty.
+
 ---
 
 ## 7. References
@@ -1934,6 +1969,12 @@ Recommended regression coverage should include both numerical convergence and ph
 ### Electrolyte Systems
 
 9. **Thomsen, K.** (2005). "Modeling electrolyte solutions with the extended UNIQUAC model." *Pure and Applied Chemistry*, 77(3), 531-542.
+
+### Hydrogen-Rich Vapor-Liquid Equilibrium
+
+10. **Sagara, H., Arai, Y., & Saito, S.** (1972). "Vapor-Liquid Equilibria of Binary and Ternary Systems Containing
+    Hydrogen and Light Hydrocarbons." *Journal of Chemical Engineering of Japan*, 5(4), 339-348.
+    [doi:10.1252/jcej.5.339](https://doi.org/10.1252/jcej.5.339)
 
 ---
 

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashHydrogenLiteratureConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashHydrogenLiteratureConsistencyTest.java
@@ -1,0 +1,236 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Arrays;
+import java.util.Comparator;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Literature-anchored qualification for hydrogen-rich binary TP flashes.
+ *
+ * <p>
+ * The experimental tie lines are from Sagara, Arai, and Saito, J. Chem. Eng. Japan 5 (1972), 339-348,
+ * doi:10.1252/jcej.5.339. Their midpoints are unambiguously inside the experimental two-phase region, while
+ * compositions beyond either endpoint anchor the adjacent one-phase regions. The cubic-EOS composition tolerance is a
+ * model qualification envelope, not the experimental uncertainty reported by the authors.
+ */
+class TPflashHydrogenLiteratureConsistencyTest extends neqsim.NeqSimTest {
+  private static final double ATM_TO_BAR = 1.01325;
+  private static final double MODEL_COMPOSITION_TOLERANCE = 0.04;
+  private static final double MATERIAL_BALANCE_TOLERANCE = 1.0e-10;
+  private static final double FUGACITY_TOLERANCE = 1.0e-8;
+  private static final TieLine[] TIE_LINES = { new TieLine("methane", 123.15, 20.0, 0.0192, 0.818),
+      new TieLine("methane", 143.05, 40.2, 0.0477, 0.721), new TieLine("methane", 173.65, 59.9, 0.0709, 0.362),
+      new TieLine("ethane", 148.15, 20.0, 0.00618, 0.986), new TieLine("ethane", 173.15, 40.0, 0.0168, 0.977) };
+
+  @Test
+  void experimentalTieLinesRemainTwoPhaseAndCrossAlgorithmConsistent() {
+    for (Eos eos : Eos.values()) {
+      for (TieLine tieLine : TIE_LINES) {
+        double overallHydrogen = tieLine.midpoint();
+        SystemInterface ordinary = flash(createSystem(eos, tieLine, overallHydrogen, false), false);
+        SystemInterface multiphase = flash(createSystem(eos, tieLine, overallHydrogen, true), false);
+
+        assertGasOilEquilibrium(ordinary, tieLine.label(eos));
+        assertEquivalent(ordinary, multiphase, tieLine.label(eos));
+        assertLiteratureAgreement(ordinary, tieLine, tieLine.label(eos));
+      }
+    }
+  }
+
+  @Test
+  void experimentalTieLinesBracketTheAdjacentSinglePhaseRegions() {
+    for (Eos eos : Eos.values()) {
+      for (TieLine tieLine : TIE_LINES) {
+        double liquidSideHydrogen = 0.5 * tieLine.liquidHydrogen;
+        double vaporSideHydrogen = Math.min(0.999, tieLine.vaporHydrogen + 0.05);
+
+        assertSinglePhaseAcrossAlgorithms(eos, tieLine, liquidSideHydrogen,
+            tieLine.label(eos) + " liquid-composition side");
+        assertSinglePhaseAcrossAlgorithms(eos, tieLine, vaporSideHydrogen,
+            tieLine.label(eos) + " vapor-composition side");
+      }
+    }
+  }
+
+  @Test
+  void poorInitializationRepeatsAndChangedStatesRecoverTheSameEquilibrium() {
+    TieLine initialPoint = TIE_LINES[1];
+    TieLine changedPoint = TIE_LINES[2];
+    for (Eos eos : Eos.values()) {
+      for (boolean multiphase : new boolean[] { false, true }) {
+        SystemInterface reference = flash(createSystem(eos, initialPoint, initialPoint.midpoint(), multiphase), false);
+        SystemInterface continued = flash(createSystem(eos, initialPoint, initialPoint.midpoint(), multiphase), true);
+        assertEquivalent(reference, continued, initialPoint.label(eos) + " poor initialization");
+
+        SystemInterface repeatedReference = reference.clone();
+        flash(reference, false);
+        assertEquivalent(repeatedReference, reference, initialPoint.label(eos) + " repeated flash");
+
+        continued.setTemperature(changedPoint.temperature, "K");
+        continued.setPressure(changedPoint.pressureBar(), "bara");
+        continued.setMolarComposition(new double[] { changedPoint.midpoint(), 1.0 - changedPoint.midpoint() });
+        flash(continued, false);
+
+        SystemInterface changedReference = flash(createSystem(eos, changedPoint, changedPoint.midpoint(), multiphase),
+            false);
+        assertEquivalent(changedReference, continued, changedPoint.label(eos) + " changed state");
+      }
+    }
+  }
+
+  private static void assertSinglePhaseAcrossAlgorithms(Eos eos, TieLine tieLine, double hydrogenFraction,
+      String label) {
+    SystemInterface ordinary = flash(createSystem(eos, tieLine, hydrogenFraction, false), false);
+    SystemInterface multiphase = flash(createSystem(eos, tieLine, hydrogenFraction, true), false);
+
+    assertEquals(1, ordinary.getNumberOfPhases(), label);
+    assertEquivalent(ordinary, multiphase, label);
+  }
+
+  private static void assertGasOilEquilibrium(SystemInterface system, String label) {
+    assertEquals(2, system.getNumberOfPhases(), label + " literature tie-line midpoint");
+    assertTrue(system.hasPhaseType(PhaseType.GAS), label);
+    assertTrue(system.hasPhaseType(PhaseType.OIL), label);
+    assertClosure(system, label);
+  }
+
+  private static void assertLiteratureAgreement(SystemInterface system, TieLine tieLine, String label) {
+    Integer[] order = phaseOrder(system);
+    double calculatedVaporHydrogen = system.getPhase(order[0]).getComponent("hydrogen").getx();
+    double calculatedLiquidHydrogen = system.getPhase(order[1]).getComponent("hydrogen").getx();
+    assertEquals(tieLine.vaporHydrogen, calculatedVaporHydrogen, MODEL_COMPOSITION_TOLERANCE,
+        label + " vapor hydrogen composition");
+    assertEquals(tieLine.liquidHydrogen, calculatedLiquidHydrogen, MODEL_COMPOSITION_TOLERANCE,
+        label + " liquid hydrogen composition");
+  }
+
+  private static SystemInterface createSystem(Eos eos, TieLine tieLine, double hydrogenFraction, boolean multiphase) {
+    SystemInterface system = eos == Eos.PR ? new SystemPrEos(tieLine.temperature, tieLine.pressureBar())
+        : new SystemSrkEos(tieLine.temperature, tieLine.pressureBar());
+    system.addComponent("hydrogen", hydrogenFraction);
+    system.addComponent(tieLine.hydrocarbon, 1.0 - hydrogenFraction);
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(multiphase);
+    return system;
+  }
+
+  private static SystemInterface flash(SystemInterface system, boolean poorGuess) {
+    if (poorGuess) {
+      system.setBeta(0, 1.0e-10);
+      system.setBeta(1, 1.0 - 1.0e-10);
+    }
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private static void assertEquivalent(SystemInterface expected, SystemInterface actual, String label) {
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases(), label);
+    assertClosure(expected, label + " reference");
+    assertClosure(actual, label + " comparison");
+    Integer[] expectedOrder = phaseOrder(expected);
+    Integer[] actualOrder = phaseOrder(actual);
+    for (int orderedPhase = 0; orderedPhase < expectedOrder.length; orderedPhase++) {
+      int expectedPhase = expectedOrder[orderedPhase];
+      int actualPhase = actualOrder[orderedPhase];
+      assertEquals(expected.getPhase(expectedPhase).getType(), actual.getPhase(actualPhase).getType(), label);
+      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), 1.0e-10, label);
+      assertEquals(expected.getPhase(expectedPhase).getZ(), actual.getPhase(actualPhase).getZ(), 1.0e-8, label);
+      for (int component = 0; component < 2; component++) {
+        assertEquals(expected.getPhase(expectedPhase).getComponent(component).getx(),
+            actual.getPhase(actualPhase).getComponent(component).getx(), 1.0e-10, label);
+      }
+    }
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(),
+        Math.max(1.0e-7, 1.0e-8 * Math.abs(expected.getGibbsEnergy())), label);
+  }
+
+  private static Integer[] phaseOrder(SystemInterface system) {
+    Integer[] order = new Integer[system.getNumberOfPhases()];
+    Arrays.setAll(order, index -> index);
+    Arrays.sort(order, Comparator.comparingDouble(index -> -system.getPhase(index).getComponent("hydrogen").getx()));
+    return order;
+  }
+
+  private static void assertClosure(SystemInterface system, String label) {
+    double betaSum = 0.0;
+    for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+      double beta = system.getBeta(phase);
+      assertTrue(Double.isFinite(beta) && beta >= 0.0 && beta <= 1.0, label);
+      betaSum += beta;
+      double compositionSum = 0.0;
+      for (int component = 0; component < 2; component++) {
+        double composition = system.getPhase(phase).getComponent(component).getx();
+        assertTrue(Double.isFinite(composition) && composition >= 0.0 && composition <= 1.0, label);
+        compositionSum += composition;
+      }
+      assertEquals(1.0, compositionSum, 1.0e-12, label);
+      assertTrue(Double.isFinite(system.getPhase(phase).getZ()) && system.getPhase(phase).getZ() > 0.0, label);
+    }
+    assertEquals(1.0, betaSum, 1.0e-12, label);
+
+    double maximumMaterialBalanceResidual = 0.0;
+    for (int component = 0; component < 2; component++) {
+      double recovered = 0.0;
+      for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+        recovered += system.getBeta(phase) * system.getPhase(phase).getComponent(component).getx();
+      }
+      maximumMaterialBalanceResidual = Math.max(maximumMaterialBalanceResidual,
+          Math.abs(system.getPhase(0).getComponent(component).getz() - recovered));
+    }
+    assertTrue(maximumMaterialBalanceResidual < MATERIAL_BALANCE_TOLERANCE,
+        label + " material balance residual " + maximumMaterialBalanceResidual);
+
+    if (system.getNumberOfPhases() == 2) {
+      double maximumFugacityResidual = 0.0;
+      for (int component = 0; component < 2; component++) {
+        double firstFugacity = system.getPhase(0).getComponent(component).getx()
+            * system.getPhase(0).getComponent(component).getFugacityCoefficient();
+        double secondFugacity = system.getPhase(1).getComponent(component).getx()
+            * system.getPhase(1).getComponent(component).getFugacityCoefficient();
+        maximumFugacityResidual = Math.max(maximumFugacityResidual, Math.abs(Math.log(firstFugacity / secondFugacity)));
+      }
+      assertTrue(maximumFugacityResidual < FUGACITY_TOLERANCE, label + " fugacity residual " + maximumFugacityResidual);
+    }
+  }
+
+  private enum Eos {
+    SRK, PR
+  }
+
+  private static final class TieLine {
+    private final String hydrocarbon;
+    private final double temperature;
+    private final double pressureAtmosphere;
+    private final double liquidHydrogen;
+    private final double vaporHydrogen;
+
+    private TieLine(String hydrocarbon, double temperature, double pressureAtmosphere, double liquidHydrogen,
+        double vaporHydrogen) {
+      this.hydrocarbon = hydrocarbon;
+      this.temperature = temperature;
+      this.pressureAtmosphere = pressureAtmosphere;
+      this.liquidHydrogen = liquidHydrogen;
+      this.vaporHydrogen = vaporHydrogen;
+    }
+
+    private double midpoint() {
+      return 0.5 * (liquidHydrogen + vaporHydrogen);
+    }
+
+    private double pressureBar() {
+      return pressureAtmosphere * ATM_TO_BAR;
+    }
+
+    private String label(Eos eos) {
+      return eos + " hydrogen+" + hydrocarbon + " at " + temperature + " K and " + pressureAtmosphere + " atm";
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Advances #2937 with a literature-anchored hydrogen-rich flash qualification. It adds no production solver changes.

- qualifies classic-mixing-rule SRK and PR against five experimental H2+methane / H2+ethane VLE tie lines;
- exercises ordinary `TPflash` and `setMultiPhaseCheck(true)` through two-phase, adjacent one-phase, poor-initialization, repeated-run, and changed-state paths;
- freezes campaign residual, normalization, boundedness, property, and cross-algorithm gates;
- documents the dataset, units, assumptions, measured deviations, and limitations.

This restores the trusted-reference coverage requested when the unqualified synthetic H2 matrix was removed in #3102; it does not resurrect that arbitrary matrix.

## Scientific basis

Source: H. Sagara, Y. Arai, and S. Saito, “Vapor-Liquid Equilibria of Binary and Ternary Systems Containing Hydrogen and Light Hydrocarbons,” *Journal of Chemical Engineering of Japan* 5 (1972), 339–348. https://doi.org/10.1252/jcej.5.339

The matrix freezes five published binary tie lines:

- H2+methane: 123.15 K / 20.0 atm, 143.05 K / 40.2 atm, and 173.65 K / 59.9 atm;
- H2+ethane: 148.15 K / 20.0 atm and 173.15 K / 40.0 atm.

Pressure is absolute and converted with `1 atm = 1.01325 bar`. No binary interaction parameters are fitted. The tie-line midpoint is inside the experimental two-phase region; compositions beyond the liquid and vapor endpoints exercise the neighboring one-phase regions.

The paper reports temperature and pressure accuracies of 0.1 K and 0.1 atm, and composition normally within 0.01 mole fraction. The test's 0.04 absolute composition tolerance is explicitly a separate cubic-EOS qualification envelope.

## Frozen acceptance and results

All five points pass for SRK and PR through both ordinary and explicit-multiphase calculation paths.

- two-phase topology: GAS+OIL at every tie-line midpoint;
- adjacent topology: one phase on both sides of every tie line;
- maximum absolute H2 endpoint deviation: SRK `0.031073`, PR `0.025274`;
- beta and phase-composition normalization: `1e-12`;
- component material-balance residual: below `1e-10`;
- two-phase maximum log-fugacity residual: below `1e-8`;
- ordinary/multiphase beta and composition agreement: `1e-10`;
- ordinary/multiphase Z agreement: `1e-8`;
- extensive Gibbs agreement: `max(1e-7 J, 1e-8 abs(G))`;
- poor beta initialization, exact repeat, and changed T/P/composition reuse recover the fresh endpoint.

This is phase-topology and numerical-consistency qualification, not parameter fitting or a claim of universal hydrogen-mixture accuracy.

## Validation

Local validation at exact branch content based on master `2a1f41b792a76f910b8a172b142f59e49a622cb8`:

- `TPflashHydrogenLiteratureConsistencyTest`: 3/3 passed;
- focused cross-algorithm set (`TPmultiflashTest`, ionic GAS+AQUEOUS, water-rich cold-seed, and this class): 16/16 passed;
- `python devtools/run_spotless.py apply`: passed;
- `python devtools/run_spotless.py check`: passed;
- `python devtools/check_documentation_search.py`: passed (655 Markdown + 1 standalone HTML page);
- pre-commit stage: passed;
- pre-push stage: passed.

The warmed new test class took 0.735 s inside the 16-test focused run. Production code and solver work are unchanged, so no before/after performance improvement is claimed.

**VALIDATION BLOCKED BY INFRASTRUCTURE** for the exact GitHub head.

## Documentation impact

Updated `docs/thermodynamicoperations/TPflash_algorithm.md` with the experimental matrix, pressure basis, EOS/mixing-rule assumptions, calculated endpoints, frozen numerical gates, source, and limitations.

## Scope and compatibility

- no public API, production algorithm, parameter, mixing rule, default, tolerance, serialization, or process behavior change;
- neutral hydrogen/light-hydrocarbon cubic-EOS qualification only;
- no electrolyte/CPA implementation overlap with #3144;
- no Column Solver, Process Performance, or Huldra work.

## Hosted CI follow-up

At exact head `e462324bc050624e0c633316f24d4f6d7774820e`, Spotless, pre-commit, documentation search, CodeQL, and Java 21 Javadoc passed. The Java 21 Ubuntu fast-test job failed before compilation because Maven Central returned HTTP 429 while resolving `maven-resources-plugin:3.4.0`; its dependent Windows and Java 8 jobs were cancelled/skipped. The slow shards remain in progress. A targeted retry was attempted but GitHub correctly refused it while the containing workflow run is still active. No source change is justified by this infrastructure failure.