### PR TITLE
[AI-Assisted] feat(thermo): add stable reaction residual diagnostics

### DIFF
--- a/docs/thermo/reactive_flash.md
+++ b/docs/thermo/reactive_flash.md
@@ -224,6 +224,21 @@ Main entry point for the reactive flash.
 | `setMaxNumberOfPhases(int)` | Override the system's max phases (use when `init()` resets it) |
 | `setUseDIIS(boolean)` | Enable/disable DIIS acceleration (default: true) |
 
+### Reaction-equilibrium diagnostics
+
+Use `ChemicalReactionOperations` after a chemical-equilibrium or reactive-flash calculation to
+inspect the database-selected reaction set without multiplying trace activities in product space.
+
+| Method | Description |
+|--------|-------------|
+| `getReactionLogResiduals()` | Immutable reaction-name map of signed `ln(Q/K)` residuals in reaction-list order |
+| `getMaximumAbsoluteReactionLogResidual()` | Largest absolute `ln(Q/K)`, or `NaN` if no reactive liquid phase or reaction is available |
+
+Individual `ChemicalReaction` objects also expose `calcLogReactionQuotient(system, phase)` and
+`calcLogReactionResidual(system, phase)`. These methods use the same mole-fraction and activity-
+coefficient standard-state convention as `calcK`, but sum logarithms directly so trace ionic
+activities do not underflow or overflow before the residual is evaluated.
+
 ### FormulaMatrix
 
 Builds the element-component mapping from the thermodynamic system.

--- a/src/main/java/neqsim/chemicalreactions/ChemicalReactionOperations.java
+++ b/src/main/java/neqsim/chemicalreactions/ChemicalReactionOperations.java
@@ -6,13 +6,17 @@
 
 package neqsim.chemicalreactions;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import Jama.Matrix;
 import neqsim.chemicalreactions.chemicalequilibrium.ChemicalEquilibrium;
 import neqsim.chemicalreactions.chemicalequilibrium.LinearProgrammingChemicalEquilibrium;
+import neqsim.chemicalreactions.chemicalreaction.ChemicalReaction;
 import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionList;
 import neqsim.chemicalreactions.kinetics.Kinetics;
 import neqsim.thermo.component.ComponentInterface;
@@ -645,6 +649,49 @@ public class ChemicalReactionOperations implements neqsim.thermo.ThermodynamicCo
    */
   public ChemicalReactionList getReactionList() {
     return reactionList;
+  }
+
+  /**
+   * Get signed logarithmic equilibrium residuals for all reactions in the reactive phase.
+   *
+   * <p>
+   * Residuals use the reaction database's mole-fraction/activity-coefficient standard-state convention and are
+   * evaluated as {@code ln(Q/K)} directly in log space. The returned map keeps reaction-list order and is immutable. An
+   * empty map indicates that no reactive liquid phase or reaction is available.
+   * </p>
+   *
+   * @return immutable map from reaction name to signed {@code ln(Q/K)} residual
+   */
+  public Map<String, Double> getReactionLogResiduals() {
+    int reactivePhase = getReactivePhaseIndex();
+    if (reactivePhase < 0 || reactionList == null) {
+      return Collections.emptyMap();
+    }
+    Map<String, Double> residuals = new LinkedHashMap<String, Double>();
+    for (ChemicalReaction reaction : reactionList.getChemicalReactionList()) {
+      residuals.put(reaction.getName(), reaction.calcLogReactionResidual(system, reactivePhase));
+    }
+    return Collections.unmodifiableMap(residuals);
+  }
+
+  /**
+   * Get the largest absolute logarithmic reaction-equilibrium residual.
+   *
+   * @return maximum absolute {@code ln(Q/K)}, or {@link Double#NaN} when no reaction residual is available
+   */
+  public double getMaximumAbsoluteReactionLogResidual() {
+    Map<String, Double> residuals = getReactionLogResiduals();
+    if (residuals.isEmpty()) {
+      return Double.NaN;
+    }
+    double maximumResidual = 0.0;
+    for (double residual : residuals.values()) {
+      if (Double.isNaN(residual)) {
+        return Double.NaN;
+      }
+      maximumResidual = Math.max(maximumResidual, Math.abs(residual));
+    }
+    return maximumResidual;
   }
 
   /**

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReaction.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReaction.java
@@ -216,6 +216,49 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
   }
 
   /**
+   * Calculate the natural logarithm of the reaction quotient directly in log space.
+   *
+   * <p>
+   * This method follows the same mole-fraction/activity-coefficient convention as {@link #calcK(SystemInterface, int)},
+   * but avoids overflow and underflow when ionic species are present at trace concentrations.
+   * </p>
+   *
+   * @param system thermodynamic system containing the reaction species
+   * @param phaseNumb phase in which the reaction quotient is evaluated
+   * @return natural logarithm of the reaction quotient
+   */
+  public double calcLogReactionQuotient(SystemInterface system, int phaseNumb) {
+    PhaseInterface phase = system.getPhase(phaseNumb);
+    double logReactionQuotient = 0.0;
+    for (int componentIndex = 0; componentIndex < names.length; componentIndex++) {
+      double stoichiometricCoefficient = stocCoefs[componentIndex];
+      if (stoichiometricCoefficient == 0.0) {
+        continue;
+      }
+      ComponentInterface component = phase.getComponent(names[componentIndex]);
+      double logActivity = Math.log(component.getx());
+      if (component.calcActivity()) {
+        double activityCoefficient = phase.getActivityCoefficient(component.getComponentNumber(),
+            phase.getComponent("water").getComponentNumber());
+        logActivity += Math.log(activityCoefficient);
+      }
+      logReactionQuotient += stoichiometricCoefficient * logActivity;
+    }
+    return logReactionQuotient;
+  }
+
+  /**
+   * Calculate the signed logarithmic reaction-equilibrium residual, {@code ln(Q/K)}.
+   *
+   * @param system thermodynamic system containing the reaction species
+   * @param phaseNumb phase in which the reaction residual is evaluated
+   * @return signed residual {@code ln(Q) - ln(K)}
+   */
+  public double calcLogReactionResidual(SystemInterface system, int phaseNumb) {
+    return calcLogReactionQuotient(system, phaseNumb) - Math.log(getK(system.getPhase(phaseNumb)));
+  }
+
+  /**
    * Generaters initial estimates for the molenumbers.
    *
    * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object

--- a/src/test/java/neqsim/chemicalreactions/ChemicalReactionUnderflowDiagnosticTest.java
+++ b/src/test/java/neqsim/chemicalreactions/ChemicalReactionUnderflowDiagnosticTest.java
@@ -1,0 +1,76 @@
+package neqsim.chemicalreactions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import neqsim.chemicalreactions.chemicalreaction.ChemicalReaction;
+import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Regression tests for stable reaction-equilibrium diagnostics. */
+class ChemicalReactionUnderflowDiagnosticTest extends neqsim.NeqSimTest {
+  @Test
+  void traceWaterDissociationQuotientUnderflows() {
+    SystemInterface fluid = createTraceWaterSystem(1.0e-200);
+
+    ChemicalReaction reaction = new ChemicalReaction("trace water dissociation",
+        new String[] { "H3O+", "OH-", "water" }, new double[] { 1.0, 1.0, -2.0 }, new double[] { 0.0, 0.0, 0.0, 0.0 },
+        0.0, 0.0, 298.15);
+
+    assertEquals(0.0, reaction.calcK(fluid, 0),
+        "The legacy product-space quotient demonstrates the current-master underflow");
+    double logReactionQuotient = reaction.calcLogReactionQuotient(fluid, 0);
+    assertTrue(Double.isFinite(logReactionQuotient));
+    assertTrue(logReactionQuotient < -700.0, "The trace-species logarithmic quotient must retain its magnitude");
+    assertEquals(logReactionQuotient, reaction.calcLogReactionQuotient(fluid, 0), 0.0,
+        "Repeated diagnostics must be deterministic");
+    assertEquals(logReactionQuotient, reaction.calcLogReactionResidual(fluid, 0), 1.0e-12,
+        "The synthetic reaction uses K=1");
+
+    SystemInterface nearbyFluid = createTraceWaterSystem(1.0e-190);
+    double nearbyLogReactionQuotient = reaction.calcLogReactionQuotient(nearbyFluid, 0);
+    assertTrue(Double.isFinite(nearbyLogReactionQuotient));
+    assertTrue(nearbyLogReactionQuotient > logReactionQuotient,
+        "Increasing both ionic trace activities must increase the reaction quotient");
+  }
+
+  @Test
+  void aqueousReactionOperationsExposeImmutableResidualDiagnostics() {
+    SystemInterface fluid = new SystemElectrolyteCPAstatoil(303.15, 14.0);
+    fluid.addComponent("water", 0.98);
+    fluid.addComponent("Na+", 0.01);
+    fluid.addComponent("Cl-", 0.01);
+    fluid.chemicalReactionInit();
+    fluid.createDatabase(true);
+    fluid.setMixingRule(10);
+    fluid.setMultiPhaseCheck(true);
+    new ThermodynamicOperations(fluid).TPflash();
+
+    Map<String, Double> residuals = fluid.getChemicalReactionOperations().getReactionLogResiduals();
+    assertFalse(residuals.isEmpty(), "The database-selected aqueous reaction set must be diagnosed");
+    double expectedMaximum = 0.0;
+    for (double residual : residuals.values()) {
+      assertTrue(Double.isFinite(residual), "Every aqueous reaction residual must be finite");
+      expectedMaximum = Math.max(expectedMaximum, Math.abs(residual));
+    }
+    assertEquals(expectedMaximum, fluid.getChemicalReactionOperations().getMaximumAbsoluteReactionLogResidual(), 0.0);
+    assertTrue(expectedMaximum <= 2.0e-6, "Maximum absolute ln(Q/K) was " + expectedMaximum);
+    assertThrows(UnsupportedOperationException.class, () -> residuals.put("mutation", 0.0),
+        "Callers must not mutate reaction-operation diagnostics");
+  }
+
+  private SystemInterface createTraceWaterSystem(double ionicMoles) {
+    SystemInterface fluid = new SystemElectrolyteCPAstatoil(298.15, 10.0);
+    fluid.addComponent("water", 1.0);
+    fluid.addComponent("H3O+", ionicMoles);
+    fluid.addComponent("OH-", ionicMoles);
+    fluid.createDatabase(true);
+    fluid.setMixingRule(10);
+    fluid.init(1);
+    return fluid;
+  }
+}

--- a/src/test/java/neqsim/thermo/system/SystemThermoReactiveCloneTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemThermoReactiveCloneTest.java
@@ -15,7 +15,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
-import neqsim.chemicalreactions.chemicalreaction.ChemicalReaction;
 import neqsim.thermo.component.ComponentInterface;
 import neqsim.thermo.phase.PhaseInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -162,14 +161,7 @@ class SystemThermoReactiveCloneTest extends neqsim.NeqSimTest {
     }
     assertEquals(0.0, charge, BALANCE_TOLERANCE, "Aqueous phase must be electroneutral");
 
-    double maximumLogReactionResidual = 0.0;
-    for (ChemicalReaction reaction : fluid.getChemicalReactionOperations().getReactionList()
-        .getChemicalReactionList()) {
-      double reactionQuotient = reaction.calcK(fluid, aqueousPhase);
-      double equilibriumConstant = reaction.getK(aqueous);
-      maximumLogReactionResidual = Math.max(maximumLogReactionResidual,
-          Math.abs(Math.log(reactionQuotient / equilibriumConstant)));
-    }
+    double maximumLogReactionResidual = fluid.getChemicalReactionOperations().getMaximumAbsoluteReactionLogResidual();
     assertTrue(maximumLogReactionResidual <= 2.0e-6, "Maximum absolute ln(Q/K) was " + maximumLogReactionResidual);
   }
 


### PR DESCRIPTION
## Summary

Adds numerically stable, Java/JPype-friendly reaction-equilibrium diagnostics for electrolyte calculations.

- computes `ln(Q)` and signed `ln(Q/K)` directly in log space while preserving the existing mole-fraction/activity-coefficient convention
- exposes an immutable, reaction-name-ordered residual map and maximum absolute residual through `ChemicalReactionOperations`
- replaces the clone regression's duplicated product-space residual calculation
- documents the additive API and no-reactive-phase `NaN`/empty-map behavior

Refs #3144.

## Frozen engineering question

On exact `master` `885e3986c195ba5ed4da95b772b3ca0407e22716`, `ChemicalReaction.calcK()` multiplies trace activities before callers take a logarithm. For water dissociation with H3O+ and OH- each initialized at `1e-200 mol`, the product-space quotient becomes exactly zero although the corresponding log-space quotient is finite.

This tranche is diagnostics-only. It does **not** change an EOS parameter, reaction constant, phase-stability/flash solver, hydrate model, absorber equipment, or salt-input API, avoiding overlap with #2937, #205, and #448.

## Model and conventions

- model: `SystemElectrolyteCPAstatoil`
- mixing rule: 10
- reproducer state: 298.15 K, 10 bara; water 1 mol; H3O+ and OH- each `1e-200 mol`
- synthetic reaction: H3O+ + OH- - 2 H2O, with K=1
- acceptance: finite log quotient below -700, deterministic repeat, correct nearby-state direction at `1e-190 mol`
- ordinary database reaction check: 303.15 K, 14 bara; 0.98/0.01/0.01 mol H2O/Na+/Cl-; max `|ln(Q/K)| <= 2e-6`
- units/composition basis: existing NeqSim temperature/pressure/moles and phase mole fractions
- standard state/species convention: unchanged from `calcK`; activity coefficients are included only for species whose components request activity treatment, with water as the reference component

## Evidence

Current-master baseline: legacy `calcK` returned `0.0` for the trace reaction.

Implemented result:
- trace `ln(Q) = -939.570271423658`
- nearby `1e-190 mol` state: `ln(Q) = -893.518569563777` (correct increasing-activity trend)
- ordinary aqueous database reaction: max `|ln(Q/K)| = 1.42108547152020e-14` across one selected reaction
- immutable residual result and deterministic exact repeat verified
- clone balance/electroneutrality/non-negative normalized phase-state gates remain covered by `SystemThermoReactiveCloneTest`

No experimental or fitted data are introduced. The trace case is a synthetic numerical regression, so data licensing, reported uncertainty, preprocessing, and train/validation splitting are not applicable. The equilibrium/log-residual formulation is consistent with the common chemical-potential basis in [White, Johnson & Dantzig (1958), DOI 10.1063/1.1744264](https://doi.org/10.1063/1.1744264); electrolyte-CPA context is documented by [Tsanas et al. (2017), DOI 10.1021/acs.iecr.7b02714](https://doi.org/10.1021/acs.iecr.7b02714).

## Validation

Passed locally from the exact GitHub-source snapshot:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py` — 655 Markdown pages and one standalone HTML page
- `python -m unittest discover -s docs -p 'test_*.py' -q` — 103/103 passed
- `./mvnw -q -Dtest=ChemicalReactionUnderflowDiagnosticTest,ChemicalReactionOperationsTest,ChemicalReactionListTest,SystemThermoReactiveCloneTest test` — 6 applicable tests passed; one pre-existing reaction-list test skipped
- `./mvnw -q -Dtest=SystemPitzerTest test` — 22/22 passed
- `./mvnw -q -DexcludedTestGroups= -Dgroups=slow -Dtest=SystemElectrolyteCPATest test` — 28/28 passed

The configured pre-commit/pre-push hook commands were run directly and passed (Spotless apply/check and documentation search); the `pre-commit` Python package is unavailable in this runtime.

Performance:
- complete flash/neutral paths have zero new diagnostic dispatch by source inspection, so the default calculation path has no added work
- optional three-species log-residual kernel: 72.9 ms/call median-like single-run average over 250 calls in this constrained runtime
- complexity is linear in diagnosed reaction species; it is incurred only when a caller requests diagnostics

## Compatibility and stop boundary

The API is additive and returns detached immutable values. It does not add serialized state or mutable caches, and the existing clone/concurrency path is unchanged. The direct methods are public Java APIs and therefore available through JPype.

**VALIDATION PENDING CI** for repository Java 21 compilation/Javadocs, complete fast/slow matrix, CodeQL, PaperLab, and platform coverage. No direct mandatory local gate is known to fail. This draft remains in progress until exact-head CI and all review threads are audited.