### PR TITLE
[AI-Assisted] feat(thermo): expose reactive balance diagnostics

### DIFF
--- a/docs/thermo/reactive_flash.md
+++ b/docs/thermo/reactive_flash.md
@@ -251,12 +251,23 @@ inspect the database-selected reaction set without multiplying trace activities 
 |--------|-------------|
 | `getReactionLogResiduals()` | Immutable reaction-name map of signed `ln(Q/K)` residuals in reaction-list order |
 | `getMaximumAbsoluteReactionLogResidual()` | Largest absolute `ln(Q/K)`, or `NaN` if no reactive liquid phase or reaction is available |
+| `getElementBalanceResiduals()` | Immutable element-name map of signed `A n - b` residuals in moles |
+| `getMaximumAbsoluteElementBalanceResidual()` | Largest absolute elemental-balance residual in moles |
+| `getReactivePhaseChargeMoles()` | Signed aqueous/reactive-phase charge inventory in moles of elementary charge |
+| `getNormalizedReactivePhaseChargeResidual()` | Absolute net charge divided by total absolute ionic charge inventory |
 | `getReactionDataSource()` | Typed source selected for the loaded reaction set |
 
 Individual `ChemicalReaction` objects also expose `calcLogReactionQuotient(system, phase)` and
-`calcLogReactionResidual(system, phase)`. These methods use the same mole-fraction and activity-
-coefficient standard-state convention as `calcK`, but sum logarithms directly so trace ionic
-activities do not underflow or overflow before the residual is evaluated.
+`calcLogReactionResidual(system, phase)`. These methods use the system-selected concentration and
+activity convention—solute molality for Pitzer and the established mole-fraction path for
+Electrolyte-CPA and Kent-Eisenberg—and sum logarithms directly so trace ionic activities do not
+underflow or overflow before the residual is evaluated.
+
+Element residuals compare the current reactive-phase inventory with the `b` vector captured during
+reaction initialization or immediately before the most recent chemical-equilibrium solve. An empty map
+means that no same-phase reference is current. Charge diagnostics include all phase components, so
+spectator ions are included even when they do not participate in an active reaction. The normalized
+charge residual is scale independent; a value of zero denotes exact electroneutrality.
 
 For parameter-level provenance, `getReference()`, `getEquilibriumConstantCoefficients()`, and
 `getReferenceTemperature()` expose the reference identifier and a defensive copy of the stored

--- a/docs/thermo/reactive_flash.md
+++ b/docs/thermo/reactive_flash.md
@@ -263,11 +263,12 @@ activity convention—solute molality for Pitzer and the established mole-fracti
 Electrolyte-CPA and Kent-Eisenberg—and sum logarithms directly so trace ionic activities do not
 underflow or overflow before the residual is evaluated.
 
-Element residuals compare the current reactive-phase inventory with the `b` vector captured during
-reaction initialization or immediately before the most recent chemical-equilibrium solve. An empty map
-means that no same-phase reference is current. Charge diagnostics include all phase components, so
-spectator ions are included even when they do not participate in an active reaction. The normalized
-charge residual is scale independent; a value of zero denotes exact electroneutrality.
+Element residuals compare the current active-reaction inventory with the `b` vector captured during
+reaction initialization or immediately before the most recent chemical-equilibrium solve. Only
+components in the active reaction basis have columns in `A`; spectator species outside that basis do not
+change `A n - b`. Charge diagnostics include all phase components, so spectator ions are included even
+when they do not participate in an active reaction. The normalized charge residual is scale independent;
+a value of zero denotes exact electroneutrality.
 
 For parameter-level provenance, `getReference()`, `getEquilibriumConstantCoefficients()`, and
 `getReferenceTemperature()` expose the reference identifier and a defensive copy of the stored

--- a/src/main/java/neqsim/chemicalreactions/ChemicalReactionOperations.java
+++ b/src/main/java/neqsim/chemicalreactions/ChemicalReactionOperations.java
@@ -789,7 +789,7 @@ public class ChemicalReactionOperations implements neqsim.thermo.ThermodynamicCo
    * Get a scale-independent reactive-phase electroneutrality residual.
    *
    * @return {@code abs(sum(z_i*n_i)) / sum(abs(z_i*n_i))}; zero when no charged material is present, or
-   *         {@link Double#NaN} when no reactive phase exists
+   * {@link Double#NaN} when no reactive phase exists
    */
   public double getNormalizedReactivePhaseChargeResidual() {
     if (!system.isChemicalSystem()) {

--- a/src/main/java/neqsim/chemicalreactions/ChemicalReactionOperations.java
+++ b/src/main/java/neqsim/chemicalreactions/ChemicalReactionOperations.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import Jama.Matrix;
@@ -663,9 +664,9 @@ public class ChemicalReactionOperations implements neqsim.thermo.ThermodynamicCo
    * Get signed logarithmic equilibrium residuals for all reactions in the reactive phase.
    *
    * <p>
-   * Residuals use the reaction database's mole-fraction/activity-coefficient standard-state convention and are
-   * evaluated as {@code ln(Q/K)} directly in log space. The returned map keeps reaction-list order and is immutable. An
-   * empty map indicates that no reactive liquid phase or reaction is available.
+   * Residuals use the system-selected reaction concentration and activity convention and are evaluated as
+   * {@code ln(Q/K)} directly in log space. The returned map keeps reaction-list order and is immutable. An empty map
+   * indicates that no reactive liquid phase or reaction is available.
    * </p>
    *
    * @return immutable map from reaction name to signed {@code ln(Q/K)} residual
@@ -703,6 +704,114 @@ public class ChemicalReactionOperations implements neqsim.thermo.ThermodynamicCo
       maximumResidual = Math.max(maximumResidual, Math.abs(residual));
     }
     return maximumResidual;
+  }
+
+  /**
+   * Get residuals of the elemental balances used by the most recent chemical-equilibrium basis.
+   *
+   * <p>
+   * Each value is {@code A * n - b} in moles for the current reactive phase. The reference vector {@code b} is captured
+   * during reaction initialization or immediately before the most recent chemical-equilibrium solve. Results are
+   * returned in deterministic element-name order and cannot be mutated. An empty map indicates that no current
+   * same-phase balance reference is available.
+   * </p>
+   *
+   * @return immutable element-name map of signed balance residuals in moles
+   */
+  public Map<String, Double> getElementBalanceResiduals() {
+    if (!system.isChemicalSystem() || Amatrix == null || bVector == null || elements == null) {
+      return Collections.emptyMap();
+    }
+    int reactivePhase = getReactivePhaseIndex();
+    if (reactivePhase < 0 || reactivePhase != phase) {
+      return Collections.emptyMap();
+    }
+
+    double[] currentMoles = calcNVector();
+    Map<String, Double> residuals = new TreeMap<String, Double>();
+    for (int elementIndex = 0; elementIndex < elements.length; elementIndex++) {
+      double elementAmount = 0.0;
+      for (int componentIndex = 0; componentIndex < currentMoles.length; componentIndex++) {
+        elementAmount += Amatrix[elementIndex][componentIndex] * currentMoles[componentIndex];
+      }
+      residuals.put(elements[elementIndex], elementAmount - bVector[elementIndex]);
+    }
+    return Collections.unmodifiableMap(residuals);
+  }
+
+  /**
+   * Get the largest absolute elemental-balance residual.
+   *
+   * @return maximum absolute {@code A * n - b} in moles, or {@link Double#NaN} when no balance reference is available
+   */
+  public double getMaximumAbsoluteElementBalanceResidual() {
+    Map<String, Double> residuals = getElementBalanceResiduals();
+    if (residuals.isEmpty()) {
+      return Double.NaN;
+    }
+    double maximumResidual = 0.0;
+    for (double residual : residuals.values()) {
+      if (!Double.isFinite(residual)) {
+        return Double.NaN;
+      }
+      maximumResidual = Math.max(maximumResidual, Math.abs(residual));
+    }
+    return maximumResidual;
+  }
+
+  /**
+   * Get the signed electric charge in the current reactive phase.
+   *
+   * <p>
+   * The sum includes every phase component, including spectator ions not participating in an active reaction.
+   * </p>
+   *
+   * @return sum of {@code z_i * n_i} in moles of elementary charge, or {@link Double#NaN} when no reactive phase exists
+   */
+  public double getReactivePhaseChargeMoles() {
+    if (!system.isChemicalSystem()) {
+      return Double.NaN;
+    }
+    int reactivePhaseIndex = getReactivePhaseIndex();
+    if (reactivePhaseIndex < 0) {
+      return Double.NaN;
+    }
+    PhaseInterface reactivePhase = system.getPhase(reactivePhaseIndex);
+    double netCharge = 0.0;
+    for (int componentIndex = 0; componentIndex < reactivePhase.getNumberOfComponents(); componentIndex++) {
+      ComponentInterface component = reactivePhase.getComponent(componentIndex);
+      netCharge += component.getIonicCharge() * component.getNumberOfMolesInPhase();
+    }
+    return netCharge;
+  }
+
+  /**
+   * Get a scale-independent reactive-phase electroneutrality residual.
+   *
+   * @return {@code abs(sum(z_i*n_i)) / sum(abs(z_i*n_i))}; zero when no charged material is present, or
+   *         {@link Double#NaN} when no reactive phase exists
+   */
+  public double getNormalizedReactivePhaseChargeResidual() {
+    if (!system.isChemicalSystem()) {
+      return Double.NaN;
+    }
+    int reactivePhaseIndex = getReactivePhaseIndex();
+    if (reactivePhaseIndex < 0) {
+      return Double.NaN;
+    }
+    PhaseInterface reactivePhase = system.getPhase(reactivePhaseIndex);
+    double netCharge = 0.0;
+    double absoluteChargeInventory = 0.0;
+    for (int componentIndex = 0; componentIndex < reactivePhase.getNumberOfComponents(); componentIndex++) {
+      ComponentInterface component = reactivePhase.getComponent(componentIndex);
+      double componentCharge = component.getIonicCharge() * component.getNumberOfMolesInPhase();
+      netCharge += componentCharge;
+      absoluteChargeInventory += Math.abs(componentCharge);
+    }
+    if (absoluteChargeInventory == 0.0) {
+      return 0.0;
+    }
+    return Math.abs(netCharge) / absoluteChargeInventory;
   }
 
   /**

--- a/src/main/java/neqsim/chemicalreactions/ChemicalReactionOperations.java
+++ b/src/main/java/neqsim/chemicalreactions/ChemicalReactionOperations.java
@@ -712,8 +712,9 @@ public class ChemicalReactionOperations implements neqsim.thermo.ThermodynamicCo
    * <p>
    * Each value is {@code A * n - b} in moles for the current reactive phase. The reference vector {@code b} is captured
    * during reaction initialization or immediately before the most recent chemical-equilibrium solve. Results are
-   * returned in deterministic element-name order and cannot be mutated. An empty map indicates that no current
-   * same-phase balance reference is available.
+   * returned in deterministic element-name order and cannot be mutated. The matrix {@code A} contains the active
+   * reaction components only, so spectator species outside that basis are intentionally excluded. An empty map
+   * indicates that no current same-phase balance reference is available.
    * </p>
    *
    * @return immutable element-name map of signed balance residuals in moles

--- a/src/test/java/neqsim/chemicalreactions/ChemicalReactionUnderflowDiagnosticTest.java
+++ b/src/test/java/neqsim/chemicalreactions/ChemicalReactionUnderflowDiagnosticTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import neqsim.chemicalreactions.chemicalreaction.ChemicalReaction;
 import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
 import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPitzer;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 /** Regression tests for stable reaction-equilibrium diagnostics. */
@@ -59,8 +60,61 @@ class ChemicalReactionUnderflowDiagnosticTest extends neqsim.NeqSimTest {
     }
     assertEquals(expectedMaximum, fluid.getChemicalReactionOperations().getMaximumAbsoluteReactionLogResidual(), 0.0);
     assertTrue(expectedMaximum <= 2.0e-6, "Maximum absolute ln(Q/K) was " + expectedMaximum);
+
+    Map<String, Double> elementResiduals = fluid.getChemicalReactionOperations().getElementBalanceResiduals();
+    assertFalse(elementResiduals.isEmpty(), "The chemical-equilibrium basis must expose element balances");
+    for (double residual : elementResiduals.values()) {
+      assertTrue(Double.isFinite(residual), "Every elemental balance residual must be finite");
+    }
+    assertTrue(fluid.getChemicalReactionOperations().getMaximumAbsoluteElementBalanceResidual() <= 1.0e-8);
+    assertTrue(Math.abs(fluid.getChemicalReactionOperations().getReactivePhaseChargeMoles()) <= 1.0e-8);
+    assertTrue(fluid.getChemicalReactionOperations().getNormalizedReactivePhaseChargeResidual() <= 1.0e-6);
+
     assertThrows(UnsupportedOperationException.class, () -> residuals.put("mutation", 0.0),
         "Callers must not mutate reaction-operation diagnostics");
+    assertThrows(UnsupportedOperationException.class, () -> elementResiduals.put("mutation", 0.0),
+        "Callers must not mutate element-balance diagnostics");
+  }
+
+  @Test
+  void pitzerDiagnosticsDetectElementAndChargePerturbation() {
+    SystemInterface fluid = new SystemPitzer(298.15, 1.01325);
+    fluid.addComponent("water", 55.508);
+    fluid.addComponent("Na+", 1.0);
+    fluid.addComponent("Cl-", 1.0);
+    fluid.chemicalReactionInit();
+    fluid.createDatabase(true);
+    fluid.setMixingRule("classic");
+    fluid.init(0);
+    fluid.init(1);
+
+    ChemicalReactionOperations diagnostics = fluid.getChemicalReactionOperations();
+    Map<String, Double> elementResidualsBefore = diagnostics.getElementBalanceResiduals();
+    assertFalse(elementResidualsBefore.isEmpty());
+    double chargeBefore = diagnostics.getReactivePhaseChargeMoles();
+    double normalizedChargeBefore = diagnostics.getNormalizedReactivePhaseChargeResidual();
+
+    int aqueousPhase = -1;
+    for (int phaseIndex = 0; phaseIndex < fluid.getNumberOfPhases(); phaseIndex++) {
+      if ("aqueous".equalsIgnoreCase(fluid.getPhase(phaseIndex).getPhaseTypeName())) {
+        aqueousPhase = phaseIndex;
+        break;
+      }
+    }
+    assertTrue(aqueousPhase >= 0, "Pitzer system must expose its aqueous phase");
+
+    fluid.getPhase(aqueousPhase).getComponent("Na+").addMolesChemReac(1.0e-6, 0.0);
+
+    Map<String, Double> elementResidualsAfter = diagnostics.getElementBalanceResiduals();
+    double largestElementResidualChange = 0.0;
+    for (Map.Entry<String, Double> entry : elementResidualsAfter.entrySet()) {
+      largestElementResidualChange = Math.max(largestElementResidualChange,
+          Math.abs(entry.getValue() - elementResidualsBefore.get(entry.getKey())));
+    }
+
+    assertEquals(1.0e-6, largestElementResidualChange, 1.0e-12);
+    assertEquals(chargeBefore + 1.0e-6, diagnostics.getReactivePhaseChargeMoles(), 1.0e-12);
+    assertTrue(diagnostics.getNormalizedReactivePhaseChargeResidual() > normalizedChargeBefore);
   }
 
   private SystemInterface createTraceWaterSystem(double ionicMoles) {

--- a/src/test/java/neqsim/chemicalreactions/ChemicalReactionUnderflowDiagnosticTest.java
+++ b/src/test/java/neqsim/chemicalreactions/ChemicalReactionUnderflowDiagnosticTest.java
@@ -77,7 +77,7 @@ class ChemicalReactionUnderflowDiagnosticTest extends neqsim.NeqSimTest {
   }
 
   @Test
-  void pitzerDiagnosticsDetectElementAndChargePerturbation() {
+  void pitzerDiagnosticsDistinguishReactiveAndSpectatorPerturbations() {
     SystemInterface fluid = new SystemPitzer(298.15, 1.01325);
     fluid.addComponent("water", 55.508);
     fluid.addComponent("Na+", 1.0);
@@ -105,16 +105,25 @@ class ChemicalReactionUnderflowDiagnosticTest extends neqsim.NeqSimTest {
 
     fluid.getPhase(aqueousPhase).getComponent("Na+").addMolesChemReac(1.0e-6, 0.0);
 
+    Map<String, Double> elementResidualsAfterSpectator = diagnostics.getElementBalanceResiduals();
+    assertEquals(elementResidualsBefore, elementResidualsAfterSpectator,
+        "A spectator ion outside the active reaction basis must not alter A*n-b");
+    assertEquals(chargeBefore + 1.0e-6, diagnostics.getReactivePhaseChargeMoles(), 1.0e-12);
+    double normalizedChargeAfterSpectator = diagnostics.getNormalizedReactivePhaseChargeResidual();
+    assertTrue(normalizedChargeAfterSpectator > normalizedChargeBefore);
+
+    fluid.getPhase(aqueousPhase).getComponent("OH-").addMolesChemReac(1.0e-6, 0.0);
+
     Map<String, Double> elementResidualsAfter = diagnostics.getElementBalanceResiduals();
     double largestElementResidualChange = 0.0;
     for (Map.Entry<String, Double> entry : elementResidualsAfter.entrySet()) {
       largestElementResidualChange = Math.max(largestElementResidualChange,
-          Math.abs(entry.getValue() - elementResidualsBefore.get(entry.getKey())));
+          Math.abs(entry.getValue() - elementResidualsAfterSpectator.get(entry.getKey())));
     }
 
     assertEquals(1.0e-6, largestElementResidualChange, 1.0e-12);
-    assertEquals(chargeBefore + 1.0e-6, diagnostics.getReactivePhaseChargeMoles(), 1.0e-12);
-    assertTrue(diagnostics.getNormalizedReactivePhaseChargeResidual() > normalizedChargeBefore);
+    assertEquals(chargeBefore, diagnostics.getReactivePhaseChargeMoles(), 1.0e-12);
+    assertTrue(diagnostics.getNormalizedReactivePhaseChargeResidual() < normalizedChargeAfterSpectator);
   }
 
   private SystemInterface createTraceWaterSystem(double ionicMoles) {


### PR DESCRIPTION
## Engineering question

Can NeqSim expose the elemental-conservation and aqueous-electroneutrality acceptance gates used alongside `ln(Q/K)` for both electrolyte EOS and electrolyte GE calculations, without changing either calculation path or adding work to neutral systems?

Current `master` exposes reaction-log residuals, while the chemical solver's existing `A`, `b`, and mole vectors and the full reactive-phase ionic inventory are not available through a stable diagnostic API. This makes charge and element acceptance checks depend on duplicated test/application code.

## Frozen scope

- **Base/master:** `3ec3e6f2a7a9acfda84c3d2bf155620b7e4e2c18`
- **Models:** `SystemElectrolyteCPAstatoil` and `SystemPitzer`
- **EOS case:** 303.15 K, 14 bara, 0.98 mol water + 0.01 mol Na+ + 0.01 mol Cl-, mixing rule 10, TP flash
- **GE case:** 298.15 K, 1.01325 bara, 55.508 mol water + 1 mol Na+ + 1 mol Cl-, classic/Pitzer mixing rule
- **Reaction source:** existing `STANDARD` set; CPA keeps mole-fraction reaction activities and Pitzer keeps the merged solute-molality convention
- **Composition/balance basis:** phase moles; elemental residual `A n - b` in mol; signed charge `sum(z_i n_i)` in mol of elementary charge
- **Acceptance:** immutable deterministic element map; finite diagnostics; CPA maximum elemental residual <= `1e-8 mol`, net charge <= `1e-8 mol`, normalized charge <= `1e-6`; a synthetic `1e-6 mol` Na+ spectator perturbation leaves reaction-basis `A n - b` unchanged while changing full-phase charge exactly, and a matching active `OH-` perturbation changes the element residual exactly
- **Compatibility/performance risk:** additive, opt-in getters only; zero new calls or branches in neutral PR/SRK/CPA and ordinary electrolyte solve paths
- **Stop boundary:** diagnostics only—no reaction, coefficient, standard-state, activity, fugacity, EOS/GE equation, flash/stability, hydrate, scale, absorber, salt-input, solver-tolerance, or phase-selection change

## Change

- add immutable deterministic element-balance residuals and maximum absolute residual to `ChemicalReactionOperations`;
- add signed reactive-phase charge and scale-independent normalized electroneutrality residuals;
- include every reactive-phase component in charge accounting, including spectator ions outside active reactions;
- reject stale element references across a reactive-phase topology change by returning an empty diagnostic;
- extend the existing stable-reaction diagnostic regression for Electrolyte-CPA and Pitzer;
- update the reactive-flash guide and correct its reaction-activity wording for the merged Pitzer molality convention.

## Scientific basis and data handling

Element constraints and reaction-equilibrium residuals are the standard constrained-equilibrium acceptance quantities used by White, Johnson & Dantzig (1958), DOI [10.1063/1.1744264](https://doi.org/10.1063/1.1744264). Pitzer's electrolyte activity framework remains documented by Pitzer (1973), DOI [10.1021/j100621a026](https://doi.org/10.1021/j100621a026).

No external numerical dataset, copyrighted table, or fitted parameter is copied, transformed, or redistributed. Tests use synthetic charge-balanced compositions and an analytical one-micromole perturbation. Uncertainty, preprocessing, fitting, and train/hold-out splitting are not applicable. Existing repository material remains Apache-2.0.

Regression evidence remains separate from scientific model validation: these tests verify diagnostic identity and conservation/charge accounting, not the accuracy of reaction or activity parameters.

## Validation

**VALIDATION PENDING CI**

Local validation was run on the formatted three-file tree published as `efff1536028196f1d2875990506ec1b4b9b34db9`:

- `./mvnw -Dtest=ChemicalReactionUnderflowDiagnosticTest test`: 3 tests, 0 failures/errors/skips;
- `./mvnw -Dtest='neqsim.chemicalreactions.*Test,neqsim.chemicalreactions.chemicalreaction.*Test' test`: 30 tests, 0 failures/errors, 4 skips;
- `python devtools/run_spotless.py apply` and `check`: passed;
- pre-commit and pre-push stages from `.pre-commit-config.yaml`: passed;
- `python devtools/check_documentation_search.py`: passed (657 Markdown pages and 1 standalone HTML page).

Local Javadoc execution was blocked because the runtime provides a Java 17 JRE without a `javadoc` executable; no local Javadoc pass is claimed. Hosted CI must still establish exact-head Java 8/21 compilation and full tests, Javadocs, CodeQL, PaperLab, and broader reactive behavior before readiness.

The focused hosted regression must verify:

- existing stable `ln(Q/K)` behavior;
- immutable finite CPA element and charge gates after a complete TP flash;
- deterministic separation of the active reaction basis from spectator ions: `Na+` changes full-phase charge but not `A n - b`, while `OH-` changes the element residual exactly;
- no branch-attributable failures in broader electrolyte, hydrate, scale, clone/serialization, and neutral suites.

## Documentation impact

`docs/thermo/reactive_flash.md` documents units, reference-state lifetime, spectator-ion inclusion, normalization, missing-reference behavior, and the Pitzer-vs-CPA reaction-activity convention.

## Performance and limitations

The implementation adds no call site to any calculation. Diagnostic evaluation is explicit and linear in the number of reactive elements/components. Therefore ordinary neutral and electrolyte calculations execute the unchanged path; exact-head hosted tests remain required. No claim is made that passing these diagnostics independently validates the stored thermodynamic parameters.

Refs #3144
