### PR TITLE
[AI-Assisted] feat(mcp): measure Phase 0 acceptance baselines

### DIFF
--- a/neqsim-mcp-server/docs/ACCEPTANCE_BASELINES.md
+++ b/neqsim-mcp-server/docs/ACCEPTANCE_BASELINES.md
@@ -1,0 +1,48 @@
+# MCP Phase 0 acceptance baselines
+
+`McpAcceptanceBaselineRunner` executes the four public synthetic fixtures defined by
+`McpAcceptanceFixtureCatalog` through the production `FlashRunner` and `ProcessRunner` contracts. It is an on-demand
+test and evidence harness, not a public MCP tool, a second simulator, a process-performance optimizer, or a plant
+qualification workflow.
+
+Run the focused exact-head gate from the repository root:
+
+```bash
+./mvnw test -Dtest=McpAcceptanceBaselineRunnerTests
+```
+
+The test records the compact baseline JSON through Log4j2 in the hosted CI log. Every fixture is executed twice. The
+report includes:
+
+| Evidence group | Recorded fields | Interpretation boundary |
+| --- | --- | --- |
+| environment | Java/runtime/OS identity, processors, maximum heap | Required context for non-portable observations |
+| runtime | outer wall time and runner provenance time for both executions | Observation, not a portable regression threshold |
+| heap snapshot | used-heap snapshots and deltas | JVM proxy; not allocation or peak-memory profiling |
+| payload and guard | raw/guarded UTF-8 bytes, configured bound, trimming and retrieval guidance | MCP response-delivery evidence only |
+| convergence | explicit provenance verdict, warnings, validation and quality-gate status | Does not substitute for physical validation |
+| determinism | SHA-256 of stable response content after temporal/correlation metadata removal | Repeated outcome check for the same fixture and runtime |
+| report evidence | report presence/size and canonical replay availability | Structural coverage, not subjective engineering usefulness |
+| balance evidence | explicitly named mass/component/energy closure response paths | Missing numerical closure is a recorded gap, never inferred from success |
+
+## Acceptance and failure behavior
+
+All four fixtures must return `success`, explicitly report convergence, remain deterministic after run-identity metadata
+is removed, and fit the configured shared response guard. A large raw payload may pass by being safely trimmed while
+retaining the standard envelope and selective-retrieval guidance.
+
+Balance evidence is deliberately fail-visible. A successful `runProcess` response without an explicitly named numeric
+mass, component, or energy closure field is classified as `GAP_NO_NUMERIC_CLOSURE_IN_MCP_RESPONSE`. The harness does not
+convert convergence, a non-empty report, or a validation label into a balance claim.
+
+## Ownership and qualification boundaries
+
+- Generic `ProcessSystem` and `ProcessModel` performance optimization remains owned by #2939.
+- Plant-wide optimization and constraint fidelity remain owned by #3154 and the completed #2941 foundation.
+- Flash/stability algorithms remain owned by #2937, dynamics by #2911, and DEXPI/P&ID ingestion by #2899.
+- Runtime, heap and payload values are comparable only for equivalent environments and fixture inputs.
+- The harness does not establish scientific accuracy, design certification, representative-plant fidelity, causality,
+  accountable engineering approval, or authority to control a live plant.
+
+Exact-head hosted CI and its retained log are the execution evidence. The static capability inventory exposes only the
+bounded measurement contract; it never performs these large calculations during capability discovery.

--- a/neqsim-mcp-server/docs/ACCEPTANCE_BASELINES.md
+++ b/neqsim-mcp-server/docs/ACCEPTANCE_BASELINES.md
@@ -11,7 +11,9 @@ Run the focused exact-head gate from the repository root:
 ./mvnw test -Dtest=McpAcceptanceBaselineRunnerTests
 ```
 
-The test records the compact baseline JSON through Log4j2 in the hosted CI log. Every fixture is executed twice. The
+The test validates the compact baseline JSON returned by the runner. Every fixture is executed twice. A caller that
+needs the exact numeric observations can serialize the returned `JsonObject` in its governed evidence store; the
+repository test deliberately does not emit environment-specific baseline data through the disabled test logger. The
 report includes:
 
 | Evidence group | Recorded fields | Interpretation boundary |
@@ -44,5 +46,6 @@ convert convergence, a non-empty report, or a validation label into a balance cl
 - The harness does not establish scientific accuracy, design certification, representative-plant fidelity, causality,
   accountable engineering approval, or authority to control a live plant.
 
-Exact-head hosted CI and its retained log are the execution evidence. The static capability inventory exposes only the
-bounded measurement contract; it never performs these large calculations during capability discovery.
+Exact-head hosted CI is pass/fail execution evidence for the asserted contract, while persisted numeric observations
+remain the responsibility of the invoking evidence workflow. The static capability inventory exposes only the bounded
+measurement contract; it never performs these large calculations during capability discovery.

--- a/neqsim-mcp-server/docs/ACCEPTANCE_FIXTURES.md
+++ b/neqsim-mcp-server/docs/ACCEPTANCE_FIXTURES.md
@@ -45,17 +45,20 @@ The large fixture is the #3153 transport/execution scale. Generic process execut
 
 Hosted exact-head CI is the execution authority when local validation is unavailable. A source fixture existing in the repository is not evidence that it passed on a particular head.
 
-## Remaining Phase 0 measurements
+## Phase 0 measurement harness
 
-The next acceptance increment must run these frozen inputs under a measurement harness and record, at minimum:
+`McpAcceptanceBaselineRunner` now runs these frozen inputs twice through the production runners and records:
 
 - runtime and environment identity;
 - memory/allocation evidence where available;
 - response size before and after MCP response guarding;
 - tool-call count and selective-retrieval behavior;
 - convergence and warnings;
-- mass/component/energy closure as applicable;
+- explicit mass/component/energy closure response paths, or a confirmed response-evidence gap;
 - deterministic repeat evidence;
-- report completeness/usefulness and explicit limitations.
+- structural report coverage and explicit usefulness limitations.
 
-The full campaign traceability matrix and discipline-level capability/maturity matrix also remain open. These fixtures provide the stable inputs those later measurements should reference.
+See [ACCEPTANCE_BASELINES.md](ACCEPTANCE_BASELINES.md) for the executable contract and interpretation boundaries.
+Exact-head values remain environment-specific and are retained in hosted CI logs rather than embedded as portable
+performance claims. The full campaign traceability matrix, discipline-level capability/maturity matrix, and justified
+closure of explicit numerical balance/report gaps remain open.

--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -18,7 +18,7 @@ manually maintained Java method list.
 | Engineering report paths | 2 | `getCapabilities.implementationInventory` | `ReportRunner`, `TaskWorkflowBridge` |
 | MCP Java test classes | 67 | `getCapabilities.phase0EvidenceInventory` | `src/test/java/neqsim/mcp/**/*Test.java` |
 | MCP protocol scenarios | 94 | `getCapabilities.phase0EvidenceInventory` | `test_mcp_server.py` |
-| MCP guides | 4 | `getCapabilities.phase0EvidenceInventory` | MCP README, contract, API reference, and this inventory |
+| MCP guides | 7 | `getCapabilities.phase0EvidenceInventory` | Core guides, foundation traceability, fixtures, and baseline harness |
 | Explicit tool trust pages | 20 of 71 tools | `getBenchmarkTrust` and `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust` |
 | Trust coverage records | 71 = 20 explicit + 51 confirmed gaps | `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust`, `McpImplementationInventory` |
 
@@ -92,7 +92,7 @@ trees and fails if the manifest drifts. These counts identify evidence locations
 claim that a test ran or passed. Exact-head CI and recorded command output remain the execution
 evidence.
 
-The four MCP guides have distinct roles:
+The seven MCP guides have distinct roles:
 
 | Guide | Role |
 | --- | --- |
@@ -100,6 +100,9 @@ The four MCP guides have distinct roles:
 | `neqsim-mcp-server/MCP_CONTRACT.md` | Versioning, stability, envelopes, governance, security, and trust metadata |
 | `neqsim-mcp-server/docs/API_REFERENCE.md` | Parameters, schemas, examples, resources, and selected result contracts |
 | `neqsim-mcp-server/docs/SURFACE_INVENTORY.md` | Exact protocol, implementation, equipment, reporting, and evidence inventory |
+| `neqsim-mcp-server/docs/FOUNDATION_TRACEABILITY.md` | Merged foundation capability evidence and remaining boundaries |
+| `neqsim-mcp-server/docs/ACCEPTANCE_FIXTURES.md` | Four public synthetic scales and canonical execution routes |
+| `neqsim-mcp-server/docs/ACCEPTANCE_BASELINES.md` | Bounded exact-run measurements, interpretation limits, and explicit evidence gaps |
 
 `BenchmarkTrust` currently contains 20 tool-specific trust pages with 64 known-limit entries and 30
 validation cases, of which 5 name a concrete `verifiedBy` test. The other 51 published tools still

--- a/neqsim-mcp-server/test_mcp_server.py
+++ b/neqsim-mcp-server/test_mcp_server.py
@@ -1505,10 +1505,19 @@ def test_capabilities():
     check("evidence inventory freezes 94 protocol scenarios",
           tests.get("protocolScenarioCount") == 94,
           str(tests))
-    check("evidence inventory lists four MCP guides",
-          guides.get("guideCount") == 4
-          and len(guides.get("entries", [])) == 4,
+    check("evidence inventory lists seven MCP guides",
+          guides.get("guideCount") == 7
+          and len(guides.get("entries", [])) == 7,
           str(guides))
+    baseline_contract = evidence.get("acceptanceBaselineContract", {})
+    check("acceptance baseline contract is bounded and non-qualifying",
+          baseline_contract.get("fixtureCount") == 4
+          and baseline_contract.get("repeatRunCount") == 2
+          and baseline_contract.get("executionMode")
+          == "ON_DEMAND_TEST_HARNESS"
+          and baseline_contract.get("performanceQualification") is False
+          and baseline_contract.get("scientificValidationComplete") is False,
+          str(baseline_contract))
 
     repo_root = Path(__file__).resolve().parent.parent
     java_test_root = repo_root / tests.get("javaTestRoot", "")

--- a/src/main/java/neqsim/mcp/runners/McpAcceptanceBaselineRunner.java
+++ b/src/main/java/neqsim/mcp/runners/McpAcceptanceBaselineRunner.java
@@ -1,0 +1,449 @@
+package neqsim.mcp.runners;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Executes the four public synthetic MCP acceptance fixtures and records bounded Phase 0 baseline evidence.
+ *
+ * <p>
+ * This runner is an on-demand test and evidence harness, not a published MCP tool and not a second process simulator.
+ * It invokes the production {@link FlashRunner} and {@link ProcessRunner} contracts, repeats every fixture once for a
+ * deterministic outcome check, and records environment-qualified runtime, heap-snapshot, payload, response-guard,
+ * convergence, report, and balance-evidence coverage.
+ * </p>
+ *
+ * <p>
+ * Runtime and heap figures are observations for the executing environment. They are not portable performance
+ * thresholds, allocation profiles, scientific validation, design qualification, or plant authority. Missing numerical
+ * balance evidence is recorded as a gap instead of being inferred from a successful solve.
+ * </p>
+ */
+public final class McpAcceptanceBaselineRunner {
+
+  private static final Gson GSON = new GsonBuilder().serializeSpecialFloatingPointValues().create();
+  private static final int REPEAT_RUN_COUNT = 2;
+
+  /** Private constructor for utility class. */
+  private McpAcceptanceBaselineRunner() {
+  }
+
+  /**
+   * Describes the bounded measurement contract without executing a fixture.
+   *
+   * @return machine-readable baseline contract
+   */
+  public static JsonObject describe() {
+    JsonObject contract = new JsonObject();
+    contract.addProperty("schemaVersion", "1.0");
+    contract.addProperty("fixtureCount", 4);
+    contract.addProperty("repeatRunCount", REPEAT_RUN_COUNT);
+    contract.addProperty("executionMode", "ON_DEMAND_TEST_HARNESS");
+    contract.addProperty("executionEvidenceStatus", "CONTRACT_DEFINED_EXACT_HEAD_EXECUTION_REQUIRED");
+    contract.addProperty("evidenceDocument", "neqsim-mcp-server/docs/ACCEPTANCE_BASELINES.md");
+    contract.add("measurementGroups", toJsonArray(new String[] { "environment", "runtime", "heapSnapshot",
+        "payloadAndGuard", "convergence", "determinism", "reportEvidence", "balanceEvidence" }));
+    contract.addProperty("canonicalExecution",
+        "Production FlashRunner and ProcessRunner execute the McpAcceptanceFixtureCatalog inputs");
+    contract.addProperty("performanceQualification", false);
+    contract.addProperty("scientificValidationComplete", false);
+    contract.addProperty("boundary",
+        "Environment-qualified observations only; no portable performance threshold, allocation profile, scientific validation, design certification, optimization claim, or plant authority");
+    return contract;
+  }
+
+  /**
+   * Executes every frozen fixture twice and records bounded baseline evidence.
+   *
+   * @return exact-run baseline report
+   */
+  public static JsonObject run() {
+    JsonObject baseline = describe();
+    baseline.addProperty("executionEvidenceStatus", "EXECUTED_CURRENT_RUNTIME");
+    baseline.add("environment", buildEnvironment());
+    baseline.addProperty("responseGuardLimitBytes", ResponseSizeGuard.getMaxBytes());
+
+    JsonArray measurements = new JsonArray();
+    JsonArray fixtures = McpAcceptanceFixtureCatalog.build().getAsJsonArray("fixtures");
+    int successCount = 0;
+    int convergedCount = 0;
+    int deterministicCount = 0;
+    int guardTriggeredCount = 0;
+    int explicitBalanceGapCount = 0;
+    int balanceEvidencePresentCount = 0;
+    for (JsonElement fixtureElement : fixtures) {
+      JsonObject measurement = measureFixture(fixtureElement.getAsJsonObject());
+      measurements.add(measurement);
+      if (measurement.get("successful").getAsBoolean()) {
+        successCount++;
+      }
+      if (measurement.getAsJsonObject("convergence").get("converged").getAsBoolean()) {
+        convergedCount++;
+      }
+      if (measurement.getAsJsonObject("determinism").get("stableOutcomeMatch").getAsBoolean()) {
+        deterministicCount++;
+      }
+      if (measurement.getAsJsonObject("payloadAndGuard").get("guardTriggered").getAsBoolean()) {
+        guardTriggeredCount++;
+      }
+      String balanceStatus = measurement.getAsJsonObject("balanceEvidence").get("status").getAsString();
+      if ("RESPONSE_EVIDENCE_PRESENT".equals(balanceStatus)) {
+        balanceEvidencePresentCount++;
+      } else if ("GAP_NO_NUMERIC_CLOSURE_IN_MCP_RESPONSE".equals(balanceStatus)) {
+        explicitBalanceGapCount++;
+      }
+    }
+    baseline.add("measurements", measurements);
+
+    JsonObject summary = new JsonObject();
+    summary.addProperty("fixtureCount", fixtures.size());
+    summary.addProperty("toolExecutionCount", fixtures.size() * REPEAT_RUN_COUNT);
+    summary.addProperty("successCount", successCount);
+    summary.addProperty("convergedCount", convergedCount);
+    summary.addProperty("deterministicCount", deterministicCount);
+    summary.addProperty("guardTriggeredCount", guardTriggeredCount);
+    summary.addProperty("balanceEvidencePresentCount", balanceEvidencePresentCount);
+    summary.addProperty("explicitBalanceGapCount", explicitBalanceGapCount);
+    summary.addProperty("status",
+        successCount == fixtures.size() && convergedCount == fixtures.size() && deterministicCount == fixtures.size()
+            ? (explicitBalanceGapCount > 0 ? "EXECUTION_COMPLETE_WITH_EXPLICIT_GAPS" : "EXECUTION_COMPLETE")
+            : "EXECUTION_FAILED_ACCEPTANCE");
+    summary.addProperty("remainingBoundary",
+        "Close explicit numerical balance/report gaps where the canonical model exposes defensible evidence; keep process performance with #2939 and optimization fidelity with #3154");
+    baseline.add("summary", summary);
+    return baseline;
+  }
+
+  /** Executes and measures one catalog fixture. */
+  private static JsonObject measureFixture(JsonObject fixture) {
+    String fixtureId = fixture.get("id").getAsString();
+    String toolName = fixture.get("executionTool").getAsString();
+    String input = GSON.toJson(fixture.get("input"));
+    long heapBefore = usedHeapBytes();
+    Observation first = execute(toolName, input);
+    long heapAfterFirst = usedHeapBytes();
+    Observation repeat = execute(toolName, input);
+    long heapAfterRepeat = usedHeapBytes();
+
+    JsonObject result = new JsonObject();
+    result.addProperty("fixtureId", fixtureId);
+    result.addProperty("scale", fixture.get("scale").getAsString());
+    result.addProperty("executionTool", toolName);
+    result.addProperty("modelKind", fixture.get("modelKind").getAsString());
+    result.addProperty("declaredAreaCount", fixture.get("areaCount").getAsInt());
+    result.addProperty("declaredUnitCount", fixture.get("unitCount").getAsInt());
+    result.addProperty("toolExecutionCount", REPEAT_RUN_COUNT);
+    result.addProperty("successful", isSuccessful(first.response) && isSuccessful(repeat.response));
+
+    JsonObject runtime = new JsonObject();
+    runtime.addProperty("firstRunMillis", first.elapsedMillis);
+    runtime.addProperty("repeatRunMillis", repeat.elapsedMillis);
+    runtime.addProperty("firstProvenanceComputationTimeMillis", provenanceComputationTime(first.response));
+    runtime.addProperty("repeatProvenanceComputationTimeMillis", provenanceComputationTime(repeat.response));
+    runtime.addProperty("qualification", "OBSERVED_CURRENT_RUNTIME_NOT_A_PORTABLE_THRESHOLD");
+    result.add("runtime", runtime);
+
+    JsonObject heap = new JsonObject();
+    heap.addProperty("beforeBytes", heapBefore);
+    heap.addProperty("afterFirstRunBytes", heapAfterFirst);
+    heap.addProperty("afterRepeatRunBytes", heapAfterRepeat);
+    heap.addProperty("firstRunDeltaBytes", heapAfterFirst - heapBefore);
+    heap.addProperty("repeatRunDeltaBytes", heapAfterRepeat - heapAfterFirst);
+    heap.addProperty("measurementMaturity", "JVM_USED_HEAP_SNAPSHOT_PROXY");
+    heap.addProperty("boundary",
+        "Snapshot deltas include JVM allocation, retention and garbage-collection effects; they are not allocation or peak-memory profiles");
+    result.add("heapSnapshot", heap);
+
+    JsonObject guarded = first.response.deepCopy();
+    int rawBytes = serializedSize(first.response);
+    boolean guardTriggered = ResponseSizeGuard.enforce(guarded, toolName);
+    int guardedBytes = serializedSize(guarded);
+    int guardLimit = ResponseSizeGuard.getMaxBytes();
+    JsonObject payload = new JsonObject();
+    payload.addProperty("rawResponseBytes", rawBytes);
+    payload.addProperty("guardedResponseBytes", guardedBytes);
+    payload.addProperty("guardLimitBytes", guardLimit);
+    payload.addProperty("guardTriggered", guardTriggered);
+    payload.addProperty("guardedWithinLimit", guardLimit <= 0 || guardedBytes <= guardLimit);
+    payload.addProperty("selectiveRetrievalGuidancePresent", hasRetrievalGuidance(guarded));
+    payload.addProperty("transportBoundary",
+        "Raw runner payload is measured before the shared guard; guarded bytes represent the bounded agent-facing form");
+    result.add("payloadAndGuard", payload);
+
+    JsonObject convergence = new JsonObject();
+    convergence.addProperty("declared", hasDeclaredConvergence(first.response));
+    convergence.addProperty("converged", isConverged(first.response));
+    convergence.addProperty("warningCount", arraySize(first.response, "warnings"));
+    convergence.addProperty("validationPresent", first.response.has("validation"));
+    convergence.addProperty("qualityGateStatus", qualityGateStatus(first.response));
+    result.add("convergence", convergence);
+
+    String firstFingerprint = stableOutcomeFingerprint(first.response);
+    String repeatFingerprint = stableOutcomeFingerprint(repeat.response);
+    JsonObject determinism = new JsonObject();
+    determinism.addProperty("stableOutcomeMatch", firstFingerprint.equals(repeatFingerprint));
+    determinism.addProperty("firstFingerprintSha256", firstFingerprint);
+    determinism.addProperty("repeatFingerprintSha256", repeatFingerprint);
+    determinism.addProperty("excludedMetadata",
+        "timestamps, computation times, generated-at fields, calculation identifiers and correlation identifiers");
+    result.add("determinism", determinism);
+
+    JsonObject report = buildReportEvidence(first.response, toolName);
+    result.add("reportEvidence", report);
+    result.add("balanceEvidence", buildBalanceEvidence(first.response, toolName));
+    result.addProperty("scientificValidationStatus", "NOT_ESTABLISHED_BY_PHASE0_EXECUTION_HARNESS");
+    return result;
+  }
+
+  /** Executes one production runner call and records elapsed wall time. */
+  private static Observation execute(String toolName, String input) {
+    long started = System.nanoTime();
+    String responseText = "runFlash".equals(toolName) ? FlashRunner.run(input) : ProcessRunner.run(input);
+    double elapsedMillis = (System.nanoTime() - started) / 1.0e6;
+    JsonObject response = JsonParser.parseString(responseText).getAsJsonObject();
+    return new Observation(response, elapsedMillis);
+  }
+
+  /** Builds environment identity for interpreting non-portable measurements. */
+  private static JsonObject buildEnvironment() {
+    Runtime runtime = Runtime.getRuntime();
+    JsonObject environment = new JsonObject();
+    environment.addProperty("javaVersion", System.getProperty("java.version", "unknown"));
+    environment.addProperty("javaVendor", System.getProperty("java.vendor", "unknown"));
+    environment.addProperty("vmName", System.getProperty("java.vm.name", "unknown"));
+    environment.addProperty("osName", System.getProperty("os.name", "unknown"));
+    environment.addProperty("osArch", System.getProperty("os.arch", "unknown"));
+    environment.addProperty("availableProcessors", runtime.availableProcessors());
+    environment.addProperty("maxHeapBytes", runtime.maxMemory());
+    environment.addProperty("identityBoundary",
+        "Runtime and heap observations are comparable only when environment and harness inputs are equivalent");
+    return environment;
+  }
+
+  /** Builds structural report coverage without claiming subjective usefulness. */
+  private static JsonObject buildReportEvidence(JsonObject response, String toolName) {
+    JsonElement reportElement = findReport(response);
+    JsonObject evidence = new JsonObject();
+    evidence.addProperty("reportPresent", reportElement != null);
+    evidence.addProperty("reportBytes", reportElement == null ? 0 : serializedSize(reportElement));
+    evidence.addProperty("canonicalReplayPresent", response.has("processDefinition"));
+    evidence.addProperty("operatorSummaryPresent", response.has("message"));
+    evidence.addProperty("status", reportElement != null ? "STRUCTURED_REPORT_PRESENT"
+        : ("runFlash".equals(toolName) ? "NOT_APPLICABLE_FLASH_RESULT_IS_STRUCTURED_DATA" : "GAP_NO_REPORT"));
+    evidence.addProperty("usefulnessBoundary",
+        "Presence and size are structural evidence only; engineering usefulness requires content review and case-specific validation");
+    return evidence;
+  }
+
+  /** Builds explicit numerical balance coverage and never infers closure from success. */
+  private static JsonObject buildBalanceEvidence(JsonObject response, String toolName) {
+    JsonObject evidence = new JsonObject();
+    if ("runFlash".equals(toolName)) {
+      evidence.addProperty("status", "NOT_APPLICABLE_SINGLE_EQUILIBRIUM_CALCULATION");
+      evidence.add("responsePaths", new JsonArray());
+      evidence.addProperty("boundary",
+          "The flash fixture is checked through convergence and thermodynamic result provenance, not a process balance");
+      return evidence;
+    }
+
+    List<String> paths = new ArrayList<String>();
+    collectBalanceEvidencePaths(response, "$", paths);
+    evidence.addProperty("status",
+        paths.isEmpty() ? "GAP_NO_NUMERIC_CLOSURE_IN_MCP_RESPONSE" : "RESPONSE_EVIDENCE_PRESENT");
+    evidence.add("responsePaths", toJsonArray(paths));
+    evidence.addProperty("boundary", paths.isEmpty()
+        ? "A successful process solve does not prove mass, component or energy closure; the MCP response exposes no explicit numerical closure field for this fixture"
+        : "Listed paths show response-level balance evidence; their values and tolerances still require engineering review");
+    return evidence;
+  }
+
+  /** Recursively finds explicitly named mass, component, or energy balance members. */
+  private static void collectBalanceEvidencePaths(JsonElement element, String path, List<String> paths) {
+    if (element == null || element.isJsonNull()) {
+      return;
+    }
+    if (element.isJsonObject()) {
+      for (Map.Entry<String, JsonElement> entry : element.getAsJsonObject().entrySet()) {
+        String normalized = entry.getKey().replace("_", "").replace("-", "").toLowerCase(java.util.Locale.ROOT);
+        String childPath = path + "." + entry.getKey();
+        if (normalized.contains("massbalance") || normalized.contains("massclosure")
+            || normalized.contains("componentbalance") || normalized.contains("energybalance")) {
+          paths.add(childPath);
+        }
+        collectBalanceEvidencePaths(entry.getValue(), childPath, paths);
+      }
+    } else if (element.isJsonArray()) {
+      JsonArray array = element.getAsJsonArray();
+      for (int index = 0; index < array.size(); index++) {
+        collectBalanceEvidencePaths(array.get(index), path + "[" + index + "]", paths);
+      }
+    }
+  }
+
+  /** Returns a stable fingerprint after removing run-identity metadata and sorting object keys. */
+  private static String stableOutcomeFingerprint(JsonObject response) {
+    JsonElement normalized = normalizeForFingerprint(response);
+    return sha256(GSON.toJson(normalized));
+  }
+
+  /** Recursively removes volatile metadata and sorts JSON object keys. */
+  private static JsonElement normalizeForFingerprint(JsonElement element) {
+    if (element == null || element.isJsonNull()) {
+      return JsonNull.INSTANCE;
+    }
+    if (element.isJsonArray()) {
+      JsonArray normalized = new JsonArray();
+      for (JsonElement item : element.getAsJsonArray()) {
+        normalized.add(normalizeForFingerprint(item));
+      }
+      return normalized;
+    }
+    if (element.isJsonObject()) {
+      JsonObject normalized = new JsonObject();
+      Map<String, JsonElement> sorted = new TreeMap<String, JsonElement>();
+      for (Map.Entry<String, JsonElement> entry : element.getAsJsonObject().entrySet()) {
+        if (!isVolatileMetadata(entry.getKey())) {
+          sorted.put(entry.getKey(), entry.getValue());
+        }
+      }
+      for (Map.Entry<String, JsonElement> entry : sorted.entrySet()) {
+        normalized.add(entry.getKey(), normalizeForFingerprint(entry.getValue()));
+      }
+      return normalized;
+    }
+    return JsonParser.parseString(element.toString());
+  }
+
+  /** Identifies temporal and correlation metadata excluded from deterministic engineering output comparison. */
+  private static boolean isVolatileMetadata(String fieldName) {
+    String normalized = fieldName.replace("_", "").replace("-", "").toLowerCase(java.util.Locale.ROOT);
+    return "timestamp".equals(normalized) || "generatedat".equals(normalized) || "computationtimems".equals(normalized)
+        || "calculationidentifier".equals(normalized) || "calculationid".equals(normalized)
+        || "correlationid".equals(normalized);
+  }
+
+  /** Returns whether a response reports success. */
+  private static boolean isSuccessful(JsonObject response) {
+    return response.has("status") && "success".equals(response.get("status").getAsString());
+  }
+
+  /** Returns whether response provenance explicitly declares convergence. */
+  private static boolean hasDeclaredConvergence(JsonObject response) {
+    return response.has("provenance") && response.get("provenance").isJsonObject()
+        && response.getAsJsonObject("provenance").has("converged");
+  }
+
+  /** Returns convergence only from explicit provenance, never from status alone. */
+  private static boolean isConverged(JsonObject response) {
+    return hasDeclaredConvergence(response) && response.getAsJsonObject("provenance").get("converged").getAsBoolean();
+  }
+
+  /** Returns the runner-reported computation time, or -1 when absent. */
+  private static long provenanceComputationTime(JsonObject response) {
+    if (response.has("provenance") && response.get("provenance").isJsonObject()
+        && response.getAsJsonObject("provenance").has("computationTimeMs")) {
+      return response.getAsJsonObject("provenance").get("computationTimeMs").getAsLong();
+    }
+    return -1L;
+  }
+
+  /** Returns quality-gate status or an explicit absence marker. */
+  private static String qualityGateStatus(JsonObject response) {
+    if (response.has("qualityGate") && response.get("qualityGate").isJsonObject()
+        && response.getAsJsonObject("qualityGate").has("status")) {
+      return response.getAsJsonObject("qualityGate").get("status").getAsString();
+    }
+    return "NOT_DECLARED";
+  }
+
+  /** Finds a top-level or canonical data-block report. */
+  private static JsonElement findReport(JsonObject response) {
+    if (response.has("report")) {
+      return response.get("report");
+    }
+    if (response.has("data") && response.get("data").isJsonObject() && response.getAsJsonObject("data").has("report")) {
+      return response.getAsJsonObject("data").get("report");
+    }
+    return null;
+  }
+
+  /** Returns whether a guarded response explains selective retrieval. */
+  private static boolean hasRetrievalGuidance(JsonObject guarded) {
+    return guarded.has("truncation") && guarded.get("truncation").isJsonObject()
+        && guarded.getAsJsonObject("truncation").has("howToRetrieve");
+  }
+
+  /** Returns an array member size or zero. */
+  private static int arraySize(JsonObject object, String field) {
+    return object.has(field) && object.get(field).isJsonArray() ? object.getAsJsonArray(field).size() : 0;
+  }
+
+  /** Returns current used-heap proxy without forcing garbage collection. */
+  private static long usedHeapBytes() {
+    Runtime runtime = Runtime.getRuntime();
+    return runtime.totalMemory() - runtime.freeMemory();
+  }
+
+  /** Returns serialized UTF-8 byte size. */
+  private static int serializedSize(JsonElement element) {
+    return GSON.toJson(element).getBytes(StandardCharsets.UTF_8).length;
+  }
+
+  /** Calculates a SHA-256 hex digest. */
+  private static String sha256(String value) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] bytes = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+      char[] hex = new char[bytes.length * 2];
+      char[] digits = "0123456789abcdef".toCharArray();
+      for (int index = 0; index < bytes.length; index++) {
+        int unsigned = bytes[index] & 0xff;
+        hex[index * 2] = digits[unsigned >>> 4];
+        hex[index * 2 + 1] = digits[unsigned & 0x0f];
+      }
+      return new String(hex);
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is unavailable", exception);
+    }
+  }
+
+  /** Converts strings to JSON. */
+  private static JsonArray toJsonArray(String[] values) {
+    List<String> ordered = new ArrayList<String>();
+    Collections.addAll(ordered, values);
+    return toJsonArray(ordered);
+  }
+
+  /** Converts ordered strings to JSON. */
+  private static JsonArray toJsonArray(Iterable<String> values) {
+    JsonArray array = new JsonArray();
+    for (String value : values) {
+      array.add(value);
+    }
+    return array;
+  }
+
+  /** One production-runner observation. */
+  private static final class Observation {
+    private final JsonObject response;
+    private final double elapsedMillis;
+
+    private Observation(JsonObject response, double elapsedMillis) {
+      this.response = response;
+      this.elapsedMillis = elapsedMillis;
+    }
+  }
+}

--- a/src/main/java/neqsim/mcp/runners/McpAcceptanceFixtureCatalog.java
+++ b/src/main/java/neqsim/mcp/runners/McpAcceptanceFixtureCatalog.java
@@ -32,7 +32,7 @@ public final class McpAcceptanceFixtureCatalog {
     catalog.addProperty("catalogVersion", "1.0");
     catalog.addProperty("fixtureCount", 4);
     catalog.addProperty("complete", true);
-    catalog.addProperty("executionEvidenceStatus", "FIXTURES_DEFINED_BASELINES_PENDING");
+    catalog.addProperty("executionEvidenceStatus", "BASELINE_HARNESS_AVAILABLE_RESULTS_RUN_SPECIFIC");
     catalog.addProperty("evidenceDocument", "neqsim-mcp-server/docs/ACCEPTANCE_FIXTURES.md");
 
     JsonArray fixtures = new JsonArray();
@@ -58,7 +58,7 @@ public final class McpAcceptanceFixtureCatalog {
     catalog.add("fixtures", fixtures);
 
     catalog.addProperty("remainingPhase0Boundary",
-        "Execute and record runtime, memory, response size, tool-call count, convergence, balance closure, and report-usefulness baselines; then complete the campaign traceability and discipline-maturity matrices");
+        "Execute McpAcceptanceBaselineRunner on each exact head, close explicit numerical balance/report gaps where justified, then complete the campaign traceability and discipline-maturity matrices");
     return catalog;
   }
 

--- a/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
@@ -35,17 +35,18 @@ public final class McpEvidenceInventory {
    */
   public static JsonObject build() {
     JsonObject inventory = new JsonObject();
-    inventory.addProperty("inventoryVersion", "1.3");
+    inventory.addProperty("inventoryVersion", "1.4");
     inventory.add("tests", buildTests());
     inventory.add("guides", buildGuides());
     inventory.add("mergedFoundations", buildMergedFoundations());
     inventory.add("knownLimitations", buildKnownLimitations());
     inventory.add("acceptanceFixtures", McpAcceptanceFixtureCatalog.build());
+    inventory.add("acceptanceBaselineContract", McpAcceptanceBaselineRunner.describe());
     inventory.addProperty("advisoryBoundary",
         "Evidence discovery does not certify a calculation or replace qualified engineering review");
     inventory.addProperty("complete", false);
     inventory.addProperty("completionReason",
-        "Published surfaces, merged foundations, per-tool trust coverage, and four-scale acceptance fixtures are inventoried, but confirmed trust gaps, traceability/maturity matrices, and measured Phase 0 baselines remain incomplete");
+        "Published surfaces, merged foundations, per-tool trust coverage, four-scale fixtures, and the bounded baseline harness are inventoried, but confirmed trust gaps, traceability/maturity matrices, run-specific measurements, and explicit balance-evidence gaps remain incomplete");
     return inventory;
   }
 
@@ -75,6 +76,12 @@ public final class McpEvidenceInventory {
         "Tool parameters, schemas, examples, resources, and selected result contracts"));
     entries.add(guide("surface-inventory", "neqsim-mcp-server/docs/SURFACE_INVENTORY.md",
         "Exact protocol, implementation, equipment, reporting, and Phase 0 evidence inventory"));
+    entries.add(guide("foundation-traceability", "neqsim-mcp-server/docs/FOUNDATION_TRACEABILITY.md",
+        "Merged #2874, #2875, and #3152 capability evidence and remaining boundaries"));
+    entries.add(guide("acceptance-fixtures", "neqsim-mcp-server/docs/ACCEPTANCE_FIXTURES.md",
+        "Four public synthetic acceptance scales and canonical execution routes"));
+    entries.add(guide("acceptance-baselines", "neqsim-mcp-server/docs/ACCEPTANCE_BASELINES.md",
+        "Bounded exact-run measurements, interpretation limits, and explicit evidence gaps"));
     guides.addProperty("guideCount", entries.size());
     guides.add("entries", entries);
     return guides;

--- a/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
@@ -167,8 +167,8 @@ class CapabilitiesRunnerTest {
     assertEquals(94, tests.get("protocolScenarioCount").getAsInt());
 
     JsonObject guides = inventory.getAsJsonObject("guides");
-    assertEquals(4, guides.get("guideCount").getAsInt());
-    assertEquals(4, guides.getAsJsonArray("entries").size());
+    assertEquals(7, guides.get("guideCount").getAsInt());
+    assertEquals(7, guides.getAsJsonArray("entries").size());
 
     JsonObject limitations = inventory.getAsJsonObject("knownLimitations");
     assertEquals(71, limitations.get("publishedToolCount").getAsInt());

--- a/src/test/java/neqsim/mcp/runners/McpAcceptanceBaselineRunnerTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpAcceptanceBaselineRunnerTests.java
@@ -1,0 +1,61 @@
+package neqsim.mcp.runners;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+/** Tests the bounded Phase 0 acceptance-baseline harness. */
+class McpAcceptanceBaselineRunnerTests {
+
+  private static final Logger logger = LogManager.getLogger(McpAcceptanceBaselineRunnerTests.class);
+
+  @Test
+  void testContractIsDiscoverableWithoutExecutingFixtures() {
+    JsonObject contract = McpAcceptanceBaselineRunner.describe();
+    assertEquals(4, contract.get("fixtureCount").getAsInt());
+    assertEquals(2, contract.get("repeatRunCount").getAsInt());
+    assertEquals("ON_DEMAND_TEST_HARNESS", contract.get("executionMode").getAsString());
+    assertFalse(contract.get("performanceQualification").getAsBoolean());
+    assertFalse(contract.get("scientificValidationComplete").getAsBoolean());
+
+    JsonObject inventory = McpEvidenceInventory.build();
+    assertEquals("1.4", inventory.get("inventoryVersion").getAsString());
+    assertTrue(inventory.has("acceptanceBaselineContract"));
+    assertFalse(inventory.get("complete").getAsBoolean());
+  }
+
+  @Test
+  void testFourScaleExecutionRecordsBoundedEvidenceAndExplicitGaps() {
+    JsonObject baseline = McpAcceptanceBaselineRunner.run();
+    logger.info("MCP Phase 0 acceptance baseline: {}", baseline);
+
+    JsonArray measurements = baseline.getAsJsonArray("measurements");
+    JsonObject summary = baseline.getAsJsonObject("summary");
+    assertEquals(4, measurements.size());
+    assertEquals(8, summary.get("toolExecutionCount").getAsInt());
+    assertEquals(4, summary.get("successCount").getAsInt(), baseline.toString());
+    assertEquals(4, summary.get("convergedCount").getAsInt(), baseline.toString());
+    assertEquals(4, summary.get("deterministicCount").getAsInt(), baseline.toString());
+    assertTrue(summary.get("status").getAsString().startsWith("EXECUTION_COMPLETE"), baseline.toString());
+
+    for (com.google.gson.JsonElement element : measurements) {
+      JsonObject measurement = element.getAsJsonObject();
+      assertTrue(measurement.get("successful").getAsBoolean(), measurement.toString());
+      assertTrue(measurement.getAsJsonObject("runtime").get("firstRunMillis").getAsDouble() >= 0.0);
+      assertTrue(measurement.getAsJsonObject("payloadAndGuard").get("rawResponseBytes").getAsInt() > 0);
+      assertTrue(measurement.getAsJsonObject("payloadAndGuard").get("guardedWithinLimit").getAsBoolean(),
+          measurement.toString());
+      assertTrue(measurement.getAsJsonObject("convergence").get("declared").getAsBoolean(), measurement.toString());
+      assertTrue(measurement.getAsJsonObject("determinism").get("stableOutcomeMatch").getAsBoolean(),
+          measurement.toString());
+      assertFalse(measurement.getAsJsonObject("balanceEvidence").get("status").getAsString().trim().isEmpty());
+      assertEquals("NOT_ESTABLISHED_BY_PHASE0_EXECUTION_HARNESS",
+          measurement.get("scientificValidationStatus").getAsString());
+    }
+  }
+}

--- a/src/test/java/neqsim/mcp/runners/McpAcceptanceBaselineRunnerTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpAcceptanceBaselineRunnerTests.java
@@ -3,16 +3,12 @@ package neqsim.mcp.runners;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 /** Tests the bounded Phase 0 acceptance-baseline harness. */
 class McpAcceptanceBaselineRunnerTests {
-
-  private static final Logger logger = LogManager.getLogger(McpAcceptanceBaselineRunnerTests.class);
 
   @Test
   void testContractIsDiscoverableWithoutExecutingFixtures() {
@@ -32,7 +28,6 @@ class McpAcceptanceBaselineRunnerTests {
   @Test
   void testFourScaleExecutionRecordsBoundedEvidenceAndExplicitGaps() {
     JsonObject baseline = McpAcceptanceBaselineRunner.run();
-    logger.info("MCP Phase 0 acceptance baseline: {}", baseline);
 
     JsonArray measurements = baseline.getAsJsonArray("measurements");
     JsonObject summary = baseline.getAsJsonObject("summary");

--- a/src/test/java/neqsim/mcp/runners/McpAcceptanceFixtureCatalogTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpAcceptanceFixtureCatalogTests.java
@@ -18,7 +18,8 @@ class McpAcceptanceFixtureCatalogTests {
     JsonObject catalog = McpAcceptanceFixtureCatalog.build();
     assertTrue(catalog.get("complete").getAsBoolean());
     assertEquals(4, catalog.get("fixtureCount").getAsInt());
-    assertEquals("FIXTURES_DEFINED_BASELINES_PENDING", catalog.get("executionEvidenceStatus").getAsString());
+    assertEquals("BASELINE_HARNESS_AVAILABLE_RESULTS_RUN_SPECIFIC",
+        catalog.get("executionEvidenceStatus").getAsString());
 
     Set<String> scales = new HashSet<String>();
     for (com.google.gson.JsonElement element : catalog.getAsJsonArray("fixtures")) {

--- a/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
@@ -85,14 +85,22 @@ class McpEvidenceInventoryFoundationTests {
     JsonObject inventory = capabilities.getAsJsonObject("phase0EvidenceInventory");
     JsonObject fixtures = inventory.getAsJsonObject("acceptanceFixtures");
 
-    assertEquals("1.3", inventory.get("inventoryVersion").getAsString());
+    assertEquals("1.4", inventory.get("inventoryVersion").getAsString());
     assertEquals(4, fixtures.get("fixtureCount").getAsInt());
     assertTrue(fixtures.get("complete").getAsBoolean());
-    assertEquals("FIXTURES_DEFINED_BASELINES_PENDING", fixtures.get("executionEvidenceStatus").getAsString());
+    assertEquals("BASELINE_HARNESS_AVAILABLE_RESULTS_RUN_SPECIFIC",
+        fixtures.get("executionEvidenceStatus").getAsString());
     assertEquals(4, fixtures.getAsJsonArray("fixtures").size());
-    assertTrue(fixtures.get("remainingPhase0Boundary").getAsString().contains("runtime"));
+    assertTrue(fixtures.get("remainingPhase0Boundary").getAsString().contains("McpAcceptanceBaselineRunner"));
 
-    // Fixture definition is complete; measured baselines and campaign matrices are still open.
+    JsonObject baselineContract = inventory.getAsJsonObject("acceptanceBaselineContract");
+    assertEquals(4, baselineContract.get("fixtureCount").getAsInt());
+    assertEquals(2, baselineContract.get("repeatRunCount").getAsInt());
+    assertEquals("CONTRACT_DEFINED_EXACT_HEAD_EXECUTION_REQUIRED",
+        baselineContract.get("executionEvidenceStatus").getAsString());
+    assertFalse(baselineContract.get("performanceQualification").getAsBoolean());
+
+    // Fixture definitions and the harness contract are complete; run-specific evidence and matrices remain open.
     assertFalse(inventory.get("complete").getAsBoolean());
   }
 }


### PR DESCRIPTION
## Summary

Advances #3153 Phase 0 by adding the executable measurement harness for the four public synthetic acceptance fixtures merged in #3192.

- executes every fixture twice through the production `FlashRunner` or `ProcessRunner`; no MCP-only simulator or new public tool is introduced
- records environment-qualified wall/provenance time, JVM used-heap snapshots, raw and guarded UTF-8 payload sizes, convergence, warnings, deterministic stable-output fingerprints, structural report coverage, and explicit balance-evidence paths or gaps
- exposes only the bounded, non-qualifying measurement contract through `getCapabilities.phase0EvidenceInventory.acceptanceBaselineContract`; capability discovery never runs the 154-unit case
- reconciles the MCP guide inventory from four to seven current guides and extends Java plus real-protocol source coverage
- documents interpretation, advisory-only, scientific-validation, design-certification, plant-authority, and owner-roadmap boundaries

## Frozen scope and overlap boundary

This PR is Phase 0 evidence infrastructure only. It does not change thermodynamics, process or pipeline algorithms, facility ingestion, public MCP tool names, request/envelope contracts, live-plant integration, or optimization behavior.

- generic ProcessSystem/ProcessModel performance remains #2939-owned
- plant-wide optimization/constraint fidelity remains #3154-owned and reuses completed #2941
- dynamics remains #2911-owned
- flash/stability algorithms remain #2937-owned
- DEXPI/P&ID ingestion remains #2899-owned

The harness reports environment-specific observations, not portable performance thresholds. A successful process solve without explicitly named numeric mass/component/energy closure is recorded as `GAP_NO_NUMERIC_CLOSURE_IN_MCP_RESPONSE`; closure is never inferred.

## Exact base / head

- base: `59ec0afe3efeb1ced0a6aeec9bcb7c852b1d83b6`
- initial head: `7b872309bf80c13d5f523c7b256f5f332f77d7a0`
- current exact head: `57b446137b999278e68f75c3b858a7c451e7c4e5`
- branch was created directly from that current master head and is one ahead / zero behind
- no update-branch, master merge, rebase, cherry-pick, or force push was used

## Local validation

Passed on the final local tree:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py` — 659 Markdown + 1 standalone HTML page
- `python3 -m py_compile neqsim-mcp-server/test_mcp_server.py`
- `./mvnw -Dtest=McpAcceptanceBaselineRunnerTests,McpAcceptanceFixtureCatalogTests,McpEvidenceInventoryFoundationTests,CapabilitiesRunnerTest test` — 16 tests, 0 failures/errors/skips
- `./mvnw -f pomJava8.xml -DskipTests compile`
- `git diff --check`

The baseline harness executed all four fixtures twice inside the focused test: 4/4 successful, 4/4 explicitly converged, and 4/4 deterministic stable outcomes.

`pre-commit` is unavailable in the local runtime. Local Javadoc execution is infrastructure-blocked because `JAVA_HOME` is not valid for the Maven Javadoc plugin. Hosted exact-head JDK 21 CI is authoritative for those gates and broader validation.

### Exact-head documentation repair

At `57b446137b999278e68f75c3b858a7c451e7c4e5`, a documentation-only follow-up removes an inactive test-logger claim and states the evidence-retention boundary accurately: hosted CI supplies pass/fail execution evidence; a governed invoking workflow owns persistence of run-specific numeric observations. No harness behavior or public MCP contract changed.

Revalidated after that repair: Spotless apply/check, documentation search (659 Markdown + 1 standalone HTML), Python syntax, focused baseline/inventory tests (5 tests, 0 failures/errors/skips), and `git diff --check`.

**VALIDATION PENDING CI**

## Documentation impact

Added `neqsim-mcp-server/docs/ACCEPTANCE_BASELINES.md`; synchronized `ACCEPTANCE_FIXTURES.md` and `SURFACE_INVENTORY.md`. `README.md`, `API_REFERENCE.md`, and `MCP_CONTRACT.md` are unchanged because no public tool, input schema, stable request, or response envelope changed.

## Remaining Phase 0 dependency

After exact-head CI/review, use the harness evidence to close only defensible numerical balance/report gaps, then complete the campaign criterion traceability matrix and discipline-level capability/maturity matrix. Runtime optimization and plant optimization remain with their owner roadmaps.

Refs #3153