### PR TITLE
[AI-Assisted] chore(skills): expose NeqSim skills to Codex

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.github/skills

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -10,6 +10,26 @@ prompts skills folder; use `--vscode-scope workspace` only when a maintainer int
 generated workspace copy. PaperLab keeps its full canonical library under `neqsim-paperlab/skills/`;
 only the `@paperlab` gateway's public skills are exported for VS Code by default.
 
+## OpenAI Codex discovery without duplicate skills
+
+The repository tracks `.agents/skills` as a symbolic link to this directory. OpenAI Codex scans
+`.agents/skills` for repository skills and follows symbolic links, while the existing NeqSim and
+GitHub Copilot tooling continues to use `.github/skills`.
+
+Maintain each core skill **only in this directory**. Do not replace `.agents/skills` with a copied
+skill tree or edit a second copy. The structural lint verifies both the link target and the resolved
+directory:
+
+```bash
+python devtools/verify_skills_agents.py
+git ls-files -s .agents/skills  # mode must be 120000
+```
+
+Windows checkouts must preserve Git symbolic links. Enable Windows Developer Mode and Git symlink
+support before cloning when a local checkout materializes the link as a plain text file. See the
+[OpenAI skill discovery documentation](https://learn.chatgpt.com/docs/build-skills) for the native
+Codex repository path and symbolic-link behavior.
+
 > **Full documentation:** See the [Skills and Agents Guide](../../docs/integration/skills_guide.md)
 > for the complete walkthrough — creating core, community, and private skills,
 > installing community/private agents, the SKILL.md and agent.yaml formats,

--- a/.github/workflows/skills_agents_lint.yml
+++ b/.github/workflows/skills_agents_lint.yml
@@ -6,6 +6,7 @@ permissions:
 on:
   pull_request:
     paths:
+      - ".agents/**"
       - ".github/skills/**"
       - ".github/agents/**"
       - "devtools/verify_skills_agents.py"
@@ -21,6 +22,7 @@ on:
   push:
     branches: [master]
     paths:
+      - ".agents/**"
       - ".github/skills/**"
       - ".github/agents/**"
 

--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,11 @@ neqsim_profile.jfr
 # Local agent data (not tracked, as it may contain sensitive information or be large)
 .agents/
 
+# Track only the OpenAI Codex repository-skill discovery link.
+!.agents/
+.agents/*
+!.agents/skills
+
 .release-run-jobs.json
 .release-run-status.json
 benchmark_results.txt

--- a/devtools/verify_skills_agents.py
+++ b/devtools/verify_skills_agents.py
@@ -8,6 +8,8 @@ Checks performed:
   4. The TF-IDF retriever (``skill_search.py``) can parse every SKILL.md
      and returns at least one match for each skill's own description.
   5. The flat keyword index in ``skill-index.json`` is valid JSON.
+  6. OpenAI Codex discovers the canonical skills through the
+     ``.agents/skills`` symbolic link without maintaining a second copy.
 
 Exit code is 1 if any structural error is found; warnings are printed but
 do not fail the run unless ``--strict`` is set.
@@ -18,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -25,6 +28,7 @@ from typing import Dict, List, Tuple
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SKILLS_DIR = REPO_ROOT / ".github" / "skills"
+CODEX_SKILLS_DIR = REPO_ROOT / ".agents" / "skills"
 AGENTS_DIR = REPO_ROOT / ".github" / "agents"
 INDEX_PATH = SKILLS_DIR / "skill-index.json"
 
@@ -144,6 +148,41 @@ def check_skill_index() -> Tuple[List[str], List[str]]:
     return errors, warnings
 
 
+def check_codex_skill_discovery() -> Tuple[List[str], List[str]]:
+    """Verify that Codex discovers the canonical skill directory via symlink."""
+    errors: List[str] = []
+    warnings: List[str] = []
+    expected_target = "../.github/skills"
+
+    if not CODEX_SKILLS_DIR.is_symlink():
+        errors.append(
+            ".agents/skills must be a symbolic link to ../.github/skills; "
+            "do not maintain a copied skill tree"
+        )
+        return errors, warnings
+
+    actual_target = os.readlink(str(CODEX_SKILLS_DIR))
+    if actual_target != expected_target:
+        errors.append(
+            ".agents/skills points to {!r}; expected {!r}".format(
+                actual_target, expected_target
+            )
+        )
+        return errors, warnings
+
+    try:
+        if not CODEX_SKILLS_DIR.resolve(strict=True).samefile(
+            SKILLS_DIR.resolve(strict=True)
+        ):
+            errors.append(
+                ".agents/skills does not resolve to the canonical .github/skills directory"
+            )
+    except OSError as error:
+        errors.append(".agents/skills cannot be resolved: {}".format(error))
+
+    return errors, warnings
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -154,14 +193,18 @@ def main() -> int:
     args = parser.parse_args()
 
     print(f"Skills dir: {SKILLS_DIR}")
+    print(f"Codex skills link: {CODEX_SKILLS_DIR}")
     print(f"Agents dir: {AGENTS_DIR}")
 
     skill_errors, skill_warnings = check_skills()
     agent_errors, agent_warnings = check_agents()
     index_errors, index_warnings = check_skill_index()
+    codex_errors, codex_warnings = check_codex_skill_discovery()
 
-    all_errors = skill_errors + agent_errors + index_errors
-    all_warnings = skill_warnings + agent_warnings + index_warnings
+    all_errors = skill_errors + agent_errors + index_errors + codex_errors
+    all_warnings = (
+        skill_warnings + agent_warnings + index_warnings + codex_warnings
+    )
 
     if all_errors:
         print("\n=== ERRORS ===")


### PR DESCRIPTION
## Summary

- keep `.github/skills` as the single maintained NeqSim skill source
- add `.agents/skills` as a Git symbolic link (mode `120000`) to `../.github/skills` for native OpenAI Codex repository discovery
- keep the existing `.github/agents` definitions unchanged and add no duplicate `.codex/agents` manifests
- extend the skills-and-agents lint to reject copied, broken, or retargeted Codex skill trees
- document the single-source layout and Windows symlink checkout requirement

Base SHA: `f3a2cf5f0891322ab2462817f0c06d0d9409f1f6`
Head SHA: `93f4358cd0e52c2431f636bf67e39a30d762848e`

## Validation

- `python devtools/verify_skills_agents.py` — PASS (0 errors; 2 pre-existing keyword-index warnings)
- `python -m unittest devtools.test_agent_search devtools.test_skill_search -v` — PASS (12 tests)
- `python devtools/check_documentation_search.py` — PASS
- `python -m py_compile devtools/verify_skills_agents.py` — PASS
- `python devtools/generate_agent_skill_map.py` — PASS; generated map unchanged
- `python devtools/run_spotless.py check` — PASS
- `pre-commit run --all-files --hook-stage pre-commit` — PASS
- `pre-commit run --all-files --hook-stage pre-push` — PASS
- `git diff --check` and staged diff check — PASS
- `git ls-files -s .agents/skills` — verified mode `120000` and target blob

The local environment did not initially include `pytest`; the same 12 repository tests were executed directly through `unittest`. GitHub CI remains authoritative for the configured pytest invocation.

## Documentation impact

Updated `.github/skills/README.md` with the Codex discovery path, single-source maintenance rule, validation commands, and Windows symlink guidance.

## Scope boundary

This PR changes discovery and validation only. It does not modify any `SKILL.md`, Copilot agent definition, Java source, simulation behavior, or public NeqSim API.