### PR TITLE
docs: repair learning path accuracy and navigation

### DIFF
--- a/docs/test_learning_paths_documentation.py
+++ b/docs/test_learning_paths_documentation.py
@@ -1,0 +1,70 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LEARNING_PATH = ROOT / "docs" / "tutorials" / "learning-paths.md"
+EXAMPLES_INDEX = ROOT / "docs" / "examples" / "index.md"
+
+
+class LearningPathsDocumentationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.page = LEARNING_PATH.read_text(encoding="utf-8")
+        cls.catalog = EXAMPLES_INDEX.read_text(encoding="utf-8")
+
+    def test_front_matter_title_is_not_duplicated_as_h1(self):
+        body = self.page.split("---", 2)[2]
+        self.assertNotRegex(body, r"(?m)^# ")
+
+    def test_role_links_match_stable_heading_anchors(self):
+        expected = {
+            "pvt-engineer-path": "## PVT engineer path",
+            "process-engineer-path": "## Process engineer path",
+            "developer-path": "## Developer path",
+        }
+        for anchor, heading in expected.items():
+            self.assertIn(f"](#" + anchor + ")", self.page)
+            self.assertIn(heading, self.page)
+
+    def test_internal_links_are_source_safe_and_resolve(self):
+        targets = re.findall(r"\]\((\.\./[^)]+)\)", self.page)
+        self.assertGreaterEqual(len(targets), 47)
+        for target in targets:
+            path_text = target.split("#", 1)[0]
+            self.assertTrue(path_text.endswith(".md"), target)
+            resolved = (LEARNING_PATH.parent / path_text).resolve()
+            self.assertTrue(resolved.is_file(), target)
+
+    def test_notebook_statuses_match_the_examples_catalog(self):
+        expected = {
+            "ReadingFluidProperties.ipynb": "Executed",
+            "PVT_Simulation_and_Tuning.ipynb": "Source only",
+            "NetworkSolverTutorial.ipynb": "Source only",
+            "ProductionOptimizer_Tutorial.ipynb": "Source only",
+        }
+        for notebook, status in expected.items():
+            catalog_row = next(
+                line for line in self.catalog.splitlines() if notebook in line
+            )
+            page_line = next(
+                line for line in self.page.splitlines() if notebook in line
+            )
+            self.assertIn(f"| **{status}** |", catalog_row)
+            self.assertIn(status, page_line)
+
+        self.assertIn("Rerun either kind against the current `master` branch", self.page)
+        self.assertNotIn("**Run**: [PVT Simulation", self.page)
+        self.assertNotIn("**Run**: [Network Solver", self.page)
+        self.assertNotIn("**Run**: [Production Optimizer", self.page)
+
+    def test_model_selection_keeps_specialized_models_bounded(self):
+        self.assertIn("consider `SystemPrDanesh`", self.page)
+        self.assertIn("it is not a general multiphase-VLE default", self.page)
+        self.assertNotIn("| Heavy oil | PR, CPA |", self.page)
+        self.assertNotIn("| CO₂ systems | SRK-CPA, GERG-2008 |", self.page)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/test_learning_paths_documentation.py
+++ b/docs/test_learning_paths_documentation.py
@@ -54,7 +54,9 @@ class LearningPathsDocumentationTest(unittest.TestCase):
             self.assertIn(f"| **{status}** |", catalog_row)
             self.assertIn(status, page_line)
 
-        self.assertIn("Rerun either kind against the current `master` branch", self.page)
+        self.assertIn(
+            "Rerun either kind against the current `master` branch", self.page
+        )
         self.assertNotIn("**Run**: [PVT Simulation", self.page)
         self.assertNotIn("**Run**: [Network Solver", self.page)
         self.assertNotIn("**Run**: [Production Optimizer", self.page)

--- a/docs/tutorials/learning-paths.md
+++ b/docs/tutorials/learning-paths.md
@@ -3,11 +3,11 @@ title: Learning Paths
 description: Structured learning paths for PVT engineers, process engineers, and developers to master NeqSim efficiently.
 ---
 
-# Learning Paths
-
 Choose the learning path that matches your role and goals.
 
-## 🎯 Choose Your Path
+Notebook labels below mirror the [examples catalog](../examples/index.md). **Executed** means the committed notebook contains stored execution counts and outputs; **Source only** means it contains source cells but no stored execution. Rerun either kind against the current `master` branch before treating its results as current validation evidence.
+
+## Choose your path
 
 | Path | For | Time | Focus |
 |------|-----|------|-------|
@@ -17,35 +17,37 @@ Choose the learning path that matches your role and goals.
 
 ---
 
-## 🔬 PVT Engineer Path
+## PVT engineer path
 
 **Goal**: Master fluid modeling, flash calculations, and PVT characterization.
 
 ### Level 1: Fundamentals (1 hour)
 
-1. **[Python Quickstart](../quickstart/python-quickstart)** - Get NeqSim running
-2. **[Reading Fluid Properties](../thermo/reading_fluid_properties)** - Understanding init levels
-3. **Run**: [Reading Fluid Properties Notebook](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/ReadingFluidProperties.ipynb)
+1. **[Python Quickstart](../quickstart/python-quickstart.md)** - Get NeqSim running
+2. **[Reading Fluid Properties](../thermo/reading_fluid_properties.md)** - Understanding init levels
+3. **Run — Executed**: [Reading Fluid Properties Notebook](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/ReadingFluidProperties.ipynb) — stored outputs are available; rerun all cells for current-master evidence
 
 ### Level 2: Thermodynamic Models (1.5 hours)
 
-1. **[Thermodynamic Models Guide](../thermo/thermodynamic_models)** - All EoS options
-2. **[Mixing Rules Guide](../thermo/mixing_rules_guide)** - BIPs and mixing rules
-3. **Reference**: [Which EoS should I use?](../cookbook/thermodynamics-recipes#which-eos-should-i-use)
+1. **[Thermodynamic Models Guide](../thermo/thermodynamic_models.md)** - All EoS options
+2. **[Mixing Rules Guide](../thermo/mixing_rules_guide.md)** - BIPs and mixing rules
+3. **Reference**: [Which EoS should I use?](../cookbook/thermodynamics-recipes.md#which-eos-should-i-use)
 
-| Fluid Type | Recommended EoS |
-|------------|-----------------|
-| Dry gas | SRK, PR |
-| Gas condensate | PR, SRK-Peneloux |
-| Black oil | PR, SRK |
-| Heavy oil | PR, CPA |
-| CO₂ systems | SRK-CPA, GERG-2008 |
-| Aqueous | CPA, Electrolyte-CPA |
+| Fluid or task | Starting model | Important qualification |
+|---|---|---|
+| Dry natural gas | SRK or PR | Validate density and calorific properties for the composition |
+| Gas condensate | PR or SRK | Tune heavy-end characterization to PVT data |
+| Black or volatile oil | PR or SRK | Characterize and tune C7+ before process studies |
+| Heavy oil | PR/SRK family; consider `SystemPrDanesh` | Validate heavy-end characterization, density, and PVT response |
+| Dry CO₂-rich fluid | PR, SRK, or a validated multiparameter model | Check impurities and phase-boundary range |
+| CO₂ with water | CPA | Validate water content, mutual solubility, and BIPs |
+| Natural-gas reference properties | GERG-2008 | Use only supported components and validity ranges; it is not a general multiphase-VLE default |
+| Electrolytes and brines | Electrolyte-CPA | Define ions, salinity basis, and precipitation scope |
 
 ### Level 3: Flash Calculations (1 hour)
 
-1. **[Flash Calculations Guide](../thermo/flash_calculations_guide)** - All flash types
-2. **[Flash Equations](../wiki/flash_equations_and_tests)** - Mathematical details
+1. **[Flash Calculations Guide](../thermo/flash_calculations_guide.md)** - All flash types
+2. **[Flash Equations](../wiki/flash_equations_and_tests.md)** - Mathematical details
 3. **Practice**: Run different flash types on same fluid
 
 | Flash Type | Specify | Calculate |
@@ -57,128 +59,128 @@ Choose the learning path that matches your role and goals.
 
 ### Level 4: Fluid Characterization (1.5 hours)
 
-1. **[PVT Fluid Characterization](../thermo/pvt_fluid_characterization)** - Plus fraction handling
-2. **[Fluid Characterization Math](../pvtsimulation/fluid_characterization_mathematics)** - Lumping details
-3. **Run**: [PVT Simulation and Tuning Notebook](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/PVT_Simulation_and_Tuning.ipynb)
+1. **[PVT Fluid Characterization](../thermo/pvt_fluid_characterization.md)** - Plus fraction handling
+2. **[Fluid Characterization Math](../pvtsimulation/fluid_characterization_mathematics.md)** - Lumping details
+3. **Inspect or run — Source only**: [PVT Simulation and Tuning Notebook](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/PVT_Simulation_and_Tuning.ipynb) — no stored execution; run all cells before relying on results
 
 ### Level 5: Advanced Topics (1 hour)
 
-1. **[Hydrate Models](../thermo/hydrate_models)** - Hydrate equilibrium
-2. **[Wax Characterization](../thermo/characterization/wax_characterization)** - Wax modeling
-3. **[Asphaltene Modeling](../pvtsimulation/flowassurance/asphaltene_modeling)** - Asphaltene precipitation
+1. **[Hydrate Models](../thermo/hydrate_models.md)** - Hydrate equilibrium
+2. **[Wax Characterization](../thermo/characterization/wax_characterization.md)** - Wax modeling
+3. **[Asphaltene Modeling](../pvtsimulation/flowassurance/asphaltene_modeling.md)** - Asphaltene precipitation
 
 ### Level 6: AI-Assisted Studies (30 min)
 
 1. **[Solve an Engineering Task](solve-engineering-task)** — Let AI agents handle the workflow
-2. **[Task Solving Guide](../development/TASK_SOLVING_GUIDE)** — How the multi-agent system works
+2. **[Task Solving Guide](../development/TASK_SOLVING_GUIDE.md)** — How the multi-agent system works
 3. **Try it**: Type `@solve.task hydrate formation temperature for rich gas at 100 bara` in VS Code
 
 The AI workflow automates the process around PVT calculations — scoping, running simulations, validating against benchmarks, and generating Word/HTML reports — so you can focus on interpreting results.
 
-### 📚 PVT Reference Materials
+### PVT reference materials
 
 - [JavaDoc: SystemInterface](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/thermo/system/SystemInterface.html)
 - [JavaDoc: ThermodynamicOperations](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/thermodynamicoperations/ThermodynamicOperations.html)
-- [Component Database Guide](../thermo/component_database_guide)
+- [Component Database Guide](../thermo/component_database_guide.md)
 
 ---
 
-## 🏭 Process Engineer Path
+## Process engineer path
 
 **Goal**: Design and simulate process flowsheets with equipment models.
 
 ### Level 1: Fundamentals (1.5 hours)
 
-1. **[Java Quickstart](../quickstart/java-quickstart)** - Process simulation basics
-2. **[Process System Guide](../process/processmodel/process_system)** - Building flowsheets
-3. **[Streams Documentation](../process/equipment/streams)** - Material streams
+1. **[Java Quickstart](../quickstart/java-quickstart.md)** - Process simulation basics
+2. **[Process System Guide](../process/processmodel/process_system.md)** - Building flowsheets
+3. **[Streams Documentation](../process/equipment/streams.md)** - Material streams
 
 ### Level 2: Core Equipment (2 hours)
 
-1. **[Separators](../process/equipment/separators)** - 2-phase and 3-phase
-2. **[Compressors](../process/equipment/compressors)** - Centrifugal, reciprocating
-3. **[Heat Exchangers](../process/equipment/heat_exchangers)** - Heaters, coolers, exchangers
-4. **[Valves](../process/equipment/valves)** - Control valves, chokes
+1. **[Separators](../process/equipment/separators.md)** - 2-phase and 3-phase
+2. **[Compressors](../process/equipment/compressors.md)** - Centrifugal, reciprocating
+3. **[Heat Exchangers](../process/equipment/heat_exchangers.md)** - Heaters, coolers, exchangers
+4. **[Valves](../process/equipment/valves.md)** - Control valves, chokes
 
 ### Level 3: Process Flowsheets (2 hours)
 
-1. **[Mixers and Splitters](../process/equipment/mixers_splitters)** - Stream combining/splitting
-2. **[Recycles](../process/equipment/util/recycles)** - Handling recycle streams
-3. **[Adjusters](../process/equipment/util/adjusters)** - Specification adjustments
-4. **Run**: [Network Solver Tutorial](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/NetworkSolverTutorial.ipynb)
+1. **[Mixers and Splitters](../process/equipment/mixers_splitters.md)** - Stream combining/splitting
+2. **[Recycles](../process/equipment/util/recycles.md)** - Handling recycle streams
+3. **[Adjusters](../process/equipment/util/adjusters.md)** - Specification adjustments
+4. **Inspect or run — Source only**: [Network Solver Tutorial](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/NetworkSolverTutorial.ipynb) — no stored execution; run all cells before relying on results
 
 ### Level 4: Advanced Equipment (1.5 hours)
 
-1. **[Distillation](../process/equipment/distillation)** - Column simulation
-2. **[Pipelines](../process/equipment/pipelines)** - Multiphase flow
-3. **[Pumps](../process/equipment/pumps)** - Pump modeling
-4. **[Wells](../process/equipment/wells)** - Well modeling
+1. **[Distillation](../process/equipment/distillation.md)** - Column simulation
+2. **[Pipelines](../process/equipment/pipelines.md)** - Multiphase flow
+3. **[Pumps](../process/equipment/pumps.md)** - Pump modeling
+4. **[Wells](../process/equipment/wells.md)** - Well modeling
 
 ### Level 5: Optimization & Control (1 hour)
 
-1. **[Optimization Overview](../process/optimization/OPTIMIZATION_OVERVIEW)** - Process optimization
-2. **[Controllers](../process/controllers)** - Process control
-3. **Run**: [Production Optimizer Tutorial](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/ProductionOptimizer_Tutorial.ipynb)
+1. **[Optimization Overview](../process/optimization/OPTIMIZATION_OVERVIEW.md)** - Process optimization
+2. **[Controllers](../process/controllers.md)** - Process control
+3. **Inspect or run — Source only**: [Production Optimizer Tutorial](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/ProductionOptimizer_Tutorial.ipynb) — no stored execution; run all cells before relying on results
 
 ### Level 6: AI-Assisted Studies (30 min)
 
 1. **[Solve an Engineering Task](solve-engineering-task)** — Let AI agents handle the workflow
-2. **[Task Solving Guide](../development/TASK_SOLVING_GUIDE)** — How the multi-agent system works
+2. **[Task Solving Guide](../development/TASK_SOLVING_GUIDE.md)** — How the multi-agent system works
 3. **Try it**: Type `@solve.task TEG dehydration sizing for 50 MMSCFD wet gas` in VS Code
 
 The AI workflow automates the work around process simulation — scoping, literature review, building flowsheets, validating against benchmarks, uncertainty analysis, and generating engineering reports — so you can focus on design decisions.
 
-### 📚 Process Reference Materials
+### Process reference materials
 
 - [JavaDoc: ProcessSystem](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/process/processmodel/ProcessSystem.html)
 - [JavaDoc: ProcessEquipmentInterface](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/process/equipment/ProcessEquipmentInterface.html)
-- [Equipment Index](../process/equipment/)
+- [Equipment Index](../process/equipment/README.md)
 
 ---
 
-## 💻 Developer Path
+## Developer path
 
 **Goal**: Understand NeqSim architecture, extend functionality, contribute code.
 
 ### Level 1: Setup & Architecture (2 hours)
 
-1. **[Developer Setup](../development/DEVELOPER_SETUP)** - Build from source
-2. **[Modules Overview](../modules)** - Package architecture
-3. **[Contributing Guide](../development/)** - Code standards
+1. **[Developer Setup](../development/DEVELOPER_SETUP.md)** - Build from source
+2. **[Modules Overview](../modules.md)** - Package architecture
+3. **[Contributing Guide](../development/README.md)** - Code standards
 
 ### Level 2: Core APIs (2 hours)
 
 1. **[SystemInterface JavaDoc](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/thermo/system/SystemInterface.html)** - Fluid API
 2. **[ProcessEquipmentInterface JavaDoc](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/process/equipment/ProcessEquipmentInterface.html)** - Equipment API
-3. **[Test Overview](../wiki/test-overview)** - Testing patterns
+3. **[Test Overview](../wiki/test-overview.md)** - Testing patterns
 
 ### Level 3: Thermodynamic Implementation (2 hours)
 
-1. **[Mathematical Models](../thermo/mathematical_models)** - EoS implementation
-2. **[Phase Package](../thermo/phase/)** - Phase calculations
-3. **[Component Package](../thermo/component/)** - Component properties
+1. **[Mathematical Models](../thermo/mathematical_models.md)** - EoS implementation
+2. **[Phase Package](../thermo/phase/README.md)** - Phase calculations
+3. **[Component Package](../thermo/component/README.md)** - Component properties
 
 ### Level 4: Process Implementation (2 hours)
 
-1. **[Equipment Base Classes](../process/)** - Equipment patterns
-2. **[Mechanical Design](../process/mechanical_design)** - Design calculations
-3. **[Graph Simulation](../process/processmodel/graph_simulation)** - Topology analysis
+1. **[Equipment Base Classes](../process/README.md)** - Equipment patterns
+2. **[Mechanical Design](../process/mechanical_design.md)** - Design calculations
+3. **[Graph Simulation](../process/processmodel/graph_simulation.md)** - Topology analysis
 
 ### Level 5: Advanced Development (2 hours)
 
-1. **[AI Integration](../integration/ai_platform_integration)** - ML/AI patterns
-2. **[MPC Integration](../integration/mpc_integration)** - Control system integration
-3. **[Serialization](../simulation/process_serialization)** - Save/load processes
+1. **[AI Integration](../integration/ai_platform_integration.md)** - ML/AI patterns
+2. **[MPC Integration](../integration/mpc_integration.md)** - Control system integration
+3. **[Serialization](../simulation/process_serialization.md)** - Save/load processes
 
-### 📚 Developer Reference Materials
+### Developer reference materials
 
 - [Full JavaDoc API](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html)
-- [Reference Manual Index](../REFERENCE_MANUAL_INDEX)
+- [Reference Manual Index](../REFERENCE_MANUAL_INDEX.md)
 - [GitHub Repository](https://github.com/equinor/neqsim)
 
 ---
 
-## 📊 Progress Checklist
+## Progress checklist
 
 Use this to track your progress:
 


### PR DESCRIPTION
## Summary

Repairs the D079 learning-path batch for documentation-quality campaign #2499.

- removes the duplicate page H1 and makes the three role anchors source-visible and stable
- converts all 47 internal documentation links to explicit `.md` or `README.md` targets
- aligns all four notebook calls with the canonical examples catalog: one **Executed**, three **Source only**
- explains stored-output semantics and the current-`master` rerun boundary
- replaces misleading heavy-oil and CO₂ model shortcuts with bounded, source-anchored selection guidance
- adds five focused regression contracts for title structure, anchors, link resolution, catalog status, and model-selection wording

## Frozen scope

- `docs/tutorials/learning-paths.md`
- `docs/test_learning_paths_documentation.py`

No notebook output, production code, broad index, unrelated tutorial, or Huldra changes.

## Validation — READY TO MERGE

Exact head: `e4d20a1153869a6d2821dc4880f600bac7ff098c`

- Run build, test and Javadoc: passed
- Documentation search coverage (including all documentation contracts and Jekyll build): passed
- Pre-commit checks: passed
- Spotless format patch: passed
- CodeQL Security Analysis: passed
- Branch comparison: mergeable, 3 commits ahead and 0 behind `master`; exactly 2 frozen files
- Review sweep: no comments, reviews, or unresolved threads

Closes no issue; campaign ledger advances only after merged-master verification.

Campaign: #2499