### PR TITLE
[AI-Assisted] fix(process): serialize shared-stream consumers

### DIFF
--- a/docs/process/processmodel/process_system.md
+++ b/docs/process/processmodel/process_system.md
@@ -382,9 +382,9 @@ Stream sharedInput = valve.getOutletStream();
 Heater heater1 = new Heater("heater1", sharedInput);  // Same stream object
 Heater heater2 = new Heater("heater2", sharedInput);  // Same stream object
 
-// These single-input units only read/clone the shared stream and may run in parallel.
-// If either consumer were multi-input, NeqSim would group the consumers into one
-// sequential task to protect mutable mixing behavior.
+// NeqSim groups both consumers into one sequential task because cloning and
+// initializing the shared thermodynamic state is not a read-only operation.
+// Consumers attached to distinct stream objects remain parallel.
 process.runParallel();
 ```
 

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -1660,8 +1660,8 @@ public class ProcessSystem extends SimulationBaseClass {
    *
    * <p>
    * Multi-input equipment (Mixer, Manifold, TurboExpanderCompressor, Ejector, HeatExchanger, MultiStreamHeatExchanger)
-   * require sequential execution to ensure correct mass balance. Parallel execution can change the order in which input
-   * streams are processed, leading to incorrect results.
+   * requires dependency-aware execution to ensure correct mass balance. Parallel and dataflow execution preserve inlet
+   * ordering and serialize consumers that share the same mutable stream object.
    * </p>
    *
    * @return true if there are multi-input equipment units in the process
@@ -1714,41 +1714,6 @@ public class ProcessSystem extends SimulationBaseClass {
       }
     }
     cachedHasMultiInput = false;
-    return false;
-  }
-
-  /**
-   * Returns true if the given graph node represents multi-input equipment. Used by
-   * {@link #groupNodesBySharedInputStreams(List)} to decide whether shared-stream consumers need to be serialised
-   * within a group.
-   *
-   * @param node the graph node
-   * @return {@code true} if the underlying equipment has 2+ inlet streams or is one of the class-based multi-input
-   * types
-   */
-  private boolean isMultiInputNode(ProcessNode node) {
-    ProcessEquipmentInterface unit = node.getEquipment();
-    if (unit == null) {
-      return false;
-    }
-    if (unit instanceof MixerInterface || unit instanceof Manifold || unit instanceof TurboExpanderCompressor
-        || unit instanceof Ejector || unit instanceof HeatExchanger || unit instanceof MultiStreamHeatExchangerInterface
-        || unit instanceof FurnaceBurner || unit instanceof FlareStack) {
-      return true;
-    }
-    if (unit instanceof neqsim.process.equipment.separator.Separator) {
-      if (((neqsim.process.equipment.separator.Separator) unit).numberOfInputStreams > 1) {
-        return true;
-      }
-    }
-    try {
-      java.util.List<neqsim.process.equipment.stream.StreamInterface> inlets = unit.getInletStreams();
-      if (inlets != null && inlets.size() > 1) {
-        return true;
-      }
-    } catch (Exception e) {
-      // Fall through - conservative default is false
-    }
     return false;
   }
 
@@ -2711,27 +2676,13 @@ public class ProcessSystem extends SimulationBaseClass {
       }
     }
 
-    // Union nodes that share the same input stream.
-    //
-    // Optimisation: only union when at least one of the nodes sharing the
-    // stream is multi-input equipment (Mixer, HeatExchanger, Separator with
-    // >1 inlets, etc.). Two single-input consumers reading the same upstream
-    // stream can run in parallel safely because the thermo clone() path is
-    // thread-safe for concurrent reads (shared read-only invariant on
-    // mixing-rule matrices). Forcing them into the same group was a legacy
-    // over-conservative grouping that limits parallelism unnecessarily.
+    // Union every pair of consumers that shares the same mutable stream object.
+    // Equipment commonly clones its inlet before calculating, but SystemInterface
+    // clone and initialization can touch shared thermodynamic helper state. Treating
+    // single-input consumers as read-only therefore permits platform-dependent races.
+    // Consumers of distinct stream objects remain in independent parallel groups.
     for (List<ProcessNode> nodesWithSameStream : streamToNodes.values()) {
       if (nodesWithSameStream.size() > 1) {
-        boolean anyMultiInput = false;
-        for (ProcessNode n : nodesWithSameStream) {
-          if (isMultiInputNode(n)) {
-            anyMultiInput = true;
-            break;
-          }
-        }
-        if (!anyMultiInput) {
-          continue; // Pure single-input readers - safe to run in parallel.
-        }
         ProcessNode first = nodesWithSameStream.get(0);
         for (int i = 1; i < nodesWithSameStream.size(); i++) {
           union.accept(first, nodesWithSameStream.get(i));

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -135,6 +138,53 @@ public class ProcessSystemTest extends neqsim.NeqSimTest {
     @Override
     public List<StreamInterface> getInletStreams() {
       return inletStreams;
+    }
+  }
+
+  private static class SharedInletConcurrencyProbe extends ProcessEquipmentBaseClass {
+    private static final long serialVersionUID = 1000L;
+    private final StreamInterface inletStream;
+    private final AtomicInteger activeConsumers;
+    private final AtomicInteger peakConsumers;
+    private final CountDownLatch startGate;
+
+    SharedInletConcurrencyProbe(String name, StreamInterface inletStream, AtomicInteger activeConsumers,
+        AtomicInteger peakConsumers, CountDownLatch startGate) {
+      super(name);
+      this.inletStream = inletStream;
+      this.activeConsumers = activeConsumers;
+      this.peakConsumers = peakConsumers;
+      this.startGate = startGate;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void run(UUID id) {
+      int active = activeConsumers.incrementAndGet();
+      updatePeak(peakConsumers, active);
+      startGate.countDown();
+      try {
+        startGate.await(500L, TimeUnit.MILLISECONDS);
+      } catch (InterruptedException ex) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("Concurrency probe interrupted", ex);
+      } finally {
+        activeConsumers.decrementAndGet();
+      }
+      setCalculationIdentifier(id);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<StreamInterface> getInletStreams() {
+      return java.util.Collections.singletonList(inletStream);
+    }
+
+    private static void updatePeak(AtomicInteger peak, int candidate) {
+      int current = peak.get();
+      while (candidate > current && !peak.compareAndSet(current, candidate)) {
+        current = peak.get();
+      }
     }
   }
 
@@ -327,6 +377,53 @@ public class ProcessSystemTest extends neqsim.NeqSimTest {
     RuntimeException thrown = Assertions.assertThrows(RuntimeException.class,
         () -> process.runParallel(UUID.randomUUID()));
     Assertions.assertTrue(thrown.getMessage().contains("SharedFailingUnit"));
+  }
+
+  @Test
+  public void testRunParallelSerializesSingleInputConsumersSharingStream() throws InterruptedException {
+    Assertions.assertEquals(1, runConsumerConcurrencyProbe(true, false),
+        "Consumers cloning the same mutable stream must execute in one sequential group");
+  }
+
+  @Test
+  public void testRunDataflowSerializesSingleInputConsumersSharingStream() throws InterruptedException {
+    Assertions.assertEquals(1, runConsumerConcurrencyProbe(true, true),
+        "Dataflow consumers cloning the same mutable stream must execute sequentially");
+  }
+
+  @Test
+  public void testRunParallelKeepsDistinctInputConsumersParallel() throws InterruptedException {
+    Assertions.assertEquals(2, runConsumerConcurrencyProbe(false, false),
+        "Consumers of distinct streams should remain parallel");
+  }
+
+  private int runConsumerConcurrencyProbe(boolean sharedInput, boolean dataflow) throws InterruptedException {
+    neqsim.thermo.system.SystemInterface firstFluid = new neqsim.thermo.system.SystemSrkEos(298.15, 10.0);
+    firstFluid.addComponent("methane", 1.0);
+    firstFluid.setMixingRule("classic");
+    Stream firstInlet = new Stream("first fan-out stream", firstFluid);
+    Stream secondInlet = sharedInput ? firstInlet : new Stream("second independent stream", firstFluid.clone());
+    AtomicInteger activeConsumers = new AtomicInteger();
+    AtomicInteger peakConsumers = new AtomicInteger();
+    CountDownLatch startGate = new CountDownLatch(2);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(firstInlet);
+    if (!sharedInput) {
+      process.add(secondInlet);
+    }
+    process.add(new SharedInletConcurrencyProbe("first fan-out consumer", firstInlet, activeConsumers, peakConsumers,
+        startGate));
+    process.add(new SharedInletConcurrencyProbe("second fan-out consumer", secondInlet, activeConsumers, peakConsumers,
+        startGate));
+
+    if (dataflow) {
+      process.runDataflow(UUID.randomUUID());
+    } else {
+      process.runParallel(UUID.randomUUID());
+    }
+
+    return peakConsumers.get();
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fix the nondeterministic process-scheduler race behind the Java 8 Windows failure in [Run build, test and javadoc #10426](https://github.com/equinor/neqsim/actions/runs/32579255481).

The failed regression was:

`MultiInputMixerPhaseRegressionTest.reusedMultiInputProcessPreservesAqueousPhaseAfterFlowChange`

The sequential reference flow was `164152.8145645417 kg/hr`, while the failing optimized run produced `164152.95362982 kg/hr`. An earlier occurrence on another head produced `164153.08260098464 kg/hr`, which confirms a scheduling race rather than a stable numerical offset.

## Root cause

`ProcessSystem.groupNodesBySharedInputStreams` serialized shared-stream consumers only when at least one consumer was multi-input equipment. Two single-input units consuming the same `StreamInterface` were therefore allowed to run concurrently.

Those units commonly clone and initialize the inlet thermodynamic system. That path can touch shared mutable thermodynamic helper state, so treating it as a concurrent read is unsafe and platform-dependent.

## Fix

- Group every pair of consumers that shares the same stream object into one sequential scheduler task.
- Preserve parallel execution for consumers attached to distinct stream objects.
- Apply the same dependency plan to both `runParallel` and `runDataflow`.
- Remove the now-unused multi-input-only classification helper.
- Correct the process-system documentation to describe the actual concurrency contract.

This is not a global sequential fallback and does not add another process or flash pass.

## Regression coverage

A deterministic scheduler probe reproduces the bug on the previous implementation: two single-input consumers of one stream reach a peak concurrency of 2 instead of 1. The fix adds assertions that:

- shared-stream consumers peak at 1 under `runParallel`;
- shared-stream consumers peak at 1 under `runDataflow`;
- distinct-stream consumers still peak at 2 under `runParallel`.

## Validation

Original exact-base validation on `0cc95dbe3d065094580f3d2a742ad5b373b5f52f`:

- Focused scheduler + mixer regressions: 4 tests, 0 failures
- Relevant process/graph/dataflow suite: 80 tests, 0 failures
- Mixer regression repeated in 5 separate Maven invocations: 5/5 passed
- Clean `pomJava8.xml` focused build (Java 8 source/target): 4 tests, 0 failures
- Documentation tests: 111 tests, 0 failures

Current-master refresh validation on exact head `fa51cef01bf2c9f7ca80e12c73aa7ce9b888f614`, based on `f8030e066d0e875bb241404c0ca4c6ff3dae1795`:

- `ProcessSystemTest`: 63 tests, 0 failures/errors/skips
- `MultiInputMixerPhaseRegressionTest`: 1 test, 0 failures/errors/skips
- `python devtools/run_spotless.py apply`: passed twice without modifications
- `python devtools/run_spotless.py check`: passed
- `python devtools/check_documentation_search.py`: passed (655 Markdown, 1 standalone HTML)
- `git diff --check origin/master...HEAD`: passed
- Optional local `pre-commit` and pre-push stages: unavailable (`pre-commit: command not found`); no unrun check is claimed

The refresh is a non-force merge of current `master`; intervening changes were confined to unrelated learning-path and MCP documentation/tests.

## Compatibility and documentation

No public API, serialization format, thermodynamic-model default, tolerance, unit, or scientific-result change. The change is limited to internal execution grouping.

Documentation impact: updated `docs/process/processmodel/process_system.md` to state the scheduler's shared-mutable-stream contract.

**VALIDATION PENDING CI:** the hosted exact-head Java 8 Windows/Ubuntu and Java 21 matrix, slow shards, Javadocs, CodeQL, Spotless, pre-commit/documentation, and PaperLab must pass before the PR is engineering-ready.
