### PR TITLE
[AI-Assisted] feat(pitzer): qualify neutral CO2-Na2SO4 interactions

### DIFF
--- a/docs/thermo/pitzer_parameter_provenance.md
+++ b/docs/thermo/pitzer_parameter_provenance.md
@@ -19,8 +19,9 @@ binary coefficients at 298.15 K and a NeqSim three-term temperature expression:
 `p(T) = p(298.15 K) + pT1 (1/T - 1/298.15 K) + pT2 ln(T/298.15 K)`.
 
 This identity documents the existing table; it does not certify every legacy row. The table has no
-usable tuple identity for same-sign `theta` or ternary `psi`, and it has no `lambda`, `zeta`, `mu`,
-or `eta` representation. Mixed-ion calculations therefore require explicit parameter definitions.
+usable tuple identity for same-sign `theta` or ternary `psi`, and it has no qualified `lambda`,
+`zeta`, `mu`, or `eta` rows. Mixed-ion and neutral-solute calculations therefore require explicit
+parameter definitions.
 
 `PhasePitzer.getPitzerParameterCoverage()` returns active primary-salt cations and anions plus every
 missing binary, `theta`, and `psi` key. For a mixed primary-salt topology, the automatic gate fails
@@ -28,18 +29,74 @@ before activity or water-osmotic evaluation when that coverage is incomplete. Es
 single-cation/single-anion calculations retain their binary behavior; callers can explicitly audit
 their binary row with `requireCompletePitzerParameterCoverage()`. An explicit zero set through
 `setBinaryParameters`, `setTheta`, or `setPsi` counts as a definition; an absent value does not.
+The neutral families are sparse and opt-in. Once any neutral interaction is configured, every active
+neutral-neutral (including repeated species) and neutral-ion `lambda` pair and every
+neutral-cation-anion `zeta` tuple must be explicit. If a dataset enables
+`mu` or `eta`, its active neutral or same-sign-ion topology is audited too. Missing rows fail before
+activity or osmotic evaluation; an explicitly defined zero remains distinct from an absent row.
 Acid-base species created as reaction-solver trial variables (`H3O+`, `OH-`, `HCO3-`, and `CO3--`)
 are outside this first gate: their transient iteration amounts are not a stable input topology, and
 they require a later model-specific reaction-dataset audit. The diagnostic is cached by active
 primary-salt topology and parameter revision, and the automatic gate runs once after each standard
 level-zero state initialization. Call `init(0)` after changing composition, as required by the
-general NeqSim state contract. This work is confined to
-`PhasePitzer`; neutral PR, SRK, CPA, Electrolyte-CPA, and Fürst electrolyte-EOS paths do no new work.
+general NeqSim state contract. This work is confined to `PhasePitzer` and `ComponentGePitzer`;
+neutral PR, SRK, CPA, Electrolyte-CPA, and Fürst electrolyte-EOS paths do no new work.
+
+### Qualified public-domain CO2-Na2SO4 subset
+
+`PitzerParameterDatasets.applyPhreeqcCo2SodiumSulfate` installs one coherent subset identified as
+`usgs-phreeqc-pitzer-b0b3be767158ccc3322d2c816625cf470045e67e-co2-na2so4-v1`.
+It is copied exactly from public-domain PHREEQC commit `b0b3be7`, database blob `324f852`, and it
+marks the phase as manually populated so the legacy table cannot be mixed into the selected set.
+The species use the molality standard state, pressure is not an argument of these interaction
+functions, the reference temperature is 298.15 K, and the six coefficients are stored in PHREEQC
+order. The Na+/SO4-- 1-2 binary uses alpha1=2 and has no beta2 term.
+Java and Python callers can use `SystemPitzer.applyPhreeqcCo2SodiumSulfateParameters()` after adding
+the required species; cloning and subsequent `init(0)` calls preserve the selected dataset.
+
+| Species tuple | Family | PHREEQC coefficients `[a0,a1,a2,a3,a4,a5]` | Source-lineage note |
+|---|---|---|---|
+| Na+ / SO4-- | `beta(0)` | `[2.73e-2, 0, -5.8, 9.89e-3, 0, -1.563e5]` | PHREEQC `pitzer.dat`; exact current public-domain row |
+| Na+ / SO4-- | `beta(1)` | `[0.956, 2.663e3, 0, 1.158e-2, 0, -3.194e5]` | same coherent binary row |
+| Na+ / SO4-- | `Cphi` (`C0`) | `[3.418e-3, -384, 0, -8.451e-4, 0, 5.177e4]` | unchanged `C0` value; downstream charge normalization is in the equation |
+| CO2 / CO2 | `lambda` | `[-1.34e-2, 348, 0.803, 0, 0, 0]` | PHREEQC comment limits this temperature function to 150 °C |
+| CO2 / Na+ | `lambda` | `0.085` | constant row in the same database |
+| CO2 / SO4-- | `lambda` | `0.075` | constant row in the same database |
+| CO2 / Na+ / SO4-- | `zeta` | `-0.015` | required ternary companion row |
+
+This is a deliberately closed species system, not a general brine database. Any additional active
+neutral or ion forces the ordinary binary/mixed-ion and neutral-family coverage checks; a missing
+interaction is never silently replaced by zero. `isWithinCo2SodiumSulfateValidationRange` records
+the independently checked envelope of 303.15–423.15 K and 1–2 mol/kg Na2SO4. It is an evidence
+envelope for this subset, not an extrapolation guarantee.
+
+Independent calculation evidence uses IPhreeqc 3.7.3 with the exact database blob above and
+MacInnes scaling disabled. Four CO2 states at 298.15, 373.15, and 423.15 K and 0.1–2 mol/kg Na2SO4
+match PHREEQC natural-log activity contributions within `1.5e-5`. At 298.15 K and approximately
+1 mol/kg Na2SO4, NeqSim gives mean ionic activity coefficient `0.20016248` versus PHREEQC
+`0.20137297` (−0.60%) and osmotic coefficient `0.64159881` versus `0.64224702` (−0.10%). The
+remaining difference is retained as an explicit tolerance because NeqSim's water electrostatic
+correlation is not PHREEQC's optional database `Aphi` function.
+
+The held-out qualitative gate is Dos Santos et al. (2020),
+[DOI 10.1021/acs.jced.0c00230](https://doi.org/10.1021/acs.jced.0c00230): 48 CO2-solubility points
+at 303.15–423.15 K and 1–2 mol/kg Na2SO4 report increased salting-out with salt molality. The
+qualified subset independently produces a larger CO2 activity coefficient from 1 to 2 mol/kg at
+373.15 K. The publication is used only as cited validation evidence; no copyrighted table is stored.
+A second outside-range comparison is Zhao et al. (2015),
+[DOI 10.1002/aic.14825](https://doi.org/10.1002/aic.14825), covering Na2SO4 ionic strength 1–6 mol/kg
+at 15 MPa and 323–423 K; it is evidence for later full-VLE work, not grounds to widen this subset's
+accepted range.
+
+The current hybrid EOS-GE flash still fails for some gas-forming CO2/brine inventories before a
+scientific VLE comparison can be made. That is a separate phase-topology dependency coordinated
+with the generic flash campaign; this subset is therefore qualified for aqueous activity and
+water/osmotic use only. It must not be described as independently validated CO2 VLE.
 
 ## Source-comparison matrix
 
-No numerical coefficient was adopted in this review. “Not inspected” means that no value may be
-inferred from the source.
+Only the complete CO2-Na2SO4 subset above is adopted. Other candidate values remain comparison
+evidence unless this document explicitly identifies them as part of that versioned set.
 
 | Source / version | Species and parameter families | Conditions, equation, scale, and alpha | Evidence, range, uncertainty | Lineage and reuse status | Mapping decision / conflict |
 |---|---|---|---|---|---|
@@ -47,7 +104,7 @@ inferred from the source.
 | Pitzer (1973), [general equations](https://doi.org/10.1021/j100621a026), and Pitzer–Mayorga (1973), [strong electrolytes](https://doi.org/10.1021/j100638a009) | Foundational binary virial families for strong electrolytes; individual tuples must be read from the original article | Molality-scale Pitzer formulation near 298.15 K; exact parameter-specific alpha and fitted range must be taken from the paper | Mean activity and osmotic-coefficient fits; no value transcribed in this review | Primary publications; ACS copyright, so values require row-level reuse review or redistributable corroboration | Equation lineage accepted; no direct adoption pending exact NeqSim term-by-term mapping. |
 | Harvie, Møller and Weare (1984), [natural-water model](https://doi.org/10.1016/0016-7037(84)90098-X) | Na/K/Mg/Ca/H with Cl/SO4/OH/HCO3/CO3/CO2/H2O; binary and mixed interactions | 25 °C, high ionic strength; molality-scale Pitzer model | Fitted isopiestic, EMF, and solubility data; multicomponent comparisons outside subsystems are reported | Primary Elsevier article; numerical-table redistribution not established here | High-priority scientific comparison. No coefficient copied; full family and electrostatic convention must be mapped together. |
 | Pitzer (1975), [higher-order electrostatic mixing](https://doi.org/10.1007/BF00646562) | Nonsymmetric same-sign electrostatic terms `Etheta` and its ionic-strength derivative for unequal charge pairs; no fitted short-range coefficient is supplied by this term | Molality-scale Pitzer formulation; the term is zero for equal charges and depends on charge tuple, ionic strength, and `Aphi` | Primary equation source; it establishes model structure rather than a parameter fit | Primary Springer article; no numerical table copied | Equation structure accepted in this increment: the public PHREEQC recurrence and its ion/activity/osmotic placement are mapped directly. No fitted coefficient is copied; short-range tuple coverage remains independently fail-closed. |
-| USGS PHRQPITZ (Plummer et al. 1988), [WRIR 88-4153](https://doi.org/10.3133/wri884153), PHREEQC 3.8.6 tag commit [`74cdaf0`](https://github.com/phreeqc-dev/phreeqc3/commit/74cdaf00f90b15b7a5bbc03f405eb2f8129aacf1), and audited current source commit [`b0b3be7`](https://github.com/phreeqc-dev/phreeqc3/commit/b0b3be767158ccc3322d2c816625cf470045e67e) | Na/K/Mg/Ca/H plus major anions and extended Fe/Mn/Sr/Ba/Li/Br; `B0`, `B1`, `B2`, `C0`, `theta`, `psi`, `lambda`, `zeta`, `mu`, `eta`, alpha, and six temperature coefficients | Molality scale; PHREEQC enables nonsymmetric electrostatic mixing by default. For 1:1 salts alpha1 is 2.0. At 298.15 K, current NaCl is `B0=0.07534`, `B1=0.2769`, `C0=0.00148`; KCl is `0.04808`, `0.2168`, `-0.000788`; K/Na `theta=-0.012`; Cl/K/Na `psi=-0.0015`. | USGS describes a 25 degrees C core with largely untested extensions; exact validity, observables, residuals, and uncertainty remain row/source specific | USGS software and data are public domain. Audited blobs: [`pitzer.cpp` `1f32a08`](https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/src/pitzer.cpp) and [`pitzer.dat` `324f852`](https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/database/pitzer.dat). | Preferred redistributable provenance index. NeqSim legacy NaCl is `0.0765/0.2664/0.00127` and KCl is `0.04835/0.2122/-0.00084`, so the sources conflict. The parameter-free `Etheta`, six-term temperature, and `C0`/`Cphi` identity mappings are accepted. The candidate rows still conflict with NeqSim legacy values, so no fitted value was adopted. |
+| USGS PHRQPITZ (Plummer et al. 1988), [WRIR 88-4153](https://doi.org/10.3133/wri884153), PHREEQC 3.8.6 tag commit [`74cdaf0`](https://github.com/phreeqc-dev/phreeqc3/commit/74cdaf00f90b15b7a5bbc03f405eb2f8129aacf1), and audited current source commit [`b0b3be7`](https://github.com/phreeqc-dev/phreeqc3/commit/b0b3be767158ccc3322d2c816625cf470045e67e) | Na/K/Mg/Ca/H plus major anions and extended Fe/Mn/Sr/Ba/Li/Br; `B0`, `B1`, `B2`, `C0`, `theta`, `psi`, `lambda`, `zeta`, `mu`, `eta`, alpha, and six temperature coefficients | Molality scale; PHREEQC enables nonsymmetric electrostatic mixing by default. The adopted Na+/SO4-- 1-2 binary uses alpha1=2. At 298.15 K, current NaCl is `B0=0.07534`, `B1=0.2769`, `C0=0.00148`; KCl is `0.04808`, `0.2168`, `-0.000788`; K/Na `theta=-0.012`; Cl/K/Na `psi=-0.0015`. | Appelo (2015), [DOI 10.1016/j.apgeochem.2014.11.007](https://doi.org/10.1016/j.apgeochem.2014.11.007), is the database's cited high-temperature lineage. Exact validity, observables, residuals, and uncertainty remain row/source specific. Rumpf and Maurer (1993), [DOI 10.1002/bbpc.19930970116](https://doi.org/10.1002/bbpc.19930970116), fitted CO2 in Na2SO4/ammonium-sulfate brines at 313.15–433.15 K and up to 10 MPa. | USGS software and data are public domain. Audited blobs: [`pitzer.cpp` `1f32a08`](https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/src/pitzer.cpp) and [`pitzer.dat` `324f852`](https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/database/pitzer.dat). | The complete CO2-Na2SO4 subset listed above is adopted and independently checked. NeqSim legacy NaCl and KCl conflict with current PHREEQC, so those unrelated rows remain legacy-only. The parameter-free `Etheta`, six-term functions, neutral-family placement, and `C0`/`Cphi` mapping are accepted. |
 | Kaasa (1998), *Prediction of pH, mineral precipitation and multiphase equilibria during oil recovery*, [National Library item](https://www.nb.no/items/d1d68b489b8ee6704786a011fd2e7283), supplied scan inspected 2026-08-23 | Appendix F printed pp. 260–263: binary `beta(0)`, `beta(1)`, occasional `beta(2)`, and `Cphi` for oil-recovery-brine ions; pp. 264–266: same-sign `theta` and ternary `psi`; pp. 266–267: neutral `lambda` and `ksi` (zeta) for CO2, H2S, and CH4 systems | Molality-scale Pitzer model; 298.15 K reference. Appendix F equation (F.1) uses six coefficients in raw order `[a,b,c,d,e,f]`; NeqSim/PHREEQC order is `[a,d,e,b,c,f]`. Pressure effects are handled separately in chapter 4. | Appendix F cites sources 1–16, including primary literature and rows marked “This work.” Chapter 4 §4.3.2, printed pp. 100–101, states that source ranges differ and some high-temperature fits were forced toward zero where extrapolation became nonphysical, with a poorer fit to experiments. Row uncertainty and complete validity are not tabulated. | User-supplied scan was visually inspected against its text layer. Thesis-table redistribution terms remain unclear; no numerical row was copied. Original cited publications require independent row-level checks and their own reuse review. | Formula, page/family inventory, and coefficient-order permutation accepted. `PitzerTemperatureFunction.fromKaasa1998` performs only the tested order mapping. No coefficient, forced extrapolation, or “This work” estimate was adopted. |
 | THEREDA release 2026-01, [official database](https://www.thereda.de/) | Quality-controlled high-salinity Pitzer datasets, including variable-temperature sets | Official site reports an oceanic set from 0 to 110 °C; formulation and scale are dataset specific | Official site reports 425 tests and more than 3200 results; row-level uncertainty remains dataset specific | Current release and licensing/reuse terms must be confirmed before storage | Candidate validation and provenance source only; no value adopted while row-level lineage, reuse, range, and complete family compatibility remain unresolved. |
 
@@ -96,12 +153,13 @@ include mean activity and osmotic coefficients or water activity, mixed-brine sp
 saturation, electroneutrality and material balance, derivative continuity, boundary behavior,
 determinism, and an independently configured exact-version implementation such as PHREEQC.
 
-The 2026-08-23 compatibility repair adopted no coefficient. The supplied Kaasa scan was inspected
-at chapter 4 §4.3.2 (printed pp. 100–101) and Appendix F (printed pp. 259–267); no numerical parameter
-was transcribed or adopted because reuse, row lineage, ranges, and independent agreement remain unresolved.
-The current PHREEQC Na/K/Cl values above disagree with the NeqSim legacy binaries and with the PHREEQC 3.8.6 ternary example.
-Although the `C0`/`Cphi` identity is now resolved, the rows remain rejected until their complete
-family lineage, validity range, and independent validation are established.
+The supplied Kaasa scan was inspected at chapter 4 §4.3.2 (printed pp. 100–101) and Appendix F
+(printed pp. 259–267). No Kaasa numerical parameter was transcribed or adopted because reuse, row
+lineage, ranges, and independent agreement remain unresolved. The exact public-domain PHREEQC
+CO2-Na2SO4 subset is the sole new fitted dataset: its complete companion families, equation mapping,
+range evidence, and independent IPhreeqc/held-out gates are recorded above. Current PHREEQC Na/K/Cl
+values still disagree with the NeqSim legacy binaries; they remain rejected until a separately
+versioned complete-family adoption and validation is ready.
 
 ## Unequal-charge electrostatic mixing mapping
 
@@ -121,15 +179,17 @@ Regression values for charges +1/+2 at independently fixed $A_\\phi=0.392$ cover
 A per-thread recurrence workspace preserves concurrency without per-call recurrence allocations, and
 a cached component-topology gate bypasses the kernel for equal-charge and ordinary binary salts.
 
-This mapping does not qualify or adopt any binary, `theta`, or `psi` coefficient. Mixed-brine
-coverage still fails closed until every short-range tuple is explicitly defined. The later sections
-resolve the PHREEQC six-term temperature representation and the `C0`/`Cphi` equation convention;
-neutral-ion terms, parameter-source conflicts, and reaction-species coverage remain unresolved. The supplied Kaasa scan was inspected during this mapping, but no Kaasa numerical value was copied
+The electrostatic mapping itself does not qualify or adopt any binary, `theta`, or `psi` coefficient.
+Mixed-brine coverage still fails closed until every short-range tuple is explicitly defined. The
+later sections resolve the PHREEQC six-term temperature representation, neutral families, and the
+`C0`/`Cphi` equation convention. Parameter-source conflicts outside the qualified CO2-Na2SO4 subset
+and reaction-species coverage remain unresolved. The supplied Kaasa scan was inspected during this mapping, but no Kaasa numerical value was copied
 or adopted. Its same-sign and ternary tables confirm the required family topology; source lineage,
 reuse, validity, and independent numerical agreement remain row-level blockers.
 
-The next dependency is a complete redistributable Na/K/Cl binary–theta–psi set with row-level
-lineage, followed by held-out mixed-brine validation.
+The next parameter dependency is a complete redistributable mixed-oilfield-brine family with
+row-level lineage and held-out mixed-brine validation; the active CO2-Na2SO4 subset is not silently
+expanded with unrelated Na/K/Cl values.
 
 ## Six-term temperature-function mapping
 
@@ -147,12 +207,43 @@ the returned parameter retains the source parameter's units and standard-state c
 
 | Family | PHREEQC six-term support | NeqSim mapping in this increment | Adoption decision |
 | --- | --- | --- | --- |
-| `beta(0)`, `beta(1)`, `C` | `B0`, `B1`, `C0` use all six coefficients | atomic binary setter for `beta0`, `beta1`, and NeqSim `Cphi` | Function adopted; PHREEQC `C0` maps identically to NeqSim `Cphi`; no coefficient adopted |
+| `beta(0)`, `beta(1)`, `C` | `B0`, `B1`, `C0` use all six coefficients | atomic binary setter for `beta0`, `beta1`, and NeqSim `Cphi` | Function adopted; PHREEQC `C0` maps identically to NeqSim `Cphi`; qualified CO2-Na2SO4 coefficients adopted |
 | `beta(2)` | `B2` uses all six coefficients | explicit `beta2` temperature setter and temperature-aware activity/osmotic calls | Function adopted; no coefficient adopted |
 | `theta` | `THETA` uses all six coefficients | sparse same-sign-pair function, including both ion and water paths | Function adopted; no coefficient adopted |
 | `psi` | `PSI` uses all six coefficients | sparse ternary function, including both ion and water paths | Function adopted; no coefficient adopted |
-| `lambda`, `zeta`, `mu`, `eta` | supported by PHREEQC | NeqSim Pitzer does not yet implement these interaction families | Not mapped; fail closed rather than storing a value in another family |
+| `lambda`, `zeta`, `mu`, `eta` | all four use six coefficients | sparse immutable neutral-family tuples in activity and both water/osmotic paths | Function and equation placement adopted; qualified CO2-Na2SO4 `lambda`/`zeta` rows adopted |
 | `Aphi` | optional database function | NeqSim retains its existing water dielectric/density correlation | Not replaced; separate validation is required |
+
+## Neutral-solute interaction mapping
+
+The neutral layer follows the public [PHREEQC PITZER contract](https://water.usgs.gov/water-resources/software/PHREEQC/documentation/phreeqc3-html/phreeqc3-37.htm)
+and exact source commit [`b0b3be7`](https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/src/pitzer.cpp).
+The parameter families remain distinct:
+
+- `lambda` is a pair containing at least one neutral solute: neutral-ion or neutral-neutral;
+- `zeta` is a neutral-cation-anion tuple;
+- `mu` is a neutral-neutral-neutral tuple, including repeated neutral species; and
+- `eta` is a neutral-cation-cation or neutral-anion-anion tuple.
+
+For a distinct lambda pair, each species receives `2 m_other lambda` and the osmotic sum receives
+`m_neutral m_ion lambda`. Zeta and eta use the direct derivative of their three-species molality
+product. Mu preserves PHREEQC's permutation multiplicities: 1 for three identical neutrals, 3 when
+two are identical, and 6 when all are distinct; repeated component slots are differentiated before
+their contributions are accumulated. All four families use the same six-term temperature function
+documented above. The water-activity denominator includes neutral-solute molality only after this
+opt-in layer is configured, which preserves the legacy result exactly when its sparse map is empty.
+
+`PitzerNeutralParameterCoverage` distinguishes absent rows from explicit zero values. Lambda and
+zeta are mandatory for every active neutral/ion topology once the layer is enabled. Mu and eta become
+topology-complete gates when their family is present. This prevents a partly imported gas/brine
+dataset from silently treating an unqualified missing cross-interaction as zero.
+
+The equations are mapped on the molality scale and contribute to natural-log activity coefficients
+and the common Pitzer osmotic sum. They do not convert activity scales, standard states, pressure
+corrections, or species definitions. The Kaasa Appendix F `lambda` and `ksi` (`zeta`) rows for CO2,
+H2S, and CH4 are now structurally representable, but no thesis value is copied or adopted. Row-level
+lineage, reuse rights, range, uncertainty, complete companion interactions, and held-out validation
+remain mandatory before a versioned parameter dataset can use them.
 
 ## PHREEQC `C0` and NeqSim `Cphi` convention
 
@@ -184,13 +275,14 @@ legacy binary systems pay only one predictable boolean branch and non-Pitzer mod
 code. Setter calls are explicit and retain dataset identity and mixed-brine coverage diagnostics.
 Functions survive serialization; clones copy only the sparse map and share immutable function values.
 
-This increment uses synthetic coefficients only to test the public equation at 298.15 and 373.15 K.
-It does not import `pitzer.dat`, change the reaction database, select reactions, or establish a
-parameter validity range. The applicable temperature, pressure, molality, ionic-strength, activity-scale,
-and standard-state limits remain those of the future versioned source dataset, which must be recorded
-row by row before adoption. Extrapolation is evaluated continuously but is not represented as validated.
+Synthetic coefficients continue to isolate the public equation mapping at 298.15 and 373.15 K.
+Separately, the named PHREEQC CO2-Na2SO4 helper embeds only the qualified rows listed above; it does
+not bulk-import `pitzer.dat`, change the reaction database, or select reactions. Its explicit
+temperature/molality evidence envelope does not make pressure-dependent VLE, extrapolation, or any
+additional species topology validated.
 
 The supplied Kaasa (1998) scan was visually inspected at chapter 4 §4.3.2 and Appendix F.
 Its family inventory and coefficient-order convention are recorded above, but no numerical table value
-was copied or adopted. The next parameter dependency is a redistributable, independently checked Na/K/Cl binary–theta–psi set with row-level
-lineage and held-out mean-activity, osmotic, water-activity, speciation, and mixed-brine validation.
+was copied or adopted. The next parameter dependency is a redistributable, independently checked
+mixed oilfield-brine family with row-level lineage and held-out mean-activity, osmotic,
+water-activity, speciation, and mixed-brine validation.

--- a/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
@@ -13,6 +13,17 @@ import neqsim.thermo.phase.PitzerElectrostaticMixing;
 public class ComponentGePitzer extends ComponentGE {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Setup-time mirror of the phase's sparse neutral-interaction gate. */
+  private boolean neutralPitzerInteractionsActive;
+
+  /**
+   * Updates the setup-time fast gate for neutral Pitzer interactions.
+   *
+   * @param active whether the owning Pitzer phase has any neutral interactions
+   */
+  public void setNeutralPitzerInteractionsActive(boolean active) {
+    neutralPitzerInteractionsActive = active;
+  }
 
   /**
    * Constructor for ComponentGePitzer.
@@ -90,7 +101,8 @@ public class ComponentGePitzer extends ComponentGE {
    * For ions (charge != 0): computes the single-ion activity coefficient from the Pitzer Debye-Huckel term and binary
    * cation-anion interaction parameters. For the solvent (water, referenceStateType = "solvent"): computes the activity
    * coefficient from the Pitzer osmotic coefficient using the Harvie and Weare (1980) mixed-electrolyte framework. For
-   * other neutral species (dissolved gases): returns gamma = 1.0 (no lambda/mu parameters available).
+   * other neutral species (dissolved gases): applies the explicitly configured lambda, zeta, mu, and eta families, with
+   * an exact gamma = 1.0 legacy fallback when that sparse layer is empty.
    * </p>
    *
    * @param phase phase object
@@ -103,6 +115,7 @@ public class ComponentGePitzer extends ComponentGE {
   public double getGamma(PhaseInterface phase, int numberOfComponents, double temperature, double pressure,
       PhaseType pt) {
     double charge = getIonicCharge();
+    PhasePitzer pitz = (PhasePitzer) phase;
 
     // Solvent (water): compute gamma from Pitzer osmotic coefficient
     if (Math.abs(charge) < 0.5 && "water".equalsIgnoreCase(getComponentName())
@@ -110,10 +123,12 @@ public class ComponentGePitzer extends ComponentGE {
       return getWaterGamma(phase, numberOfComponents, temperature);
     }
 
-    // Non-ionic, non-solvent species (dissolved gases): no Pitzer interaction parameters
+    // Non-ionic, non-solvent species use the sparse neutral Pitzer layer when configured.
     if (Math.abs(charge) < 0.5) {
-      gamma = 1.0;
-      lngamma = 0.0;
+      lngamma = neutralPitzerInteractionsActive
+          ? pitz.getNeutralPitzerLogGammaContribution(componentNumber, temperature)
+          : 0.0;
+      gamma = Math.exp(lngamma);
       return gamma;
     }
 
@@ -122,7 +137,6 @@ public class ComponentGePitzer extends ComponentGE {
     // F = -Aphi*[sqrtI/(1+b*sqrtI) + (2/b)*ln(1+b*sqrtI)] + sum_c sum_a m_c*m_a*B'_ca
     // Handles 1-1, 1-2, 2-1 electrolytes (alpha=2.0) and 2-2 electrolytes
     // (alpha1=1.4, alpha2=12.0 with beta2 parameter per Harvie & Weare 1984).
-    PhasePitzer pitz = (PhasePitzer) phase;
     double I = pitz.getIonicStrength();
     double sqrtI = Math.sqrt(I);
     // debyeHuckelAphi() returns Agamma = 3*Aphi; convert to Aphi for Pitzer formula
@@ -269,6 +283,9 @@ public class ComponentGePitzer extends ComponentGE {
     // ln(gamma_M) = z_M^2 * F + binary/mixing terms
     double F = fDH + fBprime + fEthetaPrime;
     lngamma = charge * charge * F + sum;
+    if (neutralPitzerInteractionsActive) {
+      lngamma += pitz.getNeutralPitzerLogGammaContribution(componentNumber, temperature);
+    }
     gamma = Math.exp(lngamma);
     return gamma;
   }
@@ -306,10 +323,11 @@ public class ComponentGePitzer extends ComponentGE {
     double Aphi = debyeHuckelAphi(TK) / 3.0;
     double b = 1.2;
 
-    // Sum of all ion molalities
+    // Preserve the legacy ion-only denominator until a neutral Pitzer dataset is explicitly active.
     double sumMolalities = 0.0;
     for (int k = 0; k < numberOfComponents; k++) {
-      if (phase.getComponent(k).getIonicCharge() != 0) {
+      boolean isWater = "water".equalsIgnoreCase(phase.getComponent(k).getComponentName());
+      if (phase.getComponent(k).getIonicCharge() != 0 || (neutralPitzerInteractionsActive && !isWater)) {
         sumMolalities += phase.getComponent(k).getMolality(phase);
       }
     }
@@ -446,8 +464,9 @@ public class ComponentGePitzer extends ComponentGE {
       }
     }
 
-    // Osmotic coefficient: phi - 1 = (2/sumM) * (fPhi + binarySum + thetaPsiSum)
-    double phi = 1.0 + (2.0 / sumMolalities) * (fPhi + binarySum + thetaPsiSum);
+    double neutralSum = neutralPitzerInteractionsActive ? pitz.getNeutralPitzerOsmoticContribution(TK) : 0.0;
+    // Osmotic coefficient: phi - 1 = (2/sumM) * interaction sum
+    double phi = 1.0 + (2.0 / sumMolalities) * (fPhi + binarySum + thetaPsiSum + neutralSum);
 
     // Water activity: ln(a_w) = -phi * M_w * sumM / 1000
     double Mw = 18.015; // molar mass of water in g/mol

--- a/src/main/java/neqsim/thermo/phase/PhasePitzer.java
+++ b/src/main/java/neqsim/thermo/phase/PhasePitzer.java
@@ -35,6 +35,10 @@ public class PhasePitzer extends PhaseGE {
   private static final int TEMPERATURE_BETA2 = 4;
   private static final int TEMPERATURE_THETA = 5;
   private static final int TEMPERATURE_PSI = 6;
+  static final int NEUTRAL_FAMILY_LAMBDA = 7;
+  static final int NEUTRAL_FAMILY_ZETA = 8;
+  static final int NEUTRAL_FAMILY_MU = 9;
+  static final int NEUTRAL_FAMILY_ETA = 10;
 
   private double[][] beta0;
   private double[][] beta1;
@@ -59,6 +63,12 @@ public class PhasePitzer extends PhaseGE {
   private Map<Long, PitzerTemperatureFunction> temperatureFunctions = new HashMap<Long, PitzerTemperatureFunction>();
   /** Fast gate that avoids map lookup for legacy parameter datasets. */
   private boolean hasTemperatureFunctions;
+  /** Sparse opt-in neutral-solute interaction families, keyed without tuple allocation. */
+  private Map<Long, PitzerNeutralInteraction> neutralInteractions = new HashMap<Long, PitzerNeutralInteraction>();
+  /** Fast gate keeping legacy Pitzer and every non-Pitzer path out of neutral interaction loops. */
+  private boolean hasNeutralInteractions;
+  /** Whether the active neutral-solute topology has passed its fail-closed parameter audit. */
+  private transient boolean neutralParameterCoverageValidated;
   /** Whether parameters have been loaded from database. */
   private boolean parametersLoaded = false;
   /** Whether immutable parameter arrays are shared with a clone until the next setter call. */
@@ -107,6 +117,7 @@ public class PhasePitzer extends PhaseGE {
   public PhasePitzer clone() {
     ensureDefinitionSets();
     ensureTemperatureFunctions();
+    ensureNeutralInteractions();
     PhasePitzer clonedPhase = (PhasePitzer) super.clone();
     parameterStorageShared = true;
     clonedPhase.parameterStorageShared = true;
@@ -114,10 +125,12 @@ public class PhasePitzer extends PhaseGE {
     clonedPhase.definedThetaPairs = new HashSet<String>(definedThetaPairs);
     clonedPhase.definedPsiTuples = new HashSet<String>(definedPsiTuples);
     clonedPhase.temperatureFunctions = new HashMap<Long, PitzerTemperatureFunction>(temperatureFunctions);
+    clonedPhase.neutralInteractions = new HashMap<Long, PitzerNeutralInteraction>(neutralInteractions);
     clonedPhase.cachedCoverageFingerprint = 0L;
     clonedPhase.cachedCoverageRevision = Long.MIN_VALUE;
     clonedPhase.cachedCoverage = null;
     clonedPhase.parameterCoverageValidated = false;
+    clonedPhase.neutralParameterCoverageValidated = false;
     clonedPhase.unequalChargeSameSignPairState = unequalChargeSameSignPairState;
     return clonedPhase;
   }
@@ -127,6 +140,7 @@ public class PhasePitzer extends PhaseGE {
   public void init(double totalNumberOfMoles, int numberOfComponents, int initType, PhaseType pt, double beta) {
     if (initType == 0) {
       parameterCoverageValidated = false;
+      neutralParameterCoverageValidated = false;
     }
     super.init(totalNumberOfMoles, numberOfComponents, initType, pt, beta);
   }
@@ -136,7 +150,9 @@ public class PhasePitzer extends PhaseGE {
   public void addComponent(String name, double moles, double molesInPhase, int compNumber) {
     super.addComponent(name, molesInPhase, compNumber);
     componentArray[compNumber] = new ComponentGePitzer(name, moles, molesInPhase, compNumber);
+    ((ComponentGePitzer) componentArray[compNumber]).setNeutralPitzerInteractionsActive(hasNeutralInteractions);
     unequalChargeSameSignPairState = 0;
+    neutralParameterCoverageValidated = false;
   }
 
   /**
@@ -371,6 +387,207 @@ public class PhasePitzer extends PhaseGE {
     PitzerTemperatureFunction function = new PitzerTemperatureFunction(referenceTemperature, coefficients);
     setPsi(i, j, k, coefficients[0]);
     setTemperatureFunction(tripleTemperatureKey(TEMPERATURE_PSI, i, j, k), function);
+  }
+
+  /**
+   * Sets a constant Pitzer lambda parameter containing at least one neutral solute.
+   *
+   * @param first first component index
+   * @param second second component index; may be an ion or another neutral solute
+   * @param value lambda parameter on the source dataset's molality convention
+   */
+  public void setLambda(int first, int second, double value) {
+    setLambdaTemperatureCoefficients(first, second, 298.15, new double[] { value, 0.0, 0.0, 0.0, 0.0, 0.0 });
+  }
+
+  /**
+   * Sets a PHREEQC six-term lambda temperature function containing at least one neutral solute.
+   *
+   * @param first first component index
+   * @param second second component index; may be an ion or another neutral solute
+   * @param referenceTemperature reference temperature in K
+   * @param coefficients six coefficients in PHREEQC order
+   */
+  public void setLambdaTemperatureCoefficients(int first, int second, double referenceTemperature,
+      double[] coefficients) {
+    requireComponentIndex(first);
+    requireComponentIndex(second);
+    if (!isNeutralSolute(first) && !isNeutralSolute(second)) {
+      throw new IllegalArgumentException("Pitzer lambda requires at least one neutral non-water solute");
+    }
+    if ((!isNeutralSolute(first) && Math.abs(getComponent(first).getIonicCharge()) < 0.5)
+        || (!isNeutralSolute(second) && Math.abs(getComponent(second).getIonicCharge()) < 0.5)) {
+      throw new IllegalArgumentException("Pitzer lambda does not permit water");
+    }
+    setNeutralInteraction(NEUTRAL_FAMILY_LAMBDA, new int[] { first, second },
+        new PitzerTemperatureFunction(referenceTemperature, coefficients));
+  }
+
+  /**
+   * Sets a constant neutral-cation-anion Pitzer zeta parameter.
+   *
+   * @param neutral neutral non-water component index
+   * @param cation cation component index
+   * @param anion anion component index
+   * @param value zeta parameter
+   */
+  public void setZeta(int neutral, int cation, int anion, double value) {
+    setZetaTemperatureCoefficients(neutral, cation, anion, 298.15, new double[] { value, 0.0, 0.0, 0.0, 0.0, 0.0 });
+  }
+
+  /**
+   * Sets a PHREEQC six-term neutral-cation-anion zeta temperature function.
+   *
+   * @param neutral neutral non-water component index
+   * @param cation cation component index
+   * @param anion anion component index
+   * @param referenceTemperature reference temperature in K
+   * @param coefficients six coefficients in PHREEQC order
+   */
+  public void setZetaTemperatureCoefficients(int neutral, int cation, int anion, double referenceTemperature,
+      double[] coefficients) {
+    requireNeutralSolute(neutral, "zeta");
+    requireChargeSign(cation, 1, "zeta cation");
+    requireChargeSign(anion, -1, "zeta anion");
+    setNeutralInteraction(NEUTRAL_FAMILY_ZETA, new int[] { neutral, cation, anion },
+        new PitzerTemperatureFunction(referenceTemperature, coefficients));
+  }
+
+  /**
+   * Sets a constant neutral-neutral-neutral Pitzer mu parameter.
+   *
+   * @param first first neutral non-water component index
+   * @param second second neutral non-water component index
+   * @param third third neutral non-water component index
+   * @param value mu parameter
+   */
+  public void setMu(int first, int second, int third, double value) {
+    setMuTemperatureCoefficients(first, second, third, 298.15, new double[] { value, 0.0, 0.0, 0.0, 0.0, 0.0 });
+  }
+
+  /**
+   * Sets a PHREEQC six-term neutral-neutral-neutral mu temperature function.
+   *
+   * @param first first neutral non-water component index
+   * @param second second neutral non-water component index
+   * @param third third neutral non-water component index
+   * @param referenceTemperature reference temperature in K
+   * @param coefficients six coefficients in PHREEQC order
+   */
+  public void setMuTemperatureCoefficients(int first, int second, int third, double referenceTemperature,
+      double[] coefficients) {
+    requireNeutralSolute(first, "mu");
+    requireNeutralSolute(second, "mu");
+    requireNeutralSolute(third, "mu");
+    setNeutralInteraction(NEUTRAL_FAMILY_MU, new int[] { first, second, third },
+        new PitzerTemperatureFunction(referenceTemperature, coefficients));
+  }
+
+  /**
+   * Sets a constant neutral/same-sign-ion Pitzer eta parameter.
+   *
+   * @param neutral neutral non-water component index
+   * @param firstIon first ionic component index
+   * @param secondIon second same-sign ionic component index
+   * @param value eta parameter
+   */
+  public void setEta(int neutral, int firstIon, int secondIon, double value) {
+    setEtaTemperatureCoefficients(neutral, firstIon, secondIon, 298.15,
+        new double[] { value, 0.0, 0.0, 0.0, 0.0, 0.0 });
+  }
+
+  /**
+   * Sets a PHREEQC six-term neutral/same-sign-ion eta temperature function.
+   *
+   * @param neutral neutral non-water component index
+   * @param firstIon first ionic component index
+   * @param secondIon second same-sign ionic component index
+   * @param referenceTemperature reference temperature in K
+   * @param coefficients six coefficients in PHREEQC order
+   */
+  public void setEtaTemperatureCoefficients(int neutral, int firstIon, int secondIon, double referenceTemperature,
+      double[] coefficients) {
+    requireNeutralSolute(neutral, "eta");
+    requireIon(firstIon, "eta");
+    requireIon(secondIon, "eta");
+    if (getComponent(firstIon).getIonicCharge() * getComponent(secondIon).getIonicCharge() <= 0.0) {
+      throw new IllegalArgumentException("Pitzer eta requires two ions with the same charge sign");
+    }
+    setNeutralInteraction(NEUTRAL_FAMILY_ETA, new int[] { neutral, firstIon, secondIon },
+        new PitzerTemperatureFunction(referenceTemperature, coefficients));
+  }
+
+  /**
+   * Gets a temperature-adjusted neutral-ion or neutral-neutral lambda parameter.
+   *
+   * @param first first component index
+   * @param second second component index
+   * @param temperature temperature in K
+   * @return lambda value, or zero when the tuple is not defined
+   */
+  public double getLambda(int first, int second, double temperature) {
+    return getNeutralInteractionValue(NEUTRAL_FAMILY_LAMBDA, first, second, -1, temperature);
+  }
+
+  /** Gets a temperature-adjusted zeta parameter, or zero when absent. */
+  public double getZeta(int neutral, int cation, int anion, double temperature) {
+    return getNeutralInteractionValue(NEUTRAL_FAMILY_ZETA, neutral, cation, anion, temperature);
+  }
+
+  /** Gets a temperature-adjusted mu parameter, or zero when absent. */
+  public double getMu(int first, int second, int third, double temperature) {
+    return getNeutralInteractionValue(NEUTRAL_FAMILY_MU, first, second, third, temperature);
+  }
+
+  /** Gets a temperature-adjusted eta parameter, or zero when absent. */
+  public double getEta(int neutral, int firstIon, int secondIon, double temperature) {
+    return getNeutralInteractionValue(NEUTRAL_FAMILY_ETA, neutral, firstIon, secondIon, temperature);
+  }
+
+  /**
+   * Reports whether the sparse neutral-solute interaction layer is active.
+   *
+   * @return {@code true} after at least one lambda, zeta, mu, or eta tuple is defined
+   */
+  public boolean hasNeutralPitzerInteractions() {
+    return hasNeutralInteractions;
+  }
+
+  /**
+   * Calculates all neutral-family contributions to one component's ln(gamma).
+   *
+   * @param componentIndex target component index
+   * @param temperature temperature in K
+   * @return neutral-family contribution to ln(gamma)
+   */
+  public double getNeutralPitzerLogGammaContribution(int componentIndex, double temperature) {
+    if (!hasNeutralInteractions) {
+      return 0.0;
+    }
+    validateNeutralParameterCoverageOncePerState();
+    double contribution = 0.0;
+    for (PitzerNeutralInteraction interaction : neutralInteractions.values()) {
+      contribution += interaction.logGammaContribution(componentIndex, this, temperature);
+    }
+    return contribution;
+  }
+
+  /**
+   * Calculates all neutral-family contributions to PHREEQC's osmotic sum.
+   *
+   * @param temperature temperature in K
+   * @return contribution before the common {@code 2/sum(m)} factor
+   */
+  public double getNeutralPitzerOsmoticContribution(double temperature) {
+    if (!hasNeutralInteractions) {
+      return 0.0;
+    }
+    validateNeutralParameterCoverageOncePerState();
+    double contribution = 0.0;
+    for (PitzerNeutralInteraction interaction : neutralInteractions.values()) {
+      contribution += interaction.osmoticContribution(this, temperature);
+    }
+    return contribution;
   }
 
   /**
@@ -1033,6 +1250,8 @@ public class PhasePitzer extends PhaseGE {
         double molality = getComponent(i).getMolality(this);
         sumMolalities += molality;
         zSum += Math.abs(charge) * molality;
+      } else if (hasNeutralInteractions && isNeutralSolute(i)) {
+        sumMolalities += getComponent(i).getMolality(this);
       }
     }
 
@@ -1061,7 +1280,8 @@ public class PhasePitzer extends PhaseGE {
     }
 
     double thetaPsiSum = getThetaPsiOsmoticContribution(ionicStrength, aPhi);
-    return 1.0 + (2.0 / sumMolalities) * (fPhi + binarySum + thetaPsiSum);
+    double neutralSum = hasNeutralInteractions ? getNeutralPitzerOsmoticContribution(temperature) : 0.0;
+    return 1.0 + (2.0 / sumMolalities) * (fPhi + binarySum + thetaPsiSum + neutralSum);
   }
 
   /**
@@ -1356,6 +1576,200 @@ public class PhasePitzer extends PhaseGE {
     ensureTemperatureFunctions();
     temperatureFunctions.put(key, function);
     hasTemperatureFunctions = true;
+  }
+
+  /**
+   * Audits neutral Pitzer families against the active opt-in topology.
+   *
+   * <p>
+   * Once any neutral family is configured, lambda is required for every active neutral-neutral pair (with repetition)
+   * and neutral-ion pair, and zeta for every active neutral-cation-anion tuple. Mu and eta are audited across their
+   * active topology only when that higher-order family is present in the selected dataset. An explicitly defined zero
+   * counts as a definition.
+   * </p>
+   *
+   * @return immutable coverage diagnostic
+   */
+  public PitzerNeutralParameterCoverage auditNeutralPitzerParameterCoverage() {
+    ensureDefinitionSets();
+    ensureNeutralInteractions();
+    List<Integer> neutrals = new ArrayList<Integer>();
+    List<Integer> cations = new ArrayList<Integer>();
+    List<Integer> anions = new ArrayList<Integer>();
+    List<String> neutralNames = new ArrayList<String>();
+    double activeMoles = ACTIVE_ION_MOLALITY * getSolventWeight();
+    for (int index = 0; index < numberOfComponents; index++) {
+      if (getComponent(index).getNumberOfMolesInPhase() <= activeMoles) {
+        continue;
+      }
+      double charge = getComponent(index).getIonicCharge();
+      if (Math.abs(charge) < 0.5) {
+        if (isNeutralSolute(index)) {
+          neutrals.add(index);
+          neutralNames.add(componentName(index));
+        }
+      } else if (charge > 0.0) {
+        cations.add(index);
+      } else {
+        anions.add(index);
+      }
+    }
+
+    List<String> missingLambda = new ArrayList<String>();
+    List<String> missingZeta = new ArrayList<String>();
+    List<String> missingMu = new ArrayList<String>();
+    List<String> missingEta = new ArrayList<String>();
+    for (int neutralPosition = 0; neutralPosition < neutrals.size(); neutralPosition++) {
+      int neutral = neutrals.get(neutralPosition);
+      for (int secondNeutral = neutralPosition; secondNeutral < neutrals.size(); secondNeutral++) {
+        addMissingPairIfAbsent(NEUTRAL_FAMILY_LAMBDA, neutral, neutrals.get(secondNeutral), missingLambda);
+      }
+      for (int cation : cations) {
+        addMissingPairIfAbsent(NEUTRAL_FAMILY_LAMBDA, neutral, cation, missingLambda);
+      }
+      for (int anion : anions) {
+        addMissingPairIfAbsent(NEUTRAL_FAMILY_LAMBDA, neutral, anion, missingLambda);
+      }
+      for (int cation : cations) {
+        for (int anion : anions) {
+          addMissingTripleIfAbsent(NEUTRAL_FAMILY_ZETA, neutral, cation, anion, missingZeta);
+        }
+      }
+    }
+
+    if (hasNeutralFamily(NEUTRAL_FAMILY_MU)) {
+      for (int first = 0; first < neutrals.size(); first++) {
+        for (int second = first; second < neutrals.size(); second++) {
+          for (int third = second; third < neutrals.size(); third++) {
+            addMissingTripleIfAbsent(NEUTRAL_FAMILY_MU, neutrals.get(first), neutrals.get(second), neutrals.get(third),
+                missingMu);
+          }
+        }
+      }
+    }
+    if (hasNeutralFamily(NEUTRAL_FAMILY_ETA)) {
+      for (int neutral : neutrals) {
+        addMissingEtaPairs(neutral, cations, missingEta);
+        addMissingEtaPairs(neutral, anions, missingEta);
+      }
+    }
+
+    return new PitzerNeutralParameterCoverage(parameterDatasetId, neutralNames, missingLambda, missingZeta, missingMu,
+        missingEta);
+  }
+
+  /** Throws a deterministic diagnostic when the active neutral topology is incomplete. */
+  public void requireCompleteNeutralPitzerParameterCoverage() {
+    PitzerNeutralParameterCoverage coverage = auditNeutralPitzerParameterCoverage();
+    if (!coverage.isComplete()) {
+      throw new IllegalStateException(coverage.formatDiagnostic());
+    }
+  }
+
+  private void addMissingEtaPairs(int neutral, List<Integer> ions, List<String> missing) {
+    for (int first = 0; first < ions.size(); first++) {
+      for (int second = first + 1; second < ions.size(); second++) {
+        addMissingTripleIfAbsent(NEUTRAL_FAMILY_ETA, neutral, ions.get(first), ions.get(second), missing);
+      }
+    }
+  }
+
+  private void addMissingPairIfAbsent(int family, int first, int second, List<String> missing) {
+    if (!neutralInteractions.containsKey(pairTemperatureKey(family, first, second))) {
+      missing.add(pairKey(componentName(first), componentName(second)));
+    }
+  }
+
+  private void addMissingTripleIfAbsent(int family, int first, int second, int third, List<String> missing) {
+    if (!neutralInteractions.containsKey(tripleTemperatureKey(family, first, second, third))) {
+      missing.add(psiKey(componentName(first), componentName(second), componentName(third)));
+    }
+  }
+
+  private boolean hasNeutralFamily(int family) {
+    for (PitzerNeutralInteraction interaction : neutralInteractions.values()) {
+      if (interaction.getFamily() == family) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void setNeutralInteraction(int family, int[] componentIndexes, PitzerTemperatureFunction function) {
+    ensureNeutralInteractions();
+    long key = componentIndexes.length == 2 ? pairTemperatureKey(family, componentIndexes[0], componentIndexes[1])
+        : tripleTemperatureKey(family, componentIndexes[0], componentIndexes[1], componentIndexes[2]);
+    neutralInteractions.put(key, new PitzerNeutralInteraction(family, componentIndexes, function));
+    hasNeutralInteractions = true;
+    for (int index = 0; index < numberOfComponents; index++) {
+      ((ComponentGePitzer) componentArray[index]).setNeutralPitzerInteractionsActive(true);
+    }
+    neutralParameterCoverageValidated = false;
+    invalidateCoverageCache();
+  }
+
+  private double getNeutralInteractionValue(int family, int first, int second, int third, double temperature) {
+    if (!hasNeutralInteractions) {
+      return 0.0;
+    }
+    ensureNeutralInteractions();
+    long key = third < 0 ? pairTemperatureKey(family, first, second)
+        : tripleTemperatureKey(family, first, second, third);
+    PitzerNeutralInteraction interaction = neutralInteractions.get(key);
+    return interaction == null ? 0.0 : interaction.valueAt(temperature);
+  }
+
+  private void requireNeutralSolute(int index, String family) {
+    requireComponentIndex(index);
+    if (!isNeutralSolute(index)) {
+      throw new IllegalArgumentException("Pitzer " + family + " requires a neutral non-water solute");
+    }
+  }
+
+  private void requireIon(int index, String family) {
+    requireComponentIndex(index);
+    if (Math.abs(getComponent(index).getIonicCharge()) < 0.5) {
+      throw new IllegalArgumentException("Pitzer " + family + " requires an ionic species");
+    }
+  }
+
+  private void requireChargeSign(int index, int sign, String role) {
+    requireComponentIndex(index);
+    if (sign * getComponent(index).getIonicCharge() <= 0.0) {
+      throw new IllegalArgumentException("Pitzer " + role + " has the wrong charge sign");
+    }
+  }
+
+  private void requireComponentIndex(int index) {
+    if (index < 0 || index >= numberOfComponents) {
+      throw new IllegalArgumentException("Pitzer component index out of range: " + index);
+    }
+  }
+
+  private boolean isNeutralSolute(int index) {
+    return Math.abs(getComponent(index).getIonicCharge()) < 0.5 && !"water".equalsIgnoreCase(componentName(index));
+  }
+
+  private void validateNeutralParameterCoverageOncePerState() {
+    if (hasNeutralInteractions && !neutralParameterCoverageValidated) {
+      requireCompleteNeutralPitzerParameterCoverage();
+      neutralParameterCoverageValidated = true;
+    }
+  }
+
+  /** Ensures sparse neutral-interaction state exists for older serialized objects. */
+  private void ensureNeutralInteractions() {
+    if (neutralInteractions == null) {
+      neutralInteractions = new HashMap<Long, PitzerNeutralInteraction>();
+      hasNeutralInteractions = false;
+    }
+  }
+
+  /** Marks a package-owned coherent parameter dataset as complete without loading the legacy table. */
+  void markManualParameterDatasetLoaded() {
+    parametersLoaded = true;
+    parameterCoverageValidated = false;
+    neutralParameterCoverageValidated = false;
   }
 
   /** Returns a binary temperature function without key allocation for legacy datasets. */

--- a/src/main/java/neqsim/thermo/phase/PitzerNeutralInteraction.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerNeutralInteraction.java
@@ -1,0 +1,120 @@
+package neqsim.thermo.phase;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Immutable sparse Pitzer interaction involving at least one neutral solute.
+ *
+ * <p>
+ * The activity and osmotic multiplicities follow the public-domain PHREEQC implementation. Lambda is a pair containing
+ * at least one neutral solute (neutral-ion or neutral-neutral), zeta is neutral-cation-anion, mu is
+ * neutral-neutral-neutral, and eta is neutral-cation-cation or neutral-anion-anion. Component order is immaterial.
+ * </p>
+ */
+final class PitzerNeutralInteraction implements Serializable {
+  /** Serialization version UID. */
+  private static final long serialVersionUID = 1000;
+
+  private final int family;
+  private final int[] componentIndexes;
+  private final double[] logGammaCoefficients;
+  private final double osmoticCoefficient;
+  private final PitzerTemperatureFunction temperatureFunction;
+
+  /**
+   * Creates an immutable interaction and its PHREEQC multiplicities.
+   *
+   * @param family parameter-family identifier
+   * @param componentIndexes component indexes, already validated by {@link PhasePitzer}
+   * @param temperatureFunction parameter temperature function
+   */
+  PitzerNeutralInteraction(int family, int[] componentIndexes, PitzerTemperatureFunction temperatureFunction) {
+    this.family = family;
+    this.componentIndexes = componentIndexes.clone();
+    Arrays.sort(this.componentIndexes);
+    this.temperatureFunction = temperatureFunction;
+
+    if (this.componentIndexes.length == 2) {
+      if (this.componentIndexes[0] == this.componentIndexes[1]) {
+        // PHREEQC differentiates both slots before accumulating them for the repeated species.
+        logGammaCoefficients = new double[] { 1.0, 1.0 };
+        osmoticCoefficient = 0.5;
+      } else {
+        logGammaCoefficients = new double[] { 2.0, 2.0 };
+        osmoticCoefficient = 1.0;
+      }
+    } else if (family == PhasePitzer.NEUTRAL_FAMILY_MU) {
+      double multiplicity;
+      if (this.componentIndexes[0] == this.componentIndexes[2]) {
+        multiplicity = 1.0;
+      } else if (this.componentIndexes[0] == this.componentIndexes[1]
+          || this.componentIndexes[1] == this.componentIndexes[2]) {
+        multiplicity = 3.0;
+      } else {
+        multiplicity = 6.0;
+      }
+      logGammaCoefficients = new double[] { multiplicity, multiplicity, multiplicity };
+      osmoticCoefficient = multiplicity;
+    } else {
+      logGammaCoefficients = new double[] { 1.0, 1.0, 1.0 };
+      osmoticCoefficient = 1.0;
+    }
+  }
+
+  /** @return parameter-family identifier */
+  int getFamily() {
+    return family;
+  }
+
+  /**
+   * Returns the parameter value at temperature.
+   *
+   * @param temperature temperature in K
+   * @return parameter value
+   */
+  double valueAt(double temperature) {
+    return temperatureFunction.valueAt(temperature);
+  }
+
+  /**
+   * Calculates this interaction's contribution to one component's natural-log activity coefficient.
+   *
+   * @param componentIndex target component index
+   * @param phase Pitzer phase containing current molalities
+   * @param temperature temperature in K
+   * @return contribution to ln(gamma)
+   */
+  double logGammaContribution(int componentIndex, PhasePitzer phase, double temperature) {
+    double contribution = 0.0;
+    double parameter = valueAt(temperature);
+    for (int position = 0; position < componentIndexes.length; position++) {
+      if (componentIndexes[position] != componentIndex) {
+        continue;
+      }
+      double molalityProduct = 1.0;
+      for (int other = 0; other < componentIndexes.length; other++) {
+        if (other != position) {
+          molalityProduct *= phase.getComponent(componentIndexes[other]).getMolality(phase);
+        }
+      }
+      contribution += logGammaCoefficients[position] * molalityProduct * parameter;
+    }
+    return contribution;
+  }
+
+  /**
+   * Calculates this interaction's contribution to PHREEQC's osmotic sum.
+   *
+   * @param phase Pitzer phase containing current molalities
+   * @param temperature temperature in K
+   * @return contribution before the common {@code 2/sum(m)} factor
+   */
+  double osmoticContribution(PhasePitzer phase, double temperature) {
+    double molalityProduct = 1.0;
+    for (int componentIndex : componentIndexes) {
+      molalityProduct *= phase.getComponent(componentIndex).getMolality(phase);
+    }
+    return osmoticCoefficient * molalityProduct * valueAt(temperature);
+  }
+}

--- a/src/main/java/neqsim/thermo/phase/PitzerNeutralParameterCoverage.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerNeutralParameterCoverage.java
@@ -1,0 +1,89 @@
+package neqsim.thermo.phase;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Immutable diagnostic for sparse neutral-solute Pitzer parameter coverage. */
+public final class PitzerNeutralParameterCoverage implements Serializable {
+  /** Serialization version UID. */
+  private static final long serialVersionUID = 1000;
+
+  private final String datasetId;
+  private final List<String> activeNeutralSolutes;
+  private final List<String> missingLambdaPairs;
+  private final List<String> missingZetaTuples;
+  private final List<String> missingMuTuples;
+  private final List<String> missingEtaTuples;
+
+  /**
+   * Creates an immutable coverage diagnostic.
+   *
+   * @param datasetId parameter-dataset identity
+   * @param activeNeutralSolutes active non-water neutral solutes
+   * @param missingLambdaPairs missing neutral-neutral or neutral-ion pairs
+   * @param missingZetaTuples missing neutral-cation-anion tuples
+   * @param missingMuTuples missing neutral triples when the mu family is enabled
+   * @param missingEtaTuples missing neutral/same-sign-ion tuples when eta is enabled
+   */
+  public PitzerNeutralParameterCoverage(String datasetId, List<String> activeNeutralSolutes,
+      List<String> missingLambdaPairs, List<String> missingZetaTuples, List<String> missingMuTuples,
+      List<String> missingEtaTuples) {
+    this.datasetId = datasetId;
+    this.activeNeutralSolutes = immutableSortedCopy(activeNeutralSolutes);
+    this.missingLambdaPairs = immutableSortedCopy(missingLambdaPairs);
+    this.missingZetaTuples = immutableSortedCopy(missingZetaTuples);
+    this.missingMuTuples = immutableSortedCopy(missingMuTuples);
+    this.missingEtaTuples = immutableSortedCopy(missingEtaTuples);
+  }
+
+  /** @return parameter-dataset identity */
+  public String getDatasetId() {
+    return datasetId;
+  }
+
+  /** @return active non-water neutral solutes */
+  public List<String> getActiveNeutralSolutes() {
+    return activeNeutralSolutes;
+  }
+
+  /** @return missing neutral-neutral or neutral-ion lambda pairs */
+  public List<String> getMissingLambdaPairs() {
+    return missingLambdaPairs;
+  }
+
+  /** @return missing neutral-cation-anion zeta tuples */
+  public List<String> getMissingZetaTuples() {
+    return missingZetaTuples;
+  }
+
+  /** @return missing neutral mu tuples */
+  public List<String> getMissingMuTuples() {
+    return missingMuTuples;
+  }
+
+  /** @return missing neutral/same-sign-ion eta tuples */
+  public List<String> getMissingEtaTuples() {
+    return missingEtaTuples;
+  }
+
+  /** @return {@code true} when every required tuple is explicitly defined */
+  public boolean isComplete() {
+    return missingLambdaPairs.isEmpty() && missingZetaTuples.isEmpty() && missingMuTuples.isEmpty()
+        && missingEtaTuples.isEmpty();
+  }
+
+  /** @return deterministic diagnostic suitable for an exception */
+  public String formatDiagnostic() {
+    return "Neutral Pitzer parameter coverage incomplete for dataset '" + datasetId + "': activeNeutralSolutes="
+        + activeNeutralSolutes + ", missingLambda=" + missingLambdaPairs + ", missingZeta=" + missingZetaTuples
+        + ", missingMu=" + missingMuTuples + ", missingEta=" + missingEtaTuples;
+  }
+
+  private static List<String> immutableSortedCopy(List<String> values) {
+    List<String> copy = new ArrayList<String>(values);
+    Collections.sort(copy);
+    return Collections.unmodifiableList(copy);
+  }
+}

--- a/src/main/java/neqsim/thermo/phase/PitzerParameterDatasets.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerParameterDatasets.java
@@ -1,0 +1,106 @@
+package neqsim.thermo.phase;
+
+/**
+ * Coherent, versioned Pitzer parameter datasets whose equation conventions and public provenance have been mapped to
+ * {@link PhasePitzer}.
+ *
+ * <p>
+ * A dataset method configures only the named species system and marks that phase as manually populated so the legacy
+ * NeqSim table is not mixed into it. Additional active species remain subject to the normal fail-closed binary,
+ * mixed-ion, and neutral-family coverage diagnostics.
+ * </p>
+ */
+public final class PitzerParameterDatasets {
+  /**
+   * Exact source identity for the public-domain PHREEQC CO2-Na2SO4 subset.
+   */
+  public static final String PHREEQC_CO2_NA2SO4_ID = "usgs-phreeqc-pitzer-b0b3be767158ccc3322d2c816625cf470045e67e-co2-na2so4-v1";
+
+  /** Reference temperature of the PHREEQC six-term functions, in K. */
+  public static final double PHREEQC_REFERENCE_TEMPERATURE_K = 298.15;
+
+  /**
+   * Lower temperature of the independent CO2-Na2SO4 experimental trend validation, in K.
+   *
+   * <p>
+   * This is not a generic extrapolation limit for every PHREEQC row.
+   * </p>
+   */
+  public static final double CO2_NA2SO4_VALIDATION_MIN_TEMPERATURE_K = 303.15;
+
+  /**
+   * Upper temperature of both the PHREEQC CO2-CO2 row comment and independent CO2-Na2SO4 experimental validation, in K.
+   */
+  public static final double CO2_NA2SO4_VALIDATION_MAX_TEMPERATURE_K = 423.15;
+
+  /** Lowest independently validated Na2SO4 molality, in mol/kg water. */
+  public static final double CO2_NA2SO4_VALIDATION_MIN_SALT_MOLALITY = 1.0;
+
+  /** Highest independently validated Na2SO4 molality, in mol/kg water. */
+  public static final double CO2_NA2SO4_VALIDATION_MAX_SALT_MOLALITY = 2.0;
+
+  /** Utility class. */
+  private PitzerParameterDatasets() {
+  }
+
+  /**
+   * Applies the exact public-domain PHREEQC CO2-Na2SO4 parameter subset audited at commit
+   * {@code b0b3be767158ccc3322d2c816625cf470045e67e}, database blob {@code 324f852784be84650b77bd7f07f8316aafd8188b}.
+   *
+   * <p>
+   * The configured molality-scale families are Na+/SO4-- beta0, beta1, and Cphi (PHREEQC C0); CO2/CO2, CO2/Na+, and
+   * CO2/SO4-- lambda; and CO2/Na+/SO4-- zeta. The 1-2 binary uses the standard alpha1=2 Pitzer branch and has no beta2
+   * term. Values are passed in PHREEQC six-term order without fitting or conversion.
+   * </p>
+   *
+   * @param phase Pitzer aqueous phase containing CO2, Na+, and SO4--
+   * @throws IllegalArgumentException if a required component is absent or has the wrong charge role
+   */
+  public static void applyPhreeqcCo2SodiumSulfate(PhasePitzer phase) {
+    if (phase == null) {
+      throw new IllegalArgumentException("Pitzer phase must not be null");
+    }
+    int carbonDioxide = requiredComponentIndex(phase, "CO2");
+    int sodium = requiredComponentIndex(phase, "Na+");
+    int sulfate = requiredComponentIndex(phase, "SO4--");
+    if (Math.abs(phase.getComponent(carbonDioxide).getIonicCharge()) >= 0.5
+        || phase.getComponent(sodium).getIonicCharge() <= 0.0 || phase.getComponent(sulfate).getIonicCharge() >= 0.0) {
+      throw new IllegalArgumentException("PHREEQC CO2-Na2SO4 dataset species have incompatible charge roles");
+    }
+
+    phase.setParameterDatasetId(PHREEQC_CO2_NA2SO4_ID);
+    phase.setPhreeqcBinaryTemperatureCoefficients(sodium, sulfate, PHREEQC_REFERENCE_TEMPERATURE_K,
+        new double[] { 2.73e-2, 0.0, -5.8, 9.89e-3, 0.0, -1.563e5 },
+        new double[] { 0.956, 2.663e3, 0.0, 1.158e-2, 0.0, -3.194e5 },
+        new double[] { 3.418e-3, -384.0, 0.0, -8.451e-4, 0.0, 5.177e4 });
+    phase.setLambdaTemperatureCoefficients(carbonDioxide, carbonDioxide, PHREEQC_REFERENCE_TEMPERATURE_K,
+        new double[] { -1.34e-2, 348.0, 0.803, 0.0, 0.0, 0.0 });
+    phase.setLambda(carbonDioxide, sodium, 0.085);
+    phase.setLambda(carbonDioxide, sulfate, 0.075);
+    phase.setZeta(carbonDioxide, sodium, sulfate, -0.015);
+    phase.markManualParameterDatasetLoaded();
+  }
+
+  /**
+   * Reports whether temperature and Na2SO4 molality are inside the independent experimental validation envelope
+   * recorded for this dataset subset.
+   *
+   * @param temperature temperature in K
+   * @param sodiumSulfateMolality formula-unit molality in mol/kg water
+   * @return {@code true} within the inclusive validation envelope
+   */
+  public static boolean isWithinCo2SodiumSulfateValidationRange(double temperature, double sodiumSulfateMolality) {
+    return Double.isFinite(temperature) && Double.isFinite(sodiumSulfateMolality)
+        && temperature >= CO2_NA2SO4_VALIDATION_MIN_TEMPERATURE_K
+        && temperature <= CO2_NA2SO4_VALIDATION_MAX_TEMPERATURE_K
+        && sodiumSulfateMolality >= CO2_NA2SO4_VALIDATION_MIN_SALT_MOLALITY
+        && sodiumSulfateMolality <= CO2_NA2SO4_VALIDATION_MAX_SALT_MOLALITY;
+  }
+
+  private static int requiredComponentIndex(PhasePitzer phase, String componentName) {
+    if (!phase.hasComponent(componentName)) {
+      throw new IllegalArgumentException("PHREEQC CO2-Na2SO4 dataset requires component '" + componentName + "'");
+    }
+    return phase.getComponent(componentName).getComponentNumber();
+  }
+}

--- a/src/main/java/neqsim/thermo/system/SystemPitzer.java
+++ b/src/main/java/neqsim/thermo/system/SystemPitzer.java
@@ -3,6 +3,7 @@ package neqsim.thermo.system;
 import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionConcentrationBasis;
 import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionDataSource;
 import neqsim.thermo.phase.PhasePitzer;
+import neqsim.thermo.phase.PitzerParameterDatasets;
 import neqsim.thermo.phase.PhaseSrkEos;
 
 /**
@@ -79,6 +80,18 @@ public class SystemPitzer extends SystemEosGE {
   @Override
   public ChemicalReactionDataSource getChemicalReactionDataSource() {
     return ChemicalReactionDataSource.PITZER;
+  }
+
+  /**
+   * Applies the qualified public-domain PHREEQC CO2-Na2SO4 parameter subset to this system's Pitzer aqueous role.
+   *
+   * <p>
+   * The dataset is intentionally fail-closed: additional active species require explicit companion interactions. See
+   * {@link PitzerParameterDatasets#applyPhreeqcCo2SodiumSulfate(PhasePitzer)} for source identity and validation scope.
+   * </p>
+   */
+  public void applyPhreeqcCo2SodiumSulfateParameters() {
+    PitzerParameterDatasets.applyPhreeqcCo2SodiumSulfate((PhasePitzer) phaseArray[1]);
   }
 
   /** {@inheritDoc} */

--- a/src/test/java/neqsim/thermo/phase/PitzerNeutralInteractionTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerNeutralInteractionTest.java
@@ -1,0 +1,239 @@
+package neqsim.thermo.phase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.component.ComponentGePitzer;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPitzer;
+
+/** Tests PHREEQC-compatible neutral-solute Pitzer interaction families. */
+class PitzerNeutralInteractionTest extends neqsim.NeqSimTest {
+  private static final double TEMPERATURE = 298.15;
+
+  @Test
+  void lambdaAndZetaMatchPhreeqcActivityAndOsmoticPlacement() {
+    PhasePitzer phase = createSingleNeutralBrine();
+    int carbonDioxide = index(phase, "CO2");
+    int sodium = index(phase, "Na+");
+    int chloride = index(phase, "Cl-");
+    phase.setLambda(carbonDioxide, carbonDioxide, 0.0);
+    phase.setLambda(carbonDioxide, sodium, 0.10);
+    phase.setLambda(carbonDioxide, chloride, -0.02);
+    phase.setZeta(carbonDioxide, sodium, chloride, 0.03);
+
+    double mNeutral = molality(phase, carbonDioxide);
+    double mSodium = molality(phase, sodium);
+    double mChloride = molality(phase, chloride);
+    assertEquals(2.0 * mSodium * 0.10 - 2.0 * mChloride * 0.02 + mSodium * mChloride * 0.03,
+        phase.getNeutralPitzerLogGammaContribution(carbonDioxide, TEMPERATURE), 1.0e-14);
+    assertEquals(2.0 * mNeutral * 0.10 + mNeutral * mChloride * 0.03,
+        phase.getNeutralPitzerLogGammaContribution(sodium, TEMPERATURE), 1.0e-14);
+    assertEquals(-2.0 * mNeutral * 0.02 + mNeutral * mSodium * 0.03,
+        phase.getNeutralPitzerLogGammaContribution(chloride, TEMPERATURE), 1.0e-14);
+    assertEquals(mNeutral * mSodium * 0.10 - mNeutral * mChloride * 0.02 + mNeutral * mSodium * mChloride * 0.03,
+        phase.getNeutralPitzerOsmoticContribution(TEMPERATURE), 1.0e-14);
+  }
+
+  @Test
+  void repeatedNeutralLambdaUsesPhreeqcMultiplicity() {
+    PhasePitzer phase = createSingleNeutralBrine();
+    int carbonDioxide = index(phase, "CO2");
+    int sodium = index(phase, "Na+");
+    int chloride = index(phase, "Cl-");
+    phase.setLambda(carbonDioxide, carbonDioxide, -0.0134);
+    phase.setLambda(carbonDioxide, sodium, 0.0);
+    phase.setLambda(carbonDioxide, chloride, 0.0);
+    phase.setZeta(carbonDioxide, sodium, chloride, 0.0);
+
+    double mCarbonDioxide = molality(phase, carbonDioxide);
+    assertEquals(2.0 * mCarbonDioxide * -0.0134, phase.getNeutralPitzerLogGammaContribution(carbonDioxide, TEMPERATURE),
+        1.0e-14);
+    assertEquals(0.5 * mCarbonDioxide * mCarbonDioxide * -0.0134,
+        phase.getNeutralPitzerOsmoticContribution(TEMPERATURE), 1.0e-14);
+  }
+
+  @Test
+  void muAndEtaUsePhreeqcCombinatorialMultiplicities() {
+    PhasePitzer phase = createHigherOrderPhase();
+    int carbonDioxide = index(phase, "CO2");
+    int methane = index(phase, "methane");
+    int sodium = index(phase, "Na+");
+    int potassium = index(phase, "K+");
+    PitzerTemperatureFunction parameter = new PitzerTemperatureFunction(TEMPERATURE,
+        new double[] { 0.04, 0.0, 0.0, 0.0, 0.0, 0.0 });
+
+    PitzerNeutralInteraction mu = new PitzerNeutralInteraction(PhasePitzer.NEUTRAL_FAMILY_MU,
+        new int[] { carbonDioxide, carbonDioxide, methane }, parameter);
+    double mCarbonDioxide = molality(phase, carbonDioxide);
+    double mMethane = molality(phase, methane);
+    assertEquals(6.0 * mCarbonDioxide * mMethane * 0.04, mu.logGammaContribution(carbonDioxide, phase, TEMPERATURE),
+        1.0e-14);
+    assertEquals(3.0 * mCarbonDioxide * mCarbonDioxide * 0.04, mu.logGammaContribution(methane, phase, TEMPERATURE),
+        1.0e-14);
+    assertEquals(3.0 * mCarbonDioxide * mCarbonDioxide * mMethane * 0.04, mu.osmoticContribution(phase, TEMPERATURE),
+        1.0e-14);
+
+    PitzerNeutralInteraction eta = new PitzerNeutralInteraction(PhasePitzer.NEUTRAL_FAMILY_ETA,
+        new int[] { carbonDioxide, sodium, potassium }, parameter);
+    double mSodium = molality(phase, sodium);
+    double mPotassium = molality(phase, potassium);
+    assertEquals(mSodium * mPotassium * 0.04, eta.logGammaContribution(carbonDioxide, phase, TEMPERATURE), 1.0e-14);
+    assertEquals(mCarbonDioxide * mPotassium * 0.04, eta.logGammaContribution(sodium, phase, TEMPERATURE), 1.0e-14);
+    assertEquals(mCarbonDioxide * mSodium * mPotassium * 0.04, eta.osmoticContribution(phase, TEMPERATURE), 1.0e-14);
+  }
+
+  @Test
+  void temperatureFunctionsCoverEveryNeutralFamily() {
+    PhasePitzer phase = createHigherOrderPhase();
+    int carbonDioxide = index(phase, "CO2");
+    int methane = index(phase, "methane");
+    int sodium = index(phase, "Na+");
+    int potassium = index(phase, "K+");
+    int chloride = index(phase, "Cl-");
+    double[] coefficients = { 0.12, 250.0, -0.035, 4.2e-4, -3.1e-7, 18000.0 };
+    phase.setLambdaTemperatureCoefficients(carbonDioxide, sodium, TEMPERATURE, coefficients);
+    phase.setZetaTemperatureCoefficients(carbonDioxide, sodium, chloride, TEMPERATURE, coefficients);
+    phase.setMuTemperatureCoefficients(carbonDioxide, carbonDioxide, methane, TEMPERATURE, coefficients);
+    phase.setEtaTemperatureCoefficients(carbonDioxide, sodium, potassium, TEMPERATURE, coefficients);
+
+    double expected = -0.11371073586719137;
+    assertEquals(expected, phase.getLambda(carbonDioxide, sodium, 373.15), 2.0e-15);
+    assertEquals(expected, phase.getZeta(carbonDioxide, sodium, chloride, 373.15), 2.0e-15);
+    assertEquals(expected, phase.getMu(methane, carbonDioxide, carbonDioxide, 373.15), 2.0e-15);
+    assertEquals(expected, phase.getEta(potassium, carbonDioxide, sodium, 373.15), 2.0e-15);
+  }
+
+  @Test
+  void configuredNeutralDatasetFailsClosedWhenRequiredRowsAreMissing() {
+    PhasePitzer phase = createSingleNeutralBrine();
+    int carbonDioxide = index(phase, "CO2");
+    int sodium = index(phase, "Na+");
+    phase.setLambda(carbonDioxide, sodium, 0.10);
+
+    PitzerNeutralParameterCoverage coverage = phase.auditNeutralPitzerParameterCoverage();
+    assertEquals(2, coverage.getMissingLambdaPairs().size());
+    assertEquals(1, coverage.getMissingZetaTuples().size());
+    IllegalStateException error = assertThrows(IllegalStateException.class,
+        () -> phase.getNeutralPitzerLogGammaContribution(carbonDioxide, TEMPERATURE));
+    assertTrue(error.getMessage().contains("missingLambda"));
+    assertTrue(error.getMessage().contains("missingZeta"));
+  }
+
+  @Test
+  void waterAndPhaseOsmoticPathsRemainConsistentWithNeutralTerms() {
+    PhasePitzer phase = createSingleNeutralBrine();
+    int water = index(phase, "water");
+    int carbonDioxide = index(phase, "CO2");
+    int sodium = index(phase, "Na+");
+    int chloride = index(phase, "Cl-");
+    ComponentGePitzer waterComponent = (ComponentGePitzer) phase.getComponent(water);
+    double ionicMolality = molality(phase, sodium) + molality(phase, chloride);
+    double baselinePhasePhi = phase.getOsmoticCoefficientOfWater();
+    double baselineWaterGamma = waterComponent.getGamma(phase, phase.getNumberOfComponents(), TEMPERATURE,
+        phase.getPressure(), phase.getType());
+    double baselineWaterPhi = -Math.log(baselineWaterGamma * waterComponent.getx()) * 1000.0 / (18.015 * ionicMolality);
+
+    phase.setLambda(carbonDioxide, sodium, 0.10);
+    phase.setLambda(carbonDioxide, chloride, -0.02);
+    phase.setLambda(carbonDioxide, carbonDioxide, 0.0);
+    phase.setZeta(carbonDioxide, sodium, chloride, 0.03);
+
+    double neutralOsmoticSum = phase.getNeutralPitzerOsmoticContribution(TEMPERATURE);
+    double totalSoluteMolality = ionicMolality + molality(phase, carbonDioxide);
+    double expectedPhasePhi = 1.0
+        + ((baselinePhasePhi - 1.0) * ionicMolality + 2.0 * neutralOsmoticSum) / totalSoluteMolality;
+    assertEquals(expectedPhasePhi, phase.getOsmoticCoefficientOfWater(), 2.0e-12);
+
+    double waterGamma = waterComponent.getGamma(phase, phase.getNumberOfComponents(), TEMPERATURE, phase.getPressure(),
+        phase.getType());
+    double waterActivity = waterGamma * waterComponent.getx();
+    double phiFromWaterActivity = -Math.log(waterActivity) * 1000.0 / (18.015 * totalSoluteMolality);
+    double expectedWaterPhi = 1.0
+        + ((baselineWaterPhi - 1.0) * ionicMolality + 2.0 * neutralOsmoticSum) / totalSoluteMolality;
+    assertEquals(expectedWaterPhi, phiFromWaterActivity, 2.0e-12);
+  }
+
+  @Test
+  void cloneSerializationAndLegacyBypassProtectState() throws Exception {
+    PhasePitzer phase = createSingleNeutralBrine();
+    int carbonDioxide = index(phase, "CO2");
+    int sodium = index(phase, "Na+");
+    int chloride = index(phase, "Cl-");
+    assertEquals(0.0, phase.getNeutralPitzerLogGammaContribution(carbonDioxide, TEMPERATURE), 0.0);
+
+    configureCompleteSingleNeutralDataset(phase, carbonDioxide, sodium, chloride);
+    double original = phase.getNeutralPitzerLogGammaContribution(carbonDioxide, TEMPERATURE);
+    PhasePitzer clone = phase.clone();
+    clone.setLambda(carbonDioxide, sodium, 0.25);
+    double changed = clone.getNeutralPitzerLogGammaContribution(carbonDioxide, TEMPERATURE);
+    assertNotEquals(original, changed);
+    assertEquals(original, phase.getNeutralPitzerLogGammaContribution(carbonDioxide, TEMPERATURE), 0.0);
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(phase);
+    }
+    PhasePitzer restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored = (PhasePitzer) input.readObject();
+    }
+    assertEquals(original, restored.getNeutralPitzerLogGammaContribution(carbonDioxide, TEMPERATURE), 0.0);
+  }
+
+  @Test
+  void rejectsSpeciesWithWrongFamilyRoles() {
+    PhasePitzer phase = createSingleNeutralBrine();
+    int water = index(phase, "water");
+    int carbonDioxide = index(phase, "CO2");
+    int sodium = index(phase, "Na+");
+    int chloride = index(phase, "Cl-");
+    assertThrows(IllegalArgumentException.class, () -> phase.setLambda(water, sodium, 0.1));
+    assertThrows(IllegalArgumentException.class, () -> phase.setLambda(carbonDioxide, water, 0.1));
+    assertThrows(IllegalArgumentException.class, () -> phase.setZeta(carbonDioxide, chloride, sodium, 0.1));
+    assertThrows(IllegalArgumentException.class, () -> phase.setEta(carbonDioxide, sodium, chloride, 0.1));
+  }
+
+  private static void configureCompleteSingleNeutralDataset(PhasePitzer phase, int neutral, int cation, int anion) {
+    phase.setLambda(neutral, neutral, 0.0);
+    phase.setLambda(neutral, cation, 0.10);
+    phase.setLambda(neutral, anion, -0.02);
+    phase.setZeta(neutral, cation, anion, 0.03);
+  }
+
+  private static PhasePitzer createSingleNeutralBrine() {
+    SystemInterface system = new SystemPitzer(TEMPERATURE, 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("CO2", 0.2);
+    system.addComponent("Na+", 1.0);
+    system.addComponent("Cl-", 1.0);
+    system.init(0);
+    return (PhasePitzer) system.getPhase(1);
+  }
+
+  private static PhasePitzer createHigherOrderPhase() {
+    SystemInterface system = new SystemPitzer(TEMPERATURE, 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("CO2", 0.2);
+    system.addComponent("methane", 0.1);
+    system.addComponent("Na+", 0.8);
+    system.addComponent("K+", 0.2);
+    system.addComponent("Cl-", 1.0);
+    system.init(0);
+    return (PhasePitzer) system.getPhase(1);
+  }
+
+  private static int index(PhasePitzer phase, String componentName) {
+    return phase.getComponent(componentName).getComponentNumber();
+  }
+
+  private static double molality(PhasePitzer phase, int componentIndex) {
+    return phase.getComponent(componentIndex).getMolality(phase);
+  }
+}

--- a/src/test/java/neqsim/thermo/phase/PitzerParameterDatasetsTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerParameterDatasetsTest.java
@@ -1,0 +1,173 @@
+package neqsim.thermo.phase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.component.ComponentGePitzer;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPitzer;
+
+/** Scientific and provenance regressions for versioned Pitzer parameter datasets. */
+class PitzerParameterDatasetsTest extends neqsim.NeqSimTest {
+  private static final double REFERENCE_TEMPERATURE = 298.15;
+
+  @Test
+  void exactPhreeqcRowsAndCoverageAreAppliedAsOneDataset() {
+    PhasePitzer phase = createPhase(REFERENCE_TEMPERATURE);
+    PitzerParameterDatasets.applyPhreeqcCo2SodiumSulfate(phase);
+
+    int carbonDioxide = index(phase, "CO2");
+    int sodium = index(phase, "Na+");
+    int sulfate = index(phase, "SO4--");
+    assertEquals(PitzerParameterDatasets.PHREEQC_CO2_NA2SO4_ID, phase.getParameterDatasetId());
+    assertEquals(0.0273, phase.getBeta0ij(sodium, sulfate, REFERENCE_TEMPERATURE), 0.0);
+    assertEquals(0.956, phase.getBeta1ij(sodium, sulfate, REFERENCE_TEMPERATURE), 0.0);
+    assertEquals(0.003418, phase.getCphiij(sodium, sulfate, REFERENCE_TEMPERATURE), 0.0);
+    assertEquals(-0.0134, phase.getLambda(carbonDioxide, carbonDioxide, REFERENCE_TEMPERATURE), 0.0);
+    assertEquals(0.085, phase.getLambda(carbonDioxide, sodium, REFERENCE_TEMPERATURE), 0.0);
+    assertEquals(0.075, phase.getLambda(carbonDioxide, sulfate, REFERENCE_TEMPERATURE), 0.0);
+    assertEquals(-0.015, phase.getZeta(carbonDioxide, sodium, sulfate, REFERENCE_TEMPERATURE), 0.0);
+    assertTrue(phase.getPitzerParameterCoverage().isComplete());
+    assertTrue(phase.auditNeutralPitzerParameterCoverage().isComplete());
+  }
+
+  @Test
+  void co2ActivityMatchesIndependentIphreeqc373ReferenceStates() {
+    // Generated with IPhreeqc 3.7.3, exact public-domain pitzer.dat blob
+    // 324f852784be84650b77bd7f07f8316aafd8188b, MacInnes scaling disabled.
+    assertPhreeqcCo2LogGamma(298.15, 0.009335381788874181, 0.2, 0.09997223611354554, 0.048445563893430764);
+    assertPhreeqcCo2LogGamma(298.15, 0.08226801278545755, 2.0, 0.9999294802590848, 0.457786331769995);
+    assertPhreeqcCo2LogGamma(373.15, 0.08136555608701694, 2.0, 0.9995278707441787, 0.44890462098965683);
+    assertPhreeqcCo2LogGamma(423.15, 0.14946601518796535, 4.0, 1.9980632335950677, 0.836784371391815);
+  }
+
+  @Test
+  void sodiumSulfateActivityAndOsmoticCoefficientMatchIphreeqcAt298K() {
+    PhasePitzer phase = createPhase(REFERENCE_TEMPERATURE);
+    PitzerParameterDatasets.applyPhreeqcCo2SodiumSulfate(phase);
+    setMolality(phase, "CO2", 0.0);
+    setMolality(phase, "Na+", 2.0);
+    setMolality(phase, "SO4--", 0.9999992982438045);
+
+    int sodium = index(phase, "Na+");
+    int sulfate = index(phase, "SO4--");
+    ComponentGePitzer sodiumComponent = (ComponentGePitzer) phase.getComponent(sodium);
+    ComponentGePitzer sulfateComponent = (ComponentGePitzer) phase.getComponent(sulfate);
+    double gammaSodium = sodiumComponent.getGamma(phase, phase.getNumberOfComponents(), REFERENCE_TEMPERATURE,
+        phase.getPressure(), phase.getType());
+    double gammaSulfate = sulfateComponent.getGamma(phase, phase.getNumberOfComponents(), REFERENCE_TEMPERATURE,
+        phase.getPressure(), phase.getType());
+    double meanGamma = Math.pow(gammaSodium * gammaSodium * gammaSulfate, 1.0 / 3.0);
+
+    assertEquals(0.20137297119267375, meanGamma, 1.3e-3);
+    assertEquals(0.6422470176005581, phase.getOsmoticCoefficientOfWater(), 7.0e-4);
+  }
+
+  @Test
+  void carbonDioxideShowsHeldOutSodiumSulfateSaltingOutTrend() {
+    // Dos Santos et al. (2020), DOI 10.1021/acs.jced.0c00230, independently reports
+    // lower CO2 solubility as Na2SO4 molality increases. At fixed aqueous CO2 molality,
+    // this parameter subset must therefore increase the CO2 activity coefficient.
+    double oneMolalLogGamma = carbonDioxideLogGamma(373.15, 0.08, 2.0, 1.0);
+    double twoMolalLogGamma = carbonDioxideLogGamma(373.15, 0.08, 4.0, 2.0);
+
+    assertTrue(twoMolalLogGamma > oneMolalLogGamma, "CO2 activity coefficient must increase from 1 to 2 molal Na2SO4: "
+        + oneMolalLogGamma + " -> " + twoMolalLogGamma);
+  }
+
+  @Test
+  void validationEnvelopeAndUnsupportedTopologyAreExplicit() {
+    assertTrue(PitzerParameterDatasets.isWithinCo2SodiumSulfateValidationRange(303.15, 1.0));
+    assertTrue(PitzerParameterDatasets.isWithinCo2SodiumSulfateValidationRange(423.15, 2.0));
+    assertFalse(PitzerParameterDatasets.isWithinCo2SodiumSulfateValidationRange(298.15, 1.0));
+    assertFalse(PitzerParameterDatasets.isWithinCo2SodiumSulfateValidationRange(373.15, 2.1));
+
+    SystemInterface incomplete = new SystemPitzer(REFERENCE_TEMPERATURE, 1.01325);
+    incomplete.addComponent("water", 55.508);
+    incomplete.addComponent("CO2", 0.1);
+    incomplete.addComponent("Na+", 2.0);
+    incomplete.init(0);
+    PhasePitzer phase = (PhasePitzer) incomplete.getPhase(1);
+    IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+        () -> PitzerParameterDatasets.applyPhreeqcCo2SodiumSulfate(phase));
+    assertTrue(error.getMessage().contains("SO4--"));
+  }
+
+  @Test
+  void systemApiRetainsQualifiedDatasetAcrossInitializationAndClone() {
+    SystemPitzer system = createSystem(REFERENCE_TEMPERATURE);
+    system.applyPhreeqcCo2SodiumSulfateParameters();
+    system.init(0);
+    PhasePitzer original = (PhasePitzer) system.getPhase(1);
+    int carbonDioxide = index(original, "CO2");
+    int sodium = index(original, "Na+");
+    assertEquals(PitzerParameterDatasets.PHREEQC_CO2_NA2SO4_ID, original.getParameterDatasetId());
+
+    SystemPitzer clonedSystem = system.clone();
+    PhasePitzer cloned = (PhasePitzer) clonedSystem.getPhase(1);
+    cloned.setLambda(carbonDioxide, sodium, 0.25);
+    assertNotEquals(original.getLambda(carbonDioxide, sodium, REFERENCE_TEMPERATURE),
+        cloned.getLambda(carbonDioxide, sodium, REFERENCE_TEMPERATURE));
+    assertEquals(0.085, original.getLambda(carbonDioxide, sodium, REFERENCE_TEMPERATURE), 0.0);
+  }
+
+  @Test
+  void qualifiedSubsetFailsClosedForAnAdditionalActiveNeutral() {
+    SystemPitzer system = createSystem(REFERENCE_TEMPERATURE);
+    system.addComponent("methane", 0.1);
+    system.init(0);
+    system.applyPhreeqcCo2SodiumSulfateParameters();
+    PhasePitzer phase = (PhasePitzer) system.getPhase(1);
+
+    PitzerNeutralParameterCoverage coverage = phase.auditNeutralPitzerParameterCoverage();
+    assertFalse(coverage.isComplete());
+    assertTrue(coverage.getMissingLambdaPairs().toString().contains("methane"));
+    IllegalStateException error = assertThrows(IllegalStateException.class,
+        () -> phase.getNeutralPitzerLogGammaContribution(index(phase, "CO2"), REFERENCE_TEMPERATURE));
+    assertTrue(error.getMessage().contains("methane"));
+  }
+
+  private static void assertPhreeqcCo2LogGamma(double temperature, double carbonDioxideMolality, double sodiumMolality,
+      double sulfateMolality, double expectedNaturalLogGamma) {
+    assertEquals(expectedNaturalLogGamma,
+        carbonDioxideLogGamma(temperature, carbonDioxideMolality, sodiumMolality, sulfateMolality), 1.5e-5);
+  }
+
+  private static double carbonDioxideLogGamma(double temperature, double carbonDioxideMolality, double sodiumMolality,
+      double sulfateMolality) {
+    PhasePitzer phase = createPhase(temperature);
+    PitzerParameterDatasets.applyPhreeqcCo2SodiumSulfate(phase);
+    setMolality(phase, "CO2", carbonDioxideMolality);
+    setMolality(phase, "Na+", sodiumMolality);
+    setMolality(phase, "SO4--", sulfateMolality);
+    int carbonDioxide = index(phase, "CO2");
+    return phase.getNeutralPitzerLogGammaContribution(carbonDioxide, temperature);
+  }
+
+  private static PhasePitzer createPhase(double temperature) {
+    return (PhasePitzer) createSystem(temperature).getPhase(1);
+  }
+
+  private static SystemPitzer createSystem(double temperature) {
+    SystemPitzer system = new SystemPitzer(temperature, 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("CO2", 0.1);
+    system.addComponent("Na+", 2.0);
+    system.addComponent("SO4--", 1.0);
+    system.init(0);
+    return system;
+  }
+
+  private static void setMolality(PhasePitzer phase, String componentName, double molality) {
+    double targetMoles = molality * phase.getSolventWeight();
+    double moleFraction = phase.getComponent(componentName).getx();
+    phase.getComponent(componentName).setNumberOfMolesInPhase(targetMoles == 0.0 ? 0.0 : targetMoles / moleFraction);
+  }
+
+  private static int index(PhasePitzer phase, String componentName) {
+    return phase.getComponent(componentName).getComponentNumber();
+  }
+}


### PR DESCRIPTION
Part of #3144.

## Scientific question and frozen scope

Can NeqSim's electrolyte-GE/Pitzer path represent PHREEQC-compatible neutral-solute interactions and adopt one complete, independently checked oilfield-relevant CO2/Na2SO4 subset without silently mixing parameter families, accepting missing interactions as zero, or slowing ordinary electrolyte and neutral calculations?

- Model: `SystemPitzer` / molality-scale Pitzer aqueous GE with SRK gas/oil roles
- Parameter convention: PHREEQC `B0/B1/C0`, `lambda/zeta/mu/eta`, six-term temperature functions, 298.15 K reference
- Qualified species: water, CO2, Na+, SO4--
- Qualified evidence envelope: 303.15–423.15 K and 1–2 mol/kg Na2SO4 for aqueous activity/osmotic behavior
- Stop boundary: no reaction-database changes, no Pitzer-to-electrolyte-EOS coefficient transfer, no extra brine species, and no claim of validated CO2 VLE while the separate hybrid EOS-GE ion-accommodation defect remains

## What changes

- implements sparse, immutable PHREEQC-compatible `lambda`, `zeta`, `mu`, and `eta` interactions in neutral, ion, and both water/osmotic paths;
- corrects neutral-neutral/repeated-species lambda multiplicities and supports PHREEQC six-term temperature functions;
- adds deterministic fail-closed coverage diagnostics that distinguish absent rows from explicit zero values;
- keeps a setup-time boolean fast path so legacy Pitzer pays no map lookup and non-Pitzer models execute no new code;
- adds the versioned public-domain dataset `usgs-phreeqc-pitzer-b0b3be767158ccc3322d2c816625cf470045e67e-co2-na2so4-v1`;
- prevents the coherent dataset from being mixed with the legacy table;
- exposes `SystemPitzer.applyPhreeqcCo2SodiumSulfateParameters()` for Java/Python composability;
- documents exact row provenance, conventions, range, licensing, source conflicts, Kaasa-thesis audit, and limitations.

## Scientific provenance

The stored values are exact rows from public-domain PHREEQC commit `b0b3be767158ccc3322d2c816625cf470045e67e`, database blob `324f852784be84650b77bd7f07f8316aafd8188b`. The database cites Appelo (2015), DOI 10.1016/j.apgeochem.2014.11.007; the CO2/SO4 row cites Rumpf and Maurer (1993), DOI 10.1002/bbpc.19930970116.

Independent held-out trend evidence is Dos Santos et al. (2020), DOI 10.1021/acs.jced.0c00230. Zhao et al. (2015), DOI 10.1002/aic.14825, is retained as outside-range evidence for later full-VLE work. No copyrighted experimental table is stored.

The user-supplied Kaasa (1998) scan was inspected at chapter 4 §4.3.2 and Appendix F pp. 259–267. Its family inventory and coefficient ordering are documented, but no thesis value is copied: row-level reuse, lineage, uncertainty, and independent agreement remain unresolved.

## Numerical validation

Independent IPhreeqc 3.7.3, exact database blob above, MacInnes scaling disabled:

- four CO2 states at 298.15, 373.15, and 423.15 K, 0.1–2 mol/kg Na2SO4: max absolute residual in neutral `ln(gamma)` < `1.5e-5`;
- approximately 1 mol/kg Na2SO4 at 298.15 K: NeqSim mean ionic activity `0.20016248` vs IPhreeqc `0.20137297` (−0.60%);
- osmotic coefficient `0.64159881` vs IPhreeqc `0.64224702` (−0.10%);
- held-out salting-out gate: CO2 activity coefficient increases from 1 to 2 mol/kg Na2SO4 at 373.15 K;
- exact rows, range boundary, extra-species failure, repeated execution, initialization, clone, and serialization regressions pass.

The small mean-activity/osmotic difference is kept explicit because NeqSim does not replace its water electrostatic correlation with PHREEQC's optional database `Aphi` function.

## Validation executed

- `./mvnw -q clean -Dskip.quality.gates=true -Dtest='*Pitzer*Test' test`
- focused parameter/neutral tests after final formatting
- representative hybrid Pitzer, electrolyte-CPA/MM, Fürst electrolyte-EOS, PR, and SRK-CPA controls
- 126 applicable tests: 0 failures, 0 errors
- Java-8 profile: focused neutral/dataset tests pass
- `python devtools/run_spotless.py apply` and final `check`: pass
- `python devtools/check_documentation_search.py`: pass (659 Markdown + 1 HTML)
- pre-commit and pre-push stages: pass
- `git diff --check`: pass

Performance:

- legacy binary-Pitzer activity kernel: master `187.735 ns/call`, head `189.476 ns/call` (+0.93%);
- complete methane/NaCl two-phase TP-flash benchmark: two median runs on master `421.412/490.621 us`, head `300.854/394.617 us`; runtime noise is visible, but no slowdown is observed;
- neutral PR/SRK/CPA and electrolyte-EOS source paths are unchanged.

## Known limitation and readiness

**READY TO MERGE** on exact head `aaf650108af2e81db8cb0e8f735c668dab57d3a3` (classification only; the PR remains draft). Exact-head CI completed successfully: Java 21 and Java 8 tests on Ubuntu and Windows, all four Java 21 slow-test shards, Java 21 Javadocs, CodeQL, pre-commit, Spotless, documentation search/build, and PaperLab scope detection. GitHub reports the PR mergeable; no reviews, requested changes, comments, or unresolved threads exist.

A gas-forming CO2/Na2SO4 TP-flash reproduces the existing hybrid EOS-GE ion-accommodation error before a VLE comparison can be made. This is a separate phase-topology dependency coordinated with #2937; the adopted subset is qualified for aqueous activity and water/osmotic calculations only.