### PR TITLE
[AI-Assisted] feat(pitzer): import PHREEQC catalog for scale brines

### DIFF
--- a/docs/thermo/pitzer_parameter_provenance.md
+++ b/docs/thermo/pitzer_parameter_provenance.md
@@ -164,10 +164,73 @@ license was established in this audit. No table value is stored. The exact-compo
 matrix therefore remains the mixed-family numerical gate; licensing-clear held-out mixed-salt
 experimental data are still the next evidence dependency.
 
+### Versioned PHREEQC catalog and Ca-Mg-Cl-SO4 scale-brine qualification
+
+`PhreeqcPitzerParameterCatalog` lazily reads the exact `PITZER` block from public-domain USGS
+PHREEQC commit `b0b3be767158ccc3322d2c816625cf470045e67e`, database blob
+`324f852784be84650b77bd7f07f8316aafd8188b`. The bundled catalog contains 54 `B0`, 48 `B1`,
+8 `B2`, 32 `C0`, 30 `theta`, 59 `psi`, 27 `lambda`, and 10 `zeta` rows. No reaction constant,
+mineral `log K`, gas binary, SIT, eNRTL, Extended-UNIQUAC, or electrolyte-EOS coefficient is
+imported. The resource is parsed only after an explicit catalog API call, so neutral EOS and legacy
+Pitzer paths do no catalog I/O or lookup work.
+
+`applyCompletePhreeqcPitzerCatalog` selects rows by the active aqueous species. Every active
+opposite-sign pair requires explicit `B0`, `B1`, and `C0`; every same-sign pair requires `theta`;
+every mixed-ion triple requires `psi`; and active neutral solutes require their complete `lambda`
+and `zeta` topology. An absent required row fails before phase mutation. A `B2` row is optional
+only in the strict sense that it is applied whenever the source defines it; the loader never creates
+one or silently substitutes an unqualified zero. This makes a broad source database available while
+preserving a closed, reviewable calculation topology.
+
+The first fully exercised four-ion family is Ca++/Mg++/Cl-/SO4--. It includes all four binaries,
+both same-sign pairs, and all four ternary compositions:
+
+| Tuple | Family | PHREEQC coefficients `[a0,a1,a2,a3,a4,a5]` |
+|---|---|---|
+| Ca++ / Cl- | `B0`; `B1`; `B2`; `C0` | `[0.3159,0,0,-3.27e-4,1.4e-7,0]`; `[1.614,0,0,7.63e-3,-8.19e-7,0]`; `[-1.13,0,0,-0.0476,0,0]`; `[1.4e-4,-57,-0.098,-7.83e-4,7.18e-7,0]` |
+| Ca++ / SO4-- | `B0`; `B1`; `B2`; `C0` | `[0,0,0,0,0,0]`; `[3.546,0,0,5.77e-3,0,0]`; `[-59.3,0,0,-0.443,-3.96e-6,0]`; `[0.114,0,0,0,0,0]` |
+| Mg++ / Cl- | `B0`; `B1`; `C0` | `[0.351,0,0,-9.32e-4,5.94e-7,0]`; `[1.65,0,0,-1.09e-2,2.6e-5,0]`; `[0.00651,0,0,-2.5e-4,2.418e-7,0]` |
+| Mg++ / SO4-- | `B0`; `B1`; `B2`; `C0` | `[0.2135,-951,0,-2.34e-2,2.28e-5,0]`; `[3.367,-5.78e3,0,-0.148,1.576e-4,0]`; `[-32.45,0,-3.236e3,21.812,-1.8859e-2,0]`; `[2.875e-2,0,-2.084,1.1428e-2,-8.228e-6,0]` |
+| Ca++ / Mg++; Cl- / SO4-- | `theta` | `[0.007,0,0,0,0,0]`; `[0.03,0,0,0,0,0]` |
+| Ca++ / Cl- / Mg++; Ca++ / Cl- / SO4-- | `psi` | `[-0.012,0,0,0,0,0]`; `[-0.122,0,0,-1.21e-3,0,0]` |
+| Ca++ / Mg++ / SO4--; Cl- / Mg++ / SO4-- | `psi` | `[0.024,0,0,0,0,0]`; `[-0.008,32.63,0,0,0,0]` |
+
+PHREEQC source assigns `alpha1=2` and `alpha2=12` to pairs containing a monovalent ion,
+`alpha1=1.4` and `alpha2=12` to 2-2 pairs, and `alpha1=2`, `alpha2=50` to the remaining charge
+orders. Current-master NeqSim previously discarded `B2` for every non-2-2 pair, which omitted the
+explicit CaCl2 term. The catalog path now maps this PHREEQC convention in activity, common
+`B-prime`, and both water/osmotic calculations; legacy rows with zero `B2` are unchanged.
+
+Held-out CaCl2 mean ionic activity coefficients come from Partanen (2013),
+[DOI 10.1021/je300852v](https://doi.org/10.1021/je300852v), through the NIST ThermoML archive.
+The archived states are on the molality scale at 298.15 K and 101 kPa with reported uncertainty
+0.001. At 0.1, 0.5, 1.0, and 2.0 mol/kg, NeqSim predicts 0.515385, 0.444320, 0.497186, and
+0.798718 versus 0.517, 0.449, 0.502, and 0.790; the maximum relative residual is 1.104%, without
+parameter fitting. NIST identifies the ThermoML archive as publisher-permitted and its Data.gov
+catalog applies the [NIST public-data license](https://www.nist.gov/open/license). Exact-version
+mixed-family PHREEQC activity/water comparisons and independent Mg/SO4 evidence remain validation
+dependencies; the family must stay draft until those numerical gates are recorded.
+
+The catalog is an aqueous-GE parameter source, not a complete scale or process model by itself.
+`SystemPitzer` keeps SRK gas and oil role phases and exposes catalog application on its Pitzer
+aqueous role. Hybrid gas-oil-water phase stability, model-specific aqueous reactions, mineral
+solubility/precipitation complementarity, and process mass/energy/property closure retain their
+separate gates and database semantics.
+
+`PitzerCatalogPerformanceBenchmark` measures nine fixed-work batches after warmup. On OpenJDK 17
+in the development container, the median four-ion activity/osmotic kernel was 8.29 microseconds and
+the complete aqueous `init(3)` plus physical-property calculation was 0.191 milliseconds. The same
+neutral SRK property control measured 47.7 microseconds before catalog loading and 22.0 microseconds
+after loading (ratio 0.462, reflecting additional JIT warmup rather than a regression). No neutral
+EOS production class is changed, and catalog parsing is absent until its explicit API is called.
+These figures are diagnostic wall-clock evidence, not portable hardware guarantees.
+
 ## Source-comparison matrix
 
-Only the complete CO2-Na2SO4 and Na-K-Cl subsets above are adopted. Other candidate values remain
-comparison evidence unless this document explicitly identifies them as part of a versioned set.
+The exact PHREEQC Pitzer block is now stored as a versioned catalog. A calculation may activate only
+an explicit, complete topology; the CO2-Na2SO4, Na-K-Cl, and Ca-Mg-Cl-SO4 families above have
+dedicated evidence. Other catalog rows remain source-available rather than scientifically qualified
+until their complete topology and validation matrix are documented.
 
 | Source / version | Species and parameter families | Conditions, equation, scale, and alpha | Evidence, range, uncertainty | Lineage and reuse status | Mapping decision / conflict |
 |---|---|---|---|---|---|
@@ -175,7 +238,7 @@ comparison evidence unless this document explicitly identifies them as part of a
 | Pitzer (1973), [general equations](https://doi.org/10.1021/j100621a026), and Pitzer–Mayorga (1973), [strong electrolytes](https://doi.org/10.1021/j100638a009) | Foundational binary virial families for strong electrolytes; individual tuples must be read from the original article | Molality-scale Pitzer formulation near 298.15 K; exact parameter-specific alpha and fitted range must be taken from the paper | Mean activity and osmotic-coefficient fits; no value transcribed in this review | Primary publications; ACS copyright, so values require row-level reuse review or redistributable corroboration | Equation lineage accepted; no direct adoption pending exact NeqSim term-by-term mapping. |
 | Harvie, Møller and Weare (1984), [natural-water model](https://doi.org/10.1016/0016-7037(84)90098-X) | Na/K/Mg/Ca/H with Cl/SO4/OH/HCO3/CO3/CO2/H2O; binary and mixed interactions | 25 °C, high ionic strength; molality-scale Pitzer model | Fitted isopiestic, EMF, and solubility data; multicomponent comparisons outside subsystems are reported | Primary Elsevier article; numerical-table redistribution not established here | High-priority scientific comparison. No coefficient copied; full family and electrostatic convention must be mapped together. |
 | Pitzer (1975), [higher-order electrostatic mixing](https://doi.org/10.1007/BF00646562) | Nonsymmetric same-sign electrostatic terms `Etheta` and its ionic-strength derivative for unequal charge pairs; no fitted short-range coefficient is supplied by this term | Molality-scale Pitzer formulation; the term is zero for equal charges and depends on charge tuple, ionic strength, and `Aphi` | Primary equation source; it establishes model structure rather than a parameter fit | Primary Springer article; no numerical table copied | Equation structure accepted in this increment: the public PHREEQC recurrence and its ion/activity/osmotic placement are mapped directly. No fitted coefficient is copied; short-range tuple coverage remains independently fail-closed. |
-| USGS PHRQPITZ (Plummer et al. 1988), [WRIR 88-4153](https://doi.org/10.3133/wri884153), PHREEQC 3.8.6 tag commit [`74cdaf0`](https://github.com/phreeqc-dev/phreeqc3/commit/74cdaf00f90b15b7a5bbc03f405eb2f8129aacf1), and audited current source commit [`b0b3be7`](https://github.com/phreeqc-dev/phreeqc3/commit/b0b3be767158ccc3322d2c816625cf470045e67e) | Na/K/Mg/Ca/H plus major anions and extended Fe/Mn/Sr/Ba/Li/Br; `B0`, `B1`, `B2`, `C0`, `theta`, `psi`, `lambda`, `zeta`, `mu`, `eta`, alpha, and six temperature coefficients | Molality scale; PHREEQC enables nonsymmetric electrostatic mixing by default. The adopted Na+/SO4-- 1-2 and NaCl/KCl 1-1 binaries use alpha1=2. At 298.15 K, NaCl is `B0=0.07534`, `B1=0.2769`, `C0=0.00148`; KCl is `0.04808`, `0.2168`, `-0.000788`; K/Na `theta=-0.012`; Cl/K/Na `psi=-0.0015`. Pressure is absent from these interaction functions. | Appelo (2015), [DOI 10.1016/j.apgeochem.2014.11.007](https://doi.org/10.1016/j.apgeochem.2014.11.007), documents database principles and calculations from 0–200 °C and 1–1000 atm; applicability remains parameter/system specific. Pabalan and Pitzer (1987), [DOI 10.1016/0016-7037(87)90295-X](https://doi.org/10.1016/0016-7037(87)90295-X), is primary high-temperature Na/K brine lineage. Exact fitted observables, residuals, and uncertainty remain row/source specific. Rumpf and Maurer (1993), [DOI 10.1002/bbpc.19930970116](https://doi.org/10.1002/bbpc.19930970116), fitted CO2 in sulfate brines at 313.15–433.15 K and up to 10 MPa. | USGS software and data are public domain. Audited blobs: [`pitzer.cpp` `1f32a08`](https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/src/pitzer.cpp) and [`pitzer.dat` `324f852`](https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/database/pitzer.dat). The selected rows were read twice; a locally installed database had a different full-file hash, so no unselected row was inferred from it. | The complete CO2-Na2SO4 and Na-K-Cl subsets listed above are adopted under separate identities and independently checked. Legacy rows remain default and are not overwritten. Common `B-prime`/`C0`, parameter-free `Etheta`, six-term functions, neutral-family placement, and `C0`/`Cphi` mapping are accepted only for explicitly mapped datasets. |
+| USGS PHRQPITZ (Plummer et al. 1988), [WRIR 88-4153](https://doi.org/10.3133/wri884153), PHREEQC 3.8.6 tag commit [`74cdaf0`](https://github.com/phreeqc-dev/phreeqc3/commit/74cdaf00f90b15b7a5bbc03f405eb2f8129aacf1), and audited current source commit [`b0b3be7`](https://github.com/phreeqc-dev/phreeqc3/commit/b0b3be767158ccc3322d2c816625cf470045e67e) | Na/K/Mg/Ca/H plus major anions and extended Fe/Mn/Sr/Ba/Li/Br; `B0`, `B1`, `B2`, `C0`, `theta`, `psi`, `lambda`, `zeta`, and six temperature coefficients | Molality scale; PHREEQC enables nonsymmetric electrostatic mixing by default. Default alpha is charge dependent: `2/12` when a pair contains a monovalent ion, `1.4/12` for 2-2, and `2/50` otherwise. Pressure is absent from these interaction functions. | Appelo (2015), [DOI 10.1016/j.apgeochem.2014.11.007](https://doi.org/10.1016/j.apgeochem.2014.11.007), documents database principles and calculations from 0–200 °C and 1–1000 atm; applicability remains parameter/system specific. Exact fitted observables, residuals, and uncertainty remain row/source specific. | USGS software and data are public domain. Audited blobs: [`pitzer.cpp` `1f32a08`](https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/src/pitzer.cpp) and [`pitzer.dat` `324f852`](https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/database/pitzer.dat). | The exact interaction block is stored as a lazy catalog; calculation activation fails closed on incomplete topologies. CO2-Na2SO4, Na-K-Cl, and Ca-Mg-Cl-SO4 have dedicated mappings/evidence. Legacy rows remain default and are not overwritten. |
 | Partanen and Partanen (2020), [traceable NaCl values](https://doi.org/10.1021/acs.jced.0c00402) | Recommended NaCl mean activity and water osmotic coefficients; no Pitzer parameter is supplied or adopted | 273.15–373.15 K, 0.2 mol/kg to saturation; molality scale; extended-Huckel model fitted independently of the PHREEQC implementation | Traceable synthesis of vapor-pressure, electrochemical, cryoscopic, and solubility evidence; tabulated values are rounded to 0.001 | Primary open-access article and numerical tables under CC BY 4.0 | Four 298.15 K points from 0.2–2.0 mol/kg are held-out validation only. Max NeqSim residuals are 1.36% in mean activity, 0.0053 in osmotic coefficient, and below 0.0004 in derived water activity; no coefficient was refitted. |
 | Hamer and Wu (1972), [NBS/NIST critical evaluation](https://doi.org/10.1063/1.3253108), independently reproduced by Dash et al. (2012), [open-access table](https://doi.org/10.5402/2012/730154) | Critically evaluated KCl mean activity coefficients; no Pitzer parameter is supplied or adopted | 298.15 K, molality scale, 1:1 electrolyte; four selected states span 0.0982–1.9895 mol/kg | Hamer-Wu evaluates thermodynamic literature; reproduced values are rounded to 0.001. Dash et al.'s direct single-ion-selective-electrode means are 10.7–13.4% higher at the same states and are treated as a method conflict. | U.S. NBS authorship and U.S. Secretary of Commerce publication; the four checked values are also reproduced in a CC BY open-access primary experiment | Held-out binary validation only. Max NeqSim mean-activity residual is 0.110% against a 0.20% gate; no coefficient was refitted. The critically evaluated values take precedence over the conflicting single-ion method. |
 | Rodil, Arce, Wilczek-Vera and Vera (2009), [mixed NaCl+KCl experiment](https://doi.org/10.1021/je800389q) and [mandatory correction](https://doi.org/10.1021/je9002674) | Individual Cl-/Na+/K+ activity evidence in mixed NaCl+KCl at cation molal fractions 0.75, 0.5, and 0.25 | 298.15 K; total chloride to 4 mol/kg; Henderson liquid-junction correction and single-ion convention | Original paper reports the experiment; the correction replaces erroneous Na+/K+ tabulations without changing conclusions | ACS supporting information is publicly downloadable, but copyright and no explicit data-redistribution license were established | Candidate held-out mixed-family validation only. No value is stored; licensing-clear data and convention mapping remain the blocker. Exact-composition IPhreeqc checks are retained as implementation evidence, not a substitute for experiment. |
@@ -192,7 +255,7 @@ Appendix F citations were checked against their primary publisher records before
 | [8] | He and Morse (1993), [carbonate/calcite brines](https://doi.org/10.1016/0016-7037(93)90137-L): CO2, bicarbonate, carbonate, and calcite evidence in Na/K/Ca/Mg chloride/sulfate solutions from 0 to 90 °C at about 0.1032 MPa | Supports the thesis family and temperature lineage, but does not establish redistribution rights or validate every transcribed coefficient. No row adopted. |
 | [13] | Harvie, Møller and Weare (1984), [natural-water model](https://doi.org/10.1016/0016-7037(84)90098-X): mixed Na/K/Mg/Ca/H chloride/sulfate/carbonate system at 25 °C and high ionic strength | Family topology agrees with Appendix F. The primary model is a 25 °C reference, so it cannot independently qualify Kaasa's later temperature fits. No row adopted. |
 | [14] | Pabalan and Pitzer (1987), [high-temperature mixed electrolytes](https://doi.org/10.1016/0016-7037(87)90295-X): Na/K/Mg chloride/sulfate/hydroxide mixtures and mineral solubility | Supports temperature-dependent theta/psi lineage for its stated system. Species coverage is narrower than the full thesis table and reuse remains publisher-controlled. No row adopted. |
-| [16] | Duan et al. (1992), [methane in brines](https://doi.org/10.1016/0016-7037(92)90215-5): CH4 solubility in 0–6 molal brines, 0–250 °C, and 0–1600 bar | Supports the neutral-methane interaction lane only. NeqSim lacks the required neutral Pitzer family representation, so these rows fail closed. |
+| [16] | Duan et al. (1992), [methane in brines](https://doi.org/10.1016/0016-7037(92)90215-5): CH4 solubility in 0–6 molal brines, 0–250 °C, and 0–1600 bar | Supports the neutral-methane interaction lane only. NeqSim represents neutral Pitzer families, but no complete, redistributable CH4 family with the required hybrid EOS-GE validation is adopted, so this topology still fails closed. |
 
 Appendix F
 printed page 259 defines

--- a/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
@@ -143,8 +143,8 @@ public class ComponentGePitzer extends ComponentGE {
     // --- Ion activity coefficient (extended Pitzer formulation) ---
     // Pitzer (1991) Eq. 8-3-2: ln(gamma_M) = z_M^2 * F + sum_a m_a*(2*B_Ma + Z*C_Ma)
     // F = -Aphi*[sqrtI/(1+b*sqrtI) + (2/b)*ln(1+b*sqrtI)] + sum_c sum_a m_c*m_a*B'_ca
-    // Handles 1-1, 1-2, 2-1 electrolytes (alpha=2.0) and 2-2 electrolytes
-    // (alpha1=1.4, alpha2=12.0 with beta2 parameter per Harvie & Weare 1984).
+    // Handles PHREEQC's charge-dependent alpha defaults, including beta2 for both
+    // 2-1 CaCl2 and 2-2 electrolytes.
     double I = pitz.getIonicStrength();
     double sqrtI = Math.sqrt(I);
     // debyeHuckelAphi() returns Agamma = 3*Aphi; convert to Aphi for Pitzer formula
@@ -182,17 +182,8 @@ public class ComponentGePitzer extends ComponentGE {
       double beta1 = pitz.getBeta1ij(componentNumber, j, temperature);
       double CphiVal = pitz.getCphiij(componentNumber, j, temperature);
 
-      // Determine alpha values based on electrolyte type
-      double alpha1;
-      double alpha2;
-      boolean is22 = (Math.abs(charge) >= 1.5 && Math.abs(chargej) >= 1.5);
-      if (is22) {
-        alpha1 = 1.4;
-        alpha2 = 12.0;
-      } else {
-        alpha1 = 2.0;
-        alpha2 = 0.0;
-      }
+      double alpha1 = Math.abs(charge) >= 1.5 && Math.abs(chargej) >= 1.5 ? 1.4 : 2.0;
+      boolean isTwoTwo = Math.abs(charge) >= 1.5 && Math.abs(chargej) >= 1.5;
 
       double x1 = alpha1 * sqrtI;
       double g1 = 0.0;
@@ -205,11 +196,10 @@ public class ComponentGePitzer extends ComponentGE {
       // B'(I) = dB/dI for the F-term (Pitzer 1991 Eq. 8-2-8)
       double Bprime = (I > 1e-12) ? beta1 * gp1 / I : 0.0;
 
-      // Add beta2 contribution for 2-2 electrolytes
-      if (is22) {
+      if (isTwoTwo || pitz.isNonTwoTwoBeta2Active()) {
         double beta2val = pitz.getBeta2ij(componentNumber, j, temperature);
         if (Math.abs(beta2val) > 1e-20) {
-          double x2 = alpha2 * sqrtI;
+          double x2 = pitz.getPitzerAlpha2(componentNumber, j) * sqrtI;
           double g2 = 0.0;
           double gp2 = 0.0;
           if (x2 > 1e-12) {
@@ -333,21 +323,18 @@ public class ComponentGePitzer extends ComponentGE {
   /** Calculates one binary pair's contribution to PHREEQC's common B-prime term. */
   private static double phreeqcBinaryBprime(PhasePitzer phase, int first, int second, double temperature,
       double ionicStrength, double squareRootIonicStrength, double firstCharge, double secondCharge) {
-    boolean is22 = Math.abs(firstCharge) >= 1.5 && Math.abs(secondCharge) >= 1.5;
-    double alpha1 = is22 ? 1.4 : 2.0;
+    double alpha1 = Math.abs(firstCharge) >= 1.5 && Math.abs(secondCharge) >= 1.5 ? 1.4 : 2.0;
     double x1 = alpha1 * squareRootIonicStrength;
     double derivative = 0.0;
     if (x1 > 1.0e-12 && ionicStrength > 1.0e-12) {
       double gp1 = -2.0 * (1.0 - (1.0 + x1 + x1 * x1 / 2.0) * Math.exp(-x1)) / (x1 * x1);
       derivative = phase.getBeta1ij(first, second, temperature) * gp1 / ionicStrength;
     }
-    if (is22) {
-      double beta2Value = phase.getBeta2ij(first, second, temperature);
-      double x2 = 12.0 * squareRootIonicStrength;
-      if (Math.abs(beta2Value) > 1.0e-20 && x2 > 1.0e-12 && ionicStrength > 1.0e-12) {
-        double gp2 = -2.0 * (1.0 - (1.0 + x2 + x2 * x2 / 2.0) * Math.exp(-x2)) / (x2 * x2);
-        derivative += beta2Value * gp2 / ionicStrength;
-      }
+    double beta2Value = phase.getBeta2ij(first, second, temperature);
+    double x2 = phase.getPitzerAlpha2(first, second) * squareRootIonicStrength;
+    if (Math.abs(beta2Value) > 1.0e-20 && x2 > 1.0e-12 && ionicStrength > 1.0e-12) {
+      double gp2 = -2.0 * (1.0 - (1.0 + x2 + x2 * x2 / 2.0) * Math.exp(-x2)) / (x2 * x2);
+      derivative += beta2Value * gp2 / ionicStrength;
     }
     return derivative;
   }
@@ -429,19 +416,16 @@ public class ComponentGePitzer extends ComponentGE {
         double beta1 = pitz.getBeta1ij(ic, ia, TK);
         double Cphi = pitz.getCphiij(ic, ia, TK);
 
-        // Determine alpha values based on electrolyte type
-        boolean is22 = (Math.abs(zc) >= 1.5 && Math.abs(za) >= 1.5);
-        double alpha1 = is22 ? 1.4 : 2.0;
+        double alpha1 = Math.abs(zc) >= 1.5 && Math.abs(za) >= 1.5 ? 1.4 : 2.0;
 
         // B^phi_ca = beta0 + beta1 * exp(-alpha1 * sqrt(I))
         double BphiCA = beta0 + beta1 * Math.exp(-alpha1 * sqrtI);
 
-        // Add beta2 contribution for 2-2 electrolytes
-        if (is22) {
+        boolean isTwoTwo = Math.abs(zc) >= 1.5 && Math.abs(za) >= 1.5;
+        if (isTwoTwo || pitz.isNonTwoTwoBeta2Active()) {
           double beta2val = pitz.getBeta2ij(ic, ia, TK);
           if (Math.abs(beta2val) > 1e-20) {
-            double alpha2 = 12.0;
-            BphiCA += beta2val * Math.exp(-alpha2 * sqrtI);
+            BphiCA += beta2val * Math.exp(-pitz.getPitzerAlpha2(ic, ia) * sqrtI);
           }
         }
 

--- a/src/main/java/neqsim/thermo/phase/PhasePitzer.java
+++ b/src/main/java/neqsim/thermo/phase/PhasePitzer.java
@@ -76,6 +76,8 @@ public class PhasePitzer extends PhaseGE {
   private boolean hasNeutralInteractions;
   /** Enables PHREEQC common F and C0/Cphi ion terms for explicitly mapped datasets only. */
   private boolean phreeqcCommonIonTermsActive;
+  /** Fast gate for a qualified beta2 row outside the legacy 2-2 branch. */
+  private boolean nonTwoTwoBeta2Active;
   /** Whether the active neutral-solute topology has passed its fail-closed parameter audit. */
   private transient boolean neutralParameterCoverageValidated;
   /** Whether parameters have been loaded from database. */
@@ -855,7 +857,7 @@ public class PhasePitzer extends PhaseGE {
   }
 
   /**
-   * Get beta2 parameter for 2-2 electrolytes.
+   * Get beta2 parameter for ion pairs that define the second exponential term.
    *
    * @param i component index i
    * @param j component index j
@@ -879,7 +881,7 @@ public class PhasePitzer extends PhaseGE {
   }
 
   /**
-   * Set beta2 parameter for 2-2 electrolytes.
+   * Set beta2 parameter for ion pairs that define the second exponential term.
    *
    * @param i component index i
    * @param j component index j
@@ -889,6 +891,60 @@ public class PhasePitzer extends PhaseGE {
     ensureOwnedParameterStorage();
     beta2[i][j] = value;
     beta2[j][i] = value;
+    double firstCharge = Math.abs(getComponent(i).getIonicCharge());
+    double secondCharge = Math.abs(getComponent(j).getIonicCharge());
+    if (!(firstCharge >= 1.5 && secondCharge >= 1.5) && Math.abs(value) > 1.0e-20) {
+      nonTwoTwoBeta2Active = true;
+    }
+  }
+
+  /**
+   * Reports whether a qualified dataset activates beta2 outside the legacy 2-2 branch.
+   *
+   * @return {@code true} when a non-2-2 beta2 row was configured
+   */
+  public boolean isNonTwoTwoBeta2Active() {
+    return nonTwoTwoBeta2Active;
+  }
+
+  /**
+   * Returns the PHREEQC default alpha1 coefficient for an opposite-sign ion pair.
+   *
+   * <p>
+   * PHREEQC uses 1.4 for 2-2 pairs and 2.0 for pairs containing a monovalent ion or an ion of charge magnitude above
+   * two. Dataset-specific {@code ALPHAS} overrides are not currently exposed; qualified datasets must therefore use
+   * these defaults.
+   * </p>
+   *
+   * @param i first ion component index
+   * @param j second ion component index
+   * @return alpha1 in (kg/mol)<sup>1/2</sup>
+   */
+  public double getPitzerAlpha1(int i, int j) {
+    double firstCharge = Math.abs(getComponent(i).getIonicCharge());
+    double secondCharge = Math.abs(getComponent(j).getIonicCharge());
+    return firstCharge >= 1.5 && firstCharge < 2.5 && secondCharge >= 1.5 && secondCharge < 2.5 ? 1.4 : 2.0;
+  }
+
+  /**
+   * Returns the PHREEQC default alpha2 coefficient for an opposite-sign ion pair.
+   *
+   * <p>
+   * PHREEQC assigns 12.0 when either ion is monovalent and also for 2-2 pairs; pairs containing no monovalent ion and
+   * not exactly 2-2 use 50.0. This is significant for CaCl2: its qualified PHREEQC {@code B2} row is a 2-1 term with
+   * alpha2=12 and must not be discarded by a 2-2-only branch.
+   * </p>
+   *
+   * @param i first ion component index
+   * @param j second ion component index
+   * @return alpha2 in (kg/mol)<sup>1/2</sup>
+   */
+  public double getPitzerAlpha2(int i, int j) {
+    double firstCharge = Math.abs(getComponent(i).getIonicCharge());
+    double secondCharge = Math.abs(getComponent(j).getIonicCharge());
+    boolean containsMonovalent = firstCharge < 1.5 || secondCharge < 1.5;
+    boolean isTwoTwo = firstCharge >= 1.5 && firstCharge < 2.5 && secondCharge >= 1.5 && secondCharge < 2.5;
+    return containsMonovalent || isTwoTwo ? 12.0 : 50.0;
   }
 
   /**
@@ -1344,14 +1400,18 @@ public class PhasePitzer extends PhaseGE {
    * @return B-phi interaction function
    */
   private double getBphi(int cation, int anion, double ionicStrength) {
-    double cationCharge = getComponent(cation).getIonicCharge();
-    double anionCharge = getComponent(anion).getIonicCharge();
-    boolean is22 = Math.abs(cationCharge) >= 1.5 && Math.abs(anionCharge) >= 1.5;
+    double cationCharge = Math.abs(getComponent(cation).getIonicCharge());
+    double anionCharge = Math.abs(getComponent(anion).getIonicCharge());
+    double alpha1 = cationCharge >= 1.5 && anionCharge >= 1.5 ? 1.4 : 2.0;
     double sqrtIonicStrength = Math.sqrt(ionicStrength);
     double bPhi = getBeta0ij(cation, anion, temperature)
-        + getBeta1ij(cation, anion, temperature) * Math.exp((is22 ? -1.4 : -2.0) * sqrtIonicStrength);
-    if (is22) {
-      bPhi += getBeta2ij(cation, anion, temperature) * Math.exp(-12.0 * sqrtIonicStrength);
+        + getBeta1ij(cation, anion, temperature) * Math.exp(-alpha1 * sqrtIonicStrength);
+    boolean isTwoTwo = cationCharge >= 1.5 && anionCharge >= 1.5;
+    if (isTwoTwo || nonTwoTwoBeta2Active) {
+      double beta2Value = getBeta2ij(cation, anion, temperature);
+      if (Math.abs(beta2Value) > 1.0e-20) {
+        bPhi += beta2Value * Math.exp(-getPitzerAlpha2(cation, anion) * sqrtIonicStrength);
+      }
     }
     return bPhi;
   }

--- a/src/main/java/neqsim/thermo/phase/PhreeqcPitzerParameterCatalog.java
+++ b/src/main/java/neqsim/thermo/phase/PhreeqcPitzerParameterCatalog.java
@@ -1,0 +1,189 @@
+package neqsim.thermo.phase;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Lazy, immutable reader for the exact public-domain USGS PHREEQC Pitzer parameter block bundled with NeqSim.
+ *
+ * <p>
+ * Only Pitzer interaction families are parsed. Reaction constants, mineral log K values, gas binary parameters, SIT,
+ * and electrolyte-EOS parameters are deliberately outside this catalog. Loading occurs only when a caller explicitly
+ * applies a PHREEQC dataset, so neutral EOS and legacy Pitzer calculations pay no startup or kernel cost.
+ * </p>
+ */
+public final class PhreeqcPitzerParameterCatalog {
+  /** Exact source commit represented by the bundled catalog. */
+  public static final String SOURCE_COMMIT = "b0b3be767158ccc3322d2c816625cf470045e67e";
+
+  /** Exact source database blob represented by the bundled catalog. */
+  public static final String SOURCE_BLOB = "324f852784be84650b77bd7f07f8316aafd8188b";
+
+  private static final String RESOURCE = "/neqsim/thermo/phase/phreeqc/pitzer-b0b3be767158ccc3322d2c816625cf470045e67e.dat";
+
+  /** Supported Pitzer parameter families. */
+  public enum Family {
+    B0(2), B1(2), B2(2), C0(2), THETA(2), PSI(3), LAMBDA(2), ZETA(3), MU(3), ETA(3), ALPHAS(2);
+
+    private final int speciesCount;
+
+    Family(int speciesCount) {
+      this.speciesCount = speciesCount;
+    }
+  }
+
+  private final Map<Family, Map<String, double[]>> rows;
+
+  private PhreeqcPitzerParameterCatalog(Map<Family, Map<String, double[]>> rows) {
+    this.rows = rows;
+  }
+
+  /**
+   * Returns the lazily loaded immutable catalog.
+   *
+   * @return exact-version PHREEQC Pitzer catalog
+   */
+  public static PhreeqcPitzerParameterCatalog getInstance() {
+    return Holder.INSTANCE;
+  }
+
+  /**
+   * Returns a defensive copy of one row, or {@code null} when the source does not contain that tuple.
+   *
+   * @param family parameter family
+   * @param species PHREEQC or NeqSim species names
+   * @return six PHREEQC temperature coefficients or {@code null}
+   */
+  public double[] find(Family family, String... species) {
+    double[] coefficients = rows.get(family).get(key(species));
+    return coefficients == null ? null : coefficients.clone();
+  }
+
+  /**
+   * Returns one row and fails closed when it is absent.
+   *
+   * @param family parameter family
+   * @param species species tuple
+   * @return six PHREEQC temperature coefficients
+   */
+  public double[] require(Family family, String... species) {
+    double[] coefficients = find(family, species);
+    if (coefficients == null) {
+      throw new IllegalArgumentException("PHREEQC Pitzer catalog " + SOURCE_COMMIT + " has no explicit " + family
+          + " row for " + Arrays.toString(species));
+    }
+    return coefficients;
+  }
+
+  /**
+   * Returns the number of source rows in a family.
+   *
+   * @param family parameter family
+   * @return row count
+   */
+  public int size(Family family) {
+    return rows.get(family).size();
+  }
+
+  private static PhreeqcPitzerParameterCatalog load() {
+    EnumMap<Family, Map<String, double[]>> mutable = new EnumMap<Family, Map<String, double[]>>(Family.class);
+    for (Family family : Family.values()) {
+      mutable.put(family, new HashMap<String, double[]>());
+    }
+    InputStream stream = PhreeqcPitzerParameterCatalog.class.getResourceAsStream(RESOURCE);
+    if (stream == null) {
+      throw new IllegalStateException("Missing bundled PHREEQC Pitzer catalog " + RESOURCE);
+    }
+    Family currentFamily = null;
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        int comment = line.indexOf('#');
+        String data = (comment >= 0 ? line.substring(0, comment) : line).trim();
+        if (data.isEmpty() || "PITZER".equalsIgnoreCase(data)) {
+          continue;
+        }
+        if (data.startsWith("-")) {
+          String section = data.substring(1).trim().toUpperCase();
+          if ("LAMDA".equals(section)) {
+            section = "LAMBDA";
+          }
+          try {
+            currentFamily = Family.valueOf(section);
+          } catch (IllegalArgumentException ignored) {
+            currentFamily = null;
+          }
+          continue;
+        }
+        if (currentFamily == null) {
+          continue;
+        }
+        String[] tokens = data.split("\\s+");
+        if (tokens.length <= currentFamily.speciesCount) {
+          throw new IllegalStateException("Invalid " + currentFamily + " row in bundled PHREEQC catalog: " + data);
+        }
+        String[] species = Arrays.copyOf(tokens, currentFamily.speciesCount);
+        double[] coefficients = new double[6];
+        int coefficientCount = Math.min(6, tokens.length - currentFamily.speciesCount);
+        for (int index = 0; index < coefficientCount; index++) {
+          coefficients[index] = Double.parseDouble(tokens[currentFamily.speciesCount + index]);
+        }
+        String key = key(species);
+        if (mutable.get(currentFamily).put(key, coefficients) != null) {
+          throw new IllegalStateException("Duplicate " + currentFamily + " row in bundled PHREEQC catalog: " + data);
+        }
+      }
+    } catch (IOException | NumberFormatException exception) {
+      throw new IllegalStateException("Could not parse bundled PHREEQC Pitzer catalog", exception);
+    }
+
+    EnumMap<Family, Map<String, double[]>> immutable = new EnumMap<Family, Map<String, double[]>>(Family.class);
+    for (Family family : Family.values()) {
+      immutable.put(family, Collections.unmodifiableMap(mutable.get(family)));
+    }
+    return new PhreeqcPitzerParameterCatalog(Collections.unmodifiableMap(immutable));
+  }
+
+  private static String key(String... species) {
+    List<String> canonical = new ArrayList<String>(species.length);
+    for (String name : species) {
+      canonical.add(canonicalSpeciesName(name));
+    }
+    Collections.sort(canonical);
+    return String.join("|", canonical);
+  }
+
+  private static String canonicalSpeciesName(String name) {
+    String value = name.trim();
+    if (value.endsWith("+2")) {
+      return value.substring(0, value.length() - 2) + "++";
+    }
+    if (value.endsWith("-2")) {
+      return value.substring(0, value.length() - 2) + "--";
+    }
+    if (value.endsWith("+3")) {
+      return value.substring(0, value.length() - 2) + "+++";
+    }
+    if (value.endsWith("-3")) {
+      return value.substring(0, value.length() - 2) + "---";
+    }
+    return value;
+  }
+
+  private static final class Holder {
+    private static final PhreeqcPitzerParameterCatalog INSTANCE = load();
+
+    private Holder() {
+    }
+  }
+}

--- a/src/main/java/neqsim/thermo/phase/PitzerParameterDatasets.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerParameterDatasets.java
@@ -1,5 +1,8 @@
 package neqsim.thermo.phase;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Coherent, versioned Pitzer parameter datasets whose equation conventions and public provenance have been mapped to
  * {@link PhasePitzer}.
@@ -18,6 +21,9 @@ public final class PitzerParameterDatasets {
 
   /** Exact source identity for the public-domain PHREEQC Na-K-Cl subset. */
   public static final String PHREEQC_NA_K_CL_ID = "usgs-phreeqc-pitzer-b0b3be767158ccc3322d2c816625cf470045e67e-na-k-cl-v1";
+
+  /** Exact source identity for the bundled public-domain PHREEQC Pitzer interaction catalog. */
+  public static final String PHREEQC_PITZER_CATALOG_ID = "usgs-phreeqc-pitzer-b0b3be767158ccc3322d2c816625cf470045e67e-catalog-v1";
 
   /** Reference temperature of the PHREEQC six-term functions, in K. */
   public static final double PHREEQC_REFERENCE_TEMPERATURE_K = 298.15;
@@ -139,6 +145,225 @@ public final class PitzerParameterDatasets {
         new double[] { -0.0015, 0.0, 0.0, 1.8e-5, 0.0, 0.0 });
     phase.enablePhreeqcCommonIonTerms();
     phase.markManualParameterDatasetLoaded();
+  }
+
+  /**
+   * Applies every explicit PHREEQC Pitzer row required by the phase's active species topology.
+   *
+   * <p>
+   * The exact public-domain source catalog is loaded lazily. Opposite-sign ion pairs require explicit {@code B0},
+   * {@code B1}, and {@code C0} rows; same-sign pairs require {@code THETA}; mixed-ion triples require {@code PSI}; and
+   * active neutral solutes require all applicable {@code LAMBDA} and {@code ZETA} rows. An absent required row fails
+   * before the phase is mutated. {@code B2} is applied when explicitly present, including PHREEQC's 2-1 CaCl2 term.
+   * Thus catalog breadth never turns an unqualified omitted coefficient into a silent zero.
+   * </p>
+   *
+   * @param phase Pitzer aqueous phase whose active species define the requested catalog subset
+   * @throws IllegalArgumentException if a required explicit source row is absent
+   */
+  public static void applyCompletePhreeqcPitzerCatalog(PhasePitzer phase) {
+    if (phase == null) {
+      throw new IllegalArgumentException("Pitzer phase must not be null");
+    }
+    PhreeqcPitzerParameterCatalog catalog = PhreeqcPitzerParameterCatalog.getInstance();
+    List<Integer> ions = new ArrayList<Integer>();
+    List<Integer> neutrals = new ArrayList<Integer>();
+    for (int component = 0; component < phase.getNumberOfComponents(); component++) {
+      if (phase.getComponent(component).getNumberOfMolesInPhase() <= 1.0e-20) {
+        continue;
+      }
+      double charge = phase.getComponent(component).getIonicCharge();
+      if (Math.abs(charge) >= 0.5) {
+        ions.add(component);
+      } else if (!"water".equalsIgnoreCase(phase.getComponent(component).getComponentName())) {
+        neutrals.add(component);
+      }
+    }
+
+    validateCatalogTopology(phase, catalog, ions, neutrals);
+    phase.setParameterDatasetId(PHREEQC_PITZER_CATALOG_ID);
+    applyCatalogIonRows(phase, catalog, ions);
+    applyCatalogNeutralRows(phase, catalog, ions, neutrals);
+    phase.enablePhreeqcCommonIonTerms();
+    phase.markManualParameterDatasetLoaded();
+    phase.requireCompletePitzerParameterCoverage();
+    phase.requireCompleteNeutralPitzerParameterCoverage();
+  }
+
+  /**
+   * Applies the complete Ca-Mg-Cl-SO4 family from the bundled PHREEQC catalog.
+   *
+   * @param phase aqueous Pitzer phase containing Ca++, Mg++, Cl-, and SO4--
+   */
+  public static void applyPhreeqcCalciumMagnesiumChlorideSulfate(PhasePitzer phase) {
+    if (phase == null) {
+      throw new IllegalArgumentException("Pitzer phase must not be null");
+    }
+    int calcium = requiredComponentIndex(phase, "Ca++");
+    int magnesium = requiredComponentIndex(phase, "Mg++");
+    int chloride = requiredComponentIndex(phase, "Cl-");
+    int sulfate = requiredComponentIndex(phase, "SO4--");
+    if (phase.getComponent(calcium).getIonicCharge() < 1.5 || phase.getComponent(magnesium).getIonicCharge() < 1.5
+        || phase.getComponent(chloride).getIonicCharge() > -0.5
+        || phase.getComponent(sulfate).getIonicCharge() > -1.5) {
+      throw new IllegalArgumentException("PHREEQC Ca-Mg-Cl-SO4 dataset species have incompatible charge roles");
+    }
+    applyCompletePhreeqcPitzerCatalog(phase);
+  }
+
+  private static void validateCatalogTopology(PhasePitzer phase, PhreeqcPitzerParameterCatalog catalog,
+      List<Integer> ions, List<Integer> neutrals) {
+    for (int first = 0; first < ions.size(); first++) {
+      int firstIndex = ions.get(first);
+      for (int second = first + 1; second < ions.size(); second++) {
+        int secondIndex = ions.get(second);
+        String firstName = phase.getComponent(firstIndex).getComponentName();
+        String secondName = phase.getComponent(secondIndex).getComponentName();
+        if (phase.getComponent(firstIndex).getIonicCharge() * phase.getComponent(secondIndex).getIonicCharge() < 0.0) {
+          catalog.require(PhreeqcPitzerParameterCatalog.Family.B0, firstName, secondName);
+          catalog.require(PhreeqcPitzerParameterCatalog.Family.B1, firstName, secondName);
+          catalog.require(PhreeqcPitzerParameterCatalog.Family.C0, firstName, secondName);
+        } else {
+          catalog.require(PhreeqcPitzerParameterCatalog.Family.THETA, firstName, secondName);
+        }
+      }
+    }
+    validateCatalogPsiTopology(phase, catalog, ions);
+    for (int neutralPosition = 0; neutralPosition < neutrals.size(); neutralPosition++) {
+      int neutral = neutrals.get(neutralPosition);
+      String neutralName = phase.getComponent(neutral).getComponentName();
+      for (int second = neutralPosition; second < neutrals.size(); second++) {
+        catalog.require(PhreeqcPitzerParameterCatalog.Family.LAMBDA, neutralName,
+            phase.getComponent(neutrals.get(second)).getComponentName());
+      }
+      for (int ion : ions) {
+        catalog.require(PhreeqcPitzerParameterCatalog.Family.LAMBDA, neutralName,
+            phase.getComponent(ion).getComponentName());
+      }
+      for (int cation : ions) {
+        if (phase.getComponent(cation).getIonicCharge() <= 0.0) {
+          continue;
+        }
+        for (int anion : ions) {
+          if (phase.getComponent(anion).getIonicCharge() < 0.0) {
+            catalog.require(PhreeqcPitzerParameterCatalog.Family.ZETA, neutralName,
+                phase.getComponent(cation).getComponentName(), phase.getComponent(anion).getComponentName());
+          }
+        }
+      }
+    }
+  }
+
+  private static void validateCatalogPsiTopology(PhasePitzer phase, PhreeqcPitzerParameterCatalog catalog,
+      List<Integer> ions) {
+    for (int first = 0; first < ions.size(); first++) {
+      for (int second = first + 1; second < ions.size(); second++) {
+        for (int third = second + 1; third < ions.size(); third++) {
+          int firstIndex = ions.get(first);
+          int secondIndex = ions.get(second);
+          int thirdIndex = ions.get(third);
+          int positives = (phase.getComponent(firstIndex).getIonicCharge() > 0.0 ? 1 : 0)
+              + (phase.getComponent(secondIndex).getIonicCharge() > 0.0 ? 1 : 0)
+              + (phase.getComponent(thirdIndex).getIonicCharge() > 0.0 ? 1 : 0);
+          if (positives == 1 || positives == 2) {
+            catalog.require(PhreeqcPitzerParameterCatalog.Family.PSI, phase.getComponent(firstIndex).getComponentName(),
+                phase.getComponent(secondIndex).getComponentName(), phase.getComponent(thirdIndex).getComponentName());
+          }
+        }
+      }
+    }
+  }
+
+  private static void applyCatalogIonRows(PhasePitzer phase, PhreeqcPitzerParameterCatalog catalog,
+      List<Integer> ions) {
+    for (int first = 0; first < ions.size(); first++) {
+      int firstIndex = ions.get(first);
+      for (int second = first + 1; second < ions.size(); second++) {
+        int secondIndex = ions.get(second);
+        String firstName = phase.getComponent(firstIndex).getComponentName();
+        String secondName = phase.getComponent(secondIndex).getComponentName();
+        if (phase.getComponent(firstIndex).getIonicCharge() * phase.getComponent(secondIndex).getIonicCharge() < 0.0) {
+          phase.setPhreeqcBinaryTemperatureCoefficients(firstIndex, secondIndex, PHREEQC_REFERENCE_TEMPERATURE_K,
+              catalog.require(PhreeqcPitzerParameterCatalog.Family.B0, firstName, secondName),
+              catalog.require(PhreeqcPitzerParameterCatalog.Family.B1, firstName, secondName),
+              catalog.require(PhreeqcPitzerParameterCatalog.Family.C0, firstName, secondName));
+          double[] beta2 = catalog.find(PhreeqcPitzerParameterCatalog.Family.B2, firstName, secondName);
+          if (beta2 != null) {
+            phase.setBeta2TemperatureCoefficients(firstIndex, secondIndex, PHREEQC_REFERENCE_TEMPERATURE_K, beta2);
+          }
+        } else {
+          phase.setThetaTemperatureCoefficients(firstIndex, secondIndex, PHREEQC_REFERENCE_TEMPERATURE_K,
+              catalog.require(PhreeqcPitzerParameterCatalog.Family.THETA, firstName, secondName));
+        }
+      }
+    }
+    for (int first = 0; first < ions.size(); first++) {
+      for (int second = first + 1; second < ions.size(); second++) {
+        for (int third = second + 1; third < ions.size(); third++) {
+          int firstIndex = ions.get(first);
+          int secondIndex = ions.get(second);
+          int thirdIndex = ions.get(third);
+          int positives = (phase.getComponent(firstIndex).getIonicCharge() > 0.0 ? 1 : 0)
+              + (phase.getComponent(secondIndex).getIonicCharge() > 0.0 ? 1 : 0)
+              + (phase.getComponent(thirdIndex).getIonicCharge() > 0.0 ? 1 : 0);
+          if (positives == 1 || positives == 2) {
+            int sameFirst;
+            int sameSecond;
+            int opposite;
+            if (phase.getComponent(firstIndex).getIonicCharge()
+                * phase.getComponent(secondIndex).getIonicCharge() > 0.0) {
+              sameFirst = firstIndex;
+              sameSecond = secondIndex;
+              opposite = thirdIndex;
+            } else if (phase.getComponent(firstIndex).getIonicCharge()
+                * phase.getComponent(thirdIndex).getIonicCharge() > 0.0) {
+              sameFirst = firstIndex;
+              sameSecond = thirdIndex;
+              opposite = secondIndex;
+            } else {
+              sameFirst = secondIndex;
+              sameSecond = thirdIndex;
+              opposite = firstIndex;
+            }
+            phase.setPsiTemperatureCoefficients(sameFirst, sameSecond, opposite, PHREEQC_REFERENCE_TEMPERATURE_K,
+                catalog.require(PhreeqcPitzerParameterCatalog.Family.PSI,
+                    phase.getComponent(firstIndex).getComponentName(),
+                    phase.getComponent(secondIndex).getComponentName(),
+                    phase.getComponent(thirdIndex).getComponentName()));
+          }
+        }
+      }
+    }
+  }
+
+  private static void applyCatalogNeutralRows(PhasePitzer phase, PhreeqcPitzerParameterCatalog catalog,
+      List<Integer> ions, List<Integer> neutrals) {
+    for (int neutralPosition = 0; neutralPosition < neutrals.size(); neutralPosition++) {
+      int neutral = neutrals.get(neutralPosition);
+      String neutralName = phase.getComponent(neutral).getComponentName();
+      for (int second = neutralPosition; second < neutrals.size(); second++) {
+        int secondNeutral = neutrals.get(second);
+        phase.setLambdaTemperatureCoefficients(neutral, secondNeutral, PHREEQC_REFERENCE_TEMPERATURE_K,
+            catalog.require(PhreeqcPitzerParameterCatalog.Family.LAMBDA, neutralName,
+                phase.getComponent(secondNeutral).getComponentName()));
+      }
+      for (int ion : ions) {
+        phase.setLambdaTemperatureCoefficients(neutral, ion, PHREEQC_REFERENCE_TEMPERATURE_K, catalog.require(
+            PhreeqcPitzerParameterCatalog.Family.LAMBDA, neutralName, phase.getComponent(ion).getComponentName()));
+      }
+      for (int cation : ions) {
+        if (phase.getComponent(cation).getIonicCharge() <= 0.0) {
+          continue;
+        }
+        for (int anion : ions) {
+          if (phase.getComponent(anion).getIonicCharge() < 0.0) {
+            phase.setZetaTemperatureCoefficients(neutral, cation, anion, PHREEQC_REFERENCE_TEMPERATURE_K,
+                catalog.require(PhreeqcPitzerParameterCatalog.Family.ZETA, neutralName,
+                    phase.getComponent(cation).getComponentName(), phase.getComponent(anion).getComponentName()));
+          }
+        }
+      }
+    }
   }
 
   /**

--- a/src/main/java/neqsim/thermo/system/SystemPitzer.java
+++ b/src/main/java/neqsim/thermo/system/SystemPitzer.java
@@ -108,6 +108,26 @@ public class SystemPitzer extends SystemEosGE {
     PitzerParameterDatasets.applyPhreeqcSodiumPotassiumChloride((PhasePitzer) phaseArray[1]);
   }
 
+  /**
+   * Applies the complete explicit PHREEQC Pitzer subset required by this system's active aqueous species.
+   *
+   * <p>
+   * The bundled source catalog is broad, but activation remains fail-closed: every required binary, same-sign, ternary,
+   * and neutral interaction for the active aqueous topology must exist explicitly. Gas and oil remain on their EOS role
+   * phases and do not invoke the catalog.
+   * </p>
+   */
+  public void applyCompletePhreeqcPitzerCatalogParameters() {
+    PitzerParameterDatasets.applyCompletePhreeqcPitzerCatalog((PhasePitzer) phaseArray[1]);
+  }
+
+  /**
+   * Applies the complete qualified PHREEQC Ca-Mg-Cl-SO4 family to this system's Pitzer aqueous role.
+   */
+  public void applyPhreeqcCalciumMagnesiumChlorideSulfateParameters() {
+    PitzerParameterDatasets.applyPhreeqcCalciumMagnesiumChlorideSulfate((PhasePitzer) phaseArray[1]);
+  }
+
   /** {@inheritDoc} */
   @Override
   public SystemPitzer clone() {

--- a/src/main/resources/neqsim/thermo/phase/phreeqc/pitzer-b0b3be767158ccc3322d2c816625cf470045e67e.dat
+++ b/src/main/resources/neqsim/thermo/phase/phreeqc/pitzer-b0b3be767158ccc3322d2c816625cf470045e67e.dat
@@ -1,0 +1,280 @@
+# Exact PITZER block extracted from USGS PHREEQC pitzer.dat
+# Commit b0b3be767158ccc3322d2c816625cf470045e67e; blob 324f852784be84650b77bd7f07f8316aafd8188b
+# USGS work: public domain. No reaction, mineral-logK, SIT, eNRTL, or EOS coefficients are included.
+PITZER
+-B0
+  B(OH)4-     K+      0.035
+  B(OH)4-     Na+    -0.0427
+  B3O3(OH)4-  K+     -0.13
+  B3O3(OH)4-  Na+    -0.056
+  B4O5(OH)4-2 K+     -0.022
+  B4O5(OH)4-2 Na+    -0.11
+  Ba+2      Br-       0.31455       0           0          -0.33825E-3
+  Ba+2      Cl-       0.5268        0           0           0         0     4.75e4  # ref. 3
+  Ba+2      OH-       0.17175
+  Br-       H+        0.196         0           0          -2.049E-4
+  Br-       K+        0.0569        0           0           7.39E-4
+  Br-       Li+       0.1748        0           0          -1.819E-4
+  Br-       Mg+2      0.4327        0           0          -5.625E-5
+  Br-       Na+       0.0973        0           0           7.692E-4
+  Br-       Sr+2      0.331125      0           0          -0.32775E-3
+  Ca+2      Br-       0.3816        0           0          -5.2275E-4
+  Ca+2      Cl-       0.3159        0           0          -3.27e-4    1.4e-7       # ref. 3
+  Ca+2      HCO3-     0.4
+  Ca+2      HSO4-     0.2145
+  Ca+2      OH-      -0.1747
+  Ca+2      SO4-2     0      # ref. 3
+  CaB(OH)4+   Cl-     0.12
+  Cl-       Fe+2      0.335925
+  Cl-       H+        0.1775        0           0          -3.081E-4
+  Cl-       K+        0.04808    -758.48       -4.7062      0.010072  -3.7599e-6   # ref. 3
+  Cl-       Li+       0.1494        0           0          -1.685E-4
+  Cl-       Mg+2      0.351         0           0          -9.32e-4    5.94e-7      # ref. 3
+  Cl-       MgB(OH)4+  0.16
+  Cl-       MgOH+    -0.1
+  Cl-       Mn+2      0.327225
+  Cl-       Na+       7.534e-2   9598.4        35.48     -5.8731e-2    1.798e-5   -5e5  # ref. 3
+  Cl-       Sr+2      0.2858        0           0           0.717E-3
+  CO3-2     K+        0.1488        0           0           1.788E-3
+  CO3-2     Na+       0.0399        0           0           1.79E-3
+  Fe+2      HSO4-     0.4273
+  Fe+2      SO4-2     0.2568
+  H+        HSO4-     0.2065
+  H+        SO4-2     0.0298
+  HCO3-     K+        0.0296        0           0           0.996E-3
+  HCO3-     Mg+2      0.329
+  HCO3-     Na+      -1.8e-2        0           0          -2.3e-4  # ref. 3 + new -analytic for calcite
+  HCO3-     Sr+2      0.12
+  HSO4-     K+       -0.0003
+  HSO4-     Mg+2      0.4746
+  HSO4-     Na+       0.0454
+  K+        OH-       0.1298
+  K+        SO4-2     3.17e-2       0           0           9.28e-4               # ref. 3
+  Li+       OH-       0.015
+  Li+       SO4-2     0.136275      0           0           0.5055E-3
+  Mg+2      SO4-2     0.2135     -951           0          -2.34e-2    2.28e-5     # ref. 3
+  Mn+2      SO4-2     0.2065
+  Na+       OH-       0.0864        0           0           7E-4
+  Na+       SO4-2     2.73e-2       0          -5.8         9.89e-3    0          -1.563e5 # ref. 3
+  SO4-2     Sr+2      0.2           0           0          -2.9E-3
+-B1
+  B(OH)4-   K+        0.14
+  B(OH)4-   Na+       0.089
+  B3O3(OH)4-  Na+    -0.91
+  B4O5(OH)4-2 Na+    -0.4
+  Ba+2      Br-       1.56975       0           0           6.78E-3
+  Ba+2      Cl-       0.687         0           0           1.417e-2              # ref. 3
+  Ba+2      OH-       1.2
+  Br-       H+        0.3564        0           0           4.467E-4
+  Br-       K+        0.2212        0           0           17.4E-4
+  Br-       Li+       0.2547        0           0           6.636E-4
+  Br-       Mg+2      1.753         0           0           3.8625E-3
+  Br-       Na+       0.2791        0           0           10.79E-4
+  Br-       Sr+2      1.7115        0           0           6.5325E-3
+  Ca+2      Br-       1.613         0           0           6.0375E-3
+  Ca+2      Cl-       1.614         0           0           7.63e-3    -8.19e-7   # ref. 3
+  Ca+2      HCO3-     2.977 # ref. 3 + new -analytic for calcite
+  Ca+2      HSO4-     2.53
+  Ca+2      OH-      -0.2303
+  Ca+2      SO4-2     3.546         0           0           5.77e-3               # ref. 3
+  Cl-       Fe+2      1.53225
+  Cl-       H+        0.2945        0           0           1.419E-4
+  Cl-       K+        0.2168        0          -6.895       2.262e-2   -9.293e-6  -1e5  # ref. 3
+  Cl-       Li+       0.3074        0           0           5.366E-4
+  Cl-       Mg+2      1.65          0           0          -1.09e-2     2.6e-5    # ref. 3
+  Cl-       MgOH+     1.658
+  Cl-       Mn+2      1.55025
+  Cl-       Na+       0.2769        1.377e4    46.8        -6.9512e-2   2e-5      -7.4823e5  # ref. 3
+  Cl-       Sr+2      1.667         0           0           2.8425E-3
+  CO3-2     K+        1.43          0           0           2.051E-3
+  CO3-2     Na+       1.389         0           0           2.05E-3
+  Fe+2      HSO4-     3.48
+  Fe+2      SO4-2     3.063
+  H+        HSO4-     0.5556
+  HCO3-     K+        0.25          0           0           1.104E-3              # ref. 3
+  HCO3-     Mg+2      0.6072
+  HCO3-     Na+      -1.01e-2       0           0           1.72e-3     # ref. 3 + new -analytic for calcite
+  HSO4-     K+        0.1735
+  HSO4-     Mg+2      1.729
+  HSO4-     Na+       0.398
+  K+        OH-       0.32
+  K+        SO4-2     0.756        -1.514e4   -80.3         0.1091                # ref. 3
+  Li+       OH-       0.14
+  Li+       SO4-2     1.2705        0           0           1.41E-3
+  Mg+2      SO4-2     3.367        -5.78e3      0          -1.48e-1   1.576e-4    # ref. 3
+  Mn+2      SO4-2     2.9511
+  Na+       OH-       0.253         0           0           1.34E-4
+  Na+       SO4-2     0.956         2.663e3     0           1.158e-2   0         -3.194e5   # ref. 3
+  SO4-2     Sr+2      3.1973        0           0          27e-3
+-B2
+  Ca+2      Cl-      -1.13          0           0        -0.0476                  # ref. 3
+  Ca+2      OH-      -5.72                                                        
+  Ca+2      SO4-2   -59.3           0           0        -0.443       -3.96e-6    # ref. 3
+  Fe+2      SO4-2   -42                                                         
+  HCO3-     Na+       6.84          0           0        -7.11e-3                 # ref. 3 + new -analytic for calcite           
+  Mg+2      SO4-2   -32.45          0          -3.236e3  21.812       -1.8859e-2  # ref. 3
+  Mn+2      SO4-2   -40.0
+  SO4-2     Sr+2    -54.24          0           0          -0.42
+-C0
+  B(OH)4-   Na+       0.0114
+  Ba+2      Br-      -0.0159576
+  Ba+2      Cl-      -0.143      -114.5  # ref. 3
+  Br-       Ca+2     -0.00257
+  Br-       H+        0.00827       0           0        -5.685E-5
+  Br-       K+       -0.0018        0           0        -7.004E-5
+  Br-       Li+       0.0053        0           0        -2.813E-5
+  Br-       Mg+2      0.00312
+  Br-       Na+       0.00116       0           0        -9.3E-5
+  Br-       Sr+2      0.00122506
+  Ca+2      Cl-       1.4e-4      -57          -0.098    -7.83e-4      7.18e-7    # ref. 3
+  Ca+2      SO4-2     0.114  # ref. 3                                      
+  Cl-       Fe+2     -0.00860725                                                  
+  Cl-       H+        0.0008        0           0         6.213E-5                
+  Cl-       K+       -7.88e-4      91.27        0.58643  -1.298e-3     4.9567e-7  # ref. 3
+  Cl-       Li+       0.00359       0           0        -4.52E-5
+  Cl-       Mg+2      0.00651       0  0       -2.5e-4    2.418e-7                # ref. 3
+  Cl-       Mn+2     -0.0204972
+  Cl-       Na+       1.48e-3    -120.5        -0.2081    0            1.166e-7  11121  # ref. 3
+  Cl-       Sr+2     -0.0013
+  CO3-2     K+       -0.0015
+  CO3-2     Na+       0.0044
+  Fe+2      SO4-2     0.0209
+  H+        SO4-2     0.0438
+  HCO3-     K+       -0.008
+  K+        OH-       0.0041
+  K+        SO4-2     8.18e-3    -625          -3.3       4.06e-3                 # ref. 3
+  Li+       SO4-2    -0.00399338    0           0        -2.33345e-4
+  Mg+2      SO4-2     2.875e-2      0          -2.084     1.1428e-2   -8.228e-6   # ref. 3
+  Mn+2      SO4-2     0.01636
+  Na+       OH-       0.0044        0           0       -18.94E-5
+  Na+       SO4-2     3.418e-3   -384           0        -8.451e-4     0        5.177e4  # ref. 3
+-THETA
+  B(OH)4-   Cl-      -0.065
+  B(OH)4-   SO4-2    -0.012
+  B3O3(OH)4-  Cl-     0.12
+  B3O3(OH)4-  HCO3-  -0.1
+  B3O3(OH)4-  SO4-2   0.1
+  B4O5(OH)4-2  Cl-    0.074
+  B4O5(OH)4-2  HCO3- -0.087
+  B4O5(OH)4-2  SO4-2  0.12
+  Ba+2      Na+       0.07   # ref. 3
+  Br-       OH-      -0.065
+  Ca+2      H+        0.092
+  Ca+2      K+       -5.35e-3       0           0         3.08e-4               # ref. 3
+  Ca+2      Mg+2      0.007
+  Ca+2      Na+       9.22e-2       0           0        -4.29e-4      1.21e-6  # ref. 3
+  Cl-       CO3-2    -0.02
+  Cl-       HCO3-     5.12e-2       0           0        -4.81e-4               # ref. 3
+  Cl-       HSO4-    -0.006
+  Cl-       OH-      -0.05
+  Cl-       SO4-2     0.03   # ref. 3
+  CO3-2     OH-       0.1
+  CO3-2     SO4-2     0.02
+  H+        K+        0.005
+  H+        Mg+2      0.1
+  H+        Na+       0.036
+  HCO3-     CO3-2    -0.04
+  HCO3-     SO4-2     0.01
+  K+        Na+      -0.012
+  Mg+2      Na+       0.07
+  Na+       Sr+2      0.051
+  OH-       SO4-2    -0.013
+-LAMBDA
+  B(OH)3    Cl-       0.091
+  B(OH)3    K+       -0.14
+  B(OH)3    Na+      -0.097
+  B(OH)3    SO4-2     0.018
+  B3O3(OH)4-  B(OH)3 -0.2
+  Ca+2      CO2       0.183
+  Ca+2      H4SiO4    0.238    # ref. 3
+  Cl-       CO2      -0.005
+  Cl-       H2Sg     -0.005
+  Cl-       (H2Sg)2  -0.005
+  Cl-       Hdg       0.005
+  CO2       CO2      -1.34e-2   348   0.803 # new VM("CO2"), CO2 solubilities at high P, 0 - 150°C
+  CO2       HSO4-    -0.003
+  CO2       K+        0.051
+  CO2       Mg+2      0.183
+  CO2       Na+       0.085
+  CO2       SO4-2     0.075              # Rumpf and Maurer, 1993.
+  H2Sg      Na+       0.1047  0  -0.0413 # Xia et al., 2000, Ind. Eng. Chem. Res. 39, 1064
+  H2Sg      SO4-2     0  0  0.679
+  (H2Sg)2   Na+       0.0123  0  0.256
+  H4SiO4    K+        0.0298   # ref. 3
+  H4SiO4    Li+       0.143    # ref. 3
+  H4SiO4    Mg+2      0.238  -1788       -9.023  0.0103    # ref. 3
+  H4SiO4    Na+       0.0566    75.3      0.115            # ref. 3
+  H4SiO4    SO4-2    -0.085      0        0.28  -8.25e-4   # ref. 3
+  Hdg       Mg+2      0          0        0      1.67e-2   # Crozier 1977
+  Hdg       Na+       0.1679     0.4505  -1.242  9.457e-4 3.484e-6 # Chabab 2020
+-ZETA
+  B(OH)3    Cl-       H+        -0.0102
+  B(OH)3    Na+       SO4-2      0.046
+  Cl-       H4SiO4    K+        -0.0153  # ref. 3
+  Cl-       H4SiO4    Li+       -0.0196  # ref. 3
+  CO2       Na+       SO4-2     -0.015
+  H2Sg      Cl-       Na+       -0.0123  # Xia et al., 2000, Ind. Eng. Chem. Res. 39, 1064
+  H2Sg      Na+       SO4-2      0.157
+  (H2Sg)2   Cl-       Na+        0.0119
+  (H2Sg)2   Na+       SO4-2     -0.167
+  Hdg       Cl-       Na+       -1.422e-2 0 0 -1.63877e-4 # Chabab 2020; Crozier 1977
+-PSI
+  B(OH)4-     Cl-     Na+       -0.0073
+  B3O3(OH)4-  Cl-     Na+       -0.024
+  B4O5(OH)4-2 Cl-     Na+        0.026
+  Br-       K+        Na+       -0.0022
+  Br-       K+        OH-       -0.014
+  Br-       Na+       H+        -0.012
+  Br-       Na+       OH-       -0.018
+  Ca+2      Cl-       H+        -0.015
+  Ca+2      Cl-       K+        -0.025
+  Ca+2      Cl-       Mg+2      -0.012
+  Ca+2      Cl-       Na+       -1.48e-2  0    0  -5.2e-6       # ref. 3
+  Ca+2      Cl-       OH-       -0.025
+  Ca+2      Cl-       SO4-2     -0.122    0    0  -1.21e-3      # ref. 3
+  Ca+2      K+        SO4-2     -0.0365                         # ref. 3
+  Ca+2      Mg+2      SO4-2      0.024
+  Ca+2      Na+       SO4-2     -0.055  17.2                    # ref. 3
+  Cl-       Br-       K+         0
+  Cl-       CO3-2     K+         0.004
+  Cl-       CO3-2     Na+        0.0085
+  Cl-       H+        K+        -0.011
+  Cl-       H+        Mg+2      -0.011
+  Cl-       H+        Na+       -0.004
+  Cl-       HCO3-     Mg+2      -0.096
+  Cl-       HCO3-     Na+       -4.73e-3  0    0    1.92e-4     # ref. 3 + new -analytic for calcite
+  Cl-       HSO4-     H+         0.013
+  Cl-       HSO4-     Na+       -0.006
+  Cl-       K+        Mg+2      -0.022  -14.27                  # ref. 3
+  Cl-       K+        Na+       -0.0015   0    0   1.8e-5       # ref. 3
+  Cl-       K+        OH-       -0.006
+  Cl-       K+        SO4-2     -1e-3                           # ref. 3
+  Cl-       Mg+2      MgOH+      0.028
+  Cl-       Mg+2      Na+       -0.012   -9.51 # ref. 3
+  Cl-       Mg+2      SO4-2     -0.008   32.63 # ref. 3
+  Cl-       Na+       OH-       -0.006
+  Cl-       Na+       SO4-2      0             # ref. 3
+  Cl-       Na+       Sr+2      -0.0021
+  CO3-2     HCO3-     K+         0.012
+  CO3-2     HCO3-     Na+        0.002
+  CO3-2     K+        Na+        0.003
+  CO3-2     K+        OH-       -0.01
+  CO3-2     K+        SO4-2     -0.009
+  CO3-2     Na+       OH-       -0.017
+  CO3-2     Na+       SO4-2     -0.005
+  H+        HSO4-     K+        -0.0265
+  H+        HSO4-     Mg+2      -0.0178
+  H+        HSO4-     Na+       -0.0129
+  H+        K+        Br-       -0.021
+  H+        K+        SO4-2      0.197
+  HCO3-     K+        Na+       -0.003
+  HCO3-     Mg+2      SO4-2     -0.161
+  HCO3-     Na+       SO4-2     -0.005
+  HSO4-     K+        SO4-2     -0.0677
+  HSO4-     Mg+2      SO4-2     -0.0425
+  HSO4-     Na+       SO4-2     -0.0094
+  K+        Mg+2      SO4-2     -0.048
+  K+        Na+       SO4-2     -0.01
+  K+        OH-       SO4-2     -0.05
+  Mg+2      Na+       SO4-2     -0.015
+  Na+       OH-       SO4-2     -0.009

--- a/src/test/java/neqsim/thermo/phase/PitzerCatalogPerformanceBenchmark.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerCatalogPerformanceBenchmark.java
@@ -1,0 +1,106 @@
+package neqsim.thermo.phase;
+
+import java.util.Arrays;
+import neqsim.thermo.component.ComponentGePitzer;
+import neqsim.thermo.system.SystemPitzer;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Manual median benchmark for the PHREEQC catalog kernel, complete aqueous properties, and neutral SRK control. */
+public final class PitzerCatalogPerformanceBenchmark {
+  private static volatile double sink;
+
+  private PitzerCatalogPerformanceBenchmark() {
+  }
+
+  /**
+   * Runs fixed-work batches after warmup and prints median nanoseconds per calculation.
+   *
+   * @param args ignored
+   */
+  public static void main(String[] args) {
+    SystemSrkEos neutral = createNeutralSystem();
+    for (int warmup = 0; warmup < 500; warmup++) {
+      neutral.init(3);
+    }
+    long neutralBeforeCatalog = medianBatches(() -> neutralPropertyChecksum(neutral), 100);
+
+    SystemPitzer pitzer = createPitzerSystem();
+    PhasePitzer aqueous = (PhasePitzer) pitzer.getPhase(1);
+    for (int warmup = 0; warmup < 500; warmup++) {
+      sink += kernelChecksum(aqueous);
+      pitzer.init(3);
+      neutral.init(3);
+    }
+
+    System.out.println("pitzerCatalogKernelNs=" + medianBatches(() -> kernelChecksum(aqueous), 4000));
+    System.out.println("pitzerCompletePropertyNs=" + medianBatches(() -> {
+      pitzer.init(3);
+      pitzer.initPhysicalProperties();
+      return pitzer.getPhase(1).getDensity() + pitzer.getPhase(1).getEnthalpy() + pitzer.getPhase(1).getCp();
+    }, 100));
+    long neutralAfterCatalog = medianBatches(() -> neutralPropertyChecksum(neutral), 100);
+    System.out.println("neutralSrkBeforeCatalogNs=" + neutralBeforeCatalog);
+    System.out.println("neutralSrkAfterCatalogNs=" + neutralAfterCatalog);
+    System.out.println("neutralCatalogLoadedRatio=" + (double) neutralAfterCatalog / neutralBeforeCatalog);
+    if (!Double.isFinite(sink)) {
+      throw new IllegalStateException("Benchmark checksum is not finite");
+    }
+  }
+
+  private static long medianBatches(Work work, int iterations) {
+    long[] samples = new long[9];
+    for (int sample = 0; sample < samples.length; sample++) {
+      long start = System.nanoTime();
+      for (int iteration = 0; iteration < iterations; iteration++) {
+        sink += work.run();
+      }
+      samples[sample] = (System.nanoTime() - start) / iterations;
+    }
+    Arrays.sort(samples);
+    return samples[samples.length / 2];
+  }
+
+  private static double kernelChecksum(PhasePitzer phase) {
+    double value = phase.getOsmoticCoefficientOfWater();
+    for (int component = 0; component < phase.getNumberOfComponents(); component++) {
+      if (Math.abs(phase.getComponent(component).getIonicCharge()) >= 0.5) {
+        ComponentGePitzer ion = (ComponentGePitzer) phase.getComponent(component);
+        value += ion.getGamma(phase, phase.getNumberOfComponents(), phase.getTemperature(), phase.getPressure(),
+            phase.getType());
+      }
+    }
+    return value;
+  }
+
+  private static double neutralPropertyChecksum(SystemSrkEos system) {
+    system.init(3);
+    system.initPhysicalProperties();
+    return system.getPhase(0).getDensity() + system.getPhase(0).getEnthalpy() + system.getPhase(0).getCp();
+  }
+
+  private static SystemPitzer createPitzerSystem() {
+    SystemPitzer system = new SystemPitzer(298.15, 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("Ca++", 0.2);
+    system.addComponent("Mg++", 0.3);
+    system.addComponent("Cl-", 0.4);
+    system.addComponent("SO4--", 0.3);
+    system.setMixingRule("classic");
+    system.init(0);
+    system.applyPhreeqcCalciumMagnesiumChlorideSulfateParameters();
+    return system;
+  }
+
+  private static SystemSrkEos createNeutralSystem() {
+    SystemSrkEos system = new SystemSrkEos(298.15, 20.0);
+    system.addComponent("methane", 0.8);
+    system.addComponent("ethane", 0.2);
+    system.setMixingRule("classic");
+    system.init(0);
+    return system;
+  }
+
+  private interface Work {
+    double run();
+  }
+}

--- a/src/test/java/neqsim/thermo/phase/PitzerParameterDatasetsTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerParameterDatasetsTest.java
@@ -320,6 +320,144 @@ class PitzerParameterDatasetsTest extends neqsim.NeqSimTest {
     }
   }
 
+  @Test
+  void bundledCatalogHasBroadFamiliesAndExactScaleRows() {
+    PhreeqcPitzerParameterCatalog catalog = PhreeqcPitzerParameterCatalog.getInstance();
+    assertTrue(catalog.size(PhreeqcPitzerParameterCatalog.Family.B0) > 50);
+    assertTrue(catalog.size(PhreeqcPitzerParameterCatalog.Family.B1) > 40);
+    assertTrue(catalog.size(PhreeqcPitzerParameterCatalog.Family.THETA) > 20);
+    assertTrue(catalog.size(PhreeqcPitzerParameterCatalog.Family.PSI) > 40);
+    assertEquals(0.3159, catalog.require(PhreeqcPitzerParameterCatalog.Family.B0, "Ca++", "Cl-")[0], 0.0);
+    assertEquals(-1.13, catalog.require(PhreeqcPitzerParameterCatalog.Family.B2, "Ca++", "Cl-")[0], 0.0);
+    assertEquals(-0.122, catalog.require(PhreeqcPitzerParameterCatalog.Family.PSI, "Ca++", "Cl-", "SO4--")[0], 0.0);
+  }
+
+  @Test
+  void completeCalciumMagnesiumChlorideSulfateFamilyIsApplied() {
+    SystemPitzer system = createCalciumMagnesiumChlorideSulfateSystem(REFERENCE_TEMPERATURE, 0.2, 0.3, 0.4, 0.3);
+    system.applyPhreeqcCalciumMagnesiumChlorideSulfateParameters();
+    PhasePitzer phase = (PhasePitzer) system.getPhase(1);
+    int calcium = index(phase, "Ca++");
+    int magnesium = index(phase, "Mg++");
+    int chloride = index(phase, "Cl-");
+    int sulfate = index(phase, "SO4--");
+
+    assertEquals(PitzerParameterDatasets.PHREEQC_PITZER_CATALOG_ID, phase.getParameterDatasetId());
+    assertEquals(0.3159, phase.getBeta0ij(calcium, chloride, REFERENCE_TEMPERATURE), 0.0);
+    assertEquals(-1.13, phase.getBeta2ij(calcium, chloride, REFERENCE_TEMPERATURE), 0.0);
+    assertEquals(12.0, phase.getPitzerAlpha2(calcium, chloride), 0.0);
+    assertEquals(1.4, phase.getPitzerAlpha1(calcium, sulfate), 0.0);
+    assertEquals(0.007, phase.getThetaij(calcium, magnesium, REFERENCE_TEMPERATURE), 0.0);
+    assertEquals(0.03, phase.getThetaij(chloride, sulfate, REFERENCE_TEMPERATURE), 0.0);
+    assertEquals(-0.122, phase.getPsiijk(calcium, chloride, sulfate, REFERENCE_TEMPERATURE), 0.0);
+    assertEquals(-0.008, phase.getPsiijk(chloride, magnesium, sulfate, REFERENCE_TEMPERATURE), 0.0);
+    assertTrue(phase.getPitzerParameterCoverage().isComplete());
+
+    double chargeResidual = 0.0;
+    double compositionSum = 0.0;
+    for (int component = 0; component < phase.getNumberOfComponents(); component++) {
+      double moleFraction = phase.getComponent(component).getx();
+      assertTrue(Double.isFinite(moleFraction) && moleFraction >= 0.0);
+      compositionSum += moleFraction;
+      chargeResidual += phase.getComponent(component).getMolality(phase)
+          * phase.getComponent(component).getIonicCharge();
+    }
+    assertEquals(1.0, compositionSum, 1.0e-12);
+    assertEquals(0.0, chargeResidual, 1.0e-12);
+    assertTrue(Double.isFinite(componentLogGamma(phase, "Ca++")));
+    assertTrue(Double.isFinite(componentLogGamma(phase, "Mg++")));
+    assertTrue(Double.isFinite(componentLogGamma(phase, "Cl-")));
+    assertTrue(Double.isFinite(componentLogGamma(phase, "SO4--")));
+    assertTrue(waterActivity(phase) > 0.0 && waterActivity(phase) <= 1.0);
+
+    system.init(3);
+    system.initPhysicalProperties();
+    assertTrue(system.getPhase(0) instanceof PhaseSrkEos);
+    assertTrue(system.getPhase(1) instanceof PhasePitzer);
+    assertTrue(system.getPhase(2) instanceof PhaseSrkEos);
+    assertTrue(Double.isFinite(system.getPhase(1).getDensity()) && system.getPhase(1).getDensity() > 0.0);
+    assertTrue(Double.isFinite(system.getPhase(1).getEnthalpy()));
+    assertTrue(Double.isFinite(system.getPhase(1).getCp()) && system.getPhase(1).getCp() > 0.0);
+  }
+
+  @Test
+  void calciumChlorideMatchesIndependentNistThermoMlValues() {
+    // Partanen, J. Chem. Eng. Data 58 (2013) 132-144, DOI 10.1021/je300852v.
+    // NIST ThermoML archive values are molality-scale mean ionic activity
+    // coefficients at 298.15 K and 101 kPa, uncertainty 0.001. No parameter was
+    // fitted to these held-out values.
+    double[][] reference = { { 0.1, 0.517 }, { 0.5, 0.449 }, { 1.0, 0.502 }, { 2.0, 0.790 } };
+    for (double[] state : reference) {
+      double molality = state[0];
+      PhasePitzer phase = createCalciumMagnesiumChlorideSulfatePhase(REFERENCE_TEMPERATURE, molality, 0.0,
+          2.0 * molality, 0.0);
+      PitzerParameterDatasets.applyCompletePhreeqcPitzerCatalog(phase);
+      double meanLogGamma = (componentLogGamma(phase, "Ca++") + 2.0 * componentLogGamma(phase, "Cl-")) / 3.0;
+      double relativeResidual = Math.abs(Math.exp(meanLogGamma) / state[1] - 1.0);
+      assertTrue(relativeResidual <= 0.012,
+          "CaCl2 mean activity residual at " + molality + " mol/kg: " + relativeResidual);
+    }
+  }
+
+  @Test
+  void catalogFailsBeforeMutationForMissingCarbonateFamily() {
+    SystemPitzer system = createCalciumMagnesiumChlorideSulfateSystem(REFERENCE_TEMPERATURE, 0.2, 0.3, 0.6, 0.2);
+    system.addComponent("CO3--", 0.1);
+    system.init(0);
+    PhasePitzer phase = (PhasePitzer) system.getPhase(1);
+    IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+        () -> PitzerParameterDatasets.applyCompletePhreeqcPitzerCatalog(phase));
+    assertTrue(error.getMessage().contains("no explicit"));
+    assertNotEquals(PitzerParameterDatasets.PHREEQC_PITZER_CATALOG_ID, phase.getParameterDatasetId());
+  }
+
+  @Test
+  void changedIonTopologyCannotReuseStaleCatalogCoverage() {
+    SystemPitzer system = createCalciumMagnesiumChlorideSulfateSystem(REFERENCE_TEMPERATURE, 0.2, 0.3, 0.4, 0.3);
+    system.applyPhreeqcCalciumMagnesiumChlorideSulfateParameters();
+    system.addComponent("Ba++", 0.05);
+    system.addComponent("Cl-", 0.10);
+    system.init(0);
+    IllegalStateException error = assertThrows(IllegalStateException.class,
+        () -> ((PhasePitzer) system.getPhase(1)).requireCompletePitzerParameterCoverage());
+    assertTrue(error.getMessage().contains("Ba++"));
+  }
+
+  @Test
+  void scaleFamilySurvivesCloneSerializationAndParallelConstruction() throws Exception {
+    SystemPitzer system = createCalciumMagnesiumChlorideSulfateSystem(REFERENCE_TEMPERATURE, 0.2, 0.3, 0.4, 0.3);
+    system.applyPhreeqcCalciumMagnesiumChlorideSulfateParameters();
+    double checksum = scaleFamilyChecksum((PhasePitzer) system.getPhase(1));
+    assertEquals(checksum, scaleFamilyChecksum((PhasePitzer) system.clone().getPhase(1)), 0.0);
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(system);
+    }
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      SystemPitzer restored = (SystemPitzer) input.readObject();
+      assertEquals(checksum, scaleFamilyChecksum((PhasePitzer) restored.getPhase(1)), 1.0e-12);
+    }
+
+    ExecutorService executor = Executors.newFixedThreadPool(4);
+    try {
+      List<Callable<Double>> tasks = new ArrayList<Callable<Double>>();
+      for (int task = 0; task < 8; task++) {
+        tasks.add(() -> {
+          SystemPitzer independent = createCalciumMagnesiumChlorideSulfateSystem(REFERENCE_TEMPERATURE, 0.2, 0.3, 0.4,
+              0.3);
+          independent.applyPhreeqcCalciumMagnesiumChlorideSulfateParameters();
+          return scaleFamilyChecksum((PhasePitzer) independent.getPhase(1));
+        });
+      }
+      for (Future<Double> result : executor.invokeAll(tasks)) {
+        assertEquals(checksum, result.get(), 1.0e-12);
+      }
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
   private static void assertNaKClBinaryIphreeqc(String activeCation, double sodiumMolality, double potassiumMolality,
       double expectedMeanLog10Gamma, double expectedWaterActivity, double expectedOsmoticCoefficient) {
     PhasePitzer phase = createNaKClPhase(REFERENCE_TEMPERATURE, sodiumMolality, potassiumMolality, 1.0);
@@ -384,6 +522,11 @@ class PitzerParameterDatasetsTest extends neqsim.NeqSimTest {
         + waterActivity(phase) + phase.getOsmoticCoefficientOfWater();
   }
 
+  private static double scaleFamilyChecksum(PhasePitzer phase) {
+    return componentLogGamma(phase, "Ca++") + componentLogGamma(phase, "Mg++") + componentLogGamma(phase, "Cl-")
+        + componentLogGamma(phase, "SO4--") + waterActivity(phase) + phase.getOsmoticCoefficientOfWater();
+  }
+
   private static void assertPhreeqcCo2LogGamma(double temperature, double carbonDioxideMolality, double sodiumMolality,
       double sulfateMolality, double expectedNaturalLogGamma) {
     assertEquals(expectedNaturalLogGamma,
@@ -428,6 +571,25 @@ class PitzerParameterDatasetsTest extends neqsim.NeqSimTest {
     system.addComponent("Na+", sodiumMolality);
     system.addComponent("K+", potassiumMolality);
     system.addComponent("Cl-", chlorideMolality);
+    system.setMixingRule("classic");
+    system.init(0);
+    return system;
+  }
+
+  private static PhasePitzer createCalciumMagnesiumChlorideSulfatePhase(double temperature, double calciumMolality,
+      double magnesiumMolality, double chlorideMolality, double sulfateMolality) {
+    return (PhasePitzer) createCalciumMagnesiumChlorideSulfateSystem(temperature, calciumMolality, magnesiumMolality,
+        chlorideMolality, sulfateMolality).getPhase(1);
+  }
+
+  private static SystemPitzer createCalciumMagnesiumChlorideSulfateSystem(double temperature, double calciumMolality,
+      double magnesiumMolality, double chlorideMolality, double sulfateMolality) {
+    SystemPitzer system = new SystemPitzer(temperature, 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("Ca++", calciumMolality);
+    system.addComponent("Mg++", magnesiumMolality);
+    system.addComponent("Cl-", chlorideMolality);
+    system.addComponent("SO4--", sulfateMolality);
     system.setMixingRule("classic");
     system.init(0);
     return system;


### PR DESCRIPTION
## Summary

Advances #3144 with the scalable Pitzer-parameter foundation requested for gas/oil/aqueous and scale-brine work.

This draft imports the exact public-domain USGS PHREEQC `PITZER` interaction block as a lazy, versioned catalog and qualifies the complete Ca²⁺/Mg²⁺/Cl⁻/SO₄²⁻ family as the first four-ion oilfield-scale topology. It also fixes the equation-mapping defect that made current master discard PHREEQC's explicit CaCl₂ `B2` term.

## Frozen scientific/software question

Can NeqSim expose a large authoritative Pitzer interaction database without mixing parameter formalisms or silently treating absent cross-interactions as zero, while reproducing PHREEQC's charge-dependent `alpha1/alpha2` semantics and independently credible CaCl₂ activity data?

- model: `SystemPitzer` / `PhasePitzer` electrolyte-GE aqueous role; SRK gas/oil roles unchanged
- standard state and basis: molality scale, kg water solvent basis
- source temperature function: PHREEQC six-term expression at 298.15 K
- pressure: no pressure term in these interaction functions
- reaction set: none in this PR; no reaction constant or mineral `log K` is stored in the Pitzer catalog
- accepted parameter topology: explicit `B0/B1[/B2]/C0`, same-sign `theta`, ternary `psi`, and neutral `lambda/zeta` rows
- stop boundary: catalog/import semantics plus Ca/Mg/Cl/SO4 activities, water/osmotic properties, state safety, and composability; reactive mineral precipitation and generic hybrid-flash changes remain separate dependencies
- compatibility/performance: catalog loading is opt-in; neutral PR/SRK/CPA and electrolyte-EOS code is untouched

Current master `e467ebce1e562f4838a8976f944730cec6735e25` has two concrete gaps:
1. qualified families are hand-coded subsets rather than a scalable database;
2. the activity, B-prime, and osmotic kernels evaluate `B2` only for 2:2 pairs, but PHREEQC assigns `alpha2=12` to its explicit 2:1 CaCl₂ `B2` row.

## Implementation

- bundles only the exact PHREEQC `PITZER` block from commit `b0b3be767158ccc3322d2c816625cf470045e67e`, database blob `324f852784be84650b77bd7f07f8316aafd8188b`
- lazy immutable catalog: 54 `B0`, 48 `B1`, 8 `B2`, 32 `C0`, 30 `theta`, 59 `psi`, 27 `lambda`, and 10 `zeta` rows
- explicit dataset identity `usgs-phreeqc-pitzer-b0b3be767158ccc3322d2c816625cf470045e67e-catalog-v1`
- generic active-species loader that validates the whole required topology before mutating a phase
- fail-closed diagnostics for absent binary, same-sign, ternary, and neutral interactions; explicit source zeros remain distinct from absent rows
- exact PHREEQC default alphas: 2/12 for pairs containing a monovalent ion, 1.4/12 for 2:2, and 2/50 otherwise
- non-2:2 `B2` fast gate preserves the legacy hot path when no such qualified row is active
- `SystemPitzer` APIs for the broad catalog and the complete Ca/Mg/Cl/SO4 family
- provenance/source-comparison matrix, licensing, Kaasa page/convention audit, limitations, and manual benchmark

The bundled resource contains no reaction/mineral `log K`, gas binary, SIT, eNRTL, Extended-UNIQUAC, or electrolyte-EOS coefficient. Kaasa's thesis remains a provenance index; no thesis-only numerical value is copied because redistribution rights remain unclear.

## Sources and licensing

- USGS PHREEQC source/data: public domain: https://www.usgs.gov/software/phreeqc-version-3
- exact database: https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/database/pitzer.dat
- exact alpha implementation: https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/src/pitzer.cpp
- PHRQPITZ: https://doi.org/10.3133/wri884153
- Harvie, Møller & Weare natural-water model: https://doi.org/10.1016/0016-7037(84)90098-X
- PHREEQC high-T/P implementation: https://doi.org/10.1016/j.apgeochem.2014.11.007
- held-out CaCl₂ data: Partanen (2013), https://doi.org/10.1021/je300852v, via the NIST ThermoML archive and NIST public-data license
- Kaasa (1998), supplied scan, chapter 4 §4.3.2 pp. 100–101 and Appendix F pp. 259–267; inspected but not copied

## Validation

Local exact-source results:

- `./mvnw -q -Dtest='Pitzer*Test,SystemPitzerTest,SystemHybridEosGeFlashTest' test`: **88/88 passed**
- focused dataset test: **21/21 passed**
- `./mvnw -q -f pomJava8.xml -DskipTests compile`: passed Java-8 compatibility compile
- `./mvnw -q spotless:check`: passed
- `python3 devtools/check_documentation_search.py`: passed (659 Markdown + 1 HTML)
- `git diff --check`: passed
- pre-commit executable unavailable locally
- Javadoc was attempted but the runtime image has no `javadoc` executable; no Javadoc pass is claimed

Scientific/numerical evidence:

- held-out CaCl₂ mean ionic activity at 298.15 K, 0.1–2.0 mol/kg: predictions 0.515385, 0.444320, 0.497186, 0.798718 versus NIST ThermoML 0.517, 0.449, 0.502, 0.790
- maximum relative residual: **1.104%**, without parameter fitting
- mixed-family regressions enforce electroneutrality, normalized/non-negative composition, finite activities, water activity in (0,1], deterministic repeat, changed-topology stale-state rejection, clone isolation, serialization, and parallel construction
- `init(3)` plus aqueous density/enthalpy/Cp smoke checks pass on the fixed SRK/Pitzer/SRK role system

Manual nine-batch median benchmark on OpenJDK 17:

- four-ion activity/osmotic kernel: 8.29 µs
- complete aqueous `init(3)` + physical properties: 0.191 ms
- neutral SRK properties: 47.7 µs before catalog loading, 22.0 µs after (ratio 0.462; additional JIT warmup, no measured slowdown)
- no non-Pitzer production class changed

## Status and remaining gates

**DRAFT — VALIDATION PENDING CI**

Exact-version mixed Ca/Mg/Cl/SO4 IPhreeqc comparisons and licensing-clear independent MgCl₂/MgSO₄ or mixed-brine evidence remain scientific validation dependencies. The catalog makes many more source rows available, but only complete topologies with documented validation may be described as qualified.

Gas/oil/aqueous operation remains coordinated with #2937; reactive-absorber equipment with #205; salt input/API work with #448. Mineral reaction/log-K datasets, saturation/precipitation complementarity, full hybrid VLE, and process mass/energy closure are deliberately not conflated with Pitzer interaction parameters in this PR.

## Exact revisions

- master/base: `e467ebce1e562f4838a8976f944730cec6735e25`
- head: `31274f33b91456b84e02b8b6bc459b8a64cab8fb`
- one commit ahead / zero behind at publication

Refs #3144
