### PR TITLE
[AI-Assisted] feat(optimization): add plant constraint registry

### DIFF
--- a/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
+++ b/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
@@ -52,6 +52,37 @@ This guide provides comprehensive examples for setting up and running production
 
 ---
 
+## Register plant-wide restrictions before solving
+
+Large plants have restrictions that do not belong to one equipment item: total power and utilities,
+common-shaft compressor trains, gathering and export networks, area limits, product quality, emissions,
+produced-water handling, flare capacity, availability, and nomination limits. Use
+`PlantConstraintRegistry` to give each restriction a stable identity and explicit engineering basis.
+
+The registry complements equipment constraints for compressor maps, surge/choke, speed, temperature
+and power; separator gas/oil/water capacity, residence and settling; and piping pressure, velocity,
+erosion, FIV, thermal and phase limits. It does not infer operating authority from advisory safety or
+integrity calculations.
+
+```java
+PlantConstraintRegistry registry = new PlantConstraintRegistry();
+registry.register(PlantConstraintDefinition
+    .builder("export-pressure", PlantConstraintScope.stream("Plant", "Export", "Gas export"))
+    .unit("bara")
+    .basis("absolute pressure at export battery limit")
+    .provenance("sales-gas agreement rev 3")
+    .category(PlantConstraintDefinition.Category.COMMERCIAL)
+    .build());
+```
+
+Treat this as registration, not solved evidence. A later utilization snapshot must sample every
+enabled restriction after successful convergence, validate finite values and consistent units/bases,
+and fail closed if evidence is incomplete. See the
+[Capacity Constraint Framework](../process/CAPACITY_CONSTRAINT_FRAMEWORK#plant-wide-constraint-registration)
+for aggregation and conversion rules.
+
+---
+
 ## Overview
 
 NeqSim provides a powerful production optimization framework that combines:

--- a/docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md
+++ b/docs/process/CAPACITY_CONSTRAINT_FRAMEWORK.md
@@ -22,6 +22,51 @@ The Capacity Constraint Framework extends NeqSim's existing bottleneck analysis 
 > equipment's design envelope (max design pressure drop, volume flow, power, etc.), see
 > [Equipment Utilization via Mechanical Design](equipment_utilization_via_mechanical_design.md).
 
+## Plant-wide constraint registration
+
+`PlantConstraintRegistry` adds deterministic plant identity and engineering-basis metadata without
+replacing equipment-local `CapacityConstraint` calculations. It can register constraints on an
+equipment item, stream, area, complete model, shared resource, or coupled group such as compressors
+on a common shaft. Definitions are immutable, serializable, callback-free, and directly accessible
+from Python through JPype.
+
+The registry deliberately does **not** calculate utilization or declare a process candidate feasible.
+It is the metadata layer consumed by the later complete-snapshot and solver layers.
+
+| Registration field | Contract |
+|---|---|
+| Stable identity | Escaped model, area, subject, and caller-owned constraint ID |
+| Aggregation | `DIRECT`, `SUM`, `MAXIMUM`, `MINIMUM`, `SHARED_BUDGET`, `COMMON_SETPOINT`, or explicit rate-basis conversion |
+| Engineering basis | Target unit, measurement/rating basis, provenance, owner, reference, and calculation method |
+| Evidence quality | Optional confidence and scalar validity interval |
+| Status | Registered, disabled, incomplete basis, or disabled with incomplete basis |
+
+Aggregated participants must use the target unit and basis. NeqSim never guesses a conversion; an
+unlike source must declare an explicit finite affine conversion. Aggregates also require a non-empty
+target unit and basis. This prevents, for example, silently adding shaft `kW` to electrical `MW`, or
+combining standard and actual volumetric rates.
+
+```java
+PlantConstraintRegistry registry = new PlantConstraintRegistry();
+PlantConstraintDefinition totalPower = PlantConstraintDefinition
+    .builder("total-power", PlantConstraintScope.sharedResource("NorthPlant", "electrical-power"))
+    .aggregationPolicy(PlantConstraintDefinition.AggregationPolicy.SHARED_BUDGET)
+    .unit("MW")
+    .basis("instantaneous electrical load")
+    .provenance("site power study 2026")
+    .participant(PlantConstraintParticipant.direct(
+        "compression/K-101", "MW", "instantaneous electrical load"))
+    .participant(PlantConstraintParticipant.converted(
+        "compression/K-102", "kW", "shaft power", 0.001, 0.0))
+    .build();
+registry.register(totalPower);
+```
+
+Use `registerEquipmentConstraint(...)` to copy identity-relevant metadata from an existing
+`CapacityConstraint`. The adapter does not invoke or retain its live value supplier. Runtime values,
+applicability, convergence, margins, and utilization belong in a complete immutable snapshot and
+must be regenerated after every process solve.
+
 ## Important: Constraints Disabled by Default
 
 > **⚠️ Key Behavior**: All separator, valve, pipeline, pump, and manifold constraints are **disabled by default** for backward compatibility. The optimizer checks whether any constraints are enabled before using the `CapacityConstrainedEquipment` interface.

--- a/docs/process/optimization/industrial-process-optimization-baseline.md
+++ b/docs/process/optimization/industrial-process-optimization-baseline.md
@@ -190,11 +190,29 @@ A later implementation may claim improvement only when all applicable gates pass
   [#3153](https://github.com/equinor/neqsim/issues/3153) after the Java evidence and result schemas
   are stable.
 
+## Stable plant constraint registration contract
+
+`PlantConstraintScope`, `PlantConstraintDefinition`, `PlantConstraintParticipant`, and
+`PlantConstraintRegistry` provide the dependency-ready identity layer for the restriction inventory
+above. A constraint is addressed independently of Java object identity at equipment, stream, area,
+model, shared-resource, or coupled-group scope. Registration retains unit, basis, provenance, owner,
+reference, calculation method, confidence, validity, severity, and enablement. Disabled and incomplete
+registrations remain visible instead of disappearing from the audit trail.
+
+Registration is deterministic across insertion order and Java serialization. Aggregation is explicit,
+participants are ordered by stable identity, and unlike units or bases are rejected unless the caller
+supplies a finite conversion. The equipment adapter copies the established #2941
+`CapacityConstraint` metadata without evaluating or retaining its mutable value supplier.
+
+This increment is metadata only. It does not yet sample values, aggregate total power, coordinate a
+common shaft, compute separator or piping utilization, determine feasibility, or alter process solving.
+Those operations require complete post-solve evidence and fail-closed snapshot validation.
+
 ## Next dependency-ready increments
 
 1. Execute and version cases S and M on unmodified master, then add the missing measurement fields
    without changing scheduling behavior.
-2. Introduce one stable plant-wide constraint/resource identity and complete immutable utilization
+2. Consume the stable plant-wide constraint/resource registry in a complete immutable utilization
    snapshot, reusing `InstalledEquipmentCapacityEvidence` and `ProcessBoundaryConstraintEvidence`.
 3. Add first-class total-power/shared-utility evidence, followed by a common-shaft compressor-train
    resource constraint.

--- a/src/main/java/neqsim/process/util/optimizer/PlantConstraintDefinition.java
+++ b/src/main/java/neqsim/process/util/optimizer/PlantConstraintDefinition.java
@@ -1,0 +1,449 @@
+package neqsim.process.util.optimizer;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import neqsim.process.equipment.capacity.CapacityConstraint;
+
+/**
+ * Immutable definition and engineering basis for one plant-wide optimization constraint.
+ *
+ * <p>
+ * The definition contains identity and registration metadata only. Runtime values, residuals, feasibility, and
+ * utilization belong to the complete snapshot layer so an open registration can never be mistaken for fresh solved
+ * evidence. Missing unit, basis, or provenance is retained with an explicit registration status instead of being
+ * silently discarded.
+ * </p>
+ */
+public final class PlantConstraintDefinition implements Serializable, Comparable<PlantConstraintDefinition> {
+  private static final long serialVersionUID = 1L;
+
+  /** How participant values must be combined after any declared conversion. */
+  public enum AggregationPolicy {
+    /** One direct observable or pre-calculated value. */
+    DIRECT,
+    /** Sum of compatible participant values. */
+    SUM,
+    /** Maximum participant value. */
+    MAXIMUM,
+    /** Minimum participant value. */
+    MINIMUM,
+    /** Sum compared with a shared plant budget. */
+    SHARED_BUDGET,
+    /** Participant values must use one common setpoint. */
+    COMMON_SETPOINT,
+    /** Participants require explicit conversion to the registered unit and basis. */
+    RATE_BASIS_CONVERSION
+  }
+
+  /** Direction of increasing violation. */
+  public enum LimitDirection {
+    /** Values above the upper limit are worse. */
+    MAXIMUM,
+    /** Values below the lower limit are worse. */
+    MINIMUM,
+    /** Values outside an inclusive range are worse. */
+    RANGE,
+    /** Values away from a target by more than the tolerance are worse. */
+    EQUALITY
+  }
+
+  /** Engineering role of the restriction. */
+  public enum Category {
+    PHYSICAL, DESIGN, OPERATING, QUALITY, ENVIRONMENTAL, COMMERCIAL, SCREENING
+  }
+
+  /** Completeness and enablement of the registration metadata. */
+  public enum RegistrationStatus {
+    REGISTERED, DISABLED, INCOMPLETE_BASIS, DISABLED_INCOMPLETE_BASIS
+  }
+
+  private final String id;
+  private final String qualifiedId;
+  private final PlantConstraintScope scope;
+  private final AggregationPolicy aggregationPolicy;
+  private final LimitDirection limitDirection;
+  private final Category category;
+  private final CapacityConstraint.ConstraintSeverity severity;
+  private final String unit;
+  private final String basis;
+  private final String provenance;
+  private final String owner;
+  private final String reference;
+  private final String calculationMethod;
+  private final String description;
+  private final boolean enabled;
+  private final boolean confidenceSet;
+  private final double confidence;
+  private final boolean validityRangeSet;
+  private final double validityMinimum;
+  private final double validityMaximum;
+  private final List<PlantConstraintParticipant> participants;
+  private final RegistrationStatus registrationStatus;
+
+  private PlantConstraintDefinition(Builder builder) {
+    id = PlantConstraintScope.requireText(builder.id, "Constraint id");
+    if (builder.scope == null) {
+      throw new IllegalArgumentException("Plant constraint scope is required");
+    }
+    scope = builder.scope;
+    qualifiedId = scope.getStableId() + "#" + PlantConstraintScope.escape(id);
+    aggregationPolicy = require(builder.aggregationPolicy, "Aggregation policy");
+    limitDirection = require(builder.limitDirection, "Limit direction");
+    category = require(builder.category, "Constraint category");
+    severity = require(builder.severity, "Constraint severity");
+    unit = PlantConstraintScope.safeText(builder.unit);
+    basis = PlantConstraintScope.safeText(builder.basis);
+    provenance = PlantConstraintScope.safeText(builder.provenance);
+    owner = PlantConstraintScope.safeText(builder.owner);
+    reference = PlantConstraintScope.safeText(builder.reference);
+    calculationMethod = PlantConstraintScope.safeText(builder.calculationMethod);
+    description = PlantConstraintScope.safeText(builder.description);
+    enabled = builder.enabled;
+    confidenceSet = builder.confidenceSet;
+    confidence = validateConfidence(builder.confidenceSet, builder.confidence);
+    validityRangeSet = builder.validityRangeSet;
+    validityMinimum = builder.validityMinimum;
+    validityMaximum = builder.validityMaximum;
+    validateValidity();
+    participants = validateParticipants(builder.participants);
+    boolean incomplete = unit.isEmpty() || basis.isEmpty() || provenance.isEmpty();
+    registrationStatus = enabled ? (incomplete ? RegistrationStatus.INCOMPLETE_BASIS : RegistrationStatus.REGISTERED)
+        : (incomplete ? RegistrationStatus.DISABLED_INCOMPLETE_BASIS : RegistrationStatus.DISABLED);
+  }
+
+  /** Starts a JPype-friendly fluent builder. */
+  public static Builder builder(String id, PlantConstraintScope scope) {
+    return new Builder(id, scope);
+  }
+
+  private static <T> T require(T value, String label) {
+    if (value == null) {
+      throw new IllegalArgumentException(label + " is required");
+    }
+    return value;
+  }
+
+  private static double validateConfidence(boolean set, double value) {
+    if (!set) {
+      return Double.NaN;
+    }
+    if (!Double.isFinite(value) || value < 0.0 || value > 1.0) {
+      throw new IllegalArgumentException("Confidence must be finite and in [0, 1]");
+    }
+    return value;
+  }
+
+  private void validateValidity() {
+    if (validityRangeSet && (!Double.isFinite(validityMinimum) || !Double.isFinite(validityMaximum)
+        || validityMinimum > validityMaximum)) {
+      throw new IllegalArgumentException("Validity range must be finite and ordered");
+    }
+  }
+
+  private List<PlantConstraintParticipant> validateParticipants(List<PlantConstraintParticipant> source) {
+    List<PlantConstraintParticipant> copy = new ArrayList<PlantConstraintParticipant>(source);
+    Collections.sort(copy);
+    if (aggregationPolicy != AggregationPolicy.DIRECT && copy.isEmpty()) {
+      throw new IllegalArgumentException(aggregationPolicy + " requires at least one participant");
+    }
+    if (aggregationPolicy != AggregationPolicy.DIRECT && (unit.isEmpty() || basis.isEmpty())) {
+      throw new IllegalArgumentException(aggregationPolicy + " requires an explicit target unit and basis");
+    }
+    Set<String> identities = new HashSet<String>();
+    boolean explicitConversionFound = false;
+    for (PlantConstraintParticipant participant : copy) {
+      if (!identities.add(participant.getSourceId())) {
+        throw new IllegalArgumentException("Duplicate participant identity " + participant.getSourceId());
+      }
+      if (participant.isConversionExplicit()) {
+        explicitConversionFound = true;
+      } else if (!unit.equals(participant.getUnit()) || !basis.equals(participant.getBasis())) {
+        throw new IllegalArgumentException(
+            "Participant " + participant.getSourceId() + " has unlike unit or basis without an explicit conversion");
+      }
+    }
+    if (aggregationPolicy == AggregationPolicy.RATE_BASIS_CONVERSION && !explicitConversionFound) {
+      throw new IllegalArgumentException("RATE_BASIS_CONVERSION requires an explicit participant conversion");
+    }
+    return Collections.unmodifiableList(copy);
+  }
+
+  /** @return caller-owned constraint id within its scope */
+  public String getId() {
+    return id;
+  }
+
+  /** @return escaped plant-stable scope and constraint identity */
+  public String getQualifiedId() {
+    return qualifiedId;
+  }
+
+  /** @return immutable plant subject scope */
+  public PlantConstraintScope getScope() {
+    return scope;
+  }
+
+  /** @return declared participant aggregation policy */
+  public AggregationPolicy getAggregationPolicy() {
+    return aggregationPolicy;
+  }
+
+  /** @return direction of increasing violation */
+  public LimitDirection getLimitDirection() {
+    return limitDirection;
+  }
+
+  /** @return engineering restriction category */
+  public Category getCategory() {
+    return category;
+  }
+
+  /** @return optimization severity */
+  public CapacityConstraint.ConstraintSeverity getSeverity() {
+    return severity;
+  }
+
+  /** @return physical engineering unit, or empty when not supplied */
+  public String getUnit() {
+    return unit;
+  }
+
+  /** @return measurement, rate, reference, or rating basis, or empty */
+  public String getBasis() {
+    return basis;
+  }
+
+  /** @return source of the registered restriction, or empty */
+  public String getProvenance() {
+    return provenance;
+  }
+
+  /** @return accountable constraint owner, or empty */
+  public String getOwner() {
+    return owner;
+  }
+
+  /** @return source document, tag, or external reference, or empty */
+  public String getReference() {
+    return reference;
+  }
+
+  /** @return named calculation or measurement method, or empty */
+  public String getCalculationMethod() {
+    return calculationMethod;
+  }
+
+  /** @return engineering description */
+  public String getDescription() {
+    return description;
+  }
+
+  /** @return whether the restriction participates in feasibility */
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  /** @return whether evidence-quality confidence was explicitly supplied */
+  public boolean hasConfidence() {
+    return confidenceSet;
+  }
+
+  /** @return evidence-quality confidence, or NaN when unquantified */
+  public double getConfidence() {
+    return confidence;
+  }
+
+  /** @return whether a scalar validity range was supplied */
+  public boolean hasValidityRange() {
+    return validityRangeSet;
+  }
+
+  /** @return inclusive lower validity bound in the registered unit, or NaN */
+  public double getValidityMinimum() {
+    return validityRangeSet ? validityMinimum : Double.NaN;
+  }
+
+  /** @return inclusive upper validity bound in the registered unit, or NaN */
+  public double getValidityMaximum() {
+    return validityRangeSet ? validityMaximum : Double.NaN;
+  }
+
+  /** @return deterministic participant list sorted by source identity */
+  public List<PlantConstraintParticipant> getParticipants() {
+    return participants;
+  }
+
+  /** @return registration completeness and enablement status */
+  public RegistrationStatus getRegistrationStatus() {
+    return registrationStatus;
+  }
+
+  String canonicalForm() {
+    StringBuilder value = new StringBuilder();
+    appendCanonical(value, qualifiedId);
+    appendCanonical(value, aggregationPolicy.name());
+    appendCanonical(value, limitDirection.name());
+    appendCanonical(value, category.name());
+    appendCanonical(value, severity.name());
+    appendCanonical(value, unit);
+    appendCanonical(value, basis);
+    appendCanonical(value, provenance);
+    appendCanonical(value, owner);
+    appendCanonical(value, reference);
+    appendCanonical(value, calculationMethod);
+    appendCanonical(value, description);
+    appendCanonical(value, Boolean.toString(enabled));
+    appendCanonical(value, Boolean.toString(confidenceSet));
+    appendCanonical(value, Double.toHexString(confidence));
+    appendCanonical(value, Boolean.toString(validityRangeSet));
+    appendCanonical(value, Double.toHexString(validityMinimum));
+    appendCanonical(value, Double.toHexString(validityMaximum));
+    for (PlantConstraintParticipant participant : participants) {
+      appendCanonical(value, participant.canonicalForm());
+    }
+    return value.toString();
+  }
+
+  private static void appendCanonical(StringBuilder target, String value) {
+    target.append(value.length()).append(':').append(value);
+  }
+
+  @Override
+  public int compareTo(PlantConstraintDefinition other) {
+    return qualifiedId.compareTo(other.qualifiedId);
+  }
+
+  /** Fluent, callback-free construction surface suitable for Java and JPype callers. */
+  public static final class Builder {
+    private final String id;
+    private final PlantConstraintScope scope;
+    private AggregationPolicy aggregationPolicy = AggregationPolicy.DIRECT;
+    private LimitDirection limitDirection = LimitDirection.MAXIMUM;
+    private Category category = Category.OPERATING;
+    private CapacityConstraint.ConstraintSeverity severity = CapacityConstraint.ConstraintSeverity.HARD;
+    private String unit = "";
+    private String basis = "";
+    private String provenance = "";
+    private String owner = "";
+    private String reference = "";
+    private String calculationMethod = "";
+    private String description = "";
+    private boolean enabled = true;
+    private boolean confidenceSet;
+    private double confidence = Double.NaN;
+    private boolean validityRangeSet;
+    private double validityMinimum = Double.NaN;
+    private double validityMaximum = Double.NaN;
+    private final List<PlantConstraintParticipant> participants = new ArrayList<PlantConstraintParticipant>();
+
+    private Builder(String id, PlantConstraintScope scope) {
+      this.id = id;
+      this.scope = scope;
+    }
+
+    /** Sets how participant values are combined. */
+    public Builder aggregationPolicy(AggregationPolicy value) {
+      aggregationPolicy = value;
+      return this;
+    }
+
+    /** Sets the direction in which the registered limit is violated. */
+    public Builder limitDirection(LimitDirection value) {
+      limitDirection = value;
+      return this;
+    }
+
+    /** Sets the engineering category. */
+    public Builder category(Category value) {
+      category = value;
+      return this;
+    }
+
+    /** Sets the established equipment-capacity severity. */
+    public Builder severity(CapacityConstraint.ConstraintSeverity value) {
+      severity = value;
+      return this;
+    }
+
+    /** Sets the target engineering unit. */
+    public Builder unit(String value) {
+      unit = value;
+      return this;
+    }
+
+    /** Sets the target measurement, rate, reference, or rating basis. */
+    public Builder basis(String value) {
+      basis = value;
+      return this;
+    }
+
+    /** Sets the source of the registered restriction. */
+    public Builder provenance(String value) {
+      provenance = value;
+      return this;
+    }
+
+    /** Sets the accountable owner or discipline. */
+    public Builder owner(String value) {
+      owner = value;
+      return this;
+    }
+
+    /** Sets the source document, tag, or external reference. */
+    public Builder reference(String value) {
+      reference = value;
+      return this;
+    }
+
+    /** Sets the named calculation or measurement method. */
+    public Builder calculationMethod(String value) {
+      calculationMethod = value;
+      return this;
+    }
+
+    /** Sets the engineering description. */
+    public Builder description(String value) {
+      description = value;
+      return this;
+    }
+
+    /** Sets whether the restriction participates in feasibility. */
+    public Builder enabled(boolean value) {
+      enabled = value;
+      return this;
+    }
+
+    /** Sets evidence confidence in the inclusive range {@code [0, 1]}. */
+    public Builder confidence(double value) {
+      confidence = value;
+      confidenceSet = true;
+      return this;
+    }
+
+    /** Sets an inclusive scalar validity interval in the target unit. */
+    public Builder validityRange(double minimum, double maximum) {
+      validityMinimum = minimum;
+      validityMaximum = maximum;
+      validityRangeSet = true;
+      return this;
+    }
+
+    /** Adds one participant; definitions sort participants by stable source identity. */
+    public Builder participant(PlantConstraintParticipant value) {
+      if (value == null) {
+        throw new IllegalArgumentException("Participant is required");
+      }
+      participants.add(value);
+      return this;
+    }
+
+    /** Builds and validates the immutable registration. */
+    public PlantConstraintDefinition build() {
+      return new PlantConstraintDefinition(this);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/util/optimizer/PlantConstraintParticipant.java
+++ b/src/main/java/neqsim/process/util/optimizer/PlantConstraintParticipant.java
@@ -1,0 +1,109 @@
+package neqsim.process.util.optimizer;
+
+import java.io.Serializable;
+
+/**
+ * Immutable member of an aggregated plant constraint.
+ *
+ * <p>
+ * A participant either already uses the registered target unit and basis, or declares an explicit affine conversion
+ * {@code target = source * factor + offset}. The registry never guesses conversions between unlike engineering units or
+ * rate/reference bases.
+ * </p>
+ */
+public final class PlantConstraintParticipant implements Serializable, Comparable<PlantConstraintParticipant> {
+  private static final long serialVersionUID = 1L;
+
+  private final String sourceId;
+  private final String unit;
+  private final String basis;
+  private final boolean conversionExplicit;
+  private final double conversionFactor;
+  private final double conversionOffset;
+
+  private PlantConstraintParticipant(String sourceId, String unit, String basis, boolean conversionExplicit,
+      double conversionFactor, double conversionOffset) {
+    this.sourceId = PlantConstraintScope.requireText(sourceId, "Participant source identity");
+    this.unit = PlantConstraintScope.safeText(unit);
+    this.basis = PlantConstraintScope.safeText(basis);
+    this.conversionExplicit = conversionExplicit;
+    if (!Double.isFinite(conversionFactor) || conversionFactor == 0.0 || !Double.isFinite(conversionOffset)) {
+      throw new IllegalArgumentException("Participant conversion factor must be finite and non-zero and offset finite");
+    }
+    this.conversionFactor = conversionFactor;
+    this.conversionOffset = conversionOffset;
+  }
+
+  /** Creates a participant already expressed in the registered target unit and basis. */
+  public static PlantConstraintParticipant direct(String sourceId, String unit, String basis) {
+    return new PlantConstraintParticipant(sourceId, unit, basis, false, 1.0, 0.0);
+  }
+
+  /** Creates a participant with an explicit conversion to the registered target unit and basis. */
+  public static PlantConstraintParticipant converted(String sourceId, String sourceUnit, String sourceBasis,
+      double conversionFactor, double conversionOffset) {
+    return new PlantConstraintParticipant(sourceId, sourceUnit, sourceBasis, true, conversionFactor, conversionOffset);
+  }
+
+  /** Converts a finite source value to the definition's declared target unit and basis. */
+  public double convertToTarget(double sourceValue) {
+    if (!Double.isFinite(sourceValue)) {
+      throw new IllegalArgumentException("Participant value must be finite");
+    }
+    double converted = sourceValue * conversionFactor + conversionOffset;
+    if (!Double.isFinite(converted)) {
+      throw new IllegalArgumentException("Participant conversion produced a non-finite value");
+    }
+    return converted;
+  }
+
+  /** @return stable caller-owned participant identity */
+  public String getSourceId() {
+    return sourceId;
+  }
+
+  /** @return source engineering unit */
+  public String getUnit() {
+    return unit;
+  }
+
+  /** @return source measurement or reference basis */
+  public String getBasis() {
+    return basis;
+  }
+
+  /** @return whether a source-to-target conversion was explicitly declared */
+  public boolean isConversionExplicit() {
+    return conversionExplicit;
+  }
+
+  /** @return multiplier in {@code target = source * factor + offset} */
+  public double getConversionFactor() {
+    return conversionFactor;
+  }
+
+  /** @return offset in {@code target = source * factor + offset} */
+  public double getConversionOffset() {
+    return conversionOffset;
+  }
+
+  String canonicalForm() {
+    StringBuilder value = new StringBuilder();
+    appendCanonical(value, sourceId);
+    appendCanonical(value, unit);
+    appendCanonical(value, basis);
+    appendCanonical(value, Boolean.toString(conversionExplicit));
+    appendCanonical(value, Double.toHexString(conversionFactor));
+    appendCanonical(value, Double.toHexString(conversionOffset));
+    return value.toString();
+  }
+
+  private static void appendCanonical(StringBuilder target, String value) {
+    target.append(value.length()).append(':').append(value);
+  }
+
+  @Override
+  public int compareTo(PlantConstraintParticipant other) {
+    return sourceId.compareTo(other.sourceId);
+  }
+}

--- a/src/main/java/neqsim/process/util/optimizer/PlantConstraintRegistry.java
+++ b/src/main/java/neqsim/process/util/optimizer/PlantConstraintRegistry.java
@@ -1,0 +1,160 @@
+package neqsim.process.util.optimizer;
+
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import neqsim.process.equipment.capacity.CapacityConstraint;
+
+/**
+ * Deterministic registry of equipment, stream, area, model, shared-resource, and coupled-group constraints.
+ *
+ * <p>
+ * The registry extends, rather than replaces, equipment-local {@link CapacityConstraint} objects. Registrations are
+ * immutable metadata and contain no process object, supplier, or callback reference. They therefore remain safe to
+ * serialize, inspect through JPype, and compare across process executions. Runtime sampling and utilization snapshots
+ * are deliberately outside this class.
+ * </p>
+ */
+public final class PlantConstraintRegistry implements Serializable {
+  private static final long serialVersionUID = 1L;
+  private static final String SCHEMA_VERSION = "1.0";
+
+  private final Map<String, PlantConstraintDefinition> definitions = new TreeMap<String, PlantConstraintDefinition>();
+
+  /** @return registry schema version */
+  public String getSchemaVersion() {
+    return SCHEMA_VERSION;
+  }
+
+  /**
+   * Registers one immutable definition.
+   *
+   * @param definition complete or explicitly incomplete registration evidence
+   * @return this registry for chaining
+   */
+  public PlantConstraintRegistry register(PlantConstraintDefinition definition) {
+    if (definition == null) {
+      throw new IllegalArgumentException("Plant constraint definition is required");
+    }
+    String identity = definition.getQualifiedId();
+    if (definitions.containsKey(identity)) {
+      throw new IllegalArgumentException("Duplicate plant constraint identity " + identity);
+    }
+    definitions.put(identity, definition);
+    return this;
+  }
+
+  /**
+   * Registers metadata adapted from an existing equipment-local capacity constraint.
+   *
+   * <p>
+   * The adapter copies the established #2941 identity, provenance, confidence, validity, severity, direction, unit, and
+   * enablement evidence without retaining or sampling the mutable supplier.
+   * </p>
+   *
+   * @param modelName stable process-model name
+   * @param areaName stable process-area name
+   * @param equipmentName stable equipment name
+   * @param constraintName equipment-local constraint name
+   * @param basis explicit measurement or rating basis
+   * @param category engineering category
+   * @param owner accountable owner or discipline
+   * @param reference source document or equipment tag
+   * @param constraint existing equipment-local definition
+   * @return copied immutable definition
+   */
+  public PlantConstraintDefinition registerEquipmentConstraint(String modelName, String areaName, String equipmentName,
+      String constraintName, String basis, PlantConstraintDefinition.Category category, String owner, String reference,
+      CapacityConstraint constraint) {
+    if (constraint == null) {
+      throw new IllegalArgumentException("Equipment capacity constraint is required");
+    }
+    PlantConstraintDefinition.Builder builder = PlantConstraintDefinition
+        .builder(constraintName, PlantConstraintScope.equipment(modelName, areaName, equipmentName))
+        .aggregationPolicy(PlantConstraintDefinition.AggregationPolicy.DIRECT)
+        .limitDirection(constraint.isMinimumConstraint() ? PlantConstraintDefinition.LimitDirection.MINIMUM
+            : PlantConstraintDefinition.LimitDirection.MAXIMUM)
+        .category(category).severity(constraint.getSeverity()).unit(constraint.getUnit()).basis(basis)
+        .provenance(constraint.getDataSource()).owner(owner).reference(reference)
+        .description(constraint.getDescription()).enabled(constraint.isEnabled());
+    if (constraint.hasConfidence()) {
+      builder.confidence(constraint.getConfidence());
+    }
+    if (constraint.hasValidityRange()) {
+      builder.validityRange(constraint.getValidityMinimum(), constraint.getValidityMaximum());
+    }
+    PlantConstraintDefinition definition = builder.build();
+    register(definition);
+    return definition;
+  }
+
+  /** @return number of retained registrations, including disabled and incomplete rows */
+  public int size() {
+    return definitions.size();
+  }
+
+  /** @return true when an exact qualified identity is present */
+  public boolean contains(String qualifiedId) {
+    return definitions.containsKey(qualifiedId);
+  }
+
+  /** @return exact immutable definition, or null when absent */
+  public PlantConstraintDefinition get(String qualifiedId) {
+    return definitions.get(qualifiedId);
+  }
+
+  /** @return deterministic immutable list sorted by qualified identity */
+  public List<PlantConstraintDefinition> getDefinitions() {
+    return Collections.unmodifiableList(new ArrayList<PlantConstraintDefinition>(definitions.values()));
+  }
+
+  /** Returns deterministic definitions for one exact scope. */
+  public List<PlantConstraintDefinition> getDefinitions(PlantConstraintScope scope) {
+    if (scope == null) {
+      return Collections.emptyList();
+    }
+    List<PlantConstraintDefinition> matches = new ArrayList<PlantConstraintDefinition>();
+    for (PlantConstraintDefinition definition : definitions.values()) {
+      if (scope.equals(definition.getScope())) {
+        matches.add(definition);
+      }
+    }
+    return Collections.unmodifiableList(matches);
+  }
+
+  /**
+   * Returns a deterministic SHA-256 identity for the complete registration contract.
+   *
+   * @return lowercase hexadecimal digest independent of insertion order
+   */
+  public String getIdentityDigest() {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      digest.update(SCHEMA_VERSION.getBytes(StandardCharsets.UTF_8));
+      for (PlantConstraintDefinition definition : definitions.values()) {
+        digest.update((byte) '\n');
+        digest.update(definition.canonicalForm().getBytes(StandardCharsets.UTF_8));
+      }
+      return toHex(digest.digest());
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is unavailable", exception);
+    }
+  }
+
+  private static String toHex(byte[] bytes) {
+    char[] digits = "0123456789abcdef".toCharArray();
+    char[] output = new char[bytes.length * 2];
+    for (int index = 0; index < bytes.length; index++) {
+      int value = bytes[index] & 0xff;
+      output[index * 2] = digits[value >>> 4];
+      output[index * 2 + 1] = digits[value & 0x0f];
+    }
+    return new String(output);
+  }
+}

--- a/src/main/java/neqsim/process/util/optimizer/PlantConstraintScope.java
+++ b/src/main/java/neqsim/process/util/optimizer/PlantConstraintScope.java
@@ -1,0 +1,170 @@
+package neqsim.process.util.optimizer;
+
+import java.io.Serializable;
+import java.util.Locale;
+
+/**
+ * Immutable address of the plant subject governed by a registered optimization constraint.
+ *
+ * <p>
+ * Scope identity is independent of object identity and process execution state. Names are escaped before the stable
+ * identifier is assembled, so ordinary plant names containing separators cannot collide. The class intentionally
+ * retains model, area, and subject names separately for straightforward Java and JPype reporting.
+ * </p>
+ */
+public final class PlantConstraintScope implements Serializable, Comparable<PlantConstraintScope> {
+  private static final long serialVersionUID = 1L;
+
+  /** Supported plant-wide constraint scopes. */
+  public enum Type {
+    /** One equipment item in one process area. */
+    EQUIPMENT,
+    /** One named process stream or boundary stream. */
+    STREAM,
+    /** One process area. */
+    AREA,
+    /** The complete process model. */
+    MODEL,
+    /** A shared utility, environmental, or handling resource. */
+    SHARED_RESOURCE,
+    /** A coupled equipment group such as a common-shaft compressor train. */
+    COUPLED_GROUP
+  }
+
+  private final Type type;
+  private final String modelName;
+  private final String areaName;
+  private final String subjectName;
+  private final String stableId;
+
+  private PlantConstraintScope(Type type, String modelName, String areaName, String subjectName) {
+    if (type == null) {
+      throw new IllegalArgumentException("Plant constraint scope type is required");
+    }
+    this.type = type;
+    this.modelName = requireText(modelName, "Model name");
+    this.areaName = safeText(areaName);
+    this.subjectName = safeText(subjectName);
+    validateShape();
+    this.stableId = buildStableId();
+  }
+
+  /** Creates an equipment-local scope with plant-stable identity. */
+  public static PlantConstraintScope equipment(String modelName, String areaName, String equipmentName) {
+    return new PlantConstraintScope(Type.EQUIPMENT, modelName, requireText(areaName, "Area name"),
+        requireText(equipmentName, "Equipment name"));
+  }
+
+  /** Creates a stream or process-boundary scope. */
+  public static PlantConstraintScope stream(String modelName, String areaName, String streamName) {
+    return new PlantConstraintScope(Type.STREAM, modelName, requireText(areaName, "Area name"),
+        requireText(streamName, "Stream name"));
+  }
+
+  /** Creates a process-area scope. */
+  public static PlantConstraintScope area(String modelName, String areaName) {
+    return new PlantConstraintScope(Type.AREA, modelName, requireText(areaName, "Area name"), "");
+  }
+
+  /** Creates a complete-model scope. */
+  public static PlantConstraintScope model(String modelName) {
+    return new PlantConstraintScope(Type.MODEL, modelName, "", "");
+  }
+
+  /** Creates a shared-resource scope. */
+  public static PlantConstraintScope sharedResource(String modelName, String resourceName) {
+    return new PlantConstraintScope(Type.SHARED_RESOURCE, modelName, "",
+        requireText(resourceName, "Shared resource name"));
+  }
+
+  /** Creates a coupled-equipment group scope. */
+  public static PlantConstraintScope coupledGroup(String modelName, String areaName, String groupName) {
+    return new PlantConstraintScope(Type.COUPLED_GROUP, modelName, safeText(areaName),
+        requireText(groupName, "Coupled group name"));
+  }
+
+  private void validateShape() {
+    if ((type == Type.EQUIPMENT || type == Type.STREAM) && (areaName.isEmpty() || subjectName.isEmpty())) {
+      throw new IllegalArgumentException(type + " scope requires area and subject names");
+    }
+    if (type == Type.AREA && areaName.isEmpty()) {
+      throw new IllegalArgumentException("AREA scope requires an area name");
+    }
+    if ((type == Type.SHARED_RESOURCE || type == Type.COUPLED_GROUP) && subjectName.isEmpty()) {
+      throw new IllegalArgumentException(type + " scope requires a subject name");
+    }
+  }
+
+  private String buildStableId() {
+    StringBuilder id = new StringBuilder(type.name().toLowerCase(Locale.ROOT));
+    id.append(":").append(escape(modelName));
+    if (!areaName.isEmpty()) {
+      id.append("/").append(escape(areaName));
+    }
+    if (!subjectName.isEmpty()) {
+      id.append("/").append(escape(subjectName));
+    }
+    return id.toString();
+  }
+
+  static String escape(String value) {
+    return value.replace("%", "%25").replace("/", "%2F").replace("#", "%23").replace(":", "%3A").replace("|", "%7C")
+        .replace("\r", "%0D").replace("\n", "%0A");
+  }
+
+  static String requireText(String value, String label) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(label + " is required");
+    }
+    return value.trim();
+  }
+
+  static String safeText(String value) {
+    return value == null ? "" : value.trim();
+  }
+
+  /** @return scope type */
+  public Type getType() {
+    return type;
+  }
+
+  /** @return stable model name */
+  public String getModelName() {
+    return modelName;
+  }
+
+  /** @return process area name, or empty when not applicable */
+  public String getAreaName() {
+    return areaName;
+  }
+
+  /** @return equipment, stream, resource, or group name, or empty */
+  public String getSubjectName() {
+    return subjectName;
+  }
+
+  /** @return escaped stable scope identity */
+  public String getStableId() {
+    return stableId;
+  }
+
+  @Override
+  public int compareTo(PlantConstraintScope other) {
+    return stableId.compareTo(other.stableId);
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    return object instanceof PlantConstraintScope && stableId.equals(((PlantConstraintScope) object).stableId);
+  }
+
+  @Override
+  public int hashCode() {
+    return stableId.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return stableId;
+  }
+}

--- a/src/test/java/neqsim/process/util/optimizer/PlantConstraintRegistryTest.java
+++ b/src/test/java/neqsim/process/util/optimizer/PlantConstraintRegistryTest.java
@@ -1,0 +1,147 @@
+package neqsim.process.util.optimizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.capacity.CapacityConstraint;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintSeverity;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintType;
+
+/** Regression tests for deterministic plant-wide constraint registration. */
+class PlantConstraintRegistryTest {
+
+  @Test
+  void registryIdentityIsOrderAndSerializationIndependent() throws Exception {
+    PlantConstraintDefinition pipe = directDefinition("pressure",
+        PlantConstraintScope.stream("Plant", "Export", "P-1"));
+    PlantConstraintDefinition power = PlantConstraintDefinition
+        .builder("total-power", PlantConstraintScope.sharedResource("Plant", "electricity"))
+        .aggregationPolicy(PlantConstraintDefinition.AggregationPolicy.SHARED_BUDGET).unit("MW")
+        .basis("instantaneous electrical load").provenance("power study")
+        .participant(PlantConstraintParticipant.direct("compressor-a", "MW", "instantaneous electrical load"))
+        .participant(PlantConstraintParticipant.direct("compressor-b", "MW", "instantaneous electrical load")).build();
+
+    PlantConstraintRegistry first = new PlantConstraintRegistry().register(pipe).register(power);
+    PlantConstraintRegistry second = new PlantConstraintRegistry().register(power).register(pipe);
+    PlantConstraintRegistry restored = roundTrip(first);
+
+    assertEquals(first.getIdentityDigest(), second.getIdentityDigest());
+    assertEquals(first.getIdentityDigest(), restored.getIdentityDigest());
+    assertEquals(first.getDefinitions().get(0).getQualifiedId(), restored.getDefinitions().get(0).getQualifiedId());
+    assertEquals(2, restored.size());
+  }
+
+  @Test
+  void everyScopeHasUniqueEscapedStableIdentity() {
+    PlantConstraintScope equipment = PlantConstraintScope.equipment("Plant:1", "Compression/A", "K#1|main");
+    PlantConstraintScope stream = PlantConstraintScope.stream("Plant:1", "Compression/A", "K#1");
+    PlantConstraintScope area = PlantConstraintScope.area("Plant:1", "Compression/A");
+    PlantConstraintScope model = PlantConstraintScope.model("Plant:1");
+    PlantConstraintScope resource = PlantConstraintScope.sharedResource("Plant:1", "total/power");
+    PlantConstraintScope group = PlantConstraintScope.coupledGroup("Plant:1", "Compression/A", "shaft#1");
+
+    assertNotEquals(equipment.getStableId(), stream.getStableId());
+    assertNotEquals(area.getStableId(), model.getStableId());
+    assertNotEquals(resource.getStableId(), group.getStableId());
+    assertEquals("equipment:Plant%3A1/Compression%2FA/K%231%7Cmain", equipment.getStableId());
+    assertEquals("shared_resource:Plant%3A1/total%2Fpower", resource.getStableId());
+  }
+
+  @Test
+  void aggregationRejectsImplicitUnitOrBasisConversion() {
+    PlantConstraintDefinition.Builder builder = PlantConstraintDefinition
+        .builder("total-power", PlantConstraintScope.sharedResource("Plant", "power"))
+        .aggregationPolicy(PlantConstraintDefinition.AggregationPolicy.SUM).unit("MW").basis("electrical load")
+        .participant(PlantConstraintParticipant.direct("gas-turbine", "kW", "shaft power"));
+
+    assertThrows(IllegalArgumentException.class, builder::build);
+    assertThrows(IllegalArgumentException.class,
+        () -> PlantConstraintDefinition.builder("incomplete", PlantConstraintScope.model("Plant"))
+            .aggregationPolicy(PlantConstraintDefinition.AggregationPolicy.SUM)
+            .participant(PlantConstraintParticipant.direct("source", "kg/h", "standard rate")).build());
+  }
+
+  @Test
+  void aggregationAcceptsExplicitFiniteConversion() {
+    PlantConstraintParticipant participant = PlantConstraintParticipant.converted("compressor", "kW", "shaft power",
+        0.001, 0.0);
+    PlantConstraintDefinition definition = PlantConstraintDefinition
+        .builder("driver-power", PlantConstraintScope.coupledGroup("Plant", "Compression", "shaft-1"))
+        .aggregationPolicy(PlantConstraintDefinition.AggregationPolicy.RATE_BASIS_CONVERSION).unit("MW")
+        .basis("common-shaft driver load").provenance("driver data sheet").participant(participant).build();
+
+    assertEquals(2.5, participant.convertToTarget(2500.0), 0.0);
+    assertEquals(PlantConstraintDefinition.RegistrationStatus.REGISTERED, definition.getRegistrationStatus());
+    assertThrows(IllegalArgumentException.class, () -> participant.convertToTarget(Double.NaN));
+  }
+
+  @Test
+  void disabledAndIncompleteDefinitionsRemainVisible() {
+    PlantConstraintDefinition definition = PlantConstraintDefinition
+        .builder("separator-oil-residence", PlantConstraintScope.equipment("Plant", "Separation", "V-1")).enabled(false)
+        .build();
+    PlantConstraintRegistry registry = new PlantConstraintRegistry().register(definition);
+
+    assertEquals(PlantConstraintDefinition.RegistrationStatus.DISABLED_INCOMPLETE_BASIS,
+        registry.getDefinitions().get(0).getRegistrationStatus());
+    assertFalse(registry.getDefinitions().get(0).isEnabled());
+  }
+
+  @Test
+  void equipmentAdapterCopiesEvidenceWithoutSamplingSupplier() {
+    AtomicInteger calls = new AtomicInteger();
+    CapacityConstraint source = new CapacityConstraint("speed", "rpm", ConstraintType.HARD)
+        .setSeverity(ConstraintSeverity.CRITICAL).setDescription("installed overspeed limit")
+        .setDataSource("vendor map rev 4").setConfidence(0.93).setValidityRange(7000.0, 11000.0).setEnabled(false)
+        .setValueSupplier(() -> {
+          calls.incrementAndGet();
+          return 9000.0;
+        });
+    PlantConstraintRegistry registry = new PlantConstraintRegistry();
+
+    PlantConstraintDefinition copied = registry.registerEquipmentConstraint("Plant", "Compression", "K-1", "speed",
+        "installed shaft speed", PlantConstraintDefinition.Category.DESIGN, "rotating equipment", "K-1 data sheet",
+        source);
+
+    assertEquals(0, calls.get());
+    assertEquals(ConstraintSeverity.CRITICAL, copied.getSeverity());
+    assertEquals("rpm", copied.getUnit());
+    assertEquals("vendor map rev 4", copied.getProvenance());
+    assertEquals(0.93, copied.getConfidence(), 0.0);
+    assertEquals(7000.0, copied.getValidityMinimum(), 0.0);
+    assertFalse(copied.isEnabled());
+  }
+
+  @Test
+  void duplicateQualifiedIdentityIsRejected() {
+    PlantConstraintDefinition definition = directDefinition("pressure", PlantConstraintScope.model("Plant"));
+    PlantConstraintRegistry registry = new PlantConstraintRegistry().register(definition);
+
+    assertThrows(IllegalArgumentException.class, () -> registry.register(definition));
+    assertTrue(registry.contains(definition.getQualifiedId()));
+  }
+
+  private static PlantConstraintDefinition directDefinition(String id, PlantConstraintScope scope) {
+    return PlantConstraintDefinition.builder(id, scope).unit("bara").basis("absolute pressure")
+        .provenance("operating envelope").build();
+  }
+
+  private static PlantConstraintRegistry roundTrip(PlantConstraintRegistry registry) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream output = new ObjectOutputStream(bytes);
+    output.writeObject(registry);
+    output.close();
+    ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    PlantConstraintRegistry restored = (PlantConstraintRegistry) input.readObject();
+    input.close();
+    return restored;
+  }
+}


### PR DESCRIPTION
## Summary

Advances #3154 Roadmap 1 with a deterministic, metadata-only plant constraint registry.

- stable scopes for equipment, streams, areas, complete models, shared resources, and coupled groups
- explicit aggregation, limit direction, category, severity, unit, basis, provenance, ownership, references, confidence, validity, enablement, and registration status
- length-prefixed canonical identity and SHA-256 registry digest independent of insertion order and Java serialization
- explicit participant conversions; unlike units or bases fail closed instead of being guessed
- adapter that copies existing #2941 `CapacityConstraint` metadata without retaining or sampling its mutable supplier
- Java/JPype-facing documentation in the Production Optimization Guide, Capacity Constraint Framework, and frozen industrial baseline

## Frozen engineering question

Can a large `ProcessModel` address equipment-local, boundary, plant-total, shared-utility, and common-shaft restrictions with stable identity and explicit engineering basis before runtime utilization or solver orchestration is introduced?

**Acceptance criteria:** additive Java API; stable identity across insertion order and serialization; unique escaped scope identities; explicit unit/basis conversion; disabled and incomplete registrations retained; duplicate identities rejected; existing equipment evidence copied without evaluating the supplier; affected guides and Javadocs updated.

**Compatibility:** additive, callback-free, serializable, and restricted to Java 8-compatible language/API constructs. Existing `CapacityConstraint`, process solving, convergence, thermodynamics, balances, and optimizer acceptance behavior are unchanged.

**Stop boundary:** no runtime sampling, utilization snapshot, total-power calculation, common-shaft balancing, separator/piping capacity calculation, evaluator scheduling, cache, or solver change. A registration is not solved evidence and cannot make a candidate feasible.

## Engineering coverage

The scope model can address piping pressure/velocity/erosion/FIV/thermal/phase restrictions; compressor map/surge/choke/speed/temperature/power and coupled-shaft restrictions; two-/three-phase separator gas/oil/water/settling/residence/level/carry-over/slug restrictions; pumps, heat transfer, treating/columns; shared power/fuel/cooling/injection/flare/water/emissions; export quality/nomination; and configuration/availability. Advisory safety and integrity evidence remains non-authoritative unless the caller explicitly registers an approved restriction.

## Baseline and validation

The before-edit five-fork S/M harness ran on then-current unmodified master `74a62516df7c1b2e1b419c7fd74bb1f5fa23ef15`:

- all 5 forks passed; 70 successful modes and 5 invalid fail-closed modes
- S cold median 77.883 ms; unchanged 0.158 ms
- M cold median 231.686 ms; unchanged median 65.597 ms
- unchanged diffs 0; max M unit residual 0.022293 kg/h
- restoration median 0.025821; serialized observation 24,423–24,731 bytes

The publication commit is replayed directly on current master `24121177a108c4df3eb47dbea75bedb619e733ff`; the two intervening merged commits are MCP and Pitzer-only and have no path overlap.

Local final-tree gates:

- `PlantConstraintRegistryTest`: 7/7 passed
- proportionate registry/capacity/utilization/evaluator suite: 50/50 passed
- direct Spotless apply/check: passed
- Checkstyle: 0 violations
- documentation-search audit: 659 Markdown + 1 standalone HTML passed
- `git diff --check`: passed
- pre-commit/pre-push wrapper unavailable in the environment; equivalent configured direct Spotless/docs gates were run
- Javadoc goal attempted but infrastructure lacks a `javadoc` executable and reports `JAVA_HOME is not correctly set`; hosted Javadoc remains required

No performance claim is made for this metadata-only increment.

## Exact provenance

- benchmark/edit base: `74a62516df7c1b2e1b419c7fd74bb1f5fa23ef15`
- publication base: `24121177a108c4df3eb47dbea75bedb619e733ff`
- head: `4c8913588ebb7c14c34febe8808d334adb3f8199`
- branch: `codex/3154-plant-constraint-registry`

Next dependency after merge: complete immutable post-solve utilization snapshots that consume this registry and reuse `InstalledEquipmentCapacityEvidence` and `ProcessBoundaryConstraintEvidence`.