### PR TITLE
[AI-Assisted] fix(flash): damp hybrid ionic projection

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1987,11 +1987,13 @@ prevents a gas-forming neutral component from displacing nearly all aqueous solv
 step. Both bounds are evaluated before the trial composition is used. Ionic hybrid flashes also
 cap the common beta Newton scale at 0.1, damping every phase correction along the same simplex
 direction; non-ionic hybrid and ordinary multiphase flashes retain the general iteration-dependent
-scale. The aqueous neutral composition uses the same 0.1 convex relaxation before activity and
-fugacity coefficients are reinitialized, retaining the exact ionic inventory and normalization while
-preventing a single proposal from replacing nearly all solvent. Together these guards prevent
-non-finite coefficients and clipping-driven oscillation while allowing subsequent corrections to
-approach equilibrium.
+scale. A valid aqueous neutral-composition proposal remains unchanged. If its reinitialized
+material-component fugacity coefficient is non-finite or non-positive, the ionic hybrid solver
+backtracks the neutral composition halfway toward the last finite normalized composition until all
+material neutral coefficients are finite. This retains the exact ionic inventory and normalization
+without perturbing non-ionic or already-valid paths. Together these guards prevent non-finite
+coefficients and clipping-driven oscillation while allowing subsequent corrections to approach
+equilibrium.
 The required fraction is removed proportionally from the adjustable part of the other active roles,
 their minimum fractions are preserved, and the phase-split denominator is rebuilt before
 compositions are evaluated. Feasible iterates, public tolerances, dataset parameters, and final

--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1981,9 +1981,12 @@ The unconstrained beta Newton correction can cross that physical boundary during
 iteration even when the final gas-aqueous equilibrium is feasible. The hybrid solver now projects
 only such infeasible iterates back above
 `sum(zIon) + 100 * phaseFractionMinimumLimit`. The projection also limits a single correction to
-at most a twofold increase in aqueous ionic mole fraction, using the preceding finite composition
-as a trust-region reference. This prevents a formally normalized but nearly solvent-free
-intermediate brine from overflowing activity and fugacity coefficients before Newton recovery.
+at most a twofold increase in aqueous ionic mole fraction. It uses the synchronized
+pre-Newton aqueous phase fraction as the trust-region reference; because ions are confined to that
+phase, limiting one beta reduction to one half limits the corresponding concentration increase to
+twofold without consulting a possibly invalid trial composition. This prevents a formally
+normalized but nearly solvent-free intermediate brine from overflowing activity and fugacity
+coefficients before Newton recovery.
 The required fraction is removed proportionally from the adjustable part of the other active roles,
 their minimum fractions are preserved, and the phase-split denominator is rebuilt before
 compositions are evaluated. Feasible iterates, public tolerances, dataset parameters, and final

--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1979,13 +1979,18 @@ normalized neutral solvent composition exists.
 
 The unconstrained beta Newton correction can cross that physical boundary during an intermediate
 iteration even when the final gas-aqueous equilibrium is feasible. The hybrid solver now projects
-only such infeasible iterates back to
-`sum(zIon) + 100 * phaseFractionMinimumLimit`. The required fraction is removed proportionally
-from the adjustable part of the other active roles, their minimum fractions are preserved, and the
-phase-split denominator is rebuilt before compositions are evaluated. Feasible iterates, public
-tolerances, dataset parameters, and final acceptance checks are unchanged. If the ionic inventory
-cannot fit while retaining the active roles at their numerical minima, the solver still fails with
-explicit capacity diagnostics.
+only such infeasible iterates back above
+`sum(zIon) + 100 * phaseFractionMinimumLimit`. The projection also limits a single correction to
+at most a twofold increase in aqueous ionic mole fraction, using the preceding finite composition
+as a trust-region reference. This prevents a formally normalized but nearly solvent-free
+intermediate brine from overflowing activity and fugacity coefficients before Newton recovery.
+The required fraction is removed proportionally from the adjustable part of the other active roles,
+their minimum fractions are preserved, and the phase-split denominator is rebuilt before
+compositions are evaluated. Feasible iterates, public tolerances, dataset parameters, and final
+acceptance checks are unchanged. If the ionic inventory cannot fit while retaining the active roles
+at their numerical minima, the solver still fails with explicit capacity diagnostics. Finalization
+also treats non-finite mole fractions or fugacity coefficients in a material phase as a failed
+equilibrium gate and records the offending component rather than silently excluding it.
 
 The regression uses the public-domain PHREEQC CO2-Na2SO4 subset documented in
 `docs/thermo/pitzer_parameter_provenance.md`. It forces a formerly invalid intermediate beta below

--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1987,8 +1987,11 @@ prevents a gas-forming neutral component from displacing nearly all aqueous solv
 step. Both bounds are evaluated before the trial composition is used. Ionic hybrid flashes also
 cap the common beta Newton scale at 0.1, damping every phase correction along the same simplex
 direction; non-ionic hybrid and ordinary multiphase flashes retain the general iteration-dependent
-scale. Together these guards prevent invalid activity or fugacity coefficients and clipping-driven
-oscillation while allowing subsequent corrections to approach equilibrium.
+scale. The aqueous neutral composition uses the same 0.1 convex relaxation before activity and
+fugacity coefficients are reinitialized, retaining the exact ionic inventory and normalization while
+preventing a single proposal from replacing nearly all solvent. Together these guards prevent
+non-finite coefficients and clipping-driven oscillation while allowing subsequent corrections to
+approach equilibrium.
 The required fraction is removed proportionally from the adjustable part of the other active roles,
 their minimum fractions are preserved, and the phase-split denominator is rebuilt before
 compositions are evaluated. Feasible iterates, public tolerances, dataset parameters, and final

--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1984,8 +1984,11 @@ only such infeasible iterates back above
 between one half and twice the synchronized pre-Newton aqueous phase fraction. Limiting beta
 reduction bounds the corresponding ionic-concentration increase, while limiting beta growth
 prevents a gas-forming neutral component from displacing nearly all aqueous solvent in one Newton
-step. Both bounds are evaluated before the trial composition is used, preventing invalid activity
-or fugacity coefficients while allowing subsequent corrections to approach equilibrium.
+step. Both bounds are evaluated before the trial composition is used. Ionic hybrid flashes also
+cap the common beta Newton scale at 0.1, damping every phase correction along the same simplex
+direction; non-ionic hybrid and ordinary multiphase flashes retain the general iteration-dependent
+scale. Together these guards prevent invalid activity or fugacity coefficients and clipping-driven
+oscillation while allowing subsequent corrections to approach equilibrium.
 The required fraction is removed proportionally from the adjustable part of the other active roles,
 their minimum fractions are preserved, and the phase-split denominator is rebuilt before
 compositions are evaluated. Feasible iterates, public tolerances, dataset parameters, and final

--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1981,12 +1981,11 @@ The unconstrained beta Newton correction can cross that physical boundary during
 iteration even when the final gas-aqueous equilibrium is feasible. The hybrid solver now projects
 only such infeasible iterates back above
 `sum(zIon) + 100 * phaseFractionMinimumLimit`. The projection also limits a single correction to
-at most a twofold increase in aqueous ionic mole fraction. It uses the synchronized
-pre-Newton aqueous phase fraction as the trust-region reference; because ions are confined to that
-phase, limiting one beta reduction to one half limits the corresponding concentration increase to
-twofold without consulting a possibly invalid trial composition. This prevents a formally
-normalized but nearly solvent-free intermediate brine from overflowing activity and fugacity
-coefficients before Newton recovery.
+between one half and twice the synchronized pre-Newton aqueous phase fraction. Limiting beta
+reduction bounds the corresponding ionic-concentration increase, while limiting beta growth
+prevents a gas-forming neutral component from displacing nearly all aqueous solvent in one Newton
+step. Both bounds are evaluated before the trial composition is used, preventing invalid activity
+or fugacity coefficients while allowing subsequent corrections to approach equilibrium.
 The required fraction is removed proportionally from the adjustable part of the other active roles,
 their minimum fractions are preserved, and the phase-split denominator is rebuilt before
 compositions are evaluated. Feasible iterates, public tolerances, dataset parameters, and final

--- a/src/main/java/neqsim/thermo/system/SystemEosGE.java
+++ b/src/main/java/neqsim/thermo/system/SystemEosGE.java
@@ -513,7 +513,17 @@ public abstract class SystemEosGE extends SystemEos implements HybridEosGeFlashM
         neqsim.thermo.component.ComponentInterface phaseComponent = getPhase(phaseIndex).getComponent(componentIndex);
         double moleFraction = phaseComponent.getx();
         double fugacityCoefficient = phaseComponent.getFugacityCoefficient();
-        if (!(moleFraction > 1.0e-30) || !(fugacityCoefficient > 0.0) || !Double.isFinite(fugacityCoefficient)) {
+        if (!Double.isFinite(moleFraction) || moleFraction < 0.0) {
+          lastHybridLogFugacityResidual = Double.POSITIVE_INFINITY;
+          lastHybridWorstFugacityComponent = phaseComponent.getComponentName();
+          continue;
+        }
+        if (moleFraction <= 1.0e-30) {
+          continue;
+        }
+        if (!(fugacityCoefficient > 0.0) || !Double.isFinite(fugacityCoefficient)) {
+          lastHybridLogFugacityResidual = Double.POSITIVE_INFINITY;
+          lastHybridWorstFugacityComponent = phaseComponent.getComponentName();
           continue;
         }
         double logFugacity = Math.log(moleFraction * fugacityCoefficient * getPhase(phaseIndex).getPressure());

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -49,6 +49,9 @@ public class TPHybridEosGeFlash extends TPmultiflash {
   /** Largest aqueous phase-fraction ratio allowed in one projected beta correction. */
   private static final double HYBRID_AQUEOUS_FRACTION_STEP_LIMIT = 2.0;
 
+  /** Maximum common Newton beta-step scale for a hybrid flash carrying ions. */
+  private static final double HYBRID_IONIC_BETA_STEP_SCALE = 0.1;
+
   /** Reaction-adjusted overall component fractions used by the coupled phase solve. */
   private transient double[] coupledOverallFractions;
 
@@ -67,6 +70,30 @@ public class TPHybridEosGeFlash extends TPmultiflash {
   public TPHybridEosGeFlash(SystemInterface system, HybridEosGeFlashModel hybridModel) {
     super(system, false);
     this.hybridModel = hybridModel;
+  }
+
+  /**
+   * Damp the complete beta correction while an ionic inventory is confined to the aqueous role.
+   *
+   * <p>
+   * Scaling every phase correction together preserves the Newton direction and avoids the oscillation produced by
+   * independently clipping one phase after the step. Non-ionic hybrid and ordinary multiphase flashes retain the
+   * general solver's iteration-dependent scale.
+   * </p>
+   *
+   * @param proposedScale iteration-dependent scale selected by the general solver
+   * @return damped common scale for ionic hybrid flashes
+   */
+  @Override
+  protected double limitBetaStepScale(double proposedScale) {
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      if ((component.getIonicCharge() != 0 || component.isIsIon())
+          && getCoupledOverallFraction(componentIndex) > 0.0) {
+        return Math.min(proposedScale, HYBRID_IONIC_BETA_STEP_SCALE);
+      }
+    }
+    return proposedScale;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -88,8 +88,7 @@ public class TPHybridEosGeFlash extends TPmultiflash {
   protected double limitBetaStepScale(double proposedScale) {
     for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
       ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
-      if ((component.getIonicCharge() != 0 || component.isIsIon())
-          && getCoupledOverallFraction(componentIndex) > 0.0) {
+      if ((component.getIonicCharge() != 0 || component.isIsIon()) && getCoupledOverallFraction(componentIndex) > 0.0) {
         return Math.min(proposedScale, HYBRID_IONIC_BETA_STEP_SCALE);
       }
     }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -46,6 +46,9 @@ public class TPHybridEosGeFlash extends TPmultiflash {
   /** Extra aqueous phase-fraction room retained above the fixed ionic inventory. */
   private static final double HYBRID_ION_CAPACITY_MARGIN = 100.0 * phaseFractionMinimumLimit;
 
+  /** Largest ionic-concentration increase allowed in one projected beta correction. */
+  private static final double HYBRID_ION_CONCENTRATION_STEP_LIMIT = 2.0;
+
   /** Reaction-adjusted overall component fractions used by the coupled phase solve. */
   private transient double[] coupledOverallFractions;
 
@@ -418,10 +421,13 @@ public class TPHybridEosGeFlash extends TPmultiflash {
     }
 
     double ionOverallFraction = 0.0;
+    double currentAqueousIonFraction = 0.0;
     for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
       ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
       if (component.getIonicCharge() != 0 || component.isIsIon()) {
         ionOverallFraction += Math.max(getCoupledOverallFraction(componentIndex), 0.0);
+        currentAqueousIonFraction +=
+            Math.max(system.getPhase(aqueousPhaseIndex).getComponent(componentIndex).getx(), 0.0);
       }
     }
     if (!(ionOverallFraction > 0.0) || !Double.isFinite(ionOverallFraction)) {
@@ -429,7 +435,14 @@ public class TPHybridEosGeFlash extends TPmultiflash {
     }
 
     double maximumAqueousFraction = 1.0 - (system.getNumberOfPhases() - 1.0) * phaseFractionMinimumLimit;
-    double minimumAqueousFraction = Math.min(maximumAqueousFraction, ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN);
+    double maximumProjectedIonFraction =
+        Double.isFinite(currentAqueousIonFraction) && currentAqueousIonFraction > HYBRID_ION_CAPACITY_MARGIN
+            ? Math.min(1.0 - HYBRID_ION_CAPACITY_MARGIN,
+                HYBRID_ION_CONCENTRATION_STEP_LIMIT * currentAqueousIonFraction)
+            : 1.0 / HYBRID_ION_CONCENTRATION_STEP_LIMIT;
+    double concentrationLimitedAqueousFraction = ionOverallFraction / maximumProjectedIonFraction;
+    double minimumAqueousFraction = Math.min(maximumAqueousFraction,
+        Math.max(ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN, concentrationLimitedAqueousFraction));
     double currentAqueousFraction = system.getBeta(aqueousPhaseIndex);
     if (currentAqueousFraction >= minimumAqueousFraction) {
       return false;
@@ -445,7 +458,9 @@ public class TPHybridEosGeFlash extends TPmultiflash {
     if (adjustableFraction + phaseFractionMinimumLimit < requiredTransfer) {
       throw new IllegalStateException("Hybrid EOS-GE phase fractions cannot accommodate the ionic inventory: "
           + "ionOverallFraction=" + ionOverallFraction + ", aqueousBeta=" + currentAqueousFraction
-          + ", requiredAqueousBeta=" + minimumAqueousFraction + ", adjustableFraction=" + adjustableFraction);
+          + ", requiredAqueousBeta=" + minimumAqueousFraction + ", previousAqueousIonFraction="
+          + currentAqueousIonFraction + ", maximumProjectedIonFraction=" + maximumProjectedIonFraction
+          + ", adjustableFraction=" + adjustableFraction);
     }
 
     double remainingTransfer = requiredTransfer;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -426,8 +426,8 @@ public class TPHybridEosGeFlash extends TPmultiflash {
       ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
       if (component.getIonicCharge() != 0 || component.isIsIon()) {
         ionOverallFraction += Math.max(getCoupledOverallFraction(componentIndex), 0.0);
-        currentAqueousIonFraction +=
-            Math.max(system.getPhase(aqueousPhaseIndex).getComponent(componentIndex).getx(), 0.0);
+        currentAqueousIonFraction += Math.max(system.getPhase(aqueousPhaseIndex).getComponent(componentIndex).getx(),
+            0.0);
       }
     }
     if (!(ionOverallFraction > 0.0) || !Double.isFinite(ionOverallFraction)) {
@@ -435,8 +435,8 @@ public class TPHybridEosGeFlash extends TPmultiflash {
     }
 
     double maximumAqueousFraction = 1.0 - (system.getNumberOfPhases() - 1.0) * phaseFractionMinimumLimit;
-    double maximumProjectedIonFraction =
-        Double.isFinite(currentAqueousIonFraction) && currentAqueousIonFraction > HYBRID_ION_CAPACITY_MARGIN
+    double maximumProjectedIonFraction = Double.isFinite(currentAqueousIonFraction)
+        && currentAqueousIonFraction > HYBRID_ION_CAPACITY_MARGIN
             ? Math.min(1.0 - HYBRID_ION_CAPACITY_MARGIN,
                 HYBRID_ION_CONCENTRATION_STEP_LIMIT * currentAqueousIonFraction)
             : 1.0 / HYBRID_ION_CONCENTRATION_STEP_LIMIT;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -466,7 +466,8 @@ public class TPHybridEosGeFlash extends TPmultiflash {
       }
     }
 
-    if (lineSearchAqueousPhase >= 0 && previousNeutralShares != null && proposedNeutralShares != null) {
+    if (lineSearchAqueousPhase >= 0 && previousNeutralShares != null && proposedNeutralShares != null
+        && Double.isFinite(previousAqueousFractionBeforeBetaCorrection)) {
       system.init(1);
       if (hasFiniteAqueousNeutralFugacities(lineSearchAqueousPhase)) {
         return;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -46,8 +46,8 @@ public class TPHybridEosGeFlash extends TPmultiflash {
   /** Extra aqueous phase-fraction room retained above the fixed ionic inventory. */
   private static final double HYBRID_ION_CAPACITY_MARGIN = 100.0 * phaseFractionMinimumLimit;
 
-  /** Largest ionic-concentration increase allowed in one projected beta correction. */
-  private static final double HYBRID_ION_CONCENTRATION_STEP_LIMIT = 2.0;
+  /** Largest aqueous phase-fraction ratio allowed in one projected beta correction. */
+  private static final double HYBRID_AQUEOUS_FRACTION_STEP_LIMIT = 2.0;
 
   /** Reaction-adjusted overall component fractions used by the coupled phase solve. */
   private transient double[] coupledOverallFractions;
@@ -349,7 +349,7 @@ public class TPHybridEosGeFlash extends TPmultiflash {
   /** {@inheritDoc} */
   @Override
   public void setXY() {
-    if (enforceAqueousIonCapacityBound()) {
+    if (enforceAqueousFractionBounds()) {
       // The beta Newton step was projected back into the physically admissible region. Rebuild
       // E with the projected fractions before calculating component compositions.
       calcE();
@@ -406,15 +406,16 @@ public class TPHybridEosGeFlash extends TPmultiflash {
    * <p>
    * Ions are excluded from EOS gas and oil roles, so their aqueous mole fractions sum to
    * {@code sum(zIon) / betaAqueous}. An unconstrained Newton correction can temporarily move {@code betaAqueous} below
-   * {@code sum(zIon)} even when the final equilibrium is feasible. That iterate has no normalized aqueous composition
-   * and formerly failed before the next correction could recover. This method projects only such infeasible iterates
-   * onto the ionic-capacity boundary, taking the required fraction proportionally from the adjustable part of the other
-   * active phases. Feasible iterates and the final acceptance tolerances are unchanged.
+   * {@code sum(zIon)} even when the final equilibrium is feasible. A correction in the other direction can likewise
+   * displace nearly all aqueous solvent before the phase model can update its fugacities. This method projects the
+   * aqueous fraction onto the ionic-capacity boundary and a bidirectional step-ratio trust region, transferring the
+   * correction proportionally to or from the other active phases. Feasible iterates and the final acceptance tolerances
+   * are unchanged.
    * </p>
    *
    * @return {@code true} when the phase fractions were projected
    */
-  private boolean enforceAqueousIonCapacityBound() {
+  private boolean enforceAqueousFractionBounds() {
     int aqueousPhaseIndex = -1;
     for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
       if (hybridModel.isHybridEosGeAqueousPhase(phaseIndex)) {
@@ -439,17 +440,43 @@ public class TPHybridEosGeFlash extends TPmultiflash {
 
     double maximumAqueousFraction = 1.0 - (system.getNumberOfPhases() - 1.0) * phaseFractionMinimumLimit;
     // calcQ captures the settled beta before the Newton proposal is written and initialized.
-    // Limiting beta reduction therefore bounds the corresponding ionic-concentration increase
-    // without consulting a possibly invalid trial composition.
+    // Limiting beta reduction bounds the corresponding ionic-concentration increase, while
+    // limiting beta growth prevents one proposal from displacing nearly all aqueous solvent.
     double previousAqueousFraction = previousAqueousFractionBeforeBetaCorrection;
-    double concentrationLimitedAqueousFraction = Double.isFinite(previousAqueousFraction)
-        && previousAqueousFraction > 0.0 ? previousAqueousFraction / HYBRID_ION_CONCENTRATION_STEP_LIMIT
+    double stepLimitedMinimumAqueousFraction = Double.isFinite(previousAqueousFraction)
+        && previousAqueousFraction > 0.0 ? previousAqueousFraction / HYBRID_AQUEOUS_FRACTION_STEP_LIMIT
             : ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN;
     double minimumAqueousFraction = Math.min(maximumAqueousFraction,
-        Math.max(ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN, concentrationLimitedAqueousFraction));
+        Math.max(ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN, stepLimitedMinimumAqueousFraction));
+    double stepLimitedMaximumAqueousFraction = Double.isFinite(previousAqueousFraction)
+        && previousAqueousFraction > 0.0
+            ? Math.min(maximumAqueousFraction,
+                previousAqueousFraction * HYBRID_AQUEOUS_FRACTION_STEP_LIMIT)
+            : maximumAqueousFraction;
     double currentAqueousFraction = system.getBeta(aqueousPhaseIndex);
-    if (currentAqueousFraction >= minimumAqueousFraction) {
+    if (currentAqueousFraction >= minimumAqueousFraction
+        && currentAqueousFraction <= stepLimitedMaximumAqueousFraction) {
       return false;
+    }
+
+    if (currentAqueousFraction > stepLimitedMaximumAqueousFraction) {
+      double excessAqueousFraction = currentAqueousFraction - stepLimitedMaximumAqueousFraction;
+      double nonAqueousFraction = 0.0;
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        if (phaseIndex != aqueousPhaseIndex) {
+          nonAqueousFraction += system.getBeta(phaseIndex);
+        }
+      }
+      for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+        if (phaseIndex != aqueousPhaseIndex) {
+          double share = nonAqueousFraction > 0.0 ? system.getBeta(phaseIndex) / nonAqueousFraction
+              : 1.0 / (system.getNumberOfPhases() - 1.0);
+          system.setBeta(phaseIndex, system.getBeta(phaseIndex) + excessAqueousFraction * share);
+        }
+      }
+      system.setBeta(aqueousPhaseIndex, stepLimitedMaximumAqueousFraction);
+      synchronizePhaseBetaMirrors();
+      return true;
     }
 
     double requiredTransfer = minimumAqueousFraction - currentAqueousFraction;
@@ -495,10 +522,15 @@ public class TPHybridEosGeFlash extends TPmultiflash {
     system.setBeta(aqueousPhaseIndex, 1.0 - nonAqueousFraction);
     // SystemThermo keeps beta in both the mapped system array and each phase object. The
     // composition kernel reads the phase copy immediately, before the next system init.
+    synchronizePhaseBetaMirrors();
+    return true;
+  }
+
+  /** Synchronize the mapped system beta values into their active phase objects. */
+  private void synchronizePhaseBetaMirrors() {
     for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
       system.getPhase(phaseIndex).setBeta(system.getBeta(phaseIndex));
     }
-    return true;
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -421,13 +421,10 @@ public class TPHybridEosGeFlash extends TPmultiflash {
     }
 
     double ionOverallFraction = 0.0;
-    double currentAqueousIonFraction = 0.0;
     for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
       ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
       if (component.getIonicCharge() != 0 || component.isIsIon()) {
         ionOverallFraction += Math.max(getCoupledOverallFraction(componentIndex), 0.0);
-        currentAqueousIonFraction += Math.max(system.getPhase(aqueousPhaseIndex).getComponent(componentIndex).getx(),
-            0.0);
       }
     }
     if (!(ionOverallFraction > 0.0) || !Double.isFinite(ionOverallFraction)) {
@@ -435,12 +432,14 @@ public class TPHybridEosGeFlash extends TPmultiflash {
     }
 
     double maximumAqueousFraction = 1.0 - (system.getNumberOfPhases() - 1.0) * phaseFractionMinimumLimit;
-    double maximumProjectedIonFraction = Double.isFinite(currentAqueousIonFraction)
-        && currentAqueousIonFraction > HYBRID_ION_CAPACITY_MARGIN
-            ? Math.min(1.0 - HYBRID_ION_CAPACITY_MARGIN,
-                HYBRID_ION_CONCENTRATION_STEP_LIMIT * currentAqueousIonFraction)
-            : 1.0 / HYBRID_ION_CONCENTRATION_STEP_LIMIT;
-    double concentrationLimitedAqueousFraction = ionOverallFraction / maximumProjectedIonFraction;
+    // The phase object retains the synchronized pre-Newton beta while the system beta array
+    // contains the current proposal. Limiting beta reduction therefore bounds the corresponding
+    // ionic-concentration increase without consulting a possibly invalid trial composition.
+    double previousAqueousFraction = system.getPhase(aqueousPhaseIndex).getBeta();
+    double concentrationLimitedAqueousFraction =
+        Double.isFinite(previousAqueousFraction) && previousAqueousFraction > 0.0
+            ? previousAqueousFraction / HYBRID_ION_CONCENTRATION_STEP_LIMIT
+            : ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN;
     double minimumAqueousFraction = Math.min(maximumAqueousFraction,
         Math.max(ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN, concentrationLimitedAqueousFraction));
     double currentAqueousFraction = system.getBeta(aqueousPhaseIndex);
@@ -458,9 +457,8 @@ public class TPHybridEosGeFlash extends TPmultiflash {
     if (adjustableFraction + phaseFractionMinimumLimit < requiredTransfer) {
       throw new IllegalStateException("Hybrid EOS-GE phase fractions cannot accommodate the ionic inventory: "
           + "ionOverallFraction=" + ionOverallFraction + ", aqueousBeta=" + currentAqueousFraction
-          + ", requiredAqueousBeta=" + minimumAqueousFraction + ", previousAqueousIonFraction="
-          + currentAqueousIonFraction + ", maximumProjectedIonFraction=" + maximumProjectedIonFraction
-          + ", adjustableFraction=" + adjustableFraction);
+          + ", requiredAqueousBeta=" + minimumAqueousFraction + ", previousAqueousBeta="
+          + previousAqueousFraction + ", adjustableFraction=" + adjustableFraction);
     }
 
     double remainingTransfer = requiredTransfer;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -436,9 +436,8 @@ public class TPHybridEosGeFlash extends TPmultiflash {
     // contains the current proposal. Limiting beta reduction therefore bounds the corresponding
     // ionic-concentration increase without consulting a possibly invalid trial composition.
     double previousAqueousFraction = system.getPhase(aqueousPhaseIndex).getBeta();
-    double concentrationLimitedAqueousFraction =
-        Double.isFinite(previousAqueousFraction) && previousAqueousFraction > 0.0
-            ? previousAqueousFraction / HYBRID_ION_CONCENTRATION_STEP_LIMIT
+    double concentrationLimitedAqueousFraction = Double.isFinite(previousAqueousFraction)
+        && previousAqueousFraction > 0.0 ? previousAqueousFraction / HYBRID_ION_CONCENTRATION_STEP_LIMIT
             : ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN;
     double minimumAqueousFraction = Math.min(maximumAqueousFraction,
         Math.max(ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN, concentrationLimitedAqueousFraction));
@@ -457,8 +456,8 @@ public class TPHybridEosGeFlash extends TPmultiflash {
     if (adjustableFraction + phaseFractionMinimumLimit < requiredTransfer) {
       throw new IllegalStateException("Hybrid EOS-GE phase fractions cannot accommodate the ionic inventory: "
           + "ionOverallFraction=" + ionOverallFraction + ", aqueousBeta=" + currentAqueousFraction
-          + ", requiredAqueousBeta=" + minimumAqueousFraction + ", previousAqueousBeta="
-          + previousAqueousFraction + ", adjustableFraction=" + adjustableFraction);
+          + ", requiredAqueousBeta=" + minimumAqueousFraction + ", previousAqueousBeta=" + previousAqueousFraction
+          + ", adjustableFraction=" + adjustableFraction);
     }
 
     double remainingTransfer = requiredTransfer;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -314,8 +314,8 @@ public class TPHybridEosGeFlash extends TPmultiflash {
   @Override
   public double calcQ() {
     int aqueousPhaseIndex = getHybridAqueousPhaseNumber();
-    previousAqueousFractionBeforeBetaCorrection =
-        aqueousPhaseIndex >= 0 ? system.getPhase(aqueousPhaseIndex).getBeta() : Double.NaN;
+    previousAqueousFractionBeforeBetaCorrection = aqueousPhaseIndex >= 0 ? system.getPhase(aqueousPhaseIndex).getBeta()
+        : Double.NaN;
     calcE();
     for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
       double overallFraction = getCoupledOverallFraction(componentIndex);

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -52,8 +52,6 @@ public class TPHybridEosGeFlash extends TPmultiflash {
   /** Maximum common Newton beta-step scale for a hybrid flash carrying ions. */
   private static final double HYBRID_IONIC_BETA_STEP_SCALE = 0.1;
 
-  /** Fraction of a new aqueous neutral-composition proposal accepted per iteration. */
-  private static final double HYBRID_AQUEOUS_COMPOSITION_RELAXATION = 0.1;
 
   /** Reaction-adjusted overall component fractions used by the coupled phase solve. */
   private transient double[] coupledOverallFractions;
@@ -89,13 +87,22 @@ public class TPHybridEosGeFlash extends TPmultiflash {
    */
   @Override
   protected double limitBetaStepScale(double proposedScale) {
+    return hasPositiveHybridIonicInventory() ? Math.min(proposedScale, HYBRID_IONIC_BETA_STEP_SCALE) : proposedScale;
+  }
+
+  /**
+   * Check whether the current coupled inventory contains an ion confined to the aqueous role.
+   *
+   * @return {@code true} when a positive ionic overall fraction is present
+   */
+  private boolean hasPositiveHybridIonicInventory() {
     for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
       ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
       if ((component.getIonicCharge() != 0 || component.isIsIon()) && getCoupledOverallFraction(componentIndex) > 0.0) {
-        return Math.min(proposedScale, HYBRID_IONIC_BETA_STEP_SCALE);
+        return true;
       }
     }
-    return proposedScale;
+    return false;
   }
 
   /** {@inheritDoc} */
@@ -383,21 +390,35 @@ public class TPHybridEosGeFlash extends TPmultiflash {
       // E with the projected fractions before calculating component compositions.
       calcE();
     }
+
+    int lineSearchAqueousPhase = -1;
+    double[] previousNeutralShares = null;
+    double[] proposedNeutralShares = null;
+    double lineSearchNeutralTotal = Double.NaN;
+    boolean ionicInventory = hasPositiveHybridIonicInventory();
     for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
       boolean aqueous = hybridModel.isHybridEosGeAqueousPhase(phaseIndex);
       double phaseFraction = Math.max(system.getPhase(phaseIndex).getBeta(), phaseFractionMinimumLimit);
       int numberOfComponents = system.getPhase(0).getNumberOfComponents();
-      double[] previousNeutralComposition = aqueous ? new double[numberOfComponents] : null;
       double previousNeutralFractionSum = 0.0;
-      if (aqueous) {
+      if (aqueous && ionicInventory) {
+        lineSearchAqueousPhase = phaseIndex;
+        previousNeutralShares = new double[numberOfComponents];
+        proposedNeutralShares = new double[numberOfComponents];
         for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
           ComponentInterface component = system.getPhase(phaseIndex).getComponent(componentIndex);
           if (component.getIonicCharge() == 0 && !component.isIsIon()) {
-            previousNeutralComposition[componentIndex] = Math.max(component.getx(), 0.0);
-            previousNeutralFractionSum += previousNeutralComposition[componentIndex];
+            previousNeutralShares[componentIndex] = Math.max(component.getx(), 0.0);
+            previousNeutralFractionSum += previousNeutralShares[componentIndex];
+          }
+        }
+        if (previousNeutralFractionSum > 0.0) {
+          for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+            previousNeutralShares[componentIndex] /= previousNeutralFractionSum;
           }
         }
       }
+
       double ionFractionSum = 0.0;
       double neutralFractionSum = 0.0;
       for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
@@ -433,19 +454,65 @@ public class TPHybridEosGeFlash extends TPmultiflash {
           if (referenceComponent.getIonicCharge() == 0 && !referenceComponent.isIsIon()) {
             ComponentInterface aqueousComponent = system.getPhase(phaseIndex).getComponent(componentIndex);
             double proposedNeutralShare = aqueousComponent.getx() / neutralFractionSum;
-            double relaxedNeutralShare = proposedNeutralShare;
-            if (previousNeutralFractionSum > 0.0) {
-              double previousNeutralShare = previousNeutralComposition[componentIndex] / previousNeutralFractionSum;
-              relaxedNeutralShare = previousNeutralShare
-                  + HYBRID_AQUEOUS_COMPOSITION_RELAXATION * (proposedNeutralShare - previousNeutralShare);
+            aqueousComponent.setx(neutralTotal * proposedNeutralShare);
+            if (phaseIndex == lineSearchAqueousPhase) {
+              proposedNeutralShares[componentIndex] = proposedNeutralShare;
+              lineSearchNeutralTotal = neutralTotal;
             }
-            aqueousComponent.setx(neutralTotal * relaxedNeutralShare);
           }
         }
       } else {
         system.getPhase(phaseIndex).normalize();
       }
     }
+
+    if (lineSearchAqueousPhase >= 0 && previousNeutralShares != null && proposedNeutralShares != null) {
+      system.init(1);
+      if (hasFiniteAqueousNeutralFugacities(lineSearchAqueousPhase)) {
+        return;
+      }
+      double lineSearchFraction = 0.5;
+      while (lineSearchFraction >= 1.0e-6) {
+        PhaseInterface aqueousPhase = system.getPhase(lineSearchAqueousPhase);
+        for (int componentIndex = 0; componentIndex < aqueousPhase.getNumberOfComponents(); componentIndex++) {
+          ComponentInterface component = aqueousPhase.getComponent(componentIndex);
+          if (component.getIonicCharge() == 0 && !component.isIsIon()) {
+            double neutralShare = previousNeutralShares[componentIndex] + lineSearchFraction
+                * (proposedNeutralShares[componentIndex] - previousNeutralShares[componentIndex]);
+            component.setx(lineSearchNeutralTotal * neutralShare);
+          }
+        }
+        system.init(1);
+        if (hasFiniteAqueousNeutralFugacities(lineSearchAqueousPhase)) {
+          return;
+        }
+        lineSearchFraction *= 0.5;
+      }
+      throw new IllegalStateException(
+          "Hybrid EOS-GE aqueous neutral-composition line search could not retain finite fugacity coefficients.");
+    }
+  }
+
+  /**
+   * Check finite positive fugacity coefficients for material neutral components in the aqueous role.
+   *
+   * @param aqueousPhaseIndex active aqueous phase index
+   * @return {@code true} when every material neutral component has a finite positive coefficient
+   */
+  private boolean hasFiniteAqueousNeutralFugacities(int aqueousPhaseIndex) {
+    PhaseInterface aqueousPhase = system.getPhase(aqueousPhaseIndex);
+    for (int componentIndex = 0; componentIndex < aqueousPhase.getNumberOfComponents(); componentIndex++) {
+      ComponentInterface component = aqueousPhase.getComponent(componentIndex);
+      if (getCoupledOverallFraction(componentIndex) <= 1.0e-30 || component.getIonicCharge() != 0
+          || component.isIsIon()) {
+        continue;
+      }
+      if (!(component.getx() > 0.0) || !Double.isFinite(component.getx())
+          || !(component.getFugacityCoefficient() > 0.0) || !Double.isFinite(component.getFugacityCoefficient())) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -55,6 +55,9 @@ public class TPHybridEosGeFlash extends TPmultiflash {
   /** Exact reaction-adjusted overall component mole inventory. */
   private transient double[] coupledOverallMoles;
 
+  /** Settled aqueous phase fraction captured immediately before a beta Newton correction. */
+  private transient double previousAqueousFractionBeforeBetaCorrection = Double.NaN;
+
   /**
    * Create a hybrid multiphase flash.
    *
@@ -310,6 +313,9 @@ public class TPHybridEosGeFlash extends TPmultiflash {
   /** {@inheritDoc} */
   @Override
   public double calcQ() {
+    int aqueousPhaseIndex = getHybridAqueousPhaseNumber();
+    previousAqueousFractionBeforeBetaCorrection =
+        aqueousPhaseIndex >= 0 ? system.getPhase(aqueousPhaseIndex).getBeta() : Double.NaN;
     calcE();
     for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
       double overallFraction = getCoupledOverallFraction(componentIndex);
@@ -432,10 +438,10 @@ public class TPHybridEosGeFlash extends TPmultiflash {
     }
 
     double maximumAqueousFraction = 1.0 - (system.getNumberOfPhases() - 1.0) * phaseFractionMinimumLimit;
-    // The phase object retains the synchronized pre-Newton beta while the system beta array
-    // contains the current proposal. Limiting beta reduction therefore bounds the corresponding
-    // ionic-concentration increase without consulting a possibly invalid trial composition.
-    double previousAqueousFraction = system.getPhase(aqueousPhaseIndex).getBeta();
+    // calcQ captures the settled beta before the Newton proposal is written and initialized.
+    // Limiting beta reduction therefore bounds the corresponding ionic-concentration increase
+    // without consulting a possibly invalid trial composition.
+    double previousAqueousFraction = previousAqueousFractionBeforeBetaCorrection;
     double concentrationLimitedAqueousFraction = Double.isFinite(previousAqueousFraction)
         && previousAqueousFraction > 0.0 ? previousAqueousFraction / HYBRID_ION_CONCENTRATION_STEP_LIMIT
             : ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -435,10 +435,9 @@ public class TPHybridEosGeFlash extends TPmultiflash {
             double proposedNeutralShare = aqueousComponent.getx() / neutralFractionSum;
             double relaxedNeutralShare = proposedNeutralShare;
             if (previousNeutralFractionSum > 0.0) {
-              double previousNeutralShare =
-                  previousNeutralComposition[componentIndex] / previousNeutralFractionSum;
-              relaxedNeutralShare = previousNeutralShare + HYBRID_AQUEOUS_COMPOSITION_RELAXATION
-                  * (proposedNeutralShare - previousNeutralShare);
+              double previousNeutralShare = previousNeutralComposition[componentIndex] / previousNeutralFractionSum;
+              relaxedNeutralShare = previousNeutralShare
+                  + HYBRID_AQUEOUS_COMPOSITION_RELAXATION * (proposedNeutralShare - previousNeutralShare);
             }
             aqueousComponent.setx(neutralTotal * relaxedNeutralShare);
           }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -443,16 +443,14 @@ public class TPHybridEosGeFlash extends TPmultiflash {
     // Limiting beta reduction bounds the corresponding ionic-concentration increase, while
     // limiting beta growth prevents one proposal from displacing nearly all aqueous solvent.
     double previousAqueousFraction = previousAqueousFractionBeforeBetaCorrection;
-    double stepLimitedMinimumAqueousFraction = Double.isFinite(previousAqueousFraction)
-        && previousAqueousFraction > 0.0 ? previousAqueousFraction / HYBRID_AQUEOUS_FRACTION_STEP_LIMIT
-            : ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN;
+    double stepLimitedMinimumAqueousFraction = Double.isFinite(previousAqueousFraction) && previousAqueousFraction > 0.0
+        ? previousAqueousFraction / HYBRID_AQUEOUS_FRACTION_STEP_LIMIT
+        : ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN;
     double minimumAqueousFraction = Math.min(maximumAqueousFraction,
         Math.max(ionOverallFraction + HYBRID_ION_CAPACITY_MARGIN, stepLimitedMinimumAqueousFraction));
-    double stepLimitedMaximumAqueousFraction = Double.isFinite(previousAqueousFraction)
-        && previousAqueousFraction > 0.0
-            ? Math.min(maximumAqueousFraction,
-                previousAqueousFraction * HYBRID_AQUEOUS_FRACTION_STEP_LIMIT)
-            : maximumAqueousFraction;
+    double stepLimitedMaximumAqueousFraction = Double.isFinite(previousAqueousFraction) && previousAqueousFraction > 0.0
+        ? Math.min(maximumAqueousFraction, previousAqueousFraction * HYBRID_AQUEOUS_FRACTION_STEP_LIMIT)
+        : maximumAqueousFraction;
     double currentAqueousFraction = system.getBeta(aqueousPhaseIndex);
     if (currentAqueousFraction >= minimumAqueousFraction
         && currentAqueousFraction <= stepLimitedMaximumAqueousFraction) {

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -3,6 +3,7 @@ package neqsim.thermodynamicoperations.flashops;
 import static neqsim.thermo.ThermodynamicModelSettings.phaseFractionMinimumLimit;
 import org.ejml.simple.SimpleMatrix;
 import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.phase.PhaseInterface;
 import neqsim.thermo.system.HybridEosGeFlashModel;
 import neqsim.thermo.system.SystemInterface;
 
@@ -51,7 +52,6 @@ public class TPHybridEosGeFlash extends TPmultiflash {
 
   /** Maximum common Newton beta-step scale for a hybrid flash carrying ions. */
   private static final double HYBRID_IONIC_BETA_STEP_SCALE = 0.1;
-
 
   /** Reaction-adjusted overall component fractions used by the coupled phase solve. */
   private transient double[] coupledOverallFractions;
@@ -477,8 +477,8 @@ public class TPHybridEosGeFlash extends TPmultiflash {
         for (int componentIndex = 0; componentIndex < aqueousPhase.getNumberOfComponents(); componentIndex++) {
           ComponentInterface component = aqueousPhase.getComponent(componentIndex);
           if (component.getIonicCharge() == 0 && !component.isIsIon()) {
-            double neutralShare = previousNeutralShares[componentIndex] + lineSearchFraction
-                * (proposedNeutralShares[componentIndex] - previousNeutralShares[componentIndex]);
+            double neutralShare = previousNeutralShares[componentIndex]
+                + lineSearchFraction * (proposedNeutralShares[componentIndex] - previousNeutralShares[componentIndex]);
             component.setx(lineSearchNeutralTotal * neutralShare);
           }
         }
@@ -507,8 +507,8 @@ public class TPHybridEosGeFlash extends TPmultiflash {
           || component.isIsIon()) {
         continue;
       }
-      if (!(component.getx() > 0.0) || !Double.isFinite(component.getx())
-          || !(component.getFugacityCoefficient() > 0.0) || !Double.isFinite(component.getFugacityCoefficient())) {
+      if (!(component.getx() > 0.0) || !Double.isFinite(component.getx()) || !(component.getFugacityCoefficient() > 0.0)
+          || !Double.isFinite(component.getFugacityCoefficient())) {
         return false;
       }
     }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -507,8 +507,14 @@ public class TPHybridEosGeFlash extends TPmultiflash {
           || component.isIsIon()) {
         continue;
       }
-      if (!(component.getx() > 0.0) || !Double.isFinite(component.getx()) || !(component.getFugacityCoefficient() > 0.0)
-          || !Double.isFinite(component.getFugacityCoefficient())) {
+      double moleFraction = component.getx();
+      if (!Double.isFinite(moleFraction) || moleFraction < 0.0) {
+        return false;
+      }
+      if (moleFraction <= 1.0e-30) {
+        continue;
+      }
+      if (!(component.getFugacityCoefficient() > 0.0) || !Double.isFinite(component.getFugacityCoefficient())) {
         return false;
       }
     }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPHybridEosGeFlash.java
@@ -52,6 +52,9 @@ public class TPHybridEosGeFlash extends TPmultiflash {
   /** Maximum common Newton beta-step scale for a hybrid flash carrying ions. */
   private static final double HYBRID_IONIC_BETA_STEP_SCALE = 0.1;
 
+  /** Fraction of a new aqueous neutral-composition proposal accepted per iteration. */
+  private static final double HYBRID_AQUEOUS_COMPOSITION_RELAXATION = 0.1;
+
   /** Reaction-adjusted overall component fractions used by the coupled phase solve. */
   private transient double[] coupledOverallFractions;
 
@@ -383,9 +386,21 @@ public class TPHybridEosGeFlash extends TPmultiflash {
     for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
       boolean aqueous = hybridModel.isHybridEosGeAqueousPhase(phaseIndex);
       double phaseFraction = Math.max(system.getPhase(phaseIndex).getBeta(), phaseFractionMinimumLimit);
+      int numberOfComponents = system.getPhase(0).getNumberOfComponents();
+      double[] previousNeutralComposition = aqueous ? new double[numberOfComponents] : null;
+      double previousNeutralFractionSum = 0.0;
+      if (aqueous) {
+        for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
+          ComponentInterface component = system.getPhase(phaseIndex).getComponent(componentIndex);
+          if (component.getIonicCharge() == 0 && !component.isIsIon()) {
+            previousNeutralComposition[componentIndex] = Math.max(component.getx(), 0.0);
+            previousNeutralFractionSum += previousNeutralComposition[componentIndex];
+          }
+        }
+      }
       double ionFractionSum = 0.0;
       double neutralFractionSum = 0.0;
-      for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
         ComponentInterface referenceComponent = system.getPhase(0).getComponent(componentIndex);
         double feedFraction = getCoupledOverallFraction(componentIndex);
         double newMoleFraction;
@@ -412,12 +427,20 @@ public class TPHybridEosGeFlash extends TPmultiflash {
               "Hybrid EOS-GE aqueous composition cannot accommodate overall ion amount: " + "ionFractionSum="
                   + ionFractionSum + ", neutralFractionSum=" + neutralFractionSum + ", phaseFraction=" + phaseFraction);
         }
-        double neutralScale = (1.0 - ionFractionSum) / neutralFractionSum;
-        for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+        double neutralTotal = 1.0 - ionFractionSum;
+        for (int componentIndex = 0; componentIndex < numberOfComponents; componentIndex++) {
           ComponentInterface referenceComponent = system.getPhase(0).getComponent(componentIndex);
           if (referenceComponent.getIonicCharge() == 0 && !referenceComponent.isIsIon()) {
             ComponentInterface aqueousComponent = system.getPhase(phaseIndex).getComponent(componentIndex);
-            aqueousComponent.setx(aqueousComponent.getx() * neutralScale);
+            double proposedNeutralShare = aqueousComponent.getx() / neutralFractionSum;
+            double relaxedNeutralShare = proposedNeutralShare;
+            if (previousNeutralFractionSum > 0.0) {
+              double previousNeutralShare =
+                  previousNeutralComposition[componentIndex] / previousNeutralFractionSum;
+              relaxedNeutralShare = previousNeutralShare + HYBRID_AQUEOUS_COMPOSITION_RELAXATION
+                  * (proposedNeutralShare - previousNeutralShare);
+            }
+            aqueousComponent.setx(neutralTotal * relaxedNeutralShare);
           }
         }
       } else {

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPmultiflash.java
@@ -346,7 +346,7 @@ public class TPmultiflash extends TPflash {
 
       // The linear solve already returns a column vector. Apply it directly to avoid allocating
       // transposed, scaled, and subtracted temporary matrices in every beta iteration.
-      double betaStepScale = iter / (iter + 3.0);
+      double betaStepScale = limitBetaStepScale(iter / (iter + 3.0));
       removePhase = false;
       for (int k = 0; k < system.getNumberOfPhases(); k++) {
         double currBeta = system.getPhase(k).getBeta() - betaCorrection.get(k, 0) * betaStepScale;
@@ -375,6 +375,21 @@ public class TPmultiflash extends TPflash {
     } while (((err > 1e-12 || gradResidual > 1e-10) && iter < 50) || iter < 3);
     // logger.info("iterations " + iter);
     return err;
+  }
+
+  /**
+   * Allow a specialized fixed-topology solver to damp the common beta Newton step.
+   *
+   * <p>
+   * The default leaves the existing multiphase correction unchanged. Subclasses must return one common scale so the
+   * phase-fraction correction continues to preserve its simplex direction before normalization.
+   * </p>
+   *
+   * @param proposedScale iteration-dependent scale selected by the general solver
+   * @return scale applied to every phase-fraction correction
+   */
+  protected double limitBetaStepScale(double proposedScale) {
+    return proposedScale;
   }
 
   /**

--- a/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
@@ -210,6 +210,10 @@ class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
         .getNumberOfComponents(); componentIndex++) {
       ComponentInterface component = system.getPhase(aqueousPhaseIndex).getComponent(componentIndex);
       assertTrue(Double.isFinite(component.getx()) && component.getx() > 0.0, component.getComponentName());
+      if (component.getz() > 1.0e-30 && component.getIonicCharge() == 0 && !component.isIsIon()) {
+        assertTrue(Double.isFinite(component.getFugacityCoefficient()) && component.getFugacityCoefficient() > 0.0,
+            component.getComponentName());
+      }
     }
   }
 

--- a/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
@@ -190,6 +190,7 @@ class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
     assertTrue(aqueousPhaseIndex >= 0);
 
     TPHybridEosGeFlash solver = new TPHybridEosGeFlash(system, system);
+    solver.setDoubleArrays();
     solver.calcQ();
     double settledAqueousBeta = system.getBeta(aqueousPhaseIndex);
     system.setBeta(aqueousPhaseIndex, 0.999);

--- a/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemHybridEosGeFlashTest.java
@@ -174,6 +174,45 @@ class SystemHybridEosGeFlashTest extends neqsim.NeqSimTest {
     }
   }
 
+  /** An oversized beta proposal is damped before it can invalidate the aqueous neutral fugacities. */
+  @Test
+  void hybridBetaIterationLimitsAqueousFractionIncrease() {
+    SystemPitzer system = createQualifiedCarbonDioxideSodiumSulfateSystem();
+    system.prepareHybridEosGeFlash();
+    system.init(1);
+
+    int aqueousPhaseIndex = -1;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (system.isHybridEosGeAqueousPhase(phaseIndex)) {
+        aqueousPhaseIndex = phaseIndex;
+      }
+    }
+    assertTrue(aqueousPhaseIndex >= 0);
+
+    TPHybridEosGeFlash solver = new TPHybridEosGeFlash(system, system);
+    solver.calcQ();
+    double settledAqueousBeta = system.getBeta(aqueousPhaseIndex);
+    system.setBeta(aqueousPhaseIndex, 0.999);
+    double nonAqueousBeta = 0.001 / (system.getNumberOfPhases() - 1.0);
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (phaseIndex != aqueousPhaseIndex) {
+        system.setBeta(phaseIndex, nonAqueousBeta);
+      }
+    }
+    system.init(1);
+
+    solver.setXY();
+    system.init(1);
+
+    assertTrue(system.getBeta(aqueousPhaseIndex) <= 2.0 * settledAqueousBeta + 1.0e-12);
+    assertEquals(1.0, betaSum(system), 1.0e-12);
+    for (int componentIndex = 0; componentIndex < system.getPhase(aqueousPhaseIndex)
+        .getNumberOfComponents(); componentIndex++) {
+      ComponentInterface component = system.getPhase(aqueousPhaseIndex).getComponent(componentIndex);
+      assertTrue(Double.isFinite(component.getx()) && component.getx() > 0.0, component.getComponentName());
+    }
+  }
+
   /** Qualified gas-forming CO2/Na2SO4 flashes remain closed across repeats and nearby pressure. */
   @Test
   void qualifiedCarbonDioxideSodiumSulfateGasAqueousFlashConverges() {


### PR DESCRIPTION
## Merge status

**MERGED on 2026-08-24** as [`1e0017edca4a`](https://github.com/equinor/neqsim/commit/1e0017edca4a82c7c4f633c2909390b814f11738) from exact validated head [`9741b2764c939`](https://github.com/equinor/neqsim/commit/9741b2764c939f23c7231259a9c21704ae4407c2). The PR was merged externally; this campaign did not merge or enable auto-merge.

## Summary

Advances #2937 with safeguarded ionic hybrid EOS-GE beta and aqueous-composition updates for the qualified CO2/Na2SO4 gas-aqueous regression.

The final mechanism is limited to the fixed-role hybrid flash:

- retains the exact ionic-capacity floor `sum(zIon) + 100 * phaseFractionMinimumLimit`
- captures settled aqueous beta before the Newton proposal
- bounds one aqueous-beta proposal to 0.5x-2x the settled fraction
- caps the common beta Newton scale at 0.1 only when the hybrid inventory carries ions
- leaves a valid normalized aqueous neutral-composition proposal unchanged
- if reinitialization yields a non-positive or non-finite material-neutral fugacity coefficient, backtracks the proposal halfway toward the last finite normalized composition until all material-neutral coefficients are finite
- scopes that line search to real beta-Newton contexts and applies the established `1e-30` material threshold to trace components
- synchronizes mapped/system and active-phase beta mirrors after projection
- fails closed on invalid material-phase compositions or fugacity coefficients and records the offending component

The protected `TPmultiflash.limitBetaStepScale` hook is a no-op by default. Ordinary multiphase and non-ionic hybrid flashes therefore retain their existing beta-step behavior.

## Failure-driven refinement

- Baseline collapse: `betaAqueous=0.9997176973`, material residual `0.3499082239`, non-finite CO2 fugacity.
- Bidirectional beta projection recovered `betaGas=0.3322160` and reduced material residual to `0.0040506`, but independently clipped corrections oscillated.
- Common beta-step damping converged beta/material equations (`solverResidual=1.62e-12`, material residual `1.03e-12`) but could still reach a solvent-depleted Pitzer proposal (`phiCO2=0`, `phiWater=Infinity`).
- The final conditional neutral-composition line search retains valid proposals unchanged and backtracks only invalid ones.
- Two follow-up CI repairs aligned trace-component screening with final acceptance and disabled the line search in direct projection tests where no settled Newton iterate exists.

## Regression and engineering gates

- ionic-capacity projection from an undersized aqueous beta
- oversized aqueous-beta proposal
- finite positive material-neutral aqueous fugacity coefficients
- qualified CO2/Na2SO4 phase appearance, deterministic repeat, and nearby-pressure continuity
- material balance, normalization, bounded positive compositions, and cross-phase fugacity equality
- existing hybrid gas/oil/aqueous, reactive, rollback, serialization, and cross-path coverage through the full suite

## Exact source state

- current master/base: `7d0d056b650ff8f776e2229add68a2e78f280551`
- exact PR head: `9741b2764c939f23c7231259a9c21704ae4407c2`
- GitHub compare: 28 commits ahead, 0 behind, mergeable
- branch scope: five flash-owned implementation/test/documentation files; the head merge only synchronized unrelated current-master separator work
- no public tolerance, reaction model, dataset parameter, phase topology, or Huldra change

## Validation

**MERGED AND EXACT-HEAD VALIDATED.**

Exact-head hosted CI passed:

- Java 21 fast tests: Ubuntu and Windows, 12,189 tests each, 0 failures, 0 errors
- Java 8 fast tests: Ubuntu and Windows, 12,189 tests each, 0 failures, 0 errors
- all four Java 21 slow-test shards
- Java 21 Javadoc and agent-skill cross-reference checks
- Spotless
- pre-commit
- documentation search
- CodeQL
- PaperLab

Focused `SystemHybridEosGeFlashTest` at exact head: 14/14 passed in 6.040 s (Java 21 Ubuntu), 7.040 s (Java 21 Windows), 7.514 s (Java 8 Windows), and 8.147 s (Java 8 Ubuntu). These are CI execution times, not a microbenchmark; no speedup is claimed. The performance control is structural: the new common-step hook returns immediately with unchanged behavior outside ionic hybrid flashes, and valid aqueous proposals avoid line-search backtracking.

Local focused validation was infrastructure-blocked by the pruned workspace/read-only Maven home, so no local pass is claimed.

## Documentation impact

`TPflash_algorithm.md` documents the ionic-capacity boundary, bidirectional beta trust region, ionic-only common-step damping, conditional neutral-composition line search, unchanged default behavior, fail-closed diagnostics, provenance, and limitations.

No Huldra work is included.