### PR TITLE
[AI-Assisted] feat(mcp): qualify read-only catalog contract evidence

### DIFF
--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -20,7 +20,8 @@ manually maintained Java method list.
 | MCP protocol scenarios | 94 | `getCapabilities.phase0EvidenceInventory` | `test_mcp_server.py` |
 | MCP guides | 8 | `getCapabilities.phase0EvidenceInventory` | Core guides, foundation traceability, fixtures, baseline harness, and campaign matrix |
 | Explicit benchmark-trust pages | 20 of 71 tools | `getBenchmarkTrust` and `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust` |
-| Trust coverage records | 71 = 20 explicit benchmark + 8 contract-tested non-numerical contracts + 43 confirmed gaps | `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust`, `McpImplementationInventory`, MCP contract tests |
+| Trust coverage records | 71 = 20 explicit benchmark + 6 contract-tested non-numerical contracts + 45 confirmed gaps | `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust`, `McpImplementationInventory`, MCP contract tests |
+| Contract-promotion candidates | 2 | `getCapabilities.phase0EvidenceInventory` | Existing runner tests plus real MCP protocol scenarios |
 
 The tool regression asserts the exact 71-name set grouped by its current trust tier. It also calls
 `getCapabilities` and requires `toolCatalogCoverage.complete`, equal published and described tool
@@ -118,28 +119,42 @@ from `getBenchmarkTrust`.
 
 Phase 0 does not equate that generic benchmark fallback with an unresolved scientific gap when the
 tool is intrinsically non-numerical. `knownLimitations.coverageRecords` contains one deterministic
-record for every published tool and now uses three bounded states:
+record for every published tool and uses three bounded states:
 
 - `EXPLICIT_TRUST` — a tool-specific `BenchmarkTrust` page exists, with its declared maturity and
   counts for validation cases, verified cases, limitations, and unsupported conditions;
 - `CONTRACT_TESTED` — the tool is non-numerical and its exact source, test, and real-protocol
-  evidence is listed in `contractEvidenceSources`. This applies to capability/schema/example
-  discovery, component lookup and read-only data-catalog retrieval, trust-catalog retrieval, and
-  industrial-profile access/governance policy. It does not validate advertised calculations,
-  database contents, standards applicability, EOS accuracy, component-property models, the
-  scientific claims inside trust pages, external identity or authorization, a facility
-  deployment, or accountable engineering approval; or
+  evidence is listed in `contractEvidenceSources`. This currently applies to capability/schema/
+  example discovery plus trust-catalog retrieval and industrial-profile access/governance policy.
+  It does not validate advertised calculations, the scientific claims inside trust pages, external
+  identity or authorization, a facility deployment, or accountable engineering approval; or
 - `CONFIRMED_GAP` — no tool-specific benchmark trust page or bounded non-numerical contract
-  evidence closes the gap. The record names the implementation class, retains the compatibility
-  maturity, and explicitly states that generic `TESTED` is not benchmark, accuracy,
+  classification closes the gap. The record names the implementation class, retains the
+  compatibility maturity, and explicitly states that generic `TESTED` is not benchmark, accuracy,
   applicability, or no-limitations evidence.
 
 Accordingly, `coverageComplete=true` means all 71 published tools have an explicit trust-coverage
-classification. It does **not** mean the MCP surface is scientifically validated: 43 records remain
-`CONFIRMED_GAP`, eight are `CONTRACT_TESTED`, `scientificValidationComplete=false`, and the overall
+classification. It does **not** mean the MCP surface is scientifically validated: 45 records remain
+`CONFIRMED_GAP`, six are `CONTRACT_TESTED`, `scientificValidationComplete=false`, and the overall
 Phase 0 `complete` flag remains false. The benchmark registry itself remains unchanged at 20
 explicit pages and 51 generic benchmark fallbacks, so existing benchmark-report accounting and
 protocol contracts are preserved.
+
+### Evidence-qualified promotion candidates
+
+Two of the 45 confirmed gaps now carry separate bounded promotion-candidate records. These records
+make the supporting evidence and stop boundary machine-readable without changing the frozen
+classification accounting:
+
+| Candidate | Existing direct evidence | Boundary |
+| --- | --- | --- |
+| `searchComponents` | `ComponentQuery`, `ComponentQueryTest`, and real MCP searches for exact, partial, empty, and no-match queries | Component lookup behavior only; no thermodynamic calculation or component-property-model validation |
+| `queryDataCatalog` | `DataCatalogRunner`, `DataCatalogRunnerTest`, and real MCP EOS/component-family catalog calls | Read-only catalog dispatch/retrieval only; no database-content, standards-applicability, EOS-accuracy, materials, or design validation |
+
+Each candidate targets `CONTRACT_TESTED` but explicitly reports `promotionReady=false`. Promotion
+requires one atomic exact-head change that updates both the evidence classification and the
+packaged protocol's frozen 6/45 accounting, followed by hosted validation. Until then both tools
+remain `CONFIRMED_GAP`; the candidate record is evidence traceability, not a maturity claim.
 
 Per-result provenance, convergence, warnings, assumptions, and limitations remain authoritative
 for an executed calculation. The evidence inventory is advisory discovery metadata; it does not
@@ -180,14 +195,15 @@ deployment-profile names, tool-capability reconciliation, schema resource graph,
 graph, tool implementation bindings, factory-backed equipment, report paths, test sources, guides,
 merged-foundation reconciliation, four public synthetic acceptance scales, bounded acceptance
 baseline harness, campaign traceability/maturity matrix, and explicit trust-coverage status for
-every published tool. Eight non-numerical discovery, catalog, lookup, trust-retrieval, and
-governance tools are contract-tested without being misrepresented as scientifically benchmarked
-calculations or as plant-authority controls.
+every published tool. Six non-numerical discovery, catalog, trust-retrieval, and governance tools
+remain contract-tested; two additional read-only lookup/catalog gaps now have bounded promotion
+candidate evidence without being prematurely reclassified.
 
-Follow-up work should close the remaining 43 confirmed trust gaps only where current source and
-public evidence support a specific claim, and continue closing explicit numeric component,
-energy, and facility-wide conservation/report gaps only where canonical NeqSim APIs provide
-independent evidence. Later-phase campaign criteria remain incomplete until their own merged
+Follow-up work should atomically promote those candidates only when the packaged protocol
+classification contract is updated and validated on the same exact head. The remaining 45
+confirmed trust gaps should be closed only where current source and public evidence support a
+specific claim, and explicit numeric component, energy, and facility-wide conservation/report gaps
+remain separate work. Later-phase campaign criteria remain incomplete until their own merged
 acceptance evidence exists.
 
 DEXPI/P&ID ingestion remains owned by #2899, dynamics by #2911, flash/stability/performance by

--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -20,7 +20,7 @@ manually maintained Java method list.
 | MCP protocol scenarios | 94 | `getCapabilities.phase0EvidenceInventory` | `test_mcp_server.py` |
 | MCP guides | 8 | `getCapabilities.phase0EvidenceInventory` | Core guides, foundation traceability, fixtures, baseline harness, and campaign matrix |
 | Explicit benchmark-trust pages | 20 of 71 tools | `getBenchmarkTrust` and `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust` |
-| Trust coverage records | 71 = 20 explicit benchmark + 6 contract-tested non-numerical contracts + 45 confirmed gaps | `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust`, `McpImplementationInventory`, MCP contract tests |
+| Trust coverage records | 71 = 20 explicit benchmark + 8 contract-tested non-numerical contracts + 43 confirmed gaps | `getCapabilities.phase0EvidenceInventory` | `BenchmarkTrust`, `McpImplementationInventory`, MCP contract tests |
 
 The tool regression asserts the exact 71-name set grouped by its current trust tier. It also calls
 `getCapabilities` and requires `toolCatalogCoverage.complete`, equal published and described tool
@@ -124,17 +124,19 @@ record for every published tool and now uses three bounded states:
   counts for validation cases, verified cases, limitations, and unsupported conditions;
 - `CONTRACT_TESTED` — the tool is non-numerical and its exact source, test, and real-protocol
   evidence is listed in `contractEvidenceSources`. This applies to capability/schema/example
-  discovery plus trust-catalog retrieval and industrial-profile access/governance policy. It does
-  not validate advertised calculations, the scientific claims inside trust pages, external
-  identity or authorization, a facility deployment, or accountable engineering approval; or
+  discovery, component lookup and read-only data-catalog retrieval, trust-catalog retrieval, and
+  industrial-profile access/governance policy. It does not validate advertised calculations,
+  database contents, standards applicability, EOS accuracy, component-property models, the
+  scientific claims inside trust pages, external identity or authorization, a facility
+  deployment, or accountable engineering approval; or
 - `CONFIRMED_GAP` — no tool-specific benchmark trust page or bounded non-numerical contract
   evidence closes the gap. The record names the implementation class, retains the compatibility
   maturity, and explicitly states that generic `TESTED` is not benchmark, accuracy,
   applicability, or no-limitations evidence.
 
 Accordingly, `coverageComplete=true` means all 71 published tools have an explicit trust-coverage
-classification. It does **not** mean the MCP surface is scientifically validated: 45 records remain
-`CONFIRMED_GAP`, six are `CONTRACT_TESTED`, `scientificValidationComplete=false`, and the overall
+classification. It does **not** mean the MCP surface is scientifically validated: 43 records remain
+`CONFIRMED_GAP`, eight are `CONTRACT_TESTED`, `scientificValidationComplete=false`, and the overall
 Phase 0 `complete` flag remains false. The benchmark registry itself remains unchanged at 20
 explicit pages and 51 generic benchmark fallbacks, so existing benchmark-report accounting and
 protocol contracts are preserved.
@@ -178,11 +180,11 @@ deployment-profile names, tool-capability reconciliation, schema resource graph,
 graph, tool implementation bindings, factory-backed equipment, report paths, test sources, guides,
 merged-foundation reconciliation, four public synthetic acceptance scales, bounded acceptance
 baseline harness, campaign traceability/maturity matrix, and explicit trust-coverage status for
-every published tool. Six non-numerical discovery, catalog, trust-retrieval, and governance tools
-are contract-tested without being misrepresented as scientifically benchmarked calculations or
-as plant-authority controls.
+every published tool. Eight non-numerical discovery, catalog, lookup, trust-retrieval, and
+governance tools are contract-tested without being misrepresented as scientifically benchmarked
+calculations or as plant-authority controls.
 
-Follow-up work should close the remaining 45 confirmed trust gaps only where current source and
+Follow-up work should close the remaining 43 confirmed trust gaps only where current source and
 public evidence support a specific claim, and continue closing explicit numeric component,
 energy, and facility-wide conservation/report gaps only where canonical NeqSim APIs provide
 independent evidence. Later-phase campaign criteria remain incomplete until their own merged

--- a/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
@@ -213,6 +213,7 @@ public final class McpEvidenceInventory {
     coverageDefinitions.addProperty("CONFIRMED_GAP",
         "No tool-specific BenchmarkTrust entry or bounded non-numerical contract evidence closes the gap; generic fallback maturity must not be interpreted as benchmark validation");
 
+    JsonObject promotionCandidates = buildContractPromotionCandidates();
     JsonObject limitations = new JsonObject();
     limitations.addProperty("sourceTool", "getBenchmarkTrust");
     limitations.addProperty("publishedToolCount", publishedTools.size());
@@ -234,12 +235,51 @@ public final class McpEvidenceInventory {
     limitations.add("contractTestedTools", toJsonArray(contractTestedTools));
     limitations.add("coverageStatusDefinitions", coverageDefinitions);
     limitations.add("coverageRecords", coverageRecords);
+    limitations.addProperty("contractPromotionCandidateCount", promotionCandidates.size());
+    limitations.add("contractPromotionCandidates", promotionCandidates);
+    limitations.addProperty("promotionBoundary",
+        "Promotion candidates remain CONFIRMED_GAP until their classification accounting and packaged protocol contract are changed together on one validated exact head");
     limitations.addProperty("complete", genericTools.isEmpty());
     limitations.addProperty("gapBoundary",
-        "Every published tool has an explicit coverage record; eight non-numerical discovery, catalog, lookup, trust, and governance tools are contract-tested without numerical benchmark claims, while CONFIRMED_GAP identifies the remaining missing tool-specific trust evidence");
+        "Every published tool has an explicit coverage record; six non-numerical discovery, catalog, trust, and governance tools are contract-tested without numerical benchmark claims, while CONFIRMED_GAP identifies the remaining missing tool-specific trust evidence");
     limitations.addProperty("resultBoundary",
         "Per-result provenance, convergence, warnings, assumptions, and limitations remain authoritative for an executed case");
     return limitations;
+  }
+
+  /**
+   * Builds evidence-qualified candidates for a future atomic contract-status promotion.
+   *
+   * @return candidate records keyed by public MCP tool name
+   */
+  private static JsonObject buildContractPromotionCandidates() {
+    JsonObject candidates = new JsonObject();
+    candidates.add("searchComponents",
+        contractPromotionCandidate("NOT_APPLICABLE_NON_NUMERICAL_COMPONENT_CATALOG_LOOKUP",
+            new String[] { "src/main/java/neqsim/mcp/runners/ComponentQuery.java",
+                "src/test/java/neqsim/mcp/runners/ComponentQueryTest.java", "neqsim-mcp-server/test_mcp_server.py" },
+            "Component-name lookup, substring search, empty-query enumeration, typo handling, and no-match behavior are directly tested, including real-protocol retrieval; catalog lookup does not validate thermodynamic calculations or component-property models"));
+    candidates.add("queryDataCatalog",
+        contractPromotionCandidate("NOT_APPLICABLE_NON_NUMERICAL_DATA_CATALOG_DISCOVERY",
+            new String[] { "src/main/java/neqsim/mcp/runners/DataCatalogRunner.java",
+                "src/test/java/neqsim/mcp/runners/DataCatalogRunnerTest.java", "neqsim-mcp-server/test_mcp_server.py" },
+            "Read-only catalog dispatch and representative component-family, EOS-model, component-property, and real-protocol catalog retrieval are tested; database contents, standards applicability, EOS accuracy, and material or design decisions are not validated by this evidence"));
+    return candidates;
+  }
+
+  /** Builds one bounded contract-promotion candidate. */
+  private static JsonObject contractPromotionCandidate(String benchmarkApplicability, String[] evidenceSources,
+      String evidenceBoundary) {
+    JsonObject candidate = new JsonObject();
+    candidate.addProperty("targetCoverageStatus", "CONTRACT_TESTED");
+    candidate.addProperty("benchmarkApplicability", benchmarkApplicability);
+    candidate.addProperty("contractEvidenceCount", evidenceSources.length);
+    candidate.add("contractEvidenceSources", toJsonArray(java.util.Arrays.asList(evidenceSources)));
+    candidate.addProperty("evidenceBoundary", evidenceBoundary);
+    candidate.addProperty("promotionReady", false);
+    candidate.addProperty("remainingGate",
+        "Update frozen protocol classification accounting atomically and pass exact-head hosted validation before changing coverageStatus");
+    return candidate;
   }
 
   /**
@@ -295,18 +335,6 @@ public final class McpEvidenceInventory {
           "src/test/java/neqsim/mcp/runners/McpPrincipalScopingTest.java",
           "src/test/java/neqsim/mcp/runners/McpSecurityEnforcementTest.java", "neqsim-mcp-server/test_mcp_server.py" };
       evidenceBoundary = "Profile discovery, classification, admin-gated mode changes, and principal-scoped one-shot approvals are contract-tested; deployments still require external identity, policy configuration, and accountable review";
-      break;
-    case "searchComponents":
-      benchmarkApplicability = "NOT_APPLICABLE_NON_NUMERICAL_COMPONENT_CATALOG_LOOKUP";
-      evidenceSources = new String[] { "src/main/java/neqsim/mcp/runners/ComponentQuery.java",
-          "src/test/java/neqsim/mcp/runners/ComponentQueryTest.java", "neqsim-mcp-server/test_mcp_server.py" };
-      evidenceBoundary = "Component-name lookup, substring search, empty-query enumeration, typo handling, and no-match behavior are directly tested, including real-protocol retrieval; catalog lookup does not validate thermodynamic calculations or component-property models";
-      break;
-    case "queryDataCatalog":
-      benchmarkApplicability = "NOT_APPLICABLE_NON_NUMERICAL_DATA_CATALOG_DISCOVERY";
-      evidenceSources = new String[] { "src/main/java/neqsim/mcp/runners/DataCatalogRunner.java",
-          "src/test/java/neqsim/mcp/runners/DataCatalogRunnerTest.java", "neqsim-mcp-server/test_mcp_server.py" };
-      evidenceBoundary = "Read-only catalog dispatch and representative component-family, EOS-model, component-property, and real-protocol catalog retrieval are contract-tested; database contents, standards applicability, EOS accuracy, and material or design decisions are not validated by this classification";
       break;
     default:
       return false;

--- a/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
@@ -28,7 +28,7 @@ public final class McpEvidenceInventory {
    */
   public static JsonObject build() {
     JsonObject inventory = new JsonObject();
-    inventory.addProperty("inventoryVersion", "1.8");
+    inventory.addProperty("inventoryVersion", "1.9");
     inventory.add("tests", buildTests());
     inventory.add("guides", buildGuides());
     inventory.add("mergedFoundations", buildMergedFoundations());
@@ -236,7 +236,7 @@ public final class McpEvidenceInventory {
     limitations.add("coverageRecords", coverageRecords);
     limitations.addProperty("complete", genericTools.isEmpty());
     limitations.addProperty("gapBoundary",
-        "Every published tool has an explicit coverage record; six non-numerical discovery, catalog, trust, and governance tools are contract-tested without numerical benchmark claims, while CONFIRMED_GAP identifies the remaining missing tool-specific trust evidence");
+        "Every published tool has an explicit coverage record; eight non-numerical discovery, catalog, lookup, trust, and governance tools are contract-tested without numerical benchmark claims, while CONFIRMED_GAP identifies the remaining missing tool-specific trust evidence");
     limitations.addProperty("resultBoundary",
         "Per-result provenance, convergence, warnings, assumptions, and limitations remain authoritative for an executed case");
     return limitations;
@@ -295,6 +295,18 @@ public final class McpEvidenceInventory {
           "src/test/java/neqsim/mcp/runners/McpPrincipalScopingTest.java",
           "src/test/java/neqsim/mcp/runners/McpSecurityEnforcementTest.java", "neqsim-mcp-server/test_mcp_server.py" };
       evidenceBoundary = "Profile discovery, classification, admin-gated mode changes, and principal-scoped one-shot approvals are contract-tested; deployments still require external identity, policy configuration, and accountable review";
+      break;
+    case "searchComponents":
+      benchmarkApplicability = "NOT_APPLICABLE_NON_NUMERICAL_COMPONENT_CATALOG_LOOKUP";
+      evidenceSources = new String[] { "src/main/java/neqsim/mcp/runners/ComponentQuery.java",
+          "src/test/java/neqsim/mcp/runners/ComponentQueryTest.java", "neqsim-mcp-server/test_mcp_server.py" };
+      evidenceBoundary = "Component-name lookup, substring search, empty-query enumeration, typo handling, and no-match behavior are directly tested, including real-protocol retrieval; catalog lookup does not validate thermodynamic calculations or component-property models";
+      break;
+    case "queryDataCatalog":
+      benchmarkApplicability = "NOT_APPLICABLE_NON_NUMERICAL_DATA_CATALOG_DISCOVERY";
+      evidenceSources = new String[] { "src/main/java/neqsim/mcp/runners/DataCatalogRunner.java",
+          "src/test/java/neqsim/mcp/runners/DataCatalogRunnerTest.java", "neqsim-mcp-server/test_mcp_server.py" };
+      evidenceBoundary = "Read-only catalog dispatch and representative component-family, EOS-model, component-property, and real-protocol catalog retrieval are contract-tested; database contents, standards applicability, EOS accuracy, and material or design decisions are not validated by this classification";
       break;
     default:
       return false;

--- a/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
@@ -53,15 +53,17 @@ class McpEvidenceInventoryFoundationTests {
     assertEquals(71, limitations.get("publishedToolCount").getAsInt());
     assertEquals(71, limitations.get("coverageRecordCount").getAsInt());
     assertEquals(20, limitations.get("explicitCoverageRecordCount").getAsInt());
-    assertEquals(6, limitations.get("contractTestedToolCount").getAsInt());
-    assertEquals(45, limitations.get("confirmedGapToolCount").getAsInt());
-    assertEquals(6, limitations.getAsJsonArray("contractTestedTools").size());
+    assertEquals(8, limitations.get("contractTestedToolCount").getAsInt());
+    assertEquals(43, limitations.get("confirmedGapToolCount").getAsInt());
+    assertEquals(8, limitations.getAsJsonArray("contractTestedTools").size());
     assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("getCapabilities"));
     assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("getSchema"));
     assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("getExample"));
     assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("getBenchmarkTrust"));
     assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("checkToolAccess"));
     assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("manageIndustrialProfile"));
+    assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("searchComponents"));
+    assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("queryDataCatalog"));
     assertEquals(71, coverageRecords.size());
     assertTrue(limitations.get("coverageComplete").getAsBoolean());
     assertFalse(limitations.get("scientificValidationComplete").getAsBoolean());
@@ -116,6 +118,24 @@ class McpEvidenceInventoryFoundationTests {
     assertEquals(5, profile.get("contractEvidenceCount").getAsInt());
     assertEquals(5, profile.getAsJsonArray("contractEvidenceSources").size());
     assertTrue(profile.get("evidenceBoundary").getAsString().contains("external identity"));
+
+    JsonObject componentSearch = coverageRecords.getAsJsonObject("searchComponents");
+    assertEquals("CONTRACT_TESTED", componentSearch.get("coverageStatus").getAsString());
+    assertEquals("NOT_APPLICABLE_NON_NUMERICAL_COMPONENT_CATALOG_LOOKUP",
+        componentSearch.get("benchmarkApplicability").getAsString());
+    assertEquals(3, componentSearch.get("contractEvidenceCount").getAsInt());
+    assertEquals(3, componentSearch.getAsJsonArray("contractEvidenceSources").size());
+    assertTrue(componentSearch.get("evidenceBoundary").getAsString().contains("real-protocol retrieval"));
+    assertTrue(componentSearch.get("evidenceBoundary").getAsString().contains("does not validate thermodynamic"));
+
+    JsonObject dataCatalog = coverageRecords.getAsJsonObject("queryDataCatalog");
+    assertEquals("CONTRACT_TESTED", dataCatalog.get("coverageStatus").getAsString());
+    assertEquals("NOT_APPLICABLE_NON_NUMERICAL_DATA_CATALOG_DISCOVERY",
+        dataCatalog.get("benchmarkApplicability").getAsString());
+    assertEquals(3, dataCatalog.get("contractEvidenceCount").getAsInt());
+    assertEquals(3, dataCatalog.getAsJsonArray("contractEvidenceSources").size());
+    assertTrue(dataCatalog.get("evidenceBoundary").getAsString().contains("Read-only catalog"));
+    assertTrue(dataCatalog.get("evidenceBoundary").getAsString().contains("standards applicability"));
     assertFalse(inventory.get("complete").getAsBoolean());
   }
 
@@ -125,7 +145,7 @@ class McpEvidenceInventoryFoundationTests {
     JsonObject inventory = capabilities.getAsJsonObject("phase0EvidenceInventory");
     JsonObject fixtures = inventory.getAsJsonObject("acceptanceFixtures");
 
-    assertEquals("1.8", inventory.get("inventoryVersion").getAsString());
+    assertEquals("1.9", inventory.get("inventoryVersion").getAsString());
     assertEquals(8, inventory.getAsJsonObject("guides").get("guideCount").getAsInt());
     assertEquals(4, fixtures.get("fixtureCount").getAsInt());
     assertTrue(fixtures.get("complete").getAsBoolean());

--- a/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
@@ -53,17 +53,15 @@ class McpEvidenceInventoryFoundationTests {
     assertEquals(71, limitations.get("publishedToolCount").getAsInt());
     assertEquals(71, limitations.get("coverageRecordCount").getAsInt());
     assertEquals(20, limitations.get("explicitCoverageRecordCount").getAsInt());
-    assertEquals(8, limitations.get("contractTestedToolCount").getAsInt());
-    assertEquals(43, limitations.get("confirmedGapToolCount").getAsInt());
-    assertEquals(8, limitations.getAsJsonArray("contractTestedTools").size());
+    assertEquals(6, limitations.get("contractTestedToolCount").getAsInt());
+    assertEquals(45, limitations.get("confirmedGapToolCount").getAsInt());
+    assertEquals(6, limitations.getAsJsonArray("contractTestedTools").size());
     assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("getCapabilities"));
     assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("getSchema"));
     assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("getExample"));
     assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("getBenchmarkTrust"));
     assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("checkToolAccess"));
     assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("manageIndustrialProfile"));
-    assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("searchComponents"));
-    assertTrue(limitations.getAsJsonArray("contractTestedTools").toString().contains("queryDataCatalog"));
     assertEquals(71, coverageRecords.size());
     assertTrue(limitations.get("coverageComplete").getAsBoolean());
     assertFalse(limitations.get("scientificValidationComplete").getAsBoolean());
@@ -120,23 +118,43 @@ class McpEvidenceInventoryFoundationTests {
     assertTrue(profile.get("evidenceBoundary").getAsString().contains("external identity"));
 
     JsonObject componentSearch = coverageRecords.getAsJsonObject("searchComponents");
-    assertEquals("CONTRACT_TESTED", componentSearch.get("coverageStatus").getAsString());
+    assertEquals("CONFIRMED_GAP", componentSearch.get("coverageStatus").getAsString());
+    JsonObject dataCatalog = coverageRecords.getAsJsonObject("queryDataCatalog");
+    assertEquals("CONFIRMED_GAP", dataCatalog.get("coverageStatus").getAsString());
+    assertFalse(inventory.get("complete").getAsBoolean());
+  }
+
+  @Test
+  void testReadOnlyCatalogPromotionCandidatesAreEvidenceQualifiedButNotPromoted() {
+    JsonObject limitations = McpEvidenceInventory.build().getAsJsonObject("knownLimitations");
+    JsonObject candidates = limitations.getAsJsonObject("contractPromotionCandidates");
+
+    assertEquals(2, limitations.get("contractPromotionCandidateCount").getAsInt());
+    assertEquals(2, candidates.size());
+
+    JsonObject componentSearch = candidates.getAsJsonObject("searchComponents");
+    assertEquals("CONTRACT_TESTED", componentSearch.get("targetCoverageStatus").getAsString());
     assertEquals("NOT_APPLICABLE_NON_NUMERICAL_COMPONENT_CATALOG_LOOKUP",
         componentSearch.get("benchmarkApplicability").getAsString());
     assertEquals(3, componentSearch.get("contractEvidenceCount").getAsInt());
     assertEquals(3, componentSearch.getAsJsonArray("contractEvidenceSources").size());
     assertTrue(componentSearch.get("evidenceBoundary").getAsString().contains("real-protocol retrieval"));
     assertTrue(componentSearch.get("evidenceBoundary").getAsString().contains("does not validate thermodynamic"));
+    assertFalse(componentSearch.get("promotionReady").getAsBoolean());
 
-    JsonObject dataCatalog = coverageRecords.getAsJsonObject("queryDataCatalog");
-    assertEquals("CONTRACT_TESTED", dataCatalog.get("coverageStatus").getAsString());
+    JsonObject dataCatalog = candidates.getAsJsonObject("queryDataCatalog");
+    assertEquals("CONTRACT_TESTED", dataCatalog.get("targetCoverageStatus").getAsString());
     assertEquals("NOT_APPLICABLE_NON_NUMERICAL_DATA_CATALOG_DISCOVERY",
         dataCatalog.get("benchmarkApplicability").getAsString());
     assertEquals(3, dataCatalog.get("contractEvidenceCount").getAsInt());
     assertEquals(3, dataCatalog.getAsJsonArray("contractEvidenceSources").size());
     assertTrue(dataCatalog.get("evidenceBoundary").getAsString().contains("Read-only catalog"));
     assertTrue(dataCatalog.get("evidenceBoundary").getAsString().contains("standards applicability"));
-    assertFalse(inventory.get("complete").getAsBoolean());
+    assertFalse(dataCatalog.get("promotionReady").getAsBoolean());
+
+    assertTrue(limitations.get("promotionBoundary").getAsString().contains("packaged protocol contract"));
+    assertEquals(6, limitations.get("contractTestedToolCount").getAsInt());
+    assertEquals(45, limitations.get("confirmedGapToolCount").getAsInt());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Advances #3153 Phase 0 from exact current-master base `9d750f53bbed15be24e95a8f2c5230f51aea6437` by making two additional non-numerical trust-gap evidence packages explicit without prematurely changing the frozen protocol classification contract.

- records bounded promotion-candidate evidence for `searchComponents` from `ComponentQuery`, focused JUnit coverage, and existing real-MCP lookup scenarios;
- records bounded promotion-candidate evidence for `queryDataCatalog` from the read-only `DataCatalogRunner`, focused JUnit coverage, and existing real-MCP catalog scenarios;
- keeps both tools `CONFIRMED_GAP` and preserves the current `20 EXPLICIT_TRUST + 6 CONTRACT_TESTED + 45 CONFIRMED_GAP` accounting until classification and packaged protocol expectations can change atomically on one validated head;
- exposes `promotionReady=false`, exact evidence sources, applicability boundaries, and the remaining gate through `getCapabilities.phase0EvidenceInventory`;
- updates focused regressions and `SURFACE_INVENTORY.md` accordingly.

No thermodynamic model, flash algorithm, process model, pipeline/dynamics behavior, DEXPI/P&ID path, production optimization logic, tool input/output contract, deployment default, live-plant integration, or control behavior changes.

## Validation

`VALIDATION PENDING CI`

A single local checkout/validation attempt was made but repository network access was unavailable (`Could not resolve host: github.com`). Per campaign resilient-execution rules I did not retry local infrastructure. Therefore Spotless, focused JUnit, pre-commit, Javadocs, and broader Java/MCP checks are not claimed locally; hosted exact-head CI is authoritative follow-up validation.

Source-level compatibility review confirms the packaged protocol still expects exactly six `CONTRACT_TESTED` tools and 45 confirmed gaps, and this increment deliberately preserves that accounting. The branch is ahead-only from the exact base and changes only the evidence inventory, its focused regression, and MCP surface documentation.

## Documentation impact

Documentation updated: `neqsim-mcp-server/docs/SURFACE_INVENTORY.md` now distinguishes current classifications from evidence-qualified promotion candidates and preserves the advisory/scientific-validation boundaries.

## AI-assisted development

I reviewed the repository instructions and understand the changes. This PR was AI-assisted and remains a draft pending hosted validation and review.