### PR TITLE
[AI-Assisted] fix(lng): stabilize C3MR refrigerant loops

### DIFF
--- a/src/main/java/neqsim/process/lng/LNGProcessBuilder.java
+++ b/src/main/java/neqsim/process/lng/LNGProcessBuilder.java
@@ -389,19 +389,28 @@ public class LNGProcessBuilder {
    */
   private LNGProcessModel buildC3MR() {
     BuildContext context = newContext();
+    // Preserve the seeded main-exchanger tear state until the first recycle pass, as in
+    // the SMR route. Graph scheduling would otherwise evaluate the JT valve first.
+    context.process.setUseOptimizedExecution(false);
 
-    Stream propaneSuction = createPureRefrigerant(name + " propane suction", "propane", -35.0, 1.5,
-        context.feedFlowKgPerHour * 1.25);
+    // At 1.5 bara the -35 C pure-propane suction is liquid, so the suction scrubber
+    // produces an empty gas stream. A slightly lower pressure supplies vapor to the
+    // compressors, while the larger circulation rate covers both precooler hot streams.
+    Stream propaneSuction = createPureRefrigerant(name + " propane suction", "propane", -35.0, 1.2,
+        context.feedFlowKgPerHour * 2.5);
     context.process.add(propaneSuction);
     CompressionTrain propaneTrain = addTwoStageCompression(context, name + " propane", propaneSuction, 15.0, 0.80);
 
     ThrottlingValve propaneValve = new ThrottlingValve(name + " propane JT valve", propaneTrain.outlet);
-    propaneValve.setOutletPressure(1.5, "bara");
+    propaneValve.setOutletPressure(1.2, "bara");
     context.process.add(propaneValve);
 
+    // Keep the cold MR return vapor at the suction scrubber. At the former 4 bara
+    // setting it partially condensed during recycle convergence, silently removing
+    // refrigerant inventory through the scrubber liquid outlet.
     Stream mrSuction = createMixedRefrigerant(name + " MR suction",
-        new String[] { "nitrogen", "methane", "ethane", "propane" }, new double[] { 0.04, 0.43, 0.36, 0.17 }, 20.0, 4.0,
-        context.feedFlowKgPerHour * 1.75);
+        new String[] { "nitrogen", "methane", "ethane", "propane" }, new double[] { 0.04, 0.43, 0.36, 0.17 }, 20.0,
+        0.75, context.feedFlowKgPerHour * 1.75);
     context.process.add(mrSuction);
     CompressionTrain mrTrain = addTwoStageCompression(context, name + " MR", mrSuction, 45.0, compressorEfficiency);
 
@@ -419,7 +428,7 @@ public class LNGProcessBuilder {
     mche.addInStreamMSHE(precooler.getOutStream(1), "hot", null);
 
     ThrottlingValve mrValve = new ThrottlingValve(name + " MR JT valve", mche.getOutStream(1));
-    mrValve.setOutletPressure(4.0, "bara");
+    mrValve.setOutletPressure(0.75, "bara");
     initializeExpansionInlet(mche.getOutStream(1), mrExpansionInletSeedTemperatureC, 45.0);
     mrValve.run();
     initializeColdSideWarmStart(mrValve.getOutletStream(), mrExpansionInletSeedTemperatureC,

--- a/src/test/java/neqsim/process/lng/LNGProcessBuilderTest.java
+++ b/src/test/java/neqsim/process/lng/LNGProcessBuilderTest.java
@@ -86,6 +86,28 @@ class LNGProcessBuilderTest {
   }
 
   @Test
+  void testC3MrRouteRunsForPublicFeedReproduction() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 60.0);
+    fluid.addComponent("nitrogen", 0.005);
+    fluid.addComponent("methane", 0.890);
+    fluid.addComponent("ethane", 0.065);
+    fluid.addComponent("propane", 0.025);
+    fluid.addComponent("i-butane", 0.007);
+    fluid.addComponent("n-butane", 0.008);
+    fluid.setMixingRule("classic");
+
+    LNGProcessModel model = new LNGProcessBuilder().setName("C3MR reproduction").setCycle(LNGProcessCycle.C3MR)
+        .setFeedFluid(fluid).setFeedFlowRate(20000.0).setFeedTemperature(25.0).setFeedPressure(60.0)
+        .setProductPressure(1.20).setTargetLiquefactionTemperature(-155.0).setMinimumApproach(3.0).setNumberOfZones(12)
+        .setAdaptiveRefinement(true).setUseFlashWarmStart(true).setCompressorEfficiency(0.78).build();
+
+    LNGProcessModel.Result result = model.run();
+
+    assertTrue(Double.isFinite(result.getLNGMassFlowKgPerHour()));
+    assertTrue(result.getLNGMassFlowKgPerHour() > 0.0);
+  }
+
+  @Test
   void testAcceptsLiveNeqSimFeedStream() {
     SystemSrkEos fluid = new SystemSrkEos(298.15, 60.0);
     fluid.addComponent("methane", 0.92);


### PR DESCRIPTION
## Summary

- keep the seeded C3MR main-exchanger tear state intact for the first recycle pass
- move the propane suction onto the vapor side and increase circulation to cover both precooler hot streams
- keep the mixed-refrigerant return vapor at its suction scrubber so recycle convergence does not discard refrigerant inventory
- add the exact public Python feed/configuration from the issue as a Java regression

## Root cause

The template initialized pure propane at -35 °C and 1.5 bara, where it is liquid. The compressor suction scrubber therefore produced an empty gas stream, which surfaced downstream as a propane-precooler energy ratio of 0.000. After correcting that state, the former 4 bara MR return also partially condensed during recycle convergence; its suction scrubber then removed liquid and changed the circulating flow and composition. The corrected low-side states keep both compressor feeds vapor-safe and give the precooler a feasible duty balance.

## Validation

- `./mvnw -Dtest=LNGProcessBuilderTest#testC3MrRouteRunsForPublicFeedReproduction test`
- `./mvnw -Dtest=LNGProcessBuilderTest test` (9 tests)
- `python3 devtools/run_spotless.py apply`
- `python3 devtools/run_spotless.py check`
- `python3 devtools/check_documentation_search.py`

## Documentation impact

None. This corrects internal screening-template initialization; the public builder API and documented C3MR scope are unchanged.

Closes #3189