### PR TITLE
[AI-Assisted] perf(process): skip flat no-recycle closure scans

### DIFF
--- a/src/main/java/neqsim/process/processmodel/ProcessModel.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessModel.java
@@ -117,6 +117,9 @@ public class ProcessModel implements Runnable, Serializable {
     /** Streams entering the model from outside its cached topology, keyed by identity. */
     private final java.util.Set<StreamInterface> feedStreams;
 
+    /** Top-level areas containing modules whose internal recycle units require recursive inspection. */
+    private final java.util.Set<ProcessSystem> areasWithModules;
+
     /** Structure versions observed when this plan was built. */
     private final Map<ProcessSystem, Long> structureVersions;
 
@@ -129,18 +132,21 @@ public class ProcessModel implements Runnable, Serializable {
      * @param boundaryConsumers consumer areas for each boundary stream
      * @param streamProducers producing {@code "area::unit"} label per stream identity
      * @param feedStreams streams entering the model from outside its topology
+     * @param areasWithModules top-level areas containing module equipment
      * @param structureVersions process structure versions observed while building the plan
      */
     private AreaExecutionPlan(List<List<ProcessSystem>> levels,
         Map<ProcessSystem, java.util.Set<ProcessSystem>> successors, java.util.Set<Object> boundaryStreams,
         Map<Object, java.util.Set<ProcessSystem>> boundaryConsumers, Map<Object, String> streamProducers,
-        java.util.Set<StreamInterface> feedStreams, Map<ProcessSystem, Long> structureVersions) {
+        java.util.Set<StreamInterface> feedStreams, java.util.Set<ProcessSystem> areasWithModules,
+        Map<ProcessSystem, Long> structureVersions) {
       this.levels = levels;
       this.successors = successors;
       this.boundaryStreams = boundaryStreams;
       this.boundaryConsumers = boundaryConsumers;
       this.streamProducers = streamProducers;
       this.feedStreams = feedStreams;
+      this.areasWithModules = areasWithModules;
       this.structureVersions = structureVersions;
     }
   }
@@ -2746,13 +2752,15 @@ public class ProcessModel implements Runnable, Serializable {
         .newSetFromMap(new java.util.IdentityHashMap<StreamInterface, Boolean>());
     java.util.Set<StreamInterface> plantInletStreams = java.util.Collections
         .newSetFromMap(new java.util.IdentityHashMap<StreamInterface, Boolean>());
+    java.util.Set<ProcessSystem> areasWithModules = java.util.Collections
+        .newSetFromMap(new java.util.IdentityHashMap<ProcessSystem, Boolean>());
     for (ProcessSystem process : allProcesses) {
       successorMap.put(process, java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>()));
     }
 
     if (n == 0) {
       return new AreaExecutionPlan(new ArrayList<>(), successorMap, boundaryStreams, boundaryConsumers, streamProducers,
-          plantInletStreams, structureVersions);
+          plantInletStreams, areasWithModules, structureVersions);
     }
 
     // Index processes by their position in the insertion order for
@@ -2772,6 +2780,9 @@ public class ProcessModel implements Runnable, Serializable {
       java.util.Set<Object> outs = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
       java.util.Set<Object> mem = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
       for (Object unit : p.getUnitOperations()) {
+        if (unit instanceof ModuleInterface) {
+          areasWithModules.add(p);
+        }
         if (unit instanceof StreamInterface) {
           mem.add(unit);
         }
@@ -2908,7 +2919,7 @@ public class ProcessModel implements Runnable, Serializable {
         fallback.add(single);
       }
       return new AreaExecutionPlan(fallback, successorMap, boundaryStreams, boundaryConsumers, streamProducers,
-          plantInletStreams, structureVersions);
+          plantInletStreams, areasWithModules, structureVersions);
     }
 
     int maxLevel = 0;
@@ -2923,7 +2934,7 @@ public class ProcessModel implements Runnable, Serializable {
       levels.get(level[i]).add(allProcesses.get(i));
     }
     return new AreaExecutionPlan(levels, successorMap, boundaryStreams, boundaryConsumers, streamProducers,
-        plantInletStreams, structureVersions);
+        plantInletStreams, areasWithModules, structureVersions);
   }
 
   /**
@@ -3973,8 +3984,7 @@ public class ProcessModel implements Runnable, Serializable {
    *
    * @return relative mass-closure error, or NaN when no usable flow scale exists
    */
-  private double computeMassClosureError() {
-    double scale = Math.max(detectedPlantFlowScale, getTotalFeedFlowRate());
+  private double computeMassClosureError(AreaExecutionPlan plan, double scale) {
     if (!(scale > 0.0) || Double.isInfinite(scale)) {
       massClosureOffenders = "";
       return Double.NaN;
@@ -3982,7 +3992,11 @@ public class ProcessModel implements Runnable, Serializable {
     double created = 0.0;
     List<Map.Entry<String, Double>> offenders = new ArrayList<>();
     for (Map.Entry<String, ProcessSystem> area : processes.entrySet()) {
-      for (Map.Entry<String, Recycle> recycleEntry : getRecycleUnits(area.getValue())) {
+      ProcessSystem process = area.getValue();
+      if (!process.hasRecycles() && !plan.areasWithModules.contains(process)) {
+        continue;
+      }
+      for (Map.Entry<String, Recycle> recycleEntry : getRecycleUnits(process)) {
         Recycle recycle = recycleEntry.getValue();
         if (recycle.isLockedInactive() || !recycle.isActive()) {
           continue;
@@ -4042,8 +4056,7 @@ public class ProcessModel implements Runnable, Serializable {
    *
    * @return relative unit-level closure error, or NaN when no usable flow scale exists
    */
-  private double computeUnitMassClosureError() {
-    double scale = Math.max(detectedPlantFlowScale, getTotalFeedFlowRate());
+  private double computeUnitMassClosureError(double scale) {
     if (!(scale > 0.0) || Double.isInfinite(scale)) {
       unitMassClosureOffenders = "";
       return Double.NaN;
@@ -4084,9 +4097,11 @@ public class ProcessModel implements Runnable, Serializable {
     if (!autoConvergenceTuning || !autoMassClosureGate) {
       return true;
     }
-    double closure = computeMassClosureError();
+    AreaExecutionPlan plan = getAreaExecutionPlan();
+    double scale = Math.max(detectedPlantFlowScale, getTotalFeedFlowRate(plan));
+    double closure = computeMassClosureError(plan, scale);
     lastMassClosureError = closure;
-    double unitClosure = computeUnitMassClosureError();
+    double unitClosure = computeUnitMassClosureError(scale);
     lastUnitMassClosureError = unitClosure;
 
     boolean recycleAccepted = Double.isNaN(closure) || closure <= massClosureTolerance;
@@ -4199,8 +4214,18 @@ public class ProcessModel implements Runnable, Serializable {
    * @return total feed mass flow in kg/hr, or 0.0 when no feed stream could be read
    */
   public double getTotalFeedFlowRate() {
+    return getTotalFeedFlowRate(getAreaExecutionPlan());
+  }
+
+  /**
+   * Sums live feed flow values from an already-validated execution plan.
+   *
+   * @param plan current area execution plan
+   * @return total feed mass flow in kg/hr, or 0.0 when no feed stream could be read
+   */
+  private double getTotalFeedFlowRate(AreaExecutionPlan plan) {
     double total = 0.0;
-    for (StreamInterface stream : getAreaExecutionPlan().feedStreams) {
+    for (StreamInterface stream : plan.feedStreams) {
       try {
         double flow = stream.getFlowRate("kg/hr");
         if (!Double.isNaN(flow) && !Double.isInfinite(flow) && flow > 0.0) {

--- a/src/test/java/neqsim/process/processmodel/ProcessModelAutoConvergenceTuningTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessModelAutoConvergenceTuningTest.java
@@ -74,6 +74,34 @@ class ProcessModelAutoConvergenceTuningTest {
     }
   }
 
+  /** Active module probe that executes its deliberately imbalanced internal recycle. */
+  private static final class ActiveRecycleModule extends WellFluidModule {
+    private static final long serialVersionUID = 1000L;
+
+    ActiveRecycleModule(String name) {
+      super(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void initializeModule() {
+      // This probe already owns its intentionally minimal internal operations.
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void initializeStreams() {
+      // The enclosing area owns the active feed boundary used by the closure scale.
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void run(UUID id) {
+      getOperations().run(id);
+      setCalculationIdentifier(id);
+    }
+  }
+
   /** Recycle probe that remains solved while exposing a standing tear imbalance. */
   private static final class RecycleMassImbalanceProbe extends Recycle {
     private static final long serialVersionUID = 1000L;
@@ -539,6 +567,34 @@ class ProcessModelAutoConvergenceTuningTest {
     assertEquals(0.0, massClosure.get("relativeError").getAsDouble(), 0.0,
         "The active feed boundary must make closure evaluable while the inactive recycle remains excluded");
     assertFalse(massClosure.get("worstUnits").getAsString().contains("stale inactive recycle"));
+  }
+
+  /** Adding an active module after plan creation must refresh the fast-path guard and inspect its recycle. */
+  @Test
+  void testMassClosureGateFindsRecycleInModuleAddedAfterPlanCreation() {
+    Stream feed = new Stream("active module feed", createGasFluid());
+    feed.setFlowRate(1000.0, "kg/hr");
+    Separator feedBoundary = new Separator("active module feed boundary", feed);
+
+    ProcessSystem area = new ProcessSystem("active module area");
+    area.add(feed);
+    area.add(feedBoundary);
+
+    ProcessModel model = new ProcessModel();
+    model.add("active module area", area);
+    assertEquals(1000.0, model.getTotalFeedFlowRate(), 1.0e-12,
+        "Initial diagnostic read should build a no-module execution plan");
+
+    RecycleMassImbalanceProbe recycle = new RecycleMassImbalanceProbe("late nested recycle");
+    recycle.addStream(feed);
+    ActiveRecycleModule module = new ActiveRecycleModule("late active module");
+    module.getOperations().add(recycle);
+    area.add(module);
+
+    assertFalse(model.runUntilConverged(5),
+        "A module added after plan creation must invalidate the no-recycle fast path");
+    assertEquals(0.1, model.getLastMassClosureError(), 1.0e-12);
+    assertTrue(model.getConvergenceReportJson().contains("late nested recycle"));
   }
 
   /** Disabled closure evaluation must be reported as disabled and serialize the unevaluated error as JSON null. */


### PR DESCRIPTION
## Summary

Advances #2939 with a bounded `ProcessModel` mass-closure fast path.

- skips recursive recycle discovery for top-level areas that contain neither a direct `Recycle` nor module equipment
- records module presence while the existing transient `AreaExecutionPlan` is already scanning topology
- reuses the already validated execution plan and feed-flow scale across the recycle- and unit-closure checks
- retains the full recursive path for direct recycles and all module-bearing areas
- adds a regression proving that adding a recycle-bearing active module after plan creation invalidates the fast path and preserves the open-tear diagnostic

## Bottleneck and stop boundary

After merged #3179 and #3191, the 10-area/600-unit model still recursively allocated and traversed a recycle-discovery list for every flat area during every mass-closure check even though these areas contain no recycle or module.

This PR changes only that flat no-recycle diagnostic path. It does not cache recycle instances, change execution scheduling, change flash/property work, or enter TPflash, columns, dynamics, Two-Fluid, Production Optimization, MCP, or Huldra scope.

## Benchmark methodology

Exact current process source was unchanged between authoritative master `f3a2cf5f0891322ab2462817f0c06d0d9409f1f6` and the earlier exact-source baseline checkout. Baseline and candidate were compiled separately.

Environment:

- OpenJDK 17.0.19
- Linux x86_64
- Serial GC
- fixed 512 MiB heap for the lightweight model
- one processor
- five alternating fresh-JVM pairs
- 40 warmups + 300 measured runs/fork

Representative 10-area/600-unit `ProcessModel`:

| Case | Baseline median | Candidate median | Change | Paired wins |
| --- | ---: | ---: | ---: | ---: |
| Stable | 1.664472 ms/run | 1.548722 ms/run | **6.95% faster** | 4/5 |
| Nearby flow | 1.768568 ms/run | 1.674340 ms/run | **5.33% faster** | 4/5 |
| Stable allocation | 130,041.787 B/run | 125,938.187 B/run | 3.16% lower | — |
| Nearby allocation | 130,435.120 B/run | 126,307.227 B/run | 3.16% lower | — |

All lightweight forks preserved the exact checksum, feed total, two model iterations, nine boundary streams, `converged=true`, zero mass-closure error, and exactly 600 inlet reads/run.

## Scientific and robustness controls

Three alternating fresh-JVM pairs of the four-area thermodynamic control covered stable SRK, nearby-flow SRK, and SRK-CPA. Their timings were noisy and no thermodynamic speedup is claimed, but every median was non-regressive and every fork preserved exactly:

- accumulated checksum
- outlet mass flow, temperature, and pressure
- one-phase topology
- two model iterations and three boundaries
- convergence with zero non-converged runs
- zero mass-closure error
- live feed total

The new focused regression also proves an active nested recycle added after plan creation remains detected at relative closure error 0.1. Existing direct-recycle and inactive-module guards remain in the same suite.

## Compatibility

No public API, serialized field, static/shared mutable state, thermodynamic result, tolerance, unit, phase behavior, calculation identifier, execution count, or convergence acceptance changes. The additional topology set is private and held only in the existing transient execution plan.

## Validation

Local:

- `./mvnw -q -DskipFormatting -DskipTests test-compile` — passed
- `./mvnw -q -DskipFormatting -Dtest=ProcessModelAutoConvergenceTuningTest test` — 25/25 passed
- `./mvnw -q -DskipFormatting -Dtest='ProcessModel*Test,RecycleAcceptedStateReuseTest' test` — 22 suites / 179 tests passed
- `python devtools/run_spotless.py apply` — passed and stable
- `python devtools/run_spotless.py check` — passed
- `python devtools/check_documentation_search.py` — passed (658 Markdown, 1 HTML)
- task-local `pre-commit run --all-files --hook-stage pre-commit` — passed
- task-local `pre-commit run --all-files --hook-stage pre-push` — passed
- `git diff --check` — passed

**VALIDATION PENDING CI:** hosted Java 8/21 build/test matrix, slow shards, Javadocs, CodeQL, PaperLab, and exact-head repository workflows have not yet completed. No unrun check is claimed as passed.

## Documentation impact

Documentation impact: none — this is internal, transient diagnostic traversal reuse. Public APIs, usage, units, configuration, outputs, serialization, and recommended workflows are unchanged.

Refs #2939
