### PR TITLE
[AI-Assisted] feat(mcp): classify Phase 0 trust coverage gaps

### DIFF
--- a/neqsim-mcp-server/docs/FOUNDATION_TRACEABILITY.md
+++ b/neqsim-mcp-server/docs/FOUNDATION_TRACEABILITY.md
@@ -23,6 +23,8 @@ The reconciliation is intentionally conservative:
 
 ## Remaining Phase 0 work
 
-The full Phase 0 audit is still incomplete. The next dependency is to turn the current generic benchmark-trust fallbacks into evidence-backed capability records or explicit confirmed gaps, then define the four acceptance scales and the campaign traceability/maturity matrices. Measured runtime, memory, payload size, convergence, balance closure, and report-usefulness baselines also remain to be frozen.
+The full Phase 0 audit is still incomplete. Every published tool now has an explicit trust-coverage record under `phase0EvidenceInventory.knownLimitations.coverageRecords`: 20 have tool-specific `BenchmarkTrust` metadata and 51 are explicit `CONFIRMED_GAP` records rather than an implicit generic-fallback set. Those gap records are not validation; they identify where tool-specific benchmark, accuracy, limitation, or unsupported-condition evidence is still missing.
+
+The next dependency is to establish the four public synthetic acceptance scales and the campaign traceability/maturity matrices, while closing confirmed trust gaps when current source and public evidence support a specific claim. Measured runtime, memory, payload size, convergence, balance closure, and report-usefulness baselines also remain to be frozen.
 
 This document and the `mergedFoundations` object therefore must not be interpreted as campaign completion or as accountable engineering approval.

--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -20,6 +20,7 @@ manually maintained Java method list.
 | MCP protocol scenarios | 94 | `getCapabilities.phase0EvidenceInventory` | `test_mcp_server.py` |
 | MCP guides | 4 | `getCapabilities.phase0EvidenceInventory` | MCP README, contract, API reference, and this inventory |
 | Explicit tool trust pages | 20 of 71 tools | `getBenchmarkTrust` and `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust` |
+| Trust coverage records | 71 = 20 explicit + 51 confirmed gaps | `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust`, `McpImplementationInventory` |
 
 The tool regression asserts the exact 71-name set grouped by its current trust tier. It also calls
 `getCapabilities` and requires `toolCatalogCoverage.complete`, equal published and described tool
@@ -100,12 +101,25 @@ The four MCP guides have distinct roles:
 | `neqsim-mcp-server/docs/API_REFERENCE.md` | Parameters, schemas, examples, resources, and selected result contracts |
 | `neqsim-mcp-server/docs/SURFACE_INVENTORY.md` | Exact protocol, implementation, equipment, reporting, and evidence inventory |
 
-Known-limit coverage is deliberately reported as incomplete. `BenchmarkTrust` currently contains
-20 explicit tool trust pages with 64 known-limit entries and 30 validation cases, of which 5 name
-a concrete `verifiedBy` test. The other 51 published tools use a generic `TESTED` fallback, and no
-explicit trust page currently publishes a structured `unsupported` condition. The inventory lists
-both the explicitly covered and generic-fallback tools. A generic fallback is not scientific
-validation and does not establish accuracy, applicability, or absence of limitations.
+`BenchmarkTrust` currently contains 20 tool-specific trust pages with 64 known-limit entries and 30
+validation cases, of which 5 name a concrete `verifiedBy` test. The other 51 published tools still
+use the compatibility-level generic `TESTED` fallback from `getBenchmarkTrust`.
+
+Phase 0 no longer leaves those 51 tools as an implicit set. `knownLimitations.coverageRecords`
+contains one deterministic record for every published tool and classifies it as either:
+
+- `EXPLICIT_TRUST` — a tool-specific `BenchmarkTrust` page exists, with its declared maturity and
+  counts for validation cases, verified cases, limitations, and unsupported conditions; or
+- `CONFIRMED_GAP` — no tool-specific trust page exists. The record names the implementation class,
+  retains the current compatibility maturity for backward compatibility, and explicitly states that
+  the generic `TESTED` fallback is not benchmark, accuracy, applicability, or no-limitations
+  evidence.
+
+Accordingly, `coverageComplete=true` means all 71 published tools have an explicit trust-coverage
+classification. It does **not** mean the MCP surface is scientifically validated: 51 records remain
+`CONFIRMED_GAP`, `scientificValidationComplete=false`, and the existing `complete` flag remains
+false until tool-specific trust metadata exists for every published tool. No explicit trust page
+currently publishes a structured `unsupported` condition.
 
 Per-result provenance, convergence, warnings, assumptions, and limitations remain authoritative
 for an executed calculation. The evidence inventory is advisory discovery metadata; it does not
@@ -135,20 +149,22 @@ execution and preserve each calculation's provenance, convergence, validation, a
 limitations.
 
 This increment changes no tool name, tool input, deployment default, thermodynamic model, process
-model, or response envelope. It adds an optional discovery field to the `getCapabilities` output
-schema. Process execution continues to use canonical NeqSim fluids, streams, `ProcessSystem`, and
-`ProcessModel` objects.
+model, or response envelope. It extends additive discovery metadata inside the existing
+`getCapabilities.phase0EvidenceInventory` object. Process execution continues to use canonical
+NeqSim fluids, streams, `ProcessSystem`, and `ProcessModel` objects.
 
 ## Phase 0 stop boundary
 
 The baseline now freezes the exact transport-facing tools, resources, resource templates, prompts,
 deployment-profile names, tool-capability reconciliation, schema resource graph, example resource
 graph, tool implementation bindings, factory-backed equipment, report paths, test sources, guides,
-and current known-limit/trust coverage. It does not complete the campaign's full Phase 0 audit.
-Follow-up work must reconcile merged foundations #2874, #2875, and #3152 criterion by criterion;
-turn the 51 generic trust fallbacks into evidence-based capability or confirmed-gap records; add the
-four acceptance scales; build the full traceability and discipline-maturity matrices; and record
-runtime, memory, payload, convergence, balance-closure, and report-usefulness baselines.
+merged-foundation reconciliation, and explicit trust-coverage status for every published tool. It
+does not complete the campaign's full Phase 0 audit.
+
+Follow-up work must close confirmed trust gaps where current source/public evidence supports a
+specific claim; establish the four public synthetic acceptance scales; build the full campaign
+traceability and discipline-maturity matrices; and record runtime, memory, payload, convergence,
+balance-closure, and report-usefulness baselines.
 
 DEXPI/P&ID ingestion remains owned by #2899, dynamics by #2911, flash/stability/performance by
 #2937, and merged production-optimization foundations by #2941. This inventory audits existing

--- a/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
@@ -13,9 +13,10 @@ import com.google.gson.JsonParser;
  *
  * <p>
  * Source evidence counts are frozen by the repository and protocol tests. Runtime limitation coverage is derived
- * directly from {@link BenchmarkTrust}, so tools that still use the generic trust fallback remain explicit gaps rather
- * than being presented as validated. The merged-foundation inventory records what campaign prerequisites #2874,
- * #2875, and #3152 actually established and the current source evidence that preserves those contracts.
+ * directly from {@link BenchmarkTrust}. Every published tool is classified as either having tool-specific trust
+ * metadata or an explicit confirmed gap, so a generic fallback is never mistaken for benchmark validation. The
+ * merged-foundation inventory records what campaign prerequisites #2874, #2875, and #3152 actually established and
+ * the current source evidence that preserves those contracts.
  * </p>
  */
 public final class McpEvidenceInventory {
@@ -34,7 +35,7 @@ public final class McpEvidenceInventory {
    */
   public static JsonObject build() {
     JsonObject inventory = new JsonObject();
-    inventory.addProperty("inventoryVersion", "1.1");
+    inventory.addProperty("inventoryVersion", "1.2");
     inventory.add("tests", buildTests());
     inventory.add("guides", buildGuides());
     inventory.add("mergedFoundations", buildMergedFoundations());
@@ -43,7 +44,7 @@ public final class McpEvidenceInventory {
         "Evidence discovery does not certify a calculation or replace qualified engineering review");
     inventory.addProperty("complete", false);
     inventory.addProperty("completionReason",
-        "Published surfaces and merged foundations are inventoried, but not every tool has explicit benchmark and limitation metadata and the Phase 0 acceptance baselines remain incomplete");
+        "Published surfaces, merged foundations, and per-tool trust coverage are inventoried, but confirmed trust gaps, four-scale acceptance fixtures, traceability/maturity matrices, and measured Phase 0 baselines remain incomplete");
     return inventory;
   }
 
@@ -123,7 +124,7 @@ public final class McpEvidenceInventory {
 
     foundations.add("entries", entries);
     foundations.addProperty("remainingPhase0Boundary",
-        "Convert generic trust fallbacks into evidence-backed capability or confirmed-gap records, define four acceptance scales and traceability/maturity matrices, and measure runtime, memory, payload, convergence, balance closure, and report usefulness");
+        "Close confirmed trust gaps where evidence exists, define four acceptance scales and traceability/maturity matrices, and measure runtime, memory, payload, convergence, balance closure, and report usefulness");
     return foundations;
   }
 
@@ -141,7 +142,7 @@ public final class McpEvidenceInventory {
     return entry;
   }
 
-  /** Builds limitation and maturity coverage directly from BenchmarkTrust. */
+  /** Builds limitation, maturity, and explicit per-tool trust coverage from BenchmarkTrust. */
   private static JsonObject buildKnownLimitations() {
     JsonObject trustReport = JsonParser.parseString(BenchmarkTrust.getTrustReport()).getAsJsonObject();
     JsonObject explicitTools = trustReport.getAsJsonObject("tools");
@@ -160,23 +161,64 @@ public final class McpEvidenceInventory {
       limitationCount += arraySize(trust, "knownLimitations");
       unsupportedConditionCount += arraySize(trust, "unsupported");
       validationCaseCount += arraySize(trust, "validationCases");
-      if (trust.has("validationCases")) {
-        for (JsonElement validationCase : trust.getAsJsonArray("validationCases")) {
-          if (validationCase.getAsJsonObject().has("verifiedBy")) {
-            verifiedValidationCaseCount++;
-          }
-        }
-      }
+      verifiedValidationCaseCount += verifiedValidationCaseCount(trust);
       String maturity = trust.has("maturityLevel") ? trust.get("maturityLevel").getAsString() : "UNDECLARED";
       int current = maturityCounts.has(maturity) ? maturityCounts.get(maturity).getAsInt() : 0;
       maturityCounts.addProperty(maturity, current + 1);
     }
+
+    JsonObject coverageRecords = new JsonObject();
+    int explicitCoverageRecordCount = 0;
+    int confirmedGapRecordCount = 0;
+    for (String toolName : new java.util.TreeSet<String>(publishedTools)) {
+      JsonObject record = new JsonObject();
+      String implementationClass = McpImplementationInventory.getImplementationClass(toolName);
+      if (implementationClass != null) {
+        record.addProperty("implementationClass", implementationClass);
+      }
+
+      if (explicitTools.has(toolName)) {
+        JsonObject trust = explicitTools.getAsJsonObject(toolName);
+        record.addProperty("coverageStatus", "EXPLICIT_TRUST");
+        record.addProperty("toolSpecificTrustAvailable", true);
+        record.addProperty("maturityLevel",
+            trust.has("maturityLevel") ? trust.get("maturityLevel").getAsString() : "UNDECLARED");
+        record.addProperty("knownLimitationCount", arraySize(trust, "knownLimitations"));
+        record.addProperty("unsupportedConditionCount", arraySize(trust, "unsupported"));
+        record.addProperty("validationCaseCount", arraySize(trust, "validationCases"));
+        record.addProperty("verifiedValidationCaseCount", verifiedValidationCaseCount(trust));
+        explicitCoverageRecordCount++;
+      } else {
+        record.addProperty("coverageStatus", "CONFIRMED_GAP");
+        record.addProperty("toolSpecificTrustAvailable", false);
+        record.addProperty("maturityLevel", BenchmarkTrust.getMaturityLevel(toolName));
+        record.addProperty("knownLimitationCount", 0);
+        record.addProperty("unsupportedConditionCount", 0);
+        record.addProperty("validationCaseCount", 0);
+        record.addProperty("verifiedValidationCaseCount", 0);
+        record.addProperty("gapReason",
+            "No tool-specific BenchmarkTrust entry exists; the generic TESTED fallback is compatibility metadata, not benchmark, accuracy, applicability, or no-limitations evidence");
+        confirmedGapRecordCount++;
+      }
+      coverageRecords.add(toolName, record);
+    }
+
+    JsonObject coverageDefinitions = new JsonObject();
+    coverageDefinitions.addProperty("EXPLICIT_TRUST",
+        "Tool-specific BenchmarkTrust metadata exists; use its declared maturity, validation cases, accuracy bounds, and limitations");
+    coverageDefinitions.addProperty("CONFIRMED_GAP",
+        "No tool-specific BenchmarkTrust entry exists; generic fallback maturity must not be interpreted as benchmark validation");
 
     JsonObject limitations = new JsonObject();
     limitations.addProperty("sourceTool", "getBenchmarkTrust");
     limitations.addProperty("publishedToolCount", publishedTools.size());
     limitations.addProperty("explicitTrustToolCount", explicitTools.size());
     limitations.addProperty("genericTrustToolCount", genericTools.size());
+    limitations.addProperty("confirmedGapToolCount", confirmedGapRecordCount);
+    limitations.addProperty("coverageRecordCount", coverageRecords.size());
+    limitations.addProperty("explicitCoverageRecordCount", explicitCoverageRecordCount);
+    limitations.addProperty("coverageComplete", coverageRecords.size() == publishedTools.size());
+    limitations.addProperty("scientificValidationComplete", false);
     limitations.addProperty("knownLimitationCount", limitationCount);
     limitations.addProperty("unsupportedConditionCount", unsupportedConditionCount);
     limitations.addProperty("validationCaseCount", validationCaseCount);
@@ -184,12 +226,28 @@ public final class McpEvidenceInventory {
     limitations.add("maturityCounts", maturityCounts);
     limitations.add("explicitTrustTools", toJsonArray(explicitTools.keySet()));
     limitations.add("genericTrustTools", toJsonArray(genericTools));
+    limitations.add("coverageStatusDefinitions", coverageDefinitions);
+    limitations.add("coverageRecords", coverageRecords);
     limitations.addProperty("complete", genericTools.isEmpty());
     limitations.addProperty("gapBoundary",
-        "Generic fallback means no tool-specific benchmark, accuracy, unsupported-condition, or limitation claim is available");
+        "Every published tool now has an explicit coverage record; CONFIRMED_GAP records identify missing tool-specific trust evidence without implying validation");
     limitations.addProperty("resultBoundary",
         "Per-result provenance, convergence, warnings, assumptions, and limitations remain authoritative for an executed case");
     return limitations;
+  }
+
+  /** Counts validation cases that identify a concrete verification source. */
+  private static int verifiedValidationCaseCount(JsonObject trust) {
+    if (!trust.has("validationCases")) {
+      return 0;
+    }
+    int count = 0;
+    for (JsonElement validationCase : trust.getAsJsonArray("validationCases")) {
+      if (validationCase.getAsJsonObject().has("verifiedBy")) {
+        count++;
+      }
+    }
+    return count;
   }
 
   /** Builds one guide descriptor. */

--- a/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
@@ -13,10 +13,9 @@ import com.google.gson.JsonParser;
  *
  * <p>
  * Source evidence counts are frozen by the repository and protocol tests. Runtime limitation coverage is derived
- * directly from {@link BenchmarkTrust}. Every published tool is classified as either having tool-specific trust
- * metadata or an explicit confirmed gap, so a generic fallback is never mistaken for benchmark validation. The
- * merged-foundation inventory records what campaign prerequisites #2874, #2875, and #3152 actually established and the
- * current source evidence that preserves those contracts.
+ * directly from {@link BenchmarkTrust}, so tools that still use the generic trust fallback remain explicit gaps rather
+ * than being presented as validated. The merged-foundation inventory records what campaign prerequisites #2874, #2875,
+ * and #3152 actually established and the current source evidence that preserves those contracts.
  * </p>
  */
 public final class McpEvidenceInventory {

--- a/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
@@ -15,8 +15,8 @@ import com.google.gson.JsonParser;
  * Source evidence counts are frozen by the repository and protocol tests. Runtime limitation coverage is derived
  * directly from {@link BenchmarkTrust}. Every published tool is classified as either having tool-specific trust
  * metadata or an explicit confirmed gap, so a generic fallback is never mistaken for benchmark validation. The
- * merged-foundation inventory records what campaign prerequisites #2874, #2875, and #3152 actually established and
- * the current source evidence that preserves those contracts.
+ * merged-foundation inventory records what campaign prerequisites #2874, #2875, and #3152 actually established and the
+ * current source evidence that preserves those contracts.
  * </p>
  */
 public final class McpEvidenceInventory {
@@ -96,30 +96,30 @@ public final class McpEvidenceInventory {
     JsonArray entries = new JsonArray();
     entries.add(foundation(2874, "0894b7820b6317c64ccaaaee5a3326f5bbdf5d77",
         "Caller identity, recoverable security enforcement, principal-scoped approvals, and fail-closed admin actions",
-        new String[] {"src/main/java/neqsim/mcp/runners/McpRequestContext.java",
+        new String[] { "src/main/java/neqsim/mcp/runners/McpRequestContext.java",
             "src/main/java/neqsim/mcp/runners/SecurityRunner.java",
             "src/main/java/neqsim/mcp/runners/IndustrialProfile.java",
-            "neqsim-mcp-server/src/main/java/neqsim/mcp/server/McpIdentityResolver.java"},
-        new String[] {"src/test/java/neqsim/mcp/runners/McpSecurityEnforcementTest.java"},
+            "neqsim-mcp-server/src/main/java/neqsim/mcp/server/McpIdentityResolver.java" },
+        new String[] { "src/test/java/neqsim/mcp/runners/McpSecurityEnforcementTest.java" },
         "Security remains disabled by default for local desktop use; governed deployments must supply transport identity and configured admin policy"));
     entries.add(foundation(2875, "7dac75744ebf25cfbe2b4ccd763bb30c3d14cbdf",
         "Tenant-scoped model handles, solved-model reuse, response-size protection, execution bounds, and complete tool-catalog coverage",
-        new String[] {"src/main/java/neqsim/mcp/runners/ModelRegistry.java",
+        new String[] { "src/main/java/neqsim/mcp/runners/ModelRegistry.java",
             "src/main/java/neqsim/mcp/runners/ResponseSizeGuard.java",
             "src/main/java/neqsim/mcp/runners/McpExecutionPolicy.java",
-            "src/main/java/neqsim/mcp/runners/CapabilitiesRunner.java"},
-        new String[] {"src/test/java/neqsim/mcp/runners/ModelRegistryTest.java",
+            "src/main/java/neqsim/mcp/runners/CapabilitiesRunner.java" },
+        new String[] { "src/test/java/neqsim/mcp/runners/ModelRegistryTest.java",
             "src/test/java/neqsim/mcp/runners/ResponseSizeGuardTest.java",
-            "src/test/java/neqsim/mcp/runners/McpToolSurfaceContractTest.java"},
+            "src/test/java/neqsim/mcp/runners/McpToolSurfaceContractTest.java" },
         "Bounded execution and selective retrieval do not by themselves establish scientific accuracy for every published tool"));
     entries.add(foundation(3152, "bd07729f105efb48b14c641697e0f99fe9af6898",
         "Runtime capability discovery/execution, canonical replayable ProcessSystem/ProcessModel definitions, design/capacity evidence, and typed two-fluid pipeline results",
-        new String[] {"src/main/java/neqsim/mcp/runners/GeneralCapabilityRunner.java",
+        new String[] { "src/main/java/neqsim/mcp/runners/GeneralCapabilityRunner.java",
             "src/main/java/neqsim/mcp/runners/ProcessRunner.java",
             "src/main/java/neqsim/process/processmodel/JsonProcessBuilder.java",
-            "src/main/java/neqsim/process/util/monitor/TwoFluidPipeResponse.java"},
-        new String[] {"src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java",
-            "src/test/java/neqsim/mcp/runners/ProcessRunnerTest.java"},
+            "src/main/java/neqsim/process/util/monitor/TwoFluidPipeResponse.java" },
+        new String[] { "src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java",
+            "src/test/java/neqsim/mcp/runners/ProcessRunnerTest.java" },
         "Generic execution remains narrower than discovery; stateful calculations stay behind curated runners and domain validation remains authoritative"));
 
     foundations.add("entries", entries);

--- a/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionProvenanceTest.java
+++ b/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionProvenanceTest.java
@@ -22,6 +22,8 @@ import neqsim.thermo.system.SystemPitzer;
  */
 class ChemicalReactionProvenanceTest {
   private static final double[] STANDARD_CO2_WATER = new double[] { 253.235548, -12865.665607, -39.440767, 0.0 };
+  private static final double[] PITZER_CO2_WATER = new double[] { 653.705141388, -23927.318205735, -108.892446382,
+      0.108492068 };
   private static final double[] KENT_CO2_WATER = new double[] { 231.465, -12092.1, -36.7816, 0.0 };
 
   /** Verify that Kent-Eisenberg explicitly selects its apparent-constant parameter set. */
@@ -47,10 +49,33 @@ class ChemicalReactionProvenanceTest {
     assertStandardSource(reactiveCo2WaterSystem(new SystemElectrolyteCPAstatoil(298.15, 1.01325)));
   }
 
-  /** Verify source and parameter provenance for the Pitzer electrolyte GE model. */
+  /** Verify source and molality-standard-state parameter provenance for the Pitzer electrolyte GE model. */
   @Test
-  void electrolyteGeUsesStandardReactionSource() {
-    assertStandardSource(reactiveCo2WaterSystem(new SystemPitzer(298.15, 1.01325)));
+  void electrolyteGeUsesDedicatedPitzerReactionSource() {
+    SystemInterface system = reactiveCo2WaterSystem(new SystemPitzer(298.15, 1.01325));
+
+    assertEquals(ChemicalReactionDataSource.PITZER, system.getChemicalReactionDataSource());
+    assertEquals(ChemicalReactionDataSource.PITZER, system.getChemicalReactionOperations().getReactionDataSource());
+    ChemicalReaction reaction = getCo2WaterReaction(system);
+    assertEquals("USGS-PHREEQC3-PlummerBusenberg1982-fit-0-90C", reaction.getReference());
+    assertArrayEquals(PITZER_CO2_WATER, reaction.getEquilibriumConstantCoefficients(), 1.0e-12);
+  }
+
+  /**
+   * Verify clone and serialization preservation of the Pitzer source.
+   *
+   * @throws Exception if Java serialization fails
+   */
+  @Test
+  void pitzerSourceSurvivesCloneAndSerialization() throws Exception {
+    SystemInterface original = reactiveCo2WaterSystem(new SystemPitzer(298.15, 1.01325));
+    SystemInterface cloned = original.clone();
+    SystemInterface restored = roundTrip(original);
+
+    assertEquals(ChemicalReactionDataSource.PITZER, cloned.getChemicalReactionOperations().getReactionDataSource());
+    assertArrayEquals(PITZER_CO2_WATER, getCo2WaterReaction(cloned).getEquilibriumConstantCoefficients(), 1.0e-12);
+    assertEquals(ChemicalReactionDataSource.PITZER, restored.getChemicalReactionOperations().getReactionDataSource());
+    assertArrayEquals(PITZER_CO2_WATER, getCo2WaterReaction(restored).getEquilibriumConstantCoefficients(), 1.0e-12);
   }
 
   /** Verify that callers cannot mutate stored equilibrium-constant coefficients. */

--- a/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionProvenanceTest.java
+++ b/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionProvenanceTest.java
@@ -22,8 +22,6 @@ import neqsim.thermo.system.SystemPitzer;
  */
 class ChemicalReactionProvenanceTest {
   private static final double[] STANDARD_CO2_WATER = new double[] { 253.235548, -12865.665607, -39.440767, 0.0 };
-  private static final double[] PITZER_CO2_WATER = new double[] { 653.705141388, -23927.318205735, -108.892446382,
-      0.108492068 };
   private static final double[] KENT_CO2_WATER = new double[] { 231.465, -12092.1, -36.7816, 0.0 };
 
   /** Verify that Kent-Eisenberg explicitly selects its apparent-constant parameter set. */
@@ -49,33 +47,10 @@ class ChemicalReactionProvenanceTest {
     assertStandardSource(reactiveCo2WaterSystem(new SystemElectrolyteCPAstatoil(298.15, 1.01325)));
   }
 
-  /** Verify source and molality-standard-state parameter provenance for the Pitzer electrolyte GE model. */
+  /** Verify source and parameter provenance for the Pitzer electrolyte GE model. */
   @Test
-  void electrolyteGeUsesDedicatedPitzerReactionSource() {
-    SystemInterface system = reactiveCo2WaterSystem(new SystemPitzer(298.15, 1.01325));
-
-    assertEquals(ChemicalReactionDataSource.PITZER, system.getChemicalReactionDataSource());
-    assertEquals(ChemicalReactionDataSource.PITZER, system.getChemicalReactionOperations().getReactionDataSource());
-    ChemicalReaction reaction = getCo2WaterReaction(system);
-    assertEquals("USGS-PHREEQC3-PlummerBusenberg1982-fit-0-90C", reaction.getReference());
-    assertArrayEquals(PITZER_CO2_WATER, reaction.getEquilibriumConstantCoefficients(), 1.0e-12);
-  }
-
-  /**
-   * Verify clone and serialization preservation of the Pitzer source.
-   *
-   * @throws Exception if Java serialization fails
-   */
-  @Test
-  void pitzerSourceSurvivesCloneAndSerialization() throws Exception {
-    SystemInterface original = reactiveCo2WaterSystem(new SystemPitzer(298.15, 1.01325));
-    SystemInterface cloned = original.clone();
-    SystemInterface restored = roundTrip(original);
-
-    assertEquals(ChemicalReactionDataSource.PITZER, cloned.getChemicalReactionOperations().getReactionDataSource());
-    assertArrayEquals(PITZER_CO2_WATER, getCo2WaterReaction(cloned).getEquilibriumConstantCoefficients(), 1.0e-12);
-    assertEquals(ChemicalReactionDataSource.PITZER, restored.getChemicalReactionOperations().getReactionDataSource());
-    assertArrayEquals(PITZER_CO2_WATER, getCo2WaterReaction(restored).getEquilibriumConstantCoefficients(), 1.0e-12);
+  void electrolyteGeUsesStandardReactionSource() {
+    assertStandardSource(reactiveCo2WaterSystem(new SystemPitzer(298.15, 1.01325)));
   }
 
   /** Verify that callers cannot mutate stored equilibrium-constant coefficients. */

--- a/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
-/** Tests the Phase 0 merged-foundation reconciliation exposed by MCP capability discovery. */
+/** Tests Phase 0 foundation and trust-coverage evidence exposed by MCP capability discovery. */
 class McpEvidenceInventoryFoundationTests {
 
   @Test
@@ -43,6 +43,38 @@ class McpEvidenceInventoryFoundationTests {
     assertTrue(foundations.get("remainingPhase0Boundary").getAsString().contains("acceptance scales"));
 
     // Foundation reconciliation is complete, but the overall Phase 0 evidence inventory is not.
+    assertFalse(inventory.get("complete").getAsBoolean());
+  }
+
+  @Test
+  void testEveryPublishedToolHasExplicitTrustCoverageStatus() {
+    JsonObject inventory = McpEvidenceInventory.build();
+    JsonObject limitations = inventory.getAsJsonObject("knownLimitations");
+    JsonObject coverageRecords = limitations.getAsJsonObject("coverageRecords");
+
+    assertEquals(71, limitations.get("publishedToolCount").getAsInt());
+    assertEquals(71, limitations.get("coverageRecordCount").getAsInt());
+    assertEquals(20, limitations.get("explicitCoverageRecordCount").getAsInt());
+    assertEquals(51, limitations.get("confirmedGapToolCount").getAsInt());
+    assertEquals(71, coverageRecords.size());
+    assertTrue(limitations.get("coverageComplete").getAsBoolean());
+    assertFalse(limitations.get("scientificValidationComplete").getAsBoolean());
+
+    JsonObject flash = coverageRecords.getAsJsonObject("runFlash");
+    assertEquals("EXPLICIT_TRUST", flash.get("coverageStatus").getAsString());
+    assertTrue(flash.get("toolSpecificTrustAvailable").getAsBoolean());
+    assertTrue(flash.get("validationCaseCount").getAsInt() > 0);
+    assertTrue(flash.get("knownLimitationCount").getAsInt() > 0);
+
+    JsonObject capabilities = coverageRecords.getAsJsonObject("getCapabilities");
+    assertEquals("CONFIRMED_GAP", capabilities.get("coverageStatus").getAsString());
+    assertFalse(capabilities.get("toolSpecificTrustAvailable").getAsBoolean());
+    assertEquals("TESTED", capabilities.get("maturityLevel").getAsString());
+    assertTrue(capabilities.get("implementationClass").getAsString().contains("CapabilitiesRunner"));
+    assertTrue(capabilities.get("gapReason").getAsString().contains("not benchmark"));
+
+    // Coverage classification is complete; tool-specific trust evidence is intentionally not.
+    assertFalse(limitations.get("complete").getAsBoolean());
     assertFalse(inventory.get("complete").getAsBoolean());
   }
 }


### PR DESCRIPTION
## Summary

Advances #3153 Phase 0 by converting the remaining implicit generic benchmark-trust fallback set into explicit per-tool trust-coverage records inside the existing `getCapabilities.phase0EvidenceInventory` contract.

- preserves the 20 tool-specific `BenchmarkTrust` pages as `EXPLICIT_TRUST`
- materializes the other 51 published tools as deterministic `CONFIRMED_GAP` records instead of leaving them as an implicit generic-fallback set
- records each tool's implementation class, current compatibility maturity, validation/verified-case/limitation/unsupported counts, and an explicit gap reason
- distinguishes **coverage completeness** from **scientific validation completeness**: all 71 tools are classified, while the 51 gaps remain unvalidated
- keeps the existing `complete=false` semantics until every published tool has tool-specific trust metadata
- updates the Phase 0 inventory and foundation handoff documentation without adding a new MCP tool or simulator

## Frozen scope

This is additive evidence/discovery metadata only. It does not change:

- tool names, inputs, schemas, deployment defaults, or response envelopes
- `BenchmarkTrust` maturity compatibility behavior
- thermodynamic, process, pipeline, dynamic, DEXPI, flash, or optimization calculations
- live-plant or control-system boundaries

Ownership remains with #2899 for P&ID/DEXPI, #2911 for dynamics, #2937 for flash/stability/performance, and #2941 for production optimization.

## Exact base / head

- base/master at branch creation: `e06ba2f410b187075c1ddb88e4475d51e6c1622c` (merged #3185)
- original feature head: `55b2a6787e0c532ec425b3a0b59c0c94f9c17f54`
- formatting-repair head: `a63b703eb762f6b6368532a80efaf853b687a0cc`
- conflict-avoidance head: `80d5df9ac8bb54768b3e196c1205520115d135e9`
- final scope-restored repair head: `39e1ce71108b49d351831486f1f08ab86f68b4cc`
- branch remains based directly on the recorded master head; no master merge/rebase/update-branch operation was used

## Engineering evidence

Current master publishes 71 MCP tools. `BenchmarkTrust.getTrustReport()` contains 20 tool-specific entries; the remaining 51 tools receive the current generic `TESTED` compatibility fallback from `getToolTrust`.

This PR does not reinterpret that fallback as validation. `knownLimitations.coverageRecords` now classifies every published tool as:

- `EXPLICIT_TRUST` when tool-specific trust metadata exists; or
- `CONFIRMED_GAP` when it does not.

For confirmed gaps, the record explicitly states that the generic `TESTED` fallback is not benchmark, accuracy, applicability, or no-limitations evidence. `coverageComplete=true` means classification coverage only; `scientificValidationComplete=false` remains explicit.

## Tests

The existing `McpEvidenceInventoryFoundationTests` class is extended to assert:

- 71/71 published tools have coverage records
- 20 are explicit-trust records and 51 are confirmed gaps
- `runFlash` retains explicit tool-specific trust evidence
- `getCapabilities` is explicitly classified as a confirmed gap with its implementation trace
- coverage completeness does not change overall Phase 0 or scientific-validation completeness

The regression stays in the existing `*Tests.java` file so the frozen 67 `*Test.java` source inventory and 94 protocol-scenario count are unchanged.

## Validation

`MCP REPAIR VALIDATED; CURRENT-MASTER SPOTLESS BASELINE FAILURE CONFIRMED`

The formatting failure on feature head `55b2a6787e0c532ec425b3a0b59c0c94f9c17f54` was reproduced from hosted Pre-commit run `32644367060`. Repository Spotless was applied to the exact PR branch in `a63b703eb762f6b6368532a80efaf853b687a0cc`. Current master `8d4d337083982ba2d6024d3fcb483e25044e3f13` also contained a formatter-only change to the same pre-existing Javadoc and array initializers, making the PR dirty. Repair `80d5df9ac8bb54768b3e196c1205520115d135e9` keeps the PR logic while restoring the unchanged Javadoc/formatting to the current master form. Final head `39e1ce71108b49d351831486f1f08ab86f68b4cc` preserves that repair and restores the PR to its four-file MCP scope. GitHub reports the PR mergeable. No master merge/rebase/update was used.

Passed locally on the final repair tree:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py` — 658 Markdown pages and 1 standalone HTML page
- `./mvnw -B -ntp -Dtest=McpEvidenceInventoryFoundationTests test` — 2 tests, 0 failures/errors/skips
- `pre-commit run --all-files --hook-stage pre-commit`
- `pre-commit run --all-files --hook-stage pre-push`
- `git diff --check`

Hosted exact-head CI on final head `39e1ce71108b49d351831486f1f08ab86f68b4cc` passed PaperLab run `32647689068` and Spotless patch run `32647689075`. Pre-commit run `32647689077` failed only on `ChemicalReactionProvenanceTest.java`, a formatter regression introduced on current master by merged #3187; `McpEvidenceInventory.java` was clean. A separate local merge simulation reproduced exactly two master-owned line-wrap changes, and both `McpEvidenceInventoryFoundationTests` and `ChemicalReactionProvenanceTest` passed there (9 tests total). That unrelated chemistry file is intentionally not included in this MCP PR. Hosted exact-head CI remains authoritative for the broader Java 8/21 build, full tests, Javadocs, CodeQL, and other repository gates. No unrun check is claimed as passed.

## Documentation impact

- updates `neqsim-mcp-server/docs/SURFACE_INVENTORY.md` with the 71-record trust-coverage contract and the distinction between coverage and validation
- updates `neqsim-mcp-server/docs/FOUNDATION_TRACEABILITY.md` so its next Phase 0 handoff is no longer stale
- `MCP_CONTRACT.md` is unchanged because the public tool/request/envelope contract is unchanged
- formatting repair documentation impact: none — it changes only repository style in the existing owner Java file

## Next Phase 0 dependency

After this increment is merged and verified on master, establish the four public synthetic acceptance scales and the full campaign traceability/maturity matrices, while closing individual confirmed trust gaps only where current source and public evidence support specific claims. Runtime, memory, payload, convergence, balance-closure, and report-usefulness baselines remain to be frozen.

Refs #3153