### PR TITLE
[AI-Assisted] feat(pitzer): add six-term temperature functions

### DIFF
--- a/docs/thermo/pitzer_parameter_provenance.md
+++ b/docs/thermo/pitzer_parameter_provenance.md
@@ -93,16 +93,12 @@ mapping: no Kaasa page, table, symbol, or value was read, copied, inferred, or O
 The next dependency is the PHREEQC six-term temperature function, followed by a complete
 redistributable Na/K/Cl binary–theta–psi set and held-out mixed-brine validation.
 
-
 ## Six-term temperature-function mapping
 
 NeqSim also supports the PHREEQC six-coefficient temperature function as an explicit, sparse,
 dataset-owned override:
 
-[
-p(T)=a_0+a_1(1/T-1/T_r)+a_2ln(T/T_r)+a_3(T-T_r)
-+a_4(T^2-T_r^2)+a_5(1/T^2-1/T_r^2).
-]
+`p(T) = a0 + a1(1/T - 1/Tr) + a2 ln(T/Tr) + a3(T - Tr) + a4(T² - Tr²) + a5(1/T² - 1/Tr²)`
 
 The mapping follows `calc_pitz_param` in the audited public-domain PHREEQC source
 (commit [`b0b3be7`](https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/src/pitzer.cpp#L1721-L1850)).

--- a/docs/thermo/pitzer_parameter_provenance.md
+++ b/docs/thermo/pitzer_parameter_provenance.md
@@ -92,3 +92,48 @@ mapping: no Kaasa page, table, symbol, or value was read, copied, inferred, or O
 
 The next dependency is the PHREEQC six-term temperature function, followed by a complete
 redistributable Na/K/Cl binary–theta–psi set and held-out mixed-brine validation.
+
+
+## Six-term temperature-function mapping
+
+NeqSim also supports the PHREEQC six-coefficient temperature function as an explicit, sparse,
+dataset-owned override:
+
+[
+p(T)=a_0+a_1(1/T-1/T_r)+a_2ln(T/T_r)+a_3(T-T_r)
++a_4(T^2-T_r^2)+a_5(1/T^2-1/T_r^2).
+]
+
+The mapping follows `calc_pitz_param` in the audited public-domain PHREEQC source
+(commit [`b0b3be7`](https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/src/pitzer.cpp#L1721-L1850)).
+PHREEQC fixes (T_r=298.15) K in `PTEMP`; the NeqSim value object stores the reference
+temperature explicitly so imported datasets cannot silently assume a different reference. Values within
+0.001 K of the reference reproduce PHREEQC's exact (a_0) branch. Temperature is absolute kelvin, and
+the returned parameter retains the source parameter's units and standard-state convention.
+
+| Family | PHREEQC six-term support | NeqSim mapping in this increment | Adoption decision |
+| --- | --- | --- | --- |
+| `beta(0)`, `beta(1)`, `C` | `B0`, `B1`, `C0` use all six coefficients | atomic binary setter for `beta0`, `beta1`, and NeqSim `Cphi` | Function adopted; no `C0`/ `Cphi` numerical conversion or coefficient adopted |
+| `beta(2)` | `B2` uses all six coefficients | explicit `beta2` temperature setter and temperature-aware activity/osmotic calls | Function adopted; no coefficient adopted |
+| `theta` | `THETA` uses all six coefficients | sparse same-sign-pair function, including both ion and water paths | Function adopted; no coefficient adopted |
+| `psi` | `PSI` uses all six coefficients | sparse ternary function, including both ion and water paths | Function adopted; no coefficient adopted |
+| `lambda`, `zeta`, `mu`, `eta` | supported by PHREEQC | NeqSim Pitzer does not yet implement these interaction families | Not mapped; fail closed rather than storing a value in another family |
+| `Aphi` | optional database function | NeqSim retains its existing water dielectric/density correlation | Not replaced; separate validation is required |
+
+The legacy NeqSim database columns `*_25`, `*_T1`, and `*_T2` keep their established
+three-coefficient behavior. The six-term layer is empty by default and guarded before map lookup, so
+legacy binary systems pay only one predictable boolean branch and non-Pitzer models execute no new
+code. Setter calls are explicit and retain dataset identity and mixed-brine coverage diagnostics.
+Functions survive serialization; clones copy only the sparse map and share immutable function values.
+
+This increment uses synthetic coefficients only to test the public equation at 298.15 and 373.15 K.
+It does not import `pitzer.dat`, change the reaction database, select reactions, or establish a
+parameter validity range. The applicable temperature, pressure, molality, ionic-strength, activity-scale,
+and standard-state limits remain those of the future versioned source dataset, which must be recorded
+row by row before adoption. Extrapolation is evaluated continuously but is not represented as validated.
+
+The National Library scan of Kaasa (1998) remained inaccessible for this mapping. No thesis page,
+table, parameter symbol, coefficient, or value was read, copied, inferred, or OCRed. The next parameter
+dependency is a redistributable, independently checked Na/K/Cl binary–theta–psi set with resolved
+`C0`/ `Cphi` semantics and held-out mean-activity, osmotic, water-activity, speciation, and
+mixed-brine validation.

--- a/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
@@ -181,7 +181,7 @@ public class ComponentGePitzer extends ComponentGE {
 
       // Add beta2 contribution for 2-2 electrolytes
       if (is22) {
-        double beta2val = pitz.getBeta2ij(componentNumber, j);
+        double beta2val = pitz.getBeta2ij(componentNumber, j, temperature);
         if (Math.abs(beta2val) > 1e-20) {
           double x2 = alpha2 * sqrtI;
           double g2 = 0.0;
@@ -243,7 +243,7 @@ public class ComponentGePitzer extends ComponentGE {
         continue;
       }
       double m_j = phase.getComponent(j).getMolality(phase);
-      double thetaij = pitz.getThetaij(componentNumber, j);
+      double thetaij = pitz.getThetaij(componentNumber, j, temperature);
       double eTheta = 0.0;
       if (hasElectrostaticMixing && Math.abs(charge - chargej) >= 1.0e-12) {
         if (electrostaticMixing == null) {
@@ -261,7 +261,7 @@ public class ComponentGePitzer extends ComponentGE {
           continue;
         }
         double m_k = phase.getComponent(k).getMolality(phase);
-        double psiijk = pitz.getPsiijk(componentNumber, j, k);
+        double psiijk = pitz.getPsiijk(componentNumber, j, k, temperature);
         sum += m_j * m_k * psiijk;
       }
     }
@@ -358,7 +358,7 @@ public class ComponentGePitzer extends ComponentGE {
 
         // Add beta2 contribution for 2-2 electrolytes
         if (is22) {
-          double beta2val = pitz.getBeta2ij(ic, ia);
+          double beta2val = pitz.getBeta2ij(ic, ia, TK);
           if (Math.abs(beta2val) > 1e-20) {
             double alpha2 = 12.0;
             BphiCA += beta2val * Math.exp(-alpha2 * sqrtI);
@@ -390,7 +390,7 @@ public class ComponentGePitzer extends ComponentGE {
           continue;
         }
         double mc2 = phase.getComponent(ic2).getMolality(phase);
-        double thetaCC = pitz.getThetaij(ic1, ic2);
+        double thetaCC = pitz.getThetaij(ic1, ic2, TK);
         double electrostaticPhi = 0.0;
         if (hasElectrostaticMixing && Math.abs(zc1 - zc2) >= 1.0e-12) {
           if (electrostaticMixing == null) {
@@ -407,7 +407,7 @@ public class ComponentGePitzer extends ComponentGE {
             continue;
           }
           double ma = phase.getComponent(ia).getMolality(phase);
-          thetaPsiSum += mc1 * mc2 * ma * pitz.getPsiijk(ic1, ic2, ia);
+          thetaPsiSum += mc1 * mc2 * ma * pitz.getPsiijk(ic1, ic2, ia, TK);
         }
       }
     }
@@ -424,7 +424,7 @@ public class ComponentGePitzer extends ComponentGE {
           continue;
         }
         double ma2 = phase.getComponent(ia2).getMolality(phase);
-        double thetaAA = pitz.getThetaij(ia1, ia2);
+        double thetaAA = pitz.getThetaij(ia1, ia2, TK);
         double electrostaticPhi = 0.0;
         if (hasElectrostaticMixing && Math.abs(za1 - za2) >= 1.0e-12) {
           if (electrostaticMixing == null) {
@@ -441,7 +441,7 @@ public class ComponentGePitzer extends ComponentGE {
             continue;
           }
           double mc = phase.getComponent(ic).getMolality(phase);
-          thetaPsiSum += ma1 * ma2 * mc * pitz.getPsiijk(ia1, ia2, ic);
+          thetaPsiSum += ma1 * ma2 * mc * pitz.getPsiijk(ia1, ia2, ic, TK);
         }
       }
     }

--- a/src/main/java/neqsim/thermo/phase/PhasePitzer.java
+++ b/src/main/java/neqsim/thermo/phase/PhasePitzer.java
@@ -1,8 +1,10 @@
 package neqsim.thermo.phase;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -47,6 +49,11 @@ public class PhasePitzer extends PhaseGE {
   /** T-dependent coefficients for Cphi. */
   private double[][] cphiT1;
   private double[][] cphiT2;
+  /** Sparse opt-in PHREEQC six-term temperature functions, keyed by parameter family and tuple. */
+  private Map<String, PitzerTemperatureFunction> temperatureFunctions =
+      new HashMap<String, PitzerTemperatureFunction>();
+  /** Fast gate that avoids map lookup for legacy parameter datasets. */
+  private boolean hasTemperatureFunctions;
   /** Whether parameters have been loaded from database. */
   private boolean parametersLoaded = false;
   /** Whether immutable parameter arrays are shared with a clone until the next setter call. */
@@ -94,12 +101,15 @@ public class PhasePitzer extends PhaseGE {
   @Override
   public PhasePitzer clone() {
     ensureDefinitionSets();
+    ensureTemperatureFunctions();
     PhasePitzer clonedPhase = (PhasePitzer) super.clone();
     parameterStorageShared = true;
     clonedPhase.parameterStorageShared = true;
     clonedPhase.definedBinaryPairs = new HashSet<String>(definedBinaryPairs);
     clonedPhase.definedThetaPairs = new HashSet<String>(definedThetaPairs);
     clonedPhase.definedPsiTuples = new HashSet<String>(definedPsiTuples);
+    clonedPhase.temperatureFunctions =
+        new HashMap<String, PitzerTemperatureFunction>(temperatureFunctions);
     clonedPhase.cachedCoverageFingerprint = 0L;
     clonedPhase.cachedCoverageRevision = Long.MIN_VALUE;
     clonedPhase.cachedCoverage = null;
@@ -267,6 +277,87 @@ public class PhasePitzer extends PhaseGE {
   }
 
   /**
+   * Sets PHREEQC six-term temperature functions for a cation-anion binary tuple.
+   *
+   * <p>
+   * Each coefficient array is ordered {@code a0..a5}; the function is
+   * {@code a0 + a1(1/T-1/Tr) + a2 ln(T/Tr) + a3(T-Tr) + a4(T^2-Tr^2)
+   * + a5(1/T^2-1/Tr^2)}. This method defines beta0, beta1, and Cphi as one
+   * coherent binary tuple. It performs no conversion between PHREEQC C0 and a dataset using another C
+   * convention.
+   * </p>
+   *
+   * @param i component index i
+   * @param j component index j
+   * @param referenceTemperature reference temperature in K
+   * @param beta0Coefficients beta0 coefficients in PHREEQC order
+   * @param beta1Coefficients beta1 coefficients in PHREEQC order
+   * @param cphiCoefficients Cphi coefficients in PHREEQC order
+   */
+  public void setBinaryTemperatureCoefficients(int i, int j, double referenceTemperature,
+      double[] beta0Coefficients, double[] beta1Coefficients, double[] cphiCoefficients) {
+    PitzerTemperatureFunction beta0Function =
+        new PitzerTemperatureFunction(referenceTemperature, beta0Coefficients);
+    PitzerTemperatureFunction beta1Function =
+        new PitzerTemperatureFunction(referenceTemperature, beta1Coefficients);
+    PitzerTemperatureFunction cphiFunction =
+        new PitzerTemperatureFunction(referenceTemperature, cphiCoefficients);
+    setBinaryParameters(i, j, beta0Coefficients[0], beta1Coefficients[0], cphiCoefficients[0]);
+    setTemperatureFunction(pairTemperatureKey("B0", i, j), beta0Function);
+    setTemperatureFunction(pairTemperatureKey("B1", i, j), beta1Function);
+    setTemperatureFunction(pairTemperatureKey("CPHI", i, j), cphiFunction);
+  }
+
+  /**
+   * Sets a PHREEQC six-term beta2 temperature function.
+   *
+   * @param i component index i
+   * @param j component index j
+   * @param referenceTemperature reference temperature in K
+   * @param coefficients six coefficients in PHREEQC order
+   */
+  public void setBeta2TemperatureCoefficients(int i, int j, double referenceTemperature,
+      double[] coefficients) {
+    PitzerTemperatureFunction function =
+        new PitzerTemperatureFunction(referenceTemperature, coefficients);
+    setBeta2(i, j, coefficients[0]);
+    setTemperatureFunction(pairTemperatureKey("B2", i, j), function);
+  }
+
+  /**
+   * Sets a PHREEQC six-term theta temperature function.
+   *
+   * @param i component index i
+   * @param j component index j
+   * @param referenceTemperature reference temperature in K
+   * @param coefficients six coefficients in PHREEQC order
+   */
+  public void setThetaTemperatureCoefficients(int i, int j, double referenceTemperature,
+      double[] coefficients) {
+    PitzerTemperatureFunction function =
+        new PitzerTemperatureFunction(referenceTemperature, coefficients);
+    setTheta(i, j, coefficients[0]);
+    setTemperatureFunction(pairTemperatureKey("THETA", i, j), function);
+  }
+
+  /**
+   * Sets a PHREEQC six-term psi temperature function.
+   *
+   * @param i first same-sign component index
+   * @param j second same-sign component index
+   * @param k opposite-sign component index
+   * @param referenceTemperature reference temperature in K
+   * @param coefficients six coefficients in PHREEQC order
+   */
+  public void setPsiTemperatureCoefficients(int i, int j, int k, double referenceTemperature,
+      double[] coefficients) {
+    PitzerTemperatureFunction function =
+        new PitzerTemperatureFunction(referenceTemperature, coefficients);
+    setPsi(i, j, k, coefficients[0]);
+    setTemperatureFunction(tripleTemperatureKey("PSI", i, j, k), function);
+  }
+
+  /**
    * Loads Pitzer binary parameters from the PitzerParameters database table.
    *
    * <p>
@@ -348,6 +439,10 @@ public class PhasePitzer extends PhaseGE {
    * @return beta0 at temperature T
    */
   public double getBeta0ij(int i, int j, double TK) {
+    PitzerTemperatureFunction function = getTemperatureFunction(pairTemperatureKey("B0", i, j));
+    if (function != null) {
+      return function.valueAt(TK);
+    }
     double b0_25 = beta0[i][j];
     double t1 = beta0T1[i][j];
     double t2 = beta0T2[i][j];
@@ -367,6 +462,10 @@ public class PhasePitzer extends PhaseGE {
    * @return beta1 at temperature T
    */
   public double getBeta1ij(int i, int j, double TK) {
+    PitzerTemperatureFunction function = getTemperatureFunction(pairTemperatureKey("B1", i, j));
+    if (function != null) {
+      return function.valueAt(TK);
+    }
     double b1_25 = beta1[i][j];
     double t1 = beta1T1[i][j];
     double t2 = beta1T2[i][j];
@@ -385,6 +484,11 @@ public class PhasePitzer extends PhaseGE {
    * @return Cphi at temperature T
    */
   public double getCphiij(int i, int j, double TK) {
+    PitzerTemperatureFunction function =
+        getTemperatureFunction(pairTemperatureKey("CPHI", i, j));
+    if (function != null) {
+      return function.valueAt(TK);
+    }
     double c_25 = cphi[i][j];
     double t1 = cphiT1[i][j];
     double t2 = cphiT2[i][j];
@@ -506,6 +610,19 @@ public class PhasePitzer extends PhaseGE {
   }
 
   /**
+   * Gets the temperature-adjusted beta2 parameter.
+   *
+   * @param i component index i
+   * @param j component index j
+   * @param temperature temperature in K
+   * @return beta2 parameter at temperature
+   */
+  public double getBeta2ij(int i, int j, double temperature) {
+    PitzerTemperatureFunction function = getTemperatureFunction(pairTemperatureKey("B2", i, j));
+    return function == null ? beta2[i][j] : function.valueAt(temperature);
+  }
+
+  /**
    * Set beta2 parameter for 2-2 electrolytes.
    *
    * @param i component index i
@@ -527,6 +644,20 @@ public class PhasePitzer extends PhaseGE {
    */
   public double getThetaij(int i, int j) {
     return theta[i][j];
+  }
+
+  /**
+   * Gets the temperature-adjusted theta parameter.
+   *
+   * @param i component index i
+   * @param j component index j
+   * @param temperature temperature in K
+   * @return theta parameter at temperature
+   */
+  public double getThetaij(int i, int j, double temperature) {
+    PitzerTemperatureFunction function =
+        getTemperatureFunction(pairTemperatureKey("THETA", i, j));
+    return function == null ? theta[i][j] : function.valueAt(temperature);
   }
 
   /**
@@ -555,6 +686,21 @@ public class PhasePitzer extends PhaseGE {
    */
   public double getPsiijk(int i, int j, int k) {
     return psi[i][j][k];
+  }
+
+  /**
+   * Gets the temperature-adjusted psi parameter.
+   *
+   * @param i first component index
+   * @param j second component index
+   * @param k third component index
+   * @param temperature temperature in K
+   * @return psi parameter at temperature
+   */
+  public double getPsiijk(int i, int j, int k, double temperature) {
+    PitzerTemperatureFunction function =
+        getTemperatureFunction(tripleTemperatureKey("PSI", i, j, k));
+    return function == null ? psi[i][j][k] : function.valueAt(temperature);
   }
 
   /**
@@ -948,7 +1094,7 @@ public class PhasePitzer extends PhaseGE {
     double bPhi = getBeta0ij(cation, anion, temperature)
         + getBeta1ij(cation, anion, temperature) * Math.exp((is22 ? -1.4 : -2.0) * sqrtIonicStrength);
     if (is22) {
-      bPhi += getBeta2ij(cation, anion) * Math.exp(-12.0 * sqrtIonicStrength);
+      bPhi += getBeta2ij(cation, anion, temperature) * Math.exp(-12.0 * sqrtIonicStrength);
     }
     return bPhi;
   }
@@ -984,13 +1130,13 @@ public class PhasePitzer extends PhaseGE {
               aPhi, electrostaticMixing);
           electrostaticPhi = electrostaticMixing[0] + ionicStrength * electrostaticMixing[1];
         }
-        thetaPsiSum += molalityCation1 * molalityCation2 * (getThetaij(cation1, cation2) + electrostaticPhi);
+        thetaPsiSum += molalityCation1 * molalityCation2 * (getThetaij(cation1, cation2, temperature) + electrostaticPhi);
         for (int anion = 0; anion < numberOfComponents; anion++) {
           if (getComponent(anion).getIonicCharge() >= 0.0) {
             continue;
           }
           thetaPsiSum += molalityCation1 * molalityCation2 * getComponent(anion).getMolality(this)
-              * getPsiijk(cation1, cation2, anion);
+              * getPsiijk(cation1, cation2, anion, temperature);
         }
       }
     }
@@ -1015,13 +1161,13 @@ public class PhasePitzer extends PhaseGE {
               electrostaticMixing);
           electrostaticPhi = electrostaticMixing[0] + ionicStrength * electrostaticMixing[1];
         }
-        thetaPsiSum += molalityAnion1 * molalityAnion2 * (getThetaij(anion1, anion2) + electrostaticPhi);
+        thetaPsiSum += molalityAnion1 * molalityAnion2 * (getThetaij(anion1, anion2, temperature) + electrostaticPhi);
         for (int cation = 0; cation < numberOfComponents; cation++) {
           if (getComponent(cation).getIonicCharge() <= 0.0) {
             continue;
           }
           thetaPsiSum += molalityAnion1 * molalityAnion2 * getComponent(cation).getMolality(this)
-              * getPsiijk(anion1, anion2, cation);
+              * getPsiijk(anion1, anion2, cation, temperature);
         }
       }
     }
@@ -1189,6 +1335,44 @@ public class PhasePitzer extends PhaseGE {
    */
   private static String psiKey(String first, String second, String opposite) {
     return pairKey(first, second) + "|" + opposite;
+  }
+
+  /** Stores a sparse temperature function and enables the fast gate. */
+  private void setTemperatureFunction(String key, PitzerTemperatureFunction function) {
+    ensureTemperatureFunctions();
+    temperatureFunctions.put(key, function);
+    hasTemperatureFunctions = true;
+  }
+
+  /** Returns a sparse temperature function without a map lookup for legacy datasets. */
+  private PitzerTemperatureFunction getTemperatureFunction(String key) {
+    if (!hasTemperatureFunctions) {
+      return null;
+    }
+    ensureTemperatureFunctions();
+    return temperatureFunctions.get(key);
+  }
+
+  /** Ensures temperature-function state exists for objects read from older serialized forms. */
+  private void ensureTemperatureFunctions() {
+    if (temperatureFunctions == null) {
+      temperatureFunctions = new HashMap<String, PitzerTemperatureFunction>();
+      hasTemperatureFunctions = false;
+    }
+  }
+
+  /** Builds an order-independent binary temperature-function key. */
+  private static String pairTemperatureKey(String family, int first, int second) {
+    return first <= second ? family + "|" + first + "|" + second
+        : family + "|" + second + "|" + first;
+  }
+
+  /** Builds a permutation-independent ternary temperature-function key. */
+  private static String tripleTemperatureKey(String family, int first, int second, int third) {
+    int low = Math.min(first, Math.min(second, third));
+    int high = Math.max(first, Math.max(second, third));
+    int middle = first + second + third - low - high;
+    return family + "|" + low + "|" + middle + "|" + high;
   }
 
   /** Ensures definition sets exist for objects read from older serialized forms. */

--- a/src/main/java/neqsim/thermo/phase/PhasePitzer.java
+++ b/src/main/java/neqsim/thermo/phase/PhasePitzer.java
@@ -29,6 +29,12 @@ public class PhasePitzer extends PhaseGE {
   public static final String DEFAULT_PARAMETER_DATASET_ID = "neqsim-legacy-pitzer-parameters-v1";
   /** Molality below which an ion is inactive for parameter-coverage auditing. */
   private static final double ACTIVE_ION_MOLALITY = 1.0e-8;
+  private static final int TEMPERATURE_BETA0 = 1;
+  private static final int TEMPERATURE_BETA1 = 2;
+  private static final int TEMPERATURE_CPHI = 3;
+  private static final int TEMPERATURE_BETA2 = 4;
+  private static final int TEMPERATURE_THETA = 5;
+  private static final int TEMPERATURE_PSI = 6;
 
   private double[][] beta0;
   private double[][] beta1;
@@ -50,8 +56,8 @@ public class PhasePitzer extends PhaseGE {
   private double[][] cphiT1;
   private double[][] cphiT2;
   /** Sparse opt-in PHREEQC six-term temperature functions, keyed by parameter family and tuple. */
-  private Map<String, PitzerTemperatureFunction> temperatureFunctions =
-      new HashMap<String, PitzerTemperatureFunction>();
+  private Map<Long, PitzerTemperatureFunction> temperatureFunctions =
+      new HashMap<Long, PitzerTemperatureFunction>();
   /** Fast gate that avoids map lookup for legacy parameter datasets. */
   private boolean hasTemperatureFunctions;
   /** Whether parameters have been loaded from database. */
@@ -109,7 +115,7 @@ public class PhasePitzer extends PhaseGE {
     clonedPhase.definedThetaPairs = new HashSet<String>(definedThetaPairs);
     clonedPhase.definedPsiTuples = new HashSet<String>(definedPsiTuples);
     clonedPhase.temperatureFunctions =
-        new HashMap<String, PitzerTemperatureFunction>(temperatureFunctions);
+        new HashMap<Long, PitzerTemperatureFunction>(temperatureFunctions);
     clonedPhase.cachedCoverageFingerprint = 0L;
     clonedPhase.cachedCoverageRevision = Long.MIN_VALUE;
     clonedPhase.cachedCoverage = null;
@@ -303,9 +309,9 @@ public class PhasePitzer extends PhaseGE {
     PitzerTemperatureFunction cphiFunction =
         new PitzerTemperatureFunction(referenceTemperature, cphiCoefficients);
     setBinaryParameters(i, j, beta0Coefficients[0], beta1Coefficients[0], cphiCoefficients[0]);
-    setTemperatureFunction(pairTemperatureKey("B0", i, j), beta0Function);
-    setTemperatureFunction(pairTemperatureKey("B1", i, j), beta1Function);
-    setTemperatureFunction(pairTemperatureKey("CPHI", i, j), cphiFunction);
+    setTemperatureFunction(pairTemperatureKey(TEMPERATURE_BETA0, i, j), beta0Function);
+    setTemperatureFunction(pairTemperatureKey(TEMPERATURE_BETA1, i, j), beta1Function);
+    setTemperatureFunction(pairTemperatureKey(TEMPERATURE_CPHI, i, j), cphiFunction);
   }
 
   /**
@@ -321,7 +327,7 @@ public class PhasePitzer extends PhaseGE {
     PitzerTemperatureFunction function =
         new PitzerTemperatureFunction(referenceTemperature, coefficients);
     setBeta2(i, j, coefficients[0]);
-    setTemperatureFunction(pairTemperatureKey("B2", i, j), function);
+    setTemperatureFunction(pairTemperatureKey(TEMPERATURE_BETA2, i, j), function);
   }
 
   /**
@@ -337,7 +343,7 @@ public class PhasePitzer extends PhaseGE {
     PitzerTemperatureFunction function =
         new PitzerTemperatureFunction(referenceTemperature, coefficients);
     setTheta(i, j, coefficients[0]);
-    setTemperatureFunction(pairTemperatureKey("THETA", i, j), function);
+    setTemperatureFunction(pairTemperatureKey(TEMPERATURE_THETA, i, j), function);
   }
 
   /**
@@ -354,7 +360,7 @@ public class PhasePitzer extends PhaseGE {
     PitzerTemperatureFunction function =
         new PitzerTemperatureFunction(referenceTemperature, coefficients);
     setPsi(i, j, k, coefficients[0]);
-    setTemperatureFunction(tripleTemperatureKey("PSI", i, j, k), function);
+    setTemperatureFunction(tripleTemperatureKey(TEMPERATURE_PSI, i, j, k), function);
   }
 
   /**
@@ -439,7 +445,7 @@ public class PhasePitzer extends PhaseGE {
    * @return beta0 at temperature T
    */
   public double getBeta0ij(int i, int j, double TK) {
-    PitzerTemperatureFunction function = getPairTemperatureFunction("B0", i, j);
+    PitzerTemperatureFunction function = getPairTemperatureFunction(TEMPERATURE_BETA0, i, j);
     if (function != null) {
       return function.valueAt(TK);
     }
@@ -462,7 +468,7 @@ public class PhasePitzer extends PhaseGE {
    * @return beta1 at temperature T
    */
   public double getBeta1ij(int i, int j, double TK) {
-    PitzerTemperatureFunction function = getPairTemperatureFunction("B1", i, j);
+    PitzerTemperatureFunction function = getPairTemperatureFunction(TEMPERATURE_BETA1, i, j);
     if (function != null) {
       return function.valueAt(TK);
     }
@@ -485,7 +491,7 @@ public class PhasePitzer extends PhaseGE {
    */
   public double getCphiij(int i, int j, double TK) {
     PitzerTemperatureFunction function =
-        getPairTemperatureFunction("CPHI", i, j);
+        getPairTemperatureFunction(TEMPERATURE_CPHI, i, j);
     if (function != null) {
       return function.valueAt(TK);
     }
@@ -618,7 +624,7 @@ public class PhasePitzer extends PhaseGE {
    * @return beta2 parameter at temperature
    */
   public double getBeta2ij(int i, int j, double temperature) {
-    PitzerTemperatureFunction function = getPairTemperatureFunction("B2", i, j);
+    PitzerTemperatureFunction function = getPairTemperatureFunction(TEMPERATURE_BETA2, i, j);
     return function == null ? beta2[i][j] : function.valueAt(temperature);
   }
 
@@ -656,7 +662,7 @@ public class PhasePitzer extends PhaseGE {
    */
   public double getThetaij(int i, int j, double temperature) {
     PitzerTemperatureFunction function =
-        getPairTemperatureFunction("THETA", i, j);
+        getPairTemperatureFunction(TEMPERATURE_THETA, i, j);
     return function == null ? theta[i][j] : function.valueAt(temperature);
   }
 
@@ -699,7 +705,7 @@ public class PhasePitzer extends PhaseGE {
    */
   public double getPsiijk(int i, int j, int k, double temperature) {
     PitzerTemperatureFunction function =
-        getTripleTemperatureFunction("PSI", i, j, k);
+        getTripleTemperatureFunction(TEMPERATURE_PSI, i, j, k);
     return function == null ? psi[i][j][k] : function.valueAt(temperature);
   }
 
@@ -1338,14 +1344,14 @@ public class PhasePitzer extends PhaseGE {
   }
 
   /** Stores a sparse temperature function and enables the fast gate. */
-  private void setTemperatureFunction(String key, PitzerTemperatureFunction function) {
+  private void setTemperatureFunction(long key, PitzerTemperatureFunction function) {
     ensureTemperatureFunctions();
     temperatureFunctions.put(key, function);
     hasTemperatureFunctions = true;
   }
 
   /** Returns a binary temperature function without key allocation for legacy datasets. */
-  private PitzerTemperatureFunction getPairTemperatureFunction(String family, int first,
+  private PitzerTemperatureFunction getPairTemperatureFunction(int family, int first,
       int second) {
     if (!hasTemperatureFunctions) {
       return null;
@@ -1355,7 +1361,7 @@ public class PhasePitzer extends PhaseGE {
   }
 
   /** Returns a ternary temperature function without key allocation for legacy datasets. */
-  private PitzerTemperatureFunction getTripleTemperatureFunction(String family, int first,
+  private PitzerTemperatureFunction getTripleTemperatureFunction(int family, int first,
       int second, int third) {
     if (!hasTemperatureFunctions) {
       return null;
@@ -1367,23 +1373,25 @@ public class PhasePitzer extends PhaseGE {
   /** Ensures temperature-function state exists for objects read from older serialized forms. */
   private void ensureTemperatureFunctions() {
     if (temperatureFunctions == null) {
-      temperatureFunctions = new HashMap<String, PitzerTemperatureFunction>();
+      temperatureFunctions = new HashMap<Long, PitzerTemperatureFunction>();
       hasTemperatureFunctions = false;
     }
   }
 
-  /** Builds an order-independent binary temperature-function key. */
-  private static String pairTemperatureKey(String family, int first, int second) {
-    return first <= second ? family + "|" + first + "|" + second
-        : family + "|" + second + "|" + first;
+  /** Builds an order-independent allocation-free binary temperature-function key. */
+  private static long pairTemperatureKey(int family, int first, int second) {
+    int low = Math.min(first, second);
+    int high = Math.max(first, second);
+    return ((long) family << 54) | ((long) low << 18) | (long) high;
   }
 
-  /** Builds a permutation-independent ternary temperature-function key. */
-  private static String tripleTemperatureKey(String family, int first, int second, int third) {
+  /** Builds a permutation-independent allocation-free ternary temperature-function key. */
+  private static long tripleTemperatureKey(int family, int first, int second, int third) {
     int low = Math.min(first, Math.min(second, third));
     int high = Math.max(first, Math.max(second, third));
     int middle = first + second + third - low - high;
-    return family + "|" + low + "|" + middle + "|" + high;
+    return ((long) family << 54) | ((long) low << 36) | ((long) middle << 18)
+        | (long) high;
   }
 
   /** Ensures definition sets exist for objects read from older serialized forms. */

--- a/src/main/java/neqsim/thermo/phase/PhasePitzer.java
+++ b/src/main/java/neqsim/thermo/phase/PhasePitzer.java
@@ -439,7 +439,7 @@ public class PhasePitzer extends PhaseGE {
    * @return beta0 at temperature T
    */
   public double getBeta0ij(int i, int j, double TK) {
-    PitzerTemperatureFunction function = getTemperatureFunction(pairTemperatureKey("B0", i, j));
+    PitzerTemperatureFunction function = getPairTemperatureFunction("B0", i, j);
     if (function != null) {
       return function.valueAt(TK);
     }
@@ -462,7 +462,7 @@ public class PhasePitzer extends PhaseGE {
    * @return beta1 at temperature T
    */
   public double getBeta1ij(int i, int j, double TK) {
-    PitzerTemperatureFunction function = getTemperatureFunction(pairTemperatureKey("B1", i, j));
+    PitzerTemperatureFunction function = getPairTemperatureFunction("B1", i, j);
     if (function != null) {
       return function.valueAt(TK);
     }
@@ -485,7 +485,7 @@ public class PhasePitzer extends PhaseGE {
    */
   public double getCphiij(int i, int j, double TK) {
     PitzerTemperatureFunction function =
-        getTemperatureFunction(pairTemperatureKey("CPHI", i, j));
+        getPairTemperatureFunction("CPHI", i, j);
     if (function != null) {
       return function.valueAt(TK);
     }
@@ -618,7 +618,7 @@ public class PhasePitzer extends PhaseGE {
    * @return beta2 parameter at temperature
    */
   public double getBeta2ij(int i, int j, double temperature) {
-    PitzerTemperatureFunction function = getTemperatureFunction(pairTemperatureKey("B2", i, j));
+    PitzerTemperatureFunction function = getPairTemperatureFunction("B2", i, j);
     return function == null ? beta2[i][j] : function.valueAt(temperature);
   }
 
@@ -656,7 +656,7 @@ public class PhasePitzer extends PhaseGE {
    */
   public double getThetaij(int i, int j, double temperature) {
     PitzerTemperatureFunction function =
-        getTemperatureFunction(pairTemperatureKey("THETA", i, j));
+        getPairTemperatureFunction("THETA", i, j);
     return function == null ? theta[i][j] : function.valueAt(temperature);
   }
 
@@ -699,7 +699,7 @@ public class PhasePitzer extends PhaseGE {
    */
   public double getPsiijk(int i, int j, int k, double temperature) {
     PitzerTemperatureFunction function =
-        getTemperatureFunction(tripleTemperatureKey("PSI", i, j, k));
+        getTripleTemperatureFunction("PSI", i, j, k);
     return function == null ? psi[i][j][k] : function.valueAt(temperature);
   }
 
@@ -1344,13 +1344,24 @@ public class PhasePitzer extends PhaseGE {
     hasTemperatureFunctions = true;
   }
 
-  /** Returns a sparse temperature function without a map lookup for legacy datasets. */
-  private PitzerTemperatureFunction getTemperatureFunction(String key) {
+  /** Returns a binary temperature function without key allocation for legacy datasets. */
+  private PitzerTemperatureFunction getPairTemperatureFunction(String family, int first,
+      int second) {
     if (!hasTemperatureFunctions) {
       return null;
     }
     ensureTemperatureFunctions();
-    return temperatureFunctions.get(key);
+    return temperatureFunctions.get(pairTemperatureKey(family, first, second));
+  }
+
+  /** Returns a ternary temperature function without key allocation for legacy datasets. */
+  private PitzerTemperatureFunction getTripleTemperatureFunction(String family, int first,
+      int second, int third) {
+    if (!hasTemperatureFunctions) {
+      return null;
+    }
+    ensureTemperatureFunctions();
+    return temperatureFunctions.get(tripleTemperatureKey(family, first, second, third));
   }
 
   /** Ensures temperature-function state exists for objects read from older serialized forms. */

--- a/src/main/java/neqsim/thermo/phase/PitzerTemperatureFunction.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerTemperatureFunction.java
@@ -1,0 +1,87 @@
+package neqsim.thermo.phase;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Immutable PHREEQC-compatible six-coefficient temperature function for a Pitzer parameter.
+ *
+ * <p>
+ * The function is evaluated on the absolute-temperature scale as
+ * {@code a0 + a1(1/T - 1/Tr) + a2 ln(T/Tr) + a3(T - Tr) + a4(T^2 - Tr^2)
+ * + a5(1/T^2 - 1/Tr^2)}. It follows the public-domain PHREEQC
+ * {@code calc_pitz_param} convention and performs no unit or standard-state conversion.
+ * </p>
+ */
+public final class PitzerTemperatureFunction implements Serializable {
+  /** Serialization version UID. */
+  private static final long serialVersionUID = 1000L;
+  /** PHREEQC treats temperatures within this distance of the reference as identical. */
+  private static final double REFERENCE_TOLERANCE_K = 1.0e-3;
+
+  private final double referenceTemperature;
+  private final double[] coefficients;
+
+  /**
+   * Creates a six-coefficient temperature function.
+   *
+   * @param referenceTemperature reference temperature in K
+   * @param coefficients exactly six finite coefficients in PHREEQC order
+   */
+  public PitzerTemperatureFunction(double referenceTemperature, double[] coefficients) {
+    if (!Double.isFinite(referenceTemperature) || referenceTemperature <= 0.0) {
+      throw new IllegalArgumentException("Pitzer reference temperature must be finite and positive");
+    }
+    if (coefficients == null || coefficients.length != 6) {
+      throw new IllegalArgumentException("Pitzer temperature function requires exactly six coefficients");
+    }
+    this.coefficients = coefficients.clone();
+    for (double coefficient : this.coefficients) {
+      if (!Double.isFinite(coefficient)) {
+        throw new IllegalArgumentException("Pitzer temperature coefficients must be finite");
+      }
+    }
+    this.referenceTemperature = referenceTemperature;
+  }
+
+  /**
+   * Evaluates the parameter at a temperature.
+   *
+   * @param temperature temperature in K
+   * @return temperature-adjusted parameter in the same units as the coefficients
+   */
+  public double valueAt(double temperature) {
+    if (!Double.isFinite(temperature) || temperature <= 0.0) {
+      throw new IllegalArgumentException("Pitzer parameter temperature must be finite and positive");
+    }
+    if (Math.abs(temperature - referenceTemperature) < REFERENCE_TOLERANCE_K) {
+      return coefficients[0];
+    }
+    double inverseTemperature = 1.0 / temperature;
+    double inverseReference = 1.0 / referenceTemperature;
+    return coefficients[0] + coefficients[1] * (inverseTemperature - inverseReference)
+        + coefficients[2] * Math.log(temperature / referenceTemperature)
+        + coefficients[3] * (temperature - referenceTemperature)
+        + coefficients[4] * (temperature * temperature - referenceTemperature * referenceTemperature)
+        + coefficients[5]
+            * (inverseTemperature * inverseTemperature - inverseReference * inverseReference);
+  }
+
+  /**
+   * Gets the reference temperature.
+   *
+   * @return reference temperature in K
+   */
+  public double getReferenceTemperature() {
+    return referenceTemperature;
+  }
+
+  /**
+   * Gets a defensive copy of the six coefficients.
+   *
+   * @return coefficients in PHREEQC order
+   */
+  public double[] getCoefficients() {
+    return Arrays.copyOf(coefficients, coefficients.length);
+  }
+}

--- a/src/test/java/neqsim/thermo/phase/PitzerTemperatureFunctionTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerTemperatureFunctionTest.java
@@ -3,6 +3,10 @@ package neqsim.thermo.phase;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import org.junit.jupiter.api.Test;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemPitzer;
@@ -73,6 +77,28 @@ class PitzerTemperatureFunctionTest extends neqsim.NeqSimTest {
         new double[] {0.25, 0.0, 0.0, 0.0, 0.0, 0.0});
     assertEquals(expected, phase.getThetaij(sodium, potassium, 373.15), 2.0e-15);
     assertEquals(0.25, clone.getThetaij(sodium, potassium, 373.15), 0.0);
+  }
+
+  @Test
+  void serializationPreservesSparseTemperatureFunctions() throws Exception {
+    PhasePitzer phase = createPhase();
+    int sodium = phase.getComponent("Na+").getComponentNumber();
+    int potassium = phase.getComponent("K+").getComponentNumber();
+    phase.setThetaTemperatureCoefficients(sodium, potassium, REFERENCE_TEMPERATURE,
+        COEFFICIENTS);
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(phase);
+    }
+    PhasePitzer restored;
+    try (ObjectInputStream input =
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored = (PhasePitzer) input.readObject();
+    }
+
+    assertEquals(-0.11371073586719137,
+        restored.getThetaij(sodium, potassium, 373.15), 2.0e-15);
   }
 
   @Test

--- a/src/test/java/neqsim/thermo/phase/PitzerTemperatureFunctionTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerTemperatureFunctionTest.java
@@ -1,0 +1,101 @@
+package neqsim.thermo.phase;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPitzer;
+
+/** Tests PHREEQC six-term temperature semantics and Pitzer-family placement. */
+class PitzerTemperatureFunctionTest extends neqsim.NeqSimTest {
+  private static final double REFERENCE_TEMPERATURE = 298.15;
+  private static final double[] COEFFICIENTS =
+      {0.12, 250.0, -0.035, 4.2e-4, -3.1e-7, 18000.0};
+
+  @Test
+  void matchesPublicDomainPhreeqcTemperatureFunction() {
+    PitzerTemperatureFunction function =
+        new PitzerTemperatureFunction(REFERENCE_TEMPERATURE, COEFFICIENTS);
+
+    assertEquals(0.12, function.valueAt(REFERENCE_TEMPERATURE), 0.0);
+    assertEquals(0.12, function.valueAt(REFERENCE_TEMPERATURE + 5.0e-4), 0.0);
+    assertEquals(-0.11371073586719137, function.valueAt(373.15), 2.0e-15);
+    assertEquals(REFERENCE_TEMPERATURE, function.getReferenceTemperature(), 0.0);
+  }
+
+  @Test
+  void rejectsInvalidInputsAndProtectsCoefficientState() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new PitzerTemperatureFunction(0.0, COEFFICIENTS));
+    assertThrows(IllegalArgumentException.class,
+        () -> new PitzerTemperatureFunction(REFERENCE_TEMPERATURE, new double[5]));
+    assertThrows(IllegalArgumentException.class,
+        () -> new PitzerTemperatureFunction(REFERENCE_TEMPERATURE,
+            new double[] {0.0, 0.0, Double.NaN, 0.0, 0.0, 0.0}));
+
+    PitzerTemperatureFunction function =
+        new PitzerTemperatureFunction(REFERENCE_TEMPERATURE, COEFFICIENTS);
+    double[] copy = function.getCoefficients();
+    copy[0] = 99.0;
+    assertArrayEquals(COEFFICIENTS, function.getCoefficients(), 0.0);
+    assertEquals(0.12, function.valueAt(REFERENCE_TEMPERATURE), 0.0);
+    assertThrows(IllegalArgumentException.class, () -> function.valueAt(-1.0));
+  }
+
+  @Test
+  void appliesTemperatureFunctionsToEveryImplementedPitzerFamily() {
+    PhasePitzer phase = createPhase();
+    int sodium = phase.getComponent("Na+").getComponentNumber();
+    int potassium = phase.getComponent("K+").getComponentNumber();
+    int chloride = phase.getComponent("Cl-").getComponentNumber();
+
+    phase.setBinaryTemperatureCoefficients(sodium, chloride, REFERENCE_TEMPERATURE,
+        COEFFICIENTS, COEFFICIENTS, COEFFICIENTS);
+    phase.setBeta2TemperatureCoefficients(sodium, chloride, REFERENCE_TEMPERATURE,
+        COEFFICIENTS);
+    phase.setThetaTemperatureCoefficients(sodium, potassium, REFERENCE_TEMPERATURE,
+        COEFFICIENTS);
+    phase.setPsiTemperatureCoefficients(sodium, potassium, chloride,
+        REFERENCE_TEMPERATURE, COEFFICIENTS);
+
+    double expected = -0.11371073586719137;
+    assertEquals(expected, phase.getBeta0ij(sodium, chloride, 373.15), 2.0e-15);
+    assertEquals(expected, phase.getBeta1ij(sodium, chloride, 373.15), 2.0e-15);
+    assertEquals(expected, phase.getCphiij(sodium, chloride, 373.15), 2.0e-15);
+    assertEquals(expected, phase.getBeta2ij(sodium, chloride, 373.15), 2.0e-15);
+    assertEquals(expected, phase.getThetaij(potassium, sodium, 373.15), 2.0e-15);
+    assertEquals(expected, phase.getPsiijk(chloride, potassium, sodium, 373.15),
+        2.0e-15);
+
+    PhasePitzer clone = phase.clone();
+    clone.setThetaTemperatureCoefficients(sodium, potassium, REFERENCE_TEMPERATURE,
+        new double[] {0.25, 0.0, 0.0, 0.0, 0.0, 0.0});
+    assertEquals(expected, phase.getThetaij(sodium, potassium, 373.15), 2.0e-15);
+    assertEquals(0.25, clone.getThetaij(sodium, potassium, 373.15), 0.0);
+  }
+
+  @Test
+  void preservesLegacyThreeCoefficientTemperatureBehavior() {
+    PhasePitzer phase = createPhase();
+    int sodium = phase.getComponent("Na+").getComponentNumber();
+    int chloride = phase.getComponent("Cl-").getComponentNumber();
+    phase.setBinaryParameters(sodium, chloride, 0.08, 0.2, 0.001);
+    phase.setBeta0T(sodium, chloride, 125.0, -0.03);
+
+    double temperature = 333.15;
+    double expected = 0.08 + 125.0 * (1.0 / temperature - 1.0 / REFERENCE_TEMPERATURE)
+        - 0.03 * Math.log(temperature / REFERENCE_TEMPERATURE);
+    assertEquals(expected, phase.getBeta0ij(sodium, chloride, temperature), 1.0e-15);
+    assertEquals(0.2, phase.getBeta1ij(sodium, chloride, temperature), 0.0);
+  }
+
+  private static PhasePitzer createPhase() {
+    SystemInterface system = new SystemPitzer(REFERENCE_TEMPERATURE, 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("Na+", 1.0);
+    system.addComponent("K+", 0.1);
+    system.addComponent("Cl-", 1.1);
+    return (PhasePitzer) system.getPhase(1);
+  }
+}


### PR DESCRIPTION
## Summary

Advances #3144 with PHREEQC-compatible six-term temperature functions for every Pitzer interaction family currently implemented by NeqSim.

- adds an immutable six-coefficient evaluator matching public-domain PHREEQC `calc_pitz_param`
- maps the function to beta0, beta1, beta2, NeqSim Cphi, theta, and psi
- evaluates the same temperature-adjusted values in ion-activity and both water/osmotic paths
- keeps the legacy three-coefficient database behavior unchanged
- stores functions sparsely behind a boolean fast gate; non-Pitzer models execute no new code
- adopts no fitted parameter, reaction constant, mineral log K, or database row

## Frozen engineering question

Can NeqSim represent the complete PHREEQC Pitzer temperature equation without mixing parameter families, changing legacy rows, or slowing neutral calculations?

**Current-master reproducer:** exact master `24121177a108c4df3eb47dbea75bedb619e733ff` provides only
`p(T)=p25+t1(1/T-1/298.15)+t2 ln(T/298.15)` for beta0, beta1, and Cphi. Beta2, theta, and psi are temperature-independent. A PHREEQC six-term dataset therefore cannot be represented even when every interaction tuple is present.

**Model/basis:** `SystemPitzer` / molality standard state; kelvin absolute temperature; coefficients retain the units and activity-scale convention of their source dataset. The evaluator implements

`a0 + a1(1/T-1/Tr) + a2 ln(T/Tr) + a3(T-Tr) + a4(T^2-Tr^2) + a5(1/T^2-1/Tr^2)`.

**Acceptance:** exact reference branch at Tr; independent synthetic result at 373.15 K; invalid-input rejection; defensive coefficient ownership; placement for beta0/beta1/beta2/Cphi/theta/psi; permutation symmetry for theta/psi; clone independence; serialization; preservation of the legacy three-coefficient path; exact-head Java 8/21, Spotless, docs, CodeQL, Javadocs, and broader Pitzer controls.

**Stop boundary:** no coefficient adoption; no `pitzer.dat` import; no reaction/species/mineral change; no C0-to-Cphi conversion; no lambda/zeta/mu/eta implementation; no Aphi replacement; no extrapolation claim.

## Source, license, and comparison matrix

The durable exact-branch matrix and convention mapping are in
[`docs/thermo/pitzer_parameter_provenance.md`](https://github.com/equinor/neqsim/blob/codex/pitzer-six-term-temperature-3144/docs/thermo/pitzer_parameter_provenance.md).

- Pitzer (1975): https://doi.org/10.1007/BF00646562
- PHRQPITZ: https://doi.org/10.3133/wri884153
- audited PHREEQC source commit `b0b3be767158ccc3322d2c816625cf470045e67e`: https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/src/pitzer.cpp#L1721-L1850
- USGS PHREEQC software/data are public domain: https://www.usgs.gov/software/phreeqc-version-3

The function and placement mapping are adopted. No external numerical parameter table or experimental point is copied or fitted. Baard Kaasa's 1998 thesis remains a provenance index, but the scan was not lawfully readable; no Kaasa page, symbol, table, coefficient, or value was read, copied, inferred, or OCRed.

## Implementation and compatibility

- `PitzerTemperatureFunction`: immutable, serializable, allocation-free evaluation; PHREEQC's 0.001 K reference branch
- `PhasePitzer`: atomic binary setter plus beta2/theta/psi setters; sparse serialized map; clone-owned map with immutable values; temperature-aware overloads
- `ComponentGePitzer` and the independent `PhasePitzer` osmotic API use the same temperature-adjusted families
- legacy tables retain their existing arrays and formula
- neutral PR/SRK/CPA, electrolyte EOS, flash, reaction, hydrate, mineral, and process source paths are unchanged

## Validation

Exact-source reasoning completed:

- fixed-coefficient independent evaluation: `p(298.15 K)=0.12`, `p(373.15 K)=-0.11371073586719137`
- reference tolerance, invalid input, defensive copy, all implemented families, tuple symmetry, clone independence, serialization, and legacy behavior have focused tests
- branch is nine commits ahead and zero behind exact base; five files changed

No local repository checkout or Maven environment is available in this run. No hosted check has completed yet.

**VALIDATION PENDING CI**

Exact base: `24121177a108c4df3eb47dbea75bedb619e733ff`
Exact head at publication: `ac15b31d11d52e098824c92c861ee5038b59130d`

## Performance and next dependency

The new evaluator allocates nothing per call. The sparse map is empty for legacy datasets and guarded by one boolean before lookup. Non-Pitzer paths are untouched. Hosted and follow-up exact-base/head benchmarks must still establish the complete Pitzer and neutral-control overhead before merge classification.

After merge, adopt no rows until a complete redistributable Na/K/Cl binary-theta-psi dataset resolves C0/Cphi semantics and passes held-out activity, osmotic, water-activity, speciation, mixed-brine, continuity, and performance gates.

Refs #3144