### PR TITLE
[AI-Assisted] fix(thermo): preserve reactive electrolyte state

### DIFF
--- a/docs/thermo/reactive_flash.md
+++ b/docs/thermo/reactive_flash.md
@@ -216,7 +216,9 @@ Main entry point for the reactive flash.
 | `isConverged()` | Check if the flash converged |
 | `getTotalIterations()` | Total RAND iterations used |
 | `getNumberOfReactions()` | Number of independent reactions ($N_R = N_C - \text{rank}(A)$) |
-| `getEquilibriumTotalMoles()` | Total moles at equilibrium (may differ from 1.0 when reactions change total moles) |
+| `getEquilibriumTotalMoles()` | Extensive total moles at equilibrium (may differ from the feed when reactions change total moles) |
+| `getFinalResidual()` | Final normalized chemical-potential/element-balance residual |
+| `getFinalElementResidual()` | Element-balance contribution to the final normalized residual |
 | `getFinalGibbsEnergy()` | Final Gibbs energy of the equilibrium state |
 | `setUseChemicalReactionInit(boolean)` | Enable auto-discovery of reaction products |
 | `setMaxNumberOfPhases(int)` | Override the system's max phases (use when `init()` resets it) |

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/reactiveflash/FormulaMatrix.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/reactiveflash/FormulaMatrix.java
@@ -174,20 +174,21 @@ public class FormulaMatrix implements java.io.Serializable {
   }
 
   /**
-   * Compute the total element vector b from mole fractions z.
+   * Compute the total element vector from component amounts.
    *
    * <p>
-   * b[k] = sum_i A[k][i] * z[i]
+   * The input may be a mole-fraction vector for a normalized inventory or component moles for an extensive inventory:
+   * {@code b[k] = sum_i A[k][i] * amount[i]}.
    * </p>
    *
-   * @param z mole fractions (length NC)
+   * @param componentAmounts component mole fractions or moles (length NC)
    * @return element vector b (length NE)
    */
-  public double[] computeElementVector(double[] z) {
+  public double[] computeElementVector(double[] componentAmounts) {
     double[] b = new double[numElements];
     for (int k = 0; k < numElements; k++) {
       for (int i = 0; i < numComponents; i++) {
-        b[k] += A[k][i] * z[i];
+        b[k] += A[k][i] * componentAmounts[i];
       }
     }
     return b;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ModifiedRANDSolver.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ModifiedRANDSolver.java
@@ -210,6 +210,7 @@ public class ModifiedRANDSolver implements java.io.Serializable {
     }
     b = specifiedElementBalance == null ? formulaMatrix.computeElementVector(feedMoles)
         : specifiedElementBalance.clone();
+    double elementTolerance = hasIonicSpecies ? 1.0e-8 : 1.0e-4;
 
     // When NR=0 (no independent reactions), the element balance constraints fully
     // determine the composition. The RAND Newton matrix C = A*diag(n)*A^T is singular
@@ -462,10 +463,9 @@ public class ModifiedRANDSolver implements java.io.Serializable {
       }
 
       // Relaxed convergence for multi-phase reactive systems.
-      // Achieving TOL=1e-9 simultaneously for both chemical potential and element
-      // balance is extremely difficult with damped iteration. Accept 1e-4 for
-      // multi-phase — this is engineering-accurate (composition error < 0.01%).
-      if (np > 1 && maxE < 1.0e-4 && elemResid < 1.0e-8) {
+      // Keep the established non-ionic tolerance, but require strict conservation
+      // when a charge row is part of the element constraints.
+      if (np > 1 && maxE < 1.0e-4 && elemResid < elementTolerance) {
         converged = true;
         break;
       }
@@ -514,7 +514,7 @@ public class ModifiedRANDSolver implements java.io.Serializable {
       }
 
       // If stagnating for many iterations at a small residual, accept
-      if (stagnationCount > 50 && maxE < 1.0e-3 && elemResid < 1.0e-8) {
+      if (stagnationCount > 50 && maxE < 1.0e-3 && elemResid < elementTolerance) {
         converged = true;
         break;
       }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ModifiedRANDSolver.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ModifiedRANDSolver.java
@@ -93,6 +93,9 @@ public class ModifiedRANDSolver implements java.io.Serializable {
   /** Element balance vector (total atoms). */
   private double[] b;
 
+  /** Frozen element balance supplied by the owning reactive flash. */
+  private double[] specifiedElementBalance;
+
   /** Formula matrix A[ne][nc]. */
   private double[][] A;
 
@@ -107,6 +110,9 @@ public class ModifiedRANDSolver implements java.io.Serializable {
 
   /** Final residual. */
   private double finalResidual;
+
+  /** Final normalized element-balance residual. */
+  private double finalElementResidual;
 
   /** Whether converged. */
   private boolean converged;
@@ -196,12 +202,14 @@ public class ModifiedRANDSolver implements java.io.Serializable {
     initialize();
     computeG0();
 
-    // Compute element balance from feed
-    double[] z = new double[nc];
+    // Compute the extensive element inventory from the feed when the owning flash
+    // has not supplied a frozen target.
+    double[] feedMoles = new double[nc];
     for (int i = 0; i < nc; i++) {
-      z[i] = system.getPhase(0).getComponent(i).getz();
+      feedMoles[i] = system.getPhase(0).getComponent(i).getNumberOfmoles();
     }
-    b = formulaMatrix.computeElementVector(z);
+    b = specifiedElementBalance == null ? formulaMatrix.computeElementVector(feedMoles)
+        : specifiedElementBalance.clone();
 
     // When NR=0 (no independent reactions), the element balance constraints fully
     // determine the composition. The RAND Newton matrix C = A*diag(n)*A^T is singular
@@ -214,7 +222,8 @@ public class ModifiedRANDSolver implements java.io.Serializable {
       updateLnPhi();
       converged = true;
       iterationsUsed = 0;
-      finalResidual = computeElementResidual();
+      finalElementResidual = computeElementResidual();
+      finalResidual = finalElementResidual;
       return true;
     }
 
@@ -436,6 +445,7 @@ public class ModifiedRANDSolver implements java.io.Serializable {
         }
       }
       double elemResid = computeElementResidual();
+      finalElementResidual = elemResid;
       finalResidual = Math.max(maxE, elemResid);
 
       // Debug logging for first few and periodic iterations
@@ -455,7 +465,7 @@ public class ModifiedRANDSolver implements java.io.Serializable {
       // Achieving TOL=1e-9 simultaneously for both chemical potential and element
       // balance is extremely difficult with damped iteration. Accept 1e-4 for
       // multi-phase — this is engineering-accurate (composition error < 0.01%).
-      if (np > 1 && maxE < 1.0e-4 && elemResid < 1.0e-4) {
+      if (np > 1 && maxE < 1.0e-4 && elemResid < 1.0e-8) {
         converged = true;
         break;
       }
@@ -504,7 +514,7 @@ public class ModifiedRANDSolver implements java.io.Serializable {
       }
 
       // If stagnating for many iterations at a small residual, accept
-      if (stagnationCount > 50 && finalResidual < 1.0e-3) {
+      if (stagnationCount > 50 && maxE < 1.0e-3 && elemResid < 1.0e-8) {
         converged = true;
         break;
       }
@@ -740,6 +750,7 @@ public class ModifiedRANDSolver implements java.io.Serializable {
       }
     }
 
+    double feedTotalMoles = system.getTotalNumberOfMoles();
     for (int j = 0; j < np; j++) {
       PhaseInterface phase = system.getPhase(j);
       beta[j] = phase.getBeta();
@@ -748,7 +759,7 @@ public class ModifiedRANDSolver implements java.io.Serializable {
       }
       for (int i = 0; i < nc; i++) {
         x[j][i] = phase.getComponent(i).getx();
-        n[j][i] = x[j][i] * beta[j];
+        n[j][i] = x[j][i] * beta[j] * feedTotalMoles;
         if (n[j][i] < EPS) {
           n[j][i] = EPS;
         }
@@ -757,7 +768,7 @@ public class ModifiedRANDSolver implements java.io.Serializable {
           n[j][i] = EPS;
         }
       }
-      nPhase[j] = beta[j];
+      nPhase[j] = beta[j] * feedTotalMoles;
     }
     totalMoles = 0.0;
     for (int j = 0; j < np; j++) {
@@ -974,10 +985,27 @@ public class ModifiedRANDSolver implements java.io.Serializable {
    * Update the thermodynamic system from current mole fractions and phase fractions.
    */
   private void updateSystem() {
+    double[] overallMoles = null;
+    if (hasIonicSpecies) {
+      overallMoles = new double[nc];
+      for (int i = 0; i < nc; i++) {
+        for (int j = 0; j < np; j++) {
+          overallMoles[i] += n[j][i];
+        }
+      }
+      system.setTotalNumberOfMoles(totalMoles);
+    }
     for (int j = 0; j < np; j++) {
       PhaseInterface ph = system.getPhase(j);
       for (int i = 0; i < nc; i++) {
         ph.getComponent(i).setx(x[j][i]);
+        if (hasIonicSpecies) {
+          ph.getComponent(i).setNumberOfmoles(overallMoles[i]);
+          ph.getComponent(i).setz(overallMoles[i] / totalMoles);
+        }
+      }
+      if (hasIonicSpecies) {
+        system.setBeta(j, beta[j]);
       }
       ph.setBeta(beta[j]);
     }
@@ -1060,6 +1088,27 @@ public class ModifiedRANDSolver implements java.io.Serializable {
    */
   public double getFinalResidual() {
     return finalResidual;
+  }
+
+  /**
+   * Get the normalized element-balance contribution to the final residual.
+   *
+   * @return normalized element-balance residual
+   */
+  public double getFinalElementResidual() {
+    return finalElementResidual;
+  }
+
+  /**
+   * Freeze the element inventory enforced by this solve.
+   *
+   * @param elementBalance element abundance vector in the formula-matrix row order
+   */
+  public void setElementBalance(double[] elementBalance) {
+    if (elementBalance == null || elementBalance.length != ne) {
+      throw new IllegalArgumentException("Element balance must contain exactly " + ne + " entries");
+    }
+    specifiedElementBalance = elementBalance.clone();
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ReactiveMultiphaseTPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ReactiveMultiphaseTPflash.java
@@ -286,7 +286,7 @@ public class ReactiveMultiphaseTPflash extends BaseOperation {
           // Accept near-converged multi-phase solutions to prevent outer loop
           // from restarting and overshooting a good solution
           if (system.getNumberOfPhases() > 1 && randSolver.getFinalResidual() < 5.0e-3
-              && randSolver.getFinalElementResidual() < 1.0e-8) {
+              && (!formulaMatrix.hasIonicSpecies() || randSolver.getFinalElementResidual() < 1.0e-8)) {
             converged = true;
             logger.info("Accepted near-converged (residual=" + randSolver.getFinalResidual() + ")");
             break;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ReactiveMultiphaseTPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ReactiveMultiphaseTPflash.java
@@ -84,6 +84,9 @@ public class ReactiveMultiphaseTPflash extends BaseOperation {
   /** Number of independent reactions found. */
   private int numberOfReactions;
 
+  /** Element inventory frozen before any phase initialization or outer iteration. */
+  private double[] elementBalance;
+
   /** Whether the flash converged. */
   private boolean converged;
 
@@ -171,6 +174,7 @@ public class ReactiveMultiphaseTPflash extends BaseOperation {
       // Step 1: Build the formula matrix from component elemental composition
       formulaMatrix = new FormulaMatrix(system);
       numberOfReactions = formulaMatrix.getNumberOfIndependentReactions();
+      elementBalance = formulaMatrix.computeElementVector(getOverallMoles());
 
       logger.debug("ReactiveMultiphaseTPflash: " + formulaMatrix.getNumberOfComponents() + " components, "
           + formulaMatrix.getNumberOfElements() + " elements, " + numberOfReactions + " independent reactions");
@@ -268,6 +272,7 @@ public class ReactiveMultiphaseTPflash extends BaseOperation {
         logger.debug("Outer iter " + outerIter + " np=" + system.getNumberOfPhases());
         // Step 4a: Solve the multiphase modified RAND system
         ModifiedRANDSolver randSolver = new ModifiedRANDSolver(system, formulaMatrix);
+        randSolver.setElementBalance(elementBalance);
         randSolver.setUseDIIS(this.useDIIS);
         boolean randConverged = randSolver.solve();
         totalIterations += randSolver.getIterationsUsed();
@@ -280,7 +285,8 @@ public class ReactiveMultiphaseTPflash extends BaseOperation {
           logger.warn("Modified RAND solver did not converge at outer iteration " + outerIter);
           // Accept near-converged multi-phase solutions to prevent outer loop
           // from restarting and overshooting a good solution
-          if (system.getNumberOfPhases() > 1 && randSolver.getFinalResidual() < 5.0e-3) {
+          if (system.getNumberOfPhases() > 1 && randSolver.getFinalResidual() < 5.0e-3
+              && randSolver.getFinalElementResidual() < 1.0e-8) {
             converged = true;
             logger.info("Accepted near-converged (residual=" + randSolver.getFinalResidual() + ")");
             break;
@@ -646,6 +652,7 @@ public class ReactiveMultiphaseTPflash extends BaseOperation {
     system.init(1);
 
     ModifiedRANDSolver ceSolver = new ModifiedRANDSolver(system, formulaMatrix);
+    ceSolver.setElementBalance(elementBalance);
     ceSolver.setUseDIIS(this.useDIIS);
     converged = ceSolver.solve();
     totalIterations += ceSolver.getIterationsUsed();
@@ -760,6 +767,20 @@ public class ReactiveMultiphaseTPflash extends BaseOperation {
   }
 
   /**
+   * Capture the current overall component amounts in component order.
+   *
+   * @return overall component amounts in mol
+   */
+  private double[] getOverallMoles() {
+    int numberOfComponents = system.getPhase(0).getNumberOfComponents();
+    double[] moles = new double[numberOfComponents];
+    for (int component = 0; component < numberOfComponents; component++) {
+      moles[component] = system.getPhase(0).getComponent(component).getNumberOfmoles();
+    }
+    return moles;
+  }
+
+  /**
    * Check if the flash converged.
    *
    * @return true if converged
@@ -807,6 +828,24 @@ public class ReactiveMultiphaseTPflash extends BaseOperation {
    */
   public double getEquilibriumTotalMoles() {
     return equilibriumTotalMoles;
+  }
+
+  /**
+   * Get the final combined chemical-potential and element-balance residual.
+   *
+   * @return final normalized residual, or {@link Double#NaN} if no solver ran
+   */
+  public double getFinalResidual() {
+    return solver == null ? Double.NaN : solver.getFinalResidual();
+  }
+
+  /**
+   * Get the final normalized element-balance residual.
+   *
+   * @return final normalized element-balance residual, or {@link Double#NaN} if no solver ran
+   */
+  public double getFinalElementResidual() {
+    return solver == null ? Double.NaN : solver.getFinalElementResidual();
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ReactiveElectrolyteStateConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/reactiveflash/ReactiveElectrolyteStateConsistencyTest.java
@@ -1,0 +1,125 @@
+package neqsim.thermodynamicoperations.flashops.reactiveflash;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.phase.PhaseInterface;
+import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
+import neqsim.thermo.system.SystemInterface;
+
+/** Regression tests for extensive state consistency after a reactive electrolyte flash. */
+class ReactiveElectrolyteStateConsistencyTest extends neqsim.NeqSimTest {
+  private static final double ELEMENT_RELATIVE_TOLERANCE = 1.0e-8;
+
+  /**
+   * A ten-mole CO2/brine feed must retain its scale and conserved inventory when the modified RAND variables are copied
+   * back to the public thermodynamic system.
+   */
+  @Test
+  void co2BrineFlashReturnsConservedExtensiveState() {
+    SystemInterface fluid = createFluid();
+    Map<String, Double> feedElements = elementInventoryFromOverallMoles(fluid);
+
+    ReactiveMultiphaseTPflash flash = new ReactiveMultiphaseTPflash(fluid);
+    flash.run();
+
+    assertTrue(flash.isConverged(), "Reactive flash should converge");
+    assertTrue(flash.getFinalResidual() < 1.0e-5,
+        "Chemical-potential and balance residual should be below the acceptance tolerance");
+    assertTrue(flash.getFinalElementResidual() < 1.0e-8,
+        "Normalized element-balance residual should be below the acceptance tolerance");
+    assertEquals(flash.getEquilibriumTotalMoles(), fluid.getTotalNumberOfMoles(), 1.0e-12,
+        "Solver and public system must report the same extensive total");
+
+    double betaSum = 0.0;
+    double phaseMoleSum = 0.0;
+    double charge = 0.0;
+    double[] componentMoles = new double[fluid.getPhase(0).getNumberOfComponents()];
+    for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
+      PhaseInterface phaseState = fluid.getPhase(phase);
+      betaSum += fluid.getBeta(phase);
+      phaseMoleSum += phaseState.getNumberOfMolesInPhase();
+      assertTrue(fluid.getBeta(phase) >= 0.0, "Phase fractions must be non-negative");
+      double compositionSum = 0.0;
+      for (int component = 0; component < phaseState.getNumberOfComponents(); component++) {
+        ComponentInterface species = phaseState.getComponent(component);
+        assertTrue(species.getx() >= 0.0, "Phase compositions must be non-negative");
+        compositionSum += species.getx();
+        componentMoles[component] += species.getNumberOfMolesInPhase();
+        charge += species.getNumberOfMolesInPhase() * species.getIonicCharge();
+        if ("gas".equalsIgnoreCase(phaseState.getPhaseTypeName()) && species.getIonicCharge() != 0) {
+          assertTrue(species.getNumberOfMolesInPhase() < 1.0e-20, "Ions must remain excluded from the gas phase");
+        }
+      }
+      assertEquals(1.0, compositionSum, 1.0e-12, "Every active phase must be normalized");
+    }
+
+    assertEquals(1.0, betaSum, 1.0e-12, "Active phase fractions must sum to one");
+    assertEquals(fluid.getTotalNumberOfMoles(), phaseMoleSum, 1.0e-12,
+        "Active phase moles must sum to the public system total");
+    assertEquals(0.0, charge, 1.0e-9, "The returned multiphase state must be electroneutral");
+
+    for (int component = 0; component < componentMoles.length; component++) {
+      ComponentInterface species = fluid.getPhase(0).getComponent(component);
+      assertEquals(componentMoles[component], species.getNumberOfmoles(), 1.0e-12,
+          "Overall component moles must equal the phase sum for " + species.getComponentName());
+      assertEquals(componentMoles[component] / fluid.getTotalNumberOfMoles(), species.getz(), 1.0e-12,
+          "Overall composition must match the extensive phase state for " + species.getComponentName());
+    }
+
+    Map<String, Double> equilibriumElements = elementInventoryFromPhases(fluid);
+    for (Map.Entry<String, Double> feedElement : feedElements.entrySet()) {
+      double expected = feedElement.getValue().doubleValue();
+      double actual = equilibriumElements.get(feedElement.getKey()).doubleValue();
+      assertEquals(expected, actual, Math.max(1.0, Math.abs(expected)) * ELEMENT_RELATIVE_TOLERANCE,
+          "Conserved inventory mismatch for element " + feedElement.getKey());
+    }
+  }
+
+  private static SystemInterface createFluid() {
+    SystemInterface fluid = new SystemElectrolyteCPAstatoil(303.15, 14.0);
+    fluid.addComponent("methane", 7.0);
+    fluid.addComponent("CO2", 0.5);
+    fluid.addComponent("water", 2.3);
+    fluid.addComponent("Na+", 0.1);
+    fluid.addComponent("Cl-", 0.1);
+    fluid.chemicalReactionInit();
+    fluid.createDatabase(true);
+    fluid.setMixingRule(10);
+    fluid.setMultiPhaseCheck(true);
+    return fluid;
+  }
+
+  private static Map<String, Double> elementInventoryFromOverallMoles(SystemInterface fluid) {
+    Map<String, Double> inventory = new LinkedHashMap<String, Double>();
+    for (int component = 0; component < fluid.getPhase(0).getNumberOfComponents(); component++) {
+      ComponentInterface species = fluid.getPhase(0).getComponent(component);
+      addElements(inventory, species, species.getNumberOfmoles());
+    }
+    return inventory;
+  }
+
+  private static Map<String, Double> elementInventoryFromPhases(SystemInterface fluid) {
+    Map<String, Double> inventory = new LinkedHashMap<String, Double>();
+    for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
+      PhaseInterface phaseState = fluid.getPhase(phase);
+      for (int component = 0; component < phaseState.getNumberOfComponents(); component++) {
+        ComponentInterface species = phaseState.getComponent(component);
+        addElements(inventory, species, species.getNumberOfMolesInPhase());
+      }
+    }
+    return inventory;
+  }
+
+  private static void addElements(Map<String, Double> inventory, ComponentInterface species, double moles) {
+    String[] names = species.getElements().getElementNames();
+    double[] coefficients = species.getElements().getElementCoefs();
+    for (int element = 0; element < names.length; element++) {
+      Double current = inventory.get(names[element]);
+      inventory.put(names[element], (current == null ? 0.0 : current.doubleValue()) + moles * coefficients[element]);
+    }
+  }
+}


### PR DESCRIPTION
## Campaign and frozen scope

Advances #3144 after merged PR #3151.

**Engineering question:** can the modified-RAND reactive flash return an extensive, internally consistent electrolyte system while preserving the feed element/charge inventory across its outer solves?

**Frozen reproducer:** `SystemElectrolyteCPAstatoil`, 303.15 K, 14 bara, mixing rule 10, reactions initialized, multiphase enabled; CH4/CO2/H2O/Na+/Cl- = 7.0/0.5/2.3/0.1/0.1 mol.

**Stop boundary:** solver state synchronization, frozen extensive element inventory, ionic conservation tolerances, diagnostics, regression, and API documentation only. No EOS parameters, reaction constants, ordinary TP-flash algorithm, absorber equipment (#205), salt input/API (#448), or generic TP stability work (#2937).

## Current-master defect

Exact base `bd07729f105efb48b14c641697e0f99fe9af6898` leaves modified-RAND mole and beta variables disconnected from the public `SystemInterface`. A current-master diagnostic returned:

- active beta sum: `2.0`;
- maximum element error: `0.488081974 mol` for a one-mole feed;
- returned reactive phase metadata/state insufficient for public balance diagnostics.

Each outer solver also rebuilt its element target from the preceding approximate state, allowing inventory drift.

## Implementation

- carry actual feed moles into modified RAND instead of silently normalizing every calculation to one mole;
- freeze the initial extensive element/charge vector for all outer and single-phase solves;
- synchronize total moles, component moles/`z`, and system/phase beta for ionic systems;
- require normalized ionic element residual below `1e-8` at all acceptance paths while retaining established non-ionic tolerances and writeback behavior;
- expose combined and element residual diagnostics;
- document that `FormulaMatrix.computeElementVector` accepts normalized fractions or extensive mole vectors;
- add a focused ten-mole CO2/brine regression.

## Scientific and numerical evidence

Head `f44ea9890243f4b8c7a62625c372b7fdbe02b63b`:

- converged: true, 535 RAND iterations;
- total moles: `9.999999955559398 mol`;
- beta sum: `1.0`;
- combined residual: `5.823048851993917e-7`;
- normalized element residual: `8.677387968605933e-9`;
- maximum C/H/O/Na/Cl inventory error: `1.7508681793287906e-7 mol` (H, `5.37e-9` relative);
- total charge residual: `-2.9997306138236003e-10 mol charge`;
- gas-phase ionic inventory: `1e-30 mol`;
- all active compositions normalized and non-negative; overall component moles/`z` equal phase sums.

This is a deterministic synthetic software regression, not a parameter fit or experimental validation dataset. No external data are redistributed, so no data license or preprocessing applies. Standard-state/species behavior is unchanged. The algorithmic basis remains the modified RAND Gibbs-minimization formulation described by Tsanas, Stenby, and Yan, *Ind. Eng. Chem. Res.* 56 (2017) 11983–11995, [doi:10.1021/acs.iecr.7b02714](https://doi.org/10.1021/acs.iecr.7b02714), building on White, Johnson, and Dantzig, *J. Chem. Phys.* 28 (1958) 751–755, [doi:10.1063/1.1744264](https://doi.org/10.1063/1.1744264).

## Validation

Passed locally:

- `./mvnw -q -Dtest=ReactiveElectrolyteStateConsistencyTest,ReactiveMultiphaseTPflashTest,ReactiveMultiphasePHflashTest test` — 25/25;
- four electrolyte/gas-oil-water methods from `ReactiveFlashBenchmarkTest` — 4/4;
- `bash devtools/run_spotless.sh check`;
- documentation search audit — 655 Markdown + 1 standalone HTML source;
- documentation unit suite — 103/103;
- `git diff --check`.

A prior over-broad writeback failed the existing neutral `testGibbsEnergyDecrease`; the implementation was narrowed to ionic state synchronization, after which the full 13-method TP reactive class passed. The ordinary/neutral TP-flash path has no new dispatch. One cold diagnostic was 20.69 s / 522 iterations on current master (invalid returned state) versus 22.33 s / 535 iterations on the corrected electrolyte path (+7.9% wall, +2.5% iterations); this single timing is noisy and not a statistical performance conclusion.

**VALIDATION BLOCKED BY INFRASTRUCTURE:** `./mvnw -q -DskipTests package` reached attached Javadoc generation but this runtime has no `javac`/`javadoc` executable. CI Javadoc and the broader matrix remain pending. No source-attributable mandatory failure is known.

## Compatibility and risks

Public APIs are additive. Neutral solver acceptance tolerances and state writeback remain unchanged. Serialization fields use the existing class UID behavior; the frozen inventory and solver reference are internal. Reactive absorber consumers should receive a more consistent extensive state, but equipment behavior is intentionally untouched.

