### PR TITLE
[AI-Assisted] feat(mcp): expose implementation inventory

### DIFF
--- a/neqsim-mcp-server/docs/API_REFERENCE.md
+++ b/neqsim-mcp-server/docs/API_REFERENCE.md
@@ -223,6 +223,13 @@ and routed through `EquipmentFactory`. Equipment that needs non-generic
 construction or custom multi-port semantics may still require a dedicated MCP
 runner or builder extension.
 
+The `getCapabilities` response also includes `implementationInventory`, a compact
+machine-readable trace from all published tools to their implementation classes,
+the canonical name-only `EquipmentFactory` surface, and the bounded
+`generateReport` / `bridgeTaskWorkflow` reporting paths. Use this inventory for
+discovery and audit; availability is not equivalent to benchmark validation or
+engineering approval.
+
 ---
 
 ## `runOperationalStudy` — P&ID and Plant-Data Operational Studies

--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -13,6 +13,9 @@ manually maintained Java method list.
 | Guided prompts | 9 | `prompts/list` | `NeqSimPrompts` MCP annotations |
 | Schema entries | 71 tools / 142 documents | `resources/read` | `SchemaCatalog` |
 | Example entries | 24 categories / 114 documents | `resources/read` | `ExampleCatalog` |
+| Tool implementations | 71 bindings / 60 classes | `getCapabilities.implementationInventory` | `McpImplementationInventory` |
+| Factory equipment | 205 types | `getCapabilities.implementationInventory` | `EquipmentFactory` |
+| Engineering report paths | 2 | `getCapabilities.implementationInventory` | `ReportRunner`, `TaskWorkflowBridge` |
 
 The tool regression asserts the exact 71-name set grouped by its current trust tier. It also calls
 `getCapabilities` and requires `toolCatalogCoverage.complete`, equal published and described tool
@@ -48,6 +51,32 @@ valid JSON objects. Domain examples remain representative inputs or contract-lev
 presence does not by itself establish scientific validation, benchmark maturity, or fitness for a
 specific facility decision.
 
+## Implementation, equipment, and reporting traceability
+
+`getCapabilities.implementationInventory` preserves a compact exact binding from every one of the
+71 public MCP tools to the Java class that performs its work. The 71 bindings currently resolve to
+60 implementation classes. Contract tests require the registry to have no missing or undeclared
+tool and load every named class from the running NeqSim version. This supplements the existing
+`runnerClass` descriptor: server-facade tools retain that compatibility field while
+`implementationClass` identifies the actual catalog, runner, registry, validator, or policy class.
+
+Process construction continues through the canonical
+`neqsim.process.equipment.EquipmentFactory` and
+`neqsim.process.processmodel.JsonProcessBuilder`. The inventory exposes the same 205 name-only
+factory-supported equipment types as `processJsonContract.supportedEquipmentTypes`; it does not
+claim that every type has the same input grammar, validation maturity, or multi-port construction
+support. Equipment requiring additional constructor context remains outside this name-only list.
+
+Two bounded reporting paths are explicit:
+
+| Path | MCP tool | Implementation | Output boundary |
+| --- | --- | --- | --- |
+| Engineering report | `generateReport` | `ReportRunner` | Markdown, tables, chart data, validation, and summary in the MCP response |
+| Task-workflow handoff | `bridgeTaskWorkflow` | `TaskWorkflowBridge` | `results.json`-compatible handoff for a separately reviewed rendering step |
+
+Neither path writes to a live plant system. The direct path does not persist a file, and the bridge
+does not claim that an external Word/HTML artifact has been generated or engineering-approved.
+
 ## Guided prompts
 
 - `biorefinery_analysis`
@@ -70,19 +99,20 @@ validation maturity. Call `getCapabilities`, `getBenchmarkTrust`, and `checkTool
 execution and preserve each calculation's provenance, convergence, validation, assumptions, and
 limitations.
 
-This increment changes no tool name, input or output schema, deployment default, thermodynamic
-model, process model, or response envelope. Process execution continues to use canonical NeqSim
-fluids, streams, `ProcessSystem`, and `ProcessModel` objects.
+This increment changes no tool name, tool input, deployment default, thermodynamic model, process
+model, or response envelope. It adds an optional discovery field to the `getCapabilities` output
+schema. Process execution continues to use canonical NeqSim fluids, streams, `ProcessSystem`, and
+`ProcessModel` objects.
 
 ## Phase 0 stop boundary
 
 The baseline now freezes the exact transport-facing tools, resources, resource templates, prompts,
-deployment-profile names, tool-capability reconciliation, schema resource graph, and example
-resource graph. It does not complete the campaign's full Phase 0 inventory. Follow-up work must
-still inventory runners, equipment factories, report paths, tests, guides, and known limitations;
-reconcile merged foundations #2874, #2875, and #3152 criterion by criterion; add the four
-acceptance scales; build the full traceability and discipline-maturity matrices; and record runtime,
-memory, payload, convergence, balance-closure, and report-usefulness baselines.
+deployment-profile names, tool-capability reconciliation, schema resource graph, example resource
+graph, tool implementation bindings, factory-backed equipment, and report paths. It does not
+complete the campaign's full Phase 0 inventory. Follow-up work must still inventory tests, guides,
+and known limitations; reconcile merged foundations #2874, #2875, and #3152 criterion by criterion;
+add the four acceptance scales; build the full traceability and discipline-maturity matrices; and
+record runtime, memory, payload, convergence, balance-closure, and report-usefulness baselines.
 
 DEXPI/P&ID ingestion remains owned by #2899, dynamics by #2911, flash/stability/performance by
 #2937, and merged production-optimization foundations by #2941. This inventory audits existing

--- a/neqsim-mcp-server/test_mcp_server.py
+++ b/neqsim-mcp-server/test_mcp_server.py
@@ -1466,6 +1466,32 @@ def test_capabilities():
           not coverage.get("missingDescriptors")
           and not coverage.get("undeclaredDescriptors"),
           str(coverage))
+    implementation = r.get("implementationInventory", {})
+    bindings = implementation.get("toolImplementationBindings", {})
+    check("implementation inventory is complete",
+          implementation.get("complete") is True,
+          str(implementation))
+    check("implementation inventory binds 71 tools",
+          implementation.get("toolBindingCount") == 71 and len(bindings) == 71,
+          str(implementation))
+    check("implementation inventory resolves 60 classes",
+          implementation.get("implementationClassCount") == 60,
+          str(implementation))
+    check("implementation inventory exposes 205 factory equipment types",
+          implementation.get("equipmentTypeCount") == 205,
+          str(implementation))
+    report_paths = implementation.get("reportPaths", [])
+    check("implementation inventory exposes two report paths",
+          implementation.get("reportPathCount") == 2
+          and [path.get("tool") for path in report_paths]
+          == ["generateReport", "bridgeTaskWorkflow"],
+          str(report_paths))
+    check("canonical process and report implementations are explicit",
+          bindings.get("runProcess") == "neqsim.mcp.runners.ProcessRunner"
+          and bindings.get("generateReport") == "neqsim.mcp.runners.ReportRunner"
+          and bindings.get("bridgeTaskWorkflow")
+          == "neqsim.mcp.runners.TaskWorkflowBridge",
+          str(bindings))
 
 
 def test_run_capability_search_and_invoke():

--- a/src/main/java/neqsim/mcp/catalog/SchemaCatalog.java
+++ b/src/main/java/neqsim/mcp/catalog/SchemaCatalog.java
@@ -806,6 +806,9 @@ public final class SchemaCatalog {
     properties.put("toolCapabilities",
         objectProp("Machine-readable descriptors for high-use MCP tools, including required fields, "
             + "supported models, units, limitations, and response contract fields"));
+    properties.put("implementationInventory",
+        objectProp("Compact tool-to-implementation bindings, canonical EquipmentFactory surface, "
+            + "and bounded engineering-report paths"));
 
     Map<String, Object> thermo = new LinkedHashMap<String, Object>();
     thermo.put("type", "object");

--- a/src/main/java/neqsim/mcp/runners/CapabilitiesRunner.java
+++ b/src/main/java/neqsim/mcp/runners/CapabilitiesRunner.java
@@ -178,6 +178,7 @@ public class CapabilitiesRunner {
     JsonObject toolCapabilities = buildToolCapabilities();
     root.add("toolCapabilities", toolCapabilities);
     root.add("toolCatalogCoverage", buildToolCatalogCoverage(toolCapabilities));
+    root.add("implementationInventory", McpImplementationInventory.build(toolCapabilities));
     root.add("setupTemplates", buildSetupTemplates());
     root.add("processJsonContract", buildProcessJsonContract());
     root.add("capabilityGraph", buildCapabilityGraph());
@@ -618,6 +619,7 @@ public class CapabilitiesRunner {
     descriptor.addProperty("schemaToolName", schemaToolName);
     descriptor.addProperty("runnerClass",
         runnerClass.indexOf('.') >= 0 ? runnerClass : "neqsim.mcp.runners." + runnerClass);
+    descriptor.addProperty("implementationClass", McpImplementationInventory.getImplementationClass(mcpToolName));
     descriptor.addProperty("workflowCategory", workflowCategory);
     descriptor.addProperty("maturityLevel", BenchmarkTrust.getMaturityLevel(mcpToolName));
     IndustrialProfile.ToolTier tier = IndustrialProfile.getToolTier(mcpToolName);

--- a/src/main/java/neqsim/mcp/runners/McpImplementationInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpImplementationInventory.java
@@ -1,0 +1,281 @@
+package neqsim.mcp.runners;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import neqsim.process.equipment.EquipmentFactory;
+
+/**
+ * Compact implementation traceability for the published NeqSim MCP surface.
+ *
+ * <p>
+ * The full capability descriptors are intentionally detailed and can be removed by the response-size guard. This
+ * inventory keeps the smaller tool-to-implementation bindings, canonical equipment-factory surface, and report paths
+ * available for agents that need to understand how a request reaches the normal NeqSim model.
+ * </p>
+ *
+ * <p>
+ * This is metadata only. It does not introduce a second simulator, construct equipment, run a process, persist a
+ * report, or bypass tool governance.
+ * </p>
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+public final class McpImplementationInventory {
+
+  private static final String RUNNER_PACKAGE = "neqsim.mcp.runners.";
+
+  /** Exact implementation class used by each published MCP tool. */
+  private static final Map<String, String> TOOL_IMPLEMENTATIONS = buildToolImplementations();
+
+  /**
+   * Private constructor — utility class.
+   */
+  private McpImplementationInventory() {
+  }
+
+  /**
+   * Returns the exact implementation class for a published tool.
+   *
+   * @param toolName public MCP tool name
+   * @return fully qualified implementation class, or null for an unknown tool
+   */
+  static String getImplementationClass(String toolName) {
+    return TOOL_IMPLEMENTATIONS.get(toolName);
+  }
+
+  /**
+   * Returns the immutable tool implementation registry for contract tests.
+   *
+   * @return tool-to-class bindings
+   */
+  static Map<String, String> getToolImplementations() {
+    return TOOL_IMPLEMENTATIONS;
+  }
+
+  /**
+   * Builds the machine-readable implementation inventory.
+   *
+   * @param toolCapabilities completed capability descriptors keyed by public tool name
+   * @return compact implementation, equipment, and report-path manifest
+   */
+  static JsonObject build(JsonObject toolCapabilities) {
+    JsonObject inventory = new JsonObject();
+    JsonObject bindings = new JsonObject();
+    JsonArray missing = new JsonArray();
+    JsonArray mismatched = new JsonArray();
+
+    List<String> publishedTools = new ArrayList<String>(IndustrialProfile.getAllKnownTools());
+    Collections.sort(publishedTools);
+    Set<String> implementationClasses = new TreeSet<String>();
+    for (String toolName : publishedTools) {
+      String expectedClass = TOOL_IMPLEMENTATIONS.get(toolName);
+      if (expectedClass == null) {
+        missing.add(toolName);
+        continue;
+      }
+      bindings.addProperty(toolName, expectedClass);
+      implementationClasses.add(expectedClass);
+
+      if (!toolCapabilities.has(toolName)) {
+        missing.add(toolName + " (capability descriptor)");
+        continue;
+      }
+      JsonObject descriptor = toolCapabilities.getAsJsonObject(toolName);
+      if (!descriptor.has("implementationClass")
+          || !expectedClass.equals(descriptor.get("implementationClass").getAsString())) {
+        mismatched.add(toolName);
+      }
+    }
+
+    JsonArray undeclared = new JsonArray();
+    for (String toolName : TOOL_IMPLEMENTATIONS.keySet()) {
+      if (!IndustrialProfile.getAllKnownTools().contains(toolName)) {
+        undeclared.add(toolName);
+      }
+    }
+
+    inventory.addProperty("toolBindingCount", bindings.size());
+    inventory.addProperty("implementationClassCount", implementationClasses.size());
+    inventory.addProperty("complete", missing.size() == 0 && mismatched.size() == 0 && undeclared.size() == 0);
+    inventory.add("toolImplementationBindings", bindings);
+    inventory.add("implementationClasses", toJsonArray(implementationClasses));
+    inventory.add("missingToolBindings", missing);
+    inventory.add("mismatchedCapabilityBindings", mismatched);
+    inventory.add("undeclaredToolBindings", undeclared);
+    inventory.addProperty("bindingSource", "NeqSimTools delegates reconciled with IndustrialProfile.getAllKnownTools");
+
+    List<String> equipmentTypes = EquipmentFactory.getSupportedEquipmentTypes();
+    inventory.addProperty("equipmentTypeCount", equipmentTypes.size());
+    inventory.add("supportedEquipmentTypes", toJsonArray(equipmentTypes));
+    inventory.addProperty("equipmentFactory", "neqsim.process.equipment.EquipmentFactory");
+    inventory.addProperty("processBuilder", "neqsim.process.processmodel.JsonProcessBuilder");
+    inventory.addProperty("equipmentDiscovery",
+        "Recursive runtime discovery plus specialized name-only EquipmentFactory construction");
+
+    JsonArray reportPaths = new JsonArray();
+    reportPaths
+        .add(reportPath("engineering-report", "generateReport", "ReportRunner", "Standardized simulation-result JSON",
+            new String[] { "markdown", "tables", "chartData", "validation", "summary" },
+            "Returned in the bounded MCP response; no file or plant-system write"));
+    reportPaths.add(
+        reportPath("task-workflow-handoff", "bridgeTaskWorkflow", "TaskWorkflowBridge", "Standardized MCP tool output",
+            new String[] { "resultsJson", "key_results", "validation", "approach", "conclusions" },
+            "Returns a results.json-compatible handoff; external report rendering is a separate reviewed step"));
+    inventory.addProperty("reportPathCount", reportPaths.size());
+    inventory.add("reportPaths", reportPaths);
+    inventory.addProperty("advisoryBoundary",
+        "Inventory and reports are advisory metadata and outputs; they do not control or write to live plant systems");
+    return inventory;
+  }
+
+  /**
+   * Builds one report-path descriptor.
+   *
+   * @param id stable report path id
+   * @param toolName public MCP tool name
+   * @param implementationClass simple runner class name
+   * @param inputContract input contract summary
+   * @param outputs report outputs
+   * @param persistence persistence and external-write boundary
+   * @return report-path descriptor
+   */
+  private static JsonObject reportPath(String id, String toolName, String implementationClass, String inputContract,
+      String[] outputs, String persistence) {
+    JsonObject path = new JsonObject();
+    path.addProperty("id", id);
+    path.addProperty("tool", toolName);
+    path.addProperty("implementationClass", qualify(implementationClass));
+    path.addProperty("inputContract", inputContract);
+    path.add("outputs", toJsonArray(java.util.Arrays.asList(outputs)));
+    path.addProperty("persistenceBoundary", persistence);
+    return path;
+  }
+
+  /**
+   * Builds the exact tool implementation registry.
+   *
+   * @return immutable insertion-ordered bindings
+   */
+  private static Map<String, String> buildToolImplementations() {
+    Map<String, String> implementations = new LinkedHashMap<String, String>();
+
+    bind(implementations, "runFlash", "FlashRunner");
+    bind(implementations, "runProcess", "ProcessRunner");
+    bind(implementations, "validateInput", "Validator");
+    bind(implementations, "searchComponents", "ComponentQuery");
+    bind(implementations, "getExample", "neqsim.mcp.catalog.ExampleCatalog");
+    bind(implementations, "getSchema", "neqsim.mcp.catalog.SchemaCatalog");
+    bind(implementations, "getPropertyTable", "PropertyTableRunner");
+    bind(implementations, "getPhaseEnvelope", "PhaseEnvelopeRunner");
+    bind(implementations, "getCapabilities", "CapabilitiesRunner");
+    bind(implementations, "runBatch", "BatchRunner");
+    bind(implementations, "listSimulationUnits", "AutomationRunner");
+    bind(implementations, "listUnitVariables", "AutomationRunner");
+    bind(implementations, "getSimulationVariable", "AutomationRunner");
+    bind(implementations, "setSimulationVariable", "AutomationRunner");
+    bind(implementations, "saveSimulationState", "AutomationRunner");
+    bind(implementations, "compareSimulationStates", "AutomationRunner");
+    bind(implementations, "diagnoseAutomation", "AutomationRunner");
+    bind(implementations, "getAutomationLearningReport", "AutomationRunner");
+    bind(implementations, "manageIndustrialProfile", "IndustrialProfile");
+    bind(implementations, "getBenchmarkTrust", "BenchmarkTrust");
+    bind(implementations, "checkToolAccess", "IndustrialProfile");
+    bind(implementations, "getAdjustableParameters", "AutomationRunner");
+    bind(implementations, "manageModel", "ModelRegistry");
+    bind(implementations, "inspectApi", "ApiKnowledgeRunner");
+
+    bind(implementations, "crossValidateModels", "CrossValidationRunner");
+    bind(implementations, "runParametricStudy", "ParametricStudyRunner");
+    bind(implementations, "runPVT", "PVTRunner");
+    bind(implementations, "runFlowAssurance", "FlowAssuranceRunner");
+    bind(implementations, "calculateStandard", "StandardsRunner");
+    bind(implementations, "runPipeline", "PipelineRunner");
+    bind(implementations, "runChemistry", "ChemistryRunner");
+    bind(implementations, "runMaterialsReview", "MaterialsReviewRunner");
+    bind(implementations, "runOpenDrainReview", "OpenDrainReviewRunner");
+    bind(implementations, "runNorsokS001Clause10Review", "NorsokS001Clause10ReviewRunner");
+    bind(implementations, "runWaterHammer", "WaterHammerRunner");
+    bind(implementations, "runAgenticEngineering", "AgenticEngineeringRunner");
+    bind(implementations, "runReservoir", "ReservoirRunner");
+    bind(implementations, "runFieldEconomics", "FieldDevelopmentRunner");
+    bind(implementations, "runDynamic", "DynamicRunner");
+    bind(implementations, "runBioprocess", "BioprocessRunner");
+    bind(implementations, "sizeEquipment", "EquipmentSizingRunner");
+    bind(implementations, "compareProcesses", "ProcessComparisonRunner");
+    bind(implementations, "validateResults", "EngineeringValidator");
+    bind(implementations, "runRelief", "ReliefRunner");
+    bind(implementations, "runLOPA", "LOPARunner");
+    bind(implementations, "runSIL", "SILRunner");
+    bind(implementations, "runRiskMatrix", "RiskMatrixRunner");
+    bind(implementations, "runFlareNetwork", "FlareRadiationRunner");
+    bind(implementations, "runHAZOP", "HAZOPStudyRunner");
+    bind(implementations, "runHazopScenario", "HazopScenarioRunner");
+    bind(implementations, "runBarrierRegister", "BarrierRegisterRunner");
+    bind(implementations, "runSafetySystemPerformance", "SafetySystemPerformanceRunner");
+    bind(implementations, "runOperationalStudy", "OperationalStudyRunner");
+    bind(implementations, "runRootCauseAnalysis", "RootCauseRunner");
+    bind(implementations, "runProcessLoop", "AutomationRunner");
+    bind(implementations, "designUtilities", "UtilityDesignRunner");
+
+    bind(implementations, "manageSession", "SessionRunner");
+    bind(implementations, "solveTask", "TaskSolverRunner");
+    bind(implementations, "composeWorkflow", "TaskSolverRunner");
+    bind(implementations, "generateReport", "ReportRunner");
+    bind(implementations, "runPlugin", "PluginRegistry");
+    bind(implementations, "getProgress", "ProgressTracker");
+    bind(implementations, "streamSimulation", "StreamingRunner");
+    bind(implementations, "generateVisualization", "VisualizationRunner");
+    bind(implementations, "composeMultiServerWorkflow", "CompositionRunner");
+    bind(implementations, "manageSecurity", "SecurityRunner");
+    bind(implementations, "manageState", "StatePersistenceRunner");
+    bind(implementations, "manageValidationProfile", "ValidationProfileRunner");
+    bind(implementations, "queryDataCatalog", "DataCatalogRunner");
+    bind(implementations, "bridgeTaskWorkflow", "TaskWorkflowBridge");
+    bind(implementations, "runCapability", "GeneralCapabilityRunner");
+
+    return Collections.unmodifiableMap(implementations);
+  }
+
+  /**
+   * Adds one fully qualified implementation binding.
+   *
+   * @param implementations mutable registry
+   * @param toolName public MCP tool name
+   * @param implementationClass simple runner name or fully qualified class
+   */
+  private static void bind(Map<String, String> implementations, String toolName, String implementationClass) {
+    implementations.put(toolName, qualify(implementationClass));
+  }
+
+  /**
+   * Qualifies a core MCP implementation class name.
+   *
+   * @param implementationClass simple or fully qualified class name
+   * @return fully qualified class name
+   */
+  private static String qualify(String implementationClass) {
+    return implementationClass.indexOf('.') >= 0 ? implementationClass : RUNNER_PACKAGE + implementationClass;
+  }
+
+  /**
+   * Converts strings to a JSON array.
+   *
+   * @param values string values
+   * @return JSON array
+   */
+  private static JsonArray toJsonArray(Iterable<String> values) {
+    JsonArray array = new JsonArray();
+    for (String value : values) {
+      array.add(value);
+    }
+    return array;
+  }
+}

--- a/src/test/java/neqsim/mcp/catalog/SchemaCatalogTest.java
+++ b/src/test/java/neqsim/mcp/catalog/SchemaCatalogTest.java
@@ -326,6 +326,7 @@ class SchemaCatalogTest {
     assertNotNull(output);
     assertTrue(output.contains("CapabilitiesOutput"));
     assertTrue(output.contains("toolCapabilities"));
+    assertTrue(output.contains("implementationInventory"));
     assertStandardOutputProps(output);
   }
 

--- a/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
@@ -1,6 +1,7 @@
 package neqsim.mcp.runners;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.HashSet;
@@ -31,6 +32,7 @@ class CapabilitiesRunnerTest {
     assertTrue(obj.has("processSimulation"));
     assertTrue(obj.has("calculationModes"));
     assertTrue(obj.has("toolCapabilities"));
+    assertTrue(obj.has("implementationInventory"));
     assertTrue(obj.has("setupTemplates"));
     assertTrue(obj.has("processJsonContract"));
     assertTrue(obj.has("capabilityGraph"));
@@ -110,6 +112,48 @@ class CapabilitiesRunnerTest {
 
     JsonObject safetyGate = obj.getAsJsonObject("safetyGatePolicy");
     assertTrue(safetyGate.get("engineeringReviewRequired").getAsBoolean());
+  }
+
+  @Test
+  void testImplementationInventoryIsCompleteAndResolvable() throws ClassNotFoundException {
+    JsonObject root = JsonParser.parseString(CapabilitiesRunner.getCapabilities()).getAsJsonObject();
+    JsonObject inventory = root.getAsJsonObject("implementationInventory");
+    JsonObject bindings = inventory.getAsJsonObject("toolImplementationBindings");
+
+    assertTrue(inventory.get("complete").getAsBoolean());
+    assertEquals(71, inventory.get("toolBindingCount").getAsInt());
+    assertEquals(60, inventory.get("implementationClassCount").getAsInt());
+    assertEquals(71, bindings.size());
+    assertEquals(IndustrialProfile.getAllKnownTools(), McpImplementationInventory.getToolImplementations().keySet());
+    assertEquals(0, inventory.getAsJsonArray("missingToolBindings").size());
+    assertEquals(0, inventory.getAsJsonArray("mismatchedCapabilityBindings").size());
+    assertEquals(0, inventory.getAsJsonArray("undeclaredToolBindings").size());
+
+    JsonObject toolCapabilities = root.getAsJsonObject("toolCapabilities");
+    for (Map.Entry<String, JsonElement> entry : bindings.entrySet()) {
+      String toolName = entry.getKey();
+      String implementationClass = entry.getValue().getAsString();
+      assertEquals(implementationClass,
+          toolCapabilities.getAsJsonObject(toolName).get("implementationClass").getAsString());
+      assertNotNull(Class.forName(implementationClass), "Implementation class does not resolve for " + toolName);
+    }
+
+    JsonArray equipmentTypes = inventory.getAsJsonArray("supportedEquipmentTypes");
+    JsonArray contractEquipment = root.getAsJsonObject("processJsonContract").getAsJsonArray("supportedEquipmentTypes");
+    assertEquals(205, inventory.get("equipmentTypeCount").getAsInt());
+    assertEquals(contractEquipment, equipmentTypes);
+    assertTrue(equipmentTypes.toString().contains("Compressor"));
+    assertTrue(equipmentTypes.toString().contains("ThreePhaseSeparator"));
+    assertTrue(equipmentTypes.toString().contains("ThrottlingValve"));
+
+    JsonArray reportPaths = inventory.getAsJsonArray("reportPaths");
+    assertEquals(2, inventory.get("reportPathCount").getAsInt());
+    assertEquals("generateReport", reportPaths.get(0).getAsJsonObject().get("tool").getAsString());
+    assertEquals("neqsim.mcp.runners.ReportRunner",
+        reportPaths.get(0).getAsJsonObject().get("implementationClass").getAsString());
+    assertEquals("bridgeTaskWorkflow", reportPaths.get(1).getAsJsonObject().get("tool").getAsString());
+    assertEquals("neqsim.mcp.runners.TaskWorkflowBridge",
+        reportPaths.get(1).getAsJsonObject().get("implementationClass").getAsString());
   }
 
   @Test


### PR DESCRIPTION
## Roadmap increment

Refs #3153 — Phase 0 executable implementation, equipment-factory, and report-path traceability.

Exact publication base: `f8030e066d0e875bb241404c0ca4c6ff3dae1795`.
Exact draft head: `fca8ed971aafb29166eea66cb40239b35d422a3f`.

The merged protocol inventory already froze 71 tools, 7 static resources, 7 resource templates, 9 prompts, 71 schema entries, and 114 examples. The remaining Phase 0 gap for this increment was that generic capability descriptors often named the MCP facade rather than the class doing the work, while the factory equipment surface and report handoffs were scattered across separate APIs.

## Change

`getCapabilities` now exposes a compact `implementationInventory` that:

- binds all 71 published tools to 60 exact loadable Java implementation classes;
- reconciles the bindings against `IndustrialProfile.getAllKnownTools()` and the capability descriptors, with explicit missing/mismatched/undeclared lists;
- exposes the same 205 name-only equipment types as the canonical `EquipmentFactory` / process JSON contract;
- identifies `JsonProcessBuilder` as the canonical process construction path;
- describes the two bounded reporting routes: `generateReport` through `ReportRunner`, and `bridgeTaskWorkflow` through `TaskWorkflowBridge`;
- records the advisory-only, no-live-plant-write boundary.

Each tool descriptor also gains additive `implementationClass` metadata while retaining the existing `runnerClass` compatibility field. The capabilities output schema, protocol regression, API reference, and Phase 0 inventory are synchronized.

## Engineering boundary

This is metadata and contract coverage only. It does not add an MCP-only simulator, construct or execute equipment, change thermodynamics, alter ProcessSystem/ProcessModel behavior, persist reports, write to plant systems, or claim validation/approval from availability. DEXPI/P&ID remains with #2899, dynamics with #2911, flash/stability/performance with #2937, and production optimization with #2941.

## Validation

Passed locally after the required Maven Central/proxy bootstrap:

- `CapabilitiesRunnerTest`, `SchemaCatalogTest`, and `ResponseSizeGuardTest`: **33/33**
  - exact 71-tool equality;
  - all 60 implementation classes resolve with `Class.forName`;
  - exact equality between the 205 equipment entries and the process JSON contract;
  - both report paths and their implementation classes;
  - additive output-schema coverage and response-size guarding.
- complete real stdio JSON-RPC suite: **309/309**
  - all 71 tools registered;
  - exact resource/template/prompt inventories;
  - all 142 schema resources and all 114 example resources resolve;
  - representative flash, valve, compressor, separator, pipeline, PVT, reporting, and governance behavior remains green;
  - the new implementation/equipment/report assertions pass through the packaged MCP server.
- direct Spotless apply/check: passed and stable.
- repository pre-commit and pre-push stages: passed.
- documentation search: passed (**655 Markdown pages, 1 standalone HTML page**).
- `python3 -m py_compile neqsim-mcp-server/test_mcp_server.py`: passed.
- `git diff --check`: passed.
- Maven Javadoc: **BUILD SUCCESS**; the local JRE image lacked the `javadoc` launcher, so the same bundled `jdk.javadoc` module was invoked through a task-local wrapper. Existing repository-wide warnings remain; no new error was introduced.

The first state-persistence protocol run used the sandbox's read-only default home and therefore failed only `manageState(list)`; rerunning with a task-local writable `user.home` passed 309/309. The MCP module declares Java 21 while this runtime provides Java 17 only, so packaging used a temporary local-only release-17 compiler fallback after installing the exact tested core artifact; the POM was restored and is absent from the diff. Hosted Java 21 validation remains mandatory.

No scientific equations or fitted data changed, so new benchmark claims, calibration splits, and numerical acceptance tolerances are not applicable. Representative engineering calculations were nevertheless exercised end to end to prove the additive discovery metadata does not alter behavior.

## Documentation and compatibility

Documentation impact: `API_REFERENCE.md` and `SURFACE_INVENTORY.md` now describe the exact bindings, factory scope, report boundaries, compatibility, and limitations.

Compatibility is additive: no tool name, input, deployment default, simulator, or response envelope changed. Consumers that ignore unknown JSON properties remain compatible. The existing response-size guard regression passes.

## Stop boundary and next dependency

This PR stops at one reviewable Phase 0 discovery contract. It does not mark the full Phase 0 checklist complete. The next dependency is the remaining verified inventory of tests, guides, and known limitations, followed by the four acceptance scales and traceability/maturity matrices.

**VALIDATION PENDING CI:** hosted Java 8/21 build/test/Javadoc, Spotless, documentation search, CodeQL, PaperLab, and exact-head review checks must pass before any READY TO MERGE classification.