### PR TITLE
[AI-Assisted] feat(pitzer): qualify mixed MgCl2-MgSO4 water activity

### DIFF
--- a/docs/thermo/pitzer_parameter_provenance.md
+++ b/docs/thermo/pitzer_parameter_provenance.md
@@ -229,11 +229,33 @@ uncertainties, while psi differs by about 10.3. These are fitted parameters from
 experimental/model lineage, not direct transferable validation values. NeqSim keeps the coherent
 PHREEQC family unchanged and records the disagreement; it does not mix the two parameter sets.
 
+Independent observable validation now uses the 28 mixed MgCl2+MgSO4 water activities of Guendouzi
+and Errougui (2007), [DOI 10.1021/je7002176](https://doi.org/10.1021/je7002176). The hygrometric
+measurements are at 298.15 K and 101 kPa for MgCl2 ionic-strength fractions 0.20, 0.50, and 0.80,
+with total formula-unit molality from 0.35 to 3.80 mol/kg water. The NIST ThermoML record specifies
+the pure-water standard state and 95% combined expanded water-activity uncertainties of 0.001 to
+0.004. The checked JSON has MD5 `29969a5f814eb0ad6d7ca5b4f093b658`; the unchanged numerical
+subset is stored with NIST acknowledgment under the
+[NIST public-data license](https://www.nist.gov/open/license). Composition is mapped without
+speciation or fitting as Mg++ = m(MgCl2)+m(MgSO4), Cl- = 2m(MgCl2), and SO4-- = m(MgSO4).
+
+Across all 28 states, NeqSim's maximum absolute water-activity residual is 0.002985 and its RMSE is
+0.001275; 26 states fall inside their individual reported 95% expanded uncertainty. Both calculated
+and experimental water activity decrease monotonically with total molality on each composition
+line. The regression also checks formula-unit material balance, electroneutrality, normalized and
+non-negative phase state, water-activity/osmotic-coefficient identity, deterministic repetition,
+changed-state equivalence, and complete parameter coverage. No coefficient was fitted or changed.
+This qualifies only mixed Mg-Cl-SO4 water activity at the three documented composition lines and
+298.15 K; it does not qualify Ca-bearing mixtures, pressure/temperature extrapolation, individual
+ion activities, mineral saturation, or precipitation.
+
 `PitzerParameterDatasets.getQualification(datasetId)` exposes this distinction to Java and Python
 callers. Complete PHREEQC catalog topology reports `PARTIALLY_EXPERIMENTALLY_VALIDATED`, lists the
-CaCl2 and MgCl2 binaries as checked, and explicitly lists mixed Ca-Mg-Cl-SO4 and mineral
-precipitation as unresolved. Unknown or private dataset identities report `UNQUALIFIED`. This
-metadata lookup is outside the activity/property kernels and adds no non-electrolyte overhead.
+CaCl2 and MgCl2 binaries plus mixed MgCl2-MgSO4 water activity as checked, and explicitly leaves
+Ca-bearing mixed activity and mineral precipitation unresolved. The range diagnostic accepts only
+the three experimentally checked ionic-strength-fraction lines and their line-specific molality
+intervals. Unknown or private dataset identities report `UNQUALIFIED`. This metadata lookup is
+outside the activity/property kernels and adds no non-electrolyte overhead.
 
 The catalog is an aqueous-GE parameter source, not a complete scale or process model by itself.
 `SystemPitzer` keeps SRK gas and oil role phases and exposes catalog application on its Pitzer
@@ -242,11 +264,12 @@ solubility/precipitation complementarity, and process mass/energy/property closu
 separate gates and database semantics.
 
 `PitzerCatalogPerformanceBenchmark` measures nine fixed-work batches after warmup. On OpenJDK 17
-in the development container, the median four-ion activity/osmotic kernel was 8.61 microseconds and
-the complete aqueous `init(3)` plus physical-property calculation was 0.173 milliseconds. The same
-neutral SRK property control measured 34.5 microseconds before catalog loading and 25.3 microseconds
-after loading (ratio 0.733, reflecting additional JIT warmup rather than a regression). No neutral
-EOS production class is changed, and catalog parsing is absent until its explicit API is called.
+in the development container, the median four-ion activity/osmotic kernel was 10.542 microseconds
+and the complete aqueous `init(3)` plus physical-property calculation was 0.168756 milliseconds.
+The same neutral SRK property control measured 31.940 microseconds before catalog loading and
+22.576 microseconds after loading (ratio 0.707, reflecting additional JIT warmup rather than a
+regression). No neutral EOS production class is changed, and catalog parsing is absent until its
+explicit API is called.
 These figures are diagnostic wall-clock evidence, not portable hardware guarantees.
 
 ## Source-comparison matrix
@@ -266,7 +289,8 @@ until their complete topology and validation matrix are documented.
 | Partanen and Partanen (2020), [traceable NaCl values](https://doi.org/10.1021/acs.jced.0c00402) | Recommended NaCl mean activity and water osmotic coefficients; no Pitzer parameter is supplied or adopted | 273.15–373.15 K, 0.2 mol/kg to saturation; molality scale; extended-Huckel model fitted independently of the PHREEQC implementation | Traceable synthesis of vapor-pressure, electrochemical, cryoscopic, and solubility evidence; tabulated values are rounded to 0.001 | Primary open-access article and numerical tables under CC BY 4.0 | Four 298.15 K points from 0.2–2.0 mol/kg are held-out validation only. Max NeqSim residuals are 1.36% in mean activity, 0.0053 in osmotic coefficient, and below 0.0004 in derived water activity; no coefficient was refitted. |
 | Hamer and Wu (1972), [NBS/NIST critical evaluation](https://doi.org/10.1063/1.3253108), independently reproduced by Dash et al. (2012), [open-access table](https://doi.org/10.5402/2012/730154) | Critically evaluated KCl mean activity coefficients; no Pitzer parameter is supplied or adopted | 298.15 K, molality scale, 1:1 electrolyte; four selected states span 0.0982–1.9895 mol/kg | Hamer-Wu evaluates thermodynamic literature; reproduced values are rounded to 0.001. Dash et al.'s direct single-ion-selective-electrode means are 10.7–13.4% higher at the same states and are treated as a method conflict. | U.S. NBS authorship and U.S. Secretary of Commerce publication; the four checked values are also reproduced in a CC BY open-access primary experiment | Held-out binary validation only. Max NeqSim mean-activity residual is 0.110% against a 0.20% gate; no coefficient was refitted. The critically evaluated values take precedence over the conflicting single-ion method. |
 | Partanen (2013), [traceable MgCl2 values](https://doi.org/10.1016/j.jct.2013.06.016) | Recommended MgCl2 mean activity and water osmotic coefficients; no Pitzer parameter is supplied or adopted | 298.15 K, 0–3 mol/kg, molality scale; four checked states span 0.1667–2.0 mol/kg | Traceable synthesis and tests against isopiestic and vapor-pressure literature; tabulated values are rounded | Journal of Chemical Thermodynamics data distributed through the publisher-permitted NIST ThermoML archive; NIST public-data terms and citation request recorded | Held-out binary validation only. Max NeqSim mean-activity residual is 2.27% without refitting; this does not qualify mixed Mg chloride/sulfate brines. |
-| Dinane, Messnaoui and Abou Nohra (2012), [mixed MgCl2+MgSO4 experiment](https://doi.org/10.1016/j.jct.2011.08.020) | Mean MgCl2 activities over total ionic strength 0.001–8 mol/kg; fitted `theta(Cl,SO4)` and `psi(Mg,Cl,SO4)` | 298.15 K; salt ratios 2.5, 5, 7.5, 10, and 15; potentiometric Mg-ISE/Ag-AgCl method and Pitzer fit | `theta=0.0252 +/- 0.0042`, `psi=-0.0049 +/- 0.0003`; PHREEQC has 0.03 and -0.008 | Primary Elsevier article; no table is copied and numerical-table redistribution was not established | Theta broadly agrees, but psi materially conflicts. No coefficient is adopted or mixed; exact mixed-composition observable validation remains required. |
+| Dinane, Messnaoui and Abou Nohra (2012), [mixed MgCl2+MgSO4 experiment](https://doi.org/10.1016/j.jct.2011.08.020) | Mean MgCl2 activities over total ionic strength 0.001–8 mol/kg; fitted `theta(Cl,SO4)` and `psi(Mg,Cl,SO4)` | 298.15 K; salt ratios 2.5, 5, 7.5, 10, and 15; potentiometric Mg-ISE/Ag-AgCl method and Pitzer fit | `theta=0.0252 +/- 0.0042`, `psi=-0.0049 +/- 0.0003`; PHREEQC has 0.03 and -0.008 | Primary Elsevier article; no table is copied and numerical-table redistribution was not established | Theta broadly agrees, but psi materially conflicts. No coefficient is adopted or mixed; the coherent PHREEQC family is assessed against separate observable data. |
+| Guendouzi and Errougui (2007), [mixed MgCl2+MgSO4 water activity](https://doi.org/10.1021/je7002176), NIST ThermoML MD5 `29969a5f814eb0ad6d7ca5b4f093b658` | 28 measured water activities; no interaction parameter is adopted. The paper also fits mixing parameters, but they are not transcribed or mixed with PHREEQC. | 298.15 K, 101 kPa; MgCl2 ionic-strength fractions 0.20, 0.50, 0.80; total formula-unit molality 0.35–3.80 mol/kg; molality composition and pure-water activity standard state | Hygrometric method; per-state 95% combined expanded uncertainty 0.001–0.004. NeqSim max absolute residual 0.002985, RMSE 0.001275, and 26/28 states inside individual uncertainty without refitting. | Primary article; numerical record is publisher-permitted NIST ThermoML. Stored unchanged subset follows the NIST public-data license and acknowledgment terms. | Accepted as held-out mixed Mg-Cl-SO4 water-activity evidence only. It supports PHREEQC `B0/B1/B2/C0`, Cl-/SO4-- `theta`, Mg++/Cl-/SO4-- `psi`, charge-dependent alpha, and electrostatic conventions as one coherent calculation; it does not transfer a fitted parameter or qualify Ca/minerals. |
 | Rodil, Arce, Wilczek-Vera and Vera (2009), [mixed NaCl+KCl experiment](https://doi.org/10.1021/je800389q) and [mandatory correction](https://doi.org/10.1021/je9002674) | Individual Cl-/Na+/K+ activity evidence in mixed NaCl+KCl at cation molal fractions 0.75, 0.5, and 0.25 | 298.15 K; total chloride to 4 mol/kg; Henderson liquid-junction correction and single-ion convention | Original paper reports the experiment; the correction replaces erroneous Na+/K+ tabulations without changing conclusions | ACS supporting information is publicly downloadable, but copyright and no explicit data-redistribution license were established | Candidate held-out mixed-family validation only. No value is stored; licensing-clear data and convention mapping remain the blocker. Exact-composition IPhreeqc checks are retained as implementation evidence, not a substitute for experiment. |
 | Kaasa (1998), *Prediction of pH, mineral precipitation and multiphase equilibria during oil recovery*, [National Library item](https://www.nb.no/items/d1d68b489b8ee6704786a011fd2e7283), supplied scan inspected 2026-08-23 | Appendix F printed pp. 260–263: binary `beta(0)`, `beta(1)`, occasional `beta(2)`, and `Cphi` for oil-recovery-brine ions; pp. 264–266: same-sign `theta` and ternary `psi`; pp. 266–267: neutral `lambda` and `ksi` (zeta) for CO2, H2S, and CH4 systems | Molality-scale Pitzer model; 298.15 K reference. Appendix F equation (F.1) uses six coefficients in raw order `[a,b,c,d,e,f]`; NeqSim/PHREEQC order is `[a,d,e,b,c,f]`. Pressure effects are handled separately in chapter 4. | Appendix F cites sources 1–16, including primary literature and rows marked “This work.” Chapter 4 §4.3.2, printed pp. 100–101, states that source ranges differ and some high-temperature fits were forced toward zero where extrapolation became nonphysical, with a poorer fit to experiments. Row uncertainty and complete validity are not tabulated. | User-supplied scan was visually inspected against its text layer. Thesis-table redistribution terms remain unclear; no numerical row was copied. Original cited publications require independent row-level checks and their own reuse review. | Formula, page/family inventory, and coefficient-order permutation accepted. `PitzerTemperatureFunction.fromKaasa1998` performs only the tested order mapping. No coefficient, forced extrapolation, or “This work” estimate was adopted. |
 | THEREDA release 2026-01, [official database](https://www.thereda.de/) | Quality-controlled high-salinity Pitzer datasets, including variable-temperature sets | Official site reports an oceanic set from 0 to 110 °C; formulation and scale are dataset specific | Official site reports 425 tests and more than 3200 results; row-level uncertainty remains dataset specific | Current release and licensing/reuse terms must be confirmed before storage | Candidate validation and provenance source only; no value adopted while row-level lineage, reuse, range, and complete family compatibility remain unresolved. |

--- a/src/main/java/neqsim/thermo/phase/PitzerParameterDatasets.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerParameterDatasets.java
@@ -68,6 +68,15 @@ public final class PitzerParameterDatasets {
   /** Highest independently checked binary CaCl2 or MgCl2 molality, in mol/kg water. */
   public static final double CA_MG_CL_SO4_BINARY_VALIDATION_MAX_MOLALITY = 2.0;
 
+  /** Lowest total formula-unit molality in the mixed MgCl2-MgSO4 water-activity evidence. */
+  public static final double MG_CL_SO4_WATER_ACTIVITY_VALIDATION_MIN_TOTAL_MOLALITY = 0.35;
+
+  /** Highest total formula-unit molality in the mixed MgCl2-MgSO4 water-activity evidence. */
+  public static final double MG_CL_SO4_WATER_ACTIVITY_VALIDATION_MAX_TOTAL_MOLALITY = 3.80;
+
+  private static final double MG_CL_SO4_IONIC_STRENGTH_FRACTION_TOLERANCE = 3.0e-3;
+  private static final double MG_CL_SO4_MOLALITY_BOUNDARY_TOLERANCE = 1.0e-12;
+
   /** Utility class. */
   private PitzerParameterDatasets() {
   }
@@ -445,9 +454,10 @@ public final class PitzerParameterDatasets {
     if (PHREEQC_PITZER_CATALOG_ID.equals(datasetId)) {
       return new PitzerParameterQualification(datasetId,
           PitzerParameterQualification.Level.PARTIALLY_EXPERIMENTALLY_VALIDATED,
-          Arrays.asList("CaCl2 mean activity at 298.15 K", "MgCl2 mean activity at 298.15 K"),
+          Arrays.asList("CaCl2 mean activity at 298.15 K", "MgCl2 mean activity at 298.15 K",
+              "MgCl2-MgSO4 water activity at 298.15 K"),
           Arrays.asList("Other catalog species are source-mapped, not independently qualified",
-              "Mixed Ca-Mg-Cl-SO4 activity and mineral precipitation remain unqualified"));
+              "Ca-bearing mixed Ca-Mg-Cl-SO4 activity and mineral precipitation remain unqualified"));
     }
     String identity = datasetId == null || datasetId.trim().isEmpty() ? "unknown" : datasetId;
     return new PitzerParameterQualification(identity, PitzerParameterQualification.Level.UNQUALIFIED,
@@ -466,6 +476,48 @@ public final class PitzerParameterDatasets {
         && Math.abs(temperature - PHREEQC_REFERENCE_TEMPERATURE_K) <= 1.0e-9
         && saltMolality >= CA_MG_CL_SO4_BINARY_VALIDATION_MIN_MOLALITY
         && saltMolality <= CA_MG_CL_SO4_BINARY_VALIDATION_MAX_MOLALITY;
+  }
+
+  /**
+   * Reports whether a mixed MgCl2-MgSO4 state is inside the independently checked water-activity envelope.
+   *
+   * <p>
+   * The evidence contains three composition lines at MgCl2 ionic-strength fractions 0.20, 0.50, and 0.80. The
+   * line-specific total formula-unit molality ranges are 0.60-2.96, 0.35-3.50, and 0.95-3.80 mol/kg water,
+   * respectively. The small fraction tolerance represents the source table's two-decimal composition rounding; this
+   * method does not qualify interpolation between the three composition lines.
+   * </p>
+   *
+   * @param temperature temperature in K
+   * @param magnesiumChlorideMolality MgCl2 formula-unit molality in mol/kg water
+   * @param magnesiumSulfateMolality MgSO4 formula-unit molality in mol/kg water
+   * @return {@code true} for finite, non-negative inputs on a checked composition line and inside its molality range
+   */
+  public static boolean isWithinMagnesiumChlorideSulfateWaterActivityValidationRange(double temperature,
+      double magnesiumChlorideMolality, double magnesiumSulfateMolality) {
+    if (!Double.isFinite(temperature) || !Double.isFinite(magnesiumChlorideMolality)
+        || !Double.isFinite(magnesiumSulfateMolality) || magnesiumChlorideMolality < 0.0
+        || magnesiumSulfateMolality < 0.0 || Math.abs(temperature - PHREEQC_REFERENCE_TEMPERATURE_K) > 1.0e-9) {
+      return false;
+    }
+    double totalMolality = magnesiumChlorideMolality + magnesiumSulfateMolality;
+    double ionicStrength = 3.0 * magnesiumChlorideMolality + 4.0 * magnesiumSulfateMolality;
+    if (totalMolality <= 0.0 || ionicStrength <= 0.0) {
+      return false;
+    }
+    double magnesiumChlorideIonicStrengthFraction = 3.0 * magnesiumChlorideMolality / ionicStrength;
+    if (Math.abs(magnesiumChlorideIonicStrengthFraction - 0.20) <= MG_CL_SO4_IONIC_STRENGTH_FRACTION_TOLERANCE) {
+      return totalMolality >= 0.60 - MG_CL_SO4_MOLALITY_BOUNDARY_TOLERANCE
+          && totalMolality <= 2.96 + MG_CL_SO4_MOLALITY_BOUNDARY_TOLERANCE;
+    }
+    if (Math.abs(magnesiumChlorideIonicStrengthFraction - 0.50) <= MG_CL_SO4_IONIC_STRENGTH_FRACTION_TOLERANCE) {
+      return totalMolality >= MG_CL_SO4_WATER_ACTIVITY_VALIDATION_MIN_TOTAL_MOLALITY
+          - MG_CL_SO4_MOLALITY_BOUNDARY_TOLERANCE && totalMolality <= 3.50 + MG_CL_SO4_MOLALITY_BOUNDARY_TOLERANCE;
+    }
+    return Math.abs(magnesiumChlorideIonicStrengthFraction - 0.80) <= MG_CL_SO4_IONIC_STRENGTH_FRACTION_TOLERANCE
+        && totalMolality >= 0.95 - MG_CL_SO4_MOLALITY_BOUNDARY_TOLERANCE
+        && totalMolality <= MG_CL_SO4_WATER_ACTIVITY_VALIDATION_MAX_TOTAL_MOLALITY
+            + MG_CL_SO4_MOLALITY_BOUNDARY_TOLERANCE;
   }
 
   private static int requiredComponentIndex(PhasePitzer phase, String componentName) {

--- a/src/test/java/neqsim/thermo/phase/PitzerMixedMagnesiumWaterActivityTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerMixedMagnesiumWaterActivityTest.java
@@ -1,0 +1,185 @@
+package neqsim.thermo.phase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.component.ComponentGePitzer;
+import neqsim.thermo.system.SystemPitzer;
+
+/** Held-out mixed MgCl2-MgSO4 water-activity validation for the PHREEQC Pitzer catalog. */
+class PitzerMixedMagnesiumWaterActivityTest extends neqsim.NeqSimTest {
+  private static final String REFERENCE_RESOURCE = "/data/chemistry_benchmarks/pitzer_mgcl2_mgso4_water_activity_298k.csv";
+
+  @Test
+  void mixedMagnesiumWaterActivityMatchesIndependentThermoMlData() throws IOException {
+    List<ReferenceState> states = readReferenceStates();
+    assertEquals(28, states.size());
+
+    double maximumAbsoluteResidual = 0.0;
+    double squaredResidualSum = 0.0;
+    int withinReportedExpandedUncertainty = 0;
+    Map<Integer, Double> previousCalculatedActivity = new HashMap<Integer, Double>();
+    Map<Integer, Double> previousExperimentalActivity = new HashMap<Integer, Double>();
+
+    for (ReferenceState state : states) {
+      SystemPitzer system = createSystem(state.magnesiumChlorideMolality, state.magnesiumSulfateMolality);
+      PhasePitzer phase = (PhasePitzer) system.getPhase(1);
+      phase.requireCompletePitzerParameterCoverage();
+
+      assertEquals(PitzerParameterDatasets.PHREEQC_PITZER_CATALOG_ID, phase.getParameterDatasetId());
+      assertTrue(PitzerParameterDatasets.isWithinMagnesiumChlorideSulfateWaterActivityValidationRange(298.15,
+          state.magnesiumChlorideMolality, state.magnesiumSulfateMolality));
+      assertMaterialAndPhaseState(phase);
+
+      double calculatedActivity = waterActivity(phase);
+      assertEquals(calculatedActivity, waterActivity(phase), 0.0, "Repeated evaluation changed water activity");
+      assertTrue(Double.isFinite(calculatedActivity) && calculatedActivity > 0.0 && calculatedActivity <= 1.0);
+      assertWaterActivityOsmoticConsistency(phase, calculatedActivity);
+
+      int compositionLine = compositionLine(state);
+      if (previousCalculatedActivity.containsKey(compositionLine)) {
+        assertTrue(calculatedActivity < previousCalculatedActivity.get(compositionLine),
+            "Calculated water activity must decrease with molality on composition line " + compositionLine);
+        assertTrue(state.waterActivity < previousExperimentalActivity.get(compositionLine),
+            "Experimental water activity must decrease with molality on composition line " + compositionLine);
+      }
+      previousCalculatedActivity.put(compositionLine, calculatedActivity);
+      previousExperimentalActivity.put(compositionLine, state.waterActivity);
+
+      double residual = calculatedActivity - state.waterActivity;
+      maximumAbsoluteResidual = Math.max(maximumAbsoluteResidual, Math.abs(residual));
+      squaredResidualSum += residual * residual;
+      if (Math.abs(residual) <= state.expandedUncertainty) {
+        withinReportedExpandedUncertainty++;
+      }
+    }
+
+    double rootMeanSquareResidual = Math.sqrt(squaredResidualSum / states.size());
+    assertTrue(maximumAbsoluteResidual <= 0.004,
+        "Maximum absolute water-activity residual: " + maximumAbsoluteResidual);
+    assertTrue(rootMeanSquareResidual <= 0.0015, "Water-activity root-mean-square residual: " + rootMeanSquareResidual);
+    assertEquals(26, withinReportedExpandedUncertainty,
+        "Number of states within the reported 95% expanded uncertainty");
+  }
+
+  @Test
+  void changedStateMatchesFreshConstructionWithoutStaleParameters() {
+    SystemPitzer changed = createSystem(0.20, 0.15);
+    double initialActivity = waterActivity((PhasePitzer) changed.getPhase(1));
+    changed.addComponent("Mg++", 0.35);
+    changed.addComponent("Cl-", 0.40);
+    changed.addComponent("SO4--", 0.15);
+    changed.init(0);
+
+    PhasePitzer changedPhase = (PhasePitzer) changed.getPhase(1);
+    changedPhase.requireCompletePitzerParameterCoverage();
+    double changedActivity = waterActivity(changedPhase);
+    double freshActivity = waterActivity((PhasePitzer) createSystem(0.40, 0.30).getPhase(1));
+    assertTrue(changedActivity < initialActivity);
+    assertEquals(freshActivity, changedActivity, 1.0e-12);
+  }
+
+  private static SystemPitzer createSystem(double magnesiumChlorideMolality, double magnesiumSulfateMolality) {
+    SystemPitzer system = new SystemPitzer(298.15, 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("Ca++", 0.0);
+    system.addComponent("Mg++", magnesiumChlorideMolality + magnesiumSulfateMolality);
+    system.addComponent("Cl-", 2.0 * magnesiumChlorideMolality);
+    system.addComponent("SO4--", magnesiumSulfateMolality);
+    system.setMixingRule("classic");
+    system.init(0);
+    system.applyPhreeqcCalciumMagnesiumChlorideSulfateParameters();
+    return system;
+  }
+
+  private static void assertMaterialAndPhaseState(PhasePitzer phase) {
+    double compositionSum = 0.0;
+    double chargeResidual = 0.0;
+    for (int component = 0; component < phase.getNumberOfComponents(); component++) {
+      double moleFraction = phase.getComponent(component).getx();
+      assertTrue(Double.isFinite(moleFraction) && moleFraction >= 0.0);
+      compositionSum += moleFraction;
+      chargeResidual += phase.getComponent(component).getMolality(phase)
+          * phase.getComponent(component).getIonicCharge();
+    }
+    assertEquals(1.0, compositionSum, 1.0e-12);
+    assertEquals(0.0, chargeResidual, 1.0e-12);
+
+    double magnesiumMolality = phase.getComponent("Mg++").getMolality(phase);
+    double chlorideFormulaMolality = 0.5 * phase.getComponent("Cl-").getMolality(phase);
+    double sulfateFormulaMolality = phase.getComponent("SO4--").getMolality(phase);
+    assertEquals(magnesiumMolality, chlorideFormulaMolality + sulfateFormulaMolality, 1.0e-12,
+        "Formula-unit Mg material balance");
+  }
+
+  private static void assertWaterActivityOsmoticConsistency(PhasePitzer phase, double activity) {
+    double totalIonMolality = 0.0;
+    for (int component = 0; component < phase.getNumberOfComponents(); component++) {
+      if (Math.abs(phase.getComponent(component).getIonicCharge()) >= 0.5) {
+        totalIonMolality += phase.getComponent(component).getMolality(phase);
+      }
+    }
+    double osmoticCoefficientFromActivity = -1000.0 * Math.log(activity) / (18.015 * totalIonMolality);
+    assertEquals(osmoticCoefficientFromActivity, phase.getOsmoticCoefficientOfWater(), 2.0e-10);
+  }
+
+  private static double waterActivity(PhasePitzer phase) {
+    int water = phase.getComponent("water").getComponentNumber();
+    ComponentGePitzer waterComponent = (ComponentGePitzer) phase.getComponent(water);
+    return waterComponent.getGamma(phase, phase.getNumberOfComponents(), phase.getTemperature(), phase.getPressure(),
+        phase.getType()) * phase.getComponent(water).getx();
+  }
+
+  private List<ReferenceState> readReferenceStates() throws IOException {
+    InputStream input = getClass().getResourceAsStream(REFERENCE_RESOURCE);
+    assertNotNull(input, "Missing validation resource " + REFERENCE_RESOURCE);
+    List<ReferenceState> states = new ArrayList<ReferenceState>();
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.trim().isEmpty() || line.startsWith("#") || line.startsWith("mgcl2_")) {
+          continue;
+        }
+        String[] fields = line.split(",", -1);
+        assertEquals(4, fields.length, "Unexpected validation row: " + line);
+        states.add(new ReferenceState(Double.parseDouble(fields[0]), Double.parseDouble(fields[1]),
+            Double.parseDouble(fields[2]), Double.parseDouble(fields[3])));
+      }
+    }
+    return states;
+  }
+
+  private static int compositionLine(ReferenceState state) {
+    double fraction = 3.0 * state.magnesiumChlorideMolality
+        / (3.0 * state.magnesiumChlorideMolality + 4.0 * state.magnesiumSulfateMolality);
+    if (fraction < 0.35) {
+      return 20;
+    }
+    return fraction < 0.65 ? 50 : 80;
+  }
+
+  private static final class ReferenceState {
+    private final double magnesiumChlorideMolality;
+    private final double magnesiumSulfateMolality;
+    private final double waterActivity;
+    private final double expandedUncertainty;
+
+    private ReferenceState(double magnesiumChlorideMolality, double magnesiumSulfateMolality, double waterActivity,
+        double expandedUncertainty) {
+      this.magnesiumChlorideMolality = magnesiumChlorideMolality;
+      this.magnesiumSulfateMolality = magnesiumSulfateMolality;
+      this.waterActivity = waterActivity;
+      this.expandedUncertainty = expandedUncertainty;
+    }
+  }
+}

--- a/src/test/java/neqsim/thermo/phase/PitzerParameterDatasetsTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerParameterDatasetsTest.java
@@ -425,7 +425,8 @@ class PitzerParameterDatasetsTest extends neqsim.NeqSimTest {
     assertEquals(PitzerParameterQualification.Level.PARTIALLY_EXPERIMENTALLY_VALIDATED, scaleFamily.getLevel());
     assertFalse(scaleFamily.isValidatedWithinDeclaredEnvelope());
     assertTrue(scaleFamily.getValidatedSystems().toString().contains("MgCl2"));
-    assertTrue(scaleFamily.getLimitations().toString().contains("Mixed Ca-Mg-Cl-SO4"));
+    assertTrue(scaleFamily.getValidatedSystems().toString().contains("MgCl2-MgSO4 water activity"));
+    assertTrue(scaleFamily.getLimitations().toString().contains("Ca-bearing mixed Ca-Mg-Cl-SO4"));
     assertThrows(UnsupportedOperationException.class, () -> scaleFamily.getLimitations().add("unsafe"));
 
     PitzerParameterQualification unknown = PitzerParameterDatasets.getQualification("private-project-dataset");
@@ -435,6 +436,13 @@ class PitzerParameterDatasetsTest extends neqsim.NeqSimTest {
     assertTrue(PitzerParameterDatasets.isWithinCalciumMagnesiumChlorideBinaryValidationRange(298.15, 2.0));
     assertFalse(PitzerParameterDatasets.isWithinCalciumMagnesiumChlorideBinaryValidationRange(298.15, 2.1));
     assertFalse(PitzerParameterDatasets.isWithinCalciumMagnesiumChlorideBinaryValidationRange(323.15, 1.0));
+    assertTrue(PitzerParameterDatasets.isWithinMagnesiumChlorideSulfateWaterActivityValidationRange(298.15, 0.2, 0.15));
+    assertTrue(
+        PitzerParameterDatasets.isWithinMagnesiumChlorideSulfateWaterActivityValidationRange(298.15, 0.15, 0.45));
+    assertTrue(PitzerParameterDatasets.isWithinMagnesiumChlorideSulfateWaterActivityValidationRange(298.15, 3.2, 0.6));
+    assertFalse(PitzerParameterDatasets.isWithinMagnesiumChlorideSulfateWaterActivityValidationRange(298.15, 0.1, 0.1));
+    assertFalse(
+        PitzerParameterDatasets.isWithinMagnesiumChlorideSulfateWaterActivityValidationRange(323.15, 0.2, 0.15));
   }
 
   @Test

--- a/src/test/resources/data/chemistry_benchmarks/pitzer_mgcl2_mgso4_water_activity_298k.csv
+++ b/src/test/resources/data/chemistry_benchmarks/pitzer_mgcl2_mgso4_water_activity_298k.csv
@@ -1,0 +1,36 @@
+# Guendouzi and Errougui (2007), J. Chem. Eng. Data 52, 2188-2194.
+# DOI: https://doi.org/10.1021/je7002176
+# Source: NIST ThermoML JSON https://trc.nist.gov/ThermoML/10.1021/je7002176.json
+# ThermoML MD5: 29969a5f814eb0ad6d7ca5b4f093b658; accessed 2026-08-25.
+# License: https://www.nist.gov/open/license; numerical values are an unchanged subset and NIST is acknowledged.
+# Conditions: 298.15 K, 101 kPa; molality scale; H2O pure-compound standard state; hygrometric method.
+# expanded_uncertainty_aw is the ThermoML 95% combined expanded uncertainty evaluated by the data-file compiler.
+mgcl2_molality_mol_per_kg,mgso4_molality_mol_per_kg,water_activity,expanded_uncertainty_aw
+0.15,0.45,0.983,0.001
+0.20,0.15,0.987,0.001
+0.20,0.60,0.977,0.001
+0.25,0.75,0.970,0.001
+0.30,0.90,0.963,0.001
+0.40,0.30,0.971,0.001
+0.40,1.20,0.946,0.002
+0.50,1.50,0.925,0.002
+0.60,0.45,0.955,0.001
+0.60,1.80,0.898,0.004
+0.70,2.10,0.870,0.004
+0.74,2.22,0.857,0.003
+0.80,0.15,0.951,0.001
+0.80,0.60,0.934,0.002
+1.00,0.75,0.910,0.002
+1.07,0.20,0.929,0.002
+1.20,0.90,0.882,0.004
+1.30,0.24,0.906,0.002
+1.40,1.05,0.850,0.003
+1.60,0.30,0.873,0.004
+1.60,1.20,0.816,0.003
+1.80,1.35,0.777,0.003
+1.85,0.35,0.842,0.003
+2.00,1.50,0.738,0.003
+2.13,0.40,0.805,0.003
+2.40,0.45,0.766,0.003
+2.78,0.52,0.708,0.003
+3.20,0.60,0.640,0.003


### PR DESCRIPTION
## Summary

Advances #3144 by independently qualifying the existing public-domain PHREEQC Pitzer catalogue for mixed MgCl₂–MgSO₄ water activity, without refitting or changing any interaction coefficient or thermodynamic kernel.

- stores a licensed 28-point NIST ThermoML validation subset with checksum, uncertainty, standard-state, unit, and source metadata
- adds a fail-closed range diagnostic for the three measured MgCl₂ ionic-strength-fraction lines
- adds regression gates for water activity, osmotic consistency, formula-unit material balance, electroneutrality, normalized/non-negative state, monotonic trends, repeated execution, changed-state freshness, and complete interaction coverage
- updates qualification metadata and the durable Pitzer source-comparison/provenance matrix
- leaves Ca-bearing mixed brines and mineral precipitation explicitly unqualified

## Frozen scientific scope

- **Base:** `a2f7a2d8e892a1e7a57fea927c66d865194aea92`
- **Head:** `c2b0e6d3b3a78aa2b078d64d2766ffead97cf40b`
- **Model:** `SystemPitzer`, classic Pitzer electrolyte-GE path, dataset `usgs-phreeqc-pitzer-b0b3be767158ccc3322d2c816625cf470045e67e-catalog-v1`
- **State:** 298.15 K, 1.01325 bar; H₂O/Mg²⁺/Cl⁻/SO₄²⁻ with zero-amount Ca²⁺ present for the named four-ion catalogue adapter
- **Composition basis:** Mg²⁺ = m(MgCl₂)+m(MgSO₄), Cl⁻ = 2m(MgCl₂), SO₄²⁻ = m(MgSO₄), water basis 55.508 mol
- **Stop boundary:** no coefficient adoption, reaction/log-K table, flash, phase-stability, mineral, electrolyte-EOS, absorber, or salt-input/API change

## Public evidence and conventions

Primary experiment: Guendouzi and Errougui (2007), *J. Chem. Eng. Data* 52, 2188–2194, [DOI 10.1021/je7002176](https://doi.org/10.1021/je7002176).

The stored values are the unchanged MgCl₂–MgSO₄ subset from the [NIST ThermoML record](https://trc.nist.gov/ThermoML/10.1021/je7002176.html), JSON MD5 `29969a5f814eb0ad6d7ca5b4f093b658`, accessed 2026-08-25. The record specifies 298.15 K, 101 kPa, molality composition, pure-water activity standard state, hygrometric method, and per-state 95% combined expanded uncertainty of 0.001–0.004. Redistribution follows the [NIST public-data license](https://www.nist.gov/open/license) and acknowledges NIST.

This evidence is independent of the PHREEQC parameter-regression lineage. It evaluates the existing coherent β⁽⁰⁾/β⁽¹⁾/β⁽²⁾/Cφ/θ/ψ/alpha/electrostatic mapping as a calculation; it does not transfer the paper's fitted mixing parameters or mix model families.

Kaasa (1998) remains a provenance index only. No thesis value was copied or adopted. The source matrix retains the verified Kaasa/PHREEQC six-term coefficient-order mapping and the licensing/row-lineage blockers.

## Numerical evidence

Across 28 held-out states at MgCl₂ ionic-strength fractions 0.20, 0.50, and 0.80 and total formula-unit molality 0.35–3.80 mol/kg:

- maximum absolute water-activity residual: **0.002985025686577103** (gate ≤ 0.004)
- RMSE: **0.0012747460106933936** (gate ≤ 0.0015)
- states inside their individual reported 95% expanded uncertainty: **26/28**
- calculated and experimental water activity decrease monotonically on all three composition lines
- aqueous charge and formula-unit Mg balance close within **1e-12**
- repeated evaluation is bitwise stable; changed-state result matches fresh construction within **1e-12**

No parameter was fitted to these data.

## Performance and compatibility

Only cold-path qualification metadata/range diagnostics, tests, data, and documentation change. Activity, osmotic, flash, and physical-property kernels are untouched; neutral PR/SRK/CPA and electrolyte-EOS paths do no new work.

`PitzerCatalogPerformanceBenchmark` after warmup:

- mixed-ion activity/osmotic kernel median: **10.542 µs**
- complete aqueous `init(3)` + physical properties median: **0.168756 ms**
- neutral SRK control: **31.940 µs before**, **22.576 µs after**, ratio **0.707** (additional JIT warmup, not a regression)

## Validation

- [x] `python3 devtools/run_spotless.py apply`
- [x] `python3 devtools/run_spotless.py check`
- [x] focused `PitzerMixedMagnesiumWaterActivityTest,PitzerParameterDatasetsTest`: 25 tests passed
- [x] explicit broader Pitzer/SystemPitzer/reaction/scale suite: 78 tests passed
- [x] `python3 devtools/check_documentation_search.py`: 659 Markdown + 1 HTML source passed
- [x] `git diff --check`
- [ ] full `./mvnw test` not run locally; CI remains authoritative for the repository-wide matrix
- [ ] independent CODEOWNERS/domain review not yet requested (draft PR)

The local `pre-commit` executable was unavailable; its configured Spotless and documentation-search gates were run directly. No direct mandatory scoped gate is known to fail.

## Repository checklist

- [ ] Confirm `./mvnw test` runs successfully
- [x] Verify code formatting using the repository Spotless gate
- [x] Update relevant documentation
- [x] Link to associated issue: #3144
- [ ] Request applicable CODEOWNERS and record independent domain review
- [x] NRC/migration note not applicable: additive qualification metadata and diagnostics only

## Coordination and remaining limits

Generic TP-flash remains with #2937, reactive-absorber equipment with #205, and salt input/API with #448. This PR does not overlap those scopes.

Next dependency after this PR is Ca-bearing mixed-brine activity or solubility evidence with redistributable primary data. Mineral saturation/precipitation complementarity is a separate physical-model batch.