### PR TITLE
[AI-Assisted] fix(thermo): isolate reactive state in system clones

### DIFF
--- a/src/main/java/neqsim/thermo/system/SystemInterface.java
+++ b/src/main/java/neqsim/thermo/system/SystemInterface.java
@@ -507,7 +507,12 @@ public interface SystemInterface extends Cloneable, java.io.Serializable {
   public void clearAll();
 
   /**
-   * clone.
+   * Creates an independently mutable copy of this thermodynamic system.
+   *
+   * <p>
+   * Phase, component, and initialized chemical-reaction state in the returned system are owned by the copy. Changing or
+   * solving a reactive clone must therefore not mutate the source system.
+   * </p>
    *
    * @return a {@link neqsim.thermo.system.SystemInterface} object
    */

--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -1497,8 +1497,6 @@ public abstract class SystemThermo implements SystemInterface {
     SystemThermo clonedSystem = null;
     try {
       clonedSystem = (SystemThermo) super.clone();
-      // clonedSystem.chemicalReactionOperations = (ChemicalReactionOperations)
-      // chemicalReactionOperations.clone();
     } catch (CloneNotSupportedException ex) {
       throw new AssertionError("Clone failed for SystemThermo", ex);
     }
@@ -1531,6 +1529,10 @@ public abstract class SystemThermo implements SystemInterface {
     clonedSystem.phaseArray = phaseArray.clone();
     for (int i = 0; i < getMaxNumberOfPhases(); i++) {
       clonedSystem.phaseArray[i] = phaseArray[i].clone();
+    }
+
+    if (chemicalReactionOperations != null) {
+      clonedSystem.chemicalReactionInit();
     }
 
     return clonedSystem;

--- a/src/test/java/neqsim/thermo/system/SystemThermoReactiveCloneTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemThermoReactiveCloneTest.java
@@ -1,0 +1,294 @@
+package neqsim.thermo.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Test;
+import neqsim.chemicalreactions.chemicalreaction.ChemicalReaction;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.phase.PhaseInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Regression tests for independent chemical-reaction state in thermodynamic-system clones. */
+class SystemThermoReactiveCloneTest extends neqsim.NeqSimTest {
+  private static final double BALANCE_TOLERANCE = 2.0e-8;
+  private static final double PHASE_FRACTION_TOLERANCE = 2.0e-10;
+  private static final double STATE_TOLERANCE = 2.0e-8;
+
+  @Test
+  void reactiveCloneOwnsChemicalReactionOperations() {
+    SystemInterface original = createReactiveBrine(298.15, 10.0, 0.01);
+    flash(original);
+
+    SystemInterface clone = original.clone();
+
+    assertTrue(original.isChemicalSystem());
+    assertNotNull(original.getChemicalReactionOperations());
+    assertNotNull(clone.getChemicalReactionOperations());
+    assertNotSame(original.getChemicalReactionOperations(), clone.getChemicalReactionOperations(),
+        "A reactive clone must not share mutable chemical-reaction operations with its source");
+  }
+
+  @Test
+  void changedReactiveCloneLeavesSourceUnchangedAndMatchesFreshCalculation() {
+    SystemInterface original = createReactiveBrine(298.15, 10.0, 0.01);
+    flash(original);
+    SystemState sourceBefore = SystemState.capture(original);
+
+    SystemInterface changedClone = original.clone();
+    changedClone.setTemperature(303.15);
+    changedClone.setPressure(14.0);
+    changedClone.addComponent("Na+", 0.002);
+    changedClone.addComponent("Cl-", 0.002);
+    changedClone.addComponent("water", -0.004);
+    flash(changedClone);
+
+    SystemInterface freshReference = createReactiveBrine(303.15, 14.0, 0.012);
+    flash(freshReference);
+
+    sourceBefore.assertMatches(original, 0.0);
+    assertSamePhaseState(freshReference, changedClone, STATE_TOLERANCE);
+    assertPhysicalAndChemicalGates(changedClone, expectedElements(0.012));
+
+    SystemState firstResult = SystemState.capture(changedClone);
+    flash(changedClone);
+    firstResult.assertMatches(changedClone, STATE_TOLERANCE);
+    sourceBefore.assertMatches(original, 0.0);
+  }
+
+  @Test
+  void reactiveClonesCanBeSolvedConcurrentlyAndSurviveSerialization() throws Exception {
+    SystemInterface original = createReactiveBrine(298.15, 10.0, 0.01);
+    flash(original);
+    SystemState sourceBefore = SystemState.capture(original);
+
+    final SystemInterface warmerClone = roundTrip(original.clone());
+    final SystemInterface coolerClone = original.clone();
+    assertNotSame(warmerClone.getChemicalReactionOperations(), coolerClone.getChemicalReactionOperations());
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<SystemInterface> warmer = executor.submit(() -> solveChanged(warmerClone, 306.15, 18.0, 0.002));
+      Future<SystemInterface> cooler = executor.submit(() -> solveChanged(coolerClone, 293.15, 7.0, -0.002));
+
+      SystemInterface warmResult = warmer.get();
+      SystemInterface coolResult = cooler.get();
+      SystemInterface warmReference = createReactiveBrine(306.15, 18.0, 0.012);
+      SystemInterface coolReference = createReactiveBrine(293.15, 7.0, 0.008);
+      flash(warmReference);
+      flash(coolReference);
+
+      assertSamePhaseState(warmReference, warmResult, STATE_TOLERANCE);
+      assertSamePhaseState(coolReference, coolResult, STATE_TOLERANCE);
+      assertPhysicalAndChemicalGates(warmResult, expectedElements(0.012));
+      assertPhysicalAndChemicalGates(coolResult, expectedElements(0.008));
+      sourceBefore.assertMatches(original, 0.0);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void neutralCloneDoesNotInitializeChemicalReactionState() {
+    SystemInterface neutral = new SystemSrkEos(298.15, 10.0);
+    neutral.addComponent("methane", 0.9);
+    neutral.addComponent("CO2", 0.1);
+
+    SystemInterface clone = neutral.clone();
+
+    assertNull(neutral.getChemicalReactionOperations());
+    assertNull(clone.getChemicalReactionOperations());
+    assertEquals(neutral.getTotalNumberOfMoles(), clone.getTotalNumberOfMoles(), 0.0);
+  }
+
+  private static SystemInterface solveChanged(SystemInterface fluid, double temperature, double pressure,
+      double sodiumChlorideDelta) {
+    fluid.setTemperature(temperature);
+    fluid.setPressure(pressure);
+    fluid.addComponent("Na+", sodiumChlorideDelta);
+    fluid.addComponent("Cl-", sodiumChlorideDelta);
+    fluid.addComponent("water", -2.0 * sodiumChlorideDelta);
+    flash(fluid);
+    return fluid;
+  }
+
+  private static void flash(SystemInterface fluid) {
+    new ThermodynamicOperations(fluid).TPflash();
+  }
+
+  private static void assertPhysicalAndChemicalGates(SystemInterface fluid, Map<String, Double> expectedElements) {
+    assertEquals(1.0, fluid.getTotalNumberOfMoles(), BALANCE_TOLERANCE,
+        "Reactive brine must retain its total molar inventory");
+    double betaSum = 0.0;
+    for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
+      PhaseInterface phaseState = fluid.getPhase(phase);
+      betaSum += fluid.getBeta(phase);
+      assertTrue(fluid.getBeta(phase) >= 0.0, "Phase fractions must be non-negative");
+      double moleFractionSum = 0.0;
+      for (int component = 0; component < phaseState.getNumberOfComponents(); component++) {
+        ComponentInterface componentState = phaseState.getComponent(component);
+        assertTrue(componentState.getNumberOfMolesInPhase() >= -1.0e-14,
+            "Phase component amounts must be non-negative");
+        assertTrue(componentState.getx() >= -1.0e-14, "Phase mole fractions must be non-negative");
+        moleFractionSum += componentState.getx();
+      }
+      assertEquals(1.0, moleFractionSum, 2.0e-10, "Each active phase must be normalized");
+    }
+    assertEquals(1.0, betaSum, PHASE_FRACTION_TOLERANCE, "Active phase fractions must be normalized");
+
+    Map<String, Double> actualElements = calculateElementInventory(fluid);
+    for (Map.Entry<String, Double> expected : expectedElements.entrySet()) {
+      assertEquals(expected.getValue(), actualElements.get(expected.getKey()), BALANCE_TOLERANCE,
+          "Element balance failed for " + expected.getKey());
+    }
+
+    int aqueousPhase = fluid.getPhaseNumberOfPhase("aqueous");
+    PhaseInterface aqueous = fluid.getPhase(aqueousPhase);
+    double charge = 0.0;
+    for (int component = 0; component < aqueous.getNumberOfComponents(); component++) {
+      ComponentInterface species = aqueous.getComponent(component);
+      charge += species.getNumberOfMolesInPhase() * species.getIonicCharge();
+    }
+    assertEquals(0.0, charge, BALANCE_TOLERANCE, "Aqueous phase must be electroneutral");
+
+    double maximumLogReactionResidual = 0.0;
+    for (ChemicalReaction reaction : fluid.getChemicalReactionOperations().getReactionList()
+        .getChemicalReactionList()) {
+      double reactionQuotient = reaction.calcK(fluid, aqueousPhase);
+      double equilibriumConstant = reaction.getK(aqueous);
+      maximumLogReactionResidual = Math.max(maximumLogReactionResidual,
+          Math.abs(Math.log(reactionQuotient / equilibriumConstant)));
+    }
+    assertTrue(maximumLogReactionResidual <= 2.0e-6, "Maximum absolute ln(Q/K) was " + maximumLogReactionResidual);
+  }
+
+  private static Map<String, Double> calculateElementInventory(SystemInterface fluid) {
+    Map<String, Double> inventory = new LinkedHashMap<String, Double>();
+    for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
+      PhaseInterface phaseState = fluid.getPhase(phase);
+      for (int component = 0; component < phaseState.getNumberOfComponents(); component++) {
+        ComponentInterface species = phaseState.getComponent(component);
+        String[] names = species.getElements().getElementNames();
+        double[] coefficients = species.getElements().getElementCoefs();
+        for (int element = 0; element < names.length; element++) {
+          Double current = inventory.get(names[element]);
+          inventory.put(names[element], (current == null ? 0.0 : current.doubleValue())
+              + species.getNumberOfMolesInPhase() * coefficients[element]);
+        }
+      }
+    }
+    return inventory;
+  }
+
+  private static Map<String, Double> expectedElements(double sodiumChlorideMoles) {
+    double waterMoles = 1.0 - 2.0 * sodiumChlorideMoles;
+    Map<String, Double> expected = new LinkedHashMap<String, Double>();
+    expected.put("H", 2.0 * waterMoles);
+    expected.put("O", waterMoles);
+    expected.put("Na", sodiumChlorideMoles);
+    expected.put("Cl", sodiumChlorideMoles);
+    return expected;
+  }
+
+  private static void assertSamePhaseState(SystemInterface expected, SystemInterface actual, double tolerance) {
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases());
+    for (int expectedPhase = 0; expectedPhase < expected.getNumberOfPhases(); expectedPhase++) {
+      String phaseType = expected.getPhase(expectedPhase).getPhaseTypeName();
+      int actualPhase = actual.getPhaseNumberOfPhase(phaseType);
+      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), tolerance,
+          "Phase fraction mismatch for " + phaseType);
+      PhaseInterface expectedState = expected.getPhase(expectedPhase);
+      PhaseInterface actualState = actual.getPhase(actualPhase);
+      for (int component = 0; component < expectedState.getNumberOfComponents(); component++) {
+        String componentName = expectedState.getComponent(component).getComponentName();
+        assertEquals(expectedState.getComponent(component).getNumberOfMolesInPhase(),
+            actualState.getComponent(componentName).getNumberOfMolesInPhase(), tolerance,
+            "Phase amount mismatch for " + phaseType + "/" + componentName);
+      }
+    }
+  }
+
+  private static SystemInterface createReactiveBrine(double temperature, double pressure, double sodiumChlorideMoles) {
+    SystemInterface fluid = new SystemElectrolyteCPAstatoil(temperature, pressure);
+    fluid.addComponent("water", 1.0 - 2.0 * sodiumChlorideMoles);
+    fluid.addComponent("Na+", sodiumChlorideMoles);
+    fluid.addComponent("Cl-", sodiumChlorideMoles);
+    fluid.chemicalReactionInit();
+    fluid.createDatabase(true);
+    fluid.setMixingRule(10);
+    fluid.setMultiPhaseCheck(true);
+    return fluid;
+  }
+
+  private static SystemInterface roundTrip(SystemInterface fluid) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(fluid);
+    }
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (SystemInterface) input.readObject();
+    }
+  }
+
+  private static final class SystemState {
+    private final double temperature;
+    private final double pressure;
+    private final double totalMoles;
+    private final int numberOfPhases;
+    private final Map<String, Double> componentMoles;
+    private final Map<String, Double> phaseComponentMoles;
+
+    private SystemState(SystemInterface fluid) {
+      temperature = fluid.getTemperature();
+      pressure = fluid.getPressure();
+      totalMoles = fluid.getTotalNumberOfMoles();
+      numberOfPhases = fluid.getNumberOfPhases();
+      componentMoles = new LinkedHashMap<String, Double>();
+      phaseComponentMoles = new LinkedHashMap<String, Double>();
+      for (int component = 0; component < fluid.getPhase(0).getNumberOfComponents(); component++) {
+        ComponentInterface species = fluid.getPhase(0).getComponent(component);
+        componentMoles.put(species.getComponentName(), species.getNumberOfmoles());
+      }
+      for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
+        PhaseInterface phaseState = fluid.getPhase(phase);
+        for (int component = 0; component < phaseState.getNumberOfComponents(); component++) {
+          ComponentInterface species = phaseState.getComponent(component);
+          phaseComponentMoles.put(phaseState.getPhaseTypeName() + "/" + species.getComponentName(),
+              species.getNumberOfMolesInPhase());
+        }
+      }
+    }
+
+    private static SystemState capture(SystemInterface fluid) {
+      return new SystemState(fluid);
+    }
+
+    private void assertMatches(SystemInterface actual, double tolerance) {
+      assertEquals(temperature, actual.getTemperature(), tolerance);
+      assertEquals(pressure, actual.getPressure(), tolerance);
+      assertEquals(totalMoles, actual.getTotalNumberOfMoles(), tolerance);
+      assertEquals(numberOfPhases, actual.getNumberOfPhases());
+      for (Map.Entry<String, Double> component : componentMoles.entrySet()) {
+        assertEquals(component.getValue(), actual.getPhase(0).getComponent(component.getKey()).getNumberOfmoles(),
+            tolerance, "Overall amount changed for " + component.getKey());
+      }
+      for (Map.Entry<String, Double> component : phaseComponentMoles.entrySet()) {
+        String[] key = component.getKey().split("/", 2);
+        PhaseInterface phase = actual.getPhase(actual.getPhaseNumberOfPhase(key[0]));
+        assertEquals(component.getValue(), phase.getComponent(key[1]).getNumberOfMolesInPhase(), tolerance,
+            "Phase amount changed for " + component.getKey());
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Make reactive thermodynamic-system clones own chemical-reaction state bound to their cloned phases and components.

`SystemThermo.clone()` already deep-cloned phases, but `super.clone()` left `ChemicalReactionOperations` shared with the source. Its system, reactive components, reaction list, matrices, LP/Newton state, and kinetics helpers could therefore point back to the original system. The fix rebuilds reaction operations only when the source initialized chemistry; neutral systems retain the existing null fast path.

Contributes to #3144.

## Frozen scope

- Base: `59f485417abb9cc34a3bd8c6779fc188b070ec25`
- Model: `SystemElectrolyteCPAstatoil`, mixing rule 10
- Qualified case: 298.15 K, 10 bara, 0.98 mol water + 0.01 mol Na+ + 0.01 mol Cl-, with the database-selected water-dissociation reaction set
- Changed clone states: 293.15–306.15 K, 7–18 bara, 0.008–0.012 mol NaCl on a one-mole input basis
- Stop boundary: no TP-flash equation, electrolyte parameter, reaction constant, hydrate algorithm, absorber equipment, salt-input API, or unrelated clone change
- Documentation impact: public `SystemInterface.clone()` Javadoc now promises independently mutable phase/component/reaction state

## Current-master reproducer

On unmodified master, the focused identity assertion fails because source and clone return the same mutable `ChemicalReactionOperations` instance. `CalcSaltSatauration.createTrialSystem()` already contains a local post-clone `chemicalReactionInit()` workaround, confirming the required ownership rebinding.

The two production source blobs remained byte-identical while master advanced from the locally validated `2a1f41b792a76f910b8a172b142f59e49a622cb8` to this PR base; exact-head CI remains required.

## Scientific and software gates

The new regression covers:

- distinct source/clone and clone/clone reaction-operation identities
- changed T/P/NaCl calculations versus independently constructed fresh references
- unchanged source T/P, total/species/phase inventories, topology, and reaction state
- H/O/Na/Cl elemental closure, total phase-state normalization, non-negative state, and aqueous electroneutrality
- maximum absolute `ln(Q/K)`
- deterministic repeat and changed-state execution
- serialization followed by reactive calculation
- two clones calculated concurrently at different states
- neutral SRK clone behavior without reaction initialization

Representative 303.15 K, 14 bara evidence:

- maximum elemental deviation: `4.1e-10 mol`
- aqueous charge residual: `6.6e-21 mol-equivalent`
- phase-fraction sum error: `1.9e-14`
- maximum absolute `ln(Q/K)`: `1.9e-14`
- clone result matched the fresh calculation within `2e-8 mol` and the source remained exactly unchanged

No parameter was fitted and no experimental dataset was adopted. The validation evidence is conservation/equilibrium software evidence, separate from calibration.

## Validation run

Passed locally on the support checkout whose two changed production inputs are byte-identical to this base:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- `git diff --check`
- focused clone regression: 4/4 passed
- selected reaction/electrolyte/serialization/neutral suites: 39 tests, 0 failures/errors, 1 existing skip
- explicit slow hydrate suite: 4/4 passed
- explicit slow mineral-scale suite: 6/6 passed

The `pre-commit` Python package was unavailable; its three current local hook commands (Spotless apply/check and documentation search) were run directly. This is not a claim that the wrapper itself ran.

### Neutral performance control

Seven alternating exact-master/head JVM pairs measured both the neutral `SystemSrkEos.clone()` kernel and complete clone-plus-TP-flash calculations. Median paired head/master ratios were:

- neutral clone: `0.923`
- neutral clone plus TP flash: `0.916`

Fork-to-fork ranges were wide and changed sign, so this is classified only as no detectable slowdown, not as a speedup. Checksums and phase counts were unchanged.

## Reference and license

- Java clone contract: [Oracle `Object.clone()` documentation](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/lang/Object.html#clone())
- Repository/source-data license: [Apache License 2.0](https://github.com/equinor/neqsim/blob/master/LICENSE)

## Explicit limitation / next dependency

A broader CO₂/brine attempt was not accepted: an ordinary 303.15 K/14 bara reactive TP flash showed pre-existing elemental-inventory distortion, and a reactive hydrate clone/fresh pair at 120 bara reached max `|ln(Q/K)| = 0.1011`. Clone and fresh states agreed, but the scientific gate did not pass. This PR does not modify those flash/reaction equations or claim CO₂ closure. That blocker belongs in the #3144 ledger and must be coordinated with generic TP-flash work in #2937.

**VALIDATION PENDING CI**