### PR TITLE
[AI-Assisted] fix(thermo): use activities for mineral saturation

### DIFF
--- a/docs/pvtsimulation/scale_prediction_api.md
+++ b/docs/pvtsimulation/scale_prediction_api.md
@@ -218,8 +218,7 @@ for i in range(1, len(table)):
 `ChemicalReaction.getSaturationRatio(system, phaseNumber)` evaluates the same thermodynamic definition for
 reaction-backed minerals:
 
-$\mathrm{SR}=\frac{\mathrm{IAP}}{K_{sp}},\qquad
-\mathrm{IAP}=\prod_i a_i^{-\nu_i}$
+$\mathrm{SR}=\frac{\mathrm{IAP}}{K_{sp}},\quad \mathrm{IAP}=\prod_i a_i^{-\nu_i}$
 
 Here $\nu_i<0$ identifies each dissolved reactant and $a_i$ is its dimensionless activity. Electrolyte-CPA uses its
 established mole-fraction/activity-coefficient convention; Pitzer uses solute molality and molality-scale activity

--- a/docs/pvtsimulation/scale_prediction_api.md
+++ b/docs/pvtsimulation/scale_prediction_api.md
@@ -213,6 +213,23 @@ for i in range(1, len(table)):
 - MEG-aware (temporarily replaces MEG with water for calculation)
 - Returns **saturation ratio** (SR = IAP/Ksp), where SR > 1 = supersaturated
 
+### Reaction-level saturation diagnostics
+
+`ChemicalReaction.getSaturationRatio(system, phaseNumber)` evaluates the same thermodynamic definition for
+reaction-backed minerals:
+
+$\mathrm{SR}=\frac{\mathrm{IAP}}{K_{sp}},\qquad
+\mathrm{IAP}=\prod_i a_i^{-\nu_i}$
+
+Here $\nu_i<0$ identifies each dissolved reactant and $a_i$ is its dimensionless activity. Electrolyte-CPA uses its
+established mole-fraction/activity-coefficient convention; Pitzer uses solute molality and molality-scale activity
+coefficients while retaining the solvent convention. `calcLogSaturationRatio(...)` returns $\ln(\mathrm{SR})$ directly
+for trace systems where the linear ratio may underflow.
+
+This activity-based definition is consistent with USGS PHREEQC saturation-index reporting and the calcite equilibrium
+treatment of Plummer and Busenberg (1982), DOI `10.1016/0016-7037(82)90056-4`. The regression uses synthetic
+compositions and an analytical identity; it copies or fits no external numerical data.
+
 ---
 
 ## 3. Pitzer Activity Coefficient Model

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReaction.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReaction.java
@@ -518,3 +518,78 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
   public void setRateFactor(double rateFactor) {
     this.rateFactor = rateFactor;
   }
+
+  /**
+   * Getter for property activationEnergy.
+   *
+   * @return Value of property activationEnergy.
+   */
+  public double getActivationEnergy() {
+    return activationEnergy;
+  }
+
+  /**
+   * Setter for property activationEnergy.
+   *
+   * @param activationEnergy New value of property activationEnergy.
+   */
+  public void setActivationEnergy(double activationEnergy) {
+    this.activationEnergy = activationEnergy;
+  }
+
+  /**
+   * Getter for property reactionHeat. Van't HOffs equation dh = d lnK/dT * R * T^2
+   *
+   * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
+   * @return Value of property reactionHeat.
+   */
+  public double getReactionHeat(PhaseInterface phase) {
+    double diffKt = -K[1] / Math.pow(phase.getTemperature(), 2.0) + K[2] / phase.getTemperature() + K[3];
+    double sign = shiftSignK ? -1.0 : 1.0;
+    return sign * diffKt * Math.pow(phase.getTemperature(), 2.0) * R;
+  }
+
+  /**
+   * Getter for property k.
+   *
+   * @return Value of property k.
+   */
+  public double[] getK() {
+    return this.K;
+  }
+
+  /**
+   * getK.
+   *
+   * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
+   * @return a double
+   */
+  public double getK(PhaseInterface phase) {
+    double temperature = phase.getTemperature();
+    lnK = K[0] + K[1] / (temperature) + K[2] * Math.log(temperature) + K[3] * temperature;
+    if (shiftSignK) {
+      lnK = -lnK;
+    }
+    // System.out.println("K " + Math.exp(lnK));
+    return Math.exp(lnK);
+  }
+
+  /**
+   * Setter for property k.
+   *
+   * @param k New value of property k.
+   */
+  public void setK(double[] k) {
+    this.K = k;
+  }
+
+  /**
+   * setK.
+   *
+   * @param i a int
+   * @param Kd a double
+   */
+  public void setK(int i, double Kd) {
+    this.K[i] = Kd;
+  }
+}

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReaction.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReaction.java
@@ -359,7 +359,7 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
     double logActivity = Math.log(getReactionConcentration(system, phase, component));
     if (component.calcActivity()) {
       int waterComponentNumber = phase.getComponent("water").getComponentNumber();
-      logActivity += Math.log(phase.getActivityCoefficient(component.getComponentNumber(), waterComponentNumber));
+      logActivity += phase.getLogActivityCoefficient(component.getComponentNumber(), waterComponentNumber);
     }
     return logActivity;
   }
@@ -518,78 +518,3 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
   public void setRateFactor(double rateFactor) {
     this.rateFactor = rateFactor;
   }
-
-  /**
-   * Getter for property activationEnergy.
-   *
-   * @return Value of property activationEnergy.
-   */
-  public double getActivationEnergy() {
-    return activationEnergy;
-  }
-
-  /**
-   * Setter for property activationEnergy.
-   *
-   * @param activationEnergy New value of property activationEnergy.
-   */
-  public void setActivationEnergy(double activationEnergy) {
-    this.activationEnergy = activationEnergy;
-  }
-
-  /**
-   * Getter for property reactionHeat. Van't HOffs equation dh = d lnK/dT * R * T^2
-   *
-   * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
-   * @return Value of property reactionHeat.
-   */
-  public double getReactionHeat(PhaseInterface phase) {
-    double diffKt = -K[1] / Math.pow(phase.getTemperature(), 2.0) + K[2] / phase.getTemperature() + K[3];
-    double sign = shiftSignK ? -1.0 : 1.0;
-    return sign * diffKt * Math.pow(phase.getTemperature(), 2.0) * R;
-  }
-
-  /**
-   * Getter for property k.
-   *
-   * @return Value of property k.
-   */
-  public double[] getK() {
-    return this.K;
-  }
-
-  /**
-   * getK.
-   *
-   * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
-   * @return a double
-   */
-  public double getK(PhaseInterface phase) {
-    double temperature = phase.getTemperature();
-    lnK = K[0] + K[1] / (temperature) + K[2] * Math.log(temperature) + K[3] * temperature;
-    if (shiftSignK) {
-      lnK = -lnK;
-    }
-    // System.out.println("K " + Math.exp(lnK));
-    return Math.exp(lnK);
-  }
-
-  /**
-   * Setter for property k.
-   *
-   * @param k New value of property k.
-   */
-  public void setK(double[] k) {
-    this.K = k;
-  }
-
-  /**
-   * setK.
-   *
-   * @param i a int
-   * @param Kd a double
-   */
-  public void setK(int i, double Kd) {
-    this.K[i] = Kd;
-  }
-}

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReaction.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReaction.java
@@ -237,23 +237,44 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
   }
 
   /**
-   * getSaturationRatio.
+   * Calculate the mineral saturation ratio from reactant activities.
    *
-   * @param system a {@link neqsim.thermo.system.SystemInterface} object
-   * @param phaseNumb a int
-   * @return a double
+   * <p>
+   * The ratio is {@code IAP / Ksp}. Reactant activities follow the system-selected concentration convention and include
+   * activity coefficients. Values below one are undersaturated and values above one are supersaturated.
+   * </p>
+   *
+   * @param system thermodynamic system containing the dissolved mineral species
+   * @param phaseNumb aqueous phase in which saturation is evaluated
+   * @return mineral saturation ratio {@code IAP / Ksp}
    */
-  public double getSaturationRatio(neqsim.thermo.system.SystemInterface system, int phaseNumb) {
-    double ksp = 1.0;
+  public double getSaturationRatio(SystemInterface system, int phaseNumb) {
+    return Math.exp(calcLogSaturationRatio(system, phaseNumb));
+  }
+
+  /**
+   * Calculate the natural logarithm of the mineral saturation ratio directly in log space.
+   *
+   * <p>
+   * Only negative-stoichiometry reactants contribute to the ion activity product because the mineral product is not a
+   * dissolved phase component. Log-space evaluation retains a finite diagnostic for trace activities when the
+   * corresponding linear saturation ratio underflows.
+   * </p>
+   *
+   * @param system thermodynamic system containing the dissolved mineral species
+   * @param phaseNumb aqueous phase in which saturation is evaluated
+   * @return natural logarithm of {@code IAP / Ksp}
+   */
+  public double calcLogSaturationRatio(SystemInterface system, int phaseNumb) {
     PhaseInterface phase = system.getPhase(phaseNumb);
-    for (int i = 0; i < names.length; i++) {
-      if (stocCoefs[i] < 0) {
-        ComponentInterface component = phase.getComponent(names[i]);
-        ksp *= Math.pow(getReactionConcentration(system, phase, component), -stocCoefs[i]);
+    double logSaturationRatio = -Math.log(getK(phase));
+    for (int componentIndex = 0; componentIndex < names.length; componentIndex++) {
+      if (stocCoefs[componentIndex] < 0.0) {
+        ComponentInterface component = phase.getComponent(names[componentIndex]);
+        logSaturationRatio -= stocCoefs[componentIndex] * getLogReactionActivity(system, phase, component);
       }
     }
-    ksp /= getK(phase);
-    return ksp;
+    return logSaturationRatio;
   }
 
   /**
@@ -271,8 +292,9 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
    * Calculate the natural logarithm of the reaction quotient directly in log space.
    *
    * <p>
-   * This method follows the same mole-fraction/activity-coefficient convention as {@link #calcK(SystemInterface, int)},
-   * but avoids overflow and underflow when ionic species are present at trace concentrations.
+   * This method follows the same system-selected concentration/activity convention as
+   * {@link #calcK(SystemInterface, int)}, but avoids overflow and underflow when ionic species are present at trace
+   * concentrations.
    * </p>
    *
    * @param system thermodynamic system containing the reaction species
@@ -288,13 +310,7 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
         continue;
       }
       ComponentInterface component = phase.getComponent(names[componentIndex]);
-      double logActivity = Math.log(getReactionConcentration(system, phase, component));
-      if (component.calcActivity()) {
-        double activityCoefficient = phase.getActivityCoefficient(component.getComponentNumber(),
-            phase.getComponent("water").getComponentNumber());
-        logActivity += Math.log(activityCoefficient);
-      }
-      logReactionQuotient += stoichiometricCoefficient * logActivity;
+      logReactionQuotient += stoichiometricCoefficient * getLogReactionActivity(system, phase, component);
     }
     return logReactionQuotient;
   }
@@ -329,6 +345,23 @@ public class ChemicalReaction extends NamedBaseClass implements neqsim.thermo.Th
       return component.getMolality(phase);
     }
     return component.getx();
+  }
+
+  /**
+   * Get the logarithm of a reaction activity using the system-selected standard-state convention.
+   *
+   * @param system thermodynamic system selecting the reaction convention
+   * @param phase reactive phase
+   * @param component reaction component
+   * @return logarithm of the dimensionless reaction activity
+   */
+  private double getLogReactionActivity(SystemInterface system, PhaseInterface phase, ComponentInterface component) {
+    double logActivity = Math.log(getReactionConcentration(system, phase, component));
+    if (component.calcActivity()) {
+      int waterComponentNumber = phase.getComponent("water").getComponentNumber();
+      logActivity += Math.log(phase.getActivityCoefficient(component.getComponentNumber(), waterComponentNumber));
+    }
+    return logActivity;
   }
 
   /**

--- a/src/test/java/neqsim/chemicalreactions/ChemicalReactionUnderflowDiagnosticTest.java
+++ b/src/test/java/neqsim/chemicalreactions/ChemicalReactionUnderflowDiagnosticTest.java
@@ -2,11 +2,14 @@ package neqsim.chemicalreactions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import neqsim.chemicalreactions.chemicalreaction.ChemicalReaction;
+import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionConcentrationBasis;
+import neqsim.thermo.phase.PhaseInterface;
 import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemPitzer;
@@ -37,6 +40,42 @@ class ChemicalReactionUnderflowDiagnosticTest extends neqsim.NeqSimTest {
     assertTrue(Double.isFinite(nearbyLogReactionQuotient));
     assertTrue(nearbyLogReactionQuotient > logReactionQuotient,
         "Increasing both ionic trace activities must increase the reaction quotient");
+  }
+
+  @Test
+  void mineralSaturationUsesActivitiesForElectrolyteEosAndGe() {
+    SystemInterface cpa = new SystemElectrolyteCPAstatoil(298.15, 1.01325);
+    cpa.addComponent("water", 55.508);
+    cpa.addComponent("Na+", 0.1);
+    cpa.addComponent("Cl-", 0.1);
+    cpa.createDatabase(true);
+    cpa.setMixingRule(10);
+    cpa.init(0);
+    cpa.init(1);
+    assertActivityBasedSodiumChlorideSaturation(cpa, 1, ChemicalReactionConcentrationBasis.MOLE_FRACTION);
+
+    SystemInterface pitzer = new SystemPitzer(298.15, 1.01325);
+    pitzer.addComponent("water", 55.508);
+    pitzer.addComponent("Na+", 0.1);
+    pitzer.addComponent("Cl-", 0.1);
+    pitzer.setMixingRule("classic");
+    pitzer.init(0);
+    pitzer.init(1);
+    assertActivityBasedSodiumChlorideSaturation(pitzer, 1,
+        ChemicalReactionConcentrationBasis.SOLUTE_MOLALITY);
+  }
+
+  @Test
+  void traceMineralSaturationRetainsFiniteLogarithmicDiagnostic() {
+    SystemInterface fluid = createTraceWaterSystem(1.0e-200);
+    ChemicalReaction reaction = new ChemicalReaction("trace mineral probe", new String[] { "H3O+", "OH-" },
+        new double[] { -1.0, -1.0 }, new double[] { 0.0, 0.0, 0.0, 0.0 }, 0.0, 0.0, 298.15);
+
+    assertEquals(0.0, reaction.getSaturationRatio(fluid, 0));
+    double logSaturationRatio = reaction.calcLogSaturationRatio(fluid, 0);
+    assertTrue(Double.isFinite(logSaturationRatio));
+    assertTrue(logSaturationRatio < -700.0);
+    assertEquals(logSaturationRatio, reaction.calcLogSaturationRatio(fluid, 0), 0.0);
   }
 
   @Test
@@ -124,6 +163,35 @@ class ChemicalReactionUnderflowDiagnosticTest extends neqsim.NeqSimTest {
     assertEquals(1.0e-6, largestElementResidualChange, 1.0e-12);
     assertEquals(chargeBefore, diagnostics.getReactivePhaseChargeMoles(), 1.0e-12);
     assertTrue(diagnostics.getNormalizedReactivePhaseChargeResidual() < normalizedChargeAfterSpectator);
+  }
+
+  private void assertActivityBasedSodiumChlorideSaturation(SystemInterface fluid, int phaseNumber,
+      ChemicalReactionConcentrationBasis expectedBasis) {
+    PhaseInterface phase = fluid.getPhase(phaseNumber);
+    int waterNumber = phase.getComponent("water").getComponentNumber();
+    double sodiumConcentration = expectedBasis == ChemicalReactionConcentrationBasis.SOLUTE_MOLALITY
+        ? phase.getComponent("Na+").getMolality(phase)
+        : phase.getComponent("Na+").getx();
+    double chlorideConcentration = expectedBasis == ChemicalReactionConcentrationBasis.SOLUTE_MOLALITY
+        ? phase.getComponent("Cl-").getMolality(phase)
+        : phase.getComponent("Cl-").getx();
+    double sodiumGamma =
+        phase.getActivityCoefficient(phase.getComponent("Na+").getComponentNumber(), waterNumber);
+    double chlorideGamma =
+        phase.getActivityCoefficient(phase.getComponent("Cl-").getComponentNumber(), waterNumber);
+    double expectedLogSaturationRatio =
+        Math.log(sodiumConcentration * sodiumGamma) + Math.log(chlorideConcentration * chlorideGamma);
+    double concentrationOnlyLog = Math.log(sodiumConcentration) + Math.log(chlorideConcentration);
+
+    ChemicalReaction reaction = new ChemicalReaction("NaCl mineral probe", new String[] { "Na+", "Cl-" },
+        new double[] { -1.0, -1.0 }, new double[] { 0.0, 0.0, 0.0, 0.0 }, 0.0, 0.0, 298.15);
+
+    assertEquals(expectedBasis, fluid.getChemicalReactionConcentrationBasis());
+    assertNotEquals(concentrationOnlyLog, expectedLogSaturationRatio, 1.0e-6,
+        "The fixture must distinguish activities from concentrations");
+    assertEquals(expectedLogSaturationRatio, reaction.calcLogSaturationRatio(fluid, phaseNumber), 1.0e-12);
+    assertEquals(Math.exp(expectedLogSaturationRatio), reaction.getSaturationRatio(fluid, phaseNumber),
+        Math.abs(Math.exp(expectedLogSaturationRatio)) * 1.0e-12);
   }
 
   private SystemInterface createTraceWaterSystem(double ionicMoles) {

--- a/src/test/java/neqsim/chemicalreactions/ChemicalReactionUnderflowDiagnosticTest.java
+++ b/src/test/java/neqsim/chemicalreactions/ChemicalReactionUnderflowDiagnosticTest.java
@@ -61,8 +61,7 @@ class ChemicalReactionUnderflowDiagnosticTest extends neqsim.NeqSimTest {
     pitzer.setMixingRule("classic");
     pitzer.init(0);
     pitzer.init(1);
-    assertActivityBasedSodiumChlorideSaturation(pitzer, 1,
-        ChemicalReactionConcentrationBasis.SOLUTE_MOLALITY);
+    assertActivityBasedSodiumChlorideSaturation(pitzer, 1, ChemicalReactionConcentrationBasis.SOLUTE_MOLALITY);
   }
 
   @Test
@@ -175,12 +174,10 @@ class ChemicalReactionUnderflowDiagnosticTest extends neqsim.NeqSimTest {
     double chlorideConcentration = expectedBasis == ChemicalReactionConcentrationBasis.SOLUTE_MOLALITY
         ? phase.getComponent("Cl-").getMolality(phase)
         : phase.getComponent("Cl-").getx();
-    double sodiumGamma =
-        phase.getActivityCoefficient(phase.getComponent("Na+").getComponentNumber(), waterNumber);
-    double chlorideGamma =
-        phase.getActivityCoefficient(phase.getComponent("Cl-").getComponentNumber(), waterNumber);
-    double expectedLogSaturationRatio =
-        Math.log(sodiumConcentration * sodiumGamma) + Math.log(chlorideConcentration * chlorideGamma);
+    double sodiumGamma = phase.getActivityCoefficient(phase.getComponent("Na+").getComponentNumber(), waterNumber);
+    double chlorideGamma = phase.getActivityCoefficient(phase.getComponent("Cl-").getComponentNumber(), waterNumber);
+    double expectedLogSaturationRatio = Math.log(sodiumConcentration * sodiumGamma)
+        + Math.log(chlorideConcentration * chlorideGamma);
     double concentrationOnlyLog = Math.log(sodiumConcentration) + Math.log(chlorideConcentration);
 
     ChemicalReaction reaction = new ChemicalReaction("NaCl mineral probe", new String[] { "Na+", "Cl-" },

--- a/src/test/java/neqsim/chemicalreactions/ChemicalReactionUnderflowDiagnosticTest.java
+++ b/src/test/java/neqsim/chemicalreactions/ChemicalReactionUnderflowDiagnosticTest.java
@@ -75,6 +75,10 @@ class ChemicalReactionUnderflowDiagnosticTest extends neqsim.NeqSimTest {
     assertTrue(Double.isFinite(logSaturationRatio));
     assertTrue(logSaturationRatio < -700.0);
     assertEquals(logSaturationRatio, reaction.calcLogSaturationRatio(fluid, 0), 0.0);
+
+    SystemInterface nearbyFluid = createTraceWaterSystem(1.0e-190);
+    assertTrue(reaction.calcLogSaturationRatio(nearbyFluid, 0) > logSaturationRatio,
+        "Increasing both dissolved-ion activities must increase mineral saturation");
   }
 
   @Test


### PR DESCRIPTION
## Engineering question

Can reaction-backed mineral saturation use the thermodynamic ion activity product for both electrolyte EOS and Pitzer GE models, while retaining each model's selected concentration/standard-state convention and adding no work to ordinary neutral calculations?

On current `master`, `ChemicalReaction.getSaturationRatio()` multiplies only dissolved reactant concentrations and divides by `Ksp`; it omits the activity coefficients already used by reaction-quotient and scale-potential paths. The result is a concentration product rather than the documented activity-based `IAP/Ksp`.

## Frozen scope

- **Master/base:** `32207901bfc29876278c3fc66600a30bdd6c16a3`
- **Current head:** `8493bef6d3017b548a63d96659776421193294af` (0 behind; exactly 3 scoped files)
- **Models:** `SystemElectrolyteCPAstatoil` and `SystemPitzer`
- **Conditions:** 298.15 K, 1.01325 bara
- **Composition:** 55.508 mol water + 0.1 mol Na+ + 0.1 mol Cl-
- **Mixing rules:** Electrolyte-CPA rule 10; Pitzer `classic`
- **Synthetic mineral probe:** dissolved Na+ and Cl- with stoichiometric coefficients -1/-1 and `Ksp = 1`
- **Activity conventions:** existing CPA mole-fraction/activity-coefficient convention; existing Pitzer solute-molality/activity-coefficient convention
- **Acceptance:** direct and implemented `ln(IAP/Ksp)` agree within `1e-12`; linear SR agrees with its logarithmic result; a 1e-200 mol trace-ion case retains a finite log diagnostic; repeated evaluation is exact; increasing both trace ions to 1e-190 mol increases saturation
- **Compatibility/performance boundary:** explicit reaction-level saturation evaluation only; unchanged reaction tables, parameters, activity models, flashes, salt-input API, solver tolerances, and neutral PR/SRK/CPA paths
- **Stop boundary:** activity-product identity and diagnostics only—no precipitation amount, complementarity solver, scale kinetics, parameter fit, or reaction-table split

## Change

- add `calcLogSaturationRatio(system, phase)` for stable direct `ln(IAP/Ksp)`;
- make `getSaturationRatio()` exponentiate that log result;
- share one private log-activity kernel with reaction-quotient evaluation;
- include activity coefficients for every negative-stoichiometry dissolved mineral reactant;
- retain Pitzer molality and Electrolyte-CPA mole-fraction conventions;
- use `getLogActivityCoefficient(...)` directly, avoiding an exp/log round trip in the opt-in kernel;
- cover EOS, GE, trace, deterministic-repeat, and nearby-state behavior;
- document the reaction-level API and limitations.

## Scientific basis and data handling

Thermodynamic mineral equilibrium is defined by dissolved-species activities. Plummer and Busenberg report calcite equilibrium using activity-based aqueous modeling: DOI [10.1016/0016-7037(82)90056-4](https://doi.org/10.1016/0016-7037(82)90056-4). USGS PHREEQC reports saturation index from log IAP and log K; the [PHREEQC v3 release](https://www.usgs.gov/software/phreeqc-version-3) identifies its software/materials as public domain. Pitzer's molality activity framework remains DOI [10.1021/j100621a026](https://doi.org/10.1021/j100621a026).

No external numerical table, copyrighted dataset, or fitted coefficient is copied, transformed, or redistributed. Tests use synthetic compositions and an analytical identity. Experimental uncertainty, preprocessing, fitting, and train/hold-out splitting are not applicable. This proves thermodynamic identity, not mineral-parameter accuracy. Existing repository material remains Apache-2.0.

## Validation

**VALIDATION PENDING FINAL-HEAD CI**

Completed locally with the repository Maven bootstrap:

- exact-final-source Java 17 clean focused + scale/stale-state + complete TP-flash profile selection: 57 tests passed, 1 existing test skipped.
- `./mvnw -B -ntp -f pomJava8.xml clean -Dtest=neqsim.chemicalreactions.ChemicalReactionUnderflowDiagnosticTest test`: 5/5 passed on exact final source.
- `python devtools/run_spotless.py check`: passed on current final source.
- `python devtools/check_documentation_search.py`: passed (657 Markdown pages, 1 standalone HTML).
- `git diff --check`: passed.
- pre-commit stage: Spotless apply passed.
- pre-push stage: Spotless check and documentation search passed.

A mixed Java-8/Java-17 local target initially produced EJML linkage errors; clean profile-specific builds above passed, confirming that was stale local build state rather than source behavior. The explicit slow `SaltSaturationTest` run was stopped without a result after prolonged execution, so no local slow-suite result is claimed. Local Javadoc remains unrun because this environment has no `javadoc` executable. Hosted final-head Java 8/21, slow shards, Javadocs, CodeQL, formatting, documentation, and PaperLab are required.

A connector write at `1f901e9…` accidentally truncated the file tail and correctly failed hosted build/CodeQL. Corrective commit `8493bef…` restored the complete 595-line source; the current remote blob `806ec0dba6bc5c20689d2d5f4b3599e06ffb1900` matches the locally validated full file. Checks from the truncated head are invalid and are not evidence against the restored head.

## Numerical and performance evidence

The regression establishes the analytical identity
`ln SR = sum(-nu_i ln a_i) - ln Ksp`
within `1e-12` for both EOS and GE conventions and preserves finite trace diagnostics below linear underflow.

A local repeated probe of 7 × 1.01 million explicit Pitzer saturation calls reduced total time from 66.66 s on the initial activity implementation to 59.92 s with the direct-log coefficient (-10.1%). The concentration-only master kernel took 4.67 s but is not scientifically equivalent because it omits activity coefficients. This API is opt-in and O(number of reaction species).

On the exact final source, a complete electrolyte/non-electrolyte CPA TP-flash control (10 flashes without multiphase stability, 10 with it, plus 10 non-electrolyte controls) completed in 8.183 s versus 9.997 s on the master production tree. This is a single non-statistical comparison, so it supports only “no slowdown observed,” not a precise speedup. No ordinary neutral or electrolyte flash path is added or changed.

## Documentation impact and limits

`docs/pvtsimulation/scale_prediction_api.md` defines reaction-level SR/log-SR, model-specific activity conventions, trace behavior, provenance, and limitations. This increment does not calculate precipitated mass, establish mineral complementarity, validate COMPSALT/reaction parameters, or prove that one shared reaction table is transferable between Pitzer and Electrolyte-CPA.

After merge, the next dependency is independent public carbonate/speciation and mineral-complementarity evidence with explicit species/standard-state conventions and a hold-out subset before any model-specific reaction-table split or parameter fit.

Refs #3144
