### PR TITLE
[AI-Assisted] fix(flash): refine high-pressure hydrogen boundary roots

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1948,6 +1948,27 @@ must satisfy the same normalization, material-balance, fugacity, property, repea
 disappearance, and reappearance gates listed above. Non-hydrogen feeds, hydrogen at or below one mole percent, and the
 established pressure-at-or-above-50-bar path are unchanged.
 
+The remaining `59.9 atm` hydrogen+methane point also qualifies the established high-pressure path at both calculated
+phase boundaries. Before the high-pressure boundary refinement, the ordinary SRK result `1e-4` inside the calculated
+liquid boundary retained the heavy-phase vapor-like cubic root (`Z = 0.605203`) instead of the lower liquid root
+(`Z = 0.256018`). The returned phase fractions and compositions were normalized and material-balanced, but the maximum
+log-fugacity residual was `1.25942` and total Gibbs energy was `3906.28697 J`, compared with `3734.24830 J` for the
+lower-root equilibrium.
+
+A bounded reciprocal ordinary/multiphase refinement now covers only neutral two-phase feeds above `50 bar` containing
+more than `0.01` overall hydrogen, at least one hydrocarbon, no other active non-inert component, and an incipient phase
+below `0.01`. It first retains the existing beta refinement and complete rollback behavior. An invalid endpoint may be
+replaced only by the reciprocal path when phase topology is preserved, all strict normalization, material-balance, and
+fugacity checks pass, and Gibbs energy is not increased. The corrected SRK residual is `1.63e-12`; PR remains within
+`1.00e-12`. The five-point SRK/PR matrix now checks compositions `1e-4` inside and outside both model boundaries, and
+the `40.2 atm` and `59.9 atm` points both cover poor initialization, deterministic repeat, phase disappearance, and
+reappearance.
+
+This is a correctness fallback, not a performance optimization. A constrained fresh-system probe (20 warmups and five
+blocks of 30 flashes) measured the corrected SRK boundary at about `8.5 ms/flash`, versus `4.3-5.4 ms/flash` for the
+invalid higher-root baseline. The PR boundary and adjacent retained one-phase controls were within run-to-run noise.
+Common flashes return before the hydrogen/high-pressure/incipient-phase screen.
+
 ---
 
 ## 7. References

--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1955,7 +1955,8 @@ liquid boundary retained the heavy-phase vapor-like cubic root (`Z = 0.605203`) 
 log-fugacity residual was `1.25942` and total Gibbs energy was `3906.28697 J`, compared with `3734.24830 J` for the
 lower-root equilibrium.
 
-A bounded reciprocal ordinary/multiphase refinement now covers only neutral two-phase feeds above `50 bar` containing
+A bounded reciprocal ordinary/multiphase refinement now covers only neutral two-phase feeds at or above `50 bar`
+containing
 more than `0.01` overall hydrogen, at least one hydrocarbon, no other active non-inert component, and an incipient phase
 below `0.01`. It first retains the existing beta refinement and complete rollback behavior. An invalid endpoint may be
 replaced only by the reciprocal path when phase topology is preserved, all strict normalization, material-balance, and

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -2116,14 +2116,15 @@ public class TPflash extends Flash {
   }
 
   /**
-   * Performs a bounded final SSI refinement of a stale neutral gas/liquid two-phase endpoint.
+   * Performs a bounded final refinement of a qualified neutral gas/liquid two-phase endpoint.
    *
    * <p>
    * Post-convergence phase-root selection can leave a gas/oil split with valid material balance but component
-   * fugacities just outside the flash tolerance. The refinement is attempted only for a neutral, non-aqueous,
-   * exactly-two-phase endpoint whose material balance already closes. It retains the selected active set and accepts
+   * fugacities outside the flash tolerance. The refinement is attempted only for a qualified sour-gas endpoint or a
+   * high-pressure hydrogen/hydrocarbon endpoint with an incipient phase. It retains the selected active set and accepts
    * the result only when phase fractions, compositions, material balance, fugacity equality, and Gibbs energy pass the
-   * existing strict checks. Otherwise the complete two-phase iteration state is restored.
+   * existing strict checks. A reciprocal ordinary/multiphase trial can recover a lower cubic root; otherwise the
+   * complete two-phase iteration state is restored.
    * </p>
    */
   private void refineInvalidNeutralTwoPhaseEndpoint() {
@@ -2138,7 +2139,8 @@ public class TPflash extends Flash {
       }
     }
 
-    if (!isSourGasConsistencyRefinementCase()) {
+    boolean hydrogenBoundaryCase = isHydrogenHydrocarbonBoundaryRefinementCase();
+    if (!isSourGasConsistencyRefinementCase() && !hydrogenBoundaryCase) {
       return;
     }
 
@@ -2381,6 +2383,41 @@ public class TPflash extends Flash {
     }
     return carbonDioxideFraction >= 0.05 && hydrogenSulfideFraction >= 0.20
         && carbonDioxideFraction + hydrogenSulfideFraction >= 0.30 && hydrocarbonFraction > 0.0;
+  }
+
+  /**
+   * Screens a high-pressure hydrogen/hydrocarbon endpoint with an incipient second phase.
+   *
+   * <p>
+   * Near a hydrogen-rich phase boundary, the ordinary flash can retain a higher-Gibbs cubic root while the explicit
+   * multiphase path selects the lower root. The reciprocal refinement remains restricted to neutral feeds containing
+   * only hydrogen, hydrocarbons, and inert components, with more than one mole percent hydrogen and a secondary phase
+   * below one percent. Lower-pressure hydrogen phase appearance is handled by the supplementary stability trial.
+   * </p>
+   *
+   * @return true when the endpoint is inside the qualified hydrogen/hydrocarbon boundary family
+   */
+  private boolean isHydrogenHydrocarbonBoundaryRefinementCase() {
+    if (system.getPressure() < 50.0 || system.getNumberOfPhases() != 2
+        || Math.min(system.getBeta(0), system.getBeta(1)) >= INVALID_INCIPIENT_PHASE_FRACTION_LIMIT) {
+      return false;
+    }
+    double hydrogenFraction = 0.0;
+    boolean hasHydrocarbon = false;
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      if (component.getz() <= 1.0e-50) {
+        continue;
+      }
+      if ("hydrogen".equalsIgnoreCase(component.getComponentName())) {
+        hydrogenFraction += component.getz();
+      } else if (component.isHydrocarbon()) {
+        hasHydrocarbon = true;
+      } else if (!component.isInert()) {
+        return false;
+      }
+    }
+    return hydrogenFraction > 1.0e-2 && hasHydrocarbon;
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashHydrogenLiteratureConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashHydrogenLiteratureConsistencyTest.java
@@ -64,9 +64,6 @@ class TPflashHydrogenLiteratureConsistencyTest extends neqsim.NeqSimTest {
   void calculatedBoundariesPreserveTinyPhasesAndAdjacentSinglePhaseStates() {
     for (Eos eos : Eos.values()) {
       for (TieLine tieLine : TIE_LINES) {
-        if (tieLine.pressureBar() >= 50.0) {
-          continue;
-        }
         SystemInterface midpoint = flash(createSystem(eos, tieLine, tieLine.midpoint(), false), false);
         Integer[] order = phaseOrder(midpoint);
         double vaporHydrogen = midpoint.getPhase(order[0]).getComponent("hydrogen").getx();
@@ -86,31 +83,32 @@ class TPflashHydrogenLiteratureConsistencyTest extends neqsim.NeqSimTest {
 
   @Test
   void calculatedBoundaryTransitionsDoNotRetainStalePhaseState() {
-    TieLine tieLine = TIE_LINES[1];
-    for (Eos eos : Eos.values()) {
-      SystemInterface midpoint = flash(createSystem(eos, tieLine, tieLine.midpoint(), false), false);
-      double vaporHydrogen = midpoint.getPhase(phaseOrder(midpoint)[0]).getComponent("hydrogen").getx();
-      double insideHydrogen = vaporHydrogen - BOUNDARY_COMPOSITION_OFFSET;
-      double outsideHydrogen = vaporHydrogen + BOUNDARY_COMPOSITION_OFFSET;
+    for (TieLine tieLine : new TieLine[] { TIE_LINES[1], TIE_LINES[2] }) {
+      for (Eos eos : Eos.values()) {
+        SystemInterface midpoint = flash(createSystem(eos, tieLine, tieLine.midpoint(), false), false);
+        double vaporHydrogen = midpoint.getPhase(phaseOrder(midpoint)[0]).getComponent("hydrogen").getx();
+        double insideHydrogen = vaporHydrogen - BOUNDARY_COMPOSITION_OFFSET;
+        double outsideHydrogen = vaporHydrogen + BOUNDARY_COMPOSITION_OFFSET;
 
-      for (boolean multiphase : new boolean[] { false, true }) {
-        SystemInterface insideReference = flash(createSystem(eos, tieLine, insideHydrogen, multiphase), false);
-        SystemInterface poorGuess = flash(createSystem(eos, tieLine, insideHydrogen, multiphase), true);
-        assertEquivalent(insideReference, poorGuess, tieLine.label(eos) + " boundary poor initialization");
+        for (boolean multiphase : new boolean[] { false, true }) {
+          SystemInterface insideReference = flash(createSystem(eos, tieLine, insideHydrogen, multiphase), false);
+          SystemInterface poorGuess = flash(createSystem(eos, tieLine, insideHydrogen, multiphase), true);
+          assertEquivalent(insideReference, poorGuess, tieLine.label(eos) + " boundary poor initialization");
 
-        SystemInterface repeatedReference = insideReference.clone();
-        flash(insideReference, false);
-        assertEquivalent(repeatedReference, insideReference, tieLine.label(eos) + " boundary repeat");
+          SystemInterface repeatedReference = insideReference.clone();
+          flash(insideReference, false);
+          assertEquivalent(repeatedReference, insideReference, tieLine.label(eos) + " boundary repeat");
 
-        insideReference.setMolarComposition(new double[] { outsideHydrogen, 1.0 - outsideHydrogen });
-        flash(insideReference, false);
-        SystemInterface outsideReference = flash(createSystem(eos, tieLine, outsideHydrogen, multiphase), false);
-        assertEquals(1, outsideReference.getNumberOfPhases(), tieLine.label(eos) + " boundary disappearance");
-        assertEquivalent(outsideReference, insideReference, tieLine.label(eos) + " boundary disappearance");
+          insideReference.setMolarComposition(new double[] { outsideHydrogen, 1.0 - outsideHydrogen });
+          flash(insideReference, false);
+          SystemInterface outsideReference = flash(createSystem(eos, tieLine, outsideHydrogen, multiphase), false);
+          assertEquals(1, outsideReference.getNumberOfPhases(), tieLine.label(eos) + " boundary disappearance");
+          assertEquivalent(outsideReference, insideReference, tieLine.label(eos) + " boundary disappearance");
 
-        insideReference.setMolarComposition(new double[] { insideHydrogen, 1.0 - insideHydrogen });
-        flash(insideReference, false);
-        assertEquivalent(poorGuess, insideReference, tieLine.label(eos) + " boundary reappearance");
+          insideReference.setMolarComposition(new double[] { insideHydrogen, 1.0 - insideHydrogen });
+          flash(insideReference, false);
+          assertEquivalent(poorGuess, insideReference, tieLine.label(eos) + " boundary reappearance");
+        }
       }
     }
   }


### PR DESCRIPTION
Refs #2937

## Summary

This fixes the remaining high-pressure H₂+hydrocarbon phase-boundary inconsistency in TP flash finalization.

At 173.65 K and 59.9 atm, the ordinary SRK path returned the same phase fractions and compositions as the explicit multiphase path but retained a vapor-like heavy-phase cubic root:

- ordinary heavy-phase `Z = 0.605203`, total Gibbs energy `3906.28697 J`
- lower-root equilibrium `Z = 0.256018`, total Gibbs energy `3734.24830 J`
- maximum ordinary log-fugacity residual `1.25942`

The existing safeguarded reciprocal ordinary/multiphase finalization was limited to sour-gas cases. This change admits the H₂ endpoint only under a strict private screen:

- pressure at or above 50 bar
- exactly two neutral GAS/OIL/LIQUID phases
- incipient phase fraction below 0.01
- overall H₂ above 0.01
- at least one hydrocarbon
- no active component other than hydrogen, hydrocarbon, or inert

The existing beta refinement, active-set/topology checks, material-balance and fugacity acceptance, Gibbs non-increase requirement, recursion guard, complete snapshot rollback, and tolerances remain authoritative. Public API and configuration are unchanged.

## Correctness evidence

After refinement:

- SRK maximum log-fugacity residual: `1.63e-12`
- PR maximum log-fugacity residual: `1.00e-12`
- ordinary and explicit multiphase paths agree on phase count, beta, compositions, Z, and Gibbs energy
- material balance, bounded/normalized compositions, deterministic repeats, disappearance, and reappearance are enforced

The literature matrix now covers all five published H₂+methane/ethane tie lines from Sagara, Arai, and Saito (1972), for both SRK and PR, at compositions `1e-4` inside and outside both calculated phase boundaries. The 40.2 atm and 59.9 atm cases cover poor initialization, exact repeat, changed-state disappearance, and reappearance for both ordinary and multiphase paths.

## Validation

Exact local base: `5a851750f8d12b3a598a87da0acadb3faef8b4e6`  
Exact PR head: `a1551f343dd24ff53bdb67719f8f02d915eaa796`

Passed locally:

- new H₂ qualification class: 5/5
- focused and cross-algorithm flash suite: 24/24
- Spotless apply/check
- documentation search (656 Markdown files and 1 HTML file)
- pre-commit stage
- pre-push stage
- `git diff --check`

Hosted exact-head PaperLab, Spotless, pre-commit, documentation search, CodeQL, Java 21 Javadoc, Java 21 fast tests on Ubuntu and Windows, all four Java 21 slow-test shards, and Java 8 Windows pass. The documentation workflow's first Jekyll attempt failed only on a GitHub API HTTP 504 and its retry succeeded. The aggregate Java workflow ultimately failed only in Java 8 Ubuntu on the pre-existing, unrelated `MultiInputMixerPhaseRegressionTest` numerical drift; no flash test failed.

## Performance

This is a correctness fallback, not a speed optimization. A constrained fresh-system probe used 20 warmups and five blocks of 30 flashes:

- corrected SRK boundary: about 8.5 ms/flash
- invalid higher-root baseline: 4.3–5.4 ms/flash
- PR boundary and retained adjacent one-phase controls: within run-to-run noise

Common flashes return before the hydrogen/high-pressure/incipient-phase screen.

## Documentation and scope

The TP-flash algorithm documentation records the reproduced defect, guard, acceptance rules, residuals, full boundary matrix, performance evidence, data provenance, units, and limitations.

Scope is limited to flash-owned neutral H₂+hydrocarbon high-pressure boundary finalization. No column-solver, process-performance, public-API, data-ingestion, or Huldra work is included.

**MERGED; FLASH SCOPE VALIDATED. AGGREGATE CI RETAINS AN UNRELATED JAVA 8 UBUNTU MIXER BASELINE FAILURE.**