### PR TITLE
[AI-Assisted] fix(mcp): align Phase 0 master contracts

### DIFF
--- a/src/main/java/neqsim/mcp/runners/McpCampaignMatrix.java
+++ b/src/main/java/neqsim/mcp/runners/McpCampaignMatrix.java
@@ -43,79 +43,83 @@ public final class McpCampaignMatrix {
 
   private static JsonArray buildCriteria() {
     JsonArray rows = new JsonArray();
-    add(rows, 0, new String[] {
-        "Inventory the complete public MCP surface and evidence estate",
-        "Reconcile merged foundations #2874, #2875 and #3152",
-        "Establish four public synthetic acceptance scales",
-        "Trace every campaign criterion to evidence or a confirmed gap",
-        "Record runtime, memory, response size, tool-call, convergence, balance and report baselines",
-        "Define a machine-readable capability/maturity matrix by engineering discipline"},
-        new String[] {"MERGED_EVIDENCE", "MERGED_EVIDENCE", "MERGED_EVIDENCE", "PARTIAL_EVIDENCE",
-            "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE"},
-        new String[] {"McpEvidenceInventory; SURFACE_INVENTORY.md", "mergedFoundations; FOUNDATION_TRACEABILITY.md",
+    add(rows, 0,
+        new String[] { "Inventory the complete public MCP surface and evidence estate",
+            "Reconcile merged foundations #2874, #2875 and #3152", "Establish four public synthetic acceptance scales",
+            "Trace every campaign criterion to evidence or a confirmed gap",
+            "Record runtime, memory, response size, tool-call, convergence, balance and report baselines",
+            "Define a machine-readable capability/maturity matrix by engineering discipline" },
+        new String[] { "MERGED_EVIDENCE", "MERGED_EVIDENCE", "MERGED_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE",
+            "PARTIAL_EVIDENCE" },
+        new String[] { "McpEvidenceInventory; SURFACE_INVENTORY.md", "mergedFoundations; FOUNDATION_TRACEABILITY.md",
             "McpAcceptanceFixtureCatalog; ACCEPTANCE_FIXTURES.md",
             "McpCampaignMatrix; CAMPAIGN_MATRIX.md; merged-master audit still required",
             "McpAcceptanceBaselineRunner; ACCEPTANCE_BASELINES.md; numeric closure gaps remain explicit",
-            "McpCampaignMatrix.disciplines; merged-master audit still required"});
-    add(rows, 1, new String[] {
-        "Versioned facility-description contract", "Deterministic normalized facility specification",
-        "Component/equipment/tag synonym resolution", "Pre-solve topology/unit/component/model validation",
-        "Canonical ProcessSystem or ProcessModel generation", "Incremental facility refinement",
-        "DEXPI/P&ID coordination without parallel model", "Explicit review checkpoint for inferred facility content"},
+            "McpCampaignMatrix.disciplines; merged-master audit still required" });
+    add(rows, 1,
+        new String[] { "Versioned facility-description contract", "Deterministic normalized facility specification",
+            "Component/equipment/tag synonym resolution", "Pre-solve topology/unit/component/model validation",
+            "Canonical ProcessSystem or ProcessModel generation", "Incremental facility refinement",
+            "DEXPI/P&ID coordination without parallel model",
+            "Explicit review checkpoint for inferred facility content" },
         partial(8), evidence("SchemaCatalog/Validator/ProcessRunner", 8));
-    add(rows, 2, new String[] {
-        "Reusable oil-and-gas process building blocks", "Preserve topology, recycles, controls and design identity",
-        "Composition, cloning, revision, comparison and replay", "Explicit unsupported equipment/connections",
-        "Deterministic small, medium and large execution"}, partial(5),
-        evidence("JsonProcessBuilder/ProcessModel/ModelRegistry", 5));
-    add(rows, 3, new String[] {
-        "Fluids and PVT calculation coverage", "Flow-assurance calculation coverage", "Core-equipment coverage",
-        "Facility studies, balances, capacity and case comparison", "Governed generic static capability execution"},
+    add(rows, 2,
+        new String[] { "Reusable oil-and-gas process building blocks",
+            "Preserve topology, recycles, controls and design identity",
+            "Composition, cloning, revision, comparison and replay", "Explicit unsupported equipment/connections",
+            "Deterministic small, medium and large execution" },
+        partial(5), evidence("JsonProcessBuilder/ProcessModel/ModelRegistry", 5));
+    add(rows, 3,
+        new String[] { "Fluids and PVT calculation coverage", "Flow-assurance calculation coverage",
+            "Core-equipment coverage", "Facility studies, balances, capacity and case comparison",
+            "Governed generic static capability execution" },
         partial(5), evidence("toolCapabilities/BenchmarkTrust/McpImplementationInventory", 5));
-    add(rows, 4, new String[] {
-        "Structured troubleshooting case", "Description-to-testable-hypothesis conversion", "Reusable diagnostic patterns",
-        "Reference/current/what-if evidence comparison", "Separate model, data, equipment, control and numerical causes",
-        "Recommend safe next measurement/check", "Public known-cause synthetic fault library"},
-        new String[] {"PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE",
-            "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "CONFIRMED_GAP"},
+    add(rows, 4,
+        new String[] { "Structured troubleshooting case", "Description-to-testable-hypothesis conversion",
+            "Reusable diagnostic patterns", "Reference/current/what-if evidence comparison",
+            "Separate model, data, equipment, control and numerical causes", "Recommend safe next measurement/check",
+            "Public known-cause synthetic fault library" },
+        new String[] { "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE",
+            "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "CONFIRMED_GAP" },
         evidence("RootCauseAnalysisRunner/OperationalStudyRunner; synthetic fault library remains open", 7));
-    add(rows, 5, new String[] {
-        "Bounded steady/quasi-steady/dynamic orchestration", "Compose validated transient scenarios",
-        "Coordinate dynamic-model implementation with #2911", "Preserve initial state, chronology and replay",
-        "Separate screening from qualified dynamic studies"}, partial(5),
-        evidence("DynamicRunner/#2911 ownership boundary", 5));
-    add(rows, 6, new String[] {
-        "Benchmark small, medium, large and stress-scale facilities", "Lifecycle, revision, caching, isolation and cancellation",
-        "Avoid unnecessary full solves for retrieval", "Paged/selective large-result retrieval",
-        "Compact response and deterministic retrieval after truncation", "Runtime/memory/payload regression baselines",
-        "Multi-client and tenant-isolation tests"},
-        new String[] {"PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE",
-            "MERGED_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE"},
+    add(rows, 5,
+        new String[] { "Bounded steady/quasi-steady/dynamic orchestration", "Compose validated transient scenarios",
+            "Coordinate dynamic-model implementation with #2911", "Preserve initial state, chronology and replay",
+            "Separate screening from qualified dynamic studies" },
+        partial(5), evidence("DynamicRunner/#2911 ownership boundary", 5));
+    add(rows, 6,
+        new String[] { "Benchmark small, medium, large and stress-scale facilities",
+            "Lifecycle, revision, caching, isolation and cancellation", "Avoid unnecessary full solves for retrieval",
+            "Paged/selective large-result retrieval", "Compact response and deterministic retrieval after truncation",
+            "Runtime/memory/payload regression baselines", "Multi-client and tenant-isolation tests" },
+        new String[] { "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE",
+            "MERGED_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE" },
         evidence("ModelRegistry/ResponseSizeGuard/McpExecutionPolicy/acceptance baselines", 7));
-    add(rows, 7, new String[] {
-        "Typed versioned result contracts", "Summary/detail with units, provenance and validation",
-        "Operator/support-engineer summaries", "Process-engineering detailed results",
-        "Deterministic Markdown/JSON/CSV and visual artifacts", "Report completeness and large-result validation"},
+    add(rows, 7,
+        new String[] { "Typed versioned result contracts", "Summary/detail with units, provenance and validation",
+            "Operator/support-engineer summaries", "Process-engineering detailed results",
+            "Deterministic Markdown/JSON/CSV and visual artifacts", "Report completeness and large-result validation" },
         partial(6), evidence("ApiEnvelope/ProcessResult/ReportRunner", 6));
-    add(rows, 8, new String[] {
-        "Task-oriented discovery", "Complete bounded example-backed schemas", "Fix-oriented validation errors",
-        "Resumable multi-step study handoffs", "STDIO and Streamable HTTP end-to-end protocol tests",
-        "Synchronize NeqSim agents/skills with MCP contracts"},
-        new String[] {"PARTIAL_EVIDENCE", "MERGED_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE",
-            "PARTIAL_EVIDENCE", "MERGED_EVIDENCE"},
+    add(rows, 8, new String[] { "Task-oriented discovery", "Complete bounded example-backed schemas",
+        "Fix-oriented validation errors", "Resumable multi-step study handoffs",
+        "STDIO and Streamable HTTP end-to-end protocol tests", "Synchronize NeqSim agents/skills with MCP contracts" },
+        new String[] { "PARTIAL_EVIDENCE", "MERGED_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE",
+            "PARTIAL_EVIDENCE", "MERGED_EVIDENCE" },
         evidence("CapabilitiesRunner/SchemaCatalog/test_mcp_server.py/tool-reference lint", 6));
-    add(rows, 9, new String[] {
-        "Profile, identity, tenant, audit, approval and execution security", "Correlation IDs and structured observability",
-        "Malformed/adversarial/resource-exhaustion tests", "Deployment and secret/privacy evidence"},
-        new String[] {"MERGED_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE"},
+    add(rows, 9,
+        new String[] { "Profile, identity, tenant, audit, approval and execution security",
+            "Correlation IDs and structured observability", "Malformed/adversarial/resource-exhaustion tests",
+            "Deployment and secret/privacy evidence" },
+        new String[] { "MERGED_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE" },
         evidence("SecurityRunner/McpRequestContext/McpExecutionPolicy", 4));
-    add(rows, 10, new String[] {
-        "Retained executed PVT/equipment/small/large/troubleshooting outputs",
-        "Narrative-to-model-to-validation-to-report workflow", "Progressive reuse from calculation to facility",
-        "Independent engineering validation of key results", "Full protocol/security/static/documentation release gates",
-        "Final capability/maturity/benchmark/limitation matrix", "Independent current-master completion audit"},
-        new String[] {"PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE",
-            "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "CONFIRMED_GAP"},
+    add(rows, 10,
+        new String[] { "Retained executed PVT/equipment/small/large/troubleshooting outputs",
+            "Narrative-to-model-to-validation-to-report workflow", "Progressive reuse from calculation to facility",
+            "Independent engineering validation of key results",
+            "Full protocol/security/static/documentation release gates",
+            "Final capability/maturity/benchmark/limitation matrix", "Independent current-master completion audit" },
+        new String[] { "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE",
+            "PARTIAL_EVIDENCE", "PARTIAL_EVIDENCE", "CONFIRMED_GAP" },
         evidence("Phase 10 remains completion-gate work", 7));
     return rows;
   }
@@ -123,39 +127,39 @@ public final class McpCampaignMatrix {
   private static JsonObject buildDisciplines() {
     JsonObject disciplines = new JsonObject();
     addDiscipline(disciplines, "thermodynamics-pvt", "Thermodynamics and PVT",
-        new String[] {"runFlash", "runPVT", "getPhaseEnvelope", "getPropertyTable", "crossValidateModels"},
+        new String[] { "runFlash", "runPVT", "getPhaseEnvelope", "getPropertyTable", "crossValidateModels" },
         "#2937 for generic flash internals");
     addDiscipline(disciplines, "process-simulation", "Process simulation and facility studies",
-        new String[] {"runProcess", "manageModel", "getCapabilities", "runParametricStudy"},
+        new String[] { "runProcess", "manageModel", "getCapabilities", "runParametricStudy" },
         "#2939/#3154 for execution performance and optimization");
     addDiscipline(disciplines, "flow-assurance", "Flow assurance",
-        new String[] {"runFlowAssurance", "runPipeline", "runWaterHammer", "runChemistry"},
+        new String[] { "runFlowAssurance", "runPipeline", "runWaterHammer", "runChemistry" },
         "#2907/#2935 for pipeline solver physics");
     addDiscipline(disciplines, "rotating-equipment", "Compressors, pumps and rotating equipment",
-        new String[] {"runProcess", "runOperationalStudy", "runDynamic"},
-        "#2911 for dynamic machinery behavior");
+        new String[] { "runProcess", "runOperationalStudy", "runDynamic" }, "#2911 for dynamic machinery behavior");
     addDiscipline(disciplines, "separation-treating", "Separation, treating and columns",
-        new String[] {"runProcess", "runChemistry", "runOperationalStudy"},
+        new String[] { "runProcess", "runChemistry", "runOperationalStudy" },
         "#2936/#205 for column and reactive-absorber internals");
     addDiscipline(disciplines, "reservoir-wells", "Reservoir, wells and production technology",
-        new String[] {"runReservoir", "runPipeline", "runProcess"},
+        new String[] { "runReservoir", "runPipeline", "runProcess" },
         "Core reservoir/well models remain authoritative");
     addDiscipline(disciplines, "dynamics-controls", "Dynamics and controls",
-        new String[] {"runDynamic", "runOperationalStudy", "runSafetySystemPerformance"},
+        new String[] { "runDynamic", "runOperationalStudy", "runSafetySystemPerformance" },
         "#2911 owns the dynamic engine");
     addDiscipline(disciplines, "safety-integrity", "Safety, integrity and materials",
-        new String[] {"runHAZOP", "runBarrierRegister", "runSafetySystemPerformance", "runMaterialsReview"},
+        new String[] { "runHAZOP", "runBarrierRegister", "runSafetySystemPerformance", "runMaterialsReview" },
         "Advisory only; accountable engineering remains external");
     addDiscipline(disciplines, "engineering-data", "Engineering data, diagrams and interoperability",
-        new String[] {"runProcess", "validateInput", "getCapabilities"}, "#2899 owns DEXPI/P&ID semantics");
+        new String[] { "runProcess", "validateInput", "getCapabilities" }, "#2899 owns DEXPI/P&ID semantics");
     addDiscipline(disciplines, "reporting-governance", "Reporting, lifecycle and governance",
-        new String[] {"generateReport", "manageModel", "checkToolAccess", "getBenchmarkTrust"},
+        new String[] { "generateReport", "manageModel", "checkToolAccess", "getBenchmarkTrust" },
         "MCP-owned transport, evidence and governance layer");
     return disciplines;
   }
 
   private static void addDiscipline(JsonObject root, String id, String name, String[] tools, String boundary) {
-    JsonObject trust = JsonParser.parseString(BenchmarkTrust.getTrustReport()).getAsJsonObject().getAsJsonObject("tools");
+    JsonObject trust = JsonParser.parseString(BenchmarkTrust.getTrustReport()).getAsJsonObject()
+        .getAsJsonObject("tools");
     int published = 0;
     int explicit = 0;
     JsonArray toolArray = new JsonArray();

--- a/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
@@ -9,7 +9,8 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 /**
- * Builds the Phase 0 MCP test, guide, limitation, merged-foundation, acceptance, and campaign-matrix evidence inventory.
+ * Builds the Phase 0 MCP test, guide, limitation, merged-foundation, acceptance, and campaign-matrix evidence
+ * inventory.
  */
 public final class McpEvidenceInventory {
 

--- a/src/main/java/neqsim/thermo/phase/PhasePitzer.java
+++ b/src/main/java/neqsim/thermo/phase/PhasePitzer.java
@@ -56,8 +56,7 @@ public class PhasePitzer extends PhaseGE {
   private double[][] cphiT1;
   private double[][] cphiT2;
   /** Sparse opt-in PHREEQC six-term temperature functions, keyed by parameter family and tuple. */
-  private Map<Long, PitzerTemperatureFunction> temperatureFunctions =
-      new HashMap<Long, PitzerTemperatureFunction>();
+  private Map<Long, PitzerTemperatureFunction> temperatureFunctions = new HashMap<Long, PitzerTemperatureFunction>();
   /** Fast gate that avoids map lookup for legacy parameter datasets. */
   private boolean hasTemperatureFunctions;
   /** Whether parameters have been loaded from database. */
@@ -114,8 +113,7 @@ public class PhasePitzer extends PhaseGE {
     clonedPhase.definedBinaryPairs = new HashSet<String>(definedBinaryPairs);
     clonedPhase.definedThetaPairs = new HashSet<String>(definedThetaPairs);
     clonedPhase.definedPsiTuples = new HashSet<String>(definedPsiTuples);
-    clonedPhase.temperatureFunctions =
-        new HashMap<Long, PitzerTemperatureFunction>(temperatureFunctions);
+    clonedPhase.temperatureFunctions = new HashMap<Long, PitzerTemperatureFunction>(temperatureFunctions);
     clonedPhase.cachedCoverageFingerprint = 0L;
     clonedPhase.cachedCoverageRevision = Long.MIN_VALUE;
     clonedPhase.cachedCoverage = null;
@@ -288,9 +286,8 @@ public class PhasePitzer extends PhaseGE {
    * <p>
    * Each coefficient array is ordered {@code a0..a5}; the function is
    * {@code a0 + a1(1/T-1/Tr) + a2 ln(T/Tr) + a3(T-Tr) + a4(T^2-Tr^2)
-   * + a5(1/T^2-1/Tr^2)}. This method defines beta0, beta1, and Cphi as one
-   * coherent binary tuple. It performs no conversion between PHREEQC C0 and a dataset using another C
-   * convention.
+   * + a5(1/T^2-1/Tr^2)}. This method defines beta0, beta1, and Cphi as one coherent binary tuple. It performs no
+   * conversion between PHREEQC C0 and a dataset using another C convention.
    * </p>
    *
    * @param i component index i
@@ -300,14 +297,11 @@ public class PhasePitzer extends PhaseGE {
    * @param beta1Coefficients beta1 coefficients in PHREEQC order
    * @param cphiCoefficients Cphi coefficients in PHREEQC order
    */
-  public void setBinaryTemperatureCoefficients(int i, int j, double referenceTemperature,
-      double[] beta0Coefficients, double[] beta1Coefficients, double[] cphiCoefficients) {
-    PitzerTemperatureFunction beta0Function =
-        new PitzerTemperatureFunction(referenceTemperature, beta0Coefficients);
-    PitzerTemperatureFunction beta1Function =
-        new PitzerTemperatureFunction(referenceTemperature, beta1Coefficients);
-    PitzerTemperatureFunction cphiFunction =
-        new PitzerTemperatureFunction(referenceTemperature, cphiCoefficients);
+  public void setBinaryTemperatureCoefficients(int i, int j, double referenceTemperature, double[] beta0Coefficients,
+      double[] beta1Coefficients, double[] cphiCoefficients) {
+    PitzerTemperatureFunction beta0Function = new PitzerTemperatureFunction(referenceTemperature, beta0Coefficients);
+    PitzerTemperatureFunction beta1Function = new PitzerTemperatureFunction(referenceTemperature, beta1Coefficients);
+    PitzerTemperatureFunction cphiFunction = new PitzerTemperatureFunction(referenceTemperature, cphiCoefficients);
     setBinaryParameters(i, j, beta0Coefficients[0], beta1Coefficients[0], cphiCoefficients[0]);
     setTemperatureFunction(pairTemperatureKey(TEMPERATURE_BETA0, i, j), beta0Function);
     setTemperatureFunction(pairTemperatureKey(TEMPERATURE_BETA1, i, j), beta1Function);
@@ -322,10 +316,8 @@ public class PhasePitzer extends PhaseGE {
    * @param referenceTemperature reference temperature in K
    * @param coefficients six coefficients in PHREEQC order
    */
-  public void setBeta2TemperatureCoefficients(int i, int j, double referenceTemperature,
-      double[] coefficients) {
-    PitzerTemperatureFunction function =
-        new PitzerTemperatureFunction(referenceTemperature, coefficients);
+  public void setBeta2TemperatureCoefficients(int i, int j, double referenceTemperature, double[] coefficients) {
+    PitzerTemperatureFunction function = new PitzerTemperatureFunction(referenceTemperature, coefficients);
     setBeta2(i, j, coefficients[0]);
     setTemperatureFunction(pairTemperatureKey(TEMPERATURE_BETA2, i, j), function);
   }
@@ -338,10 +330,8 @@ public class PhasePitzer extends PhaseGE {
    * @param referenceTemperature reference temperature in K
    * @param coefficients six coefficients in PHREEQC order
    */
-  public void setThetaTemperatureCoefficients(int i, int j, double referenceTemperature,
-      double[] coefficients) {
-    PitzerTemperatureFunction function =
-        new PitzerTemperatureFunction(referenceTemperature, coefficients);
+  public void setThetaTemperatureCoefficients(int i, int j, double referenceTemperature, double[] coefficients) {
+    PitzerTemperatureFunction function = new PitzerTemperatureFunction(referenceTemperature, coefficients);
     setTheta(i, j, coefficients[0]);
     setTemperatureFunction(pairTemperatureKey(TEMPERATURE_THETA, i, j), function);
   }
@@ -355,10 +345,8 @@ public class PhasePitzer extends PhaseGE {
    * @param referenceTemperature reference temperature in K
    * @param coefficients six coefficients in PHREEQC order
    */
-  public void setPsiTemperatureCoefficients(int i, int j, int k, double referenceTemperature,
-      double[] coefficients) {
-    PitzerTemperatureFunction function =
-        new PitzerTemperatureFunction(referenceTemperature, coefficients);
+  public void setPsiTemperatureCoefficients(int i, int j, int k, double referenceTemperature, double[] coefficients) {
+    PitzerTemperatureFunction function = new PitzerTemperatureFunction(referenceTemperature, coefficients);
     setPsi(i, j, k, coefficients[0]);
     setTemperatureFunction(tripleTemperatureKey(TEMPERATURE_PSI, i, j, k), function);
   }
@@ -490,8 +478,7 @@ public class PhasePitzer extends PhaseGE {
    * @return Cphi at temperature T
    */
   public double getCphiij(int i, int j, double TK) {
-    PitzerTemperatureFunction function =
-        getPairTemperatureFunction(TEMPERATURE_CPHI, i, j);
+    PitzerTemperatureFunction function = getPairTemperatureFunction(TEMPERATURE_CPHI, i, j);
     if (function != null) {
       return function.valueAt(TK);
     }
@@ -661,8 +648,7 @@ public class PhasePitzer extends PhaseGE {
    * @return theta parameter at temperature
    */
   public double getThetaij(int i, int j, double temperature) {
-    PitzerTemperatureFunction function =
-        getPairTemperatureFunction(TEMPERATURE_THETA, i, j);
+    PitzerTemperatureFunction function = getPairTemperatureFunction(TEMPERATURE_THETA, i, j);
     return function == null ? theta[i][j] : function.valueAt(temperature);
   }
 
@@ -704,8 +690,7 @@ public class PhasePitzer extends PhaseGE {
    * @return psi parameter at temperature
    */
   public double getPsiijk(int i, int j, int k, double temperature) {
-    PitzerTemperatureFunction function =
-        getTripleTemperatureFunction(TEMPERATURE_PSI, i, j, k);
+    PitzerTemperatureFunction function = getTripleTemperatureFunction(TEMPERATURE_PSI, i, j, k);
     return function == null ? psi[i][j][k] : function.valueAt(temperature);
   }
 
@@ -1136,7 +1121,8 @@ public class PhasePitzer extends PhaseGE {
               aPhi, electrostaticMixing);
           electrostaticPhi = electrostaticMixing[0] + ionicStrength * electrostaticMixing[1];
         }
-        thetaPsiSum += molalityCation1 * molalityCation2 * (getThetaij(cation1, cation2, temperature) + electrostaticPhi);
+        thetaPsiSum += molalityCation1 * molalityCation2
+            * (getThetaij(cation1, cation2, temperature) + electrostaticPhi);
         for (int anion = 0; anion < numberOfComponents; anion++) {
           if (getComponent(anion).getIonicCharge() >= 0.0) {
             continue;
@@ -1351,8 +1337,7 @@ public class PhasePitzer extends PhaseGE {
   }
 
   /** Returns a binary temperature function without key allocation for legacy datasets. */
-  private PitzerTemperatureFunction getPairTemperatureFunction(int family, int first,
-      int second) {
+  private PitzerTemperatureFunction getPairTemperatureFunction(int family, int first, int second) {
     if (!hasTemperatureFunctions) {
       return null;
     }
@@ -1361,8 +1346,7 @@ public class PhasePitzer extends PhaseGE {
   }
 
   /** Returns a ternary temperature function without key allocation for legacy datasets. */
-  private PitzerTemperatureFunction getTripleTemperatureFunction(int family, int first,
-      int second, int third) {
+  private PitzerTemperatureFunction getTripleTemperatureFunction(int family, int first, int second, int third) {
     if (!hasTemperatureFunctions) {
       return null;
     }
@@ -1390,8 +1374,7 @@ public class PhasePitzer extends PhaseGE {
     int low = Math.min(first, Math.min(second, third));
     int high = Math.max(first, Math.max(second, third));
     int middle = first + second + third - low - high;
-    return ((long) family << 54) | ((long) low << 36) | ((long) middle << 18)
-        | (long) high;
+    return ((long) family << 54) | ((long) low << 36) | ((long) middle << 18) | (long) high;
   }
 
   /** Ensures definition sets exist for objects read from older serialized forms. */

--- a/src/main/java/neqsim/thermo/phase/PitzerTemperatureFunction.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerTemperatureFunction.java
@@ -9,8 +9,8 @@ import java.util.Arrays;
  * <p>
  * The function is evaluated on the absolute-temperature scale as
  * {@code a0 + a1(1/T - 1/Tr) + a2 ln(T/Tr) + a3(T - Tr) + a4(T^2 - Tr^2)
- * + a5(1/T^2 - 1/Tr^2)}. It follows the public-domain PHREEQC
- * {@code calc_pitz_param} convention and performs no unit or standard-state conversion.
+ * + a5(1/T^2 - 1/Tr^2)}. It follows the public-domain PHREEQC {@code calc_pitz_param} convention and performs no unit
+ * or standard-state conversion.
  * </p>
  */
 public final class PitzerTemperatureFunction implements Serializable {
@@ -63,8 +63,7 @@ public final class PitzerTemperatureFunction implements Serializable {
         + coefficients[2] * Math.log(temperature / referenceTemperature)
         + coefficients[3] * (temperature - referenceTemperature)
         + coefficients[4] * (temperature * temperature - referenceTemperature * referenceTemperature)
-        + coefficients[5]
-            * (inverseTemperature * inverseTemperature - inverseReference * inverseReference);
+        + coefficients[5] * (inverseTemperature * inverseTemperature - inverseReference * inverseReference);
   }
 
   /**

--- a/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
@@ -167,8 +167,8 @@ class CapabilitiesRunnerTest {
     assertEquals(94, tests.get("protocolScenarioCount").getAsInt());
 
     JsonObject guides = inventory.getAsJsonObject("guides");
-    assertEquals(7, guides.get("guideCount").getAsInt());
-    assertEquals(7, guides.getAsJsonArray("entries").size());
+    assertEquals(8, guides.get("guideCount").getAsInt());
+    assertEquals(8, guides.getAsJsonArray("entries").size());
 
     JsonObject limitations = inventory.getAsJsonObject("knownLimitations");
     assertEquals(71, limitations.get("publishedToolCount").getAsInt());

--- a/src/test/java/neqsim/mcp/runners/McpAcceptanceBaselineRunnerTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpAcceptanceBaselineRunnerTests.java
@@ -20,7 +20,7 @@ class McpAcceptanceBaselineRunnerTests {
     assertFalse(contract.get("scientificValidationComplete").getAsBoolean());
 
     JsonObject inventory = McpEvidenceInventory.build();
-    assertEquals("1.4", inventory.get("inventoryVersion").getAsString());
+    assertEquals("1.5", inventory.get("inventoryVersion").getAsString());
     assertTrue(inventory.has("acceptanceBaselineContract"));
     assertFalse(inventory.get("complete").getAsBoolean());
   }

--- a/src/test/java/neqsim/mcp/runners/McpCampaignMatrixTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpCampaignMatrixTests.java
@@ -32,8 +32,8 @@ class McpCampaignMatrixTests {
       assertFalse(row.get("criterion").getAsString().isEmpty());
       assertFalse(row.get("evidence").getAsString().isEmpty());
       String status = row.get("evidenceStatus").getAsString();
-      assertTrue(status.equals("MERGED_EVIDENCE") || status.equals("PARTIAL_EVIDENCE")
-          || status.equals("CONFIRMED_GAP"));
+      assertTrue(
+          status.equals("MERGED_EVIDENCE") || status.equals("PARTIAL_EVIDENCE") || status.equals("CONFIRMED_GAP"));
       if (status.equals("MERGED_EVIDENCE")) {
         merged++;
       } else if (status.equals("PARTIAL_EVIDENCE")) {
@@ -72,8 +72,8 @@ class McpCampaignMatrixTests {
       JsonObject discipline = entry.getValue().getAsJsonObject();
       assertFalse(discipline.get("qualifiedForAccountableEngineeringApproval").getAsBoolean());
       assertTrue(discipline.get("publishedRepresentativeToolCount").getAsInt() > 0);
-      assertTrue(discipline.get("toolSpecificTrustCount").getAsInt()
-          <= discipline.get("publishedRepresentativeToolCount").getAsInt());
+      assertTrue(discipline.get("toolSpecificTrustCount").getAsInt() <= discipline
+          .get("publishedRepresentativeToolCount").getAsInt());
       String maturity = discipline.get("maturityStatus").getAsString();
       assertTrue(maturity.equals("TOOL_SPECIFIC_TRUST") || maturity.equals("PARTIAL_TOOL_SPECIFIC_TRUST")
           || maturity.equals("CONFIRMED_TRUST_GAP"));

--- a/src/test/java/neqsim/thermo/phase/PitzerTemperatureFunctionTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerTemperatureFunctionTest.java
@@ -14,13 +14,11 @@ import neqsim.thermo.system.SystemPitzer;
 /** Tests PHREEQC six-term temperature semantics and Pitzer-family placement. */
 class PitzerTemperatureFunctionTest extends neqsim.NeqSimTest {
   private static final double REFERENCE_TEMPERATURE = 298.15;
-  private static final double[] COEFFICIENTS =
-      {0.12, 250.0, -0.035, 4.2e-4, -3.1e-7, 18000.0};
+  private static final double[] COEFFICIENTS = { 0.12, 250.0, -0.035, 4.2e-4, -3.1e-7, 18000.0 };
 
   @Test
   void matchesPublicDomainPhreeqcTemperatureFunction() {
-    PitzerTemperatureFunction function =
-        new PitzerTemperatureFunction(REFERENCE_TEMPERATURE, COEFFICIENTS);
+    PitzerTemperatureFunction function = new PitzerTemperatureFunction(REFERENCE_TEMPERATURE, COEFFICIENTS);
 
     assertEquals(0.12, function.valueAt(REFERENCE_TEMPERATURE), 0.0);
     assertEquals(0.12, function.valueAt(REFERENCE_TEMPERATURE + 5.0e-4), 0.0);
@@ -30,16 +28,13 @@ class PitzerTemperatureFunctionTest extends neqsim.NeqSimTest {
 
   @Test
   void rejectsInvalidInputsAndProtectsCoefficientState() {
-    assertThrows(IllegalArgumentException.class,
-        () -> new PitzerTemperatureFunction(0.0, COEFFICIENTS));
+    assertThrows(IllegalArgumentException.class, () -> new PitzerTemperatureFunction(0.0, COEFFICIENTS));
     assertThrows(IllegalArgumentException.class,
         () -> new PitzerTemperatureFunction(REFERENCE_TEMPERATURE, new double[5]));
-    assertThrows(IllegalArgumentException.class,
-        () -> new PitzerTemperatureFunction(REFERENCE_TEMPERATURE,
-            new double[] {0.0, 0.0, Double.NaN, 0.0, 0.0, 0.0}));
+    assertThrows(IllegalArgumentException.class, () -> new PitzerTemperatureFunction(REFERENCE_TEMPERATURE,
+        new double[] { 0.0, 0.0, Double.NaN, 0.0, 0.0, 0.0 }));
 
-    PitzerTemperatureFunction function =
-        new PitzerTemperatureFunction(REFERENCE_TEMPERATURE, COEFFICIENTS);
+    PitzerTemperatureFunction function = new PitzerTemperatureFunction(REFERENCE_TEMPERATURE, COEFFICIENTS);
     double[] copy = function.getCoefficients();
     copy[0] = 99.0;
     assertArrayEquals(COEFFICIENTS, function.getCoefficients(), 0.0);
@@ -54,14 +49,11 @@ class PitzerTemperatureFunctionTest extends neqsim.NeqSimTest {
     int potassium = phase.getComponent("K+").getComponentNumber();
     int chloride = phase.getComponent("Cl-").getComponentNumber();
 
-    phase.setBinaryTemperatureCoefficients(sodium, chloride, REFERENCE_TEMPERATURE,
-        COEFFICIENTS, COEFFICIENTS, COEFFICIENTS);
-    phase.setBeta2TemperatureCoefficients(sodium, chloride, REFERENCE_TEMPERATURE,
+    phase.setBinaryTemperatureCoefficients(sodium, chloride, REFERENCE_TEMPERATURE, COEFFICIENTS, COEFFICIENTS,
         COEFFICIENTS);
-    phase.setThetaTemperatureCoefficients(sodium, potassium, REFERENCE_TEMPERATURE,
-        COEFFICIENTS);
-    phase.setPsiTemperatureCoefficients(sodium, potassium, chloride,
-        REFERENCE_TEMPERATURE, COEFFICIENTS);
+    phase.setBeta2TemperatureCoefficients(sodium, chloride, REFERENCE_TEMPERATURE, COEFFICIENTS);
+    phase.setThetaTemperatureCoefficients(sodium, potassium, REFERENCE_TEMPERATURE, COEFFICIENTS);
+    phase.setPsiTemperatureCoefficients(sodium, potassium, chloride, REFERENCE_TEMPERATURE, COEFFICIENTS);
 
     double expected = -0.11371073586719137;
     assertEquals(expected, phase.getBeta0ij(sodium, chloride, 373.15), 2.0e-15);
@@ -69,12 +61,11 @@ class PitzerTemperatureFunctionTest extends neqsim.NeqSimTest {
     assertEquals(expected, phase.getCphiij(sodium, chloride, 373.15), 2.0e-15);
     assertEquals(expected, phase.getBeta2ij(sodium, chloride, 373.15), 2.0e-15);
     assertEquals(expected, phase.getThetaij(potassium, sodium, 373.15), 2.0e-15);
-    assertEquals(expected, phase.getPsiijk(chloride, potassium, sodium, 373.15),
-        2.0e-15);
+    assertEquals(expected, phase.getPsiijk(chloride, potassium, sodium, 373.15), 2.0e-15);
 
     PhasePitzer clone = phase.clone();
     clone.setThetaTemperatureCoefficients(sodium, potassium, REFERENCE_TEMPERATURE,
-        new double[] {0.25, 0.0, 0.0, 0.0, 0.0, 0.0});
+        new double[] { 0.25, 0.0, 0.0, 0.0, 0.0, 0.0 });
     assertEquals(expected, phase.getThetaij(sodium, potassium, 373.15), 2.0e-15);
     assertEquals(0.25, clone.getThetaij(sodium, potassium, 373.15), 0.0);
   }
@@ -84,21 +75,18 @@ class PitzerTemperatureFunctionTest extends neqsim.NeqSimTest {
     PhasePitzer phase = createPhase();
     int sodium = phase.getComponent("Na+").getComponentNumber();
     int potassium = phase.getComponent("K+").getComponentNumber();
-    phase.setThetaTemperatureCoefficients(sodium, potassium, REFERENCE_TEMPERATURE,
-        COEFFICIENTS);
+    phase.setThetaTemperatureCoefficients(sodium, potassium, REFERENCE_TEMPERATURE, COEFFICIENTS);
 
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
       output.writeObject(phase);
     }
     PhasePitzer restored;
-    try (ObjectInputStream input =
-        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
       restored = (PhasePitzer) input.readObject();
     }
 
-    assertEquals(-0.11371073586719137,
-        restored.getThetaij(sodium, potassium, 373.15), 2.0e-15);
+    assertEquals(-0.11371073586719137, restored.getThetaij(sodium, potassium, 373.15), 2.0e-15);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- align `CapabilitiesRunnerTest` with the eight-guide Phase 0 inventory introduced by #3203
- align `McpAcceptanceBaselineRunnerTests` with inventory contract version `1.5`
- apply the repository formatter to the newly merged MCP and Pitzer files required by the pre-commit gate

## Root cause

Parallel MCP changes merged cleanly at the Git level but left two source-count/contract assertions pinned to the prior Phase 0 inventory (`7` guides and version `1.4`). The current implementation intentionally exposes eight guides, including the campaign matrix, under inventory version `1.5`.

## Validation

- `./mvnw -Dtest=CapabilitiesRunnerTest,McpAcceptanceBaselineRunnerTests,McpCampaignMatrixTests,PitzerTemperatureFunctionTest test` — 16 tests, 0 failures, 0 errors
- `python devtools/run_spotless.py apply` — passed
- `python devtools/run_spotless.py check` — passed
- `python devtools/check_documentation_search.py` — passed (659 Markdown pages, 1 standalone HTML page)
- `git diff --check` — passed
- local `pre-commit` executable unavailable; the mandatory direct formatter and documentation gates passed
- full repository suite: pending GitHub CI

Documentation impact: none — this repairs stale internal test contracts and formatting only; no runtime behavior, public API, inputs, outputs, or recommended usage changes.