### PR TITLE
[AI-Assisted] feat(mcp): expose Phase 0 evidence inventory

### DIFF
--- a/neqsim-mcp-server/README.md
+++ b/neqsim-mcp-server/README.md
@@ -824,7 +824,8 @@ response schemas for all tools and browsable resources, see
 **[docs/API_REFERENCE.md](docs/API_REFERENCE.md)**.
 
 For the exact protocol-tested inventory of published tools, resources, resource templates, guided
-prompts, deployment profiles, and cross-layer capability coverage, see
+prompts, deployment profiles, cross-layer capability coverage, test sources, guides, and current
+known-limit/trust gaps, see
 **[docs/SURFACE_INVENTORY.md](docs/SURFACE_INVENTORY.md)**.
 
 ---

--- a/neqsim-mcp-server/docs/API_REFERENCE.md
+++ b/neqsim-mcp-server/docs/API_REFERENCE.md
@@ -4,8 +4,8 @@ Detailed parameter documentation for MCP tools and resources.
 For the governance model, tier structure, and stability promises, see
 [MCP_CONTRACT.md](../MCP_CONTRACT.md).
 
-The exact protocol-tested tool, resource, resource-template, prompt, deployment-profile, and
-capability-coverage baseline is recorded in
+The exact protocol-tested tool, resource, resource-template, prompt, deployment-profile,
+capability, test-source, guide, and known-limit/trust baseline is recorded in
 [MCP published-surface inventory](SURFACE_INVENTORY.md).
 
 ---
@@ -229,6 +229,11 @@ the canonical name-only `EquipmentFactory` surface, and the bounded
 `generateReport` / `bridgeTaskWorkflow` reporting paths. Use this inventory for
 discovery and audit; availability is not equivalent to benchmark validation or
 engineering approval.
+
+`phase0EvidenceInventory` adds source-counted Java and real-protocol test inventories, the four MCP
+guide paths, and a runtime reconciliation of `getBenchmarkTrust`. Its `complete` flag remains false
+while published tools use generic trust fallbacks. Test presence is not test execution, and generic
+`TESTED` maturity is not a benchmark, accuracy, applicability, or no-limitations claim.
 
 ---
 

--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -16,6 +16,10 @@ manually maintained Java method list.
 | Tool implementations | 71 bindings / 60 classes | `getCapabilities.implementationInventory` | `McpImplementationInventory` |
 | Factory equipment | 205 types | `getCapabilities.implementationInventory` | `EquipmentFactory` |
 | Engineering report paths | 2 | `getCapabilities.implementationInventory` | `ReportRunner`, `TaskWorkflowBridge` |
+| MCP Java test classes | 67 | `getCapabilities.phase0EvidenceInventory` | `src/test/java/neqsim/mcp/**/*Test.java` |
+| MCP protocol scenarios | 94 | `getCapabilities.phase0EvidenceInventory` | `test_mcp_server.py` |
+| MCP guides | 4 | `getCapabilities.phase0EvidenceInventory` | MCP README, contract, API reference, and this inventory |
+| Explicit tool trust pages | 20 of 71 tools | `getBenchmarkTrust` and `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust` |
 
 The tool regression asserts the exact 71-name set grouped by its current trust tier. It also calls
 `getCapabilities` and requires `toolCatalogCoverage.complete`, equal published and described tool
@@ -77,6 +81,37 @@ Two bounded reporting paths are explicit:
 Neither path writes to a live plant system. The direct path does not persist a file, and the bridge
 does not claim that an external Word/HTML artifact has been generated or engineering-approved.
 
+## Tests, guides, and known limitations
+
+`getCapabilities.phase0EvidenceInventory` freezes the remaining source-evidence dimensions of the
+Phase 0 inventory. The exact current source contains 67 JUnit test classes under
+`src/test/java/neqsim/mcp` and 94 named scenarios in the packaged real-STDIO JSON-RPC harness
+`neqsim-mcp-server/test_mcp_server.py`. The protocol regression independently recounts both source
+trees and fails if the manifest drifts. These counts identify evidence locations; they are not a
+claim that a test ran or passed. Exact-head CI and recorded command output remain the execution
+evidence.
+
+The four MCP guides have distinct roles:
+
+| Guide | Role |
+| --- | --- |
+| `neqsim-mcp-server/README.md` | Installation, profiles, tools, workflows, testing, and troubleshooting |
+| `neqsim-mcp-server/MCP_CONTRACT.md` | Versioning, stability, envelopes, governance, security, and trust metadata |
+| `neqsim-mcp-server/docs/API_REFERENCE.md` | Parameters, schemas, examples, resources, and selected result contracts |
+| `neqsim-mcp-server/docs/SURFACE_INVENTORY.md` | Exact protocol, implementation, equipment, reporting, and evidence inventory |
+
+Known-limit coverage is deliberately reported as incomplete. `BenchmarkTrust` currently contains
+20 explicit tool trust pages with 64 known-limit entries and 30 validation cases, of which 5 name
+a concrete `verifiedBy` test. The other 51 published tools use a generic `TESTED` fallback, and no
+explicit trust page currently publishes a structured `unsupported` condition. The inventory lists
+both the explicitly covered and generic-fallback tools. A generic fallback is not scientific
+validation and does not establish accuracy, applicability, or absence of limitations.
+
+Per-result provenance, convergence, warnings, assumptions, and limitations remain authoritative
+for an executed calculation. The evidence inventory is advisory discovery metadata; it does not
+certify a facility, claim causality, replace qualified engineering review, or write to a live plant
+system.
+
 ## Guided prompts
 
 - `biorefinery_analysis`
@@ -108,11 +143,12 @@ schema. Process execution continues to use canonical NeqSim fluids, streams, `Pr
 
 The baseline now freezes the exact transport-facing tools, resources, resource templates, prompts,
 deployment-profile names, tool-capability reconciliation, schema resource graph, example resource
-graph, tool implementation bindings, factory-backed equipment, and report paths. It does not
-complete the campaign's full Phase 0 inventory. Follow-up work must still inventory tests, guides,
-and known limitations; reconcile merged foundations #2874, #2875, and #3152 criterion by criterion;
-add the four acceptance scales; build the full traceability and discipline-maturity matrices; and
-record runtime, memory, payload, convergence, balance-closure, and report-usefulness baselines.
+graph, tool implementation bindings, factory-backed equipment, report paths, test sources, guides,
+and current known-limit/trust coverage. It does not complete the campaign's full Phase 0 audit.
+Follow-up work must reconcile merged foundations #2874, #2875, and #3152 criterion by criterion;
+turn the 51 generic trust fallbacks into evidence-based capability or confirmed-gap records; add the
+four acceptance scales; build the full traceability and discipline-maturity matrices; and record
+runtime, memory, payload, convergence, balance-closure, and report-usefulness baselines.
 
 DEXPI/P&ID ingestion remains owned by #2899, dynamics by #2911, flash/stability/performance by
 #2937, and merged production-optimization foundations by #2941. This inventory audits existing

--- a/neqsim-mcp-server/test_mcp_server.py
+++ b/neqsim-mcp-server/test_mcp_server.py
@@ -50,6 +50,8 @@ import json
 import time
 import sys
 import math
+import re
+from pathlib import Path
 
 JAR = "target/neqsim-mcp-server-1.0.0-SNAPSHOT-runner.jar"
 
@@ -1492,6 +1494,63 @@ def test_capabilities():
           and bindings.get("bridgeTaskWorkflow")
           == "neqsim.mcp.runners.TaskWorkflowBridge",
           str(bindings))
+
+    evidence = r.get("phase0EvidenceInventory", {})
+    tests = evidence.get("tests", {})
+    guides = evidence.get("guides", {})
+    limitations = evidence.get("knownLimitations", {})
+    check("evidence inventory freezes 67 Java test classes",
+          tests.get("javaTestClassCount") == 67,
+          str(tests))
+    check("evidence inventory freezes 94 protocol scenarios",
+          tests.get("protocolScenarioCount") == 94,
+          str(tests))
+    check("evidence inventory lists four MCP guides",
+          guides.get("guideCount") == 4
+          and len(guides.get("entries", [])) == 4,
+          str(guides))
+
+    repo_root = Path(__file__).resolve().parent.parent
+    java_test_root = repo_root / tests.get("javaTestRoot", "")
+    java_test_files = sorted(java_test_root.rglob("*Test.java"))
+    protocol_source = Path(__file__).read_text(encoding="utf-8")
+    protocol_scenarios = re.findall(r"^def test_", protocol_source, re.MULTILINE)
+    guide_paths = [repo_root / entry.get("path", "")
+                   for entry in guides.get("entries", [])]
+    check("Java test source count matches the evidence inventory",
+          len(java_test_files) == tests.get("javaTestClassCount"),
+          f"found {len(java_test_files)}")
+    check("protocol scenario count matches the evidence inventory",
+          len(protocol_scenarios) == tests.get("protocolScenarioCount"),
+          f"found {len(protocol_scenarios)}")
+    check("every inventoried MCP guide resolves on the exact source tree",
+          all(path.is_file() for path in guide_paths),
+          str(guide_paths))
+
+    trust_report = call_tool("getBenchmarkTrust", {"action": "getAll"})
+    explicit_trust = trust_report.get("tools", {})
+    limitation_count = sum(len(tool.get("knownLimitations", []))
+                           for tool in explicit_trust.values())
+    validation_case_count = sum(len(tool.get("validationCases", []))
+                                for tool in explicit_trust.values())
+    verified_case_count = sum(
+        1 for tool in explicit_trust.values()
+        for case in tool.get("validationCases", [])
+        if "verifiedBy" in case)
+    check("limitation inventory reconciles the runtime trust report",
+          set(explicit_trust) == set(limitations.get("explicitTrustTools", []))
+          and limitation_count == limitations.get("knownLimitationCount")
+          and validation_case_count == limitations.get("validationCaseCount")
+          and verified_case_count == limitations.get("verifiedValidationCaseCount"),
+          str(limitations))
+    check("uncovered tool-specific trust remains an explicit Phase 0 gap",
+          limitations.get("publishedToolCount") == 71
+          and limitations.get("explicitTrustToolCount") == 20
+          and limitations.get("genericTrustToolCount") == 51
+          and limitations.get("unsupportedConditionCount") == 0
+          and limitations.get("complete") is False
+          and evidence.get("complete") is False,
+          str(limitations))
 
 
 def test_run_capability_search_and_invoke():

--- a/src/main/java/neqsim/mcp/catalog/SchemaCatalog.java
+++ b/src/main/java/neqsim/mcp/catalog/SchemaCatalog.java
@@ -809,6 +809,9 @@ public final class SchemaCatalog {
     properties.put("implementationInventory",
         objectProp("Compact tool-to-implementation bindings, canonical EquipmentFactory surface, "
             + "and bounded engineering-report paths"));
+    properties.put("phase0EvidenceInventory",
+        objectProp("Phase 0 test and guide source inventory plus explicit benchmark, validation-case, "
+            + "known-limitation, and uncovered-tool evidence"));
 
     Map<String, Object> thermo = new LinkedHashMap<String, Object>();
     thermo.put("type", "object");

--- a/src/main/java/neqsim/mcp/runners/CapabilitiesRunner.java
+++ b/src/main/java/neqsim/mcp/runners/CapabilitiesRunner.java
@@ -179,6 +179,7 @@ public class CapabilitiesRunner {
     root.add("toolCapabilities", toolCapabilities);
     root.add("toolCatalogCoverage", buildToolCatalogCoverage(toolCapabilities));
     root.add("implementationInventory", McpImplementationInventory.build(toolCapabilities));
+    root.add("phase0EvidenceInventory", McpEvidenceInventory.build());
     root.add("setupTemplates", buildSetupTemplates());
     root.add("processJsonContract", buildProcessJsonContract());
     root.add("capabilityGraph", buildCapabilityGraph());

--- a/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
@@ -1,0 +1,152 @@
+package neqsim.mcp.runners;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Builds the Phase 0 MCP test, guide, and limitation-evidence inventory.
+ *
+ * <p>
+ * Source evidence counts are frozen by the repository and protocol tests. Runtime limitation coverage is derived
+ * directly from {@link BenchmarkTrust}, so tools that still use the generic trust fallback remain explicit gaps rather
+ * than being presented as validated.
+ * </p>
+ */
+public final class McpEvidenceInventory {
+
+  private static final int JAVA_TEST_CLASS_COUNT = 67;
+  private static final int PROTOCOL_SCENARIO_COUNT = 94;
+
+  /** Private constructor for utility class. */
+  private McpEvidenceInventory() {
+  }
+
+  /**
+   * Builds the evidence inventory.
+   *
+   * @return test, guide, and limitation evidence
+   */
+  public static JsonObject build() {
+    JsonObject inventory = new JsonObject();
+    inventory.addProperty("inventoryVersion", "1.0");
+    inventory.add("tests", buildTests());
+    inventory.add("guides", buildGuides());
+    inventory.add("knownLimitations", buildKnownLimitations());
+    inventory.addProperty("advisoryBoundary",
+        "Evidence discovery does not certify a calculation or replace qualified engineering review");
+    inventory.addProperty("complete", false);
+    inventory.addProperty("completionReason",
+        "Test and guide sources are inventoried, but not every published tool has explicit benchmark and limitation metadata");
+    return inventory;
+  }
+
+  /** Builds source-level test evidence. */
+  private static JsonObject buildTests() {
+    JsonObject tests = new JsonObject();
+    tests.addProperty("javaTestClassCount", JAVA_TEST_CLASS_COUNT);
+    tests.addProperty("javaTestRoot", "src/test/java/neqsim/mcp");
+    tests.addProperty("protocolScenarioCount", PROTOCOL_SCENARIO_COUNT);
+    tests.addProperty("protocolHarness", "neqsim-mcp-server/test_mcp_server.py");
+    tests.addProperty("sourceCountContract",
+        "CapabilitiesRunnerTest and the packaged MCP protocol suite freeze these source inventories");
+    tests.addProperty("executionBoundary",
+        "Inventory presence is not an execution result; use exact-head CI and recorded test output as pass evidence");
+    return tests;
+  }
+
+  /** Builds the exact MCP guide inventory. */
+  private static JsonObject buildGuides() {
+    JsonObject guides = new JsonObject();
+    JsonArray entries = new JsonArray();
+    entries.add(guide("server-readme", "neqsim-mcp-server/README.md",
+        "Installation, profiles, tools, workflows, testing, and troubleshooting"));
+    entries.add(guide("protocol-contract", "neqsim-mcp-server/MCP_CONTRACT.md",
+        "Versioning, stability, response envelopes, governance, security, and trust metadata"));
+    entries.add(guide("api-reference", "neqsim-mcp-server/docs/API_REFERENCE.md",
+        "Tool parameters, schemas, examples, resources, and selected result contracts"));
+    entries.add(guide("surface-inventory", "neqsim-mcp-server/docs/SURFACE_INVENTORY.md",
+        "Exact protocol, implementation, equipment, reporting, and Phase 0 evidence inventory"));
+    guides.addProperty("guideCount", entries.size());
+    guides.add("entries", entries);
+    return guides;
+  }
+
+  /** Builds limitation and maturity coverage directly from BenchmarkTrust. */
+  private static JsonObject buildKnownLimitations() {
+    JsonObject trustReport = JsonParser.parseString(BenchmarkTrust.getTrustReport()).getAsJsonObject();
+    JsonObject explicitTools = trustReport.getAsJsonObject("tools");
+
+    Set<String> publishedTools = IndustrialProfile.getAllKnownTools();
+    Set<String> genericTools = new LinkedHashSet<String>(publishedTools);
+    genericTools.removeAll(explicitTools.keySet());
+
+    int limitationCount = 0;
+    int unsupportedConditionCount = 0;
+    int validationCaseCount = 0;
+    int verifiedValidationCaseCount = 0;
+    JsonObject maturityCounts = new JsonObject();
+    for (Map.Entry<String, JsonElement> entry : explicitTools.entrySet()) {
+      JsonObject trust = entry.getValue().getAsJsonObject();
+      limitationCount += arraySize(trust, "knownLimitations");
+      unsupportedConditionCount += arraySize(trust, "unsupported");
+      validationCaseCount += arraySize(trust, "validationCases");
+      if (trust.has("validationCases")) {
+        for (JsonElement validationCase : trust.getAsJsonArray("validationCases")) {
+          if (validationCase.getAsJsonObject().has("verifiedBy")) {
+            verifiedValidationCaseCount++;
+          }
+        }
+      }
+      String maturity = trust.has("maturityLevel") ? trust.get("maturityLevel").getAsString() : "UNDECLARED";
+      int current = maturityCounts.has(maturity) ? maturityCounts.get(maturity).getAsInt() : 0;
+      maturityCounts.addProperty(maturity, current + 1);
+    }
+
+    JsonObject limitations = new JsonObject();
+    limitations.addProperty("sourceTool", "getBenchmarkTrust");
+    limitations.addProperty("publishedToolCount", publishedTools.size());
+    limitations.addProperty("explicitTrustToolCount", explicitTools.size());
+    limitations.addProperty("genericTrustToolCount", genericTools.size());
+    limitations.addProperty("knownLimitationCount", limitationCount);
+    limitations.addProperty("unsupportedConditionCount", unsupportedConditionCount);
+    limitations.addProperty("validationCaseCount", validationCaseCount);
+    limitations.addProperty("verifiedValidationCaseCount", verifiedValidationCaseCount);
+    limitations.add("maturityCounts", maturityCounts);
+    limitations.add("explicitTrustTools", toJsonArray(explicitTools.keySet()));
+    limitations.add("genericTrustTools", toJsonArray(genericTools));
+    limitations.addProperty("complete", genericTools.isEmpty());
+    limitations.addProperty("gapBoundary",
+        "Generic fallback means no tool-specific benchmark, accuracy, unsupported-condition, or limitation claim is available");
+    limitations.addProperty("resultBoundary",
+        "Per-result provenance, convergence, warnings, assumptions, and limitations remain authoritative for an executed case");
+    return limitations;
+  }
+
+  /** Builds one guide descriptor. */
+  private static JsonObject guide(String id, String path, String scope) {
+    JsonObject guide = new JsonObject();
+    guide.addProperty("id", id);
+    guide.addProperty("path", path);
+    guide.addProperty("scope", scope);
+    return guide;
+  }
+
+  /** Returns an array size or zero when the member is absent. */
+  private static int arraySize(JsonObject object, String member) {
+    return object.has(member) ? object.getAsJsonArray(member).size() : 0;
+  }
+
+  /** Converts ordered values to JSON. */
+  private static JsonArray toJsonArray(Iterable<String> values) {
+    JsonArray array = new JsonArray();
+    for (String value : values) {
+      array.add(value);
+    }
+    return array;
+  }
+}

--- a/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
@@ -33,6 +33,7 @@ class CapabilitiesRunnerTest {
     assertTrue(obj.has("calculationModes"));
     assertTrue(obj.has("toolCapabilities"));
     assertTrue(obj.has("implementationInventory"));
+    assertTrue(obj.has("phase0EvidenceInventory"));
     assertTrue(obj.has("setupTemplates"));
     assertTrue(obj.has("processJsonContract"));
     assertTrue(obj.has("capabilityGraph"));
@@ -154,6 +155,33 @@ class CapabilitiesRunnerTest {
     assertEquals("bridgeTaskWorkflow", reportPaths.get(1).getAsJsonObject().get("tool").getAsString());
     assertEquals("neqsim.mcp.runners.TaskWorkflowBridge",
         reportPaths.get(1).getAsJsonObject().get("implementationClass").getAsString());
+  }
+
+  @Test
+  void testPhase0EvidenceInventoryMakesTrustGapsExplicit() {
+    JsonObject root = JsonParser.parseString(CapabilitiesRunner.getCapabilities()).getAsJsonObject();
+    JsonObject inventory = root.getAsJsonObject("phase0EvidenceInventory");
+
+    JsonObject tests = inventory.getAsJsonObject("tests");
+    assertEquals(67, tests.get("javaTestClassCount").getAsInt());
+    assertEquals(94, tests.get("protocolScenarioCount").getAsInt());
+
+    JsonObject guides = inventory.getAsJsonObject("guides");
+    assertEquals(4, guides.get("guideCount").getAsInt());
+    assertEquals(4, guides.getAsJsonArray("entries").size());
+
+    JsonObject limitations = inventory.getAsJsonObject("knownLimitations");
+    assertEquals(71, limitations.get("publishedToolCount").getAsInt());
+    assertEquals(20, limitations.get("explicitTrustToolCount").getAsInt());
+    assertEquals(51, limitations.get("genericTrustToolCount").getAsInt());
+    assertEquals(64, limitations.get("knownLimitationCount").getAsInt());
+    assertEquals(0, limitations.get("unsupportedConditionCount").getAsInt());
+    assertEquals(30, limitations.get("validationCaseCount").getAsInt());
+    assertEquals(5, limitations.get("verifiedValidationCaseCount").getAsInt());
+    assertEquals(20, limitations.getAsJsonArray("explicitTrustTools").size());
+    assertEquals(51, limitations.getAsJsonArray("genericTrustTools").size());
+    assertFalse(limitations.get("complete").getAsBoolean());
+    assertFalse(inventory.get("complete").getAsBoolean());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Completes the next bounded Phase 0 inventory increment for #3153 by making the remaining source-evidence dimensions discoverable through the existing `getCapabilities` response.

- freezes 67 MCP JUnit test classes, 94 real-STDIO protocol scenarios, and four MCP guide paths
- reconciles the published 71-tool surface against `getBenchmarkTrust`
- exposes the current gap honestly: 20 explicit trust pages, 51 generic fallbacks, 64 known-limit entries, 30 validation cases, 5 with a concrete `verifiedBy` test, and no structured `unsupported` entries
- keeps `complete: false` until every published tool has explicit evidence or a confirmed-gap record
- documents that source presence is not execution evidence and generic `TESTED` maturity is not benchmark validation

## Frozen scope and boundaries

This PR is one additive discovery-and-regression concept. It does not add a new MCP tool, simulator, equipment model, benchmark claim, or live-plant action. Canonical NeqSim models and all numerical behavior remain unchanged. Per-result provenance, units, convergence, assumptions, warnings, and limitations remain authoritative.

DEXPI/P&ID remains owned by #2899, dynamics by #2911, flash/stability/performance by #2937, and production-optimization foundations by #2941. No companion agent/skill contract update is required because the published tool/request/envelope contract is unchanged.

Exact base: `e537b6c24eb8a5137e79bdd8956820804a37bcc6`
Exact head: `911f63124e7869f523ff78f9b1aaf8d05fdfc499`

## Validation

- focused Java 17: 34/34 passed (`CapabilitiesRunnerTest`, `SchemaCatalogTest`, `ResponseSizeGuardTest`)
- Java 8 target: 34/34 passed with `pomJava8.xml`
- broad MCP JUnit suite: 480 tests, 0 failures/errors, 1 expected skip
- packaged real-STDIO MCP protocol suite: 317/317 passed, including flash, PVT, process, valve, compressor, separator, pipeline, reporting, catalog, and evidence reconciliation
- MCP runner packaging passed under the locally available JDK 17 using a temporary local-only compiler-release adjustment; the repository POM was restored unchanged and hosted JDK 21 CI remains authoritative
- Spotless apply/check passed
- documentation search passed: 655 Markdown and 1 standalone HTML source
- pre-commit and pre-push stages passed
- Javadocs completed successfully (existing warnings remain)
- `python -m py_compile` and `git diff --check` passed

The first broad-suite attempt reached the known read-only `/root/.neqsim` environment failure in `StatePersistenceRunnerTest`; the exact same suite passed after setting a task-local writable `user.home`. The installed JRE lacked a `javadoc` launcher, so the successful direct Javadoc gate used its bundled `jdk.javadoc` module through a task-local wrapper.

## Documentation impact

Updated the MCP README, API reference, and published-surface inventory. `MCP_CONTRACT.md` was assessed and does not require a change because this is additive capability metadata rather than a tool/request/envelope stability change.

Refs #3153