### PR TITLE
[AI-Assisted] feat(scale): expose mineral complementarity diagnostics

### DIFF
--- a/docs/pvtsimulation/scale_prediction_api.md
+++ b/docs/pvtsimulation/scale_prediction_api.md
@@ -453,6 +453,41 @@ System.out.println("Total SI: " + ss.getTotalSaturationIndex());
 
 ---
 
+## Coupled mineral-equilibrium diagnostics
+
+`MultiMineralScaleEquilibrium` exposes the numerical evidence needed to decide whether a coupled precipitation result
+is acceptable:
+
+- `getIterationCount()` reports coordinate-descent updates;
+- `hasReachedIterationLimit()` distinguishes normal step convergence from an exhausted solver budget;
+- `getMaximumComplementarityViolation()` reports `abs(SI)` for minerals with solid present and
+  `max(SI, 0)` for absent solids;
+- `getMaximumIonBalanceResidualMolPerL()` closes each tracked free-ion inventory against the sum of 1:1 mineral
+  precipitation extents.
+
+The same values appear in the JSON `diagnostics` object. Acceptance remains case-specific: an iteration-limit flag is
+not itself a thermodynamic residual, and a small step does not prove that the mineral inequalities are satisfied. The
+reference regression requires maximum complementarity violation <= 1e-3 SI and maximum tracked-ion balance residual <=
+1e-12 mol/L. A deliberately one-iteration solve remains material-balanced but fails complementarity, preventing silent
+classification as an equilibrated mineral state.
+
+This contract follows the equilibrium-phase convention in Parkhurst (1995), *U.S. Geological Survey
+Water-Resources Investigations Report 95-4227*, [doi:10.3133/wri954227](https://doi.org/10.3133/wri954227):
+minerals in the stable phase assemblage satisfy the target SI equality, while absent minerals remain inequality
+constraints at or below the target. The current PHREEQC 3
+[`EQUILIBRIUM_PHASES` documentation](https://water.usgs.gov/water-resources/software/PHREEQC/documentation/phreeqc3-html/phreeqc3-13.htm)
+states the same convention. USGS-authored information is
+[public domain](https://www.usgs.gov/faqs/are-usgs-reportspublications-copyrighted). No numerical data, parameter,
+correlation or PHREEQC code is copied or fitted by this diagnostic regression.
+
+The diagnostic is limited to the standalone coupled solver's tracked free ions and fixed 1:1 mineral stoichiometries.
+It does not prove elemental/charge closure for the predictor's aqueous speciation, update activity coefficients during
+precipitation, select a globally stable phase topology, or validate Ksp and activity parameters against independent
+precipitation data. Full electrolyte EOS/GE calculations must continue to apply their model-specific activity,
+speciation and balance gates.
+
+---
+
 ## Comparison of thermodynamic routes
 
 | Feature | Davies standalone | Pitzer binary + coupled solids | Electrolyte EOS / full Pitzer |

--- a/src/main/java/neqsim/pvtsimulation/flowassurance/MultiMineralScaleEquilibrium.java
+++ b/src/main/java/neqsim/pvtsimulation/flowassurance/MultiMineralScaleEquilibrium.java
@@ -1,5 +1,7 @@
 package neqsim.pvtsimulation.flowassurance;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -636,6 +638,28 @@ public class MultiMineralScaleEquilibrium implements Serializable {
   public Map<String, Double> getActivityCoefficientsUsed() {
     ensureSolved();
     return new LinkedHashMap<String, Double>(activityCoefficients);
+  }
+
+  /**
+   * Invalidates cached equilibrium and diagnostic state after deserialization.
+   *
+   * <p>
+   * Older serialized objects do not contain the diagnostic fields. Requiring a lazy re-solve prevents their
+   * default-zero values from being interpreted as evidence of convergence and also prevents stale cached results after
+   * a version transition.
+   * </p>
+   *
+   * @param stream serialized object input
+   * @throws IOException if the object cannot be read
+   * @throws ClassNotFoundException if a serialized class cannot be resolved
+   */
+  private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+    stream.defaultReadObject();
+    solved = false;
+    iterationsUsed = 0;
+    iterationLimitReached = false;
+    maximumComplementarityViolation = Double.NaN;
+    maximumIonBalanceResidualMolPerL = Double.NaN;
   }
 
   /**

--- a/src/main/java/neqsim/pvtsimulation/flowassurance/MultiMineralScaleEquilibrium.java
+++ b/src/main/java/neqsim/pvtsimulation/flowassurance/MultiMineralScaleEquilibrium.java
@@ -398,8 +398,7 @@ public class MultiMineralScaleEquilibrium implements Serializable {
     maximumIonBalanceResidualMolPerL = 0.0;
     for (int ion = 0; ion < free.length; ion++) {
       double balanceResidual = initialFree[ion] - free[ion] - precipitatedByIon[ion];
-      maximumIonBalanceResidualMolPerL =
-          Math.max(maximumIonBalanceResidualMolPerL, Math.abs(balanceResidual));
+      maximumIonBalanceResidualMolPerL = Math.max(maximumIonBalanceResidualMolPerL, Math.abs(balanceResidual));
     }
 
     residualFreeIons.put("Ca++", free[CA]);

--- a/src/main/java/neqsim/pvtsimulation/flowassurance/MultiMineralScaleEquilibrium.java
+++ b/src/main/java/neqsim/pvtsimulation/flowassurance/MultiMineralScaleEquilibrium.java
@@ -119,6 +119,10 @@ public class MultiMineralScaleEquilibrium implements Serializable {
   private double convergenceThreshold = 1.0e-15;
 
   private boolean solved = false;
+  private int iterationsUsed = 0;
+  private boolean iterationLimitReached = false;
+  private double maximumComplementarityViolation = Double.NaN;
+  private double maximumIonBalanceResidualMolPerL = Double.NaN;
   private double divalentGamma = Double.NaN;
   private final Map<String, MineralResult> results = new LinkedHashMap<String, MineralResult>();
   private final Map<String, Double> residualFreeIons = new LinkedHashMap<String, Double>();
@@ -236,6 +240,10 @@ public class MultiMineralScaleEquilibrium implements Serializable {
     results.clear();
     residualFreeIons.clear();
     activityCoefficients.clear();
+    iterationsUsed = 0;
+    iterationLimitReached = false;
+    maximumComplementarityViolation = Double.NaN;
+    maximumIonBalanceResidualMolPerL = Double.NaN;
 
     double ionicStrength = predictor.getIonicStrengthMolPerL();
     double gamma2 = Double.NaN;
@@ -261,6 +269,7 @@ public class MultiMineralScaleEquilibrium implements Serializable {
     free[FE] = Math.max(predictor.getTotalIronMolPerL(), 0.0);
     free[SO4] = Math.max(predictor.getFreeSulphateMolPerL(), 0.0);
     free[CO3] = Math.max(predictor.getFreeCarbonateMolPerL(), 0.0);
+    double[] initialFree = free.clone();
 
     // Mineral definitions: {cation index, anion index, Ksp, molar mass, name, formula}.
     List<Mineral> minerals = new ArrayList<Mineral>();
@@ -287,6 +296,7 @@ public class MultiMineralScaleEquilibrium implements Serializable {
     // competition (e.g. barite, celestite and anhydrite drawing on one sulphate pool), which a
     // simultaneous Gauss-Seidel sweep can stall on.
     double convThreshold = convergenceThreshold;
+    boolean stoppedBeforeIterationLimit = false;
     for (int iter = 0; iter < maxIterations; iter++) {
       Mineral best = null;
       double bestAbs = 0.0;
@@ -332,6 +342,7 @@ public class MultiMineralScaleEquilibrium implements Serializable {
       }
 
       if (best == null || bestAbs < convThreshold) {
+        stoppedBeforeIterationLimit = true;
         break;
       }
 
@@ -348,9 +359,14 @@ public class MultiMineralScaleEquilibrium implements Serializable {
       if (free[best.anion] < 0.0) {
         free[best.anion] = 0.0;
       }
+      iterationsUsed++;
     }
+    iterationLimitReached = !stoppedBeforeIterationLimit && iterationsUsed >= maxIterations;
 
-    // Store results.
+    // Store results and evaluate the pure-phase complementarity residual. USGS PHREEQC
+    // treats absent equilibrium phases as inequality constraints (SI <= target) and phases
+    // present in the stable assemblage as equality constraints (SI = target).
+    maximumComplementarityViolation = 0.0;
     for (Mineral m : minerals) {
       double massMgL = m.precipitatedMolL * m.molarMass * 1000.0;
       double finalSI = saturationIndex(free[m.cation], free[m.anion], m.activityCoefficientProduct, m.ksp);
@@ -366,6 +382,24 @@ public class MultiMineralScaleEquilibrium implements Serializable {
       r.limitingIonExhausted = (free[m.cation] <= 10.0 * EPS || free[m.anion] <= 10.0 * EPS)
           && m.precipitatedMolL > EPS;
       results.put(m.name, r);
+
+      double violation = m.precipitatedMolL > EPS ? Math.abs(finalSI) : Math.max(finalSI, 0.0);
+      if (!Double.isFinite(violation)) {
+        violation = Double.POSITIVE_INFINITY;
+      }
+      maximumComplementarityViolation = Math.max(maximumComplementarityViolation, violation);
+    }
+
+    double[] precipitatedByIon = new double[free.length];
+    for (Mineral m : minerals) {
+      precipitatedByIon[m.cation] += m.precipitatedMolL;
+      precipitatedByIon[m.anion] += m.precipitatedMolL;
+    }
+    maximumIonBalanceResidualMolPerL = 0.0;
+    for (int ion = 0; ion < free.length; ion++) {
+      double balanceResidual = initialFree[ion] - free[ion] - precipitatedByIon[ion];
+      maximumIonBalanceResidualMolPerL =
+          Math.max(maximumIonBalanceResidualMolPerL, Math.abs(balanceResidual));
     }
 
     residualFreeIons.put("Ca++", free[CA]);
@@ -525,6 +559,62 @@ public class MultiMineralScaleEquilibrium implements Serializable {
   }
 
   /**
+   * Returns the number of coordinate-descent updates used by the last solve.
+   *
+   * @return iteration count
+   */
+  public int getIterationCount() {
+    ensureSolved();
+    return iterationsUsed;
+  }
+
+  /**
+   * Returns whether the last solve exhausted the configured iteration limit.
+   *
+   * <p>
+   * This is an algorithmic stop diagnostic. Call {@link #getMaximumComplementarityViolation()} and
+   * {@link #getMaximumIonBalanceResidualMolPerL()} to apply case-specific scientific acceptance tolerances.
+   * </p>
+   *
+   * @return true if the solver stopped at {@code maxIterations}
+   */
+  public boolean hasReachedIterationLimit() {
+    ensureSolved();
+    return iterationLimitReached;
+  }
+
+  /**
+   * Returns the maximum pure-phase complementarity violation in saturation-index units.
+   *
+   * <p>
+   * For a mineral with precipitated solid, the violation is {@code abs(SI)}. For an absent solid, it is
+   * {@code max(SI, 0)}, so undersaturation is admissible.
+   * </p>
+   *
+   * @return maximum complementarity violation in log10 saturation-index units
+   */
+  public double getMaximumComplementarityViolation() {
+    ensureSolved();
+    return maximumComplementarityViolation;
+  }
+
+  /**
+   * Returns the maximum absolute free-ion material-balance residual from precipitation.
+   *
+   * <p>
+   * The residual compares each initial free-ion amount with the final free amount plus all 1:1 mineral extents that
+   * consumed that ion. Ion-pairing and aqueous speciation are frozen by the configured predictor before this standalone
+   * precipitation solve.
+   * </p>
+   *
+   * @return maximum absolute ion-balance residual in mol/L
+   */
+  public double getMaximumIonBalanceResidualMolPerL() {
+    ensureSolved();
+    return maximumIonBalanceResidualMolPerL;
+  }
+
+  /**
    * Returns the common divalent coefficient used by Davies/B-dot, or the calcium coefficient for binary Pitzer.
    *
    * @return common divalent or representative calcium activity coefficient, or NaN if not solved
@@ -598,6 +688,13 @@ public class MultiMineralScaleEquilibrium implements Serializable {
     out.put("minerals", mineralMap);
     out.put("totalScaleMass_mgL", getTotalScaleMassMgPerL());
     out.put("residualFreeIons_molL", residualFreeIons);
+
+    Map<String, Object> diagnostics = new LinkedHashMap<String, Object>();
+    diagnostics.put("iterationCount", iterationsUsed);
+    diagnostics.put("iterationLimitReached", iterationLimitReached);
+    diagnostics.put("maximumComplementarityViolation_SI", maximumComplementarityViolation);
+    diagnostics.put("maximumIonBalanceResidual_molL", maximumIonBalanceResidualMolPerL);
+    out.put("diagnostics", diagnostics);
 
     Gson gson = new GsonBuilder().serializeSpecialFloatingPointValues().setPrettyPrinting().create();
     return gson.toJson(out);

--- a/src/test/java/neqsim/pvtsimulation/flowassurance/MultiMineralScaleEquilibriumTest.java
+++ b/src/test/java/neqsim/pvtsimulation/flowassurance/MultiMineralScaleEquilibriumTest.java
@@ -47,6 +47,13 @@ public class MultiMineralScaleEquilibriumTest {
     MultiMineralScaleEquilibrium eq = new MultiMineralScaleEquilibrium(sulphateLimitedBrine());
     eq.solve();
 
+    assertFalse(eq.hasReachedIterationLimit(), "Reference brine should converge before the iteration limit");
+    assertTrue(eq.getIterationCount() > 0, "Supersaturated reference brine should require an equilibrium update");
+    assertTrue(eq.getMaximumComplementarityViolation() <= 1.0e-3,
+        "Converged reference brine should satisfy the frozen complementarity tolerance");
+    assertEquals(0.0, eq.getMaximumIonBalanceResidualMolPerL(), 1.0e-12,
+        "Precipitation extents must close every tracked free-ion balance");
+
     for (MultiMineralScaleEquilibrium.MineralResult r : eq.getResults().values()) {
       if (r.getPrecipitatedMolPerL() > 1.0e-12) {
         assertEquals(0.0, r.getFinalSI(), 1.0e-3,
@@ -232,12 +239,38 @@ public class MultiMineralScaleEquilibriumTest {
   }
 
   @Test
+  @DisplayName("Diagnostics expose deterministic iteration-limited mineral states")
+  void testIterationLimitDiagnostics() {
+    MultiMineralScaleEquilibrium eq = new MultiMineralScaleEquilibrium(sulphateLimitedBrine())
+        .setSolverControls(1, 0.5, 1.0e-30);
+    eq.solve();
+
+    assertTrue(eq.hasReachedIterationLimit(), "One coordinate update must expose the configured stop boundary");
+    assertEquals(1, eq.getIterationCount(), "Exactly one coordinate update was allowed");
+    assertTrue(eq.getMaximumComplementarityViolation() > 1.0e-3,
+        "The deliberately truncated solve must not be reported as satisfying complementarity");
+    assertEquals(0.0, eq.getMaximumIonBalanceResidualMolPerL(), 1.0e-12,
+        "Even a truncated solve must conserve tracked ions");
+
+    double firstComplementarity = eq.getMaximumComplementarityViolation();
+    double firstBalance = eq.getMaximumIonBalanceResidualMolPerL();
+    eq.solve();
+    assertEquals(firstComplementarity, eq.getMaximumComplementarityViolation(), 0.0,
+        "Repeated execution must reproduce the complementarity residual exactly");
+    assertEquals(firstBalance, eq.getMaximumIonBalanceResidualMolPerL(), 0.0,
+        "Repeated execution must reproduce the ion-balance residual exactly");
+  }
+
+  @Test
   @DisplayName("JSON report is produced and contains total scale mass")
   void testJsonReport() {
     MultiMineralScaleEquilibrium eq = new MultiMineralScaleEquilibrium(sulphateLimitedBrine());
     String json = eq.toJson();
     assertTrue(json.contains("totalScaleMass_mgL"), "JSON must report total scale mass");
     assertTrue(json.contains("residualFreeIons_molL"), "JSON must report residual free ions");
+    assertTrue(json.contains("maximumComplementarityViolation_SI"),
+        "JSON must report the complementarity acceptance diagnostic");
+    assertTrue(json.contains("maximumIonBalanceResidual_molL"), "JSON must report the ion-balance diagnostic");
   }
 
   /**

--- a/src/test/java/neqsim/pvtsimulation/flowassurance/MultiMineralScaleEquilibriumTest.java
+++ b/src/test/java/neqsim/pvtsimulation/flowassurance/MultiMineralScaleEquilibriumTest.java
@@ -3,6 +3,10 @@ package neqsim.pvtsimulation.flowassurance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -259,6 +263,35 @@ public class MultiMineralScaleEquilibriumTest {
         "Repeated execution must reproduce the complementarity residual exactly");
     assertEquals(firstBalance, eq.getMaximumIonBalanceResidualMolPerL(), 0.0,
         "Repeated execution must reproduce the ion-balance residual exactly");
+  }
+
+  @Test
+  @DisplayName("Serialization invalidates cached diagnostics and recomputes deterministically")
+  void testSerializationInvalidatesCachedDiagnostics() throws Exception {
+    MultiMineralScaleEquilibrium original = new MultiMineralScaleEquilibrium(sulphateLimitedBrine());
+    original.solve();
+    double expectedComplementarity = original.getMaximumComplementarityViolation();
+    double expectedBalance = original.getMaximumIonBalanceResidualMolPerL();
+
+    byte[] serialized;
+    try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(original);
+      output.flush();
+      serialized = bytes.toByteArray();
+    }
+
+    MultiMineralScaleEquilibrium restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      restored = (MultiMineralScaleEquilibrium) input.readObject();
+    }
+
+    assertFalse(restored.isSolved(), "Deserialization must invalidate cached solve and diagnostic state");
+    assertEquals(expectedComplementarity, restored.getMaximumComplementarityViolation(), 0.0,
+        "Lazy post-deserialization solve must reproduce complementarity exactly");
+    assertEquals(expectedBalance, restored.getMaximumIonBalanceResidualMolPerL(), 0.0,
+        "Lazy post-deserialization solve must reproduce ion balance exactly");
+    assertTrue(restored.isSolved(), "Reading a diagnostic should complete the lazy re-solve");
   }
 
   @Test

--- a/src/test/java/neqsim/pvtsimulation/flowassurance/MultiMineralScaleEquilibriumTest.java
+++ b/src/test/java/neqsim/pvtsimulation/flowassurance/MultiMineralScaleEquilibriumTest.java
@@ -241,8 +241,8 @@ public class MultiMineralScaleEquilibriumTest {
   @Test
   @DisplayName("Diagnostics expose deterministic iteration-limited mineral states")
   void testIterationLimitDiagnostics() {
-    MultiMineralScaleEquilibrium eq = new MultiMineralScaleEquilibrium(sulphateLimitedBrine())
-        .setSolverControls(1, 0.5, 1.0e-30);
+    MultiMineralScaleEquilibrium eq = new MultiMineralScaleEquilibrium(sulphateLimitedBrine()).setSolverControls(1, 0.5,
+        1.0e-30);
     eq.solve();
 
     assertTrue(eq.hasReachedIterationLimit(), "One coordinate update must expose the configured stop boundary");


### PR DESCRIPTION
## Engineering question

Can the coupled mineral-precipitation solver expose enough numerical evidence to distinguish a genuinely equilibrated pure-phase assemblage from an iteration-limited state, while retaining current precipitation results and adding no work to thermodynamic flashes or neutral calculations?

Current `master` stops coordinate descent when the step threshold is met or the iteration budget is exhausted, then always sets `solved=true`. Callers can inspect per-mineral SI and amounts, but cannot inspect the stop reason, iteration count, aggregate Gibbs-complementarity violation, or ion-balance closure. A deliberately one-iteration solve is therefore indistinguishable at the API/report level from ordinary convergence unless every mineral is manually audited.

## Frozen scope

- **Master/base:** `3e7dc6c64ad16992de652f95707b0194c374870c`
- **Head:** `7900dbc6820245a9bdccbf5c44863dd469c0f71b`
- **Model/solver:** opt-in `MultiMineralScaleEquilibrium`; existing Davies, B-dot and binary-Pitzer activity selections; existing fixed 1:1 BaSO4/SrSO4/CaSO4/CaCO3/FeCO3 mineral definitions
- **Reference brine:** existing 70 °C, 100 bara sulphate-limited Ba/Sr/Ca brine fixture
- **Composition basis:** predictor free-ion concentrations and precipitation extents in mol/L; SI = log10(IAP/Ksp)
- **Acceptance:** converged fixture must stop before the limit, perform at least one update, have maximum complementarity violation <= 1e-3 SI and tracked-ion balance residual <= 1e-12 mol/L; a one-iteration negative control must flag the limit, fail the SI gate, retain balance, and repeat diagnostics exactly
- **Compatibility/performance boundary:** no EOS/GE model, reaction, flash, activity, Ksp, parameter, precipitation step, solver tolerance, salt-input API, or neutral path change; diagnostics are accumulated only inside an explicitly requested coupled scale solve
- **Stop boundary:** no activity-coefficient iteration, carbonate re-speciation during precipitation, stoichiometry generalization, phase-topology selection, Ksp fit, or external precipitation-data calibration

## Scientific convention and public evidence

The diagnostic follows Parkhurst (1995), *USGS Water-Resources Investigations Report 95-4227*, DOI [10.3133/wri954227](https://doi.org/10.3133/wri954227), and current USGS PHREEQC 3 [`EQUILIBRIUM_PHASES` documentation](https://water.usgs.gov/water-resources/software/PHREEQC/documentation/phreeqc3-html/phreeqc3-13.htm): a phase present in the stable assemblage satisfies the target saturation-index equality, while an absent phase is an inequality constraint with SI at or below the target. USGS-authored information is [public domain](https://www.usgs.gov/faqs/are-usgs-reportspublications-copyrighted).

No numerical data, code, parameter, or correlation is copied, transformed, fitted, or redistributed. This is analytical/software acceptance evidence, not a parameter-validation dataset.

## Change

- record coordinate-update count and whether the configured iteration limit was reached;
- calculate maximum complementarity violation as `abs(SI)` for present solids and `max(SI, 0)` for absent solids;
- calculate maximum tracked free-ion balance residual from initial/free/final precipitation extents;
- expose the diagnostics through Java getters and the JSON report;
- invalidate cached solve/diagnostic state after deserialization so older serialized objects cannot supply false zero residuals;
- add converged, deliberately truncated, material-balance, deterministic-repeat, serialization round-trip, stale-state, and JSON regressions;
- document residual definitions, units, tolerances, provenance and scientific limitations.

## Validation

**VALIDATION PENDING CI**

Completed locally on the exact final Java files:

- repository Eclipse formatter through Spotless 3.9.0: `apply` and `check` passed;
- connector compare: exactly three scoped files, 7 commits ahead / 0 behind.

Hosted exact-head checks passed so far: Spotless, pre-commit, PaperLab, and Java 21 Javadocs. Documentation search, CodeQL, Java 21 Ubuntu/Windows fast tests, all four slow shards, and later Java 8 jobs remain active.

Not claimed locally: Java compilation, focused/full JUnit execution, Java 8/21 suites, slow shards, Javadocs, CodeQL, repository pre-commit/pre-push, or documentation-search coverage. Maven Central DNS remains unavailable in this environment beyond cached formatter artifacts; all remaining hosted exact-head gates are mandatory.

## Numerical and performance evidence

The converged reference and one-iteration negative-control assertions are pending hosted execution. The balance residual is an O(number of tracked ions + minerals) post-solve reduction; complementarity is accumulated while existing final SIs are already calculated. No new branch or call site exists in neutral PR/SRK/CPA calculations, full electrolyte EOS/GE flashes, or ordinary scale screening.

## Documentation impact and limitations

`docs/pvtsimulation/scale_prediction_api.md` defines the diagnostic contract and explicitly separates algorithmic stopping from scientific residual acceptance. These diagnostics cover the standalone solver's frozen free-ion inventories and 1:1 mineral extents only. They do not prove aqueous elemental/charge closure, update activities/speciation during precipitation, establish global phase stability, or validate mineral parameters against independent precipitation measurements.

After merge, the next dependency remains independent carbonate/speciation evidence shared across electrolyte EOS and GE models before any reaction-table split or coefficient fit.

Refs #3144
