### PR TITLE
[AI-Assisted] fix(flash): synchronize hybrid beta projection

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -475,6 +475,11 @@ public class TPHybridEosGeFlash extends TPmultiflash {
       }
     }
     system.setBeta(aqueousPhaseIndex, 1.0 - nonAqueousFraction);
+    // SystemThermo keeps beta in both the mapped system array and each phase object. The
+    // composition kernel reads the phase copy immediately, before the next system init.
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      system.getPhase(phaseIndex).setBeta(system.getBeta(phaseIndex));
+    }
     return true;
   }
 


### PR DESCRIPTION
Refs #2937
Follow-up to merged #3216.

## Summary

PR #3216 was merged while its Java 21 fast suites were still running. The Windows exact-head job then reported two branch-attributable failures in `SystemHybridEosGeFlashTest`:

- `hybridBetaIterationRetainsAqueousIonCapacity`: projected ionic material balance was stale;
- `qualifiedCarbonDioxideSodiumSulfateGasAqueousFlashConverges`: the hybrid solver still reached an impossible aqueous ion composition.

The root cause is dual beta storage. `SystemThermo` stores mapped phase fractions in its system beta array, while each `Phase` also caches its own beta. The #3216 projection updated only the system array; `calcE()` and `setXY()` immediately read the unchanged phase copy before the next `system.init(1)`.

This repair synchronizes every active phase beta from the mapped system beta immediately after the infeasible iterate is projected and before the composition kernel runs.

## Scope and safeguards

- Exact current-master base: `2e9f471e9ca37f32c1888ecac205b21b523d41eb`.
- Exact head: `c89de7dd8d06edf97fa5a1a6f062f23930681a50`.
- One production file; no test, tolerance, dataset, API, reaction, or topology changes.
- The physical ionic-capacity bound from #3216 is unchanged.
- The synchronization loop runs only when an infeasible beta iterate is projected; the ordinary feasible path is unchanged.
- The existing #3216 regressions remain the direct acceptance tests for forced infeasible initialization, ionic material balance, full 150-bar convergence, repeat determinism, and the nearby 140-bar state.
- Final normalization, material balance, molecular fugacity, role restoration, and acceptance gates are unchanged.

## Documentation impact

No additional documentation is required. The algorithm section merged in #3216 remains accurate; this follow-up repairs the internal dual-state implementation needed to realize that documented projection.

## Validation

The failure was reproduced by hosted exact-head Java 21 Windows CI on merged #3216: 12,181 tests, one failure and one error, both in the new hybrid regression class. All four slow shards, Spotless, pre-commit, PaperLab, documentation, CodeQL, and Javadoc had passed. The replacement exact head requires a fresh full CI run; no local Java/Maven result is claimed.

No Column Solver, Process Performance, electrolyte-parameter, data-ingestion, or Huldra work is included.

**VALIDATION PENDING CI**