### PR TITLE
[AI-Assisted] feat(diagrams): add exchange-neutral graphical projection

### DIFF
--- a/docs/integration/dexpi-engineering-generation.md
+++ b/docs/integration/dexpi-engineering-generation.md
@@ -717,8 +717,7 @@ must define the required cases, documents, checks, approvals and authoring-tool 
 Company or project rules can implement `EngineeringRule` and be registered with `addRule(...)`. Keep
 operator-specific alarm philosophy, trip thresholds, voting, proprietary design requirements, and
 internal document references in a private rule package; the public NORSOK profile remains
-plant-agnostic.
-## Exchange-neutral graphical projection contract
+plant-agnostic.\n\n## Exchange-neutral graphical projection contract
 
 `EngineeringGraphicalProjection` is the controlled, exchange-neutral source for future DEXPI Core
 diagram primitives. It preserves stable semantic and external keys, millimetre geometry, parallel

--- a/docs/integration/dexpi-engineering-generation.md
+++ b/docs/integration/dexpi-engineering-generation.md
@@ -718,3 +718,17 @@ Company or project rules can implement `EngineeringRule` and be registered with 
 operator-specific alarm philosophy, trip thresholds, voting, proprietary design requirements, and
 internal document references in a private rule package; the public NORSOK profile remains
 plant-agnostic.
+## Exchange-neutral graphical projection contract
+
+`EngineeringGraphicalProjection` is the controlled, exchange-neutral source for future DEXPI Core
+diagram primitives. It preserves stable semantic and external keys, millimetre geometry, parallel
+routes, source/revision evidence, verification status, and structured fallback diagnostics without
+binding NeqSim to a licensed or project-specific symbol catalogue.
+
+This tranche defines and regression-tests the projection contract only. The native DEXPI 2.0 Plant
+writer continues to emit its existing semantic exchange bytes unless an existing export option is
+explicitly selected; it does not yet serialize the projection as Core `Diagram`/
+`RepresentationGroup` elements. That adapter must map every represented-object identity to a real
+DEXPI object, emit non-empty supported primitives, and report every dropped shape, route, or
+reference. Until that adapter and external DEXPIViewer evidence exist, the projection is not a
+clean-validation, profile-conformance, or drawing-approval claim.

--- a/docs/integration/dexpi-engineering-generation.md
+++ b/docs/integration/dexpi-engineering-generation.md
@@ -717,7 +717,9 @@ must define the required cases, documents, checks, approvals and authoring-tool 
 Company or project rules can implement `EngineeringRule` and be registered with `addRule(...)`. Keep
 operator-specific alarm philosophy, trip thresholds, voting, proprietary design requirements, and
 internal document references in a private rule package; the public NORSOK profile remains
-plant-agnostic.\n\n## Exchange-neutral graphical projection contract
+plant-agnostic.
+
+## Exchange-neutral graphical projection contract
 
 `EngineeringGraphicalProjection` is the controlled, exchange-neutral source for future DEXPI Core
 diagram primitives. It preserves stable semantic and external keys, millimetre geometry, parallel

--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -621,7 +621,7 @@ from both semantic engineering state and renderer-specific SVG, PDF, or DEXPI ob
 - stable primitive and represented-object identities;
 - explicit millimetre coordinates, dimensions, colours, line styles, and text anchors;
 - source graph fingerprint, controlled source reference, revision, and verification status;
-- separate primitives for parallel semantic connections; and
+- separate primitives with deterministic 3 mm interior lane offsets for parallel semantic connections; and
 - deterministic structured diagnostics for generic symbol fallback or missing semantic objects.
 
 The generic `RECTANGLE`, `POLYGON`, `POLYLINE`, and `TEXT` primitives are an adapter contract, not

--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -610,7 +610,9 @@ The native-renderer regression verifies byte-deterministic SVG/PDF, A3 and A1 ge
 coordinates and protected routes, reciprocal off-page references, deterministic connection labels,
 route/object and route-label obstacle diagnostics, collision, clipping, label-overflow and
 broken-reference diagnostics, normalized visual fingerprints, multi-page drawing sets, fresh-model
-determinism, and unchanged Classic DOT and controlled-document JSON.\n\n## Exchange-neutral graphical projection
+determinism, and unchanged Classic DOT and controlled-document JSON.
+
+## Exchange-neutral graphical projection
 
 `EngineeringGraphicalProjectionBuilder` converts the canonical `EngineeringGraph` into an
 immutable, restartable `EngineeringGraphicalProjection`. The projection is deliberately separate

--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -611,4 +611,26 @@ coordinates and protected routes, reciprocal off-page references, deterministic 
 route/object and route-label obstacle diagnostics, collision, clipping, label-overflow and
 broken-reference diagnostics, normalized visual fingerprints, multi-page drawing sets, fresh-model
 determinism, and unchanged Classic DOT and controlled-document JSON.
+## Exchange-neutral graphical projection
 
+`EngineeringGraphicalProjectionBuilder` converts the canonical `EngineeringGraph` into an
+immutable, restartable `EngineeringGraphicalProjection`. The projection is deliberately separate
+from both semantic engineering state and renderer-specific SVG, PDF, or DEXPI objects. It carries:
+
+- stable primitive and represented-object identities;
+- explicit millimetre coordinates, dimensions, colours, line styles, and text anchors;
+- source graph fingerprint, controlled source reference, revision, and verification status;
+- separate primitives for parallel semantic connections; and
+- deterministic structured diagnostics for generic symbol fallback or missing semantic objects.
+
+The generic `RECTANGLE`, `POLYGON`, `POLYLINE`, and `TEXT` primitives are an adapter contract, not
+a symbol standard. A `REVIEWED` projection records reviewed input evidence only; it does not approve
+a drawing for design or construction. Missing project conventions use an explicit generic rectangle
+and emit `GRAPHICAL_PROJECTION_GENERIC_SYMBOL_FALLBACK`. No ISO 10628, ISO 14617, ISA, DEXPI profile,
+or company-symbol conformance is inferred.
+
+The projection is deterministic JSON (`neqsim_engineering_graphical_projection.v1`) and can be
+restored with `EngineeringGraphicalProjection.fromJson(...)`. Native SVG/PDF and DEXPI Core adapters
+should consume this same projection. Each adapter must preserve supported stable identities and
+report unsupported primitive, symbol, or semantic-reference mappings as structured losses. DEXPI
+`RepresentationGroup` objects must not be emitted as empty placeholders.

--- a/docs/integration/engineering-diagram-document-model.md
+++ b/docs/integration/engineering-diagram-document-model.md
@@ -610,8 +610,7 @@ The native-renderer regression verifies byte-deterministic SVG/PDF, A3 and A1 ge
 coordinates and protected routes, reciprocal off-page references, deterministic connection labels,
 route/object and route-label obstacle diagnostics, collision, clipping, label-overflow and
 broken-reference diagnostics, normalized visual fingerprints, multi-page drawing sets, fresh-model
-determinism, and unchanged Classic DOT and controlled-document JSON.
-## Exchange-neutral graphical projection
+determinism, and unchanged Classic DOT and controlled-document JSON.\n\n## Exchange-neutral graphical projection
 
 `EngineeringGraphicalProjectionBuilder` converts the canonical `EngineeringGraph` into an
 immutable, restartable `EngineeringGraphicalProjection`. The projection is deliberately separate

--- a/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjection.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjection.java
@@ -18,10 +18,9 @@ import com.google.gson.JsonParser;
  * Immutable exchange-neutral graphical projection of the canonical engineering graph.
  *
  * <p>
- * Coordinates and dimensions use millimetres. Primitives retain stable semantic identities, but
- * deliberately carry no DEXPI profile symbol, ISO symbol, or accountable drawing-approval claim.
- * Format adapters may render these generic primitives natively or translate the supported subset
- * into an exchange format while reporting every loss.
+ * Coordinates and dimensions use millimetres. Primitives retain stable semantic identities, but deliberately carry no
+ * DEXPI profile symbol, ISO symbol, or accountable drawing-approval claim. Format adapters may render these generic
+ * primitives natively or translate the supported subset into an exchange format while reporting every loss.
  * </p>
  */
 public final class EngineeringGraphicalProjection implements Serializable {
@@ -100,18 +99,17 @@ public final class EngineeringGraphicalProjection implements Serializable {
     private final String textAnchor;
     private final boolean protectedGeometry;
 
-    private Primitive(String id, PrimitiveType type, String representedObjectId,
-        String representedExternalKey, List<Point> points, double x, double y, double width,
-        double height, double size, String text, String strokeColor, String fillColor,
-        double strokeWidth, String dashPattern, String textAnchor, boolean protectedGeometry) {
+    private Primitive(String id, PrimitiveType type, String representedObjectId, String representedExternalKey,
+        List<Point> points, double x, double y, double width, double height, double size, String text,
+        String strokeColor, String fillColor, double strokeWidth, String dashPattern, String textAnchor,
+        boolean protectedGeometry) {
       this.id = requireText(id, "id");
       if (type == null) {
         throw new IllegalArgumentException("type must not be null");
       }
       this.type = type;
       this.representedObjectId = requireText(representedObjectId, "representedObjectId");
-      this.representedExternalKey =
-          requireText(representedExternalKey, "representedExternalKey");
+      this.representedExternalKey = requireText(representedExternalKey, "representedExternalKey");
       this.points = immutablePoints(points);
       this.x = finite(x, "x");
       this.y = finite(y, "y");
@@ -128,36 +126,30 @@ public final class EngineeringGraphicalProjection implements Serializable {
       validateGeometry();
     }
 
-    public static Primitive rectangle(String id, String representedObjectId,
-        String representedExternalKey, double x, double y, double width, double height,
-        String strokeColor, String fillColor, double strokeWidth) {
-      return new Primitive(id, PrimitiveType.RECTANGLE, representedObjectId,
-          representedExternalKey, Collections.<Point>emptyList(), x, y, width, height, 0.0, "",
-          strokeColor, fillColor, strokeWidth, "", "", false);
+    public static Primitive rectangle(String id, String representedObjectId, String representedExternalKey, double x,
+        double y, double width, double height, String strokeColor, String fillColor, double strokeWidth) {
+      return new Primitive(id, PrimitiveType.RECTANGLE, representedObjectId, representedExternalKey,
+          Collections.<Point>emptyList(), x, y, width, height, 0.0, "", strokeColor, fillColor, strokeWidth, "", "",
+          false);
     }
 
-    public static Primitive polyline(String id, String representedObjectId,
-        String representedExternalKey, List<Point> points, String strokeColor, double strokeWidth,
-        String dashPattern, boolean protectedGeometry) {
-      return new Primitive(id, PrimitiveType.POLYLINE, representedObjectId,
-          representedExternalKey, points, 0.0, 0.0, 0.0, 0.0, 0.0, "", strokeColor, "none",
-          strokeWidth, dashPattern, "", protectedGeometry);
+    public static Primitive polyline(String id, String representedObjectId, String representedExternalKey,
+        List<Point> points, String strokeColor, double strokeWidth, String dashPattern, boolean protectedGeometry) {
+      return new Primitive(id, PrimitiveType.POLYLINE, representedObjectId, representedExternalKey, points, 0.0, 0.0,
+          0.0, 0.0, 0.0, "", strokeColor, "none", strokeWidth, dashPattern, "", protectedGeometry);
     }
 
-    public static Primitive polygon(String id, String representedObjectId,
-        String representedExternalKey, List<Point> points, String strokeColor, String fillColor,
-        double strokeWidth) {
-      return new Primitive(id, PrimitiveType.POLYGON, representedObjectId,
-          representedExternalKey, points, 0.0, 0.0, 0.0, 0.0, 0.0, "", strokeColor, fillColor,
-          strokeWidth, "", "", false);
+    public static Primitive polygon(String id, String representedObjectId, String representedExternalKey,
+        List<Point> points, String strokeColor, String fillColor, double strokeWidth) {
+      return new Primitive(id, PrimitiveType.POLYGON, representedObjectId, representedExternalKey, points, 0.0, 0.0,
+          0.0, 0.0, 0.0, "", strokeColor, fillColor, strokeWidth, "", "", false);
     }
 
-    public static Primitive text(String id, String representedObjectId,
-        String representedExternalKey, double x, double y, double size, String text,
-        String fillColor, String textAnchor) {
+    public static Primitive text(String id, String representedObjectId, String representedExternalKey, double x,
+        double y, double size, String text, String fillColor, String textAnchor) {
       return new Primitive(id, PrimitiveType.TEXT, representedObjectId, representedExternalKey,
-          Collections.<Point>emptyList(), x, y, 0.0, 0.0, size, requireText(text, "text"), "none",
-          fillColor, 0.0, "", textAnchor, false);
+          Collections.<Point>emptyList(), x, y, 0.0, 0.0, size, requireText(text, "text"), "none", fillColor, 0.0, "",
+          textAnchor, false);
     }
 
     public String getId() {
@@ -326,9 +318,9 @@ public final class EngineeringGraphicalProjection implements Serializable {
   private final List<Primitive> primitives;
   private final List<Diagnostic> diagnostics;
 
-  public EngineeringGraphicalProjection(String projectId, String revision,
-      String sourceGraphFingerprint, String sourceReference, VerificationStatus verificationStatus,
-      List<Primitive> primitives, List<Diagnostic> diagnostics) {
+  public EngineeringGraphicalProjection(String projectId, String revision, String sourceGraphFingerprint,
+      String sourceReference, VerificationStatus verificationStatus, List<Primitive> primitives,
+      List<Diagnostic> diagnostics) {
     this.projectId = requireText(projectId, "projectId");
     this.revision = requireText(revision, "revision");
     this.sourceGraphFingerprint = requireText(sourceGraphFingerprint, "sourceGraphFingerprint");
@@ -432,14 +424,11 @@ public final class EngineeringGraphicalProjection implements Serializable {
     for (JsonElement element : root.getAsJsonArray("diagnostics")) {
       JsonObject item = element.getAsJsonObject();
       diagnostics.add(new Diagnostic(Severity.valueOf(item.get("severity").getAsString()),
-          item.get("code").getAsString(), item.get("message").getAsString(),
-          item.get("subjectId").getAsString()));
+          item.get("code").getAsString(), item.get("message").getAsString(), item.get("subjectId").getAsString()));
     }
-    return new EngineeringGraphicalProjection(root.get("projectId").getAsString(),
-        root.get("revision").getAsString(), root.get("sourceGraphFingerprint").getAsString(),
-        root.get("sourceReference").getAsString(),
-        VerificationStatus.valueOf(root.get("verificationStatus").getAsString()), primitives,
-        diagnostics);
+    return new EngineeringGraphicalProjection(root.get("projectId").getAsString(), root.get("revision").getAsString(),
+        root.get("sourceGraphFingerprint").getAsString(), root.get("sourceReference").getAsString(),
+        VerificationStatus.valueOf(root.get("verificationStatus").getAsString()), primitives, diagnostics);
   }
 
   private static Primitive primitiveFromJson(JsonObject item) {
@@ -453,13 +442,12 @@ public final class EngineeringGraphicalProjection implements Serializable {
       JsonObject point = element.getAsJsonObject();
       points.add(new Point(point.get("x").getAsDouble(), point.get("y").getAsDouble()));
     }
-    return new Primitive(id, type, representedObjectId, representedExternalKey, points,
-        item.get("x").getAsDouble(), item.get("y").getAsDouble(),
-        item.get("width").getAsDouble(), item.get("height").getAsDouble(),
-        item.get("size").getAsDouble(), item.get("text").getAsString(),
-        item.get("strokeColor").getAsString(), item.get("fillColor").getAsString(),
-        item.get("strokeWidth").getAsDouble(), item.get("dashPattern").getAsString(),
-        item.get("textAnchor").getAsString(), item.get("protectedGeometry").getAsBoolean());
+    return new Primitive(id, type, representedObjectId, representedExternalKey, points, item.get("x").getAsDouble(),
+        item.get("y").getAsDouble(), item.get("width").getAsDouble(), item.get("height").getAsDouble(),
+        item.get("size").getAsDouble(), item.get("text").getAsString(), item.get("strokeColor").getAsString(),
+        item.get("fillColor").getAsString(), item.get("strokeWidth").getAsDouble(),
+        item.get("dashPattern").getAsString(), item.get("textAnchor").getAsString(),
+        item.get("protectedGeometry").getAsBoolean());
   }
 
   private static List<Primitive> immutablePrimitives(List<Primitive> values) {

--- a/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjection.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjection.java
@@ -416,8 +416,7 @@ public final class EngineeringGraphicalProjection implements Serializable {
     if (!Unit.MILLIMETRE.name().equals(root.get("unit").getAsString())) {
       throw new IllegalArgumentException("Unsupported graphical projection unit");
     }
-    if (!root.has("engineeringApprovalRequired")
-        || !root.get("engineeringApprovalRequired").isJsonPrimitive()
+    if (!root.has("engineeringApprovalRequired") || !root.get("engineeringApprovalRequired").isJsonPrimitive()
         || !root.getAsJsonPrimitive("engineeringApprovalRequired").isBoolean()
         || !root.get("engineeringApprovalRequired").getAsBoolean()) {
       throw new IllegalArgumentException("engineeringApprovalRequired must be true");

--- a/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjection.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjection.java
@@ -416,6 +416,12 @@ public final class EngineeringGraphicalProjection implements Serializable {
     if (!Unit.MILLIMETRE.name().equals(root.get("unit").getAsString())) {
       throw new IllegalArgumentException("Unsupported graphical projection unit");
     }
+    if (!root.has("engineeringApprovalRequired")
+        || !root.get("engineeringApprovalRequired").isJsonPrimitive()
+        || !root.getAsJsonPrimitive("engineeringApprovalRequired").isBoolean()
+        || !root.get("engineeringApprovalRequired").getAsBoolean()) {
+      throw new IllegalArgumentException("engineeringApprovalRequired must be true");
+    }
     List<Primitive> primitives = new ArrayList<Primitive>();
     for (JsonElement element : root.getAsJsonArray("primitives")) {
       primitives.add(primitiveFromJson(element.getAsJsonObject()));

--- a/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjection.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjection.java
@@ -1,0 +1,549 @@
+package neqsim.process.engineering.model;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Immutable exchange-neutral graphical projection of the canonical engineering graph.
+ *
+ * <p>
+ * Coordinates and dimensions use millimetres. Primitives retain stable semantic identities, but
+ * deliberately carry no DEXPI profile symbol, ISO symbol, or accountable drawing-approval claim.
+ * Format adapters may render these generic primitives natively or translate the supported subset
+ * into an exchange format while reporting every loss.
+ * </p>
+ */
+public final class EngineeringGraphicalProjection implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  public static final String SCHEMA_VERSION = "neqsim_engineering_graphical_projection.v1";
+
+  /** Coordinate and dimension unit used by every primitive. */
+  public enum Unit {
+    /** Millimetres in drawing space. */
+    MILLIMETRE
+  }
+
+  /** Verification state of the graphical projection. */
+  public enum VerificationStatus {
+    /** Simulation-derived engineering proposal requiring accountable review. */
+    PROPOSAL,
+    /** Projection inputs have review evidence; drawing approval is still separate. */
+    REVIEWED
+  }
+
+  /** Generic graphical primitive types. */
+  public enum PrimitiveType {
+    RECTANGLE, POLYLINE, POLYGON, TEXT
+  }
+
+  /** Projection diagnostic severity. */
+  public enum Severity {
+    INFO, WARNING, ERROR
+  }
+
+  /** Immutable two-dimensional drawing point in millimetres. */
+  public static final class Point implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final double x;
+    private final double y;
+
+    public Point(double x, double y) {
+      this.x = finite(x, "x");
+      this.y = finite(y, "y");
+    }
+
+    public double getX() {
+      return x;
+    }
+
+    public double getY() {
+      return y;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("x", Double.valueOf(x));
+      result.put("y", Double.valueOf(y));
+      return result;
+    }
+  }
+
+  /** Immutable generic primitive with stable projection and semantic identities. */
+  public static final class Primitive implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String id;
+    private final PrimitiveType type;
+    private final String representedObjectId;
+    private final String representedExternalKey;
+    private final List<Point> points;
+    private final double x;
+    private final double y;
+    private final double width;
+    private final double height;
+    private final double size;
+    private final String text;
+    private final String strokeColor;
+    private final String fillColor;
+    private final double strokeWidth;
+    private final String dashPattern;
+    private final String textAnchor;
+    private final boolean protectedGeometry;
+
+    private Primitive(String id, PrimitiveType type, String representedObjectId,
+        String representedExternalKey, List<Point> points, double x, double y, double width,
+        double height, double size, String text, String strokeColor, String fillColor,
+        double strokeWidth, String dashPattern, String textAnchor, boolean protectedGeometry) {
+      this.id = requireText(id, "id");
+      if (type == null) {
+        throw new IllegalArgumentException("type must not be null");
+      }
+      this.type = type;
+      this.representedObjectId = requireText(representedObjectId, "representedObjectId");
+      this.representedExternalKey =
+          requireText(representedExternalKey, "representedExternalKey");
+      this.points = immutablePoints(points);
+      this.x = finite(x, "x");
+      this.y = finite(y, "y");
+      this.width = finite(width, "width");
+      this.height = finite(height, "height");
+      this.size = finite(size, "size");
+      this.text = optionalText(text);
+      this.strokeColor = color(strokeColor, "strokeColor");
+      this.fillColor = color(fillColor, "fillColor");
+      this.strokeWidth = finite(strokeWidth, "strokeWidth");
+      this.dashPattern = optionalText(dashPattern);
+      this.textAnchor = optionalText(textAnchor);
+      this.protectedGeometry = protectedGeometry;
+      validateGeometry();
+    }
+
+    public static Primitive rectangle(String id, String representedObjectId,
+        String representedExternalKey, double x, double y, double width, double height,
+        String strokeColor, String fillColor, double strokeWidth) {
+      return new Primitive(id, PrimitiveType.RECTANGLE, representedObjectId,
+          representedExternalKey, Collections.<Point>emptyList(), x, y, width, height, 0.0, "",
+          strokeColor, fillColor, strokeWidth, "", "", false);
+    }
+
+    public static Primitive polyline(String id, String representedObjectId,
+        String representedExternalKey, List<Point> points, String strokeColor, double strokeWidth,
+        String dashPattern, boolean protectedGeometry) {
+      return new Primitive(id, PrimitiveType.POLYLINE, representedObjectId,
+          representedExternalKey, points, 0.0, 0.0, 0.0, 0.0, 0.0, "", strokeColor, "none",
+          strokeWidth, dashPattern, "", protectedGeometry);
+    }
+
+    public static Primitive polygon(String id, String representedObjectId,
+        String representedExternalKey, List<Point> points, String strokeColor, String fillColor,
+        double strokeWidth) {
+      return new Primitive(id, PrimitiveType.POLYGON, representedObjectId,
+          representedExternalKey, points, 0.0, 0.0, 0.0, 0.0, 0.0, "", strokeColor, fillColor,
+          strokeWidth, "", "", false);
+    }
+
+    public static Primitive text(String id, String representedObjectId,
+        String representedExternalKey, double x, double y, double size, String text,
+        String fillColor, String textAnchor) {
+      return new Primitive(id, PrimitiveType.TEXT, representedObjectId, representedExternalKey,
+          Collections.<Point>emptyList(), x, y, 0.0, 0.0, size, requireText(text, "text"), "none",
+          fillColor, 0.0, "", textAnchor, false);
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public PrimitiveType getType() {
+      return type;
+    }
+
+    public String getRepresentedObjectId() {
+      return representedObjectId;
+    }
+
+    public String getRepresentedExternalKey() {
+      return representedExternalKey;
+    }
+
+    public List<Point> getPoints() {
+      return Collections.unmodifiableList(new ArrayList<Point>(points));
+    }
+
+    public double getX() {
+      return x;
+    }
+
+    public double getY() {
+      return y;
+    }
+
+    public double getWidth() {
+      return width;
+    }
+
+    public double getHeight() {
+      return height;
+    }
+
+    public double getSize() {
+      return size;
+    }
+
+    public String getText() {
+      return text;
+    }
+
+    public String getStrokeColor() {
+      return strokeColor;
+    }
+
+    public String getFillColor() {
+      return fillColor;
+    }
+
+    public double getStrokeWidth() {
+      return strokeWidth;
+    }
+
+    public String getDashPattern() {
+      return dashPattern;
+    }
+
+    public String getTextAnchor() {
+      return textAnchor;
+    }
+
+    public boolean isProtectedGeometry() {
+      return protectedGeometry;
+    }
+
+    private void validateGeometry() {
+      if (strokeWidth < 0.0) {
+        throw new IllegalArgumentException("strokeWidth must not be negative");
+      }
+      if (type == PrimitiveType.RECTANGLE && (width <= 0.0 || height <= 0.0)) {
+        throw new IllegalArgumentException("rectangle width and height must be positive");
+      }
+      if (type == PrimitiveType.POLYLINE && points.size() < 2) {
+        throw new IllegalArgumentException("polyline requires at least two points");
+      }
+      if (type == PrimitiveType.POLYGON && points.size() < 3) {
+        throw new IllegalArgumentException("polygon requires at least three points");
+      }
+      if (type == PrimitiveType.TEXT && (size <= 0.0 || text.isEmpty())) {
+        throw new IllegalArgumentException("text size and content must be present");
+      }
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("id", id);
+      result.put("type", type.name());
+      result.put("representedObjectId", representedObjectId);
+      result.put("representedExternalKey", representedExternalKey);
+      List<Map<String, Object>> pointMaps = new ArrayList<Map<String, Object>>();
+      for (Point point : points) {
+        pointMaps.add(point.toMap());
+      }
+      result.put("points", pointMaps);
+      result.put("x", Double.valueOf(x));
+      result.put("y", Double.valueOf(y));
+      result.put("width", Double.valueOf(width));
+      result.put("height", Double.valueOf(height));
+      result.put("size", Double.valueOf(size));
+      result.put("text", text);
+      result.put("strokeColor", strokeColor);
+      result.put("fillColor", fillColor);
+      result.put("strokeWidth", Double.valueOf(strokeWidth));
+      result.put("dashPattern", dashPattern);
+      result.put("textAnchor", textAnchor);
+      result.put("protectedGeometry", Boolean.valueOf(protectedGeometry));
+      return result;
+    }
+  }
+
+  /** Immutable diagnostic describing fallback, loss, or invalid projection input. */
+  public static final class Diagnostic implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Severity severity;
+    private final String code;
+    private final String message;
+    private final String subjectId;
+
+    public Diagnostic(Severity severity, String code, String message, String subjectId) {
+      if (severity == null) {
+        throw new IllegalArgumentException("severity must not be null");
+      }
+      this.severity = severity;
+      this.code = requireText(code, "code");
+      this.message = requireText(message, "message");
+      this.subjectId = requireText(subjectId, "subjectId");
+    }
+
+    public Severity getSeverity() {
+      return severity;
+    }
+
+    public String getCode() {
+      return code;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public String getSubjectId() {
+      return subjectId;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("severity", severity.name());
+      result.put("code", code);
+      result.put("message", message);
+      result.put("subjectId", subjectId);
+      return result;
+    }
+  }
+
+  private final String projectId;
+  private final String revision;
+  private final String sourceGraphFingerprint;
+  private final String sourceReference;
+  private final Unit unit = Unit.MILLIMETRE;
+  private final VerificationStatus verificationStatus;
+  private final List<Primitive> primitives;
+  private final List<Diagnostic> diagnostics;
+
+  public EngineeringGraphicalProjection(String projectId, String revision,
+      String sourceGraphFingerprint, String sourceReference, VerificationStatus verificationStatus,
+      List<Primitive> primitives, List<Diagnostic> diagnostics) {
+    this.projectId = requireText(projectId, "projectId");
+    this.revision = requireText(revision, "revision");
+    this.sourceGraphFingerprint = requireText(sourceGraphFingerprint, "sourceGraphFingerprint");
+    this.sourceReference = requireText(sourceReference, "sourceReference");
+    if (verificationStatus == null) {
+      throw new IllegalArgumentException("verificationStatus must not be null");
+    }
+    this.verificationStatus = verificationStatus;
+    this.primitives = immutablePrimitives(primitives);
+    this.diagnostics = immutableDiagnostics(diagnostics);
+  }
+
+  public String getProjectId() {
+    return projectId;
+  }
+
+  public String getRevision() {
+    return revision;
+  }
+
+  public String getSourceGraphFingerprint() {
+    return sourceGraphFingerprint;
+  }
+
+  public String getSourceReference() {
+    return sourceReference;
+  }
+
+  public Unit getUnit() {
+    return unit;
+  }
+
+  public VerificationStatus getVerificationStatus() {
+    return verificationStatus;
+  }
+
+  public List<Primitive> getPrimitives() {
+    return Collections.unmodifiableList(new ArrayList<Primitive>(primitives));
+  }
+
+  public List<Diagnostic> getDiagnostics() {
+    return Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+  }
+
+  public boolean isComplete() {
+    for (Diagnostic diagnostic : diagnostics) {
+      if (diagnostic.getSeverity() == Severity.ERROR) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", SCHEMA_VERSION);
+    result.put("projectId", projectId);
+    result.put("revision", revision);
+    result.put("sourceGraphFingerprint", sourceGraphFingerprint);
+    result.put("sourceReference", sourceReference);
+    result.put("unit", unit.name());
+    result.put("verificationStatus", verificationStatus.name());
+    List<Map<String, Object>> primitiveMaps = new ArrayList<Map<String, Object>>();
+    for (Primitive primitive : primitives) {
+      primitiveMaps.add(primitive.toMap());
+    }
+    result.put("primitives", primitiveMaps);
+    List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
+    for (Diagnostic diagnostic : diagnostics) {
+      diagnosticMaps.add(diagnostic.toMap());
+    }
+    result.put("diagnostics", diagnosticMaps);
+    result.put("engineeringApprovalRequired", Boolean.TRUE);
+    return result;
+  }
+
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+  }
+
+  public static EngineeringGraphicalProjection fromJson(String json) {
+    if (json == null || json.trim().isEmpty()) {
+      throw new IllegalArgumentException("json must not be blank");
+    }
+    JsonElement parsed = JsonParser.parseString(json);
+    if (!parsed.isJsonObject()) {
+      throw new IllegalArgumentException("Graphical projection JSON root must be an object");
+    }
+    JsonObject root = parsed.getAsJsonObject();
+    if (!root.has("schemaVersion") || !SCHEMA_VERSION.equals(root.get("schemaVersion").getAsString())) {
+      throw new IllegalArgumentException("Unsupported graphical projection schema version");
+    }
+    if (!Unit.MILLIMETRE.name().equals(root.get("unit").getAsString())) {
+      throw new IllegalArgumentException("Unsupported graphical projection unit");
+    }
+    List<Primitive> primitives = new ArrayList<Primitive>();
+    for (JsonElement element : root.getAsJsonArray("primitives")) {
+      primitives.add(primitiveFromJson(element.getAsJsonObject()));
+    }
+    List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
+    for (JsonElement element : root.getAsJsonArray("diagnostics")) {
+      JsonObject item = element.getAsJsonObject();
+      diagnostics.add(new Diagnostic(Severity.valueOf(item.get("severity").getAsString()),
+          item.get("code").getAsString(), item.get("message").getAsString(),
+          item.get("subjectId").getAsString()));
+    }
+    return new EngineeringGraphicalProjection(root.get("projectId").getAsString(),
+        root.get("revision").getAsString(), root.get("sourceGraphFingerprint").getAsString(),
+        root.get("sourceReference").getAsString(),
+        VerificationStatus.valueOf(root.get("verificationStatus").getAsString()), primitives,
+        diagnostics);
+  }
+
+  private static Primitive primitiveFromJson(JsonObject item) {
+    PrimitiveType type = PrimitiveType.valueOf(item.get("type").getAsString());
+    String id = item.get("id").getAsString();
+    String representedObjectId = item.get("representedObjectId").getAsString();
+    String representedExternalKey = item.get("representedExternalKey").getAsString();
+    List<Point> points = new ArrayList<Point>();
+    JsonArray pointArray = item.getAsJsonArray("points");
+    for (JsonElement element : pointArray) {
+      JsonObject point = element.getAsJsonObject();
+      points.add(new Point(point.get("x").getAsDouble(), point.get("y").getAsDouble()));
+    }
+    return new Primitive(id, type, representedObjectId, representedExternalKey, points,
+        item.get("x").getAsDouble(), item.get("y").getAsDouble(),
+        item.get("width").getAsDouble(), item.get("height").getAsDouble(),
+        item.get("size").getAsDouble(), item.get("text").getAsString(),
+        item.get("strokeColor").getAsString(), item.get("fillColor").getAsString(),
+        item.get("strokeWidth").getAsDouble(), item.get("dashPattern").getAsString(),
+        item.get("textAnchor").getAsString(), item.get("protectedGeometry").getAsBoolean());
+  }
+
+  private static List<Primitive> immutablePrimitives(List<Primitive> values) {
+    if (values == null) {
+      throw new IllegalArgumentException("primitives must not be null");
+    }
+    List<Primitive> result = new ArrayList<Primitive>(values);
+    for (Primitive primitive : result) {
+      if (primitive == null) {
+        throw new IllegalArgumentException("primitive must not be null");
+      }
+    }
+    Collections.sort(result, new Comparator<Primitive>() {
+      @Override
+      public int compare(Primitive left, Primitive right) {
+        return left.getId().compareTo(right.getId());
+      }
+    });
+    TreeSet<String> ids = new TreeSet<String>();
+    for (Primitive primitive : result) {
+      if (!ids.add(primitive.getId())) {
+        throw new IllegalArgumentException("Duplicate graphical primitive " + primitive.getId());
+      }
+    }
+    return Collections.unmodifiableList(result);
+  }
+
+  private static List<Diagnostic> immutableDiagnostics(List<Diagnostic> values) {
+    if (values == null) {
+      throw new IllegalArgumentException("diagnostics must not be null");
+    }
+    List<Diagnostic> result = new ArrayList<Diagnostic>(values);
+    for (Diagnostic diagnostic : result) {
+      if (diagnostic == null) {
+        throw new IllegalArgumentException("diagnostic must not be null");
+      }
+    }
+    Collections.sort(result, new Comparator<Diagnostic>() {
+      @Override
+      public int compare(Diagnostic left, Diagnostic right) {
+        int code = left.getCode().compareTo(right.getCode());
+        return code == 0 ? left.getSubjectId().compareTo(right.getSubjectId()) : code;
+      }
+    });
+    return Collections.unmodifiableList(result);
+  }
+
+  private static List<Point> immutablePoints(List<Point> values) {
+    if (values == null) {
+      throw new IllegalArgumentException("points must not be null");
+    }
+    List<Point> result = new ArrayList<Point>(values);
+    for (Point point : result) {
+      if (point == null) {
+        throw new IllegalArgumentException("point must not be null");
+      }
+    }
+    return Collections.unmodifiableList(result);
+  }
+
+  private static String color(String value, String name) {
+    String result = requireText(value, name).toLowerCase(java.util.Locale.ROOT);
+    if (!"none".equals(result) && !result.matches("#[0-9a-f]{6}")) {
+      throw new IllegalArgumentException(name + " must use #RRGGBB or none");
+    }
+    return result;
+  }
+
+  private static String optionalText(String value) {
+    return value == null ? "" : value.trim();
+  }
+
+  private static String requireText(String value, String name) {
+    String result = optionalText(value);
+    if (result.isEmpty()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return result;
+  }
+
+  private static double finite(double value, String name) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(name + " must be finite");
+    }
+    return value;
+  }
+}

--- a/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionBuilder.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionBuilder.java
@@ -7,6 +7,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import neqsim.process.engineering.model.EngineeringDiagramConventionRegister.EvidenceState;
 import neqsim.process.engineering.model.EngineeringDiagramConventionRegister.SymbolConvention;
 import neqsim.process.engineering.model.EngineeringDiagramConventionRegister.SymbolShape;
@@ -55,6 +56,7 @@ public final class EngineeringGraphicalProjectionBuilder {
     List<Primitive> primitives = new ArrayList<Primitive>();
     List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
     Set<EngineeringNode.Kind> fallbackKinds = EnumSet.noneOf(EngineeringNode.Kind.class);
+    Set<EngineeringNode.Kind> proposedKinds = EnumSet.noneOf(EngineeringNode.Kind.class);
 
     for (Map<String, Object> placement : maps(layout.get("placements"))) {
       String nodeId = text(placement.get("nodeId"));
@@ -78,7 +80,8 @@ public final class EngineeringGraphicalProjectionBuilder {
             "GRAPHICAL_PROJECTION_GENERIC_SYMBOL_FALLBACK",
             "No project convention is registered; generic rectangles are retained without a standards-symbol claim",
             node.getKind().name()));
-      } else if (convention != null && convention.getEvidenceState() == EvidenceState.PROPOSED) {
+      } else if (convention != null && convention.getEvidenceState() == EvidenceState.PROPOSED
+          && proposedKinds.add(node.getKind())) {
         diagnostics.add(new Diagnostic(Severity.INFO,
             "GRAPHICAL_PROJECTION_PROPOSED_CONVENTION",
             "Project convention is proposed and still requires accountable review",
@@ -90,6 +93,7 @@ public final class EngineeringGraphicalProjectionBuilder {
     }
 
     List<Map<String, Object>> routes = maps(layout.get("routes"));
+    Set<String> routedEdgeIds = new TreeSet<String>();
     Collections.sort(routes, new Comparator<Map<String, Object>>() {
       @Override
       public int compare(Map<String, Object> left, Map<String, Object> right) {
@@ -105,12 +109,25 @@ public final class EngineeringGraphicalProjectionBuilder {
             edgeId));
         continue;
       }
+      routedEdgeIds.add(edgeId);
       List<Point> points = new ArrayList<Point>();
       for (Map<String, Object> point : maps(route.get("points"))) {
         points.add(new Point(number(point.get("x")), number(point.get("y"))));
       }
       primitives.add(Primitive.polyline(edgeId + ":route", edgeId, edgeId, points,
           routeColor(edge.getKind()), 0.8, routeDash(edge.getKind()), false));
+    }
+    for (EngineeringEdge edge : graph.getEdges().values()) {
+      if (isGraphicalRoute(edge.getKind()) && !routedEdgeIds.contains(edge.getId())) {
+        diagnostics.add(new Diagnostic(Severity.WARNING,
+            "GRAPHICAL_PROJECTION_ROUTE_ENDPOINT_NOT_PLACED",
+            "Graphical relationship is retained semantically but has no route because an endpoint is not drawable",
+            edge.getId()));
+      }
+    }
+    if (primitives.isEmpty()) {
+      diagnostics.add(new Diagnostic(Severity.ERROR, "GRAPHICAL_PROJECTION_EMPTY",
+          "Canonical engineering graph contains no drawable nodes or routes", graph.getProjectId()));
     }
 
     return new EngineeringGraphicalProjection(graph.getProjectId(), graph.getRevision(),
@@ -162,6 +179,13 @@ public final class EngineeringGraphicalProjectionBuilder {
     return kind == EngineeringEdge.Kind.SIGNAL_FLOW || kind == EngineeringEdge.Kind.MEASURES
         ? "4 2"
         : "";
+  }
+
+  private static boolean isGraphicalRoute(EngineeringEdge.Kind kind) {
+    return kind == EngineeringEdge.Kind.PROCESS_FLOW || kind == EngineeringEdge.Kind.SIGNAL_FLOW
+        || kind == EngineeringEdge.Kind.ENERGY_FLOW || kind == EngineeringEdge.Kind.CONNECTS_TO
+        || kind == EngineeringEdge.Kind.HAS_PORT || kind == EngineeringEdge.Kind.PART_OF_LINE
+        || kind == EngineeringEdge.Kind.MEASURES;
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionBuilder.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionBuilder.java
@@ -29,9 +29,9 @@ public final class EngineeringGraphicalProjectionBuilder {
    * Builds one exchange-neutral graphical projection.
    *
    * <p>
-   * Missing symbol conventions are represented by explicit generic rectangles and structured
-   * diagnostics. Reviewed project conventions control only generic shape and colour; they do not
-   * create a standards-profile symbol binding or approve a P&amp;ID.
+   * Missing symbol conventions are represented by explicit generic rectangles and structured diagnostics. Reviewed
+   * project conventions control only generic shape and colour; they do not create a standards-profile symbol binding or
+   * approve a P&amp;ID.
    * </p>
    *
    * @param graph canonical semantic graph
@@ -41,8 +41,7 @@ public final class EngineeringGraphicalProjectionBuilder {
    * @return deterministic immutable graphical projection
    */
   public static EngineeringGraphicalProjection build(EngineeringGraph graph,
-      EngineeringDiagramConventionRegister conventions, String sourceReference,
-      VerificationStatus verificationStatus) {
+      EngineeringDiagramConventionRegister conventions, String sourceReference, VerificationStatus verificationStatus) {
     if (graph == null) {
       throw new IllegalArgumentException("graph must not be null");
     }
@@ -63,8 +62,7 @@ public final class EngineeringGraphicalProjectionBuilder {
       EngineeringNode node = graph.getNode(nodeId);
       if (node == null) {
         diagnostics.add(new Diagnostic(Severity.ERROR, "GRAPHICAL_PROJECTION_NODE_MISSING",
-            "Layout placement references a node absent from the canonical engineering graph",
-            nodeId));
+            "Layout placement references a node absent from the canonical engineering graph", nodeId));
         continue;
       }
       double x = number(placement.get("x"));
@@ -76,20 +74,17 @@ public final class EngineeringGraphicalProjectionBuilder {
       String stroke = convention == null ? FALLBACK_STROKE : convention.getStrokeColor();
       String fill = convention == null ? FALLBACK_FILL : convention.getFillColor();
       if (convention == null && fallbackKinds.add(node.getKind())) {
-        diagnostics.add(new Diagnostic(Severity.WARNING,
-            "GRAPHICAL_PROJECTION_GENERIC_SYMBOL_FALLBACK",
+        diagnostics.add(new Diagnostic(Severity.WARNING, "GRAPHICAL_PROJECTION_GENERIC_SYMBOL_FALLBACK",
             "No project convention is registered; generic rectangles are retained without a standards-symbol claim",
             node.getKind().name()));
       } else if (convention != null && convention.getEvidenceState() == EvidenceState.PROPOSED
           && proposedKinds.add(node.getKind())) {
-        diagnostics.add(new Diagnostic(Severity.INFO,
-            "GRAPHICAL_PROJECTION_PROPOSED_CONVENTION",
-            "Project convention is proposed and still requires accountable review",
-            node.getKind().name()));
+        diagnostics.add(new Diagnostic(Severity.INFO, "GRAPHICAL_PROJECTION_PROPOSED_CONVENTION",
+            "Project convention is proposed and still requires accountable review", node.getKind().name()));
       }
       primitives.add(shape(node, shape, x, y, width, height, stroke, fill));
-      primitives.add(Primitive.text(nodeId + ":label", nodeId, node.getExternalKey(), x, y,
-          3.0, node.getLabel(), "#111827", "middle"));
+      primitives.add(Primitive.text(nodeId + ":label", nodeId, node.getExternalKey(), x, y, 3.0, node.getLabel(),
+          "#111827", "middle"));
     }
 
     List<Map<String, Object>> routes = maps(layout.get("routes"));
@@ -105,8 +100,7 @@ public final class EngineeringGraphicalProjectionBuilder {
       EngineeringEdge edge = graph.getEdges().get(edgeId);
       if (edge == null) {
         diagnostics.add(new Diagnostic(Severity.ERROR, "GRAPHICAL_PROJECTION_EDGE_MISSING",
-            "Layout route references an edge absent from the canonical engineering graph",
-            edgeId));
+            "Layout route references an edge absent from the canonical engineering graph", edgeId));
         continue;
       }
       routedEdgeIds.add(edgeId);
@@ -114,13 +108,12 @@ public final class EngineeringGraphicalProjectionBuilder {
       for (Map<String, Object> point : maps(route.get("points"))) {
         points.add(new Point(number(point.get("x")), number(point.get("y"))));
       }
-      primitives.add(Primitive.polyline(edgeId + ":route", edgeId, edgeId, points,
-          routeColor(edge.getKind()), 0.8, routeDash(edge.getKind()), false));
+      primitives.add(Primitive.polyline(edgeId + ":route", edgeId, edgeId, points, routeColor(edge.getKind()), 0.8,
+          routeDash(edge.getKind()), false));
     }
     for (EngineeringEdge edge : graph.getEdges().values()) {
       if (isGraphicalRoute(edge.getKind()) && !routedEdgeIds.contains(edge.getId())) {
-        diagnostics.add(new Diagnostic(Severity.WARNING,
-            "GRAPHICAL_PROJECTION_ROUTE_ENDPOINT_NOT_PLACED",
+        diagnostics.add(new Diagnostic(Severity.WARNING, "GRAPHICAL_PROJECTION_ROUTE_ENDPOINT_NOT_PLACED",
             "Graphical relationship is retained semantically but has no route because an endpoint is not drawable",
             edge.getId()));
       }
@@ -131,12 +124,11 @@ public final class EngineeringGraphicalProjectionBuilder {
     }
 
     return new EngineeringGraphicalProjection(graph.getProjectId(), graph.getRevision(),
-        text(graph.toMap().get("fingerprint")), sourceReference, verificationStatus, primitives,
-        diagnostics);
+        text(graph.toMap().get("fingerprint")), sourceReference, verificationStatus, primitives, diagnostics);
   }
 
-  private static Primitive shape(EngineeringNode node, SymbolShape shape, double x, double y,
-      double width, double height, String stroke, String fill) {
+  private static Primitive shape(EngineeringNode node, SymbolShape shape, double x, double y, double width,
+      double height, String stroke, String fill) {
     String id = node.getId() + ":shape";
     if (shape == SymbolShape.DIAMOND) {
       List<Point> points = new ArrayList<Point>();
@@ -157,8 +149,8 @@ public final class EngineeringGraphicalProjectionBuilder {
       points.add(new Point(x - width / 2.0, y));
       return Primitive.polygon(id, node.getId(), node.getExternalKey(), points, stroke, fill, 0.8);
     }
-    return Primitive.rectangle(id, node.getId(), node.getExternalKey(), x - width / 2.0,
-        y - height / 2.0, width, height, stroke, fill, 0.8);
+    return Primitive.rectangle(id, node.getId(), node.getExternalKey(), x - width / 2.0, y - height / 2.0, width,
+        height, stroke, fill, 0.8);
   }
 
   private static String routeColor(EngineeringEdge.Kind kind) {
@@ -176,9 +168,7 @@ public final class EngineeringGraphicalProjectionBuilder {
   }
 
   private static String routeDash(EngineeringEdge.Kind kind) {
-    return kind == EngineeringEdge.Kind.SIGNAL_FLOW || kind == EngineeringEdge.Kind.MEASURES
-        ? "4 2"
-        : "";
+    return kind == EngineeringEdge.Kind.SIGNAL_FLOW || kind == EngineeringEdge.Kind.MEASURES ? "4 2" : "";
   }
 
   private static boolean isGraphicalRoute(EngineeringEdge.Kind kind) {

--- a/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionBuilder.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionBuilder.java
@@ -1,0 +1,195 @@
+package neqsim.process.engineering.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import neqsim.process.engineering.model.EngineeringDiagramConventionRegister.EvidenceState;
+import neqsim.process.engineering.model.EngineeringDiagramConventionRegister.SymbolConvention;
+import neqsim.process.engineering.model.EngineeringDiagramConventionRegister.SymbolShape;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection.Diagnostic;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection.Point;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection.Primitive;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection.Severity;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection.VerificationStatus;
+
+/** Builds deterministic generic drawing primitives from the canonical engineering graph. */
+public final class EngineeringGraphicalProjectionBuilder {
+  private static final String FALLBACK_STROKE = "#374151";
+  private static final String FALLBACK_FILL = "#ffffff";
+
+  private EngineeringGraphicalProjectionBuilder() {
+  }
+
+  /**
+   * Builds one exchange-neutral graphical projection.
+   *
+   * <p>
+   * Missing symbol conventions are represented by explicit generic rectangles and structured
+   * diagnostics. Reviewed project conventions control only generic shape and colour; they do not
+   * create a standards-profile symbol binding or approve a P&amp;ID.
+   * </p>
+   *
+   * @param graph canonical semantic graph
+   * @param conventions project convention register; may be empty
+   * @param sourceReference controlled source or document reference
+   * @param verificationStatus proposal or reviewed-input status
+   * @return deterministic immutable graphical projection
+   */
+  public static EngineeringGraphicalProjection build(EngineeringGraph graph,
+      EngineeringDiagramConventionRegister conventions, String sourceReference,
+      VerificationStatus verificationStatus) {
+    if (graph == null) {
+      throw new IllegalArgumentException("graph must not be null");
+    }
+    if (conventions == null) {
+      throw new IllegalArgumentException("conventions must not be null");
+    }
+    if (verificationStatus == null) {
+      throw new IllegalArgumentException("verificationStatus must not be null");
+    }
+    Map<String, Object> layout = EngineeringDiagramLayout.build(graph);
+    List<Primitive> primitives = new ArrayList<Primitive>();
+    List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
+    Set<EngineeringNode.Kind> fallbackKinds = EnumSet.noneOf(EngineeringNode.Kind.class);
+
+    for (Map<String, Object> placement : maps(layout.get("placements"))) {
+      String nodeId = text(placement.get("nodeId"));
+      EngineeringNode node = graph.getNode(nodeId);
+      if (node == null) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "GRAPHICAL_PROJECTION_NODE_MISSING",
+            "Layout placement references a node absent from the canonical engineering graph",
+            nodeId));
+        continue;
+      }
+      double x = number(placement.get("x"));
+      double y = number(placement.get("y"));
+      double width = number(placement.get("width"));
+      double height = number(placement.get("height"));
+      SymbolConvention convention = conventions.getSymbolConvention(node.getKind());
+      SymbolShape shape = convention == null ? SymbolShape.RECTANGLE : convention.getShape();
+      String stroke = convention == null ? FALLBACK_STROKE : convention.getStrokeColor();
+      String fill = convention == null ? FALLBACK_FILL : convention.getFillColor();
+      if (convention == null && fallbackKinds.add(node.getKind())) {
+        diagnostics.add(new Diagnostic(Severity.WARNING,
+            "GRAPHICAL_PROJECTION_GENERIC_SYMBOL_FALLBACK",
+            "No project convention is registered; generic rectangles are retained without a standards-symbol claim",
+            node.getKind().name()));
+      } else if (convention != null && convention.getEvidenceState() == EvidenceState.PROPOSED) {
+        diagnostics.add(new Diagnostic(Severity.INFO,
+            "GRAPHICAL_PROJECTION_PROPOSED_CONVENTION",
+            "Project convention is proposed and still requires accountable review",
+            node.getKind().name()));
+      }
+      primitives.add(shape(node, shape, x, y, width, height, stroke, fill));
+      primitives.add(Primitive.text(nodeId + ":label", nodeId, node.getExternalKey(), x, y,
+          3.0, node.getLabel(), "#111827", "middle"));
+    }
+
+    List<Map<String, Object>> routes = maps(layout.get("routes"));
+    Collections.sort(routes, new Comparator<Map<String, Object>>() {
+      @Override
+      public int compare(Map<String, Object> left, Map<String, Object> right) {
+        return text(left.get("edgeId")).compareTo(text(right.get("edgeId")));
+      }
+    });
+    for (Map<String, Object> route : routes) {
+      String edgeId = text(route.get("edgeId"));
+      EngineeringEdge edge = graph.getEdges().get(edgeId);
+      if (edge == null) {
+        diagnostics.add(new Diagnostic(Severity.ERROR, "GRAPHICAL_PROJECTION_EDGE_MISSING",
+            "Layout route references an edge absent from the canonical engineering graph",
+            edgeId));
+        continue;
+      }
+      List<Point> points = new ArrayList<Point>();
+      for (Map<String, Object> point : maps(route.get("points"))) {
+        points.add(new Point(number(point.get("x")), number(point.get("y"))));
+      }
+      primitives.add(Primitive.polyline(edgeId + ":route", edgeId, edgeId, points,
+          routeColor(edge.getKind()), 0.8, routeDash(edge.getKind()), false));
+    }
+
+    return new EngineeringGraphicalProjection(graph.getProjectId(), graph.getRevision(),
+        text(graph.toMap().get("fingerprint")), sourceReference, verificationStatus, primitives,
+        diagnostics);
+  }
+
+  private static Primitive shape(EngineeringNode node, SymbolShape shape, double x, double y,
+      double width, double height, String stroke, String fill) {
+    String id = node.getId() + ":shape";
+    if (shape == SymbolShape.DIAMOND) {
+      List<Point> points = new ArrayList<Point>();
+      points.add(new Point(x, y - height / 2.0));
+      points.add(new Point(x + width / 2.0, y));
+      points.add(new Point(x, y + height / 2.0));
+      points.add(new Point(x - width / 2.0, y));
+      return Primitive.polygon(id, node.getId(), node.getExternalKey(), points, stroke, fill, 0.8);
+    }
+    if (shape == SymbolShape.HEXAGON) {
+      double shoulder = width * 0.2;
+      List<Point> points = new ArrayList<Point>();
+      points.add(new Point(x - width / 2.0 + shoulder, y - height / 2.0));
+      points.add(new Point(x + width / 2.0 - shoulder, y - height / 2.0));
+      points.add(new Point(x + width / 2.0, y));
+      points.add(new Point(x + width / 2.0 - shoulder, y + height / 2.0));
+      points.add(new Point(x - width / 2.0 + shoulder, y + height / 2.0));
+      points.add(new Point(x - width / 2.0, y));
+      return Primitive.polygon(id, node.getId(), node.getExternalKey(), points, stroke, fill, 0.8);
+    }
+    return Primitive.rectangle(id, node.getId(), node.getExternalKey(), x - width / 2.0,
+        y - height / 2.0, width, height, stroke, fill, 0.8);
+  }
+
+  private static String routeColor(EngineeringEdge.Kind kind) {
+    if (kind == EngineeringEdge.Kind.ENERGY_FLOW) {
+      return "#d97706";
+    }
+    if (kind == EngineeringEdge.Kind.SIGNAL_FLOW || kind == EngineeringEdge.Kind.MEASURES) {
+      return "#7c3aed";
+    }
+    if (kind == EngineeringEdge.Kind.PROCESS_FLOW || kind == EngineeringEdge.Kind.CONNECTS_TO
+        || kind == EngineeringEdge.Kind.PART_OF_LINE) {
+      return "#2563eb";
+    }
+    return "#64748b";
+  }
+
+  private static String routeDash(EngineeringEdge.Kind kind) {
+    return kind == EngineeringEdge.Kind.SIGNAL_FLOW || kind == EngineeringEdge.Kind.MEASURES
+        ? "4 2"
+        : "";
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Map<String, Object>> maps(Object value) {
+    if (!(value instanceof List<?>)) {
+      throw new IllegalArgumentException("Layout collection is missing");
+    }
+    List<Map<String, Object>> result = new ArrayList<Map<String, Object>>();
+    for (Object item : (List<?>) value) {
+      if (!(item instanceof Map<?, ?>)) {
+        throw new IllegalArgumentException("Layout collection contains a non-map item");
+      }
+      result.add((Map<String, Object>) item);
+    }
+    return result;
+  }
+
+  private static String text(Object value) {
+    if (value == null || value.toString().trim().isEmpty()) {
+      throw new IllegalArgumentException("Layout text value is missing");
+    }
+    return value.toString().trim();
+  }
+
+  private static double number(Object value) {
+    if (!(value instanceof Number)) {
+      throw new IllegalArgumentException("Layout numeric value is missing");
+    }
+    return ((Number) value).doubleValue();
+  }
+}

--- a/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionBuilder.java
+++ b/src/main/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionBuilder.java
@@ -7,6 +7,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import neqsim.process.engineering.model.EngineeringDiagramConventionRegister.EvidenceState;
 import neqsim.process.engineering.model.EngineeringDiagramConventionRegister.SymbolConvention;
@@ -21,6 +22,7 @@ import neqsim.process.engineering.model.EngineeringGraphicalProjection.Verificat
 public final class EngineeringGraphicalProjectionBuilder {
   private static final String FALLBACK_STROKE = "#374151";
   private static final String FALLBACK_FILL = "#ffffff";
+  private static final double PARALLEL_LANE_SPACING = 3.0;
 
   private EngineeringGraphicalProjectionBuilder() {
   }
@@ -95,6 +97,16 @@ public final class EngineeringGraphicalProjectionBuilder {
         return text(left.get("edgeId")).compareTo(text(right.get("edgeId")));
       }
     });
+    Map<String, Integer> laneCountByEndpoints = new TreeMap<String, Integer>();
+    for (Map<String, Object> route : routes) {
+      EngineeringEdge edge = graph.getEdges().get(text(route.get("edgeId")));
+      if (edge != null) {
+        String laneKey = laneKey(edge);
+        Integer count = laneCountByEndpoints.get(laneKey);
+        laneCountByEndpoints.put(laneKey, Integer.valueOf(count == null ? 1 : count.intValue() + 1));
+      }
+    }
+    Map<String, Integer> laneIndexByEndpoints = new TreeMap<String, Integer>();
     for (Map<String, Object> route : routes) {
       String edgeId = text(route.get("edgeId"));
       EngineeringEdge edge = graph.getEdges().get(edgeId);
@@ -104,9 +116,22 @@ public final class EngineeringGraphicalProjectionBuilder {
         continue;
       }
       routedEdgeIds.add(edgeId);
+      String laneKey = laneKey(edge);
+      int laneCount = laneCountByEndpoints.get(laneKey).intValue();
+      Integer previousLaneIndex = laneIndexByEndpoints.get(laneKey);
+      int laneIndex = previousLaneIndex == null ? 0 : previousLaneIndex.intValue();
+      laneIndexByEndpoints.put(laneKey, Integer.valueOf(laneIndex + 1));
+      double laneOffset = PARALLEL_LANE_SPACING * (laneIndex - 0.5 * (laneCount - 1));
+
+      List<Map<String, Object>> routePoints = maps(route.get("points"));
       List<Point> points = new ArrayList<Point>();
-      for (Map<String, Object> point : maps(route.get("points"))) {
-        points.add(new Point(number(point.get("x")), number(point.get("y"))));
+      for (int pointIndex = 0; pointIndex < routePoints.size(); pointIndex++) {
+        Map<String, Object> point = routePoints.get(pointIndex);
+        double x = number(point.get("x"));
+        if (laneCount > 1 && pointIndex > 0 && pointIndex < routePoints.size() - 1) {
+          x += laneOffset;
+        }
+        points.add(new Point(x, number(point.get("y"))));
       }
       primitives.add(Primitive.polyline(edgeId + ":route", edgeId, edgeId, points, routeColor(edge.getKind()), 0.8,
           routeDash(edge.getKind()), false));
@@ -151,6 +176,11 @@ public final class EngineeringGraphicalProjectionBuilder {
     }
     return Primitive.rectangle(id, node.getId(), node.getExternalKey(), x - width / 2.0, y - height / 2.0, width,
         height, stroke, fill, 0.8);
+  }
+
+  private static String laneKey(EngineeringEdge edge) {
+    String sourceId = edge.getSourceId();
+    return sourceId.length() + ":" + sourceId + edge.getTargetId();
   }
 
   private static String routeColor(EngineeringEdge.Kind kind) {

--- a/src/test/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionTest.java
+++ b/src/test/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionTest.java
@@ -1,0 +1,112 @@
+package neqsim.process.engineering.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import neqsim.process.engineering.model.EngineeringDiagramConventionRegister.EvidenceState;
+import neqsim.process.engineering.model.EngineeringDiagramConventionRegister.SymbolConvention;
+import neqsim.process.engineering.model.EngineeringDiagramConventionRegister.SymbolShape;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection.Primitive;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection.PrimitiveType;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection.Unit;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection.VerificationStatus;
+
+class EngineeringGraphicalProjectionTest {
+  @Test
+  void deterministicProjectionRetainsParallelSemanticConnections() {
+    EngineeringGraph graph = graph();
+
+    EngineeringGraphicalProjection first = EngineeringGraphicalProjectionBuilder.build(graph,
+        new EngineeringDiagramConventionRegister(), "DOC-PFD-001", VerificationStatus.PROPOSAL);
+    EngineeringGraphicalProjection second = EngineeringGraphicalProjectionBuilder.build(graph,
+        new EngineeringDiagramConventionRegister(), "DOC-PFD-001", VerificationStatus.PROPOSAL);
+
+    assertEquals(first.toJson(), second.toJson());
+    assertEquals(Unit.MILLIMETRE, first.getUnit());
+    assertEquals(2L, first.getPrimitives().stream()
+        .filter(item -> item.getType() == PrimitiveType.POLYLINE).count());
+    assertNotNull(primitive(first, "flow-main:route"));
+    assertNotNull(primitive(first, "flow-bypass:route"));
+    assertTrue(first.isComplete());
+    assertTrue(first.getDiagnostics().stream()
+        .anyMatch(item -> "GRAPHICAL_PROJECTION_GENERIC_SYMBOL_FALLBACK".equals(item.getCode())));
+  }
+
+  @Test
+  void projectConventionControlsGenericShapeWithoutApprovalClaim() {
+    SymbolConvention equipment = new SymbolConvention(EngineeringNode.Kind.EQUIPMENT,
+        SymbolShape.DIAMOND, "#123456", "#abcdef", "PROJECT-SYMBOLS-7",
+        EvidenceState.REVIEWED, "diagram-reviewer", "RVW-42", "2026-08-22T08:00:00Z",
+        "C");
+    EngineeringDiagramConventionRegister register =
+        new EngineeringDiagramConventionRegister(Arrays.asList(equipment));
+
+    EngineeringGraphicalProjection projection = EngineeringGraphicalProjectionBuilder.build(
+        graph(), register, "DOC-PFD-001", VerificationStatus.REVIEWED);
+    Primitive shape = primitive(projection, "pump-a:shape");
+
+    assertEquals(PrimitiveType.POLYGON, shape.getType());
+    assertEquals("#123456", shape.getStrokeColor());
+    assertEquals("#abcdef", shape.getFillColor());
+    assertEquals(VerificationStatus.REVIEWED, projection.getVerificationStatus());
+    assertTrue((Boolean) projection.toMap().get("engineeringApprovalRequired"));
+  }
+
+  @Test
+  void jsonRoundTripPreservesProjectionAndDiagnostics() {
+    EngineeringGraphicalProjection original = EngineeringGraphicalProjectionBuilder.build(graph(),
+        new EngineeringDiagramConventionRegister(), "DOC-PFD-001", VerificationStatus.PROPOSAL);
+
+    EngineeringGraphicalProjection restored =
+        EngineeringGraphicalProjection.fromJson(original.toJson());
+
+    assertEquals(original.toJson(), restored.toJson());
+    assertEquals(original.getSourceGraphFingerprint(), restored.getSourceGraphFingerprint());
+    assertFalse(restored.getDiagnostics().isEmpty());
+  }
+
+  @Test
+  void rejectsDuplicatePrimitiveIdentity() {
+    Primitive first = Primitive.rectangle("duplicate", "pump-a", "P-100", 0.0, 0.0, 10.0,
+        10.0, "#000000", "none", 0.5);
+    Primitive second = Primitive.text("duplicate", "pump-a", "P-100", 5.0, 5.0, 3.0,
+        "P-100", "#000000", "middle");
+
+    assertThrows(IllegalArgumentException.class,
+        () -> new EngineeringGraphicalProjection("plant", "A", "fingerprint", "DOC",
+            VerificationStatus.PROPOSAL, Arrays.asList(first, second),
+            java.util.Collections.<EngineeringGraphicalProjection.Diagnostic>emptyList()));
+  }
+
+  private static EngineeringGraph graph() {
+    EngineeringGraph graph = new EngineeringGraph("plant-alpha", "A");
+    graph.addNode(new EngineeringNode("area-a", EngineeringNode.Kind.AREA, "AREA-A", "Area A"));
+    graph.addNode(new EngineeringNode("area-b", EngineeringNode.Kind.AREA, "AREA-B", "Area B"));
+    graph.addNode(
+        new EngineeringNode("pump-a", EngineeringNode.Kind.EQUIPMENT, "P-100", "Feed pump"));
+    graph.addNode(new EngineeringNode("separator-b", EngineeringNode.Kind.EQUIPMENT, "V-200",
+        "Product separator"));
+    graph.addEdge(new EngineeringEdge("area-a-pump", "area-a", "pump-a",
+        EngineeringEdge.Kind.CONTAINS, "equipment"));
+    graph.addEdge(new EngineeringEdge("area-b-separator", "area-b", "separator-b",
+        EngineeringEdge.Kind.CONTAINS, "equipment"));
+    graph.addEdge(new EngineeringEdge("flow-main", "pump-a", "separator-b",
+        EngineeringEdge.Kind.PROCESS_FLOW, "main"));
+    graph.addEdge(new EngineeringEdge("flow-bypass", "pump-a", "separator-b",
+        EngineeringEdge.Kind.PROCESS_FLOW, "bypass"));
+    return graph;
+  }
+
+  private static Primitive primitive(EngineeringGraphicalProjection projection, String id) {
+    for (Primitive primitive : projection.getPrimitives()) {
+      if (id.equals(primitive.getId())) {
+        return primitive;
+      }
+    }
+    return null;
+  }
+}

--- a/src/test/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionTest.java
+++ b/src/test/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionTest.java
@@ -66,6 +66,16 @@ class EngineeringGraphicalProjectionTest {
   }
 
   @Test
+  void rejectsRestartThatWeakensApprovalBoundary() {
+    EngineeringGraphicalProjection projection = EngineeringGraphicalProjectionBuilder.build(graph(),
+        new EngineeringDiagramConventionRegister(), "DOC-PFD-001", VerificationStatus.PROPOSAL);
+    String weakened = projection.toJson().replace("\"engineeringApprovalRequired\": true",
+        "\"engineeringApprovalRequired\": false");
+
+    assertThrows(IllegalArgumentException.class, () -> EngineeringGraphicalProjection.fromJson(weakened));
+  }
+
+  @Test
   void rejectsDuplicatePrimitiveIdentity() {
     Primitive first = Primitive.rectangle("duplicate", "pump-a", "P-100", 0.0, 0.0, 10.0, 10.0, "#000000", "none", 0.5);
     Primitive second = Primitive.text("duplicate", "pump-a", "P-100", 5.0, 5.0, 3.0, "P-100", "#000000", "middle");

--- a/src/test/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionTest.java
+++ b/src/test/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionTest.java
@@ -2,6 +2,7 @@ package neqsim.process.engineering.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,8 +29,11 @@ class EngineeringGraphicalProjectionTest {
     assertEquals(first.toJson(), second.toJson());
     assertEquals(Unit.MILLIMETRE, first.getUnit());
     assertEquals(2L, first.getPrimitives().stream().filter(item -> item.getType() == PrimitiveType.POLYLINE).count());
-    assertNotNull(primitive(first, "flow-main:route"));
-    assertNotNull(primitive(first, "flow-bypass:route"));
+    Primitive mainRoute = primitive(first, "flow-main:route");
+    Primitive bypassRoute = primitive(first, "flow-bypass:route");
+    assertNotNull(mainRoute);
+    assertNotNull(bypassRoute);
+    assertNotEquals(mainRoute.getPoints().get(1).getX(), bypassRoute.getPoints().get(1).getX());
     assertTrue(first.isComplete());
     assertTrue(first.getDiagnostics().stream()
         .anyMatch(item -> "GRAPHICAL_PROJECTION_GENERIC_SYMBOL_FALLBACK".equals(item.getCode())));

--- a/src/test/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionTest.java
+++ b/src/test/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionTest.java
@@ -32,8 +32,7 @@ class EngineeringGraphicalProjectionTest {
     Primitive bypassRoute = primitive(first, "flow-bypass:route");
     assertNotNull(mainRoute);
     assertNotNull(bypassRoute);
-    assertEquals(3.0,
-        Math.abs(mainRoute.getPoints().get(1).getX() - bypassRoute.getPoints().get(1).getX()), 1.0e-12);
+    assertEquals(3.0, Math.abs(mainRoute.getPoints().get(1).getX() - bypassRoute.getPoints().get(1).getX()), 1.0e-12);
     assertEquals(mainRoute.getPoints().get(0).getX(), bypassRoute.getPoints().get(0).getX(), 0.0);
     assertEquals(mainRoute.getPoints().get(0).getY(), bypassRoute.getPoints().get(0).getY(), 0.0);
     assertEquals(mainRoute.getPoints().get(3).getX(), bypassRoute.getPoints().get(3).getX(), 0.0);

--- a/src/test/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionTest.java
+++ b/src/test/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionTest.java
@@ -27,8 +27,7 @@ class EngineeringGraphicalProjectionTest {
 
     assertEquals(first.toJson(), second.toJson());
     assertEquals(Unit.MILLIMETRE, first.getUnit());
-    assertEquals(2L, first.getPrimitives().stream()
-        .filter(item -> item.getType() == PrimitiveType.POLYLINE).count());
+    assertEquals(2L, first.getPrimitives().stream().filter(item -> item.getType() == PrimitiveType.POLYLINE).count());
     assertNotNull(primitive(first, "flow-main:route"));
     assertNotNull(primitive(first, "flow-bypass:route"));
     assertTrue(first.isComplete());
@@ -38,15 +37,13 @@ class EngineeringGraphicalProjectionTest {
 
   @Test
   void projectConventionControlsGenericShapeWithoutApprovalClaim() {
-    SymbolConvention equipment = new SymbolConvention(EngineeringNode.Kind.EQUIPMENT,
-        SymbolShape.DIAMOND, "#123456", "#abcdef", "PROJECT-SYMBOLS-7",
-        EvidenceState.REVIEWED, "diagram-reviewer", "RVW-42", "2026-08-22T08:00:00Z",
+    SymbolConvention equipment = new SymbolConvention(EngineeringNode.Kind.EQUIPMENT, SymbolShape.DIAMOND, "#123456",
+        "#abcdef", "PROJECT-SYMBOLS-7", EvidenceState.REVIEWED, "diagram-reviewer", "RVW-42", "2026-08-22T08:00:00Z",
         "C");
-    EngineeringDiagramConventionRegister register =
-        new EngineeringDiagramConventionRegister(Arrays.asList(equipment));
+    EngineeringDiagramConventionRegister register = new EngineeringDiagramConventionRegister(Arrays.asList(equipment));
 
-    EngineeringGraphicalProjection projection = EngineeringGraphicalProjectionBuilder.build(
-        graph(), register, "DOC-PFD-001", VerificationStatus.REVIEWED);
+    EngineeringGraphicalProjection projection = EngineeringGraphicalProjectionBuilder.build(graph(), register,
+        "DOC-PFD-001", VerificationStatus.REVIEWED);
     Primitive shape = primitive(projection, "pump-a:shape");
 
     assertEquals(PrimitiveType.POLYGON, shape.getType());
@@ -61,8 +58,7 @@ class EngineeringGraphicalProjectionTest {
     EngineeringGraphicalProjection original = EngineeringGraphicalProjectionBuilder.build(graph(),
         new EngineeringDiagramConventionRegister(), "DOC-PFD-001", VerificationStatus.PROPOSAL);
 
-    EngineeringGraphicalProjection restored =
-        EngineeringGraphicalProjection.fromJson(original.toJson());
+    EngineeringGraphicalProjection restored = EngineeringGraphicalProjection.fromJson(original.toJson());
 
     assertEquals(original.toJson(), restored.toJson());
     assertEquals(original.getSourceGraphFingerprint(), restored.getSourceGraphFingerprint());
@@ -71,25 +67,21 @@ class EngineeringGraphicalProjectionTest {
 
   @Test
   void rejectsDuplicatePrimitiveIdentity() {
-    Primitive first = Primitive.rectangle("duplicate", "pump-a", "P-100", 0.0, 0.0, 10.0,
-        10.0, "#000000", "none", 0.5);
-    Primitive second = Primitive.text("duplicate", "pump-a", "P-100", 5.0, 5.0, 3.0,
-        "P-100", "#000000", "middle");
+    Primitive first = Primitive.rectangle("duplicate", "pump-a", "P-100", 0.0, 0.0, 10.0, 10.0, "#000000", "none", 0.5);
+    Primitive second = Primitive.text("duplicate", "pump-a", "P-100", 5.0, 5.0, 3.0, "P-100", "#000000", "middle");
 
     assertThrows(IllegalArgumentException.class,
-        () -> new EngineeringGraphicalProjection("plant", "A", "fingerprint", "DOC",
-            VerificationStatus.PROPOSAL, Arrays.asList(first, second),
+        () -> new EngineeringGraphicalProjection("plant", "A", "fingerprint", "DOC", VerificationStatus.PROPOSAL,
+            Arrays.asList(first, second),
             java.util.Collections.<EngineeringGraphicalProjection.Diagnostic>emptyList()));
   }
 
   @Test
   void reportsEmptyAndUnplacedGraphicalContent() {
     EngineeringGraph empty = new EngineeringGraph("empty-plant", "A");
-    empty.addNode(new EngineeringNode("area-only", EngineeringNode.Kind.AREA, "AREA-ONLY",
-        "Area only"));
-    EngineeringGraphicalProjection emptyProjection = EngineeringGraphicalProjectionBuilder.build(
-        empty, new EngineeringDiagramConventionRegister(), "DOC-EMPTY",
-        VerificationStatus.PROPOSAL);
+    empty.addNode(new EngineeringNode("area-only", EngineeringNode.Kind.AREA, "AREA-ONLY", "Area only"));
+    EngineeringGraphicalProjection emptyProjection = EngineeringGraphicalProjectionBuilder.build(empty,
+        new EngineeringDiagramConventionRegister(), "DOC-EMPTY", VerificationStatus.PROPOSAL);
 
     assertFalse(emptyProjection.isComplete());
     assertTrue(emptyProjection.getDiagnostics().stream()
@@ -97,35 +89,28 @@ class EngineeringGraphicalProjectionTest {
 
     EngineeringGraph unplaced = new EngineeringGraph("unplaced-plant", "A");
     unplaced.addNode(new EngineeringNode("area", EngineeringNode.Kind.AREA, "AREA-A", "Area"));
-    unplaced.addNode(
-        new EngineeringNode("pump", EngineeringNode.Kind.EQUIPMENT, "P-1", "Pump"));
-    unplaced.addEdge(new EngineeringEdge("unplaced-flow", "pump", "area",
-        EngineeringEdge.Kind.PROCESS_FLOW, "invalid drawing endpoint"));
-    EngineeringGraphicalProjection unplacedProjection =
-        EngineeringGraphicalProjectionBuilder.build(unplaced,
-            new EngineeringDiagramConventionRegister(), "DOC-UNPLACED",
-            VerificationStatus.PROPOSAL);
+    unplaced.addNode(new EngineeringNode("pump", EngineeringNode.Kind.EQUIPMENT, "P-1", "Pump"));
+    unplaced.addEdge(new EngineeringEdge("unplaced-flow", "pump", "area", EngineeringEdge.Kind.PROCESS_FLOW,
+        "invalid drawing endpoint"));
+    EngineeringGraphicalProjection unplacedProjection = EngineeringGraphicalProjectionBuilder.build(unplaced,
+        new EngineeringDiagramConventionRegister(), "DOC-UNPLACED", VerificationStatus.PROPOSAL);
 
-    assertTrue(unplacedProjection.getDiagnostics().stream().anyMatch(
-        item -> "GRAPHICAL_PROJECTION_ROUTE_ENDPOINT_NOT_PLACED".equals(item.getCode())));
+    assertTrue(unplacedProjection.getDiagnostics().stream()
+        .anyMatch(item -> "GRAPHICAL_PROJECTION_ROUTE_ENDPOINT_NOT_PLACED".equals(item.getCode())));
   }
 
   private static EngineeringGraph graph() {
     EngineeringGraph graph = new EngineeringGraph("plant-alpha", "A");
     graph.addNode(new EngineeringNode("area-a", EngineeringNode.Kind.AREA, "AREA-A", "Area A"));
     graph.addNode(new EngineeringNode("area-b", EngineeringNode.Kind.AREA, "AREA-B", "Area B"));
-    graph.addNode(
-        new EngineeringNode("pump-a", EngineeringNode.Kind.EQUIPMENT, "P-100", "Feed pump"));
-    graph.addNode(new EngineeringNode("separator-b", EngineeringNode.Kind.EQUIPMENT, "V-200",
-        "Product separator"));
-    graph.addEdge(new EngineeringEdge("area-a-pump", "area-a", "pump-a",
-        EngineeringEdge.Kind.CONTAINS, "equipment"));
-    graph.addEdge(new EngineeringEdge("area-b-separator", "area-b", "separator-b",
-        EngineeringEdge.Kind.CONTAINS, "equipment"));
-    graph.addEdge(new EngineeringEdge("flow-main", "pump-a", "separator-b",
-        EngineeringEdge.Kind.PROCESS_FLOW, "main"));
-    graph.addEdge(new EngineeringEdge("flow-bypass", "pump-a", "separator-b",
-        EngineeringEdge.Kind.PROCESS_FLOW, "bypass"));
+    graph.addNode(new EngineeringNode("pump-a", EngineeringNode.Kind.EQUIPMENT, "P-100", "Feed pump"));
+    graph.addNode(new EngineeringNode("separator-b", EngineeringNode.Kind.EQUIPMENT, "V-200", "Product separator"));
+    graph.addEdge(new EngineeringEdge("area-a-pump", "area-a", "pump-a", EngineeringEdge.Kind.CONTAINS, "equipment"));
+    graph.addEdge(
+        new EngineeringEdge("area-b-separator", "area-b", "separator-b", EngineeringEdge.Kind.CONTAINS, "equipment"));
+    graph.addEdge(new EngineeringEdge("flow-main", "pump-a", "separator-b", EngineeringEdge.Kind.PROCESS_FLOW, "main"));
+    graph.addEdge(
+        new EngineeringEdge("flow-bypass", "pump-a", "separator-b", EngineeringEdge.Kind.PROCESS_FLOW, "bypass"));
     return graph;
   }
 

--- a/src/test/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionTest.java
+++ b/src/test/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionTest.java
@@ -2,7 +2,6 @@ package neqsim.process.engineering.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,7 +32,12 @@ class EngineeringGraphicalProjectionTest {
     Primitive bypassRoute = primitive(first, "flow-bypass:route");
     assertNotNull(mainRoute);
     assertNotNull(bypassRoute);
-    assertNotEquals(mainRoute.getPoints().get(1).getX(), bypassRoute.getPoints().get(1).getX());
+    assertEquals(3.0,
+        Math.abs(mainRoute.getPoints().get(1).getX() - bypassRoute.getPoints().get(1).getX()), 1.0e-12);
+    assertEquals(mainRoute.getPoints().get(0).getX(), bypassRoute.getPoints().get(0).getX(), 0.0);
+    assertEquals(mainRoute.getPoints().get(0).getY(), bypassRoute.getPoints().get(0).getY(), 0.0);
+    assertEquals(mainRoute.getPoints().get(3).getX(), bypassRoute.getPoints().get(3).getX(), 0.0);
+    assertEquals(mainRoute.getPoints().get(3).getY(), bypassRoute.getPoints().get(3).getY(), 0.0);
     assertTrue(first.isComplete());
     assertTrue(first.getDiagnostics().stream()
         .anyMatch(item -> "GRAPHICAL_PROJECTION_GENERIC_SYMBOL_FALLBACK".equals(item.getCode())));

--- a/src/test/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionTest.java
+++ b/src/test/java/neqsim/process/engineering/model/EngineeringGraphicalProjectionTest.java
@@ -82,6 +82,34 @@ class EngineeringGraphicalProjectionTest {
             java.util.Collections.<EngineeringGraphicalProjection.Diagnostic>emptyList()));
   }
 
+  @Test
+  void reportsEmptyAndUnplacedGraphicalContent() {
+    EngineeringGraph empty = new EngineeringGraph("empty-plant", "A");
+    empty.addNode(new EngineeringNode("area-only", EngineeringNode.Kind.AREA, "AREA-ONLY",
+        "Area only"));
+    EngineeringGraphicalProjection emptyProjection = EngineeringGraphicalProjectionBuilder.build(
+        empty, new EngineeringDiagramConventionRegister(), "DOC-EMPTY",
+        VerificationStatus.PROPOSAL);
+
+    assertFalse(emptyProjection.isComplete());
+    assertTrue(emptyProjection.getDiagnostics().stream()
+        .anyMatch(item -> "GRAPHICAL_PROJECTION_EMPTY".equals(item.getCode())));
+
+    EngineeringGraph unplaced = new EngineeringGraph("unplaced-plant", "A");
+    unplaced.addNode(new EngineeringNode("area", EngineeringNode.Kind.AREA, "AREA-A", "Area"));
+    unplaced.addNode(
+        new EngineeringNode("pump", EngineeringNode.Kind.EQUIPMENT, "P-1", "Pump"));
+    unplaced.addEdge(new EngineeringEdge("unplaced-flow", "pump", "area",
+        EngineeringEdge.Kind.PROCESS_FLOW, "invalid drawing endpoint"));
+    EngineeringGraphicalProjection unplacedProjection =
+        EngineeringGraphicalProjectionBuilder.build(unplaced,
+            new EngineeringDiagramConventionRegister(), "DOC-UNPLACED",
+            VerificationStatus.PROPOSAL);
+
+    assertTrue(unplacedProjection.getDiagnostics().stream().anyMatch(
+        item -> "GRAPHICAL_PROJECTION_ROUTE_ENDPOINT_NOT_PLACED".equals(item.getCode())));
+  }
+
   private static EngineeringGraph graph() {
     EngineeringGraph graph = new EngineeringGraph("plant-alpha", "A");
     graph.addNode(new EngineeringNode("area-a", EngineeringNode.Kind.AREA, "AREA-A", "Area A"));


### PR DESCRIPTION
## Summary

Selects the exchange-neutral route at the shared #1332/#2899 graphical-representation gate.

- adds immutable `EngineeringGraphicalProjection` v1 with stable primitive and represented-object identities
- makes millimetre units, source graph fingerprint, controlled source reference, revision, verification state, and approval boundary explicit
- adds generic rectangle/polygon/polyline/text primitives without a DEXPI profile, ISO, ISA, or company-symbol claim
- builds deterministic primitives from the canonical `EngineeringGraph`, preserving parallel semantic connections as distinct 3 mm interior lanes
- applies reviewed project convention shapes/colours when supplied and emits structured fallback diagnostics otherwise
- diagnoses empty projections and drawable relationships whose endpoints cannot be placed
- supports deterministic JSON serialization/restart and rejects payloads that weaken the accountable-approval boundary
- documents the native SVG/PDF and DEXPI adapter contract and explicitly rejects empty `RepresentationGroup` placeholders

## Compatibility

This is additive. Existing DOT/Graphviz, controlled document, native SVG/PDF, Classic, Proteus, DEXPI 2.0 Plant, metadata, and boundary-connector code paths and defaults are unchanged.

The DEXPI writer does **not** serialize this projection in this tranche. That subsequent adapter must map represented identities to real DEXPI objects, emit only supported non-empty Core primitives, and report every loss. No external DEXPIViewer rerun, clean-validation claim, profile-conformance claim, ISO 10628 claim, or drawing approval is made.

## Tests

Added `EngineeringGraphicalProjectionTest` covering:

- byte-stable deterministic JSON
- stable distinct parallel-route identities and non-overlapping deterministic lane geometry
- multi-area semantic inputs
- explicit millimetre units and approval boundary
- generic fallback diagnostics
- reviewed project-convention geometry/colours
- JSON round-trip restart and rejection of a disabled approval-required invariant
- duplicate primitive rejection
- empty-projection and unplaced-route loss diagnostics

## Validation

**VALIDATION PENDING CI**

Exact head: `49422474676abe097bfacb1123f903df59f0c2b2`

Passed locally on this exact head:

- `python devtools/run_spotless.py apply` — passed with no diff
- `python devtools/run_spotless.py check` — passed
- `python devtools/check_documentation_search.py` — passed (655 Markdown pages and 1 standalone HTML page)
- `pre-commit run --all-files --hook-stage pre-commit` — passed
- `pre-commit run --all-files --hook-stage pre-push` — passed
- `./mvnw -B test -ntp -Dtest=EngineeringGraphicalProjectionTest,MultiInputMixerPhaseRegressionTest -Djacoco.skip=true` — 7 tests passed on OpenJDK 17

Passed remotely on this exact head:

- Spotless format patch
- Pre-commit checks
- PaperLab Replication Gate
- Documentation search coverage
- Execute process-to-engineering simulator notebook
- Execute complete offshore engineering notebook
- CodeQL Security Analysis

Still running remotely on this exact head:

- Run build, test and javadoc

The earlier Java 8 Ubuntu failure on `2fd91e0a763acf604640786e4a5c8e91fd9a2702` was in `MultiInputMixerPhaseRegressionTest`, outside the five diagram/documentation files changed at that head. The reported total-flow difference was 0.268 kg/h on 164,153 kg/h (about 1.6 ppm). On that exact head, the focused regression passed once, passed 20 repeated sequential/optimized comparisons, and passed together with the diagram suite on OpenJDK 17. A remote Java 8 rerun was started but GitHub cancelled it before reaching this test when the branch advanced; it is not reported as passed. The fresh exact-head build matrix is authoritative.

This head adds deterministic 3 mm interior offsets for parallel connections, keeps their semantic endpoints unchanged, documents the lane contract, and locks both separation and unchanged endpoints in the focused regression.

## Documentation impact

Updated:

- `docs/integration/engineering-diagram-document-model.md`
- `docs/integration/dexpi-engineering-generation.md`

Refs #1332
Refs #2899