### PR TITLE
[AI-Assisted] feat(valves): assess vendor trim Cv capacity

### DIFF
--- a/docs/process/ValveMechanicalDesign.md
+++ b/docs/process/ValveMechanicalDesign.md
@@ -12,10 +12,86 @@ This document describes the mechanical design calculations for control valves in
 The valve mechanical design module provides sizing and design calculations for control valves based on **IEC 60534**, **ANSI/ISA-75**, and **ASME B16.34** standards. The calculations enable:
 
 - Valve body sizing and pressure rating selection
+- Vendor trim-capacity selection and Cv utilization
 - Body wall thickness estimation
 - Weight estimation for procurement and installation planning
 - Actuator sizing for control applications
 - Module dimension calculation for layout planning
+
+## Required Cv versus available trim Cv
+
+`ValveMechanicalDesign` distinguishes the process-case requirement from the capacity of an
+available physical trim:
+
+| Quantity | Meaning |
+| --- | --- |
+| Required Cv | Full-open Cv required for the simulated flow, pressure drop, valve characteristic, and opening |
+| Trim maximum design Cv | Vendor-qualified capacity limit for one body/trim configuration |
+| Trim Cv utilization | `required Cv / selected maximum design Cv` |
+| Cv capacity margin | `selected maximum design Cv - required Cv` |
+
+The available trim catalog is explicit input. NeqSim does not embed vendor product tables or infer
+a universal derating from a material/construction label. This is important for severe-service
+tungsten-carbide trims: a metallic **brickstopper** protects brittle carbide components from impact
+by large debris, but it is not itself a universal Cv correction. Use the maximum design Cv values
+qualified by the applicable vendor for the body, trim, pressure class, flow direction, and service.
+
+### Carbide trim with brickstopper example
+
+```java
+import neqsim.process.mechanicaldesign.valve.ValveMechanicalDesign;
+import neqsim.process.mechanicaldesign.valve.ValveTrimOption;
+import neqsim.process.mechanicaldesign.valve.ValveTrimSizingResult;
+
+ValveMechanicalDesign design = valve.getMechanicalDesign();
+design.setMaximumAllowedTrimUtilization(0.80); // reserve at least 20% Cv capacity
+design.addAvailableTrimOption(
+    "TC-BS-50", 50.0, 42.0, "tungsten carbide", "metallic brickstopper");
+design.addAvailableTrimOption(
+    "TC-BS-75", 75.0, 68.0, "tungsten carbide", "metallic brickstopper");
+design.addAvailableTrimOption(
+    "TC-BS-100", 100.0, 95.0, "tungsten carbide", "metallic brickstopper");
+
+design.calcDesign();
+ValveTrimSizingResult trimResult = design.getTrimSizingResult();
+
+boolean feasible = trimResult.isFeasible();
+double requiredCv = trimResult.getRequiredCv();
+double utilization = trimResult.getUtilization();
+double marginCv = trimResult.getCapacityMarginCv();
+ValveTrimOption selectedTrim = trimResult.getSelectedTrimOption();
+```
+
+Automatic selection chooses the smallest relative trim satisfying the configured utilization
+limit. Equal-size options are ordered by maximum design Cv and then identifier. If none is
+feasible, `getSelectedTrimOption()` returns `null`; the result status is `NO_FEASIBLE_TRIM`, and
+utilization/margin are evaluated against the largest supplied maximum design Cv so the bottleneck
+stays visible.
+
+For a required Cv that already includes project-specific flow cases, safety factors, or target
+opening, call `assessTrimOptionsForRequiredCv(requiredCv)` directly. Setting
+`setMaxDesignCv(value)` without a catalog also works: the operating numerator is the latest
+calculated required Cv.
+
+The assessment is exposed through `ValveMechanicalDesignResponse`/JSON and through the generic
+mechanical-design utilization bridge:
+
+```java
+double cvUtilization = design.getDesignUtilization().get("design Cv");
+valve.applyMechanicalDesignCapacityConstraints();
+double bottleneckUtilization = valve.getMaxUtilization();
+```
+
+The trim-capacity assessment is a preliminary engineering screen, not vendor certification.
+
+Engineering context:
+
+- [Trillium Flow Technologies BV992/BV993 choke valves](https://www.trilliumflow.com/product/blakeborough-bv992-and-bv993-choke/)
+  lists non-collapsible brickstopper and high-toughness carbide trim options.
+- S. Tattersall, *Choke Valve Technology in Subsea Environments*, Measurement and Control 49(3),
+  2016, [DOI 10.1177/0020294016640556](https://doi.org/10.1177/0020294016640556), describes
+  metallic brick stoppers as impact protection and identifies trim capacity and design Cv as key
+  selection inputs.
 
 ## Design Standards Reference
 
@@ -190,6 +266,9 @@ System.out.println("Total Weight: " + mechDesign.getWeightTotal() + " kg");
 | `getDesignPressure()`         | double | Returns design pressure in bara                     |
 | `getDesignTemperature()`      | double | Returns design temperature in °C                    |
 | `getWeightTotal()`            | double | Returns total valve weight in kg                    |
+| `getRequiredCv()`             | double | Returns the calculated required full-open Cv        |
+| `addAvailableTrimOption(...)` | void   | Adds an explicit relative trim size and maximum Cv  |
+| `getTrimSizingResult()`       | `ValveTrimSizingResult` | Returns selection, utilization, margin, and feasibility |
 
 ## Valve Sizing Standards
 

--- a/docs/process/equipment_utilization_via_mechanical_design.md
+++ b/docs/process/equipment_utilization_via_mechanical_design.md
@@ -110,6 +110,12 @@ Equipment subclasses (or specialised `MechanicalDesign` subclasses) may override
 kW, m/s). Until a hook is overridden, the corresponding design limit simply produces no
 constraint, so utilization is never reported on an undefined basis.
 
+`ValveMechanicalDesign` supplies the Cv hook as the calculated required Cv. When an explicit
+vendor trim catalog is configured, `maxDesignCv` is the selected trim maximum Cv (or the largest
+available maximum when no option is feasible), so `design Cv` utilization is
+`Cv_required / Cv_trim,max`. See [Valve Mechanical Design](ValveMechanicalDesign.md) for relative
+trim sizes, utilization reserve, and severe-service carbide/brickstopper metadata.
+
 ## Worked example
 
 ```java

--- a/docs/process/mechanical_design.md
+++ b/docs/process/mechanical_design.md
@@ -457,7 +457,10 @@ ValveMechanicalDesignResponse valveResponse =
     (ValveMechanicalDesignResponse) valve.getMechanicalDesign().getResponse();
 
 int ansiClass = valveResponse.getAnsiPressureClass();
+double cvRequired = valveResponse.getCvRequired();
 double cvMax = valveResponse.getCvMax();
+double trimUtilization = valveResponse.getTrimCvUtilization();
+boolean trimFeasible = valveResponse.isTrimFeasible();
 double faceToFace = valveResponse.getFaceToFace();  // mm
 String valveType = valveResponse.getValveType();
 ```
@@ -801,6 +804,7 @@ ValveMechanicalDesign valveDesign =
 
 // Key parameters
 double cvMax = valveDesign.getValveCvMax();
+double requiredCv = valveDesign.getRequiredCv();
 int ansiClass = valveDesign.getAnsiPressureClass();
 double faceToFace = valveDesign.getFaceToFace();           // mm
 double actuatorThrust = valveDesign.getRequiredActuatorThrust(); // N
@@ -808,6 +812,8 @@ double actuatorThrust = valveDesign.getRequiredActuatorThrust(); // N
 
 Design calculations include:
 - Cv/Kv sizing per IEC 60534
+- Explicit vendor trim catalogs with relative trim size, maximum design Cv, utilization, margin, and feasibility
+- Material/construction provenance for severe-service trims without unsupported generic derating factors
 - ANSI pressure class selection
 - Body sizing and wall thickness
 - Actuator sizing

--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -11,6 +11,7 @@ import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.TwoPortEquipment;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.mechanicaldesign.valve.ValveMechanicalDesign;
+import neqsim.process.mechanicaldesign.valve.ValveTrimSizingResult;
 import neqsim.process.util.monitor.ValveResponse;
 import neqsim.process.util.report.ReportConfig;
 import neqsim.process.util.report.ReportConfig.DetailLevel;
@@ -1632,8 +1633,12 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
     // Set the Cv on the valve (this is what controls valve sizing)
     setCv(designCv);
 
-    // Also set maxDesignCv for capacity constraint tracking
-    getMechanicalDesign().setMaxDesignCv(designCv);
+    // Assess any explicit vendor trim catalog against the final design Cv.
+    ValveTrimSizingResult trimResult = getMechanicalDesign().assessTrimOptionsForRequiredCv(designCv);
+    if (!trimResult.isEvaluated()) {
+      // Preserve legacy behavior when no explicit trim catalog is configured.
+      getMechanicalDesign().setMaxDesignCv(designCv);
+    }
 
     // Set the valve opening to the design point for meaningful utilization
     if (hasFlow) {

--- a/src/main/java/neqsim/process/mechanicaldesign/valve/ValveMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/valve/ValveMechanicalDesign.java
@@ -2,7 +2,11 @@ package neqsim.process.mechanicaldesign.valve;
 
 import java.awt.BorderLayout;
 import java.awt.Container;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.swing.JFrame;
 import javax.swing.JScrollPane;
@@ -52,6 +56,34 @@ public class ValveMechanicalDesign extends MechanicalDesign {
   /** Design pressure margin factor. */
   private static final double DESIGN_PRESSURE_MARGIN = 1.10;
 
+  /** Deterministic ordering used when selecting the smallest feasible relative trim. */
+  private static final Comparator<ValveTrimOption> TRIM_OPTION_ORDER = new Comparator<ValveTrimOption>() {
+    @Override
+    public int compare(ValveTrimOption first, ValveTrimOption second) {
+      int sizeComparison = Double.compare(first.getRelativeTrimSizePercent(), second.getRelativeTrimSizePercent());
+      if (sizeComparison != 0) {
+        return sizeComparison;
+      }
+      int cvComparison = Double.compare(first.getMaximumDesignCv(), second.getMaximumDesignCv());
+      if (cvComparison != 0) {
+        return cvComparison;
+      }
+      return first.getIdentifier().compareTo(second.getIdentifier());
+    }
+  };
+
+  /** Deterministic ordering used to identify the largest available design Cv. */
+  private static final Comparator<ValveTrimOption> TRIM_CAPACITY_ORDER = new Comparator<ValveTrimOption>() {
+    @Override
+    public int compare(ValveTrimOption first, ValveTrimOption second) {
+      int cvComparison = Double.compare(first.getMaximumDesignCv(), second.getMaximumDesignCv());
+      if (cvComparison != 0) {
+        return cvComparison;
+      }
+      return TRIM_OPTION_ORDER.compare(first, second);
+    }
+  };
+
   /** ANSI Class 150 maximum pressure at ambient [bara]. */
   private static final double ANSI_150_MAX_PRESSURE = 19.6;
 
@@ -75,6 +107,12 @@ public class ValveMechanicalDesign extends MechanicalDesign {
   // ============================================================================
 
   double valveCvMax = 1.0;
+  private double requiredCv = Double.NaN;
+  private final List<ValveTrimOption> availableTrimOptions = new ArrayList<ValveTrimOption>();
+  private double maximumAllowedTrimUtilization = 1.0;
+  private ValveTrimSizingResult trimSizingResult = ValveTrimSizingResult.notEvaluated(Double.NaN,
+      "No valve sizing case or trim catalog has been evaluated", maximumAllowedTrimUtilization);
+  private boolean trimCatalogControlsMaxDesignCv = false;
   double valveWeight = 100.0;
   double inletPressure = 0.0;
   double outletPressure = 0.0;
@@ -361,13 +399,15 @@ public class ValveMechanicalDesign extends MechanicalDesign {
 
     // Calculate valve sizing
     Map<String, Object> result = calcValveSize();
-    this.valveCvMax = (double) result.get("Cv");
+    this.requiredCv = (double) result.get("Cv");
+    this.valveCvMax = requiredCv;
+    evaluateAvailableTrimOptions();
 
     // Select ANSI pressure class
     selectPressureClass(designPressure);
 
     // Calculate nominal valve size from Cv
-    calculateNominalSize(valveCvMax);
+    calculateNominalSize(requiredCv);
 
     // Calculate face-to-face dimension
     calculateFaceToFace();
@@ -581,6 +621,217 @@ public class ValveMechanicalDesign extends MechanicalDesign {
   }
 
   // ============================================================================
+  // Vendor Trim Capacity Assessment
+  // ============================================================================
+
+  /**
+   * Adds an available trim capacity option without material or construction metadata.
+   *
+   * @param identifier unique option identifier or catalog label
+   * @param relativeTrimSizePercent relative trim size in percent of the vendor reference trim
+   * @param maximumDesignCv vendor-qualified maximum design Cv
+   * @throws IllegalArgumentException when the option data is invalid or the identifier is duplicated
+   */
+  public void addAvailableTrimOption(String identifier, double relativeTrimSizePercent, double maximumDesignCv) {
+    addAvailableTrimOption(identifier, relativeTrimSizePercent, maximumDesignCv, "", "");
+  }
+
+  /**
+   * Adds an available trim capacity option with engineering provenance.
+   *
+   * <p>
+   * Material and construction are descriptive metadata. NeqSim does not apply a universal Cv correction for terms such
+   * as tungsten carbide or brickstopper; the supplied maximum design Cv remains authoritative.
+   * </p>
+   *
+   * @param identifier unique option identifier or catalog label
+   * @param relativeTrimSizePercent relative trim size in percent of the vendor reference trim
+   * @param maximumDesignCv vendor-qualified maximum design Cv
+   * @param material trim material description
+   * @param construction trim construction or protection description
+   * @throws IllegalArgumentException when the option data is invalid or the identifier is duplicated
+   */
+  public void addAvailableTrimOption(String identifier, double relativeTrimSizePercent, double maximumDesignCv,
+      String material, String construction) {
+    ValveTrimOption option = new ValveTrimOption(identifier, relativeTrimSizePercent, maximumDesignCv, material,
+        construction);
+    for (ValveTrimOption existing : availableTrimOptions) {
+      if (existing.getIdentifier().equals(option.getIdentifier())) {
+        throw new IllegalArgumentException("Duplicate trim option identifier: " + option.getIdentifier());
+      }
+    }
+    availableTrimOptions.add(option);
+    evaluateAvailableTrimOptions();
+  }
+
+  /**
+   * Removes all available trim capacity options.
+   */
+  public void clearAvailableTrimOptions() {
+    availableTrimOptions.clear();
+    trimSizingResult = ValveTrimSizingResult.notEvaluated(requiredCv, "No vendor trim capacity options were supplied",
+        maximumAllowedTrimUtilization);
+    if (trimCatalogControlsMaxDesignCv) {
+      setMaxDesignCv(0.0);
+      trimCatalogControlsMaxDesignCv = false;
+    }
+  }
+
+  /**
+   * Gets an immutable snapshot of the available trim options.
+   *
+   * @return trim options in insertion order
+   */
+  public List<ValveTrimOption> getAvailableTrimOptions() {
+    return Collections.unmodifiableList(new ArrayList<ValveTrimOption>(availableTrimOptions));
+  }
+
+  /**
+   * Sets the maximum Cv utilization allowed when automatically selecting a trim.
+   *
+   * <p>
+   * A value of {@code 1.0} permits selection up to the vendor-qualified maximum design Cv. A lower value reserves
+   * capacity margin, for example {@code 0.8} limits the design case to 80% of the option's maximum Cv.
+   * </p>
+   *
+   * @param maximumAllowedTrimUtilization utilization fraction in the interval (0, 1]
+   * @throws IllegalArgumentException when the value is non-finite or outside the permitted interval
+   */
+  public void setMaximumAllowedTrimUtilization(double maximumAllowedTrimUtilization) {
+    if (!Double.isFinite(maximumAllowedTrimUtilization) || maximumAllowedTrimUtilization <= 0.0
+        || maximumAllowedTrimUtilization > 1.0) {
+      throw new IllegalArgumentException("Maximum allowed trim utilization must be finite and in the interval (0, 1]");
+    }
+    this.maximumAllowedTrimUtilization = maximumAllowedTrimUtilization;
+    evaluateAvailableTrimOptions();
+  }
+
+  /**
+   * Gets the maximum Cv utilization allowed for automatic trim selection.
+   *
+   * @return allowed utilization fraction
+   */
+  public double getMaximumAllowedTrimUtilization() {
+    return maximumAllowedTrimUtilization;
+  }
+
+  /**
+   * Compares the calculated required Cv with the available trim catalog.
+   *
+   * <p>
+   * The smallest relative trim satisfying {@code requiredCv / maximumDesignCv <=
+   * maximumAllowedTrimUtilization} is selected. Equal-size options are ordered by maximum design Cv and then
+   * identifier. When none is feasible, no option is selected and utilization is reported against the largest supplied
+   * maximum design Cv so overload remains visible.
+   * </p>
+   *
+   * @return trim sizing result
+   */
+  public ValveTrimSizingResult evaluateAvailableTrimOptions() {
+    if (!Double.isFinite(requiredCv) || requiredCv <= 0.0) {
+      trimSizingResult = ValveTrimSizingResult.notEvaluated(requiredCv,
+          "A positive finite required Cv is needed before trim selection", maximumAllowedTrimUtilization);
+      return trimSizingResult;
+    }
+    if (availableTrimOptions.isEmpty()) {
+      trimSizingResult = ValveTrimSizingResult.notEvaluated(requiredCv, "No vendor trim capacity options were supplied",
+          maximumAllowedTrimUtilization);
+      return trimSizingResult;
+    }
+
+    List<ValveTrimOption> orderedOptions = new ArrayList<ValveTrimOption>(availableTrimOptions);
+    Collections.sort(orderedOptions, TRIM_OPTION_ORDER);
+    ValveTrimOption largestOption = Collections.max(orderedOptions, TRIM_CAPACITY_ORDER);
+    ValveTrimOption selectedOption = null;
+    for (ValveTrimOption option : orderedOptions) {
+      double utilization = requiredCv / option.getMaximumDesignCv();
+      if (utilization <= maximumAllowedTrimUtilization) {
+        selectedOption = option;
+        break;
+      }
+    }
+
+    if (selectedOption != null) {
+      trimSizingResult = ValveTrimSizingResult.feasible(requiredCv, selectedOption, largestOption.getMaximumDesignCv(),
+          maximumAllowedTrimUtilization);
+    } else {
+      trimSizingResult = ValveTrimSizingResult.infeasible(requiredCv, largestOption, maximumAllowedTrimUtilization);
+    }
+
+    setMaxDesignCv(trimSizingResult.getLimitingTrimOption().getMaximumDesignCv());
+    trimCatalogControlsMaxDesignCv = true;
+    return trimSizingResult;
+  }
+
+  /**
+   * Assesses the available trim catalog for an explicitly supplied required Cv.
+   *
+   * <p>
+   * This is useful when the required Cv includes a project-specific design opening, flow case, or safety factor
+   * calculated outside {@link #calcDesign()}. The supplied value becomes the current required Cv used by
+   * mechanical-design utilization.
+   * </p>
+   *
+   * @param requiredCv required full-open Cv for the design case
+   * @return trim sizing result
+   * @throws IllegalArgumentException when required Cv is non-finite or not greater than zero
+   */
+  public ValveTrimSizingResult assessTrimOptionsForRequiredCv(double requiredCv) {
+    if (!Double.isFinite(requiredCv) || requiredCv <= 0.0) {
+      throw new IllegalArgumentException("Required Cv must be finite and greater than zero");
+    }
+    this.requiredCv = requiredCv;
+    this.valveCvMax = requiredCv;
+    return evaluateAvailableTrimOptions();
+  }
+
+  /**
+   * Gets the latest trim capacity assessment.
+   *
+   * @return trim sizing result
+   */
+  public ValveTrimSizingResult getTrimSizingResult() {
+    return trimSizingResult;
+  }
+
+  /**
+   * Gets the selected trim option.
+   *
+   * @return selected option, or {@code null} when no feasible option was found
+   */
+  public ValveTrimOption getSelectedTrimOption() {
+    return trimSizingResult.getSelectedTrimOption();
+  }
+
+  /**
+   * Gets the Cv utilization reported by the trim assessment.
+   *
+   * @return required Cv divided by the limiting option maximum Cv, or zero when not evaluated
+   */
+  public double getTrimCvUtilization() {
+    return trimSizingResult.getUtilization();
+  }
+
+  /**
+   * Gets the largest maximum design Cv in the supplied trim catalog.
+   *
+   * @return maximum available Cv, or zero when not evaluated
+   */
+  public double getMaximumAvailableTrimCv() {
+    return trimSizingResult.getMaximumAvailableCv();
+  }
+
+  /**
+   * Returns the required Cv as the operating value for mechanical-design utilization.
+   *
+   * @return required Cv, or {@link Double#NaN} before a valid sizing calculation
+   */
+  @Override
+  protected double getOperatingCv() {
+    return Double.isFinite(requiredCv) && requiredCv > 0.0 ? requiredCv : Double.NaN;
+  }
+
+  // ============================================================================
   // Getters for Design Results
   // ============================================================================
 
@@ -666,12 +917,26 @@ public class ValveMechanicalDesign extends MechanicalDesign {
   }
 
   /**
-   * Get the maximum valve Cv.
+   * Gets the calculated required full-open Cv for the current sizing case.
    *
-   * @return maximum Cv at full open
+   * <p>
+   * This legacy method retains its historical behavior. Use {@link #getRequiredCv()} for explicit semantics and
+   * {@link #getTrimSizingResult()} for the selected trim maximum Cv.
+   * </p>
+   *
+   * @return required full-open Cv
    */
   public double getValveCvMax() {
     return valveCvMax;
+  }
+
+  /**
+   * Gets the calculated required full-open Cv for the current sizing case.
+   *
+   * @return required Cv, or {@link Double#NaN} before sizing
+   */
+  public double getRequiredCv() {
+    return requiredCv;
   }
 
   /**

--- a/src/main/java/neqsim/process/mechanicaldesign/valve/ValveMechanicalDesignResponse.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/valve/ValveMechanicalDesignResponse.java
@@ -1,5 +1,9 @@
 package neqsim.process.mechanicaldesign.valve;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import neqsim.process.equipment.valve.ValveInterface;
 import neqsim.process.mechanicaldesign.MechanicalDesignResponse;
 
 /**
@@ -36,8 +40,47 @@ public class ValveMechanicalDesignResponse extends MechanicalDesignResponse {
   /** Required valve Cv. */
   private double cvRequired;
 
-  /** Maximum valve Cv at full open. */
+  /** Selected/limiting trim maximum Cv, or legacy required Cv when no catalog is evaluated. */
   private double cvMax;
+
+  /** Available vendor trim capacity options. */
+  private List<ValveTrimOption> availableTrimOptions = new ArrayList<ValveTrimOption>();
+
+  /** Trim capacity assessment status. */
+  private String trimAssessmentStatus;
+
+  /** Identifier of the automatically selected trim. */
+  private String selectedTrimIdentifier;
+
+  /** Relative size of the selected or limiting trim [%]. */
+  private double relativeTrimSizePercent;
+
+  /** Maximum design Cv of the selected or limiting trim. */
+  private double selectedTrimMaximumCv;
+
+  /** Largest maximum design Cv in the supplied trim catalog. */
+  private double maximumAvailableTrimCv;
+
+  /** Required-Cv utilization of the selected or limiting trim. */
+  private double trimCvUtilization;
+
+  /** Remaining Cv capacity of the selected or limiting trim. */
+  private double trimCvCapacityMargin;
+
+  /** Maximum allowed trim utilization used for selection. */
+  private double maximumAllowedTrimUtilization;
+
+  /** Whether a feasible trim was selected. */
+  private boolean trimFeasible;
+
+  /** Selected or limiting trim material. */
+  private String trimMaterial;
+
+  /** Selected or limiting trim construction. */
+  private String trimConstruction;
+
+  /** Engineering recommendation from the trim capacity assessment. */
+  private String trimRecommendation;
 
   /** Valve opening percentage at design point. */
   private double valveOpening;
@@ -140,7 +183,9 @@ public class ValveMechanicalDesignResponse extends MechanicalDesignResponse {
     this.valveCharacteristic = mecDesign.getValveCharacterization();
     this.ansiPressureClass = mecDesign.getAnsiPressureClass();
     this.nominalSizeInches = mecDesign.getNominalSizeInches();
+    this.cvRequired = Double.isFinite(mecDesign.getRequiredCv()) ? mecDesign.getRequiredCv() : 0.0;
     this.cvMax = mecDesign.getValveCvMax();
+    this.availableTrimOptions = new ArrayList<ValveTrimOption>(mecDesign.getAvailableTrimOptions());
     this.faceToFace = mecDesign.getFaceToFace();
     this.bodyWallThickness = mecDesign.getBodyWallThickness();
     this.bodyWeight = mecDesign.getBodyWeight();
@@ -153,6 +198,38 @@ public class ValveMechanicalDesignResponse extends MechanicalDesignResponse {
     this.pressureDrop = mecDesign.getDp();
     this.flFactor = mecDesign.getFL();
     this.xtFactor = mecDesign.getxT();
+
+    if (mecDesign.getProcessEquipment() instanceof ValveInterface) {
+      this.valveOpening = ((ValveInterface) mecDesign.getProcessEquipment()).getPercentValveOpening();
+    }
+
+    ValveTrimSizingResult trimResult = mecDesign.getTrimSizingResult();
+    this.trimAssessmentStatus = trimResult.getStatus().name();
+    this.maximumAvailableTrimCv = trimResult.getMaximumAvailableCv();
+    this.trimCvUtilization = trimResult.getUtilization();
+    this.trimCvCapacityMargin = trimResult.getCapacityMarginCv();
+    this.maximumAllowedTrimUtilization = trimResult.getMaximumAllowedUtilization();
+    this.trimFeasible = trimResult.isFeasible();
+    this.trimRecommendation = trimResult.getRecommendation();
+
+    ValveTrimOption selectedOption = trimResult.getSelectedTrimOption();
+    if (selectedOption != null) {
+      this.selectedTrimIdentifier = selectedOption.getIdentifier();
+    } else {
+      this.selectedTrimIdentifier = "";
+    }
+
+    ValveTrimOption limitingOption = trimResult.getLimitingTrimOption();
+    if (limitingOption != null) {
+      this.cvMax = limitingOption.getMaximumDesignCv();
+      this.relativeTrimSizePercent = limitingOption.getRelativeTrimSizePercent();
+      this.selectedTrimMaximumCv = limitingOption.getMaximumDesignCv();
+      this.trimMaterial = limitingOption.getMaterial();
+      this.trimConstruction = limitingOption.getConstruction();
+    } else {
+      this.trimMaterial = "";
+      this.trimConstruction = "";
+    }
   }
 
   // ============================================================================
@@ -205,6 +282,111 @@ public class ValveMechanicalDesignResponse extends MechanicalDesignResponse {
 
   public void setCvMax(double cvMax) {
     this.cvMax = cvMax;
+  }
+
+  public List<ValveTrimOption> getAvailableTrimOptions() {
+    return Collections.unmodifiableList(new ArrayList<ValveTrimOption>(availableTrimOptions));
+  }
+
+  public void setAvailableTrimOptions(List<ValveTrimOption> availableTrimOptions) {
+    this.availableTrimOptions = availableTrimOptions == null ? new ArrayList<ValveTrimOption>()
+        : new ArrayList<ValveTrimOption>(availableTrimOptions);
+  }
+
+  public String getTrimAssessmentStatus() {
+    return trimAssessmentStatus;
+  }
+
+  public void setTrimAssessmentStatus(String trimAssessmentStatus) {
+    this.trimAssessmentStatus = trimAssessmentStatus;
+  }
+
+  public String getSelectedTrimIdentifier() {
+    return selectedTrimIdentifier;
+  }
+
+  public void setSelectedTrimIdentifier(String selectedTrimIdentifier) {
+    this.selectedTrimIdentifier = selectedTrimIdentifier;
+  }
+
+  public double getRelativeTrimSizePercent() {
+    return relativeTrimSizePercent;
+  }
+
+  public void setRelativeTrimSizePercent(double relativeTrimSizePercent) {
+    this.relativeTrimSizePercent = relativeTrimSizePercent;
+  }
+
+  public double getSelectedTrimMaximumCv() {
+    return selectedTrimMaximumCv;
+  }
+
+  public void setSelectedTrimMaximumCv(double selectedTrimMaximumCv) {
+    this.selectedTrimMaximumCv = selectedTrimMaximumCv;
+  }
+
+  public double getMaximumAvailableTrimCv() {
+    return maximumAvailableTrimCv;
+  }
+
+  public void setMaximumAvailableTrimCv(double maximumAvailableTrimCv) {
+    this.maximumAvailableTrimCv = maximumAvailableTrimCv;
+  }
+
+  public double getTrimCvUtilization() {
+    return trimCvUtilization;
+  }
+
+  public void setTrimCvUtilization(double trimCvUtilization) {
+    this.trimCvUtilization = trimCvUtilization;
+  }
+
+  public double getTrimCvCapacityMargin() {
+    return trimCvCapacityMargin;
+  }
+
+  public void setTrimCvCapacityMargin(double trimCvCapacityMargin) {
+    this.trimCvCapacityMargin = trimCvCapacityMargin;
+  }
+
+  public double getMaximumAllowedTrimUtilization() {
+    return maximumAllowedTrimUtilization;
+  }
+
+  public void setMaximumAllowedTrimUtilization(double maximumAllowedTrimUtilization) {
+    this.maximumAllowedTrimUtilization = maximumAllowedTrimUtilization;
+  }
+
+  public boolean isTrimFeasible() {
+    return trimFeasible;
+  }
+
+  public void setTrimFeasible(boolean trimFeasible) {
+    this.trimFeasible = trimFeasible;
+  }
+
+  public String getTrimMaterial() {
+    return trimMaterial;
+  }
+
+  public void setTrimMaterial(String trimMaterial) {
+    this.trimMaterial = trimMaterial;
+  }
+
+  public String getTrimConstruction() {
+    return trimConstruction;
+  }
+
+  public void setTrimConstruction(String trimConstruction) {
+    this.trimConstruction = trimConstruction;
+  }
+
+  public String getTrimRecommendation() {
+    return trimRecommendation;
+  }
+
+  public void setTrimRecommendation(String trimRecommendation) {
+    this.trimRecommendation = trimRecommendation;
   }
 
   public double getValveOpening() {

--- a/src/main/java/neqsim/process/mechanicaldesign/valve/ValveTrimOption.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/valve/ValveTrimOption.java
@@ -1,0 +1,112 @@
+package neqsim.process.mechanicaldesign.valve;
+
+import java.io.Serializable;
+
+/**
+ * Describes one vendor-qualified valve or choke trim capacity option.
+ *
+ * <p>
+ * NeqSim does not infer capacity derating from material or construction labels. The maximum design Cv must come from
+ * the applicable vendor data for the body, trim, pressure class, flow direction, and service. Material and construction
+ * are retained as engineering provenance so, for example, a tungsten-carbide trim protected by a metallic brickstopper
+ * can be distinguished from a standard metallic trim.
+ * </p>
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+public final class ValveTrimOption implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final String identifier;
+  private final double relativeTrimSizePercent;
+  private final double maximumDesignCv;
+  private final String material;
+  private final String construction;
+
+  /**
+   * Creates a trim option without material or construction metadata.
+   *
+   * @param identifier unique option identifier or catalog label
+   * @param relativeTrimSizePercent relative trim size in percent of the vendor reference trim
+   * @param maximumDesignCv vendor-qualified maximum design Cv for this option
+   * @throws IllegalArgumentException when the identifier, relative size, or maximum Cv is invalid
+   */
+  public ValveTrimOption(String identifier, double relativeTrimSizePercent, double maximumDesignCv) {
+    this(identifier, relativeTrimSizePercent, maximumDesignCv, "", "");
+  }
+
+  /**
+   * Creates a trim option with engineering provenance.
+   *
+   * @param identifier unique option identifier or catalog label
+   * @param relativeTrimSizePercent relative trim size in percent of the vendor reference trim
+   * @param maximumDesignCv vendor-qualified maximum design Cv for this option
+   * @param material trim material description
+   * @param construction trim construction or protection description
+   * @throws IllegalArgumentException when the identifier, relative size, or maximum Cv is invalid
+   */
+  public ValveTrimOption(String identifier, double relativeTrimSizePercent, double maximumDesignCv, String material,
+      String construction) {
+    if (identifier == null || identifier.trim().isEmpty()) {
+      throw new IllegalArgumentException("Trim option identifier must not be empty");
+    }
+    if (!Double.isFinite(relativeTrimSizePercent) || relativeTrimSizePercent <= 0.0
+        || relativeTrimSizePercent > 100.0) {
+      throw new IllegalArgumentException("Relative trim size must be finite and in the interval (0, 100]");
+    }
+    if (!Double.isFinite(maximumDesignCv) || maximumDesignCv <= 0.0) {
+      throw new IllegalArgumentException("Maximum design Cv must be finite and greater than zero");
+    }
+    this.identifier = identifier.trim();
+    this.relativeTrimSizePercent = relativeTrimSizePercent;
+    this.maximumDesignCv = maximumDesignCv;
+    this.material = material == null ? "" : material.trim();
+    this.construction = construction == null ? "" : construction.trim();
+  }
+
+  /**
+   * Gets the option identifier.
+   *
+   * @return option identifier or catalog label
+   */
+  public String getIdentifier() {
+    return identifier;
+  }
+
+  /**
+   * Gets the relative trim size.
+   *
+   * @return relative trim size in percent of the vendor reference trim
+   */
+  public double getRelativeTrimSizePercent() {
+    return relativeTrimSizePercent;
+  }
+
+  /**
+   * Gets the vendor-qualified maximum design Cv.
+   *
+   * @return maximum design Cv
+   */
+  public double getMaximumDesignCv() {
+    return maximumDesignCv;
+  }
+
+  /**
+   * Gets the trim material description.
+   *
+   * @return material description, or an empty string when not supplied
+   */
+  public String getMaterial() {
+    return material;
+  }
+
+  /**
+   * Gets the trim construction or protection description.
+   *
+   * @return construction description, or an empty string when not supplied
+   */
+  public String getConstruction() {
+    return construction;
+  }
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/valve/ValveTrimSizingResult.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/valve/ValveTrimSizingResult.java
@@ -1,0 +1,211 @@
+package neqsim.process.mechanicaldesign.valve;
+
+import java.io.Serializable;
+
+/**
+ * Result of comparing a required valve Cv with explicitly supplied trim capacity options.
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+public final class ValveTrimSizingResult implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Assessment status. */
+  public enum Status {
+    /** No trim catalog or valid required Cv was available. */
+    NOT_EVALUATED,
+    /** A trim satisfying the configured utilization limit was selected. */
+    FEASIBLE,
+    /** No supplied trim satisfies the configured utilization limit. */
+    NO_FEASIBLE_TRIM
+  }
+
+  private final Status status;
+  private final double requiredCv;
+  private final ValveTrimOption selectedTrimOption;
+  private final ValveTrimOption limitingTrimOption;
+  private final double maximumAvailableCv;
+  private final double utilization;
+  private final double capacityMarginCv;
+  private final double maximumAllowedUtilization;
+  private final String recommendation;
+
+  private ValveTrimSizingResult(Status status, double requiredCv, ValveTrimOption selectedTrimOption,
+      ValveTrimOption limitingTrimOption, double maximumAvailableCv, double utilization, double capacityMarginCv,
+      double maximumAllowedUtilization, String recommendation) {
+    this.status = status;
+    this.requiredCv = requiredCv;
+    this.selectedTrimOption = selectedTrimOption;
+    this.limitingTrimOption = limitingTrimOption;
+    this.maximumAvailableCv = maximumAvailableCv;
+    this.utilization = utilization;
+    this.capacityMarginCv = capacityMarginCv;
+    this.maximumAllowedUtilization = maximumAllowedUtilization;
+    this.recommendation = recommendation;
+  }
+
+  /**
+   * Creates a result for a case that could not be evaluated.
+   *
+   * @param requiredCv calculated required Cv, possibly not finite
+   * @param recommendation reason why the assessment was not performed
+   * @return not-evaluated result
+   */
+  public static ValveTrimSizingResult notEvaluated(double requiredCv, String recommendation) {
+    return notEvaluated(requiredCv, recommendation, 1.0);
+  }
+
+  /**
+   * Creates a result for a case that could not be evaluated while retaining the configured utilization criterion.
+   *
+   * @param requiredCv calculated required Cv, possibly not finite
+   * @param recommendation reason why the assessment was not performed
+   * @param maximumAllowedUtilization configured utilization limit
+   * @return not-evaluated result
+   */
+  public static ValveTrimSizingResult notEvaluated(double requiredCv, String recommendation,
+      double maximumAllowedUtilization) {
+    return new ValveTrimSizingResult(Status.NOT_EVALUATED, requiredCv, null, null, 0.0, 0.0, 0.0,
+        maximumAllowedUtilization, recommendation);
+  }
+
+  /**
+   * Creates a feasible trim selection result.
+   *
+   * @param requiredCv calculated required Cv
+   * @param selectedTrimOption selected trim option
+   * @param maximumAvailableCv largest Cv in the supplied catalog
+   * @param maximumAllowedUtilization configured utilization limit
+   * @return feasible result
+   */
+  public static ValveTrimSizingResult feasible(double requiredCv, ValveTrimOption selectedTrimOption,
+      double maximumAvailableCv, double maximumAllowedUtilization) {
+    double utilization = requiredCv / selectedTrimOption.getMaximumDesignCv();
+    double margin = selectedTrimOption.getMaximumDesignCv() - requiredCv;
+    String recommendation = "Selected the smallest supplied trim satisfying the configured Cv utilization limit";
+    return new ValveTrimSizingResult(Status.FEASIBLE, requiredCv, selectedTrimOption, selectedTrimOption,
+        maximumAvailableCv, utilization, margin, maximumAllowedUtilization, recommendation);
+  }
+
+  /**
+   * Creates an infeasible result referenced to the largest supplied trim.
+   *
+   * @param requiredCv calculated required Cv
+   * @param largestTrimOption largest supplied trim option
+   * @param maximumAllowedUtilization configured utilization limit
+   * @return infeasible result
+   */
+  public static ValveTrimSizingResult infeasible(double requiredCv, ValveTrimOption largestTrimOption,
+      double maximumAllowedUtilization) {
+    double utilization = requiredCv / largestTrimOption.getMaximumDesignCv();
+    double margin = largestTrimOption.getMaximumDesignCv() - requiredCv;
+    String recommendation = "No supplied trim satisfies the configured Cv utilization limit; "
+        + "review the body/trim catalog or process design case";
+    return new ValveTrimSizingResult(Status.NO_FEASIBLE_TRIM, requiredCv, null, largestTrimOption,
+        largestTrimOption.getMaximumDesignCv(), utilization, margin, maximumAllowedUtilization, recommendation);
+  }
+
+  /**
+   * Gets the assessment status.
+   *
+   * @return assessment status
+   */
+  public Status getStatus() {
+    return status;
+  }
+
+  /**
+   * Gets the calculated required Cv.
+   *
+   * @return required Cv
+   */
+  public double getRequiredCv() {
+    return requiredCv;
+  }
+
+  /**
+   * Gets the automatically selected trim.
+   *
+   * @return selected trim, or {@code null} when no feasible trim exists
+   */
+  public ValveTrimOption getSelectedTrimOption() {
+    return selectedTrimOption;
+  }
+
+  /**
+   * Gets the option used to calculate the reported utilization and margin.
+   *
+   * <p>
+   * This is the selected option for a feasible result and the largest available option for an infeasible result.
+   * </p>
+   *
+   * @return limiting trim option, or {@code null} when not evaluated
+   */
+  public ValveTrimOption getLimitingTrimOption() {
+    return limitingTrimOption;
+  }
+
+  /**
+   * Gets the largest maximum design Cv in the supplied catalog.
+   *
+   * @return maximum available Cv, or zero when not evaluated
+   */
+  public double getMaximumAvailableCv() {
+    return maximumAvailableCv;
+  }
+
+  /**
+   * Gets Cv utilization relative to the limiting trim option.
+   *
+   * @return required Cv divided by the limiting trim maximum Cv
+   */
+  public double getUtilization() {
+    return utilization;
+  }
+
+  /**
+   * Gets the remaining Cv capacity of the limiting option.
+   *
+   * @return limiting maximum Cv minus required Cv; negative means overload
+   */
+  public double getCapacityMarginCv() {
+    return capacityMarginCv;
+  }
+
+  /**
+   * Gets the configured maximum allowed utilization used for selection.
+   *
+   * @return allowed utilization fraction
+   */
+  public double getMaximumAllowedUtilization() {
+    return maximumAllowedUtilization;
+  }
+
+  /**
+   * Gets the engineering recommendation.
+   *
+   * @return recommendation text
+   */
+  public String getRecommendation() {
+    return recommendation;
+  }
+
+  /**
+   * Checks whether a feasible trim was selected.
+   *
+   * @return {@code true} when the result is feasible
+   */
+  public boolean isFeasible() {
+    return status == Status.FEASIBLE;
+  }
+
+  /**
+   * Checks whether a trim catalog was evaluated.
+   *
+   * @return {@code true} for feasible and infeasible catalog assessments
+   */
+  public boolean isEvaluated() {
+    return status != Status.NOT_EVALUATED;
+  }
+}

--- a/src/test/java/neqsim/process/mechanicaldesign/valve/ValveMechanicalDesignTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/valve/ValveMechanicalDesignTest.java
@@ -1,5 +1,8 @@
 package neqsim.process.mechanicaldesign.valve;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.stream.Stream;
@@ -13,6 +16,141 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
 public class ValveMechanicalDesignTest {
   @Test
   void testCalcDesign() {
+    ThrottlingValve valve = createDesignedGasValve();
+    assertTrue(valve.getMechanicalDesign().getWeightTotal() > 0.0);
+    assertEquals(valve.getMechanicalDesign().getRequiredCv(), valve.getMechanicalDesign().getValveCvMax(), 1.0e-12);
+    double requiredCv = valve.getMechanicalDesign().getRequiredCv();
+    valve.getMechanicalDesign().setMaxDesignCv(requiredCv * 2.0);
+    assertEquals(0.5, valve.getMechanicalDesign().getDesignUtilization().get("design Cv"), 1.0e-12);
+  }
+
+  @Test
+  void testSelectsSmallestFeasibleVendorTrimAndReportsUtilization() {
+    ThrottlingValve valve = createDesignedGasValve();
+    ValveMechanicalDesign design = valve.getMechanicalDesign();
+    double requiredCv = design.getRequiredCv();
+
+    design.addAvailableTrimOption("TC-40", 40.0, requiredCv * 0.80, "tungsten carbide", "metallic brickstopper");
+    design.addAvailableTrimOption("TC-60", 60.0, requiredCv * 1.25, "tungsten carbide", "metallic brickstopper");
+    design.addAvailableTrimOption("TC-100", 100.0, requiredCv * 2.00, "tungsten carbide", "metallic brickstopper");
+
+    ValveTrimSizingResult result = design.getTrimSizingResult();
+    assertTrue(result.isFeasible());
+    assertEquals("TC-60", result.getSelectedTrimOption().getIdentifier());
+    assertEquals(60.0, result.getSelectedTrimOption().getRelativeTrimSizePercent(), 1.0e-12);
+    assertEquals(0.80, result.getUtilization(), 1.0e-12);
+    assertEquals(requiredCv * 0.25, result.getCapacityMarginCv(), 1.0e-12);
+    assertEquals(result.getUtilization(), design.getDesignUtilization().get("design Cv"), 1.0e-12);
+    assertTrue(valve.applyMechanicalDesignCapacityConstraints() >= 1);
+    assertEquals(result.getUtilization(), valve.getMaxUtilization(), 1.0e-12);
+  }
+
+  @Test
+  void testTrimSelectionUsesDeterministicTieBreak() {
+    ThrottlingValve valve = createDesignedGasValve();
+    ValveMechanicalDesign design = valve.getMechanicalDesign();
+    double feasibleCv = design.getRequiredCv() * 1.25;
+
+    design.addAvailableTrimOption("TC-75", 75.0, feasibleCv);
+    design.addAvailableTrimOption("TC-50-B", 50.0, feasibleCv);
+    design.addAvailableTrimOption("TC-50-A", 50.0, feasibleCv);
+
+    assertEquals("TC-50-A", design.getSelectedTrimOption().getIdentifier());
+  }
+
+  @Test
+  void testTrimSelectionPrioritizesRelativeSizeForNonMonotoneVendorCatalog() {
+    ThrottlingValve valve = createDesignedGasValve();
+    ValveMechanicalDesign design = valve.getMechanicalDesign();
+    double requiredCv = design.getRequiredCv();
+
+    design.addAvailableTrimOption("REL-70", 70.0, requiredCv * 1.25);
+    design.addAvailableTrimOption("REL-50", 50.0, requiredCv * 2.00);
+
+    assertEquals("REL-50", design.getSelectedTrimOption().getIdentifier());
+    assertEquals(requiredCv * 2.00, design.getMaximumAvailableTrimCv(), 1.0e-12);
+  }
+
+  @Test
+  void testInfeasibleTrimCatalogUsesLargestOptionAsLimitingCapacity() {
+    ThrottlingValve valve = createDesignedGasValve();
+    ValveMechanicalDesign design = valve.getMechanicalDesign();
+    double requiredCv = design.getRequiredCv();
+
+    design.addAvailableTrimOption("TC-40", 40.0, requiredCv * 0.40);
+    design.addAvailableTrimOption("TC-80", 80.0, requiredCv * 0.80);
+
+    ValveTrimSizingResult result = design.getTrimSizingResult();
+    assertFalse(result.isFeasible());
+    assertEquals(ValveTrimSizingResult.Status.NO_FEASIBLE_TRIM, result.getStatus());
+    assertNull(result.getSelectedTrimOption());
+    assertEquals("TC-80", result.getLimitingTrimOption().getIdentifier());
+    assertEquals(1.25, result.getUtilization(), 1.0e-12);
+    assertTrue(result.getCapacityMarginCv() < 0.0);
+    assertEquals(1.25, design.getDesignUtilization().get("design Cv"), 1.0e-12);
+  }
+
+  @Test
+  void testResponseSeparatesRequiredAndAvailableTrimCv() {
+    ThrottlingValve valve = createDesignedGasValve();
+    ValveMechanicalDesign design = valve.getMechanicalDesign();
+    double requiredCv = design.getRequiredCv();
+    design.setMaximumAllowedTrimUtilization(0.80);
+    design.addAvailableTrimOption("TC-BS-75", 75.0, requiredCv / 0.75, "tungsten carbide",
+        "non-collapsible metallic brickstopper");
+
+    ValveMechanicalDesignResponse response = design.getResponse();
+    assertEquals(requiredCv, response.getCvRequired(), 1.0e-12);
+    assertEquals("FEASIBLE", response.getTrimAssessmentStatus());
+    assertEquals("TC-BS-75", response.getSelectedTrimIdentifier());
+    assertEquals(requiredCv / 0.75, response.getSelectedTrimMaximumCv(), 1.0e-12);
+    assertEquals(0.75, response.getTrimCvUtilization(), 1.0e-12);
+    assertEquals("tungsten carbide", response.getTrimMaterial());
+    assertEquals("non-collapsible metallic brickstopper", response.getTrimConstruction());
+    assertTrue(response.isTrimFeasible());
+    assertTrue(design.toJson().contains("selectedTrimMaximumCv"));
+  }
+
+  @Test
+  void testExplicitRequiredCvAndUtilizationReserve() {
+    ThrottlingValve valve = createDesignedGasValve();
+    ValveMechanicalDesign design = valve.getMechanicalDesign();
+    design.setMaximumAllowedTrimUtilization(0.80);
+    design.addAvailableTrimOption("REL-50", 50.0, 50.0);
+    design.addAvailableTrimOption("REL-75", 75.0, 75.0);
+
+    ValveTrimSizingResult result = design.assessTrimOptionsForRequiredCv(45.0);
+
+    assertTrue(result.isFeasible());
+    assertEquals("REL-75", result.getSelectedTrimOption().getIdentifier());
+    assertEquals(0.60, result.getUtilization(), 1.0e-12);
+  }
+
+  @Test
+  void testAutoSizePreservesCatalogCapacityAsDesignLimit() {
+    ThrottlingValve valve = createDesignedGasValve();
+    ValveMechanicalDesign design = valve.getMechanicalDesign();
+    double trimMaximumCv = design.getRequiredCv() * 20.0;
+    design.addAvailableTrimOption("AUTO-TC", 100.0, trimMaximumCv, "tungsten carbide", "metallic brickstopper");
+
+    valve.autoSize(1.0, 50.0);
+
+    assertTrue(design.getTrimSizingResult().isFeasible());
+    assertEquals("AUTO-TC", design.getSelectedTrimOption().getIdentifier());
+    assertEquals(trimMaximumCv, design.getMaxDesignCv(), 1.0e-12);
+  }
+
+  @Test
+  void testUnrunValveResponseDoesNotSerializeNonFiniteRequiredCv() {
+    ThrottlingValve valve = new ThrottlingValve("unrun valve");
+
+    ValveMechanicalDesignResponse response = valve.getMechanicalDesign().getResponse();
+
+    assertEquals(0.0, response.getCvRequired(), 1.0e-12);
+    assertTrue(response.toJson().contains("NOT_EVALUATED"));
+  }
+
+  private ThrottlingValve createDesignedGasValve() {
     SystemInterface gas = new SystemSrkEos(300.0, 10.0);
     gas.addComponent("methane", 1.0);
     gas.setMixingRule(2);
@@ -32,6 +170,6 @@ public class ValveMechanicalDesignTest {
 
     valve.initMechanicalDesign();
     valve.getMechanicalDesign().calcDesign();
-    assertTrue(valve.getMechanicalDesign().getWeightTotal() > 0.0);
+    return valve;
   }
 }


### PR DESCRIPTION
## Summary

- separate calculated required Cv from the vendor-qualified maximum design Cv of a physical trim
- add an explicit vendor-neutral trim catalog with relative trim size, maximum design Cv, material/construction provenance, utilization reserve, deterministic smallest-relative-trim selection, and explicit infeasible results
- feed the selected/limiting trim capacity into generic mechanical-design utilization and preserve it through `ThrottlingValve.autoSize(...)`
- expose required Cv, selected/limiting trim, maximum available Cv, utilization, margin, feasibility, and recommendation through `ValveMechanicalDesignResponse` and JSON
- document carbide/brickstopper use, API examples, and the engineering boundary

The implementation does not embed vendor product tables and does not infer a universal Cv derating from material or construction labels. A metallic brickstopper is recorded as protection/provenance; the supplied vendor-qualified maximum design Cv remains authoritative for the applicable body, trim, pressure class, flow direction, and service.

Engineering context:
- https://www.trilliumflow.com/product/blakeborough-bv992-and-bv993-choke/
- https://doi.org/10.1177/0020294016640556

Closes #3169

## Validation

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py` — passed (655 Markdown pages, 1 standalone HTML page)
- `./mvnw test -Dtest=ValveMechanicalDesignTest -Djacoco.skip=true` — 9 tests passed
- `./mvnw -f pomJava8.xml clean test -Dtest=ValveMechanicalDesignTest -Djacoco.skip=true` — clean Java 8 target compile; 9 tests passed
- `./mvnw test -Dtest='*Valve*Test,ControlValve*Test,ThrottlingValve*Test,ChokeCollapse*Test' -Djacoco.skip=true` — 222 tests passed
- `./mvnw -DskipTests checkstyle:check pmd:check` — Checkstyle: 0 violations; PMD completed with the repository-wide 6334-item baseline and no findings in the new trim/result/response code
- `./mvnw -DskipTests -Dspotbugs.onlyAnalyze='neqsim.process.mechanicaldesign.valve.*' -Dspotbugs.maxHeap=1024 spotbugs:spotbugs spotbugs:check` — completed; 27 existing package findings, none in the new trim/result/response code or new methods
- `git diff --check` — passed

VALIDATION PENDING CI: `./mvnw -DskipTests javadoc:javadoc` cannot run in this runtime because the installed Java image has no `javadoc` executable. Java 17 and Java 8 compilation both pass.

Documentation impact: updated the valve mechanical-design guide, mechanical-design response guide, and equipment-utilization guide.

## AI assistance

AI-assisted implementation. The source, tests, documentation, diff scope, and published branch contents were reviewed and validated in this session.