### PR TITLE
[AI-Assisted] docs(thermo): repair model selection guidance

### DIFF
--- a/docs/test_thermodynamic_models_documentation.py
+++ b/docs/test_thermodynamic_models_documentation.py
@@ -40,8 +40,8 @@ class ThermodynamicModelsDocumentationContractTest(unittest.TestCase):
         source_contracts = (
             'hasComponent("MDEA")',
             'hasComponent("water")',
-            'hasComponent("Na+")',
             'return setModel("Electrolyte-ScRK-EOS");',
+            'hasComponent("Na+")',
             'return setModel("Electrolyte-CPA-EOS-statoil");',
             'return setModel("CPAs-SRK-EOS-statoil");',
             'return setModel("SRK-TwuCoon-Statoil-EOS");',

--- a/docs/test_thermodynamic_models_documentation.py
+++ b/docs/test_thermodynamic_models_documentation.py
@@ -1,0 +1,93 @@
+import re
+import unittest
+from pathlib import Path
+
+
+DOCS_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = DOCS_DIR.parent
+GUIDE = DOCS_DIR / "thermo" / "thermodynamic_models.md"
+SYSTEM_SOURCE_DIR = (
+    REPOSITORY_ROOT / "src/main/java/neqsim/thermo/system"
+)
+SYSTEM_THERMO = SYSTEM_SOURCE_DIR / "SystemThermo.java"
+
+
+class ThermodynamicModelsDocumentationContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+        cls.system_thermo = SYSTEM_THERMO.read_text(encoding="utf-8")
+
+    def test_front_matter_is_complete_and_scoped(self):
+        front_matter = self.guide.split("---", 2)[1]
+        self.assertIn(
+            "Source-anchored guide to NeqSim thermodynamic model families",
+            front_matter,
+        )
+        self.assertNotIn("...", front_matter)
+        self.assertIn("not accuracy guarantees", self.guide)
+
+    def test_display_math_uses_compact_katex_delimiters(self):
+        blocks = re.findall(r"\$\$(.*?)\$\$", self.guide, flags=re.DOTALL)
+        self.assertEqual(23, len(blocks))
+        for block in blocks:
+            with self.subTest(equation=block[:40]):
+                self.assertTrue(block)
+                self.assertFalse(block[0].isspace())
+                self.assertFalse(block[-1].isspace())
+
+    def test_auto_selection_table_matches_source_order(self):
+        source_contracts = (
+            'hasComponent("MDEA")',
+            'hasComponent("water")',
+            'hasComponent("Na+")',
+            'return setModel("Electrolyte-ScRK-EOS");',
+            'return setModel("Electrolyte-CPA-EOS-statoil");',
+            'return setModel("CPAs-SRK-EOS-statoil");',
+            'return setModel("SRK-TwuCoon-Statoil-EOS");',
+            'return setModel("SRK-EOS");',
+        )
+        positions = []
+        for contract in source_contracts:
+            with self.subTest(source_contract=contract):
+                self.assertIn(contract, self.system_thermo)
+                positions.append(self.system_thermo.index(contract))
+        self.assertEqual(sorted(positions), positions)
+
+        documented_contracts = (
+            "callers must retain the returned object",
+            "current pure-water",
+            "returns `CPAs-SRK-EOS-statoil`, not `ScRK-EOS`",
+            "not a validation or model-ranking service",
+            "optimizedFluid.autoSelectMixingRule();",
+        )
+        for contract in documented_contracts:
+            with self.subTest(documented_contract=contract):
+                self.assertIn(contract, self.guide)
+
+    def test_nonexistent_generic_ionic_activity_call_is_not_an_example(self):
+        self.assertNotIn(
+            'getMeanIonicActivityCoefficient("Na+", "Cl-")',
+            self.guide,
+        )
+        self.assertIn(
+            "does not expose a general "
+            "`getMeanIonicActivityCoefficient(...)` method",
+            self.guide,
+        )
+
+    def test_documented_system_classes_exist(self):
+        documented_classes = set(
+            re.findall(r"`(System[A-Z][A-Za-z0-9]+)`", self.guide)
+        )
+        self.assertGreaterEqual(len(documented_classes), 50)
+        for class_name in documented_classes:
+            with self.subTest(class_name=class_name):
+                self.assertTrue(
+                    (SYSTEM_SOURCE_DIR / (class_name + ".java")).is_file(),
+                    "Missing source for documented class " + class_name,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/test_thermodynamic_models_documentation.py
+++ b/docs/test_thermodynamic_models_documentation.py
@@ -47,11 +47,18 @@ class ThermodynamicModelsDocumentationContractTest(unittest.TestCase):
             'return setModel("SRK-TwuCoon-Statoil-EOS");',
             'return setModel("SRK-EOS");',
         )
+        method_start = self.system_thermo.index(
+            "public SystemInterface autoSelectModel()"
+        )
+        method_end = self.system_thermo.index(
+            "/** {@inheritDoc} */", method_start + 1
+        )
+        auto_select_method = self.system_thermo[method_start:method_end]
         positions = []
         for contract in source_contracts:
             with self.subTest(source_contract=contract):
-                self.assertIn(contract, self.system_thermo)
-                positions.append(self.system_thermo.index(contract))
+                self.assertIn(contract, auto_select_method)
+                positions.append(auto_select_method.index(contract))
         self.assertEqual(sorted(positions), positions)
 
         documented_contracts = (

--- a/docs/thermo/thermodynamic_models.md
+++ b/docs/thermo/thermodynamic_models.md
@@ -1,6 +1,6 @@
 ---
 title: "Thermodynamic Models in NeqSim"
-description: "This document provides a comprehensive overview of the thermodynamic models available in NeqSim, their theoretical foundations, and practical guidance on when and how to use each model. Models are cla..."
+description: "Source-anchored guide to NeqSim thermodynamic model families, selection boundaries, mixing rules, and representative APIs."
 keywords: "thermodynamic model, SRK, Peng-Robinson, CPA, UMR-CPA, SystemUMRCPAEoS, TEG dehydration, GERG-2008, EOS-CG, UMR-PRU, electrolyte, cubic EOS, activity coefficient, NRTL, UNIFAC"
 ---
 
@@ -24,7 +24,7 @@ This document provides a comprehensive overview of the thermodynamic models avai
 
 ## 1. Introduction
 
-NeqSim (Non-Equilibrium Simulator) provides a rich library of thermodynamic models for simulating phase equilibria, physical properties, and process operations. Choosing the appropriate thermodynamic model is crucial for obtaining accurate results in process simulation.
+NeqSim (Non-Equilibrium Simulator) provides thermodynamic models for phase equilibria, physical properties, and process operations. Model choice must follow the components, phases, property targets, operating envelope, and available parameter validation; the tables below are starting points, not accuracy guarantees.
 
 ### General Workflow
 
@@ -67,9 +67,7 @@ fluid.init(0);
 
 Cubic equations of state express pressure as a function of temperature and molar volume in a cubic polynomial form:
 
-$$
-P = \frac{RT}{v - b} - \frac{a(T)}{(v + \epsilon b)(v + \sigma b)}
-$$
+$$P = \frac{RT}{v - b} - \frac{a(T)}{(v + \epsilon b)(v + \sigma b)}$$
 
 Where:
 - $P$ = pressure
@@ -82,9 +80,7 @@ Where:
 
 The energy parameter typically uses an alpha function:
 
-$$
-a(T) = a_c \cdot \alpha(T_r, \omega)
-$$
+$$a(T) = a_c \cdot \alpha(T_r, \omega)$$
 
 Where $T_r = T/T_c$ is the reduced temperature and $\omega$ is the acentric factor.
 
@@ -92,9 +88,7 @@ Where $T_r = T/T_c$ is the reduced temperature and $\omega$ is the acentric fact
 
 For SRK: $\epsilon = 0$, $\sigma = 1$
 
-$$
-P = \frac{RT}{v - b} - \frac{a(T)}{v(v + b)}
-$$
+$$P = \frac{RT}{v - b} - \frac{a(T)}{v(v + b)}$$
 
 | Class | Description | Best For |
 |-------|-------------|----------|
@@ -118,9 +112,7 @@ fluid.setMixingRule("classic");
 
 For PR: $\epsilon = 1 - \sqrt{2}$, $\sigma = 1 + \sqrt{2}$
 
-$$
-P = \frac{RT}{v - b} - \frac{a(T)}{v(v + b) + b(v - b)}
-$$
+$$P = \frac{RT}{v - b} - \frac{a(T)}{v(v + b) + b(v - b)}$$
 
 | Class | Description | Best For |
 |-------|-------------|----------|
@@ -157,15 +149,11 @@ fluid.setMixingRule("classic");
 
 CPA (Cubic Plus Association) extends cubic EoS to handle hydrogen bonding in polar molecules like water, alcohols, and glycols. The pressure is expressed as:
 
-$$
-P = P_{\text{cubic}} + P_{\text{association}}
-$$
+$$P = P_{\text{cubic}} + P_{\text{association}}$$
 
 The association term accounts for hydrogen bonding:
 
-$$
-P_{\text{association}} = -\frac{1}{2} RT \rho \sum_i x_i \sum_{A_i} \left( 1 - X_{A_i} \right) \frac{\partial \ln g}{\partial v}
-$$
+$$P_{\text{association}} = -\frac{1}{2} RT \rho \sum_i x_i \sum_{A_i} \left( 1 - X_{A_i} \right) \frac{\partial \ln g}{\partial v}$$
 
 Where:
 - $X_{A_i}$ = fraction of site A on molecule $i$ not bonded to other active sites
@@ -174,9 +162,7 @@ Where:
 
 The non-bonded site fraction $X_{A_i}$ is determined by solving:
 
-$$
-X_{A_i} = \frac{1}{1 + \rho \sum_j x_j \sum_{B_j} X_{B_j} \Delta^{A_i B_j}}
-$$
+$$X_{A_i} = \frac{1}{1 + \rho \sum_j x_j \sum_{B_j} X_{B_j} \Delta^{A_i B_j}}$$
 
 Where $\Delta^{A_i B_j}$ is the association strength between site A on molecule $i$ and site B on molecule $j$.
 
@@ -236,9 +222,7 @@ in a single equation of state:
 
 The pressure is the sum of a physical and an association contribution:
 
-$$
-P = P_{\text{PR}}(\text{UMR mixing, MC alpha}) + P_{\text{association}}(\text{CPA})
-$$
+$$P = P_{\text{PR}}(\text{UMR mixing, MC alpha}) + P_{\text{association}}(\text{CPA})$$
 
 A key design principle is the **division of labour** between the terms:
 hydrogen bonding is captured by the **CPA association** term (not by dedicated
@@ -324,9 +308,7 @@ to molecular type:
 
 Reference equations of state are explicit in the dimensionless Helmholtz free energy $\alpha$:
 
-$$
-\alpha(\delta, \tau, \bar{x}) = \frac{a(\rho, T, \bar{x})}{RT} = \alpha^0(\delta, \tau, \bar{x}) + \alpha^r(\delta, \tau, \bar{x})
-$$
+$$\alpha(\delta, \tau, \bar{x}) = \frac{a(\rho, T, \bar{x})}{RT} = \alpha^0(\delta, \tau, \bar{x}) + \alpha^r(\delta, \tau, \bar{x})$$
 
 Where:
 - $\delta = \rho / \rho_r$ = reduced density
@@ -336,9 +318,7 @@ Where:
 
 The residual contribution is fitted to high-accuracy experimental data:
 
-$$
-\alpha^r(\delta, \tau, \bar{x}) = \sum_{i=1}^{N} x_i \alpha_{0i}^r(\delta, \tau) + \sum_{i=1}^{N-1} \sum_{j=i+1}^{N} x_i x_j F_{ij} \alpha_{ij}^r(\delta, \tau)
-$$
+$$\alpha^r(\delta, \tau, \bar{x}) = \sum_{i=1}^{N} x_i \alpha_{0i}^r(\delta, \tau) + \sum_{i=1}^{N-1} \sum_{j=i+1}^{N} x_i x_j F_{ij} \alpha_{ij}^r(\delta, \tau)$$
 
 These models provide superior accuracy for density, speed of sound, and heat capacity compared to cubic EoS.
 
@@ -422,9 +402,7 @@ double density = fluid.getPhase(0).getDensity_EOSCG();
 
 Activity coefficient models describe non-ideal liquid behavior through the excess Gibbs energy:
 
-$$
-G^E = RT \sum_i x_i \ln \gamma_i
-$$
+$$G^E = RT \sum_i x_i \ln \gamma_i$$
 
 Where $\gamma_i$ is the activity coefficient of component $i$.
 
@@ -432,9 +410,7 @@ Where $\gamma_i$ is the activity coefficient of component $i$.
 
 Group contribution method that predicts activity coefficients from molecular group interactions:
 
-$$
-\ln \gamma_i = \ln \gamma_i^C + \ln \gamma_i^R
-$$
+$$\ln \gamma_i = \ln \gamma_i^C + \ln \gamma_i^R$$
 
 Where the combinatorial ($C$) and residual ($R$) contributions are calculated from group properties.
 
@@ -450,9 +426,7 @@ fluid.addComponent("water", 0.7);
 
 Local composition model with binary interaction parameters:
 
-$$
-\ln \gamma_i = \frac{\sum_j x_j \tau_{ji} G_{ji}}{\sum_k x_k G_{ki}} + \sum_j \frac{x_j G_{ij}}{\sum_k x_k G_{kj}} \left( \tau_{ij} - \frac{\sum_m x_m \tau_{mj} G_{mj}}{\sum_k x_k G_{kj}} \right)
-$$
+$$\ln \gamma_i = \frac{\sum_j x_j \tau_{ji} G_{ji}}{\sum_k x_k G_{ki}} + \sum_j \frac{x_j G_{ij}}{\sum_k x_k G_{kj}} \left( \tau_{ij} - \frac{\sum_m x_m \tau_{mj} G_{mj}}{\sum_k x_k G_{kj}} \right)$$
 
 ```java
 import neqsim.thermo.system.SystemNRTL;
@@ -479,15 +453,11 @@ fluid.addComponent("water", 0.6);
 
 Electrolyte models extend CPA with electrostatic contributions for aqueous salt solutions:
 
-$$
-A^{res} = A^{CPA} + A^{elec}
-$$
+$$A^{res} = A^{CPA} + A^{elec}$$
 
 The electrostatic contribution typically includes:
 
-$$
-A^{elec} = A^{MSA} + A^{Born} + A^{SR}
-$$
+$$A^{elec} = A^{MSA} + A^{Born} + A^{SR}$$
 
 Where:
 - $A^{MSA}$ = Mean Spherical Approximation (ion-ion screening)
@@ -496,9 +466,7 @@ Where:
 
 **Born Solvation Term:**
 
-$$
-\frac{A^{Born}}{RT} = -\frac{e^2 N_A}{8\pi\varepsilon_0 k_B T} \sum_i n_i \frac{z_i^2}{\sigma_i} \left(1 - \frac{1}{\varepsilon_r}\right)
-$$
+$$\frac{A^{Born}}{RT} = -\frac{e^2 N_A}{8\pi\varepsilon_0 k_B T} \sum_i n_i \frac{z_i^2}{\sigma_i} \left(1 - \frac{1}{\varepsilon_r}\right)$$
 
 ### 7.2 Electrolyte-CPA (Equinor)
 
@@ -517,10 +485,9 @@ system.setMixingRule(10);  // Required for electrolyte CPA
 
 ThermodynamicOperations ops = new ThermodynamicOperations(system);
 ops.TPflash();
-
-// Access activity coefficients
-double meanGamma = system.getPhase(0).getMeanIonicActivityCoefficient("Na+", "Cl-");
 ```
+
+`PhaseInterface` does not expose a general `getMeanIonicActivityCoefficient(...)` method. Activity and osmotic-coefficient access is model-specific; use the APIs and parameter-coverage checks documented in [Electrolyte CPA Model](ElectrolyteCPAModel.md) and [Pitzer Parameter Provenance and Coverage](pitzer_parameter_provenance.md).
 
 ### 7.3 Søreide-Whitson Model
 
@@ -530,15 +497,11 @@ The Søreide-Whitson model is a modified Peng-Robinson equation of state specifi
 
 The key innovation is a modified alpha function for water that incorporates salinity:
 
-$$
-\alpha = A^2
-$$
+$$\alpha = A^2$$
 
 where:
 
-$$
-A(T_r, c_s) = 1.0 + 0.453 \left[ 1.0 - T_r \left( 1.0 - 0.0103 \cdot c_s^{1.1} \right) \right] + 0.0034 \left( T_r^{-3} - 1.0 \right)
-$$
+$$A(T_r, c_s) = 1.0 + 0.453 \left[ 1.0 - T_r \left( 1.0 - 0.0103 \cdot c_s^{1.1} \right) \right] + 0.0034 \left( T_r^{-3} - 1.0 \right)$$
 
 - $T_r = T / T_c$ is the reduced temperature
 - $c_s$ is the salinity expressed as equivalent NaCl molality (mol/kg H₂O)
@@ -595,19 +558,13 @@ Mixing rules determine how pure-component parameters are combined for mixtures. 
 
 **van der Waals One-Fluid Mixing Rule:**
 
-$$
-a_{mix} = \sum_i \sum_j x_i x_j a_{ij}
-$$
+$$a_{mix} = \sum_i \sum_j x_i x_j a_{ij}$$
 
-$$
-b_{mix} = \sum_i x_i b_i
-$$
+$$b_{mix} = \sum_i x_i b_i$$
 
 With combining rule:
 
-$$
-a_{ij} = \sqrt{a_i a_j}(1 - k_{ij})
-$$
+$$a_{ij} = \sqrt{a_i a_j}(1 - k_{ij})$$
 
 | Type | Name | Description |
 |------|------|-------------|
@@ -620,9 +577,7 @@ $$
 
 Combines cubic EoS with activity coefficient models at infinite pressure:
 
-$$
-a_{mix} = b_{mix} \left( \sum_i x_i \frac{a_i}{b_i} - \frac{G^E}{\Lambda} \right)
-$$
+$$a_{mix} = b_{mix} \left( \sum_i x_i \frac{a_i}{b_i} - \frac{G^E}{\Lambda} \right)$$
 
 Where $\Lambda \approx 0.693$ for SRK.
 
@@ -642,9 +597,7 @@ fluid.setMixingRule("HV", "NRTL");
 
 Matches both second virial coefficient and excess Gibbs energy:
 
-$$
-b_{mix} = \frac{\sum_i \sum_j x_i x_j \left( b - \frac{a}{RT} \right)_{ij}}{1 - \frac{A_\infty^E}{CRT} - \sum_i x_i \frac{a_i}{RTb_i}}
-$$
+$$b_{mix} = \frac{\sum_i \sum_j x_i x_j \left( b - \frac{a}{RT} \right)_{ij}}{1 - \frac{A_\infty^E}{CRT} - \sum_i x_i \frac{a_i}{RTb_i}}$$
 
 | Type | Name | Description |
 |------|------|-------------|
@@ -729,49 +682,26 @@ has units of kelvin because the implementation divides it by absolute temperatur
 
 NeqSim provides an `autoSelectModel()` method that automatically chooses an appropriate thermodynamic model based on the components in your fluid. This is useful for quick setups or when you're unsure which model to use.
 
-### 9.2 Auto-Selection Logic
+### 9.2 Current Source Behavior
 
-The `autoSelectModel()` method follows this decision tree:
+The heuristic is implemented by `SystemThermo.autoSelectModel()`. It returns a model-converted
+`SystemInterface`, so callers must retain the returned object. The current decision order is:
 
-```java
-public SystemInterface autoSelectModel() {
-    if (hasComponent("MDEA") && hasComponent("water") && hasComponent("CO2")) {
-        return setModel("Electrolyte-ScRK-EOS");  // Amine systems
-    }
-    else if (hasComponent("water") || hasComponent("methanol") ||
-             hasComponent("MEG") || hasComponent("TEG") ||
-             hasComponent("ethanol") || hasComponent("DEG")) {
-        if (hasComponent("Na+") || hasComponent("K+") ||
-            hasComponent("Br-") || hasComponent("Mg++") ||
-            hasComponent("Cl-") || hasComponent("Ca++") ||
-            hasComponent("Fe++") || hasComponent("SO4--")) {
-            return setModel("Electrolyte-CPA-EOS-statoil");  // Electrolytes
-        } else {
-            return setModel("CPAs-SRK-EOS-statoil");  // Polar/associating
-        }
-    }
-    else if (hasComponent("water")) {
-        return setModel("ScRK-EOS");  // Water present
-    }
-    else if (hasComponent("mercury")) {
-        return setModel("SRK-TwuCoon-Statoil-EOS");  // Mercury
-    }
-    else {
-        return setModel("SRK-EOS");  // Default: standard SRK
-    }
-}
-```
+| First matching condition | Returned model |
+|--------------------------|----------------|
+| MDEA + water + CO₂ | `Electrolyte-ScRK-EOS` |
+| Any of water, methanol, MEG, TEG, ethanol, or DEG, plus a recognized ion | `Electrolyte-CPA-EOS-statoil` |
+| Any of water, methanol, MEG, TEG, ethanol, or DEG, without a recognized ion | `CPAs-SRK-EOS-statoil` |
+| Mercury, with none of the earlier associating components | `SRK-TwuCoon-Statoil-EOS` |
+| Otherwise | `SRK-EOS` |
 
-### 9.3 Model Selection Summary
+The source contains a later pure-water `ScRK-EOS` branch, but it is unreachable because water
+already matches the preceding associating-component condition. Consequently, current pure-water
+auto-selection returns `CPAs-SRK-EOS-statoil`, not `ScRK-EOS`.
 
-| Components Present | Selected Model |
-|-------------------|----------------|
-| MDEA + water + CO2 | Electrolyte-ScRK-EOS |
-| Water/glycols + ions | Electrolyte-CPA-EOS-statoil |
-| Water/glycols (no ions) | CPAs-SRK-EOS-statoil |
-| Only water (no glycols) | ScRK-EOS |
-| Mercury | SRK-TwuCoon-Statoil-EOS |
-| Default (hydrocarbons only) | SRK-EOS |
+This is a convenience heuristic, not a validation or model-ranking service. It does not inspect
+property targets, operating range, binary-parameter coverage, or uncertainty. For engineering
+work, make the model choice explicit and validate it against relevant data.
 
 ### 9.4 Usage
 
@@ -790,13 +720,14 @@ gas.addComponent("water", 0.15);
 gas.addComponent("MEG", 0.05);
 gas.createDatabase(true);
 
-// Auto-select will switch to CPA model
+// Retain the returned model-converted system.
 SystemInterface optimizedFluid = gas.autoSelectModel();
+optimizedFluid.autoSelectMixingRule();
 ```
 
 ### 9.5 Auto-Select Mixing Rule
 
-There is also an `autoSelectMixingRule()` method that selects an appropriate mixing rule based on the model type:
+There is also an `autoSelectMixingRule()` method. It mutates the selected system and uses model-name/component checks; it does not validate parameter coverage:
 
 ```java
 fluid.autoSelectMixingRule();  // Automatically sets appropriate mixing rule
@@ -949,4 +880,3 @@ fluid.autoSelectMixingRule();  // Automatically sets appropriate mixing rule
 
 ---
 
-*Last updated: February 2026*


### PR DESCRIPTION
## Summary

Advances documentation campaign #2499 with D083, a frozen thermodynamic-model selection and rendering batch.

- repairs the truncated front-matter description and removes the stale manual update date
- converts all 23 display equations to the repository's compact KaTeX delimiter form
- removes a nonexistent `PhaseInterface.getMeanIonicActivityCoefficient(...)` call and points readers to model-specific electrolyte guidance
- replaces the copied `autoSelectModel()` implementation with a source-anchored decision table
- documents the currently unreachable pure-water `ScRK-EOS` branch and the need to retain the returned converted system
- qualifies model-selection tables as starting points rather than accuracy guarantees
- adds focused contracts for front matter, equation rendering, exact source-order behavior, invalid API regression, and all 56 documented `System*` classes

## Frozen scope

Exactly two files:

- `docs/thermo/thermodynamic_models.md`
- `docs/test_thermodynamic_models_documentation.py`

This batch does not touch production code, the active Pitzer/electrolyte campaign files, notebooks, or Huldra work.

## Validation

Exact-head validation at `47238c7cf0155434378c47e1b3fe2bfe13a94f81`:

- all five GitHub workflows passed: build/tests/Javadocs, documentation/Jekyll/search, pre-commit, Spotless, and CodeQL
- 23/23 display equations have non-whitespace content immediately inside `$$...$$`
- the invalid ionic-activity call is absent
- the documented auto-selection order matches `SystemThermo.autoSelectModel()`
- all 56 backticked `System*` class references resolve to current source files
- branch is 4 commits ahead and 0 behind `master`
- diff is limited to the two frozen files
- PR is mergeable and has no comments, reviews, or unresolved threads

Local validation was not run; the completed GitHub workflows are the authoritative validator.

## Review notes

The source itself still contains an unreachable pure-water branch; this PR documents current behavior and does not make a production-code architecture decision.

Closes no issue.