### PR TITLE
[AI-Assisted] test(mcp): freeze published protocol surface

### DIFF
--- a/neqsim-mcp-server/README.md
+++ b/neqsim-mcp-server/README.md
@@ -823,6 +823,10 @@ For detailed parameter documentation, JSON formats, example calls, and
 response schemas for all tools and browsable resources, see
 **[docs/API_REFERENCE.md](docs/API_REFERENCE.md)**.
 
+For the exact protocol-tested inventory of published tools, resources, resource templates, guided
+prompts, deployment profiles, and cross-layer capability coverage, see
+**[docs/SURFACE_INVENTORY.md](docs/SURFACE_INVENTORY.md)**.
+
 ---
 
 ## How the LLM Uses the Server (Typical Flow)

--- a/neqsim-mcp-server/docs/API_REFERENCE.md
+++ b/neqsim-mcp-server/docs/API_REFERENCE.md
@@ -4,6 +4,10 @@ Detailed parameter documentation for MCP tools and resources.
 For the governance model, tier structure, and stability promises, see
 [MCP_CONTRACT.md](../MCP_CONTRACT.md).
 
+The exact protocol-tested tool, resource, resource-template, prompt, deployment-profile, and
+capability-coverage baseline is recorded in
+[MCP published-surface inventory](SURFACE_INVENTORY.md).
+
 ---
 
 ## `runFlash` — Thermodynamic Flash Calculation

--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -1,0 +1,72 @@
+# MCP published-surface inventory
+
+This inventory records the public MCP protocol surface on campaign issue #3153's Phase 0
+baseline. The focused protocol regression in `test_mcp_server.py` obtains every entry through the
+running server's standards-conforming list operations; it does not infer publication from a
+manually maintained Java method list.
+
+| Surface | Count | Protocol evidence | Authoritative implementation |
+| --- | ---: | --- | --- |
+| Tools | 71 | `tools/list` | `NeqSimTools` MCP annotations |
+| Static resources | 7 | `resources/list` | `NeqSimResources` MCP annotations |
+| Resource templates | 7 | `resources/templates/list` | `NeqSimResources` MCP annotations |
+| Guided prompts | 9 | `prompts/list` | `NeqSimPrompts` MCP annotations |
+
+The tool regression asserts the exact 71-name set grouped by its current trust tier. It also calls
+`getCapabilities` and requires `toolCatalogCoverage.complete`, equal published and described tool
+counts, and empty missing/undeclared descriptor lists. That reconciles transport publication with
+the governance and capability registries without introducing a second MCP-only simulator.
+
+## Resources
+
+| Static resource | Resource template |
+| --- | --- |
+| `neqsim://components` | `neqsim://components/{name}` |
+| `neqsim://data-tables` | `neqsim://materials/{type}` |
+| `neqsim://example-catalog` | `neqsim://examples/{category}/{name}` |
+| `neqsim://models` | `neqsim://api/{className}` |
+| `neqsim://schema-catalog` | `neqsim://schemas/{tool}/{type}` |
+| `neqsim://setup-templates` | `neqsim://setup-templates/{id}` |
+| `neqsim://standards` | `neqsim://standards/{code}` |
+
+The two columns are independent inventories; rows do not imply a one-to-one relationship.
+
+## Guided prompts
+
+- `biorefinery_analysis`
+- `co2_ccs_chain`
+- `design_gas_processing`
+- `dynamic_simulation`
+- `field_development_screening`
+- `flow_assurance_screening`
+- `pipeline_sizing`
+- `pvt_study`
+- `teg_dehydration_design`
+
+## Governance and compatibility
+
+The published tools are classified by `IndustrialProfile` as trusted core, engineering advanced,
+or experimental, and as advisory, calculation, execution, or platform operations. The supported
+deployment profiles are `DESKTOP_ENGINEER`, `STUDY_TEAM`, `DIGITAL_TWIN`, and `ENTERPRISE`.
+Publication does not mean that every tool is enabled in every profile or has the same engineering
+validation maturity. Call `getCapabilities`, `getBenchmarkTrust`, and `checkToolAccess` before
+execution and preserve each calculation's provenance, convergence, validation, assumptions, and
+limitations.
+
+This increment changes no tool name, input or output schema, deployment default, thermodynamic
+model, process model, or response envelope. Process execution continues to use canonical NeqSim
+fluids, streams, `ProcessSystem`, and `ProcessModel` objects.
+
+## Phase 0 stop boundary
+
+This increment freezes the exact transport-facing tools, resources, resource templates, prompts,
+deployment-profile names, and tool-capability reconciliation on the tested baseline. It does not
+complete the campaign's full Phase 0 inventory. Follow-up work must still inventory individual
+schemas, examples, runners, equipment factories, report paths, tests, guides, and known
+limitations; reconcile merged foundations #2874, #2875, and #3152 criterion by criterion; add the
+four acceptance scales; build the full traceability and discipline-maturity matrices; and record
+runtime, memory, payload, convergence, balance-closure, and report-usefulness baselines.
+
+DEXPI/P&ID ingestion remains owned by #2899, dynamics by #2911, flash/stability/performance by
+#2937, and merged production-optimization foundations by #2941. This inventory audits existing
+publication only and does not implement competing domain functionality.

--- a/neqsim-mcp-server/test_mcp_server.py
+++ b/neqsim-mcp-server/test_mcp_server.py
@@ -254,7 +254,7 @@ def get_composition(result, phase, component):
 # ===========================================================================
 
 def test_protocol():
-    """Test MCP protocol basics: tools/list, resources/list."""
+    """Test the exact MCP publication surface through list operations."""
     print("\n=== Protocol Tests ===")
 
     send({"jsonrpc": "2.0", "id": next_id(), "method": "tools/list", "params": {}})
@@ -302,12 +302,55 @@ def test_protocol():
     send({"jsonrpc": "2.0", "id": next_id(), "method": "resources/list", "params": {}})
     r = recv()
     resources = r.get("result", {}).get("resources", [])
-    check("7 resources", len(resources) == 7, f"got {len(resources)}")
+    resource_uris = sorted(resource["uri"] for resource in resources)
+    expected_resource_uris = sorted([
+        "neqsim://components",
+        "neqsim://data-tables",
+        "neqsim://example-catalog",
+        "neqsim://models",
+        "neqsim://schema-catalog",
+        "neqsim://setup-templates",
+        "neqsim://standards",
+    ])
+    check("exact static resource inventory",
+          resource_uris == expected_resource_uris,
+          f"got {resource_uris}")
 
     send({"jsonrpc": "2.0", "id": next_id(), "method": "resources/templates/list", "params": {}})
     r = recv()
     templates = r.get("result", {}).get("resourceTemplates", [])
-    check("7 templates", len(templates) == 7, f"got {len(templates)}")
+    template_uris = sorted(template["uriTemplate"] for template in templates)
+    expected_template_uris = sorted([
+        "neqsim://api/{className}",
+        "neqsim://components/{name}",
+        "neqsim://examples/{category}/{name}",
+        "neqsim://materials/{type}",
+        "neqsim://schemas/{tool}/{type}",
+        "neqsim://setup-templates/{id}",
+        "neqsim://standards/{code}",
+    ])
+    check("exact resource-template inventory",
+          template_uris == expected_template_uris,
+          f"got {template_uris}")
+
+    send({"jsonrpc": "2.0", "id": next_id(), "method": "prompts/list", "params": {}})
+    r = recv()
+    prompts = r.get("result", {}).get("prompts", [])
+    prompt_names = sorted(prompt["name"] for prompt in prompts)
+    expected_prompt_names = sorted([
+        "biorefinery_analysis",
+        "co2_ccs_chain",
+        "design_gas_processing",
+        "dynamic_simulation",
+        "field_development_screening",
+        "flow_assurance_screening",
+        "pipeline_sizing",
+        "pvt_study",
+        "teg_dehydration_design",
+    ])
+    check("exact guided-prompt inventory",
+          prompt_names == expected_prompt_names,
+          f"got {prompt_names}")
 
 
 def test_component_search():
@@ -1320,6 +1363,20 @@ def test_capabilities():
     check("capabilities has engine", r.get("engine") == "NeqSim")
     check("capabilities has thermo models", "thermodynamicModels" in r)
     check("capabilities has equipment", "processEquipment" in r)
+    coverage = r.get("toolCatalogCoverage", {})
+    check("capability descriptors cover every published tool",
+          coverage.get("complete") is True,
+          str(coverage))
+    check("capability coverage reports 71 published tools",
+          coverage.get("publishedToolCount") == 71,
+          str(coverage))
+    check("capability coverage reports 71 described tools",
+          coverage.get("describedToolCount") == 71,
+          str(coverage))
+    check("capability coverage has no missing or undeclared descriptors",
+          not coverage.get("missingDescriptors")
+          and not coverage.get("undeclaredDescriptors"),
+          str(coverage))
 
 
 def test_run_capability_search_and_invoke():


### PR DESCRIPTION
## Roadmap criterion advanced

Refs #3153 — Phase 0 current-master audit and acceptance matrix.

This increment freezes the exact transport-facing MCP publication contract and reconciles the published tool set with the existing capability/governance catalog. It deliberately does **not** mark any Phase 0 checkbox complete.

## Problem and engineering value

The server already published 71 tools, 7 static resources, 7 resource templates, and 9 guided prompts, but the end-to-end protocol regression only asserted exact tool names and resource/template counts. Prompt publication and exact resource URIs could drift without a focused failure, and the current audit baseline was not documented in one reviewable place.

## Scope

- require exact URI identity for all static resources and resource templates through real MCP list calls;
- require the exact guided-prompt name set through `prompts/list`;
- require `getCapabilities.toolCatalogCoverage` to reconcile 71 published and described tools with no missing or undeclared descriptors;
- document sources, deployment profiles, governance/validation boundaries, compatibility, roadmap overlap, and the remaining Phase 0 stop boundary;
- link the inventory from the MCP README and API reference.

The canonical simulator remains normal NeqSim fluids, streams, `ProcessSystem`, and `ProcessModel`. No tool, schema, response, deployment default, thermodynamic model, process model, or agent/skill contract changes.

## Validation

- focused real MCP STDIO protocol: **83/83 checks passed**;
- module packaged successfully under the available JDK 17 fallback solely to execute the unchanged server source for the protocol check; the temporary compiler override was restored and is not in this diff;
- `python3 -m py_compile neqsim-mcp-server/test_mcp_server.py` — passed;
- `python devtools/run_spotless.py check` — passed;
- `python devtools/check_documentation_search.py` — passed (655 Markdown pages, 1 standalone HTML);
- `pre-commit run --all-files --hook-stage pre-commit` — passed;
- `pre-commit run --all-files --hook-stage pre-push` — passed;
- `git diff --check` — passed.

Hosted JDK 21 CI remains required before merge classification. No scientific/numerical calculation changed, so thermodynamic benchmark or conservation evidence is not applicable to this contract-only increment.

## Documentation impact

Updated `neqsim-mcp-server/README.md` and `docs/API_REFERENCE.md`; added `docs/SURFACE_INVENTORY.md`.

## Compatibility and boundaries

Additive test/documentation change only. DEXPI/P&ID remains with #2899, dynamics with #2911, flash/stability/performance with #2937, and production-optimization foundations with #2941. Operational support remains advisory-only.

## Stop boundary and next dependency

Remaining Phase 0 work: schema/example/runner/equipment/report/test/guide/limitation inventory; criterion-level reconciliation of #2874/#2875/#3152; four public acceptance scales; traceability and discipline-maturity matrices; runtime/memory/payload/convergence/balance/report baselines.
