### PR TITLE
[AI-Assisted] fix(thermo): reject stale reaction topology

### DIFF
--- a/docs/thermo/hydrate_models.md
+++ b/docs/thermo/hydrate_models.md
@@ -156,6 +156,10 @@ and chemical equilibrium are then iterated together. Reactions may change the sp
 CO₂ can form bicarbonate and carbonate—so the coupled flash propagates reaction-adjusted species amounts while
 conserving elements and aqueous charge. Fixed salt ions remain confined to the aqueous phase.
 
+If a component is added, removed, or renamed after reaction initialization, repeat
+`chemicalReactionInit()`, `createDatabase(true)`, and `setMixingRule(...)`. NeqSim rejects the stale
+reaction topology instead of silently applying the earlier reaction set.
+
 ```java
 SystemInterface fluid = new SystemElectrolyteCPAstatoil(273.15 + 10.0, 100.0);
 fluid.addComponent("methane", 0.75);

--- a/docs/thermo/reactive_flash.md
+++ b/docs/thermo/reactive_flash.md
@@ -184,6 +184,16 @@ flash.run();
 
 When you provide only molecular species, the flash can automatically discover ionic products from the reaction database:
 
+`chemicalReactionInit()` captures the component identities present at that call. If a component is
+later added, removed, or renamed, NeqSim rejects access to the stale reaction state. Repeat
+`chemicalReactionInit()`, `createDatabase(true)`, and `setMixingRule(...)` before the next reactive
+calculation. Changing only the amount of an existing component does not invalidate the reaction
+topology.
+
+This lifecycle rule is shared by electrolyte EOS systems and electrolyte GE systems such as Pitzer.
+Reinitialization reruns the existing reaction-database selection for that system; it does not make the
+reaction tables or equilibrium-constant parameters interchangeable between thermodynamic models.
+
 ```java
 SystemInterface system = new SystemElectrolyteCPAstatoil(298.15, 1.0);
 system.addComponent("CO2", 0.01);

--- a/src/main/java/neqsim/chemicalreactions/ChemicalReactionOperations.java
+++ b/src/main/java/neqsim/chemicalreactions/ChemicalReactionOperations.java
@@ -558,6 +558,9 @@ public class ChemicalReactionOperations implements neqsim.thermo.ThermodynamicCo
    * @return a boolean
    */
   public boolean solveChemEq(int phaseNum, int type) {
+    if (!system.isChemicalSystem()) {
+      return false;
+    }
     // Get the reactive phase - this finds aqueous or liquid phases
     int reactivePhase = getReactivePhaseIndex();
     if (reactivePhase < 0) {
@@ -573,10 +576,6 @@ public class ChemicalReactionOperations implements neqsim.thermo.ThermodynamicCo
       // Keep chem ref potentials updated for the current reactive phase.
       chemRefPot = calcChemRefPot(phaseNum);
     }
-    if (!system.isChemicalSystem()) {
-      return false;
-    }
-
     if (Amatrix == null) {
       Amatrix = calcAmatrix();
     }
@@ -663,6 +662,9 @@ public class ChemicalReactionOperations implements neqsim.thermo.ThermodynamicCo
    * @return immutable map from reaction name to signed {@code ln(Q/K)} residual
    */
   public Map<String, Double> getReactionLogResiduals() {
+    if (!system.isChemicalSystem()) {
+      return Collections.emptyMap();
+    }
     int reactivePhase = getReactivePhaseIndex();
     if (reactivePhase < 0 || reactionList == null) {
       return Collections.emptyMap();

--- a/src/main/java/neqsim/thermo/system/SystemInterface.java
+++ b/src/main/java/neqsim/thermo/system/SystemInterface.java
@@ -497,7 +497,12 @@ public interface SystemInterface extends Cloneable, java.io.Serializable {
   public void checkStability(boolean val);
 
   /**
-   * chemicalReactionInit.
+   * Initialize chemical-reaction topology for the current component identities.
+   *
+   * <p>
+   * Adding, removing, or renaming a component after this call makes the reaction state stale. Before the next reactive
+   * calculation, call this method again, repopulate the component database, and reapply the mixing rule.
+   * </p>
    */
   public void chemicalReactionInit();
 

--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -146,6 +146,7 @@ public abstract class SystemThermo implements SystemInterface {
   protected boolean checkStability = true;
   protected ChemicalReactionOperations chemicalReactionOperations = null;
   protected boolean chemicalSystem = false;
+  private boolean chemicalReactionStateStale = false;
   private ArrayList<String> componentNames = new ArrayList<String>();
 
   // TODO: componentNameTag is not working yet, a kind of alias-postfix for
@@ -378,6 +379,7 @@ public abstract class SystemThermo implements SystemInterface {
         getPhase(i).setAttractiveTerm(attractiveTermNumber);
       }
       numberOfComponents++;
+      markChemicalReactionStateStale();
     } else {
       for (PhaseInterface tmpPhase : phaseArray) {
         if (tmpPhase != null && (tmpPhase.getComponent(componentName).getNumberOfMolesInPhase() + moles) < 0.0) {
@@ -465,6 +467,7 @@ public abstract class SystemThermo implements SystemInterface {
       getPhase(i).setAttractiveTerm(attractiveTermNumber);
     }
     numberOfComponents++;
+    markChemicalReactionStateStale();
     // TODO: isInitialized = false;
   }
 
@@ -1431,6 +1434,7 @@ public abstract class SystemThermo implements SystemInterface {
   /** {@inheritDoc} */
   @Override
   public void changeComponentName(String name, String newName) {
+    markChemicalReactionStateStale();
     for (int i = 0; i < numberOfComponents; i++) {
       if (componentNames.get(i).equals(name)) {
         componentNames.set(i, newName);
@@ -1454,9 +1458,28 @@ public abstract class SystemThermo implements SystemInterface {
     checkStability = val;
   }
 
+  /** Mark initialized chemical-reaction topology stale after a component identity change. */
+  private void markChemicalReactionStateStale() {
+    if (chemicalReactionOperations != null) {
+      chemicalReactionStateStale = true;
+    }
+  }
+
+  /** Reject use of chemical-reaction state built for a different component set. */
+  private void requireCurrentChemicalReactionState() {
+    if (chemicalReactionStateStale) {
+      throw new IllegalStateException(
+          "Chemical-reaction state is stale because component identities changed after chemicalReactionInit(). "
+              + "Re-run chemicalReactionInit(), createDatabase(true), and setMixingRule(...) before the next reactive calculation.");
+    }
+  }
+
   /** {@inheritDoc} */
   @Override
   public void chemicalReactionInit() {
+    chemicalReactionOperations = null;
+    chemicalSystem = false;
+    chemicalReactionStateStale = false;
     chemicalReactionOperations = new ChemicalReactionOperations(this);
     chemicalSystem = chemicalReactionOperations.hasReactions();
   }
@@ -1476,6 +1499,8 @@ public abstract class SystemThermo implements SystemInterface {
     beta[4] = 1.0;
     beta[5] = 1.0;
     chemicalSystem = false;
+    chemicalReactionOperations = null;
+    chemicalReactionStateStale = false;
 
     double oldTemp = phaseArray[0].getTemperature();
     double oldPres = phaseArray[0].getPressure();
@@ -2029,6 +2054,7 @@ public abstract class SystemThermo implements SystemInterface {
   /** {@inheritDoc} */
   @Override
   public ChemicalReactionOperations getChemicalReactionOperations() {
+    requireCurrentChemicalReactionState();
     return chemicalReactionOperations;
   }
 
@@ -4132,6 +4158,7 @@ public abstract class SystemThermo implements SystemInterface {
   /** {@inheritDoc} */
   @Override
   public final boolean isChemicalSystem() {
+    requireCurrentChemicalReactionState();
     return chemicalSystem;
   }
 
@@ -4480,6 +4507,7 @@ public abstract class SystemThermo implements SystemInterface {
   @Override
   public void removeComponent(String name) {
     name = ComponentInterface.getComponentNameFromAlias(name);
+    markChemicalReactionStateStale();
 
     setTotalNumberOfMolesRaw(getTotalNumberOfMoles() - phaseArray[0].getComponent(name).getNumberOfmoles());
     for (int i = 0; i < getMaxNumberOfPhases(); i++) {

--- a/src/test/java/neqsim/thermo/system/SystemThermoChemicalReactionStaleStateTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemThermoChemicalReactionStaleStateTest.java
@@ -1,0 +1,166 @@
+package neqsim.thermo.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import neqsim.chemicalreactions.ChemicalReactionOperations;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.phase.PhaseType;
+
+/** Regression test for reaction topology after the system component set changes. */
+class SystemThermoChemicalReactionStaleStateTest extends neqsim.NeqSimTest {
+  @Test
+  void componentIdentityChangeRequiresReactionReinitialization() {
+    SystemInterface fluid = new SystemElectrolyteCPAstatoil(298.15, 1.01325);
+    fluid.addComponent("water", 1.0);
+    fluid.setPhaseType(0, PhaseType.AQUEOUS);
+    fluid.chemicalReactionInit();
+    ChemicalReactionOperations waterOnlyOperations = fluid.getChemicalReactionOperations();
+
+    fluid.addComponent("CO2", 0.001);
+
+    IllegalStateException accessFailure = assertThrows(IllegalStateException.class,
+        fluid::getChemicalReactionOperations);
+    assertTrue(accessFailure.getMessage().contains("chemicalReactionInit()"));
+    assertTrue(accessFailure.getMessage().contains("createDatabase(true)"));
+    assertThrows(IllegalStateException.class, fluid::isChemicalSystem);
+    assertThrows(IllegalStateException.class, () -> waterOnlyOperations.solveChemEq(0, 1),
+        "A retained operations reference must fail before using stale topology");
+    assertThrows(IllegalStateException.class, waterOnlyOperations::getReactionLogResiduals);
+    SystemInterface refreshedClone = fluid.clone();
+    assertNotNull(refreshedClone);
+    assertTrue(refreshedClone.isChemicalSystem());
+    assertTrue(refreshedClone.getPhase(0).hasComponent("HCO3-"));
+    assertThrows(IllegalStateException.class, fluid::isChemicalSystem,
+        "Cloning must not silently clear stale state on the source");
+
+    fluid.chemicalReactionInit();
+    ChemicalReactionOperations refreshedOperations = fluid.getChemicalReactionOperations();
+    assertNotSame(waterOnlyOperations, refreshedOperations);
+    assertTrue(fluid.isChemicalSystem());
+    assertTrue(fluid.getPhase(0).hasComponent("HCO3-"));
+    assertTrue(fluid.getPhase(0).hasComponent("CO3--"));
+
+    fluid.createDatabase(true);
+    fluid.setMixingRule(10);
+    fluid.setMultiPhaseCheck(false);
+    fluid.setMaxNumberOfPhases(1);
+    fluid.setNumberOfPhases(1);
+    fluid.setPhaseType(0, PhaseType.AQUEOUS);
+    fluid.init(0);
+    refreshedOperations.solveChemEq(0, 0);
+    refreshedOperations.solveChemEq(0, 1);
+    fluid.init(1);
+
+    assertFalse(refreshedOperations.getReactionLogResiduals().isEmpty());
+    double carbonMoles = 0.0;
+    double chargeMoles = 0.0;
+    for (int component = 0; component < fluid.getPhase(0).getNumberOfComponents(); component++) {
+      ComponentInterface species = fluid.getPhase(0).getComponent(component);
+      if ("CO2".equals(species.getComponentName()) || "HCO3-".equals(species.getComponentName())
+          || "CO3--".equals(species.getComponentName())) {
+        carbonMoles += species.getNumberOfMolesInPhase();
+      }
+      chargeMoles += species.getNumberOfMolesInPhase() * species.getIonicCharge();
+    }
+    assertEquals(0.001, carbonMoles, 1.0e-9);
+    assertEquals(0.0, chargeMoles, 1.0e-9);
+  }
+
+  @Test
+  void changingOnlyExistingComponentAmountKeepsReactionStateCurrent() {
+    SystemInterface fluid = new SystemElectrolyteCPAstatoil(298.15, 1.01325);
+    fluid.addComponent("CO2", 0.001);
+    fluid.addComponent("water", 1.0);
+    fluid.chemicalReactionInit();
+    ChemicalReactionOperations operations = fluid.getChemicalReactionOperations();
+
+    fluid.addComponent("CO2", 0.0001);
+    fluid.addComponent("CO2", 0.0001, 0);
+
+    assertSame(operations, fluid.getChemicalReactionOperations());
+    assertTrue(fluid.isChemicalSystem());
+  }
+
+  @Test
+  void geElectrolyteModelUsesTheSameTopologyGuard() {
+    SystemInterface fluid = new SystemPitzer(298.15, 10.0);
+    fluid.addComponent("water", 55.508);
+    fluid.chemicalReactionInit();
+
+    fluid.addComponent("CO2", 0.001);
+
+    assertThrows(IllegalStateException.class, fluid::getChemicalReactionOperations);
+    fluid.chemicalReactionInit();
+    assertTrue(fluid.isChemicalSystem());
+    assertTrue(fluid.getPhase(0).hasComponent("HCO3-"));
+  }
+
+  @Test
+  void phaseSpecificAdditionAndIdentityRemovalAlsoMarkReactionStateStale() {
+    SystemInterface addition = new SystemElectrolyteCPAstatoil(298.15, 1.01325);
+    addition.addComponent("water", 1.0);
+    addition.chemicalReactionInit();
+    addition.addComponent("CO2", 0.001, 0);
+    assertThrows(IllegalStateException.class, addition::getChemicalReactionOperations);
+
+    SystemInterface removal = new SystemElectrolyteCPAstatoil(298.15, 1.01325);
+    removal.addComponent("CO2", 0.001);
+    removal.addComponent("water", 1.0);
+    removal.chemicalReactionInit();
+    removal.removeComponent("CO2");
+    assertThrows(IllegalStateException.class, removal::isChemicalSystem);
+
+    SystemInterface rename = new SystemElectrolyteCPAstatoil(298.15, 1.01325);
+    rename.addComponent("CO2", 0.001);
+    rename.addComponent("water", 1.0);
+    rename.chemicalReactionInit();
+    rename.changeComponentName("CO2", "renamed CO2");
+    assertThrows(IllegalStateException.class, rename::getChemicalReactionOperations);
+  }
+
+  @Test
+  void clearAllRemovesChemicalReactionState() {
+    SystemInterface fluid = new SystemElectrolyteCPAstatoil(298.15, 1.01325);
+    fluid.addComponent("water", 1.0);
+    fluid.chemicalReactionInit();
+
+    fluid.clearAll();
+
+    assertFalse(fluid.isChemicalSystem());
+    assertNull(fluid.getChemicalReactionOperations());
+  }
+
+  @Test
+  void staleReactionStateSurvivesSerialization() throws Exception {
+    SystemInterface fluid = new SystemElectrolyteCPAstatoil(298.15, 1.01325);
+    fluid.addComponent("water", 1.0);
+    fluid.chemicalReactionInit();
+    fluid.addComponent("CO2", 0.001);
+
+    SystemInterface restored = roundTrip(fluid);
+
+    assertThrows(IllegalStateException.class, restored::getChemicalReactionOperations);
+    assertThrows(IllegalStateException.class, restored::isChemicalSystem);
+  }
+
+  private SystemInterface roundTrip(SystemInterface fluid) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(fluid);
+    }
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (SystemInterface) input.readObject();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fail fast when a reactive thermodynamic system's component identities change after `chemicalReactionInit()`, instead of silently reusing a reaction topology built for the old component set.

Refs #3144.

## Frozen engineering question and baseline

Can NeqSim prevent a reactive electrolyte calculation from using stale reactions after a component is added, removed, or renamed, while preserving fast amount-only updates and neutral-fluid performance?

Exact publication base: `c63eaa00320ba309dc5a27ab888fe37091c32b54`. The reproducer was established on unmodified `3c2a7234c20a1579c858613aecee2f7690a2aef0`; connector comparison proves all files in this increment are unchanged between that commit and the publication base.

Reproducer:

1. create `SystemElectrolyteCPAstatoil` at 298.15 K and 1.01325 bara with 1.0 mol water;
2. call `chemicalReactionInit()`;
3. retain the returned `ChemicalReactionOperations`;
4. add 0.001 mol CO2.

Current master kept the same water-only operations object, reported a chemical system, and had no bicarbonate. A calculation could therefore proceed with a reaction set that did not match the component identities.

The focused regression confirmed the defect on unmodified master before the production change.

## Scope and behavior

- Track whether initialized reaction topology is stale after a database component is added, removed, or renamed.
- Reject `isChemicalSystem()`, `getChemicalReactionOperations()`, retained-operation solves, and residual diagnostics until the caller repeats:
  `chemicalReactionInit(); createDatabase(true); setMixingRule(...)`.
- Keep amount-only updates to existing components valid and allocation-free.
- Reset reaction state before constructing new operations, so reaction-product discovery during initialization does not invalidate itself.
- Preserve stale state across serialization.
- Keep clone independence: cloning a stale source rebuilds current clone-owned reaction state from the clone's full component set without clearing the source's stale flag.
- Apply the same lifecycle rule to electrolyte EOS and electrolyte GE/Pitzer systems.

This increment does **not** change reaction tables, active-reaction policy, equilibrium constants, standard states, EOS/GE parameters, flash topology, hydrate equations, salt APIs, absorber equipment, or generic TP-flash algorithms. Model-specific reaction-table/parameter selection remains a separate #3144 scientific increment.

## Acceptance and scientific evidence

The refreshed Electrolyte-CPA CO2/water case uses mixing rule 10, a one-phase aqueous basis, and the existing database carbonate reaction set.

- bicarbonate and carbonate are discovered after refresh;
- retained stale operations fail before preprocessing or solve work;
- carbon inventory: expected `0.001 mol`, absolute residual `2.0e-10 mol` (constructor trace seed), tolerance `1.0e-9 mol`;
- aqueous charge residual: `3.0e-10 mol`, tolerance `1.0e-9 mol`;
- reaction diagnostic map is non-empty;
- phase/species state remains non-negative under the existing solver regressions;
- repeated amount-only updates retain object identity;
- add/remove/rename, clone, clear, serialization, and retained-reference paths are covered;
- Pitzer/GE directly reproduces the same stale guard and refreshes to a bicarbonate-containing topology.

No experimental or fitted data is introduced. Data licensing, preprocessing, uncertainty, calibration/hold-out separation, and parameter validity range are therefore not applicable to this synthetic lifecycle regression. Background numerical-equilibrium references: White, Johnson & Dantzig (1958), [DOI 10.1063/1.1744264](https://doi.org/10.1063/1.1744264); Tsanas et al. (2017), [DOI 10.1021/acs.iecr.7b02714](https://doi.org/10.1021/acs.iecr.7b02714).

## Validation

Passed locally after the Maven Central/proxy bootstrap:

- `SystemThermoChemicalReactionStaleStateTest`: **6/6**
- `SystemPitzerTest`: **22/22**
- focused clone/diagnostic/CO2-water/Pitzer batch: **38/38**
- explicit slow `SystemElectrolyteCPATest` + `ElectrolyteCPAHydrateEquilibriumTest`: **32/32**
- complete neutral SRK single-phase benchmark: **1/1**, 100 warmups + 2,000 measured flashes; Surefire wall time `68.39 s`
- `python devtools/run_spotless.py apply`: passed and stable
- `python devtools/run_spotless.py check`: passed
- `python devtools/check_documentation_search.py`: passed (655 Markdown pages, 1 standalone HTML)
- documentation unit suite: **103/103**

Performance boundary: no EOS, activity, fugacity, stability, or flash kernel changed. Neutral systems pay one predictable boolean check only when `isChemicalSystem()` is queried; component and flash arithmetic are unchanged. Amount-only updates add no new work. The complete neutral SRK benchmark passed, but no paired statistically powered exact-master comparison is claimed.

The optional `pre-commit` Python module is unavailable locally. A local `pomJava8.xml` test attempt also failed before any branch assertion because the Java-8 dependency classpath lacked `org.ejml.simple.ConstMatrix`; this is recorded rather than claimed as passing.

**VALIDATION PENDING CI:** hosted Spotless/pre-commit, Java 8/21 build/test/Javadoc, documentation search, CodeQL, and PaperLab checks are required on the exact head.

## Documentation and compatibility

Documentation updates:

- reactive-flash lifecycle and EOS/GE model boundary;
- reactive hydrate-fluid recovery sequence;
- `chemicalReactionInit()` Javadoc.

Compatibility tightening is intentional: code that mutates component identities after reaction initialization must now rebuild dependent database/mixing-rule state before reactive work. Public signatures are unchanged. Serialization adds one boolean field with a safe default of `false` for older streams.

## Stop boundary

This PR stops at common reaction-topology lifecycle protection. It does not overlap #2937 generic TP-flash work, #205 reactive-absorber equipment, or #448 salt input/API work. The next dependency is evidence-backed model-specific active-reaction and parameter selection across electrolyte EOS and GE models.