### PR TITLE
[AI-Assisted] docs(safety): correct overview API boundaries

### DIFF
--- a/docs/process/safety/README.md
+++ b/docs/process/safety/README.md
@@ -1,240 +1,196 @@
 ---
 title: Safety Systems Package
-description: Documentation for safety systems modeling in NeqSim.
+description: Current NeqSim safety-equipment, ESD, HIPPS, relief, and transient-simulation API boundaries.
 ---
 
-# Safety Systems Package
+NeqSim provides stream-connected safety equipment, sequenced process logic, scenario runners,
+and screening utilities. These layers serve different purposes and should not be presented as
+one universal safety-design API.
 
-Documentation for safety systems modeling in NeqSim.
+Safety calculations are engineering evidence, not an approval. A project must still establish
+credible scenarios, design conditions, standards editions, safeguard independence, uncertainty,
+acceptance criteria, and accountable review.
 
-## Table of Contents
-- [Overview](#overview)
-- [Safety Equipment](#safety-equipment)
-- [Emergency Shutdown (ESD)](#emergency-shutdown-esd)
-- [Closed-loop SIF Verification](closed-loop-sif-verification.md)
-- [SIF Reliability and Degraded Modes](sif-reliability-and-degraded-modes.md)
-- [HAZOP/LOPA to Draft SRS Handoff](hazop-lopa-srs-handoff.md)
-- [Integrated Facility Safety Response](integrated-facility-safety-response.md)
-- [Safety Change Revalidation and Independent Benchmarks](safety-change-revalidation-and-benchmarks.md)
-- [Blowdown Systems](#blowdown-systems)
-- [Pressure Safety Valves](#pressure-safety-valves)
-- [Release and Gas Dispersion Scenarios](release-dispersion-scenarios.md)
-- [CFD Source-Term Handoff](release-dispersion-scenarios.md#cfd-source-term-handoff)
-- [Open Drain Review](../../safety/open_drain_review.md)
-- [HIPPS](#hipps)
+## Choose the correct layer
 
----
+| Need | Current API | Boundary |
+| --- | --- | --- |
+| Model pressure-responsive or fail-safe equipment | `SafetyValve`, `RuptureDisk`, `ESDValve`, `BlowdownValve` | Constructors accept a `StreamInterface`, not a vessel object |
+| Sequence shutdown actions | `ESDLogic` with `TripValveAction`, `ActivateBlowdownAction`, and related actions | Call `activate()` and advance both logic and equipment with the same time-step basis |
+| Model HIPPS voting and final action | `HIPPSLogic`, `Detector`, and `VotingLogic` | Sensor quality, bypasses, proof testing, SIL claims, and independence require separate evidence |
+| Produce structured transient evidence | `EmergencyShutdownTestRunner`, `DynamicSafetyScenarioRunner`, and `ClosedLoopSafetyFunction` | Define monitored tags, criteria, calculation identity, and result retention explicitly |
+| Screen relief load and area | `ReliefValveSizing` and the scenario definitions on `SafetyValve` | Static sizing is separate from the valve's dynamic opening and reseating behavior |
+| Hand off consequence inputs | Release, dispersion, open-drain, flare, and CFD source-term utilities | Layout, weather, leak frequency, escalation, and QRA conclusions remain external qualification tasks |
 
-## Overview
+## Units and state ownership
 
-**Location:** `neqsim.process.equipment.safety`, `neqsim.process.safety`
+| API | Input meaning |
+| --- | --- |
+| `SafetyValve.setPressureSpec(double)` | Absolute set pressure in bara |
+| `SafetyValve.setFullOpenPressure(double)` | Absolute fully-open pressure in bara |
+| `SafetyValve.setBlowdown(double)` | Reseating margin as percent below set pressure |
+| `RuptureDisk.setBurstPressure(double)` | Absolute burst pressure in bara |
+| `RuptureDisk.setFullOpenPressure(double)` | Absolute fully-open pressure in bara |
+| `ESDValve.setStrokeTime(double)` | Closure time in seconds |
+| `BlowdownValve.setOpeningTime(double)` | Opening time in seconds |
+| `runTransient(double, UUID)` | Time increment in seconds plus a stable calculation identity |
 
-NeqSim provides equipment and logic for modeling process safety systems:
-- Pressure Safety Valves (PSV)
-- Relief valves
-- Emergency Shutdown (ESD) systems
-- Blowdown and depressuring systems
-- High Integrity Pressure Protection Systems (HIPPS)
-- NORSOK S-001 Clause 9 open-drain review from NeqSim-calculated liquid and hydraulic evidence
-- Automatic release source terms and gas dispersion screening from process streams
-- Formal CFD source-term JSON handoff cases for OpenFOAM, FLACS, KFX, PHAST, and Safeti workflows
-- Integrated ESD, compressor-trip, relief, blowdown, flare, MDMT, and hydrate-margin review handoff
+The valve classes inherit unit-aware outlet-pressure methods from `ThrottlingValve`, for example
+`setOutletPressure(1.5, "bara")`. The device-specific set, burst, and full-open setters above do
+not accept a unit string. Convert project gauge-pressure values to absolute pressure before using
+those setters.
 
-The release, dispersion, and CFD handoff workflow is intended for screening, case generation,
-and auditable source-term transfer. Final facility layout, regulatory QRA, and CFD conclusions
-still require project-specific validation, site geometry, leak-frequency data, and approved
-consequence-analysis methods.
+`RuptureDisk.reset()` exists to reset a simulation case. It does not imply that a ruptured physical
+disk can reseat or be returned to service.
 
----
+## Executable Java 8 quick start
 
-## Safety Equipment
-
-### Pressure Safety Valve (PSV)
+This example configures pressure-protection devices and executes a fail-close/fail-open ESD
+sequence. It demonstrates API behavior; it does not size a relief device or validate a safety
+function.
 
 ```java
-import neqsim.process.equipment.valve.SafetyValve;
-
-SafetyValve psv = new SafetyValve("PSV-100", vessel);
-psv.setOpeningPressure(95.0, "barg");  // Set pressure
-psv.setFullOpenPressure(100.0, "barg"); // Overpressure
-psv.setBlowdownPressure(85.0, "barg");  // Reseating pressure
-```
-
-### Rupture Disk
-
-```java
-import neqsim.process.equipment.valve.RuptureDisk;
-
-RuptureDisk disk = new RuptureDisk("RD-100", vessel);
-disk.setBurstPressure(110.0, "barg");
-disk.setDiameter(150.0, "mm");
-```
-
----
-
-## Emergency Shutdown (ESD)
-
-### ESD Logic and Dynamic Evidence
-
-```java
-ESDValve inletValve = new ESDValve("ESD Inlet Isolation", feed);
-inletValve.setStrokeTime(4.0);
-inletValve.setCv(500.0);
-
-ESDLogic esdLogic = new ESDLogic("ESD Level 1");
-esdLogic.addAction(new TripValveAction(inletValve), 0.0);
-```
-
-Use `neqsim.process.safety.esd.EmergencyShutdownTestRunner` when the ESD sequence needs a
-structured dynamic evidence report with monitored time series, tagreader comparisons, standards
-references, and acceptance criteria.
-
-Use [`ClosedLoopSafetyFunction`](closed-loop-sif-verification.md) with
-`DynamicSafetyScenarioRunner` when the test must include live process detection, channel response
-and fault modes, MooN voting, logic-solver delay, and physical final-element response in one
-isolated transient.
-
-### ESD Levels
-
-| Level | Description | Actions |
-|-------|-------------|---------|
-| ESD-0 | Total shutdown | Full plant shutdown |
-| ESD-1 | Process shutdown | Process area isolation |
-| ESD-2 | Unit shutdown | Single unit isolation |
-| ESD-3 | Equipment shutdown | Single equipment stop |
-
----
-
-## Blowdown Systems
-
-### Depressuring Calculation
-
-```java
+import java.util.UUID;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.valve.BlowdownValve;
+import neqsim.process.equipment.valve.ESDValve;
+import neqsim.process.equipment.valve.RuptureDisk;
+import neqsim.process.equipment.valve.SafetyValve;
+import neqsim.process.logic.action.ActivateBlowdownAction;
+import neqsim.process.logic.action.TripValveAction;
+import neqsim.process.logic.esd.ESDLogic;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
 
-BlowdownValve blowdown = new BlowdownValve("BDV-100", vessel);
-blowdown.setDownstreamPressure(1.0, "barg");  // Flare pressure
-blowdown.setOrificeSize(100.0, "mm");
+public final class ProcessSafetyOverviewQuickStart {
+  private static final Logger logger =
+      LogManager.getLogger(ProcessSafetyOverviewQuickStart.class);
 
-// Run depressuring transient
-for (double t = 0; t < 900; t += 1.0) {
-    blowdown.runTransient();
+  private ProcessSafetyOverviewQuickStart() {}
 
-    double P = vessel.getPressure("barg");
-    double T = vessel.getTemperature("C");
+  public static void main(String[] args) {
+    SystemInterface fluid = new SystemSrkEos(298.15, 80.0);
+    fluid.addComponent("methane", 0.95);
+    fluid.addComponent("ethane", 0.05);
+    fluid.setMixingRule("classic");
 
-    if (P < 7.0) {  // 15 minute rule target
-        System.out.println("Reached target at " + t + " seconds");
-        break;
+    Stream feed = new Stream("safety feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    feed.run();
+
+    SafetyValve safetyValve = new SafetyValve("PSV-100", feed);
+    safetyValve.setPressureSpec(75.0);
+    safetyValve.setFullOpenPressure(82.5);
+    safetyValve.setBlowdown(7.0);
+    safetyValve.setOutletPressure(1.5, "bara");
+
+    RuptureDisk ruptureDisk = new RuptureDisk("RD-100", feed);
+    ruptureDisk.setBurstPressure(85.0);
+    ruptureDisk.setFullOpenPressure(89.25);
+    ruptureDisk.setOutletPressure(1.5, "bara");
+
+    ESDValve inletIsolation = new ESDValve("ESD-XV-100", feed);
+    inletIsolation.setStrokeTime(2.0);
+    inletIsolation.setCv(500.0);
+    inletIsolation.setOutletPressure(75.0, "bara");
+    inletIsolation.setCalculateSteadyState(false);
+    inletIsolation.energize();
+
+    BlowdownValve blowdownValve = new BlowdownValve("BDV-100", feed);
+    blowdownValve.setOpeningTime(2.0);
+    blowdownValve.setCv(100.0);
+    blowdownValve.setOutletPressure(1.5, "bara");
+    blowdownValve.setCalculateSteadyState(false);
+
+    ESDLogic esdLogic = new ESDLogic("ESD level 1");
+    esdLogic.addAction(new TripValveAction(inletIsolation), 0.0);
+    esdLogic.addAction(new ActivateBlowdownAction(blowdownValve), 0.0);
+    esdLogic.activate();
+
+    UUID calculationId = UUID.randomUUID();
+    double timeStepSeconds = 0.5;
+    for (int step = 0; step < 20 && !esdLogic.isComplete(); step++) {
+      esdLogic.execute(timeStepSeconds);
+      inletIsolation.runTransient(timeStepSeconds, calculationId);
+      blowdownValve.runTransient(timeStepSeconds, calculationId);
     }
+
+    if (!esdLogic.isComplete()
+        || inletIsolation.getPercentValveOpening() > 1.0
+        || blowdownValve.getPercentValveOpening() < 90.0
+        || Math.abs(safetyValve.getBlowdownPressure() - 69.75) > 1.0e-9
+        || ruptureDisk.getBurstPressure() != 85.0) {
+      throw new IllegalStateException("Safety-equipment sequence did not complete");
+    }
+
+    logger.info(
+        "ESD complete: inlet opening {}%, blowdown opening {}%",
+        inletIsolation.getPercentValveOpening(),
+        blowdownValve.getPercentValveOpening());
+  }
 }
 ```
 
-### Fire Case Calculation
+The regression test
+`src/test/java/neqsim/process/safety/ProcessSafetyOverviewDocumentationTest.java` executes this
+sequence and protects the documented constructors, units, state transitions, and completion
+criteria.
 
-```java
-// Calculate heat input from fire
-double wettedArea = 50.0;  // m²
-double Q = 43200 * Math.pow(wettedArea, 0.82);  // API 521 formula
+## Transient execution contract
 
-vessel.setHeatInput(Q, "W");
-```
+1. Initialize and run the upstream thermodynamic stream or steady-state process.
+2. Set stateful safety equipment to transient mode where its automatic travel logic is required.
+3. Activate the ESD or HIPPS logic explicitly; construction alone does not trigger it.
+4. Advance logic and equipment using a justified time step and a stable `UUID` for the calculation.
+5. Capture pressure, temperature, inventory, valve position, relief flow, flare load, MDMT or
+   hydrate margin, and acceptance-criterion results in structured evidence.
+6. Check conservation, numerical convergence, event ordering, time-step sensitivity, and the
+   final safe state before interpreting the scenario.
 
----
+A valve connected to a stream is not a complete depressuring model. The protected inventory,
+equipment holdup, heat transfer, flare-header backpressure, downstream equipment, control logic,
+and scenario boundary conditions must also be represented.
 
-## Pressure Safety Valves
+## Relief and fire screening boundary
 
-### PSV Sizing
+Use [Relief-Valve Sizing Screening](../../safety/relief_valve_sizing_api.md) for the maintained
+gas, liquid, two-phase, and wetted-fire sizing interfaces. Do not attach an undocumented heat
+input to an arbitrary vessel or infer an API 526 letter from `SafetyValve`; the dynamic equipment
+class does not expose those sizing methods.
 
-```java
-// Calculate required relief rate
-double reliefRate = psv.getReliefRate("kg/hr");
+Use [Integrated Facility Safety Response](integrated-facility-safety-response.md) when relief,
+blowdown, flare, compressor trip, process limits, MDMT, and hydrate margin must be reviewed as one
+scenario. Static relief sizing and dynamic transient response answer different questions and
+should both retain method, unit, input-basis, and qualification metadata.
 
-// API 520 sizing
-double area = psv.getRequiredOrificeArea("mm2");
-String orifice = psv.getAPIOrificeLetter();
+## Safety lifecycle boundary
 
-System.out.println("Required area: " + area + " mm²");
-System.out.println("API orifice: " + orifice);
-```
+NeqSim can calculate and retain evidence, but it does not:
 
-### Multiple Relief Scenarios
+- decide which initiating events or safeguards are credible;
+- certify IEC 61511 independence, SIL capability, proof-test coverage, or bypass policy;
+- replace API, ISO, NORSOK, company, vendor, or authority requirements;
+- approve relief loads, flare-network capacity, depressuring time, MDMT, hazardous-area extent,
+  fire protection, QRA, HAZOP, LOPA, or an SRS; or
+- make a model fit for design or operation without project-specific verification and accountable
+  review.
 
-| Scenario | Description |
-|----------|-------------|
-| Blocked outlet | Outlet valve closed |
-| Fire case | External fire exposure |
-| Tube rupture | Heat exchanger tube failure |
-| Power failure | Loss of cooling/control |
-| Thermal relief | Liquid expansion |
+Avoid fixed ESD-level meanings or universal depressuring-time targets. Define them in the project
+basis and trace each acceptance criterion to the applicable controlled source.
 
----
+## Related documentation
 
-## HIPPS
-
-High Integrity Pressure Protection System.
-
-```java
-import neqsim.process.safety.HIPPS;
-
-HIPPS hipps = new HIPPS("HIPPS-1");
-
-// Add sensors (2oo3 voting)
-hipps.addPressureSensor(pt1);
-hipps.addPressureSensor(pt2);
-hipps.addPressureSensor(pt3);
-
-// Set trip point
-hipps.setTripPressure(95.0, "barg");
-
-// Add final elements
-hipps.addIsolationValve(sdv1);
-hipps.addIsolationValve(sdv2);
-
-// Set voting logic
-hipps.setVotingLogic("2oo3");  // 2 out of 3
-```
-
----
-
-## Example: ESD Dynamic Test Evidence
-
-```java
-OperationalTagMap tagMap = new OperationalTagMap()
-    .addBinding(OperationalTagBinding.builder("xv_opening")
-        .automationAddress("ESD Inlet Isolation.percentValveOpening")
-        .unit("%")
-        .role(InstrumentTagRole.BENCHMARK)
-        .build());
-
-EmergencyShutdownTestPlan plan = EmergencyShutdownTestPlan.builder("ESD1 isolation closure")
-    .duration(8.0)
-    .timeStep(1.0)
-    .tagMap(tagMap)
-    .enableLogic("ESD Level 1")
-    .triggerLogic("ESD Level 1")
-    .criterion(EmergencyShutdownTestCriterion.finalAtMost(
-        "ESD-XV-CLOSED", "xv_opening", 5.0, "%"))
-    .criterion(EmergencyShutdownTestCriterion.logicCompleted(
-        "ESD-LOGIC-COMPLETE", "ESD Level 1"))
-    .build();
-
-EmergencyShutdownTestResult report = EmergencyShutdownTestRunner.run(process, plan, esdLogic);
-```
-
----
-
-## Related Documentation
-
-- [Process Package](../) - Process simulation overview
-- [Release and Gas Dispersion Scenarios](release-dispersion-scenarios.md) - Automatic source-term and cloud endpoint screening from ProcessSystem streams
-- [Open Drain Review](../../safety/open_drain_review.md) - NORSOK S-001 Clause 9 review with NeqSim stream evidence and normalized STID/tagreader inputs
-- [ESD Dynamic Testing Workflow](../../safety/esd_testing_workflow.md) - ESD transient testing with process logic, tagreader evidence, and criteria reports
-- [Closed-loop SIF Verification](closed-loop-sif-verification.md) - Sensor-to-vote-to-final-element transient verification with structured evidence
-- [SIF Reliability and Degraded Modes](sif-reliability-and-degraded-modes.md) - Seeded PFD/PFH uncertainty and governed bypass, maintenance, failure, and proof-test assessment
-- [HAZOP/LOPA to Draft SRS Handoff](hazop-lopa-srs-handoff.md) - IPL eligibility, LOPA arithmetic, and traceable unapproved SRS drafting
-- [Integrated Facility Safety Response](integrated-facility-safety-response.md) - Executed ESD, compressor-trip, relief, blowdown, flare, and process-limit evidence in one review package
-- [Safety Change Revalidation and Independent Benchmarks](safety-change-revalidation-and-benchmarks.md) - Graph-driven lifecycle rework and versioned external-reference qualification
-- [ESD Blowdown System](../../safety/ESD_BLOWDOWN_SYSTEM) - Detailed ESD guide
-- [HIPPS Summary](../../safety/HIPPS_SUMMARY) - HIPPS overview
-- [PSV Dynamic Sizing](../../safety/psv_dynamic_sizing_example) - PSV sizing example
+- [Safety documentation index](../../safety/README.md)
+- [Relief-Valve Sizing Screening](../../safety/relief_valve_sizing_api.md)
+- [ESD Dynamic Testing Workflow](../../safety/esd_testing_workflow.md)
+- [HIPPS overview](../../safety/HIPPS_SUMMARY.md)
+- [Closed-loop SIF verification](closed-loop-sif-verification.md)
+- [SIF reliability and degraded modes](sif-reliability-and-degraded-modes.md)
+- [HAZOP/LOPA to draft SRS handoff](hazop-lopa-srs-handoff.md)
+- [Integrated facility safety response](integrated-facility-safety-response.md)
+- [Safety change revalidation and benchmarks](safety-change-revalidation-and-benchmarks.md)
+- [Release and dispersion scenarios](release-dispersion-scenarios.md)
+- [Valve equipment guide](../equipment/valves.md)
+- [Process package overview](../README.md)

--- a/docs/test_process_safety_overview_documentation.py
+++ b/docs/test_process_safety_overview_documentation.py
@@ -1,0 +1,202 @@
+import re
+import unittest
+from pathlib import Path
+from urllib.parse import unquote
+
+
+DOCS_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = DOCS_DIR.parent
+OVERVIEW = DOCS_DIR / "process" / "safety" / "README.md"
+SAFETY_VALVE = REPOSITORY_ROOT / (
+    "src/main/java/neqsim/process/equipment/valve/SafetyValve.java"
+)
+RUPTURE_DISK = REPOSITORY_ROOT / (
+    "src/main/java/neqsim/process/equipment/valve/RuptureDisk.java"
+)
+BLOWDOWN_VALVE = REPOSITORY_ROOT / (
+    "src/main/java/neqsim/process/equipment/valve/BlowdownValve.java"
+)
+ESD_VALVE = REPOSITORY_ROOT / (
+    "src/main/java/neqsim/process/equipment/valve/ESDValve.java"
+)
+ESD_LOGIC = REPOSITORY_ROOT / (
+    "src/main/java/neqsim/process/logic/esd/ESDLogic.java"
+)
+HIPPS_LOGIC = REPOSITORY_ROOT / (
+    "src/main/java/neqsim/process/logic/hipps/HIPPSLogic.java"
+)
+
+
+def heading_slugs(content):
+    without_fences = re.sub(r"```.*?```", "", content, flags=re.DOTALL)
+    return {
+        re.sub(r"[^a-z0-9 -]", "", heading.lower())
+        .strip()
+        .replace(" ", "-")
+        for heading in re.findall(
+            r"^#{1,6}\s+(.+)$",
+            without_fences,
+            flags=re.MULTILINE,
+        )
+    }
+
+
+def resolve_internal_target(source_path, destination):
+    target, _, fragment = unquote(destination).partition("#")
+    if not target:
+        return source_path, fragment
+
+    raw_target = source_path.parent / target
+    candidates = [raw_target]
+    if target.endswith("/"):
+        candidates = [raw_target / "README.md", raw_target / "index.md"]
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve(), fragment
+    raise AssertionError(
+        "Unresolved link from {}: {}".format(source_path, destination)
+    )
+
+
+class ProcessSafetyOverviewDocumentationContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.overview = OVERVIEW.read_text(encoding="utf-8")
+        cls.sources = {
+            "SafetyValve": SAFETY_VALVE.read_text(encoding="utf-8"),
+            "RuptureDisk": RUPTURE_DISK.read_text(encoding="utf-8"),
+            "BlowdownValve": BLOWDOWN_VALVE.read_text(encoding="utf-8"),
+            "ESDValve": ESD_VALVE.read_text(encoding="utf-8"),
+            "ESDLogic": ESD_LOGIC.read_text(encoding="utf-8"),
+            "HIPPSLogic": HIPPS_LOGIC.read_text(encoding="utf-8"),
+        }
+
+    def test_structure_and_internal_links_are_source_safe(self):
+        self.assertTrue(self.overview.startswith("---\n"))
+        self.assertEqual(self.overview.count("```") % 2, 0)
+        without_fences = re.sub(
+            r"```.*?```",
+            "",
+            self.overview,
+            flags=re.DOTALL,
+        )
+        self.assertNotRegex(without_fences, re.compile(r"^# ", re.MULTILINE))
+
+        markdown_links = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+        for destination in markdown_links.findall(self.overview):
+            if destination.startswith(("http://", "https://", "mailto:")):
+                continue
+            target, _, fragment = destination.partition("#")
+            with self.subTest(destination=destination):
+                if target and not target.endswith("/"):
+                    self.assertTrue(target.endswith(".md"))
+                target_path, resolved_fragment = resolve_internal_target(
+                    OVERVIEW,
+                    destination,
+                )
+                self.assertTrue(target_path.is_file())
+                if fragment:
+                    self.assertEqual(fragment, resolved_fragment)
+                    self.assertIn(
+                        resolved_fragment,
+                        heading_slugs(
+                            target_path.read_text(encoding="utf-8")
+                        ),
+                    )
+
+    def test_documented_api_matches_current_source(self):
+        expected_signatures = {
+            "SafetyValve": (
+                "public SafetyValve(String name, StreamInterface inletStream)",
+                "public void setPressureSpec(double pressureSpec)",
+                "public void setFullOpenPressure(double fullOpenPressure)",
+                "public void setBlowdown(double blowdownPercent)",
+            ),
+            "RuptureDisk": (
+                "public RuptureDisk(String name, StreamInterface inletStream)",
+                "public void setBurstPressure(double burstPressure)",
+                "public void setFullOpenPressure(double fullOpenPressure)",
+                "public void reset()",
+            ),
+            "BlowdownValve": (
+                "public BlowdownValve(String name, StreamInterface inletStream)",
+                "public void setOpeningTime(double openingTime)",
+                "public void activate()",
+                "public void runTransient(double dt, UUID id)",
+            ),
+            "ESDValve": (
+                "public ESDValve(String name, StreamInterface inletStream)",
+                "public void setStrokeTime(double strokeTime)",
+                "public void energize()",
+                "public void trip()",
+            ),
+            "ESDLogic": (
+                "public ESDLogic(String name)",
+                "public void addAction(LogicAction action, double delay)",
+                "public void activate()",
+                "public void execute(double timeStep)",
+            ),
+            "HIPPSLogic": (
+                "public HIPPSLogic(String name, VotingLogic votingLogic)",
+                "public void addPressureSensor(Detector sensor)",
+                "public void setIsolationValve(ThrottlingValve valve)",
+                "public void update(double... pressureValues)",
+            ),
+        }
+        for class_name, signatures in expected_signatures.items():
+            for signature in signatures:
+                with self.subTest(class_name=class_name, signature=signature):
+                    self.assertIn(signature, self.sources[class_name])
+
+        for documented_call in (
+            "safetyValve.setPressureSpec(75.0);",
+            "safetyValve.setBlowdown(7.0);",
+            "ruptureDisk.setBurstPressure(85.0);",
+            "inletIsolation.setStrokeTime(2.0);",
+            "blowdownValve.setOpeningTime(2.0);",
+            "esdLogic.activate();",
+            "esdLogic.execute(timeStepSeconds);",
+        ):
+            with self.subTest(documented_call=documented_call):
+                self.assertIn(documented_call, self.overview)
+
+    def test_quick_start_and_engineering_boundaries_are_retained(self):
+        self.assertEqual(
+            self.overview.count(
+                "public final class ProcessSafetyOverviewQuickStart"
+            ),
+            1,
+        )
+        self.assertIn("new SafetyValve(\"PSV-100\", feed)", self.overview)
+        self.assertIn("new RuptureDisk(\"RD-100\", feed)", self.overview)
+        self.assertIn("new ESDLogic(\"ESD level 1\")", self.overview)
+        self.assertIn("stable `UUID`", self.overview)
+        self.assertIn("accountable review", self.overview)
+        self.assertIn("does not size a relief device", self.overview)
+
+    def test_stale_or_unsafe_fragments_do_not_return(self):
+        for stale_pattern in (
+            "System.out.println",
+            "System.err.println",
+            "new SafetyValve(\"PSV-100\", vessel)",
+            "new RuptureDisk(\"RD-100\", vessel)",
+            "setOpeningPressure(",
+            "setDownstreamPressure(",
+            "setOrificeSize(",
+            "setDiameter(",
+            "runTransient();",
+            "getReliefRate(",
+            "getRequiredOrificeArea(",
+            "getAPIOrificeLetter(",
+            "import neqsim.process.safety.HIPPS;",
+            "43200 * Math.pow",
+            "15 minute rule",
+            "ESD-0",
+        ):
+            with self.subTest(stale_pattern=stale_pattern):
+                self.assertNotIn(stale_pattern, self.overview)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test/java/neqsim/process/safety/ProcessSafetyOverviewDocumentationTest.java
+++ b/src/test/java/neqsim/process/safety/ProcessSafetyOverviewDocumentationTest.java
@@ -1,0 +1,108 @@
+package neqsim.process.safety;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.equipment.valve.BlowdownValve;
+import neqsim.process.equipment.valve.ESDValve;
+import neqsim.process.equipment.valve.RuptureDisk;
+import neqsim.process.equipment.valve.SafetyValve;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.logic.LogicState;
+import neqsim.process.logic.action.ActivateBlowdownAction;
+import neqsim.process.logic.action.TripValveAction;
+import neqsim.process.logic.esd.ESDLogic;
+import neqsim.process.logic.hipps.HIPPSLogic;
+import neqsim.process.logic.sis.VotingLogic;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+class ProcessSafetyOverviewDocumentationTest {
+  @Test
+  void documentedSafetyEquipmentUsesStreamInputsAndExplicitUnits() throws Exception {
+    Stream feed = createFeed();
+
+    SafetyValve safetyValve = new SafetyValve("PSV-100", feed);
+    safetyValve.setPressureSpec(75.0);
+    safetyValve.setFullOpenPressure(82.5);
+    safetyValve.setBlowdown(7.0);
+    safetyValve.setOutletPressure(1.5, "bara");
+
+    RuptureDisk ruptureDisk = new RuptureDisk("RD-100", feed);
+    ruptureDisk.setBurstPressure(85.0);
+    ruptureDisk.setFullOpenPressure(89.25);
+    ruptureDisk.setOutletPressure(1.5, "bara");
+
+    assertSame(feed, safetyValve.getInletStream());
+    assertSame(feed, ruptureDisk.getInletStream());
+    assertEquals(69.75, safetyValve.getBlowdownPressure(), 1.0e-9);
+    assertEquals(85.0, ruptureDisk.getBurstPressure(), 0.0);
+    assertSame(StreamInterface.class,
+        SafetyValve.class.getConstructor(String.class, StreamInterface.class).getParameterTypes()[1]);
+    assertSame(StreamInterface.class,
+        RuptureDisk.class.getConstructor(String.class, StreamInterface.class).getParameterTypes()[1]);
+  }
+
+  @Test
+  void documentedEsdSequenceClosesIsolationAndOpensBlowdown() {
+    Stream feed = createFeed();
+
+    ESDValve inletIsolation = new ESDValve("ESD-XV-100", feed);
+    inletIsolation.setStrokeTime(2.0);
+    inletIsolation.setCv(500.0);
+    inletIsolation.setOutletPressure(75.0, "bara");
+    inletIsolation.setCalculateSteadyState(false);
+    inletIsolation.energize();
+
+    BlowdownValve blowdownValve = new BlowdownValve("BDV-100", feed);
+    blowdownValve.setOpeningTime(2.0);
+    blowdownValve.setCv(100.0);
+    blowdownValve.setOutletPressure(1.5, "bara");
+    blowdownValve.setCalculateSteadyState(false);
+
+    ESDLogic esdLogic = new ESDLogic("ESD level 1");
+    esdLogic.addAction(new TripValveAction(inletIsolation), 0.0);
+    esdLogic.addAction(new ActivateBlowdownAction(blowdownValve), 0.0);
+    esdLogic.activate();
+
+    UUID calculationId = UUID.randomUUID();
+    double timeStepSeconds = 0.5;
+    for (int step = 0; step < 20 && !esdLogic.isComplete(); step++) {
+      esdLogic.execute(timeStepSeconds);
+      inletIsolation.runTransient(timeStepSeconds, calculationId);
+      blowdownValve.runTransient(timeStepSeconds, calculationId);
+    }
+
+    assertEquals(LogicState.COMPLETED, esdLogic.getState());
+    assertTrue(inletIsolation.hasTripCompleted());
+    assertTrue(inletIsolation.getPercentValveOpening() <= 1.0);
+    assertTrue(blowdownValve.isActivated());
+    assertTrue(blowdownValve.getPercentValveOpening() > 90.0);
+  }
+
+  @Test
+  void hippsDocumentationNamesTheCurrentLogicTypes() throws Exception {
+    assertSame(VotingLogic.class,
+        HIPPSLogic.class.getConstructor(String.class, VotingLogic.class).getParameterTypes()[1]);
+    assertSame(void.class,
+        HIPPSLogic.class.getMethod("setIsolationValve", ThrottlingValve.class).getReturnType());
+    assertSame(void.class,
+        HIPPSLogic.class.getMethod("update", double[].class).getReturnType());
+  }
+
+  private static Stream createFeed() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 80.0);
+    fluid.addComponent("methane", 0.95);
+    fluid.addComponent("ethane", 0.05);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("safety feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    feed.run();
+    return feed;
+  }
+}

--- a/src/test/java/neqsim/process/safety/ProcessSafetyOverviewDocumentationTest.java
+++ b/src/test/java/neqsim/process/safety/ProcessSafetyOverviewDocumentationTest.java
@@ -88,10 +88,8 @@ class ProcessSafetyOverviewDocumentationTest {
   void hippsDocumentationNamesTheCurrentLogicTypes() throws Exception {
     assertSame(VotingLogic.class,
         HIPPSLogic.class.getConstructor(String.class, VotingLogic.class).getParameterTypes()[1]);
-    assertSame(void.class,
-        HIPPSLogic.class.getMethod("setIsolationValve", ThrottlingValve.class).getReturnType());
-    assertSame(void.class,
-        HIPPSLogic.class.getMethod("update", double[].class).getReturnType());
+    assertSame(void.class, HIPPSLogic.class.getMethod("setIsolationValve", ThrottlingValve.class).getReturnType());
+    assertSame(void.class, HIPPSLogic.class.getMethod("update", double[].class).getReturnType());
   }
 
   private static Stream createFeed() {


### PR DESCRIPTION
## Summary

Repairs D077 of documentation campaign #2499: the process-safety overview now reflects the current stream-connected equipment, ESD/HIPPS logic, transient-execution, and relief-screening APIs.

### Frozen scope

- Base: `59f485417abb9cc34a3bd8c6779fc188b070ec25`
- Head: `d260c788ce528dc7ffec68b6550dec72688abc02`
- Files:
  - `docs/process/safety/README.md`
  - `docs/test_process_safety_overview_documentation.py`
  - `src/test/java/neqsim/process/safety/ProcessSafetyOverviewDocumentationTest.java`
- Stop boundary: no production API, DEXPI/P&ID, individual safety-guide rewrite, standards expansion, notebook, or Huldra work.

## Confirmed defects repaired

1. Removed the duplicate page H1 and retained Jekyll front matter as the title source.
2. Replaced vessel-based `SafetyValve` construction with its current `StreamInterface` constructor.
3. Replaced nonexistent safety-valve opening/unit APIs with `setPressureSpec`, `setFullOpenPressure`, `setBlowdown`, and inherited unit-aware outlet pressure.
4. Replaced vessel-based and nonexistent `RuptureDisk` calls with the current burst/full-open API.
5. Replaced nonexistent blowdown setters and zero-argument transient execution with current opening time, Cv, outlet-pressure, and `runTransient(double, UUID)` calls.
6. Added explicit stream initialization, stable calculation identity, transient state, and logger-based output.
7. Removed the undocumented hard-coded fire-input formula and nonexistent vessel heat-input call.
8. Removed nonexistent dynamic-valve sizing getters and separated relief sizing from valve dynamics.
9. Replaced nonexistent `neqsim.process.safety.HIPPS` with the current `HIPPSLogic`, `Detector`, and `VotingLogic` boundary.
10. Removed universal ESD-level and 15-minute claims; project criteria must trace to controlled sources.
11. Replaced ambiguous extensionless links with explicit source-safe Markdown targets.
12. Added source-anchored Python contracts and an executable Java regression for the documented sequence.

## Documentation impact

Documentation impact: updated. The user-facing safety overview, quick start, units/state ownership, execution contract, engineering limitations, and navigation were corrected in this PR. No public production API or numerical model changes are included.

## Validation

Exact head `d260c788ce528dc7ffec68b6550dec72688abc02`:

- Build/tests/Javadocs: passed
  - Java 8 Ubuntu and Windows fast suites
  - Java 21 Ubuntu and Windows fast suites
  - all four Java 21 slow-test shards
  - Javadocs and agent-skill cross-reference validation
- Spotless format patch: passed
- Pre-commit checks: passed
- Documentation search coverage, source audit, Jekyll build, and D077 Python contracts: passed
- CodeQL security analysis: passed
- Local `python -m py_compile docs/test_process_safety_overview_documentation.py`: passed
- Final connector audit: exactly three frozen files, four commits ahead and zero behind `master`; no comments, reviews, or unresolved threads.

Full local Maven, Spotless, pre-commit, and documentation-search checks were not run because this environment does not contain a NeqSim checkout; GitHub Actions supplied the exact-head validation above.

## Safety boundary

The guide presents NeqSim calculations as engineering evidence, not approval or certification. Project-specific scenarios, standards editions, independence, uncertainty, acceptance criteria, verification, and accountable review remain required.

Closes no issue; contributes to #2499.