### PR TITLE
[AI-Assisted] feat(mcp): qualify capability discovery contract evidence

### DIFF
--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -19,8 +19,8 @@ manually maintained Java method list.
 | MCP Java test classes | 67 | `getCapabilities.phase0EvidenceInventory` | `src/test/java/neqsim/mcp/**/*Test.java` |
 | MCP protocol scenarios | 94 | `getCapabilities.phase0EvidenceInventory` | `test_mcp_server.py` |
 | MCP guides | 8 | `getCapabilities.phase0EvidenceInventory` | Core guides, foundation traceability, fixtures, baseline harness, and campaign matrix |
-| Explicit tool trust pages | 20 of 71 tools | `getBenchmarkTrust` and `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust` |
-| Trust coverage records | 71 = 20 explicit + 51 confirmed gaps | `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust`, `McpImplementationInventory` |
+| Explicit benchmark-trust pages | 20 of 71 tools | `getBenchmarkTrust` and `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust` |
+| Trust coverage records | 71 = 20 explicit benchmark + 1 contract-tested discovery + 50 confirmed gaps | `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust`, `McpImplementationInventory`, MCP contract tests |
 
 The tool regression asserts the exact 71-name set grouped by its current trust tier. It also calls
 `getCapabilities` and requires `toolCatalogCoverage.complete`, equal published and described tool
@@ -111,25 +111,33 @@ equivalent selective-retrieval route. Omitted catalog detail remains identified 
 can be queried through `getSchema`, `getExample`, `getBenchmarkTrust`, and the MCP catalog
 resources.
 
-`BenchmarkTrust` currently contains 20 tool-specific trust pages with 64 known-limit entries and 30
-validation cases, of which 5 name a concrete `verifiedBy` test. The other 51 published tools still
-use the compatibility-level generic `TESTED` fallback from `getBenchmarkTrust`.
+`BenchmarkTrust` currently contains 20 tool-specific numerical/engineering trust pages with 64
+known-limit entries and 30 validation cases, of which 5 name a concrete `verifiedBy` test. The
+other 51 published tools still use the compatibility-level generic `TESTED` benchmark fallback
+from `getBenchmarkTrust`.
 
-Phase 0 no longer leaves those 51 tools as an implicit set. `knownLimitations.coverageRecords`
-contains one deterministic record for every published tool and classifies it as either:
+Phase 0 does not equate that generic benchmark fallback with an unresolved scientific gap when the
+tool is intrinsically non-numerical. `knownLimitations.coverageRecords` contains one deterministic
+record for every published tool and now uses three bounded states:
 
 - `EXPLICIT_TRUST` — a tool-specific `BenchmarkTrust` page exists, with its declared maturity and
-  counts for validation cases, verified cases, limitations, and unsupported conditions; or
-- `CONFIRMED_GAP` — no tool-specific trust page exists. The record names the implementation class,
-  retains the current compatibility maturity for backward compatibility, and explicitly states that
-  the generic `TESTED` fallback is not benchmark, accuracy, applicability, or no-limitations
-  evidence.
+  counts for validation cases, verified cases, limitations, and unsupported conditions;
+- `CONTRACT_TESTED` — the tool is non-numerical and direct source, contract-test, response-guard,
+  and real-protocol evidence demonstrates its MCP contract. `getCapabilities` is the first such
+  record. Its engineering benchmark applicability is explicitly
+  `NOT_APPLICABLE_NON_NUMERICAL_DISCOVERY`; this status does not validate any advertised
+  thermodynamic or process calculation; or
+- `CONFIRMED_GAP` — no tool-specific benchmark trust page or bounded non-numerical contract
+  evidence closes the gap. The record names the implementation class, retains the compatibility
+  maturity, and explicitly states that generic `TESTED` is not benchmark, accuracy,
+  applicability, or no-limitations evidence.
 
 Accordingly, `coverageComplete=true` means all 71 published tools have an explicit trust-coverage
-classification. It does **not** mean the MCP surface is scientifically validated: 51 records remain
-`CONFIRMED_GAP`, `scientificValidationComplete=false`, and the existing `complete` flag remains
-false until tool-specific trust metadata exists for every published tool. No explicit trust page
-currently publishes a structured `unsupported` condition.
+classification. It does **not** mean the MCP surface is scientifically validated: 50 records remain
+`CONFIRMED_GAP`, one is `CONTRACT_TESTED`, `scientificValidationComplete=false`, and the overall
+Phase 0 `complete` flag remains false. The benchmark registry itself remains unchanged at 20
+explicit pages and 51 generic benchmark fallbacks, so existing benchmark-report accounting and
+protocol contracts are preserved.
 
 Per-result provenance, convergence, warnings, assumptions, and limitations remain authoritative
 for an executed calculation. The evidence inventory is advisory discovery metadata; it does not
@@ -168,13 +176,16 @@ NeqSim fluids, streams, `ProcessSystem`, and `ProcessModel` objects.
 The baseline now freezes the exact transport-facing tools, resources, resource templates, prompts,
 deployment-profile names, tool-capability reconciliation, schema resource graph, example resource
 graph, tool implementation bindings, factory-backed equipment, report paths, test sources, guides,
-merged-foundation reconciliation, and explicit trust-coverage status for every published tool. It
-does not complete the campaign's full Phase 0 audit.
+merged-foundation reconciliation, four public synthetic acceptance scales, bounded acceptance
+baseline harness, campaign traceability/maturity matrix, and explicit trust-coverage status for
+every published tool. `getCapabilities` is now contract-tested without being misrepresented as a
+scientifically benchmarked calculation.
 
-Follow-up work must close confirmed trust gaps where current source/public evidence supports a
-specific claim; establish the four public synthetic acceptance scales; build the full campaign
-traceability and discipline-maturity matrices; and record runtime, memory, payload, convergence,
-balance-closure, and report-usefulness baselines.
+Follow-up work should close the remaining 50 confirmed trust gaps only where current source and
+public evidence support a specific claim, and continue closing explicit numeric component,
+energy, and facility-wide conservation/report gaps only where canonical NeqSim APIs provide
+independent evidence. Later-phase campaign criteria remain incomplete until their own merged
+acceptance evidence exists.
 
 DEXPI/P&ID ingestion remains owned by #2899, dynamics by #2911, flash/stability/performance by
 #2937, and merged production-optimization foundations by #2941. This inventory audits existing

--- a/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
@@ -28,7 +28,7 @@ public final class McpEvidenceInventory {
    */
   public static JsonObject build() {
     JsonObject inventory = new JsonObject();
-    inventory.addProperty("inventoryVersion", "1.5");
+    inventory.addProperty("inventoryVersion", "1.6");
     inventory.add("tests", buildTests());
     inventory.add("guides", buildGuides());
     inventory.add("mergedFoundations", buildMergedFoundations());
@@ -166,6 +166,7 @@ public final class McpEvidenceInventory {
 
     JsonObject coverageRecords = new JsonObject();
     int explicitCoverageRecordCount = 0;
+    int contractTestedRecordCount = 0;
     int confirmedGapRecordCount = 0;
     for (String toolName : new java.util.TreeSet<String>(publishedTools)) {
       JsonObject record = new JsonObject();
@@ -185,6 +186,20 @@ public final class McpEvidenceInventory {
         record.addProperty("validationCaseCount", arraySize(trust, "validationCases"));
         record.addProperty("verifiedValidationCaseCount", verifiedValidationCaseCount(trust));
         explicitCoverageRecordCount++;
+      } else if ("getCapabilities".equals(toolName)) {
+        record.addProperty("coverageStatus", "CONTRACT_TESTED");
+        record.addProperty("toolSpecificTrustAvailable", false);
+        record.addProperty("contractTrustAvailable", true);
+        record.addProperty("benchmarkApplicability", "NOT_APPLICABLE_NON_NUMERICAL_DISCOVERY");
+        record.addProperty("maturityLevel", "TESTED");
+        record.addProperty("contractEvidenceCount", 4);
+        record.addProperty("knownLimitationCount", 0);
+        record.addProperty("unsupportedConditionCount", 0);
+        record.addProperty("validationCaseCount", 0);
+        record.addProperty("verifiedValidationCaseCount", 0);
+        record.addProperty("evidenceBoundary",
+            "CapabilitiesRunnerTest, McpToolSurfaceContractTest, ResponseSizeGuardTest, and the packaged MCP protocol verify discovery-contract fidelity; this is not scientific validation of advertised calculations");
+        contractTestedRecordCount++;
       } else {
         record.addProperty("coverageStatus", "CONFIRMED_GAP");
         record.addProperty("toolSpecificTrustAvailable", false);
@@ -203,14 +218,17 @@ public final class McpEvidenceInventory {
     JsonObject coverageDefinitions = new JsonObject();
     coverageDefinitions.addProperty("EXPLICIT_TRUST",
         "Tool-specific BenchmarkTrust metadata exists; use its declared maturity, validation cases, accuracy bounds, and limitations");
+    coverageDefinitions.addProperty("CONTRACT_TESTED",
+        "Non-numerical MCP contract behavior has direct source, contract-test, response-guard, and real-protocol evidence; no engineering accuracy benchmark is applicable or implied");
     coverageDefinitions.addProperty("CONFIRMED_GAP",
-        "No tool-specific BenchmarkTrust entry exists; generic fallback maturity must not be interpreted as benchmark validation");
+        "No tool-specific BenchmarkTrust entry or bounded non-numerical contract evidence closes the gap; generic fallback maturity must not be interpreted as benchmark validation");
 
     JsonObject limitations = new JsonObject();
     limitations.addProperty("sourceTool", "getBenchmarkTrust");
     limitations.addProperty("publishedToolCount", publishedTools.size());
     limitations.addProperty("explicitTrustToolCount", explicitTools.size());
     limitations.addProperty("genericTrustToolCount", genericTools.size());
+    limitations.addProperty("contractTestedToolCount", contractTestedRecordCount);
     limitations.addProperty("confirmedGapToolCount", confirmedGapRecordCount);
     limitations.addProperty("coverageRecordCount", coverageRecords.size());
     limitations.addProperty("explicitCoverageRecordCount", explicitCoverageRecordCount);
@@ -227,7 +245,7 @@ public final class McpEvidenceInventory {
     limitations.add("coverageRecords", coverageRecords);
     limitations.addProperty("complete", genericTools.isEmpty());
     limitations.addProperty("gapBoundary",
-        "Every published tool has an explicit coverage record; CONFIRMED_GAP identifies missing tool-specific trust evidence without implying validation");
+        "Every published tool has an explicit coverage record; getCapabilities is contract-tested without a numerical benchmark claim, while CONFIRMED_GAP identifies the remaining missing tool-specific trust evidence");
     limitations.addProperty("resultBoundary",
         "Per-result provenance, convergence, warnings, assumptions, and limitations remain authoritative for an executed case");
     return limitations;

--- a/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
@@ -68,8 +68,7 @@ class McpEvidenceInventoryFoundationTests {
     assertEquals("CONTRACT_TESTED", capabilities.get("coverageStatus").getAsString());
     assertFalse(capabilities.get("toolSpecificTrustAvailable").getAsBoolean());
     assertTrue(capabilities.get("contractTrustAvailable").getAsBoolean());
-    assertEquals("NOT_APPLICABLE_NON_NUMERICAL_DISCOVERY",
-        capabilities.get("benchmarkApplicability").getAsString());
+    assertEquals("NOT_APPLICABLE_NON_NUMERICAL_DISCOVERY", capabilities.get("benchmarkApplicability").getAsString());
     assertEquals("TESTED", capabilities.get("maturityLevel").getAsString());
     assertEquals(4, capabilities.get("contractEvidenceCount").getAsInt());
     assertTrue(capabilities.get("evidenceBoundary").getAsString().contains("not scientific validation"));

--- a/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
@@ -53,7 +53,8 @@ class McpEvidenceInventoryFoundationTests {
     assertEquals(71, limitations.get("publishedToolCount").getAsInt());
     assertEquals(71, limitations.get("coverageRecordCount").getAsInt());
     assertEquals(20, limitations.get("explicitCoverageRecordCount").getAsInt());
-    assertEquals(51, limitations.get("confirmedGapToolCount").getAsInt());
+    assertEquals(1, limitations.get("contractTestedToolCount").getAsInt());
+    assertEquals(50, limitations.get("confirmedGapToolCount").getAsInt());
     assertEquals(71, coverageRecords.size());
     assertTrue(limitations.get("coverageComplete").getAsBoolean());
     assertFalse(limitations.get("scientificValidationComplete").getAsBoolean());
@@ -64,9 +65,14 @@ class McpEvidenceInventoryFoundationTests {
     assertTrue(flash.get("validationCaseCount").getAsInt() > 0);
 
     JsonObject capabilities = coverageRecords.getAsJsonObject("getCapabilities");
-    assertEquals("CONFIRMED_GAP", capabilities.get("coverageStatus").getAsString());
+    assertEquals("CONTRACT_TESTED", capabilities.get("coverageStatus").getAsString());
     assertFalse(capabilities.get("toolSpecificTrustAvailable").getAsBoolean());
-    assertTrue(capabilities.get("gapReason").getAsString().contains("not benchmark"));
+    assertTrue(capabilities.get("contractTrustAvailable").getAsBoolean());
+    assertEquals("NOT_APPLICABLE_NON_NUMERICAL_DISCOVERY",
+        capabilities.get("benchmarkApplicability").getAsString());
+    assertEquals("TESTED", capabilities.get("maturityLevel").getAsString());
+    assertEquals(4, capabilities.get("contractEvidenceCount").getAsInt());
+    assertTrue(capabilities.get("evidenceBoundary").getAsString().contains("not scientific validation"));
     assertFalse(inventory.get("complete").getAsBoolean());
   }
 
@@ -76,7 +82,7 @@ class McpEvidenceInventoryFoundationTests {
     JsonObject inventory = capabilities.getAsJsonObject("phase0EvidenceInventory");
     JsonObject fixtures = inventory.getAsJsonObject("acceptanceFixtures");
 
-    assertEquals("1.5", inventory.get("inventoryVersion").getAsString());
+    assertEquals("1.6", inventory.get("inventoryVersion").getAsString());
     assertEquals(8, inventory.getAsJsonObject("guides").get("guideCount").getAsInt());
     assertEquals(4, fixtures.get("fixtureCount").getAsInt());
     assertTrue(fixtures.get("complete").getAsBoolean());


### PR DESCRIPTION
## Summary

Advances #3153 Phase 0 by resolving one non-numerical trust-coverage gap without manufacturing a scientific benchmark claim.

`getCapabilities` is a static MCP discovery/evidence contract, not an engineering calculation. Current master already has direct source and contract evidence for its published-tool reconciliation, implementation/equipment inventory, Phase 0 evidence, response-size preservation, and real packaged MCP protocol behavior. This PR therefore reclassifies only its Phase 0 coverage record from `CONFIRMED_GAP` to `CONTRACT_TESTED`.

- preserves the existing `BenchmarkTrust` registry unchanged at 20 explicit engineering/numerical pages and 51 generic benchmark fallbacks
- adds a third bounded coverage state, `CONTRACT_TESTED`, for non-numerical MCP contracts whose behavior is directly demonstrated without an applicable engineering-accuracy benchmark
- marks `getCapabilities.benchmarkApplicability = NOT_APPLICABLE_NON_NUMERICAL_DISCOVERY`
- records four concrete evidence families: `CapabilitiesRunnerTest`, `McpToolSurfaceContractTest`, `ResponseSizeGuardTest`, and the packaged MCP protocol suite
- reduces true unresolved Phase 0 trust gaps from 51 to 50 while keeping `scientificValidationComplete=false` and overall Phase 0 `complete=false`
- updates the authoritative MCP surface inventory and focused regression

## Frozen scope and owner boundaries

MCP evidence/discovery metadata only. No thermodynamic, process, pipeline, dynamic, DEXPI/P&ID, optimization, facility-ingestion, tool-name, input-schema, response-envelope, or live-plant behavior changes.

Owner boundaries remain with #2937 for generic flash/stability, #2911 for dynamics, #2899 for DEXPI/P&ID, #2939 for generic process performance, and #3154/#2941 for plant optimization.

## Exact base / head

Branch created directly from current master `e467ebce1e562f4838a8976f944730cec6735e25`.

Immediately before publication, the branch was three commits ahead / zero behind that exact base and changed only:
- `src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java`
- `src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java`
- `neqsim-mcp-server/docs/SURFACE_INVENTORY.md`

No update-branch, master merge, rebase, cherry-pick, force push, or master write was used.

## Validation

`VALIDATION PENDING CI`

One bounded local checkout attempt was made and failed only because the task runtime could not resolve `github.com`. Per the campaign resilience policy, no local Maven/JDK/Spotless/pre-commit result is claimed and GitHub-plugin-backed implementation continued.

Existing frozen protocol accounting is intentionally preserved: `BenchmarkTrust.getAll` remains 20 explicit / 51 generic, so the 94-scenario packaged protocol contract does not need a count change. The focused Java regression now requires 71 coverage records = 20 `EXPLICIT_TRUST` + 1 `CONTRACT_TESTED` + 50 `CONFIRMED_GAP`, with capability discovery explicitly non-benchmark and non-scientific.

Hosted exact-head CI is authoritative for Java 8/21 compilation/tests, Spotless, pre-commit, Javadocs, CodeQL, PaperLab, and broader MCP/protocol validation. No unrun check is claimed as passed.

## Documentation impact

`SURFACE_INVENTORY.md` now distinguishes scientific/engineering benchmark trust from non-numerical contract evidence, preserves the 20/51 benchmark registry accounting, and records the 20 + 1 + 50 coverage split. No companion agent/skill update is required because invocation contracts and tool names are unchanged.

## Remaining Phase 0 dependency

After merge and current-master re-audit, close only the remaining 50 trust gaps where current source plus defensible evidence supports a specific classification. Component, energy, and facility-wide conservation/report gaps remain explicit unless canonical NeqSim APIs provide independent evidence; later campaign phases remain incomplete until their own acceptance evidence is merged.

Refs #3153