### PR TITLE
[AI-Assisted] fix(optimization): reject non-finite plant candidates

### DIFF
--- a/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
+++ b/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
@@ -715,6 +715,36 @@ and multi-variable optimization, multi-objective (Pareto) optimization, and scen
 > The bottleneck reported in the result is the plant-wide bottleneck — the most-utilized unit
 > across every area — consistent with `ProcessModel.getBottleneck()`.
 
+#### Fail-closed external candidate evaluation
+
+Use `ProcessModelSimulationEvaluator` when an external solver proposes a vector of plant setpoints.
+The evaluator applies the complete vector, runs the full `ProcessModel`, and samples each objective
+and constraint callback once. Candidate values must be finite before they are applied. After the
+solve, every raw/scalarized objective value and every constraint value/margin must also be finite.
+
+An invalid proposal is rejected before it can mutate the live process state. A non-finite callback
+sample makes the result infeasible even when the affected constraint is configured as soft; the
+sample remains visible for diagnosis, its margin is reported as negative infinity, and
+`getErrorMessage()` identifies the affected objective or constraint. `isSimulationConverged()` is
+kept separate so callers can distinguish a valid process solve from invalid optimization evidence.
+Invalid evidence receives a deterministic terminal penalty and must not be accepted or cached by an
+external optimizer.
+
+```java
+ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(plant);
+evaluator.addParameter("separation::feed.flowRate", 500.0, 12000.0, "kg/hr");
+evaluator.addObjective("export rate", model -> export.getFlowRate("kg/hr"),
+    ProcessModelSimulationEvaluator.ObjectiveDefinition.Direction.MAXIMIZE);
+evaluator.addConstraintUpperBound("total power", model -> model.getPower("MW"), 40.0);
+
+ProcessModelSimulationEvaluator.EvaluationResult candidate =
+    evaluator.evaluate(new double[] { proposedFeedRate });
+if (!candidate.isSimulationConverged() || !candidate.isFeasible()
+    || candidate.getErrorMessage() != null) {
+  // Reject the external-solver proposal; do not use it as a plant operating point.
+}
+```
+
 #### Multi-objective (Pareto) optimization of a plant
 
 Provide **two or more** objectives (for example, maximize throughput while minimizing compression
@@ -1521,4 +1551,3 @@ try {
 | `getMaxUtilization()` | Get maximum utilization across constraints |
 | `isOverloaded()` | Any constraint > 100% |
 | `isHardLimitExceeded()` | Any HARD constraint violated |
-

--- a/src/main/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluator.java
+++ b/src/main/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluator.java
@@ -51,6 +51,9 @@ public class ProcessModelSimulationEvaluator implements Serializable {
   /** Logger. */
   private static final Logger logger = LogManager.getLogger(ProcessModelSimulationEvaluator.class);
 
+  /** Deterministic terminal penalty for an invalid external-optimizer candidate. */
+  private static final double INVALID_CANDIDATE_PENALTY = Double.MAX_VALUE / 2.0;
+
   /** Serializable callback that returns one structured boundary sample after a model run. */
   public interface BoundarySampleEvaluator extends Serializable {
     /**
@@ -3840,6 +3843,12 @@ public class ProcessModelSimulationEvaluator implements Serializable {
           "Parameter array length (" + (parameterValues == null ? "null" : Integer.toString(parameterValues.length))
               + ") must match parameter count (" + parameters.size() + ")");
     }
+    for (int parameterIndex = 0; parameterIndex < parameterValues.length; parameterIndex++) {
+      if (!Double.isFinite(parameterValues[parameterIndex])) {
+        throw new IllegalArgumentException(
+            "Parameter " + parameterIndex + " must be finite, but was " + parameterValues[parameterIndex]);
+      }
+    }
 
     long startTime = System.currentTimeMillis();
     evaluationCount++;
@@ -3855,10 +3864,14 @@ public class ProcessModelSimulationEvaluator implements Serializable {
 
       double[] objectiveValues = new double[objectives.size()];
       double[] rawObjectiveValues = new double[objectives.size()];
+      List<String> invalidSamples = new ArrayList<String>();
       for (int objectiveIndex = 0; objectiveIndex < objectives.size(); objectiveIndex++) {
         ObjectiveDefinition objective = objectives.get(objectiveIndex);
         rawObjectiveValues[objectiveIndex] = objective.evaluateRaw(processModel);
         objectiveValues[objectiveIndex] = objective.toMinimizerValue(rawObjectiveValues[objectiveIndex]);
+        if (!Double.isFinite(rawObjectiveValues[objectiveIndex]) || !Double.isFinite(objectiveValues[objectiveIndex])) {
+          invalidSamples.add("Non-finite objective '" + objective.getName() + "'");
+        }
       }
       result.setObjectives(objectiveValues);
       result.setObjectivesRaw(rawObjectiveValues);
@@ -3913,6 +3926,12 @@ public class ProcessModelSimulationEvaluator implements Serializable {
         if (evaluatedBoundary == null) {
           margins[constraintIndex] = constraint.marginFromValue(constraintValues[constraintIndex]);
         }
+        if (!Double.isFinite(constraintValues[constraintIndex]) || !Double.isFinite(margins[constraintIndex])) {
+          margins[constraintIndex] = Double.NEGATIVE_INFINITY;
+          invalidSamples.add("Non-finite constraint '" + constraint.getName() + "'");
+          feasible = false;
+          continue;
+        }
         if (margins[constraintIndex] < 0.0) {
           if (evaluatedBoundary == null) {
             penaltySum += constraint.penaltyFromMargin(margins[constraintIndex]);
@@ -3934,13 +3953,19 @@ public class ProcessModelSimulationEvaluator implements Serializable {
       List<BottleneckStatus> rankedCapacityConstraints = toBottleneckStatuses(installedCapacityEvidence);
       result.setRankedCapacityConstraints(rankedCapacityConstraints);
       result.setActiveBottleneck(selectActiveBottleneck(rankedCapacityConstraints));
+      if (!invalidSamples.isEmpty()) {
+        feasible = false;
+        penaltySum = INVALID_CANDIDATE_PENALTY;
+        result.setPenaltySum(penaltySum);
+        result.setErrorMessage(String.join("; ", invalidSamples));
+      }
       result.setFeasible(feasible);
     } catch (Exception exception) {
       logger.warn("ProcessModel evaluation failed: " + exception.getMessage());
       result.setSimulationConverged(false);
       result.setFeasible(false);
       result.setErrorMessage(exception.getMessage());
-      result.setPenaltySum(Double.MAX_VALUE / 2.0);
+      result.setPenaltySum(INVALID_CANDIDATE_PENALTY);
       double[] objectiveValues = new double[objectives.size()];
       Arrays.fill(objectiveValues, Double.NaN);
       result.setObjectives(objectiveValues);

--- a/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/ProcessModelSimulationEvaluatorTest.java
@@ -333,6 +333,42 @@ class ProcessModelSimulationEvaluatorTest {
     assertEquals(1000.0, result.getPenaltySum(), 0.0);
   }
 
+  /** Verifies non-finite objective and constraint samples can never be accepted as feasible. */
+  @Test
+  void evaluateFailsClosedForNonFiniteSamples() {
+    ModelFixture fixture = createModelFixture();
+    ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(fixture.model);
+    evaluator.addObjective("invalid production objective", model -> Double.NaN);
+    evaluator.addConstraintUpperBound("invalid total power", model -> Double.POSITIVE_INFINITY, 10.0);
+    evaluator.getConstraints().get(0).setHard(false);
+
+    ProcessModelSimulationEvaluator.EvaluationResult result = evaluator.evaluate(new double[0]);
+
+    assertTrue(result.isSimulationConverged(), "the process solve itself should remain distinguishable");
+    assertFalse(result.isFeasible(), "non-finite evidence must fail closed even for a soft constraint");
+    assertEquals(Double.MAX_VALUE / 2.0, result.getPenaltySum(), 0.0);
+    assertTrue(Double.isNaN(result.getObjectivesRaw()[0]));
+    assertEquals(Double.POSITIVE_INFINITY, result.getConstraintValues()[0]);
+    assertEquals(Double.NEGATIVE_INFINITY, result.getConstraintMargins()[0]);
+    assertTrue(result.getErrorMessage().contains("invalid production objective"));
+    assertTrue(result.getErrorMessage().contains("invalid total power"));
+  }
+
+  /** Verifies a non-finite external proposal is rejected before it can mutate live process state. */
+  @Test
+  void evaluateRejectsNonFiniteParameterBeforeApplyingIt() {
+    ModelFixture fixture = createModelFixture();
+    ProcessModelSimulationEvaluator evaluator = new ProcessModelSimulationEvaluator(fixture.model);
+    evaluator.addParameter("wells::feed.flowRate", 5000.0, 20000.0, "kg/hr");
+    double originalFlowRate = fixture.feed.getFlowRate("kg/hr");
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> evaluator.evaluate(new double[] { Double.NaN }));
+
+    assertTrue(exception.getMessage().contains("Parameter 0"));
+    assertEquals(originalFlowRate, fixture.feed.getFlowRate("kg/hr"), 0.0);
+  }
+
   /**
    * Verifies installed capacity discovery and active bottleneck reporting across model areas.
    */


### PR DESCRIPTION
## Roadmap criterion advanced

Refs #3154 — prerequisite fail-closed evaluator invariant discovered during dependency-0 capability audit.

This increment does not mark a roadmap checkbox complete. It freezes and repairs one measured evaluator safety gap before plant-wide constraint identity/shared-resource work builds on the same API.

## Engineering question and frozen baseline

Can an external optimizer cause a converged multi-area `ProcessModel` point to be accepted when its proposal, objective, or plant-constraint evidence is non-finite?

Reproduction baseline: `0cc95dbe3d065094580f3d2a742ad5b373b5f52f`. Publication base: `c63eaa00320ba309dc5a27ab888fe37091c32b54`. Exact draft head: `42d6e2e9a44ad9687127db35998c729ed48075ca`. The branch includes current master as a second parent without a force update; the three optimization blobs were unchanged across the base advance.

On the unmodified evaluator, two focused regressions failed:

- a `NaN` objective plus infinite soft total-power constraint returned `isFeasible() == true`;
- a `NaN` decision vector reached the live parameter application path instead of being rejected before mutation.

Assumptions: scalar plant callbacks use their declared engineering units; constraint margins retain the same unit as their values; a missing/non-finite sample is invalid evidence, not a soft physical exceedance. The terminal penalty is dimensionless optimizer scoring metadata.

## Change

- reject every non-finite external decision value before any setter or process run;
- sample the full model/objectives/constraints as before, but fail the candidate closed if a raw/scalarized objective, constraint value, or margin is non-finite;
- preserve `isSimulationConverged()` separately from evidence feasibility;
- preserve invalid sampled values for diagnosis, normalize their margin to negative infinity, identify affected callbacks in `getErrorMessage()`, and apply one deterministic terminal penalty;
- document the external-candidate contract in the Production Optimization Guide.

Soft constraints remain soft for finite physical violations. Only unavailable/non-finite evidence is terminal.

## Acceptance and validation

Acceptance criteria:

1. non-finite proposals cannot mutate process state;
2. non-finite objective/constraint evidence is never feasible, including for a soft constraint;
3. process convergence remains independently observable;
4. callbacks remain sampled once and diagnostic values remain available;
5. existing finite evaluation, boundary, installed-capacity, sensitivity, throughput, and debottleneck behavior remains green.

Executed locally:

- baseline focused regression: **2 failures**, demonstrating both gaps;
- repaired focused regression: **2/2 passed**;
- `ProcessModelSimulationEvaluatorTest`: passed;
- `ProcessModelThroughputOptimizerTest` and `ProcessModelDebottleneckStudyTest`: passed;
- direct Spotless apply/check: passed;
- documentation search audit: passed (655 Markdown pages, 1 standalone HTML);
- `git diff --check`: passed.

The optional `pre-commit` executable is unavailable in this runtime (`pre-commit: command not found`); no claim is made for local pre-commit/pre-push wrapper stages. Hosted Java 8/21 CI remains required.

No thermodynamic, balance, equipment, scheduling, caching, allocation, or solver-execution code changed. The #2939 end-to-end performance gate and the large-plant runtime matrix are therefore not applicable to this validation-only execution path guard.

## Compatibility, documentation, and stop boundary

Java 8 compatible; no public signature or serialization field changed. Compatibility tightening: callers that previously treated non-finite soft evidence as feasible must now handle an infeasible result and diagnostic error, which is the intended safety contract.

Documentation impact: `docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md` now explains the fail-closed external-candidate contract and total-power callback pattern.

Stop boundary: no plant constraint registry, utilization snapshot, shared resource, shaft, separator, piping, execution scheduler, or optimizer orchestration implementation is included. Next dependency is the dependency-0 capability/benchmark inventory, followed by stable plant-wide constraint identity.