### PR TITLE
[AI-Assisted] feat(thermo): expose reaction parameter provenance

### DIFF
--- a/docs/thermo/reactive_flash.md
+++ b/docs/thermo/reactive_flash.md
@@ -194,6 +194,14 @@ This lifecycle rule is shared by electrolyte EOS systems and electrolyte GE syst
 Reinitialization reruns the existing reaction-database selection for that system; it does not make the
 reaction tables or equilibrium-constant parameters interchangeable between thermodynamic models.
 
+Reaction data selection is explicit and inspectable. `SystemKentEisenberg` selects the dedicated
+`KENT_EISENBERG` source of apparent equilibrium constants; electrolyte EOS systems and electrolyte
+GE systems (including Pitzer) currently select `STANDARD`. This mapping records the implemented
+database choice—it is not evidence that a parameter set has been independently validated for every
+model or salinity range. Use `system.getChemicalReactionDataSource()` before initialization and
+`system.getChemicalReactionOperations().getReactionDataSource()` after initialization to record the
+selection in calculation provenance.
+
 ```java
 SystemInterface system = new SystemElectrolyteCPAstatoil(298.15, 1.0);
 system.addComponent("CO2", 0.01);
@@ -243,11 +251,22 @@ inspect the database-selected reaction set without multiplying trace activities 
 |--------|-------------|
 | `getReactionLogResiduals()` | Immutable reaction-name map of signed `ln(Q/K)` residuals in reaction-list order |
 | `getMaximumAbsoluteReactionLogResidual()` | Largest absolute `ln(Q/K)`, or `NaN` if no reactive liquid phase or reaction is available |
+| `getReactionDataSource()` | Typed source selected for the loaded reaction set |
 
 Individual `ChemicalReaction` objects also expose `calcLogReactionQuotient(system, phase)` and
 `calcLogReactionResidual(system, phase)`. These methods use the same mole-fraction and activity-
 coefficient standard-state convention as `calcK`, but sum logarithms directly so trace ionic
 activities do not underflow or overflow before the residual is evaluated.
+
+For parameter-level provenance, `getReference()`, `getEquilibriumConstantCoefficients()`, and
+`getReferenceTemperature()` expose the reference identifier and a defensive copy of the stored
+temperature-correlation data. The `CO2water` entry in `STANDARD`, for example, cites Plummer and
+Busenberg (1982), DOI: [10.1016/0016-7037(82)90056-4](https://doi.org/10.1016/0016-7037(82)90056-4).
+Kent-Eisenberg parameters are kept distinct because that screening model uses apparent constants;
+see Kent and Eisenberg, *Hydrocarbon Processing* 55 (1976), 87–90. For rigorous MDEA modeling,
+Huttenhuis et al. describe activity-based constants on a mole-fraction, infinite-dilution-in-water
+reference state and report their temperature validity ranges, DOI:
+[10.1016/j.fluid.2007.10.020](https://doi.org/10.1016/j.fluid.2007.10.020).
 
 ### FormulaMatrix
 

--- a/src/main/java/neqsim/chemicalreactions/ChemicalReactionOperations.java
+++ b/src/main/java/neqsim/chemicalreactions/ChemicalReactionOperations.java
@@ -651,6 +651,15 @@ public class ChemicalReactionOperations implements neqsim.thermo.ThermodynamicCo
   }
 
   /**
+   * Get the database source selected for this system's reaction set.
+   *
+   * @return selected reaction-data source
+   */
+  public neqsim.chemicalreactions.chemicalreaction.ChemicalReactionDataSource getReactionDataSource() {
+    return reactionList.getReactionDataSource();
+  }
+
+  /**
    * Get signed logarithmic equilibrium residuals for all reactions in the reactive phase.
    *
    * <p>

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReaction.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReaction.java
@@ -34,6 +34,7 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
   double rateFactor = 0;
   double activationEnergy;
   double refT;
+  String reference = "";
   double G = 0;
   double lnK = 0;
   int numberOfReactants = 0;
@@ -51,6 +52,23 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
    */
   public ChemicalReaction(String name, String[] names, double[] stocCoefs, double[] K, double r,
       double activationEnergy, double refT) {
+    this(name, names, stocCoefs, K, r, activationEnergy, refT, "");
+  }
+
+  /**
+   * Constructor for a chemical reaction with parameter provenance.
+   *
+   * @param name reaction name
+   * @param names component names
+   * @param stocCoefs stoichiometric coefficients
+   * @param K equilibrium-constant correlation coefficients
+   * @param r rate factor
+   * @param activationEnergy activation energy
+   * @param refT reference temperature in kelvin
+   * @param reference literature or data reference stored with the parameters
+   */
+  public ChemicalReaction(String name, String[] names, double[] stocCoefs, double[] K, double r,
+      double activationEnergy, double refT, String reference) {
     /*
      * this.names = names; this.stocCoefs = stocCoefs; this.K = K;
      */
@@ -62,6 +80,7 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
     this.rateFactor = r;
     this.refT = refT;
     this.activationEnergy = activationEnergy;
+    this.reference = reference == null ? "" : reference;
 
     System.arraycopy(names, 0, this.names, 0, names.length);
     System.arraycopy(stocCoefs, 0, this.stocCoefs, 0, stocCoefs.length);
@@ -90,6 +109,37 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
         productNames[l++] = this.names[i];
       }
     }
+  }
+
+  /**
+   * Get the literature or data reference stored with the equilibrium parameters.
+   *
+   * @return reference identifier, or an empty string when no reference was supplied
+   */
+  public String getReference() {
+    return reference == null ? "" : reference;
+  }
+
+  /**
+   * Get a defensive copy of the equilibrium-constant correlation coefficients.
+   *
+   * <p>
+   * The coefficients are used by {@link #getK(PhaseInterface)} in the order defined by the reaction database.
+   * </p>
+   *
+   * @return copied equilibrium-constant coefficient array
+   */
+  public double[] getEquilibriumConstantCoefficients() {
+    return K.clone();
+  }
+
+  /**
+   * Get the reference temperature stored with the reaction parameters.
+   *
+   * @return reference temperature in kelvin
+   */
+  public double getReferenceTemperature() {
+    return refT;
   }
 
   /**

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionDataSource.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionDataSource.java
@@ -1,0 +1,52 @@
+package neqsim.chemicalreactions.chemicalreaction;
+
+/**
+ * Identifies the database source used to load a thermodynamic system's chemical reactions.
+ *
+ * <p>
+ * A source identifies a reaction set and its equilibrium-constant parameters. It does not imply that the parameters are
+ * valid for another thermodynamic model or standard-state convention.
+ * </p>
+ *
+ * @author OpenAI Codex
+ * @version 1.0
+ */
+public enum ChemicalReactionDataSource {
+  /** General NeqSim reaction data used by electrolyte EOS and electrolyte GE systems. */
+  STANDARD("standard", "reactiondata"),
+
+  /** Apparent-equilibrium-constant data used by the Kent-Eisenberg model. */
+  KENT_EISENBERG("kent-eisenberg", "reactiondatakenteisenberg");
+
+  private final String identifier;
+  private final String databaseTableName;
+
+  /**
+   * Create a reaction-data source descriptor.
+   *
+   * @param identifier stable diagnostic identifier
+   * @param databaseTableName internal NeqSim database table name
+   */
+  ChemicalReactionDataSource(String identifier, String databaseTableName) {
+    this.identifier = identifier;
+    this.databaseTableName = databaseTableName;
+  }
+
+  /**
+   * Get the stable, implementation-independent source identifier.
+   *
+   * @return source identifier suitable for diagnostics and serialized output
+   */
+  public String getIdentifier() {
+    return identifier;
+  }
+
+  /**
+   * Get the internal NeqSim database table containing this reaction set.
+   *
+   * @return database table name
+   */
+  public String getDatabaseTableName() {
+    return databaseTableName;
+  }
+}

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionFactory.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionFactory.java
@@ -39,6 +39,7 @@ public final class ChemicalReactionFactory {
     double refT = 0;
     double rateFactor = 0;
     double activationEnergy = 0;
+    String reference = "";
 
     try (neqsim.util.database.NeqSimDataBase database = new neqsim.util.database.NeqSimDataBase();
         java.sql.ResultSet dataSet = database.getResultSet("SELECT * FROM reactiondata where name='" + name + "'")) {
@@ -50,6 +51,7 @@ public final class ChemicalReactionFactory {
         K[3] = Double.parseDouble(dataSet.getString("K4"));
         refT = Double.parseDouble(dataSet.getString("Tref"));
         rateFactor = Double.parseDouble(dataSet.getString("r"));
+        reference = dataSet.getString("Reference");
 
         activationEnergy = Double.parseDouble(dataSet.getString("ACTENERGY"));
         try (java.sql.ResultSet dataSet2 = database
@@ -80,7 +82,7 @@ public final class ChemicalReactionFactory {
       nameArray[i] = names.get(i);
       stocCoefArray[i] = Double.parseDouble(stocCoef.get(i));
     }
-    return new ChemicalReaction(name, nameArray, stocCoefArray, K, rateFactor, activationEnergy, refT);
+    return new ChemicalReaction(name, nameArray, stocCoefArray, K, rateFactor, activationEnergy, refT, reference);
   }
 
   /**

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionList.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionList.java
@@ -38,6 +38,7 @@ public class ChemicalReactionList implements ThermodynamicConstantsInterface {
   double[][] tempStocMatrix;
   /** Components array for reference potential calculations. */
   private ComponentInterface[] refPotComponents;
+  private ChemicalReactionDataSource reactionDataSource = ChemicalReactionDataSource.STANDARD;
 
   /**
    * readReactions.
@@ -54,15 +55,9 @@ public class ChemicalReactionList implements ThermodynamicConstantsInterface {
     double actH;
     double[] K = new double[4];
     boolean useReaction = false;
+    reactionDataSource = system.getChemicalReactionDataSource();
     try (neqsim.util.database.NeqSimDataBase database = new neqsim.util.database.NeqSimDataBase()) {
-      java.sql.ResultSet dataSet = null;
-      if (system.getModelName().equals("Kent Eisenberg-model")) {
-        // System.out.println("selecting Kent-Eisenberg reaction set");
-        dataSet = database.getResultSet("SELECT * FROM reactiondatakenteisenberg");
-      } else {
-        // System.out.println("selecting standard reaction set");
-        dataSet = database.getResultSet("SELECT * FROM reactiondata");
-      }
+      java.sql.ResultSet dataSet = database.getResultSet("SELECT * FROM " + reactionDataSource.getDatabaseTableName());
 
       double[] coefArray;
       String[] nameArray;
@@ -81,6 +76,7 @@ public class ChemicalReactionList implements ThermodynamicConstantsInterface {
           refT = Double.parseDouble(dataSet.getString("Tref"));
           r = Double.parseDouble(dataSet.getString("r"));
           actH = Double.parseDouble(dataSet.getString("ACTENERGY"));
+          String reference = dataSet.getString("Reference");
 
           try (neqsim.util.database.NeqSimDataBase database2 = new neqsim.util.database.NeqSimDataBase();
               java.sql.ResultSet dataSet2 = database2
@@ -103,7 +99,7 @@ public class ChemicalReactionList implements ThermodynamicConstantsInterface {
             nameArray[i] = names.get(i);
           }
 
-          ChemicalReaction reaction = new ChemicalReaction(reacname, nameArray, coefArray, K, r, actH, refT);
+          ChemicalReaction reaction = new ChemicalReaction(reacname, nameArray, coefArray, K, r, actH, refT, reference);
           chemicalReactionList.add(reaction);
           // System.out.println("reaction added ok...");
         }
@@ -111,6 +107,15 @@ public class ChemicalReactionList implements ThermodynamicConstantsInterface {
     } catch (Exception ex) {
       logger.error("could not add reaction: ", ex);
     }
+  }
+
+  /**
+   * Get the reaction-data source selected when this list was loaded.
+   *
+   * @return selected reaction-data source
+   */
+  public ChemicalReactionDataSource getReactionDataSource() {
+    return reactionDataSource == null ? ChemicalReactionDataSource.STANDARD : reactionDataSource;
   }
 
   /**

--- a/src/main/java/neqsim/thermo/system/SystemInterface.java
+++ b/src/main/java/neqsim/thermo/system/SystemInterface.java
@@ -1,6 +1,7 @@
 package neqsim.thermo.system;
 
 import neqsim.chemicalreactions.ChemicalReactionOperations;
+import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionDataSource;
 import neqsim.physicalproperties.PhysicalPropertyType;
 import neqsim.physicalproperties.interfaceproperties.InterphasePropertiesInterface;
 import neqsim.physicalproperties.system.PhysicalPropertyModel;
@@ -650,6 +651,20 @@ public interface SystemInterface extends Cloneable, java.io.Serializable {
    * @return a {@link neqsim.chemicalreactions.ChemicalReactionOperations} object
    */
   public ChemicalReactionOperations getChemicalReactionOperations();
+
+  /**
+   * Get the reaction-data source appropriate for this thermodynamic model.
+   *
+   * <p>
+   * The default source is shared by electrolyte EOS and electrolyte GE systems. Models with a dedicated
+   * parameterization override this method explicitly.
+   * </p>
+   *
+   * @return reaction-data source used by {@link #chemicalReactionInit()}
+   */
+  public default ChemicalReactionDataSource getChemicalReactionDataSource() {
+    return ChemicalReactionDataSource.STANDARD;
+  }
 
   /**
    * getCompFormulaes.

--- a/src/main/java/neqsim/thermo/system/SystemKentEisenberg.java
+++ b/src/main/java/neqsim/thermo/system/SystemKentEisenberg.java
@@ -1,5 +1,6 @@
 package neqsim.thermo.system;
 
+import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionDataSource;
 import neqsim.thermo.phase.PhaseKentEisenberg;
 import neqsim.thermo.phase.PhaseSrkEos;
 
@@ -50,6 +51,12 @@ public class SystemKentEisenberg extends SystemEosGE {
     attractiveTermNumber = 0;
 
     configureHybridEosGePhases(T, P, new PhaseSrkEos(), new PhaseKentEisenberg(), new PhaseSrkEos());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ChemicalReactionDataSource getChemicalReactionDataSource() {
+    return ChemicalReactionDataSource.KENT_EISENBERG;
   }
 
   /** {@inheritDoc} */

--- a/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionProvenanceTest.java
+++ b/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionProvenanceTest.java
@@ -1,0 +1,154 @@
+package neqsim.chemicalreactions.chemicalreaction;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemKentEisenberg;
+import neqsim.thermo.system.SystemPitzer;
+
+/**
+ * Tests reaction-source selection and equilibrium-parameter provenance diagnostics.
+ *
+ * @author OpenAI Codex
+ * @version 1.0
+ */
+class ChemicalReactionProvenanceTest {
+  private static final double[] STANDARD_CO2_WATER = new double[] { 253.235548, -12865.665607, -39.440767, 0.0 };
+  private static final double[] KENT_CO2_WATER = new double[] { 231.465, -12092.1, -36.7816, 0.0 };
+
+  /** Verify that Kent-Eisenberg explicitly selects its apparent-constant parameter set. */
+  @Test
+  void kentEisenbergUsesDedicatedApparentConstantSource() {
+    SystemInterface system = reactiveCo2WaterSystem(new SystemKentEisenberg(298.15, 1.01325));
+
+    assertEquals(ChemicalReactionDataSource.KENT_EISENBERG, system.getChemicalReactionDataSource());
+    assertEquals(ChemicalReactionDataSource.KENT_EISENBERG,
+        system.getChemicalReactionOperations().getReactionDataSource());
+    assertEquals("reactiondatakenteisenberg",
+        system.getChemicalReactionOperations().getReactionDataSource().getDatabaseTableName());
+
+    ChemicalReaction reaction = getCo2WaterReaction(system);
+    assertEquals("KentEisenberg1976", reaction.getReference());
+    assertArrayEquals(KENT_CO2_WATER, reaction.getEquilibriumConstantCoefficients(), 1.0e-12);
+    assertEquals(298.15, reaction.getReferenceTemperature(), 1.0e-12);
+  }
+
+  /** Verify source and parameter provenance for the electrolyte EOS model. */
+  @Test
+  void electrolyteEosUsesStandardReactionSource() {
+    assertStandardSource(reactiveCo2WaterSystem(new SystemElectrolyteCPAstatoil(298.15, 1.01325)));
+  }
+
+  /** Verify source and parameter provenance for the Pitzer electrolyte GE model. */
+  @Test
+  void electrolyteGeUsesStandardReactionSource() {
+    assertStandardSource(reactiveCo2WaterSystem(new SystemPitzer(298.15, 1.01325)));
+  }
+
+  /** Verify that callers cannot mutate stored equilibrium-constant coefficients. */
+  @Test
+  void coefficientDiagnosticReturnsDefensiveCopy() {
+    SystemInterface system = reactiveCo2WaterSystem(new SystemElectrolyteCPAstatoil(298.15, 1.01325));
+    ChemicalReaction reaction = getCo2WaterReaction(system);
+    double[] first = reaction.getEquilibriumConstantCoefficients();
+    double[] second = reaction.getEquilibriumConstantCoefficients();
+
+    assertNotSame(first, second);
+    first[0] = -1.0;
+    assertArrayEquals(STANDARD_CO2_WATER, reaction.getEquilibriumConstantCoefficients(), 1.0e-12);
+  }
+
+  /** Verify that factory-created reactions preserve their database reference. */
+  @Test
+  void factoryPreservesStandardParameterReference() {
+    ChemicalReaction reaction = ChemicalReactionFactory.getChemicalReaction("CO2water");
+
+    assertEquals("Plummer-Busenberg1982", reaction.getReference());
+    assertArrayEquals(STANDARD_CO2_WATER, reaction.getEquilibriumConstantCoefficients(), 1.0e-12);
+  }
+
+  /**
+   * Verify clone and serialization preservation of source and parameter provenance.
+   *
+   * @throws Exception if Java serialization fails
+   */
+  @Test
+  void provenanceSurvivesCloneAndSerialization() throws Exception {
+    SystemInterface original = reactiveCo2WaterSystem(new SystemKentEisenberg(298.15, 1.01325));
+    SystemInterface cloned = original.clone();
+    SystemInterface restored = roundTrip(original);
+
+    assertEquals(ChemicalReactionDataSource.KENT_EISENBERG,
+        cloned.getChemicalReactionOperations().getReactionDataSource());
+    assertEquals("KentEisenberg1976", getCo2WaterReaction(cloned).getReference());
+    assertEquals(ChemicalReactionDataSource.KENT_EISENBERG,
+        restored.getChemicalReactionOperations().getReactionDataSource());
+    assertEquals("KentEisenberg1976", getCo2WaterReaction(restored).getReference());
+  }
+
+  /**
+   * Initialize a two-component reactive CO2-water system.
+   *
+   * @param system thermodynamic system to initialize
+   * @return initialized reactive system
+   */
+  private static SystemInterface reactiveCo2WaterSystem(SystemInterface system) {
+    system.addComponent("CO2", 0.01);
+    system.addComponent("water", 0.99);
+    system.chemicalReactionInit();
+    return system;
+  }
+
+  /**
+   * Get the loaded CO2 hydration reaction.
+   *
+   * @param system initialized reactive system
+   * @return loaded CO2-water reaction
+   */
+  private static ChemicalReaction getCo2WaterReaction(SystemInterface system) {
+    ChemicalReaction reaction = system.getChemicalReactionOperations().getReactionList().getReaction("CO2water");
+    assertNotNull(reaction);
+    return reaction;
+  }
+
+  /**
+   * Assert the standard source and CO2-water parameter provenance.
+   *
+   * @param system initialized electrolyte system
+   */
+  private static void assertStandardSource(SystemInterface system) {
+    assertEquals(ChemicalReactionDataSource.STANDARD, system.getChemicalReactionDataSource());
+    assertEquals(ChemicalReactionDataSource.STANDARD, system.getChemicalReactionOperations().getReactionDataSource());
+    assertEquals("standard", system.getChemicalReactionOperations().getReactionDataSource().getIdentifier());
+
+    ChemicalReaction reaction = getCo2WaterReaction(system);
+    assertEquals("Plummer-Busenberg1982", reaction.getReference());
+    assertArrayEquals(STANDARD_CO2_WATER, reaction.getEquilibriumConstantCoefficients(), 1.0e-12);
+    assertEquals(298.15, reaction.getReferenceTemperature(), 1.0e-12);
+  }
+
+  /**
+   * Serialize and restore a thermodynamic system.
+   *
+   * @param system system to serialize
+   * @return restored system
+   * @throws Exception if Java serialization fails
+   */
+  private static SystemInterface roundTrip(SystemInterface system) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(system);
+    }
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (SystemInterface) input.readObject();
+    }
+  }
+}


### PR DESCRIPTION
## Scientific question

Can NeqSim make the selected reaction table and each equilibrium-constant parameter source auditable across electrolyte EOS and electrolyte GE models, without changing reaction thermodynamics or adding cost to neutral calculations?

Current master selected the Kent-Eisenberg table through an exact model-name string and otherwise silently used the standard table. It also discarded each row's `Reference` field after loading. That prevented callers from recording which parameterization produced a reactive result and made model-specific validation difficult.

## Change

- adds typed `ChemicalReactionDataSource` identities for `STANDARD` and `KENT_EISENBERG`;
- makes source selection an explicit `SystemInterface` policy hook, with `SystemKentEisenberg` overriding the default;
- records and exposes the loaded source through `ChemicalReactionOperations`;
- preserves each database row's literature/data reference, reference temperature, and a defensive copy of its equilibrium-correlation coefficients;
- preserves source/reference provenance through cloning and Java serialization, including a compatibility fallback for older serialized reaction lists;
- documents the current model mapping and its scientific limits.

The implemented mapping is intentionally unchanged numerically: Electrolyte-CPA and Pitzer GE use `STANDARD`; Kent-Eisenberg uses `KENT_EISENBERG`. No reaction was activated/deactivated, no coefficient was changed, and no EOS, activity, fugacity, flash, reaction-equilibrium, balance, or phase-stability equation was modified.

## Frozen scope and conventions

- Reproducer: current master lacks source/reference/coefficient diagnostics; the reflection probe passed 1/1 before implementation.
- Conditions used for focused regression: CO2/water, 298.15 K, 1.01325 bara, mole basis.
- Models: Electrolyte-CPA-EOS-statoil, Pitzer-GE, and Kent-Eisenberg.
- Standard parameters remain the repository's mole-fraction/activity-coefficient convention; Kent-Eisenberg remains its existing apparent-constant screening model.
- Acceptance: exact typed source identity, exact stored references/coefficient vectors/Tref, defensive copies, clone/serialization preservation, unchanged broader reactive behavior, Java 8 compatibility, and no new neutral hot-path work.
- Stop boundary: provenance and selection plumbing only; no new table, reaction-set change, parameter fit, or claim that `STANDARD` is independently valid for every EOS/GE model or salinity.

## Scientific references and data handling

- Plummer and Busenberg (1982), DOI [10.1016/0016-7037(82)90056-4](https://doi.org/10.1016/0016-7037(82)90056-4), is the existing `CO2water` reference identifier in the standard table.
- Kent and Eisenberg (1976), *Hydrocarbon Processing* 55, 87–90, is the existing apparent-constant source identifier for the dedicated table.
- Huttenhuis et al. (2008), DOI [10.1016/j.fluid.2007.10.020](https://doi.org/10.1016/j.fluid.2007.10.020), distinguishes activity-based, mole-fraction/infinite-dilution-in-water constants and reports temperature validity ranges relevant to future rigorous MDEA validation.

No external numerical dataset or copyrighted table was copied, transformed, or fitted in this increment. It only preserves identifiers and values already shipped in NeqSim. Repository content remains under the project's [Apache-2.0 license](https://github.com/equinor/neqsim/blob/master/LICENSE); literature is cited, not redistributed. Training/validation splits and fit uncertainty are therefore not applicable.

## Validation

Passed locally:

- `ChemicalReactionProvenanceTest`: **6/6** on the normal build and **6/6** with `pomJava8.xml` (target 1.8).
- broader reactive matrix: **53/53** across `SystemKentEisenbergTest`, `SystemPitzerTest`, `CO2WaterEquilibriumTest`, `SystemThermoChemicalReactionStaleStateTest`, `SystemThermoReactiveCloneTest`, and `ChemicalReactionUnderflowDiagnosticTest`.
- Maven Javadoc: **BUILD SUCCESS**. The runtime omitted the launcher executable, so the bundled `jdk.javadoc` module was invoked through a task-local shim; existing repository-wide warnings remain.
- direct Spotless apply/check: passed and stable.
- documentation-search audit: passed (**655 Markdown pages, 1 standalone HTML page**).
- trailing-whitespace check on all changed files: passed.

The `pre-commit` executable is not installed in this runtime. Its mandatory repository actions were executed directly; no hook result is claimed.

Regression evidence remains separate from scientific validation: these tests prove mapping/provenance compatibility and existing reactive behavior, not independent accuracy of the stored parameters.

## Numerical and performance evidence

- Standard `CO2water`: reference `Plummer-Busenberg1982`, coefficients `[253.235548, -12865.665607, -39.440767, 0]`, Tref 298.15 K.
- Kent-Eisenberg `CO2water`: reference `KentEisenberg1976`, coefficients `[231.465, -12092.1, -36.7816, 0]`, Tref 298.15 K.
- Typed selector microbenchmark median: **11.5 ns/call** versus **12.0 ns/call** for the legacy model-name string check.
- Complete Electrolyte-CPA reaction initialization median: **19.8 ms**.
- Neutral SRK clone + TP-flash control median: **76.2 µs**. The change adds no call on the neutral calculation path.

These timings are local diagnostic medians, not universal hardware-independent guarantees.

## Compatibility, limitations, and next dependency

The old seven-argument `ChemicalReaction` constructor remains. The new system method has a default implementation, so third-party `SystemInterface` implementations retain source compatibility. Returned coefficient arrays are defensive copies; diagnostics are additive.

The principal limitation is now explicit: CPA and Pitzer still share `STANDARD`. That mapping is an implementation fact, not scientific validation of parameter/standard-state interchangeability. The next campaign dependency is an evidence-and-license-qualified audit of active reactions and equilibrium parameters by model family and validity range, followed by independent validation data before any table split or parameter change.

Implementation base: `242b9539d68d5a6a16faacd783bf60b2238e4ca7`  
Current master/base: `fc01e56e228e61ecf0dafbbe2c28d40e4d43eb0e`  
Exact head: `ce62a8dd483cf71c93f4b85b60f72a99d2c7e02c`

Refs #3144


The exact head merges current master `fc01e56e228e61ecf0dafbbe2c28d40e4d43eb0e` after the unrelated #3166 MCP inventory merge; the nine electrolyte provenance files are byte-identical to the validated implementation.
