### PR TITLE
[AI-Assisted] test(thermo): validate Pitzer NaCl against public data

### DIFF
--- a/docs/pvtsimulation/scale_prediction_api.md
+++ b/docs/pvtsimulation/scale_prediction_api.md
@@ -251,7 +251,20 @@ Parameters follow the form:
 
 $$\beta(T) = \beta_{25} + T_1 \left(\frac{1}{T} - \frac{1}{298.15}\right) + T_2 \ln\left(\frac{T}{298.15}\right)$$
 
-The Pitzer parameter database (`PitzerParameters.csv`) currently contains 30 cation-anion rows. Of these, 23 non-estimated rows have populated binary parameters and are covered by regression tests for database loading plus finite mean ionic activity and osmotic coefficients. The covered ions include Na, K, Ca, Mg, Ba, Sr, Fe and H with Cl, SO4, HCO3, CO3 and OH. NaCl is additionally benchmarked against Robinson & Stokes / Pitzer 25 C mean ionic activity and osmotic-coefficient data.
+The Pitzer parameter database (`PitzerParameters.csv`) currently contains 30 cation-anion rows. Of these, 23 non-estimated rows have populated binary parameters and are covered by regression tests for database loading plus finite mean ionic activity and osmotic coefficients. The covered ions include Na, K, Ca, Mg, Ba, Sr, Fe and H with Cl, SO4, HCO3, CO3 and OH.
+
+At 298.15 K and 1.01325 bara, NaCl has a separate public reference validation against the traceable recommended
+values in Tables 6 and 10 of Partanen and Partanen (2020), DOI
+[10.1021/acs.jced.0c00402](https://doi.org/10.1021/acs.jced.0c00402), licensed
+[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). The validation covers 0.2, 0.5 and 1.0 mol/kg water;
+2.0 and 3.0 mol/kg water are retained as a concentrated hold-out. Pointwise acceptance limits are 2% relative for the
+mean molal activity coefficient and 0.75% relative for the osmotic coefficient. The tabulated values are rounded to
+0.001 and were derived by the authors from traceable electrochemical, isopiestic, vapor-pressure and solubility
+evidence. NeqSim parameters are not fitted or changed by this validation.
+
+This evidence applies only to binary NaCl(aq) at 298.15 K on the molality standard state. It does not validate
+temperature dependence, mixed salts, carbonate speciation, mineral parameters, precipitation complementarity or
+transfer of Pitzer parameters to electrolyte EOS models.
 
 ### Using the Pitzer Model
 

--- a/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
@@ -270,19 +270,42 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
   }
 
   /**
-   * Verify NaCl mean ionic activity and osmotic coefficients against standard Pitzer literature values at 25 C.
+   * Validate dilute-to-moderate NaCl activity and osmotic coefficients against traceable 25 C reference values.
+   *
+   * <p>
+   * Reference values are from Partanen and Partanen (2020), Tables 6 and 10, DOI
+   * 10.1021/acs.jced.0c00402 (CC BY 4.0). The Pitzer parameters are not fitted in this test.
+   * </p>
    */
   @Test
-  public void testNaClActivityAndOsmoticCoefficientAgainstLiterature() {
-    double[] molalities = { 0.1, 0.5, 1.0, 2.0, 3.0 };
-    double[] meanActivityCoefficients = { 0.778, 0.681, 0.657, 0.668, 0.714 };
-    double[] osmoticCoefficients = { 0.932, 0.921, 0.936, 1.002, 1.085 };
+  public void testNaClActivityAndOsmoticCoefficientAgainstPartanen2020() {
+    assertNaClReferenceValues(new double[][] { { 0.2, 0.735, 0.924 }, { 0.5, 0.684, 0.924 },
+        { 1.0, 0.662, 0.940 } });
+  }
 
-    for (int i = 0; i < molalities.length; i++) {
+  /**
+   * Validate concentrated NaCl behavior on reference points excluded from the core validation set.
+   */
+  @Test
+  public void testConcentratedNaClActivityAndOsmoticCoefficientHoldout() {
+    assertNaClReferenceValues(new double[][] { { 2.0, 0.677, 0.989 }, { 3.0, 0.721, 1.047 } });
+  }
+
+  /**
+   * Compare Pitzer results with independent traceable NaCl reference values.
+   *
+   * @param referenceRows rows of molality, mean molal activity coefficient and osmotic coefficient
+   */
+  private static void assertNaClReferenceValues(double[][] referenceRows) {
+    final double maximumMeanActivityRelativeDeviation = 0.02;
+    final double maximumOsmoticRelativeDeviation = 0.0075;
+
+    for (double[] referenceRow : referenceRows) {
+      double molality = referenceRow[0];
       SystemInterface system = new SystemPitzer(298.15, 1.01325);
       system.addComponent("water", 55.508);
-      system.addComponent("Na+", molalities[i]);
-      system.addComponent("Cl-", molalities[i]);
+      system.addComponent("Na+", molality);
+      system.addComponent("Cl-", molality);
       system.setMixingRule("classic");
       system.init(0);
       system.init(1);
@@ -290,12 +313,17 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
       PhaseInterface phase = system.getPhase(1);
       int sodiumComponentNumber = phase.getComponent("Na+").getComponentNumber();
       int chlorideComponentNumber = phase.getComponent("Cl-").getComponentNumber();
+      double actualMolality = phase.getComponent("Na+").getMolality(phase);
+      double meanActivityCoefficient = phase.getMeanIonicActivity(sodiumComponentNumber, chlorideComponentNumber);
+      double osmoticCoefficient = phase.getOsmoticCoefficientOfWater();
 
-      assertEquals(meanActivityCoefficients[i],
-          phase.getMeanIonicActivity(sodiumComponentNumber, chlorideComponentNumber),
-          0.08 * meanActivityCoefficients[i]);
-      assertEquals(osmoticCoefficients[i], phase.getOsmoticCoefficientOfWater(), 0.04 * osmoticCoefficients[i]);
-      assertEquals(phase.getOsmoticCoefficientOfWater(), phase.getOsmoticCoefficientOfWaterMolality(), 1.0e-12);
+      assertEquals(molality, actualMolality, 2.0e-5, "Reference composition must be on the molality basis");
+      assertEquals(referenceRow[1], meanActivityCoefficient,
+          maximumMeanActivityRelativeDeviation * referenceRow[1]);
+      assertEquals(referenceRow[2], osmoticCoefficient, maximumOsmoticRelativeDeviation * referenceRow[2]);
+      assertEquals(meanActivityCoefficient, phase.getMeanIonicActivity(sodiumComponentNumber, chlorideComponentNumber),
+          0.0, "Repeated mean activity evaluation must be deterministic");
+      assertEquals(osmoticCoefficient, phase.getOsmoticCoefficientOfWaterMolality(), 1.0e-12);
     }
   }
 

--- a/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
@@ -316,7 +316,7 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
       double meanActivityCoefficient = phase.getMeanIonicActivity(sodiumComponentNumber, chlorideComponentNumber);
       double osmoticCoefficient = phase.getOsmoticCoefficientOfWater();
 
-      assertEquals(molality, actualMolality, 2.0e-5, "Reference composition must be on the molality basis");
+      assertEquals(molality, actualMolality, 1.0e-4, "Reference composition must be on the molality basis");
       assertEquals(referenceRow[1], meanActivityCoefficient, maximumMeanActivityRelativeDeviation * referenceRow[1]);
       assertEquals(referenceRow[2], osmoticCoefficient, maximumOsmoticRelativeDeviation * referenceRow[2]);
       assertEquals(meanActivityCoefficient, phase.getMeanIonicActivity(sodiumComponentNumber, chlorideComponentNumber),

--- a/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
@@ -273,14 +273,13 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
    * Validate dilute-to-moderate NaCl activity and osmotic coefficients against traceable 25 C reference values.
    *
    * <p>
-   * Reference values are from Partanen and Partanen (2020), Tables 6 and 10, DOI
-   * 10.1021/acs.jced.0c00402 (CC BY 4.0). The Pitzer parameters are not fitted in this test.
+   * Reference values are from Partanen and Partanen (2020), Tables 6 and 10, DOI 10.1021/acs.jced.0c00402 (CC BY 4.0).
+   * The Pitzer parameters are not fitted in this test.
    * </p>
    */
   @Test
   public void testNaClActivityAndOsmoticCoefficientAgainstPartanen2020() {
-    assertNaClReferenceValues(new double[][] { { 0.2, 0.735, 0.924 }, { 0.5, 0.684, 0.924 },
-        { 1.0, 0.662, 0.940 } });
+    assertNaClReferenceValues(new double[][] { { 0.2, 0.735, 0.924 }, { 0.5, 0.684, 0.924 }, { 1.0, 0.662, 0.940 } });
   }
 
   /**
@@ -318,8 +317,7 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
       double osmoticCoefficient = phase.getOsmoticCoefficientOfWater();
 
       assertEquals(molality, actualMolality, 2.0e-5, "Reference composition must be on the molality basis");
-      assertEquals(referenceRow[1], meanActivityCoefficient,
-          maximumMeanActivityRelativeDeviation * referenceRow[1]);
+      assertEquals(referenceRow[1], meanActivityCoefficient, maximumMeanActivityRelativeDeviation * referenceRow[1]);
       assertEquals(referenceRow[2], osmoticCoefficient, maximumOsmoticRelativeDeviation * referenceRow[2]);
       assertEquals(meanActivityCoefficient, phase.getMeanIonicActivity(sodiumComponentNumber, chlorideComponentNumber),
           0.0, "Repeated mean activity evaluation must be deterministic");


### PR DESCRIPTION
## Engineering question

Can NeqSim's Pitzer NaCl validation use a current, traceable, openly licensed reference with explicit molality/standard-state conventions, a concentrated hold-out, and acceptance limits tight enough to detect scientifically material drift—without changing parameters or any production calculation path?

Current `master` labels five values as generic “standard Pitzer literature,” gives no stable citation or license, uses incorrect high-molality osmotic targets (1.002 and 1.085 at 2 and 3 mol/kg), and permits 8% activity / 4% osmotic deviations. Those broad bands allow the wrong targets to pass.

## Frozen scope

- **Base/master:** `796db4febe9d69412c97b7f5418cc230345cc303`
- **Head:** `96fc692c796c4d1044d7ed34c4e5bc57f5cbfb3f`
- **Model:** `SystemPitzer`, classic mixing rule
- **System:** binary water + Na+ + Cl−
- **Conditions:** 298.15 K, 1.01325 bara
- **Composition basis:** molality, mol/kg water; 55.508 mol water approximates 1 kg solvent
- **Core validation:** 0.2, 0.5 and 1.0 mol/kg
- **Concentrated hold-out:** 2.0 and 3.0 mol/kg
- **Properties:** mean molal NaCl activity coefficient and molality-scale water osmotic coefficient
- **Acceptance:** composition within 1e-4 mol/kg; each mean-activity value within 2% relative; each osmotic value within 0.75% relative; repeated activity evaluation exact; osmotic APIs agree within 1e-12
- **Compatibility/performance boundary:** test and documentation only; no production source, parameter, reaction, flash, salt-input, or neutral PR/SRK/CPA path changes
- **Stop boundary:** no parameter fit, reaction-table split, carbonate/mineral validation, temperature extrapolation, mixed salt, or precipitation solver

## Public reference, license, and preprocessing

Reference: Partanen and Partanen, “Traceable Values for Activity and Osmotic Coefficients in Aqueous Sodium Chloride Solutions at Temperatures from 273.15 to 373.15 K up to the Saturated Solutions,” *J. Chem. Eng. Data* 65 (2020) 5226–5239, DOI [10.1021/acs.jced.0c00402](https://doi.org/10.1021/acs.jced.0c00402).

The article is published under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). Values are copied from the 298.15 K columns of Tables 6 and 10. No interpolation, unit conversion, smoothing, or refitting is performed. The tables report values rounded to 0.001; the article derives them from a traceable experimental compilation and states agreement within experimental error, but does not provide pointwise uncertainty for each tabulated value. The first three rows are the core validation set; 2 and 3 mol/kg are retained as a concentrated hold-out.

This dataset postdates the retained `Pitzer1984` NaCl parameters and is not used to fit them. Validation evidence is therefore separate from ordinary regression locking.

## Change

- replace the uncited, loose five-point test with citation-backed Partanen 2020 core and hold-out tests;
- correct the 2 and 3 mol/kg osmotic targets to 0.989 and 1.047;
- use current recommended activity targets 0.735/0.684/0.662/0.677/0.721;
- tighten pointwise relative gates to 2% for mean activity and 0.75% for osmotic coefficient;
- assert molality basis and deterministic repeated property evaluation;
- document provenance, license, tolerances, validity range, and exclusions.

## Validation

**VALIDATION PENDING CI**

Completed locally:

- repository Eclipse formatter through Spotless: passed on the exact final Java source;
- independent analytical reproduction of the current `PhasePitzer` / `ComponentGePitzer` NaCl equations and database parameters: maximum pointwise relative deviation 1.8001% for mean activity and 0.5060% for osmotic coefficient;
- final diff inspection: exactly two scoped files, no production source.

Not claimed locally: compilation, JUnit execution, repository-wide documentation search, pre-commit, Java 8/21 suites, slow shards, Javadocs, CodeQL, or PaperLab. Hosted exact-head CI is mandatory.

## Numerical and performance evidence

Analytical pre-check over the five reference rows:

| mol/kg | gamma model | gamma reference | relative deviation | phi model | phi reference | relative deviation |
|---:|---:|---:|---:|---:|---:|---:|
| 0.2 | 0.731726 | 0.735 | 0.4455% | 0.923034 | 0.924 | 0.1046% |
| 0.5 | 0.678950 | 0.684 | 0.7383% | 0.920980 | 0.924 | 0.3268% |
| 1.0 | 0.654449 | 0.662 | 1.1406% | 0.935616 | 0.940 | 0.4663% |
| 2.0 | 0.664814 | 0.677 | 1.8000% | 0.983996 | 0.989 | 0.5060% |
| 3.0 | 0.708021 | 0.721 | 1.8001% | 1.045362 | 1.047 | 0.1565% |

This is a source-equation pre-check, not a claimed JUnit result. Because production code is unchanged, ordinary electrolyte and all non-electrolyte calculations perform exactly the same work as master.

## Documentation impact and limitations

`docs/pvtsimulation/scale_prediction_api.md` now records the validation source, CC BY 4.0 license, data split, tolerances, standard state, and limits. The evidence validates only binary NaCl(aq) at 298.15 K from 0.2 to 3.0 mol/kg. It does not validate mixed salts, temperature dependence, carbonate speciation, mineral parameters/complementarity, or transfer to electrolyte EOS.

After merge, the next dependency remains independent public carbonate/speciation and mineral-complementarity evidence before any model-specific reaction-table split or parameter fit.

Refs #3144
