### PR TITLE
[AI-Assisted] test(optimization): make S/M baseline reproducible

### DIFF
--- a/.github/workflows/devtools_tests.yml
+++ b/.github/workflows/devtools_tests.yml
@@ -37,6 +37,7 @@ jobs:
           python -m pytest -q \
             devtools/test_agent_search.py \
             devtools/test_check_documentation_search.py \
+            devtools/test_industrial_sm_benchmark.py \
             devtools/test_skill_search.py \
             devtools/test_verify_agent_skill_refs.py \
             devtools/test_report_workflow.py \

--- a/devtools/industrial_sm_benchmark.py
+++ b/devtools/industrial_sm_benchmark.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Run, aggregate, and validate the industrial S/M optimization benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import math
+import statistics
+import subprocess
+import sys
+import time
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
+
+
+ROOT = Path(__file__).resolve().parent.parent
+RAW_SCHEMA_VERSION = "1.0"
+AGGREGATE_SCHEMA_VERSION = "2.0"
+GENERATOR = "devtools/industrial_sm_benchmark.py"
+TEST_CLASS = "neqsim.process.util.optimizer.IndustrialPlantOptimizationBaselineTest"
+SUCCESS_MODES = {
+    "S": ["cold", "unchanged", "nearby-state", "constraint-change"],
+    "M": [
+        "cold",
+        "unchanged",
+        "unchanged",
+        "unchanged",
+        "unchanged",
+        "unchanged",
+        "nearby-state",
+        "constraint-change",
+        "discrete-line-up",
+        "restored-line-up",
+    ],
+}
+
+
+class BenchmarkValidationError(ValueError):
+    """Raised when benchmark evidence violates the frozen contract."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise BenchmarkValidationError(message)
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    def reject_constant(value: str) -> None:
+        raise BenchmarkValidationError(f"{path}: non-finite JSON token {value}")
+
+    with path.open(encoding="utf-8") as stream:
+        value = json.load(stream, parse_constant=reject_constant)
+    _require(isinstance(value, dict), f"{path}: root must be an object")
+    return value
+
+
+def _finite_number(value: Any, label: str) -> float:
+    _require(
+        isinstance(value, (int, float)) and not isinstance(value, bool),
+        f"{label} must be numeric",
+    )
+    number = float(value)
+    _require(math.isfinite(number), f"{label} must be finite")
+    return number
+
+
+def _case_map(report: Mapping[str, Any], label: str) -> Dict[str, Mapping[str, Any]]:
+    cases = report.get("cases")
+    _require(isinstance(cases, list), f"{label}.cases must be an array")
+    result: Dict[str, Mapping[str, Any]] = {}
+    for case in cases:
+        _require(isinstance(case, dict), f"{label}.cases entries must be objects")
+        case_id = case.get("caseId")
+        _require(case_id in {"S", "M"}, f"{label}: unexpected caseId {case_id!r}")
+        _require(case_id not in result, f"{label}: duplicate caseId {case_id}")
+        result[str(case_id)] = case
+    _require(set(result) == {"S", "M"}, f"{label}: cases must be exactly S and M")
+    return result
+
+
+def _validate_success_mode(mode: Mapping[str, Any], label: str) -> None:
+    _require(mode.get("outcome") == "SUCCESS", f"{label}.outcome must be SUCCESS")
+    _require(mode.get("processSolved") is True, f"{label}.processSolved must be true")
+    _finite_number(mode.get("elapsedMs"), f"{label}.elapsedMs")
+    _finite_number(mode.get("feedMassRateKgPerHr"), f"{label}.feedMassRateKgPerHr")
+    _finite_number(mode.get("productMassRateKgPerHr"), f"{label}.productMassRateKgPerHr")
+
+    execution = mode.get("executionWork")
+    _require(isinstance(execution, dict), f"{label}.executionWork must be an object")
+    calls = _finite_number(execution.get("equipmentCalls"), f"{label}.executionWork.equipmentCalls")
+    _require(calls >= 0.0, f"{label}.executionWork.equipmentCalls must be non-negative")
+    equipment = execution.get("equipment")
+    _require(isinstance(equipment, dict) and equipment, f"{label}.executionWork.equipment is required")
+    for name, observation in equipment.items():
+        _require(isinstance(observation, dict), f"{label}.executionWork.equipment.{name} must be an object")
+        _finite_number(observation.get("elapsedMs"), f"{label}.executionWork.equipment.{name}.elapsedMs")
+        _finite_number(observation.get("calls"), f"{label}.executionWork.equipment.{name}.calls")
+    for unavailable_name in ("areaRuns", "flashAndPropertyWork"):
+        unavailable = execution.get(unavailable_name)
+        _require(
+            isinstance(unavailable, dict) and unavailable.get("status") == "UNAVAILABLE" and unavailable.get("reason"),
+            f"{label}.executionWork.{unavailable_name} must explain unavailability",
+        )
+
+    mass_balance = mode.get("massBalance")
+    _require(isinstance(mass_balance, dict), f"{label}.massBalance must be an object")
+    residual = _finite_number(mass_balance.get("maximumAbsoluteError"), f"{label}.massBalance.maximumAbsoluteError")
+    _require(residual <= 0.1, f"{label}: mass residual {residual} kg/hr exceeds 0.1 kg/hr")
+    _require(mass_balance.get("unit") == "kg/hr", f"{label}.massBalance.unit must be kg/hr")
+
+    bottleneck = mode.get("bottleneck")
+    _require(isinstance(bottleneck, dict), f"{label}.bottleneck must be an object")
+    _require(bottleneck.get("status") == "AVAILABLE", f"{label}.bottleneck must be available")
+    _require(bottleneck.get("finiteEvidence") is True, f"{label}.bottleneck evidence must be finite")
+    _finite_number(bottleneck.get("utilization"), f"{label}.bottleneck.utilization")
+    for required in ("equipment", "constraint", "unit", "type", "severity", "provenance"):
+        _require(required in bottleneck, f"{label}.bottleneck.{required} is required")
+
+    run_status = mode.get("runStatus")
+    _require(isinstance(run_status, dict), f"{label}.runStatus must be an object")
+    _require(run_status.get("completed") is True, f"{label}.runStatus.completed must be true")
+    _require(run_status.get("success") is True, f"{label}.runStatus.success must be true")
+    _require(
+        _finite_number(mode.get("serializedObservationBytes"), f"{label}.serializedObservationBytes") > 0.0,
+        f"{label}.serializedObservationBytes must be positive",
+    )
+    _require(
+        mode.get("utilizationSnapshotSchemaVersion") == RAW_SCHEMA_VERSION,
+        f"{label}.utilizationSnapshotSchemaVersion must be {RAW_SCHEMA_VERSION}",
+    )
+
+
+def validate_raw_report(report: Mapping[str, Any], baseline_commit: str, label: str) -> None:
+    """Validate one exact harness report against the frozen S/M contract."""
+
+    _require(report.get("schemaVersion") == RAW_SCHEMA_VERSION, f"{label}: raw schema must be {RAW_SCHEMA_VERSION}")
+    _require(report.get("neqsimCommit") == baseline_commit, f"{label}: baseline commit mismatch")
+    _require(isinstance(report.get("environment"), dict), f"{label}.environment must be an object")
+    _require(
+        isinstance(report.get("measurementCoverage"), dict),
+        f"{label}.measurementCoverage must be an object",
+    )
+
+    cases = _case_map(report, label)
+    _require(cases["S"].get("unitCount") == 3, f"{label}: case S must have 3 units")
+    medium_units = _finite_number(cases["M"].get("unitCount"), f"{label}.M.unitCount")
+    _require(25.0 <= medium_units <= 50.0, f"{label}: case M must have 25-50 units")
+    _require(cases["M"].get("recycleCount", 0) >= 1, f"{label}: case M must contain a recycle")
+
+    for case_id, expected_modes in SUCCESS_MODES.items():
+        modes = cases[case_id].get("modes")
+        _require(isinstance(modes, list), f"{label}.{case_id}.modes must be an array")
+        successful = [mode for mode in modes if mode.get("mode") != "invalid-candidate"]
+        _require(
+            [mode.get("mode") for mode in successful] == expected_modes,
+            f"{label}.{case_id}: mode sequence does not match the frozen matrix",
+        )
+        for index, mode in enumerate(successful):
+            _require(isinstance(mode, dict), f"{label}.{case_id}.modes[{index}] must be an object")
+            _validate_success_mode(mode, f"{label}.{case_id}.{mode.get('mode')}[{index}]")
+
+    small_modes = cases["S"]["modes"]
+    invalid = [mode for mode in small_modes if mode.get("mode") == "invalid-candidate"]
+    _require(len(invalid) == 1, f"{label}.S must contain one invalid-candidate record")
+    _require(invalid[0].get("outcome") == "REJECTED_BEFORE_MUTATION", f"{label}.S invalid candidate must fail closed")
+    _require(invalid[0].get("finiteEvidence") is False, f"{label}.S invalid candidate must record non-finite evidence")
+    _require(
+        invalid[0].get("restoration") == "NOT_REQUIRED_STATE_UNCHANGED",
+        f"{label}.S invalid candidate must preserve live state",
+    )
+    _require(invalid[0].get("rejectionReason"), f"{label}.S invalid candidate needs a rejection reason")
+
+    restored = [mode for mode in cases["M"]["modes"] if mode.get("mode") == "restored-line-up"]
+    _require(len(restored) == 1, f"{label}.M must contain one restored-line-up record")
+    restoration_difference = _finite_number(
+        restored[0].get("repeatabilityAbsoluteDifferenceKgPerHr"),
+        f"{label}.M.restored-line-up.repeatabilityAbsoluteDifferenceKgPerHr",
+    )
+    _require(restoration_difference <= 0.1, f"{label}.M restoration exceeds 0.1 kg/hr")
+    _require(restored[0].get("restoration") == "FULL_REPLAY_COMPLETED", f"{label}.M restoration must be complete")
+
+
+def _successful_modes(report: Mapping[str, Any], case_id: str) -> List[Mapping[str, Any]]:
+    case = _case_map(report, "report")[case_id]
+    return [mode for mode in case["modes"] if mode.get("mode") != "invalid-candidate"]
+
+
+def _mode_values(reports: Sequence[Mapping[str, Any]], case_id: str, mode_name: str, field: str) -> List[float]:
+    values: List[float] = []
+    for report in reports:
+        for mode in _successful_modes(report, case_id):
+            if mode.get("mode") == mode_name:
+                values.append(_finite_number(mode.get(field), f"{case_id}.{mode_name}.{field}"))
+    return values
+
+
+def _summary(values: Sequence[float]) -> Dict[str, Any]:
+    _require(bool(values), "cannot summarize an empty sample")
+    median = float(statistics.median(values))
+    deviations = [abs(value - median) for value in values]
+    return {
+        "sampleCount": len(values),
+        "median": median,
+        "medianAbsoluteDeviation": float(statistics.median(deviations)),
+        "minimum": min(values),
+        "maximum": max(values),
+    }
+
+
+def _identity_sequence(report: Mapping[str, Any]) -> List[Tuple[str, str, int, str]]:
+    sequence: List[Tuple[str, str, int, str]] = []
+    for case_id in ("S", "M"):
+        for mode in _successful_modes(report, case_id):
+            sequence.append(
+                (
+                    case_id,
+                    str(mode["mode"]),
+                    int(mode["repetition"]),
+                    str(mode["calculationIdentity"]),
+                )
+            )
+    return sequence
+
+
+def build_aggregate(
+    reports: Sequence[Mapping[str, Any]],
+    wall_times_ms: Sequence[float],
+    baseline_commit: str,
+    generated_date: str,
+) -> Dict[str, Any]:
+    """Build deterministic aggregate evidence while preserving each raw report verbatim."""
+
+    _require(len(reports) == len(wall_times_ms), "report and wall-time counts differ")
+    _require(len(reports) >= 5, "at least five independent forks are required")
+    for index, report in enumerate(reports, start=1):
+        validate_raw_report(report, baseline_commit, f"fork-{index}")
+    finite_wall_times = [_finite_number(value, f"fork-{index}.wallTimeMs") for index, value in enumerate(wall_times_ms, 1)]
+    _require(all(value > 0.0 for value in finite_wall_times), "wall times must be positive")
+
+    expected_identities = _identity_sequence(reports[0])
+    for index, report in enumerate(reports[1:], start=2):
+        _require(
+            _identity_sequence(report) == expected_identities,
+            f"fork-{index}: deterministic calculation identities changed",
+        )
+
+    small_unchanged = _mode_values(reports, "S", "unchanged", "repeatabilityAbsoluteDifferenceKgPerHr")
+    medium_unchanged = _mode_values(reports, "M", "unchanged", "repeatabilityAbsoluteDifferenceKgPerHr")
+    restoration = _mode_values(reports, "M", "restored-line-up", "repeatabilityAbsoluteDifferenceKgPerHr")
+    medium_modes = [mode for report in reports for mode in _successful_modes(report, "M")]
+    medium_residuals = [
+        _finite_number(mode["massBalance"]["maximumAbsoluteError"], "M.massBalance.maximumAbsoluteError")
+        for mode in medium_modes
+    ]
+    medium_sizes = [
+        _finite_number(mode["serializedObservationBytes"], "M.serializedObservationBytes")
+        for mode in medium_modes
+    ]
+    equipment_calls = [
+        _finite_number(mode["executionWork"]["equipmentCalls"], "executionWork.equipmentCalls")
+        for report in reports
+        for case_id in ("S", "M")
+        for mode in _successful_modes(report, case_id)
+    ]
+
+    forks: List[Dict[str, Any]] = []
+    for index, (report, wall_time) in enumerate(zip(reports, finite_wall_times), start=1):
+        raw_copy = copy.deepcopy(report)
+        canonical_payload = json.dumps(
+            raw_copy, allow_nan=False, separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+        forks.append(
+            {
+                "fork": index,
+                "externalWallTimeMs": wall_time,
+                "canonicalRawReportBytes": len(canonical_payload),
+                "canonicalRawReportSha256": hashlib.sha256(canonical_payload).hexdigest(),
+                "rawReport": raw_copy,
+            }
+        )
+
+    return {
+        "schemaVersion": AGGREGATE_SCHEMA_VERSION,
+        "evidenceKind": "industrial-process-optimization-SM-five-fork-baseline",
+        "baselineCommit": baseline_commit,
+        "generatedDate": generated_date,
+        "aggregation": {
+            "generator": GENERATOR,
+            "rawReportSchemaVersion": RAW_SCHEMA_VERSION,
+            "forkCount": len(reports),
+            "rawReportsPreserved": True,
+            "validationStatus": "PASS",
+        },
+        "externalWallTimeMs": finite_wall_times,
+        "statistics": {
+            "externalWallTimeMs": _summary(finite_wall_times),
+            "smallColdElapsedMs": _summary(_mode_values(reports, "S", "cold", "elapsedMs")),
+            "smallUnchangedElapsedMs": _summary(_mode_values(reports, "S", "unchanged", "elapsedMs")),
+            "mediumColdElapsedMs": _summary(_mode_values(reports, "M", "cold", "elapsedMs")),
+            "mediumUnchangedElapsedMs": _summary(_mode_values(reports, "M", "unchanged", "elapsedMs")),
+            "smallUnchangedDifferenceKgPerHr": _summary(small_unchanged),
+            "mediumUnchangedDifferenceKgPerHr": _summary(medium_unchanged),
+            "mediumRestorationDifferenceKgPerHr": _summary(restoration),
+            "mediumMaximumUnitMassResidualKgPerHr": _summary(medium_residuals),
+            "mediumSerializedObservationBytes": _summary(medium_sizes),
+            "successfulModeEquipmentCalls": _summary(equipment_calls),
+        },
+        "acceptance": {
+            "allForksValidated": True,
+            "successfulModeCount": len(equipment_calls),
+            "invalidCandidateCount": len(reports),
+            "allUnchangedProductDifferencesAtMostKgPerHr": 0.1,
+            "allMassResidualsAtMostKgPerHr": 0.1,
+            "allRestorationDifferencesAtMostKgPerHr": 0.1,
+        },
+        "forks": forks,
+    }
+
+
+def validate_aggregate(aggregate: Mapping[str, Any]) -> None:
+    """Validate an aggregate and prove its summary is derived from preserved raw reports."""
+
+    _require(aggregate.get("schemaVersion") == AGGREGATE_SCHEMA_VERSION, "aggregate schema mismatch")
+    baseline_commit = aggregate.get("baselineCommit")
+    generated_date = aggregate.get("generatedDate")
+    _require(isinstance(baseline_commit, str) and baseline_commit, "aggregate baselineCommit is required")
+    _require(isinstance(generated_date, str) and generated_date, "aggregate generatedDate is required")
+    forks = aggregate.get("forks")
+    _require(isinstance(forks, list), "aggregate forks must be an array")
+    reports = []
+    wall_times = []
+    for expected_index, fork in enumerate(forks, start=1):
+        _require(isinstance(fork, dict), f"fork-{expected_index} must be an object")
+        _require(fork.get("fork") == expected_index, f"fork-{expected_index} index mismatch")
+        report = fork.get("rawReport")
+        _require(isinstance(report, dict), f"fork-{expected_index}.rawReport must be an object")
+        canonical_payload = json.dumps(
+            report, allow_nan=False, separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+        _require(
+            fork.get("canonicalRawReportBytes") == len(canonical_payload),
+            f"fork-{expected_index}.canonicalRawReportBytes mismatch",
+        )
+        _require(
+            fork.get("canonicalRawReportSha256") == hashlib.sha256(canonical_payload).hexdigest(),
+            f"fork-{expected_index}.canonicalRawReportSha256 mismatch",
+        )
+        reports.append(report)
+        wall_times.append(fork.get("externalWallTimeMs"))
+
+    rebuilt = build_aggregate(reports, wall_times, baseline_commit, generated_date)
+    _require(dict(aggregate) == rebuilt, "aggregate fields or statistics do not match preserved raw reports")
+
+
+def _write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, allow_nan=False) + "\n", encoding="utf-8")
+
+
+def _read_fork_inputs(raw_dir: Path, fork_count: int) -> Tuple[List[Dict[str, Any]], List[float]]:
+    reports: List[Dict[str, Any]] = []
+    wall_times: List[float] = []
+    for index in range(1, fork_count + 1):
+        reports.append(_load_json(raw_dir / f"fork-{index}.json"))
+        wall_path = raw_dir / f"fork-{index}.wall-ms"
+        wall_times.append(float(wall_path.read_text(encoding="utf-8").strip()))
+    return reports, wall_times
+
+
+def _aggregate_command(args: argparse.Namespace) -> None:
+    reports, wall_times = _read_fork_inputs(args.raw_dir, args.forks)
+    aggregate = build_aggregate(reports, wall_times, args.baseline_commit, args.generated_date)
+    validate_aggregate(aggregate)
+    _write_json(args.output, aggregate)
+    print(f"validated {len(reports)} forks and wrote {args.output}")
+
+
+def _run_command(args: argparse.Namespace) -> None:
+    raw_dir = args.raw_dir.resolve()
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    wrapper = ROOT / ("mvnw.cmd" if sys.platform.startswith("win") else "mvnw")
+    for index in range(1, args.forks + 1):
+        raw_path = raw_dir / f"fork-{index}.json"
+        command = [
+            str(wrapper),
+            "-Dgroups=slow",
+            "-DexcludedTestGroups=",
+            "-Djacoco.skip=true",
+            f"-Dtest={TEST_CLASS}",
+            f"-Dneqsim.optimization.baseline.commit={args.baseline_commit}",
+            f"-Dneqsim.optimization.baseline.output={raw_path}",
+            "test",
+        ]
+        started = time.perf_counter()
+        subprocess.run(command, cwd=ROOT, check=True)
+        wall_time_ms = (time.perf_counter() - started) * 1000.0
+        (raw_dir / f"fork-{index}.wall-ms").write_text(f"{wall_time_ms:.3f}\n", encoding="utf-8")
+        validate_raw_report(_load_json(raw_path), args.baseline_commit, f"fork-{index}")
+    _aggregate_command(args)
+
+
+def _validate_command(args: argparse.Namespace) -> None:
+    aggregate = _load_json(args.input)
+    validate_aggregate(aggregate)
+    print(f"validated {args.input}")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--baseline-commit", required=True, help="exact unmodified NeqSim commit")
+    common.add_argument("--forks", type=int, default=5, help="independent JVM fork count (minimum 5)")
+    common.add_argument("--raw-dir", type=Path, required=True, help="directory for fork JSON and wall times")
+    common.add_argument("--output", type=Path, required=True, help="aggregate JSON output path")
+    common.add_argument("--generated-date", default=date.today().isoformat(), help="ISO date stored in the aggregate")
+
+    run_parser = subparsers.add_parser("run", parents=[common], help="execute Maven forks, aggregate, and validate")
+    run_parser.set_defaults(handler=_run_command)
+
+    aggregate_parser = subparsers.add_parser(
+        "aggregate", parents=[common], help="aggregate and validate existing fork outputs"
+    )
+    aggregate_parser.set_defaults(handler=_aggregate_command)
+
+    validate_parser = subparsers.add_parser("validate", help="validate a checked aggregate")
+    validate_parser.add_argument("--input", type=Path, required=True)
+    validate_parser.set_defaults(handler=_validate_command)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        args.handler(args)
+    except (BenchmarkValidationError, FileNotFoundError, json.JSONDecodeError, ValueError) as exc:
+        print(f"industrial S/M benchmark validation failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/industrial_sm_benchmark.py
+++ b/devtools/industrial_sm_benchmark.py
@@ -14,7 +14,7 @@ import sys
 import time
 from datetime import date
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
+from typing import Any, Dict, List, Mapping, Sequence, Tuple
 
 
 ROOT = Path(__file__).resolve().parent.parent

--- a/devtools/test_industrial_sm_benchmark.py
+++ b/devtools/test_industrial_sm_benchmark.py
@@ -1,0 +1,177 @@
+"""Unit tests for industrial S/M benchmark aggregation and validation."""
+
+import copy
+import json
+import unittest
+
+from devtools import industrial_sm_benchmark as benchmark
+
+
+BASELINE = "0123456789abcdef0123456789abcdef01234567"
+
+
+def unavailable(reason="not attributable"):
+    return {"status": "UNAVAILABLE", "reason": reason}
+
+
+def success_mode(name, repetition=1, repeatability=None):
+    mode = {
+        "mode": name,
+        "repetition": repetition,
+        "outcome": "SUCCESS",
+        "processSolved": True,
+        "calculationIdentity": f"identity-{name}-{repetition}",
+        "elapsedMs": 2.0 + repetition,
+        "usedHeapBytesBefore": 100,
+        "usedHeapBytesAfter": 120,
+        "usedHeapDeltaBytes": 20,
+        "feedMassRateKgPerHr": 1000.0,
+        "productMassRateKgPerHr": 999.99,
+        "executionWork": {
+            "equipmentCalls": 2,
+            "equipment": {
+                "Feed": {"elapsedMs": 0.1, "calls": 1},
+                "Separator": {"elapsedMs": 0.2, "calls": 1},
+            },
+            "areaRuns": unavailable(),
+            "flashAndPropertyWork": unavailable(),
+        },
+        "massBalance": {
+            "maximumAbsoluteError": 0.01,
+            "maximumPercentError": 0.001,
+            "unit": "kg/hr",
+            "worstUnit": "Separator",
+            "energyBalance": unavailable(),
+        },
+        "bottleneck": {
+            "status": "AVAILABLE",
+            "equipment": "Separator",
+            "constraint": "gasLoad",
+            "utilization": 0.8,
+            "finiteEvidence": True,
+            "unit": "m/s",
+            "type": "HARD",
+            "severity": "HARD",
+            "provenance": "synthetic benchmark design basis",
+        },
+        "runStatus": {"schemaVersion": "1.0", "completed": True, "success": True},
+        "serializedObservationBytes": 1000,
+        "utilizationSnapshotSchemaVersion": "1.0",
+    }
+    if repeatability is not None:
+        mode["repeatabilityAbsoluteDifferenceKgPerHr"] = repeatability
+    if name == "discrete-line-up":
+        mode["availabilityAction"] = "train unavailable"
+    if name == "restored-line-up":
+        mode["restoration"] = "FULL_REPLAY_COMPLETED"
+    return mode
+
+
+def raw_report():
+    small_modes = [
+        success_mode("cold"),
+        success_mode("unchanged", repeatability=0.0),
+        success_mode("nearby-state"),
+        success_mode("constraint-change"),
+        {
+            "mode": "invalid-candidate",
+            "outcome": "REJECTED_BEFORE_MUTATION",
+            "finiteEvidence": False,
+            "restoration": "NOT_REQUIRED_STATE_UNCHANGED",
+            "rejectionReason": "decision variable must be finite",
+        },
+    ]
+    medium_modes = [success_mode("cold")]
+    medium_modes.extend(success_mode("unchanged", repetition=index, repeatability=0.0) for index in range(1, 6))
+    medium_modes.extend(
+        [
+            success_mode("nearby-state"),
+            success_mode("constraint-change"),
+            success_mode("discrete-line-up"),
+            success_mode("restored-line-up", repeatability=0.02),
+        ]
+    )
+    return {
+        "schemaVersion": "1.0",
+        "neqsimCommit": BASELINE,
+        "environment": {"javaVersion": "17"},
+        "measurementCoverage": {"convergenceAndRunStatus": "AVAILABLE"},
+        "cases": [
+            {
+                "caseSchemaVersion": "1.0",
+                "caseId": "S",
+                "unitCount": 3,
+                "recycleCount": 0,
+                "modes": small_modes,
+            },
+            {
+                "caseSchemaVersion": "1.0",
+                "caseId": "M",
+                "unitCount": 27,
+                "recycleCount": 1,
+                "modes": medium_modes,
+            },
+        ],
+    }
+
+
+class IndustrialSmBenchmarkTest(unittest.TestCase):
+    def test_checked_current_master_aggregate_validates(self):
+        path = (
+            benchmark.ROOT
+            / "docs"
+            / "process"
+            / "optimization"
+            / "benchmarks"
+            / "industrial-sm-baseline-f3a2cf5f.json"
+        )
+        with path.open(encoding="utf-8") as stream:
+            aggregate = json.load(stream)
+
+        benchmark.validate_aggregate(aggregate)
+
+    def test_aggregate_preserves_raw_reports_and_recomputes_statistics(self):
+        reports = [raw_report() for _ in range(5)]
+        aggregate = benchmark.build_aggregate(reports, [10, 11, 12, 13, 14], BASELINE, "2026-08-23")
+
+        benchmark.validate_aggregate(aggregate)
+
+        self.assertEqual(aggregate["schemaVersion"], "2.0")
+        self.assertEqual(aggregate["forks"][0]["rawReport"], reports[0])
+        self.assertEqual(aggregate["statistics"]["externalWallTimeMs"]["median"], 12.0)
+        self.assertEqual(aggregate["statistics"]["mediumUnchangedElapsedMs"]["sampleCount"], 25)
+        self.assertEqual(aggregate["acceptance"]["successfulModeCount"], 70)
+
+    def test_missing_per_equipment_execution_work_is_rejected(self):
+        report = raw_report()
+        del report["cases"][0]["modes"][0]["executionWork"]
+
+        with self.assertRaisesRegex(benchmark.BenchmarkValidationError, "executionWork"):
+            benchmark.validate_raw_report(report, BASELINE, "fork-1")
+
+    def test_non_finite_constraint_evidence_is_rejected(self):
+        report = raw_report()
+        report["cases"][1]["modes"][0]["bottleneck"]["utilization"] = float("nan")
+
+        with self.assertRaisesRegex(benchmark.BenchmarkValidationError, "must be finite"):
+            benchmark.validate_raw_report(report, BASELINE, "fork-1")
+
+    def test_tampered_summary_is_rejected(self):
+        reports = [raw_report() for _ in range(5)]
+        aggregate = benchmark.build_aggregate(reports, [10, 11, 12, 13, 14], BASELINE, "2026-08-23")
+        tampered = copy.deepcopy(aggregate)
+        tampered["statistics"]["externalWallTimeMs"]["median"] = 99.0
+
+        with self.assertRaisesRegex(benchmark.BenchmarkValidationError, "do not match"):
+            benchmark.validate_aggregate(tampered)
+
+    def test_changed_calculation_identity_between_forks_is_rejected(self):
+        reports = [raw_report() for _ in range(5)]
+        reports[3]["cases"][1]["modes"][0]["calculationIdentity"] = "different"
+
+        with self.assertRaisesRegex(benchmark.BenchmarkValidationError, "identities changed"):
+            benchmark.build_aggregate(reports, [10, 11, 12, 13, 14], BASELINE, "2026-08-23")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
+++ b/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
@@ -46,7 +46,7 @@ This guide provides comprehensive examples for setting up and running production
 | [Flow Rate Optimization](../process/optimization/flow-rate-optimization) | FlowRateOptimizer and lift curves |
 | [Batch Studies](../process/optimization/batch-studies) | Parallel parameter sweeps |
 | [Industrial Process Optimization Baseline](../process/optimization/industrial-process-optimization-baseline) | Capability coverage, restriction gaps, and frozen large-plant benchmark contract |
-| [Industrial S/M Benchmark Evidence](../process/optimization/industrial-sm-benchmark) | Executed small guide and 27-unit multi-train recycle baseline with reproducible raw records |
+| [Industrial S/M Benchmark Evidence](../process/optimization/industrial-sm-benchmark) | Executed small guide and 27-unit multi-train recycle baseline with a checked-in five-fork runner, exact raw records, and validation |
 | [External Optimizer Integration](../integration/EXTERNAL_OPTIMIZER_INTEGRATION) | Python/SciPy integration |
 | [CAPACITY_CONSTRAINT_FRAMEWORK.md](../process/CAPACITY_CONSTRAINT_FRAMEWORK) | Multi-constraint equipment and bottleneck detection |
 

--- a/docs/process/optimization/README.md
+++ b/docs/process/optimization/README.md
@@ -18,7 +18,7 @@ This page is the landing page for NeqSim process optimization. Use it to find th
 | [Compressor Optimization Guide](COMPRESSOR_OPTIMIZATION_GUIDE) | Multi-train compressor optimization with VFD, driver curves, and two-stage approach |
 | [Optimizer Plugin Architecture](OPTIMIZER_PLUGIN_ARCHITECTURE) | Equipment capacity strategies, constraint evaluation, throughput optimization, sensitivity analysis, and FlowRateOptimizer integration |
 | [Production Optimization Guide](../../examples/PRODUCTION_OPTIMIZATION_GUIDE) | Complete examples for ProductionOptimizer |
-| [Industrial S/M Benchmark Evidence](industrial-sm-benchmark) | Executed small guide and 27-unit multi-train recycle baseline, raw records, and known instrumentation gaps |
+| [Industrial S/M Benchmark Evidence](industrial-sm-benchmark) | Executed small guide and 27-unit multi-train recycle baseline, reproducible five-fork aggregation, raw records, and known instrumentation gaps |
 | [Capacity Constraint Framework](../CAPACITY_CONSTRAINT_FRAMEWORK) | Core constraint definition and bottleneck detection |
 | [Getting Started](getting-started) | Step-by-step workflow for first optimization run |
 | [Batch Studies](batch-studies) | Sensitivity analysis with parameter sweeps |

--- a/docs/process/optimization/benchmarks/industrial-sm-baseline-f3a2cf5f.json
+++ b/docs/process/optimization/benchmarks/industrial-sm-baseline-f3a2cf5f.json
@@ -1,0 +1,17829 @@
+{
+  "schemaVersion": "2.0",
+  "evidenceKind": "industrial-process-optimization-SM-five-fork-baseline",
+  "baselineCommit": "f3a2cf5f0891322ab2462817f0c06d0d9409f1f6",
+  "generatedDate": "2026-08-23",
+  "aggregation": {
+    "generator": "devtools/industrial_sm_benchmark.py",
+    "rawReportSchemaVersion": "1.0",
+    "forkCount": 5,
+    "rawReportsPreserved": true,
+    "validationStatus": "PASS"
+  },
+  "externalWallTimeMs": [
+    67879.749,
+    41493.165,
+    55437.389,
+    48105.17,
+    49955.003
+  ],
+  "statistics": {
+    "externalWallTimeMs": {
+      "sampleCount": 5,
+      "median": 49955.003,
+      "medianAbsoluteDeviation": 5482.386000000006,
+      "minimum": 41493.165,
+      "maximum": 67879.749
+    },
+    "smallColdElapsedMs": {
+      "sampleCount": 5,
+      "median": 110.737632,
+      "medianAbsoluteDeviation": 20.09872700000001,
+      "minimum": 90.191959,
+      "maximum": 147.209716
+    },
+    "smallUnchangedElapsedMs": {
+      "sampleCount": 5,
+      "median": 0.192061,
+      "medianAbsoluteDeviation": 0.004527000000000003,
+      "minimum": 0.143975,
+      "maximum": 0.196588
+    },
+    "mediumColdElapsedMs": {
+      "sampleCount": 5,
+      "median": 422.029047,
+      "medianAbsoluteDeviation": 147.52599800000002,
+      "minimum": 274.503049,
+      "maximum": 822.561699
+    },
+    "mediumUnchangedElapsedMs": {
+      "sampleCount": 25,
+      "median": 140.867187,
+      "medianAbsoluteDeviation": 44.527623000000006,
+      "minimum": 59.880643,
+      "maximum": 602.387338
+    },
+    "smallUnchangedDifferenceKgPerHr": {
+      "sampleCount": 5,
+      "median": 0.0,
+      "medianAbsoluteDeviation": 0.0,
+      "minimum": 0.0,
+      "maximum": 0.0
+    },
+    "mediumUnchangedDifferenceKgPerHr": {
+      "sampleCount": 25,
+      "median": 0.0,
+      "medianAbsoluteDeviation": 0.0,
+      "minimum": 0.0,
+      "maximum": 0.0
+    },
+    "mediumRestorationDifferenceKgPerHr": {
+      "sampleCount": 5,
+      "median": 0.025821060582529753,
+      "medianAbsoluteDeviation": 7.9016899690032e-09,
+      "minimum": 0.025820072216447443,
+      "maximum": 0.02582125153276138
+    },
+    "mediumMaximumUnitMassResidualKgPerHr": {
+      "sampleCount": 50,
+      "median": 0.02226421765954001,
+      "medianAbsoluteDeviation": 2.7934838726650923e-05,
+      "minimum": 0.0019012067496078089,
+      "maximum": 0.022292152512818575
+    },
+    "mediumSerializedObservationBytes": {
+      "sampleCount": 50,
+      "median": 24442.5,
+      "medianAbsoluteDeviation": 4.0,
+      "minimum": 24429.0,
+      "maximum": 24733.0
+    },
+    "successfulModeEquipmentCalls": {
+      "sampleCount": 70,
+      "median": 33.0,
+      "medianAbsoluteDeviation": 9.0,
+      "minimum": 1.0,
+      "maximum": 63.0
+    }
+  },
+  "acceptance": {
+    "allForksValidated": true,
+    "successfulModeCount": 70,
+    "invalidCandidateCount": 5,
+    "allUnchangedProductDifferencesAtMostKgPerHr": 0.1,
+    "allMassResidualsAtMostKgPerHr": 0.1,
+    "allRestorationDifferencesAtMostKgPerHr": 0.1
+  },
+  "forks": [
+    {
+      "fork": 1,
+      "externalWallTimeMs": 67879.749,
+      "canonicalRawReportBytes": 60488,
+      "canonicalRawReportSha256": "abcc2f82ddd793344776d41b09926787b481a4d0423b9b70881321ac24a264b8",
+      "rawReport": {
+        "schemaVersion": "1.0",
+        "neqsimCommit": "f3a2cf5f0891322ab2462817f0c06d0d9409f1f6",
+        "environment": {
+          "javaVersion": "17.0.19",
+          "javaVendor": "Ubuntu",
+          "jvmName": "OpenJDK 64-Bit Server VM",
+          "osName": "Linux",
+          "osVersion": "6.18.35",
+          "osArchitecture": "amd64",
+          "availableProcessors": 9,
+          "maximumHeapBytes": 3221225472,
+          "inputArguments": "[-Xmx3g, --add-opens=java.base/java.util=ALL-UNNAMED, --add-opens=java.base/java.lang=ALL-UNNAMED, --add-opens=java.base/java.io=ALL-UNNAMED, --add-opens=java.base/java.lang.reflect=ALL-UNNAMED]",
+          "cpuModel": {
+            "status": "UNAVAILABLE",
+            "reason": "not exposed by a portable Java 8 runtime API; capture in run ledger"
+          }
+        },
+        "measurementCoverage": {
+          "convergenceAndRunStatus": "AVAILABLE",
+          "equipmentExecutionCallsAndTiming": "AVAILABLE",
+          "massBalance": "AVAILABLE",
+          "utilizationAndBottleneck": "AVAILABLE",
+          "resultSize": "AVAILABLE",
+          "usedHeapBeforeAfterProxy": "AVAILABLE",
+          "areaExecutionCounts": {
+            "status": "UNAVAILABLE",
+            "reason": "no public ProcessSystem area counter"
+          },
+          "flashAndPropertyWork": {
+            "status": "UNAVAILABLE",
+            "reason": "no public attributable counter"
+          },
+          "cacheHitsMissesInvalidations": {
+            "status": "UNAVAILABLE",
+            "reason": "optimizer cache is not used by this solve-only baseline"
+          },
+          "allocatedBytes": {
+            "status": "UNAVAILABLE",
+            "reason": "no portable Java 8 per-run allocation counter configured"
+          },
+          "peakUsedHeap": {
+            "status": "UNAVAILABLE",
+            "reason": "no sampling profiler configured; before/after used heap is retained as proxy"
+          }
+        },
+        "cases": [
+          {
+            "caseSchemaVersion": "1.0",
+            "caseId": "S",
+            "identity": "guide-small",
+            "seed": 3154,
+            "unitCount": 3,
+            "areaCount": 1,
+            "connectionCount": 0,
+            "recycleCount": 0,
+            "boundaryCount": 1,
+            "decisionVariableCount": 1,
+            "objectiveCount": 1,
+            "assumptionsAndUnits": "Synthetic SRK gas; rates on mass basis in kg/hr; pressure in bara; power in kW",
+            "compatibilityRisk": "test-and-documentation-only; no runtime behavior change",
+            "modes": [
+              {
+                "mode": "cold",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "48577283-8387-33c7-a314-eb9e6bb633ae",
+                "elapsedMs": 90.638905,
+                "usedHeapBytesBefore": 15098360,
+                "usedHeapBytesAfter": 20476328,
+                "usedHeapDeltaBytes": 5377968,
+                "feedMassRateKgPerHr": 5000.0,
+                "productMassRateKgPerHr": 5000.0,
+                "executionWork": {
+                  "equipmentCalls": 3,
+                  "equipment": {
+                    "Gas Compressor": {
+                      "elapsedMs": 41.240874,
+                      "calls": 1
+                    },
+                    "Well Feed": {
+                      "elapsedMs": 16.886068,
+                      "calls": 1
+                    },
+                    "HP Separator": {
+                      "elapsedMs": 2.358044,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 0.9077488817569662,
+                  "utilizationPercent": 90.77488817569662,
+                  "finiteEvidence": true,
+                  "currentValue": 149.77856548989942,
+                  "designValue": 165.0,
+                  "signedPhysicalMargin": 15.221434510100579,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3145,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "d5b3d8b1-7636-303c-9dc1-e582ec0e1720",
+                "elapsedMs": 0.143975,
+                "usedHeapBytesBefore": 21440536,
+                "usedHeapBytesAfter": 21440536,
+                "usedHeapDeltaBytes": 0,
+                "feedMassRateKgPerHr": 5000.0,
+                "productMassRateKgPerHr": 5000.0,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 1,
+                  "equipment": {
+                    "HP Separator": {
+                      "elapsedMs": 0.11979,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 0.9077488817569662,
+                  "utilizationPercent": 90.77488817569662,
+                  "finiteEvidence": true,
+                  "currentValue": 149.77856548989942,
+                  "designValue": 165.0,
+                  "signedPhysicalMargin": 15.221434510100579,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3145,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "nearby-state",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "0bae417b-33b2-3a9d-ac25-e9ce9dd047cb",
+                "elapsedMs": 16.450312,
+                "usedHeapBytesBefore": 21440536,
+                "usedHeapBytesAfter": 23024888,
+                "usedHeapDeltaBytes": 1584352,
+                "feedMassRateKgPerHr": 5049.999999999999,
+                "productMassRateKgPerHr": 5049.999999999999,
+                "executionWork": {
+                  "equipmentCalls": 3,
+                  "equipment": {
+                    "Gas Compressor": {
+                      "elapsedMs": 14.622854,
+                      "calls": 1
+                    },
+                    "Well Feed": {
+                      "elapsedMs": 1.001569,
+                      "calls": 1
+                    },
+                    "HP Separator": {
+                      "elapsedMs": 0.786891,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 0.9168263705745356,
+                  "utilizationPercent": 91.68263705745356,
+                  "finiteEvidence": true,
+                  "currentValue": 151.27635114479838,
+                  "designValue": 165.0,
+                  "signedPhysicalMargin": 13.723648855201617,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3144,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "constraint-change",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "9ac63a24-99a3-3d28-9f93-8f48aee789c4",
+                "elapsedMs": 0.41438,
+                "usedHeapBytesBefore": 23024888,
+                "usedHeapBytesAfter": 23024888,
+                "usedHeapDeltaBytes": 0,
+                "feedMassRateKgPerHr": 5049.999999999999,
+                "productMassRateKgPerHr": 5049.999999999999,
+                "executionWork": {
+                  "equipmentCalls": 1,
+                  "equipment": {
+                    "HP Separator": {
+                      "elapsedMs": 0.379217,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 1.0526315789473686,
+                  "utilizationPercent": 105.26315789473686,
+                  "finiteEvidence": true,
+                  "currentValue": 151.27635114479838,
+                  "designValue": 143.71253358755845,
+                  "signedPhysicalMargin": -7.563817557239929,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3157,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "invalid-candidate",
+                "outcome": "REJECTED_BEFORE_MUTATION",
+                "finiteEvidence": false,
+                "restoration": "NOT_REQUIRED_STATE_UNCHANGED",
+                "rejectionReason": "Parameter 0 must be finite, but was NaN"
+              }
+            ]
+          },
+          {
+            "caseSchemaVersion": "1.0",
+            "caseId": "M",
+            "identity": "three-train-tail-recycle",
+            "seed": 3154,
+            "unitCount": 27,
+            "areaCount": 1,
+            "connectionCount": 0,
+            "recycleCount": 1,
+            "boundaryCount": 1,
+            "decisionVariableCount": 1,
+            "objectiveCount": 1,
+            "assumptionsAndUnits": "Synthetic SRK rich gas; rates on mass basis in kg/hr; pressure in bara; velocity in m/s",
+            "compatibilityRisk": "test-and-documentation-only; no runtime behavior change",
+            "bottleneckTransition": {
+              "status": "PARTIAL",
+              "observedInitialBottleneck": "M Export Pipe/velocity",
+              "observedConstraintChangeBottleneck": "M Feed Pipe/installedMixtureVelocity",
+              "missing": "ordered piping/compressor/separator shift under one continuous variable requires stable plant constraint identity",
+              "owner": "#3154 next increment; execution counters and cache attribution coordinate with #2939"
+            },
+            "modes": [
+              {
+                "mode": "cold",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "3b46cf14-1772-30b4-91e5-cd8954dcdb52",
+                "elapsedMs": 822.561699,
+                "usedHeapBytesBefore": 41007712,
+                "usedHeapBytesAfter": 70367840,
+                "usedHeapDeltaBytes": 29360128,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837210278,
+                "executionWork": {
+                  "equipmentCalls": 63,
+                  "equipment": {
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 290.736083,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 269.645895,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 121.180267,
+                      "calls": 7
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 104.347993,
+                      "calls": 7
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 90.738748,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 37.966716,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 33.519342,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 32.667221,
+                      "calls": 7
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 32.329697,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 28.818836,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 17.693154,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 15.489266,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 14.565219,
+                      "calls": 7
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 13.374831,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 12.934156,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 12.669118,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 11.527617,
+                      "calls": 7
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 10.316656,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 9.710109,
+                      "calls": 7
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 8.178153,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 7.463983,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 5.727864,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 4.163511,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 4.079337,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.689301,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 1.123398,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 1.025466,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.022236422140849754,
+                  "maximumPercentError": 3.117187500323107e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901811068864,
+                  "utilizationPercent": 4.096901811068864,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803622137729,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.180619637786226,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24454,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "ab7a0d7c-9f8f-382b-8c31-f1c597b7f394",
+                "elapsedMs": 140.867187,
+                "usedHeapBytesBefore": 72464992,
+                "usedHeapBytesAfter": 86096480,
+                "usedHeapDeltaBytes": 13631488,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837210278,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Export Mixer": {
+                      "elapsedMs": 33.855339,
+                      "calls": 2
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 33.485581,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 31.734952,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 29.434666,
+                      "calls": 2
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 25.482581,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 12.960466,
+                      "calls": 2
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 3.306146,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 3.019114,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 2.904337,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 2.882698,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 2.847064,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 2.820985,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 2.783777,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 2.566716,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 2.467959,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 2.237723,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.504452,
+                      "calls": 2
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.689665,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 0.661845,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 0.573645,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.240786,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.14982,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.115681,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.084638,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.076703,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.073226,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.0703,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02229201319278218,
+                  "maximumPercentError": 3.124980466159241e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901814600033,
+                  "utilizationPercent": 4.0969018146000336,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803629200066,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.180619637079992,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24452,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 2,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "7d12b3fc-b0ef-320f-871d-a827183706eb",
+                "elapsedMs": 82.163435,
+                "usedHeapBytesBefore": 87145056,
+                "usedHeapBytesAfter": 99727968,
+                "usedHeapDeltaBytes": 12582912,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837210278,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 27.747931,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 23.719166,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 19.505888,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 15.976392,
+                      "calls": 2
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 7.576808,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 4.445969,
+                      "calls": 2
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 3.401053,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 2.945317,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.869623,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 2.568264,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 2.512211,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 2.460265,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.755579,
+                      "calls": 2
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.339634,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.329426,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.01743,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.991487,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.987262,
+                      "calls": 2
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 0.960965,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.931401,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.144443,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.105163,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.102179,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.096225,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.07414,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.058942,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.046779,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02229215216357261,
+                  "maximumPercentError": 3.124999947615043e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901814594696,
+                  "utilizationPercent": 4.096901814594696,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803629189391,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.18061963708106,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24445,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 3,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "c7e2ae29-ddba-3830-9dc6-bd092a91a141",
+                "elapsedMs": 96.339564,
+                "usedHeapBytesBefore": 100776544,
+                "usedHeapBytesAfter": 112310880,
+                "usedHeapDeltaBytes": 11534336,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837210278,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 33.952414,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 29.603435,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 23.987488,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 18.17293,
+                      "calls": 2
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 12.238254,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 8.256493,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.637321,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 2.427752,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 2.366097,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 2.243781,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.966444,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.915917,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.850027,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.166572,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.142183,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.097383,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 0.999347,
+                      "calls": 2
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 0.9229,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.848706,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.742015,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.166805,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.15666,
+                      "calls": 2
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.105001,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.095094,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.089054,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.074278,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.069251,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.022292152512818575,
+                  "maximumPercentError": 3.124999996573675e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.040969018142681356,
+                  "utilizationPercent": 4.0969018142681355,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628536271,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.18061963714637,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24453,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 4,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "d54afe98-1101-378c-a1bb-a6a6bbf5f374",
+                "elapsedMs": 95.558524,
+                "usedHeapBytesBefore": 113359456,
+                "usedHeapBytesAfter": 125942368,
+                "usedHeapDeltaBytes": 12582912,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837210278,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 42.519323,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 39.907538,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 31.053317,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 9.334319,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 6.507276,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 5.627126,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 3.421846,
+                      "calls": 2
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.72851,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 2.602417,
+                      "calls": 2
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 2.581823,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 2.082842,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.981034,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.978229,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.662736,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.096053,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.078804,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.972554,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 0.923245,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.853839,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.612643,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.14452,
+                      "calls": 2
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.136165,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.114316,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.11269,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.100317,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.073274,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.056251,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.022292152512818575,
+                  "maximumPercentError": 3.124999996573675e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.040969018142686706,
+                  "utilizationPercent": 4.09690181426867,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628537341,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.180619637146265,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24447,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 5,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "a4a8685d-adf4-3d77-ac7c-dd33cdce9ada",
+                "elapsedMs": 142.845599,
+                "usedHeapBytesBefore": 126990944,
+                "usedHeapBytesAfter": 19756720,
+                "usedHeapDeltaBytes": -107234224,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837210278,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 47.965904,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 43.201782,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 42.394714,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 34.936419,
+                      "calls": 2
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 19.243101,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 9.404299,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 7.871835,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 7.837738,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 5.769686,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 2.366445,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 2.241481,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.829509,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.690572,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.394985,
+                      "calls": 2
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.192691,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.183546,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.084408,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.041697,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.746624,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.571698,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.133853,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.124502,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.092681,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.092651,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.091542,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.055983,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.048455,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.022292152512818575,
+                  "maximumPercentError": 3.124999996573675e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901814268858,
+                  "utilizationPercent": 4.096901814268858,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628537716,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.18061963714623,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24446,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "nearby-state",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "982f66f7-f724-3be3-8d87-e9854bff4574",
+                "elapsedMs": 152.949116,
+                "usedHeapBytesBefore": 20591776,
+                "usedHeapBytesAfter": 40514720,
+                "usedHeapDeltaBytes": 19922944,
+                "feedMassRateKgPerHr": 90900.00000000001,
+                "productMassRateKgPerHr": 69543.78024377135,
+                "executionWork": {
+                  "equipmentCalls": 51,
+                  "equipment": {
+                    "M Export Mixer": {
+                      "elapsedMs": 52.007945,
+                      "calls": 5
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 33.509614,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 30.296588,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 29.895782,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 15.929019,
+                      "calls": 5
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 12.113083,
+                      "calls": 5
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 10.165837,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 7.501708,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 2.332025,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 2.064736,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.976143,
+                      "calls": 5
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 1.796137,
+                      "calls": 5
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.783772,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.600691,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.270679,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 1.187733,
+                      "calls": 5
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 0.873011,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.816024,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 0.780157,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 0.750973,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.477612,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.459971,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.442428,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.419556,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.409156,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.370411,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.334815,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.004235514978063293,
+                  "maximumPercentError": 5.87872098821213e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.041378827782483696,
+                  "utilizationPercent": 4.13788277824837,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8275765556496739,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.172423444350326,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24431,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "constraint-change",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "1f859357-0cc4-3fa6-bff2-ec204c0c5f8b",
+                "elapsedMs": 120.455526,
+                "usedHeapBytesBefore": 40514720,
+                "usedHeapBytesAfter": 54146208,
+                "usedHeapDeltaBytes": 13631488,
+                "feedMassRateKgPerHr": 90900.00000000001,
+                "productMassRateKgPerHr": 69543.78024377135,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Export Pipe": {
+                      "elapsedMs": 33.394897,
+                      "calls": 2
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 32.321466,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 31.049667,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 19.74171,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 15.745049,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 11.738175,
+                      "calls": 2
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 3.231527,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 3.224887,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.244493,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.631783,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.588931,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.442728,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.369358,
+                      "calls": 2
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.356475,
+                      "calls": 2
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.099358,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.999423,
+                      "calls": 2
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.920268,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 0.783305,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 0.758818,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.446844,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.123495,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.074911,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.066747,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.066102,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.038148,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.031164,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.027568,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.004457880073459819,
+                  "maximumPercentError": 6.187354596932976e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Feed Pipe",
+                  "constraint": "installedMixtureVelocity",
+                  "utilization": 1.0526315789473684,
+                  "utilizationPercent": 105.26315789473684,
+                  "finiteEvidence": true,
+                  "currentValue": 0.7735209909497517,
+                  "designValue": 0.7348449414022641,
+                  "signedPhysicalMargin": -0.0386760495474876,
+                  "unit": "m/s",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 50.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24717,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "discrete-line-up",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "54d0f9ae-9544-314f-b42f-641127ac1d6c",
+                "elapsedMs": 113.13169,
+                "usedHeapBytesBefore": 55194784,
+                "usedHeapBytesAfter": 66729120,
+                "usedHeapDeltaBytes": 11534336,
+                "feedMassRateKgPerHr": 90900.00000000001,
+                "productMassRateKgPerHr": 69543.91206343795,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 30.310226,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 27.926429,
+                      "calls": 2
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 17.915668,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 17.166447,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 11.453104,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 10.036391,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 9.083954,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 8.751578,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 3.062943,
+                      "calls": 2
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 2.879713,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 2.211557,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.570687,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.561634,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.152551,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 0.930252,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 0.677623,
+                      "calls": 2
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.610907,
+                      "calls": 2
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.588586,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.575877,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.450911,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.376294,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.332655,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.24481,
+                      "calls": 2
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.239562,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.194265,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 0.064809,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 0.058992,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0019012169359484687,
+                  "maximumPercentError": 2.6388096215724766e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Feed Pipe",
+                  "constraint": "installedMixtureVelocity",
+                  "utilization": 1.0526315789473684,
+                  "utilizationPercent": 105.26315789473684,
+                  "finiteEvidence": true,
+                  "currentValue": 0.7735209909497517,
+                  "designValue": 0.7348449414022641,
+                  "signedPhysicalMargin": -0.0386760495474876,
+                  "unit": "m/s",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 50.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24629,
+                "utilizationSnapshotSchemaVersion": "1.0",
+                "availabilityAction": "train-3 unavailable through zero split allocation"
+              },
+              {
+                "mode": "restored-line-up",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "5ac7b216-4e95-3b19-9630-2912d1c0e5a6",
+                "elapsedMs": 120.81562,
+                "usedHeapBytesBefore": 67851608,
+                "usedHeapBytesAfter": 84554912,
+                "usedHeapDeltaBytes": 16703304,
+                "feedMassRateKgPerHr": 89999.99999999996,
+                "productMassRateKgPerHr": 68855.244192175,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.025820072216447443,
+                "executionWork": {
+                  "equipmentCalls": 51,
+                  "equipment": {
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 36.429518,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 26.462985,
+                      "calls": 5
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 25.425434,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 19.029485,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 17.218304,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 15.374617,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 8.455662,
+                      "calls": 5
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 5.999262,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 4.064521,
+                      "calls": 5
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 2.757695,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.313797,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 2.286405,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 2.161985,
+                      "calls": 5
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.921563,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.866668,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 1.782835,
+                      "calls": 5
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 1.634435,
+                      "calls": 5
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.51884,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.351564,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.249871,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.785178,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.45598,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.410624,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.40735,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.403102,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.346662,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.334593,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.004235762302414514,
+                  "maximumPercentError": 5.93785509569332e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Feed Pipe",
+                  "constraint": "installedMixtureVelocity",
+                  "utilization": 1.0422088265813942,
+                  "utilizationPercent": 104.22088265813943,
+                  "finiteEvidence": true,
+                  "currentValue": 0.765861884098127,
+                  "designValue": 0.7348449414022641,
+                  "signedPhysicalMargin": -0.03101694269586297,
+                  "unit": "m/s",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 50.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24727,
+                "utilizationSnapshotSchemaVersion": "1.0",
+                "restoration": "FULL_REPLAY_COMPLETED"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fork": 2,
+      "externalWallTimeMs": 41493.165,
+      "canonicalRawReportBytes": 60522,
+      "canonicalRawReportSha256": "e20987afba7ff639529704dfa65cb348fc792f89f7ffae272bd90b5cd44c0d0a",
+      "rawReport": {
+        "schemaVersion": "1.0",
+        "neqsimCommit": "f3a2cf5f0891322ab2462817f0c06d0d9409f1f6",
+        "environment": {
+          "javaVersion": "17.0.19",
+          "javaVendor": "Ubuntu",
+          "jvmName": "OpenJDK 64-Bit Server VM",
+          "osName": "Linux",
+          "osVersion": "6.18.35",
+          "osArchitecture": "amd64",
+          "availableProcessors": 9,
+          "maximumHeapBytes": 3221225472,
+          "inputArguments": "[-Xmx3g, --add-opens=java.base/java.util=ALL-UNNAMED, --add-opens=java.base/java.lang=ALL-UNNAMED, --add-opens=java.base/java.io=ALL-UNNAMED, --add-opens=java.base/java.lang.reflect=ALL-UNNAMED]",
+          "cpuModel": {
+            "status": "UNAVAILABLE",
+            "reason": "not exposed by a portable Java 8 runtime API; capture in run ledger"
+          }
+        },
+        "measurementCoverage": {
+          "convergenceAndRunStatus": "AVAILABLE",
+          "equipmentExecutionCallsAndTiming": "AVAILABLE",
+          "massBalance": "AVAILABLE",
+          "utilizationAndBottleneck": "AVAILABLE",
+          "resultSize": "AVAILABLE",
+          "usedHeapBeforeAfterProxy": "AVAILABLE",
+          "areaExecutionCounts": {
+            "status": "UNAVAILABLE",
+            "reason": "no public ProcessSystem area counter"
+          },
+          "flashAndPropertyWork": {
+            "status": "UNAVAILABLE",
+            "reason": "no public attributable counter"
+          },
+          "cacheHitsMissesInvalidations": {
+            "status": "UNAVAILABLE",
+            "reason": "optimizer cache is not used by this solve-only baseline"
+          },
+          "allocatedBytes": {
+            "status": "UNAVAILABLE",
+            "reason": "no portable Java 8 per-run allocation counter configured"
+          },
+          "peakUsedHeap": {
+            "status": "UNAVAILABLE",
+            "reason": "no sampling profiler configured; before/after used heap is retained as proxy"
+          }
+        },
+        "cases": [
+          {
+            "caseSchemaVersion": "1.0",
+            "caseId": "S",
+            "identity": "guide-small",
+            "seed": 3154,
+            "unitCount": 3,
+            "areaCount": 1,
+            "connectionCount": 0,
+            "recycleCount": 0,
+            "boundaryCount": 1,
+            "decisionVariableCount": 1,
+            "objectiveCount": 1,
+            "assumptionsAndUnits": "Synthetic SRK gas; rates on mass basis in kg/hr; pressure in bara; power in kW",
+            "compatibilityRisk": "test-and-documentation-only; no runtime behavior change",
+            "modes": [
+              {
+                "mode": "cold",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "48577283-8387-33c7-a314-eb9e6bb633ae",
+                "elapsedMs": 110.737632,
+                "usedHeapBytesBefore": 15072688,
+                "usedHeapBytesAfter": 20846496,
+                "usedHeapDeltaBytes": 5773808,
+                "feedMassRateKgPerHr": 5000.0,
+                "productMassRateKgPerHr": 5000.0,
+                "executionWork": {
+                  "equipmentCalls": 3,
+                  "equipment": {
+                    "Gas Compressor": {
+                      "elapsedMs": 39.077543,
+                      "calls": 1
+                    },
+                    "Well Feed": {
+                      "elapsedMs": 24.202573,
+                      "calls": 1
+                    },
+                    "HP Separator": {
+                      "elapsedMs": 5.274092,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 0.9077488817569662,
+                  "utilizationPercent": 90.77488817569662,
+                  "finiteEvidence": true,
+                  "currentValue": 149.77856548989942,
+                  "designValue": 165.0,
+                  "signedPhysicalMargin": 15.221434510100579,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3145,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "d5b3d8b1-7636-303c-9dc1-e582ec0e1720",
+                "elapsedMs": 0.192061,
+                "usedHeapBytesBefore": 21336800,
+                "usedHeapBytesAfter": 21336800,
+                "usedHeapDeltaBytes": 0,
+                "feedMassRateKgPerHr": 5000.0,
+                "productMassRateKgPerHr": 5000.0,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 1,
+                  "equipment": {
+                    "HP Separator": {
+                      "elapsedMs": 0.156258,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 0.9077488817569662,
+                  "utilizationPercent": 90.77488817569662,
+                  "finiteEvidence": true,
+                  "currentValue": 149.77856548989942,
+                  "designValue": 165.0,
+                  "signedPhysicalMargin": 15.221434510100579,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3145,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "nearby-state",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "0bae417b-33b2-3a9d-ac25-e9ce9dd047cb",
+                "elapsedMs": 21.198824,
+                "usedHeapBytesBefore": 21831696,
+                "usedHeapBytesAfter": 22943624,
+                "usedHeapDeltaBytes": 1111928,
+                "feedMassRateKgPerHr": 5049.999999999999,
+                "productMassRateKgPerHr": 5049.999999999999,
+                "executionWork": {
+                  "equipmentCalls": 3,
+                  "equipment": {
+                    "Gas Compressor": {
+                      "elapsedMs": 17.764105,
+                      "calls": 1
+                    },
+                    "HP Separator": {
+                      "elapsedMs": 1.895703,
+                      "calls": 1
+                    },
+                    "Well Feed": {
+                      "elapsedMs": 1.486187,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 0.9168263705745356,
+                  "utilizationPercent": 91.68263705745356,
+                  "finiteEvidence": true,
+                  "currentValue": 151.27635114479838,
+                  "designValue": 165.0,
+                  "signedPhysicalMargin": 13.723648855201617,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3144,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "constraint-change",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "9ac63a24-99a3-3d28-9f93-8f48aee789c4",
+                "elapsedMs": 0.167707,
+                "usedHeapBytesBefore": 22943624,
+                "usedHeapBytesAfter": 22943624,
+                "usedHeapDeltaBytes": 0,
+                "feedMassRateKgPerHr": 5049.999999999999,
+                "productMassRateKgPerHr": 5049.999999999999,
+                "executionWork": {
+                  "equipmentCalls": 1,
+                  "equipment": {
+                    "HP Separator": {
+                      "elapsedMs": 0.138535,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 1.0526315789473686,
+                  "utilizationPercent": 105.26315789473686,
+                  "finiteEvidence": true,
+                  "currentValue": 151.27635114479838,
+                  "designValue": 143.71253358755845,
+                  "signedPhysicalMargin": -7.563817557239929,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3157,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "invalid-candidate",
+                "outcome": "REJECTED_BEFORE_MUTATION",
+                "finiteEvidence": false,
+                "restoration": "NOT_REQUIRED_STATE_UNCHANGED",
+                "rejectionReason": "Parameter 0 must be finite, but was NaN"
+              }
+            ]
+          },
+          {
+            "caseSchemaVersion": "1.0",
+            "caseId": "M",
+            "identity": "three-train-tail-recycle",
+            "seed": 3154,
+            "unitCount": 27,
+            "areaCount": 1,
+            "connectionCount": 0,
+            "recycleCount": 1,
+            "boundaryCount": 1,
+            "decisionVariableCount": 1,
+            "objectiveCount": 1,
+            "assumptionsAndUnits": "Synthetic SRK rich gas; rates on mass basis in kg/hr; pressure in bara; velocity in m/s",
+            "compatibilityRisk": "test-and-documentation-only; no runtime behavior change",
+            "bottleneckTransition": {
+              "status": "PARTIAL",
+              "observedInitialBottleneck": "M Export Pipe/velocity",
+              "observedConstraintChangeBottleneck": "M Feed Pipe/installedMixtureVelocity",
+              "missing": "ordered piping/compressor/separator shift under one continuous variable requires stable plant constraint identity",
+              "owner": "#3154 next increment; execution counters and cache attribution coordinate with #2939"
+            },
+            "modes": [
+              {
+                "mode": "cold",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "3b46cf14-1772-30b4-91e5-cd8954dcdb52",
+                "elapsedMs": 777.810839,
+                "usedHeapBytesBefore": 39304816,
+                "usedHeapBytesAfter": 67616368,
+                "usedHeapDeltaBytes": 28311552,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "executionWork": {
+                  "equipmentCalls": 63,
+                  "equipment": {
+                    "M Export Mixer": {
+                      "elapsedMs": 280.043444,
+                      "calls": 7
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 108.944408,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 92.490342,
+                      "calls": 7
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 69.738196,
+                      "calls": 7
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 63.896418,
+                      "calls": 7
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 29.977382,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 28.120306,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 27.336948,
+                      "calls": 7
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 13.884193,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 12.395894,
+                      "calls": 7
+                    },
+                    "M Feed": {
+                      "elapsedMs": 11.445405,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 10.695158,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 10.069792,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 8.747769,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 8.517327,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 8.377056,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 8.213761,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 8.186459,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 7.670044,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 7.219179,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 4.495923,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 4.035781,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 2.130964,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 1.68557,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.456023,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 1.438816,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 0.892989,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02223642212629784,
+                  "maximumPercentError": 3.1171874982831635e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901811396201,
+                  "utilizationPercent": 4.096901811396201,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803622792402,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.18061963772076,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24440,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "ab7a0d7c-9f8f-382b-8c31-f1c597b7f394",
+                "elapsedMs": 468.770689,
+                "usedHeapBytesBefore": 69713520,
+                "usedHeapBytesAfter": 82296432,
+                "usedHeapDeltaBytes": 12582912,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 196.134444,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 184.328625,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 73.886426,
+                      "calls": 2
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 66.473335,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 58.373866,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 48.093095,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 39.308453,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 37.01065,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 32.600784,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 26.934347,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 11.046842,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 7.767674,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 4.460519,
+                      "calls": 2
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 3.721276,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 3.693252,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 2.12926,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.941484,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.715366,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.565058,
+                      "calls": 2
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 1.515788,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.034623,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.976946,
+                      "calls": 2
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.478648,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.407925,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.328164,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.270416,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.13674,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.022292013178230263,
+                  "maximumPercentError": 3.124980464119297e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901814261824,
+                  "utilizationPercent": 4.096901814261824,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628523648,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.180619637147636,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24441,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 2,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "7d12b3fc-b0ef-320f-871d-a827183706eb",
+                "elapsedMs": 566.701139,
+                "usedHeapBytesBefore": 83345008,
+                "usedHeapBytesAfter": 96976496,
+                "usedHeapDeltaBytes": 13631488,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Export Mixer": {
+                      "elapsedMs": 261.671819,
+                      "calls": 2
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 104.186558,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 62.540568,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 49.584372,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 48.86933,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 48.626553,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 46.97554,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 33.265448,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 25.796404,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 7.268102,
+                      "calls": 2
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 6.305199,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 4.544415,
+                      "calls": 2
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 3.765541,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 3.157913,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 3.112999,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 2.170692,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 2.077194,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 2.010117,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 1.347639,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 1.256499,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.174159,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 1.11114,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.82641,
+                      "calls": 2
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.60057,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.521249,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.1915,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.067217,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.022292152149020694,
+                  "maximumPercentError": 3.124999945575099e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901814268822,
+                  "utilizationPercent": 4.096901814268822,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628537644,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.180619637146236,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24440,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 3,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "c7e2ae29-ddba-3830-9dc6-bd092a91a141",
+                "elapsedMs": 353.126217,
+                "usedHeapBytesBefore": 98025072,
+                "usedHeapBytesAfter": 110607984,
+                "usedHeapDeltaBytes": 12582912,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Feed Pipe": {
+                      "elapsedMs": 76.371703,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 74.816509,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 73.389061,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 48.913875,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 46.127676,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 45.612795,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 20.183824,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 19.637213,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 15.975472,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 15.92802,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 15.921058,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 10.796182,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 9.011358,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 7.15635,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 5.931029,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 4.45863,
+                      "calls": 2
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 3.466316,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 3.151476,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 2.552484,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 2.36251,
+                      "calls": 2
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 1.966449,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.891735,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.431618,
+                      "calls": 2
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.331004,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.247401,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.116875,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.098371,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02229215249826666,
+                  "maximumPercentError": 3.124999994533731e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.040969018142860206,
+                  "utilizationPercent": 4.096901814286021,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628572041,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.180619637142797,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24445,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 4,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "d54afe98-1101-378c-a1bb-a6a6bbf5f374",
+                "elapsedMs": 602.387338,
+                "usedHeapBytesBefore": 111656560,
+                "usedHeapBytesAfter": 123190896,
+                "usedHeapDeltaBytes": 11534336,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Export Pipe": {
+                      "elapsedMs": 158.046025,
+                      "calls": 2
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 135.974087,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 133.514197,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 108.036803,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 107.840266,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 75.89029,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 62.407704,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 58.181902,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 38.741399,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 7.172055,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 5.32064,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 5.178526,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 3.076068,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 2.679147,
+                      "calls": 2
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.641804,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.459735,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 1.238912,
+                      "calls": 2
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.216956,
+                      "calls": 2
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.00823,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.849734,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.696435,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.662994,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.59449,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.306857,
+                      "calls": 2
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.189962,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.092059,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.054407,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02229215249826666,
+                  "maximumPercentError": 3.124999994533731e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901814597213,
+                  "utilizationPercent": 4.096901814597214,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803629194426,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.180619637080557,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24441,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 5,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "a4a8685d-adf4-3d77-ac7c-dd33cdce9ada",
+                "elapsedMs": 118.183964,
+                "usedHeapBytesBefore": 124239472,
+                "usedHeapBytesAfter": 137870960,
+                "usedHeapDeltaBytes": 13631488,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 70.514094,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 61.538398,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 19.810958,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 12.297212,
+                      "calls": 2
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 7.350076,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 4.855678,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 4.758762,
+                      "calls": 2
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.896159,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 2.254589,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 2.179134,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.608683,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.524298,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.415972,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.377676,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.367468,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.26295,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.206776,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.095248,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.769296,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.754264,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.545464,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.249736,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.238141,
+                      "calls": 2
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.14685,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.113252,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.096359,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.055662,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02229215249826666,
+                  "maximumPercentError": 3.124999994533731e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901814268887,
+                  "utilizationPercent": 4.096901814268887,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628537774,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.180619637146222,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24443,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "nearby-state",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "982f66f7-f724-3be3-8d87-e9854bff4574",
+                "elapsedMs": 233.727445,
+                "usedHeapBytesBefore": 138919536,
+                "usedHeapBytesAfter": 37546152,
+                "usedHeapDeltaBytes": -101373384,
+                "feedMassRateKgPerHr": 90900.00000000001,
+                "productMassRateKgPerHr": 69543.78024377135,
+                "executionWork": {
+                  "equipmentCalls": 51,
+                  "equipment": {
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 67.425542,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 67.224304,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 64.344162,
+                      "calls": 5
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 55.334495,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 24.027843,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 16.729631,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 14.964669,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 14.676298,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 9.540587,
+                      "calls": 5
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 8.242586,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 7.575527,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 6.635665,
+                      "calls": 5
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 5.728309,
+                      "calls": 5
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 4.266549,
+                      "calls": 5
+                    },
+                    "M Feed": {
+                      "elapsedMs": 3.180477,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 1.787768,
+                      "calls": 5
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.543571,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 1.170131,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.052247,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 1.036945,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.867521,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.766994,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 0.752498,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 0.702563,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.457412,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.34747,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.334403,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.004235514978063293,
+                  "maximumPercentError": 5.87872098821213e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.041378827782483696,
+                  "utilizationPercent": 4.13788277824837,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8275765556496739,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.172423444350326,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24431,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "constraint-change",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "1f859357-0cc4-3fa6-bff2-ec204c0c5f8b",
+                "elapsedMs": 300.469265,
+                "usedHeapBytesBefore": 37546152,
+                "usedHeapBytesAfter": 50129064,
+                "usedHeapDeltaBytes": 12582912,
+                "feedMassRateKgPerHr": 90900.00000000001,
+                "productMassRateKgPerHr": 69543.78024377135,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 111.449457,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 100.294596,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 58.133762,
+                      "calls": 2
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 52.984781,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 29.871418,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 17.790754,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 14.415813,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 12.212213,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 12.204496,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 6.729905,
+                      "calls": 2
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 6.31476,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 3.027974,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 2.655531,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.958785,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.557242,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 1.52329,
+                      "calls": 2
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.208773,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.195561,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.008352,
+                      "calls": 2
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.836705,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.135621,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.119319,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.08927,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.080862,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.057337,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.040908,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.03692,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.004457880073459819,
+                  "maximumPercentError": 6.187354596932976e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Feed Pipe",
+                  "constraint": "installedMixtureVelocity",
+                  "utilization": 1.0526315789473684,
+                  "utilizationPercent": 105.26315789473684,
+                  "finiteEvidence": true,
+                  "currentValue": 0.7735209909497517,
+                  "designValue": 0.7348449414022641,
+                  "signedPhysicalMargin": -0.0386760495474876,
+                  "unit": "m/s",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 50.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24716,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "discrete-line-up",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "54d0f9ae-9544-314f-b42f-641127ac1d6c",
+                "elapsedMs": 358.97871,
+                "usedHeapBytesBefore": 50129064,
+                "usedHeapBytesAfter": 62711976,
+                "usedHeapDeltaBytes": 12582912,
+                "feedMassRateKgPerHr": 90900.00000000001,
+                "productMassRateKgPerHr": 69543.91206368386,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Export Mixer": {
+                      "elapsedMs": 167.911377,
+                      "calls": 2
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 52.561493,
+                      "calls": 2
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 41.500091,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 29.27345,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 23.833098,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 23.403822,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 22.80643,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 13.418376,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 12.843867,
+                      "calls": 2
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 3.946525,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.975351,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.660639,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.56595,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.372629,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.166417,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.158039,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 0.77246,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.733767,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.595821,
+                      "calls": 2
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.575684,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.465947,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.376191,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.372218,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.371368,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.196847,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.151527,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 0.088434,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0019012347038369626,
+                  "maximumPercentError": 2.6388342826452025e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Feed Pipe",
+                  "constraint": "installedMixtureVelocity",
+                  "utilization": 1.0526315789473684,
+                  "utilizationPercent": 105.26315789473684,
+                  "finiteEvidence": true,
+                  "currentValue": 0.7735209909497517,
+                  "designValue": 0.7348449414022641,
+                  "signedPhysicalMargin": -0.0386760495474876,
+                  "unit": "m/s",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 50.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24636,
+                "utilizationSnapshotSchemaVersion": "1.0",
+                "availabilityAction": "train-3 unavailable through zero split allocation"
+              },
+              {
+                "mode": "restored-line-up",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "5ac7b216-4e95-3b19-9630-2912d1c0e5a6",
+                "elapsedMs": 408.509337,
+                "usedHeapBytesBefore": 63760552,
+                "usedHeapBytesAfter": 80537768,
+                "usedHeapDeltaBytes": 16777216,
+                "feedMassRateKgPerHr": 89999.99999999996,
+                "productMassRateKgPerHr": 68855.24419314352,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.025821052680839784,
+                "executionWork": {
+                  "equipmentCalls": 51,
+                  "equipment": {
+                    "M Export Mixer": {
+                      "elapsedMs": 124.942743,
+                      "calls": 5
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 87.099403,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 72.827553,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 68.956064,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 38.47996,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 33.111891,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 21.099769,
+                      "calls": 5
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 12.229692,
+                      "calls": 5
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 8.271387,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 6.020993,
+                      "calls": 5
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 4.327625,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 3.198925,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 2.741619,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 2.568904,
+                      "calls": 5
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 2.085353,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.963062,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 1.934244,
+                      "calls": 5
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 1.891658,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.542187,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 1.541586,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.528421,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.403566,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.333321,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 1.277072,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.932697,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.875362,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.525822,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.004235762360622175,
+                  "maximumPercentError": 5.9378551772619634e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Feed Pipe",
+                  "constraint": "installedMixtureVelocity",
+                  "utilization": 1.0422088265813942,
+                  "utilizationPercent": 104.22088265813943,
+                  "finiteEvidence": true,
+                  "currentValue": 0.765861884098127,
+                  "designValue": 0.7348449414022641,
+                  "signedPhysicalMargin": -0.03101694269586297,
+                  "unit": "m/s",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 50.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24731,
+                "utilizationSnapshotSchemaVersion": "1.0",
+                "restoration": "FULL_REPLAY_COMPLETED"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fork": 3,
+      "externalWallTimeMs": 55437.389,
+      "canonicalRawReportBytes": 60466,
+      "canonicalRawReportSha256": "6f4423eb1e04b7e061038b84c173d7cb2112af9e30ba04c9aa44890a848022ac",
+      "rawReport": {
+        "schemaVersion": "1.0",
+        "neqsimCommit": "f3a2cf5f0891322ab2462817f0c06d0d9409f1f6",
+        "environment": {
+          "javaVersion": "17.0.19",
+          "javaVendor": "Ubuntu",
+          "jvmName": "OpenJDK 64-Bit Server VM",
+          "osName": "Linux",
+          "osVersion": "6.18.35",
+          "osArchitecture": "amd64",
+          "availableProcessors": 9,
+          "maximumHeapBytes": 3221225472,
+          "inputArguments": "[-Xmx3g, --add-opens=java.base/java.util=ALL-UNNAMED, --add-opens=java.base/java.lang=ALL-UNNAMED, --add-opens=java.base/java.io=ALL-UNNAMED, --add-opens=java.base/java.lang.reflect=ALL-UNNAMED]",
+          "cpuModel": {
+            "status": "UNAVAILABLE",
+            "reason": "not exposed by a portable Java 8 runtime API; capture in run ledger"
+          }
+        },
+        "measurementCoverage": {
+          "convergenceAndRunStatus": "AVAILABLE",
+          "equipmentExecutionCallsAndTiming": "AVAILABLE",
+          "massBalance": "AVAILABLE",
+          "utilizationAndBottleneck": "AVAILABLE",
+          "resultSize": "AVAILABLE",
+          "usedHeapBeforeAfterProxy": "AVAILABLE",
+          "areaExecutionCounts": {
+            "status": "UNAVAILABLE",
+            "reason": "no public ProcessSystem area counter"
+          },
+          "flashAndPropertyWork": {
+            "status": "UNAVAILABLE",
+            "reason": "no public attributable counter"
+          },
+          "cacheHitsMissesInvalidations": {
+            "status": "UNAVAILABLE",
+            "reason": "optimizer cache is not used by this solve-only baseline"
+          },
+          "allocatedBytes": {
+            "status": "UNAVAILABLE",
+            "reason": "no portable Java 8 per-run allocation counter configured"
+          },
+          "peakUsedHeap": {
+            "status": "UNAVAILABLE",
+            "reason": "no sampling profiler configured; before/after used heap is retained as proxy"
+          }
+        },
+        "cases": [
+          {
+            "caseSchemaVersion": "1.0",
+            "caseId": "S",
+            "identity": "guide-small",
+            "seed": 3154,
+            "unitCount": 3,
+            "areaCount": 1,
+            "connectionCount": 0,
+            "recycleCount": 0,
+            "boundaryCount": 1,
+            "decisionVariableCount": 1,
+            "objectiveCount": 1,
+            "assumptionsAndUnits": "Synthetic SRK gas; rates on mass basis in kg/hr; pressure in bara; power in kW",
+            "compatibilityRisk": "test-and-documentation-only; no runtime behavior change",
+            "modes": [
+              {
+                "mode": "cold",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "48577283-8387-33c7-a314-eb9e6bb633ae",
+                "elapsedMs": 121.99688,
+                "usedHeapBytesBefore": 36100120,
+                "usedHeapBytesAfter": 42391576,
+                "usedHeapDeltaBytes": 6291456,
+                "feedMassRateKgPerHr": 5000.0,
+                "productMassRateKgPerHr": 5000.0,
+                "executionWork": {
+                  "equipmentCalls": 3,
+                  "equipment": {
+                    "Gas Compressor": {
+                      "elapsedMs": 48.864304,
+                      "calls": 1
+                    },
+                    "Well Feed": {
+                      "elapsedMs": 30.621262,
+                      "calls": 1
+                    },
+                    "HP Separator": {
+                      "elapsedMs": 4.103208,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 0.9077488817569662,
+                  "utilizationPercent": 90.77488817569662,
+                  "finiteEvidence": true,
+                  "currentValue": 149.77856548989942,
+                  "designValue": 165.0,
+                  "signedPhysicalMargin": 15.221434510100579,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3145,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "d5b3d8b1-7636-303c-9dc1-e582ec0e1720",
+                "elapsedMs": 0.196588,
+                "usedHeapBytesBefore": 42391576,
+                "usedHeapBytesAfter": 42391576,
+                "usedHeapDeltaBytes": 0,
+                "feedMassRateKgPerHr": 5000.0,
+                "productMassRateKgPerHr": 5000.0,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 1,
+                  "equipment": {
+                    "HP Separator": {
+                      "elapsedMs": 0.165384,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 0.9077488817569662,
+                  "utilizationPercent": 90.77488817569662,
+                  "finiteEvidence": true,
+                  "currentValue": 149.77856548989942,
+                  "designValue": 165.0,
+                  "signedPhysicalMargin": 15.221434510100579,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3145,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "nearby-state",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "0bae417b-33b2-3a9d-ac25-e9ce9dd047cb",
+                "elapsedMs": 17.173747,
+                "usedHeapBytesBefore": 42391576,
+                "usedHeapBytesAfter": 44488728,
+                "usedHeapDeltaBytes": 2097152,
+                "feedMassRateKgPerHr": 5049.999999999999,
+                "productMassRateKgPerHr": 5049.999999999999,
+                "executionWork": {
+                  "equipmentCalls": 3,
+                  "equipment": {
+                    "Gas Compressor": {
+                      "elapsedMs": 14.76341,
+                      "calls": 1
+                    },
+                    "HP Separator": {
+                      "elapsedMs": 1.292241,
+                      "calls": 1
+                    },
+                    "Well Feed": {
+                      "elapsedMs": 1.071494,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 0.9168263705745356,
+                  "utilizationPercent": 91.68263705745356,
+                  "finiteEvidence": true,
+                  "currentValue": 151.27635114479838,
+                  "designValue": 165.0,
+                  "signedPhysicalMargin": 13.723648855201617,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3144,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "constraint-change",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "9ac63a24-99a3-3d28-9f93-8f48aee789c4",
+                "elapsedMs": 0.218435,
+                "usedHeapBytesBefore": 44488728,
+                "usedHeapBytesAfter": 44488728,
+                "usedHeapDeltaBytes": 0,
+                "feedMassRateKgPerHr": 5049.999999999999,
+                "productMassRateKgPerHr": 5049.999999999999,
+                "executionWork": {
+                  "equipmentCalls": 1,
+                  "equipment": {
+                    "HP Separator": {
+                      "elapsedMs": 0.191824,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 1.0526315789473686,
+                  "utilizationPercent": 105.26315789473686,
+                  "finiteEvidence": true,
+                  "currentValue": 151.27635114479838,
+                  "designValue": 143.71253358755845,
+                  "signedPhysicalMargin": -7.563817557239929,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3157,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "invalid-candidate",
+                "outcome": "REJECTED_BEFORE_MUTATION",
+                "finiteEvidence": false,
+                "restoration": "NOT_REQUIRED_STATE_UNCHANGED",
+                "rejectionReason": "Parameter 0 must be finite, but was NaN"
+              }
+            ]
+          },
+          {
+            "caseSchemaVersion": "1.0",
+            "caseId": "M",
+            "identity": "three-train-tail-recycle",
+            "seed": 3154,
+            "unitCount": 27,
+            "areaCount": 1,
+            "connectionCount": 0,
+            "recycleCount": 1,
+            "boundaryCount": 1,
+            "decisionVariableCount": 1,
+            "objectiveCount": 1,
+            "assumptionsAndUnits": "Synthetic SRK rich gas; rates on mass basis in kg/hr; pressure in bara; velocity in m/s",
+            "compatibilityRisk": "test-and-documentation-only; no runtime behavior change",
+            "bottleneckTransition": {
+              "status": "PARTIAL",
+              "observedInitialBottleneck": "M Export Pipe/velocity",
+              "observedConstraintChangeBottleneck": "M Feed Pipe/installedMixtureVelocity",
+              "missing": "ordered piping/compressor/separator shift under one continuous variable requires stable plant constraint identity",
+              "owner": "#3154 next increment; execution counters and cache attribution coordinate with #2939"
+            },
+            "modes": [
+              {
+                "mode": "cold",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "3b46cf14-1772-30b4-91e5-cd8954dcdb52",
+                "elapsedMs": 304.747848,
+                "usedHeapBytesBefore": 61265944,
+                "usedHeapBytesAfter": 89577496,
+                "usedHeapDeltaBytes": 28311552,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "executionWork": {
+                  "equipmentCalls": 63,
+                  "equipment": {
+                    "M Export Mixer": {
+                      "elapsedMs": 66.056041,
+                      "calls": 7
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 65.366268,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 62.947495,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 37.486704,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 27.79478,
+                      "calls": 7
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 13.628552,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 13.299988,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 12.055935,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 11.878095,
+                      "calls": 7
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 11.525705,
+                      "calls": 7
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 10.318748,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 8.832563,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 7.735004,
+                      "calls": 7
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 7.683569,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 5.62685,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 4.279277,
+                      "calls": 7
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 4.039702,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 4.003586,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 3.880303,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 3.549824,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 3.177042,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 3.129087,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.965309,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.944063,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 1.149118,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.837332,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.745045,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02223642212629784,
+                  "maximumPercentError": 3.1171874982831635e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901811396201,
+                  "utilizationPercent": 4.096901811396201,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803622792402,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.18061963772076,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24440,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "ab7a0d7c-9f8f-382b-8c31-f1c597b7f394",
+                "elapsedMs": 104.672155,
+                "usedHeapBytesBefore": 90626072,
+                "usedHeapBytesAfter": 104257560,
+                "usedHeapDeltaBytes": 13631488,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 50.778953,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 47.116585,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 15.831413,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 11.758411,
+                      "calls": 2
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 8.715134,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 6.059239,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 5.079988,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 4.020464,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 2.787891,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 2.41173,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 2.273493,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 2.217067,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 2.194491,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.730392,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.676745,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.300285,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.240857,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.182445,
+                      "calls": 2
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 1.115625,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 1.115268,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.169718,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.148495,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.113297,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.092263,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.076938,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.07606,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.071241,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.022292013178230263,
+                  "maximumPercentError": 3.124980464119297e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.040969018142608005,
+                  "utilizationPercent": 4.0969018142608,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628521601,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.18061963714784,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24439,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 2,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "7d12b3fc-b0ef-320f-871d-a827183706eb",
+                "elapsedMs": 168.828744,
+                "usedHeapBytesBefore": 105306136,
+                "usedHeapBytesAfter": 117889048,
+                "usedHeapDeltaBytes": 12582912,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 53.812328,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 47.727639,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 42.095998,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 33.075175,
+                      "calls": 2
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 25.422834,
+                      "calls": 2
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 10.184992,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 7.935996,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 2.882692,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 2.708701,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.624582,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 2.092118,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.966186,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.858551,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.677855,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.505466,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.144446,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.989246,
+                      "calls": 2
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 0.927675,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.9021,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.8183,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.533935,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.378738,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.211163,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.108805,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.084294,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.083658,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.05418,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.022292152149020694,
+                  "maximumPercentError": 3.124999945575099e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.040969018142681966,
+                  "utilizationPercent": 4.096901814268197,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628536394,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.18061963714636,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24441,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 3,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "c7e2ae29-ddba-3830-9dc6-bd092a91a141",
+                "elapsedMs": 165.829708,
+                "usedHeapBytesBefore": 118937624,
+                "usedHeapBytesAfter": 131520536,
+                "usedHeapDeltaBytes": 12582912,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 52.783691,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 29.927883,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 27.096661,
+                      "calls": 2
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 25.369678,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 21.805952,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 10.721088,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 5.66197,
+                      "calls": 2
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 3.943123,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 3.462342,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 3.455161,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 3.432275,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 3.176457,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 2.938706,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.770827,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 2.181127,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.6829,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 1.306488,
+                      "calls": 2
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.280482,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.158658,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.035678,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.504983,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.408933,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.361376,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.294294,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.09236,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.065906,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.055455,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02229215249826666,
+                  "maximumPercentError": 3.124999994533731e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901814285081,
+                  "utilizationPercent": 4.096901814285081,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628570162,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.180619637142982,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24444,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 4,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "d54afe98-1101-378c-a1bb-a6a6bbf5f374",
+                "elapsedMs": 173.970585,
+                "usedHeapBytesBefore": 131520536,
+                "usedHeapBytesAfter": 27967744,
+                "usedHeapDeltaBytes": -103552792,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 59.0446,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 57.806306,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 56.597009,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 47.468425,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 40.375308,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 23.244822,
+                      "calls": 2
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 21.392585,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 5.25706,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 3.532764,
+                      "calls": 2
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 2.817661,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 2.746023,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.344803,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 2.281505,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.751483,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.650255,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.508745,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.358601,
+                      "calls": 2
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.341712,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.913728,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.598652,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.545168,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.325121,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.116225,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.09835,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.082872,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.079144,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.037368,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02229215249826666,
+                  "maximumPercentError": 3.124999994533731e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.040969018142700146,
+                  "utilizationPercent": 4.096901814270015,
+                  "finiteEvidence": true,
+                  "currentValue": 0.819380362854003,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.180619637146,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24429,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 5,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "a4a8685d-adf4-3d77-ac7c-dd33cdce9ada",
+                "elapsedMs": 217.493935,
+                "usedHeapBytesBefore": 27967744,
+                "usedHeapBytesAfter": 39502080,
+                "usedHeapDeltaBytes": 11534336,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train Splitter": {
+                      "elapsedMs": 58.978196,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 48.950557,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 28.715592,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 27.675188,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 20.898468,
+                      "calls": 2
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 19.039624,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 13.924928,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 7.37881,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 6.380978,
+                      "calls": 2
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 5.626907,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 5.048285,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 2.508755,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 1.995752,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.736179,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.628973,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.495395,
+                      "calls": 2
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 1.481378,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.291541,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.140299,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.105114,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.200435,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.170509,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.132276,
+                      "calls": 2
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.105451,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.059266,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.052506,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.046621,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02229215249826666,
+                  "maximumPercentError": 3.124999994533731e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.040969018142839826,
+                  "utilizationPercent": 4.096901814283982,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628567965,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.180619637143202,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24443,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "nearby-state",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "982f66f7-f724-3be3-8d87-e9854bff4574",
+                "elapsedMs": 139.489898,
+                "usedHeapBytesBefore": 40767952,
+                "usedHeapBytesAfter": 58376448,
+                "usedHeapDeltaBytes": 17608496,
+                "feedMassRateKgPerHr": 90900.00000000001,
+                "productMassRateKgPerHr": 69543.7802217941,
+                "executionWork": {
+                  "equipmentCalls": 51,
+                  "equipment": {
+                    "M Export Mixer": {
+                      "elapsedMs": 40.72624,
+                      "calls": 5
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 32.404711,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 23.922051,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 17.185451,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 8.231451,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 7.35963,
+                      "calls": 5
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 7.091172,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 5.268013,
+                      "calls": 5
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 4.555353,
+                      "calls": 5
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.951936,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 2.86608,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 2.551346,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 2.258851,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 2.176488,
+                      "calls": 5
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 2.166954,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 2.091651,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 2.054291,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.87424,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 1.541721,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 1.230167,
+                      "calls": 5
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.067341,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.956258,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 0.816748,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 0.716567,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.69977,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.528375,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.465597,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.004235525193507783,
+                  "maximumPercentError": 5.878735166829899e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.041378827782491384,
+                  "utilizationPercent": 4.137882778249138,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8275765556498277,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.172423444350173,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24434,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "constraint-change",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "1f859357-0cc4-3fa6-bff2-ec204c0c5f8b",
+                "elapsedMs": 82.438637,
+                "usedHeapBytesBefore": 58376448,
+                "usedHeapBytesAfter": 70959360,
+                "usedHeapDeltaBytes": 12582912,
+                "feedMassRateKgPerHr": 90900.00000000001,
+                "productMassRateKgPerHr": 69543.7802217941,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 28.888056,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 18.457676,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 13.896341,
+                      "calls": 2
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 13.679392,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 11.576761,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 8.4071,
+                      "calls": 2
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 6.254992,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 4.550545,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 3.155274,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.524934,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.498713,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.467266,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.266664,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.222838,
+                      "calls": 2
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.199415,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.172617,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.168577,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.08464,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 0.641542,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.599521,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.536799,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.424894,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.114318,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.092246,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.073607,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.071888,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.039001,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.004457890288904309,
+                  "maximumPercentError": 6.187368775550701e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Feed Pipe",
+                  "constraint": "installedMixtureVelocity",
+                  "utilization": 1.0526315789473684,
+                  "utilizationPercent": 105.26315789473684,
+                  "finiteEvidence": true,
+                  "currentValue": 0.7735209909497517,
+                  "designValue": 0.7348449414022641,
+                  "signedPhysicalMargin": -0.0386760495474876,
+                  "unit": "m/s",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 50.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24714,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "discrete-line-up",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "54d0f9ae-9544-314f-b42f-641127ac1d6c",
+                "elapsedMs": 388.160669,
+                "usedHeapBytesBefore": 72007936,
+                "usedHeapBytesAfter": 83542272,
+                "usedHeapDeltaBytes": 11534336,
+                "feedMassRateKgPerHr": 90900.00000000001,
+                "productMassRateKgPerHr": 69543.91209009592,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 235.208791,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 97.886274,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 27.73851,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 25.034913,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 19.746683,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 11.37491,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 8.439792,
+                      "calls": 2
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 3.187828,
+                      "calls": 2
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 2.236154,
+                      "calls": 2
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.460447,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.37935,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.335601,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.219643,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.176459,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.012102,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.886856,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 0.832383,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.444357,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.437324,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.433043,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.42066,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.382524,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.221747,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.197772,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.159671,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 0.046857,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 0.029357,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0019012067496078089,
+                  "maximumPercentError": 2.6387954833575083e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Feed Pipe",
+                  "constraint": "installedMixtureVelocity",
+                  "utilization": 1.0526315789473684,
+                  "utilizationPercent": 105.26315789473684,
+                  "finiteEvidence": true,
+                  "currentValue": 0.7735209909497517,
+                  "designValue": 0.7348449414022641,
+                  "signedPhysicalMargin": -0.0386760495474876,
+                  "unit": "m/s",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 50.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24634,
+                "utilizationSnapshotSchemaVersion": "1.0",
+                "availabilityAction": "train-3 unavailable through zero split allocation"
+              },
+              {
+                "mode": "restored-line-up",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "5ac7b216-4e95-3b19-9630-2912d1c0e5a6",
+                "elapsedMs": 264.348188,
+                "usedHeapBytesBefore": 84590848,
+                "usedHeapBytesAfter": 102416640,
+                "usedHeapDeltaBytes": 17825792,
+                "feedMassRateKgPerHr": 89999.99999999996,
+                "productMassRateKgPerHr": 68855.24419334237,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.02582125153276138,
+                "executionWork": {
+                  "equipmentCalls": 51,
+                  "equipment": {
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 69.949961,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 69.928597,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 58.304076,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 29.926539,
+                      "calls": 5
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 16.07563,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 9.694763,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 8.435144,
+                      "calls": 5
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 8.081011,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 6.13152,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 4.518427,
+                      "calls": 5
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 3.216719,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 3.063467,
+                      "calls": 5
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 2.582279,
+                      "calls": 5
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 2.459326,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 2.081753,
+                      "calls": 5
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 2.019645,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.367151,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.207455,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.143639,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.086343,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.01606,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.665555,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.570732,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.562081,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.559899,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.542294,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.432381,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.00423576234607026,
+                  "maximumPercentError": 5.937855156862527e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Feed Pipe",
+                  "constraint": "installedMixtureVelocity",
+                  "utilization": 1.0422088265813942,
+                  "utilizationPercent": 104.22088265813943,
+                  "finiteEvidence": true,
+                  "currentValue": 0.765861884098127,
+                  "designValue": 0.7348449414022641,
+                  "signedPhysicalMargin": -0.03101694269586297,
+                  "unit": "m/s",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 50.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24732,
+                "utilizationSnapshotSchemaVersion": "1.0",
+                "restoration": "FULL_REPLAY_COMPLETED"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fork": 4,
+      "externalWallTimeMs": 48105.17,
+      "canonicalRawReportBytes": 60452,
+      "canonicalRawReportSha256": "fab7c2a45664639a3dd2e400569376ba75c6085a86baeb037990e5d9d92fc9e2",
+      "rawReport": {
+        "schemaVersion": "1.0",
+        "neqsimCommit": "f3a2cf5f0891322ab2462817f0c06d0d9409f1f6",
+        "environment": {
+          "javaVersion": "17.0.19",
+          "javaVendor": "Ubuntu",
+          "jvmName": "OpenJDK 64-Bit Server VM",
+          "osName": "Linux",
+          "osVersion": "6.18.35",
+          "osArchitecture": "amd64",
+          "availableProcessors": 9,
+          "maximumHeapBytes": 3221225472,
+          "inputArguments": "[-Xmx3g, --add-opens=java.base/java.util=ALL-UNNAMED, --add-opens=java.base/java.lang=ALL-UNNAMED, --add-opens=java.base/java.io=ALL-UNNAMED, --add-opens=java.base/java.lang.reflect=ALL-UNNAMED]",
+          "cpuModel": {
+            "status": "UNAVAILABLE",
+            "reason": "not exposed by a portable Java 8 runtime API; capture in run ledger"
+          }
+        },
+        "measurementCoverage": {
+          "convergenceAndRunStatus": "AVAILABLE",
+          "equipmentExecutionCallsAndTiming": "AVAILABLE",
+          "massBalance": "AVAILABLE",
+          "utilizationAndBottleneck": "AVAILABLE",
+          "resultSize": "AVAILABLE",
+          "usedHeapBeforeAfterProxy": "AVAILABLE",
+          "areaExecutionCounts": {
+            "status": "UNAVAILABLE",
+            "reason": "no public ProcessSystem area counter"
+          },
+          "flashAndPropertyWork": {
+            "status": "UNAVAILABLE",
+            "reason": "no public attributable counter"
+          },
+          "cacheHitsMissesInvalidations": {
+            "status": "UNAVAILABLE",
+            "reason": "optimizer cache is not used by this solve-only baseline"
+          },
+          "allocatedBytes": {
+            "status": "UNAVAILABLE",
+            "reason": "no portable Java 8 per-run allocation counter configured"
+          },
+          "peakUsedHeap": {
+            "status": "UNAVAILABLE",
+            "reason": "no sampling profiler configured; before/after used heap is retained as proxy"
+          }
+        },
+        "cases": [
+          {
+            "caseSchemaVersion": "1.0",
+            "caseId": "S",
+            "identity": "guide-small",
+            "seed": 3154,
+            "unitCount": 3,
+            "areaCount": 1,
+            "connectionCount": 0,
+            "recycleCount": 0,
+            "boundaryCount": 1,
+            "decisionVariableCount": 1,
+            "objectiveCount": 1,
+            "assumptionsAndUnits": "Synthetic SRK gas; rates on mass basis in kg/hr; pressure in bara; power in kW",
+            "compatibilityRisk": "test-and-documentation-only; no runtime behavior change",
+            "modes": [
+              {
+                "mode": "cold",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "48577283-8387-33c7-a314-eb9e6bb633ae",
+                "elapsedMs": 90.191959,
+                "usedHeapBytesBefore": 32469904,
+                "usedHeapBytesAfter": 37965600,
+                "usedHeapDeltaBytes": 5495696,
+                "feedMassRateKgPerHr": 5000.0,
+                "productMassRateKgPerHr": 5000.0,
+                "executionWork": {
+                  "equipmentCalls": 3,
+                  "equipment": {
+                    "Gas Compressor": {
+                      "elapsedMs": 38.101196,
+                      "calls": 1
+                    },
+                    "Well Feed": {
+                      "elapsedMs": 18.55702,
+                      "calls": 1
+                    },
+                    "HP Separator": {
+                      "elapsedMs": 2.659655,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 0.9077488817569662,
+                  "utilizationPercent": 90.77488817569662,
+                  "finiteEvidence": true,
+                  "currentValue": 149.77856548989942,
+                  "designValue": 165.0,
+                  "signedPhysicalMargin": 15.221434510100579,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3145,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "d5b3d8b1-7636-303c-9dc1-e582ec0e1720",
+                "elapsedMs": 0.156179,
+                "usedHeapBytesBefore": 38761360,
+                "usedHeapBytesAfter": 38761360,
+                "usedHeapDeltaBytes": 0,
+                "feedMassRateKgPerHr": 5000.0,
+                "productMassRateKgPerHr": 5000.0,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 1,
+                  "equipment": {
+                    "HP Separator": {
+                      "elapsedMs": 0.127888,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 0.9077488817569662,
+                  "utilizationPercent": 90.77488817569662,
+                  "finiteEvidence": true,
+                  "currentValue": 149.77856548989942,
+                  "designValue": 165.0,
+                  "signedPhysicalMargin": 15.221434510100579,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3145,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "nearby-state",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "0bae417b-33b2-3a9d-ac25-e9ce9dd047cb",
+                "elapsedMs": 21.088249,
+                "usedHeapBytesBefore": 38761360,
+                "usedHeapBytesAfter": 40062232,
+                "usedHeapDeltaBytes": 1300872,
+                "feedMassRateKgPerHr": 5049.999999999999,
+                "productMassRateKgPerHr": 5049.999999999999,
+                "executionWork": {
+                  "equipmentCalls": 3,
+                  "equipment": {
+                    "Gas Compressor": {
+                      "elapsedMs": 17.08687,
+                      "calls": 1
+                    },
+                    "HP Separator": {
+                      "elapsedMs": 2.04809,
+                      "calls": 1
+                    },
+                    "Well Feed": {
+                      "elapsedMs": 1.900565,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 0.9168263705745356,
+                  "utilizationPercent": 91.68263705745356,
+                  "finiteEvidence": true,
+                  "currentValue": 151.27635114479838,
+                  "designValue": 165.0,
+                  "signedPhysicalMargin": 13.723648855201617,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3144,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "constraint-change",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "9ac63a24-99a3-3d28-9f93-8f48aee789c4",
+                "elapsedMs": 0.602007,
+                "usedHeapBytesBefore": 40062232,
+                "usedHeapBytesAfter": 40062232,
+                "usedHeapDeltaBytes": 0,
+                "feedMassRateKgPerHr": 5049.999999999999,
+                "productMassRateKgPerHr": 5049.999999999999,
+                "executionWork": {
+                  "equipmentCalls": 1,
+                  "equipment": {
+                    "HP Separator": {
+                      "elapsedMs": 0.565356,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 1.0526315789473686,
+                  "utilizationPercent": 105.26315789473686,
+                  "finiteEvidence": true,
+                  "currentValue": 151.27635114479838,
+                  "designValue": 143.71253358755845,
+                  "signedPhysicalMargin": -7.563817557239929,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3157,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "invalid-candidate",
+                "outcome": "REJECTED_BEFORE_MUTATION",
+                "finiteEvidence": false,
+                "restoration": "NOT_REQUIRED_STATE_UNCHANGED",
+                "rejectionReason": "Parameter 0 must be finite, but was NaN"
+              }
+            ]
+          },
+          {
+            "caseSchemaVersion": "1.0",
+            "caseId": "M",
+            "identity": "three-train-tail-recycle",
+            "seed": 3154,
+            "unitCount": 27,
+            "areaCount": 1,
+            "connectionCount": 0,
+            "recycleCount": 1,
+            "boundaryCount": 1,
+            "decisionVariableCount": 1,
+            "objectiveCount": 1,
+            "assumptionsAndUnits": "Synthetic SRK rich gas; rates on mass basis in kg/hr; pressure in bara; velocity in m/s",
+            "compatibilityRisk": "test-and-documentation-only; no runtime behavior change",
+            "bottleneckTransition": {
+              "status": "PARTIAL",
+              "observedInitialBottleneck": "M Export Pipe/velocity",
+              "observedConstraintChangeBottleneck": "M Feed Pipe/installedMixtureVelocity",
+              "missing": "ordered piping/compressor/separator shift under one continuous variable requires stable plant constraint identity",
+              "owner": "#3154 next increment; execution counters and cache attribution coordinate with #2939"
+            },
+            "modes": [
+              {
+                "mode": "cold",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "3b46cf14-1772-30b4-91e5-cd8954dcdb52",
+                "elapsedMs": 274.503049,
+                "usedHeapBytesBefore": 42020720,
+                "usedHeapBytesAfter": 39020000,
+                "usedHeapDeltaBytes": -3000720,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "executionWork": {
+                  "equipmentCalls": 63,
+                  "equipment": {
+                    "M Export Mixer": {
+                      "elapsedMs": 76.656319,
+                      "calls": 7
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 42.975706,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 41.797575,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 38.197238,
+                      "calls": 7
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 34.784817,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 15.062404,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 13.22878,
+                      "calls": 7
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 12.305248,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 10.91508,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 10.684436,
+                      "calls": 7
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 10.58708,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 9.886155,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 7.85761,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 7.327833,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 6.164052,
+                      "calls": 7
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 6.017599,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 4.79232,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 4.43846,
+                      "calls": 7
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 3.965811,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 3.520802,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 3.466538,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 2.820659,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 2.576093,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 2.23335,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 1.913963,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.536422,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.395806,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02223642212629784,
+                  "maximumPercentError": 3.1171874982831635e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901811396201,
+                  "utilizationPercent": 4.096901811396201,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803622792402,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.18061963772076,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24440,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "ab7a0d7c-9f8f-382b-8c31-f1c597b7f394",
+                "elapsedMs": 94.756576,
+                "usedHeapBytesBefore": 41117096,
+                "usedHeapBytesAfter": 25215280,
+                "usedHeapDeltaBytes": -15901816,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 27.037503,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 22.388175,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 20.909151,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 15.79785,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 11.265423,
+                      "calls": 2
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 9.246512,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 4.912101,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 3.985292,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 2.874536,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 2.785543,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 2.716493,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 2.623982,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 2.456161,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.71734,
+                      "calls": 2
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.459363,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.436301,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.211444,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 0.990862,
+                      "calls": 2
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.971661,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.829438,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.121541,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.0894,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.087523,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.081192,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.059609,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.048604,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.037274,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.022292013178230263,
+                  "maximumPercentError": 3.124980464119297e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.040969018142608005,
+                  "utilizationPercent": 4.0969018142608,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628521601,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.18061963714784,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24438,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 2,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "7d12b3fc-b0ef-320f-871d-a827183706eb",
+                "elapsedMs": 104.466678,
+                "usedHeapBytesBefore": 25215280,
+                "usedHeapBytesAfter": 37798192,
+                "usedHeapDeltaBytes": 12582912,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 44.826567,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 42.907631,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 35.683469,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 15.604965,
+                      "calls": 2
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 6.10369,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 5.301328,
+                      "calls": 2
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 4.951643,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 4.62969,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 2.364296,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 2.172088,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.967057,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.912318,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.899172,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.754273,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.717476,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.693875,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.688557,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.264958,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 1.224524,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.703099,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.160205,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.111183,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.091905,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.076449,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.051015,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.041214,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.036945,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.022292152149020694,
+                  "maximumPercentError": 3.124999945575099e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.040969018142681966,
+                  "utilizationPercent": 4.096901814268197,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628536394,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.18061963714636,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24441,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 3,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "c7e2ae29-ddba-3830-9dc6-bd092a91a141",
+                "elapsedMs": 99.813877,
+                "usedHeapBytesBefore": 38846768,
+                "usedHeapBytesAfter": 52478256,
+                "usedHeapDeltaBytes": 13631488,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 38.83811,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 22.012499,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 22.009393,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 11.280256,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 8.813445,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 8.018975,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 3.464384,
+                      "calls": 2
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.857802,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 2.826888,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 2.158022,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 2.152971,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.99717,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.892549,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.840046,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.784467,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.771248,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.458645,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.380131,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.909364,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.680951,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.130212,
+                      "calls": 2
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.128093,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.120939,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.108543,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.087602,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.079925,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.043259,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02229215249826666,
+                  "maximumPercentError": 3.124999994533731e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901814285081,
+                  "utilizationPercent": 4.096901814285081,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628570162,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.180619637142982,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24442,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 4,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "d54afe98-1101-378c-a1bb-a6a6bbf5f374",
+                "elapsedMs": 80.542515,
+                "usedHeapBytesBefore": 52478256,
+                "usedHeapBytesAfter": 66109744,
+                "usedHeapDeltaBytes": 13631488,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 26.580497,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 21.051032,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 19.986427,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 12.139526,
+                      "calls": 2
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 8.877579,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 4.197506,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 3.54757,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 2.73634,
+                      "calls": 2
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.678871,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 2.482378,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 2.407946,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.990146,
+                      "calls": 2
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.708853,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.535663,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.195403,
+                      "calls": 2
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.077714,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.815539,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 0.709265,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.687399,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 0.520454,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.142598,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.118145,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.110832,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.107051,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.102558,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.052602,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.048912,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02229215249826666,
+                  "maximumPercentError": 3.124999994533731e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901814268885,
+                  "utilizationPercent": 4.096901814268885,
+                  "finiteEvidence": true,
+                  "currentValue": 0.819380362853777,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.180619637146222,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24439,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 5,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "a4a8685d-adf4-3d77-ac7c-dd33cdce9ada",
+                "elapsedMs": 85.152982,
+                "usedHeapBytesBefore": 66109744,
+                "usedHeapBytesAfter": 79741232,
+                "usedHeapDeltaBytes": 13631488,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 42.585437,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 34.951428,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 29.744325,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 11.417198,
+                      "calls": 2
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 4.078032,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 3.828616,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 3.762248,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 3.573919,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 3.564993,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 3.15644,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.688239,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.477187,
+                      "calls": 2
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.368201,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.322207,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.285853,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 0.901827,
+                      "calls": 2
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 0.897577,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 0.874313,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.645351,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.51651,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.142007,
+                      "calls": 2
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.128827,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.095086,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.071452,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.065972,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.062056,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.0614,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02229215249826666,
+                  "maximumPercentError": 3.124999994533731e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901814268854,
+                  "utilizationPercent": 4.096901814268854,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628537707,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.18061963714623,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24438,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "nearby-state",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "982f66f7-f724-3be3-8d87-e9854bff4574",
+                "elapsedMs": 121.596859,
+                "usedHeapBytesBefore": 79741232,
+                "usedHeapBytesAfter": 97567024,
+                "usedHeapDeltaBytes": 17825792,
+                "feedMassRateKgPerHr": 90900.00000000001,
+                "productMassRateKgPerHr": 69543.78022180362,
+                "executionWork": {
+                  "equipmentCalls": 51,
+                  "equipment": {
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 49.196692,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 47.973635,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 35.341249,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 23.667718,
+                      "calls": 5
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 9.459608,
+                      "calls": 5
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 4.629699,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 4.418194,
+                      "calls": 5
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 3.515968,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 3.425838,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 3.237036,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 2.073663,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 2.048432,
+                      "calls": 5
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 1.987418,
+                      "calls": 5
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 1.743205,
+                      "calls": 5
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.603139,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.332061,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.270876,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.264738,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 0.893007,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 0.859278,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.720181,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.676738,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.647629,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.626775,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.575372,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.538195,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.358963,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.004235525178955868,
+                  "maximumPercentError": 5.8787351466324375e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.041378827782485646,
+                  "utilizationPercent": 4.1378827782485645,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8275765556497129,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.172423444350287,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24439,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "constraint-change",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "1f859357-0cc4-3fa6-bff2-ec204c0c5f8b",
+                "elapsedMs": 67.191888,
+                "usedHeapBytesBefore": 98615600,
+                "usedHeapBytesAfter": 111198512,
+                "usedHeapDeltaBytes": 12582912,
+                "feedMassRateKgPerHr": 90900.00000000001,
+                "productMassRateKgPerHr": 69543.78022180362,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 28.069001,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 22.12484,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 16.092699,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 11.583637,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 9.214583,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 5.02692,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 4.025882,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 3.466422,
+                      "calls": 2
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 2.732346,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 2.602629,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 2.09928,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.701324,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.268834,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.135399,
+                      "calls": 2
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.131626,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 0.934238,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 0.776362,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 0.669387,
+                      "calls": 2
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.634005,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.380474,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.132532,
+                      "calls": 2
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.091227,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.087541,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.071171,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.061455,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.048387,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.045921,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.004457890274352394,
+                  "maximumPercentError": 6.1873687553532395e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Feed Pipe",
+                  "constraint": "installedMixtureVelocity",
+                  "utilization": 1.0526315789473684,
+                  "utilizationPercent": 105.26315789473684,
+                  "finiteEvidence": true,
+                  "currentValue": 0.7735209909497517,
+                  "designValue": 0.7348449414022641,
+                  "signedPhysicalMargin": -0.0386760495474876,
+                  "unit": "m/s",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 50.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24717,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "discrete-line-up",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "54d0f9ae-9544-314f-b42f-641127ac1d6c",
+                "elapsedMs": 97.620191,
+                "usedHeapBytesBefore": 112247088,
+                "usedHeapBytesAfter": 122732848,
+                "usedHeapDeltaBytes": 10485760,
+                "feedMassRateKgPerHr": 90900.00000000001,
+                "productMassRateKgPerHr": 69543.91206325396,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 27.952229,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 23.565218,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 17.425206,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 16.270056,
+                      "calls": 2
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 11.607357,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 9.256283,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 3.71404,
+                      "calls": 2
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.973954,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.968605,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.712971,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.220655,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.190294,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.09827,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 0.970173,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.960583,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 0.946259,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.936753,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.62118,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.542572,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.464904,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.429123,
+                      "calls": 2
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.405417,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.380989,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.185645,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.117054,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 0.057682,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 0.042207,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0019012169650522992,
+                  "maximumPercentError": 2.6388096619673763e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Feed Pipe",
+                  "constraint": "installedMixtureVelocity",
+                  "utilization": 1.0526315789473684,
+                  "utilizationPercent": 105.26315789473684,
+                  "finiteEvidence": true,
+                  "currentValue": 0.7735209909497517,
+                  "designValue": 0.7348449414022641,
+                  "signedPhysicalMargin": -0.0386760495474876,
+                  "unit": "m/s",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 50.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24622,
+                "utilizationSnapshotSchemaVersion": "1.0",
+                "availabilityAction": "train-3 unavailable through zero split allocation"
+              },
+              {
+                "mode": "restored-line-up",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "5ac7b216-4e95-3b19-9630-2912d1c0e5a6",
+                "elapsedMs": 109.334362,
+                "usedHeapBytesBefore": 123781424,
+                "usedHeapBytesAfter": 141607216,
+                "usedHeapDeltaBytes": 17825792,
+                "feedMassRateKgPerHr": 89999.99999999996,
+                "productMassRateKgPerHr": 68855.24419315142,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.025821060582529753,
+                "executionWork": {
+                  "equipmentCalls": 51,
+                  "equipment": {
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 36.242246,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 32.717041,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 28.508556,
+                      "calls": 5
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 12.148378,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 10.687878,
+                      "calls": 5
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 5.522534,
+                      "calls": 5
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 4.9789,
+                      "calls": 5
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 4.060775,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 3.737713,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 2.844671,
+                      "calls": 5
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 2.487269,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 2.322264,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.84675,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.780587,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 1.636639,
+                      "calls": 5
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.436662,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.277143,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.145634,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.037994,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.985862,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.689068,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.644356,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.556529,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.506252,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.45402,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.439042,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.392314,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.00423576234607026,
+                  "maximumPercentError": 5.937855156862527e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Feed Pipe",
+                  "constraint": "installedMixtureVelocity",
+                  "utilization": 1.0422088265813942,
+                  "utilizationPercent": 104.22088265813943,
+                  "finiteEvidence": true,
+                  "currentValue": 0.765861884098127,
+                  "designValue": 0.7348449414022641,
+                  "signedPhysicalMargin": -0.03101694269586297,
+                  "unit": "m/s",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 50.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24730,
+                "utilizationSnapshotSchemaVersion": "1.0",
+                "restoration": "FULL_REPLAY_COMPLETED"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fork": 5,
+      "externalWallTimeMs": 49955.003,
+      "canonicalRawReportBytes": 60466,
+      "canonicalRawReportSha256": "95f543437ccf6552bb31dcf8c3ccb710ab24741612d943ca7413bdd03bdefbf4",
+      "rawReport": {
+        "schemaVersion": "1.0",
+        "neqsimCommit": "f3a2cf5f0891322ab2462817f0c06d0d9409f1f6",
+        "environment": {
+          "javaVersion": "17.0.19",
+          "javaVendor": "Ubuntu",
+          "jvmName": "OpenJDK 64-Bit Server VM",
+          "osName": "Linux",
+          "osVersion": "6.18.35",
+          "osArchitecture": "amd64",
+          "availableProcessors": 9,
+          "maximumHeapBytes": 3221225472,
+          "inputArguments": "[-Xmx3g, --add-opens=java.base/java.util=ALL-UNNAMED, --add-opens=java.base/java.lang=ALL-UNNAMED, --add-opens=java.base/java.io=ALL-UNNAMED, --add-opens=java.base/java.lang.reflect=ALL-UNNAMED]",
+          "cpuModel": {
+            "status": "UNAVAILABLE",
+            "reason": "not exposed by a portable Java 8 runtime API; capture in run ledger"
+          }
+        },
+        "measurementCoverage": {
+          "convergenceAndRunStatus": "AVAILABLE",
+          "equipmentExecutionCallsAndTiming": "AVAILABLE",
+          "massBalance": "AVAILABLE",
+          "utilizationAndBottleneck": "AVAILABLE",
+          "resultSize": "AVAILABLE",
+          "usedHeapBeforeAfterProxy": "AVAILABLE",
+          "areaExecutionCounts": {
+            "status": "UNAVAILABLE",
+            "reason": "no public ProcessSystem area counter"
+          },
+          "flashAndPropertyWork": {
+            "status": "UNAVAILABLE",
+            "reason": "no public attributable counter"
+          },
+          "cacheHitsMissesInvalidations": {
+            "status": "UNAVAILABLE",
+            "reason": "optimizer cache is not used by this solve-only baseline"
+          },
+          "allocatedBytes": {
+            "status": "UNAVAILABLE",
+            "reason": "no portable Java 8 per-run allocation counter configured"
+          },
+          "peakUsedHeap": {
+            "status": "UNAVAILABLE",
+            "reason": "no sampling profiler configured; before/after used heap is retained as proxy"
+          }
+        },
+        "cases": [
+          {
+            "caseSchemaVersion": "1.0",
+            "caseId": "S",
+            "identity": "guide-small",
+            "seed": 3154,
+            "unitCount": 3,
+            "areaCount": 1,
+            "connectionCount": 0,
+            "recycleCount": 0,
+            "boundaryCount": 1,
+            "decisionVariableCount": 1,
+            "objectiveCount": 1,
+            "assumptionsAndUnits": "Synthetic SRK gas; rates on mass basis in kg/hr; pressure in bara; power in kW",
+            "compatibilityRisk": "test-and-documentation-only; no runtime behavior change",
+            "modes": [
+              {
+                "mode": "cold",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "48577283-8387-33c7-a314-eb9e6bb633ae",
+                "elapsedMs": 147.209716,
+                "usedHeapBytesBefore": 36513856,
+                "usedHeapBytesAfter": 41841048,
+                "usedHeapDeltaBytes": 5327192,
+                "feedMassRateKgPerHr": 5000.0,
+                "productMassRateKgPerHr": 5000.0,
+                "executionWork": {
+                  "equipmentCalls": 3,
+                  "equipment": {
+                    "Gas Compressor": {
+                      "elapsedMs": 73.781994,
+                      "calls": 1
+                    },
+                    "Well Feed": {
+                      "elapsedMs": 25.350829,
+                      "calls": 1
+                    },
+                    "HP Separator": {
+                      "elapsedMs": 7.90174,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 0.9077488817569662,
+                  "utilizationPercent": 90.77488817569662,
+                  "finiteEvidence": true,
+                  "currentValue": 149.77856548989942,
+                  "designValue": 165.0,
+                  "signedPhysicalMargin": 15.221434510100579,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3145,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "d5b3d8b1-7636-303c-9dc1-e582ec0e1720",
+                "elapsedMs": 0.192183,
+                "usedHeapBytesBefore": 15272848,
+                "usedHeapBytesAfter": 15272848,
+                "usedHeapDeltaBytes": 0,
+                "feedMassRateKgPerHr": 5000.0,
+                "productMassRateKgPerHr": 5000.0,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 1,
+                  "equipment": {
+                    "HP Separator": {
+                      "elapsedMs": 0.158054,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 0.9077488817569662,
+                  "utilizationPercent": 90.77488817569662,
+                  "finiteEvidence": true,
+                  "currentValue": 149.77856548989942,
+                  "designValue": 165.0,
+                  "signedPhysicalMargin": 15.221434510100579,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3145,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "nearby-state",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "0bae417b-33b2-3a9d-ac25-e9ce9dd047cb",
+                "elapsedMs": 20.882889,
+                "usedHeapBytesBefore": 15347744,
+                "usedHeapBytesAfter": 16410064,
+                "usedHeapDeltaBytes": 1062320,
+                "feedMassRateKgPerHr": 5049.999999999999,
+                "productMassRateKgPerHr": 5049.999999999999,
+                "executionWork": {
+                  "equipmentCalls": 3,
+                  "equipment": {
+                    "Gas Compressor": {
+                      "elapsedMs": 17.863483,
+                      "calls": 1
+                    },
+                    "Well Feed": {
+                      "elapsedMs": 1.641987,
+                      "calls": 1
+                    },
+                    "HP Separator": {
+                      "elapsedMs": 1.318895,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 0.9168263705745356,
+                  "utilizationPercent": 91.68263705745356,
+                  "finiteEvidence": true,
+                  "currentValue": 151.27635114479838,
+                  "designValue": 165.0,
+                  "signedPhysicalMargin": 13.723648855201617,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3144,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "constraint-change",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "9ac63a24-99a3-3d28-9f93-8f48aee789c4",
+                "elapsedMs": 0.21499,
+                "usedHeapBytesBefore": 16410064,
+                "usedHeapBytesAfter": 16410064,
+                "usedHeapDeltaBytes": 0,
+                "feedMassRateKgPerHr": 5049.999999999999,
+                "productMassRateKgPerHr": 5049.999999999999,
+                "executionWork": {
+                  "equipmentCalls": 1,
+                  "equipment": {
+                    "HP Separator": {
+                      "elapsedMs": 0.188006,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0,
+                  "maximumPercentError": 0.0,
+                  "unit": "kg/hr",
+                  "worstUnit": "HP Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "Gas Compressor",
+                  "constraint": "installedPower",
+                  "utilization": 1.0526315789473686,
+                  "utilizationPercent": 105.26315789473686,
+                  "finiteEvidence": true,
+                  "currentValue": 151.27635114479838,
+                  "designValue": 143.71253358755845,
+                  "signedPhysicalMargin": -7.563817557239929,
+                  "unit": "kW",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 5000.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 3,
+                  "units": [
+                    {
+                      "unitName": "Well Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "HP Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "Gas Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 3157,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "invalid-candidate",
+                "outcome": "REJECTED_BEFORE_MUTATION",
+                "finiteEvidence": false,
+                "restoration": "NOT_REQUIRED_STATE_UNCHANGED",
+                "rejectionReason": "Parameter 0 must be finite, but was NaN"
+              }
+            ]
+          },
+          {
+            "caseSchemaVersion": "1.0",
+            "caseId": "M",
+            "identity": "three-train-tail-recycle",
+            "seed": 3154,
+            "unitCount": 27,
+            "areaCount": 1,
+            "connectionCount": 0,
+            "recycleCount": 1,
+            "boundaryCount": 1,
+            "decisionVariableCount": 1,
+            "objectiveCount": 1,
+            "assumptionsAndUnits": "Synthetic SRK rich gas; rates on mass basis in kg/hr; pressure in bara; velocity in m/s",
+            "compatibilityRisk": "test-and-documentation-only; no runtime behavior change",
+            "bottleneckTransition": {
+              "status": "PARTIAL",
+              "observedInitialBottleneck": "M Export Pipe/velocity",
+              "observedConstraintChangeBottleneck": "M Feed Pipe/installedMixtureVelocity",
+              "missing": "ordered piping/compressor/separator shift under one continuous variable requires stable plant constraint identity",
+              "owner": "#3154 next increment; execution counters and cache attribution coordinate with #2939"
+            },
+            "modes": [
+              {
+                "mode": "cold",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "3b46cf14-1772-30b4-91e5-cd8954dcdb52",
+                "elapsedMs": 422.029047,
+                "usedHeapBytesBefore": 31740176,
+                "usedHeapBytesAfter": 61100304,
+                "usedHeapDeltaBytes": 29360128,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "executionWork": {
+                  "equipmentCalls": 63,
+                  "equipment": {
+                    "M Export Mixer": {
+                      "elapsedMs": 88.830102,
+                      "calls": 7
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 66.762407,
+                      "calls": 7
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 66.467869,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 58.991012,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 51.955523,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 34.106916,
+                      "calls": 7
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 17.066922,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 15.758475,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 13.649473,
+                      "calls": 7
+                    },
+                    "M Feed": {
+                      "elapsedMs": 13.185916,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 12.906286,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 8.344979,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 7.804251,
+                      "calls": 7
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 6.577703,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 5.625143,
+                      "calls": 7
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 5.445838,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 5.311591,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 5.134031,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 5.029485,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 4.877635,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 4.433774,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 2.492262,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 2.151348,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 2.133222,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 1.568658,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 1.539436,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 1.241507,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02223642212629784,
+                  "maximumPercentError": 3.1171874982831635e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901811396201,
+                  "utilizationPercent": 4.096901811396201,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803622792402,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.18061963772076,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24439,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "ab7a0d7c-9f8f-382b-8c31-f1c597b7f394",
+                "elapsedMs": 311.210737,
+                "usedHeapBytesBefore": 63197456,
+                "usedHeapBytesAfter": 75780368,
+                "usedHeapDeltaBytes": 12582912,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 90.664666,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 86.019994,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 66.958329,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 36.483622,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 28.279722,
+                      "calls": 2
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 20.392818,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 14.554217,
+                      "calls": 2
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 13.862891,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 13.790059,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 13.707822,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 7.591185,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 6.722862,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 5.5193,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 4.200027,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 3.222215,
+                      "calls": 2
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.559252,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.501132,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 1.409179,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.290235,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.250173,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.329656,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.21577,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.208114,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.19201,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.135051,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.075054,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.063913,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.022292013178230263,
+                  "maximumPercentError": 3.124980464119297e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.040969018142608005,
+                  "utilizationPercent": 4.0969018142608,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628521601,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.18061963714784,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24442,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 2,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "7d12b3fc-b0ef-320f-871d-a827183706eb",
+                "elapsedMs": 182.38357,
+                "usedHeapBytesBefore": 76828944,
+                "usedHeapBytesAfter": 90460432,
+                "usedHeapDeltaBytes": 13631488,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 54.212527,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 37.099853,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 32.500944,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 26.543883,
+                      "calls": 2
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 22.138856,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 13.035422,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 9.809842,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 8.719714,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 8.629836,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 8.437089,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 7.859314,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 5.25802,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 4.03816,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 2.797431,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 2.772176,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 2.733574,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 2.306824,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 2.031627,
+                      "calls": 2
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.04349,
+                      "calls": 2
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.90563,
+                      "calls": 2
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.526682,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.186519,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.117455,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.110753,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.109902,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.090082,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.0392,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.022292152149020694,
+                  "maximumPercentError": 3.124999945575099e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.040969018142681966,
+                  "utilizationPercent": 4.096901814268197,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628536394,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.18061963714636,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24441,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 3,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "c7e2ae29-ddba-3830-9dc6-bd092a91a141",
+                "elapsedMs": 149.964255,
+                "usedHeapBytesBefore": 90460432,
+                "usedHeapBytesAfter": 103043344,
+                "usedHeapDeltaBytes": 12582912,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 81.395563,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 68.253983,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 45.631297,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 9.382965,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 8.85995,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 8.367525,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 6.912605,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 4.175055,
+                      "calls": 2
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 2.939387,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 2.754457,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 2.683524,
+                      "calls": 2
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.575449,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 2.137098,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 2.13502,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 2.047627,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 2.017352,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.904468,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.25152,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.123961,
+                      "calls": 2
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 1.043423,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.223781,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.155386,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.148229,
+                      "calls": 2
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.119794,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.118103,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.10451,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.061708,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02229215249826666,
+                  "maximumPercentError": 3.124999994533731e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901814285081,
+                  "utilizationPercent": 4.096901814285081,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628570162,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.180619637142982,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24442,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 4,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "d54afe98-1101-378c-a1bb-a6a6bbf5f374",
+                "elapsedMs": 114.960936,
+                "usedHeapBytesBefore": 103043344,
+                "usedHeapBytesAfter": 115402576,
+                "usedHeapDeltaBytes": 12359232,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 31.736552,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 24.174336,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 15.284986,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 10.491162,
+                      "calls": 2
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 5.710006,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 4.058155,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 3.996591,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 3.44498,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 2.897376,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 2.521381,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.879824,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.844578,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.42836,
+                      "calls": 2
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 1.399871,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.302025,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.074331,
+                      "calls": 2
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.032522,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.770417,
+                      "calls": 2
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 0.61972,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.554758,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.282752,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.148756,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.111003,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.105034,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.095478,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.056237,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.054693,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02229215249826666,
+                  "maximumPercentError": 3.124999994533731e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901814268885,
+                  "utilizationPercent": 4.096901814268885,
+                  "finiteEvidence": true,
+                  "currentValue": 0.819380362853777,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.180619637146222,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24439,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "unchanged",
+                "repetition": 5,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "a4a8685d-adf4-3d77-ac7c-dd33cdce9ada",
+                "elapsedMs": 59.880643,
+                "usedHeapBytesBefore": 116674832,
+                "usedHeapBytesAfter": 130306320,
+                "usedHeapDeltaBytes": 13631488,
+                "feedMassRateKgPerHr": 89999.99999999999,
+                "productMassRateKgPerHr": 68855.21837209084,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.0,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 26.211336,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 18.682133,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 17.064518,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 10.487834,
+                      "calls": 2
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 3.725044,
+                      "calls": 2
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 3.093776,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.879826,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 2.683347,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.654704,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.494082,
+                      "calls": 2
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.415773,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.226975,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 1.098656,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.018139,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 0.988532,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 0.952412,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 0.852741,
+                      "calls": 2
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.82505,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 0.550848,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.361792,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.146627,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.083557,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.074271,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.049838,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.043007,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.042649,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.041939,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.02229215249826666,
+                  "maximumPercentError": 3.124999994533731e-05,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.04096901814268854,
+                  "utilizationPercent": 4.096901814268854,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8193803628537707,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.18061963714623,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24440,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "nearby-state",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "982f66f7-f724-3be3-8d87-e9854bff4574",
+                "elapsedMs": 109.224565,
+                "usedHeapBytesBefore": 131354896,
+                "usedHeapBytesAfter": 27967400,
+                "usedHeapDeltaBytes": -103387496,
+                "feedMassRateKgPerHr": 90900.00000000001,
+                "productMassRateKgPerHr": 69543.78022180362,
+                "executionWork": {
+                  "equipmentCalls": 51,
+                  "equipment": {
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 28.27787,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 21.710403,
+                      "calls": 5
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 19.116635,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 18.368734,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 17.492723,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 16.135284,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 8.809976,
+                      "calls": 5
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 3.452156,
+                      "calls": 5
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.872455,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 2.672036,
+                      "calls": 5
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.9173,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.914026,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.899624,
+                      "calls": 5
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.891752,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 1.637999,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 1.495066,
+                      "calls": 5
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.405096,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.254888,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.174208,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.038625,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 0.865585,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.634254,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.584105,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.56891,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.568612,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.521008,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.420597,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.004235525178955868,
+                  "maximumPercentError": 5.8787351466324375e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Export Pipe",
+                  "constraint": "velocity",
+                  "utilization": 0.041378827782485646,
+                  "utilizationPercent": 4.1378827782485645,
+                  "finiteEvidence": true,
+                  "currentValue": 0.8275765556497129,
+                  "designValue": 20.0,
+                  "signedPhysicalMargin": 19.172423444350287,
+                  "unit": "m/s",
+                  "type": "SOFT",
+                  "severity": "HARD",
+                  "provenance": "not_set",
+                  "confidenceAvailable": false,
+                  "validityRangeAvailable": false
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24440,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "constraint-change",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "1f859357-0cc4-3fa6-bff2-ec204c0c5f8b",
+                "elapsedMs": 80.072288,
+                "usedHeapBytesBefore": 29015976,
+                "usedHeapBytesAfter": 42647464,
+                "usedHeapDeltaBytes": 13631488,
+                "feedMassRateKgPerHr": 90900.00000000001,
+                "productMassRateKgPerHr": 69543.78022180362,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 36.536066,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 32.216966,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 26.058013,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 10.110496,
+                      "calls": 2
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 8.061414,
+                      "calls": 1
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 3.927525,
+                      "calls": 2
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 2.82798,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 2.673391,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.709992,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.418243,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.341299,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.309466,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.195096,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.115206,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.11078,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 0.806216,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 0.731736,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 0.609338,
+                      "calls": 2
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.583672,
+                      "calls": 2
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.464895,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.232434,
+                      "calls": 2
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.168902,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.090128,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.072726,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.070267,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.042589,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.037265,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.004457890274352394,
+                  "maximumPercentError": 6.1873687553532395e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Feed Pipe",
+                  "constraint": "installedMixtureVelocity",
+                  "utilization": 1.0526315789473684,
+                  "utilizationPercent": 105.26315789473684,
+                  "finiteEvidence": true,
+                  "currentValue": 0.7735209909497517,
+                  "designValue": 0.7348449414022641,
+                  "signedPhysicalMargin": -0.0386760495474876,
+                  "unit": "m/s",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 50.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24717,
+                "utilizationSnapshotSchemaVersion": "1.0"
+              },
+              {
+                "mode": "discrete-line-up",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "54d0f9ae-9544-314f-b42f-641127ac1d6c",
+                "elapsedMs": 85.672543,
+                "usedHeapBytesBefore": 42647464,
+                "usedHeapBytesAfter": 54181800,
+                "usedHeapDeltaBytes": 11534336,
+                "feedMassRateKgPerHr": 90900.00000000001,
+                "productMassRateKgPerHr": 69543.91206325396,
+                "executionWork": {
+                  "equipmentCalls": 33,
+                  "equipment": {
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 33.738018,
+                      "calls": 1
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 25.870442,
+                      "calls": 1
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 23.429473,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 18.907004,
+                      "calls": 1
+                    },
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 18.86583,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 11.17657,
+                      "calls": 2
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 3.794176,
+                      "calls": 2
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 1.935173,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 1.725948,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 1.556187,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 1.478447,
+                      "calls": 2
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 1.435106,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 1.400503,
+                      "calls": 2
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.019068,
+                      "calls": 1
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 0.992853,
+                      "calls": 1
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 0.81492,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 0.768067,
+                      "calls": 2
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 0.617227,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.563315,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 0.555777,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 0.429335,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 0.418506,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 0.368922,
+                      "calls": 2
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.169576,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.154528,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 0.085366,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 0.043881,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.0019012169650522992,
+                  "maximumPercentError": 2.6388096619673763e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Feed Pipe",
+                  "constraint": "installedMixtureVelocity",
+                  "utilization": 1.0526315789473684,
+                  "utilizationPercent": 105.26315789473684,
+                  "finiteEvidence": true,
+                  "currentValue": 0.7735209909497517,
+                  "designValue": 0.7348449414022641,
+                  "signedPhysicalMargin": -0.0386760495474876,
+                  "unit": "m/s",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 50.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24624,
+                "utilizationSnapshotSchemaVersion": "1.0",
+                "availabilityAction": "train-3 unavailable through zero split allocation"
+              },
+              {
+                "mode": "restored-line-up",
+                "repetition": 1,
+                "outcome": "SUCCESS",
+                "processSolved": true,
+                "calculationIdentity": "5ac7b216-4e95-3b19-9630-2912d1c0e5a6",
+                "elapsedMs": 167.341269,
+                "usedHeapBytesBefore": 54181800,
+                "usedHeapBytesAfter": 73056168,
+                "usedHeapDeltaBytes": 18874368,
+                "feedMassRateKgPerHr": 89999.99999999996,
+                "productMassRateKgPerHr": 68855.24419315142,
+                "repeatabilityAbsoluteDifferenceKgPerHr": 0.025821060582529753,
+                "executionWork": {
+                  "equipmentCalls": 51,
+                  "equipment": {
+                    "M Train 2 Compressor": {
+                      "elapsedMs": 64.475048,
+                      "calls": 1
+                    },
+                    "M Train 3 Compressor": {
+                      "elapsedMs": 47.83047,
+                      "calls": 1
+                    },
+                    "M Train 1 Compressor": {
+                      "elapsedMs": 45.085693,
+                      "calls": 1
+                    },
+                    "M Export Mixer": {
+                      "elapsedMs": 34.822977,
+                      "calls": 5
+                    },
+                    "M Export Pipe": {
+                      "elapsedMs": 20.542823,
+                      "calls": 5
+                    },
+                    "M Train 2 Outlet Pipe": {
+                      "elapsedMs": 8.475052,
+                      "calls": 1
+                    },
+                    "M Train 3 Outlet Pipe": {
+                      "elapsedMs": 8.102149,
+                      "calls": 1
+                    },
+                    "M Tail Splitter": {
+                      "elapsedMs": 5.291436,
+                      "calls": 5
+                    },
+                    "M Train 1 Outlet Pipe": {
+                      "elapsedMs": 4.865735,
+                      "calls": 1
+                    },
+                    "M Tail Recycle": {
+                      "elapsedMs": 4.011507,
+                      "calls": 5
+                    },
+                    "M Train 1 Aftercooler": {
+                      "elapsedMs": 3.021836,
+                      "calls": 1
+                    },
+                    "M Feed Pipe": {
+                      "elapsedMs": 2.901704,
+                      "calls": 1
+                    },
+                    "M Recycle Valve": {
+                      "elapsedMs": 2.78115,
+                      "calls": 5
+                    },
+                    "M Train 1 Inlet Pipe": {
+                      "elapsedMs": 2.707128,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Pipe": {
+                      "elapsedMs": 2.387522,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Pipe": {
+                      "elapsedMs": 2.180909,
+                      "calls": 1
+                    },
+                    "M Train 3 Aftercooler": {
+                      "elapsedMs": 1.685463,
+                      "calls": 1
+                    },
+                    "M Train Splitter": {
+                      "elapsedMs": 1.668814,
+                      "calls": 1
+                    },
+                    "M Export Separator": {
+                      "elapsedMs": 1.603895,
+                      "calls": 5
+                    },
+                    "M Train 2 Aftercooler": {
+                      "elapsedMs": 1.572869,
+                      "calls": 1
+                    },
+                    "M Train 1 Scrubber": {
+                      "elapsedMs": 1.347784,
+                      "calls": 1
+                    },
+                    "M Train 2 Scrubber": {
+                      "elapsedMs": 1.3015,
+                      "calls": 1
+                    },
+                    "M Train 2 Inlet Separator": {
+                      "elapsedMs": 1.199636,
+                      "calls": 1
+                    },
+                    "M Train 1 Inlet Separator": {
+                      "elapsedMs": 1.139781,
+                      "calls": 1
+                    },
+                    "M Feed": {
+                      "elapsedMs": 0.84183,
+                      "calls": 1
+                    },
+                    "M Train 3 Inlet Separator": {
+                      "elapsedMs": 0.808043,
+                      "calls": 1
+                    },
+                    "M Train 3 Scrubber": {
+                      "elapsedMs": 0.592323,
+                      "calls": 1
+                    }
+                  },
+                  "areaRuns": {
+                    "status": "UNAVAILABLE",
+                    "reason": "ProcessSystem has no public attributable area-run counter"
+                  },
+                  "flashAndPropertyWork": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no public per-candidate flash/property counter on this baseline"
+                  }
+                },
+                "massBalance": {
+                  "maximumAbsoluteError": 0.00423576234607026,
+                  "maximumPercentError": 5.937855156862527e-06,
+                  "unit": "kg/hr",
+                  "worstUnit": "M Export Separator",
+                  "energyBalance": {
+                    "status": "UNAVAILABLE",
+                    "reason": "no whole-ProcessSystem energy-balance residual API on this baseline"
+                  }
+                },
+                "bottleneck": {
+                  "status": "AVAILABLE",
+                  "equipment": "M Feed Pipe",
+                  "constraint": "installedMixtureVelocity",
+                  "utilization": 1.0422088265813942,
+                  "utilizationPercent": 104.22088265813943,
+                  "finiteEvidence": true,
+                  "currentValue": 0.765861884098127,
+                  "designValue": 0.7348449414022641,
+                  "signedPhysicalMargin": -0.03101694269586297,
+                  "unit": "m/s",
+                  "type": "HARD",
+                  "severity": "HARD",
+                  "provenance": "synthetic benchmark design basis",
+                  "confidenceAvailable": true,
+                  "confidence": 1.0,
+                  "validityRangeAvailable": true,
+                  "validityMinimum": 0.0,
+                  "validityMaximum": 50.0,
+                  "withinValidityRange": true
+                },
+                "runStatus": {
+                  "schemaVersion": "1.0",
+                  "completed": true,
+                  "success": true,
+                  "unitCount": 27,
+                  "units": [
+                    {
+                      "unitName": "M Feed",
+                      "unitType": "Stream",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Feed Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 1 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 2 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Inlet Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Compressor",
+                      "unitType": "Compressor",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Aftercooler",
+                      "unitType": "Cooler",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Scrubber",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Train 3 Outlet Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Mixer",
+                      "unitType": "Mixer",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Splitter",
+                      "unitType": "Splitter",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Pipe",
+                      "unitType": "PipeBeggsAndBrills",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Export Separator",
+                      "unitType": "Separator",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Recycle Valve",
+                      "unitType": "ThrottlingValve",
+                      "success": true
+                    },
+                    {
+                      "unitName": "M Tail Recycle",
+                      "unitType": "Recycle",
+                      "success": true
+                    }
+                  ]
+                },
+                "serializedObservationBytes": 24733,
+                "utilizationSnapshotSchemaVersion": "1.0",
+                "restoration": "FULL_REPLAY_COMPLETED"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/process/optimization/industrial-process-optimization-baseline.md
+++ b/docs/process/optimization/industrial-process-optimization-baseline.md
@@ -140,11 +140,13 @@ benchmark PR must preserve raw machine-readable records and a concise human-read
 
 ## Executed S/M baseline
 
-Cases S and M now have a maintained test-only harness and a five-fork reference record at exact
-commit `5a851750f8d12b3a598a87da0acadb3faef8b4e6`. Case M contains 27 units, three parallel
-compression trains, and one tail recycle. The harness exercises cold, unchanged, nearby-state,
-constraint-change, discrete-line-up, restoration, and non-finite-candidate rejection modes without
-changing production execution or solver behavior.
+Cases S and M now have a maintained test-only harness and a reproducible five-fork reference record
+at exact commit `f3a2cf5f0891322ab2462817f0c06d0d9409f1f6`. Case M contains 27 units, three parallel
+compression trains, and one tail recycle. The checked-in runner preserves the exact harness schema,
+validates every mode and acceptance threshold, derives statistics from the raw reports, and records
+canonical SHA-256 digests. The harness exercises cold, unchanged, nearby-state, constraint-change,
+discrete-line-up, restoration, and non-finite-candidate rejection modes without changing production
+execution or solver behavior.
 
 See the [Industrial S/M Benchmark Evidence](industrial-sm-benchmark) for the exact command,
 environment, raw samples, acceptance criteria, and unavailable metrics. The record intentionally

--- a/docs/process/optimization/industrial-sm-benchmark.md
+++ b/docs/process/optimization/industrial-sm-benchmark.md
@@ -11,7 +11,7 @@ evidence for roadmap [#3154](https://github.com/equinor/neqsim/issues/3154), not
 improvement claim and not qualification of the flowsheets for design or operations.
 
 The measured source is unmodified NeqSim `master` commit
-`5a851750f8d12b3a598a87da0acadb3faef8b4e6`. The harness is additive test code. It does not change
+`f3a2cf5f0891322ab2462817f0c06d0d9409f1f6`. The harness is additive test code. It does not change
 process calculations, thermodynamics, scheduling, recycle convergence, caching, or optimizer search
 behavior.
 
@@ -42,20 +42,34 @@ unset provenance or validity, which is recorded rather than inferred.
 The class is tagged `slow`. NeqSim excludes slow tests by default, so both the selected group and an
 empty exclusion list are mandatory. A zero-test Maven result is not valid benchmark evidence.
 
+First prepare Maven as required by the NeqSim development workflow. Then use the checked-in runner;
+it executes five independent Maven/JVM forks, rejects a zero-test or malformed report, preserves
+each exact harness report under `forks[].rawReport`, derives the statistics, and validates the final
+aggregate before writing it.
+
 ```bash
 eval "$(python3 /path/to/work-with-neqsim/scripts/prepare_maven.py)"
-./mvnw -Dgroups=slow "-DexcludedTestGroups=" -Djacoco.skip=true \
-  -Dtest=neqsim.process.util.optimizer.IndustrialPlantOptimizationBaselineTest \
-  -Dneqsim.optimization.baseline.commit="$(git rev-parse HEAD)" \
-  -Dneqsim.optimization.baseline.output=target/industrial-optimization-sm-baseline.json \
-  test
+python devtools/industrial_sm_benchmark.py run \
+  --baseline-commit "$(git rev-parse HEAD)" \
+  --forks 5 \
+  --raw-dir target/industrial-sm-benchmark \
+  --output target/industrial-sm-baseline.json
 ```
 
-Confirm that Surefire reports one executed test with zero failures. Repeat the command in at least
-five independent Maven/JVM forks before comparing wall time. The JSON output records deterministic
-calculation identities, case and topology counts, every mode, per-equipment execution work,
-mass-balance residuals, constraint evidence, heap before/after proxy, observation size, failure or
-restoration outcome, and unsupported metrics with reasons.
+Validate a previously generated or checked-in aggregate without running Maven:
+
+```bash
+python devtools/industrial_sm_benchmark.py validate \
+  --input docs/process/optimization/benchmarks/industrial-sm-baseline-f3a2cf5f.json
+```
+
+The aggregate uses schema `2.0`. It records the generator, raw schema, fork count, wall time,
+canonical byte count and SHA-256 digest for every preserved raw report. Validation recomputes the
+full aggregate from those reports and fails if any field or statistic differs. Each raw report
+contains deterministic calculation identities, case and topology counts, every mode,
+per-equipment calls and timing, run status, mass-balance residuals, constraint evidence, the
+heap-before/after proxy, observation size, failure or restoration outcome, and unsupported metrics
+with reasons.
 
 ## Reference environment
 
@@ -74,25 +88,32 @@ count, heap, and JVM input arguments are also stored in the machine-readable rec
 
 | Observation | Samples | Median | Median absolute deviation | Range |
 |---|---:|---:|---:|---:|
-| Startup-inclusive S/M harness wall time | 5 forks | 18,954.293 ms | 245.332 ms | 18,507.921–19,222.640 ms |
-| S cold process solve | 5 forks | 54.215 ms | 3.757 ms | 50.208–69.074 ms |
-| S unchanged process solve | 5 forks | 0.175 ms | 0.027 ms | 0.142–0.256 ms |
-| M cold process solve | 5 forks | 155.787 ms | 6.491 ms | 131.767–162.277 ms |
-| M unchanged process solve | 25 runs | 33.460 ms | 4.618 ms | 22.612–50.351 ms |
+| Maven-fork-inclusive S/M harness wall time | 5 forks | 49,955.003 ms | 5,482.386 ms | 41,493.165–67,879.749 ms |
+| S cold process solve | 5 forks | 110.738 ms | 20.099 ms | 90.192–147.210 ms |
+| S unchanged process solve | 5 forks | 0.192 ms | 0.005 ms | 0.144–0.197 ms |
+| M cold process solve | 5 forks | 422.029 ms | 147.526 ms | 274.503–822.562 ms |
+| M unchanged process solve | 25 runs | 140.867 ms | 44.528 ms | 59.881–602.387 ms |
 
-The five startup-inclusive fork samples are `18507.921`, `19222.640`, `18925.934`, `18954.293`,
-and `19199.625` ms. The full raw arrays and per-mode measurements are in
-[`industrial-sm-baseline-5a851750.json`](benchmarks/industrial-sm-baseline-5a851750.json).
+The five Maven-fork-inclusive samples are `67879.749`, `41493.165`, `55437.389`, `48105.170`,
+and `49955.003` ms. They include Maven startup and any compile work and therefore are not a pure
+process-solve performance metric. The exact preserved raw reports and derived measurements are in
+[`industrial-sm-baseline-f3a2cf5f.json`](benchmarks/industrial-sm-baseline-f3a2cf5f.json).
 
 Every unchanged M run reproduced the cold product mass rate exactly within double precision. Across
 the five forks, the restored-line-up product differed from cold by a median `0.0258211 kg/hr`; the
-largest observed difference was `0.0258364 kg/hr`, below the `0.1 kg/hr` acceptance criterion. The
+largest observed difference was `0.0258211 kg/hr`, below the `0.1 kg/hr` acceptance criterion. The
 largest unit mass-balance residual across 50 M mode records was `0.0222922 kg/hr`. Serialized M
-utilization observations ranged from 24,428 to 24,734 bytes.
+utilization observations ranged from 24,429 to 24,733 bytes. All 70 successful mode records retain
+their per-equipment execution maps; total equipment calls range from 1 to 63 per mode.
 
 Case S rejected a non-finite external proposal before it mutated the feed. Case M observed the
 default export-pipe velocity constraint, then a controlled installed feed-pipe velocity constraint
 after the limit change, and completed a train-unavailable action plus full replay restoration.
+
+The earlier
+[`industrial-sm-baseline-5a851750.json`](benchmarks/industrial-sm-baseline-5a851750.json) is retained
+as historical evidence but is superseded. It normalized harness fields without a checked-in
+aggregation contract and cannot satisfy the reproducibility gate used by later roadmap increments.
 
 ## Measured gaps and handoffs
 


### PR DESCRIPTION
## Scope

Closes the #3154 Roadmap 0 reproducibility gap in the merged S/M inventory/benchmark freeze. This is an additive evidence and tooling increment only: it does not change production process calculations, thermodynamics, execution scheduling, recycle convergence, caching, or optimizer behavior.

## Engineering question

Can the frozen small guide case and 27-unit, three-train recycle case be rerun from one checked-in command while preserving exact harness records and failing closed if the evidence, mode matrix, calculation identity, or numerical acceptance gates drift?

## Exact baseline and assumptions

- Base/current-master measurement commit: `f3a2cf5f0891322ab2462817f0c06d0d9409f1f6`
- Synthetic SRK cases only; no proprietary plant data
- Mass rate/residual basis: kg/hr; pressure: bara; compressor power: kW; pipe velocity: m/s
- Five independent Maven/JVM forks, one slow-tagged harness execution per fork
- Minimum acceptance: solved/full run status, finite bottleneck evidence, per-equipment work, unchanged/replay differences <= 0.1 kg/hr, unit mass residual <= 0.1 kg/hr, deterministic calculation identities, and rejection of the non-finite proposal before mutation

## Change

- Add `devtools/industrial_sm_benchmark.py` with `run`, `aggregate`, and `validate` commands.
- Preserve every exact schema-1 harness report inside schema-2 evidence.
- Record canonical UTF-8 byte counts and SHA-256 digests.
- Recompute and compare the complete aggregate during validation.
- Add six hermetic fail-closed regressions and route them through devtools CI.
- Regenerate the exact-current-master five-fork evidence and update all affected optimization guides.

## Validation

- Two complete five-fork campaigns passed (initial exact-current freeze plus checked-in runner replay); each fork executed exactly one test with zero failures/errors/skips.
- Checked artifact validation: PASS
- Six Python aggregation/validation regressions: PASS
- Direct Spotless apply/check after Maven bootstrap: PASS
- Documentation search audit: PASS (659 Markdown and 1 standalone HTML page)
- Repository pre-commit and pre-push stages: PASS
- Python compileall and `git diff --check`: PASS

Measured medians on the frozen environment: 49,955.003 ms Maven-fork-inclusive wall time; 110.738 ms S cold solve; 0.192 ms S unchanged; 422.029 ms M cold; 140.867 ms across 25 M unchanged runs. All 70 successful mode records retained per-equipment maps. Maximum M unit mass residual was 0.0222922 kg/hr; maximum restoration difference was 0.0258213 kg/hr.

## Documentation and stop boundary

Documentation impact is complete in this PR: the Production Optimization Guide index, optimization landing page, baseline contract, benchmark method, exact replay command, measured results, and known gaps are updated.

The increment stops at reproducible S/M evidence. It makes no performance-improvement claim and does not begin plant-wide constraint identity, shared total-power/common-shaft resources, separator or piping adapters, solver orchestration, or L-case execution. Those remain ordered follow-ups under #3154 and execution-layer work remains coordinated with #2939.

Refs #3154