### PR TITLE
docs: make reference index source-safe

### DIFF
--- a/docs/REFERENCE_MANUAL_INDEX.md
+++ b/docs/REFERENCE_MANUAL_INDEX.md
@@ -1,11 +1,9 @@
 ---
 title: NeqSim Reference Manual - Master Index
-description: This document maps all 360+ documentation files to the reference manual structure. Use this as a comprehensive table of contents and navigation guide.
+description: Curated source-level navigation for NeqSim guides, tutorials, references, examples, and engineering workflows.
 ---
 
-# NeqSim Reference Manual - Master Index
-
-This document maps all 360+ documentation files to the reference manual structure. Use this as a comprehensive table of contents and navigation guide.
+This curated index groups the principal NeqSim guides, tutorials, references, examples, and engineering workflows. It is a maintained navigation layer, not an inventory of every Markdown, generated, test, or internal maintenance file in `docs/`.
 
 **NeqSim Homepage:** [https://equinor.github.io/neqsimhome/](https://equinor.github.io/neqsimhome/)
 
@@ -40,7 +38,7 @@ NeqSim is distributed under the Apache-2.0 license and can be used via:
 | -------------- | --------------------------------------------------------- | -------------------------------------- |
 | NeqSim Web App | [neqsim.streamlit.app](https://neqsim.streamlit.app/)     | Browser-based calculations             |
 | NeqSim Colab   | [NeqSim-Colab](https://github.com/EvenSol/NeqSim-Colab)   | Jupyter/Colab notebook examples        |
-| NeqSimLive API | [Deployment workflow](process/plant-data-tagreader#step-5-neqsimapi-cloud-rest) | Container-based APIs for digital twins |
+| NeqSimLive API | [Deployment workflow](process/plant-data-tagreader.md#step-5-neqsimapi-cloud-rest) | Container-based APIs for digital twins |
 | Process Models | [neqsimprocess](https://github.com/equinor/neqsimprocess) | Pre-built process model library        |
 
 ### AI & Optimization
@@ -63,60 +61,60 @@ NeqSim is distributed under the Apache-2.0 license and can be used via:
 
 | Document              | Path                                                                                       | Description                                                             |
 | --------------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
-| Overview              | [docs/README.md](README)                                                                   | Package overview and quick start                                        |
-| Modules               | [docs/modules.md](modules)                                                                 | Architecture and module structure                                       |
+| Overview              | [docs/README.md](README.md)                                                                   | Package overview and quick start                                        |
+| Modules               | [docs/modules.md](modules.md)                                                                 | Architecture and module structure                                       |
 
-### Chapter 2: Quickstart Guides (NEW!)
+### Chapter 2: Quickstart Guides
 
 | Document           | Path                                                                 | Description                                         |
 | ------------------ | -------------------------------------------------------------------- | --------------------------------------------------- |
-| **Quickstart Hub** | [docs/quickstart/index.md](quickstart/index)                         | **Get running in 5 minutes** - choose your platform |
-| Java Quickstart    | [docs/quickstart/java-quickstart.md](quickstart/java-quickstart)     | Maven setup, first flash, first process             |
-| Python Quickstart  | [docs/quickstart/python-quickstart.md](quickstart/python-quickstart) | pip install, jneqsim imports, gotchas               |
-| Colab Quickstart   | [docs/quickstart/colab-quickstart.md](quickstart/colab-quickstart)   | One-click notebooks, no setup required              |
+| **Quickstart Hub** | [docs/quickstart/index.md](quickstart/index.md)                         | **Get running in 5 minutes** - choose your platform |
+| Java Quickstart    | [docs/quickstart/java-quickstart.md](quickstart/java-quickstart.md)     | Maven setup, first flash, first process             |
+| Python Quickstart  | [docs/quickstart/python-quickstart.md](quickstart/python-quickstart.md) | pip install, jneqsim imports, gotchas               |
+| Colab Quickstart   | [docs/quickstart/colab-quickstart.md](quickstart/colab-quickstart.md)   | One-click notebooks, no setup required              |
 
-### Chapter 3: Tutorials & Learning Paths (NEW!)
+### Chapter 3: Tutorials & Learning Paths
 
 | Document            | Path                                                                             | Description                                           |
 | ------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| **Tutorials Hub**   | [docs/tutorials/index.md](tutorials/index)                                       | All tutorials organized by topic                      |
-| Learning Paths      | [docs/tutorials/learning-paths.md](tutorials/learning-paths)                     | PVT Engineer, Process Engineer, Developer tracks      |
-| **TEG Dehydration** | [docs/tutorials/teg_dehydration_tutorial.md](tutorials/teg_dehydration_tutorial) | **Mass-conserving equilibrium-contact screening with Java and Python examples** |
-| **Solve Engineering Task** | [docs/tutorials/solve-engineering-task.md](tutorials/solve-engineering-task) | **Complete hands-on guide to the 3-step AI task-solving workflow** |
+| **Tutorials Hub**   | [docs/tutorials/index.md](tutorials/index.md)                                       | All tutorials organized by topic                      |
+| Learning Paths      | [docs/tutorials/learning-paths.md](tutorials/learning-paths.md)                     | PVT Engineer, Process Engineer, Developer tracks      |
+| **TEG Dehydration** | [docs/tutorials/teg_dehydration_tutorial.md](tutorials/teg_dehydration_tutorial.md) | **Mass-conserving equilibrium-contact screening with Java and Python examples** |
+| **Solve Engineering Task** | [docs/tutorials/solve-engineering-task.md](tutorials/solve-engineering-task.md) | **Complete hands-on guide to the 3-step AI task-solving workflow** |
 | **GOSP Tutorial**   | [docs/tutorials/gosp_tutorial.md](tutorials/gosp_tutorial.md)                       | **Gas-oil separation plant (multi-stage separation)** |
-| **PVT Lab Tests**   | [docs/pvtsimulation/pvt_lab_tests.md](pvtsimulation/pvt_lab_tests)               | **CCE, CVD, DL, separator test simulations**          |
+| **PVT Lab Tests**   | [docs/pvtsimulation/pvt_lab_tests.md](pvtsimulation/pvt_lab_tests.md)               | **CCE, CVD, DL, separator test simulations**          |
 
 ### Chapter 4: Installation & Setup
 
 | Document        | Path                                                                                               | Description                   |
 | --------------- | -------------------------------------------------------------------------------------------------- | ----------------------------- |
-| Getting Started | [docs/wiki/getting_started.md](wiki/getting_started)                                               | Installation and first steps  |
-| GitHub Setup    | [docs/wiki/Getting-started-with-NeqSim-and-Github.md](wiki/Getting-started-with-NeqSim-and-Github) | NeqSim and GitHub setup       |
-| **Docker Setup** | [docs/docker-getting-started.md](docker-getting-started)                                          | **Build and run NeqSim in a Docker container; use it from Java and Python (jpype)** |
-| Developer Setup | [docs/development/DEVELOPER_SETUP.md](development/DEVELOPER_SETUP)                                 | Development environment setup |
+| Getting Started | [docs/wiki/getting_started.md](wiki/getting_started.md)                                               | Installation and first steps  |
+| GitHub Setup    | [docs/wiki/Getting-started-with-NeqSim-and-Github.md](wiki/Getting-started-with-NeqSim-and-Github.md) | NeqSim and GitHub setup       |
+| **Docker Setup** | [docs/docker-getting-started.md](docker-getting-started.md)                                          | **Build and run NeqSim in a Docker container; use it from Java and Python (jpype)** |
+| Developer Setup | [docs/development/DEVELOPER_SETUP.md](development/DEVELOPER_SETUP.md)                                 | Development environment setup |
 | Productization Roadmap | docs/development/PRODUCTIZATION_ROADMAP.md *(planned)*                                       | Adoption, trust, contributor scaling plan |
-| Image Tools, Agents, and Skills | [docs/development/image_tools_agents_skills.md](development/image_tools_agents_skills)        | Engineering-image workflow for P&IDs, drawings, scanned PDFs, maps, screenshots, and related agents/skills |
-| Benchmark Gallery | [docs/benchmarks/index.md](benchmarks/index)                                                    | Validation against NIST and published data |
-| Consolidated Benchmarks | [docs/benchmarks/consolidated_benchmarks.md](benchmarks/consolidated_benchmarks)          | All benchmark results from task-solving studies |
+| Image Tools, Agents, and Skills | [docs/development/image_tools_agents_skills.md](development/image_tools_agents_skills.md)        | Engineering-image workflow for P&IDs, drawings, scanned PDFs, maps, screenshots, and related agents/skills |
+| Benchmark Gallery | [docs/benchmarks/index.md](benchmarks/index.md)                                                    | Validation against NIST and published data |
+| Consolidated Benchmarks | [docs/benchmarks/consolidated_benchmarks.md](benchmarks/consolidated_benchmarks.md)          | All benchmark results from task-solving studies |
 
 ### Chapter 5: Quick Start Examples
 
 | Document       | Path                                               | Description                |
 | -------------- | -------------------------------------------------- | -------------------------- |
-| Usage Examples | [docs/wiki/usage_examples.md](wiki/usage_examples) | Basic usage patterns       |
-| FAQ            | [docs/wiki/faq.md](wiki/faq)                       | Frequently asked questions |
-| Wiki Index     | [docs/wiki/index.md](wiki/index)                   | Wiki documentation index   |
+| Usage Examples | [docs/wiki/usage_examples.md](wiki/usage_examples.md) | Basic usage patterns       |
+| FAQ            | [docs/wiki/faq.md](wiki/faq.md)                       | Frequently asked questions |
+| Wiki Index     | [docs/wiki/index.md](wiki/index.md)                   | Wiki documentation index   |
 
-### Chapter 6: Cookbook & Troubleshooting (NEW!)
+### Chapter 6: Cookbook & Troubleshooting
 
 | Document               | Path                                                                         | Description                                   |
 | ---------------------- | ---------------------------------------------------------------------------- | --------------------------------------------- |
-| **Cookbook Index**     | [docs/cookbook/index.md](cookbook/index)                                     | **Quick copy-paste recipes for common tasks** |
-| Thermodynamics Recipes | [docs/cookbook/thermodynamics-recipes.md](cookbook/thermodynamics-recipes)   | Fluids, flash, properties, phase envelopes    |
-| Process Recipes        | [docs/cookbook/process-recipes.md](cookbook/process-recipes)                 | Separators, compressors, heat exchangers      |
-| Pipeline Recipes       | [docs/cookbook/pipeline-recipes.md](cookbook/pipeline-recipes)               | Pressure drop, multiphase flow                |
-| Unit Conversion        | [docs/cookbook/unit-conversion-recipes.md](cookbook/unit-conversion-recipes) | All supported unit strings                    |
-| **Troubleshooting**    | [docs/troubleshooting/index.md](troubleshooting/index)                       | **Solutions to common problems**              |
+| **Cookbook Index**     | [docs/cookbook/index.md](cookbook/index.md)                                     | **Quick copy-paste recipes for common tasks** |
+| Thermodynamics Recipes | [docs/cookbook/thermodynamics-recipes.md](cookbook/thermodynamics-recipes.md)   | Fluids, flash, properties, phase envelopes    |
+| Process Recipes        | [docs/cookbook/process-recipes.md](cookbook/process-recipes.md)                 | Separators, compressors, heat exchangers      |
+| Pipeline Recipes       | [docs/cookbook/pipeline-recipes.md](cookbook/pipeline-recipes.md)               | Pressure drop, multiphase flow                |
+| Unit Conversion        | [docs/cookbook/unit-conversion-recipes.md](cookbook/unit-conversion-recipes.md) | All supported unit strings                    |
+| **Troubleshooting**    | [docs/troubleshooting/index.md](troubleshooting/index.md)                       | **Solutions to common problems**              |
 
 ### External Getting Started Guides
 
@@ -136,48 +134,48 @@ NeqSim is distributed under the Apache-2.0 license and can be used via:
 
 | Document             | Path                                                           | Description                        |
 | -------------------- | -------------------------------------------------------------- | ---------------------------------- |
-| Thermo Overview      | [docs/thermo/README.md](thermo/)                               | Thermodynamics module overview     |
-| Thermodynamics Guide | [docs/wiki/thermodynamics_guide.md](wiki/thermodynamics_guide) | Comprehensive thermodynamics guide |
-| System Types         | [docs/thermo/system/README.md](thermo/system/)                 | EoS system implementations         |
+| Thermo Overview      | [docs/thermo/README.md](thermo/README.md)                               | Thermodynamics module overview     |
+| Thermodynamics Guide | [docs/wiki/thermodynamics_guide.md](wiki/thermodynamics_guide.md) | Comprehensive thermodynamics guide |
+| System Types         | [docs/thermo/system/README.md](thermo/system/README.md)                 | EoS system implementations         |
 
 ### Chapter 5: Fluid Creation & Components
 
 | Document                 | Path                                                                       | Description                                                                                |
 | ------------------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| Fluid Creation Guide     | [docs/thermo/fluid_creation_guide.md](thermo/fluid_creation_guide)         | Creating thermodynamic systems                                                             |
-| **Fluid Classification** | [docs/thermo/fluid_classification.md](thermo/fluid_classification)         | **Whitson methodology: FluidClassifier, ReservoirFluidType, GOR/C7+ classification**       |
-| **Component List**       | [docs/thermo/component_list.md](thermo/component_list)                     | **Complete searchable list of all ~150+ components with CAS numbers and EoS availability** |
-| Component Database       | [docs/thermo/component_database_guide.md](thermo/component_database_guide) | Component properties and database                                                          |
-| Component Package        | [docs/thermo/component/README.md](thermo/component/)                       | Component class documentation                                                              |
-| Mathematical Models      | [docs/thermo/mathematical_models.md](thermo/mathematical_models)           | Underlying mathematical models                                                             |
+| Fluid Creation Guide     | [docs/thermo/fluid_creation_guide.md](thermo/fluid_creation_guide.md)         | Creating thermodynamic systems                                                             |
+| **Fluid Classification** | [docs/thermo/fluid_classification.md](thermo/fluid_classification.md)         | **Whitson methodology: FluidClassifier, ReservoirFluidType, GOR/C7+ classification**       |
+| **Component List**       | [docs/thermo/component_list.md](thermo/component_list.md)                     | **Complete searchable list of all ~150+ components with CAS numbers and EoS availability** |
+| Component Database       | [docs/thermo/component_database_guide.md](thermo/component_database_guide.md) | Component properties and database                                                          |
+| Component Package        | [docs/thermo/component/README.md](thermo/component/README.md)                       | Component class documentation                                                              |
+| Mathematical Models      | [docs/thermo/mathematical_models.md](thermo/mathematical_models.md)           | Underlying mathematical models                                                             |
 
 ### Chapter 6: Equations of State
 
 | Document                  | Path                                                               | Description                                                                                                          |
 | ------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| Thermodynamic Models      | [docs/thermo/thermodynamic_models.md](thermo/thermodynamic_models) | **Comprehensive guide** to all thermodynamic models (EoS, CPA, GERG, electrolytes, GE models) with theory and usage  |
-| Mercury Thermodynamics    | [docs/thermo/mercury_thermodynamics.md](thermo/mercury_thermodynamics) | Mercury-focused SRK-TwuCoon-Statoil-EOS usage, TPflash setup, and thesis-linked BIP/correlation guidance |
-| **Søreide-Whitson Model** | [docs/thermo/SoreideWhitsonModel.md](thermo/SoreideWhitsonModel)   | **Gas solubility in brine** - Modified PR EoS with salinity effects, used in NeqSimLive for produced water emissions |
-| GERG-2008                 | [docs/thermo/gerg2008_eoscg.md](thermo/gerg2008_eoscg)             | GERG-2008, GERG-2008-H2, GERG-2008-NH3, and EOS-CG equations of state                                               |
+| Thermodynamic Models      | [docs/thermo/thermodynamic_models.md](thermo/thermodynamic_models.md) | **Comprehensive guide** to all thermodynamic models (EoS, CPA, GERG, electrolytes, GE models) with theory and usage  |
+| Mercury Thermodynamics    | [docs/thermo/mercury_thermodynamics.md](thermo/mercury_thermodynamics.md) | Mercury-focused SRK-TwuCoon-Statoil-EOS usage, TPflash setup, and thesis-linked BIP/correlation guidance |
+| **Søreide-Whitson Model** | [docs/thermo/SoreideWhitsonModel.md](thermo/SoreideWhitsonModel.md)   | **Gas solubility in brine** - Modified PR EoS with salinity effects, used in NeqSimLive for produced water emissions |
+| GERG-2008                 | [docs/thermo/gerg2008_eoscg.md](thermo/gerg2008_eoscg.md)             | GERG-2008, GERG-2008-H2, GERG-2008-NH3, and EOS-CG equations of state                                               |
 | GERG-2008-NH3 Notebook    | [docs/examples/GERG2008_NH3_Ammonia_Properties.ipynb](https://github.com/equinor/neqsim/blob/master/docs/examples/GERG2008_NH3_Ammonia_Properties.ipynb) | Ammonia properties with Gao EOS — density validation, mixture properties, isotherms |
-| Mixing Rules              | [docs/thermo/mixing_rules_guide.md](thermo/mixing_rules_guide)     | Mixing rules and BIPs                                                                                                |
-| Mixing Rule Package       | [docs/thermo/mixingrule/README.md](thermo/mixingrule/)             | Mixing rule implementations                                                                                          |
-| Phase Package             | [docs/thermo/phase/README.md](thermo/phase/)                       | Phase modeling                                                                                                       |
-| Electrolyte CPA           | [docs/thermo/ElectrolyteCPAModel.md](thermo/ElectrolyteCPAModel)   | Electrolyte CPA model                                                                                                |
+| Mixing Rules              | [docs/thermo/mixing_rules_guide.md](thermo/mixing_rules_guide.md)     | Mixing rules and BIPs                                                                                                |
+| Mixing Rule Package       | [docs/thermo/mixingrule/README.md](thermo/mixingrule/README.md)             | Mixing rule implementations                                                                                          |
+| Phase Package             | [docs/thermo/phase/README.md](thermo/phase/README.md)                       | Phase modeling                                                                                                       |
+| Electrolyte CPA           | [docs/thermo/ElectrolyteCPAModel.md](thermo/ElectrolyteCPAModel.md)   | Electrolyte CPA model                                                                                                |
 
 ### Chapter 7: Flash Calculations
 
 | Document            | Path                                                                                           | Description                     |
 | ------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------- |
-| Flash Guide         | [docs/thermo/flash_calculations_guide.md](thermo/flash_calculations_guide)                     | Flash calculation methods       |
-| Flash Equations     | [docs/wiki/flash_equations_and_tests.md](wiki/flash_equations_and_tests)                       | Flash equations and testing     |
-| Thermo Operations   | [docs/thermo/thermodynamic_operations.md](thermo/thermodynamic_operations)                     | Thermodynamic operations        |
-| TP Flash Algorithm  | [docs/thermodynamicoperations/TPflash_algorithm.md](thermodynamicoperations/TPflash_algorithm) | TP flash algorithm details      |
-| Reactive Flash      | [docs/thermo/reactive_flash.md](thermo/reactive_flash)                                        | Simultaneous chemical and phase equilibrium (Modified RAND method) |
+| Flash Guide         | [docs/thermo/flash_calculations_guide.md](thermo/flash_calculations_guide.md)                     | Flash calculation methods       |
+| Flash Equations     | [docs/wiki/flash_equations_and_tests.md](wiki/flash_equations_and_tests.md)                       | Flash equations and testing     |
+| Thermo Operations   | [docs/thermo/thermodynamic_operations.md](thermo/thermodynamic_operations.md)                     | Thermodynamic operations        |
+| TP Flash Algorithm  | [docs/thermodynamicoperations/TPflash_algorithm.md](thermodynamicoperations/TPflash_algorithm.md) | TP flash algorithm details      |
+| Reactive Flash      | [docs/thermo/reactive_flash.md](thermo/reactive_flash.md)                                        | Simultaneous chemical and phase equilibrium (Modified RAND method) |
 | Reactive PH Flash   | [examples/notebooks/reactive_ph_flash_examples.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/reactive_ph_flash_examples.ipynb) | Isenthalpic/isentropic reactive flash examples (PH, PS flash) |
-| Reactive Distillation | [docs/process/reactive_distillation.md](process/reactive_distillation)                        | Reactive distillation column with equilibrium-based reactive flash on each tray |
-| Phase Envelope Algorithm | [docs/thermodynamicoperations/phase_envelope_algorithm.md](thermodynamicoperations/phase_envelope_algorithm) | Michelsen continuation method, cricondenbar/cricondentherm Newton refinement, critical point detection |
-| Thermo Ops Overview | [docs/thermodynamicoperations/README.md](thermodynamicoperations/)                             | Thermodynamic operations module |
+| Reactive Distillation | [docs/process/reactive_distillation.md](process/reactive_distillation.md)                        | Reactive distillation column with equilibrium-based reactive flash on each tray |
+| Phase Envelope Algorithm | [docs/thermodynamicoperations/phase_envelope_algorithm.md](thermodynamicoperations/phase_envelope_algorithm.md) | Michelsen continuation method, cricondenbar/cricondentherm Newton refinement, critical point detection |
+| Thermo Ops Overview | [docs/thermodynamicoperations/README.md](thermodynamicoperations/README.md)                             | Thermodynamic operations module |
 
 ### Chapter 8: Fluid Characterization
 
@@ -185,49 +183,49 @@ Fluid characterization handles plus fraction splitting, property estimation, and
 
 | Document                 | Path                                                                                                                         | Description                                         |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| Characterization         | [docs/wiki/fluid_characterization.md](wiki/fluid_characterization)                                                           | Fluid characterization guide with lumping API       |
-| TBP Fractions            | [docs/wiki/tbp_fraction_models.md](wiki/tbp_fraction_models)                                                                 | TBP fraction modeling                               |
-| PVT Characterization     | [docs/thermo/pvt_fluid_characterization.md](thermo/pvt_fluid_characterization)                                               | PVT fluid characterization with lumping             |
-| Characterization Package | [docs/thermo/characterization/README.md](thermo/characterization/)                                                           | Characterization module                             |
-| Combining Methods        | [docs/thermo/characterization/fluid_characterization_combining.md](thermo/characterization/fluid_characterization_combining) | Fluid combining methods                             |
-| Char Mathematics         | [docs/pvtsimulation/fluid_characterization_mathematics.md](pvtsimulation/fluid_characterization_mathematics)                 | Characterization mathematics with lumping equations |
+| Characterization         | [docs/wiki/fluid_characterization.md](wiki/fluid_characterization.md)                                                           | Fluid characterization guide with lumping API       |
+| TBP Fractions            | [docs/wiki/tbp_fraction_models.md](wiki/tbp_fraction_models.md)                                                                 | TBP fraction modeling                               |
+| PVT Characterization     | [docs/thermo/pvt_fluid_characterization.md](thermo/pvt_fluid_characterization.md)                                               | PVT fluid characterization with lumping             |
+| Characterization Package | [docs/thermo/characterization/README.md](thermo/characterization/README.md)                                                           | Characterization module                             |
+| Combining Methods        | [docs/thermo/characterization/fluid_characterization_combining.md](thermo/characterization/fluid_characterization_combining.md) | Fluid combining methods                             |
+| Char Mathematics         | [docs/pvtsimulation/fluid_characterization_mathematics.md](pvtsimulation/fluid_characterization_mathematics.md)                 | Characterization mathematics with lumping equations |
 
 ### Chapter 9: Physical Properties
 
 | Document                        | Path                                                                                                       | Description                                                                                       |
 | ------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **Reading Fluid Properties**    | [docs/thermo/reading_fluid_properties.md](thermo/reading_fluid_properties)                                 | **Comprehensive guide to calculating and reading properties from fluids, phases, and components** |
-| Properties Overview             | [docs/thermo/physical_properties.md](thermo/physical_properties)                                           | Physical property calculations                                                                    |
-| Attainable Metastability        | [docs/thermo/attainable_metastability.md](thermo/attainable_metastability)                                 | Volume balancing method (Log, 2025) for the superheat / pressure-undershoot limit of a depressurising liquid |
-| Physical Props Module           | [docs/physical_properties/README.md](physical_properties/)                                                 | Physical properties module                                                                        |
-| **H2S Distribution (Quick)**    | [docs/thermo/H2S_distribution_guide.md](thermo/H2S_distribution_guide)                                     | **H2S phase distribution with Python examples - quick reference**                                 |
-| **H2S Distribution (Detailed)** | [docs/thermo/H2S_DISTRIBUTION_MODELING.md](thermo/H2S_DISTRIBUTION_MODELING)                               | **Comprehensive H2S modeling with Java examples and theory**                                      |
-| **Amine CO2 Solubility**        | [docs/thermo/amine_co2_solubility.md](thermo/amine_co2_solubility)                                         | **Kent-Eisenberg screening model for CO2 solubility in MEA/DEA/MDEA/aMDEA solvents**              |
-| Viscosity Models                | [docs/wiki/viscosity_models.md](wiki/viscosity_models)                                                     | Viscosity calculation models                                                                      |
-| Viscosity Detailed              | [docs/physical_properties/viscosity_models.md](physical_properties/viscosity_models)                       | Detailed viscosity models                                                                         |
-| **Density Models**              | [docs/physical_properties/density_models.md](physical_properties/density_models)                           | **COSTALD (Hankinson-Thomson), Peneloux volume translation, Rackett — liquid density for mixtures, TBP fractions, aqueous/polar systems** |
-| Thermal Conductivity            | [docs/physical_properties/thermal_conductivity_models.md](physical_properties/thermal_conductivity_models) | Thermal conductivity models                                                                       |
-| Diffusivity                     | [docs/physical_properties/diffusivity_models.md](physical_properties/diffusivity_models)                   | Gas and liquid diffusivity models (Chapman-Enskog, Wilke-Lee, Fuller, Siddiqi-Lucas, Wilke-Chang, Tyn-Calus, Hayduk-Minhas) with experimental validation |
-| Interfacial Props               | [docs/physical_properties/interfacial_properties.md](physical_properties/interfacial_properties)           | Interfacial tension, etc.                                                                         |
-| Scale Potential                 | [docs/physical_properties/scale_potential.md](physical_properties/scale_potential)                         | Scale potential calculations                                                                      |
-| **Adsorption Isotherm Models**  | [docs/thermo/adsorption_isotherms.md](thermo/adsorption_isotherms)                                         | **Langmuir, BET, Freundlich, Sips, DRA potential theory, capillary condensation**                 |
-| Steam Tables                    | [docs/wiki/steam_tables_if97.md](wiki/steam_tables_if97)                                                   | IF97 steam table implementation                                                                   |
-| Thermodynamic Workflows         | [docs/thermo/thermodynamic_workflows.md](thermo/thermodynamic_workflows)                                   | Common thermodynamic workflows                                                                    |
-| Interaction Tables              | [docs/thermo/inter_table_guide.md](thermo/inter_table_guide)                                               | Binary interaction parameters                                                                     |  |
+| **Reading Fluid Properties**    | [docs/thermo/reading_fluid_properties.md](thermo/reading_fluid_properties.md)                                 | **Comprehensive guide to calculating and reading properties from fluids, phases, and components** |
+| Properties Overview             | [docs/thermo/physical_properties.md](thermo/physical_properties.md)                                           | Physical property calculations                                                                    |
+| Attainable Metastability        | [docs/thermo/attainable_metastability.md](thermo/attainable_metastability.md)                                 | Volume balancing method (Log, 2025) for the superheat / pressure-undershoot limit of a depressurising liquid |
+| Physical Props Module           | [docs/physical_properties/README.md](physical_properties/README.md)                                                 | Physical properties module                                                                        |
+| **H2S Distribution (Quick)**    | [docs/thermo/H2S_distribution_guide.md](thermo/H2S_distribution_guide.md)                                     | **H2S phase distribution with Python examples - quick reference**                                 |
+| **H2S Distribution (Detailed)** | [docs/thermo/H2S_DISTRIBUTION_MODELING.md](thermo/H2S_DISTRIBUTION_MODELING.md)                               | **Comprehensive H2S modeling with Java examples and theory**                                      |
+| **Amine CO2 Solubility**        | [docs/thermo/amine_co2_solubility.md](thermo/amine_co2_solubility.md)                                         | **Kent-Eisenberg screening model for CO2 solubility in MEA/DEA/MDEA/aMDEA solvents**              |
+| Viscosity Models                | [docs/wiki/viscosity_models.md](wiki/viscosity_models.md)                                                     | Viscosity calculation models                                                                      |
+| Viscosity Detailed              | [docs/physical_properties/viscosity_models.md](physical_properties/viscosity_models.md)                       | Detailed viscosity models                                                                         |
+| **Density Models**              | [docs/physical_properties/density_models.md](physical_properties/density_models.md)                           | **COSTALD (Hankinson-Thomson), Peneloux volume translation, Rackett — liquid density for mixtures, TBP fractions, aqueous/polar systems** |
+| Thermal Conductivity            | [docs/physical_properties/thermal_conductivity_models.md](physical_properties/thermal_conductivity_models.md) | Thermal conductivity models                                                                       |
+| Diffusivity                     | [docs/physical_properties/diffusivity_models.md](physical_properties/diffusivity_models.md)                   | Gas and liquid diffusivity models (Chapman-Enskog, Wilke-Lee, Fuller, Siddiqi-Lucas, Wilke-Chang, Tyn-Calus, Hayduk-Minhas) with experimental validation |
+| Interfacial Props               | [docs/physical_properties/interfacial_properties.md](physical_properties/interfacial_properties.md)           | Interfacial tension, etc.                                                                         |
+| Scale Potential                 | [docs/physical_properties/scale_potential.md](physical_properties/scale_potential.md)                         | Scale potential calculations                                                                      |
+| **Adsorption Isotherm Models**  | [docs/thermo/adsorption_isotherms.md](thermo/adsorption_isotherms.md)                                         | **Langmuir, BET, Freundlich, Sips, DRA potential theory, capillary condensation**                 |
+| Steam Tables                    | [docs/wiki/steam_tables_if97.md](wiki/steam_tables_if97.md)                                                   | IF97 steam table implementation                                                                   |
+| Thermodynamic Workflows         | [docs/thermo/thermodynamic_workflows.md](thermo/thermodynamic_workflows.md)                                   | Common thermodynamic workflows                                                                    |
+| Interaction Tables              | [docs/thermo/inter_table_guide.md](thermo/inter_table_guide.md)                                               | Binary interaction parameters                                                                     |  |
 
 ### Chapter 10: Hydrates & Flow Assurance
 
 | Document                         | Path                                                                                                               | Description                                                       |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
-| **Flow Assurance Overview**      | [docs/pvtsimulation/flow_assurance_overview.md](pvtsimulation/flow_assurance_overview)                             | **Integrated guide: hydrates, wax, asphaltenes, scale screening** |
-| **Mineral Scale Formation**      | [docs/pvtsimulation/mineral_scale_formation.md](pvtsimulation/mineral_scale_formation)                             | **Carbonate/sulfate scale, seawater mixing, SR calculations**     |
-| **Scale Prediction API**         | [docs/pvtsimulation/scale_prediction_api.md](pvtsimulation/scale_prediction_api)                                   | **API reference: empirical vs EOS, solid solution, compatibility** |
-| **pH Stabilization & Corrosion** | [docs/pvtsimulation/ph_stabilization_corrosion.md](pvtsimulation/ph_stabilization_corrosion)                       | **Corrosion control, FeCO3 layer, Electrolyte CPA EoS**           |
-| **Chemical Compatibility & RCA** | [docs/chemistry/chemical_compatibility_guide.md](chemistry/chemical_compatibility_guide)                           | **Production chemistry: compatibility, scale/CI/acid/scavenger, root cause analysis** |
-| Hydrate Models                   | [docs/thermo/hydrate_models.md](thermo/hydrate_models)                                                             | Hydrate equilibrium models                                        |
-| Hydrate Flash                    | [docs/thermodynamicoperations/hydrate_flash_operations.md](thermodynamicoperations/hydrate_flash_operations)       | Hydrate flash operations                                          |
-| Wax Characterization             | [docs/thermo/characterization/wax_characterization.md](thermo/characterization/wax_characterization)               | Wax modeling, WAT calculation, flow assurance                     |
-| Asphaltene Characterization      | [docs/thermo/characterization/asphaltene_characterization.md](thermo/characterization/asphaltene_characterization) | SARA analysis, CII, CPA parameters                                |
+| **Flow Assurance Overview**      | [docs/pvtsimulation/flow_assurance_overview.md](pvtsimulation/flow_assurance_overview.md)                             | **Integrated guide: hydrates, wax, asphaltenes, scale screening** |
+| **Mineral Scale Formation**      | [docs/pvtsimulation/mineral_scale_formation.md](pvtsimulation/mineral_scale_formation.md)                             | **Carbonate/sulfate scale, seawater mixing, SR calculations**     |
+| **Scale Prediction API**         | [docs/pvtsimulation/scale_prediction_api.md](pvtsimulation/scale_prediction_api.md)                                   | **API reference: empirical vs EOS, solid solution, compatibility** |
+| **pH Stabilization & Corrosion** | [docs/pvtsimulation/ph_stabilization_corrosion.md](pvtsimulation/ph_stabilization_corrosion.md)                       | **Corrosion control, FeCO3 layer, Electrolyte CPA EoS**           |
+| **Chemical Compatibility & RCA** | [docs/chemistry/chemical_compatibility_guide.md](chemistry/chemical_compatibility_guide.md)                           | **Production chemistry: compatibility, scale/CI/acid/scavenger, root cause analysis** |
+| Hydrate Models                   | [docs/thermo/hydrate_models.md](thermo/hydrate_models.md)                                                             | Hydrate equilibrium models                                        |
+| Hydrate Flash                    | [docs/thermodynamicoperations/hydrate_flash_operations.md](thermodynamicoperations/hydrate_flash_operations.md)       | Hydrate flash operations                                          |
+| Wax Characterization             | [docs/thermo/characterization/wax_characterization.md](thermo/characterization/wax_characterization.md)               | Wax modeling, WAT calculation, flow assurance                     |
+| Asphaltene Characterization      | [docs/thermo/characterization/asphaltene_characterization.md](thermo/characterization/asphaltene_characterization.md) | SARA analysis, CII, CPA parameters                                |
 
 ---
 
@@ -237,212 +235,212 @@ Fluid characterization handles plus fraction splitting, property estimation, and
 
 | Document             | Path                                                                                           | Description                               |
 | -------------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| Process Overview     | [docs/process/README.md](process/)                                                             | Process simulation module                 |
+| Process Overview     | [docs/process/README.md](process/README.md)                                                             | Process simulation module                 |
 | Energy Streams & Equipment Ports | [docs/process/energy_streams.md](process/energy_streams.md)                  | Typed heat, shaft-work, and electrical connections, unit-aware duties, buses, and shafts |
-| NeqSim Studio (Python) | [docs/process/neqsim-studio.md](process/neqsim-studio)                                        | Newcomer-friendly Python process builder (natural language, templates, wizard, edit-by-chat, gallery) |
-| Process Guide        | [docs/wiki/process_simulation.md](wiki/process_simulation)                                     | Process simulation guide                  |
-| Advanced Process     | [docs/wiki/advanced_process_simulation.md](wiki/advanced_process_simulation)                   | Advanced techniques                       |
-| Logical Operations   | [docs/wiki/logical_unit_operations.md](wiki/logical_unit_operations)                           | Logical unit operations                   |
-| Process Design       | [docs/process/process_design_guide.md](process/process_design_guide)                           | Process design guide                      |
-| Design Framework     | [docs/process/DESIGN_FRAMEWORK.md](process/DESIGN_FRAMEWORK)                                   | Automated design & optimization framework |
-| Pipeline Network Optimization | [docs/process/pipeline_network_optimization.md](process/pipeline_network_optimization) | NLP optimizer, sparse solver, Pareto, benchmarks |
-| Gas Network Operations | [docs/process/gas_network_operations.md](process/gas_network_operations) | Conservative mixing, edge-local thermal hydraulics, quality, allocation, and linepack |
-| Oil Network Operations | [docs/process/oil_network_operations.md](process/oil_network_operations) | Pumps, crude assays, tanks, parcels, blending, and cargo scheduling |
+| NeqSim Studio (Python) | [docs/process/neqsim-studio.md](process/neqsim-studio.md)                                        | Newcomer-friendly Python process builder (natural language, templates, wizard, edit-by-chat, gallery) |
+| Process Guide        | [docs/wiki/process_simulation.md](wiki/process_simulation.md)                                     | Process simulation guide                  |
+| Advanced Process     | [docs/wiki/advanced_process_simulation.md](wiki/advanced_process_simulation.md)                   | Advanced techniques                       |
+| Logical Operations   | [docs/wiki/logical_unit_operations.md](wiki/logical_unit_operations.md)                           | Logical unit operations                   |
+| Process Design       | [docs/process/process_design_guide.md](process/process_design_guide.md)                           | Process design guide                      |
+| Design Framework     | [docs/process/DESIGN_FRAMEWORK.md](process/DESIGN_FRAMEWORK.md)                                   | Automated design & optimization framework |
+| Pipeline Network Optimization | [docs/process/pipeline_network_optimization.md](process/pipeline_network_optimization.md) | NLP optimizer, sparse solver, Pareto, benchmarks |
+| Gas Network Operations | [docs/process/gas_network_operations.md](process/gas_network_operations.md) | Conservative mixing, edge-local thermal hydraulics, quality, allocation, and linepack |
+| Oil Network Operations | [docs/process/oil_network_operations.md](process/oil_network_operations.md) | Pumps, crude assays, tanks, parcels, blending, and cargo scheduling |
 
 ### Chapter 12: Process Systems & Models
 
 | Document              | Path                                                                                                                       | Description               |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| ProcessModel Overview | [docs/process/processmodel/README.md](process/processmodel/)                                                               | Process system management |
-| ProcessSystem         | [docs/process/processmodel/process_system.md](process/processmodel/process_system)                                         | ProcessSystem class (connections, stream introspection, named controllers, unified elements) |
-| ProcessModel          | [docs/process/processmodel/process_model.md](process/processmodel/process_model)                                           | Multi-process models      |
-| ProcessModule         | [docs/process/processmodel/process_module.md](process/processmodel/process_module)                                         | Modular process units     |
-| Process JSON Export   | [docs/process/process_json_export_and_e300_fluids.md](process/process_json_export_and_e300_fluids)                         | Export ProcessSystem and ProcessModel JSON for MCP, including E300-equivalent component properties, volume correction, stream-specific fluids, recycle settings, and convergence checks |
-| Graph Simulation      | [docs/process/processmodel/graph_simulation.md](process/processmodel/graph_simulation)                                     | Graph-based simulation    |
-| Diagram Export        | [docs/process/processmodel/diagram_export.md](process/processmodel/diagram_export)                                         | PFD diagram export        |
-| DEXPI Architecture    | [docs/process/processmodel/DIAGRAM_ARCHITECTURE_DEXPI_SYNERGY.md](process/processmodel/DIAGRAM_ARCHITECTURE_DEXPI_SYNERGY) | DEXPI integration         |
-| Low-Flow Bypass       | [docs/process/processmodel/low_flow_bypass.md](process/processmodel/low_flow_bypass)                                       | Auto-bypass / manual deactivation of low-flow process sections; feed-flow configuration patterns for parallel trains |
-| Parallel Scenario Sweeps | [docs/process/processmodel/parallel_scenario_sweeps.md](process/processmodel/parallel_scenario_sweeps)                  | Safe clone-and-run pattern for running parameter sweeps / DoE scenarios in parallel via ProcessSystem.copy() deep copy |
-| Run Status            | [docs/process/processmodel/run_status.md](process/processmodel/run_status)                                                 | Detect failed runs and identify the failing unit via structured RunStatus / UnitRunStatus and schema-versioned JSON |
-| Simulation Hooks      | [docs/process/simulation-hooks-and-events.md](process/simulation-hooks-and-events)                                         | Lifecycle hooks, ProcessEventBus, auto-validation for ProcessSystem and ProcessModel |
-| **UniSim/HYSYS Conversion** | [docs/process/unisim-to-neqsim-conversion.md](process/unisim-to-neqsim-conversion)                                  | **Convert UniSim Design (.usc) models to NeqSim and export NeqSim back to UniSim — COM automation, mapping tables, topology reconstruction, verification** |
-| **Exergy Analysis**   | [docs/process/exergy-analysis.md](process/exergy-analysis)                                                                 | **Plant-wide exergy destruction hotspots — ProcessSystem, ProcessModel, ExergyAnalysisReport API, JSON export** |
-| **Production Allocation** | [docs/process/production-allocation.md](process/production-allocation)                                                  | **Back-allocate metered production to wells/sources via a linear recovery-factor proxy network — split factors, (I−A)v=b solve, mass closure, auto-detection, closed-form first-order uncertainty propagation, JSON export** |
-| **Cached K-Value Fast Simulation** | [docs/process/k-value-fast-simulation.md](process/k-value-fast-simulation)                                      | **Run one rigorous base-case ProcessSystem, freeze separator K-values and fallback split factors, then execute fast source-rate scenarios without repeated EOS flashes** |
-| **Screening & Sizing Calculators** | [docs/process/screening_calculators.md](process/screening_calculators)                                          | **Standalone serializable screening calculators — flare radiation (API 521), line sizing/erosion LOF (API RP 14E), flow-induced vibration (AVIFF), pump NPSH, control-valve sizing/noise (IEC 60534), thermowell strength (ASME PTC 19.3), pipeline overpressure protection, orifice metering (GPSA/ISO 5167), and crude desalting, each with optional Stream/Pump/Flare/Valve bridges and JSON output** |
+| ProcessModel Overview | [docs/process/processmodel/README.md](process/processmodel/README.md)                                                               | Process system management |
+| ProcessSystem         | [docs/process/processmodel/process_system.md](process/processmodel/process_system.md)                                         | ProcessSystem class (connections, stream introspection, named controllers, unified elements) |
+| ProcessModel          | [docs/process/processmodel/process_model.md](process/processmodel/process_model.md)                                           | Multi-process models      |
+| ProcessModule         | [docs/process/processmodel/process_module.md](process/processmodel/process_module.md)                                         | Modular process units     |
+| Process JSON Export   | [docs/process/process_json_export_and_e300_fluids.md](process/process_json_export_and_e300_fluids.md)                         | Export ProcessSystem and ProcessModel JSON for MCP, including E300-equivalent component properties, volume correction, stream-specific fluids, recycle settings, and convergence checks |
+| Graph Simulation      | [docs/process/processmodel/graph_simulation.md](process/processmodel/graph_simulation.md)                                     | Graph-based simulation    |
+| Diagram Export        | [docs/process/processmodel/diagram_export.md](process/processmodel/diagram_export.md)                                         | PFD diagram export        |
+| DEXPI Architecture    | [docs/process/processmodel/DIAGRAM_ARCHITECTURE_DEXPI_SYNERGY.md](process/processmodel/DIAGRAM_ARCHITECTURE_DEXPI_SYNERGY.md) | DEXPI integration         |
+| Low-Flow Bypass       | [docs/process/processmodel/low_flow_bypass.md](process/processmodel/low_flow_bypass.md)                                       | Auto-bypass / manual deactivation of low-flow process sections; feed-flow configuration patterns for parallel trains |
+| Parallel Scenario Sweeps | [docs/process/processmodel/parallel_scenario_sweeps.md](process/processmodel/parallel_scenario_sweeps.md)                  | Safe clone-and-run pattern for running parameter sweeps / DoE scenarios in parallel via ProcessSystem.copy() deep copy |
+| Run Status            | [docs/process/processmodel/run_status.md](process/processmodel/run_status.md)                                                 | Detect failed runs and identify the failing unit via structured RunStatus / UnitRunStatus and schema-versioned JSON |
+| Simulation Hooks      | [docs/process/simulation-hooks-and-events.md](process/simulation-hooks-and-events.md)                                         | Lifecycle hooks, ProcessEventBus, auto-validation for ProcessSystem and ProcessModel |
+| **UniSim/HYSYS Conversion** | [docs/process/unisim-to-neqsim-conversion.md](process/unisim-to-neqsim-conversion.md)                                  | **Convert UniSim Design (.usc) models to NeqSim and export NeqSim back to UniSim — COM automation, mapping tables, topology reconstruction, verification** |
+| **Exergy Analysis**   | [docs/process/exergy-analysis.md](process/exergy-analysis.md)                                                                 | **Plant-wide exergy destruction hotspots — ProcessSystem, ProcessModel, ExergyAnalysisReport API, JSON export** |
+| **Production Allocation** | [docs/process/production-allocation.md](process/production-allocation.md)                                                  | **Back-allocate metered production to wells/sources via a linear recovery-factor proxy network — split factors, (I−A)v=b solve, mass closure, auto-detection, closed-form first-order uncertainty propagation, JSON export** |
+| **Cached K-Value Fast Simulation** | [docs/process/k-value-fast-simulation.md](process/k-value-fast-simulation.md)                                      | **Run one rigorous base-case ProcessSystem, freeze separator K-values and fallback split factors, then execute fast source-rate scenarios without repeated EOS flashes** |
+| **Screening & Sizing Calculators** | [docs/process/screening_calculators.md](process/screening_calculators.md)                                          | **Standalone serializable screening calculators — flare radiation (API 521), line sizing/erosion LOF (API RP 14E), flow-induced vibration (AVIFF), pump NPSH, control-valve sizing/noise (IEC 60534), thermowell strength (ASME PTC 19.3), pipeline overpressure protection, orifice metering (GPSA/ISO 5167), and crude desalting, each with optional Stream/Pump/Flare/Valve bridges and JSON output** |
 
 ### Chapter 13: Streams & Mixers
 
 | Document           | Path                                                                             | Description               |
 | ------------------ | -------------------------------------------------------------------------------- | ------------------------- |
-| Streams            | [docs/process/equipment/streams.md](process/equipment/streams)                   | Stream models             |
-| Mixers/Splitters   | [docs/process/equipment/mixers_splitters.md](process/equipment/mixers_splitters) | Mixer and splitter models |
-| Equipment Overview | [docs/process/equipment/README.md](process/equipment/)                           | Equipment module overview |
+| Streams            | [docs/process/equipment/streams.md](process/equipment/streams.md)                   | Stream models             |
+| Mixers/Splitters   | [docs/process/equipment/mixers_splitters.md](process/equipment/mixers_splitters.md) | Mixer and splitter models |
+| Equipment Overview | [docs/process/equipment/README.md](process/equipment/README.md)                           | Equipment module overview |
 
 ### Chapter 13b: Bio-Processing Unit Operations
 
 | Document             | Path                                                   | Description                                                                                                                                                                                                 |
 | -------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Bio-Processing Guide | [docs/process/bioprocessing.md](process/bioprocessing) | **Reactors, fermenters, enzyme treatment, solid-liquid separators, liquid-liquid extraction, multi-effect evaporators, dryers, crystallizers — mathematical models, design equations, simulation examples** |
+| Bio-Processing Guide | [docs/process/bioprocessing.md](process/bioprocessing.md) | **Reactors, fermenters, enzyme treatment, solid-liquid separators, liquid-liquid extraction, multi-effect evaporators, dryers, crystallizers — mathematical models, design equations, simulation examples** |
 
 ### Chapter 14: Separation Equipment
 
 | Document           | Path                                                                           | Description                                                                                                                                                                                                        |
 | ------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Separators         | [docs/process/equipment/separators.md](process/equipment/separators)           | Two/three-phase separators, scrubbers, **entrainment specification (setEntrainment)**, design parameters, performance constraints (K-value, droplet cut size, retention time), Equinor TR3500 & API 12J compliance, **entrainment performance in mechanical design JSON**, **separation-efficiency report** (`calculateSeparationEfficiency()` → `SeparatorEfficiencyReport` with per-internal K-factor operating windows; `setEfficiencyModelEnabled` toggle), **GasScrubberMechanicalDesign internals API** (cyclones, mesh pads, vane packs, drain pipes, level alarms), **conformity checking** (`checkConformity()` with TR3500 rule set) |
+| Separators         | [docs/process/equipment/separators.md](process/equipment/separators.md)           | Two/three-phase separators, scrubbers, **entrainment specification (setEntrainment)**, design parameters, performance constraints (K-value, droplet cut size, retention time), Equinor TR3500 & API 12J compliance, **entrainment performance in mechanical design JSON**, **separation-efficiency report** (`calculateSeparationEfficiency()` → `SeparatorEfficiencyReport` with per-internal K-factor operating windows; `setEfficiencyModelEnabled` toggle), **GasScrubberMechanicalDesign internals API** (cyclones, mesh pads, vane packs, drain pipes, level alarms), **conformity checking** (`checkConformity()` with TR3500 rule set) |
 | Separator Demisting Internals | (Java source) | **Demisting internal classes** (`process.mechanicaldesign.separator.internals`) — `DemistingInternal` (wire mesh, vane pack, cyclone; Souders-Brown velocity, Eu-number pressure drop, carry-over model), `DemistingInternalWithDrainage` (adds drainage efficiency). Used by `SeparatorMechanicalDesign` for mist eliminator sizing. |
 | Separator Primary Separation | (Java source) | **Primary separation / inlet device classes** (`process.mechanicaldesign.separator.primaryseparation`) — `PrimarySeparation` (inlet momentum, bulk efficiency), `InletVane` (6000 Pa, 85%), `InletVaneWithMeshpad` (92%+mesh), `InletCyclones` (8000 Pa, 95%). Used by `SeparatorMechanicalDesign` bridge methods. |
 | Gas Scrubber Internals API | (Java source) | **`GasScrubberMechanicalDesign`** — ~40 methods for configuring scrubber internals: `setInletDevice(String)`, `setDemistingCyclones(n, diam, deckElev, length)`, `setMeshPad(area, thickness)`, `setVanePack(area)`, drain pipes, level alarm elevations. Geometry owned by `SeparatorMechanicalDesign`; `Separator` delegates via computed getters. |
 | Scrubber Conformity Checking | (Java source) | **Conformity checking package** (`process.mechanicaldesign.separator.conformity`) — `ConformityResult` (PASS/WARNING/FAIL, 90% threshold), `ConformityReport` (collection with `isConforming()`, `toTextReport()`), `ConformityRuleSet` (abstract base + `TR3500RuleSet`: K-factor ≤0.15, inlet momentum ≤15000 Pa, drainage head, cyclone-dp-to-drain ≤50 mbar, mesh-K ≤0.27). |
-| Separator Entrainment Modeling | [docs/process/equipment/separator-entrainment-modeling.md](process/equipment/separator-entrainment-modeling) | **Enhanced physics-based separator performance** — droplet size distributions, flow regime prediction (Mandhane, Taitel-Dukler), inlet device modeling (7 types, Bothamley momentum), grade efficiency curves, Schiller-Naumann settling, **expanded internals database (70+ internals, 31 inlet devices, 25 vendor curves)**, K-factor flooding, three-phase liquid-liquid separation, **Csanady turbulence correction**, **API 12J compliance check**, **partial flooding model** (Fabian/GPSA), **auto liquid-liquid DSD** (Hinze/ε inlet dissipation), EOS-derived oil-water volume fractions, **vendor-certified efficiency curves** (from factory acceptance tests), **calibration framework** (manual, auto, grouped, CSV batch fitting, JSON reports), **mechanical design integration** (entrainment fractions, efficiency, calibration factors in `calcDesign()`/`toJson()`), **dynamic simulation integration** (transient entrainment via `runTransient()`, VU flash → performance calculator → outlet composition, vessel inventory preserved, two-phase and three-phase separators) |
+| Separator Entrainment Modeling | [docs/process/equipment/separator-entrainment-modeling.md](process/equipment/separator-entrainment-modeling.md) | **Enhanced physics-based separator performance** — droplet size distributions, flow regime prediction (Mandhane, Taitel-Dukler), inlet device modeling (7 types, Bothamley momentum), grade efficiency curves, Schiller-Naumann settling, **expanded internals database (70+ internals, 31 inlet devices, 25 vendor curves)**, K-factor flooding, three-phase liquid-liquid separation, **Csanady turbulence correction**, **API 12J compliance check**, **partial flooding model** (Fabian/GPSA), **auto liquid-liquid DSD** (Hinze/ε inlet dissipation), EOS-derived oil-water volume fractions, **vendor-certified efficiency curves** (from factory acceptance tests), **calibration framework** (manual, auto, grouped, CSV batch fitting, JSON reports), **mechanical design integration** (entrainment fractions, efficiency, calibration factors in `calcDesign()`/`toJson()`), **dynamic simulation integration** (transient entrainment via `runTransient()`, VU flash → performance calculator → outlet composition, vessel inventory preserved, two-phase and three-phase separators) |
 | Separator Entrainment Notebook | [examples/notebooks/separator_entrainment_modeling.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/separator_entrainment_modeling.ipynb) | **Jupyter notebook: separator entrainment modeling** — physics-based entrainment, droplet distributions, grade efficiency, internals selection, K-factor analysis, flow regime maps |
 | Separator Vendor Curves & Calibration Notebook | [examples/notebooks/separator_vendor_curves_and_calibration.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/separator_vendor_curves_and_calibration.ipynb) | **Jupyter notebook: vendor curves & calibration** — expanded internals database (70+ records), 25 vendor-certified efficiency curves, vendor vs generic comparison, calibration framework (manual, auto, grouped, batch), JSON calibration reports, full database catalog export |
 | Separator Dynamic Entrainment Notebook | [examples/notebooks/separator_dynamic_entrainment.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/separator_dynamic_entrainment.ipynb) | **Jupyter notebook: dynamic separator entrainment** — transient simulation with enhanced entrainment, entrainment tracking over time, feed rate disturbance response, with/without entrainment comparison, three-phase separator dynamic, matplotlib visualizations |
-| Distillation       | [docs/process/equipment/distillation.md](process/equipment/distillation)       | Distillation columns, **ColumnSpecification**, builder pattern, solver options including **AUTO**, specification homotopy, side draws, pumparounds, condenser/reboiler modes, hydraulic pressure-drop coupling, shortcut initialization, tray efficiency, dynamic screening, rate-based packed columns, and MESH residual diagnostics |
-| Distillation Wiki  | [docs/wiki/distillation_column.md](wiki/distillation_column)                   | Distillation column equations, solver details including **AUTO**, specification homotopy, outer tear variables for side draws, pumparounds, and hydraulics, convergence diagnostics, and MESH residual monitoring                                                                                                                |
-| Absorbers          | [docs/process/equipment/absorbers.md](process/equipment/absorbers)             | Absorption equipment: **SimpleTEGAbsorber (Fs-factor sizing, dew point validation), SimpleAmineAbsorber (MDEA/DEA/MEA gas sweetening, design validation), RateBasedAbsorber (Onda/Billet-Schultes mass transfer, Hatta enhancement, packed column design)** |
-| **H2S Scavenger**  | [docs/process/H2S_scavenger_guide.md](process/H2S_scavenger_guide)             | **Chemical scavenging of H2S from gas - triazine, glyoxal, iron sponge, caustic, liquid redox**                                                                                                                    |
-| Membrane           | [docs/wiki/membrane_separation.md](wiki/membrane_separation)                   | Membrane separation                                                                                                                                                                                                |
-| Membrane Equipment | [docs/process/equipment/membranes.md](process/equipment/membranes)             | Membrane equipment                                                                                                                                                                                                 |
-| Filters            | [docs/process/equipment/filters.md](process/equipment/filters)                 | Oil and gas filter types, beta-ratio capture, measured/flow-scaled/Ergun pressure drop, dynamic loading, bypass, sulfur `S8` capture, and mechanical design                                                            |
-| Water Treatment    | [docs/process/equipment/water_treatment.md](process/equipment/water_treatment) | **Hydrocyclones (physics-based d50, DSD integration, PDR model, liner sizing, OSPAR compliance, ASME VIII mechanical design), GasFlotationUnit (IGF/DGF, per-stage efficiency, reject flow)**, produced water treatment trains, OIW limits |
+| Distillation       | [docs/process/equipment/distillation.md](process/equipment/distillation.md)       | Distillation columns, **ColumnSpecification**, builder pattern, solver options including **AUTO**, specification homotopy, side draws, pumparounds, condenser/reboiler modes, hydraulic pressure-drop coupling, shortcut initialization, tray efficiency, dynamic screening, rate-based packed columns, and MESH residual diagnostics |
+| Distillation Wiki  | [docs/wiki/distillation_column.md](wiki/distillation_column.md)                   | Distillation column equations, solver details including **AUTO**, specification homotopy, outer tear variables for side draws, pumparounds, and hydraulics, convergence diagnostics, and MESH residual monitoring                                                                                                                |
+| Absorbers          | [docs/process/equipment/absorbers.md](process/equipment/absorbers.md)             | Absorption equipment: **SimpleTEGAbsorber (Fs-factor sizing, dew point validation), SimpleAmineAbsorber (MDEA/DEA/MEA gas sweetening, design validation), RateBasedAbsorber (Onda/Billet-Schultes mass transfer, Hatta enhancement, packed column design)** |
+| **H2S Scavenger**  | [docs/process/H2S_scavenger_guide.md](process/H2S_scavenger_guide.md)             | **Chemical scavenging of H2S from gas - triazine, glyoxal, iron sponge, caustic, liquid redox**                                                                                                                    |
+| Membrane           | [docs/wiki/membrane_separation.md](wiki/membrane_separation.md)                   | Membrane separation                                                                                                                                                                                                |
+| Membrane Equipment | [docs/process/equipment/membranes.md](process/equipment/membranes.md)             | Membrane equipment                                                                                                                                                                                                 |
+| Filters            | [docs/process/equipment/filters.md](process/equipment/filters.md)                 | Oil and gas filter types, beta-ratio capture, measured/flow-scaled/Ergun pressure drop, dynamic loading, bypass, sulfur `S8` capture, and mechanical design                                                            |
+| Water Treatment    | [docs/process/equipment/water_treatment.md](process/equipment/water_treatment.md) | **Hydrocyclones (physics-based d50, DSD integration, PDR model, liner sizing, OSPAR compliance, ASME VIII mechanical design), GasFlotationUnit (IGF/DGF, per-stage efficiency, reject flow)**, produced water treatment trains, OIW limits |
 
 ### Chapter 15: Rotating Equipment
 
 | Document          | Path                                                                                           | Description                                       |
 | ----------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| Compressors       | [docs/process/equipment/compressors.md](process/equipment/compressors)                         | Compressor models, drivers, speed-dependent power |
-| Compressor Curves | [docs/process/equipment/compressor_curves.md](process/equipment/compressor_curves)             | Compressor performance curves                     |
-| Compressor Anti-Surge Control | [docs/process/equipment/compressor_antisurge_control.md](process/equipment/compressor_antisurge_control) | Dynamic anti-surge recycle, pressure-speed control, predictive supervision, coordinated override philosophy, and application-design scan logic |
-| Compressor Shaft (shared drive) | [docs/process/equipment/compressor_shaft.md](process/equipment/compressor_shaft) | Multiple compressor bodies on one shaft at a single common speed; iterate the common speed to the final discharge with floating intermediates |
-| Compressor Design | [docs/process/CompressorMechanicalDesign.md](process/CompressorMechanicalDesign)               | Compressor mechanical design                      |
-| Compressor Feasibility | [docs/process/compressor_design_feasibility.md](process/compressor_design_feasibility) | Feasibility report: mechanical, cost, suppliers, curves |
-| Compressor Deposit / Degradation | [docs/process/compressor_deposit_degradation.md](process/compressor_deposit_degradation) | Mass-based fouling (S8, salt, scale, wax) → head/efficiency loss, degraded chart, per-impeller deposit location |
-| Pumps             | [docs/process/equipment/pumps.md](process/equipment/pumps)                                     | Pump models                                       |
-| Pump Guide        | [docs/wiki/pump_usage_guide.md](wiki/pump_usage_guide)                                         | Pump usage guide                                  |
-| Pump Theory       | [docs/wiki/pump_theory_and_implementation.md](wiki/pump_theory_and_implementation)             | Pump theory                                       |
-| Expanders         | [docs/process/equipment/expanders.md](process/equipment/expanders)                             | Expander models                                   |
-| Turboexpander     | [docs/simulation/turboexpander_compressor_model.md](simulation/turboexpander_compressor_model) | Turboexpander model                               |
-| Ejectors          | [docs/process/equipment/ejectors.md](process/equipment/ejectors)                               | Ejector systems                                   |
+| Compressors       | [docs/process/equipment/compressors.md](process/equipment/compressors.md)                         | Compressor models, drivers, speed-dependent power |
+| Compressor Curves | [docs/process/equipment/compressor_curves.md](process/equipment/compressor_curves.md)             | Compressor performance curves                     |
+| Compressor Anti-Surge Control | [docs/process/equipment/compressor_antisurge_control.md](process/equipment/compressor_antisurge_control.md) | Dynamic anti-surge recycle, pressure-speed control, predictive supervision, coordinated override philosophy, and application-design scan logic |
+| Compressor Shaft (shared drive) | [docs/process/equipment/compressor_shaft.md](process/equipment/compressor_shaft.md) | Multiple compressor bodies on one shaft at a single common speed; iterate the common speed to the final discharge with floating intermediates |
+| Compressor Design | [docs/process/CompressorMechanicalDesign.md](process/CompressorMechanicalDesign.md)               | Compressor mechanical design                      |
+| Compressor Feasibility | [docs/process/compressor_design_feasibility.md](process/compressor_design_feasibility.md) | Feasibility report: mechanical, cost, suppliers, curves |
+| Compressor Deposit / Degradation | [docs/process/compressor_deposit_degradation.md](process/compressor_deposit_degradation.md) | Mass-based fouling (S8, salt, scale, wax) → head/efficiency loss, degraded chart, per-impeller deposit location |
+| Pumps             | [docs/process/equipment/pumps.md](process/equipment/pumps.md)                                     | Pump models                                       |
+| Pump Guide        | [docs/wiki/pump_usage_guide.md](wiki/pump_usage_guide.md)                                         | Pump usage guide                                  |
+| Pump Theory       | [docs/wiki/pump_theory_and_implementation.md](wiki/pump_theory_and_implementation.md)             | Pump theory                                       |
+| Expanders         | [docs/process/equipment/expanders.md](process/equipment/expanders.md)                             | Expander models                                   |
+| Turboexpander     | [docs/simulation/turboexpander_compressor_model.md](simulation/turboexpander_compressor_model.md) | Turboexpander model                               |
+| Ejectors          | [docs/process/equipment/ejectors.md](process/equipment/ejectors.md)                               | Ejector systems                                   |
 
 ### Chapter 16: Heat Transfer Equipment
 
 | Document                        | Path                                                                                                 | Description                                                                                                         |
 | ------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| Heat Exchangers                 | [docs/process/equipment/heat_exchangers.md](process/equipment/heat_exchangers)                       | Heat exchanger models                                                                                               |
-| **Multi-Stream Heat Exchanger** | [docs/process/equipment/multistream_heat_exchanger.md](process/equipment/multistream_heat_exchanger) | **Comprehensive guide: composite curves, pinch analysis, LMTD, 1-3 unknown solvers for LNG/cryogenic applications** |
-| **LNG Heat Exchanger (BAHX)**   | [docs/process/equipment/LNGHeatExchanger.md](process/equipment/LNGHeatExchanger)                     | **Brazed aluminium plate-fin: P1-P10 features, exergy, adaptive zones, Manglik-Bergles, transient, core sizing, freeze-out, maldistribution, mechanical design, cost** |
-| **LNG Ageing Package**          | [docs/process/lng-ageing.md](process/lng-ageing)                                                     | **LNG weathering, stratification, rollover, BOG handling, methane number, sloshing, multi-tank ship models, ISO 6578** |
-| Air Cooler                      | [docs/wiki/air_cooler.md](wiki/air_cooler)                                                           | Air cooler models                                                                                                   |
-| **Process Sim Enhancements**    | [docs/process/process-simulation-enhancements.md](process/process-simulation-enhancements)           | **AirCooler thermal design, PackedColumn, column internals sizing, shortcut distillation, PVF flash, stream summary** |
-| Water Cooler                    | [docs/wiki/water_cooler.md](wiki/water_cooler)                                                       | Water cooler models                                                                                                 |
-| Steam Heater                    | [docs/wiki/steam_heater.md](wiki/steam_heater)                                                       | Steam heater models                                                                                                 |
-| **Water Cooler & Reboiler**     | [docs/process/equipment/water_cooler_reboiler.md](process/equipment/water_cooler_reboiler)           | **WaterCooler (IAPWS), ReBoiler for distillation**                                                                  |
-| Mechanical Design               | [docs/wiki/heat_exchanger_mechanical_design.md](wiki/heat_exchanger_mechanical_design)               | HX mechanical design                                                                                                |
-| **Thermal-Hydraulic Design**    | [docs/process/mechanical_design/thermal_hydraulic_design.md](process/mechanical_design/thermal_hydraulic_design) | **Shell-and-tube thermal design: Gnielinski, Kern, Bell-Delaware, LMTD correction, vibration screening, zone analysis** |
-| **Two-Phase Heat Transfer**     | [docs/process/mechanical_design/two_phase_heat_transfer.md](process/mechanical_design/two_phase_heat_transfer) | **Shah condensation, Chen/Gungor-Winterton boiling, Friedel/MSH two-phase pressure drop, Ebert-Panchal fouling, incremental zone analysis, tube inserts** |
-| **Heat Integration (Pinch Analysis)** | [docs/process/equipment/heat_integration.md](process/equipment/heat_integration) | **PinchAnalysis class: Linnhoff method, composite curves, grand composite curve, minimum utility targeting, HeatStream model** |
+| Heat Exchangers                 | [docs/process/equipment/heat_exchangers.md](process/equipment/heat_exchangers.md)                       | Heat exchanger models                                                                                               |
+| **Multi-Stream Heat Exchanger** | [docs/process/equipment/multistream_heat_exchanger.md](process/equipment/multistream_heat_exchanger.md) | **Comprehensive guide: composite curves, pinch analysis, LMTD, 1-3 unknown solvers for LNG/cryogenic applications** |
+| **LNG Heat Exchanger (BAHX)**   | [docs/process/equipment/LNGHeatExchanger.md](process/equipment/LNGHeatExchanger.md)                     | **Brazed aluminium plate-fin: P1-P10 features, exergy, adaptive zones, Manglik-Bergles, transient, core sizing, freeze-out, maldistribution, mechanical design, cost** |
+| **LNG Ageing Package**          | [docs/process/lng-ageing.md](process/lng-ageing.md)                                                     | **LNG weathering, stratification, rollover, BOG handling, methane number, sloshing, multi-tank ship models, ISO 6578** |
+| Air Cooler                      | [docs/wiki/air_cooler.md](wiki/air_cooler.md)                                                           | Air cooler models                                                                                                   |
+| **Process Sim Enhancements**    | [docs/process/process-simulation-enhancements.md](process/process-simulation-enhancements.md)           | **AirCooler thermal design, PackedColumn, column internals sizing, shortcut distillation, PVF flash, stream summary** |
+| Water Cooler                    | [docs/wiki/water_cooler.md](wiki/water_cooler.md)                                                       | Water cooler models                                                                                                 |
+| Steam Heater                    | [docs/wiki/steam_heater.md](wiki/steam_heater.md)                                                       | Steam heater models                                                                                                 |
+| **Water Cooler & Reboiler**     | [docs/process/equipment/water_cooler_reboiler.md](process/equipment/water_cooler_reboiler.md)           | **WaterCooler (IAPWS), ReBoiler for distillation**                                                                  |
+| Mechanical Design               | [docs/wiki/heat_exchanger_mechanical_design.md](wiki/heat_exchanger_mechanical_design.md)               | HX mechanical design                                                                                                |
+| **Thermal-Hydraulic Design**    | [docs/process/mechanical_design/thermal_hydraulic_design.md](process/mechanical_design/thermal_hydraulic_design.md) | **Shell-and-tube thermal design: Gnielinski, Kern, Bell-Delaware, LMTD correction, vibration screening, zone analysis** |
+| **Two-Phase Heat Transfer**     | [docs/process/mechanical_design/two_phase_heat_transfer.md](process/mechanical_design/two_phase_heat_transfer.md) | **Shah condensation, Chen/Gungor-Winterton boiling, Friedel/MSH two-phase pressure drop, Ebert-Panchal fouling, incremental zone analysis, tube inserts** |
+| **Heat Integration (Pinch Analysis)** | [docs/process/equipment/heat_integration.md](process/equipment/heat_integration.md) | **PinchAnalysis class: Linnhoff method, composite curves, grand composite curve, minimum utility targeting, HeatStream model** |
 
 ### Chapter 17: Valves & Flow Control
 
 | Document                      | Path                                                                                           | Description                                                                                                                                                            |
 | ----------------------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Valves                        | [docs/process/equipment/valves.md](process/equipment/valves)                                   | Valve models                                                                                                                                                           |
-| **Control Valves**            | [docs/process/equipment/control_valves.md](process/equipment/control_valves)                   | **CheckValve, LevelControlValve, PressureControlValve, ESD/PSD valves**                                                                                                |
-| Valve Design                  | [docs/process/ValveMechanicalDesign.md](process/ValveMechanicalDesign)                         | Valve mechanical design                                                                                                                                                |
-| **Multiphase Choke Flow**     | [docs/process/MultiphaseChokeFlow.md](process/MultiphaseChokeFlow)                             | **Sachdeva, Gilbert two-phase choke models**                                                                                                                           |
-| **Well Choke Implementation** | [docs/process/well_choke_implementation.md](process/well_choke_implementation)                 | **Architecture, models, ThrottlingValve integration, Python usage**                                                                                                    |
-| **Choke Collapse Analysis**   | [docs/process/choke-collapse.md](process/choke-collapse)                                       | **ChokeCollapseAnalyzer — critical pressure ratio, flashing & cavitation flags for throttling valves**                                                                 |
-| **Inadvertent Valve Operation** | [docs/process/inadvertent-valve-operation.md](process/inadvertent-valve-operation)             | **InadvertentValveOperationAnalyzer — API 521 §4.4.13 / NORSOK P-002 §5.5 IVO scenario screening with severity, frequency and recommendations**                       |
-| Flow Meters                   | [docs/wiki/flow_meter_models.md](wiki/flow_meter_models)                                       | Flow metering                                                                                                                                                          |
-| Venturi                       | [docs/wiki/venturi_calculation.md](wiki/venturi_calculation)                                   | Venturi calculations                                                                                                                                                   |
-| Tanks                         | [docs/process/equipment/tanks.md](process/equipment/tanks)                                     | Tank models                                                                                                                                                            |
-| **Vessel Depressurization**   | [docs/process/equipment/vessel_depressurization.md](process/equipment/vessel_depressurization) | **Filling, blowdown, fire cases, transient wall HT, composite vessels, CNG/H2 tanks, flow assurance, real-gas beta, Biot correction, Rohsenow boiling, API reference** |
-| **Measurement Devices**       | [docs/process/equipment/measurement_devices.md](process/equipment/measurement_devices)         | **CO2 emissions, FIV analysis, NMVOC, dew points, safety detectors**                                                                                                   |
+| Valves                        | [docs/process/equipment/valves.md](process/equipment/valves.md)                                   | Valve models                                                                                                                                                           |
+| **Control Valves**            | [docs/process/equipment/control_valves.md](process/equipment/control_valves.md)                   | **CheckValve, LevelControlValve, PressureControlValve, ESD/PSD valves**                                                                                                |
+| Valve Design                  | [docs/process/ValveMechanicalDesign.md](process/ValveMechanicalDesign.md)                         | Valve mechanical design                                                                                                                                                |
+| **Multiphase Choke Flow**     | [docs/process/MultiphaseChokeFlow.md](process/MultiphaseChokeFlow.md)                             | **Sachdeva, Gilbert two-phase choke models**                                                                                                                           |
+| **Well Choke Implementation** | [docs/process/well_choke_implementation.md](process/well_choke_implementation.md)                 | **Architecture, models, ThrottlingValve integration, Python usage**                                                                                                    |
+| **Choke Collapse Analysis**   | [docs/process/choke-collapse.md](process/choke-collapse.md)                                       | **ChokeCollapseAnalyzer — critical pressure ratio, flashing & cavitation flags for throttling valves**                                                                 |
+| **Inadvertent Valve Operation** | [docs/process/inadvertent-valve-operation.md](process/inadvertent-valve-operation.md)             | **InadvertentValveOperationAnalyzer — API 521 §4.4.13 / NORSOK P-002 §5.5 IVO scenario screening with severity, frequency and recommendations**                       |
+| Flow Meters                   | [docs/wiki/flow_meter_models.md](wiki/flow_meter_models.md)                                       | Flow metering                                                                                                                                                          |
+| Venturi                       | [docs/wiki/venturi_calculation.md](wiki/venturi_calculation.md)                                   | Venturi calculations                                                                                                                                                   |
+| Tanks                         | [docs/process/equipment/tanks.md](process/equipment/tanks.md)                                     | Tank models                                                                                                                                                            |
+| **Vessel Depressurization**   | [docs/process/equipment/vessel_depressurization.md](process/equipment/vessel_depressurization.md) | **Filling, blowdown, fire cases, transient wall HT, composite vessels, CNG/H2 tanks, flow assurance, real-gas beta, Biot correction, Rohsenow boiling, API reference** |
+| **Measurement Devices**       | [docs/process/equipment/measurement_devices.md](process/equipment/measurement_devices.md)         | **CO2 emissions, FIV analysis, NMVOC, dew points, safety detectors**                                                                                                   |
 
 ### Chapter 18: Special Equipment
 
 | Document                       | Path                                                                                       | Description                                                                                                        |
 | ------------------------------ | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
-| Reactors                       | [docs/process/equipment/reactors.md](process/equipment/reactors)                           | All reactor types overview (PFR, CSTR, Gibbs, stoichiometric, ammonia, sulfur oxidation/deposition, bio-processing) |
-| **Iron-Sulfide Wall Source**   | [docs/process/equipment/iron_sulfide_wall_source.md](process/equipment/iron_sulfide_wall_source) | **Historical FeS/FeCO3 wall inventory, oxygen-limited S8 source, uncertainty, condensate and warm-shaft deposition coupling** |
-| **Plug Flow Reactor Guide**    | [docs/process/equipment/plug_flow_reactor.md](process/equipment/plug_flow_reactor)         | **Kinetic PFR: power-law/LHHW/reversible kinetics, catalyst bed, Ergun ΔP, energy modes, axial profiles, Python** |
-| Gibbs Reactor                  | [docs/wiki/gibbs_reactor.md](wiki/gibbs_reactor)                                           | Gibbs reactor                                                                                                      |
-| Electrolyzers                  | [docs/process/equipment/electrolyzers.md](process/equipment/electrolyzers)                 | Electrolyzer systems                                                                                               |
-| CO2 Electrolyzer               | [docs/pvtsimulation/CO2ElectrolyzerExample.md](pvtsimulation/CO2ElectrolyzerExample)       | CO2 electrolyzer example                                                                                           |
-| Flares                         | [docs/process/equipment/flares.md](process/equipment/flares)                               | Flare systems                                                                                                      |
-| Adsorbers (SimpleAdsorber)     | [docs/process/equipment/adsorbers.md](process/equipment/adsorbers)                         | Simplified gas absorption with MDEA                                                                                |
-| **Adsorption Bed (Transient)** | [docs/process/equipment/adsorption_bed.md](process/equipment/adsorption_bed)               | **Fixed-bed adsorption with LDF mass transfer, MTZ, PSA/TSA cycles**                                               |
-| **Mercury Removal Guard Bed**  | [docs/process/mercury_removal.md](process/mercury_removal)                                 | **Chemisorption (PuraSpec), transient bed loading, breakthrough, degradation, mechanical design, cost estimation** |
-| Power Generation               | [docs/process/equipment/power_generation.md](process/equipment/power_generation)           | **GasTurbine, SteamTurbine, HRSG, CombinedCycleSystem, FuelCell, renewables (SolarPanel, WindTurbine, WindFarm). Capacity constraints, auto-sizing, and optimization integration. `gasturbine` sub-package: GasTurbineCatalog (14 aero/industrial models), GasTurbineUnit, TurbineDispatchOptimizer (N+1 reserve), LateLifeRetrofitStudy, CO2TaxSchedule (Norway 2020-2040), GasTurbineDegradation, GasTurbineEmissions** |
-| Diff. Pressure                 | [docs/process/equipment/differential_pressure.md](process/equipment/differential_pressure) | Orifice plates, flow measurement                                                                                   |
-| Manifolds                      | [docs/process/equipment/manifolds.md](process/equipment/manifolds)                         | Multi-stream routing                                                                                               |
-| **Battery Storage**            | [docs/process/equipment/battery_storage.md](process/equipment/battery_storage)             | **Energy storage systems, charge/discharge cycles, grid integration**                                              |
-| Solar Panel                    | [docs/wiki/solar_panel.md](wiki/solar_panel)                                               | Solar panel models                                                                                                 |
-| **Failure Mode Modeling**      | [docs/process/equipment/failure_modes.md](process/equipment/failure_modes)                 | **Equipment failure modes, reliability analysis, MTBF/MTTR calculations**                                          |
+| Reactors                       | [docs/process/equipment/reactors.md](process/equipment/reactors.md)                           | All reactor types overview (PFR, CSTR, Gibbs, stoichiometric, ammonia, sulfur oxidation/deposition, bio-processing) |
+| **Iron-Sulfide Wall Source**   | [docs/process/equipment/iron_sulfide_wall_source.md](process/equipment/iron_sulfide_wall_source.md) | **Historical FeS/FeCO3 wall inventory, oxygen-limited S8 source, uncertainty, condensate and warm-shaft deposition coupling** |
+| **Plug Flow Reactor Guide**    | [docs/process/equipment/plug_flow_reactor.md](process/equipment/plug_flow_reactor.md)         | **Kinetic PFR: power-law/LHHW/reversible kinetics, catalyst bed, Ergun ΔP, energy modes, axial profiles, Python** |
+| Gibbs Reactor                  | [docs/wiki/gibbs_reactor.md](wiki/gibbs_reactor.md)                                           | Gibbs reactor                                                                                                      |
+| Electrolyzers                  | [docs/process/equipment/electrolyzers.md](process/equipment/electrolyzers.md)                 | Electrolyzer systems                                                                                               |
+| CO2 Electrolyzer               | [docs/pvtsimulation/CO2ElectrolyzerExample.md](pvtsimulation/CO2ElectrolyzerExample.md)       | CO2 electrolyzer example                                                                                           |
+| Flares                         | [docs/process/equipment/flares.md](process/equipment/flares.md)                               | Flare systems                                                                                                      |
+| Adsorbers (SimpleAdsorber)     | [docs/process/equipment/adsorbers.md](process/equipment/adsorbers.md)                         | Simplified gas absorption with MDEA                                                                                |
+| **Adsorption Bed (Transient)** | [docs/process/equipment/adsorption_bed.md](process/equipment/adsorption_bed.md)               | **Fixed-bed adsorption with LDF mass transfer, MTZ, PSA/TSA cycles**                                               |
+| **Mercury Removal Guard Bed**  | [docs/process/mercury_removal.md](process/mercury_removal.md)                                 | **Chemisorption (PuraSpec), transient bed loading, breakthrough, degradation, mechanical design, cost estimation** |
+| Power Generation               | [docs/process/equipment/power_generation.md](process/equipment/power_generation.md)           | **GasTurbine, SteamTurbine, HRSG, CombinedCycleSystem, FuelCell, renewables (SolarPanel, WindTurbine, WindFarm). Capacity constraints, auto-sizing, and optimization integration. `gasturbine` sub-package: GasTurbineCatalog (14 aero/industrial models), GasTurbineUnit, TurbineDispatchOptimizer (N+1 reserve), LateLifeRetrofitStudy, CO2TaxSchedule (Norway 2020-2040), GasTurbineDegradation, GasTurbineEmissions** |
+| Diff. Pressure                 | [docs/process/equipment/differential_pressure.md](process/equipment/differential_pressure.md) | Orifice plates, flow measurement                                                                                   |
+| Manifolds                      | [docs/process/equipment/manifolds.md](process/equipment/manifolds.md)                         | Multi-stream routing                                                                                               |
+| **Battery Storage**            | [docs/process/equipment/battery_storage.md](process/equipment/battery_storage.md)             | **Energy storage systems, charge/discharge cycles, grid integration**                                              |
+| Solar Panel                    | [docs/wiki/solar_panel.md](wiki/solar_panel.md)                                               | Solar panel models                                                                                                 |
+| **Failure Mode Modeling**      | [docs/process/equipment/failure_modes.md](process/equipment/failure_modes.md)                 | **Equipment failure modes, reliability analysis, MTBF/MTTR calculations**                                          |
 
 ### Chapter 19: Wells, Pipelines & Subsea
 
 | Document                              | Path                                                                                               | Description                                                                                                                                              |
 | ------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Wells                                 | [docs/process/equipment/wells.md](process/equipment/wells)                                         | Well equipment                                                                                                                                           |
-| Well Simulation                       | [docs/simulation/well_simulation_guide.md](simulation/well_simulation_guide)                       | Well simulation guide                                                                                                                                    |
-| Well & Choke                          | [docs/simulation/well_and_choke_simulation.md](simulation/well_and_choke_simulation)               | Choke valve simulation                                                                                                                                   |
-| Well Allocation                       | [docs/process/equipment/well_allocation.md](process/equipment/well_allocation)                     | Production allocation for commingled wells, VFM, well test methods                                                                                       |
-| Pipelines                             | [docs/process/equipment/pipelines.md](process/equipment/pipelines)                                 | Pipeline and riser models                                                                                                                                |
-| **Piping Route Builder**              | [docs/process/piping_route_builder.md](process/piping_route_builder)                               | **STID/E3D line-list route hydraulics: build serial Beggs-and-Brill pipe models from route tables, fittings, valves, elevations, and equipment nodes**    |
-| **TwoFluidPipe Model**                | [docs/process/TWOFLUIDPIPE_MODEL.md](process/TWOFLUIDPIPE_MODEL)                                   | **Two-fluid multiphase flow model**                                                                                                                      |
-| **TwoFluidPipe Detailed Review**      | [docs/wiki/two_fluid_model_review.md](wiki/two_fluid_model_review)               | **Mathematical equations, slug flow physics, Lagrangian tracking**                                                                                       |
+| Wells                                 | [docs/process/equipment/wells.md](process/equipment/wells.md)                                         | Well equipment                                                                                                                                           |
+| Well Simulation                       | [docs/simulation/well_simulation_guide.md](simulation/well_simulation_guide.md)                       | Well simulation guide                                                                                                                                    |
+| Well & Choke                          | [docs/simulation/well_and_choke_simulation.md](simulation/well_and_choke_simulation.md)               | Choke valve simulation                                                                                                                                   |
+| Well Allocation                       | [docs/process/equipment/well_allocation.md](process/equipment/well_allocation.md)                     | Production allocation for commingled wells, VFM, well test methods                                                                                       |
+| Pipelines                             | [docs/process/equipment/pipelines.md](process/equipment/pipelines.md)                                 | Pipeline and riser models                                                                                                                                |
+| **Piping Route Builder**              | [docs/process/piping_route_builder.md](process/piping_route_builder.md)                               | **STID/E3D line-list route hydraulics: build serial Beggs-and-Brill pipe models from route tables, fittings, valves, elevations, and equipment nodes**    |
+| **TwoFluidPipe Model**                | [docs/process/TWOFLUIDPIPE_MODEL.md](process/TWOFLUIDPIPE_MODEL.md)                                   | **Two-fluid multiphase flow model**                                                                                                                      |
+| **TwoFluidPipe Detailed Review**      | [docs/wiki/two_fluid_model_review.md](wiki/two_fluid_model_review.md)               | **Mathematical equations, slug flow physics, Lagrangian tracking**                                                                                       |
 | **TwoFluidPipe Tutorial (Jupyter)**   | [docs/examples/TwoFluidPipe_Tutorial.ipynb](https://github.com/equinor/neqsim/blob/master/docs/examples/TwoFluidPipe_Tutorial.ipynb)                  | **Interactive notebook: multiphase flow, slug tracking, terrain effects, heat transfer**                                                                 |
 | **TwoFluidPipe Comprehensive Tutorial** | [examples/notebooks/TwoFluidPipeMultiphaseFlowTutorial.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/TwoFluidPipeMultiphaseFlowTutorial.ipynb) | **Complete guide: steady-state, transient, three-phase (gas-oil-water), terrain effects, heat transfer, Beggs-Brill validation, slug tracking** |
-| **Risers**                            | [docs/process/equipment/pipelines.md#risers](process/equipment/pipelines#risers)                   | **SCR, TTR, Flexible, Lazy-Wave risers**                                                                                                                 |
-| Beggs & Brill                         | [docs/process/PipeBeggsAndBrills.md](process/PipeBeggsAndBrills)                                   | Beggs & Brill correlation                                                                                                                                |
-| **Multiphase Flow Correlations**      | [docs/process/equipment/multiphase_flow_correlations.md](process/equipment/multiphase_flow_correlations) | **Hagedorn-Brown (1965), Mukherjee-Brill (1985), comparison with Beggs & Brill — holdup, pressure gradient, flow pattern** |
-| **CO2 Injection Well Analysis**       | [docs/process/co2_injection_well_analysis.md](process/co2_injection_well_analysis)                  | **CO2InjectionWellAnalyzer, ImpurityMonitor, TransientWellbore, CO2FlowCorrections — integrated safety analysis for CO2 injection wells**                 |
-| **Hydrogen Production**               | [docs/process/hydrogen_production.md](process/hydrogen_production)                                  | **SMR/ATR/POX route templates, WGS, CO2 capture/compression, H2 drying/compression, carbon intensity, PSACascade, Electrolyzer — blue/green H2 plant modeling** |
-| Networks                              | [docs/process/equipment/networks.md](process/equipment/networks)                                   | Pipeline network modeling                                                                                                                                |
-| **Looped Pipeline Networks**          | [docs/process/equipment/looped_networks.md](process/equipment/looped_networks)                     | **Hardy Cross solver, ring mains, parallel pipelines, loop detection**                                                                                   |
-| **Production Well Networks**          | [docs/process/equipment/production_well_networks.md](process/equipment/production_well_networks)   | **IPR (PI, Vogel, Fetkovich), chokes, tubing VLP, multiphase pipe, artificial lift, water handling, sand/solids, corrosion, emissions in NR-GGA solver** |
+| **Risers**                            | [docs/process/equipment/pipelines.md#risers](process/equipment/pipelines.md#risers)                   | **SCR, TTR, Flexible, Lazy-Wave risers**                                                                                                                 |
+| Beggs & Brill                         | [docs/process/PipeBeggsAndBrills.md](process/PipeBeggsAndBrills.md)                                   | Beggs & Brill correlation                                                                                                                                |
+| **Multiphase Flow Correlations**      | [docs/process/equipment/multiphase_flow_correlations.md](process/equipment/multiphase_flow_correlations.md) | **Hagedorn-Brown (1965), Mukherjee-Brill (1985), comparison with Beggs & Brill — holdup, pressure gradient, flow pattern** |
+| **CO2 Injection Well Analysis**       | [docs/process/co2_injection_well_analysis.md](process/co2_injection_well_analysis.md)                  | **CO2InjectionWellAnalyzer, ImpurityMonitor, TransientWellbore, CO2FlowCorrections — integrated safety analysis for CO2 injection wells**                 |
+| **Hydrogen Production**               | [docs/process/hydrogen_production.md](process/hydrogen_production.md)                                  | **SMR/ATR/POX route templates, WGS, CO2 capture/compression, H2 drying/compression, carbon intensity, PSACascade, Electrolyzer — blue/green H2 plant modeling** |
+| Networks                              | [docs/process/equipment/networks.md](process/equipment/networks.md)                                   | Pipeline network modeling                                                                                                                                |
+| **Looped Pipeline Networks**          | [docs/process/equipment/looped_networks.md](process/equipment/looped_networks.md)                     | **Hardy Cross solver, ring mains, parallel pipelines, loop detection**                                                                                   |
+| **Production Well Networks**          | [docs/process/equipment/production_well_networks.md](process/equipment/production_well_networks.md)   | **IPR (PI, Vogel, Fetkovich), chokes, tubing VLP, multiphase pipe, artificial lift, water handling, sand/solids, corrosion, emissions in NR-GGA solver** |
 | **Production Network Tutorial**       | [examples/notebooks/production_well_network.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/production_well_network.ipynb) | **8-example notebook: IPR models, choke sensitivity, complete well system, multi-well gathering, choke allocation optimization**                    |
 | **Advanced Network Features**         | [examples/notebooks/production_network_advanced_features.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/production_network_advanced_features.ipynb) | **Artificial lift, 120-well scale, water handling, sand erosion (DNV RP O501), corrosion (NORSOK M-506), GHG emissions** |
-| **Looped Network Solver**             | [docs/process/PIPELINE_NETWORK_SOLVER_ENHANCEMENT.md](process/PIPELINE_NETWORK_SOLVER_ENHANCEMENT) | **Hardy Cross looped network solver for ring mains and parallel pipelines**                                                                              |
+| **Looped Network Solver**             | [docs/process/PIPELINE_NETWORK_SOLVER_ENHANCEMENT.md](process/PIPELINE_NETWORK_SOLVER_ENHANCEMENT.md) | **Hardy Cross looped network solver for ring mains and parallel pipelines**                                                                              |
 | **Looped Network Tutorial**           | [docs/examples/LoopedPipelineNetworkExample.ipynb](https://github.com/equinor/neqsim/blob/master/docs/examples/LoopedPipelineNetworkExample.ipynb)    | **Interactive notebook: ring mains, offshore rings, loop detection, Hardy Cross**                                                                        |
-| **Network Solver Tutorial**           | [docs/examples/NetworkSolverTutorial.md](examples/NetworkSolverTutorial)                           | **Tutorial for pipeline network solvers with worked examples**                                                                                           |
-| **Pipe Fittings & Equivalent Length** | [docs/process/PIPE_FITTINGS_EQUIVALENT_LENGTH.md](process/PIPE_FITTINGS_EQUIVALENT_LENGTH)         | **Equivalent length method for fittings: elbows, tees, valves, reducers per CRANE TP-410**                                                               |
-| Reservoirs                            | [docs/process/equipment/reservoirs.md](process/equipment/reservoirs)                               | Reservoir modeling                                                                                                                                       |
-| **Out-of-Zone Injection**             | [docs/process/out_of_zone_injection.md](process/out_of_zone_injection)                             | **Multi-zone injection, fracture containment, annular leakage, MAASP (API RP 90), cement degradation, conformance monitoring**                           |
+| **Network Solver Tutorial**           | [docs/examples/NetworkSolverTutorial.md](examples/NetworkSolverTutorial.md)                           | **Tutorial for pipeline network solvers with worked examples**                                                                                           |
+| **Pipe Fittings & Equivalent Length** | [docs/process/PIPE_FITTINGS_EQUIVALENT_LENGTH.md](process/PIPE_FITTINGS_EQUIVALENT_LENGTH.md)         | **Equivalent length method for fittings: elbows, tees, valves, reducers per CRANE TP-410**                                                               |
+| Reservoirs                            | [docs/process/equipment/reservoirs.md](process/equipment/reservoirs.md)                               | Reservoir modeling                                                                                                                                       |
+| **Out-of-Zone Injection**             | [docs/process/out_of_zone_injection.md](process/out_of_zone_injection.md)                             | **Multi-zone injection, fracture containment, annular leakage, MAASP (API RP 90), cement degradation, conformance monitoring**                           |
 | **Out-of-Zone Injection Tutorial**    | [examples/notebooks/out_of_zone_injection.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/out_of_zone_injection.ipynb)| **Interactive notebook: WellFlow injection mode, thermal stress, cement CO2 degradation, Hall plot**                                                     |
-| Subsea Systems                        | [docs/process/equipment/subsea_systems.md](process/equipment/subsea_systems)                       | Subsea wells and flowlines                                                                                                                               |
-| Subsea Equipment                      | [docs/process/equipment/subsea_equipment.md](process/equipment/subsea_equipment)                   | SubseaWell, SimpleFlowLine, flow assurance                                                                                                               |
-| **Subsea Trees**                      | [docs/process/equipment/subsea_trees.md](process/equipment/subsea_trees)                           | **Christmas trees: horizontal/vertical, dual-bore, valve configurations, wellhead integration**                                                          |
-| **Subsea Manifolds**                  | [docs/process/equipment/subsea_manifolds.md](process/equipment/subsea_manifolds)                   | **Production/injection manifolds, valve skids, well routing, gathering systems**                                                                         |
-| **Subsea Boosters**                   | [docs/process/equipment/subsea_boosters.md](process/equipment/subsea_boosters)                     | **Subsea pumps & compressors, helico-axial/multiphase, performance curves**                                                                              |
-| **Umbilicals**                        | [docs/process/equipment/umbilicals.md](process/equipment/umbilicals)                               | **Control umbilicals: hydraulic, electrical, chemical injection lines**                                                                                  |
-| **SURF Subsea Equipment**             | [docs/process/SURF_SUBSEA_EQUIPMENT.md](process/SURF_SUBSEA_EQUIPMENT)                             | **Comprehensive SURF equipment: PLET, PLEM, manifolds, trees, jumpers, umbilicals, flexible pipes, boosters with mechanical design and cost estimation** |
-| **Well Mechanical Design**            | [docs/process/well_mechanical_design.md](process/well_mechanical_design)                           | **Standards-based well design: barrier elements/envelopes per NORSOK D-010, MAASP per API RP 90, CSV-driven design factors, cost estimation**            |
+| Subsea Systems                        | [docs/process/equipment/subsea_systems.md](process/equipment/subsea_systems.md)                       | Subsea wells and flowlines                                                                                                                               |
+| Subsea Equipment                      | [docs/process/equipment/subsea_equipment.md](process/equipment/subsea_equipment.md)                   | SubseaWell, SimpleFlowLine, flow assurance                                                                                                               |
+| **Subsea Trees**                      | [docs/process/equipment/subsea_trees.md](process/equipment/subsea_trees.md)                           | **Christmas trees: horizontal/vertical, dual-bore, valve configurations, wellhead integration**                                                          |
+| **Subsea Manifolds**                  | [docs/process/equipment/subsea_manifolds.md](process/equipment/subsea_manifolds.md)                   | **Production/injection manifolds, valve skids, well routing, gathering systems**                                                                         |
+| **Subsea Boosters**                   | [docs/process/equipment/subsea_boosters.md](process/equipment/subsea_boosters.md)                     | **Subsea pumps & compressors, helico-axial/multiphase, performance curves**                                                                              |
+| **Umbilicals**                        | [docs/process/equipment/umbilicals.md](process/equipment/umbilicals.md)                               | **Control umbilicals: hydraulic, electrical, chemical injection lines**                                                                                  |
+| **SURF Subsea Equipment**             | [docs/process/SURF_SUBSEA_EQUIPMENT.md](process/SURF_SUBSEA_EQUIPMENT.md)                             | **Comprehensive SURF equipment: PLET, PLEM, manifolds, trees, jumpers, umbilicals, flexible pipes, boosters with mechanical design and cost estimation** |
+| **Well Mechanical Design**            | [docs/process/well_mechanical_design.md](process/well_mechanical_design.md)                           | **Standards-based well design: barrier elements/envelopes per NORSOK D-010, MAASP per API RP 90, CSV-driven design factors, cost estimation**            |
 
 ### Chapter 20: Utility Equipment
 
 | Document                     | Path                                                                                                       | Description                                                                                      |
 | ---------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| Utility Overview             | [docs/process/equipment/util/README.md](process/equipment/util/)                                           | Utility equipment                                                                                |
-| Adjusters                    | [docs/process/equipment/util/adjusters.md](process/equipment/util/adjusters)                               | **Adjuster (single-variable) and MultiVariableAdjuster (Broyden quasi-Newton for N simultaneous specs)** |
-| Recycles                     | [docs/process/equipment/util/recycles.md](process/equipment/util/recycles)                                 | Recycle units                                                                                    |
-| Calculators                  | [docs/process/equipment/util/calculators.md](process/equipment/util/calculators)                           | Calculator units                                                                                 |
-| **Stream Saturator**         | [docs/process/equipment/util/saturators.md](process/equipment/util/saturators)                             | **Water saturation utility for simulating reservoir conditions and wet gas systems**             |
-| **Stream Fitters**           | [docs/process/equipment/util/stream_fitters.md](process/equipment/util/stream_fitters)                     | **GORfitter, MPFMfitter: GOR/GVF adjustment, MPFM reference fluids**                             |
-| **Fuel Gas System**          | [docs/process/equipment/util/fuel_gas_system.md](process/equipment/util/fuel_gas_system)                   | **Complete fuel gas conditioning: gas turbines, fired heaters, pilots, Wobbe Index, JT cooling** |
-| **Utility Air System**       | [docs/process/equipment/util/utility_air_system.md](process/equipment/util/utility_air_system)             | **ISO 8573-1 utility air: instrument/plant/breathing air, compressor/dryer sizing**              |
-| **Produced Water Degassing** | [docs/process/equipment/util/produced_water_degassing.md](process/equipment/util/produced_water_degassing) | **Multi-stage degassing with GHG emissions per Norwegian regulations (Aktivitetsforskriften)**   |
+| Utility Overview             | [docs/process/equipment/util/README.md](process/equipment/util/README.md)                                           | Utility equipment                                                                                |
+| Adjusters                    | [docs/process/equipment/util/adjusters.md](process/equipment/util/adjusters.md)                               | **Adjuster (single-variable) and MultiVariableAdjuster (Broyden quasi-Newton for N simultaneous specs)** |
+| Recycles                     | [docs/process/equipment/util/recycles.md](process/equipment/util/recycles.md)                                 | Recycle units                                                                                    |
+| Calculators                  | [docs/process/equipment/util/calculators.md](process/equipment/util/calculators.md)                           | Calculator units                                                                                 |
+| **Stream Saturator**         | [docs/process/equipment/util/saturators.md](process/equipment/util/saturators.md)                             | **Water saturation utility for simulating reservoir conditions and wet gas systems**             |
+| **Stream Fitters**           | [docs/process/equipment/util/stream_fitters.md](process/equipment/util/stream_fitters.md)                     | **GORfitter, MPFMfitter: GOR/GVF adjustment, MPFM reference fluids**                             |
+| **Fuel Gas System**          | [docs/process/equipment/util/fuel_gas_system.md](process/equipment/util/fuel_gas_system.md)                   | **Complete fuel gas conditioning: gas turbines, fired heaters, pilots, Wobbe Index, JT cooling** |
+| **Utility Air System**       | [docs/process/equipment/util/utility_air_system.md](process/equipment/util/utility_air_system.md)             | **ISO 8573-1 utility air: instrument/plant/breathing air, compressor/dryer sizing**              |
+| **Produced Water Degassing** | [docs/process/equipment/util/produced_water_degassing.md](process/equipment/util/produced_water_degassing.md) | **Multi-stage degassing with GHG emissions per Norwegian regulations (Aktivitetsforskriften)**   |
 
 ### Chapter 21: Process Control
 
 | Document                 | Path                                                                                       | Description                                      |
 | ------------------------ | ------------------------------------------------------------------------------------------ | ------------------------------------------------ |
-| Controllers              | [docs/process/controllers.md](process/controllers)                                         | Process controllers                              |
-| Process Control          | [docs/wiki/process_control.md](wiki/process_control)                                       | Control systems                                  |
-| Dynamic Simulation Guide | [docs/simulation/dynamic_simulation_guide.md](simulation/dynamic_simulation_guide)         | Comprehensive dynamic/transient simulation guide |
-| Transient Simulation     | [docs/wiki/process_transient_simulation_guide.md](wiki/process_transient_simulation_guide) | Transient simulation patterns                    |
+| Controllers              | [docs/process/controllers.md](process/controllers.md)                                         | Process controllers                              |
+| Process Control          | [docs/wiki/process_control.md](wiki/process_control.md)                                       | Control systems                                  |
+| Dynamic Simulation Guide | [docs/simulation/dynamic_simulation_guide.md](simulation/dynamic_simulation_guide.md)         | Comprehensive dynamic/transient simulation guide |
+| Transient Simulation     | [docs/wiki/process_transient_simulation_guide.md](wiki/process_transient_simulation_guide.md) | Transient simulation patterns                    |
 
 ### Chapter 22: Optimization and Constraints
 
@@ -450,69 +448,69 @@ Fluid characterization handles plus fraction splitting, property estimation, and
 
 | Document                             | Path                                                                                                             | Description                                                                                                                               |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| **Engineering Utilities Reference**  | [docs/util/engineering_utilities.md](util/engineering_utilities)                                                  | **FluidBuilder, HMB, SensitivityAnalysis, MonteCarloSimulator, ConvergenceDiagnostics, HydrateRiskMapper, EOSComparison**                |
-| **Process Engineering Utilities v2** | [docs/process/engineering_utilities_v2.md](process/engineering_utilities_v2)                                     | **PinchAnalyzer, DCFCalculator, DebottleneckAnalyzer, FiredHeater, ProcessValidator, CoolingWaterSystem**                                |
-| **Optimization & Constraints Guide** | [docs/process/optimization/OPTIMIZATION_AND_CONSTRAINTS.md](process/optimization/OPTIMIZATION_AND_CONSTRAINTS)   | **COMPREHENSIVE: Complete guide to optimization algorithms, constraint types, bottleneck analysis, and practical examples**               |
-| **Optimization Overview**            | [docs/process/optimization/OPTIMIZATION_OVERVIEW.md](process/optimization/OPTIMIZATION_OVERVIEW)                 | **START HERE: Introduction to process optimization, when to use ProcessOptimizationEngine vs ProductionOptimizer**                        |
-| **Process Researcher**               | [docs/process/optimization/process-researcher.md](process/optimization/process-researcher)                       | **Generate, simulate, optimize, and rank candidate flowsheets from feed/product targets, including reaction routes**                      |
-| **ProductionOptimizer Tutorial**     | [docs/examples/ProductionOptimizer_Tutorial.md](examples/ProductionOptimizer_Tutorial)                           | **Interactive Jupyter notebook with complete ProductionOptimizer guide: algorithms, single/multi-variable, Pareto, constraints**          |
-| **Python Optimization Tutorial**     | [docs/examples/NeqSim_Python_Optimization.md](examples/NeqSim_Python_Optimization)                               | **Using SciPy/Python optimizers with NeqSim process simulations: constraints, Pareto, global optimization**                               |
-| **Capacity Constraint Framework**    | [docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md](process/CAPACITY_CONSTRAINT_FRAMEWORK)                           | **Framework for equipment capacity limits, bottleneck detection, utilization tracking, and AIV/FIV vibration analysis**                   |
-| **Equipment Utilization via Mechanical Design** | [docs/process/equipment_utilization_via_mechanical_design.md](process/equipment_utilization_via_mechanical_design) | **Set design limits on MechanicalDesign so capacity utilization can be calculated and reported for any equipment type**                 |
-| **Optimizer Plugin Architecture**    | [docs/process/optimization/OPTIMIZER_PLUGIN_ARCHITECTURE.md](process/optimization/OPTIMIZER_PLUGIN_ARCHITECTURE) | **Equipment capacity strategies, throughput optimization, gradient descent, sensitivity analysis, shadow prices, and Eclipse VFP export** |
-| **External Optimizer Integration**   | [docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md](integration/EXTERNAL_OPTIMIZER_INTEGRATION)                 | **ProcessSimulationEvaluator for Python/SciPy/NLopt/Pyomo integration with gradient estimation**                                          |
+| **Engineering Utilities Reference**  | [docs/util/engineering_utilities.md](util/engineering_utilities.md)                                                  | **FluidBuilder, HMB, SensitivityAnalysis, MonteCarloSimulator, ConvergenceDiagnostics, HydrateRiskMapper, EOSComparison**                |
+| **Process Engineering Utilities v2** | [docs/process/engineering_utilities_v2.md](process/engineering_utilities_v2.md)                                     | **PinchAnalyzer, DCFCalculator, DebottleneckAnalyzer, FiredHeater, ProcessValidator, CoolingWaterSystem**                                |
+| **Optimization & Constraints Guide** | [docs/process/optimization/OPTIMIZATION_AND_CONSTRAINTS.md](process/optimization/OPTIMIZATION_AND_CONSTRAINTS.md)   | **COMPREHENSIVE: Complete guide to optimization algorithms, constraint types, bottleneck analysis, and practical examples**               |
+| **Optimization Overview**            | [docs/process/optimization/OPTIMIZATION_OVERVIEW.md](process/optimization/OPTIMIZATION_OVERVIEW.md)                 | **START HERE: Introduction to process optimization, when to use ProcessOptimizationEngine vs ProductionOptimizer**                        |
+| **Process Researcher**               | [docs/process/optimization/process-researcher.md](process/optimization/process-researcher.md)                       | **Generate, simulate, optimize, and rank candidate flowsheets from feed/product targets, including reaction routes**                      |
+| **ProductionOptimizer Tutorial**     | [docs/examples/ProductionOptimizer_Tutorial.md](examples/ProductionOptimizer_Tutorial.md)                           | **Interactive Jupyter notebook with complete ProductionOptimizer guide: algorithms, single/multi-variable, Pareto, constraints**          |
+| **Python Optimization Tutorial**     | [docs/examples/NeqSim_Python_Optimization.md](examples/NeqSim_Python_Optimization.md)                               | **Using SciPy/Python optimizers with NeqSim process simulations: constraints, Pareto, global optimization**                               |
+| **Capacity Constraint Framework**    | [docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md](process/CAPACITY_CONSTRAINT_FRAMEWORK.md)                           | **Framework for equipment capacity limits, bottleneck detection, utilization tracking, and AIV/FIV vibration analysis**                   |
+| **Equipment Utilization via Mechanical Design** | [docs/process/equipment_utilization_via_mechanical_design.md](process/equipment_utilization_via_mechanical_design.md) | **Set design limits on MechanicalDesign so capacity utilization can be calculated and reported for any equipment type**                 |
+| **Optimizer Plugin Architecture**    | [docs/process/optimization/OPTIMIZER_PLUGIN_ARCHITECTURE.md](process/optimization/OPTIMIZER_PLUGIN_ARCHITECTURE.md) | **Equipment capacity strategies, throughput optimization, gradient descent, sensitivity analysis, shadow prices, and Eclipse VFP export** |
+| **External Optimizer Integration**   | [docs/integration/EXTERNAL_OPTIMIZER_INTEGRATION.md](integration/EXTERNAL_OPTIMIZER_INTEGRATION.md)                 | **ProcessSimulationEvaluator for Python/SciPy/NLopt/Pyomo integration with gradient estimation**                                          |
 | **Capacity Constraints Demo**        | [examples/notebooks/capacity_constraints_optimization_demo.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/capacity_constraints_optimization_demo.ipynb) | **Interactive notebook: constraint builder API, equipment/system queries, strategy registry, enable/disable, flow sweep, utilization charts** |
-| **Web API / JSON Process Builder**   | [docs/integration/web_api_json_process_builder.md](integration/web_api_json_process_builder)                     | **Build and run process simulations from JSON, structured error responses, equipment wiring API, multi-user session management**          |
-| **MCP Core Layer**                   | [docs/integration/mcp_neqsim_core_layer.md](integration/mcp_neqsim_core_layer)                                  | **MCP runners (FlashRunner, ProcessRunner, Validator, ComponentQuery), typed models, example/schema catalogs**                            |
-| **MCP Getting Started**              | [docs/integration/mcp_getting_started.md](integration/mcp_getting_started)                                       | **5-minute guide: connect any LLM to NeqSim via MCP — setup, first calculation, tool selection, common patterns**                        |
-| **MCP Server Guide**                | [docs/integration/mcp_server_guide.md](integration/mcp_server_guide)                                             | **Quarkus MCP Server for VS Code Copilot, Claude Desktop, Cursor — installation, tools, resources, testing**                              |
-| **MCP Agentic Workflow Improvements** | [docs/integration/mcp_agentic_workflow_improvements.md](integration/mcp_agentic_workflow_improvements)          | **Response contracts, provenance, validation-first execution, all-tool schema/example coverage, setup templates, process JSON contracts, benchmark trust, lifecycle metadata, safety gates, and coverage tests for MCP agent workflows** |
-| **Production Optimization Guide**    | [docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md](examples/PRODUCTION_OPTIMIZATION_GUIDE)                         | **Complete guide to production optimization with Java and Python examples**                                                               |
-| **Reservoir-to-Market Optimization** | [docs/examples/reservoir_to_market_optimization.md](examples/reservoir_to_market_optimization)                   | **Notebook: integrated reservoir-to-market value chain optimization — production, plant operation, energy, CO₂, economics, multi-objective trade-offs** |
-| **ProcessModel Plant Optimization**  | [docs/examples/processmodel_plant_optimization.md](examples/processmodel_plant_optimization)                     | **Notebook: closed-loop multi-area ProcessModel optimization via ProcessAutomation adjustable parameters, evaluate() gating, utilization snapshots** |
-| **Oil & Gas Production & Energy Optimization** | [docs/examples/oilgas_production_energy_optimization.md](examples/oilgas_production_energy_optimization) | **Notebook: optimize production for throughput and energy efficiency, Pareto trade-off of rate vs compression power and CO₂ emissions** |
-| **Autosize & Optimize Workflows**    | [docs/examples/autosize_and_optimize_workflows.md](examples/autosize_and_optimize_workflows)                     | **Notebook: auto-size equipment from mechanical design, then optimize operating setpoints with capacity-constraint awareness**            |
-| **Pressure Boundary Optimization**   | [docs/process/pressure_boundary_optimization.md](process/pressure_boundary_optimization)                         | **Calculate flow rates for pressure boundaries, generate Eclipse VFP lift curves, optimize compressor power**                             |
-| **Flow Rate Optimization**           | [docs/process/optimization/flow-rate-optimization.md](process/optimization/flow-rate-optimization)               | **Comprehensive flow rate optimizer with lift curve generation for Eclipse reservoir simulation**                                         |
-| **Compressor Optimization Guide**    | [docs/process/optimization/COMPRESSOR_OPTIMIZATION_GUIDE.md](process/optimization/COMPRESSOR_OPTIMIZATION_GUIDE) | **Specialized guide for compressor train optimization, anti-surge control, and power minimization**                                       |
-| **Practical Examples**               | [docs/process/optimization/PRACTICAL_EXAMPLES.md](process/optimization/PRACTICAL_EXAMPLES)                       | **Working examples for optimization scenarios including gas processing, LNG, and offshore platforms**                                     |
-| **SQP Optimizer**                    | [docs/process/optimization/sqp_optimizer.md](process/optimization/sqp_optimizer)                                 | **Sequential Quadratic Programming — constrained NLP with BFGS Hessian, active-set QP, L1 merit function**                              |
+| **Web API / JSON Process Builder**   | [docs/integration/web_api_json_process_builder.md](integration/web_api_json_process_builder.md)                     | **Build and run process simulations from JSON, structured error responses, equipment wiring API, multi-user session management**          |
+| **MCP Core Layer**                   | [docs/integration/mcp_neqsim_core_layer.md](integration/mcp_neqsim_core_layer.md)                                  | **MCP runners (FlashRunner, ProcessRunner, Validator, ComponentQuery), typed models, example/schema catalogs**                            |
+| **MCP Getting Started**              | [docs/integration/mcp_getting_started.md](integration/mcp_getting_started.md)                                       | **5-minute guide: connect any LLM to NeqSim via MCP — setup, first calculation, tool selection, common patterns**                        |
+| **MCP Server Guide**                | [docs/integration/mcp_server_guide.md](integration/mcp_server_guide.md)                                             | **Quarkus MCP Server for VS Code Copilot, Claude Desktop, Cursor — installation, tools, resources, testing**                              |
+| **MCP Agentic Workflow Improvements** | [docs/integration/mcp_agentic_workflow_improvements.md](integration/mcp_agentic_workflow_improvements.md)          | **Response contracts, provenance, validation-first execution, all-tool schema/example coverage, setup templates, process JSON contracts, benchmark trust, lifecycle metadata, safety gates, and coverage tests for MCP agent workflows** |
+| **Production Optimization Guide**    | [docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md](examples/PRODUCTION_OPTIMIZATION_GUIDE.md)                         | **Complete guide to production optimization with Java and Python examples**                                                               |
+| **Reservoir-to-Market Optimization** | [docs/examples/reservoir_to_market_optimization.md](examples/reservoir_to_market_optimization.md)                   | **Notebook: integrated reservoir-to-market value chain optimization — production, plant operation, energy, CO₂, economics, multi-objective trade-offs** |
+| **ProcessModel Plant Optimization**  | [docs/examples/processmodel_plant_optimization.md](examples/processmodel_plant_optimization.md)                     | **Notebook: closed-loop multi-area ProcessModel optimization via ProcessAutomation adjustable parameters, evaluate() gating, utilization snapshots** |
+| **Oil & Gas Production & Energy Optimization** | [docs/examples/oilgas_production_energy_optimization.md](examples/oilgas_production_energy_optimization.md) | **Notebook: optimize production for throughput and energy efficiency, Pareto trade-off of rate vs compression power and CO₂ emissions** |
+| **Autosize & Optimize Workflows**    | [docs/examples/autosize_and_optimize_workflows.md](examples/autosize_and_optimize_workflows.md)                     | **Notebook: auto-size equipment from mechanical design, then optimize operating setpoints with capacity-constraint awareness**            |
+| **Pressure Boundary Optimization**   | [docs/process/pressure_boundary_optimization.md](process/pressure_boundary_optimization.md)                         | **Calculate flow rates for pressure boundaries, generate Eclipse VFP lift curves, optimize compressor power**                             |
+| **Flow Rate Optimization**           | [docs/process/optimization/flow-rate-optimization.md](process/optimization/flow-rate-optimization.md)               | **Comprehensive flow rate optimizer with lift curve generation for Eclipse reservoir simulation**                                         |
+| **Compressor Optimization Guide**    | [docs/process/optimization/COMPRESSOR_OPTIMIZATION_GUIDE.md](process/optimization/COMPRESSOR_OPTIMIZATION_GUIDE.md) | **Specialized guide for compressor train optimization, anti-surge control, and power minimization**                                       |
+| **Practical Examples**               | [docs/process/optimization/PRACTICAL_EXAMPLES.md](process/optimization/PRACTICAL_EXAMPLES.md)                       | **Working examples for optimization scenarios including gas processing, LNG, and offshore platforms**                                     |
+| **SQP Optimizer**                    | [docs/process/optimization/sqp_optimizer.md](process/optimization/sqp_optimizer.md)                                 | **Sequential Quadratic Programming — constrained NLP with BFGS Hessian, active-set QP, L1 merit function**                              |
 
 ### Chapter 23: Mechanical Design
 
 | Document                          | Path                                                                                                                                                   | Description                                                                                                                      |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| Mechanical Design                 | [docs/process/mechanical_design.md](process/mechanical_design)                                                                                         | Mechanical design overview, process design parameters, validation, and JSON export                                               |
-| **Equipment Design Parameters**   | [docs/process/EQUIPMENT_DESIGN_PARAMETERS.md](process/EQUIPMENT_DESIGN_PARAMETERS)                                                                     | **Comprehensive guide to autoSize vs MechanicalDesign, manual sizing, validation methods, and capacity constraints**             |
-| **Process Design Parameters**     | [docs/process/mechanical_design.md#process-design-parameters](process/mechanical_design#process-design-parameters)                                     | **Industry-standard process design parameters for separators, compressors, pumps, heat exchangers**                              |
-| **Design Validation**             | [docs/process/mechanical_design.md#design-validation](process/mechanical_design#design-validation)                                                     | **Validation methods per API-610, API-617, TEMA, API-12J standards**                                                             |
-| **Mechanical Design Report**      | [docs/process/mechanical_design.md#comprehensive-mechanical-design-report-json](process/mechanical_design#comprehensive-mechanical-design-report-json) | **Combined JSON output for all mechanical design data (equipment + piping)**                                                     |
-| **Compressor Casing Design**      | [docs/process/CompressorMechanicalDesign.md#casing-wall-thickness-asme-viii-div-1-ug-27](process/CompressorMechanicalDesign#casing-wall-thickness-asme-viii-div-1-ug-27) | **Compressor casing design per API 617 / ASME VIII: wall thickness, material selection, flange rating, nozzle loads, NACE MR0175, thermal growth, split-line bolts, barrel casing** |
-| Design Standards                  | [docs/process/mechanical_design_standards.md](process/mechanical_design_standards)                                                                     | Design standards                                                                                                                 |
-| **Standards Implementation Program** | [docs/process/process_design_standards_program.md](process/process_design_standards_program)                                                         | Standards priorities, evidence gates, requirement coverage, and change control                                                   |
-| **Typed Standards Migration**     | [docs/process/standard_design_kernel_migration.md](process/standard_design_kernel_migration)                                                           | Fail-closed migration to explicit editions, kernels, requirement packs, and complete case envelopes                              |
-| Design Database                   | [docs/process/mechanical_design_database.md](process/mechanical_design_database)                                                                       | Design database                                                                                                                  |
-| **Pipeline Mechanical Design**    | [docs/process/pipeline_mechanical_design.md](process/pipeline_mechanical_design)                                                                       | **Comprehensive pipeline mechanical design with wall thickness, stress analysis, cost estimation**                               |
-| **DNV-RP-F109 On-Bottom Stability** | [docs/process/dnv_rp_f109_on_bottom_stability.md](process/dnv_rp_f109_on_bottom_stability)                                                           | **Fail-closed vertical, transparent absolute-static lateral, and external-response displacement screening for pipelines, cables, and umbilicals** |
-| **DNV-ST-F101 Pipeline Screening** | [docs/process/dnv_st_f101_pipeline_screening.md](process/dnv_st_f101_pipeline_screening)                                                               | **Fail-closed 2021 screening for containment, collapse, propagation, load interaction, fatigue, pressure cases, ovality, fabrication, and installation strain** |
-| **Topside Piping Design**         | [docs/process/topside_piping_design.md](process/topside_piping_design)                                                                                 | **Topside piping design with velocity, support spacing, vibration (AIV/FIV), stress analysis per ASME B31.3**                    |
-| **Manifold Mechanical Design**    | [docs/process/equipment/manifold_design.md](process/equipment/manifold_design)                                                                         | **Manifold design for topside, onshore, and subsea with velocity limits, reinforcement, support per ASME B31.3 and DNV-ST-F101** |
-| **Riser Mechanical Design**       | [docs/process/riser_mechanical_design.md](process/riser_mechanical_design)                                                                             | **Riser design with catenary mechanics, VIV, fatigue per DNV-OS-F201**                                                           |
-| **Pipeline Design Math**          | [docs/process/pipeline_mechanical_design_math.md](process/pipeline_mechanical_design_math)                                                             | **Mathematical methods and formulas for pipeline design**                                                                        |
-| **Subsea SURF Mechanical Design** | [docs/process/SURF_SUBSEA_EQUIPMENT.md#mechanical-design](process/SURF_SUBSEA_EQUIPMENT#mechanical-design)                                             | **Mechanical design for PLET, PLEM, trees, manifolds, jumpers, umbilicals, flexible pipes, boosters per DNV, API, ISO, NORSOK**  |
-| **Well Mechanical Design**        | [docs/process/well_mechanical_design.md](process/well_mechanical_design)                                                                               | **Standards-based well design: barrier elements/envelopes per NORSOK D-010, MAASP per API RP 90, CSV-driven design factors, cost estimation**|
-| **Equipment Datasheet Generator** | [docs/process/equipment_datasheets.md](process/equipment_datasheets)                                                                                   | **Structured JSON equipment datasheets from process simulation (separator, compressor, heater, valve)**                          |
-| **Dual EoS Comparison**           | [docs/process/dual_eos_comparison.md](process/dual_eos_comparison)                                                                                     | **SRK vs PR78 cross-check per TR1244 for field development QA**                                                                  |
-| TORG Integration                  | [docs/process/torg_integration.md](process/torg_integration)                                                                                           | TORG integration                                                                                                                 |
-| Field Development                 | [docs/process/field_development_orchestration.md](process/field_development_orchestration)                                                             | Field development orchestration                                                                                                  |
+| Mechanical Design                 | [docs/process/mechanical_design.md](process/mechanical_design.md)                                                                                         | Mechanical design overview, process design parameters, validation, and JSON export                                               |
+| **Equipment Design Parameters**   | [docs/process/EQUIPMENT_DESIGN_PARAMETERS.md](process/EQUIPMENT_DESIGN_PARAMETERS.md)                                                                     | **Comprehensive guide to autoSize vs MechanicalDesign, manual sizing, validation methods, and capacity constraints**             |
+| **Process Design Parameters**     | [docs/process/mechanical_design.md#process-design-parameters](process/mechanical_design.md#process-design-parameters)                                     | **Industry-standard process design parameters for separators, compressors, pumps, heat exchangers**                              |
+| **Design Validation**             | [docs/process/mechanical_design.md#design-validation](process/mechanical_design.md#design-validation)                                                     | **Validation methods per API-610, API-617, TEMA, API-12J standards**                                                             |
+| **Mechanical Design Report**      | [docs/process/mechanical_design.md#comprehensive-mechanical-design-report-json](process/mechanical_design.md#comprehensive-mechanical-design-report-json) | **Combined JSON output for all mechanical design data (equipment + piping)**                                                     |
+| **Compressor Casing Design**      | [docs/process/CompressorMechanicalDesign.md#casing-wall-thickness-asme-viii-div-1-ug-27](process/CompressorMechanicalDesign.md#casing-wall-thickness-asme-viii-div-1-ug-27) | **Compressor casing design per API 617 / ASME VIII: wall thickness, material selection, flange rating, nozzle loads, NACE MR0175, thermal growth, split-line bolts, barrel casing** |
+| Design Standards                  | [docs/process/mechanical_design_standards.md](process/mechanical_design_standards.md)                                                                     | Design standards                                                                                                                 |
+| **Standards Implementation Program** | [docs/process/process_design_standards_program.md](process/process_design_standards_program.md)                                                         | Standards priorities, evidence gates, requirement coverage, and change control                                                   |
+| **Typed Standards Migration**     | [docs/process/standard_design_kernel_migration.md](process/standard_design_kernel_migration.md)                                                           | Fail-closed migration to explicit editions, kernels, requirement packs, and complete case envelopes                              |
+| Design Database                   | [docs/process/mechanical_design_database.md](process/mechanical_design_database.md)                                                                       | Design database                                                                                                                  |
+| **Pipeline Mechanical Design**    | [docs/process/pipeline_mechanical_design.md](process/pipeline_mechanical_design.md)                                                                       | **Comprehensive pipeline mechanical design with wall thickness, stress analysis, cost estimation**                               |
+| **DNV-RP-F109 On-Bottom Stability** | [docs/process/dnv_rp_f109_on_bottom_stability.md](process/dnv_rp_f109_on_bottom_stability.md)                                                           | **Fail-closed vertical, transparent absolute-static lateral, and external-response displacement screening for pipelines, cables, and umbilicals** |
+| **DNV-ST-F101 Pipeline Screening** | [docs/process/dnv_st_f101_pipeline_screening.md](process/dnv_st_f101_pipeline_screening.md)                                                               | **Fail-closed 2021 screening for containment, collapse, propagation, load interaction, fatigue, pressure cases, ovality, fabrication, and installation strain** |
+| **Topside Piping Design**         | [docs/process/topside_piping_design.md](process/topside_piping_design.md)                                                                                 | **Topside piping design with velocity, support spacing, vibration (AIV/FIV), stress analysis per ASME B31.3**                    |
+| **Manifold Mechanical Design**    | [docs/process/equipment/manifold_design.md](process/equipment/manifold_design.md)                                                                         | **Manifold design for topside, onshore, and subsea with velocity limits, reinforcement, support per ASME B31.3 and DNV-ST-F101** |
+| **Riser Mechanical Design**       | [docs/process/riser_mechanical_design.md](process/riser_mechanical_design.md)                                                                             | **Riser design with catenary mechanics, VIV, fatigue per DNV-OS-F201**                                                           |
+| **Pipeline Design Math**          | [docs/process/pipeline_mechanical_design_math.md](process/pipeline_mechanical_design_math.md)                                                             | **Mathematical methods and formulas for pipeline design**                                                                        |
+| **Subsea SURF Mechanical Design** | [docs/process/SURF_SUBSEA_EQUIPMENT.md#mechanical-design](process/SURF_SUBSEA_EQUIPMENT.md#mechanical-design)                                             | **Mechanical design for PLET, PLEM, trees, manifolds, jumpers, umbilicals, flexible pipes, boosters per DNV, API, ISO, NORSOK**  |
+| **Well Mechanical Design**        | [docs/process/well_mechanical_design.md](process/well_mechanical_design.md)                                                                               | **Standards-based well design: barrier elements/envelopes per NORSOK D-010, MAASP per API RP 90, CSV-driven design factors, cost estimation**|
+| **Equipment Datasheet Generator** | [docs/process/equipment_datasheets.md](process/equipment_datasheets.md)                                                                                   | **Structured JSON equipment datasheets from process simulation (separator, compressor, heater, valve)**                          |
+| **Dual EoS Comparison**           | [docs/process/dual_eos_comparison.md](process/dual_eos_comparison.md)                                                                                     | **SRK vs PR78 cross-check per TR1244 for field development QA**                                                                  |
+| TORG Integration                  | [docs/process/torg_integration.md](process/torg_integration.md)                                                                                           | TORG integration                                                                                                                 |
+| Field Development                 | [docs/process/field_development_orchestration.md](process/field_development_orchestration.md)                                                             | Field development orchestration                                                                                                  |
 
 ### Chapter 24: Electrical Design
 
 | Document                          | Path                                                                                                       | Description                                                                                                                      |
 | --------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| **Electrical Design Guide**       | [docs/process/electrical-design.md](process/electrical-design)                                             | **Comprehensive guide to electrical design: motor sizing (IEC 60034), VFD topology, cable sizing, transformer, switchgear, hazardous area, load list, equipment-specific designs (separator, heater/cooler, pipeline), plant-wide SystemElectricalDesign** |
-| **Motor Mechanical Design**       | [docs/process/motor-mechanical-design.md](process/motor-mechanical-design)                                 | **Motor physical/mechanical design: foundation loads (IEEE 841), cooling (IEC 60034-6), bearings (ISO 281), vibration (ISO 10816-3), noise (IEC 60034-9, NORSOK S-002), enclosure (IEC 60034-5, IEC 60079), derating (IEC 60034-1)** |
-| **Combined Equipment Design Report** | [docs/process/motor-mechanical-design.md#equipmentdesignreport](process/motor-mechanical-design#equipmentdesignreport) | **EquipmentDesignReport: combined mechanical + electrical + motor design report with feasibility verdict for any equipment** |
+| **Electrical Design Guide**       | [docs/process/electrical-design.md](process/electrical-design.md)                                             | **Comprehensive guide to electrical design: motor sizing (IEC 60034), VFD topology, cable sizing, transformer, switchgear, hazardous area, load list, equipment-specific designs (separator, heater/cooler, pipeline), plant-wide SystemElectricalDesign** |
+| **Motor Mechanical Design**       | [docs/process/motor-mechanical-design.md](process/motor-mechanical-design.md)                                 | **Motor physical/mechanical design: foundation loads (IEEE 841), cooling (IEC 60034-6), bearings (ISO 281), vibration (ISO 10816-3), noise (IEC 60034-9, NORSOK S-002), enclosure (IEC 60034-5, IEC 60079), derating (IEC 60034-1)** |
+| **Combined Equipment Design Report** | [docs/process/motor-mechanical-design.md#equipmentdesignreport](process/motor-mechanical-design.md#equipmentdesignreport) | **EquipmentDesignReport: combined mechanical + electrical + motor design report with feasibility verdict for any equipment** |
 | **Compressor Electrical Design**  | [examples/notebooks/electrical/compressor_electrical_design.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/electrical/compressor_electrical_design.ipynb) | **Jupyter notebook: 2-stage compression electrical design with motor curves, power triangle, efficiency chain** |
 | **Process Plant Load List**       | [examples/notebooks/electrical/process_plant_load_list.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/electrical/process_plant_load_list.ipynb) | **Jupyter notebook: plant-wide electrical load list, demand/diversity factors, transformer sizing** |
 | **Motor & VFD Analysis**          | [examples/notebooks/electrical/motor_vfd_analysis.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/electrical/motor_vfd_analysis.ipynb) | **Jupyter notebook: motor efficiency classes IE1-IE4, VFD topology selection, harmonics, efficiency maps, cable sizing, hazardous area** |
@@ -522,58 +520,58 @@ Fluid characterization handles plus fraction splitting, property estimation, and
 
 | Document                          | Path                                                                                                       | Description                                                                                                                      |
 | --------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| **Instrument Design Guide**       | [docs/process/instrument-design.md](process/instrument-design)                                             | **Comprehensive guide to instrument design: ISA-5.1 identification, SIL-rated safety instruments, I/O counting, DCS/SIS cabinet sizing, cost estimation, equipment-specific designs (separator, compressor, heat exchanger, pipeline, valve), plant-wide SystemInstrumentDesign** |
+| **Instrument Design Guide**       | [docs/process/instrument-design.md](process/instrument-design.md)                                             | **Comprehensive guide to instrument design: ISA-5.1 identification, SIL-rated safety instruments, I/O counting, DCS/SIS cabinet sizing, cost estimation, equipment-specific designs (separator, compressor, heat exchanger, pipeline, valve), plant-wide SystemInstrumentDesign** |
 
 ### Chapter 26: Dynamic Simulation
 
 | Document                          | Path                                                                                                       | Description                                                                                                                      |
 | --------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| **Dynamic Simulation Guide**      | [docs/process/dynamic-simulation.md](process/dynamic-simulation)                                           | **DynamicProcessHelper utility — auto-instruments a sized steady-state process with transmitters and PID controllers for transient simulation, configurable PID tuning, flow and temperature control loops** |
-| **Dynamic Simulation Enhancements** | [docs/process/dynamic-simulation-enhancements.md](process/dynamic-simulation-enhancements)               | **Advanced dynamic features: controller modes (AUTO/MANUAL/CASCADE), bumpless transfer, 2-DOF PID, SFC sequencing (IEC 61131-3), override/split-range control, sensor fault injection, transmitter filtering, alarm shelving, valve nonlinearities (deadband/stiction/hysteresis), separator internals (weir, mist eliminator), HX thermal ODE (wall + CSTR holdup), distillation MESH dynamics, adaptive time stepping, parallel transient, RK4 integration** |
+| **Dynamic Simulation Guide**      | [docs/process/dynamic-simulation.md](process/dynamic-simulation.md)                                           | **DynamicProcessHelper utility — auto-instruments a sized steady-state process with transmitters and PID controllers for transient simulation, configurable PID tuning, flow and temperature control loops** |
+| **Dynamic Simulation Enhancements** | [docs/process/dynamic-simulation-enhancements.md](process/dynamic-simulation-enhancements.md)               | **Advanced dynamic features: controller modes (AUTO/MANUAL/CASCADE), bumpless transfer, 2-DOF PID, SFC sequencing (IEC 61131-3), override/split-range control, sensor fault injection, transmitter filtering, alarm shelving, valve nonlinearities (deadband/stiction/hysteresis), separator internals (weir, mist eliminator), HX thermal ODE (wall + CSTR holdup), distillation MESH dynamics, adaptive time stepping, parallel transient, RK4 integration** |
 
 ### Chapter 23b: Cost Estimation
 
 | Document                        | Path                                                                                                                                         | Description                                                                                                 |
 | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **Cost Estimation Framework**   | [docs/process/COST_ESTIMATION_FRAMEWORK.md](process/COST_ESTIMATION_FRAMEWORK)                                                               | **Comprehensive capital and operating cost estimation framework with scope-safe result reconciliation**      |
-| **Cost Estimation API**         | [docs/process/COST_ESTIMATION_API_REFERENCE.md](process/COST_ESTIMATION_API_REFERENCE)                                                       | **Detailed API reference for all cost estimation classes and CostEstimateResult output maps**                |
-| **Subsea SURF Cost Estimation** | [docs/process/SURF_SUBSEA_EQUIPMENT.md#cost-estimation](process/SURF_SUBSEA_EQUIPMENT#cost-estimation)                                       | **Cost estimation for all SURF equipment with regional factors, labor rates, vessel costs, BOM generation** |
-| **Cost Result Schema**          | [docs/process/COST_ESTIMATION_FRAMEWORK.md#result-schema-and-reconciliation](process/COST_ESTIMATION_FRAMEWORK#result-schema-and-reconciliation) | **Additive cost, summary total, breakdown, quantity-basis, and located/base reconciliation rules**           |
-| Equipment Costs                 | [docs/process/COST_ESTIMATION_FRAMEWORK.md#equipment-cost-estimation](process/COST_ESTIMATION_FRAMEWORK#equipment-cost-estimation)           | Equipment-specific cost correlations                                                                        |
-| Tank Costs                      | [docs/process/COST_ESTIMATION_FRAMEWORK.md#tank-cost](process/COST_ESTIMATION_FRAMEWORK#tank-cost)                                           | Storage tank cost estimation (API 650/620)                                                                  |
-| Expander Costs                  | [docs/process/COST_ESTIMATION_FRAMEWORK.md#expander-cost](process/COST_ESTIMATION_FRAMEWORK#expander-cost)                                   | Turboexpander cost estimation                                                                               |
-| Ejector Costs                   | [docs/process/COST_ESTIMATION_FRAMEWORK.md#ejector-cost](process/COST_ESTIMATION_FRAMEWORK#ejector-cost)                                     | Ejector and vacuum system costs                                                                             |
-| Absorber Costs                  | [docs/process/COST_ESTIMATION_FRAMEWORK.md#absorber-cost](process/COST_ESTIMATION_FRAMEWORK#absorber-cost)                                   | Absorption tower cost estimation                                                                            |
-| Currency & Location             | [docs/process/COST_ESTIMATION_FRAMEWORK.md#currency-and-location-support](process/COST_ESTIMATION_FRAMEWORK#currency-and-location-support)   | Multi-currency and location factors                                                                         |
-| OPEX Estimation                 | [docs/process/COST_ESTIMATION_FRAMEWORK.md#operating-cost-opex-estimation](process/COST_ESTIMATION_FRAMEWORK#operating-cost-opex-estimation) | Operating cost calculation                                                                                  |
-| Financial Metrics               | [docs/process/COST_ESTIMATION_FRAMEWORK.md#financial-metrics](process/COST_ESTIMATION_FRAMEWORK#financial-metrics)                           | Payback, ROI, NPV calculations                                                                              |
+| **Cost Estimation Framework**   | [docs/process/COST_ESTIMATION_FRAMEWORK.md](process/COST_ESTIMATION_FRAMEWORK.md)                                                               | **Comprehensive capital and operating cost estimation framework with scope-safe result reconciliation**      |
+| **Cost Estimation API**         | [docs/process/COST_ESTIMATION_API_REFERENCE.md](process/COST_ESTIMATION_API_REFERENCE.md)                                                       | **Detailed API reference for all cost estimation classes and CostEstimateResult output maps**                |
+| **Subsea SURF Cost Estimation** | [docs/process/SURF_SUBSEA_EQUIPMENT.md#cost-estimation](process/SURF_SUBSEA_EQUIPMENT.md#cost-estimation)                                       | **Cost estimation for all SURF equipment with regional factors, labor rates, vessel costs, BOM generation** |
+| **Cost Result Schema**          | [docs/process/COST_ESTIMATION_FRAMEWORK.md#result-schema-and-reconciliation](process/COST_ESTIMATION_FRAMEWORK.md#result-schema-and-reconciliation) | **Additive cost, summary total, breakdown, quantity-basis, and located/base reconciliation rules**           |
+| Equipment Costs                 | [docs/process/COST_ESTIMATION_FRAMEWORK.md#equipment-cost-estimation](process/COST_ESTIMATION_FRAMEWORK.md#equipment-cost-estimation)           | Equipment-specific cost correlations                                                                        |
+| Tank Costs                      | [docs/process/COST_ESTIMATION_FRAMEWORK.md#tank-cost](process/COST_ESTIMATION_FRAMEWORK.md#tank-cost)                                           | Storage tank cost estimation (API 650/620)                                                                  |
+| Expander Costs                  | [docs/process/COST_ESTIMATION_FRAMEWORK.md#expander-cost](process/COST_ESTIMATION_FRAMEWORK.md#expander-cost)                                   | Turboexpander cost estimation                                                                               |
+| Ejector Costs                   | [docs/process/COST_ESTIMATION_FRAMEWORK.md#ejector-cost](process/COST_ESTIMATION_FRAMEWORK.md#ejector-cost)                                     | Ejector and vacuum system costs                                                                             |
+| Absorber Costs                  | [docs/process/COST_ESTIMATION_FRAMEWORK.md#absorber-cost](process/COST_ESTIMATION_FRAMEWORK.md#absorber-cost)                                   | Absorption tower cost estimation                                                                            |
+| Currency & Location             | [docs/process/COST_ESTIMATION_FRAMEWORK.md#currency-and-location-support](process/COST_ESTIMATION_FRAMEWORK.md#currency-and-location-support)   | Multi-currency and location factors                                                                         |
+| OPEX Estimation                 | [docs/process/COST_ESTIMATION_FRAMEWORK.md#operating-cost-opex-estimation](process/COST_ESTIMATION_FRAMEWORK.md#operating-cost-opex-estimation) | Operating cost calculation                                                                                  |
+| Financial Metrics               | [docs/process/COST_ESTIMATION_FRAMEWORK.md#financial-metrics](process/COST_ESTIMATION_FRAMEWORK.md#financial-metrics)                           | Payback, ROI, NPV calculations                                                                              |
 
 ### Chapter 23c: Corrosion Analysis
 
 | Document                              | Path                                                                                                             | Description                                                                                                     |
 | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| **Corrosion Module Overview**         | [docs/process/corrosion/index.md](process/corrosion/)                                                           | **Package overview, quick start, standards coverage for NORSOK M-506 and M-001**                                 |
-| **Process-Wide Materials Review**     | [docs/process/corrosion/materials_review.md](process/corrosion/materials_review)                                 | **STID-backed material selection, degradation, CUI, remaining-life, and MCP materials review workflow**           |
-| **NORSOK M-506 Corrosion Rate**       | [docs/process/corrosion/norsok_m506_corrosion_rate.md](process/corrosion/norsok_m506_corrosion_rate)             | **CO2 corrosion rate prediction — fugacity, pH, correction factors, parameter sweeps, JSON reporting**           |
-| **NORSOK M-001 Material Selection**   | [docs/process/corrosion/norsok_m001_material_selection.md](process/corrosion/norsok_m001_material_selection)     | **Material grade recommendation — sweet/sour classification, CRA selection, chloride SCC, corrosion allowance** |
-| **Pipeline Corrosion Integration**    | [docs/process/corrosion/pipeline_corrosion_integration.md](process/corrosion/pipeline_corrosion_integration)     | **Automated corrosion analysis from process simulation — stream extraction, combined mechanical + corrosion**    |
-| **Sour Service Assessment**           | [docs/process/corrosion/sour_service_assessment.md](process/corrosion/sour_service_assessment)                   | **ISO 15156 / NACE MR0175 sour region classification, SSC/HIC/SOHIC risk, material recommendations**           |
-| **CO2 Corrosion Material Selection**  | [docs/process/corrosion/co2_corrosion_material_selection.md](process/corrosion/co2_corrosion_material_selection) | **CRA selection hierarchy — 13Cr/22Cr/25Cr/nickel alloy based on CO2 rate, H2S, chloride, temperature**        |
-| **Chloride SCC Assessment**           | [docs/process/corrosion/chloride_scc_assessment.md](process/corrosion/chloride_scc_assessment)                   | **Chloride stress corrosion cracking risk for austenitic and duplex stainless steels per NORSOK M-001/MTI 15**  |
-| **Oxygen Corrosion Assessment**       | [docs/process/corrosion/oxygen_corrosion_assessment.md](process/corrosion/oxygen_corrosion_assessment)           | **Dissolved O2 corrosion/pitting for injection water and utility systems per NORSOK M-001 / NACE SP0499**       |
-| **Dense Phase CO2 Corrosion**         | [docs/process/corrosion/dense_phase_co2_corrosion.md](process/corrosion/dense_phase_co2_corrosion)               | **CCS pipeline corrosion — impurity specs, free water risk, water solubility per DNV-RP-J202 / ISO 27913**      |
-| **Ammonia Compatibility**             | [docs/process/corrosion/ammonia_compatibility.md](process/corrosion/ammonia_compatibility)                       | **NH3 service material assessment — SCC, O2 inhibitor, copper restriction per CGA G-2.1 / ASME B31.3**         |
+| **Corrosion Module Overview**         | [docs/process/corrosion/index.md](process/corrosion/index.md)                                                           | **Package overview, quick start, standards coverage for NORSOK M-506 and M-001**                                 |
+| **Process-Wide Materials Review**     | [docs/process/corrosion/materials_review.md](process/corrosion/materials_review.md)                                 | **STID-backed material selection, degradation, CUI, remaining-life, and MCP materials review workflow**           |
+| **NORSOK M-506 Corrosion Rate**       | [docs/process/corrosion/norsok_m506_corrosion_rate.md](process/corrosion/norsok_m506_corrosion_rate.md)             | **CO2 corrosion rate prediction — fugacity, pH, correction factors, parameter sweeps, JSON reporting**           |
+| **NORSOK M-001 Material Selection**   | [docs/process/corrosion/norsok_m001_material_selection.md](process/corrosion/norsok_m001_material_selection.md)     | **Material grade recommendation — sweet/sour classification, CRA selection, chloride SCC, corrosion allowance** |
+| **Pipeline Corrosion Integration**    | [docs/process/corrosion/pipeline_corrosion_integration.md](process/corrosion/pipeline_corrosion_integration.md)     | **Automated corrosion analysis from process simulation — stream extraction, combined mechanical + corrosion**    |
+| **Sour Service Assessment**           | [docs/process/corrosion/sour_service_assessment.md](process/corrosion/sour_service_assessment.md)                   | **ISO 15156 / NACE MR0175 sour region classification, SSC/HIC/SOHIC risk, material recommendations**           |
+| **CO2 Corrosion Material Selection**  | [docs/process/corrosion/co2_corrosion_material_selection.md](process/corrosion/co2_corrosion_material_selection.md) | **CRA selection hierarchy — 13Cr/22Cr/25Cr/nickel alloy based on CO2 rate, H2S, chloride, temperature**        |
+| **Chloride SCC Assessment**           | [docs/process/corrosion/chloride_scc_assessment.md](process/corrosion/chloride_scc_assessment.md)                   | **Chloride stress corrosion cracking risk for austenitic and duplex stainless steels per NORSOK M-001/MTI 15**  |
+| **Oxygen Corrosion Assessment**       | [docs/process/corrosion/oxygen_corrosion_assessment.md](process/corrosion/oxygen_corrosion_assessment.md)           | **Dissolved O2 corrosion/pitting for injection water and utility systems per NORSOK M-001 / NACE SP0499**       |
+| **Dense Phase CO2 Corrosion**         | [docs/process/corrosion/dense_phase_co2_corrosion.md](process/corrosion/dense_phase_co2_corrosion.md)               | **CCS pipeline corrosion — impurity specs, free water risk, water solubility per DNV-RP-J202 / ISO 27913**      |
+| **Ammonia Compatibility**             | [docs/process/corrosion/ammonia_compatibility.md](process/corrosion/ammonia_compatibility.md)                       | **NH3 service material assessment — SCC, O2 inhibitor, copper restriction per CGA G-2.1 / ASME B31.3**         |
 
 ### Chapter 24: Serialization & Persistence
 
 | Document                | Path                                                                                           | Description                                                          |
 | ----------------------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| Process Serialization   | [docs/simulation/process_serialization.md](simulation/process_serialization)                   | Save/load process models                                             |
-| Process Model Lifecycle | [docs/process/lifecycle/process_model_lifecycle.md](process/lifecycle/process_model_lifecycle) | ProcessModelState, versioning, checkpointing, digital twin lifecycle |
-| Process Automation API  | [docs/simulation/process_automation.md](simulation/process_automation)                         | String-addressable API for reading/writing simulation variables       |
-| ProcessAutomation Foundations | [docs/simulation/automation/automation_foundations.md](simulation/automation/automation_foundations) | Address resolution, variable catalogs, unit handling, and safe-access schema |
-| ProcessAutomation Integration Patterns | [docs/simulation/automation/automation_integrations.md](simulation/automation/automation_integrations) | Multi-area addressing plus optimizer/digital-twin integration workflows |
-| ProcessAutomation Operations and Troubleshooting | [docs/simulation/automation/automation_operations.md](simulation/automation/automation_operations) | Diagnostics playbook, bounds validation, and troubleshooting checklist |
+| Process Serialization   | [docs/simulation/process_serialization.md](simulation/process_serialization.md)                   | Save/load process models                                             |
+| Process Model Lifecycle | [docs/process/lifecycle/process_model_lifecycle.md](process/lifecycle/process_model_lifecycle.md) | ProcessModelState, versioning, checkpointing, digital twin lifecycle |
+| Process Automation API  | [docs/simulation/process_automation.md](simulation/process_automation.md)                         | String-addressable API for reading/writing simulation variables       |
+| ProcessAutomation Foundations | [docs/simulation/automation/automation_foundations.md](simulation/automation/automation_foundations.md) | Address resolution, variable catalogs, unit handling, and safe-access schema |
+| ProcessAutomation Integration Patterns | [docs/simulation/automation/automation_integrations.md](simulation/automation/automation_integrations.md) | Multi-area addressing plus optimizer/digital-twin integration workflows |
+| ProcessAutomation Operations and Troubleshooting | [docs/simulation/automation/automation_operations.md](simulation/automation/automation_operations.md) | Diagnostics playbook, bounds validation, and troubleshooting checklist |
 
 ---
 
@@ -583,38 +581,38 @@ Fluid characterization handles plus fraction splitting, property estimation, and
 
 | Document | Path | Description |
 | --- | --- | --- |
-| **Engineering Hub** | [docs/engineering/index.md](engineering/) | **Dedicated entry point for design cases, closed-loop sizing, discipline verification, safety, handover, and lifecycle evidence** |
-| **Engineering Guide** | [docs/engineering/guide.md](engineering/guide) | **Practical, gated workflow from a validated process model to review-ready deliverables** |
-| **Current Engineering Capabilities** | [docs/engineering/current-capabilities.md](engineering/current-capabilities) | **Implemented entry points, discipline coverage, qualification layers, readiness levels, and accountable-review boundaries** |
-| **Design Cases and Governing Envelopes** | [docs/engineering/design-cases-and-envelopes.md](engineering/design-cases-and-envelopes) | **Controlled cases, metric direction, acceptance limits, isolated execution, and governing-value selection** |
-| **DEXPI Engineering Guide** | [docs/engineering/dexpi-guide.md](engineering/dexpi-guide) | **Choose, generate, validate, and qualify DEXPI Plant, Process, Proteus, and pyDEXPI exchanges, including SIS/HIPPS semantics** |
-| **Engineering Deliverables and Handover** | [docs/engineering/deliverables-and-handover.md](engineering/deliverables-and-handover) | **Package layers, registers, DEXPI, CFIHOS, issue controls, approvals, and revisions** |
-| Engineering Simulator Foundations | [docs/integration/engineering-simulator-foundations.md](integration/engineering-simulator-foundations) | Isolated case execution, provenance, readiness, uncertainty, and dynamic verification contracts |
-| Process-to-Engineering Simulator | [docs/integration/process-to-engineering-simulator.md](integration/process-to-engineering-simulator) | Iterative process/design convergence and explicit discipline sizing modules |
-| Process Model to Engineering Workflow | [docs/integration/process-to-engineering-workflow.md](integration/process-to-engineering-workflow) | Governed compilation, artifact contracts, approvals, and revision workflow |
-| Numerical Health and Engineering Closure | [docs/integration/numerical-health-and-engineering-closure.md](integration/numerical-health-and-engineering-closure) | Convergence, closure, residual, and sensitivity evidence |
+| **Engineering Hub** | [docs/engineering/index.md](engineering/index.md) | **Dedicated entry point for design cases, closed-loop sizing, discipline verification, safety, handover, and lifecycle evidence** |
+| **Engineering Guide** | [docs/engineering/guide.md](engineering/guide.md) | **Practical, gated workflow from a validated process model to review-ready deliverables** |
+| **Current Engineering Capabilities** | [docs/engineering/current-capabilities.md](engineering/current-capabilities.md) | **Implemented entry points, discipline coverage, qualification layers, readiness levels, and accountable-review boundaries** |
+| **Design Cases and Governing Envelopes** | [docs/engineering/design-cases-and-envelopes.md](engineering/design-cases-and-envelopes.md) | **Controlled cases, metric direction, acceptance limits, isolated execution, and governing-value selection** |
+| **DEXPI Engineering Guide** | [docs/engineering/dexpi-guide.md](engineering/dexpi-guide.md) | **Choose, generate, validate, and qualify DEXPI Plant, Process, Proteus, and pyDEXPI exchanges, including SIS/HIPPS semantics** |
+| **Engineering Deliverables and Handover** | [docs/engineering/deliverables-and-handover.md](engineering/deliverables-and-handover.md) | **Package layers, registers, DEXPI, CFIHOS, issue controls, approvals, and revisions** |
+| Engineering Simulator Foundations | [docs/integration/engineering-simulator-foundations.md](integration/engineering-simulator-foundations.md) | Isolated case execution, provenance, readiness, uncertainty, and dynamic verification contracts |
+| Process-to-Engineering Simulator | [docs/integration/process-to-engineering-simulator.md](integration/process-to-engineering-simulator.md) | Iterative process/design convergence and explicit discipline sizing modules |
+| Process Model to Engineering Workflow | [docs/integration/process-to-engineering-workflow.md](integration/process-to-engineering-workflow.md) | Governed compilation, artifact contracts, approvals, and revision workflow |
+| Numerical Health and Engineering Closure | [docs/integration/numerical-health-and-engineering-closure.md](integration/numerical-health-and-engineering-closure.md) | Convergence, closure, residual, and sensitivity evidence |
 
 ### Discipline engineering and deliverables
 
 | Document | Path | Description |
 | --- | --- | --- |
-| Process Design Guide | [docs/process/process_design_guide.md](process/process_design_guide) | Process design, mechanical design, validation, and reporting |
-| Mechanical Design | [docs/process/mechanical_design.md](process/mechanical_design) | Equipment sizing, ratings, standards, and design reports |
-| Topside Piping Design | [docs/process/topside_piping_design.md](process/topside_piping_design) | Hydraulic, mechanical, vibration, and stress screening |
-| Instrument Design | [docs/process/instrument-design.md](process/instrument-design) | Instrument ranges, I/O, uncertainty, response, and SIS interfaces |
-| Electrical Design | [docs/process/electrical-design.md](process/electrical-design) | Motors, VFDs, cables, transformers, switchgear, and load lists |
-| DEXPI Engineering Generation | [docs/integration/dexpi-engineering-generation.md](integration/dexpi-engineering-generation) | Canonical graph, governed DEXPI, registers, datasheets, and calculation evidence |
-| CFIHOS Engineering Handover | [docs/integration/cfihos-20-engineering-handover.md](integration/cfihos-20-engineering-handover) | Controlled engineering data handover and readiness assessment |
+| Process Design Guide | [docs/process/process_design_guide.md](process/process_design_guide.md) | Process design, mechanical design, validation, and reporting |
+| Mechanical Design | [docs/process/mechanical_design.md](process/mechanical_design.md) | Equipment sizing, ratings, standards, and design reports |
+| Topside Piping Design | [docs/process/topside_piping_design.md](process/topside_piping_design.md) | Hydraulic, mechanical, vibration, and stress screening |
+| Instrument Design | [docs/process/instrument-design.md](process/instrument-design.md) | Instrument ranges, I/O, uncertainty, response, and SIS interfaces |
+| Electrical Design | [docs/process/electrical-design.md](process/electrical-design.md) | Motors, VFDs, cables, transformers, switchgear, and load lists |
+| DEXPI Engineering Generation | [docs/integration/dexpi-engineering-generation.md](integration/dexpi-engineering-generation.md) | Canonical graph, governed DEXPI, registers, datasheets, and calculation evidence |
+| CFIHOS Engineering Handover | [docs/integration/cfihos-20-engineering-handover.md](integration/cfihos-20-engineering-handover.md) | Controlled engineering data handover and readiness assessment |
 
 ### Examples and lifecycle
 
 | Document | Path | Description |
 | --- | --- | --- |
-| Complete Offshore Engineering Study | [docs/integration/complete-offshore-process-engineering-study.md](integration/complete-offshore-process-engineering-study) | Full-facility executed example from benchmark to review-governed package |
-| Model Change Events | [docs/process/model-change-events.md](process/model-change-events) | Controlled model revisions and event identity |
-| Model Impact Analysis | [docs/process/model-impact-analysis.md](process/model-impact-analysis) | Dependency-derived recalculation, revalidation, and reapproval scope |
-| Operational Evidence Package | [docs/process/operational_evidence_package.md](process/operational_evidence_package) | Evidence linking simulation results, constraints, and review status |
-| Industrial Method Qualification | [docs/integration/industrial-method-qualification.md](integration/industrial-method-qualification) | Method qualification boundaries and external evidence requirements |
+| Complete Offshore Engineering Study | [docs/integration/complete-offshore-process-engineering-study.md](integration/complete-offshore-process-engineering-study.md) | Full-facility executed example from benchmark to review-governed package |
+| Model Change Events | [docs/process/model-change-events.md](process/model-change-events.md) | Controlled model revisions and event identity |
+| Model Impact Analysis | [docs/process/model-impact-analysis.md](process/model-impact-analysis.md) | Dependency-derived recalculation, revalidation, and reapproval scope |
+| Operational Evidence Package | [docs/process/operational_evidence_package.md](process/operational_evidence_package.md) | Evidence linking simulation results, constraints, and review status |
+| Industrial Method Qualification | [docs/integration/industrial-method-qualification.md](integration/industrial-method-qualification.md) | Method qualification boundaries and external evidence requirements |
 
 ---
 
@@ -624,52 +622,52 @@ Fluid characterization handles plus fraction splitting, property estimation, and
 
 | Document                   | Path                                                                                   | Description                                                                                                     |
 | -------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Fluid Mechanics Overview   | [docs/fluidmechanics/README.md](fluidmechanics/)                                       | Fluid mechanics module                                                                                          |
-| Pipeline Index             | [docs/wiki/pipeline_index.md](wiki/pipeline_index)                                     | Pipeline documentation index                                                                                    |
-| **Pipeline Simulation**    | [docs/process/equipment/pipeline_simulation.md](process/equipment/pipeline_simulation) | **Comprehensive pipeline simulation guide with PipeLineInterface, all pipe types, flow regimes, heat transfer** |
-| Flow Equations             | [docs/wiki/pipeline_flow_equations.md](wiki/pipeline_flow_equations)                   | Pipeline flow equations                                                                                         |
-| Single Phase Flow          | [docs/fluidmechanics/single_phase_pipe_flow.md](fluidmechanics/single_phase_pipe_flow) | Single phase pipe flow                                                                                          |
-| **Flow Pattern Detection** | [docs/fluidmechanics/flow_pattern_detection.md](fluidmechanics/flow_pattern_detection) | **Taitel-Dukler, Baker, Barnea models, FlowPatternDetector API**                                                |
+| Fluid Mechanics Overview   | [docs/fluidmechanics/README.md](fluidmechanics/README.md)                                       | Fluid mechanics module                                                                                          |
+| Pipeline Index             | [docs/wiki/pipeline_index.md](wiki/pipeline_index.md)                                     | Pipeline documentation index                                                                                    |
+| **Pipeline Simulation**    | [docs/process/equipment/pipeline_simulation.md](process/equipment/pipeline_simulation.md) | **Comprehensive pipeline simulation guide with PipeLineInterface, all pipe types, flow regimes, heat transfer** |
+| Flow Equations             | [docs/wiki/pipeline_flow_equations.md](wiki/pipeline_flow_equations.md)                   | Pipeline flow equations                                                                                         |
+| Single Phase Flow          | [docs/fluidmechanics/single_phase_pipe_flow.md](fluidmechanics/single_phase_pipe_flow.md) | Single phase pipe flow                                                                                          |
+| **Flow Pattern Detection** | [docs/fluidmechanics/flow_pattern_detection.md](fluidmechanics/flow_pattern_detection.md) | **Taitel-Dukler, Baker, Barnea models, FlowPatternDetector API**                                                |
 
 ### Chapter 25: Pressure Drop Calculations
 
 | Document         | Path                                                                         | Description               |
 | ---------------- | ---------------------------------------------------------------------------- | ------------------------- |
-| Pressure Drop    | [docs/wiki/pipeline_pressure_drop.md](wiki/pipeline_pressure_drop)           | Pressure drop calculation |
-| Beggs & Brill    | [docs/wiki/beggs_and_brill_correlation.md](wiki/beggs_and_brill_correlation) | Beggs & Brill correlation |
-| Friction Factors | [docs/wiki/friction_factor_models.md](wiki/friction_factor_models)           | Friction factor models    |
+| Pressure Drop    | [docs/wiki/pipeline_pressure_drop.md](wiki/pipeline_pressure_drop.md)           | Pressure drop calculation |
+| Beggs & Brill    | [docs/wiki/beggs_and_brill_correlation.md](wiki/beggs_and_brill_correlation.md) | Beggs & Brill correlation |
+| Friction Factors | [docs/wiki/friction_factor_models.md](wiki/friction_factor_models.md)           | Friction factor models    |
 
 ### Chapter 26: Heat Transfer in Pipelines
 
 | Document                               | Path                                                                                                       | Description                                                                             |
 | -------------------------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| Heat Transfer                          | [docs/wiki/pipeline_heat_transfer.md](wiki/pipeline_heat_transfer)                                         | Pipeline heat transfer                                                                  |
-| Heat Transfer Module                   | [docs/fluidmechanics/heat_transfer.md](fluidmechanics/heat_transfer)                                       | Heat transfer module                                                                    |
-| Pipe Wall                              | [docs/wiki/pipe_wall_heat_transfer.md](wiki/pipe_wall_heat_transfer)                                       | Pipe wall heat transfer                                                                 |
-| Interphase                             | [docs/fluidmechanics/InterphaseHeatMassTransfer.md](fluidmechanics/InterphaseHeatMassTransfer)             | Interphase heat/mass transfer                                                           |
-| **Droplet/Bubble Flow Correlations**   | [docs/fluidmechanics/droplet_flow_correlations.md](fluidmechanics/droplet_flow_correlations)               | **Ranz-Marshall, Kronig-Brink, Abramzon-Sirignano for dispersed flow**                 |
-| Mass Transfer                          | [docs/fluidmechanics/mass_transfer.md](fluidmechanics/mass_transfer)                                       | Mass transfer models                                                                    |
-| **Mass Transfer API**                  | [docs/fluidmechanics/MassTransferAPI.md](fluidmechanics/MassTransferAPI)                                   | **Complete API documentation for mass transfer with methods, parameters, and examples** |
-| **Evaporation & Dissolution Tutorial** | [docs/fluidmechanics/EvaporationDissolutionTutorial.md](fluidmechanics/EvaporationDissolutionTutorial)     | **Practical tutorial for liquid evaporation and gas dissolution with worked examples**  |
-| **Model Improvements**                 | [docs/fluidmechanics/MASS_TRANSFER_MODEL_IMPROVEMENTS.md](fluidmechanics/MASS_TRANSFER_MODEL_IMPROVEMENTS) | **Technical review of mass transfer model with improvement recommendations**            |
+| Heat Transfer                          | [docs/wiki/pipeline_heat_transfer.md](wiki/pipeline_heat_transfer.md)                                         | Pipeline heat transfer                                                                  |
+| Heat Transfer Module                   | [docs/fluidmechanics/heat_transfer.md](fluidmechanics/heat_transfer.md)                                       | Heat transfer module                                                                    |
+| Pipe Wall                              | [docs/wiki/pipe_wall_heat_transfer.md](wiki/pipe_wall_heat_transfer.md)                                       | Pipe wall heat transfer                                                                 |
+| Interphase                             | [docs/fluidmechanics/InterphaseHeatMassTransfer.md](fluidmechanics/InterphaseHeatMassTransfer.md)             | Interphase heat/mass transfer                                                           |
+| **Droplet/Bubble Flow Correlations**   | [docs/fluidmechanics/droplet_flow_correlations.md](fluidmechanics/droplet_flow_correlations.md)               | **Ranz-Marshall, Kronig-Brink, Abramzon-Sirignano for dispersed flow**                 |
+| Mass Transfer                          | [docs/fluidmechanics/mass_transfer.md](fluidmechanics/mass_transfer.md)                                       | Mass transfer models                                                                    |
+| **Mass Transfer API**                  | [docs/fluidmechanics/MassTransferAPI.md](fluidmechanics/MassTransferAPI.md)                                   | **Complete API documentation for mass transfer with methods, parameters, and examples** |
+| **Evaporation & Dissolution Tutorial** | [docs/fluidmechanics/EvaporationDissolutionTutorial.md](fluidmechanics/EvaporationDissolutionTutorial.md)     | **Practical tutorial for liquid evaporation and gas dissolution with worked examples**  |
+| **Model Improvements**                 | [docs/fluidmechanics/MASS_TRANSFER_MODEL_IMPROVEMENTS.md](fluidmechanics/MASS_TRANSFER_MODEL_IMPROVEMENTS.md) | **Technical review of mass transfer model with improvement recommendations**            |
 
 ### Chapter 27: Two-Phase & Multiphase Flow
 
 | Document             | Path                                                                                                                     | Description               |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------- |
-| Two-Phase Model      | [docs/fluidmechanics/TwoPhasePipeFlowModel.md](fluidmechanics/TwoPhasePipeFlowModel)                                     | Two-phase pipe flow       |
-| Two-Fluid Model      | [docs/wiki/two_fluid_model.md](wiki/two_fluid_model)                                                                     | Two-fluid model           |
-| Multiphase Transient | [docs/wiki/multiphase_transient_model.md](wiki/multiphase_transient_model)                                               | Multiphase transient      |
-| Transient Pipe Wiki  | [docs/wiki/transient_multiphase_pipe.md](wiki/transient_multiphase_pipe)                                                 | Transient multiphase pipe |
-| Development Plan     | [docs/fluidmechanics/TwoPhasePipeFlowSystem_Development_Plan.md](fluidmechanics/TwoPhasePipeFlowSystem_Development_Plan) | Development plan          |
+| Two-Phase Model      | [docs/fluidmechanics/TwoPhasePipeFlowModel.md](fluidmechanics/TwoPhasePipeFlowModel.md)                                     | Two-phase pipe flow       |
+| Two-Fluid Model      | [docs/wiki/two_fluid_model.md](wiki/two_fluid_model.md)                                                                     | Two-fluid model           |
+| Multiphase Transient | [docs/wiki/multiphase_transient_model.md](wiki/multiphase_transient_model.md)                                               | Multiphase transient      |
+| Transient Pipe Wiki  | [docs/wiki/transient_multiphase_pipe.md](wiki/transient_multiphase_pipe.md)                                                 | Transient multiphase pipe |
+| Development Plan     | [docs/fluidmechanics/TwoPhasePipeFlowSystem_Development_Plan.md](fluidmechanics/TwoPhasePipeFlowSystem_Development_Plan.md) | Development plan          |
 
 ### Chapter 28: Transient Pipeline Simulation
 
 | Document              | Path                                                                               | Description           |
 | --------------------- | ---------------------------------------------------------------------------------- | --------------------- |
-| Transient Simulation  | [docs/wiki/pipeline_transient_simulation.md](wiki/pipeline_transient_simulation)   | Transient pipeline    |
-| Model Recommendations | [docs/wiki/pipeline_model_recommendations.md](wiki/pipeline_model_recommendations) | Model recommendations |
-| Water Hammer          | [docs/wiki/water_hammer_implementation.md](wiki/water_hammer_implementation)       | Water hammer          |
+| Transient Simulation  | [docs/wiki/pipeline_transient_simulation.md](wiki/pipeline_transient_simulation.md)   | Transient pipeline    |
+| Model Recommendations | [docs/wiki/pipeline_model_recommendations.md](wiki/pipeline_model_recommendations.md) | Model recommendations |
+| Water Hammer          | [docs/wiki/water_hammer_implementation.md](wiki/water_hammer_implementation.md)       | Water hammer          |
 
 ---
 
@@ -679,79 +677,79 @@ Fluid characterization handles plus fraction splitting, property estimation, and
 
 | Document             | Path                                                                             | Description                 |
 | -------------------- | -------------------------------------------------------------------------------- | --------------------------- |
-| Safety Overview      | [docs/safety/README.md](safety/)                                                 | Safety systems module       |
-| Safety Roadmap       | [docs/safety/SAFETY_SIMULATION_ROADMAP.md](safety/SAFETY_SIMULATION_ROADMAP)     | Safety simulation roadmap   |
-| Layered Architecture | [docs/safety/layered_safety_architecture.md](safety/layered_safety_architecture) | Layered safety architecture |
-| Process Safety       | [docs/process/safety/README.md](process/safety/)                                 | Process safety module       |
+| Safety Overview      | [docs/safety/README.md](safety/README.md)                                                 | Safety systems module       |
+| Safety Roadmap       | [docs/safety/SAFETY_SIMULATION_ROADMAP.md](safety/SAFETY_SIMULATION_ROADMAP.md)     | Safety simulation roadmap   |
+| Layered Architecture | [docs/safety/layered_safety_architecture.md](safety/layered_safety_architecture.md) | Layered safety architecture |
+| Process Safety       | [docs/process/safety/README.md](process/safety/README.md)                                 | Process safety module       |
 
 ### Chapter 30: Alarm Systems
 
 | Document            | Path                                                                                 | Description                |
 | ------------------- | ------------------------------------------------------------------------------------ | -------------------------- |
-| Alarm System Guide  | [docs/safety/alarm_system_guide.md](safety/alarm_system_guide)                       | Alarm system configuration |
-| Alarm Logic Example | [docs/safety/alarm_triggered_logic_example.md](safety/alarm_triggered_logic_example) | Alarm-triggered logic      |
-| ESD Fire Alarm      | [docs/wiki/esd_fire_alarm_system.md](wiki/esd_fire_alarm_system)                     | ESD/Fire alarm systems     |
+| Alarm System Guide  | [docs/safety/alarm_system_guide.md](safety/alarm_system_guide.md)                       | Alarm system configuration |
+| Alarm Logic Example | [docs/safety/alarm_triggered_logic_example.md](safety/alarm_triggered_logic_example.md) | Alarm-triggered logic      |
+| ESD Fire Alarm      | [docs/wiki/esd_fire_alarm_system.md](wiki/esd_fire_alarm_system.md)                     | ESD/Fire alarm systems     |
 
 ### Chapter 31: Pressure Relief Systems
 
 | Document                    | Path                                                                                 | Description                                                                           |
 | --------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
-| PSV Dynamic Sizing Wiki     | [docs/wiki/psv_dynamic_sizing_example.md](wiki/psv_dynamic_sizing_example)           | PSV dynamic sizing                                                                    |
-| PSV Dynamic Sizing          | [docs/safety/psv_dynamic_sizing_example.md](safety/psv_dynamic_sizing_example)       | PSV sizing example                                                                    |
-| Trapped Inventory Calculator | [docs/safety/trapped_inventory_calculator.md](safety/trapped_inventory_calculator) | Evidence-linked trapped inventory for isolation, blowdown, flare-load, and MDMT screening |
-| Trapped Liquid Fire Rupture | [docs/safety/trapped_liquid_fire_rupture.md](safety/trapped_liquid_fire_rupture) | Blocked-in liquid segment fire rupture screening with material, flange, PFP, and source-term handoff |
-| **Blocked-In Liquid Thermal Expansion** | [docs/safety/blocked_in_liquid_thermal_expansion.md](safety/blocked_in_liquid_thermal_expansion) | **Rigorous isochoric pressure-rise screening (API 521 §4.4.12) plus simplified beta/kappa relation for blocked-in liquid segments** |
-| Vessel Thermomechanical Safety | [docs/safety/vessel_thermomechanical_safety.md](safety/vessel_thermomechanical_safety) | Transient non-equilibrium blowdown, dynamic PSV sizing, fast filling, cryogenic boil-off, composite-wall conduction, and fire/blowdown wall rupture |
-| **Relief Valve Sizing API** | [docs/safety/relief_valve_sizing_api.md](safety/relief_valve_sizing_api)             | **API 520/521 PSV sizing for gas, liquid, and two-phase relief with fire heat input** |
-| PSD Valve Trip              | [docs/wiki/psd_valve_hihi_trip.md](wiki/psd_valve_hihi_trip)                         | PSD valve HIHI trip                                                                   |
-| Rupture Disks               | [docs/safety/rupture_disk_dynamic_behavior.md](safety/rupture_disk_dynamic_behavior) | Rupture disk behavior                                                                 |
+| PSV Dynamic Sizing Wiki     | [docs/wiki/psv_dynamic_sizing_example.md](wiki/psv_dynamic_sizing_example.md)           | PSV dynamic sizing                                                                    |
+| PSV Dynamic Sizing          | [docs/safety/psv_dynamic_sizing_example.md](safety/psv_dynamic_sizing_example.md)       | PSV sizing example                                                                    |
+| Trapped Inventory Calculator | [docs/safety/trapped_inventory_calculator.md](safety/trapped_inventory_calculator.md) | Evidence-linked trapped inventory for isolation, blowdown, flare-load, and MDMT screening |
+| Trapped Liquid Fire Rupture | [docs/safety/trapped_liquid_fire_rupture.md](safety/trapped_liquid_fire_rupture.md) | Blocked-in liquid segment fire rupture screening with material, flange, PFP, and source-term handoff |
+| **Blocked-In Liquid Thermal Expansion** | [docs/safety/blocked_in_liquid_thermal_expansion.md](safety/blocked_in_liquid_thermal_expansion.md) | **Rigorous isochoric pressure-rise screening (API 521 §4.4.12) plus simplified beta/kappa relation for blocked-in liquid segments** |
+| Vessel Thermomechanical Safety | [docs/safety/vessel_thermomechanical_safety.md](safety/vessel_thermomechanical_safety.md) | Transient non-equilibrium blowdown, dynamic PSV sizing, fast filling, cryogenic boil-off, composite-wall conduction, and fire/blowdown wall rupture |
+| **Relief Valve Sizing API** | [docs/safety/relief_valve_sizing_api.md](safety/relief_valve_sizing_api.md)             | **API 520/521 PSV sizing for gas, liquid, and two-phase relief with fire heat input** |
+| PSD Valve Trip              | [docs/wiki/psd_valve_hihi_trip.md](wiki/psd_valve_hihi_trip.md)                         | PSD valve HIHI trip                                                                   |
+| Rupture Disks               | [docs/safety/rupture_disk_dynamic_behavior.md](safety/rupture_disk_dynamic_behavior.md) | Rupture disk behavior                                                                 |
 
 ### Chapter 32: HIPPS Systems
 
 | Document             | Path                                                               | Description          |
 | -------------------- | ------------------------------------------------------------------ | -------------------- |
-| HIPPS Summary        | [docs/safety/HIPPS_SUMMARY.md](safety/HIPPS_SUMMARY)               | HIPPS summary        |
-| HIPPS Implementation | [docs/safety/hipps_implementation.md](safety/hipps_implementation) | HIPPS implementation |
-| HIPPS Safety Logic   | [docs/safety/hipps_safety_logic.md](safety/hipps_safety_logic)     | HIPPS safety logic   |
+| HIPPS Summary        | [docs/safety/HIPPS_SUMMARY.md](safety/HIPPS_SUMMARY.md)               | HIPPS summary        |
+| HIPPS Implementation | [docs/safety/hipps_implementation.md](safety/hipps_implementation.md) | HIPPS implementation |
+| HIPPS Safety Logic   | [docs/safety/hipps_safety_logic.md](safety/hipps_safety_logic.md)     | HIPPS safety logic   |
 
 ### Chapter 33: ESD & Fire Systems
 
 | Document            | Path                                                                                     | Description                |
 | ------------------- | ---------------------------------------------------------------------------------------- | -------------------------- |
-| ESD Dynamic Testing | [docs/safety/esd_testing_workflow.md](safety/esd_testing_workflow)                       | ESD dynamic testing with process logic, tagreader evidence, and criteria reports |
-| ESD Blowdown        | [docs/safety/ESD_BLOWDOWN_SYSTEM.md](safety/ESD_BLOWDOWN_SYSTEM)                         | ESD blowdown system        |
-| Pressure Monitoring | [docs/safety/PRESSURE_MONITORING_ESD.md](safety/PRESSURE_MONITORING_ESD)                 | Pressure monitoring ESD    |
-| Fire Heat Transfer  | [docs/safety/fire_heat_transfer_enhancements.md](safety/fire_heat_transfer_enhancements) | Fire heat transfer         |
-| Fire Blowdown       | [docs/safety/fire_blowdown_capabilities.md](safety/fire_blowdown_capabilities)           | Fire blowdown capabilities |
+| ESD Dynamic Testing | [docs/safety/esd_testing_workflow.md](safety/esd_testing_workflow.md)                       | ESD dynamic testing with process logic, tagreader evidence, and criteria reports |
+| ESD Blowdown        | [docs/safety/ESD_BLOWDOWN_SYSTEM.md](safety/ESD_BLOWDOWN_SYSTEM.md)                         | ESD blowdown system        |
+| Pressure Monitoring | [docs/safety/PRESSURE_MONITORING_ESD.md](safety/PRESSURE_MONITORING_ESD.md)                 | Pressure monitoring ESD    |
+| Fire Heat Transfer  | [docs/safety/fire_heat_transfer_enhancements.md](safety/fire_heat_transfer_enhancements.md) | Fire heat transfer         |
+| Fire Blowdown       | [docs/safety/fire_blowdown_capabilities.md](safety/fire_blowdown_capabilities.md)           | Fire blowdown capabilities |
 
 ### Chapter 34: Integrated Safety Systems
 
 | Document            | Path                                                                                   | Description                   |
 | ------------------- | -------------------------------------------------------------------------------------- | ----------------------------- |
-| Integrated Safety   | [docs/safety/INTEGRATED_SAFETY_SYSTEMS.md](safety/INTEGRATED_SAFETY_SYSTEMS)           | Integrated safety systems     |
-| SIS Logic           | [docs/safety/sis_logic_implementation.md](safety/sis_logic_implementation)             | SIS logic implementation      |
-| Choke Protection    | [docs/wiki/choke_collapse_psd_protection.md](wiki/choke_collapse_psd_protection)       | Choke collapse protection     |
-| Safety Chain Tests  | [docs/safety/integration_safety_chain_tests.md](safety/integration_safety_chain_tests) | Safety chain tests            |
-| Scenario Generation | [docs/process/safety/scenario-generation.md](process/safety/scenario-generation)       | Automatic scenario generation |
-| Release Dispersion Scenarios | [docs/process/safety/release-dispersion-scenarios.md](process/safety/release-dispersion-scenarios) | Automatic leak source terms, gas dispersion screening, scenario taxonomy, trapped inventory, CFD source-term handoff cases, and industrial-readiness guidance from ProcessSystem streams |
-| Barrier Management  | [docs/safety/barrier_management.md](safety/barrier_management)                         | Evidence-linked PSF/SCE barrier register and safety-analysis handoffs |
-| Automated HAZOP     | [docs/safety/automated_hazop_from_stid.md](safety/automated_hazop_from_stid)           | STID/P&ID, plant data, NeqSim process simulation, HAZOP worksheet, barrier handoff, and report workflow |
-| Open Drain Review   | [docs/safety/open_drain_review.md](safety/open_drain_review)                           | NORSOK S-001 Clause 9 open-drain review using NeqSim-calculated liquid leak rate, firewater load, liquid density, pressure, and drain hydraulic capacity plus STID/tagreader evidence |
+| Integrated Safety   | [docs/safety/INTEGRATED_SAFETY_SYSTEMS.md](safety/INTEGRATED_SAFETY_SYSTEMS.md)           | Integrated safety systems     |
+| SIS Logic           | [docs/safety/sis_logic_implementation.md](safety/sis_logic_implementation.md)             | SIS logic implementation      |
+| Choke Protection    | [docs/wiki/choke_collapse_psd_protection.md](wiki/choke_collapse_psd_protection.md)       | Choke collapse protection     |
+| Safety Chain Tests  | [docs/safety/integration_safety_chain_tests.md](safety/integration_safety_chain_tests.md) | Safety chain tests            |
+| Scenario Generation | [docs/process/safety/scenario-generation.md](process/safety/scenario-generation.md)       | Automatic scenario generation |
+| Release Dispersion Scenarios | [docs/process/safety/release-dispersion-scenarios.md](process/safety/release-dispersion-scenarios.md) | Automatic leak source terms, gas dispersion screening, scenario taxonomy, trapped inventory, CFD source-term handoff cases, and industrial-readiness guidance from ProcessSystem streams |
+| Barrier Management  | [docs/safety/barrier_management.md](safety/barrier_management.md)                         | Evidence-linked PSF/SCE barrier register and safety-analysis handoffs |
+| Automated HAZOP     | [docs/safety/automated_hazop_from_stid.md](safety/automated_hazop_from_stid.md)           | STID/P&ID, plant data, NeqSim process simulation, HAZOP worksheet, barrier handoff, and report workflow |
+| Open Drain Review   | [docs/safety/open_drain_review.md](safety/open_drain_review.md)                           | NORSOK S-001 Clause 9 open-drain review using NeqSim-calculated liquid leak rate, firewater load, liquid density, pressure, and drain hydraulic capacity plus STID/tagreader evidence |
 
 ### Chapter 34b: Consequence Analysis & QRA
 
 | Document                   | Path                                                                                | Description                                                                       |
 | -------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Depressurization (API 521) | [docs/safety/depressurization_per_API_521.md](safety/depressurization_per_API_521) | Transient blowdown via VU-flash, BDV sizing, fire heat input                      |
-| MDMT Assessment            | [docs/safety/mdmt_assessment.md](safety/mdmt_assessment)                           | UCS-66 / API 579 / EN 13445 minimum design metal temperature                      |
-| Dispersion & Consequence   | [docs/safety/dispersion_and_consequence.md](safety/dispersion_and_consequence)     | Gaussian/heavy-gas dispersion, jet/pool/VCE/BLEVE, probit, IRPA roll-up           |
-| HAZOP Worksheet            | [docs/safety/HAZOP.md](safety/HAZOP)                                               | IEC 61882 guidewords, process parameters, deviation rows, and text reports        |
-| FMEA / FMECA               | [docs/safety/FMEA.md](safety/FMEA)                                                 | IEC 60812 RPN = S·O·D, criticality threshold filtering                            |
-| Event & Fault Trees        | [docs/safety/event_fault_trees.md](safety/event_fault_trees)                       | IEC 61025 / 62502 ETA + FTA with β-factor common-cause and k-of-N voting gates    |
-| NOG 070 SIL / STS-0131 / ESD | [docs/safety/nog070_sil_sts0131_esd.md](safety/nog070_sil_sts0131_esd)           | Pre-determined SIL (NOG 070), STS-0131 acceptance gate, IEC 61511 ESD response time |
-| API 14C SAFE / NORSOK P-002 | [docs/safety/api14c_norsok_p002.md](safety/api14c_norsok_p002)                    | API RP 14C SAFE chart, NORSOK P-002 flare/blowdown/vent screening, coupled blowdown |
-| MAH Bow-Tie / EI AVIFF FIV | [docs/safety/mah_bowtie_fiv_screening.md](safety/mah_bowtie_fiv_screening)         | ISO 17776 major-accident-hazard bow-tie and EI AVIFF flow-induced-vibration screening |
-| Flare Flame / Hazardous Area / PFP | [docs/safety/flare_flame_hazardous_area_pfp.md](safety/flare_flame_hazardous_area_pfp) | API 537 flare flame/radiation/noise, IEC 60079-10-1 zoning, API 521 PFP demand |
+| Depressurization (API 521) | [docs/safety/depressurization_per_API_521.md](safety/depressurization_per_API_521.md) | Transient blowdown via VU-flash, BDV sizing, fire heat input                      |
+| MDMT Assessment            | [docs/safety/mdmt_assessment.md](safety/mdmt_assessment.md)                           | UCS-66 / API 579 / EN 13445 minimum design metal temperature                      |
+| Dispersion & Consequence   | [docs/safety/dispersion_and_consequence.md](safety/dispersion_and_consequence.md)     | Gaussian/heavy-gas dispersion, jet/pool/VCE/BLEVE, probit, IRPA roll-up           |
+| HAZOP Worksheet            | [docs/safety/HAZOP.md](safety/HAZOP.md)                                               | IEC 61882 guidewords, process parameters, deviation rows, and text reports        |
+| FMEA / FMECA               | [docs/safety/FMEA.md](safety/FMEA.md)                                                 | IEC 60812 RPN = S·O·D, criticality threshold filtering                            |
+| Event & Fault Trees        | [docs/safety/event_fault_trees.md](safety/event_fault_trees.md)                       | IEC 61025 / 62502 ETA + FTA with β-factor common-cause and k-of-N voting gates    |
+| NOG 070 SIL / STS-0131 / ESD | [docs/safety/nog070_sil_sts0131_esd.md](safety/nog070_sil_sts0131_esd.md)           | Pre-determined SIL (NOG 070), STS-0131 acceptance gate, IEC 61511 ESD response time |
+| API 14C SAFE / NORSOK P-002 | [docs/safety/api14c_norsok_p002.md](safety/api14c_norsok_p002.md)                    | API RP 14C SAFE chart, NORSOK P-002 flare/blowdown/vent screening, coupled blowdown |
+| MAH Bow-Tie / EI AVIFF FIV | [docs/safety/mah_bowtie_fiv_screening.md](safety/mah_bowtie_fiv_screening.md)         | ISO 17776 major-accident-hazard bow-tie and EI AVIFF flow-induced-vibration screening |
+| Flare Flame / Hazardous Area / PFP | [docs/safety/flare_flame_hazardous_area_pfp.md](safety/flare_flame_hazardous_area_pfp.md) | API 537 flare flame/radiation/noise, IEC 60079-10-1 zoning, API 521 PFP demand |
 
 ### Chapter 35: Risk Simulation Framework
 
@@ -759,20 +757,20 @@ Comprehensive operational risk simulation framework for equipment failure analys
 
 | Document                       | Path                                                                               | Description                                                                               |
 | ------------------------------ | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| **Risk Framework Index**       | [docs/risk/index.md](risk/index)                                                   | **START HERE**: Quick start guide, architecture overview, package structure               |
-| **Framework Overview**         | [docs/risk/overview.md](risk/overview)                                             | Core concepts, capabilities, industry standards compliance (ISO 14224, OREDA, NORSOK)     |
-| **Equipment Failure Modeling** | [docs/risk/equipment-failure.md](risk/equipment-failure)                           | FailureType enum, capacity factors, OREDA reliability data, λ/R(t)/MTTF formulas          |
-| **Risk Matrix**                | [docs/risk/risk-matrix.md](risk/risk-matrix)                                       | 5×5 probability/consequence matrix, risk scoring, cost calculations                       |
-| **Monte Carlo Simulation**     | [docs/risk/monte-carlo.md](risk/monte-carlo)                                       | OperationalRiskSimulator, exponential sampling, P10/P50/P90 statistics, convergence       |
-| **Production Impact Analysis** | [docs/risk/production-impact.md](risk/production-impact)                           | Loss calculations, criticality index, cascade analysis, economic impact                   |
-| **Degraded Operation**         | [docs/risk/degraded-operation.md](risk/degraded-operation)                         | DegradedOperationOptimizer, recovery planning, operating modes                            |
-| **Process Topology**           | [docs/risk/topology.md](risk/topology)                                             | ProcessTopologyAnalyzer, graph extraction, topological ordering, DOT/JSON export          |
-| **STID Tagging**               | [docs/risk/stid-tagging.md](risk/stid-tagging)                                     | FunctionalLocation class, PPPP-TT-NNNNN[S] format, installation/equipment codes           |
-| **Dependency Analysis**        | [docs/risk/dependency-analysis.md](risk/dependency-analysis)                       | DependencyAnalyzer, cascade failure trees, cross-installation effects                     |
-| **Mathematical Reference**     | [docs/risk/mathematical-reference.md](risk/mathematical-reference)                 | Complete formulas: reliability, system availability, Monte Carlo, risk calculations       |
-| **API Reference**              | [docs/risk/api-reference.md](risk/api-reference)                                   | Full API documentation for all risk simulation classes                                    |
-| **Reliability Data Guide**     | [docs/risk/RELIABILITY_DATA_GUIDE.md](risk/RELIABILITY_DATA_GUIDE)                 | Multi-source reliability data (IOGP/SINTEF, CCPS, IEEE 493, Lees, OREDA), CSV format  |
-| **Physics-Based Integration**  | [docs/risk/PHYSICS_BASED_RISK_INTEGRATION.md](risk/PHYSICS_BASED_RISK_INTEGRATION) | **Integration of physics-based models with risk simulation for dynamic failure analysis** |
+| **Risk Framework Index**       | [docs/risk/index.md](risk/index.md)                                                   | **START HERE**: Quick start guide, architecture overview, package structure               |
+| **Framework Overview**         | [docs/risk/overview.md](risk/overview.md)                                             | Core concepts, capabilities, industry standards compliance (ISO 14224, OREDA, NORSOK)     |
+| **Equipment Failure Modeling** | [docs/risk/equipment-failure.md](risk/equipment-failure.md)                           | FailureType enum, capacity factors, OREDA reliability data, λ/R(t)/MTTF formulas          |
+| **Risk Matrix**                | [docs/risk/risk-matrix.md](risk/risk-matrix.md)                                       | 5×5 probability/consequence matrix, risk scoring, cost calculations                       |
+| **Monte Carlo Simulation**     | [docs/risk/monte-carlo.md](risk/monte-carlo.md)                                       | OperationalRiskSimulator, exponential sampling, P10/P50/P90 statistics, convergence       |
+| **Production Impact Analysis** | [docs/risk/production-impact.md](risk/production-impact.md)                           | Loss calculations, criticality index, cascade analysis, economic impact                   |
+| **Degraded Operation**         | [docs/risk/degraded-operation.md](risk/degraded-operation.md)                         | DegradedOperationOptimizer, recovery planning, operating modes                            |
+| **Process Topology**           | [docs/risk/topology.md](risk/topology.md)                                             | ProcessTopologyAnalyzer, graph extraction, topological ordering, DOT/JSON export          |
+| **STID Tagging**               | [docs/risk/stid-tagging.md](risk/stid-tagging.md)                                     | FunctionalLocation class, PPPP-TT-NNNNN[S] format, installation/equipment codes           |
+| **Dependency Analysis**        | [docs/risk/dependency-analysis.md](risk/dependency-analysis.md)                       | DependencyAnalyzer, cascade failure trees, cross-installation effects                     |
+| **Mathematical Reference**     | [docs/risk/mathematical-reference.md](risk/mathematical-reference.md)                 | Complete formulas: reliability, system availability, Monte Carlo, risk calculations       |
+| **API Reference**              | [docs/risk/api-reference.md](risk/api-reference.md)                                   | Full API documentation for all risk simulation classes                                    |
+| **Reliability Data Guide**     | [docs/risk/RELIABILITY_DATA_GUIDE.md](risk/RELIABILITY_DATA_GUIDE.md)                 | Multi-source reliability data (IOGP/SINTEF, CCPS, IEEE 493, Lees, OREDA), CSV format  |
+| **Physics-Based Integration**  | [docs/risk/PHYSICS_BASED_RISK_INTEGRATION.md](risk/PHYSICS_BASED_RISK_INTEGRATION.md) | **Integration of physics-based models with risk simulation for dynamic failure analysis** |
 
 ### Chapter 35a: Advanced Risk Framework (**NEW**)
 
@@ -780,11 +778,11 @@ Extended risk analysis capabilities implementing P1-P7 priority improvements for
 
 | Document                            | Path                                                                                                | Description                                                   |
 | ----------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| **Advanced Framework Overview**     | [docs/risk/README.md](risk/)                                                                        | **START HERE**: Overview of all 7 priority packages           |
-| **P1: Dynamic Simulation**          | [docs/risk/dynamic-simulation.md](risk/dynamic-simulation)                                          | Monte Carlo with transient effects, shutdown/startup modeling |
-| **P2: SIS/SIF Integration**         | [docs/risk/sis-integration.md](risk/sis-integration)                                                | IEC 61508/61511, LOPA analysis, SIL verification              |
-| **P4: Bow-Tie Analysis**            | [docs/risk/bowtie-analysis.md](risk/bowtie-analysis)                                                | Barrier analysis, threat/consequence visualization            |
-| **P6: Condition-Based Reliability** | [docs/risk/condition-based.md](risk/condition-based)                                                | Health monitoring, RUL estimation, predictive maintenance     |
+| **Advanced Framework Overview**     | [docs/risk/README.md](risk/README.md)                                                                        | **START HERE**: Overview of all 7 priority packages           |
+| **P1: Dynamic Simulation**          | [docs/risk/dynamic-simulation.md](risk/dynamic-simulation.md)                                          | Monte Carlo with transient effects, shutdown/startup modeling |
+| **P2: SIS/SIF Integration**         | [docs/risk/sis-integration.md](risk/sis-integration.md)                                                | IEC 61508/61511, LOPA analysis, SIL verification              |
+| **P4: Bow-Tie Analysis**            | [docs/risk/bowtie-analysis.md](risk/bowtie-analysis.md)                                                | Barrier analysis, threat/consequence visualization            |
+| **P6: Condition-Based Reliability** | [docs/risk/condition-based.md](risk/condition-based.md)                                                | Health monitoring, RUL estimation, predictive maintenance     |
 | **Tutorial Notebook**               | [docs/examples/AdvancedRiskFramework_Tutorial.ipynb](https://github.com/equinor/neqsim/blob/master/docs/examples/AdvancedRiskFramework_Tutorial.ipynb) | Comprehensive Jupyter tutorial                                |
 
 #### Advanced Risk Framework Packages
@@ -826,7 +824,7 @@ hypothesis scoring with OREDA, historian, STID, and NeqSim simulation verificati
 
 | Document                   | Path                                                                               | Description                                                               |
 | -------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| **Root Cause Analysis**    | [docs/diagnostics/root_cause_analysis.md](diagnostics/root_cause_analysis)         | RCA framework architecture, confidence scoring, usage examples            |
+| **Root Cause Analysis**    | [docs/diagnostics/root_cause_analysis.md](diagnostics/root_cause_analysis.md)         | RCA framework architecture, confidence scoring, usage examples            |
 
 #### Key Classes in Diagnostics Framework
 
@@ -848,51 +846,51 @@ hypothesis scoring with OREDA, historian, STID, and NeqSim simulation verificati
 
 | Document                                | Path                                                                                                       | Description                                                                                                      |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Phase Envelope Guide**                | [docs/pvtsimulation/phase_envelope_guide.md](pvtsimulation/phase_envelope_guide)                           | **Cricondenbar, cricondentherm, HCDP, bubble/dew points**                                                        |
-| **PVT Lab Tests**                       | [docs/pvtsimulation/pvt_lab_tests.md](pvtsimulation/pvt_lab_tests)                                         | **CCE, CVD, DL, separator test, swelling test simulations**                                                      |
-| PVT Overview                            | [docs/pvtsimulation/README.md](pvtsimulation/)                                                             | PVT simulation module                                                                                            |
-| PVT Workflows                           | [docs/wiki/pvt_simulation_workflows.md](wiki/pvt_simulation_workflows)                                     | PVT simulation workflows                                                                                         |
-| PVT Workflow Module                     | [docs/pvtsimulation/pvt_workflow.md](pvtsimulation/pvt_workflow)                                           | PVT workflow module                                                                                              |
-| Property Flash                          | [docs/wiki/property_flash_workflows.md](wiki/property_flash_workflows)                                     | Property flash workflows                                                                                         |
-| **Relative Permeability**               | [docs/pvtsimulation/relative_permeability.md](pvtsimulation/relative_permeability)                         | **Corey and LET relative permeability models, Eclipse table export (SWOF/SGOF/SOF3)**                            |
-| **Reservoir Material Balance & Decline** | [docs/pvtsimulation/reservoir_material_balance.md](pvtsimulation/reservoir_material_balance)              | **Gas/oil material balance (OGIP/OOIP, drive indices), Van Everdingen-Hurst / Carter-Tracy aquifer influx, Arps + Duong decline history matching** |
-| **Gas Pseudopressure & Pseudocritical** | [docs/pvtsimulation/gas_pseudopressure_pseudocritical.md](pvtsimulation/gas_pseudopressure_pseudocritical) | **Real gas pseudopressure integral, Standing/Sutton/Piper pseudocritical correlations, Wichert-Aziz correction** |
-| Whitson Reader                          | [docs/pvtsimulation/whitson_pvt_reader.md](pvtsimulation/whitson_pvt_reader)                               | Whitson PVT reader                                                                                               |
-| **Eclipse E300 Fluid Import**           | [docs/pvtsimulation/eclipse_e300_fluid_import.md](pvtsimulation/eclipse_e300_fluid_import)                 | **E300 file format reference, reading/writing Eclipse fluids, PVTsim integration, reservoir coupling workflows** |
-| **JSON Fluid Format**                   | [docs/pvtsimulation/json_fluid_format.md](pvtsimulation/json_fluid_format)                                 | **JSON fluid file format reference, reading/writing/converting fluids, E300 interconversion, API integration**   |
-| Solution Gas-Water Ratio                | [docs/pvtsimulation/SolutionGasWaterRatio.md](pvtsimulation/SolutionGasWaterRatio)                         | Rsw calculation methods (McCain, Søreide-Whitson, Electrolyte CPA)                                               |
+| **Phase Envelope Guide**                | [docs/pvtsimulation/phase_envelope_guide.md](pvtsimulation/phase_envelope_guide.md)                           | **Cricondenbar, cricondentherm, HCDP, bubble/dew points**                                                        |
+| **PVT Lab Tests**                       | [docs/pvtsimulation/pvt_lab_tests.md](pvtsimulation/pvt_lab_tests.md)                                         | **CCE, CVD, DL, separator test, swelling test simulations**                                                      |
+| PVT Overview                            | [docs/pvtsimulation/README.md](pvtsimulation/README.md)                                                             | PVT simulation module                                                                                            |
+| PVT Workflows                           | [docs/wiki/pvt_simulation_workflows.md](wiki/pvt_simulation_workflows.md)                                     | PVT simulation workflows                                                                                         |
+| PVT Workflow Module                     | [docs/pvtsimulation/pvt_workflow.md](pvtsimulation/pvt_workflow.md)                                           | PVT workflow module                                                                                              |
+| Property Flash                          | [docs/wiki/property_flash_workflows.md](wiki/property_flash_workflows.md)                                     | Property flash workflows                                                                                         |
+| **Relative Permeability**               | [docs/pvtsimulation/relative_permeability.md](pvtsimulation/relative_permeability.md)                         | **Corey and LET relative permeability models, Eclipse table export (SWOF/SGOF/SOF3)**                            |
+| **Reservoir Material Balance & Decline** | [docs/pvtsimulation/reservoir_material_balance.md](pvtsimulation/reservoir_material_balance.md)              | **Gas/oil material balance (OGIP/OOIP, drive indices), Van Everdingen-Hurst / Carter-Tracy aquifer influx, Arps + Duong decline history matching** |
+| **Gas Pseudopressure & Pseudocritical** | [docs/pvtsimulation/gas_pseudopressure_pseudocritical.md](pvtsimulation/gas_pseudopressure_pseudocritical.md) | **Real gas pseudopressure integral, Standing/Sutton/Piper pseudocritical correlations, Wichert-Aziz correction** |
+| Whitson Reader                          | [docs/pvtsimulation/whitson_pvt_reader.md](pvtsimulation/whitson_pvt_reader.md)                               | Whitson PVT reader                                                                                               |
+| **Eclipse E300 Fluid Import**           | [docs/pvtsimulation/eclipse_e300_fluid_import.md](pvtsimulation/eclipse_e300_fluid_import.md)                 | **E300 file format reference, reading/writing Eclipse fluids, PVTsim integration, reservoir coupling workflows** |
+| **JSON Fluid Format**                   | [docs/pvtsimulation/json_fluid_format.md](pvtsimulation/json_fluid_format.md)                                 | **JSON fluid file format reference, reading/writing/converting fluids, E300 interconversion, API integration**   |
+| Solution Gas-Water Ratio                | [docs/pvtsimulation/SolutionGasWaterRatio.md](pvtsimulation/SolutionGasWaterRatio.md)                         | Rsw calculation methods (McCain, Søreide-Whitson, Electrolyte CPA)                                               |
 
 ### Chapter 36: Black Oil Models
 
 | Document           | Path                                                                           | Description                                                                                    |
 | ------------------ | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
-| Black Oil Overview | [docs/blackoil/README.md](blackoil/)                                           | Black oil module                                                                               |
-| Flash Playbook     | [docs/wiki/black_oil_flash_playbook.md](wiki/black_oil_flash_playbook)         | Black oil flash playbook                                                                       |
-| Black Oil Export   | [docs/pvtsimulation/blackoil_pvt_export.md](pvtsimulation/blackoil_pvt_export) | Black oil PVT export, E300 compositional export, and E300 import with automatic water addition |
+| Black Oil Overview | [docs/blackoil/README.md](blackoil/README.md)                                           | Black oil module                                                                               |
+| Flash Playbook     | [docs/wiki/black_oil_flash_playbook.md](wiki/black_oil_flash_playbook.md)         | Black oil flash playbook                                                                       |
+| Black Oil Export   | [docs/pvtsimulation/blackoil_pvt_export.md](pvtsimulation/blackoil_pvt_export.md) | Black oil PVT export, E300 compositional export, and E300 import with automatic water addition |
 
 ### Chapter 37: Flow Assurance
 
 | Document                           | Path                                                                                                                             | Description                                                                                        |
 | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| Flow Assurance                     | [docs/pvtsimulation/flowassurance/README.md](pvtsimulation/flowassurance/)                                                       | Flow assurance module                                                                              |
-| Asphaltene Modeling                | [docs/pvtsimulation/flowassurance/asphaltene_modeling.md](pvtsimulation/flowassurance/asphaltene_modeling)                       | Asphaltene modeling                                                                                |
-| Asphaltene CPA                     | [docs/pvtsimulation/flowassurance/asphaltene_cpa_calculations.md](pvtsimulation/flowassurance/asphaltene_cpa_calculations)       | CPA calculations                                                                                   |
-| De Boer Screening                  | [docs/pvtsimulation/flowassurance/asphaltene_deboer_screening.md](pvtsimulation/flowassurance/asphaltene_deboer_screening)       | De Boer screening                                                                                  |
-| Method Comparison                  | [docs/pvtsimulation/flowassurance/asphaltene_method_comparison.md](pvtsimulation/flowassurance/asphaltene_method_comparison)     | Method comparison                                                                                  |
-| Parameter Fitting                  | [docs/pvtsimulation/flowassurance/asphaltene_parameter_fitting.md](pvtsimulation/flowassurance/asphaltene_parameter_fitting)     | Parameter fitting                                                                                  |
-| Validation                         | [docs/pvtsimulation/flowassurance/asphaltene_validation.md](pvtsimulation/flowassurance/asphaltene_validation)                   | Validation                                                                                         |
+| Flow Assurance                     | [docs/pvtsimulation/flowassurance/README.md](pvtsimulation/flowassurance/README.md)                                                       | Flow assurance module                                                                              |
+| Asphaltene Modeling                | [docs/pvtsimulation/flowassurance/asphaltene_modeling.md](pvtsimulation/flowassurance/asphaltene_modeling.md)                       | Asphaltene modeling                                                                                |
+| Asphaltene CPA                     | [docs/pvtsimulation/flowassurance/asphaltene_cpa_calculations.md](pvtsimulation/flowassurance/asphaltene_cpa_calculations.md)       | CPA calculations                                                                                   |
+| De Boer Screening                  | [docs/pvtsimulation/flowassurance/asphaltene_deboer_screening.md](pvtsimulation/flowassurance/asphaltene_deboer_screening.md)       | De Boer screening                                                                                  |
+| Method Comparison                  | [docs/pvtsimulation/flowassurance/asphaltene_method_comparison.md](pvtsimulation/flowassurance/asphaltene_method_comparison.md)     | Method comparison                                                                                  |
+| Parameter Fitting                  | [docs/pvtsimulation/flowassurance/asphaltene_parameter_fitting.md](pvtsimulation/flowassurance/asphaltene_parameter_fitting.md)     | Parameter fitting                                                                                  |
+| Validation                         | [docs/pvtsimulation/flowassurance/asphaltene_validation.md](pvtsimulation/flowassurance/asphaltene_validation.md)                   | Validation                                                                                         |
 | **Asphaltene Stability Notebook**  | [examples/notebooks/AsphalteneStabilityAnalysis.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/AsphalteneStabilityAnalysis.ipynb)                  | **Jupyter notebook: 6-method asphaltene prediction (De Boer, FH, CPA, Pedersen, RI, benchmark), literature validation (7 cases), parity plot** |
-| **Flow Assurance Screening Tools** | [docs/pvtsimulation/flowassurance/flow_assurance_screening_tools.md](pvtsimulation/flowassurance/flow_assurance_screening_tools) | **Pipeline cooldown, CO2 corrosion (de Waard-Milliams), scale prediction, wax curve monotonicity** |
-| **Erosion Prediction**             | [docs/pvtsimulation/flowassurance/erosion_prediction.md](pvtsimulation/flowassurance/erosion_prediction)                         | **API RP 14E erosional velocity, DNV RP O501 sand erosion, sand load defaults by completion type, corrosion-limited velocity, risk assessment** |
-| **Emulsion Viscosity**             | [docs/pvtsimulation/flowassurance/emulsion_viscosity_calculator.md](pvtsimulation/flowassurance/emulsion_viscosity_calculator)   | **Einstein, Taylor, Brinkman, Pal-Rhodes, Woelflin, Richardson models, phase inversion**           |
+| **Flow Assurance Screening Tools** | [docs/pvtsimulation/flowassurance/flow_assurance_screening_tools.md](pvtsimulation/flowassurance/flow_assurance_screening_tools.md) | **Pipeline cooldown, CO2 corrosion (de Waard-Milliams), scale prediction, wax curve monotonicity** |
+| **Erosion Prediction**             | [docs/pvtsimulation/flowassurance/erosion_prediction.md](pvtsimulation/flowassurance/erosion_prediction.md)                         | **API RP 14E erosional velocity, DNV RP O501 sand erosion, sand load defaults by completion type, corrosion-limited velocity, risk assessment** |
+| **Emulsion Viscosity**             | [docs/pvtsimulation/flowassurance/emulsion_viscosity_calculator.md](pvtsimulation/flowassurance/emulsion_viscosity_calculator.md)   | **Einstein, Taylor, Brinkman, Pal-Rhodes, Woelflin, Richardson models, phase inversion**           |
 
 
 ### Chapter 38: Gas Quality
 
 | Document              | Path                                                                                   | Description            |
 | --------------------- | -------------------------------------------------------------------------------------- | ---------------------- |
-| Gas Quality Standards | [docs/wiki/gas_quality_standards_from_tests.md](wiki/gas_quality_standards_from_tests) | Gas quality standards  |
-| Humid Air             | [docs/wiki/humid_air_math.md](wiki/humid_air_math)                                     | Humid air calculations |
+| Gas Quality Standards | [docs/wiki/gas_quality_standards_from_tests.md](wiki/gas_quality_standards_from_tests.md) | Gas quality standards  |
+| Humid Air             | [docs/wiki/humid_air_math.md](wiki/humid_air_math.md)                                     | Humid air calculations |
 
 ---
 
@@ -902,15 +900,15 @@ hypothesis scoring with OREDA, historian, STID, and NeqSim simulation verificati
 
 | Document                  | Path                                                                             | Description                                        |
 | ------------------------- | -------------------------------------------------------------------------------- | -------------------------------------------------- |
-| Standards Overview        | [docs/standards/README.md](standards/)                                           | Standards module                                   |
-| ISO 6976                  | [docs/standards/iso6976_calorific_values.md](standards/iso6976_calorific_values) | ISO 6976 calorific values                          |
-| ISO 6578                  | [docs/standards/iso6578_lng_density.md](standards/iso6578_lng_density)           | ISO 6578 LNG density                               |
-| ISO 15403                 | [docs/standards/iso15403_cng_quality.md](standards/iso15403_cng_quality)         | ISO 15403 CNG quality                              |
-| Dew Point                 | [docs/standards/dew_point_standards.md](standards/dew_point_standards)           | Dew point standards                                |
-| ASTM D6377                | [docs/standards/astm_d6377_rvp.md](standards/astm_d6377_rvp)                     | ASTM D6377 RVP                                     |
-| **Oil Quality Standards** | [docs/standards/oil_quality_standards.md](standards/oil_quality_standards)       | **ASTM D86, D445, D4052, D4294, D6377, TVP, D4737, D611, D1322, EN 116, D3230, D2500, D97, BS&W** |
-| Sales Contracts           | [docs/standards/sales_contracts.md](standards/sales_contracts)                   | Sales contracts                                    |
-| **IEC 81346 Reference Designations** | [docs/standards/iec81346-reference-designations.md](standards/iec81346-reference-designations) | **IEC 81346 structured equipment identification — letter codes, automatic designation generation, hierarchical/flat function numbering, ProcessModel integration, lifecycle state persistence, engineering deliverables, ISA-5.1 cross-reference, DEXPI export, ProcessAutomation integration** |
+| Standards Overview        | [docs/standards/README.md](standards/README.md)                                           | Standards module                                   |
+| ISO 6976                  | [docs/standards/iso6976_calorific_values.md](standards/iso6976_calorific_values.md) | ISO 6976 calorific values                          |
+| ISO 6578                  | [docs/standards/iso6578_lng_density.md](standards/iso6578_lng_density.md)           | ISO 6578 LNG density                               |
+| ISO 15403                 | [docs/standards/iso15403_cng_quality.md](standards/iso15403_cng_quality.md)         | ISO 15403 CNG quality                              |
+| Dew Point                 | [docs/standards/dew_point_standards.md](standards/dew_point_standards.md)           | Dew point standards                                |
+| ASTM D6377                | [docs/standards/astm_d6377_rvp.md](standards/astm_d6377_rvp.md)                     | ASTM D6377 RVP                                     |
+| **Oil Quality Standards** | [docs/standards/oil_quality_standards.md](standards/oil_quality_standards.md)       | **ASTM D86, D445, D4052, D4294, D6377, TVP, D4737, D611, D1322, EN 116, D3230, D2500, D97, BS&W** |
+| Sales Contracts           | [docs/standards/sales_contracts.md](standards/sales_contracts.md)                   | Sales contracts                                    |
+| **IEC 81346 Reference Designations** | [docs/standards/iec81346-reference-designations.md](standards/iec81346-reference-designations.md) | **IEC 81346 structured equipment identification — letter codes, automatic designation generation, hierarchical/flat function numbering, ProcessModel integration, lifecycle state persistence, engineering deliverables, ISA-5.1 cross-reference, DEXPI export, ProcessAutomation integration** |
 
 ---
 
@@ -920,124 +918,124 @@ hypothesis scoring with OREDA, historian, STID, and NeqSim simulation verificati
 
 | Document              | Path                                                                   | Description                   |
 | --------------------- | ---------------------------------------------------------------------- | ----------------------------- |
-| Future Infrastructure | [docs/process/future-infrastructure.md](process/future-infrastructure) | Future infrastructure classes |
-| API Reference         | [docs/process/future-api-reference.md](process/future-api-reference)   | Future API reference          |
+| Future Infrastructure | [docs/process/future-infrastructure.md](process/future-infrastructure.md) | Future infrastructure classes |
+| API Reference         | [docs/process/future-api-reference.md](process/future-api-reference.md)   | Future API reference          |
 
 ### Chapter 41: Digital Twins
 
 | Document     | Path                                                                         | Description              |
 | ------------ | ---------------------------------------------------------------------------- | ------------------------ |
-| Digital Twin | [docs/process/digital-twin-integration.md](process/digital-twin-integration) | Digital twin integration |
-| Plant Data & Tagreader | [docs/process/plant-data-tagreader.md](process/plant-data-tagreader) | Connecting NeqSim to plant historians (PI/IP.21) via tagreader |
-| Operational Evidence Package | [docs/process/operational_evidence_package.md](process/operational_evidence_package) | Combine P&ID/STID references, tagreader values, NeqSim scenario actions, and bottleneck detection into one operational study |
-| Lifecycle    | [docs/process/lifecycle/README.md](process/lifecycle/)                       | Lifecycle management     |
+| Digital Twin | [docs/process/digital-twin-integration.md](process/digital-twin-integration.md) | Digital twin integration |
+| Plant Data & Tagreader | [docs/process/plant-data-tagreader.md](process/plant-data-tagreader.md) | Connecting NeqSim to plant historians (PI/IP.21) via tagreader |
+| Operational Evidence Package | [docs/process/operational_evidence_package.md](process/operational_evidence_package.md) | Combine P&ID/STID references, tagreader values, NeqSim scenario actions, and bottleneck detection into one operational study |
+| Lifecycle    | [docs/process/lifecycle/README.md](process/lifecycle/README.md)                       | Lifecycle management     |
 
 ### Chapter 42: AI/ML Integration
 
 | Document             | Path                                                                                     | Description             |
 | -------------------- | ---------------------------------------------------------------------------------------- | ----------------------- |
-| AI Platform          | [docs/integration/ai_platform_integration.md](integration/ai_platform_integration)       | AI platform integration |
-| AI Validation        | [docs/integration/ai_validation_framework.md](integration/ai_validation_framework)       | AI validation framework |
-| AI Validation PR     | [docs/integration/PR_AI_VALIDATION_FRAMEWORK.md](integration/PR_AI_VALIDATION_FRAMEWORK) | AI validation PR docs   |
-| ML Integration       | [docs/integration/ml_integration.md](integration/ml_integration)                         | ML integration guide    |
-| ML Surrogate         | [docs/process/ml/README.md](process/ml/)                                                 | ML surrogate models     |
-| Integration Overview | [docs/integration/README.md](integration/)                                               | Integration module      |
-| **Agentic Engineering Introduction** | [docs/integration/ai_agentic_programming_intro.md](integration/ai_agentic_programming_intro) | **NEW: Comprehensive introduction to AI agent-assisted engineering with NeqSim** |
-| **Agents & Skills Reference** | [docs/integration/ai_agents_reference.md](integration/ai_agents_reference) | **Complete catalog of all 16 agents and 14 skills with commands and examples** |
-| **Agentic Workflow Examples** | [docs/integration/ai_workflow_examples.md](integration/ai_workflow_examples) | **NEW: Step-by-step walkthroughs of agent-driven engineering workflows** |
-| **Agentic Java Classes** | [docs/integration/ai_agentic_classes.md](integration/ai_agentic_classes) | **TaskResultValidator, SimulationQualityGate, AgentSession, AgentFeedbackCollector — Java infrastructure for AI-driven simulation QA** |
-| **Skills and Agents Guide** | [docs/integration/skills_guide.md](integration/skills_guide) | **Creating, using, and managing skills and installable agents — core, community, and private extension workflows** |
-| **PaperLab CLI and VS Code Install** | [docs/integration/paperlab_vscode_install.md](integration/paperlab_vscode_install) | **PaperLab CLI command reference for help, list, dry-run, and VS Code Chat install commands** |
-| **Agent and Skill Catalog Schema** | [docs/integration/agent_skill_catalog_schema.md](integration/agent_skill_catalog_schema) | **Shared schema, trust namespace, and alias policy for agent and skill catalogs** |
-| **Agent to Skill Map** | [docs/integration/agent_skill_map.md](integration/agent_skill_map) | **Generated cross-catalog map of community and enterprise agents and their required skill dependencies** |
-| **Enterprise Agent and Skill Repositories** | [docs/integration/enterprise_agent_skill_repos.md](integration/enterprise_agent_skill_repos) | **How to set up private company NeqSim enterprise agent and skill repositories and configure Engineering Harness discovery/install** |
+| AI Platform          | [docs/integration/ai_platform_integration.md](integration/ai_platform_integration.md)       | AI platform integration |
+| AI Validation        | [docs/integration/ai_validation_framework.md](integration/ai_validation_framework.md)       | AI validation framework |
+| AI Validation PR     | [docs/integration/PR_AI_VALIDATION_FRAMEWORK.md](integration/PR_AI_VALIDATION_FRAMEWORK.md) | AI validation PR docs   |
+| ML Integration       | [docs/integration/ml_integration.md](integration/ml_integration.md)                         | ML integration guide    |
+| ML Surrogate         | [docs/process/ml/README.md](process/ml/README.md)                                                 | ML surrogate models     |
+| Integration Overview | [docs/integration/README.md](integration/README.md)                                               | Integration module      |
+| **Agentic Engineering Introduction** | [docs/integration/ai_agentic_programming_intro.md](integration/ai_agentic_programming_intro.md) | **NEW: Comprehensive introduction to AI agent-assisted engineering with NeqSim** |
+| **Agents & Skills Reference** | [docs/integration/ai_agents_reference.md](integration/ai_agents_reference.md) | **Complete catalog of all 16 agents and 14 skills with commands and examples** |
+| **Agentic Workflow Examples** | [docs/integration/ai_workflow_examples.md](integration/ai_workflow_examples.md) | **NEW: Step-by-step walkthroughs of agent-driven engineering workflows** |
+| **Agentic Java Classes** | [docs/integration/ai_agentic_classes.md](integration/ai_agentic_classes.md) | **TaskResultValidator, SimulationQualityGate, AgentSession, AgentFeedbackCollector — Java infrastructure for AI-driven simulation QA** |
+| **Skills and Agents Guide** | [docs/integration/skills_guide.md](integration/skills_guide.md) | **Creating, using, and managing skills and installable agents — core, community, and private extension workflows** |
+| **PaperLab CLI and VS Code Install** | [docs/integration/paperlab_vscode_install.md](integration/paperlab_vscode_install.md) | **PaperLab CLI command reference for help, list, dry-run, and VS Code Chat install commands** |
+| **Agent and Skill Catalog Schema** | [docs/integration/agent_skill_catalog_schema.md](integration/agent_skill_catalog_schema.md) | **Shared schema, trust namespace, and alias policy for agent and skill catalogs** |
+| **Agent to Skill Map** | [docs/integration/agent_skill_map.md](integration/agent_skill_map.md) | **Generated cross-catalog map of community and enterprise agents and their required skill dependencies** |
+| **Enterprise Agent and Skill Repositories** | [docs/integration/enterprise_agent_skill_repos.md](integration/enterprise_agent_skill_repos.md) | **How to set up private company NeqSim enterprise agent and skill repositories and configure Engineering Harness discovery/install** |
 
 ### Chapter 43: Sustainability & Emissions
 
 | Document                                  | Path                                                                                                 | Description                                                                                                                  |
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| Emissions Tracking                        | [docs/process/sustainability/README.md](process/sustainability/)                                     | Emissions tracking overview                                                                                                  |
-| **Offshore Emission Reporting Guide**     | [docs/emissions/OFFSHORE_EMISSION_REPORTING.md](emissions/OFFSHORE_EMISSION_REPORTING)               | **Comprehensive guide for offshore platform GHG emission reporting with regulatory references**                              |
-| **Produced Water Emissions Tutorial**     | [docs/examples/ProducedWaterEmissions_Tutorial.md](examples/ProducedWaterEmissions_Tutorial)         | **Comprehensive tutorial for produced water degassing emissions calculation**                                                |
-| **Norwegian Emission Methods Comparison** | [docs/examples/NorwegianEmissionMethods_Comparison.md](examples/NorwegianEmissionMethods_Comparison) | **NeqSim vs Norwegian handbook method: validation, uncertainty, regulatory compliance**                                      |
+| Emissions Tracking                        | [docs/process/sustainability/README.md](process/sustainability/README.md)                                     | Emissions tracking overview                                                                                                  |
+| **Offshore Emission Reporting Guide**     | [docs/emissions/OFFSHORE_EMISSION_REPORTING.md](emissions/OFFSHORE_EMISSION_REPORTING.md)               | **Comprehensive guide for offshore platform GHG emission reporting with regulatory references**                              |
+| **Produced Water Emissions Tutorial**     | [docs/examples/ProducedWaterEmissions_Tutorial.md](examples/ProducedWaterEmissions_Tutorial.md)         | **Comprehensive tutorial for produced water degassing emissions calculation**                                                |
+| **Norwegian Emission Methods Comparison** | [docs/examples/NorwegianEmissionMethods_Comparison.md](examples/NorwegianEmissionMethods_Comparison.md) | **NeqSim vs Norwegian handbook method: validation, uncertainty, regulatory compliance**                                      |
 | **GFMW 2023 Reference**                   | *External publication*                                                                               | **"Virtual Measurement of Emissions from Produced Water Using an Online Process Simulator" - Kristiansen et al., GFMW 2023** |
 
 ### Chapter 44: Optimization
 
 | Document                                                | Path                                                                                                                                                                   | Description                                                                                                             |
 | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Optimization Overview                                   | [docs/process/optimization/README.md](process/optimization/)                                                                                                           | Optimization module                                                                                                     |
-| **Process Researcher**                                  | [docs/process/optimization/process-researcher.md](process/optimization/process-researcher)                                                                              | **Candidate flowsheet generation and ranking from feed/product specifications, including reaction-route candidates**     |
-| **Flow Rate Optimization**                              | [docs/process/optimization/flow-rate-optimization.md](process/optimization/flow-rate-optimization)                                                                     | **Comprehensive flow rate optimizer with lift curve generation for Eclipse reservoir simulation**                       |
-| **Multi-Objective Optimization**                        | [docs/process/optimization/multi-objective-optimization.md](process/optimization/multi-objective-optimization)                                                         | **Pareto front generation for competing objectives (throughput vs energy)**                                             |
-| **Constraint Framework**                                | [docs/process/optimization/constraint-framework.md](process/optimization/constraint-framework)                                                                         | **Unified ProcessConstraint interface bridging equipment, internal, and external optimizer constraints**                |
-| **Data Reconciliation and Steady-State Detection**      | [docs/process/optimization/data-reconciliation.md](process/optimization/data-reconciliation)                                                                           | **R-statistic steady-state detection, WLS data reconciliation, gross error detection, SSD-to-reconciliation bridge**    |
-| Batch Studies                                           | [docs/process/optimization/batch-studies.md](process/optimization/batch-studies)                                                                                       | Batch studies                                                                                                           |
-| Bottleneck Analysis                                     | [docs/wiki/bottleneck_analysis.md](wiki/bottleneck_analysis)                                                                                                           | Bottleneck analysis and ProductionOptimizer                                                                             |
-| **Multi-Variable Optimization**                         | [docs/wiki/bottleneck_analysis.md#multi-variable-optimization-with-manipulatedvariable](wiki/bottleneck_analysis#multi-variable-optimization-with-manipulatedvariable) | **ManipulatedVariable for split factors, dual feeds, pressure setpoints**                                               |
-| Calibration                                             | [docs/process/calibration/README.md](process/calibration/)                                                                                                             | Model calibration                                                                                                       |
-| **Data Reconciliation → Parameter Estimation Workflow** | [docs/calibration/data_reconciliation_parameter_estimation.md](calibration/data_reconciliation_parameter_estimation)                                                   | **End-to-end plant-data-to-model-tuning: DataReconciliationEngine, BatchParameterEstimator (L-M), EnKF, Python helper** |
-| Advisory                                                | [docs/process/advisory/README.md](process/advisory/)                                                                                                                   | Advisory systems                                                                                                        |
+| Optimization Overview                                   | [docs/process/optimization/README.md](process/optimization/README.md)                                                                                                           | Optimization module                                                                                                     |
+| **Process Researcher**                                  | [docs/process/optimization/process-researcher.md](process/optimization/process-researcher.md)                                                                              | **Candidate flowsheet generation and ranking from feed/product specifications, including reaction-route candidates**     |
+| **Flow Rate Optimization**                              | [docs/process/optimization/flow-rate-optimization.md](process/optimization/flow-rate-optimization.md)                                                                     | **Comprehensive flow rate optimizer with lift curve generation for Eclipse reservoir simulation**                       |
+| **Multi-Objective Optimization**                        | [docs/process/optimization/multi-objective-optimization.md](process/optimization/multi-objective-optimization.md)                                                         | **Pareto front generation for competing objectives (throughput vs energy)**                                             |
+| **Constraint Framework**                                | [docs/process/optimization/constraint-framework.md](process/optimization/constraint-framework.md)                                                                         | **Unified ProcessConstraint interface bridging equipment, internal, and external optimizer constraints**                |
+| **Data Reconciliation and Steady-State Detection**      | [docs/process/optimization/data-reconciliation.md](process/optimization/data-reconciliation.md)                                                                           | **R-statistic steady-state detection, WLS data reconciliation, gross error detection, SSD-to-reconciliation bridge**    |
+| Batch Studies                                           | [docs/process/optimization/batch-studies.md](process/optimization/batch-studies.md)                                                                                       | Batch studies                                                                                                           |
+| Bottleneck Analysis                                     | [docs/wiki/bottleneck_analysis.md](wiki/bottleneck_analysis.md)                                                                                                           | Bottleneck analysis and ProductionOptimizer                                                                             |
+| **Multi-Variable Optimization**                         | [docs/wiki/bottleneck_analysis.md#multi-variable-optimization-with-manipulatedvariable](wiki/bottleneck_analysis.md#multi-variable-optimization-with-manipulatedvariable) | **ManipulatedVariable for split factors, dual feeds, pressure setpoints**                                               |
+| Calibration                                             | [docs/process/calibration/README.md](process/calibration/README.md)                                                                                                             | Model calibration                                                                                                       |
+| **Data Reconciliation → Parameter Estimation Workflow** | [docs/calibration/data_reconciliation_parameter_estimation.md](calibration/data_reconciliation_parameter_estimation.md)                                                   | **End-to-end plant-data-to-model-tuning: DataReconciliationEngine, BatchParameterEstimator (L-M), EnKF, Python helper** |
+| Advisory                                                | [docs/process/advisory/README.md](process/advisory/README.md)                                                                                                                   | Advisory systems                                                                                                        |
 
 ### Chapter 45: Real-Time Integration
 
 | Document        | Path                                                                                                   | Description           |
 | --------------- | ------------------------------------------------------------------------------------------------------ | --------------------- |
-| Real-Time Guide | [docs/integration/REAL_TIME_INTEGRATION_GUIDE.md](integration/REAL_TIME_INTEGRATION_GUIDE)             | Real-time integration |
-| Seeq Data Lab   | [docs/integration/seeq_datalab.md](integration/seeq_datalab)                                           | NeqSim in Seeq Data Lab (JDK setup, SPy pull/push) |
-| MPC Integration | [docs/integration/mpc_integration.md](integration/mpc_integration)                                     | MPC integration       |
-| Industrial MPC  | [docs/integration/neqsim_industrial_mpc_integration.md](integration/neqsim_industrial_mpc_integration) | Industrial MPC        |
+| Real-Time Guide | [docs/integration/REAL_TIME_INTEGRATION_GUIDE.md](integration/REAL_TIME_INTEGRATION_GUIDE.md)             | Real-time integration |
+| Seeq Data Lab   | [docs/integration/seeq_datalab.md](integration/seeq_datalab.md)                                           | NeqSim in Seeq Data Lab (JDK setup, SPy pull/push) |
+| MPC Integration | [docs/integration/mpc_integration.md](integration/mpc_integration.md)                                     | MPC integration       |
+| Industrial MPC  | [docs/integration/neqsim_industrial_mpc_integration.md](integration/neqsim_industrial_mpc_integration.md) | Industrial MPC        |
 
 ### Chapter 46: External Integrations
 
 | Document        | Path                                                                           | Description     |
 | --------------- | ------------------------------------------------------------------------------ | --------------- |
-| DEXPI P&ID Import, Export & Visualization | [docs/integration/dexpi-reader.md](integration/dexpi-reader) | DEXPI import/export/round-trip, ISO 10628 shapes, auto-layout, instruments, SIL markers, fail-position, mechanical design, stream table, drawing border, symbol legend, configurable layout, topology, equipment factory, simulation builder, multi-area ProcessModel export, pyDEXPI namespace-omitted export, NORSOK Z-003 line numbers, connection line data, off-page boundary connectors, ISA-5.1 tag validation, Proteus 4.1.1 / DEXPI 2.0 schema version selection |
-| Standards-based DEXPI Engineering Generation | [docs/integration/dexpi-engineering-generation.md](integration/dexpi-engineering-generation) | Canonical engineering graph, calculation provenance, design-case envelopes, revision impact, coordinated equipment/line/instrument/valve/SIF/relief/evidence registers, governed DEXPI generation, installed relief and disposal screening, dynamic shutdown evidence, per-object coverage, validation, package hashes, compressor maps and ProcessModel area packages |
-| Process Model to Engineering Workflow | [docs/integration/process-to-engineering-workflow.md](integration/process-to-engineering-workflow) | End-to-end compiler guide, artifact contracts, approval and revision workflow, validation checklist, P&ID figure rendering, tests and executed notebook learning path |
-| Engineering Simulator Foundations | [docs/integration/engineering-simulator-foundations.md](integration/engineering-simulator-foundations) | Isolated deterministic case execution, typed readiness/provenance/uncertainty contracts, coupled relief-blowdown-flare envelopes, and dynamic control/SIS scenario verification |
-| Process-to-Engineering Simulator | [docs/integration/process-to-engineering-simulator.md](integration/process-to-engineering-simulator) | Iterative process/design convergence, discipline sizing modules, designed-process DEXPI export, and review-governed engineering handoff |
-| QRA Integration | [docs/integration/QRA_INTEGRATION_GUIDE.md](integration/QRA_INTEGRATION_GUIDE) | QRA integration |
-| OLGA PVT Table and Hydrate Curve Generation | [docs/integration/olga_pvt_table_generation.md](integration/olga_pvt_table_generation) | Export any NeqSim fluid as an OLGA `.tab` PVT table and hydrate equilibrium curve: two-phase and three-phase generators, absent-phase extrapolation, grid selection, source phase-split conventions, hydrate curve export, and OLGA-run validation |
+| DEXPI P&ID Import, Export & Visualization | [docs/integration/dexpi-reader.md](integration/dexpi-reader.md) | DEXPI import/export/round-trip, ISO 10628 shapes, auto-layout, instruments, SIL markers, fail-position, mechanical design, stream table, drawing border, symbol legend, configurable layout, topology, equipment factory, simulation builder, multi-area ProcessModel export, pyDEXPI namespace-omitted export, NORSOK Z-003 line numbers, connection line data, off-page boundary connectors, ISA-5.1 tag validation, Proteus 4.1.1 / DEXPI 2.0 schema version selection |
+| Standards-based DEXPI Engineering Generation | [docs/integration/dexpi-engineering-generation.md](integration/dexpi-engineering-generation.md) | Canonical engineering graph, calculation provenance, design-case envelopes, revision impact, coordinated equipment/line/instrument/valve/SIF/relief/evidence registers, governed DEXPI generation, installed relief and disposal screening, dynamic shutdown evidence, per-object coverage, validation, package hashes, compressor maps and ProcessModel area packages |
+| Process Model to Engineering Workflow | [docs/integration/process-to-engineering-workflow.md](integration/process-to-engineering-workflow.md) | End-to-end compiler guide, artifact contracts, approval and revision workflow, validation checklist, P&ID figure rendering, tests and executed notebook learning path |
+| Engineering Simulator Foundations | [docs/integration/engineering-simulator-foundations.md](integration/engineering-simulator-foundations.md) | Isolated deterministic case execution, typed readiness/provenance/uncertainty contracts, coupled relief-blowdown-flare envelopes, and dynamic control/SIS scenario verification |
+| Process-to-Engineering Simulator | [docs/integration/process-to-engineering-simulator.md](integration/process-to-engineering-simulator.md) | Iterative process/design convergence, discipline sizing modules, designed-process DEXPI export, and review-governed engineering handoff |
+| QRA Integration | [docs/integration/QRA_INTEGRATION_GUIDE.md](integration/QRA_INTEGRATION_GUIDE.md) | QRA integration |
+| OLGA PVT Table and Hydrate Curve Generation | [docs/integration/olga_pvt_table_generation.md](integration/olga_pvt_table_generation.md) | Export any NeqSim fluid as an OLGA `.tab` PVT table and hydrate equilibrium curve: two-phase and three-phase generators, absent-phase extrapolation, grid selection, source phase-split conventions, hydrate curve export, and OLGA-run validation |
 
 ### Chapter 47: Process Logic Framework
 
 | Document              | Path                                                                                                       | Description               |
 | --------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------- |
-| Simulation Overview   | [docs/simulation/README.md](simulation/)                                                                   | Simulation module         |
-| Process Logic         | [docs/simulation/process_logic_framework.md](simulation/process_logic_framework)                           | Process logic framework   |
-| Advanced Logic        | [docs/simulation/advanced_process_logic.md](simulation/advanced_process_logic)                             | Advanced process logic    |
-| Implementation        | [docs/simulation/process_logic_implementation_summary.md](simulation/process_logic_implementation_summary) | Implementation summary    |
-| Enhancements          | [docs/simulation/ProcessLogicEnhancements.md](simulation/ProcessLogicEnhancements)                         | Logic enhancements        |
-| Runtime Flexibility   | [docs/simulation/RuntimeLogicFlexibility.md](simulation/RuntimeLogicFlexibility)                           | Runtime flexibility       |
-| Graph-Based           | [docs/simulation/graph_based_process_simulation.md](simulation/graph_based_process_simulation)             | Graph-based simulation    |
-| Parallel Simulation   | [docs/simulation/parallel_process_simulation.md](simulation/parallel_process_simulation)                   | Parallel simulation       |
-| Recycle Acceleration  | [docs/simulation/recycle_acceleration_guide.md](simulation/recycle_acceleration_guide)                     | Recycle acceleration      |
-| Process Calculator    | [docs/simulation/process_calculator.md](simulation/process_calculator)                                     | Process calculator        |
-| Integrated Workflow   | [docs/simulation/INTEGRATED_WORKFLOW_GUIDE.md](simulation/INTEGRATED_WORKFLOW_GUIDE)                       | Integrated workflow       |
-| Differentiable Thermo | [docs/simulation/differentiable_thermodynamics.md](simulation/differentiable_thermodynamics)               | Auto-differentiation      |
-| Derivatives           | [docs/simulation/derivatives_and_gradients.md](simulation/derivatives_and_gradients)                       | Derivatives and gradients |
-| Equipment Factory     | [docs/simulation/equipment_factory.md](simulation/equipment_factory)                                       | Equipment factory         |
+| Simulation Overview   | [docs/simulation/README.md](simulation/README.md)                                                                   | Simulation module         |
+| Process Logic         | [docs/simulation/process_logic_framework.md](simulation/process_logic_framework.md)                           | Process logic framework   |
+| Advanced Logic        | [docs/simulation/advanced_process_logic.md](simulation/advanced_process_logic.md)                             | Advanced process logic    |
+| Implementation        | [docs/simulation/process_logic_implementation_summary.md](simulation/process_logic_implementation_summary.md) | Implementation summary    |
+| Enhancements          | [docs/simulation/ProcessLogicEnhancements.md](simulation/ProcessLogicEnhancements.md)                         | Logic enhancements        |
+| Runtime Flexibility   | [docs/simulation/RuntimeLogicFlexibility.md](simulation/RuntimeLogicFlexibility.md)                           | Runtime flexibility       |
+| Graph-Based           | [docs/simulation/graph_based_process_simulation.md](simulation/graph_based_process_simulation.md)             | Graph-based simulation    |
+| Parallel Simulation   | [docs/simulation/parallel_process_simulation.md](simulation/parallel_process_simulation.md)                   | Parallel simulation       |
+| Recycle Acceleration  | [docs/simulation/recycle_acceleration_guide.md](simulation/recycle_acceleration_guide.md)                     | Recycle acceleration      |
+| Process Calculator    | [docs/simulation/process_calculator.md](simulation/process_calculator.md)                                     | Process calculator        |
+| Integrated Workflow   | [docs/simulation/INTEGRATED_WORKFLOW_GUIDE.md](simulation/INTEGRATED_WORKFLOW_GUIDE.md)                       | Integrated workflow       |
+| Differentiable Thermo | [docs/simulation/differentiable_thermodynamics.md](simulation/differentiable_thermodynamics.md)               | Auto-differentiation      |
+| Derivatives           | [docs/simulation/derivatives_and_gradients.md](simulation/derivatives_and_gradients.md)                       | Derivatives and gradients |
+| Equipment Factory     | [docs/simulation/equipment_factory.md](simulation/equipment_factory.md)                                       | Equipment factory         |
 
 ### Chapter 48: Field Development
 
 | Document                          | Path                                                                                                                       | Description                                                             |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| Field Development Overview        | [docs/fielddevelopment/README.md](fielddevelopment/)                                                                       | Field development module overview                                       |
-| **Digital Field Twin**            | [docs/fielddevelopment/DIGITAL_FIELD_TWIN.md](fielddevelopment/DIGITAL_FIELD_TWIN)                                         | **NEW** Comprehensive architecture for lifecycle consistency            |
-| **Mathematical Reference**        | [docs/fielddevelopment/MATHEMATICAL_REFERENCE.md](fielddevelopment/MATHEMATICAL_REFERENCE)                                 | **NEW** Mathematical foundations for all calculations                   |
-| **API Guide**                     | [docs/fielddevelopment/API_GUIDE.md](fielddevelopment/API_GUIDE)                                                           | **NEW** Detailed usage examples for all components                      |
-| **Integrated Framework**          | [docs/fielddevelopment/INTEGRATED_FIELD_DEVELOPMENT_FRAMEWORK.md](fielddevelopment/INTEGRATED_FIELD_DEVELOPMENT_FRAMEWORK) | PVT→Reservoir→Well→Process integration guide                            |
-| **Decision Engine Workflows**      | [docs/fielddevelopment/DECISION_ENGINE_WORKFLOWS.md](fielddevelopment/DECISION_ENGINE_WORKFLOWS)                           | Tieback, greenfield, portfolio, process, reservoir, and reporting workflows |
-| **Host Tie-In Capacity**          | [docs/fielddevelopment/HOST_TIE_IN_CAPACITY.md](fielddevelopment/HOST_TIE_IN_CAPACITY)                                     | Base-host and satellite production capacity, holdback, process bottlenecks, and debottleneck decisions |
-| **Integrated Production Modelling** | [docs/fielddevelopment/INTEGRATED_PRODUCTION_MODELLING.md](fielddevelopment/INTEGRATED_PRODUCTION_MODELLING)             | Reservoir-to-market IPM: reservoir drives, deliverability curves, network solver, gas-lift allocation, well-test matching, artificial-lift pumps, choke optimisation |
-| **Strategy**                      | [docs/fielddevelopment/FIELD_DEVELOPMENT_STRATEGY.md](fielddevelopment/FIELD_DEVELOPMENT_STRATEGY)                         | Field development strategy and roadmap                                  |
-| **Late-Life Operations**          | [docs/fielddevelopment/LATE_LIFE_OPERATIONS.md](fielddevelopment/LATE_LIFE_OPERATIONS)                                     | **Turndown, debottlenecking, and decommissioning timing analysis**      |
-| **Multi-Scenario VFP Generation** | [docs/fielddevelopment/MULTI_SCENARIO_PRODUCTION_OPTIMIZATION.md](fielddevelopment/MULTI_SCENARIO_PRODUCTION_OPTIMIZATION) | VFP tables with varying GOR/water cut for reservoir simulation coupling |
-| Field Planning                    | [docs/wiki/field_development_planning.md](wiki/field_development_planning)                                                 | Field development planning                                              |
-| Field Engine                      | [docs/simulation/field_development_engine.md](simulation/field_development_engine)                                         | Field development engine                                                |
-| **Economics**                     | [docs/process/economics/README.md](process/economics/)                                                                     | Economics module: NPV, IRR, tax models, decline curves                  |
-| **Subsea Systems**                | [docs/process/equipment/subsea_systems.md](process/equipment/subsea_systems)                                               | Subsea production systems, tieback analysis                             |
+| Field Development Overview        | [docs/fielddevelopment/README.md](fielddevelopment/README.md)                                                                       | Field development module overview                                       |
+| **Digital Field Twin**            | [docs/fielddevelopment/DIGITAL_FIELD_TWIN.md](fielddevelopment/DIGITAL_FIELD_TWIN.md)                                         | **NEW** Comprehensive architecture for lifecycle consistency            |
+| **Mathematical Reference**        | [docs/fielddevelopment/MATHEMATICAL_REFERENCE.md](fielddevelopment/MATHEMATICAL_REFERENCE.md)                                 | **NEW** Mathematical foundations for all calculations                   |
+| **API Guide**                     | [docs/fielddevelopment/API_GUIDE.md](fielddevelopment/API_GUIDE.md)                                                           | **NEW** Detailed usage examples for all components                      |
+| **Integrated Framework**          | [docs/fielddevelopment/INTEGRATED_FIELD_DEVELOPMENT_FRAMEWORK.md](fielddevelopment/INTEGRATED_FIELD_DEVELOPMENT_FRAMEWORK.md) | PVT→Reservoir→Well→Process integration guide                            |
+| **Decision Engine Workflows**      | [docs/fielddevelopment/DECISION_ENGINE_WORKFLOWS.md](fielddevelopment/DECISION_ENGINE_WORKFLOWS.md)                           | Tieback, greenfield, portfolio, process, reservoir, and reporting workflows |
+| **Host Tie-In Capacity**          | [docs/fielddevelopment/HOST_TIE_IN_CAPACITY.md](fielddevelopment/HOST_TIE_IN_CAPACITY.md)                                     | Base-host and satellite production capacity, holdback, process bottlenecks, and debottleneck decisions |
+| **Integrated Production Modelling** | [docs/fielddevelopment/INTEGRATED_PRODUCTION_MODELLING.md](fielddevelopment/INTEGRATED_PRODUCTION_MODELLING.md)             | Reservoir-to-market IPM: reservoir drives, deliverability curves, network solver, gas-lift allocation, well-test matching, artificial-lift pumps, choke optimisation |
+| **Strategy**                      | [docs/fielddevelopment/FIELD_DEVELOPMENT_STRATEGY.md](fielddevelopment/FIELD_DEVELOPMENT_STRATEGY.md)                         | Field development strategy and roadmap                                  |
+| **Late-Life Operations**          | [docs/fielddevelopment/LATE_LIFE_OPERATIONS.md](fielddevelopment/LATE_LIFE_OPERATIONS.md)                                     | **Turndown, debottlenecking, and decommissioning timing analysis**      |
+| **Multi-Scenario VFP Generation** | [docs/fielddevelopment/MULTI_SCENARIO_PRODUCTION_OPTIMIZATION.md](fielddevelopment/MULTI_SCENARIO_PRODUCTION_OPTIMIZATION.md) | VFP tables with varying GOR/water cut for reservoir simulation coupling |
+| Field Planning                    | [docs/wiki/field_development_planning.md](wiki/field_development_planning.md)                                                 | Field development planning                                              |
+| Field Engine                      | [docs/simulation/field_development_engine.md](simulation/field_development_engine.md)                                         | Field development engine                                                |
+| **Economics**                     | [docs/process/economics/README.md](process/economics/README.md)                                                                     | Economics module: NPV, IRR, tax models, decline curves                  |
+| **Subsea Systems**                | [docs/process/equipment/subsea_systems.md](process/equipment/subsea_systems.md)                                               | Subsea production systems, tieback analysis                             |
 
 #### Digital Field Twin Lifecycle Components
 
@@ -1073,73 +1071,73 @@ hypothesis scoring with OREDA, historian, STID, and NeqSim simulation verificati
 
 | Document                           | Path                                                                                             | Description                                                                           |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
-| Development Overview               | [docs/development/README.md](development/)                                                       | Development overview                                                                  |
-| Contributing Structure             | [docs/development/contributing-structure.md](development/contributing-structure)                 | Contributing guidelines                                                               |
-| Developer Setup                    | [docs/development/DEVELOPER_SETUP.md](development/DEVELOPER_SETUP)                               | Developer setup                                                                       |
-| **Extending Process Equipment**    | [docs/development/extending_process_equipment.md](development/extending_process_equipment)       | **Add custom equipment, stream introspection, MultiPortEquipment base class**         |
-| **Extending Physical Properties**  | [docs/development/extending_physical_properties.md](development/extending_physical_properties)   | **NEW: Add viscosity, conductivity, diffusivity models**                              |
-| **Extending Thermodynamic Models** | [docs/development/extending_thermodynamic_models.md](development/extending_thermodynamic_models) | **NEW: Add custom equations of state**                                                |
-| **Python Extension Patterns**      | [docs/development/python_extension_patterns.md](development/python_extension_patterns)           | **NEW: Python integration, wrappers, JPype interfaces**                               |
-| **Jupyter Development Workflow**   | [docs/development/jupyter_development_workflow.md](development/jupyter_development_workflow)     | **Live Java development from Jupyter notebooks with auto-compile and kernel restart** |
-| **Task Solving Guide**             | [docs/development/TASK_SOLVING_GUIDE.md](development/TASK_SOLVING_GUIDE)                         | **Step-by-step workflow for solving engineering tasks, including study_config.yaml, intake pauses, document inputs, NeqSim Runner execution, and detailed multi-notebook studies** |
-| **Code Patterns**                  | [docs/development/CODE_PATTERNS.md](development/CODE_PATTERNS)                                   | **Copy-paste starters for common coding tasks**                                       |
-| **Task Log**                       | [docs/development/TASK_LOG.md](development/TASK_LOG)                                             | **Searchable log of all solved tasks**                                                |
-| **Lessons Learned**                | [docs/development/LESSONS_LEARNED.md](development/LESSONS_LEARNED)                               | **Practical lessons from 45+ solved tasks (EOS, convergence, API gotchas)**           |
-| Build Guide                        | [docs/development/BUILD.md](development/BUILD)                                                   | Build system, Maven profiles, packaging                                               |
-| Getting Started (Developer)        | [docs/development/GETTING_STARTED_DEVELOPER.md](development/GETTING_STARTED_DEVELOPER)           | Quick-start guide for new contributors                                                |
-| Project Structure Recommendations  | [docs/development/PROJECT_STRUCTURE_RECOMMENDATIONS.md](development/PROJECT_STRUCTURE_RECOMMENDATIONS) | Recommended package layout and module boundaries                                 |
+| Development Overview               | [docs/development/README.md](development/README.md)                                                       | Development overview                                                                  |
+| Contributing Structure             | [docs/development/contributing-structure.md](development/contributing-structure.md)                 | Contributing guidelines                                                               |
+| Developer Setup                    | [docs/development/DEVELOPER_SETUP.md](development/DEVELOPER_SETUP.md)                               | Developer setup                                                                       |
+| **Extending Process Equipment**    | [docs/development/extending_process_equipment.md](development/extending_process_equipment.md)       | **Add custom equipment, stream introspection, MultiPortEquipment base class**         |
+| **Extending Physical Properties**  | [docs/development/extending_physical_properties.md](development/extending_physical_properties.md)   | **NEW: Add viscosity, conductivity, diffusivity models**                              |
+| **Extending Thermodynamic Models** | [docs/development/extending_thermodynamic_models.md](development/extending_thermodynamic_models.md) | **NEW: Add custom equations of state**                                                |
+| **Python Extension Patterns**      | [docs/development/python_extension_patterns.md](development/python_extension_patterns.md)           | **NEW: Python integration, wrappers, JPype interfaces**                               |
+| **Jupyter Development Workflow**   | [docs/development/jupyter_development_workflow.md](development/jupyter_development_workflow.md)     | **Live Java development from Jupyter notebooks with auto-compile and kernel restart** |
+| **Task Solving Guide**             | [docs/development/TASK_SOLVING_GUIDE.md](development/TASK_SOLVING_GUIDE.md)                         | **Step-by-step workflow for solving engineering tasks, including study_config.yaml, intake pauses, document inputs, NeqSim Runner execution, and detailed multi-notebook studies** |
+| **Code Patterns**                  | [docs/development/CODE_PATTERNS.md](development/CODE_PATTERNS.md)                                   | **Copy-paste starters for common coding tasks**                                       |
+| **Task Log**                       | [docs/development/TASK_LOG.md](development/TASK_LOG.md)                                             | **Searchable log of all solved tasks**                                                |
+| **Lessons Learned**                | [docs/development/LESSONS_LEARNED.md](development/LESSONS_LEARNED.md)                               | **Practical lessons from 45+ solved tasks (EOS, convergence, API gotchas)**           |
+| Build Guide                        | [docs/development/BUILD.md](development/BUILD.md)                                                   | Build system, Maven profiles, packaging                                               |
+| Getting Started (Developer)        | [docs/development/GETTING_STARTED_DEVELOPER.md](development/GETTING_STARTED_DEVELOPER.md)           | Quick-start guide for new contributors                                                |
+| Project Structure Recommendations  | [docs/development/PROJECT_STRUCTURE_RECOMMENDATIONS.md](development/PROJECT_STRUCTURE_RECOMMENDATIONS.md) | Recommended package layout and module boundaries                                 |
 
 ### Chapter 50: Testing
 
 | Document      | Path                                                                                   | Description          |
 | ------------- | -------------------------------------------------------------------------------------- | -------------------- |
-| Test Overview | [docs/wiki/test-overview.md](wiki/test-overview)                                       | Test overview        |
-| Flash Tests   | [docs/wiki/flash_equations_and_tests.md](wiki/flash_equations_and_tests)               | Flash equation tests |
-| Safety Tests  | [docs/safety/integration_safety_chain_tests.md](safety/integration_safety_chain_tests) | Safety chain tests   |
+| Test Overview | [docs/wiki/test-overview.md](wiki/test-overview.md)                                       | Test overview        |
+| Flash Tests   | [docs/wiki/flash_equations_and_tests.md](wiki/flash_equations_and_tests.md)               | Flash equation tests |
+| Safety Tests  | [docs/safety/integration_safety_chain_tests.md](safety/integration_safety_chain_tests.md) | Safety chain tests   |
 
 ### Chapter 51: Notebooks & Examples
 
 | Document                                  | Path                                                                                                           | Description                                                                                                        |
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| **Reading Fluid Properties**              | [docs/examples/ReadingFluidProperties.md](examples/ReadingFluidProperties)                                     | **NEW: Comprehensive guide to reading thermodynamic and physical properties**                                      |
-| Colab Notebooks                           | [docs/wiki/java_simulation_from_colab_notebooks.md](wiki/java_simulation_from_colab_notebooks)                 | Colab notebooks                                                                                                    |
-| Transient Slug Example                    | [docs/examples/transient_slug_separator_control_example.md](examples/transient_slug_separator_control_example) | Transient slug example                                                                                             |
-| Selective Logic                           | [docs/examples/selective-logic-execution.md](examples/selective-logic-execution)                               | Selective logic execution                                                                                          |
-| Comparison Quickstart                     | [docs/examples/comparesimulations_quickstart.md](examples/comparesimulations_quickstart)                       | Simulation comparison                                                                                              |
-| **PVT Simulation & Tuning**               | [docs/examples/PVT_Simulation_and_Tuning.md](examples/PVT_Simulation_and_Tuning)                               | **PVT simulation setup, EoS tuning, and characterization examples**                                                |
-| **TVP/RVP Study**                         | [docs/examples/TVP_RVP_Study.md](examples/TVP_RVP_Study)                                                       | **True Vapor Pressure and Reid Vapor Pressure calculations**                                                       |
+| **Reading Fluid Properties**              | [docs/examples/ReadingFluidProperties.md](examples/ReadingFluidProperties.md)                                     | **NEW: Comprehensive guide to reading thermodynamic and physical properties**                                      |
+| Colab Notebooks                           | [docs/wiki/java_simulation_from_colab_notebooks.md](wiki/java_simulation_from_colab_notebooks.md)                 | Colab notebooks                                                                                                    |
+| Transient Slug Example                    | [docs/examples/transient_slug_separator_control_example.md](examples/transient_slug_separator_control_example.md) | Transient slug example                                                                                             |
+| Selective Logic                           | [docs/examples/selective-logic-execution.md](examples/selective-logic-execution.md)                               | Selective logic execution                                                                                          |
+| Comparison Quickstart                     | [docs/examples/comparesimulations_quickstart.md](examples/comparesimulations_quickstart.md)                       | Simulation comparison                                                                                              |
+| **PVT Simulation & Tuning**               | [docs/examples/PVT_Simulation_and_Tuning.md](examples/PVT_Simulation_and_Tuning.md)                               | **PVT simulation setup, EoS tuning, and characterization examples**                                                |
+| **TVP/RVP Study**                         | [docs/examples/TVP_RVP_Study.md](examples/TVP_RVP_Study.md)                                                       | **True Vapor Pressure and Reid Vapor Pressure calculations**                                                       |
 | **Separator Efficiency (Scrubber & 3-Phase)** | [docs/examples/SeparatorEfficiency_GasScrubber_ThreePhase.ipynb](https://github.com/equinor/neqsim/blob/master/docs/examples/SeparatorEfficiency_GasScrubber_ThreePhase.ipynb) | **Separation-efficiency report with per-internal K-factor operating windows** for a two-phase gas scrubber and a three-phase separator, plus a turndown sweep |
-| **ESP Pump Tutorial**                     | [docs/examples/ESP_Pump_Tutorial.md](examples/ESP_Pump_Tutorial)                                               | **Electric Submersible Pump simulation and sizing**                                                                |
-| **Graph-Based Simulation**                | [docs/examples/GraphBasedProcessSimulation.md](examples/GraphBasedProcessSimulation)                           | **Graph-based process simulation tutorial**                                                                        |
+| **ESP Pump Tutorial**                     | [docs/examples/ESP_Pump_Tutorial.md](examples/ESP_Pump_Tutorial.md)                                               | **Electric Submersible Pump simulation and sizing**                                                                |
+| **Graph-Based Simulation**                | [docs/examples/GraphBasedProcessSimulation.md](examples/GraphBasedProcessSimulation.md)                           | **Graph-based process simulation tutorial**                                                                        |
 | **Dynamic Compressor Good Maps**          | [examples/notebooks/process/dynamic_compressor_good_maps.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/process/dynamic_compressor_good_maps.ipynb) | **Dynamic compressor examples with explicit GOOD compressor maps, map diagnostics, anti-surge sweep, ramped anti-surge transient validation, and steady-state-to-dynamic handoff** |
-| **Field Development Workflow**            | [docs/examples/FieldDevelopmentWorkflow.md](examples/FieldDevelopmentWorkflow)                                 | **End-to-end field development workflow example**                                                                  |
+| **Field Development Workflow**            | [docs/examples/FieldDevelopmentWorkflow.md](examples/FieldDevelopmentWorkflow.md)                                 | **End-to-end field development workflow example**                                                                  |
 | **Field Development Decision Engine**     | [examples/notebooks/field_development_decision_engine.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/field_development_decision_engine.ipynb) | **Concept templates, lifecycle emissions, MCDA ranking, portfolio optimization, and report-ready tables** |
 | **Field Development Process Coupling**    | [examples/notebooks/field_development_process_reservoir_coupling.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/field_development_process_reservoir_coupling.ipynb) | **Tieback route networks, gathering allocation, process utility generation, and VFP/schedule export** |
 | **Host Tie-In Capacity and Holdback**     | [examples/notebooks/host_tie_in_capacity_and_holdback.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/host_tie_in_capacity_and_holdback.ipynb) | **Brownfield host capacity, satellite holdback, process-equipment bottlenecks, and debottleneck value** |
-| **Multi-Scenario VFP Tutorial**           | [docs/examples/MultiScenarioVFP_Tutorial.ipynb](examples/MultiScenarioVFP_Tutorial)                            | **VFP generation with varying GOR/water cut scenarios**                                                            |
-| **Production System Bottleneck Analysis** | [docs/examples/ProductionSystem_BottleneckAnalysis.ipynb](examples/ProductionSystem_BottleneckAnalysis)        | **Multi-well system optimization, bottleneck identification, and well prioritization**                             |
-| **Integrated Production & Risk Analysis** | [docs/examples/IntegratedProductionRiskAnalysis.ipynb](examples/IntegratedProductionRiskAnalysis)              | **Complete operational workflow combining bottleneck analysis with risk simulation, Monte Carlo, and risk matrix** |
+| **Multi-Scenario VFP Tutorial**           | [docs/examples/MultiScenarioVFP_Tutorial.ipynb](examples/MultiScenarioVFP_Tutorial.md)                            | **VFP generation with varying GOR/water cut scenarios**                                                            |
+| **Production System Bottleneck Analysis** | [docs/examples/ProductionSystem_BottleneckAnalysis.ipynb](examples/ProductionSystem_BottleneckAnalysis.md)        | **Multi-well system optimization, bottleneck identification, and well prioritization**                             |
+| **Integrated Production & Risk Analysis** | [docs/examples/IntegratedProductionRiskAnalysis.ipynb](examples/IntegratedProductionRiskAnalysis.md)              | **Complete operational workflow combining bottleneck analysis with risk simulation, Monte Carlo, and risk matrix** |
 | **LNG Heat Exchanger Demo**               | [examples/notebooks/LNGHeatExchanger_ComprehensiveDemo.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/LNGHeatExchanger_ComprehensiveDemo.ipynb) | **Comprehensive BAHX demo: composite curves, exergy, adaptive zones, Manglik-Bergles, transient cool-down, core sizing, freeze-out, maldistribution, mechanical design, cost estimation, SMR cycle** |
 | **LNG Ageing Basics**                     | [examples/notebooks/lng_ageing_basics.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/lng_ageing_basics.ipynb)                                   | **Single-tank LNG ageing simulation: composition evolution, BOG, Wobbe index, voyage profiles** |
 | **LNG Ageing Advanced**                   | [examples/notebooks/lng_ageing_advanced.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/lng_ageing_advanced.ipynb)                               | **Advanced LNG ageing: tank geometry, sloshing, methane number, rollover detection, multi-zone heat transfer** |
 | **LNG Ship Voyage**                       | [examples/notebooks/lng_ship_voyage.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/lng_ship_voyage.ipynb)                                       | **Multi-tank Q-Max carrier voyage: per-tank evolution, shared BOG handling, ship-level KPIs** |
-| **MPC Integration Tutorial**              | [docs/examples/MPC_Integration_Tutorial.md](examples/MPC_Integration_Tutorial)                                 | **Model Predictive Control integration example**                                                                   |
-| **AI Platform Integration**               | [docs/examples/AIPlatformIntegration.md](examples/AIPlatformIntegration)                                       | **AI platform integration tutorial**                                                                               |
-| **Beer Brewing Bio-Process**              | [docs/examples/BeerBrewing_BioProcess_Simulation.md](examples/BeerBrewing_BioProcess_Simulation)               | **Bio-process simulation for brewing applications**                                                                |
-| **H2S Distribution Modeling**             | [docs/examples/H2S_Distribution_Modeling.md](examples/H2S_Distribution_Modeling)                               | **H2S distribution and partitioning across phases**                                                                |
-| **Multiphase Flow Pipeline Riser**        | [docs/examples/MultiphaseFlowPipelineRiser_Interactive.md](examples/MultiphaseFlowPipelineRiser_Interactive)   | **Interactive multiphase pipeline-riser simulation**                                                               |
-| **Looped Pipeline Network**               | [docs/examples/LoopedPipelineNetworkExample.md](examples/LoopedPipelineNetworkExample)                         | **Looped pipeline network simulation example**                                                                     |
-| **Advanced Risk Framework**               | [docs/examples/AdvancedRiskFramework_Tutorial.md](examples/AdvancedRiskFramework_Tutorial)                     | **Advanced risk framework tutorial**                                                                               |
-| **Two-Fluid Pipe Tutorial**               | [docs/examples/TwoFluidPipe_Tutorial.md](examples/TwoFluidPipe_Tutorial)                                       | **Two-fluid pipe model tutorial**                                                                                  |
-| Examples Index                            | [docs/examples/index.md](examples/index)                                                                       | Examples documentation index                                                                                       |
+| **MPC Integration Tutorial**              | [docs/examples/MPC_Integration_Tutorial.md](examples/MPC_Integration_Tutorial.md)                                 | **Model Predictive Control integration example**                                                                   |
+| **AI Platform Integration**               | [docs/examples/AIPlatformIntegration.md](examples/AIPlatformIntegration.md)                                       | **AI platform integration tutorial**                                                                               |
+| **Beer Brewing Bio-Process**              | [docs/examples/BeerBrewing_BioProcess_Simulation.md](examples/BeerBrewing_BioProcess_Simulation.md)               | **Bio-process simulation for brewing applications**                                                                |
+| **H2S Distribution Modeling**             | [docs/examples/H2S_Distribution_Modeling.md](examples/H2S_Distribution_Modeling.md)                               | **H2S distribution and partitioning across phases**                                                                |
+| **Multiphase Flow Pipeline Riser**        | [docs/examples/MultiphaseFlowPipelineRiser_Interactive.md](examples/MultiphaseFlowPipelineRiser_Interactive.md)   | **Interactive multiphase pipeline-riser simulation**                                                               |
+| **Looped Pipeline Network**               | [docs/examples/LoopedPipelineNetworkExample.md](examples/LoopedPipelineNetworkExample.md)                         | **Looped pipeline network simulation example**                                                                     |
+| **Advanced Risk Framework**               | [docs/examples/AdvancedRiskFramework_Tutorial.md](examples/AdvancedRiskFramework_Tutorial.md)                     | **Advanced risk framework tutorial**                                                                               |
+| **Two-Fluid Pipe Tutorial**               | [docs/examples/TwoFluidPipe_Tutorial.md](examples/TwoFluidPipe_Tutorial.md)                                       | **Two-fluid pipe model tutorial**                                                                                  |
+| Examples Index                            | [docs/examples/index.md](examples/index.md)                                                                       | Examples documentation index                                                                                       |
 
 ### Chapter 52: Documentation Infrastructure
 
 | Document               | Path                                                                            | Description                                          |
 | ---------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| **GitHub Pages Setup** | [docs/GITHUB_PAGES_SETUP.md](GITHUB_PAGES_SETUP)                                | **NEW** Enable GitHub Pages for hosted documentation |
+| **GitHub Pages Setup** | [docs/GITHUB_PAGES_SETUP.md](GITHUB_PAGES_SETUP.md)                                | **NEW** Enable GitHub Pages for hosted documentation |
 | Reference Manual       | [docs/manual/neqsim_reference_manual.html](manual/neqsim_reference_manual.html) | Interactive reference manual                         |
-| Documentation Index    | [docs/index.md](index)                                                          | GitHub Pages home page                               |
+| Documentation Index    | [docs/index.md](index.md)                                                          | GitHub Pages home page                               |
 
 ---
 
@@ -1149,75 +1147,75 @@ hypothesis scoring with OREDA, historian, STID, and NeqSim simulation verificati
 
 | Document                   | Path                                                                                                       | Description                                                 |
 | -------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| Chemical Reactions         | [docs/chemicalreactions/README.md](chemicalreactions/)                                                     | Chemical reactions module                                   |
-| Sulfur Deposition Analysis | [docs/chemicalreactions/sulfur_deposition_analysis.md](chemicalreactions/sulfur_deposition_analysis)       | Sulfur formation, solubility, deposition, and FeS corrosion |
-| Chemistry & Integrity      | [docs/chemistry/index.md](chemistry/)                                                                      | Open standards-traceable chemical integrity stack (scale, corrosion, scavengers, RCA, MCP) |
-| Electrolyte Scale (Davies) | [docs/chemistry/electrolyte_scale.md](chemistry/electrolyte_scale)                                         | Davies SI math, ion conventions, North-Sea worked example   |
-| High-salinity scale & chemicals | [docs/pvtsimulation/mineral_scale_chemical_treatment_validation.md](pvtsimulation/mineral_scale_chemical_treatment_validation) | Pitzer validation, production-chemical scenarios and RCA |
-| Mechanistic CO2 Corrosion  | [docs/chemistry/mechanistic_corrosion.md](chemistry/mechanistic_corrosion)                                 | NORSOK + Nesic + Langmuir inhibitor with worked example     |
-| Packed-bed Scavenger       | [docs/chemistry/packed_bed_scavenger.md](chemistry/packed_bed_scavenger)                                   | 1D PFR PDE for H2S scavenger sizing and breakthrough        |
-| Closed-loop Deposition     | [docs/chemistry/closed_loop_deposition.md](chemistry/closed_loop_deposition)                               | Coupling pipe hydraulics with `ScaleDepositionAccumulator`  |
-| MCP `runChemistry` tool    | [docs/chemistry/mcp.md](chemistry/mcp)                                                                     | JSON schema for the chemistry MCP tool                      |
+| Chemical Reactions         | [docs/chemicalreactions/README.md](chemicalreactions/README.md)                                                     | Chemical reactions module                                   |
+| Sulfur Deposition Analysis | [docs/chemicalreactions/sulfur_deposition_analysis.md](chemicalreactions/sulfur_deposition_analysis.md)       | Sulfur formation, solubility, deposition, and FeS corrosion |
+| Chemistry & Integrity      | [docs/chemistry/index.md](chemistry/index.md)                                                                      | Open standards-traceable chemical integrity stack (scale, corrosion, scavengers, RCA, MCP) |
+| Electrolyte Scale (Davies) | [docs/chemistry/electrolyte_scale.md](chemistry/electrolyte_scale.md)                                         | Davies SI math, ion conventions, North-Sea worked example   |
+| High-salinity scale & chemicals | [docs/pvtsimulation/mineral_scale_chemical_treatment_validation.md](pvtsimulation/mineral_scale_chemical_treatment_validation.md) | Pitzer validation, production-chemical scenarios and RCA |
+| Mechanistic CO2 Corrosion  | [docs/chemistry/mechanistic_corrosion.md](chemistry/mechanistic_corrosion.md)                                 | NORSOK + Nesic + Langmuir inhibitor with worked example     |
+| Packed-bed Scavenger       | [docs/chemistry/packed_bed_scavenger.md](chemistry/packed_bed_scavenger.md)                                   | 1D PFR PDE for H2S scavenger sizing and breakthrough        |
+| Closed-loop Deposition     | [docs/chemistry/closed_loop_deposition.md](chemistry/closed_loop_deposition.md)                               | Coupling pipe hydraulics with `ScaleDepositionAccumulator`  |
+| MCP `runChemistry` tool    | [docs/chemistry/mcp.md](chemistry/mcp.md)                                                                     | JSON schema for the chemistry MCP tool                      |
 
 ### Appendix B: Statistics
 
 | Document          | Path                                                                           | Description            |
 | ----------------- | ------------------------------------------------------------------------------ | ---------------------- |
-| Statistics        | [docs/statistics/README.md](statistics/)                                       | Statistics module      |
-| Parameter Fitting | [docs/statistics/parameter_fitting.md](statistics/parameter_fitting)           | Detailed parameter fitting guide with legacy API, CSV/YAML data files, specs, robust objectives, validation, and reports      |
-| Monte Carlo       | [docs/statistics/monte_carlo_simulation.md](statistics/monte_carlo_simulation) | Monte Carlo simulation |
-| Data Analysis     | [docs/statistics/data_analysis.md](statistics/data_analysis)                   | Data analysis          |
+| Statistics        | [docs/statistics/README.md](statistics/README.md)                                       | Statistics module      |
+| Parameter Fitting | [docs/statistics/parameter_fitting.md](statistics/parameter_fitting.md)           | Detailed parameter fitting guide with legacy API, CSV/YAML data files, specs, robust objectives, validation, and reports      |
+| Monte Carlo       | [docs/statistics/monte_carlo_simulation.md](statistics/monte_carlo_simulation.md) | Monte Carlo simulation |
+| Data Analysis     | [docs/statistics/data_analysis.md](statistics/data_analysis.md)                   | Data analysis          |
 
 ### Appendix C: Mathematical Library
 
 | Document     | Path                               | Description          |
 | ------------ | ---------------------------------- | -------------------- |
-| Math Library | [docs/mathlib/README.md](mathlib/) | Mathematical library |
+| Math Library | [docs/mathlib/README.md](mathlib/README.md) | Mathematical library |
 
 ### Appendix D: Utilities
 
 | Document                    | Path                                                                         | Description                                                                          |
 | --------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| Utilities                   | [docs/util/README.md](util/)                                                 | Utility functions                                                                    |
-| Unit Conversion             | [docs/util/unit_conversion.md](util/unit_conversion)                         | Unit conversion guide                                                                |
-| **Unit Conversion Recipes** | [docs/cookbook/unit-conversion-recipes.md](cookbook/unit-conversion-recipes) | **NEW** Quick reference for all supported unit strings                               |
-| **Optimizer Guide**         | [docs/util/optimizer_guide.md](util/optimizer_guide)                         | **NEW** Comprehensive optimization framework with BFGS, Pareto, sensitivity analysis |
+| Utilities                   | [docs/util/README.md](util/README.md)                                                 | Utility functions                                                                    |
+| Unit Conversion             | [docs/util/unit_conversion.md](util/unit_conversion.md)                         | Unit conversion guide                                                                |
+| **Unit Conversion Recipes** | [docs/cookbook/unit-conversion-recipes.md](cookbook/unit-conversion-recipes.md) | **NEW** Quick reference for all supported unit strings                               |
+| **Optimizer Guide**         | [docs/util/optimizer_guide.md](util/optimizer_guide.md)                         | **NEW** Comprehensive optimization framework with BFGS, Pareto, sensitivity analysis |
 
 ### Appendix F: Process Design Templates
 
 | Document            | Path                                                                     | Description                                                                 |
 | ------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
-| **Templates Guide** | [docs/process/design/templates_guide.md](process/design/templates_guide) | **NEW** Pre-built process templates (compression, dehydration, CO2 capture) |
+| **Templates Guide** | [docs/process/design/templates_guide.md](process/design/templates_guide.md) | **NEW** Pre-built process templates (compression, dehydration, CO2 capture) |
 
 ### Appendix G: Mechanical Design Standards
 
 | Document                | Path                                                                                                   | Description                                                 |
 | ----------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
-| **TEMA Standard Guide** | [docs/process/mechanical_design/tema_standard_guide.md](process/mechanical_design/tema_standard_guide) | **NEW** TEMA shell and tube heat exchanger design standards |
-| **Thermal-Hydraulic Design** | [docs/process/mechanical_design/thermal_hydraulic_design.md](process/mechanical_design/thermal_hydraulic_design) | **NEW** Tube/shell HTC (Gnielinski, Kern, Bell-Delaware), overall U, pressure drops, LMTD correction, vibration screening, rating mode |
-| **Two-Phase Heat Transfer** | [docs/process/mechanical_design/two_phase_heat_transfer.md](process/mechanical_design/two_phase_heat_transfer) | **NEW** Shah condensation, Chen/Gungor-Winterton boiling, Friedel/MSH two-phase pressure drop, Ebert-Panchal fouling, incremental zone analysis, tube inserts |
+| **TEMA Standard Guide** | [docs/process/mechanical_design/tema_standard_guide.md](process/mechanical_design/tema_standard_guide.md) | **NEW** TEMA shell and tube heat exchanger design standards |
+| **Thermal-Hydraulic Design** | [docs/process/mechanical_design/thermal_hydraulic_design.md](process/mechanical_design/thermal_hydraulic_design.md) | **NEW** Tube/shell HTC (Gnielinski, Kern, Bell-Delaware), overall U, pressure drops, LMTD correction, vibration screening, rating mode |
+| **Two-Phase Heat Transfer** | [docs/process/mechanical_design/two_phase_heat_transfer.md](process/mechanical_design/two_phase_heat_transfer.md) | **NEW** Shah condensation, Chen/Gungor-Winterton boiling, Friedel/MSH two-phase pressure drop, Ebert-Panchal fouling, incremental zone analysis, tube inserts |
 
 ### Appendix H: Cookbook (Quick Recipes)
 
 | Document               | Path                                                                       | Description                                         |
 | ---------------------- | -------------------------------------------------------------------------- | --------------------------------------------------- |
-| **Cookbook Index**     | [docs/cookbook/index.md](cookbook/index)                                   | **NEW** Quick copy-paste recipes for common tasks   |
-| Thermodynamics Recipes | [docs/cookbook/thermodynamics-recipes.md](cookbook/thermodynamics-recipes) | Fluids, flash, properties, phase envelopes          |
-| Process Recipes        | [docs/cookbook/process-recipes.md](cookbook/process-recipes)               | Separators, compressors, heat exchangers            |
-| Pipeline Recipes       | [docs/cookbook/pipeline-recipes.md](cookbook/pipeline-recipes)             | Pressure drop, multiphase flow                      |
-| **Adsorption Recipes** | [docs/cookbook/adsorption-recipes.md](cookbook/adsorption-recipes)         | **Adsorption bed simulation recipes and workflows** |
+| **Cookbook Index**     | [docs/cookbook/index.md](cookbook/index.md)                                   | **NEW** Quick copy-paste recipes for common tasks   |
+| Thermodynamics Recipes | [docs/cookbook/thermodynamics-recipes.md](cookbook/thermodynamics-recipes.md) | Fluids, flash, properties, phase envelopes          |
+| Process Recipes        | [docs/cookbook/process-recipes.md](cookbook/process-recipes.md)               | Separators, compressors, heat exchangers            |
+| Pipeline Recipes       | [docs/cookbook/pipeline-recipes.md](cookbook/pipeline-recipes.md)             | Pressure drop, multiphase flow                      |
+| **Adsorption Recipes** | [docs/cookbook/adsorption-recipes.md](cookbook/adsorption-recipes.md)         | **Adsorption bed simulation recipes and workflows** |
 
 ### Appendix I: Troubleshooting
 
 | Document                  | Path                                                   | Description                          |
 | ------------------------- | ------------------------------------------------------ | ------------------------------------ |
-| **Troubleshooting Guide** | [docs/troubleshooting/index.md](troubleshooting/index) | **NEW** Solutions to common problems |
+| **Troubleshooting Guide** | [docs/troubleshooting/index.md](troubleshooting/index.md) | **NEW** Solutions to common problems |
 
 ### Appendix E: Wiki Reference
 
 | Document      | Path                         | Description        |
 | ------------- | ---------------------------- | ------------------ |
-| Wiki Overview | [docs/wiki/README.md](wiki/) | Wiki documentation |
+| Wiki Overview | [docs/wiki/README.md](wiki/README.md) | Wiki documentation |
 
 ---
 
@@ -1251,14 +1249,14 @@ hypothesis scoring with OREDA, historian, STID, and NeqSim simulation verificati
 
 ## Navigation Tips
 
-1. **Start Here**: If new to NeqSim, begin with [Quickstart Guides](quickstart/index) or [Getting Started](wiki/getting_started)
-2. **Learning Path**: Follow the [Learning Paths](tutorials/learning-paths) for structured learning
-3. **Quick Recipes**: Use the [Cookbook](cookbook/index) for copy-paste solutions
+1. **Start Here**: If new to NeqSim, begin with [Quickstart Guides](quickstart/index.md) or [Getting Started](wiki/getting_started.md)
+2. **Learning Path**: Follow the [Learning Paths](tutorials/learning-paths.md) for structured learning
+3. **Quick Recipes**: Use the [Cookbook](cookbook/index.md) for copy-paste solutions
 4. **By Task**: Use the chapter structure above to find relevant sections
 5. **By Equipment**: See Part III, Chapters 13-20 for equipment-specific docs
 6. **For Developers**: Jump to Part IX for contribution guidelines
-7. **Problems?**: Check the [Troubleshooting Guide](troubleshooting/index)
-8. **Process Serialization**: See [Chapter 23](simulation/process_serialization) for save/load
+7. **Problems?**: Check the [Troubleshooting Guide](troubleshooting/index.md)
+8. **Process Serialization**: See [Chapter 23](simulation/process_serialization.md) for save/load
 
 ---
 

--- a/docs/test_reference_manual_index_documentation.py
+++ b/docs/test_reference_manual_index_documentation.py
@@ -1,0 +1,73 @@
+import re
+import unittest
+from pathlib import Path
+from urllib.parse import unquote
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX_PATH = ROOT / "docs" / "REFERENCE_MANUAL_INDEX.md"
+
+
+class ReferenceManualIndexDocumentationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.index = INDEX_PATH.read_text(encoding="utf-8")
+        cls.body = cls.index.split("---", 2)[2]
+        cls.targets = re.findall(r"\[[^\]]+\]\(([^)\s]+)\)", cls.index)
+
+    def test_front_matter_is_not_duplicated_as_h1(self):
+        self.assertNotRegex(self.body, r"(?m)^# ")
+        self.assertIn("Curated source-level navigation", self.index)
+
+    def test_scope_claim_is_truthful_and_not_count_bound(self):
+        self.assertIn("This curated index groups the principal NeqSim guides", self.index)
+        self.assertIn("not an inventory of every Markdown", self.index)
+        self.assertNotIn("maps all 360+", self.index)
+        self.assertNotRegex(self.index, r"Chapter \d+:[^\n]*\(NEW!\)")
+
+    def test_every_internal_target_names_an_explicit_source_file(self):
+        internal = []
+        for target in self.targets:
+            path_text = target.split("#", 1)[0].split("?", 1)[0]
+            if not path_text or re.match(r"^[a-z][a-z0-9+.-]*:", path_text, re.IGNORECASE):
+                continue
+            internal.append(path_text)
+            self.assertTrue(
+                Path(unquote(path_text)).suffix,
+                "Internal link must name an explicit source file: {}".format(target),
+            )
+        self.assertGreater(len(internal), 600)
+
+    def test_every_internal_target_resolves_in_repository(self):
+        failures = []
+        for target in self.targets:
+            path_text = target.split("#", 1)[0].split("?", 1)[0]
+            if not path_text or re.match(r"^[a-z][a-z0-9+.-]*:", path_text, re.IGNORECASE):
+                continue
+            resolved = (INDEX_PATH.parent / unquote(path_text)).resolve()
+            try:
+                resolved.relative_to(ROOT.resolve())
+            except ValueError:
+                failures.append("{} escapes the repository".format(target))
+                continue
+            if not resolved.is_file():
+                failures.append("{} -> {}".format(target, resolved.relative_to(ROOT)))
+        self.assertEqual([], failures)
+
+    def test_fragment_and_landing_targets_are_source_safe(self):
+        self.assertIn(
+            "(process/plant-data-tagreader.md#step-5-neqsimapi-cloud-rest)",
+            self.index,
+        )
+        for target in (
+            "(thermo/README.md)",
+            "(process/README.md)",
+            "(risk/README.md)",
+            "(quickstart/index.md)",
+            "(tutorials/index.md)",
+        ):
+            self.assertIn(target, self.index)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Repairs D082 for documentation-quality campaign #2499.

- makes the 658-file documentation estate's master index truthful as a curated navigation layer rather than an exhaustive static count
- removes the duplicate rendered title and three dated “(NEW!)” chapter markers
- rewrites 609 relative destinations to explicit repository source files, including 39 directory-style landing links
- preserves existing fragments while making the NeqSimLive API target source-safe
- adds five focused repository-tree navigation contracts

## Frozen scope

- `docs/REFERENCE_MANUAL_INDEX.md`
- `docs/test_reference_manual_index_documentation.py`

No linked-page content, Java/API example, notebook, production code, DEXPI/P&ID, optimization, electrolyte, or Huldra changes.

## Documentation impact

The change corrects source-level discoverability and the stated scope of the reference-manual index. It does not change the rendered destination semantics of links that already resolved.

## Validation — READY TO MERGE

Exact head: `4ff8fb08e4a493ea29390fd0549ff85c2306aec0`

Connector-backed final verification:

- branch is 2 commits ahead and 0 behind `master`
- exactly 2 frozen files changed
- all 609 extensionless relative targets were rewritten to explicit existing repository files
- all internal destinations resolve against the repository tree
- duplicate H1, stale “360+” exhaustive claim, and chapter “(NEW!)” markers are absent
- all five GitHub workflows passed:
  - build, tests, and Javadocs
  - documentation contracts, Jekyll build, and generated search coverage
  - pre-commit
  - Spotless
  - CodeQL
- PR is mergeable with no comments, reviews, or unresolved threads

No rendered-browser inspection is claimed; this batch changes link targets and prose only, with no equations, images, examples, or layout structure.

Campaign: #2499