### PR TITLE
[AI-Assisted] fix(flash): constrain hybrid aqueous ion capacity

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1970,6 +1970,35 @@ blocks of 30 flashes) measured the corrected SRK boundary at about `8.5 ms/flash
 invalid higher-root baseline. The PR boundary and adjacent retained one-phase controls were within run-to-run noise.
 Common flashes return before the hydrogen/high-pressure/incipient-phase screen.
 
+### 6.5 Hybrid EOS-GE ionic-capacity safeguard
+
+In a fixed-role EOS-gas/GE-aqueous calculation, ions are excluded from every non-aqueous role.
+Consequently the aqueous phase fraction must remain strictly greater than the sum of the overall
+ionic mole fractions: otherwise the required aqueous ionic mole fractions sum to one or more and no
+normalized neutral solvent composition exists.
+
+The unconstrained beta Newton correction can cross that physical boundary during an intermediate
+iteration even when the final gas-aqueous equilibrium is feasible. The hybrid solver now projects
+only such infeasible iterates back to
+`sum(zIon) + 100 * phaseFractionMinimumLimit`. The required fraction is removed proportionally
+from the adjustable part of the other active roles, their minimum fractions are preserved, and the
+phase-split denominator is rebuilt before compositions are evaluated. Feasible iterates, public
+tolerances, dataset parameters, and final acceptance checks are unchanged. If the ionic inventory
+cannot fit while retaining the active roles at their numerical minima, the solver still fails with
+explicit capacity diagnostics.
+
+The regression uses the public-domain PHREEQC CO2-Na2SO4 subset documented in
+`docs/thermo/pitzer_parameter_provenance.md`. It forces a formerly invalid intermediate beta below
+the ionic inventory, then checks projection, ion confinement, normalization, and exact ionic
+material balance. A complete 373.15 K gas-aqueous flash at 150 bar is repeated and changed to
+140 bar; both states must retain gas and aqueous roles, bounded normalized compositions, component
+material balance below `1e-7`, and molecular log-fugacity residual below `1e-5`.
+
+This is a feasibility safeguard, not a performance optimization. The common feasible hybrid path
+adds one allocation-free component scan to each composition update and performs no extra property
+initialization. Only a projected iterate rebuilds the already allocated phase-split denominator.
+Neutral EOS flashes do not dispatch to this solver.
+
 ---
 
 ## 7. References

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -396,11 +396,11 @@ public class TPHybridEosGeFlash extends TPmultiflash {
    *
    * <p>
    * Ions are excluded from EOS gas and oil roles, so their aqueous mole fractions sum to
-   * {@code sum(zIon) / betaAqueous}. An unconstrained Newton correction can temporarily move
-   * {@code betaAqueous} below {@code sum(zIon)} even when the final equilibrium is feasible. That iterate has no
-   * normalized aqueous composition and formerly failed before the next correction could recover. This method projects
-   * only such infeasible iterates onto the ionic-capacity boundary, taking the required fraction proportionally from the
-   * adjustable part of the other active phases. Feasible iterates and the final acceptance tolerances are unchanged.
+   * {@code sum(zIon) / betaAqueous}. An unconstrained Newton correction can temporarily move {@code betaAqueous} below
+   * {@code sum(zIon)} even when the final equilibrium is feasible. That iterate has no normalized aqueous composition
+   * and formerly failed before the next correction could recover. This method projects only such infeasible iterates
+   * onto the ionic-capacity boundary, taking the required fraction proportionally from the adjustable part of the other
+   * active phases. Feasible iterates and the final acceptance tolerances are unchanged.
    * </p>
    *
    * @return {@code true} when the phase fractions were projected
@@ -428,10 +428,8 @@ public class TPHybridEosGeFlash extends TPmultiflash {
       return false;
     }
 
-    double maximumAqueousFraction =
-        1.0 - (system.getNumberOfPhases() - 1.0) * phaseFractionMinimumLimit;
-    double minimumAqueousFraction =
-        Math.min(maximumAqueousFraction, ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN);
+    double maximumAqueousFraction = 1.0 - (system.getNumberOfPhases() - 1.0) * phaseFractionMinimumLimit;
+    double minimumAqueousFraction = Math.min(maximumAqueousFraction, ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN);
     double currentAqueousFraction = system.getBeta(aqueousPhaseIndex);
     if (currentAqueousFraction >= minimumAqueousFraction) {
       return false;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -43,6 +43,9 @@ public class TPHybridEosGeFlash extends TPmultiflash {
   /** Positive floor for trace species after conservative reaction-delta projection. */
   private static final double MINIMUM_COUPLED_COMPONENT_MOLES = 1.0e-45;
 
+  /** Extra aqueous phase-fraction room retained above the fixed ionic inventory. */
+  private static final double HYBRID_ION_CAPACITY_MARGIN = 100.0 * phaseFractionMinimumLimit;
+
   /** Reaction-adjusted overall component fractions used by the coupled phase solve. */
   private transient double[] coupledOverallFractions;
 
@@ -337,6 +340,11 @@ public class TPHybridEosGeFlash extends TPmultiflash {
   /** {@inheritDoc} */
   @Override
   public void setXY() {
+    if (enforceAqueousIonCapacityBound()) {
+      // The beta Newton step was projected back into the physically admissible region. Rebuild
+      // E with the projected fractions before calculating component compositions.
+      calcE();
+    }
     for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
       boolean aqueous = hybridModel.isHybridEosGeAqueousPhase(phaseIndex);
       double phaseFraction = Math.max(system.getPhase(phaseIndex).getBeta(), phaseFractionMinimumLimit);
@@ -381,6 +389,95 @@ public class TPHybridEosGeFlash extends TPmultiflash {
         system.getPhase(phaseIndex).normalize();
       }
     }
+  }
+
+  /**
+   * Keep the fixed-topology beta iterate large enough to contain the complete ionic inventory.
+   *
+   * <p>
+   * Ions are excluded from EOS gas and oil roles, so their aqueous mole fractions sum to
+   * {@code sum(zIon) / betaAqueous}. An unconstrained Newton correction can temporarily move
+   * {@code betaAqueous} below {@code sum(zIon)} even when the final equilibrium is feasible. That iterate has no
+   * normalized aqueous composition and formerly failed before the next correction could recover. This method projects
+   * only such infeasible iterates onto the ionic-capacity boundary, taking the required fraction proportionally from the
+   * adjustable part of the other active phases. Feasible iterates and the final acceptance tolerances are unchanged.
+   * </p>
+   *
+   * @return {@code true} when the phase fractions were projected
+   */
+  private boolean enforceAqueousIonCapacityBound() {
+    int aqueousPhaseIndex = -1;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (hybridModel.isHybridEosGeAqueousPhase(phaseIndex)) {
+        aqueousPhaseIndex = phaseIndex;
+        break;
+      }
+    }
+    if (aqueousPhaseIndex < 0 || system.getNumberOfPhases() < 2) {
+      return false;
+    }
+
+    double ionOverallFraction = 0.0;
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      if (component.getIonicCharge() != 0 || component.isIsIon()) {
+        ionOverallFraction += Math.max(getCoupledOverallFraction(componentIndex), 0.0);
+      }
+    }
+    if (!(ionOverallFraction > 0.0) || !Double.isFinite(ionOverallFraction)) {
+      return false;
+    }
+
+    double maximumAqueousFraction =
+        1.0 - (system.getNumberOfPhases() - 1.0) * phaseFractionMinimumLimit;
+    double minimumAqueousFraction =
+        Math.min(maximumAqueousFraction, ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN);
+    double currentAqueousFraction = system.getBeta(aqueousPhaseIndex);
+    if (currentAqueousFraction >= minimumAqueousFraction) {
+      return false;
+    }
+
+    double requiredTransfer = minimumAqueousFraction - currentAqueousFraction;
+    double adjustableFraction = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (phaseIndex != aqueousPhaseIndex) {
+        adjustableFraction += Math.max(system.getBeta(phaseIndex) - phaseFractionMinimumLimit, 0.0);
+      }
+    }
+    if (adjustableFraction + phaseFractionMinimumLimit < requiredTransfer) {
+      throw new IllegalStateException("Hybrid EOS-GE phase fractions cannot accommodate the ionic inventory: "
+          + "ionOverallFraction=" + ionOverallFraction + ", aqueousBeta=" + currentAqueousFraction
+          + ", requiredAqueousBeta=" + minimumAqueousFraction + ", adjustableFraction=" + adjustableFraction);
+    }
+
+    double remainingTransfer = requiredTransfer;
+    int lastAdjustablePhase = -1;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (phaseIndex == aqueousPhaseIndex) {
+        continue;
+      }
+      double available = Math.max(system.getBeta(phaseIndex) - phaseFractionMinimumLimit, 0.0);
+      if (available <= 0.0) {
+        continue;
+      }
+      lastAdjustablePhase = phaseIndex;
+      double transfer = requiredTransfer * available / adjustableFraction;
+      transfer = Math.min(transfer, remainingTransfer);
+      system.setBeta(phaseIndex, system.getBeta(phaseIndex) - transfer);
+      remainingTransfer -= transfer;
+    }
+    if (remainingTransfer > 0.0 && lastAdjustablePhase >= 0) {
+      system.setBeta(lastAdjustablePhase, system.getBeta(lastAdjustablePhase) - remainingTransfer);
+    }
+
+    double nonAqueousFraction = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (phaseIndex != aqueousPhaseIndex) {
+        nonAqueousFraction += system.getBeta(phaseIndex);
+      }
+    }
+    system.setBeta(aqueousPhaseIndex, 1.0 - nonAqueousFraction);
+    return true;
   }
 
   /**

--- a/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
@@ -18,6 +18,7 @@ import neqsim.thermo.phase.PhaseInterface;
 import neqsim.thermo.phase.PhasePitzer;
 import neqsim.thermo.phase.PhaseType;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
+import neqsim.thermodynamicoperations.flashops.TPHybridEosGeFlash;
 
 /** Regression tests for fixed-role EOS-gas / EOS-oil / GE-aqueous flashes. */
 class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
@@ -42,6 +43,24 @@ class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
     system.addComponent("water", 55.5);
     system.addComponent("Na+", 1.0);
     system.addComponent("Cl-", 1.0);
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(true);
+    return system;
+  }
+
+  /**
+   * Build a gas-forming system using the qualified PHREEQC CO2-Na2SO4 subset.
+   *
+   * @return configured unflashed system
+   */
+  private SystemPitzer createQualifiedCarbonDioxideSodiumSulfateSystem() {
+    SystemPitzer system = new SystemPitzer(373.15, 150.0);
+    system.addComponent("CO2", 100.0);
+    system.addComponent("water", 55.508);
+    system.addComponent("Na+", 2.0);
+    system.addComponent("SO4--", 1.0);
+    system.init(0);
+    system.applyPhreeqcCo2SodiumSulfateParameters();
     system.setMixingRule("classic");
     system.setMultiPhaseCheck(true);
     return system;
@@ -106,6 +125,79 @@ class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
         }
       }
     }
+  }
+
+  /** An infeasible beta iterate is projected above the aqueous phase's fixed ionic inventory. */
+  @Test
+  void hybridBetaIterationRetainsAqueousIonCapacity() {
+    SystemPitzer system = createQualifiedCarbonDioxideSodiumSulfateSystem();
+    system.prepareHybridEosGeFlash();
+    system.init(1);
+
+    int aqueousPhaseIndex = -1;
+    double ionOverallFraction = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (system.isHybridEosGeAqueousPhase(phaseIndex)) {
+        aqueousPhaseIndex = phaseIndex;
+      }
+    }
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      if (component.getIonicCharge() != 0 || component.isIsIon()) {
+        ionOverallFraction += component.getz();
+      }
+    }
+    assertTrue(aqueousPhaseIndex >= 0);
+    assertTrue(system.getNumberOfPhases() >= 2);
+    system.setBeta(aqueousPhaseIndex, 0.5 * ionOverallFraction);
+    double nonAqueousBeta = (1.0 - system.getBeta(aqueousPhaseIndex))
+        / (system.getNumberOfPhases() - 1.0);
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (phaseIndex != aqueousPhaseIndex) {
+        system.setBeta(phaseIndex, nonAqueousBeta);
+      }
+    }
+
+    TPHybridEosGeFlash solver = new TPHybridEosGeFlash(system, system);
+    solver.calcE();
+    solver.setXY();
+    system.init(1);
+
+    assertTrue(system.getBeta(aqueousPhaseIndex) > ionOverallFraction);
+    assertEquals(1.0, betaSum(system), 1.0e-12);
+    PhaseInterface aqueous = system.getPhase(aqueousPhaseIndex);
+    for (int componentIndex = 0; componentIndex < aqueous.getNumberOfComponents(); componentIndex++) {
+      ComponentInterface component = aqueous.getComponent(componentIndex);
+      if (component.getIonicCharge() != 0 || component.isIsIon()) {
+        assertEquals(component.getz(), system.getBeta(aqueousPhaseIndex) * component.getx(), 1.0e-12,
+            component.getComponentName());
+      }
+    }
+  }
+
+  /** Qualified gas-forming CO2/Na2SO4 flashes remain closed across repeats and nearby pressure. */
+  @Test
+  void qualifiedCarbonDioxideSodiumSulfateGasAqueousFlashConverges() {
+    SystemPitzer system = createQualifiedCarbonDioxideSodiumSulfateSystem();
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+
+    operations.TPflash();
+    assertEquals(2, system.getNumberOfPhases(), phaseDiagnostics(system));
+    assertTrue(hasPhaseType(system, PhaseType.GAS), phaseDiagnostics(system));
+    assertTrue(hasPhaseType(system, PhaseType.AQUEOUS), phaseDiagnostics(system));
+    assertBalancedAndAtEquilibrium(system);
+    double firstGasBeta = findPhaseBeta(system, PhaseType.GAS);
+
+    operations.TPflash();
+    assertEquals(firstGasBeta, findPhaseBeta(system, PhaseType.GAS), 1.0e-10);
+    assertBalancedAndAtEquilibrium(system);
+
+    system.setPressure(140.0);
+    operations.TPflash();
+    assertEquals(2, system.getNumberOfPhases(), phaseDiagnostics(system));
+    assertTrue(hasPhaseType(system, PhaseType.GAS), phaseDiagnostics(system));
+    assertTrue(hasPhaseType(system, PhaseType.AQUEOUS), phaseDiagnostics(system));
+    assertBalancedAndAtEquilibrium(system);
   }
 
   /** Every SystemEosGE subclass can explicitly promote its GE liquid to the hybrid aqueous role. */
@@ -565,6 +657,36 @@ class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
     for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
       if (system.getPhase(phaseIndex).getType() == phaseType) {
         return system.getPhase(phaseIndex);
+      }
+    }
+    throw new AssertionError("Missing phase type " + phaseType);
+  }
+
+  /**
+   * Sum active phase fractions.
+   *
+   * @param system system to inspect
+   * @return active phase-fraction sum
+   */
+  private double betaSum(SystemInterface system) {
+    double total = 0.0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      total += system.getBeta(phaseIndex);
+    }
+    return total;
+  }
+
+  /**
+   * Find the active fraction of a phase type.
+   *
+   * @param system system to inspect
+   * @param phaseType requested phase type
+   * @return matching phase fraction
+   */
+  private double findPhaseBeta(SystemInterface system, PhaseType phaseType) {
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (system.getPhase(phaseIndex).getType() == phaseType) {
+        return system.getBeta(phaseIndex);
       }
     }
     throw new AssertionError("Missing phase type " + phaseType);

--- a/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
@@ -150,8 +150,7 @@ class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
     assertTrue(aqueousPhaseIndex >= 0);
     assertTrue(system.getNumberOfPhases() >= 2);
     system.setBeta(aqueousPhaseIndex, 0.5 * ionOverallFraction);
-    double nonAqueousBeta = (1.0 - system.getBeta(aqueousPhaseIndex))
-        / (system.getNumberOfPhases() - 1.0);
+    double nonAqueousBeta = (1.0 - system.getBeta(aqueousPhaseIndex)) / (system.getNumberOfPhases() - 1.0);
     for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
       if (phaseIndex != aqueousPhaseIndex) {
         system.setBeta(phaseIndex, nonAqueousBeta);


### PR DESCRIPTION
Refs #2937

## Summary

This fixes a deterministic feasibility failure in the fixed-role hybrid EOS-GE TP-flash used by `SystemPitzer` and related systems.

Ions are excluded from gas and oil roles, so the aqueous phase must satisfy:

`betaAqueous > sum(zIon)`

The unconstrained beta Newton correction can temporarily cross that boundary even when the final gas-aqueous equilibrium is feasible. The following `setXY()` call then requires aqueous ion mole fractions whose sum is at least one and aborts with `Hybrid EOS-GE aqueous composition cannot accommodate overall ion amount` before another Newton correction can recover.

The fix projects only that infeasible intermediate iterate back above the fixed ionic inventory. It takes the required fraction proportionally from the adjustable part of the other active phases, preserves every phase-fraction minimum, rebuilds the existing phase-split denominator, and leaves feasible iterates plus all final acceptance tolerances unchanged.

## Scope and safeguards

- Fixed-role hybrid EOS-GE flashes only; ordinary SRK/PR/CPA flashes do not dispatch here.
- Projection threshold: `sum(zIon) + 100 * phaseFractionMinimumLimit`.
- No dataset parameters, public API, convergence tolerances, phase-role semantics, or chemical-reaction equations change.
- No extra property initialization is performed on the normal feasible path.
- A physically impossible inventory still fails with explicit ion fraction, current/required aqueous beta, and adjustable phase-fraction diagnostics.
- Final normalization, material balance, molecular fugacity equality, phase-role restoration, trace-phase cleanup, and existing acceptance gates remain authoritative.

## Regression scope

The expanded `SystemHybridEosGeFlashTest`:

- deterministically forces the pre-fix failure by setting `betaAqueous = 0.5 * sum(zIon)`;
- verifies projection above the ionic inventory, beta normalization, ion confinement, and ionic material balance;
- runs the newly merged public-domain PHREEQC CO2-Na2SO4 subset at 373.15 K and 150 bar;
- requires GAS+AQUEOUS topology, bounded/normalized compositions, material balance below `1e-7`, and molecular log-fugacity residual below `1e-5`;
- repeats the settled flash and changes pressure to 140 bar to cover stale state and nearby-state continuity.

## Performance evidence

This is a correctness safeguard, not a speed optimization. The feasible hybrid path adds one allocation-free component scan to each composition update and performs no additional thermodynamic initialization. Only an infeasible projected iterate rebuilds the already allocated phase-split denominator. Neutral EOS flashes execute no new code. No wall-time claim is made without an executable local toolchain.

## Documentation impact

`docs/thermodynamicoperations/TPflash_algorithm.md` now documents the physical capacity inequality, projection rule, retained gates, regression matrix, performance boundary, and qualified Pitzer provenance link.

## Validation

Exact base: `cbca0e372e476a02ddae9302430317bcf348ec67`  
Exact head: `e80937872d051d56786f738883fce5495e430d9c`

Connector comparison confirms exactly three in-scope files and zero commits behind. The initial hosted pre-commit failure was Spotless-only; GitHub's exact three-hunk formatter output was applied in `e8093787`. Exact-head Spotless, pre-commit, PaperLab, documentation search/build, CodeQL, and Java 21 Javadoc pass. Java 21 Ubuntu/Windows fast tests and all four slow shards remain active without a reported failure. Local Java/Maven execution was unavailable in this environment, so no local test is claimed as passed.

No Column Solver, Process Performance, reaction-database, parameter-fitting, data-ingestion, or Huldra work is included.

**VALIDATION PENDING CI**