### PR TITLE
[AI-Assisted] docs(standards): correct sales-contract workflow

### DIFF
--- a/docs/standards/sales_contracts.md
+++ b/docs/standards/sales_contracts.md
@@ -1,370 +1,169 @@
 ---
-title: "Sales Contracts"
-description: "The sales contract system enables specification verification and compliance checking for natural gas quality."
+title: "Gas Sales Contract Checks"
+description: "Run NeqSim's database-backed gas-quality contract checks, interpret the 12-column result table, and apply explicit project limits safely."
 ---
 
-# Sales Contracts
+The `neqsim.standards.salescontract` package runs gas-quality calculations selected
+from NeqSim's bundled `GASCONTRACTSPECIFICATIONS.csv` data. It is a legacy,
+database-backed screening facility. It is not a general contract authoring API,
+does not establish that a product complies with a current commercial agreement,
+and does not replace representative sampling, validated composition analysis, or
+accountable contract review.
 
-The sales contract system enables specification verification and compliance checking for natural gas quality.
+## Current workflow and boundary
 
-## Table of Contents
-- [Overview](#overview)
-- [Architecture](#architecture)
-- [Creating Contracts](#creating-contracts)
-- [Contract Specifications](#contract-specifications)
-- [Usage Examples](#usage-examples)
-- [Database Integration](#database-integration)
+`BaseContract(SystemInterface, terminal, country)` selects rows whose `TERMINAL`
+and `COUNTRY` exactly match the supplied strings. Each row names a calculation
+method, parameter key, limits, unit, and reference conditions. `runCheck()` calls
+the selected standards and fills a 12-column string table.
 
----
+Treat terminal and country as trusted lookup keys for the bundled data, not as
+free-form user input. The current source builds its database query by string
+concatenation. Also verify the selected rows in the repository before use: the
+file is example data shipped with NeqSim, not a maintained register of current
+pipeline, terminal, national, or contractual limits.
 
-## Overview
+The two empty-construction routes are not complete custom-contract workflows:
 
-**Location:** `neqsim.standards.salescontract`
+- `new BaseContract()` contains zero specifications.
+- `new BaseContract(system)` adds an internal water-dew-point object but does not
+  update the specification count used by `runCheck()`.
+- `BaseContract` and `ContractInterface` expose no `addSpecification` or removal
+  method. Constructing a `ContractSpecification` does not attach it to a contract.
 
-**Purpose:**
-- Define quality specifications for gas sales points
-- Verify gas quality against contractual limits
-- Generate compliance reports
-- Support multi-specification contracts
+Use the database-backed constructor for the current public workflow. Implementing
+a supported programmatic contract builder requires a separate production-API
+change with validation and compatibility review.
 
-**Classes:**
-- `BaseContract` - Main contract implementation
-- `ContractInterface` - Contract interface
-- `ContractSpecification` - Individual specification
+## Complete Java example
 
----
-
-## Architecture
-
-### Class Hierarchy
-
-```
-ContractInterface
-    │
-    └── BaseContract
-            │
-            ├── ArrayList<ContractSpecification>
-            │       │
-            │       └── StandardInterface (method)
-            │
-            └── Database connection (gascontractspecifications)
-```
-
-### Workflow
-
-```
-1. Create Contract (from database or manually)
-        ↓
-2. Add Specifications (linked to standards)
-        ↓
-3. Run Compliance Check
-        ↓
-4. Generate Results Table
-        ↓
-5. Display/Export Results
-```
-
----
-
-## Creating Contracts
-
-### From Database
+This fixture uses the exact case-sensitive `central` / `Brazil` keys present in
+the bundled data. It keeps calculated values and limits separate so the caller,
+rather than `isOnSpec()`, owns the explicit row-by-row decision.
 
 ```java
 import neqsim.standards.salescontract.BaseContract;
-import neqsim.standards.salescontract.ContractInterface;
+import neqsim.thermo.system.SystemGERGwaterEos;
+import neqsim.thermo.system.SystemInterface;
 
-// Load contract from database by terminal and country
-ContractInterface contract = new BaseContract(
-    thermoSystem,    // Gas composition
-    "Kaarstoe",      // Terminal name
-    "Norway"         // Country
-);
-```
-
-### Programmatic Creation
-
-```java
-// Create empty contract
-ContractInterface contract = new BaseContract();
-
-// Or with basic water dew point spec
-ContractInterface contract = new BaseContract(thermoSystem);
-```
-
----
-
-## Contract Specifications
-
-### ContractSpecification Class
-
-Each specification contains:
-
-| Field | Description |
-|-------|-------------|
-| `name` | Specification name |
-| `specification` | Description |
-| `country` | Country code |
-| `terminal` | Terminal/delivery point |
-| `standard` | StandardInterface method |
-| `minValue` | Minimum acceptable value |
-| `maxValue` | Maximum acceptable value |
-| `unit` | Unit of measurement |
-| `referenceTemperatureMeasurement` | Reference T for measurement |
-| `referenceTemperatureCombustion` | Reference T for combustion |
-| `referencePressure` | Reference pressure |
-| `comments` | Additional notes |
-
-### Creating Specifications
-
-```java
-import neqsim.standards.salescontract.ContractSpecification;
-import neqsim.standards.gasquality.Draft_ISO18453;
-
-// Create water dew point specification
-StandardInterface waterDPMethod = new Draft_ISO18453(thermoSystem);
-
-ContractSpecification waterSpec = new ContractSpecification(
-    "Water Dew Point",           // Name
-    "Maximum water dew point",   // Specification description
-    "Norway",                    // Country
-    "Kaarstoe",                  // Terminal
-    waterDPMethod,               // Calculation method
-    -20.0,                       // Minimum value
-    -8.0,                        // Maximum value
-    "°C",                        // Unit
-    15.0,                        // Reference T measurement
-    15.0,                        // Reference T combustion
-    70.0,                        // Reference pressure (bar)
-    "At 70 bar"                  // Comments
-);
-```
-
-### Available Standard Methods
-
-| Method Name | Class | Purpose |
-|-------------|-------|---------|
-| `ISO18453` | `Draft_ISO18453` | Water dew point |
-| `ISO6974` | `Standard_ISO6974` | Gas composition |
-| `ISO6976` | `Standard_ISO6976` | Calorific values, Wobbe |
-| `BestPracticeHydrocarbonDewPoint` | `BestPracticeHydrocarbonDewPoint` | HC dew point |
-| `SulfurSpecificationMethod` | `SulfurSpecificationMethod` | H2S and sulfur |
-| `UKspecifications` | `UKspecifications_ICF_SI` | UK ICF/SI specs |
-
----
-
-## Usage Examples
-
-### Basic Contract Check
-
-```java
-import neqsim.thermo.system.SystemSrkCPAstatoil;
-import neqsim.standards.salescontract.BaseContract;
-
-// Create gas composition
-SystemInterface gas = new SystemSrkCPAstatoil(273.15 + 15, 70.0);
+SystemInterface gas = new SystemGERGwaterEos(268.15, 20.0);
 gas.addComponent("methane", 0.90);
-gas.addComponent("ethane", 0.05);
+gas.addComponent("ethane", 0.04);
 gas.addComponent("propane", 0.02);
-gas.addComponent("CO2", 0.02);
-gas.addComponent("nitrogen", 0.005);
-gas.addComponent("water", 30e-6);  // 30 ppm water
-gas.setMixingRule("CPA_Statoil");
+gas.addComponent("n-heptane", 0.00012);
+gas.addComponent("H2S", 0.000012);
+gas.addComponent("water", 0.000071);
+gas.addComponent("oxygen", 0.0012);
+gas.addComponent("CO2", 0.022);
+gas.addComponent("nitrogen", 0.022);
+gas.setMixingRule(8);
+gas.init(0);
 
-// Load contract from database
-BaseContract contract = new BaseContract(gas, "Kaarstoe", "Norway");
-
-// Run compliance check
+BaseContract contract = new BaseContract(gas, "central", "Brazil");
 contract.runCheck();
 
-// Get results
-String[][] results = contract.getResultTable();
-int numSpecs = contract.getSpecificationsNumber();
-
-System.out.printf("Checked %d specifications%n", numSpecs);
-
-// Display results
-contract.display();
-```
-
-### Custom Contract
-
-```java
-import neqsim.standards.salescontract.*;
-import neqsim.standards.gasquality.*;
-
-// Create empty contract
-BaseContract contract = new BaseContract();
-
-// Add water dew point specification
-Draft_ISO18453 waterMethod = new Draft_ISO18453(gas);
-waterMethod.setReferencePressure(70.0);
-ContractSpecification waterSpec = new ContractSpecification(
-    "Water DP", "Water dew point max", "Export", "Platform",
-    waterMethod, -100, -8, "°C", 15, 15, 70, ""
-);
-contract.addSpecification(waterSpec);
-
-// Add Wobbe index specification
-Standard_ISO6976 wobbeMethod = new Standard_ISO6976(gas, 15, 25, "volume");
-ContractSpecification wobbeSpec = new ContractSpecification(
-    "Wobbe Index", "Wobbe index range", "Export", "Platform",
-    wobbeMethod, 47300, 51500, "kJ/m³", 15, 25, 1.01325, ""
-);
-contract.addSpecification(wobbeSpec);
-
-// Add GCV specification
-ContractSpecification gcvSpec = new ContractSpecification(
-    "GCV", "Gross calorific value", "Export", "Platform",
-    wobbeMethod, 37500, 43000, "kJ/m³", 15, 25, 1.01325, ""
-);
-contract.addSpecification(gcvSpec);
-
-// Run check
-contract.runCheck();
-```
-
-### Attaching Contract to Standard
-
-```java
-import neqsim.standards.gasquality.Draft_ISO18453;
-
-// Create standard with contract
-Draft_ISO18453 waterDP = new Draft_ISO18453(gas);
-waterDP.setSalesContract(contract);
-
-// Calculate
-waterDP.calculate();
-
-// Check specification compliance
-if (waterDP.isOnSpec()) {
-    System.out.println("PASS: Water dew point within specification");
-} else {
-    System.out.println("FAIL: Water dew point out of specification");
+String[][] rows = contract.getResultTable();
+int specificationCount = contract.getSpecificationsNumber();
+int rowsWithinLimits = 0;
+for (int rowIndex = 0; rowIndex < specificationCount; rowIndex++) {
+  double value = Double.parseDouble(rows[rowIndex][1]);
+  double minimum = Double.parseDouble(rows[rowIndex][4]);
+  double maximum = Double.parseDouble(rows[rowIndex][5]);
+  if (Double.isFinite(value) && value >= minimum && value <= maximum) {
+    rowsWithinLimits++;
+  }
 }
 ```
 
-### Contract Results Table
+For this repository fixture, `specificationCount` is 8 and the second row is
+`CO2`, approximately 2.188 mol%, with stored limits of 0 to 3 mol%. Those values
+are regression evidence for the bundled example, not a recommended sales-gas
+specification.
 
-```java
-// After running check
-String[][] results = contract.getResultTable();
+## Result-table contract
 
-// Results table structure:
-// [row][0] = Specification name
-// [row][1] = Measured value
-// [row][2] = Min specification
-// [row][3] = Max specification
-// [row][4] = Unit
-// [row][5] = Pass/Fail status
+After `runCheck()`, each row has exactly these columns:
 
-System.out.println("Specification | Value | Min | Max | Unit | Status");
-System.out.println("--------------|-------|-----|-----|------|-------");
+| Index | Meaning |
+| ---: | --- |
+| 0 | Parameter key passed to the standard's `getValue(...)` |
+| 1 | Calculated value, serialized as a string |
+| 2 | Country lookup value |
+| 3 | Terminal lookup value |
+| 4 | Stored minimum |
+| 5 | Stored maximum |
+| 6 | Unit passed to `getValue(...)` |
+| 7 | Standard name |
+| 8 | Measurement reference temperature |
+| 9 | Combustion reference temperature |
+| 10 | Reference pressure in bara |
+| 11 | Comments |
 
-for (int i = 0; i < contract.getSpecificationsNumber(); i++) {
-    System.out.printf("%13s | %5s | %3s | %3s | %4s | %6s%n",
-        results[i][0], results[i][1], results[i][2],
-        results[i][3], results[i][4], results[i][5]);
-}
-```
+There is no pass/fail column. Compare the parsed value with columns 4 and 5
+explicitly, then apply measurement uncertainty, rounding rules, exception policy,
+and any contractual hierarchy outside this class. Do not infer compliance from a
+row's presence.
 
----
+`runCheck()` invokes each standard's `isOnSpec()` only for a diagnostic console
+line; it does not store that boolean in the result table. The standards do not
+share one generic min/max implementation, and some calculation-only standards
+return `true` unconditionally. Therefore `isOnSpec()` is not a substitute for the
+explicit comparison above.
 
-## Database Integration
+## Bundled method keys
 
-### Database Table Structure
+The current `BaseContract.getMethod(...)` recognizes these exact keys:
 
-Table: `gascontractspecifications`
-
-| Column | Description |
-|--------|-------------|
-| `NAME` | Specification name |
-| `SPECIFICATION` | Description |
-| `COUNTRY` | Country code |
-| `TERMINAL` | Delivery point |
-| `METHOD` | Calculation method name |
-| `MINVALUE` | Minimum value |
-| `MAXVALUE` | Maximum value |
-| `UNIT` | Unit string |
-| `ReferenceTdegC` | Reference temperature |
-| `ReferencePbar` | Reference pressure |
-| `Comments` | Additional notes |
-
-### Method Name Mapping
-
-| Database Method | Class |
-|-----------------|-------|
+| Data key | Calculation class |
+| --- | --- |
 | `ISO18453` | `Draft_ISO18453` |
-| `ISO6974` | `Standard_ISO6974` |
+| `ISO6974` or `oxygen` | `Standard_ISO6974` |
+| `Total sulphur` | `GasChromotograpyhBase` |
 | `ISO6976` | `Standard_ISO6976` |
-| `BestPracticeHydrocarbonDewPoint` | `BestPracticeHydrocarbonDewPoint` |
 | `SulfurSpecificationMethod` | `SulfurSpecificationMethod` |
+| `BestPracticeHydrocarbonDewPoint` | `BestPracticeHydrocarbonDewPoint` |
 | `UKspecifications` | `UKspecifications_ICF_SI` |
 
-### Querying Contracts
+Unknown keys return `null`. One bundled Norway row currently contains
+`StatoilBestPracticeHydrocarbonDewPoint`, which is not one of the recognized
+keys. Do not treat that data set as a validated complete contract until its
+method mapping is repaired and requalified.
 
-```java
-// Contracts are loaded by terminal and country
-BaseContract norwegianContract = new BaseContract(gas, "Kaarstoe", "Norway");
-BaseContract ukContract = new BaseContract(gas, "StFergus", "UK");
-BaseContract belgianContract = new BaseContract(gas, "Zeebrugge", "Belgium");
-```
+## Database-loading limitations
 
----
+- The CSV has one `ReferenceTdegC` field. The loader copies it into both the
+  measurement and combustion reference-temperature columns.
+- Although the CSV has a `Comments` field, the current loader supplies an empty
+  string to `ContractSpecification`; column 11 is therefore empty for loaded
+  rows.
+- The constructor does not assign terminal or country to `contractName`.
+- Loading stops at the first exception, logs a generic error, and retains only
+  rows added before that exception.
+- `display()` opens Swing and is unsuitable for headless services.
+  `prettyPrint()` and the current `runCheck()` path write to standard output;
+  consume `getResultTable()` for structured integration and account for the
+  remaining console side effect.
+- The contract and its standards are mutable. Do not share one instance across
+  concurrent calculations.
 
-## Typical Specifications
+## Safe reporting checklist
 
-### Norwegian Pipeline Gas
+1. Freeze the governing contract revision and its authoritative source outside
+   NeqSim.
+2. Verify the exact terminal/country rows and method keys before calculation.
+3. Record composition basis, NeqSim version, class, reference temperatures,
+   reference pressure, unit, and standard edition for every result.
+4. Parse and validate all numeric cells; fail closed on missing, non-finite, or
+   unsupported values.
+5. Apply min/max limits, uncertainty, rounding, and waiver rules in a
+   version-controlled project layer.
+6. Compare important results with certified measurements or another qualified
+   method before fiscal or contractual use.
 
-| Parameter | Min | Max | Unit | Reference |
-|-----------|-----|-----|------|-----------|
-| Water dew point | - | -8 | °C | 70 bar |
-| HC dew point | - | -2 | °C | cricondentherm |
-| GCV | 36.5 | 44.0 | MJ/Sm³ | 15°C/15°C |
-| Wobbe index | 47.0 | 52.0 | MJ/Sm³ | 15°C/15°C |
-| CO₂ | - | 2.5 | mol% | - |
-| H₂S | - | 5 | mg/Sm³ | - |
+## Related documentation
 
-### UK NTS Gas
+- [Standards package overview](README.md)
+- [ISO 6976 calorific values and Wobbe index](iso6976_calorific_values.md)
+- [Water and hydrocarbon dew-point methods](dew_point_standards.md)
+- [ISO 15403 CNG quality](iso15403_cng_quality.md)
 
-| Parameter | Min | Max | Unit | Reference |
-|-----------|-----|-----|------|-----------|
-| GCV | 36.9 | 42.3 | MJ/m³ | 15°C/15°C |
-| Wobbe index | 47.2 | 51.41 | MJ/m³ | 15°C/15°C |
-| ICF | - | 0.48 | - | - |
-| SI | - | 0.60 | - | - |
-
----
-
-## Best Practices
-
-### Contract Management
-
-1. Store specifications in database for consistency
-2. Version control specification changes
-3. Document reference conditions clearly
-4. Include measurement uncertainty allowances
-
-### Compliance Checking
-
-1. Run checks before custody transfer
-2. Log all specification results
-3. Alert on near-limit values
-4. Track specification trends over time
-
-### Integration
-
-1. Link to online analyzers for real-time checking
-2. Interface with SCADA systems
-3. Generate automatic compliance reports
-4. Archive historical compliance data
-
----
-
-## References
-
-1. EASEE-gas Common Business Practice 2005-001 - Harmonisation of Natural Gas Quality
-2. EN 16726 - Gas infrastructure - Quality of gas - Group H
-3. ISO 13686 - Natural gas — Quality designation
-4. GTS (Dutch) - Gas quality specifications
-5. National Grid (UK) - Gas Ten Year Statement

--- a/docs/test_sales_contracts_documentation.py
+++ b/docs/test_sales_contracts_documentation.py
@@ -1,0 +1,172 @@
+import csv
+import re
+import unittest
+from pathlib import Path
+
+
+DOCS_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = DOCS_DIR.parent
+GUIDE = DOCS_DIR / "standards" / "sales_contracts.md"
+STANDARDS_INDEX = DOCS_DIR / "standards" / "README.md"
+REFERENCE_INDEX = DOCS_DIR / "REFERENCE_MANUAL_INDEX.md"
+BASE_CONTRACT = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/standards/salescontract/BaseContract.java"
+)
+CONTRACT_INTERFACE = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/standards/salescontract/ContractInterface.java"
+)
+CONTRACT_SPECIFICATION = (
+    REPOSITORY_ROOT
+    / "src/main/java/neqsim/standards/salescontract/ContractSpecification.java"
+)
+CONTRACT_DATA = (
+    REPOSITORY_ROOT
+    / "src/main/resources/commercial/GASCONTRACTSPECIFICATIONS.csv"
+)
+
+
+class SalesContractsDocumentationContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+        cls.base_contract = BASE_CONTRACT.read_text(encoding="utf-8")
+        cls.contract_interface = CONTRACT_INTERFACE.read_text(encoding="utf-8")
+        cls.contract_specification = CONTRACT_SPECIFICATION.read_text(
+            encoding="utf-8"
+        )
+        with CONTRACT_DATA.open(encoding="utf-8", newline="") as data_file:
+            cls.contract_rows = list(csv.DictReader(data_file))
+
+    def test_structure_fences_and_internal_links_are_valid(self):
+        self.assertTrue(self.guide.startswith("---\n"))
+        without_fences = re.sub(
+            r"```.*?```",
+            "",
+            self.guide,
+            flags=re.DOTALL,
+        )
+        self.assertNotRegex(without_fences, re.compile(r"^# ", re.MULTILINE))
+        self.assertEqual(self.guide.count("```"), 2)
+        self.assertEqual(self.guide.count("```java"), 1)
+        self.assertNotIn(r"\[", without_fences)
+        self.assertNotIn(r"\(", without_fences)
+
+        destinations = re.findall(r"(?<!!)\[[^\]]+\]\(([^)]+)\)", self.guide)
+        for destination in destinations:
+            if destination.startswith(("http://", "https://", "mailto:")):
+                continue
+            target, _, _fragment = destination.partition("#")
+            with self.subTest(destination=destination):
+                self.assertTrue(target.endswith(".md"))
+                self.assertTrue((GUIDE.parent / target).resolve().is_file())
+
+    def test_complete_example_uses_the_current_database_backed_api(self):
+        required_fragments = (
+            "new SystemGERGwaterEos(268.15, 20.0)",
+            "gas.setMixingRule(8)",
+            'new BaseContract(gas, "central", "Brazil")',
+            "contract.runCheck()",
+            "contract.getResultTable()",
+            "contract.getSpecificationsNumber()",
+            "Double.parseDouble(rows[rowIndex][1])",
+            "value >= minimum && value <= maximum",
+        )
+        for fragment in required_fragments:
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, self.guide)
+        self.assertNotIn("System.out.", self.guide)
+        self.assertNotIn("contract.display()", self.guide)
+        self.assertNotIn("contract.addSpecification", self.guide)
+        self.assertNotIn("new ContractSpecification(", self.guide)
+
+    def test_documented_public_api_and_result_columns_match_source(self):
+        flattened = self.base_contract.replace("\n", " ")
+        for signature in (
+            "public BaseContract()",
+            "public BaseContract(SystemInterface system)",
+            "public BaseContract(SystemInterface system, String terminal, String country)",
+            "public void runCheck()",
+            "public String[][] getResultTable()",
+            "public int getSpecificationsNumber()",
+        ):
+            with self.subTest(signature=signature):
+                self.assertIn(signature, flattened)
+
+        combined_api = self.base_contract + self.contract_interface
+        self.assertNotIn("addSpecification", combined_api)
+        self.assertIn("extends NamedBaseClass", self.contract_specification)
+        self.assertIn("new String[specificationsNumber][12]", self.base_contract)
+        self.assertIn("There is no pass/fail column", self.guide)
+        for column in range(12):
+            self.assertIn("| {} |".format(column), self.guide)
+
+    def test_method_keys_and_bundled_dataset_limitations_are_explicit(self):
+        supported_keys = (
+            "ISO18453",
+            "ISO6974",
+            "Total sulphur",
+            "oxygen",
+            "ISO6976",
+            "SulfurSpecificationMethod",
+            "BestPracticeHydrocarbonDewPoint",
+            "UKspecifications",
+        )
+        for key in supported_keys:
+            with self.subTest(key=key):
+                self.assertIn('methodName.equals("{}")'.format(key), self.base_contract)
+                self.assertIn("`{}`".format(key), self.guide)
+
+        brazil_rows = [
+            row
+            for row in self.contract_rows
+            if row["TERMINAL"] == "central" and row["COUNTRY"] == "Brazil"
+        ]
+        self.assertEqual(8, len(brazil_rows))
+        self.assertEqual("CO2", brazil_rows[1]["SPECIFICATION"])
+        self.assertEqual("0.0", brazil_rows[1]["MINVALUE"])
+        self.assertEqual("3.0", brazil_rows[1]["MAXVALUE"])
+        self.assertEqual("mol%", brazil_rows[1]["UNIT"])
+        self.assertFalse(
+            any(row["TERMINAL"] == "Kaarstoe" for row in self.contract_rows)
+        )
+        self.assertTrue(
+            any(
+                row["METHOD"] == "StatoilBestPracticeHydrocarbonDewPoint"
+                for row in self.contract_rows
+            )
+        )
+        self.assertIn("`StatoilBestPracticeHydrocarbonDewPoint`", self.guide)
+
+    def test_loader_and_compliance_boundaries_are_not_overstated(self):
+        normalized_guide = " ".join(self.guide.split())
+        required_boundaries = (
+            "not a general contract authoring API",
+            "There is no pass/fail column",
+            "return `true` unconditionally",
+            "builds its database query by string concatenation",
+            "supplies an empty string to `ContractSpecification`",
+            "does not assign terminal or country to `contractName`",
+            "write to standard output",
+            "not a maintained register of current pipeline",
+        )
+        for boundary in required_boundaries:
+            with self.subTest(boundary=boundary):
+                self.assertIn(boundary, normalized_guide)
+
+        self.assertIn("setSalesContract(this)", self.base_contract)
+        self.assertIn("isOnSpec()", self.base_contract)
+        self.assertIn('referencePressure, ""', self.base_contract)
+        self.assertIn("this.setContractName(contractName)", self.base_contract)
+        self.assertIn("System.out.println", self.base_contract)
+
+    def test_existing_indexes_discover_the_guide(self):
+        standards_index = STANDARDS_INDEX.read_text(encoding="utf-8")
+        reference_index = REFERENCE_INDEX.read_text(encoding="utf-8")
+        self.assertIn("[Sales contracts](sales_contracts.md)", standards_index)
+        self.assertIn("standards/sales_contracts.md", reference_index)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test/java/neqsim/standards/salescontract/SalesContractDocumentationTest.java
+++ b/src/test/java/neqsim/standards/salescontract/SalesContractDocumentationTest.java
@@ -32,9 +32,9 @@ class SalesContractDocumentationTest extends NeqSimTest {
     int specificationCount = contract.getSpecificationsNumber();
     int rowsWithinLimits = 0;
     for (int rowIndex = 0; rowIndex < specificationCount; rowIndex++) {
-      double value = Double.parseDouble(rows[rowIndex][1]);
-      double minimum = Double.parseDouble(rows[rowIndex][4]);
-      double maximum = Double.parseDouble(rows[rowIndex][5]);
+      double value = parseDoubleOrFail(rows[rowIndex][1], rowIndex, 1);
+      double minimum = parseDoubleOrFail(rows[rowIndex][4], rowIndex, 4);
+      double maximum = parseDoubleOrFail(rows[rowIndex][5], rowIndex, 5);
       if (Double.isFinite(value) && value >= minimum && value <= maximum) {
         rowsWithinLimits++;
       }
@@ -44,14 +44,24 @@ class SalesContractDocumentationTest extends NeqSimTest {
     assertEquals(8, rows.length);
     assertEquals(12, rows[0].length);
     assertEquals("CO2", rows[1][0]);
-    assertEquals(2.18817727816606, Double.parseDouble(rows[1][1]), 1.0e-6);
+    assertEquals(2.18817727816606, parseDoubleOrFail(rows[1][1], 1, 1), 1.0e-6);
     assertEquals("Brazil", rows[1][2]);
     assertEquals("central", rows[1][3]);
-    assertEquals(0.0, Double.parseDouble(rows[1][4]), 0.0);
-    assertEquals(3.0, Double.parseDouble(rows[1][5]), 0.0);
+    assertEquals(0.0, parseDoubleOrFail(rows[1][4], 1, 4), 0.0);
+    assertEquals(3.0, parseDoubleOrFail(rows[1][5], 1, 5), 0.0);
     assertEquals("mol%", rows[1][6]);
-    assertEquals(1.0, Double.parseDouble(rows[1][10]), 0.0);
+    assertEquals(1.0, parseDoubleOrFail(rows[1][10], 1, 10), 0.0);
     assertEquals("", rows[1][11]);
     assertTrue(rowsWithinLimits > 0);
+  }
+
+  private static double parseDoubleOrFail(String value, int rowIndex, int columnIndex) {
+    try {
+      return Double.parseDouble(value);
+    } catch (NumberFormatException | NullPointerException exception) {
+      throw new AssertionError(
+          "Expected a numeric contract result at row " + rowIndex + ", column " + columnIndex,
+          exception);
+    }
   }
 }

--- a/src/test/java/neqsim/standards/salescontract/SalesContractDocumentationTest.java
+++ b/src/test/java/neqsim/standards/salescontract/SalesContractDocumentationTest.java
@@ -59,8 +59,7 @@ class SalesContractDocumentationTest extends NeqSimTest {
     try {
       return Double.parseDouble(value);
     } catch (NumberFormatException | NullPointerException exception) {
-      throw new AssertionError(
-          "Expected a numeric contract result at row " + rowIndex + ", column " + columnIndex,
+      throw new AssertionError("Expected a numeric contract result at row " + rowIndex + ", column " + columnIndex,
           exception);
     }
   }

--- a/src/test/java/neqsim/standards/salescontract/SalesContractDocumentationTest.java
+++ b/src/test/java/neqsim/standards/salescontract/SalesContractDocumentationTest.java
@@ -1,0 +1,57 @@
+package neqsim.standards.salescontract;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import neqsim.NeqSimTest;
+import neqsim.thermo.system.SystemGERGwaterEos;
+import neqsim.thermo.system.SystemInterface;
+import org.junit.jupiter.api.Test;
+
+/** Executes the database-backed example in the gas sales-contract guide. */
+class SalesContractDocumentationTest extends NeqSimTest {
+  @Test
+  void testBrazilContractExampleAndResultTableContract() {
+    SystemInterface gas = new SystemGERGwaterEos(268.15, 20.0);
+    gas.addComponent("methane", 0.90);
+    gas.addComponent("ethane", 0.04);
+    gas.addComponent("propane", 0.02);
+    gas.addComponent("n-heptane", 0.00012);
+    gas.addComponent("H2S", 0.000012);
+    gas.addComponent("water", 0.000071);
+    gas.addComponent("oxygen", 0.0012);
+    gas.addComponent("CO2", 0.022);
+    gas.addComponent("nitrogen", 0.022);
+    gas.setMixingRule(8);
+    gas.init(0);
+
+    BaseContract contract = new BaseContract(gas, "central", "Brazil");
+    contract.runCheck();
+
+    String[][] rows = contract.getResultTable();
+    int specificationCount = contract.getSpecificationsNumber();
+    int rowsWithinLimits = 0;
+    for (int rowIndex = 0; rowIndex < specificationCount; rowIndex++) {
+      double value = Double.parseDouble(rows[rowIndex][1]);
+      double minimum = Double.parseDouble(rows[rowIndex][4]);
+      double maximum = Double.parseDouble(rows[rowIndex][5]);
+      if (Double.isFinite(value) && value >= minimum && value <= maximum) {
+        rowsWithinLimits++;
+      }
+    }
+
+    assertEquals(8, specificationCount);
+    assertEquals(8, rows.length);
+    assertEquals(12, rows[0].length);
+    assertEquals("CO2", rows[1][0]);
+    assertEquals(2.18817727816606, Double.parseDouble(rows[1][1]), 1.0e-6);
+    assertEquals("Brazil", rows[1][2]);
+    assertEquals("central", rows[1][3]);
+    assertEquals(0.0, Double.parseDouble(rows[1][4]), 0.0);
+    assertEquals(3.0, Double.parseDouble(rows[1][5]), 0.0);
+    assertEquals("mol%", rows[1][6]);
+    assertEquals(1.0, Double.parseDouble(rows[1][10]), 0.0);
+    assertEquals("", rows[1][11]);
+    assertTrue(rowsWithinLimits > 0);
+  }
+}


### PR DESCRIPTION
## Summary

Advances #2499 as D086 (rotation scope 5: PVT, flow assurance, standards, and gas/oil quality).

This replaces the stale gas sales-contract guide with the only currently supported database-backed workflow and repairs all 12 confirmed defects in the frozen batch:

- removes the duplicate H1 and obsolete table-of-contents scaffolding;
- removes nonexistent `addSpecification` and unsupported custom-contract examples;
- replaces the nonexistent `Kaarstoe` fixture with the exact bundled `central` / `Brazil` keys;
- documents the real 12-column result table instead of an invented six-column pass/fail table;
- makes min/max ownership explicit because `isOnSpec()` is not a generic row-limit evaluator;
- records all exact `getMethod(...)` keys and the bundled unsupported `StatoilBestPracticeHydrocarbonDewPoint` row;
- documents the one-temperature loading behavior, dropped comments, unchanged contract name, partial-load behavior, mutable state, query construction, and console/Swing boundaries;
- removes unsourced generic Norwegian/UK limit tables and compliance claims;
- adds a complete Java 8 example with explicit units and row-by-row project-limit comparison;
- adds six hermetic documentation/source/data/navigation contracts; and
- adds executable Java regression coverage for all calls and expected Brazil fixture results.

## Frozen scope

Exact base: `7d62ab77aff4526011b10bffc68c8f24b2375207`

Exact head at publication: `bb0129fe0a23d20e1bdfba6647a84d3c4b6d8894`

Changed files:

- `docs/standards/sales_contracts.md`
- `docs/test_sales_contracts_documentation.py`
- `src/test/java/neqsim/standards/salescontract/SalesContractDocumentationTest.java`

The standards landing page and reference-manual index already discover the guide and are intentionally unchanged. Open autonomous PRs #3221, #3223, #3226, and #3227 do not overlap these files.

Stop boundary: no production sales-contract API, database, standard coefficient, external contract qualification, PVT/flow-assurance algorithm, notebook, image, browser-rendering, or Huldra change.

## Evidence and acceptance

Confirmed against exact master source/data blobs:

- `BaseContract.java` `47d1105489727be570c0798b0004acf90dcb545a`
- `ContractInterface.java` `1af193afead87c4af4bcae0ffb99858aa56e8e09`
- `ContractSpecification.java` `3f9c085aaa3c7b99f4f687834c107a19d227c046`
- `GASCONTRACTSPECIFICATIONS.csv` `3eeec03fbb95832f74759c9cb2cabc7a964e4049`

Passed locally against those exact source/data blobs:

- `python -m unittest docs/test_sales_contracts_documentation.py` — 6 tests, 0 failures/errors
- `python -m py_compile docs/test_sales_contracts_documentation.py`
- front matter, no duplicate H1, balanced fence, link resolution, source signatures, all 12 result columns, supported method keys, bundled row counts/values, index discoverability, and stale-API exclusion
- final scope comparison: 5 commits ahead, 0 behind, exactly the three frozen files

## VALIDATION PENDING CI

A justified code-quality review finding was repaired on the current head by replacing unguarded numeric parsing with a contextual assertion helper. All seven duplicate inline findings share that resolved root cause.

The available local support checkout is intentionally sparse and has no Maven wrapper or `devtools/run_spotless.py`; no unrun local check is claimed as passed.

Passed locally after the review repair:

- `python -m unittest docs/test_sales_contracts_documentation.py` — 6 tests, 0 failures/errors;
- `python -m py_compile docs/test_sales_contracts_documentation.py`; and
- manual Java 8 syntax/style inspection. The formatter-prescribed layout from the failed pre-commit log was then applied exactly.

Hosted exact-head status on `bb0129fe0a23d20e1bdfba6647a84d3c4b6d8894`:

- pre-commit and Spotless passed;
- documentation source/contracts, Jekyll, and generated search coverage passed;
- agent-skill cross-references and Java 21 Javadocs passed;
- CodeQL passed; and
- Java 21 fast tests and all four slow-test shards are still running.

The PR remains draft pending terminal exact-head CI and the final audit.

Documentation impact: the public gas sales-contract guide now matches current constructors, data selection, result semantics, units, and engineering/contractual boundaries.

Next rotation scope: 6 — tutorials, cookbook, troubleshooting, and examples.