### PR TITLE
[AI-Assisted] fix(flash): retain low-pressure hydrogen boundary phases

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1933,6 +1933,21 @@ For each experimental tie line, the regression verifies the following:
 This is an evidence-level-1 literature qualification of phase topology and numerical consistency. It does not claim
 that classic cubic EOS models reproduce every hydrogen-rich VLE dataset within experimental uncertainty.
 
+The same reference matrix also anchors a low-pressure phase-boundary safeguard. At 143.05 K and 40.2 atm, an overall
+hydrogen fraction `1e-4` inside the calculated vapor boundary previously collapsed to one phase through ordinary
+`TPflash`, while the explicit-multiphase path retained the equilibrium liquid with beta `1.4778e-4` for SRK and
+`1.5109e-4` for PR. The ordinary stability path had rejected every amplified-K supplementary trial below 50 bar before
+applying its Wilson-sum or tangent-plane screens.
+
+For feeds containing more than `0.01` overall hydrogen, the pressure prefilter now permits that existing supplementary
+trial below 50 bar. All later Wilson-sum, K-value-spread, convergence, non-trivial-composition, and non-physical-state
+rollback gates remain unchanged. The regression recomputes each EOS boundary for the four literature points below
+50 bar, then evaluates overall compositions `1e-4` to either side of both calculated endpoints. Inside states retain
+GAS+OIL with a small phase of order `1e-4`; outside states remain single-phase. Ordinary and explicit-multiphase paths
+must satisfy the same normalization, material-balance, fugacity, property, repeat, poor-initialization, phase
+disappearance, and reappearance gates listed above. Non-hydrogen feeds, hydrogen at or below one mole percent, and the
+established pressure-at-or-above-50-bar path are unchanged.
+
 ---
 
 ## 7. References

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/Flash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/Flash.java
@@ -189,8 +189,10 @@ public abstract class Flash extends BaseOperation {
    * Wilson K values approach 1 and standard trials converge to trivial solutions).
    *
    * <p>
-   * Only runs when Wilson K-values indicate near-critical conditions (trial sums close to 1.0), avoiding false
-   * positives in clearly non-critical systems.
+   * Runs at moderate-to-high pressure, or below 50 bar for feeds containing more than one mole percent hydrogen, and
+   * only proceeds when the Wilson K-value sums or tangent-plane result indicate an ambiguous phase boundary. The
+   * existing K-value-spread and non-physical-state rollback gates avoid false positives in clearly single-phase
+   * systems.
    *
    * @return true if instability was found (K-values on system are updated)
    */
@@ -214,8 +216,20 @@ public abstract class Flash extends BaseOperation {
     boolean nearlyPure = maxZ > 0.999;
     boolean trivialSolution = !nearlyPure && ((Math.abs(tm[0]) < 1e-12) || (Math.abs(tm[1]) < 1e-12));
 
-    // Only retry at moderate-to-high pressures where near-critical VLE issues occur.
-    if (system.getPressure() < 50.0) {
+    boolean hydrogenRichFeed = false;
+    for (int i = 0; i < numComp; i++) {
+      ComponentInterface component = system.getPhase(0).getComponent(i);
+      if ("hydrogen".equalsIgnoreCase(component.getComponentName()) && component.getz() > 1.0e-2) {
+        hydrogenRichFeed = true;
+        break;
+      }
+    }
+
+    // Most supplementary retries target moderate-to-high-pressure near-critical VLE. Hydrogen
+    // binaries can have equally difficult, highly asymmetric boundaries below 50 bar, so retain
+    // the later Wilson-sum and TPD screens for hydrogen-bearing feeds instead of rejecting them
+    // only on pressure.
+    if (system.getPressure() < 50.0 && !hydrogenRichFeed) {
       return false;
     }
 

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashHydrogenLiteratureConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashHydrogenLiteratureConsistencyTest.java
@@ -25,6 +25,7 @@ class TPflashHydrogenLiteratureConsistencyTest extends neqsim.NeqSimTest {
   private static final double MODEL_COMPOSITION_TOLERANCE = 0.04;
   private static final double MATERIAL_BALANCE_TOLERANCE = 1.0e-10;
   private static final double FUGACITY_TOLERANCE = 1.0e-8;
+  private static final double BOUNDARY_COMPOSITION_OFFSET = 1.0e-4;
   private static final TieLine[] TIE_LINES = { new TieLine("methane", 123.15, 20.0, 0.0192, 0.818),
       new TieLine("methane", 143.05, 40.2, 0.0477, 0.721), new TieLine("methane", 173.65, 59.9, 0.0709, 0.362),
       new TieLine("ethane", 148.15, 20.0, 0.00618, 0.986), new TieLine("ethane", 173.15, 40.0, 0.0168, 0.977) };
@@ -55,6 +56,61 @@ class TPflashHydrogenLiteratureConsistencyTest extends neqsim.NeqSimTest {
             tieLine.label(eos) + " liquid-composition side");
         assertSinglePhaseAcrossAlgorithms(eos, tieLine, vaporSideHydrogen,
             tieLine.label(eos) + " vapor-composition side");
+      }
+    }
+  }
+
+  @Test
+  void calculatedBoundariesPreserveTinyPhasesAndAdjacentSinglePhaseStates() {
+    for (Eos eos : Eos.values()) {
+      for (TieLine tieLine : TIE_LINES) {
+        if (tieLine.pressureBar() >= 50.0) {
+          continue;
+        }
+        SystemInterface midpoint = flash(createSystem(eos, tieLine, tieLine.midpoint(), false), false);
+        Integer[] order = phaseOrder(midpoint);
+        double vaporHydrogen = midpoint.getPhase(order[0]).getComponent("hydrogen").getx();
+        double liquidHydrogen = midpoint.getPhase(order[1]).getComponent("hydrogen").getx();
+
+        assertBoundaryStateAcrossAlgorithms(eos, tieLine, liquidHydrogen - BOUNDARY_COMPOSITION_OFFSET, 1,
+            tieLine.label(eos) + " below calculated liquid boundary");
+        assertBoundaryStateAcrossAlgorithms(eos, tieLine, liquidHydrogen + BOUNDARY_COMPOSITION_OFFSET, 2,
+            tieLine.label(eos) + " inside calculated liquid boundary");
+        assertBoundaryStateAcrossAlgorithms(eos, tieLine, vaporHydrogen - BOUNDARY_COMPOSITION_OFFSET, 2,
+            tieLine.label(eos) + " inside calculated vapor boundary");
+        assertBoundaryStateAcrossAlgorithms(eos, tieLine, vaporHydrogen + BOUNDARY_COMPOSITION_OFFSET, 1,
+            tieLine.label(eos) + " above calculated vapor boundary");
+      }
+    }
+  }
+
+  @Test
+  void calculatedBoundaryTransitionsDoNotRetainStalePhaseState() {
+    TieLine tieLine = TIE_LINES[1];
+    for (Eos eos : Eos.values()) {
+      SystemInterface midpoint = flash(createSystem(eos, tieLine, tieLine.midpoint(), false), false);
+      double vaporHydrogen = midpoint.getPhase(phaseOrder(midpoint)[0]).getComponent("hydrogen").getx();
+      double insideHydrogen = vaporHydrogen - BOUNDARY_COMPOSITION_OFFSET;
+      double outsideHydrogen = vaporHydrogen + BOUNDARY_COMPOSITION_OFFSET;
+
+      for (boolean multiphase : new boolean[] { false, true }) {
+        SystemInterface insideReference = flash(createSystem(eos, tieLine, insideHydrogen, multiphase), false);
+        SystemInterface poorGuess = flash(createSystem(eos, tieLine, insideHydrogen, multiphase), true);
+        assertEquivalent(insideReference, poorGuess, tieLine.label(eos) + " boundary poor initialization");
+
+        SystemInterface repeatedReference = insideReference.clone();
+        flash(insideReference, false);
+        assertEquivalent(repeatedReference, insideReference, tieLine.label(eos) + " boundary repeat");
+
+        insideReference.setMolarComposition(new double[] { outsideHydrogen, 1.0 - outsideHydrogen });
+        flash(insideReference, false);
+        SystemInterface outsideReference = flash(createSystem(eos, tieLine, outsideHydrogen, multiphase), false);
+        assertEquals(1, outsideReference.getNumberOfPhases(), tieLine.label(eos) + " boundary disappearance");
+        assertEquivalent(outsideReference, insideReference, tieLine.label(eos) + " boundary disappearance");
+
+        insideReference.setMolarComposition(new double[] { insideHydrogen, 1.0 - insideHydrogen });
+        flash(insideReference, false);
+        assertEquivalent(poorGuess, insideReference, tieLine.label(eos) + " boundary reappearance");
       }
     }
   }
@@ -91,6 +147,16 @@ class TPflashHydrogenLiteratureConsistencyTest extends neqsim.NeqSimTest {
     SystemInterface multiphase = flash(createSystem(eos, tieLine, hydrogenFraction, true), false);
 
     assertEquals(1, ordinary.getNumberOfPhases(), label);
+    assertEquivalent(ordinary, multiphase, label);
+  }
+
+  private static void assertBoundaryStateAcrossAlgorithms(Eos eos, TieLine tieLine, double hydrogenFraction,
+      int expectedPhases, String label) {
+    SystemInterface ordinary = flash(createSystem(eos, tieLine, hydrogenFraction, false), false);
+    SystemInterface multiphase = flash(createSystem(eos, tieLine, hydrogenFraction, true), false);
+
+    assertEquals(expectedPhases, ordinary.getNumberOfPhases(), label + " ordinary path");
+    assertEquals(expectedPhases, multiphase.getNumberOfPhases(), label + " multiphase path");
     assertEquivalent(ordinary, multiphase, label);
   }
 


### PR DESCRIPTION
## Summary

Advances #2937 with a narrowly screened low-pressure hydrogen phase-boundary recovery.

- lets the existing amplified-K supplementary stability retry run below 50 bar only when overall hydrogen exceeds 0.01;
- retains the established Wilson-sum, tangent-plane, K-spread, convergence, non-trivial-composition, and non-physical-state rollback gates;
- extends the Sagara et al. H2+methane / H2+ethane qualification across calculated phase appearance and disappearance boundaries;
- covers ordinary and explicit-multiphase paths, tiny phases, poor initialization, exact repeat, changed composition, disappearance, and reappearance;
- documents the method, evidence, bounds, and unchanged paths.

## Reproduced defect

On exact merged source from #3149, the ordinary stability path unconditionally rejected the amplified-K supplementary retry below 50 bar before evaluating its existing ambiguity screens.

At 143.05 K and 40.2 atm, with overall H2 set 1e-4 inside the calculated vapor boundary:

| EOS | ordinary baseline | explicit multiphase | smallest multiphase beta |
|---|---|---|---:|
| SRK | one phase | GAS+OIL | 1.4778267e-4 |
| PR | one phase | GAS+OIL | 1.5109015e-4 |

The discrepancy is deterministic. Compositions 1e-4 outside the same calculated boundary remain single-phase through both paths.

## Frozen scope and acceptance

The recovery is limited to feeds with more than one mole percent hydrogen below 50 bar. Non-hydrogen feeds, hydrogen at or below 0.01 overall fraction, and the established pressure-at-or-above-50-bar path are unchanged.

For SRK and PR at the four published tie lines below 50 bar, the regression computes the model's liquid and vapor endpoints and tests overall compositions 1e-4 to either side of both boundaries:

- inside boundary: exactly GAS+OIL, retaining the small phase;
- outside boundary: exactly one phase;
- beta and composition finite, bounded, and normalized within 1e-12;
- component material balance below 1e-10;
- interphase log-fugacity residual below 1e-8;
- ordinary/multiphase beta and composition agreement within 1e-10;
- Z agreement within 1e-8 and extensive Gibbs agreement within max(1e-7 J, 1e-8 abs(G));
- poor beta, exact repeat, two-phase-to-one-phase disappearance, and one-phase-to-two-phase reappearance match fresh references.

The 59.9 atm literature point remains on the pre-existing >=50 bar supplementary path and is intentionally outside this low-pressure tranche.

## Scientific basis

The boundary states are derived from the literature-anchored binary qualification merged in #3149:

H. Sagara, Y. Arai, and S. Saito, “Vapor-Liquid Equilibria of Binary and Ternary Systems Containing Hydrogen and Light Hydrocarbons,” *Journal of Chemical Engineering of Japan* 5 (1972), 339–348. https://doi.org/10.1252/jcej.5.339

No experimental data, EOS parameter, binary interaction parameter, or tolerance is fitted or changed.

## Validation

Local validation used the exact #3149 merged source; connector inspection confirmed that current master `885e3986c195ba5ed4da95b772b3ca0407e22716` has identical blobs for all three touched files before this branch was created.

Passed:

- `TPflashHydrogenLiteratureConsistencyTest`: 5/5;
- focused cross-algorithm/nearby suite: 24/24 across the hydrogen, multiphase, sour-gas, LLE, cold water-rich, and ionic GAS+AQUEOUS classes;
- `python devtools/run_spotless.py apply`;
- `python devtools/run_spotless.py check`;
- `python devtools/check_documentation_search.py` — 655 Markdown pages and one standalone HTML page;
- `git diff --check`.

The Python `pre-commit` package is unavailable in this runtime; its direct repository-equivalent Spotless and documentation gates passed.

Performance probe (fresh systems, 20 warmups, five blocks of 30 flashes in this constrained runtime):

- corrected boundary path necessarily changes from an incorrect one-phase calculation to a two-phase calculation; median-like block timings changed SRK 7.08 -> 8.53 ms and PR 6.12 -> 12.07 ms;
- the adjacent retained one-phase control showed no observed slowdown (SRK 5.37 -> 4.80 ms; PR 4.08 -> 3.69 ms), but this is not treated as a speed claim.

Hosted exact-head PaperLab, Spotless, pre-commit, documentation search, CodeQL, Java 8/21 fast tests, all slow-test shards, and Javadoc passed. The PR had no reviews or unresolved threads and was merged into protected `master` as `0cc95dbe3d065094580f3d2a742ad5b373b5f52f`.

**MERGED AND VALIDATED**

## Documentation impact

Updated the private-method Javadoc and `docs/thermodynamicoperations/TPflash_algorithm.md` with the low-pressure hydrogen gate, reproduced phase fractions, boundary matrix, preserved safeguards, acceptance tolerances, and unchanged paths.

## Compatibility and stop boundary

- no public API, serialization, EOS parameter, mixing rule, unit, or default tolerance change;
- no electrolyte/reaction implementation overlap with #3158;
- no Column Solver, Process Performance, notebook, or Huldra work;
- the separate high-pressure near-boundary behavior remains outside this sub-50-bar correction.