### PR TITLE
[AI-Assisted] test(mcp): verify schema and example resources

### DIFF
--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -11,6 +11,8 @@ manually maintained Java method list.
 | Static resources | 7 | `resources/list` | `NeqSimResources` MCP annotations |
 | Resource templates | 7 | `resources/templates/list` | `NeqSimResources` MCP annotations |
 | Guided prompts | 9 | `prompts/list` | `NeqSimPrompts` MCP annotations |
+| Schema entries | 71 tools / 142 documents | `resources/read` | `SchemaCatalog` |
+| Example entries | 24 categories / 114 documents | `resources/read` | `ExampleCatalog` |
 
 The tool regression asserts the exact 71-name set grouped by its current trust tier. It also calls
 `getCapabilities` and requires `toolCatalogCoverage.complete`, equal published and described tool
@@ -30,6 +32,21 @@ the governance and capability registries without introducing a second MCP-only s
 | `neqsim://standards` | `neqsim://standards/{code}` |
 
 The two columns are independent inventories; rows do not imply a one-to-one relationship.
+
+## Schemas and examples
+
+Every one of the 71 schema-backed tool names has an input and output document at the canonical
+`neqsim://schemas/{tool}/input` and `neqsim://schemas/{tool}/output` resource URIs. The protocol
+regression reads all 142 documents and requires each to decode as a JSON Schema object with a
+top-level `properties` map. It also requires the schema catalog's URI fields to match the requested
+resource exactly, preventing stale or redirected catalog entries from passing silently.
+
+The example catalog contains 114 entries across 24 categories. Seventy-one are canonical
+`tool/{schema_tool_name}` starters, and their names must exactly equal the schema catalog names.
+The regression reads every catalog entry through `neqsim://examples/{category}/{name}` and requires
+valid JSON objects. Domain examples remain representative inputs or contract-level starters; their
+presence does not by itself establish scientific validation, benchmark maturity, or fitness for a
+specific facility decision.
 
 ## Guided prompts
 
@@ -59,13 +76,13 @@ fluids, streams, `ProcessSystem`, and `ProcessModel` objects.
 
 ## Phase 0 stop boundary
 
-This increment freezes the exact transport-facing tools, resources, resource templates, prompts,
-deployment-profile names, and tool-capability reconciliation on the tested baseline. It does not
-complete the campaign's full Phase 0 inventory. Follow-up work must still inventory individual
-schemas, examples, runners, equipment factories, report paths, tests, guides, and known
-limitations; reconcile merged foundations #2874, #2875, and #3152 criterion by criterion; add the
-four acceptance scales; build the full traceability and discipline-maturity matrices; and record
-runtime, memory, payload, convergence, balance-closure, and report-usefulness baselines.
+The baseline now freezes the exact transport-facing tools, resources, resource templates, prompts,
+deployment-profile names, tool-capability reconciliation, schema resource graph, and example
+resource graph. It does not complete the campaign's full Phase 0 inventory. Follow-up work must
+still inventory runners, equipment factories, report paths, tests, guides, and known limitations;
+reconcile merged foundations #2874, #2875, and #3152 criterion by criterion; add the four
+acceptance scales; build the full traceability and discipline-maturity matrices; and record runtime,
+memory, payload, convergence, balance-closure, and report-usefulness baselines.
 
 DEXPI/P&ID ingestion remains owned by #2899, dynamics by #2911, flash/stability/performance by
 #2937, and merged production-optimization foundations by #2941. This inventory audits existing

--- a/neqsim-mcp-server/test_mcp_server.py
+++ b/neqsim-mcp-server/test_mcp_server.py
@@ -165,6 +165,33 @@ def call_tool(name, arguments):
     return {}
 
 
+def read_json_resource(uri):
+    """Read and decode a JSON MCP resource through the real protocol."""
+    send(
+        {
+            "jsonrpc": "2.0",
+            "id": next_id(),
+            "method": "resources/read",
+            "params": {"uri": uri},
+        }
+    )
+    response = recv()
+    contents = response.get("result", {}).get("contents", [])
+    if not contents:
+        return {"_protocolError": response}
+
+    resource = contents[0]
+    if resource.get("uri") != uri:
+        return {
+            "_protocolError": f"requested {uri}, received {resource.get('uri')}"
+        }
+
+    try:
+        return json.loads(resource.get("text", ""))
+    except json.JSONDecodeError as error:
+        return {"_protocolError": f"invalid JSON at {uri}: {error}"}
+
+
 def normalize_tool_arguments(name, arguments):
     json_arg = JSON_TOOL_ARGS.get(name)
     if not json_arg or json_arg in arguments:
@@ -383,8 +410,70 @@ def test_component_search():
 
 
 def test_examples_and_schemas():
-    """Test example catalog and schema retrieval."""
+    """Test complete example/schema catalogs and representative tool retrieval."""
     print("\n=== Examples & Schemas Tests ===")
+
+    schema_catalog = read_json_resource("neqsim://schema-catalog")
+    check("schema catalog is JSON", "_protocolError" not in schema_catalog,
+          schema_catalog.get("_protocolError", ""))
+    check("schema catalog has 71 tools", len(schema_catalog) == 71,
+          f"got {len(schema_catalog)}")
+
+    schema_uri_errors = []
+    schema_resource_errors = []
+    for tool_name, schema_refs in sorted(schema_catalog.items()):
+        if tool_name == "_protocolError":
+            continue
+        for schema_type in ("input", "output"):
+            ref_name = f"{schema_type}SchemaUri"
+            expected_uri = f"neqsim://schemas/{tool_name}/{schema_type}"
+            schema_uri = schema_refs.get(ref_name)
+            if schema_uri != expected_uri:
+                schema_uri_errors.append(
+                    f"{tool_name}/{schema_type}: {schema_uri!r} != {expected_uri!r}"
+                )
+                continue
+            schema = read_json_resource(schema_uri)
+            if ("_protocolError" in schema or schema.get("type") != "object"
+                    or not isinstance(schema.get("properties"), dict)):
+                schema_resource_errors.append(f"{tool_name}/{schema_type}")
+
+    check("all 142 catalog schema URIs are canonical", not schema_uri_errors,
+          "; ".join(schema_uri_errors))
+    check("all 142 catalog schemas resolve as JSON objects",
+          not schema_resource_errors,
+          f"invalid: {schema_resource_errors}")
+
+    example_catalog = read_json_resource("neqsim://example-catalog")
+    check("example catalog is JSON", "_protocolError" not in example_catalog,
+          example_catalog.get("_protocolError", ""))
+    check("example catalog has 24 categories", len(example_catalog) == 24,
+          f"got {len(example_catalog)}")
+    example_count = sum(
+        len(examples) for examples in example_catalog.values()
+        if isinstance(examples, dict)
+    )
+    check("example catalog has 114 entries", example_count == 114,
+          f"got {example_count}")
+
+    tool_examples = example_catalog.get("tool", {})
+    check("schema tools exactly match canonical tool examples",
+          set(tool_examples) == set(schema_catalog),
+          f"missing={sorted(set(schema_catalog) - set(tool_examples))}, "
+          f"extra={sorted(set(tool_examples) - set(schema_catalog))}")
+
+    example_resource_errors = []
+    for category, examples in sorted(example_catalog.items()):
+        if not isinstance(examples, dict):
+            example_resource_errors.append(f"{category}: not an object")
+            continue
+        for name in sorted(examples):
+            example = read_json_resource(f"neqsim://examples/{category}/{name}")
+            if "_protocolError" in example or not isinstance(example, dict):
+                example_resource_errors.append(f"{category}/{name}")
+    check("all 114 catalog examples resolve as JSON objects",
+          not example_resource_errors,
+          f"invalid: {example_resource_errors}")
 
     r = call_tool("getExample", {"category": "flash", "name": "tp-simple-gas"})
     check("flash example has model", "model" in r)


### PR DESCRIPTION
## Roadmap increment

Refs #3153 — Phase 0 executable schema/example catalog traceability.

This is the next dependency-ready increment after merged protocol-surface baseline #3162. It adds no tool, adapter, runner, or simulator and does not mark the broader Phase 0 inventory complete.

## Change

- read MCP JSON resources through the real JSON-RPC `resources/read` operation;
- require all 71 schema catalog entries to publish canonical input/output URIs;
- resolve and parse all 142 schema documents as JSON Schema objects with top-level property maps;
- require the 71 canonical tool examples to exactly match the schema-backed tool-name set;
- resolve and parse all 114 examples across 24 categories;
- document the measured schema/example inventory, evidence path, and validation limitations.

The checks exercise the published resource graph rather than inferring availability from Java catalog methods.

## Validation

Exact publication base: `c63eaa00320ba309dc5a27ab888fe37091c32b54`.

- focused schema/example protocol checks: **35 passed, 0 failed**;
- combined publication, catalog, and capability protocol checks: **118 passed, 0 failed**;
- Python bytecode compilation: passed;
- direct Spotless check: passed;
- documentation search audit: passed (**655 Markdown pages, 1 standalone HTML page**);
- pre-commit stage after Maven bootstrap: passed;
- pre-push stage: completed successfully;
- `git diff --check`: passed.

The MCP runner was packaged from the unchanged server source used by the merged baseline. This PR changes only Python protocol regression coverage and Markdown documentation, so no Java compile/test gate or new scientific calculation was applicable.

## Compatibility and engineering boundary

No public tool name, schema, example payload, deployment default, response envelope, thermodynamic model, process model, or runtime bound changes. Canonical NeqSim execution remains unchanged. Example presence is documented as discovery/contract evidence, not scientific validation, plant authority, design certification, or causality evidence.

## Stop boundary

This increment stops at executable schema/example resource traceability. It does not implement DEXPI/P&ID (#2899), dynamics (#2911), flash/stability/performance (#2937), or production optimization (#2941). Remaining Phase 0 work includes runner/equipment/report/test/guide/limitation inventories, the acceptance scales and traceability matrices, and measured runtime/memory/payload/convergence/balance/report baselines.