### PR TITLE
[AI-Assisted] feat(thermo): audit reaction data across electrolyte models

### DIFF
--- a/docs/thermo/reaction_model_audit.md
+++ b/docs/thermo/reaction_model_audit.md
@@ -1,0 +1,41 @@
+---
+title: "Reaction Model Audit"
+description: "Compare active chemical reactions and parameter provenance across electrolyte EOS and GE models without changing the calculation path."
+---
+
+# Reaction Model Audit
+
+NeqSim can use chemical-reaction equilibrium together with electrolyte EOS models such as Electrolyte-CPA and electrolyte GE models such as Pitzer. These models currently select the `STANDARD` reaction-data source, while `SystemKentEisenberg` selects the dedicated `KENT_EISENBERG` apparent-constant source.
+
+A shared reaction table is an implementation choice, not evidence that the same active reaction set, equilibrium constants, activity convention, or validity range has been independently validated for every thermodynamic model. Before splitting a table or changing model-specific reactions, capture the actual initialized state with `ChemicalReactionModelAudit`.
+
+```java
+SystemInterface cpa = new SystemElectrolyteCPAstatoil(298.15, 1.01325);
+cpa.addComponent("CO2", 0.01);
+cpa.addComponent("water", 0.99);
+cpa.chemicalReactionInit();
+
+SystemInterface pitzer = new SystemPitzer(298.15, 1.01325);
+pitzer.addComponent("CO2", 0.01);
+pitzer.addComponent("water", 0.99);
+pitzer.chemicalReactionInit();
+
+ChemicalReactionModelAudit.AuditComparison comparison =
+    ChemicalReactionModelAudit.compare(cpa, pitzer);
+```
+
+The audit reports the selected typed data source, deterministic active-reaction list, stoichiometry, stored literature/data reference, reference temperature, and equilibrium-constant coefficients. The comparison separates reactions present in only one model from common reactions whose stored parameters differ.
+
+The API is deliberately read-only. It requires `chemicalReactionInit()` to have been called and never initializes reactions implicitly, runs a flash, or changes model state. It therefore adds no work to ordinary neutral PR/SRK/CPA calculations and no work to electrolyte calculations unless the audit is explicitly requested.
+
+## Scientific use
+
+Use this diagnostic to freeze model-specific validation questions before changing reaction data:
+
+1. Compare EOS and GE systems with the same feed species and reaction-init lifecycle.
+2. Record differences in active reactions and stored parameter provenance.
+3. Check the activity/standard-state convention used by each thermodynamic model.
+4. Validate equilibrium constants and speciation against independent public data over a declared temperature, pressure, ionic-strength, and composition range.
+5. Split reaction tables or activate/deactivate model-specific reactions only when the scientific evidence requires it.
+
+Relevant foundations include Plummer and Busenberg (1982), DOI `10.1016/0016-7037(82)90056-4`, for carbonate equilibria represented in the existing standard reaction data, and the Pitzer electrolyte framework for activity-coefficient treatment. NeqSim does not infer model-specific parameter validity merely because two models currently select the same source.

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionModelAudit.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionModelAudit.java
@@ -14,24 +14,23 @@ import neqsim.thermo.system.SystemInterface;
  * Audits the active chemical-reaction set and parameter provenance of a thermodynamic system.
  *
  * <p>
- * Electrolyte EOS and electrolyte GE models may legitimately share a reaction table when their
- * activity/standard-state conventions are compatible, but sharing a table is not evidence that the
- * same active reactions or parameters have been independently validated for both model families.
- * This utility provides an explicit, side-effect-free comparison surface before changing reaction
- * activation or splitting parameter tables.
+ * Electrolyte EOS and electrolyte GE models may legitimately share a reaction table when their activity/standard-state
+ * conventions are compatible, but sharing a table is not evidence that the same active reactions or parameters have
+ * been independently validated for both model families. This utility provides an explicit, side-effect-free comparison
+ * surface before changing reaction activation or splitting parameter tables.
  * </p>
  *
  * <p>
- * The audit only reads an already initialized {@link ChemicalReactionOperations} object. It does
- * not initialize reactions, run equilibrium calculations, change a thermodynamic model, or add work
- * to ordinary neutral calculations.
+ * The audit only reads an already initialized {@link ChemicalReactionOperations} object. It does not initialize
+ * reactions, run equilibrium calculations, change a thermodynamic model, or add work to ordinary neutral calculations.
  * </p>
  *
  * @author OpenAI Codex
  * @version 1.0
  */
 public final class ChemicalReactionModelAudit {
-  private ChemicalReactionModelAudit() {}
+  private ChemicalReactionModelAudit() {
+  }
 
   /**
    * Capture the active reaction set and equilibrium-parameter provenance for a system.
@@ -98,8 +97,8 @@ public final class ChemicalReactionModelAudit {
       }
     }
 
-    return new AuditComparison(first.getReactionDataSource() == second.getReactionDataSource(),
-        onlyInFirst, onlyInSecond, parameterDifferences);
+    return new AuditComparison(first.getReactionDataSource() == second.getReactionDataSource(), onlyInFirst,
+        onlyInSecond, parameterDifferences);
   }
 
   /** Immutable snapshot of one system's selected reaction source and active reactions. */
@@ -127,7 +126,7 @@ public final class ChemicalReactionModelAudit {
 
     /** @return immutable active-reaction snapshots in deterministic name order */
     public List<ReactionParameterSnapshot> getReactions() {
-      return reactions;
+      return Collections.unmodifiableList(new ArrayList<ReactionParameterSnapshot>(reactions));
     }
 
     /** @return number of active independent reactions retained after initialization */
@@ -136,8 +135,7 @@ public final class ChemicalReactionModelAudit {
     }
 
     private Map<String, ReactionParameterSnapshot> asMap() {
-      Map<String, ReactionParameterSnapshot> values =
-          new LinkedHashMap<String, ReactionParameterSnapshot>();
+      Map<String, ReactionParameterSnapshot> values = new LinkedHashMap<String, ReactionParameterSnapshot>();
       for (ReactionParameterSnapshot reaction : reactions) {
         values.put(reaction.getName(), reaction);
       }
@@ -146,8 +144,7 @@ public final class ChemicalReactionModelAudit {
   }
 
   /** Immutable per-reaction parameter/provenance snapshot. */
-  public static final class ReactionParameterSnapshot
-      implements Comparable<ReactionParameterSnapshot> {
+  public static final class ReactionParameterSnapshot implements Comparable<ReactionParameterSnapshot> {
     private final String name;
     private final String reference;
     private final double referenceTemperature;

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionModelAudit.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionModelAudit.java
@@ -1,0 +1,265 @@
+package neqsim.chemicalreactions.chemicalreaction;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import neqsim.chemicalreactions.ChemicalReactionOperations;
+import neqsim.thermo.system.SystemInterface;
+
+/**
+ * Audits the active chemical-reaction set and parameter provenance of a thermodynamic system.
+ *
+ * <p>
+ * Electrolyte EOS and electrolyte GE models may legitimately share a reaction table when their
+ * activity/standard-state conventions are compatible, but sharing a table is not evidence that the
+ * same active reactions or parameters have been independently validated for both model families.
+ * This utility provides an explicit, side-effect-free comparison surface before changing reaction
+ * activation or splitting parameter tables.
+ * </p>
+ *
+ * <p>
+ * The audit only reads an already initialized {@link ChemicalReactionOperations} object. It does
+ * not initialize reactions, run equilibrium calculations, change a thermodynamic model, or add work
+ * to ordinary neutral calculations.
+ * </p>
+ *
+ * @author OpenAI Codex
+ * @version 1.0
+ */
+public final class ChemicalReactionModelAudit {
+  private ChemicalReactionModelAudit() {}
+
+  /**
+   * Capture the active reaction set and equilibrium-parameter provenance for a system.
+   *
+   * @param system system with initialized chemical reactions
+   * @return immutable audit snapshot
+   * @throws IllegalStateException if chemical reactions have not been initialized
+   */
+  public static AuditSnapshot inspect(SystemInterface system) {
+    Objects.requireNonNull(system, "system");
+    ChemicalReactionOperations operations = system.getChemicalReactionOperations();
+    if (operations == null) {
+      throw new IllegalStateException(
+          "Chemical reactions are not initialized. Call chemicalReactionInit() before auditing reaction data.");
+    }
+
+    List<ReactionParameterSnapshot> reactions = new ArrayList<ReactionParameterSnapshot>();
+    for (ChemicalReaction reaction : operations.getReactionList().getChemicalReactionList()) {
+      reactions.add(new ReactionParameterSnapshot(reaction));
+    }
+    Collections.sort(reactions);
+    return new AuditSnapshot(system.getModelName(), operations.getReactionDataSource(), reactions);
+  }
+
+  /**
+   * Compare two initialized systems without running either model.
+   *
+   * @param first first system
+   * @param second second system
+   * @return immutable comparison of selected source, active reactions, and reaction parameters
+   */
+  public static AuditComparison compare(SystemInterface first, SystemInterface second) {
+    return compare(inspect(first), inspect(second));
+  }
+
+  /**
+   * Compare two previously captured audit snapshots.
+   *
+   * @param first first audit snapshot
+   * @param second second audit snapshot
+   * @return immutable comparison
+   */
+  public static AuditComparison compare(AuditSnapshot first, AuditSnapshot second) {
+    Objects.requireNonNull(first, "first");
+    Objects.requireNonNull(second, "second");
+
+    Map<String, ReactionParameterSnapshot> firstByName = first.asMap();
+    Map<String, ReactionParameterSnapshot> secondByName = second.asMap();
+    List<String> onlyInFirst = new ArrayList<String>();
+    List<String> onlyInSecond = new ArrayList<String>();
+    List<String> parameterDifferences = new ArrayList<String>();
+
+    for (Map.Entry<String, ReactionParameterSnapshot> entry : firstByName.entrySet()) {
+      ReactionParameterSnapshot other = secondByName.get(entry.getKey());
+      if (other == null) {
+        onlyInFirst.add(entry.getKey());
+      } else if (!entry.getValue().hasSameParameters(other)) {
+        parameterDifferences.add(entry.getKey());
+      }
+    }
+    for (String reactionName : secondByName.keySet()) {
+      if (!firstByName.containsKey(reactionName)) {
+        onlyInSecond.add(reactionName);
+      }
+    }
+
+    return new AuditComparison(first.getReactionDataSource() == second.getReactionDataSource(),
+        onlyInFirst, onlyInSecond, parameterDifferences);
+  }
+
+  /** Immutable snapshot of one system's selected reaction source and active reactions. */
+  public static final class AuditSnapshot {
+    private final String modelName;
+    private final ChemicalReactionDataSource reactionDataSource;
+    private final List<ReactionParameterSnapshot> reactions;
+
+    private AuditSnapshot(String modelName, ChemicalReactionDataSource reactionDataSource,
+        List<ReactionParameterSnapshot> reactions) {
+      this.modelName = modelName;
+      this.reactionDataSource = reactionDataSource;
+      this.reactions = Collections.unmodifiableList(new ArrayList<ReactionParameterSnapshot>(reactions));
+    }
+
+    /** @return thermodynamic model name recorded by the system */
+    public String getModelName() {
+      return modelName;
+    }
+
+    /** @return selected reaction-data source */
+    public ChemicalReactionDataSource getReactionDataSource() {
+      return reactionDataSource;
+    }
+
+    /** @return immutable active-reaction snapshots in deterministic name order */
+    public List<ReactionParameterSnapshot> getReactions() {
+      return reactions;
+    }
+
+    /** @return number of active independent reactions retained after initialization */
+    public int getReactionCount() {
+      return reactions.size();
+    }
+
+    private Map<String, ReactionParameterSnapshot> asMap() {
+      Map<String, ReactionParameterSnapshot> values =
+          new LinkedHashMap<String, ReactionParameterSnapshot>();
+      for (ReactionParameterSnapshot reaction : reactions) {
+        values.put(reaction.getName(), reaction);
+      }
+      return values;
+    }
+  }
+
+  /** Immutable per-reaction parameter/provenance snapshot. */
+  public static final class ReactionParameterSnapshot
+      implements Comparable<ReactionParameterSnapshot> {
+    private final String name;
+    private final String reference;
+    private final double referenceTemperature;
+    private final double[] equilibriumConstantCoefficients;
+    private final String[] componentNames;
+    private final double[] stoichiometricCoefficients;
+
+    private ReactionParameterSnapshot(ChemicalReaction reaction) {
+      this.name = reaction.getName();
+      this.reference = reaction.getReference();
+      this.referenceTemperature = reaction.getReferenceTemperature();
+      this.equilibriumConstantCoefficients = reaction.getEquilibriumConstantCoefficients();
+      this.componentNames = reaction.getNames().clone();
+      this.stoichiometricCoefficients = reaction.getStocCoefs().clone();
+    }
+
+    /** @return reaction name */
+    public String getName() {
+      return name;
+    }
+
+    /** @return stored literature/data reference identifier */
+    public String getReference() {
+      return reference;
+    }
+
+    /** @return reference temperature in kelvin */
+    public double getReferenceTemperature() {
+      return referenceTemperature;
+    }
+
+    /** @return defensive copy of equilibrium-constant correlation coefficients */
+    public double[] getEquilibriumConstantCoefficients() {
+      return equilibriumConstantCoefficients.clone();
+    }
+
+    /** @return defensive copy of reaction component names */
+    public String[] getComponentNames() {
+      return componentNames.clone();
+    }
+
+    /** @return defensive copy of stoichiometric coefficients */
+    public double[] getStoichiometricCoefficients() {
+      return stoichiometricCoefficients.clone();
+    }
+
+    /**
+     * Check whether another reaction snapshot uses the same stoichiometry and stored parameterization.
+     *
+     * @param other other snapshot
+     * @return true when all auditable reaction parameters are equal
+     */
+    public boolean hasSameParameters(ReactionParameterSnapshot other) {
+      return other != null && Objects.equals(reference, other.reference)
+          && Double.doubleToLongBits(referenceTemperature) == Double.doubleToLongBits(other.referenceTemperature)
+          && Arrays.equals(equilibriumConstantCoefficients, other.equilibriumConstantCoefficients)
+          && Arrays.equals(componentNames, other.componentNames)
+          && Arrays.equals(stoichiometricCoefficients, other.stoichiometricCoefficients);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int compareTo(ReactionParameterSnapshot other) {
+      return name.compareTo(other.name);
+    }
+  }
+
+  /** Immutable difference summary between two reaction-model audit snapshots. */
+  public static final class AuditComparison {
+    private final boolean sameReactionDataSource;
+    private final List<String> reactionsOnlyInFirst;
+    private final List<String> reactionsOnlyInSecond;
+    private final List<String> parameterDifferences;
+
+    private AuditComparison(boolean sameReactionDataSource, List<String> reactionsOnlyInFirst,
+        List<String> reactionsOnlyInSecond, List<String> parameterDifferences) {
+      this.sameReactionDataSource = sameReactionDataSource;
+      this.reactionsOnlyInFirst = immutableCopy(reactionsOnlyInFirst);
+      this.reactionsOnlyInSecond = immutableCopy(reactionsOnlyInSecond);
+      this.parameterDifferences = immutableCopy(parameterDifferences);
+    }
+
+    /** @return true when both systems selected the same typed reaction-data source */
+    public boolean hasSameReactionDataSource() {
+      return sameReactionDataSource;
+    }
+
+    /** @return immutable reaction names active only in the first system */
+    public List<String> getReactionsOnlyInFirst() {
+      return reactionsOnlyInFirst;
+    }
+
+    /** @return immutable reaction names active only in the second system */
+    public List<String> getReactionsOnlyInSecond() {
+      return reactionsOnlyInSecond;
+    }
+
+    /** @return immutable common reaction names whose stoichiometry or parameters differ */
+    public List<String> getParameterDifferences() {
+      return parameterDifferences;
+    }
+
+    /**
+     * @return true when data source, active reaction names, stoichiometry, and auditable parameters are identical
+     */
+    public boolean isEquivalent() {
+      return sameReactionDataSource && reactionsOnlyInFirst.isEmpty() && reactionsOnlyInSecond.isEmpty()
+          && parameterDifferences.isEmpty();
+    }
+
+    private static List<String> immutableCopy(List<String> values) {
+      return Collections.unmodifiableList(new ArrayList<String>(values));
+    }
+  }
+}

--- a/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionModelAuditTest.java
+++ b/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionModelAuditTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
@@ -23,8 +24,7 @@ class ChemicalReactionModelAuditTest {
 
     ChemicalReactionModelAudit.AuditSnapshot cpaAudit = ChemicalReactionModelAudit.inspect(cpa);
     ChemicalReactionModelAudit.AuditSnapshot pitzerAudit = ChemicalReactionModelAudit.inspect(pitzer);
-    ChemicalReactionModelAudit.AuditComparison comparison =
-        ChemicalReactionModelAudit.compare(cpaAudit, pitzerAudit);
+    ChemicalReactionModelAudit.AuditComparison comparison = ChemicalReactionModelAudit.compare(cpaAudit, pitzerAudit);
 
     assertNotEquals(cpaAudit.getModelName(), pitzerAudit.getModelName());
     assertTrue(cpaAudit.getReactionCount() > 0);
@@ -43,8 +43,7 @@ class ChemicalReactionModelAuditTest {
     SystemInterface cpa = reactiveCo2WaterSystem(new SystemElectrolyteCPAstatoil(298.15, 1.01325));
     SystemInterface kent = reactiveCo2WaterSystem(new SystemKentEisenberg(298.15, 1.01325));
 
-    ChemicalReactionModelAudit.AuditComparison comparison =
-        ChemicalReactionModelAudit.compare(cpa, kent);
+    ChemicalReactionModelAudit.AuditComparison comparison = ChemicalReactionModelAudit.compare(cpa, kent);
 
     assertFalse(comparison.hasSameReactionDataSource());
     assertFalse(comparison.isEquivalent());
@@ -63,6 +62,7 @@ class ChemicalReactionModelAuditTest {
     double[] modified = reaction.getEquilibriumConstantCoefficients();
     modified[0] = -123.0;
     assertArrayEquals(original, reaction.getEquilibriumConstantCoefficients(), 0.0);
+    assertNotSame(audit.getReactions(), audit.getReactions());
     assertThrows(UnsupportedOperationException.class, () -> audit.getReactions().clear());
   }
 

--- a/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionModelAuditTest.java
+++ b/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionModelAuditTest.java
@@ -1,0 +1,96 @@
+package neqsim.chemicalreactions.chemicalreaction;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemKentEisenberg;
+import neqsim.thermo.system.SystemPitzer;
+
+/** Tests model-to-model reaction set and parameter audit diagnostics. */
+class ChemicalReactionModelAuditTest {
+  /** Electrolyte CPA and Pitzer currently share the same active standard reaction data. */
+  @Test
+  void electrolyteEosAndGeCanBeAuditedWithoutAssumingInterchangeability() {
+    SystemInterface cpa = reactiveCo2WaterSystem(new SystemElectrolyteCPAstatoil(298.15, 1.01325));
+    SystemInterface pitzer = reactiveCo2WaterSystem(new SystemPitzer(298.15, 1.01325));
+
+    ChemicalReactionModelAudit.AuditSnapshot cpaAudit = ChemicalReactionModelAudit.inspect(cpa);
+    ChemicalReactionModelAudit.AuditSnapshot pitzerAudit = ChemicalReactionModelAudit.inspect(pitzer);
+    ChemicalReactionModelAudit.AuditComparison comparison =
+        ChemicalReactionModelAudit.compare(cpaAudit, pitzerAudit);
+
+    assertNotEquals(cpaAudit.getModelName(), pitzerAudit.getModelName());
+    assertTrue(cpaAudit.getReactionCount() > 0);
+    assertTrue(pitzerAudit.getReactionCount() > 0);
+    assertTrue(comparison.hasSameReactionDataSource());
+    assertTrue(comparison.getReactionsOnlyInFirst().isEmpty());
+    assertTrue(comparison.getReactionsOnlyInSecond().isEmpty());
+    assertTrue(comparison.getParameterDifferences().isEmpty());
+    assertTrue(comparison.isEquivalent());
+    assertNotNull(findReaction(cpaAudit, "CO2water"));
+  }
+
+  /** A dedicated Kent-Eisenberg source is reported as a parameter/source difference. */
+  @Test
+  void dedicatedApparentConstantSourceDoesNotCompareEquivalentToStandard() {
+    SystemInterface cpa = reactiveCo2WaterSystem(new SystemElectrolyteCPAstatoil(298.15, 1.01325));
+    SystemInterface kent = reactiveCo2WaterSystem(new SystemKentEisenberg(298.15, 1.01325));
+
+    ChemicalReactionModelAudit.AuditComparison comparison =
+        ChemicalReactionModelAudit.compare(cpa, kent);
+
+    assertFalse(comparison.hasSameReactionDataSource());
+    assertFalse(comparison.isEquivalent());
+    assertTrue(comparison.getParameterDifferences().contains("CO2water"));
+  }
+
+  /** Returned audit arrays and lists cannot mutate the underlying reaction data. */
+  @Test
+  void auditSnapshotsAreDefensiveAndImmutable() {
+    SystemInterface cpa = reactiveCo2WaterSystem(new SystemElectrolyteCPAstatoil(298.15, 1.01325));
+    ChemicalReactionModelAudit.AuditSnapshot audit = ChemicalReactionModelAudit.inspect(cpa);
+    ChemicalReactionModelAudit.ReactionParameterSnapshot reaction = findReaction(audit, "CO2water");
+    assertNotNull(reaction);
+
+    double[] original = reaction.getEquilibriumConstantCoefficients();
+    double[] modified = reaction.getEquilibriumConstantCoefficients();
+    modified[0] = -123.0;
+    assertArrayEquals(original, reaction.getEquilibriumConstantCoefficients(), 0.0);
+    assertThrows(UnsupportedOperationException.class, () -> audit.getReactions().clear());
+  }
+
+  /** Audit deliberately refuses to mutate an uninitialized system. */
+  @Test
+  void auditRequiresExplicitReactionInitialization() {
+    SystemInterface system = new SystemElectrolyteCPAstatoil(298.15, 1.01325);
+    system.addComponent("CO2", 0.01);
+    system.addComponent("water", 0.99);
+
+    assertThrows(IllegalStateException.class, () -> ChemicalReactionModelAudit.inspect(system));
+  }
+
+  private static SystemInterface reactiveCo2WaterSystem(SystemInterface system) {
+    system.addComponent("CO2", 0.01);
+    system.addComponent("water", 0.99);
+    system.chemicalReactionInit();
+    return system;
+  }
+
+  private static ChemicalReactionModelAudit.ReactionParameterSnapshot findReaction(
+      ChemicalReactionModelAudit.AuditSnapshot audit, String name) {
+    List<ChemicalReactionModelAudit.ReactionParameterSnapshot> reactions = audit.getReactions();
+    for (ChemicalReactionModelAudit.ReactionParameterSnapshot reaction : reactions) {
+      if (name.equals(reaction.getName())) {
+        return reaction;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Scientific/software question

Can NeqSim compare the *actual initialized* reaction set and stored equilibrium-parameter provenance across electrolyte EOS and electrolyte GE models before deciding whether those models need different active reactions or database tables?

Current master makes the selected table and per-reaction provenance inspectable, but callers still have to traverse internal reaction objects manually to answer whether two models initialize the same reactions and parameters. Electrolyte-CPA and Pitzer currently both select `STANDARD`; that shared selection is an implementation fact, not independent validation that the reaction set or parameters are interchangeable.

## Change

- adds side-effect-free `ChemicalReactionModelAudit.inspect(...)` snapshots;
- records model name, typed reaction-data source, deterministic active-reaction list, stoichiometry, stored reference, reference temperature, and equilibrium-constant coefficients;
- adds `compare(...)` to separate reaction-set differences from parameter/stoichiometry differences;
- returns immutable lists and defensive array copies;
- deliberately requires prior `chemicalReactionInit()` rather than mutating or implicitly initializing the system;
- documents the EOS/GE audit workflow and the scientific stop boundary.

No reaction is activated/deactivated. No reaction coefficient, database table, EOS/GE activity model, flash/stability path, hydrate path, salt input/API, or absorber equipment is changed. The utility is never called from the solve path, so neutral and non-audited electrolyte calculations add zero runtime work.

## Frozen scope

- Base/master: `5a851750f8d12b3a598a87da0acadb3faef8b4e6`
- Model examples: `SystemElectrolyteCPAstatoil`, `SystemPitzer`, and `SystemKentEisenberg`
- Composition basis: 0.01 mol CO2 + 0.99 mol water, reaction initialization only
- Current expected mapping: CPA/Pitzer -> `STANDARD`; Kent-Eisenberg -> `KENT_EISENBERG`
- Stop boundary: audit/comparison infrastructure only. This PR does **not** claim that CPA and Pitzer should share parameters, and it does not split tables without independent scientific evidence.

## Regression coverage

Added `ChemicalReactionModelAuditTest` for:

- explicit CPA-vs-Pitzer comparison of source, active reaction set, and stored parameters;
- Kent-Eisenberg detection as a distinct source/parameterization;
- immutable/defensive audit snapshots;
- fail-fast behavior before reaction initialization.

The tests intentionally distinguish regression evidence from scientific validation. They verify what the repository currently loads; they do not validate parameter accuracy.

## Scientific references/data

No external numerical data are copied, transformed, regressed, or redistributed. The documentation points to the existing carbonate-equilibrium foundation already referenced by NeqSim: Plummer & Busenberg (1982), DOI `10.1016/0016-7037(82)90056-4`, and to the Pitzer activity-coefficient framework as the relevant GE-model context. Existing repository data remain under Apache-2.0.

A future parameter/reaction-set change must separately document standard-state/species conventions, validity range, uncertainty, licensing, preprocessing, and independent validation evidence.

## Validation

`VALIDATION PENDING CI`

This run used the connected GitHub source as the authoritative implementation path. The exact branch contains only the three intended added files and is 3 commits ahead / 0 behind the frozen base. Local Maven/Spotless execution was not performed in this connector-only run, so no unrun gate is claimed as passed. Hosted CI must establish Java 8 compatibility, Spotless, pre-commit, Javadoc, documentation search, and focused/broader tests before readiness classification.

## Performance/compatibility

The new API is opt-in and side-effect-free. It adds no calls to neutral PR/SRK/CPA calculations and no calls to electrolyte solve paths unless explicitly invoked. Returned arrays are defensive copies; the implementation uses Java 8-compatible APIs.

## Coordination

- generic TP/phase-stability work remains #2937;
- reactive absorber equipment remains #205;
- salt input/API remains #448.

Next dependency after this PR is exact-head CI/review, then an evidence/license-qualified model-family audit using independent data before any split of active reactions or equilibrium-parameter tables.

Refs #3144