### PR TITLE
[AI-Assisted] fix(mcp): preserve Phase 0 evidence through transport guard

### DIFF
--- a/neqsim-mcp-server/MCP_CONTRACT.md
+++ b/neqsim-mcp-server/MCP_CONTRACT.md
@@ -220,6 +220,14 @@ Schema resource paths use snake_case tool names such as `run_flash`, but respons
 the MCP method names such as `runFlash`. Schema lookups accept only `input` and `output` as schema
 types; any other type is treated as schema-not-found.
 
+Responses larger than 256 KiB are reduced by the shared transport guard unless
+`neqsim.mcp.maxResponseBytes` or `NEQSIM_MCP_MAX_RESPONSE_BYTES` configures another limit. The
+`truncation` block identifies omitted root fields and focused retrieval routes, and the legacy
+top-level and canonical `data` views are reduced together. For `getCapabilities`,
+`phase0EvidenceInventory` is retained because it has no equivalent selective-retrieval route;
+larger catalog sections may be queried through `getSchema`, `getExample`, `getBenchmarkTrust`, and
+the MCP catalog resources.
+
 ### Warning taxonomy
 
 Warnings in the root `warnings` array, and any tool-specific warning details, use these standard

--- a/neqsim-mcp-server/docs/API_REFERENCE.md
+++ b/neqsim-mcp-server/docs/API_REFERENCE.md
@@ -230,10 +230,13 @@ the canonical name-only `EquipmentFactory` surface, and the bounded
 discovery and audit; availability is not equivalent to benchmark validation or
 engineering approval.
 
-`phase0EvidenceInventory` adds source-counted Java and real-protocol test inventories, the four MCP
-guide paths, and a runtime reconciliation of `getBenchmarkTrust`. Its `complete` flag remains false
-while published tools use generic trust fallbacks. Test presence is not test execution, and generic
-`TESTED` maturity is not a benchmark, accuracy, applicability, or no-limitations claim.
+`phase0EvidenceInventory` adds source-counted Java and real-protocol test inventories, eight MCP
+guide paths, acceptance fixtures and their bounded baseline contract, the campaign matrix, and a
+runtime reconciliation of `getBenchmarkTrust`. Its `complete` flag remains false while 51 published
+tools have explicit `CONFIRMED_GAP` coverage records instead of tool-specific trust pages. Test
+presence is not test execution, and generic `TESTED` maturity is not a benchmark, accuracy,
+applicability, or no-limitations claim. The transport response-size guard retains this inventory
+when larger capability-catalog sections must be omitted.
 
 ---
 

--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -18,7 +18,7 @@ manually maintained Java method list.
 | Engineering report paths | 2 | `getCapabilities.implementationInventory` | `ReportRunner`, `TaskWorkflowBridge` |
 | MCP Java test classes | 67 | `getCapabilities.phase0EvidenceInventory` | `src/test/java/neqsim/mcp/**/*Test.java` |
 | MCP protocol scenarios | 94 | `getCapabilities.phase0EvidenceInventory` | `test_mcp_server.py` |
-| MCP guides | 7 | `getCapabilities.phase0EvidenceInventory` | Core guides, foundation traceability, fixtures, and baseline harness |
+| MCP guides | 8 | `getCapabilities.phase0EvidenceInventory` | Core guides, foundation traceability, fixtures, baseline harness, and campaign matrix |
 | Explicit tool trust pages | 20 of 71 tools | `getBenchmarkTrust` and `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust` |
 | Trust coverage records | 71 = 20 explicit + 51 confirmed gaps | `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust`, `McpImplementationInventory` |
 
@@ -92,7 +92,7 @@ trees and fails if the manifest drifts. These counts identify evidence locations
 claim that a test ran or passed. Exact-head CI and recorded command output remain the execution
 evidence.
 
-The seven MCP guides have distinct roles:
+The eight MCP guides have distinct roles:
 
 | Guide | Role |
 | --- | --- |
@@ -103,6 +103,13 @@ The seven MCP guides have distinct roles:
 | `neqsim-mcp-server/docs/FOUNDATION_TRACEABILITY.md` | Merged foundation capability evidence and remaining boundaries |
 | `neqsim-mcp-server/docs/ACCEPTANCE_FIXTURES.md` | Four public synthetic scales and canonical execution routes |
 | `neqsim-mcp-server/docs/ACCEPTANCE_BASELINES.md` | Bounded exact-run measurements, interpretation limits, and explicit evidence gaps |
+| `neqsim-mcp-server/docs/CAMPAIGN_MATRIX.md` | All 66 campaign criteria and discipline-level trust maturity with explicit gaps |
+
+The default response-size guard may omit large capability-catalog sections when the full manifest
+exceeds 256 KiB. It retains `phase0EvidenceInventory` because that evidence contract has no
+equivalent selective-retrieval route. Omitted catalog detail remains identified in `truncation` and
+can be queried through `getSchema`, `getExample`, `getBenchmarkTrust`, and the MCP catalog
+resources.
 
 `BenchmarkTrust` currently contains 20 tool-specific trust pages with 64 known-limit entries and 30
 validation cases, of which 5 name a concrete `verifiedBy` test. The other 51 published tools still

--- a/neqsim-mcp-server/test_mcp_server.py
+++ b/neqsim-mcp-server/test_mcp_server.py
@@ -1505,9 +1505,9 @@ def test_capabilities():
     check("evidence inventory freezes 94 protocol scenarios",
           tests.get("protocolScenarioCount") == 94,
           str(tests))
-    check("evidence inventory lists seven MCP guides",
-          guides.get("guideCount") == 7
-          and len(guides.get("entries", [])) == 7,
+    check("evidence inventory lists eight MCP guides",
+          guides.get("guideCount") == 8
+          and len(guides.get("entries", [])) == 8,
           str(guides))
     baseline_contract = evidence.get("acceptanceBaselineContract", {})
     check("acceptance baseline contract is bounded and non-qualifying",

--- a/src/main/java/neqsim/mcp/runners/ResponseSizeGuard.java
+++ b/src/main/java/neqsim/mcp/runners/ResponseSizeGuard.java
@@ -29,6 +29,11 @@ import com.google.gson.JsonObject;
  * </p>
  *
  * <p>
+ * The {@code getCapabilities} manifest uses discovery-specific recovery guidance and retains its Phase 0 evidence
+ * inventory because that contract has no separate selective-retrieval route.
+ * </p>
+ *
+ * <p>
  * The limit is configurable through the {@code neqsim.mcp.maxResponseBytes} system property or the
  * {@code NEQSIM_MCP_MAX_RESPONSE_BYTES} environment variable. Set it to {@code 0} to disable trimming.
  * </p>
@@ -50,6 +55,10 @@ public final class ResponseSizeGuard {
   private static final List<String> PROTECTED_FIELDS = Collections
       .unmodifiableList(java.util.Arrays.asList("apiVersion", "status", "tool", "message", "provenance", "validation",
           "qualityGate", "warnings", "errors", "truncation"));
+
+  /** Discovery members that have no equivalent selective-retrieval route. */
+  private static final List<String> PROTECTED_CAPABILITY_FIELDS = Collections
+      .unmodifiableList(java.util.Arrays.asList("phase0EvidenceInventory"));
 
   /**
    * Private constructor — utility class.
@@ -83,7 +92,7 @@ public final class ResponseSizeGuard {
     }
 
     JsonArray omitted = new JsonArray();
-    for (String field : trimCandidates(response)) {
+    for (String field : trimCandidates(response, toolName)) {
       JsonElement removed = response.remove(field);
       if (removed == null) {
         continue;
@@ -117,9 +126,7 @@ public final class ResponseSizeGuard {
     truncation.addProperty("returnedBytes", size);
     truncation.addProperty("limitBytes", MAX_BYTES);
     truncation.add("omitted", omitted);
-    truncation.addProperty("howToRetrieve",
-        "Register the model with manageModel(action='register'), then read only what you need via "
-            + "listSimulationUnits, listUnitVariables and getSimulationVariable on the returned modelId.");
+    truncation.addProperty("howToRetrieve", recoveryGuidance(toolName));
     truncation.addProperty("configuration",
         "Raise or disable the limit with neqsim.mcp.maxResponseBytes (0 disables trimming).");
     response.add("truncation", truncation);
@@ -136,12 +143,13 @@ public final class ResponseSizeGuard {
    * Lists trimmable members in descending serialized size.
    *
    * @param response the response object
+   * @param toolName the MCP tool that produced the response
    * @return field names eligible for removal, largest first
    */
-  private static List<String> trimCandidates(JsonObject response) {
+  private static List<String> trimCandidates(JsonObject response, String toolName) {
     List<Map.Entry<String, Integer>> sized = new ArrayList<Map.Entry<String, Integer>>();
     for (Map.Entry<String, JsonElement> entry : response.entrySet()) {
-      if (PROTECTED_FIELDS.contains(entry.getKey()) || "data".equals(entry.getKey())) {
+      if (isProtected(entry.getKey(), toolName) || "data".equals(entry.getKey())) {
         continue;
       }
       sized.add(new java.util.AbstractMap.SimpleEntry<String, Integer>(entry.getKey(),
@@ -158,6 +166,34 @@ public final class ResponseSizeGuard {
       names.add(entry.getKey());
     }
     return names;
+  }
+
+  /**
+   * Returns whether a response member must survive transport trimming.
+   *
+   * @param fieldName response member name
+   * @param toolName MCP tool that produced the response
+   * @return true when the member must not be removed
+   */
+  private static boolean isProtected(String fieldName, String toolName) {
+    return PROTECTED_FIELDS.contains(fieldName)
+        || ("getCapabilities".equals(toolName) && PROTECTED_CAPABILITY_FIELDS.contains(fieldName));
+  }
+
+  /**
+   * Returns selective-retrieval guidance appropriate for the response type.
+   *
+   * @param toolName MCP tool that produced the response
+   * @return recovery guidance for omitted fields
+   */
+  private static String recoveryGuidance(String toolName) {
+    if ("getCapabilities".equals(toolName)) {
+      return "Use getSchema and getExample for focused tool contracts, getBenchmarkTrust for "
+          + "tool-specific trust evidence, and MCP catalog resources for selective discovery. "
+          + "The Phase 0 evidence inventory is retained in this response.";
+    }
+    return "Register the model with manageModel(action='register'), then read only what you need via "
+        + "listSimulationUnits, listUnitVariables and getSimulationVariable on the returned modelId.";
   }
 
   /**

--- a/src/test/java/neqsim/mcp/runners/ResponseSizeGuardTest.java
+++ b/src/test/java/neqsim/mcp/runners/ResponseSizeGuardTest.java
@@ -98,6 +98,35 @@ class ResponseSizeGuardTest {
   }
 
   /**
+   * The Phase 0 evidence inventory has no separate selective-retrieval route, so it must remain discoverable when the
+   * larger capability catalog is trimmed.
+   */
+  @Test
+  @DisplayName("Capability trimming preserves the Phase 0 evidence contract")
+  void testCapabilitiesPreservePhase0EvidenceWhenTrimmed() {
+    JsonObject response = JsonParser.parseString(CapabilitiesRunner.getCapabilities()).getAsJsonObject();
+    int originalBytes = GSON.toJson(response).getBytes(StandardCharsets.UTF_8).length;
+    assertTrue(originalBytes > ResponseSizeGuard.getMaxBytes(),
+        "Capability fixture must exercise the response-size guard, was " + originalBytes);
+
+    assertTrue(ResponseSizeGuard.enforce(response, "getCapabilities"), "Oversized capability response must be trimmed");
+
+    int trimmedBytes = GSON.toJson(response).getBytes(StandardCharsets.UTF_8).length;
+    assertTrue(trimmedBytes <= ResponseSizeGuard.getMaxBytes(),
+        "Trimmed capability response must fit the limit, was " + trimmedBytes);
+    assertTrue(response.has("phase0EvidenceInventory"),
+        "The non-retrievable Phase 0 evidence contract must survive trimming");
+    assertTrue(response.getAsJsonObject("data").has("phase0EvidenceInventory"),
+        "The canonical data view must retain the same evidence contract");
+    assertTrue(response.getAsJsonObject("phase0EvidenceInventory").has("tests"));
+    assertTrue(response.getAsJsonObject("phase0EvidenceInventory").has("knownLimitations"));
+    JsonObject truncation = response.getAsJsonObject("truncation");
+    assertFalse(truncation.getAsJsonArray("omitted").toString().contains("phase0EvidenceInventory"));
+    assertTrue(truncation.get("howToRetrieve").getAsString().contains("getSchema"),
+        "Discovery truncation must point to focused capability retrieval");
+  }
+
+  /**
    * The trimmed response must still be parseable JSON — a truncated payload is worse than useless if the client cannot
    * read it.
    */


### PR DESCRIPTION
## Summary

- retain `phase0EvidenceInventory` when the 256 KiB response-size guard reduces `getCapabilities`
- keep the legacy root and canonical `data` views synchronized and provide discovery-specific recovery guidance
- update the real-protocol assertions and MCP documentation for the eight-guide evidence inventory

## Root cause

The generated capability manifest is larger than the default transport limit. The shared guard removed the entire Phase 0 evidence inventory before the JSON-RPC response reached clients, so the protocol checks observed an empty evidence contract even though the source inventory already contained 67 Java test classes, 94 protocol scenarios, eight guides, the bounded acceptance contract, and the trust-gap reconciliation.

## Validation

- `python test_mcp_server.py` on the packaged server with JDK 21: **318/318 passed**
- `./mvnw -q -Dtest=ResponseSizeGuardTest,CapabilitiesRunnerTest,McpEvidenceInventoryFoundationTests,McpAcceptanceBaselineRunnerTests test`
- root `mvn install -DskipTests` and MCP server package build
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- pre-commit and pre-push hooks

## Documentation impact

Updated the MCP contract, API reference, and surface inventory to document response reduction, selective retrieval routes, and the current eight-guide Phase 0 inventory.