### PR TITLE
docs: correct Python extension boundaries

### DIFF
--- a/docs/development/python_extension_patterns.md
+++ b/docs/development/python_extension_patterns.md
@@ -1,18 +1,16 @@
 ---
 title: Python Extension Patterns for NeqSim
-description: Guide to extending NeqSim from Python using JPype, implementing Java interfaces, and creating custom models.
+description: Safe JPype interop, Python composition wrappers, narrow interface proxies, batch calculations, and scientific-Python integration for NeqSim.
 ---
 
-# Python Extension Patterns for NeqSim
-
-This guide covers how to extend NeqSim functionality from Python, including implementing Java interfaces, creating custom calculation wrappers, and integrating with Python scientific libraries.
+This guide shows how to use NeqSim safely from Python, wrap Java objects by composition, implement only narrow Java interfaces when a proxy is genuinely required, and integrate calculations with scientific Python. Core thermodynamic and physical-property models should be implemented and tested in Java rather than approximated with incomplete Python proxies.
 
 ## Table of Contents
 
 1. [Overview](#overview)
 2. [Setting Up JPype with NeqSim](#setting-up-jpype-with-neqsim)
 3. [Calling Java from Python](#calling-java-from-python)
-4. [Implementing Java Interfaces in Python](#implementing-java-interfaces-in-python)
+4. [Python Proxies and Extension Boundaries](#python-proxies-and-extension-boundaries)
 5. [Custom Process Equipment Wrappers](#custom-process-equipment-wrappers)
 6. [Custom Thermodynamic Calculations](#custom-thermodynamic-calculations)
 7. [Batch Processing and Optimization](#batch-processing-and-optimization)
@@ -24,19 +22,21 @@ This guide covers how to extend NeqSim functionality from Python, including impl
 
 ## Overview
 
-NeqSim Python integration works through three approaches:
+NeqSim Python integration has four distinct boundaries:
 
-| Approach | Use Case | Complexity |
-|----------|----------|------------|
-| Direct Java Access | Use existing NeqSim classes | Low |
-| Python Wrappers | Simplify API, add features | Medium |
-| Interface Implementation | Custom calculations in Python | High |
+| Approach | Use case | Boundary |
+|----------|----------|----------|
+| Direct Java access | Use released NeqSim classes | Preferred for standard simulations |
+| Python composition wrapper | Add Python ergonomics, validation, or tabular results around Java objects | Does not become a NeqSim process unit or thermodynamic model |
+| Narrow Java-interface proxy | Supply callbacks to an API that explicitly accepts a small interface | Must implement every abstract method; validate lifetime and threading |
+| Java extension | Add process equipment, thermodynamic models, or physical-property methods | Implement and test in `src/main/java` and `src/test/java` |
 
-### When to Use Each Approach
+### When to use each approach
 
-- **Direct Java Access**: Standard simulations using existing models
-- **Python Wrappers**: When you need Pythonic interfaces or want to combine with NumPy/pandas
-- **Interface Implementation**: When you need custom behavior that integrates into NeqSim's calculation flow
+- **Direct Java access** for standard simulations using existing models.
+- **Python composition wrappers** for units, validation, orchestration, NumPy, pandas, plotting, and result shaping.
+- **Narrow interface proxies** only when a current Java API explicitly accepts that interface and its complete method contract is practical to implement.
+- **Java extensions** for reusable NeqSim equipment, stateful calculations, serialization, cloning, thermodynamic models, and physical-property methods.
 
 ---
 
@@ -183,122 +183,75 @@ numpy_back = np.array(list(java_array))
 
 ---
 
-## Implementing Java Interfaces in Python
+## Python Proxies and Extension Boundaries
 
-### Using @JImplements Decorator
+JPype can expose a Python object as an implementation of an existing Java **interface**. A proxy
+must implement every abstract method with compatible argument and return types. It does not create
+a Java class, cannot extend a concrete Java class, and does not automatically acquire NeqSim
+lifecycle, cloning, serialization, calculation-identity, or thread-safety behavior.
 
-JPype allows you to implement Java interfaces directly in Python:
+### Do not proxy core thermodynamic or property-model interfaces
+
+The following shortcuts are invalid extension patterns:
+
+- `neqsim.util.CalculationInterface` does not exist on current `master`.
+- `ComponentInterface` is a large core thermodynamic contract; implementing a few getters does
+  not create a usable component.
+- The viscosity contract is
+  `neqsim.physicalproperties.methods.methodinterface.ViscosityInterface`. It extends
+  `PhysicalPropertyMethodInterface` and requires the inherited phase and cloning contract in
+  addition to viscosity methods.
+
+Implement reusable components, phases, equations of state, physical-property methods, and process
+equipment in Java with focused Java tests. Use Python composition for study-specific calculations
+that do not need to enter NeqSim's Java object graph.
+
+### Complete narrow-interface proxy example
+
+`NamedInterface` is a deliberately small example with four abstract methods. Importing
+`jneqsim` starts the JVM before JPype resolves the interface name.
 
 ```python
-import jpype
-from jpype import JImplements, JOverride
+from jpype import JImplements
+from jpype import JOverride
 from neqsim import jneqsim
 
-@JImplements('neqsim.thermo.component.ComponentInterface')
-class CustomComponent:
-    """Custom component implementation in Python."""
 
-    def __init__(self, name, moles):
-        self.name = name
-        self.moles = moles
-        self.mole_fraction = 0.0
-        self.fugacity_coeff = 1.0
+@JImplements("neqsim.util.NamedInterface")
+class PythonTag:
+    """Complete proxy for NeqSim's narrow NamedInterface contract."""
+
+    def __init__(self, name, tag_number):
+        self._name = str(name)
+        self._tag_number = str(tag_number)
 
     @JOverride
     def getName(self):
-        return self.name
+        return self._name
 
     @JOverride
-    def getNumberOfMolesInPhase(self):
-        return self.moles
+    def setName(self, name):
+        self._name = str(name)
 
     @JOverride
-    def getx(self):
-        """Get mole fraction."""
-        return self.mole_fraction
+    def getTagNumber(self):
+        return self._tag_number
 
     @JOverride
-    def setx(self, x):
-        """Set mole fraction."""
-        self.mole_fraction = float(x)
+    def setTagNumber(self, tag_number):
+        self._tag_number = str(tag_number)
 
-    @JOverride
-    def getFugacityCoefficient(self):
-        return self.fugacity_coeff
 
-    @JOverride
-    def getTC(self):
-        """Critical temperature in K."""
-        # Return from database or calculate
-        return 190.56  # Example: methane
-
-    @JOverride
-    def getPC(self):
-        """Critical pressure in bar."""
-        return 45.99  # Example: methane
+python_tag = PythonTag("inlet separator", "20-VG-001")
+assert python_tag.getName() == "inlet separator"
+assert python_tag.getTagNumber() == "20-VG-001"
 ```
 
-### Implementing Custom Calculation Interface
-
-```python
-@JImplements('neqsim.util.CalculationInterface')
-class CustomCalculation:
-    """Custom calculation that can be called from NeqSim."""
-
-    def __init__(self, param1=1.0, param2=2.0):
-        self.param1 = param1
-        self.param2 = param2
-        self.result = None
-
-    @JOverride
-    def run(self):
-        """Execute the calculation."""
-        # Your custom logic here
-        self.result = self.param1 * self.param2
-        return True
-
-    @JOverride
-    def getResult(self):
-        return self.result
-```
-
-### Implementing Property Models
-
-```python
-@JImplements('neqsim.physicalproperties.ViscosityInterface')
-class CustomViscosityModel:
-    """Custom viscosity model in Python."""
-
-    def __init__(self):
-        self.viscosity = 0.0
-        self._phase = None
-
-    @JOverride
-    def setPhase(self, phase):
-        self._phase = phase
-
-    @JOverride
-    def calcViscosity(self):
-        """Calculate viscosity using custom correlation."""
-        if self._phase is None:
-            return 0.0
-
-        T = self._phase.getTemperature()  # K
-        P = self._phase.getPressure()     # bar
-        rho = self._phase.getDensity()    # mol/m³
-
-        # Custom correlation (example: simple gas viscosity)
-        # mu = A * T^0.5 / (1 + B/T)
-        A = 2.6693e-6
-        B = 127.0
-
-        self.viscosity = A * (T ** 0.5) / (1.0 + B / T)
-        return self.viscosity
-
-    @JOverride
-    def getViscosity(self):
-        return self.viscosity
-```
+This proxy only demonstrates the JPype boundary. It is not a process unit and cannot be added to a
+`ProcessSystem`. Before using any proxy in production, read the current
+[NamedInterface JavaDoc](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/util/NamedInterface.html)
+and the accepting Java API, then test callback lifetime, exceptions, Java threads, and repeated
+execution.
 
 ---
 
@@ -1208,9 +1161,9 @@ T_K = uc.C_to_K(25)  # 298.15 K
 
 ## See Also
 
-- [Extending Process Equipment](extending_process_equipment)
-- [Extending Physical Properties](extending_physical_properties)
-- [Extending Thermodynamic Models](extending_thermodynamic_models)
+- [Extending Process Equipment](extending_process_equipment.md)
+- [Extending Physical Properties](extending_physical_properties.md)
+- [Extending Thermodynamic Models](extending_thermodynamic_models.md)
 - [NeqSim Python Documentation](https://equinor.github.io/neqsim-python/)
 - [JPype Documentation](https://jpype.readthedocs.io/)
 

--- a/docs/test_python_extension_patterns_documentation.py
+++ b/docs/test_python_extension_patterns_documentation.py
@@ -1,0 +1,86 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDE_PATH = ROOT / "docs" / "development" / "python_extension_patterns.md"
+NAMED_INTERFACE_PATH = (
+    ROOT / "src" / "main" / "java" / "neqsim" / "util" / "NamedInterface.java"
+)
+
+
+class PythonExtensionPatternsDocumentationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE_PATH.read_text(encoding="utf-8")
+        cls.named_interface = NAMED_INTERFACE_PATH.read_text(encoding="utf-8")
+
+    def test_front_matter_title_is_not_duplicated_as_h1(self):
+        body = self.guide.split("---", 2)[2]
+        prose = re.sub(r"```.*?```", "", body, flags=re.DOTALL)
+        self.assertNotRegex(prose, r"(?m)^# ")
+
+    def test_internal_see_also_links_are_source_safe_and_resolve(self):
+        targets = [
+            target
+            for target in re.findall(r"\]\(([^)]+)\)", self.guide)
+            if not target.startswith(("#", "http://", "https://"))
+        ]
+        self.assertEqual(len(targets), 3)
+        for target in targets:
+            self.assertTrue(target.endswith(".md"), target)
+            self.assertTrue((GUIDE_PATH.parent / target).is_file(), target)
+
+    def test_removed_proxy_examples_do_not_reference_invalid_contracts(self):
+        self.assertNotIn(
+            "@JImplements('neqsim.util.CalculationInterface')",
+            self.guide,
+        )
+        self.assertIn(
+            "`neqsim.util.CalculationInterface` does not exist",
+            self.guide,
+        )
+        self.assertNotIn(
+            "@JImplements('neqsim.thermo.component.ComponentInterface')",
+            self.guide,
+        )
+        self.assertNotIn(
+            "@JImplements('neqsim.physicalproperties.ViscosityInterface')",
+            self.guide,
+        )
+        self.assertIn(
+            "neqsim.physicalproperties.methods.methodinterface.ViscosityInterface",
+            self.guide,
+        )
+
+    def test_named_interface_proxy_implements_every_abstract_method(self):
+        abstract_methods = set(
+            re.findall(
+                r"(?m)^  public (?:String|void) (\w+)\(",
+                self.named_interface,
+            )
+        )
+        self.assertEqual(
+            abstract_methods,
+            {"getName", "setName", "getTagNumber", "setTagNumber"},
+        )
+        self.assertIn(
+            '@JImplements("neqsim.util.NamedInterface")',
+            self.guide,
+        )
+        for method in abstract_methods:
+            self.assertIn(f"def {method}(", self.guide)
+
+    def test_proxy_boundary_is_explicit(self):
+        for contract in (
+            "must implement every abstract method",
+            "cannot extend a concrete Java class",
+            "It is not a process unit",
+            "Implement reusable components",
+        ):
+            self.assertIn(contract, self.guide)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Repairs D080 for documentation-quality campaign #2499.

- replaces three invalid Python proxy examples with one complete, source-anchored `NamedInterface` proxy
- removes references to nonexistent `neqsim.util.CalculationInterface`
- corrects the viscosity-interface package and explains inherited contract requirements
- distinguishes direct Java access, Python composition, narrow proxies, and Java extensions
- documents lifecycle, cloning, serialization, calculation-identity, callback-lifetime, and threading boundaries
- removes the duplicate H1 and makes all three internal See Also links source-safe
- adds five focused documentation contracts anchored to current `NamedInterface.java`

## Frozen scope

- `docs/development/python_extension_patterns.md`
- `docs/test_python_extension_patterns_documentation.py`

No production Java API, `neqsim-python` release, notebook, broad extension-guide, process-equipment, valve, DEXPI, electrolyte, or Huldra changes.

## Documentation impact

The change is documentation-only and corrects user-visible Python extension guidance. The new contract verifies title structure, link resolution, removal of invalid proxy examples, exact Java-interface coverage, and explicit extension boundaries.

## Validation — READY TO MERGE

Exact head: `2bd72890346e41c15b62a071b7397a48b9db50af`

- build/test/Javadoc: passed
- documentation contracts, Jekyll build, generated search coverage, and search JavaScript: passed
- pre-commit: passed
- Spotless: passed
- CodeQL: passed
- complete `NamedInterface` proxy covers all four current abstract methods
- all three internal links resolve to current-master Markdown files
- mergeable, 2 commits ahead and 0 behind `master`; exactly 2 frozen files
- no comments, reviews, or unresolved threads

Campaign: #2499