### PR TITLE
[AI-Assisted] feat(mcp): qualify governance contract evidence

### DIFF
--- a/neqsim-mcp-server/docs/FOUNDATION_TRACEABILITY.md
+++ b/neqsim-mcp-server/docs/FOUNDATION_TRACEABILITY.md
@@ -26,16 +26,16 @@ The reconciliation is intentionally conservative:
 Every published tool has an explicit coverage record under `phase0EvidenceInventory.knownLimitations.coverageRecords`.
 
 - 20 tools have tool-specific `BenchmarkTrust` pages and remain `EXPLICIT_TRUST`.
-- `getCapabilities`, `getSchema`, and `getExample` are `CONTRACT_TESTED`: they are non-numerical discovery/catalog contracts with direct source, contract-test, and real-protocol evidence, so an engineering-accuracy benchmark is not applicable.
-- 48 tools remain `CONFIRMED_GAP` and must not inherit scientific validation from the generic `TESTED` compatibility fallback.
+- `getCapabilities`, `getSchema`, `getExample`, `getBenchmarkTrust`, `checkToolAccess`, and `manageIndustrialProfile` are `CONTRACT_TESTED`: they are non-numerical discovery, catalog, trust-retrieval, and governance contracts with exact source/test/protocol evidence, so an engineering-accuracy benchmark is not applicable.
+- 45 tools remain `CONFIRMED_GAP` and must not inherit scientific validation from the generic `TESTED` compatibility fallback.
 
 The underlying `BenchmarkTrust` registry itself is intentionally unchanged at 20 explicit pages and 51 generic fallbacks. Contract-tested catalog/discovery evidence is a separate Phase 0 classification and does not certify any thermodynamic, process, pipeline, dynamic, safety, or optimization calculation advertised by those catalogs.
 
-The catalog classification is backed by current source plus the packaged MCP protocol suite: all 142 canonical input/output schema resources resolve as JSON schema objects, all 114 example-catalog entries resolve through MCP resources, and `CapabilitiesRunnerTest` cross-checks advertised schemas/examples against the current catalogs. These are software-contract checks, not scientific benchmark cases.
+The discovery/catalog classification is backed by current source plus the packaged MCP protocol suite: all 142 canonical input/output schema resources resolve as JSON schema objects, all 114 example-catalog entries resolve through MCP resources, and `CapabilitiesRunnerTest` cross-checks advertised schemas/examples against the current catalogs. The trust/governance classification additionally uses the complete `IndustrialProfileTest` access matrix, fail-closed security and principal-scoping regressions, and real-protocol trust/profile/access calls. Exact paths are carried in each record's `contractEvidenceSources` array. These are software-policy and transport-contract checks, not validation of scientific trust-page claims, external authorization, or a configured facility deployment.
 
 ## Remaining Phase 0 work
 
-The four public synthetic acceptance scales, bounded baseline harness, 66-criterion campaign traceability matrix, and ten-discipline maturity matrix are already merged and discoverable. Phase 0 is still incomplete because the acceptance baseline retains explicit component, energy, and complete facility-wide single-area closure gaps, and 48 published tools still lack a defensible tool-specific or bounded non-numerical trust classification.
+The four public synthetic acceptance scales, bounded baseline harness, 66-criterion campaign traceability matrix, and ten-discipline maturity matrix are already merged and discoverable. Phase 0 is still incomplete because the acceptance baseline retains explicit component, energy, and complete facility-wide single-area closure gaps, and 45 published tools still lack a defensible tool-specific or bounded non-numerical trust classification.
 
 Close those trust gaps only where current source plus concrete tests, public benchmark evidence, authoritative data, or a clearly non-numerical contract supports the classification. Do not manufacture accuracy bounds for discovery/catalog tools and do not reconstruct a second MCP-side conservation model when canonical NeqSim does not expose independent evidence.
 

--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -20,7 +20,7 @@ manually maintained Java method list.
 | MCP protocol scenarios | 94 | `getCapabilities.phase0EvidenceInventory` | `test_mcp_server.py` |
 | MCP guides | 8 | `getCapabilities.phase0EvidenceInventory` | Core guides, foundation traceability, fixtures, baseline harness, and campaign matrix |
 | Explicit benchmark-trust pages | 20 of 71 tools | `getBenchmarkTrust` and `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust` |
-| Trust coverage records | 71 = 20 explicit benchmark + 1 contract-tested discovery + 50 confirmed gaps | `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust`, `McpImplementationInventory`, MCP contract tests |
+| Trust coverage records | 71 = 20 explicit benchmark + 6 contract-tested non-numerical contracts + 45 confirmed gaps | `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust`, `McpImplementationInventory`, MCP contract tests |
 
 The tool regression asserts the exact 71-name set grouped by its current trust tier. It also calls
 `getCapabilities` and requires `toolCatalogCoverage.complete`, equal published and described tool
@@ -122,19 +122,19 @@ record for every published tool and now uses three bounded states:
 
 - `EXPLICIT_TRUST` — a tool-specific `BenchmarkTrust` page exists, with its declared maturity and
   counts for validation cases, verified cases, limitations, and unsupported conditions;
-- `CONTRACT_TESTED` — the tool is non-numerical and direct source, contract-test, response-guard,
-  and real-protocol evidence demonstrates its MCP contract. `getCapabilities` is the first such
-  record. Its engineering benchmark applicability is explicitly
-  `NOT_APPLICABLE_NON_NUMERICAL_DISCOVERY`; this status does not validate any advertised
-  thermodynamic or process calculation; or
+- `CONTRACT_TESTED` — the tool is non-numerical and its exact source, test, and real-protocol
+  evidence is listed in `contractEvidenceSources`. This applies to capability/schema/example
+  discovery plus trust-catalog retrieval and industrial-profile access/governance policy. It does
+  not validate advertised calculations, the scientific claims inside trust pages, external
+  identity or authorization, a facility deployment, or accountable engineering approval; or
 - `CONFIRMED_GAP` — no tool-specific benchmark trust page or bounded non-numerical contract
   evidence closes the gap. The record names the implementation class, retains the compatibility
   maturity, and explicitly states that generic `TESTED` is not benchmark, accuracy,
   applicability, or no-limitations evidence.
 
 Accordingly, `coverageComplete=true` means all 71 published tools have an explicit trust-coverage
-classification. It does **not** mean the MCP surface is scientifically validated: 50 records remain
-`CONFIRMED_GAP`, one is `CONTRACT_TESTED`, `scientificValidationComplete=false`, and the overall
+classification. It does **not** mean the MCP surface is scientifically validated: 45 records remain
+`CONFIRMED_GAP`, six are `CONTRACT_TESTED`, `scientificValidationComplete=false`, and the overall
 Phase 0 `complete` flag remains false. The benchmark registry itself remains unchanged at 20
 explicit pages and 51 generic benchmark fallbacks, so existing benchmark-report accounting and
 protocol contracts are preserved.
@@ -178,10 +178,11 @@ deployment-profile names, tool-capability reconciliation, schema resource graph,
 graph, tool implementation bindings, factory-backed equipment, report paths, test sources, guides,
 merged-foundation reconciliation, four public synthetic acceptance scales, bounded acceptance
 baseline harness, campaign traceability/maturity matrix, and explicit trust-coverage status for
-every published tool. `getCapabilities` is now contract-tested without being misrepresented as a
-scientifically benchmarked calculation.
+every published tool. Six non-numerical discovery, catalog, trust-retrieval, and governance tools
+are contract-tested without being misrepresented as scientifically benchmarked calculations or
+as plant-authority controls.
 
-Follow-up work should close the remaining 50 confirmed trust gaps only where current source and
+Follow-up work should close the remaining 45 confirmed trust gaps only where current source and
 public evidence support a specific claim, and continue closing explicit numeric component,
 energy, and facility-wide conservation/report gaps only where canonical NeqSim APIs provide
 independent evidence. Later-phase campaign criteria remain incomplete until their own merged

--- a/neqsim-mcp-server/test_mcp_server.py
+++ b/neqsim-mcp-server/test_mcp_server.py
@@ -1552,10 +1552,36 @@ def test_capabilities():
           and validation_case_count == limitations.get("validationCaseCount")
           and verified_case_count == limitations.get("verifiedValidationCaseCount"),
           str(limitations))
+    contract_tools = {
+        "getCapabilities", "getSchema", "getExample", "getBenchmarkTrust",
+        "checkToolAccess", "manageIndustrialProfile",
+    }
+    coverage_records = limitations.get("coverageRecords", {})
+    check("six non-numerical contracts have bounded evidence",
+          limitations.get("contractTestedToolCount") == 6
+          and limitations.get("confirmedGapToolCount") == 45
+          and set(limitations.get("contractTestedTools", [])) == contract_tools
+          and all(coverage_records.get(tool, {}).get("coverageStatus")
+                  == "CONTRACT_TESTED" for tool in contract_tools),
+          str(limitations))
+    contract_sources = [
+        source
+        for tool in contract_tools
+        for source in coverage_records.get(tool, {}).get(
+            "contractEvidenceSources", [])
+    ]
+    check("contract evidence paths resolve on the exact source tree",
+          all((repo_root / source).is_file() for source in contract_sources)
+          and all(len(coverage_records.get(tool, {}).get(
+              "contractEvidenceSources", []))
+              == coverage_records.get(tool, {}).get("contractEvidenceCount")
+              for tool in contract_tools),
+          str(contract_sources))
     check("uncovered tool-specific trust remains an explicit Phase 0 gap",
           limitations.get("publishedToolCount") == 71
           and limitations.get("explicitTrustToolCount") == 20
           and limitations.get("genericTrustToolCount") == 51
+          and limitations.get("confirmedGapToolCount") == 45
           and limitations.get("unsupportedConditionCount") == 0
           and limitations.get("complete") is False
           and evidence.get("complete") is False,

--- a/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
@@ -28,7 +28,7 @@ public final class McpEvidenceInventory {
    */
   public static JsonObject build() {
     JsonObject inventory = new JsonObject();
-    inventory.addProperty("inventoryVersion", "1.7");
+    inventory.addProperty("inventoryVersion", "1.8");
     inventory.add("tests", buildTests());
     inventory.add("guides", buildGuides());
     inventory.add("mergedFoundations", buildMergedFoundations());
@@ -187,31 +187,7 @@ public final class McpEvidenceInventory {
         record.addProperty("validationCaseCount", arraySize(trust, "validationCases"));
         record.addProperty("verifiedValidationCaseCount", verifiedValidationCaseCount(trust));
         explicitCoverageRecordCount++;
-      } else if ("getCapabilities".equals(toolName) || "getSchema".equals(toolName) || "getExample".equals(toolName)) {
-        record.addProperty("coverageStatus", "CONTRACT_TESTED");
-        record.addProperty("toolSpecificTrustAvailable", false);
-        record.addProperty("contractTrustAvailable", true);
-        record.addProperty("maturityLevel", "TESTED");
-        record.addProperty("knownLimitationCount", 0);
-        record.addProperty("unsupportedConditionCount", 0);
-        record.addProperty("validationCaseCount", 0);
-        record.addProperty("verifiedValidationCaseCount", 0);
-        if ("getCapabilities".equals(toolName)) {
-          record.addProperty("benchmarkApplicability", "NOT_APPLICABLE_NON_NUMERICAL_DISCOVERY");
-          record.addProperty("contractEvidenceCount", 4);
-          record.addProperty("evidenceBoundary",
-              "CapabilitiesRunnerTest, McpToolSurfaceContractTest, ResponseSizeGuardTest, and the packaged MCP protocol verify discovery-contract fidelity; this is not scientific validation of advertised calculations");
-        } else if ("getSchema".equals(toolName)) {
-          record.addProperty("benchmarkApplicability", "NOT_APPLICABLE_NON_NUMERICAL_SCHEMA_CATALOG");
-          record.addProperty("contractEvidenceCount", 3);
-          record.addProperty("evidenceBoundary",
-              "SchemaCatalog source, CapabilitiesRunnerTest catalog resolution, and the packaged MCP protocol verify all 142 canonical input/output schema resources; schema availability does not validate the calculations described by those schemas");
-        } else {
-          record.addProperty("benchmarkApplicability", "NOT_APPLICABLE_NON_NUMERICAL_EXAMPLE_CATALOG");
-          record.addProperty("contractEvidenceCount", 3);
-          record.addProperty("evidenceBoundary",
-              "ExampleCatalog source, CapabilitiesRunnerTest example resolution, and the packaged MCP protocol verify all 114 catalog examples; example availability does not establish scientific accuracy or fitness for a facility decision");
-        }
+      } else if (addContractTestedEvidence(toolName, record)) {
         contractTestedTools.add(toolName);
         contractTestedRecordCount++;
       } else {
@@ -260,10 +236,83 @@ public final class McpEvidenceInventory {
     limitations.add("coverageRecords", coverageRecords);
     limitations.addProperty("complete", genericTools.isEmpty());
     limitations.addProperty("gapBoundary",
-        "Every published tool has an explicit coverage record; getCapabilities, getSchema, and getExample are contract-tested without numerical benchmark claims, while CONFIRMED_GAP identifies the remaining missing tool-specific trust evidence");
+        "Every published tool has an explicit coverage record; six non-numerical discovery, catalog, trust, and governance tools are contract-tested without numerical benchmark claims, while CONFIRMED_GAP identifies the remaining missing tool-specific trust evidence");
     limitations.addProperty("resultBoundary",
         "Per-result provenance, convergence, warnings, assumptions, and limitations remain authoritative for an executed case");
     return limitations;
+  }
+
+  /**
+   * Adds bounded contract evidence for a non-numerical MCP tool.
+   *
+   * @param toolName published MCP tool name
+   * @param record mutable coverage record
+   * @return true when the tool has a bounded contract-evidence definition
+   */
+  private static boolean addContractTestedEvidence(String toolName, JsonObject record) {
+    String benchmarkApplicability;
+    String evidenceBoundary;
+    String[] evidenceSources;
+
+    switch (toolName) {
+    case "getCapabilities":
+      benchmarkApplicability = "NOT_APPLICABLE_NON_NUMERICAL_DISCOVERY";
+      evidenceSources = new String[] { "src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java",
+          "src/test/java/neqsim/mcp/runners/McpToolSurfaceContractTest.java",
+          "src/test/java/neqsim/mcp/runners/ResponseSizeGuardTest.java", "neqsim-mcp-server/test_mcp_server.py" };
+      evidenceBoundary = "Capability discovery, published-surface reconciliation, response guarding, and real-protocol retrieval are contract-tested; this is not scientific validation of advertised calculations";
+      break;
+    case "getSchema":
+      benchmarkApplicability = "NOT_APPLICABLE_NON_NUMERICAL_SCHEMA_CATALOG";
+      evidenceSources = new String[] { "src/main/java/neqsim/mcp/catalog/SchemaCatalog.java",
+          "src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java", "neqsim-mcp-server/test_mcp_server.py" };
+      evidenceBoundary = "All 142 canonical input/output schema resources resolve through source, catalog reconciliation, and the packaged MCP protocol; schema availability does not validate the calculations described by those schemas";
+      break;
+    case "getExample":
+      benchmarkApplicability = "NOT_APPLICABLE_NON_NUMERICAL_EXAMPLE_CATALOG";
+      evidenceSources = new String[] { "src/main/java/neqsim/mcp/catalog/ExampleCatalog.java",
+          "src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java", "neqsim-mcp-server/test_mcp_server.py" };
+      evidenceBoundary = "All 114 catalog examples resolve through source, catalog reconciliation, and the packaged MCP protocol; example availability does not establish scientific accuracy or fitness for a facility decision";
+      break;
+    case "getBenchmarkTrust":
+      benchmarkApplicability = "NOT_APPLICABLE_NON_NUMERICAL_TRUST_CATALOG";
+      evidenceSources = new String[] { "src/main/java/neqsim/mcp/runners/BenchmarkTrust.java",
+          "src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java",
+          "neqsim-mcp-server/test_mcp_server.py" };
+      evidenceBoundary = "Trust-catalog all-tool and single-tool retrieval plus runtime inventory reconciliation are contract-tested; retrieval fidelity does not validate the scientific claims inside any trust page";
+      break;
+    case "checkToolAccess":
+      benchmarkApplicability = "NOT_APPLICABLE_NON_NUMERICAL_ACCESS_POLICY";
+      evidenceSources = new String[] { "src/main/java/neqsim/mcp/runners/IndustrialProfile.java",
+          "src/test/java/neqsim/mcp/runners/IndustrialProfileTest.java",
+          "src/test/java/neqsim/mcp/runners/McpSecurityEnforcementTest.java", "neqsim-mcp-server/test_mcp_server.py" };
+      evidenceBoundary = "The profile-tier access matrix, fail-closed security enforcement, and real-protocol access response are contract-tested; this does not grant external authorization or plant authority";
+      break;
+    case "manageIndustrialProfile":
+      benchmarkApplicability = "NOT_APPLICABLE_NON_NUMERICAL_GOVERNANCE_POLICY";
+      evidenceSources = new String[] { "src/main/java/neqsim/mcp/runners/IndustrialProfile.java",
+          "src/test/java/neqsim/mcp/runners/IndustrialProfileTest.java",
+          "src/test/java/neqsim/mcp/runners/McpPrincipalScopingTest.java",
+          "src/test/java/neqsim/mcp/runners/McpSecurityEnforcementTest.java", "neqsim-mcp-server/test_mcp_server.py" };
+      evidenceBoundary = "Profile discovery, classification, admin-gated mode changes, and principal-scoped one-shot approvals are contract-tested; deployments still require external identity, policy configuration, and accountable review";
+      break;
+    default:
+      return false;
+    }
+
+    record.addProperty("coverageStatus", "CONTRACT_TESTED");
+    record.addProperty("toolSpecificTrustAvailable", false);
+    record.addProperty("contractTrustAvailable", true);
+    record.addProperty("benchmarkApplicability", benchmarkApplicability);
+    record.addProperty("maturityLevel", "TESTED");
+    record.addProperty("contractEvidenceCount", evidenceSources.length);
+    record.add("contractEvidenceSources", toJsonArray(java.util.Arrays.asList(evidenceSources)));
+    record.addProperty("knownLimitationCount", 0);
+    record.addProperty("unsupportedConditionCount", 0);
+    record.addProperty("validationCaseCount", 0);
+    record.addProperty("verifiedValidationCaseCount", 0);
+    record.addProperty("evidenceBoundary", evidenceBoundary);
+    return true;
   }
 
   /** Counts validation cases that identify a concrete verification source. */

--- a/src/test/java/neqsim/mcp/runners/McpAcceptanceBaselineRunnerTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpAcceptanceBaselineRunnerTests.java
@@ -20,7 +20,7 @@ class McpAcceptanceBaselineRunnerTests {
     assertFalse(contract.get("scientificValidationComplete").getAsBoolean());
 
     JsonObject inventory = McpEvidenceInventory.build();
-    assertEquals("1.7", inventory.get("inventoryVersion").getAsString());
+    assertEquals("1.8", inventory.get("inventoryVersion").getAsString());
     assertTrue(inventory.has("acceptanceBaselineContract"));
     assertFalse(inventory.get("complete").getAsBoolean());
   }

--- a/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
@@ -53,12 +53,15 @@ class McpEvidenceInventoryFoundationTests {
     assertEquals(71, limitations.get("publishedToolCount").getAsInt());
     assertEquals(71, limitations.get("coverageRecordCount").getAsInt());
     assertEquals(20, limitations.get("explicitCoverageRecordCount").getAsInt());
-    assertEquals(3, limitations.get("contractTestedToolCount").getAsInt());
-    assertEquals(48, limitations.get("confirmedGapToolCount").getAsInt());
-    assertEquals(3, limitations.getAsJsonArray("contractTestedTools").size());
+    assertEquals(6, limitations.get("contractTestedToolCount").getAsInt());
+    assertEquals(45, limitations.get("confirmedGapToolCount").getAsInt());
+    assertEquals(6, limitations.getAsJsonArray("contractTestedTools").size());
     assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("getCapabilities"));
     assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("getSchema"));
     assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("getExample"));
+    assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("getBenchmarkTrust"));
+    assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("checkToolAccess"));
+    assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("manageIndustrialProfile"));
     assertEquals(71, coverageRecords.size());
     assertTrue(limitations.get("coverageComplete").getAsBoolean());
     assertFalse(limitations.get("scientificValidationComplete").getAsBoolean());
@@ -75,19 +78,44 @@ class McpEvidenceInventoryFoundationTests {
     assertEquals("NOT_APPLICABLE_NON_NUMERICAL_DISCOVERY", capabilities.get("benchmarkApplicability").getAsString());
     assertEquals("TESTED", capabilities.get("maturityLevel").getAsString());
     assertEquals(4, capabilities.get("contractEvidenceCount").getAsInt());
+    assertEquals(4, capabilities.getAsJsonArray("contractEvidenceSources").size());
     assertTrue(capabilities.get("evidenceBoundary").getAsString().contains("not scientific validation"));
 
     JsonObject schema = coverageRecords.getAsJsonObject("getSchema");
     assertEquals("CONTRACT_TESTED", schema.get("coverageStatus").getAsString());
     assertEquals("NOT_APPLICABLE_NON_NUMERICAL_SCHEMA_CATALOG", schema.get("benchmarkApplicability").getAsString());
     assertEquals(3, schema.get("contractEvidenceCount").getAsInt());
+    assertEquals(3, schema.getAsJsonArray("contractEvidenceSources").size());
     assertTrue(schema.get("evidenceBoundary").getAsString().contains("142 canonical"));
 
     JsonObject example = coverageRecords.getAsJsonObject("getExample");
     assertEquals("CONTRACT_TESTED", example.get("coverageStatus").getAsString());
     assertEquals("NOT_APPLICABLE_NON_NUMERICAL_EXAMPLE_CATALOG", example.get("benchmarkApplicability").getAsString());
     assertEquals(3, example.get("contractEvidenceCount").getAsInt());
+    assertEquals(3, example.getAsJsonArray("contractEvidenceSources").size());
     assertTrue(example.get("evidenceBoundary").getAsString().contains("114 catalog examples"));
+
+    JsonObject benchmarkTrust = coverageRecords.getAsJsonObject("getBenchmarkTrust");
+    assertEquals("CONTRACT_TESTED", benchmarkTrust.get("coverageStatus").getAsString());
+    assertEquals("NOT_APPLICABLE_NON_NUMERICAL_TRUST_CATALOG",
+        benchmarkTrust.get("benchmarkApplicability").getAsString());
+    assertEquals(3, benchmarkTrust.get("contractEvidenceCount").getAsInt());
+    assertEquals(3, benchmarkTrust.getAsJsonArray("contractEvidenceSources").size());
+    assertTrue(benchmarkTrust.get("evidenceBoundary").getAsString().contains("does not validate"));
+
+    JsonObject access = coverageRecords.getAsJsonObject("checkToolAccess");
+    assertEquals("CONTRACT_TESTED", access.get("coverageStatus").getAsString());
+    assertEquals("NOT_APPLICABLE_NON_NUMERICAL_ACCESS_POLICY", access.get("benchmarkApplicability").getAsString());
+    assertEquals(4, access.get("contractEvidenceCount").getAsInt());
+    assertEquals(4, access.getAsJsonArray("contractEvidenceSources").size());
+    assertTrue(access.get("evidenceBoundary").getAsString().contains("does not grant external authorization"));
+
+    JsonObject profile = coverageRecords.getAsJsonObject("manageIndustrialProfile");
+    assertEquals("CONTRACT_TESTED", profile.get("coverageStatus").getAsString());
+    assertEquals("NOT_APPLICABLE_NON_NUMERICAL_GOVERNANCE_POLICY", profile.get("benchmarkApplicability").getAsString());
+    assertEquals(5, profile.get("contractEvidenceCount").getAsInt());
+    assertEquals(5, profile.getAsJsonArray("contractEvidenceSources").size());
+    assertTrue(profile.get("evidenceBoundary").getAsString().contains("external identity"));
     assertFalse(inventory.get("complete").getAsBoolean());
   }
 
@@ -97,7 +125,7 @@ class McpEvidenceInventoryFoundationTests {
     JsonObject inventory = capabilities.getAsJsonObject("phase0EvidenceInventory");
     JsonObject fixtures = inventory.getAsJsonObject("acceptanceFixtures");
 
-    assertEquals("1.7", inventory.get("inventoryVersion").getAsString());
+    assertEquals("1.8", inventory.get("inventoryVersion").getAsString());
     assertEquals(8, inventory.getAsJsonObject("guides").get("guideCount").getAsInt());
     assertEquals(4, fixtures.get("fixtureCount").getAsInt());
     assertTrue(fixtures.get("complete").getAsBoolean());


### PR DESCRIPTION
## Summary

Advances #3153 Phase 0 by turning three already-implemented, non-numerical governance/trust contracts into evidence-backed `CONTRACT_TESTED` records:

- `getBenchmarkTrust`
- `checkToolAccess`
- `manageIndustrialProfile`

It also makes the existing capability/schema/example contract evidence machine-readable through exact `contractEvidenceSources` paths. The inventory moves from 20 explicit + 3 contract-tested + 48 confirmed gaps to 20 + 6 + 45. The underlying `BenchmarkTrust` registry remains unchanged at 20 explicit pages and 51 generic fallbacks, and `scientificValidationComplete` remains false.

## Frozen scope and stop boundary

This PR only classifies retrieval, transport, access-matrix, fail-closed, principal-scoping, and governance-policy behavior that current source and tests already demonstrate. It does **not**:

- validate scientific claims inside trust pages;
- assert thermodynamic/process accuracy or close conservation gaps;
- provide external identity/authorization, plant authority, facility configuration, control commands, or accountable engineering approval;
- change tools, schemas, request/response envelopes, numerical models, DEXPI, dynamics, flash/stability/performance, or production optimization.

No companion agent/skill contract changes are required because the invocation surface is unchanged.

Exact base: `a2f7a2d8e892a1e7a57fea927c66d865194aea92`
Exact head: `115b0ae2522943777b6ca1213dade8d290183de8`

## Implementation and regression evidence

- Refactors bounded non-numerical evidence into a reusable six-tool classifier.
- Exposes exact source/test/protocol paths and derives evidence counts from those paths.
- Pins status, applicability, evidence counts, boundaries, and the 45 remaining gaps in Java tests.
- Extends the real MCP protocol suite assertions to reconcile the exact six-tool set and verify every evidence path exists.
- Keeps all 71 published tools explicitly classified and preserves 20 explicit / 51 generic benchmark-registry accounting.

## Validation

Locally run on the exact base/head source:

- `python devtools/run_spotless.py apply` — passed.
- `python devtools/run_spotless.py check` — passed.
- `python devtools/check_documentation_search.py` — passed (659 Markdown, 1 HTML).
- Focused Maven tests — passed: 57 tests, 0 failures/errors/skips across inventory, acceptance baseline, industrial-profile, security-enforcement, and principal-scoping suites.
- `python3 -m py_compile neqsim-mcp-server/test_mcp_server.py` — passed.
- `git diff --check` — passed.

Local `pre-commit` was unavailable. The packaged MCP protocol suite requires JDK 21 while the available local runtime is JDK 17, so full packaged STDIO execution is **VALIDATION PENDING CI**. Hosted exact-head JDK 21 CI is authoritative.

## Documentation impact

Updates `SURFACE_INVENTORY.md` and `FOUNDATION_TRACEABILITY.md` to correct the merged-master accounting and state the scientific, deployment, authorization, and plant-authority boundaries. No MCP contract/API/schema/example documentation change is needed because no invocation contract changed.

Refs #3153
