### PR TITLE
[AI-Assisted] feat(mcp): expose ProcessModel mass-closure evidence

### DIFF
--- a/neqsim-mcp-server/docs/ACCEPTANCE_BASELINES.md
+++ b/neqsim-mcp-server/docs/ACCEPTANCE_BASELINES.md
@@ -8,7 +8,7 @@ qualification workflow.
 Run the focused exact-head gate from the repository root:
 
 ```bash
-./mvnw test -Dtest=McpAcceptanceBaselineRunnerTests
+./mvnw test -Dtest=McpAcceptanceBaselineRunnerTests,ProcessRunnerBalanceEvidenceTests
 ```
 
 The test validates the compact baseline JSON returned by the runner. Every fixture is executed twice. A caller that
@@ -36,6 +36,17 @@ retaining the standard envelope and selective-retrieval guidance.
 Balance evidence is deliberately fail-visible. A successful `runProcess` response without an explicitly named numeric
 mass, component, or energy closure field is classified as `GAP_NO_NUMERIC_CLOSURE_IN_MCP_RESPONSE`. The harness does not
 convert convergence, a non-empty report, or a validation label into a balance claim.
+
+For multi-area `ProcessModel` execution, `runProcess` now exposes the existing solver-native
+`convergenceReport` returned by `ProcessModel.getConvergenceReportJson()`. Its `massClosure` object carries the numeric
+`relativeError`, configured `tolerance`, summary, and worst-unit evidence already used by the canonical ProcessModel
+convergence machinery. `relativeError` is a fraction of detected plant feed, not an independently reconstructed MCP
+balance. The same report is retained in both the legacy top-level response and the strict `data` block.
+
+This closes one defensible response-evidence gap for the public multi-area acceptance fixture. It does **not** establish
+component closure or energy closure, and it does not invent a corresponding balance for single-area `ProcessSystem`
+responses. Those response paths remain explicit gaps until the canonical model exposes equally defensible numerical
+evidence. A successful solver result therefore remains distinct from conservation evidence and scientific validation.
 
 ## Ownership and qualification boundaries
 

--- a/src/main/java/neqsim/mcp/runners/ProcessRunner.java
+++ b/src/main/java/neqsim/mcp/runners/ProcessRunner.java
@@ -952,6 +952,7 @@ public class ProcessRunner {
       }
     }
     result.addProperty("convergenceSummary", buildResult.model.getConvergenceSummary());
+    result.add("convergenceReport", JsonParser.parseString(buildResult.model.getConvergenceReportJson()));
     if (autoSizing != null) {
       result.add("autoSizing", autoSizing);
     }
@@ -1543,8 +1544,9 @@ public class ProcessRunner {
       return;
     }
     JsonObject data = new JsonObject();
-    String[] fields = { "processSystemName", "processModelName", "areaCount", "areas", "report", "autoSizing",
-        "designReport", "utilizationSnapshot", "bottleneckRanking", "processDefinition", "pythonScript" };
+    String[] fields = { "processSystemName", "processModelName", "areaCount", "areas", "report",
+        "convergenceSummary", "convergenceReport", "autoSizing", "designReport", "utilizationSnapshot",
+        "bottleneckRanking", "processDefinition", "pythonScript" };
     for (String field : fields) {
       if (response.has(field)) {
         data.add(field, response.get(field));

--- a/src/main/java/neqsim/mcp/runners/ProcessRunner.java
+++ b/src/main/java/neqsim/mcp/runners/ProcessRunner.java
@@ -651,7 +651,7 @@ public class ProcessRunner {
    * @return non-empty string value
    */
   private static String requireString(JsonObject object, String name) {
-    String value = getOptionalString(object, name, null);
+    String value = getOptionalString(object, "name".equals(name) ? name : name, null);
     if (value == null) {
       throw new IllegalArgumentException("Required string property '" + name + "' is missing");
     }
@@ -1544,9 +1544,9 @@ public class ProcessRunner {
       return;
     }
     JsonObject data = new JsonObject();
-    String[] fields = { "processSystemName", "processModelName", "areaCount", "areas", "report",
-        "convergenceSummary", "convergenceReport", "autoSizing", "designReport", "utilizationSnapshot",
-        "bottleneckRanking", "processDefinition", "pythonScript" };
+    String[] fields = { "processSystemName", "processModelName", "areaCount", "areas", "report", "convergenceSummary",
+        "convergenceReport", "autoSizing", "designReport", "utilizationSnapshot", "bottleneckRanking",
+        "processDefinition", "pythonScript" };
     for (String field : fields) {
       if (response.has(field)) {
         data.add(field, response.get(field));

--- a/src/main/java/neqsim/mcp/runners/ProcessRunner.java
+++ b/src/main/java/neqsim/mcp/runners/ProcessRunner.java
@@ -651,7 +651,7 @@ public class ProcessRunner {
    * @return non-empty string value
    */
   private static String requireString(JsonObject object, String name) {
-    String value = getOptionalString(object, "name".equals(name) ? name : name, null);
+    String value = getOptionalString(object, name, null);
     if (value == null) {
       throw new IllegalArgumentException("Required string property '" + name + "' is missing");
     }

--- a/src/test/java/neqsim/mcp/runners/McpAcceptanceBaselineRunnerTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpAcceptanceBaselineRunnerTests.java
@@ -53,8 +53,7 @@ class McpAcceptanceBaselineRunnerTests {
       assertFalse(measurement.getAsJsonObject("balanceEvidence").get("status").getAsString().trim().isEmpty());
       if ("multi-area-facility".equals(measurement.get("fixtureId").getAsString())) {
         JsonObject balanceEvidence = measurement.getAsJsonObject("balanceEvidence");
-        assertEquals("RESPONSE_EVIDENCE_PRESENT", balanceEvidence.get("status").getAsString(),
-            measurement.toString());
+        assertEquals("RESPONSE_EVIDENCE_PRESENT", balanceEvidence.get("status").getAsString(), measurement.toString());
         assertTrue(balanceEvidence.getAsJsonArray("responsePaths").toString().contains("massClosure"),
             balanceEvidence.toString());
         multiAreaMassClosureEvidenceFound = true;

--- a/src/test/java/neqsim/mcp/runners/McpAcceptanceBaselineRunnerTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpAcceptanceBaselineRunnerTests.java
@@ -36,8 +36,10 @@ class McpAcceptanceBaselineRunnerTests {
     assertEquals(4, summary.get("successCount").getAsInt(), baseline.toString());
     assertEquals(4, summary.get("convergedCount").getAsInt(), baseline.toString());
     assertEquals(4, summary.get("deterministicCount").getAsInt(), baseline.toString());
+    assertTrue(summary.get("balanceEvidencePresentCount").getAsInt() >= 1, baseline.toString());
     assertTrue(summary.get("status").getAsString().startsWith("EXECUTION_COMPLETE"), baseline.toString());
 
+    boolean multiAreaMassClosureEvidenceFound = false;
     for (com.google.gson.JsonElement element : measurements) {
       JsonObject measurement = element.getAsJsonObject();
       assertTrue(measurement.get("successful").getAsBoolean(), measurement.toString());
@@ -49,8 +51,17 @@ class McpAcceptanceBaselineRunnerTests {
       assertTrue(measurement.getAsJsonObject("determinism").get("stableOutcomeMatch").getAsBoolean(),
           measurement.toString());
       assertFalse(measurement.getAsJsonObject("balanceEvidence").get("status").getAsString().trim().isEmpty());
+      if ("multi-area-facility".equals(measurement.get("fixtureId").getAsString())) {
+        JsonObject balanceEvidence = measurement.getAsJsonObject("balanceEvidence");
+        assertEquals("RESPONSE_EVIDENCE_PRESENT", balanceEvidence.get("status").getAsString(),
+            measurement.toString());
+        assertTrue(balanceEvidence.getAsJsonArray("responsePaths").toString().contains("massClosure"),
+            balanceEvidence.toString());
+        multiAreaMassClosureEvidenceFound = true;
+      }
       assertEquals("NOT_ESTABLISHED_BY_PHASE0_EXECUTION_HARNESS",
           measurement.get("scientificValidationStatus").getAsString());
     }
+    assertTrue(multiAreaMassClosureEvidenceFound, baseline.toString());
   }
 }

--- a/src/test/java/neqsim/mcp/runners/ProcessRunnerBalanceEvidenceTests.java
+++ b/src/test/java/neqsim/mcp/runners/ProcessRunnerBalanceEvidenceTests.java
@@ -1,0 +1,39 @@
+package neqsim.mcp.runners;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/** Tests solver-native ProcessModel convergence and mass-closure evidence in MCP process responses. */
+class ProcessRunnerBalanceEvidenceTests {
+
+  @Test
+  void testMultiAreaRunExposesSolverNativeMassClosureEvidence() {
+    JsonObject response = JsonParser.parseString(ProcessRunner.run(McpAcceptanceFixtureCatalog.multiAreaInput()))
+        .getAsJsonObject();
+
+    assertEquals("success", response.get("status").getAsString(), response.toString());
+    assertTrue(response.has("convergenceReport"), response.toString());
+
+    JsonObject report = response.getAsJsonObject("convergenceReport");
+    assertEquals("1.0", report.get("schemaVersion").getAsString());
+    assertTrue(report.get("converged").getAsBoolean(), report.toString());
+
+    JsonObject massClosure = report.getAsJsonObject("massClosure");
+    assertTrue(massClosure.get("tolerance").getAsDouble() > 0.0, massClosure.toString());
+    assertFalse(massClosure.get("relativeError").isJsonNull(), massClosure.toString());
+    double relativeError = massClosure.get("relativeError").getAsDouble();
+    assertTrue(Double.isFinite(relativeError), massClosure.toString());
+    assertTrue(relativeError >= 0.0, massClosure.toString());
+    assertTrue(relativeError <= massClosure.get("tolerance").getAsDouble(), massClosure.toString());
+    assertTrue(massClosure.has("summary"));
+    assertTrue(massClosure.has("worstUnits"));
+
+    JsonObject data = response.getAsJsonObject("data");
+    assertTrue(data.has("convergenceReport"), data.toString());
+    assertEquals(report, data.getAsJsonObject("convergenceReport"));
+  }
+}


### PR DESCRIPTION
## Summary

Advances #3153 Phase 0 by closing one defensible numerical-balance response gap without inventing an MCP-only balance calculation.

- exposes the existing canonical `ProcessModel.getConvergenceReportJson()` as `runProcess.convergenceReport` for multi-area executions
- preserves the same structured report in the standard `data` block alongside the existing legacy top-level process fields
- makes the solver-native `massClosure.relativeError`, `tolerance`, summary, worst-unit evidence, and convergence diagnostics visible to MCP callers
- extends the four-scale acceptance harness regression so the public `multi-area-facility` fixture must be classified `RESPONSE_EVIDENCE_PRESENT` with a `massClosure` response path
- adds a focused ProcessRunner regression that pins finite solver-native mass closure within its configured tolerance
- documents the evidence/qualification boundary in `ACCEPTANCE_BASELINES.md`

No thermodynamic, process, recycle, convergence, performance, optimization, DEXPI, dynamic, or plant-control algorithm is changed.

## Frozen scope and owner boundaries

This increment is MCP reporting/evidence only. It reuses the mass-closure calculation already used by the canonical `ProcessModel` convergence machinery.

It deliberately does **not** derive a second MCP-side balance, infer component/energy closure, add synthetic single-area balance evidence, change #2939 process performance, #3154/#2941 optimization fidelity, #2911 dynamics, #2937 flash/stability internals, or #2899 DEXPI/P&ID semantics, or claim scientific validation/design certification/plant authority.

Single-area `ProcessSystem` acceptance fixtures remain explicit `GAP_NO_NUMERIC_CLOSURE_IN_MCP_RESPONSE` cases unless a later current-source audit finds equally defensible canonical evidence.

## Exact base / head

- branch creation base: `c4a97aeec6f93ec91564cbd80726cc2c7f5fc7d1`
- current exact head: `390209914f9d02748ff6c2066e15942afa7bc88a`
- current master: `5c3feaddc576d2cd5ed60e3d96dd4204845de97f` (unrelated Pitzer work)
- branch is seven commits ahead / one behind current master because master advanced independently; GitHub reports the four-file draft mergeable
- no Update branch, master merge, rebase, cherry-pick, force push, or master write was used

## Engineering evidence

Current `ProcessModel.getConvergenceReportJson()` already reports convergence diagnostics plus `massClosure.enabled`, `massClosure.tolerance`, numeric `massClosure.relativeError` when evaluated, summary, worst-unit evidence, and optional unit-level diagnostics. The tolerance/error are solver-native fractions of detected plant feed. This PR only transports that canonical evidence through the existing `runProcess` response.

The frozen three-area public acceptance fixture exercises canonical `ProcessModel` execution. The focused regression requires returned mass closure to be finite, non-negative, and no greater than its configured tolerance when convergence is reported. The full baseline harness executes all four fixtures twice and requires at least one explicit numeric balance-evidence result, specifically the multi-area fixture.

## Validation

**READY TO MERGE — exact head `390209914f9d02748ff6c2066e15942afa7bc88a`**

This is a validation classification only; it grants no merge authority and the PR remains draft.

A local checkout/bootstrap was attempted once and blocked by DNS (`Could not resolve host: github.com`); no local Maven/JDK/Spotless/pre-commit/Javadoc pass is claimed.

Hosted CI on prior exact head `45f419427bd18ec430bf61f50eb298bff82063a0` identified a branch-attributable pre-commit formatting failure. The successful hosted `Spotless format patch` artifact was inspected and its exact two formatting changes were applied. During connector-only repair, a transient no-op edit was detected from the PR diff and removed before this head. The resulting `ProcessRunner.java` blob is `783d70eda074af07f9d8d93311b5827d2ae082c8`, matching the hosted formatter target prefix `783d70e`; the final PR diff again contains only the intended MCP reporting changes.

All hosted workflows on exact head `390209914f9d02748ff6c2066e15942afa7bc88a` completed successfully:
- `Run build, test and javadoc`: success
- `Pre-commit checks`: success
- `Spotless format patch`: success
- `CodeQL Security Analysis`: success
- `PaperLab Replication Gate`: success

GitHub reports the draft mergeable. No reviews, PR comments/Copilot findings, or unresolved review threads are present. CODEOWNERS assigns the MCP surface to `@EvenSol`; this reporting-only change introduces no new scientific model or public contract requiring a separate domain-qualification claim.

Focused regressions:
- `ProcessRunnerBalanceEvidenceTests`
- `McpAcceptanceBaselineRunnerTests`

No direct schema mutation is required: the existing process output schema and standard `data` object are open. No tool name, input, stable envelope field, or request schema changes.

## Documentation impact

`neqsim-mcp-server/docs/ACCEPTANCE_BASELINES.md` documents the multi-area solver-native mass-closure path, its plant-feed-relative basis, and explicit remaining component/energy/single-area gaps. No companion agent/skill handoff is required because tool names, invocation flow, and request contracts are unchanged.

## Remaining Phase 0 boundary

This does not complete the Phase 0 balance criterion. After merge and current-master re-audit, inspect whether canonical single-area `ProcessSystem` results expose an equally defensible numeric closure contract; otherwise keep the gap explicit. The remaining tool-specific trust gaps must likewise be closed only where current source and public evidence support specific claims.

Refs #3153