### PR TITLE
[AI-Assisted] fix(flash): refine large-volatility hydrocarbon endpoints

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -2067,3 +2067,44 @@ system.setMultiPhaseCheck(true);
 ThermodynamicOperations ops = new ThermodynamicOperations(system);
 ops.TPflash();  // Automatically solves chemical equilibrium in aqueous phase
 ```
+
+### Large-volatility hydrocarbon endpoint refinement
+
+For neutral high-pressure hydrocarbon mixtures with a large volatility contrast, an ordinary
+two-phase flash can retain a higher-Gibbs stationary point even though the reciprocal explicit
+multiphase path finds a closed equilibrium. A private finalization screen now admits a reciprocal
+candidate only when all active components are hydrocarbons or inerts, pressure is at least 50 bar,
+at least two components are active, the component critical-temperature span is at least 300 K, and
+the least volatile component contributes at least 0.01 of the feed. Public API and tolerances are
+unchanged.
+
+Four deterministic methane/n-heptane regressions were reproduced on SRK and PR:
+
+| EOS | Temperature (K) | Pressure (bar) | `z(n-heptane)` | Ordinary maximum log-fugacity residual before refinement |
+| --- | ---: | ---: | ---: | ---: |
+| SRK | 180 | 50 | 0.05 | 4.58128e-2 |
+| SRK | 180 | 100 | 0.10 | 1.10606e-2 |
+| SRK | 220 | 200 | 0.10 | 5.80033e-5 |
+| PR | 260 | 200 | 0.10 | 1.02025e-2 |
+
+The reciprocal candidate is reset to the feed before reflashing. If it retains two liquid-like
+cubic roots and fails material closure, the lighter phase is initialized on the gas root and the
+heavier phase on the oil root before bounded multiphase beta refinement. Acceptance still requires
+neutral fluid phases, normalized and bounded compositions, maximum component material-balance
+residual below `1e-10`, maximum log-fugacity residual below `1e-8`, and a lower Gibbs energy within
+the existing numerical allowance. Recursion is guarded and a rejected or failed candidate cannot
+modify the original state.
+
+An exact-master qualification matrix covered 1,200 SRK/PR states: methane/n-heptane and the
+nearby methane/ethane control, 180--380 K, 5--200 bar, and heavy-component feed fractions from
+`1e-8` to `0.8`. All states met ordinary/multiphase agreement of `1e-10` for beta and compositions
+and `1e-8` for compressibility factor. Focused regressions also cover poor initialization, exact
+settled repeats, cold-to-warm and changed-state continuity, nearby compositions, material balance,
+fugacity equality, and screen-excluded controls.
+
+This is a correctness fallback rather than a speed optimization. In a constrained fresh-system
+probe (20 warmups and five blocks of 60 flashes), the corrected SRK 180 K/50 bar case changed from
+a median 14.25 ms/flash for the invalid endpoint to 18.20 ms/flash for the accepted equilibrium.
+The screen-excluded SRK 300 K/100 bar trace-heavy control was 10.98 versus 10.88 ms/flash, within
+run-to-run noise. No speedup is claimed, and common flashes return before the new refinement.
+

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -102,6 +102,14 @@ public class TPflash extends Flash {
   private static final double MAX_FINAL_EQUILIBRIUM_REFINEMENT_RESIDUAL = 1.0e-5;
   /** Maximum multiphase beta updates used to repair an invalid neutral two-phase endpoint. */
   private static final int MAX_FINAL_BETA_REFINEMENT_ITERATIONS = 20;
+  /** Maximum beta updates used by the rare large-volatility hydrocarbon root refinement. */
+  private static final int MAX_LARGE_VOLATILITY_REFINEMENT_ITERATIONS = 160;
+  /** Tight closure target for the rare large-volatility hydrocarbon root refinement. */
+  private static final double LARGE_VOLATILITY_REFINEMENT_TOLERANCE = 1.0e-14;
+  /** Minimum critical-temperature span (K) for a large-volatility hydrocarbon refinement. */
+  private static final double LARGE_VOLATILITY_CRITICAL_TEMPERATURE_SPAN = 300.0;
+  /** Minimum feed fraction of the least volatile component for large-volatility refinement. */
+  private static final double LARGE_VOLATILITY_LEAST_VOLATILE_FEED_FRACTION = 1.0e-2;
   /** Cubic phase roots evaluated by the post-convergence root checks. */
   private static final PhaseType[] CUBIC_ROOT_PHASE_TYPES = { PhaseType.GAS, PhaseType.LIQUID };
   /** Iteration limit for damped direct gamma-phi flashes near a phase-fraction boundary. */
@@ -2121,10 +2129,11 @@ public class TPflash extends Flash {
    * <p>
    * Post-convergence phase-root selection can leave a gas/oil split with valid material balance but component
    * fugacities outside the flash tolerance. The refinement is attempted only for a qualified sour-gas endpoint or a
-   * high-pressure hydrogen/hydrocarbon endpoint with an incipient phase. It retains the selected active set and accepts
-   * the result only when phase fractions, compositions, material balance, fugacity equality, and Gibbs energy pass the
-   * existing strict checks. A reciprocal ordinary/multiphase trial can recover a lower cubic root; otherwise the
-   * complete two-phase iteration state is restored.
+   * high-pressure hydrogen/hydrocarbon endpoint with an incipient phase, or a high-pressure hydrocarbon endpoint with a
+   * large critical-temperature span. It retains the selected active set and accepts the result only when phase
+   * fractions, compositions, material balance, fugacity equality, and Gibbs energy pass the existing strict checks. A
+   * reciprocal ordinary/multiphase trial can recover a lower cubic root; otherwise the complete two-phase iteration
+   * state is restored.
    * </p>
    */
   private void refineInvalidNeutralTwoPhaseEndpoint() {
@@ -2140,7 +2149,8 @@ public class TPflash extends Flash {
     }
 
     boolean hydrogenBoundaryCase = isHydrogenHydrocarbonBoundaryRefinementCase();
-    if (!isSourGasConsistencyRefinementCase() && !hydrogenBoundaryCase) {
+    boolean largeVolatilityHydrocarbonCase = isLargeVolatilityHydrocarbonRefinementCase();
+    if (!isSourGasConsistencyRefinementCase() && !hydrogenBoundaryCase && !largeVolatilityHydrocarbonCase) {
       return;
     }
 
@@ -2158,27 +2168,29 @@ public class TPflash extends Flash {
     boolean referenceWasInvalid = !Double.isFinite(referenceMaterialResidual)
         || referenceMaterialResidual > WATER_RICH_MATERIAL_BALANCE_TOLERANCE
         || !Double.isFinite(referenceFugacityResidual) || referenceFugacityResidual >= PHASE_ROOT_EQUILIBRIUM_TOLERANCE;
-    try {
-      TPmultiflash endpointSolver = new TPmultiflash(system, false);
-      endpointSolver.setDoubleArrays();
-      for (int refinement = 0; refinement < MAX_FINAL_BETA_REFINEMENT_ITERATIONS
-          && !isBalancedEquilibriumCandidate(system); refinement++) {
-        endpointSolver.solveBeta();
-      }
-      double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceState.gibbsEnergy) * 1.0e-8);
-      if (isBalancedEquilibriumCandidate(system) && preservesTwoPhaseActiveSet(system, referenceState.phaseTypes)
-          && (referenceWasInvalid || system.getGibbsEnergy() <= referenceState.gibbsEnergy + gibbsTolerance)) {
-        rescueLowerGibbsHydrocarbonPhaseRoots();
-        system.orderByDensity();
-        system.init(1);
-        if (isBalancedEquilibriumCandidate(system)) {
-          return;
+    if (!largeVolatilityHydrocarbonCase) {
+      try {
+        TPmultiflash endpointSolver = new TPmultiflash(system, false);
+        endpointSolver.setDoubleArrays();
+        for (int refinement = 0; refinement < MAX_FINAL_BETA_REFINEMENT_ITERATIONS
+            && !isBalancedEquilibriumCandidate(system); refinement++) {
+          endpointSolver.solveBeta();
         }
+        double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceState.gibbsEnergy) * 1.0e-8);
+        if (isBalancedEquilibriumCandidate(system) && preservesTwoPhaseActiveSet(system, referenceState.phaseTypes)
+            && (referenceWasInvalid || system.getGibbsEnergy() <= referenceState.gibbsEnergy + gibbsTolerance)) {
+          rescueLowerGibbsHydrocarbonPhaseRoots();
+          system.orderByDensity();
+          system.init(1);
+          if (isBalancedEquilibriumCandidate(system)) {
+            return;
+          }
+        }
+        restoreTwoPhaseIterationState(referenceState);
+      } catch (Exception ex) {
+        restoreTwoPhaseIterationState(referenceState);
+        logger.debug("Final neutral two-phase beta refinement failed: {}", ex.getMessage());
       }
-      restoreTwoPhaseIterationState(referenceState);
-    } catch (Exception ex) {
-      restoreTwoPhaseIterationState(referenceState);
-      logger.debug("Final neutral two-phase beta refinement failed: {}", ex.getMessage());
     }
 
     if (MULTIPHASE_RESCUE_ACTIVE.get().booleanValue()) {
@@ -2192,6 +2204,9 @@ public class TPflash extends Flash {
       candidate.setEnhancedMultiPhaseCheck(false);
       new TPflash(candidate, false).run();
       candidate.init(1);
+      if (largeVolatilityHydrocarbonCase && !isBalancedEquilibriumCandidate(candidate)) {
+        refineLargeVolatilityHydrocarbonCandidate(candidate);
+      }
       double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceState.gibbsEnergy) * 1.0e-8);
       boolean replacesInvalidIncipientPhase = !Double.isFinite(referenceFugacityResidual)
           || referenceFugacityResidual >= PHASE_ROOT_EQUILIBRIUM_TOLERANCE;
@@ -2208,6 +2223,46 @@ public class TPflash extends Flash {
       logger.debug("Final neutral two-phase cross-algorithm refinement failed: {}", ex.getMessage());
     } finally {
       MULTIPHASE_RESCUE_ACTIVE.set(Boolean.FALSE);
+    }
+  }
+
+  /**
+   * Refines a reciprocal large-volatility hydrocarbon candidate whose compositions are equilibrated but whose phase
+   * fractions do not close material balance.
+   *
+   * <p>
+   * Near a high-pressure cubic-root crossover, both converged phases can retain liquid-like labels. Initializing the
+   * lighter phase on the gas root and the heavier phase on the liquid root supplies the missing root distinction before
+   * the bounded multiphase beta solve. The caller still applies the ordinary material-balance, fugacity, Gibbs,
+   * active-set, and rollback acceptance checks.
+   * </p>
+   *
+   * @param candidate reciprocal two-phase candidate
+   */
+  private void refineLargeVolatilityHydrocarbonCandidate(SystemInterface candidate) {
+    if (candidate.getNumberOfPhases() != 2) {
+      return;
+    }
+    int lightPhaseIndex =
+        candidate.getPhase(0).getMolarMass() <= candidate.getPhase(1).getMolarMass() ? 0 : 1;
+    int heavyPhaseIndex = 1 - lightPhaseIndex;
+    try {
+      candidate.setPhaseType(lightPhaseIndex, PhaseType.GAS);
+      candidate.setPhaseType(heavyPhaseIndex, PhaseType.OIL);
+      candidate.init(1);
+      TPmultiflash endpointSolver = new TPmultiflash(candidate, false);
+      endpointSolver.setDoubleArrays();
+      for (int refinement = 0; refinement < MAX_LARGE_VOLATILITY_REFINEMENT_ITERATIONS
+          && (maximumComponentMaterialBalanceResidual(candidate) > LARGE_VOLATILITY_REFINEMENT_TOLERANCE
+              || maximumLogFugacityResidual(candidate.getPhase(0),
+                  candidate.getPhase(1)) > LARGE_VOLATILITY_REFINEMENT_TOLERANCE);
+          refinement++) {
+        endpointSolver.solveBeta();
+      }
+      candidate.orderByDensity();
+      candidate.init(1);
+    } catch (Exception ex) {
+      logger.debug("Large-volatility hydrocarbon candidate refinement failed: {}", ex.getMessage());
     }
   }
 
@@ -2418,6 +2473,49 @@ public class TPflash extends Flash {
       }
     }
     return hydrogenFraction > 1.0e-2 && hasHydrocarbon;
+  }
+
+  /**
+   * Screens a high-pressure hydrocarbon endpoint with a large critical-temperature span.
+   *
+   * <p>
+   * Strongly asymmetric light/heavy hydrocarbon mixtures can retain a non-equilibrium ordinary two-phase endpoint
+   * while the reciprocal multiphase path converges to the balanced lower-Gibbs split. The screen requires only
+   * hydrocarbon/inert active components, pressure at or above 50 bar, at least two active components, a critical
+   * temperature span of at least 300 K, and at least one mole percent of the least volatile component. The subsequent
+   * material-balance, fugacity, active-set, Gibbs, and rollback gates remain authoritative.
+   * </p>
+   *
+   * @return true when the endpoint is inside the qualified large-volatility hydrocarbon family
+   */
+  private boolean isLargeVolatilityHydrocarbonRefinementCase() {
+    if (system.getPressure() < 50.0 || system.getNumberOfPhases() != 2) {
+      return false;
+    }
+    int activeComponents = 0;
+    double minimumCriticalTemperature = Double.POSITIVE_INFINITY;
+    double maximumCriticalTemperature = Double.NEGATIVE_INFINITY;
+    double leastVolatileFeedFraction = 0.0;
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      double feedFraction = component.getz();
+      if (feedFraction <= 1.0e-50) {
+        continue;
+      }
+      if (!component.isHydrocarbon() && !component.isInert()) {
+        return false;
+      }
+      activeComponents++;
+      minimumCriticalTemperature = Math.min(minimumCriticalTemperature, component.getTC());
+      if (component.getTC() > maximumCriticalTemperature) {
+        maximumCriticalTemperature = component.getTC();
+        leastVolatileFeedFraction = feedFraction;
+      }
+    }
+    return activeComponents >= 2
+        && leastVolatileFeedFraction >= LARGE_VOLATILITY_LEAST_VOLATILE_FEED_FRACTION
+        && maximumCriticalTemperature
+            - minimumCriticalTemperature >= LARGE_VOLATILITY_CRITICAL_TEMPERATURE_SPAN;
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -2243,8 +2243,7 @@ public class TPflash extends Flash {
     if (candidate.getNumberOfPhases() != 2) {
       return;
     }
-    int lightPhaseIndex =
-        candidate.getPhase(0).getMolarMass() <= candidate.getPhase(1).getMolarMass() ? 0 : 1;
+    int lightPhaseIndex = candidate.getPhase(0).getMolarMass() <= candidate.getPhase(1).getMolarMass() ? 0 : 1;
     int heavyPhaseIndex = 1 - lightPhaseIndex;
     try {
       candidate.setPhaseType(lightPhaseIndex, PhaseType.GAS);
@@ -2255,8 +2254,7 @@ public class TPflash extends Flash {
       for (int refinement = 0; refinement < MAX_LARGE_VOLATILITY_REFINEMENT_ITERATIONS
           && (maximumComponentMaterialBalanceResidual(candidate) > LARGE_VOLATILITY_REFINEMENT_TOLERANCE
               || maximumLogFugacityResidual(candidate.getPhase(0),
-                  candidate.getPhase(1)) > LARGE_VOLATILITY_REFINEMENT_TOLERANCE);
-          refinement++) {
+                  candidate.getPhase(1)) > LARGE_VOLATILITY_REFINEMENT_TOLERANCE); refinement++) {
         endpointSolver.solveBeta();
       }
       candidate.orderByDensity();
@@ -2479,8 +2477,8 @@ public class TPflash extends Flash {
    * Screens a high-pressure hydrocarbon endpoint with a large critical-temperature span.
    *
    * <p>
-   * Strongly asymmetric light/heavy hydrocarbon mixtures can retain a non-equilibrium ordinary two-phase endpoint
-   * while the reciprocal multiphase path converges to the balanced lower-Gibbs split. The screen requires only
+   * Strongly asymmetric light/heavy hydrocarbon mixtures can retain a non-equilibrium ordinary two-phase endpoint while
+   * the reciprocal multiphase path converges to the balanced lower-Gibbs split. The screen requires only
    * hydrocarbon/inert active components, pressure at or above 50 bar, at least two active components, a critical
    * temperature span of at least 300 K, and at least one mole percent of the least volatile component. The subsequent
    * material-balance, fugacity, active-set, Gibbs, and rollback gates remain authoritative.
@@ -2512,10 +2510,8 @@ public class TPflash extends Flash {
         leastVolatileFeedFraction = feedFraction;
       }
     }
-    return activeComponents >= 2
-        && leastVolatileFeedFraction >= LARGE_VOLATILITY_LEAST_VOLATILE_FEED_FRACTION
-        && maximumCriticalTemperature
-            - minimumCriticalTemperature >= LARGE_VOLATILITY_CRITICAL_TEMPERATURE_SPAN;
+    return activeComponents >= 2 && leastVolatileFeedFraction >= LARGE_VOLATILITY_LEAST_VOLATILE_FEED_FRACTION
+        && maximumCriticalTemperature - minimumCriticalTemperature >= LARGE_VOLATILITY_CRITICAL_TEMPERATURE_SPAN;
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashLargeVolatilityHydrocarbonConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashLargeVolatilityHydrocarbonConsistencyTest.java
@@ -15,9 +15,9 @@ class TPflashLargeVolatilityHydrocarbonConsistencyTest extends neqsim.NeqSimTest
   private static final double MATERIAL_BALANCE_TOLERANCE = 1.0e-10;
   private static final double FUGACITY_TOLERANCE = 1.0e-8;
   private static final double STATE_TOLERANCE = 1.0e-10;
-  private static final Case[] REGRESSION_CASES = {
-      new Case(Eos.SRK, 180.0, 50.0, 0.05), new Case(Eos.SRK, 180.0, 100.0, 0.10),
-      new Case(Eos.SRK, 220.0, 200.0, 0.10), new Case(Eos.PR, 260.0, 200.0, 0.10) };
+  private static final Case[] REGRESSION_CASES = { new Case(Eos.SRK, 180.0, 50.0, 0.05),
+      new Case(Eos.SRK, 180.0, 100.0, 0.10), new Case(Eos.SRK, 220.0, 200.0, 0.10),
+      new Case(Eos.PR, 260.0, 200.0, 0.10) };
 
   @Test
   void largeVolatilityEndpointsCloseAndAgreeAcrossAlgorithms() {
@@ -48,8 +48,8 @@ class TPflashLargeVolatilityHydrocarbonConsistencyTest extends neqsim.NeqSimTest
         double changedPressure = regression.pressure * 1.01;
         reference.setPressure(changedPressure, "bara");
         flash(reference, false);
-        SystemInterface changedReference =
-            flash(createSystem(regression.withPressure(changedPressure), multiphase), false);
+        SystemInterface changedReference = flash(createSystem(regression.withPressure(changedPressure), multiphase),
+            false);
         assertEquivalent(changedReference, reference, regression.label() + " changed pressure", 1.0e-8);
       }
     }
@@ -88,8 +88,7 @@ class TPflashLargeVolatilityHydrocarbonConsistencyTest extends neqsim.NeqSimTest
   }
 
   private static SystemInterface createSystem(Case testCase, boolean multiphase) {
-    SystemInterface system = testCase.eos == Eos.PR
-        ? new SystemPrEos(testCase.temperature, testCase.pressure)
+    SystemInterface system = testCase.eos == Eos.PR ? new SystemPrEos(testCase.temperature, testCase.pressure)
         : new SystemSrkEos(testCase.temperature, testCase.pressure);
     system.addComponent("methane", 1.0 - testCase.heavyFraction);
     system.addComponent(testCase.heavyComponent, testCase.heavyFraction);
@@ -137,8 +136,7 @@ class TPflashLargeVolatilityHydrocarbonConsistencyTest extends neqsim.NeqSimTest
   private static Integer[] phaseOrder(SystemInterface system) {
     Integer[] order = new Integer[system.getNumberOfPhases()];
     Arrays.setAll(order, index -> index);
-    Arrays.sort(order, Comparator.comparingDouble(
-        index -> system.getPhase(index).getComponent(1).getx()));
+    Arrays.sort(order, Comparator.comparingDouble(index -> system.getPhase(index).getComponent(1).getx()));
     return order;
   }
 
@@ -155,8 +153,7 @@ class TPflashLargeVolatilityHydrocarbonConsistencyTest extends neqsim.NeqSimTest
         compositionSum += composition;
       }
       assertEquals(1.0, compositionSum, 1.0e-12, label);
-      assertTrue(Double.isFinite(system.getPhase(phase).getZ()) && system.getPhase(phase).getZ() > 0.0,
-          label);
+      assertTrue(Double.isFinite(system.getPhase(phase).getZ()) && system.getPhase(phase).getZ() > 0.0, label);
     }
     assertEquals(1.0, betaSum, 1.0e-12, label);
 
@@ -179,11 +176,9 @@ class TPflashLargeVolatilityHydrocarbonConsistencyTest extends neqsim.NeqSimTest
             * system.getPhase(0).getComponent(component).getFugacityCoefficient();
         double second = system.getPhase(1).getComponent(component).getx()
             * system.getPhase(1).getComponent(component).getFugacityCoefficient();
-        maximumFugacityResidual =
-            Math.max(maximumFugacityResidual, Math.abs(Math.log(first / second)));
+        maximumFugacityResidual = Math.max(maximumFugacityResidual, Math.abs(Math.log(first / second)));
       }
-      assertTrue(maximumFugacityResidual < FUGACITY_TOLERANCE,
-          label + " fugacity residual " + maximumFugacityResidual);
+      assertTrue(maximumFugacityResidual < FUGACITY_TOLERANCE, label + " fugacity residual " + maximumFugacityResidual);
     }
   }
 
@@ -202,8 +197,7 @@ class TPflashLargeVolatilityHydrocarbonConsistencyTest extends neqsim.NeqSimTest
       this(eos, temperature, pressure, heavyFraction, "n-heptane");
     }
 
-    private Case(Eos eos, double temperature, double pressure, double heavyFraction,
-        String heavyComponent) {
+    private Case(Eos eos, double temperature, double pressure, double heavyFraction, String heavyComponent) {
       this.eos = eos;
       this.temperature = temperature;
       this.pressure = pressure;
@@ -220,8 +214,8 @@ class TPflashLargeVolatilityHydrocarbonConsistencyTest extends neqsim.NeqSimTest
     }
 
     private String label() {
-      return eos + " methane+" + heavyComponent + " at " + temperature + " K, " + pressure
-          + " bar, z(" + heavyComponent + ")=" + heavyFraction;
+      return eos + " methane+" + heavyComponent + " at " + temperature + " K, " + pressure + " bar, z(" + heavyComponent
+          + ")=" + heavyFraction;
     }
   }
 }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashLargeVolatilityHydrocarbonConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashLargeVolatilityHydrocarbonConsistencyTest.java
@@ -1,0 +1,227 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Arrays;
+import java.util.Comparator;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Qualification of high-pressure hydrocarbon flashes with a large volatility contrast. */
+class TPflashLargeVolatilityHydrocarbonConsistencyTest extends neqsim.NeqSimTest {
+  private static final double MATERIAL_BALANCE_TOLERANCE = 1.0e-10;
+  private static final double FUGACITY_TOLERANCE = 1.0e-8;
+  private static final double STATE_TOLERANCE = 1.0e-10;
+  private static final Case[] REGRESSION_CASES = {
+      new Case(Eos.SRK, 180.0, 50.0, 0.05), new Case(Eos.SRK, 180.0, 100.0, 0.10),
+      new Case(Eos.SRK, 220.0, 200.0, 0.10), new Case(Eos.PR, 260.0, 200.0, 0.10) };
+
+  @Test
+  void largeVolatilityEndpointsCloseAndAgreeAcrossAlgorithms() {
+    for (Case regression : REGRESSION_CASES) {
+      SystemInterface ordinary = flash(createSystem(regression, false), false);
+      SystemInterface multiphase = flash(createSystem(regression, true), false);
+
+      assertEquals(2, ordinary.getNumberOfPhases(), regression.label());
+      assertEquivalent(ordinary, multiphase, regression.label());
+    }
+  }
+
+  @Test
+  void poorInitializationRepeatsAndChangedPressureRemainDeterministic() {
+    for (Case regression : REGRESSION_CASES) {
+      for (boolean multiphase : new boolean[] { false, true }) {
+        SystemInterface reference = flash(createSystem(regression, multiphase), false);
+        SystemInterface poorGuess = flash(createSystem(regression, multiphase), true);
+        assertEquivalent(reference, poorGuess, regression.label() + " poor initialization");
+
+        SystemInterface repeatedReference = reference.clone();
+        flash(reference, false);
+        assertEquivalent(repeatedReference, reference, regression.label() + " cold-to-warm repeat", 1.0e-8);
+        SystemInterface settledReference = reference.clone();
+        flash(reference, false);
+        assertEquivalent(settledReference, reference, regression.label() + " settled repeat");
+
+        double changedPressure = regression.pressure * 1.01;
+        reference.setPressure(changedPressure, "bara");
+        flash(reference, false);
+        SystemInterface changedReference =
+            flash(createSystem(regression.withPressure(changedPressure), multiphase), false);
+        assertEquivalent(changedReference, reference, regression.label() + " changed pressure", 1.0e-8);
+      }
+    }
+  }
+
+  @Test
+  void nearbyCompositionsRemainContinuousAcrossAlgorithms() {
+    for (Case regression : REGRESSION_CASES) {
+      SystemInterface lower = null;
+      for (double offset : new double[] { -1.0e-4, 0.0, 1.0e-4 }) {
+        Case nearby = regression.withHeavyFraction(regression.heavyFraction + offset);
+        SystemInterface ordinary = flash(createSystem(nearby, false), false);
+        SystemInterface multiphase = flash(createSystem(nearby, true), false);
+        assertEquivalent(ordinary, multiphase, nearby.label());
+        if (lower != null && lower.getNumberOfPhases() == 2 && ordinary.getNumberOfPhases() == 2) {
+          Integer[] lowerOrder = phaseOrder(lower);
+          Integer[] ordinaryOrder = phaseOrder(ordinary);
+          assertTrue(Math.abs(lower.getBeta(lowerOrder[0]) - ordinary.getBeta(ordinaryOrder[0])) < 0.02,
+              nearby.label() + " nearby-state beta continuity");
+        }
+        lower = ordinary;
+      }
+    }
+  }
+
+  @Test
+  void screenExcludedControlsRemainClosedAndCrossAlgorithmConsistent() {
+    Case methaneEthane = new Case(Eos.SRK, 220.0, 200.0, 0.10, "ethane");
+    Case traceHeavy = new Case(Eos.SRK, 300.0, 100.0, 1.0e-3);
+    Case lowPressure = new Case(Eos.PR, 260.0, 20.0, 0.10);
+    for (Case control : new Case[] { methaneEthane, traceHeavy, lowPressure }) {
+      SystemInterface ordinary = flash(createSystem(control, false), false);
+      SystemInterface multiphase = flash(createSystem(control, true), false);
+      assertEquivalent(ordinary, multiphase, control.label());
+    }
+  }
+
+  private static SystemInterface createSystem(Case testCase, boolean multiphase) {
+    SystemInterface system = testCase.eos == Eos.PR
+        ? new SystemPrEos(testCase.temperature, testCase.pressure)
+        : new SystemSrkEos(testCase.temperature, testCase.pressure);
+    system.addComponent("methane", 1.0 - testCase.heavyFraction);
+    system.addComponent(testCase.heavyComponent, testCase.heavyFraction);
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(multiphase);
+    return system;
+  }
+
+  private static SystemInterface flash(SystemInterface system, boolean poorGuess) {
+    if (poorGuess) {
+      system.setBeta(0, 1.0e-10);
+      system.setBeta(1, 1.0 - 1.0e-10);
+    }
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private static void assertEquivalent(SystemInterface expected, SystemInterface actual, String label) {
+    assertEquivalent(expected, actual, label, STATE_TOLERANCE);
+  }
+
+  private static void assertEquivalent(SystemInterface expected, SystemInterface actual, String label,
+      double stateTolerance) {
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases(), label);
+    assertClosure(expected, label + " reference");
+    assertClosure(actual, label + " comparison");
+    Integer[] expectedOrder = phaseOrder(expected);
+    Integer[] actualOrder = phaseOrder(actual);
+    for (int orderedPhase = 0; orderedPhase < expectedOrder.length; orderedPhase++) {
+      int expectedPhase = expectedOrder[orderedPhase];
+      int actualPhase = actualOrder[orderedPhase];
+      assertEquals(expected.getPhase(expectedPhase).getType(), actual.getPhase(actualPhase).getType(), label);
+      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), stateTolerance, label);
+      assertEquals(expected.getPhase(expectedPhase).getZ(), actual.getPhase(actualPhase).getZ(), 1.0e-8, label);
+      for (int component = 0; component < 2; component++) {
+        assertEquals(expected.getPhase(expectedPhase).getComponent(component).getx(),
+            actual.getPhase(actualPhase).getComponent(component).getx(), stateTolerance, label);
+      }
+    }
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(),
+        Math.max(1.0e-7, 1.0e-8 * Math.abs(expected.getGibbsEnergy())), label);
+  }
+
+  private static Integer[] phaseOrder(SystemInterface system) {
+    Integer[] order = new Integer[system.getNumberOfPhases()];
+    Arrays.setAll(order, index -> index);
+    Arrays.sort(order, Comparator.comparingDouble(
+        index -> system.getPhase(index).getComponent(1).getx()));
+    return order;
+  }
+
+  private static void assertClosure(SystemInterface system, String label) {
+    double betaSum = 0.0;
+    for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+      double beta = system.getBeta(phase);
+      assertTrue(Double.isFinite(beta) && beta >= 0.0 && beta <= 1.0, label);
+      betaSum += beta;
+      double compositionSum = 0.0;
+      for (int component = 0; component < 2; component++) {
+        double composition = system.getPhase(phase).getComponent(component).getx();
+        assertTrue(Double.isFinite(composition) && composition >= 0.0 && composition <= 1.0, label);
+        compositionSum += composition;
+      }
+      assertEquals(1.0, compositionSum, 1.0e-12, label);
+      assertTrue(Double.isFinite(system.getPhase(phase).getZ()) && system.getPhase(phase).getZ() > 0.0,
+          label);
+    }
+    assertEquals(1.0, betaSum, 1.0e-12, label);
+
+    double maximumMaterialBalanceResidual = 0.0;
+    for (int component = 0; component < 2; component++) {
+      double recovered = 0.0;
+      for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+        recovered += system.getBeta(phase) * system.getPhase(phase).getComponent(component).getx();
+      }
+      maximumMaterialBalanceResidual = Math.max(maximumMaterialBalanceResidual,
+          Math.abs(system.getPhase(0).getComponent(component).getz() - recovered));
+    }
+    assertTrue(maximumMaterialBalanceResidual < MATERIAL_BALANCE_TOLERANCE,
+        label + " material balance residual " + maximumMaterialBalanceResidual);
+
+    if (system.getNumberOfPhases() == 2) {
+      double maximumFugacityResidual = 0.0;
+      for (int component = 0; component < 2; component++) {
+        double first = system.getPhase(0).getComponent(component).getx()
+            * system.getPhase(0).getComponent(component).getFugacityCoefficient();
+        double second = system.getPhase(1).getComponent(component).getx()
+            * system.getPhase(1).getComponent(component).getFugacityCoefficient();
+        maximumFugacityResidual =
+            Math.max(maximumFugacityResidual, Math.abs(Math.log(first / second)));
+      }
+      assertTrue(maximumFugacityResidual < FUGACITY_TOLERANCE,
+          label + " fugacity residual " + maximumFugacityResidual);
+    }
+  }
+
+  private enum Eos {
+    SRK, PR
+  }
+
+  private static final class Case {
+    private final Eos eos;
+    private final double temperature;
+    private final double pressure;
+    private final double heavyFraction;
+    private final String heavyComponent;
+
+    private Case(Eos eos, double temperature, double pressure, double heavyFraction) {
+      this(eos, temperature, pressure, heavyFraction, "n-heptane");
+    }
+
+    private Case(Eos eos, double temperature, double pressure, double heavyFraction,
+        String heavyComponent) {
+      this.eos = eos;
+      this.temperature = temperature;
+      this.pressure = pressure;
+      this.heavyFraction = heavyFraction;
+      this.heavyComponent = heavyComponent;
+    }
+
+    private Case withPressure(double changedPressure) {
+      return new Case(eos, temperature, changedPressure, heavyFraction, heavyComponent);
+    }
+
+    private Case withHeavyFraction(double changedFraction) {
+      return new Case(eos, temperature, pressure, changedFraction, heavyComponent);
+    }
+
+    private String label() {
+      return eos + " methane+" + heavyComponent + " at " + temperature + " K, " + pressure
+          + " bar, z(" + heavyComponent + ")=" + heavyFraction;
+    }
+  }
+}


### PR DESCRIPTION
Refs #2937

## Summary

This repairs four deterministic high-pressure methane/n-heptane TP-flash endpoints where the ordinary SRK/PR path retained a higher-Gibbs or materially unclosed stationary point while explicit multiphase refinement found the balanced equilibrium.

The change extends the existing private neutral-endpoint reciprocal fallback under a strict feed-only screen:

- pressure at or above 50 bar
- exactly two fluid phases
- only active hydrocarbons or inerts
- at least two active components
- critical-temperature span at least 300 K
- at least 0.01 feed fraction of the least volatile component

If the reciprocal candidate retains two liquid-like roots and does not close material balance, the lighter phase is initialized on the gas root and the heavier phase on the oil root before bounded multiphase beta refinement. Existing recursion, neutral topology, normalized/bounded composition, material-balance, fugacity, Gibbs, and complete-state rollback gates remain authoritative. Public API and configured tolerances are unchanged.

## Reproduced defects and results

| EOS | T (K) | P (bar) | z(n-heptane) | ordinary max log-fugacity residual before |
| --- | ---: | ---: | ---: | ---: |
| SRK | 180 | 50 | 0.05 | 4.58128e-2 |
| SRK | 180 | 100 | 0.10 | 1.10606e-2 |
| SRK | 220 | 200 | 0.10 | 5.80033e-5 |
| PR | 260 | 200 | 0.10 | 1.02025e-2 |

After refinement, ordinary and explicit multiphase results satisfy material balance below `1e-10`, log-fugacity residual below `1e-8`, and agreement within `1e-10` for beta/compositions and `1e-8` for Z.

## Regression scope

The focused class covers:

- all four SRK/PR defect states
- poor beta initialization
- ordinary versus explicit multiphase execution
- cold-to-warm and exact settled repeats
- changed pressure from reused and fresh systems
- nearby compositions at ±`1e-4`
- material balance, fugacity equality, bounded/normalized compositions, Z, beta, Gibbs, and topology
- screen-excluded methane/ethane, trace-heavy, and low-pressure controls

A broader exact-master diagnostic matrix covered 1,200 states across SRK/PR, methane/n-heptane and methane/ethane, 180–380 K, 5–200 bar, and heavy-component fractions `1e-8`–`0.8`; zero states failed the cross-algorithm gates.

## Performance

This is a correctness fallback, not a speed optimization. A constrained fresh-system probe (20 warmups; five blocks of 60 flashes) measured:

- corrected SRK 180 K/50 bar endpoint: median 18.20 ms/flash
- invalid baseline endpoint: median 14.25 ms/flash
- screen-excluded trace-heavy control: 10.88 versus 10.98 ms/flash, within noise

Common flashes return before the new screen.

## Validation

Exact base: `eed348be246f941e9b25c0a307163b7ffb2a0464`  
Exact head: `bb74f5eba80ee40603c0173e3161bfe5e91b669d`  
Merged on protected `master` as `59ec0afe3efeb1ced0a6aeec9bcb7c852b1d83b6`.

Passed locally against exact GitHub source:

- focused regression methods: 4/4
- 1,200-state SRK/PR cross-algorithm matrix: 0 flags
- Java compilation of the modified flash classes and focused test harness

All exact-head hosted workflows completed successfully:

- Java 8/21 Ubuntu and Windows fast tests
- all four Java 21 slow-test shards
- Java 21 Javadoc
- Spotless
- pre-commit
- documentation search/build
- CodeQL
- PaperLab

GitHub's exact Spotless artifact was applied to the two Java files before the final green run. No reviews or unresolved review threads were present.

## Documentation impact

`docs/thermodynamicoperations/TPflash_algorithm.md` documents the screen, acceptance/rollback gates, measured correctness cost, and scope limitations.

## Scope boundaries

No column-solver, generic process-performance, public-API, electrolyte, data-ingestion, or Huldra work is included.

**MERGED AND VALIDATED**