### PR TITLE
[AI-Assisted] fix(thermo): use molality activities for Pitzer reactions

### DIFF
--- a/docs/thermo/reaction_model_audit.md
+++ b/docs/thermo/reaction_model_audit.md
@@ -24,15 +24,15 @@ ChemicalReactionModelAudit.AuditComparison comparison =
     ChemicalReactionModelAudit.compare(cpa, pitzer);
 ```
 
-The audit reports the selected typed data source, deterministic active-reaction list, stoichiometry, stored literature/data reference, reference temperature, and equilibrium-constant coefficients. The comparison separates reactions present in only one model from common reactions whose stored parameters differ.
+The audit reports the selected typed data source, reaction-quotient concentration basis, deterministic active-reaction list, stoichiometry, stored literature/data reference, reference temperature, and equilibrium-constant coefficients. The comparison separates concentration conventions, reactions present in only one model, and common reactions whose stored parameters differ.
 
 The API is deliberately read-only. It requires `chemicalReactionInit()` to have been called and never initializes reactions implicitly, runs a flash, or changes model state. It therefore adds no work to ordinary neutral PR/SRK/CPA calculations and no work to electrolyte calculations unless the audit is explicitly requested.
 
-## Pitzer concentration basis
+## Pitzer reaction concentration basis
 
-`SystemPitzer` evaluates solute molality as moles of solute per kilogram of water solvent. This is the concentration basis of the Pitzer ion-interaction equations, rather than moles per kilogram of total solution. The distinction grows with salinity and affects ionic strength, activity coefficients, osmotic properties, reactive speciation, and mineral saturation.
+`SystemPitzer` evaluates solute activities from molality, defined as moles of solute per kilogram of water solvent, while solvent activity retains its mole-fraction convention. This matches the concentration basis of the Pitzer ion-interaction equations and the thermodynamic carbonate constants represented in the standard reaction table. Electrolyte EOS and Kent-Eisenberg systems retain their existing reaction conventions.
 
-The basis correction is confined to `ComponentGePitzer`; electrolyte EOS and neutral calculations keep their existing paths. It does not split the shared reaction table or change any stored equilibrium-constant coefficient. Pitzer's thermodynamic framework is documented in DOI `10.1021/j100621a026` and the binary-electrolyte formulation in DOI `10.1021/j100638a009`.
+The concentration-basis selector changes only Pitzer chemical-reaction quotients and mineral saturation ratios. It does not split the shared reaction table or change any stored equilibrium or Pitzer interaction coefficient. Pitzer's thermodynamic framework is documented in DOI `10.1021/j100621a026` and the binary-electrolyte formulation in DOI `10.1021/j100638a009`.
 
 ## Scientific use
 

--- a/docs/thermo/reaction_model_audit.md
+++ b/docs/thermo/reaction_model_audit.md
@@ -28,6 +28,12 @@ The audit reports the selected typed data source, deterministic active-reaction 
 
 The API is deliberately read-only. It requires `chemicalReactionInit()` to have been called and never initializes reactions implicitly, runs a flash, or changes model state. It therefore adds no work to ordinary neutral PR/SRK/CPA calculations and no work to electrolyte calculations unless the audit is explicitly requested.
 
+## Pitzer concentration basis
+
+`SystemPitzer` evaluates solute molality as moles of solute per kilogram of water solvent. This is the concentration basis of the Pitzer ion-interaction equations, rather than moles per kilogram of total solution. The distinction grows with salinity and affects ionic strength, activity coefficients, osmotic properties, reactive speciation, and mineral saturation.
+
+The basis correction is confined to `ComponentGePitzer`; electrolyte EOS and neutral calculations keep their existing paths. It does not split the shared reaction table or change any stored equilibrium-constant coefficient. Pitzer's thermodynamic framework is documented in DOI `10.1021/j100621a026` and the binary-electrolyte formulation in DOI `10.1021/j100638a009`.
+
 ## Scientific use
 
 Use this diagnostic to freeze model-specific validation questions before changing reaction data:

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReaction.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReaction.java
@@ -208,9 +208,10 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
    */
   public double calcKx(neqsim.thermo.system.SystemInterface system, int phaseNumb) {
     double kx = 1.0;
+    PhaseInterface phase = system.getPhase(phaseNumb);
     for (int i = 0; i < names.length; i++) {
-      // System.out.println("name " + names[i] + " stcoc " + stocCoefs[i]);
-      kx *= Math.pow(system.getPhase(phaseNumb).getComponent(names[i]).getx(), stocCoefs[i]);
+      ComponentInterface component = phase.getComponent(names[i]);
+      kx *= Math.pow(getReactionConcentration(system, phase, component), stocCoefs[i]);
     }
     return kx;
   }
@@ -244,13 +245,14 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
    */
   public double getSaturationRatio(neqsim.thermo.system.SystemInterface system, int phaseNumb) {
     double ksp = 1.0;
+    PhaseInterface phase = system.getPhase(phaseNumb);
     for (int i = 0; i < names.length; i++) {
-      // System.out.println("name " + names[i] + " stcoc " + stocCoefs[i]);
       if (stocCoefs[i] < 0) {
-        ksp *= Math.pow(system.getPhase(phaseNumb).getComponent(names[i]).getx(), -stocCoefs[i]);
+        ComponentInterface component = phase.getComponent(names[i]);
+        ksp *= Math.pow(getReactionConcentration(system, phase, component), -stocCoefs[i]);
       }
     }
-    ksp /= (getK(system.getPhase(phaseNumb)));
+    ksp /= getK(phase);
     return ksp;
   }
 
@@ -286,7 +288,7 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
         continue;
       }
       ComponentInterface component = phase.getComponent(names[componentIndex]);
-      double logActivity = Math.log(component.getx());
+      double logActivity = Math.log(getReactionConcentration(system, phase, component));
       if (component.calcActivity()) {
         double activityCoefficient = phase.getActivityCoefficient(component.getComponentNumber(),
             phase.getComponent("water").getComponentNumber());
@@ -306,6 +308,28 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
    */
   public double calcLogReactionResidual(SystemInterface system, int phaseNumb) {
     return calcLogReactionQuotient(system, phaseNumb) - Math.log(getK(system.getPhase(phaseNumb)));
+  }
+
+  /**
+   * Get the dimensionless concentration used by the system's reaction-equilibrium convention.
+   *
+   * <p>
+   * Pitzer equilibrium constants use solute molality divided by the standard molality of 1 mol/kg. Solvent activities
+   * remain on the mole-fraction convention. Other models retain the established mole-fraction concentration path.
+   * </p>
+   *
+   * @param system thermodynamic system selecting the reaction convention
+   * @param phase reactive phase
+   * @param component reaction component
+   * @return dimensionless reaction concentration
+   */
+  private double getReactionConcentration(SystemInterface system, PhaseInterface phase,
+      ComponentInterface component) {
+    if (system.getChemicalReactionConcentrationBasis() == ChemicalReactionConcentrationBasis.SOLUTE_MOLALITY
+        && !"solvent".equalsIgnoreCase(component.getReferenceStateType())) {
+      return component.getMolality(phase);
+    }
+    return component.getx();
   }
 
   /**

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReaction.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReaction.java
@@ -323,8 +323,7 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
    * @param component reaction component
    * @return dimensionless reaction concentration
    */
-  private double getReactionConcentration(SystemInterface system, PhaseInterface phase,
-      ComponentInterface component) {
+  private double getReactionConcentration(SystemInterface system, PhaseInterface phase, ComponentInterface component) {
     if (system.getChemicalReactionConcentrationBasis() == ChemicalReactionConcentrationBasis.SOLUTE_MOLALITY
         && !"solvent".equalsIgnoreCase(component.getReferenceStateType())) {
       return component.getMolality(phase);

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionConcentrationBasis.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionConcentrationBasis.java
@@ -1,0 +1,10 @@
+package neqsim.chemicalreactions.chemicalreaction;
+
+/** Concentration convention used to evaluate dimensionless chemical-reaction quotients. */
+public enum ChemicalReactionConcentrationBasis {
+  /** Mole fraction multiplied by the model's activity coefficient. */
+  MOLE_FRACTION,
+
+  /** Solute molality divided by 1 mol/kg; solvent activity remains on the mole-fraction convention. */
+  SOLUTE_MOLALITY
+}

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionModelAudit.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionModelAudit.java
@@ -52,7 +52,8 @@ public final class ChemicalReactionModelAudit {
       reactions.add(new ReactionParameterSnapshot(reaction));
     }
     Collections.sort(reactions);
-    return new AuditSnapshot(system.getModelName(), operations.getReactionDataSource(), reactions);
+    return new AuditSnapshot(system.getModelName(), operations.getReactionDataSource(),
+        system.getChemicalReactionConcentrationBasis(), reactions);
   }
 
   /**
@@ -97,20 +98,23 @@ public final class ChemicalReactionModelAudit {
       }
     }
 
-    return new AuditComparison(first.getReactionDataSource() == second.getReactionDataSource(), onlyInFirst,
-        onlyInSecond, parameterDifferences);
+    return new AuditComparison(first.getReactionDataSource() == second.getReactionDataSource(),
+        first.getReactionConcentrationBasis() == second.getReactionConcentrationBasis(), onlyInFirst, onlyInSecond,
+        parameterDifferences);
   }
 
   /** Immutable snapshot of one system's selected reaction source and active reactions. */
   public static final class AuditSnapshot {
     private final String modelName;
     private final ChemicalReactionDataSource reactionDataSource;
+    private final ChemicalReactionConcentrationBasis reactionConcentrationBasis;
     private final List<ReactionParameterSnapshot> reactions;
 
     private AuditSnapshot(String modelName, ChemicalReactionDataSource reactionDataSource,
-        List<ReactionParameterSnapshot> reactions) {
+        ChemicalReactionConcentrationBasis reactionConcentrationBasis, List<ReactionParameterSnapshot> reactions) {
       this.modelName = modelName;
       this.reactionDataSource = reactionDataSource;
+      this.reactionConcentrationBasis = reactionConcentrationBasis;
       this.reactions = Collections.unmodifiableList(new ArrayList<ReactionParameterSnapshot>(reactions));
     }
 
@@ -122,6 +126,11 @@ public final class ChemicalReactionModelAudit {
     /** @return selected reaction-data source */
     public ChemicalReactionDataSource getReactionDataSource() {
       return reactionDataSource;
+    }
+
+    /** @return concentration basis used to evaluate reaction quotients */
+    public ChemicalReactionConcentrationBasis getReactionConcentrationBasis() {
+      return reactionConcentrationBasis;
     }
 
     /** @return immutable active-reaction snapshots in deterministic name order */
@@ -215,13 +224,15 @@ public final class ChemicalReactionModelAudit {
   /** Immutable difference summary between two reaction-model audit snapshots. */
   public static final class AuditComparison {
     private final boolean sameReactionDataSource;
+    private final boolean sameReactionConcentrationBasis;
     private final List<String> reactionsOnlyInFirst;
     private final List<String> reactionsOnlyInSecond;
     private final List<String> parameterDifferences;
 
-    private AuditComparison(boolean sameReactionDataSource, List<String> reactionsOnlyInFirst,
-        List<String> reactionsOnlyInSecond, List<String> parameterDifferences) {
+    private AuditComparison(boolean sameReactionDataSource, boolean sameReactionConcentrationBasis,
+        List<String> reactionsOnlyInFirst, List<String> reactionsOnlyInSecond, List<String> parameterDifferences) {
       this.sameReactionDataSource = sameReactionDataSource;
+      this.sameReactionConcentrationBasis = sameReactionConcentrationBasis;
       this.reactionsOnlyInFirst = immutableCopy(reactionsOnlyInFirst);
       this.reactionsOnlyInSecond = immutableCopy(reactionsOnlyInSecond);
       this.parameterDifferences = immutableCopy(parameterDifferences);
@@ -230,6 +241,11 @@ public final class ChemicalReactionModelAudit {
     /** @return true when both systems selected the same typed reaction-data source */
     public boolean hasSameReactionDataSource() {
       return sameReactionDataSource;
+    }
+
+    /** @return true when both systems use the same reaction-quotient concentration basis */
+    public boolean hasSameReactionConcentrationBasis() {
+      return sameReactionConcentrationBasis;
     }
 
     /** @return immutable reaction names active only in the first system */
@@ -251,7 +267,8 @@ public final class ChemicalReactionModelAudit {
      * @return true when data source, active reaction names, stoichiometry, and auditable parameters are identical
      */
     public boolean isEquivalent() {
-      return sameReactionDataSource && reactionsOnlyInFirst.isEmpty() && reactionsOnlyInSecond.isEmpty()
+      return sameReactionDataSource && sameReactionConcentrationBasis && reactionsOnlyInFirst.isEmpty()
+          && reactionsOnlyInSecond.isEmpty()
           && parameterDifferences.isEmpty();
     }
 

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionModelAudit.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionModelAudit.java
@@ -268,8 +268,7 @@ public final class ChemicalReactionModelAudit {
      */
     public boolean isEquivalent() {
       return sameReactionDataSource && sameReactionConcentrationBasis && reactionsOnlyInFirst.isEmpty()
-          && reactionsOnlyInSecond.isEmpty()
-          && parameterDifferences.isEmpty();
+          && reactionsOnlyInSecond.isEmpty() && parameterDifferences.isEmpty();
     }
 
     private static List<String> immutableCopy(List<String> values) {

--- a/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
@@ -46,28 +46,6 @@ public class ComponentGePitzer extends ComponentGE {
   }
 
   /**
-   * {@inheritDoc}
-   *
-   * <p>
-   * Pitzer ion-interaction equations use moles of solute per kilogram of water solvent. The generic component
-   * implementation derives moles per kilogram of total solution from molarity and density, which is not the Pitzer
-   * concentration basis at finite salinity.
-   * </p>
-   */
-  @Override
-  public double getMolality(PhaseInterface phase) {
-    if (!phase.hasComponent("water")) {
-      return super.getMolality(phase);
-    }
-    ComponentInterface water = phase.getComponent("water");
-    double solventMassKg = water.getNumberOfMolesInPhase() * water.getMolarMass();
-    if (!(solventMassKg > 0.0) || !Double.isFinite(solventMassKg)) {
-      return super.getMolality(phase);
-    }
-    return getNumberOfMolesInPhase() / solventMassKg;
-  }
-
-  /**
    * Check the database molecular formula for a pure hydrocarbon.
    *
    * <p>

--- a/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
@@ -46,6 +46,28 @@ public class ComponentGePitzer extends ComponentGE {
   }
 
   /**
+   * {@inheritDoc}
+   *
+   * <p>
+   * Pitzer ion-interaction equations use moles of solute per kilogram of water solvent. The generic component
+   * implementation derives moles per kilogram of total solution from molarity and density, which is not the Pitzer
+   * concentration basis at finite salinity.
+   * </p>
+   */
+  @Override
+  public double getMolality(PhaseInterface phase) {
+    if (!phase.hasComponent("water")) {
+      return super.getMolality(phase);
+    }
+    ComponentInterface water = phase.getComponent("water");
+    double solventMassKg = water.getNumberOfMolesInPhase() * water.getMolarMass();
+    if (!(solventMassKg > 0.0) || !Double.isFinite(solventMassKg)) {
+      return super.getMolality(phase);
+    }
+    return getNumberOfMolesInPhase() / solventMassKg;
+  }
+
+  /**
    * Check the database molecular formula for a pure hydrocarbon.
    *
    * <p>

--- a/src/main/java/neqsim/thermo/system/SystemInterface.java
+++ b/src/main/java/neqsim/thermo/system/SystemInterface.java
@@ -1,6 +1,7 @@
 package neqsim.thermo.system;
 
 import neqsim.chemicalreactions.ChemicalReactionOperations;
+import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionConcentrationBasis;
 import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionDataSource;
 import neqsim.physicalproperties.PhysicalPropertyType;
 import neqsim.physicalproperties.interfaceproperties.InterphasePropertiesInterface;
@@ -664,6 +665,15 @@ public interface SystemInterface extends Cloneable, java.io.Serializable {
    */
   public default ChemicalReactionDataSource getChemicalReactionDataSource() {
     return ChemicalReactionDataSource.STANDARD;
+  }
+
+  /**
+   * Get the concentration basis used to evaluate chemical-reaction quotients.
+   *
+   * @return reaction concentration basis used by chemical equilibrium
+   */
+  public default ChemicalReactionConcentrationBasis getChemicalReactionConcentrationBasis() {
+    return ChemicalReactionConcentrationBasis.MOLE_FRACTION;
   }
 
   /**

--- a/src/main/java/neqsim/thermo/system/SystemPitzer.java
+++ b/src/main/java/neqsim/thermo/system/SystemPitzer.java
@@ -12,7 +12,8 @@ import neqsim.thermo.phase.PhaseSrkEos;
  * calling {@code setMultiPhaseCheck(true)} before running the flash. Phase disappearance only changes the active
  * mapping; repeated flashes, cloning and serialization retain the role objects. Systems initialized through
  * {@code chemicalReactionInit()} alternate fixed-role phase equilibrium with chemical equilibrium in the Pitzer aqueous
- * phase, enabling reactive gas-aqueous and gas-oil-aqueous scale-potential calculations.
+ * phase, enabling reactive gas-aqueous and gas-oil-aqueous scale-potential calculations. Pitzer solute molalities
+ * are evaluated per kilogram of water solvent, independent of dissolved-salt mass.
  * </p>
  *
  * <p>

--- a/src/main/java/neqsim/thermo/system/SystemPitzer.java
+++ b/src/main/java/neqsim/thermo/system/SystemPitzer.java
@@ -1,5 +1,6 @@
 package neqsim.thermo.system;
 
+import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionConcentrationBasis;
 import neqsim.thermo.phase.PhasePitzer;
 import neqsim.thermo.phase.PhaseSrkEos;
 
@@ -12,8 +13,7 @@ import neqsim.thermo.phase.PhaseSrkEos;
  * calling {@code setMultiPhaseCheck(true)} before running the flash. Phase disappearance only changes the active
  * mapping; repeated flashes, cloning and serialization retain the role objects. Systems initialized through
  * {@code chemicalReactionInit()} alternate fixed-role phase equilibrium with chemical equilibrium in the Pitzer aqueous
- * phase, enabling reactive gas-aqueous and gas-oil-aqueous scale-potential calculations. Pitzer solute molalities
- * are evaluated per kilogram of water solvent, independent of dissolved-salt mass.
+ * phase, enabling reactive gas-aqueous and gas-oil-aqueous scale-potential calculations.
  * </p>
  *
  * <p>
@@ -66,6 +66,12 @@ public class SystemPitzer extends SystemEosGE {
     for (int i = 1; i < numberOfPhases; i++) {
       phaseArray[i].initRefPhases(false);
     }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ChemicalReactionConcentrationBasis getChemicalReactionConcentrationBasis() {
+    return ChemicalReactionConcentrationBasis.SOLUTE_MOLALITY;
   }
 
   /** {@inheritDoc} */

--- a/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionModelAuditTest.java
+++ b/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionModelAuditTest.java
@@ -30,10 +30,11 @@ class ChemicalReactionModelAuditTest {
     assertTrue(cpaAudit.getReactionCount() > 0);
     assertTrue(pitzerAudit.getReactionCount() > 0);
     assertTrue(comparison.hasSameReactionDataSource());
+    assertFalse(comparison.hasSameReactionConcentrationBasis());
     assertTrue(comparison.getReactionsOnlyInFirst().isEmpty());
     assertTrue(comparison.getReactionsOnlyInSecond().isEmpty());
     assertTrue(comparison.getParameterDifferences().isEmpty());
-    assertTrue(comparison.isEquivalent());
+    assertFalse(comparison.isEquivalent());
     assertNotNull(findReaction(cpaAudit, "CO2water"));
   }
 

--- a/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
@@ -240,6 +240,27 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
     assertEquals(1.0, gammaNa * naMolality * gammaCl * clMolality / naclKsp, 1.0e-3);
   }
 
+  /** Pitzer molality is solute amount per kilogram of water, not per kilogram of solution. */
+  @Test
+  public void testMolalityUsesWaterSolventMass() {
+    SystemInterface system = new SystemPitzer(298.15, 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("Na+", 1.0);
+    system.addComponent("Cl-", 1.0);
+    system.setMixingRule("classic");
+    system.init(0);
+    system.init(1);
+
+    PhaseInterface phase = system.getPhase(1);
+    double waterMassKg = phase.getComponent("water").getNumberOfMolesInPhase()
+        * phase.getComponent("water").getMolarMass();
+    double expectedMolality = 1.0 / waterMassKg;
+
+    assertEquals(expectedMolality, phase.getComponent("Na+").getMolality(phase), 1.0e-12);
+    assertEquals(expectedMolality, phase.getComponent("Cl-").getMolality(phase), 1.0e-12);
+    assertEquals(expectedMolality, ((PhasePitzer) phase).getIonicStrength(), 1.0e-12);
+  }
+
   /**
    * Verify NaCl mean ionic activity and osmotic coefficients against standard Pitzer literature values at 25 C.
    */

--- a/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import neqsim.chemicalreactions.chemicalreaction.ChemicalReaction;
+import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionConcentrationBasis;
 import neqsim.thermo.phase.PhaseInterface;
 import neqsim.thermo.phase.PhasePitzer;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -240,9 +242,9 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
     assertEquals(1.0, gammaNa * naMolality * gammaCl * clMolality / naclKsp, 1.0e-3);
   }
 
-  /** Pitzer molality is solute amount per kilogram of water, not per kilogram of solution. */
+  /** Pitzer reaction quotients use solute molality with solvent mole-fraction activity. */
   @Test
-  public void testMolalityUsesWaterSolventMass() {
+  public void testReactionQuotientUsesPitzerMolalityBasis() {
     SystemInterface system = new SystemPitzer(298.15, 1.01325);
     system.addComponent("water", 55.508);
     system.addComponent("Na+", 1.0);
@@ -252,13 +254,21 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
     system.init(1);
 
     PhaseInterface phase = system.getPhase(1);
-    double waterMassKg = phase.getComponent("water").getNumberOfMolesInPhase()
-        * phase.getComponent("water").getMolarMass();
-    double expectedMolality = 1.0 / waterMassKg;
+    int waterNumber = phase.getComponent("water").getComponentNumber();
+    double sodiumMolality = phase.getComponent("Na+").getMolality(phase);
+    double chlorideMolality = phase.getComponent("Cl-").getMolality(phase);
+    double sodiumGamma = phase.getActivityCoefficient(phase.getComponent("Na+").getComponentNumber(), waterNumber);
+    double chlorideGamma = phase.getActivityCoefficient(phase.getComponent("Cl-").getComponentNumber(), waterNumber);
+    double expectedLogQuotient = Math.log(sodiumMolality * sodiumGamma)
+        + Math.log(chlorideMolality * chlorideGamma);
 
-    assertEquals(expectedMolality, phase.getComponent("Na+").getMolality(phase), 1.0e-12);
-    assertEquals(expectedMolality, phase.getComponent("Cl-").getMolality(phase), 1.0e-12);
-    assertEquals(expectedMolality, ((PhasePitzer) phase).getIonicStrength(), 1.0e-12);
+    ChemicalReaction ionicProduct = new ChemicalReaction("PitzerMolalityProbe", new String[] { "Na+", "Cl-" },
+        new double[] { 1.0, 1.0 }, new double[] { 0.0, 0.0, 0.0, 0.0 }, 0.0, 0.0, 298.15);
+
+    assertEquals(ChemicalReactionConcentrationBasis.SOLUTE_MOLALITY,
+        system.getChemicalReactionConcentrationBasis());
+    assertEquals(sodiumMolality * chlorideMolality, ionicProduct.calcKx(system, 1), 1.0e-12);
+    assertEquals(expectedLogQuotient, ionicProduct.calcLogReactionQuotient(system, 1), 1.0e-12);
   }
 
   /**

--- a/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
@@ -259,14 +259,12 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
     double chlorideMolality = phase.getComponent("Cl-").getMolality(phase);
     double sodiumGamma = phase.getActivityCoefficient(phase.getComponent("Na+").getComponentNumber(), waterNumber);
     double chlorideGamma = phase.getActivityCoefficient(phase.getComponent("Cl-").getComponentNumber(), waterNumber);
-    double expectedLogQuotient = Math.log(sodiumMolality * sodiumGamma)
-        + Math.log(chlorideMolality * chlorideGamma);
+    double expectedLogQuotient = Math.log(sodiumMolality * sodiumGamma) + Math.log(chlorideMolality * chlorideGamma);
 
     ChemicalReaction ionicProduct = new ChemicalReaction("PitzerMolalityProbe", new String[] { "Na+", "Cl-" },
         new double[] { 1.0, 1.0 }, new double[] { 0.0, 0.0, 0.0, 0.0 }, 0.0, 0.0, 298.15);
 
-    assertEquals(ChemicalReactionConcentrationBasis.SOLUTE_MOLALITY,
-        system.getChemicalReactionConcentrationBasis());
+    assertEquals(ChemicalReactionConcentrationBasis.SOLUTE_MOLALITY, system.getChemicalReactionConcentrationBasis());
     assertEquals(sodiumMolality * chlorideMolality, ionicProduct.calcKx(system, 1), 1.0e-12);
     assertEquals(expectedLogQuotient, ionicProduct.calcLogReactionQuotient(system, 1), 1.0e-12);
   }


### PR DESCRIPTION
## Scientific question

NeqSim's Pitzer components already calculate ionic activity coefficients and solute concentrations on a molality basis. Do chemical-reaction quotients and mineral saturation ratios use the same thermodynamic `mol/kg water solvent` convention, without changing electrolyte EOS or neutral calculations?

On current master, `ChemicalReaction.calcKx()`, `calcLogReactionQuotient()`, and `getSaturationRatio()` always use component mole fractions. `ComponentGePitzer` correctly supplies molality-scale ion activity coefficients, so the Pitzer reaction path mixes concentration conventions. For a 1:1 ionic product, master omits the two solute molality-to-mole-fraction standard-state factors.

## Frozen scope

- **Base/master:** `49063c3342632ca9534a3bc515b690d6a60c01c8`
- **Model:** `SystemPitzer` / Pitzer GE aqueous phase with SRK gas/oil roles
- **Conditions:** 298.15 K, 1.01325 bara
- **Composition basis:** 55.508 mol water + 1 mol Na+ + 1 mol Cl-
- **Mixing rule:** `classic`
- **Reaction probe:** synthetic Na+/Cl- ionic product; dimensionless solute activity is `gamma_m * m/(1 mol/kg)`
- **Acceptance:** exact typed basis selection; `calcKx` and log quotient agree with direct molality/activity-coefficient evaluation within `1e-12`; CPA/Kent conventions and stored reaction parameters remain unchanged
- **Compatibility boundary:** Pitzer reaction quotient and saturation evaluation only; no reaction table, coefficient, EOS/CPA equation, flash, hydrate, salt-input, or absorber-equipment changes
- **Performance boundary:** one predictable enum comparison per reaction species only during reactive/saturation diagnostics; no neutral-path call or branch
- **Stop boundary:** correct and expose the concentration convention; do not split tables or refit reaction/Pitzer parameters

## Change

- add typed `ChemicalReactionConcentrationBasis` metadata;
- keep the default `MOLE_FRACTION` path for electrolyte EOS and Kent-Eisenberg;
- select `SOLUTE_MOLALITY` for `SystemPitzer`;
- use Pitzer solute molality in `calcKx`, log reaction quotients, and mineral saturation ratios while retaining solvent mole-fraction activity;
- include the concentration convention in `ChemicalReactionModelAudit`, so CPA and Pitzer no longer compare as thermodynamically equivalent solely because they share the `STANDARD` table;
- add analytical Pitzer quotient regressions and update the model-audit regression/docs.

The initial PR head duplicated an existing `ComponentGePitzer.getMolality()` override and failed compilation. Exact head `769c0e885c8dd9e181f9339f28e42e1d5d67c162` removes that duplicate completely and implements the narrower reaction-basis correction.

## Scientific basis and data handling

Pitzer's thermodynamic framework and binary-electrolyte activity formulation use molality:

- Pitzer (1973), DOI [10.1021/j100621a026](https://doi.org/10.1021/j100621a026)
- Pitzer & Mayorga (1973), DOI [10.1021/j100638a009](https://doi.org/10.1021/j100638a009)
- Plummer & Busenberg (1982), DOI [10.1016/0016-7037(82)90056-4](https://doi.org/10.1016/0016-7037(82)90056-4), is the existing carbonate-equilibrium parameter foundation referenced by the standard table.

No external numerical table, copyrighted dataset, or fitted coefficient is copied or transformed. The new regression is an analytical standard-state/concentration-basis check; uncertainty, preprocessing, fitting, and train/hold-out splitting are not applicable. Existing NeqSim data and code remain Apache-2.0.

## Validation

**VALIDATION PENDING CI**

The initial exact-head build and CodeQL compile failed because of the duplicate override; that branch-attributable defect is removed on the repaired head. On the repaired exact head, hosted Spotless, pre-commit, and PaperLab workflows pass. Documentation search, CodeQL, and the full build/test/Javadoc matrix remain in progress. No local Maven, pre-commit, Javadoc, or test execution is claimed.

Exact-head CI must establish:

- Spotless and pre-commit workflows;
- Java 8/21 compilation and full tests;
- focused reaction-basis and `SystemPitzerTest` coverage, including existing literature activity/osmotic checks;
- broader reactive Pitzer, scale, VLLE, clone/serialization, documentation-search, Javadoc, PaperLab, and CodeQL gates;
- no regression in electrolyte CPA/Kent behavior.

## Documentation impact

`SystemInterface`/audit Javadocs and `docs/thermo/reaction_model_audit.md` now expose the concentration convention and explain why shared reaction parameters do not imply cross-model standard-state equivalence.

Refs #3144
