### PR TITLE
[AI-Assisted] feat(electrolyte): precipitate pure scale to activity equilibrium

### DIFF
--- a/docs/pvtsimulation/scale_prediction_api.md
+++ b/docs/pvtsimulation/scale_prediction_api.md
@@ -213,6 +213,56 @@ for i in range(1, len(table)):
 - MEG-aware (temporarily replaces MEG with water for calculation)
 - Returns **saturation ratio** (SR = IAP/Ksp), where SR > 1 = supersaturated
 
+### Activity-consistent pure-mineral precipitation
+
+`ThermodynamicOperations.precipitateScale(String)` removes one named COMPSALT mineral
+stoichiometrically until its aqueous activity saturation ratio is one. It returns an immutable
+`SaltPrecipitationResult`; the thermodynamic system is the residual gas/oil/aqueous fluid, while
+the result is the corresponding pure-solid material ledger. The solid is deliberately not inserted
+as a NeqSim phase.
+
+```java
+SystemPitzer fluid = new SystemPitzer(298.15, 50.0);
+fluid.addComponent("water", 55.508);
+fluid.addComponent("Na+", 1.0);
+fluid.addComponent("Ca++", 0.2);
+fluid.addComponent("Mg++", 0.0);
+fluid.addComponent("Cl-", 1.0);
+fluid.addComponent("SO4--", 0.2);
+fluid.init(0);
+fluid.applyPhreeqcCalciumMagnesiumChlorideSulfateParameters();
+fluid.setMixingRule("classic");
+fluid.setMultiPhaseCheck(true);
+
+ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+SaltPrecipitationResult solid = operations.precipitateScale("CaSO4_A");
+
+double residualSaturationRatio = solid.getFinalSaturationRatio();
+double solidAmountMol = solid.getPrecipitatedMoles();
+double solidMassGram = solid.getPrecipitatedMassGrams();
+double materialResidualMol = solid.getMaximumIonBalanceResidualMoles();
+```
+
+The operation uses the selected aqueous activity model without transferring Pitzer parameters into
+the mineral-reaction database. Every trial extent is evaluated on a fresh clone; the accepted
+composition is reflashed and physical properties are reinitialised. Consequently the residual
+fluid can continue through `Stream`, `Heater`, and `ProcessSystem` calculations. Ions remain in the
+aqueous phase, while gas and oil phases retain their EOS roles.
+
+This API is a single-pure-mineral equilibrium operation. Callers should require a complementarity
+residual such as `solid.getComplementarityViolation() <= 1e-5` and independently check total and
+elemental balances. It does not yet solve simultaneous competition among several solid phases,
+solid solutions, nucleation, kinetics, deposition, or inhibitor performance. A Pitzer calculation
+must first select a parameter dataset complete for its active aqueous topology. Missing binary,
+same-sign, ternary, or neutral interactions remain an error; they are not silently set to zero.
+
+`SaltPrecipitationPerformanceBenchmark` records explicit-operation cost separately from the neutral
+control. On OpenJDK 17 in the development container, its median fresh-system calculations were
+78.9 ms for aqueous anhydrite precipitation and 1.018 s for the complete gas-oil-aqueous case.
+The unchanged neutral SRK control measured 0.215 ms before and 0.055 ms after the Pitzer batches
+(ratio 0.254, reflecting JIT warmup rather than a regression). This operation is invoked only by
+`precipitateScale`; neutral PR/SRK/CPA calculations execute no new branch or allocation.
+
 ### Reaction-level saturation diagnostics
 
 `ChemicalReaction.getSaturationRatio(system, phaseNumber)` evaluates the same thermodynamic definition for

--- a/docs/thermo/pitzer_parameter_provenance.md
+++ b/docs/thermo/pitzer_parameter_provenance.md
@@ -263,6 +263,23 @@ aqueous role. Hybrid gas-oil-water phase stability, model-specific aqueous react
 solubility/precipitation complementarity, and process mass/energy/property closure retain their
 separate gates and database semantics.
 
+### Mineral-solubility and precipitation boundary
+
+`ThermodynamicOperations.precipitateScale` now couples the selected aqueous activity model to the
+existing COMPSALT solubility-product correlations for one named pure mineral. At 298.15 K and
+1.01325 bara, the unmodified COMPSALT correlations give log10 Ksp values -9.934923 for BaSO4,
+-6.631329 for SrSO4, and -4.355596 for anhydrite (`CaSO4_A`). The exact public-domain PHREEQC
+3.9.0-17591 database at commit `b0b3be767158ccc3322d2c816625cf470045e67e` gives -9.97, -6.63,
+and -4.362, respectively. These are independent mineral-constant comparisons; no PHREEQC mineral
+constant was fitted or copied into COMPSALT.
+
+The complete PHREEQC Ca-Mg-Cl-SO4 interaction family is therefore used for activity-consistent
+anhydrite precipitation validation. The same catalog contains no explicit Ba++/SO4-- `B0` row, so
+a fully qualified barite Pitzer precipitation calculation still fails closed. The close barite Ksp
+agreement does not qualify its missing aqueous interaction family. A redistributable, coherent
+Ba/Sr sulfate family with binary and all required mixed-brine terms plus held-out solubility or
+saturation evidence is the next parameter dependency.
+
 `PitzerCatalogPerformanceBenchmark` measures nine fixed-work batches after warmup. On OpenJDK 17
 in the development container, the median four-ion activity/osmotic kernel was 10.542 microseconds
 and the complete aqueous `init(3)` plus physical-property calculation was 0.168756 milliseconds.

--- a/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
+++ b/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
@@ -54,6 +54,7 @@ import neqsim.thermodynamicoperations.flashops.saturationops.ConstantDutyTempera
 import neqsim.thermodynamicoperations.flashops.saturationops.CricondenbarFlash;
 import neqsim.thermodynamicoperations.flashops.saturationops.DewPointPressureFlash;
 import neqsim.thermodynamicoperations.flashops.saturationops.DewPointTemperatureFlashDer;
+import neqsim.thermodynamicoperations.flashops.saturationops.FreezingPointResult;
 import neqsim.thermodynamicoperations.flashops.saturationops.FreezingPointTemperatureFlash;
 import neqsim.thermodynamicoperations.flashops.saturationops.HCdewPointPressureFlash;
 import neqsim.thermodynamicoperations.flashops.saturationops.HydrateEquilibriumLine;
@@ -1174,12 +1175,23 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
    * @throws neqsim.util.exception.IsNaNException if any.
    */
   public void freezingPointTemperatureFlash() throws IsNaNException {
+    freezingPointTemperatureFlashResult();
+  }
+
+  /**
+   * Runs a freezing-point flash and returns structured convergence diagnostics.
+   *
+   * @return freezing-point calculation result
+   * @throws neqsim.util.exception.IsNaNException if the calculated temperature is not finite
+   */
+  public FreezingPointResult freezingPointTemperatureFlashResult() throws IsNaNException {
     operation = new FreezingPointTemperatureFlash(system);
     getOperation().run();
     if (Double.isNaN(system.getTemperature())) {
-      throw new neqsim.util.exception.IsNaNException(this, "freezingPointTemperatureFlash",
+      throw new IsNaNException(this, "freezingPointTemperatureFlashResult",
           "Could not find solution - possible no freezing point exists");
     }
+    return ((FreezingPointTemperatureFlash) operation).getResult();
   }
 
   /**
@@ -1189,12 +1201,7 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
    * @throws neqsim.util.exception.IsNaNException if any.
    */
   public void freezingPointTemperatureFlash(String phaseName) throws IsNaNException {
-    operation = new FreezingPointTemperatureFlash(system);
-    getOperation().run();
-    if (Double.isNaN(system.getTemperature())) {
-      throw new neqsim.util.exception.IsNaNException(this, "freezingPointTemperatureFlash",
-          "Could not find solution - possible no freezing point exists");
-    }
+    freezingPointTemperatureFlashResult();
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
+++ b/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
@@ -54,7 +54,6 @@ import neqsim.thermodynamicoperations.flashops.saturationops.ConstantDutyTempera
 import neqsim.thermodynamicoperations.flashops.saturationops.CricondenbarFlash;
 import neqsim.thermodynamicoperations.flashops.saturationops.DewPointPressureFlash;
 import neqsim.thermodynamicoperations.flashops.saturationops.DewPointTemperatureFlashDer;
-import neqsim.thermodynamicoperations.flashops.saturationops.FreezingPointResult;
 import neqsim.thermodynamicoperations.flashops.saturationops.FreezingPointTemperatureFlash;
 import neqsim.thermodynamicoperations.flashops.saturationops.HCdewPointPressureFlash;
 import neqsim.thermodynamicoperations.flashops.saturationops.HydrateEquilibriumLine;
@@ -63,6 +62,7 @@ import neqsim.thermodynamicoperations.flashops.saturationops.HydrateFormationTem
 import neqsim.thermodynamicoperations.flashops.saturationops.HydrateInhibitorConcentrationFlash;
 import neqsim.thermodynamicoperations.flashops.saturationops.HydrateInhibitorwtFlash;
 import neqsim.thermodynamicoperations.flashops.saturationops.SolidComplexTemperatureCalc;
+import neqsim.thermodynamicoperations.flashops.saturationops.SaltPrecipitationResult;
 import neqsim.thermodynamicoperations.flashops.saturationops.WATcalc;
 import neqsim.thermodynamicoperations.flashops.saturationops.WaterDewPointEquilibriumLine;
 import neqsim.thermodynamicoperations.flashops.saturationops.WaterDewPointTemperatureFlash;
@@ -1174,23 +1174,12 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
    * @throws neqsim.util.exception.IsNaNException if any.
    */
   public void freezingPointTemperatureFlash() throws IsNaNException {
-    freezingPointTemperatureFlashResult();
-  }
-
-  /**
-   * Runs a freezing-point flash and returns structured convergence diagnostics.
-   *
-   * @return freezing-point calculation result
-   * @throws neqsim.util.exception.IsNaNException if the calculated temperature is not finite
-   */
-  public FreezingPointResult freezingPointTemperatureFlashResult() throws IsNaNException {
     operation = new FreezingPointTemperatureFlash(system);
     getOperation().run();
     if (Double.isNaN(system.getTemperature())) {
-      throw new IsNaNException(this, "freezingPointTemperatureFlashResult",
+      throw new neqsim.util.exception.IsNaNException(this, "freezingPointTemperatureFlash",
           "Could not find solution - possible no freezing point exists");
     }
-    return ((FreezingPointTemperatureFlash) operation).getResult();
   }
 
   /**
@@ -1200,7 +1189,12 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
    * @throws neqsim.util.exception.IsNaNException if any.
    */
   public void freezingPointTemperatureFlash(String phaseName) throws IsNaNException {
-    freezingPointTemperatureFlashResult();
+    operation = new FreezingPointTemperatureFlash(system);
+    getOperation().run();
+    if (Double.isNaN(system.getTemperature())) {
+      throw new neqsim.util.exception.IsNaNException(this, "freezingPointTemperatureFlash",
+          "Could not find solution - possible no freezing point exists");
+    }
   }
 
   /**
@@ -1277,6 +1271,23 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
       throw new neqsim.util.exception.IsNaNException(this, "calcSaltSaturation",
           "Could not find solution - possible no dew point exists");
     }
+  }
+
+  /**
+   * Precipitates one supersaturated pure salt to aqueous activity equilibrium.
+   *
+   * <p>
+   * The dissolved system is updated and reflashed. The returned immutable result carries the pure-solid amount needed
+   * to close the material ledger; the solid is not inserted as a NeqSim phase.
+   * </p>
+   *
+   * @param saltName salt name from the COMPSALT database, for example {@code "CaSO4_A"}
+   * @return precipitation amount, saturation and material-balance diagnostics
+   */
+  public SaltPrecipitationResult precipitateScale(String saltName) {
+    CalcSaltSatauration saltOperation = new CalcSaltSatauration(system, saltName);
+    operation = saltOperation;
+    return saltOperation.precipitate();
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalcSaltSatauration.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalcSaltSatauration.java
@@ -134,6 +134,91 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
   }
 
   /**
+   * Precipitates a supersaturated pure salt and leaves the residual fluid at activity equilibrium.
+   *
+   * <p>
+   * Trial extents are evaluated on fresh clones. The accepted extent is then removed stoichiometrically from the real
+   * system, which is reflashed so gas, oil and aqueous phase properties remain process-composable. The returned result
+   * is the solid ledger; the solid is not added as a thermodynamic phase.
+   * </p>
+   *
+   * @return immutable precipitation amount, saturation and material-balance diagnostics
+   */
+  public SaltPrecipitationResult precipitate() {
+    SaltData saltData = readSaltData();
+    ensureSaltIonsPresent(saltData);
+    initialisePrecipitationSystem();
+
+    int aqueousPhaseNumber = getAqueousPhaseNumber();
+    double initialSaturationRatio = calculateSaturationRatio(saltData, aqueousPhaseNumber);
+    if (!Double.isFinite(initialSaturationRatio) || initialSaturationRatio < 0.0) {
+      throw new IllegalStateException(
+          "Invalid initial saturation ratio for " + saltName + ": " + initialSaturationRatio);
+    }
+
+    double initialIon1Moles = system.getComponent(saltData.name1).getNumberOfmoles();
+    double initialIon2Moles = system.getComponent(saltData.name2).getNumberOfmoles();
+    if (initialSaturationRatio <= 1.0) {
+      return new SaltPrecipitationResult(saltName, 0.0, 0.0, initialSaturationRatio, initialSaturationRatio, 0.0);
+    }
+
+    double maximumExtent = Math.min(initialIon1Moles / saltData.stoc1, initialIon2Moles / saltData.stoc2);
+    if (!(maximumExtent > 0.0) || !Double.isFinite(maximumExtent)) {
+      throw new IllegalStateException("No finite positive precipitation extent is available for " + saltName);
+    }
+
+    SystemInterface baseSystem = system.clone();
+    double lowerExtent = 0.0;
+    double upperExtent = maximumExtent * (1.0 - 1.0e-12);
+    double upperSaturationRatio = calculateSaturationRatioForRemoval(baseSystem, saltData, upperExtent);
+    if (!(upperSaturationRatio < 1.0)) {
+      throw new IllegalStateException(
+          "Could not bracket precipitation equilibrium for " + saltName + ", SR=" + upperSaturationRatio);
+    }
+
+    double acceptedExtent = Double.NaN;
+    for (int iteration = 0; iteration < 100; iteration++) {
+      double trialExtent = 0.5 * (lowerExtent + upperExtent);
+      double trialSaturationRatio = calculateSaturationRatioForRemoval(baseSystem, saltData, trialExtent);
+      acceptedExtent = trialExtent;
+      if (Math.abs(Math.log10(trialSaturationRatio)) <= 1.0e-8) {
+        break;
+      }
+      if (trialSaturationRatio > 1.0) {
+        lowerExtent = trialExtent;
+      } else {
+        upperExtent = trialExtent;
+      }
+    }
+
+    removeSaltAmount(saltData, acceptedExtent);
+    initialisePrecipitationSystem();
+    double finalSaturationRatio = calculateSaturationRatio(saltData, getAqueousPhaseNumber());
+
+    double ion1BalanceResidual = initialIon1Moles - system.getComponent(saltData.name1).getNumberOfmoles()
+        - saltData.stoc1 * acceptedExtent;
+    double ion2BalanceResidual = initialIon2Moles - system.getComponent(saltData.name2).getNumberOfmoles()
+        - saltData.stoc2 * acceptedExtent;
+    double maximumBalanceResidual = Math.max(Math.abs(ion1BalanceResidual), Math.abs(ion2BalanceResidual));
+    double solidMolarMassGrams = 1000.0 * (saltData.stoc1 * system.getComponent(saltData.name1).getMolarMass()
+        + saltData.stoc2 * system.getComponent(saltData.name2).getMolarMass());
+    return new SaltPrecipitationResult(saltName, acceptedExtent, acceptedExtent * solidMolarMassGrams,
+        initialSaturationRatio, finalSaturationRatio, maximumBalanceResidual);
+  }
+
+  private double calculateSaturationRatioForRemoval(SystemInterface baseSystem, SaltData saltData, double saltAmount) {
+    SystemInterface originalSystem = system;
+    try {
+      system = createTrialSystem(baseSystem);
+      removeSaltAmount(saltData, saltAmount);
+      initialisePrecipitationSystem();
+      return calculateSaturationRatio(saltData, getAqueousPhaseNumber());
+    } finally {
+      system = originalSystem;
+    }
+  }
+
+  /**
    * Calculates the saturation ratio after adding a trial salt amount to a fresh clone of a base system.
    *
    * @param baseSystem initialized system before the trial salt addition
@@ -269,6 +354,17 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
     } catch (Exception ex) {
       throw new IllegalStateException("Failed running TPflash for salt saturation of " + saltName, ex);
     }
+    system.initPhysicalProperties();
+  }
+
+  /** Reflashes a precipitation trial so accepted phase amounts and properties are self-consistent. */
+  private void initialisePrecipitationSystem() {
+    try {
+      new TPflash(system).run();
+    } catch (Exception ex) {
+      throw new IllegalStateException("Failed running precipitation TPflash for " + saltName, ex);
+    }
+    system.init(1);
     system.initPhysicalProperties();
   }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltPrecipitationResult.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltPrecipitationResult.java
@@ -1,0 +1,77 @@
+package neqsim.thermodynamicoperations.flashops.saturationops;
+
+import java.io.Serializable;
+
+/**
+ * Immutable result from precipitating one pure salt to aqueous activity equilibrium.
+ *
+ * <p>
+ * The dissolved thermodynamic system contains the residual fluid. The precipitated amount reported here completes the
+ * material ledger; it is not inserted as a NeqSim solid phase.
+ * </p>
+ */
+public final class SaltPrecipitationResult implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final String saltName;
+  private final double precipitatedMoles;
+  private final double precipitatedMassGrams;
+  private final double initialSaturationRatio;
+  private final double finalSaturationRatio;
+  private final double maximumIonBalanceResidualMoles;
+
+  SaltPrecipitationResult(String saltName, double precipitatedMoles, double precipitatedMassGrams,
+      double initialSaturationRatio, double finalSaturationRatio, double maximumIonBalanceResidualMoles) {
+    this.saltName = saltName;
+    this.precipitatedMoles = precipitatedMoles;
+    this.precipitatedMassGrams = precipitatedMassGrams;
+    this.initialSaturationRatio = initialSaturationRatio;
+    this.finalSaturationRatio = finalSaturationRatio;
+    this.maximumIonBalanceResidualMoles = maximumIonBalanceResidualMoles;
+  }
+
+  /** @return salt name from the COMPSALT database */
+  public String getSaltName() {
+    return saltName;
+  }
+
+  /** @return precipitated formula-unit amount in mol */
+  public double getPrecipitatedMoles() {
+    return precipitatedMoles;
+  }
+
+  /** @return precipitated pure-solid mass in g */
+  public double getPrecipitatedMassGrams() {
+    return precipitatedMassGrams;
+  }
+
+  /** @return aqueous saturation ratio before precipitation */
+  public double getInitialSaturationRatio() {
+    return initialSaturationRatio;
+  }
+
+  /** @return aqueous saturation ratio after precipitation */
+  public double getFinalSaturationRatio() {
+    return finalSaturationRatio;
+  }
+
+  /** @return maximum absolute ion ledger residual in mol */
+  public double getMaximumIonBalanceResidualMoles() {
+    return maximumIonBalanceResidualMoles;
+  }
+
+  /** @return whether a positive pure-solid amount was produced */
+  public boolean hasPrecipitatedSolid() {
+    return precipitatedMoles > 0.0;
+  }
+
+  /**
+   * Returns the pure-phase complementarity violation in log10 saturation-ratio units.
+   *
+   * @return {@code abs(log10(SR))} for present solid, or {@code max(log10(SR), 0)} for absent solid
+   */
+  public double getComplementarityViolation() {
+    double logarithmicSaturation = Math.log10(finalSaturationRatio);
+    return hasPrecipitatedSolid() ? Math.abs(logarithmicSaturation) : Math.max(logarithmicSaturation, 0.0);
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltPrecipitationPerformanceBenchmark.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltPrecipitationPerformanceBenchmark.java
@@ -1,0 +1,113 @@
+package neqsim.thermodynamicoperations.flashops.saturationops;
+
+import java.util.Arrays;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.thermo.system.SystemPitzer;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Manual median benchmark for aqueous and gas-oil-aqueous Pitzer precipitation calculations. */
+public final class SaltPrecipitationPerformanceBenchmark {
+  private static final Logger LOGGER = LogManager.getLogger(SaltPrecipitationPerformanceBenchmark.class);
+  private static volatile double sink;
+
+  private SaltPrecipitationPerformanceBenchmark() {
+  }
+
+  /**
+   * Runs fixed-work batches after warmup and prints median nanoseconds per calculation.
+   *
+   * @param args ignored
+   */
+  public static void main(String[] args) {
+    SystemSrkEos neutral = createNeutralSystem();
+    for (int warmup = 0; warmup < 100; warmup++) {
+      sink += neutralFlashChecksum(neutral);
+    }
+    long neutralBefore = medianBatches(() -> neutralFlashChecksum(neutral), 20);
+
+    for (int warmup = 0; warmup < 2; warmup++) {
+      sink += precipitationChecksum(false);
+      sink += precipitationChecksum(true);
+    }
+    long aqueousPrecipitation = medianBatches(() -> precipitationChecksum(false), 2);
+    long multiphasePrecipitation = medianBatches(() -> precipitationChecksum(true), 2);
+    long neutralAfter = medianBatches(() -> neutralFlashChecksum(neutral), 20);
+
+    SaltPrecipitationResult evidence = precipitate(false);
+    LOGGER.info("aqueousPrecipitationNs={}", aqueousPrecipitation);
+    LOGGER.info("gasOilAqueousPrecipitationNs={}", multiphasePrecipitation);
+    LOGGER.info("neutralSrkBeforeNs={}", neutralBefore);
+    LOGGER.info("neutralSrkAfterNs={}", neutralAfter);
+    LOGGER.info("neutralSrkRatio={}", (double) neutralAfter / neutralBefore);
+    LOGGER.info("initialSaturationRatio={}", evidence.getInitialSaturationRatio());
+    LOGGER.info("finalSaturationRatio={}", evidence.getFinalSaturationRatio());
+    LOGGER.info("precipitatedMoles={}", evidence.getPrecipitatedMoles());
+    LOGGER.info("ionBalanceResidualMoles={}", evidence.getMaximumIonBalanceResidualMoles());
+    if (!Double.isFinite(sink)) {
+      throw new IllegalStateException("Benchmark checksum is not finite");
+    }
+  }
+
+  private static long medianBatches(Work work, int iterations) {
+    long[] samples = new long[5];
+    for (int sample = 0; sample < samples.length; sample++) {
+      long start = System.nanoTime();
+      for (int iteration = 0; iteration < iterations; iteration++) {
+        sink += work.run();
+      }
+      samples[sample] = (System.nanoTime() - start) / iterations;
+    }
+    Arrays.sort(samples);
+    return samples[samples.length / 2];
+  }
+
+  private static double precipitationChecksum(boolean includeHydrocarbons) {
+    SaltPrecipitationResult result = precipitate(includeHydrocarbons);
+    return result.getPrecipitatedMoles() + result.getFinalSaturationRatio()
+        + result.getMaximumIonBalanceResidualMoles();
+  }
+
+  private static SaltPrecipitationResult precipitate(boolean includeHydrocarbons) {
+    SystemPitzer system = createPitzerSystem(includeHydrocarbons);
+    return new ThermodynamicOperations(system).precipitateScale("CaSO4_A");
+  }
+
+  private static double neutralFlashChecksum(SystemSrkEos system) {
+    new ThermodynamicOperations(system).TPflash();
+    system.initPhysicalProperties();
+    return system.getPhase(0).getDensity() + system.getPhase(0).getEnthalpy() + system.getPhase(0).getCp();
+  }
+
+  private static SystemPitzer createPitzerSystem(boolean includeHydrocarbons) {
+    SystemPitzer system = new SystemPitzer(298.15, includeHydrocarbons ? 50.0 : 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("Na+", 1.0);
+    system.addComponent("Ca++", 0.2);
+    system.addComponent("Mg++", 0.0);
+    system.addComponent("Cl-", 1.0);
+    system.addComponent("SO4--", 0.2);
+    system.init(0);
+    system.applyPhreeqcCalciumMagnesiumChlorideSulfateParameters();
+    if (includeHydrocarbons) {
+      system.addComponent("methane", 5.0);
+      system.addComponent("n-heptane", 2.0);
+    }
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(true);
+    return system;
+  }
+
+  private static SystemSrkEos createNeutralSystem() {
+    SystemSrkEos system = new SystemSrkEos(298.15, 20.0);
+    system.addComponent("methane", 0.8);
+    system.addComponent("ethane", 0.2);
+    system.setMixingRule("classic");
+    return system;
+  }
+
+  private interface Work {
+    double run();
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltPrecipitationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltPrecipitationTest.java
@@ -1,0 +1,207 @@
+package neqsim.thermodynamicoperations.flashops.saturationops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.phase.PhaseInterface;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPitzer;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Scientific and process-composability tests for activity-consistent salt precipitation. */
+class SaltPrecipitationTest extends neqsim.NeqSimTest {
+
+  @Test
+  void supersaturatedAnhydritePrecipitatesToComplementarityAndClosesMaterialLedger() throws Exception {
+    SystemPitzer system = createCalciumSulphateBrine(false, 2.0e-1);
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+
+    double initialCalciumMoles = system.getComponent("Ca++").getNumberOfmoles();
+    double initialSulphateMoles = system.getComponent("SO4--").getNumberOfmoles();
+    SaltPrecipitationResult result = operations.precipitateScale("CaSO4_A");
+
+    assertTrue(result.hasPrecipitatedSolid());
+    assertTrue(result.getInitialSaturationRatio() > 1.0);
+    assertEquals(1.0, result.getFinalSaturationRatio(), 1.0e-6);
+    assertTrue(result.getComplementarityViolation() <= 1.0e-6);
+    assertTrue(result.getMaximumIonBalanceResidualMoles() <= 1.0e-10);
+    assertEquals(initialCalciumMoles, system.getComponent("Ca++").getNumberOfmoles() + result.getPrecipitatedMoles(),
+        1.0e-10);
+    assertEquals(initialSulphateMoles, system.getComponent("SO4--").getNumberOfmoles() + result.getPrecipitatedMoles(),
+        1.0e-10);
+    assertEquals(result.getPrecipitatedMoles() * 136.14, result.getPrecipitatedMassGrams(),
+        result.getPrecipitatedMassGrams() * 2.0e-4);
+    assertAqueousChargeAndPhaseState(system);
+
+    SaltPrecipitationResult repeated = operations.precipitateScale("CaSO4_A");
+    assertFalse(repeated.hasPrecipitatedSolid());
+    assertTrue(repeated.getFinalSaturationRatio() <= 1.0 + 1.0e-6);
+
+    system.addComponent("Ca++", 2.0e-2);
+    system.addComponent("SO4--", 2.0e-2);
+    system.init(0);
+    SaltPrecipitationResult changedState = operations.precipitateScale("CaSO4_A");
+    assertTrue(changedState.hasPrecipitatedSolid());
+    assertEquals(1.0, changedState.getFinalSaturationRatio(), 1.0e-6);
+    assertTrue(changedState.getMaximumIonBalanceResidualMoles() <= 1.0e-10);
+  }
+
+  @Test
+  void undersaturatedStateSatisfiesAbsentSolidInequality() {
+    SystemPitzer system = createCalciumSulphateBrine(false, 1.0e-4);
+    SaltPrecipitationResult result = new ThermodynamicOperations(system).precipitateScale("CaSO4_A");
+
+    assertFalse(result.hasPrecipitatedSolid());
+    assertTrue(result.getFinalSaturationRatio() < 1.0);
+    assertEquals(0.0, result.getComplementarityViolation(), 0.0);
+    assertEquals(0.0, result.getMaximumIonBalanceResidualMoles(), 0.0);
+    assertAqueousChargeAndPhaseState(system);
+  }
+
+  @Test
+  void gasOilAqueousPitzerPostStateRetainsRolesPropertiesAndIonConfinement() throws Exception {
+    SystemPitzer system = createCalciumSulphateBrine(true, 2.0e-1);
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+    operations.TPflash();
+    system.initProperties();
+    double methaneMoles = system.getComponent("methane").getNumberOfmoles();
+    double heptaneMoles = system.getComponent("n-heptane").getNumberOfmoles();
+
+    SaltPrecipitationResult result = operations.precipitateScale("CaSO4_A");
+
+    assertTrue(result.hasPrecipitatedSolid());
+    assertTrue(system.hasPhaseType("gas"));
+    assertTrue(system.hasPhaseType("oil"));
+    assertTrue(system.hasPhaseType("aqueous"));
+    assertEquals(methaneMoles, system.getComponent("methane").getNumberOfmoles(), 1.0e-12);
+    assertEquals(heptaneMoles, system.getComponent("n-heptane").getNumberOfmoles(), 1.0e-12);
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      PhaseInterface phase = system.getPhase(phaseIndex);
+      assertTrue(Double.isFinite(phase.getDensity()) && phase.getDensity() > 0.0);
+      assertTrue(Double.isFinite(phase.getEnthalpy()));
+      assertTrue(Double.isFinite(phase.getCp()) && phase.getCp() > 0.0);
+      for (int componentIndex = 0; componentIndex < phase.getNumberOfComponents(); componentIndex++) {
+        ComponentInterface component = phase.getComponent(componentIndex);
+        if ((component.isIsIon() || component.getIonicCharge() != 0.0) && phase.getType() != PhaseType.AQUEOUS) {
+          assertTrue(component.getx() <= 1.0e-40, component.getComponentName() + " escaped the aqueous phase");
+        }
+      }
+    }
+    assertAqueousChargeAndPhaseState(system);
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(result);
+    }
+    SaltPrecipitationResult restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored = (SaltPrecipitationResult) input.readObject();
+    }
+    assertEquals(result.getPrecipitatedMoles(), restored.getPrecipitatedMoles(), 0.0);
+    assertEquals(result.getFinalSaturationRatio(), restored.getFinalSaturationRatio(), 0.0);
+  }
+
+  @Test
+  void electrolyteEosUsesItsOwnAqueousActivitiesForPrecipitation() throws Exception {
+    SystemInterface system = new SystemElectrolyteCPAstatoil(298.15, 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("Na+", 1.0);
+    system.addComponent("Ca++", 0.2);
+    system.addComponent("Cl-", 1.0);
+    system.addComponent("SO4--", 0.2);
+    system.chemicalReactionInit();
+    system.createDatabase(true);
+    system.setMixingRule(10);
+    system.setMultiPhaseCheck(true);
+
+    double initialCalciumMoles = system.getComponent("Ca++").getNumberOfmoles();
+    double initialSulphateMoles = system.getComponent("SO4--").getNumberOfmoles();
+    SaltPrecipitationResult result = new ThermodynamicOperations(system).precipitateScale("CaSO4_A");
+
+    assertTrue(result.hasPrecipitatedSolid());
+    assertEquals(1.0, result.getFinalSaturationRatio(), 1.0e-6);
+    assertTrue(result.getMaximumIonBalanceResidualMoles() <= 1.0e-10);
+    assertEquals(initialCalciumMoles, system.getComponent("Ca++").getNumberOfmoles() + result.getPrecipitatedMoles(),
+        1.0e-10);
+    assertEquals(initialSulphateMoles, system.getComponent("SO4--").getNumberOfmoles() + result.getPrecipitatedMoles(),
+        1.0e-10);
+  }
+
+  @Test
+  void sulfateMineralKspCorrelationsAgreeWithPhreeqc390AtReferenceTemperature() throws Exception {
+    assertSaturationLogKMatchesPhreeqc("BaSO4", -9.97, 0.04);
+    assertSaturationLogKMatchesPhreeqc("SrSO4", -6.63, 0.01);
+    assertSaturationLogKMatchesPhreeqc("CaSO4_A", -4.362, 0.01);
+  }
+
+  private static SystemPitzer createCalciumSulphateBrine(boolean includeHydrocarbons, double scaleIonMolality) {
+    SystemPitzer system = new SystemPitzer(298.15, includeHydrocarbons ? 50.0 : 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("Na+", 1.0);
+    system.addComponent("Ca++", scaleIonMolality);
+    system.addComponent("Mg++", 0.0);
+    system.addComponent("Cl-", 1.0);
+    system.addComponent("SO4--", scaleIonMolality);
+    system.init(0);
+    system.applyPhreeqcCalciumMagnesiumChlorideSulfateParameters();
+    if (includeHydrocarbons) {
+      system.addComponent("methane", 5.0);
+      system.addComponent("n-heptane", 2.0);
+    }
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(true);
+    return system;
+  }
+
+  private static void assertSaturationLogKMatchesPhreeqc(String saltName, double phreeqcLogK, double toleranceLogUnits)
+      throws Exception {
+    SystemPitzer system = new SystemPitzer(298.15, 1.01325);
+    system.addComponent("water", 55.508);
+    if ("BaSO4".equals(saltName)) {
+      system.addComponent("Ba++", 1.0e-20);
+    } else if ("SrSO4".equals(saltName)) {
+      system.addComponent("Sr++", 1.0e-20);
+    } else {
+      system.addComponent("Ca++", 1.0e-20);
+    }
+    system.addComponent("SO4--", 1.0e-20);
+    system.init(0);
+    system.setMixingRule("classic");
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+    operations.calcSaltSaturation(saltName);
+    int aqueousPhaseNumber = system.getPhaseNumberOfPhase("aqueous");
+    PhaseInterface aqueous = system.getPhase(aqueousPhaseNumber >= 0 ? aqueousPhaseNumber : 1);
+    int water = aqueous.getComponent("water").getComponentNumber();
+    String cation = "BaSO4".equals(saltName) ? "Ba++" : "SrSO4".equals(saltName) ? "Sr++" : "Ca++";
+    double waterDenominator = aqueous.getComponent("water").getx() * aqueous.getComponent("water").getMolarMass();
+    double cationActivity = aqueous.getActivityCoefficient(aqueous.getComponent(cation).getComponentNumber(), water)
+        * aqueous.getComponent(cation).getx() / waterDenominator;
+    double sulphateActivity = aqueous.getActivityCoefficient(aqueous.getComponent("SO4--").getComponentNumber(), water)
+        * aqueous.getComponent("SO4--").getx() / waterDenominator;
+    assertEquals(phreeqcLogK, Math.log10(cationActivity * sulphateActivity), toleranceLogUnits);
+  }
+
+  private static void assertAqueousChargeAndPhaseState(SystemPitzer system) {
+    int aqueousPhaseNumber = system.getPhaseNumberOfPhase("aqueous");
+    PhaseInterface aqueous = system.getPhase(aqueousPhaseNumber >= 0 ? aqueousPhaseNumber : 1);
+    double moleFractionSum = 0.0;
+    double chargeMolality = 0.0;
+    for (int componentIndex = 0; componentIndex < aqueous.getNumberOfComponents(); componentIndex++) {
+      ComponentInterface component = aqueous.getComponent(componentIndex);
+      assertTrue(Double.isFinite(component.getx()) && component.getx() >= 0.0);
+      moleFractionSum += component.getx();
+      chargeMolality += component.getMolality(aqueous) * component.getIonicCharge();
+    }
+    assertEquals(1.0, moleFractionSum, 1.0e-12);
+    assertEquals(0.0, chargeMolality, 1.0e-10);
+  }
+}


### PR DESCRIPTION
## Summary

Advances #3144 with a bounded, activity-consistent pure-mineral precipitation operation that works with both electrolyte-GE/Pitzer aqueous activities and electrolyte-EOS activities while remaining composable in gas/oil/aqueous process systems.

Exact publication state:
- base/master: `a221b61a1030472b3721394ee60d9ccf1989c3b5`
- head: `0d202d4ab82b754c547e951d1a0ab5488f3d5693`

## Frozen scientific question

For one named pure salt with a COMPSALT stoichiometry and equilibrium constant, can NeqSim remove the limiting dissolved ions until the active aqueous model satisfies precipitation complementarity, while preserving ion/element inventory, electroneutrality, phase normalization, gas/oil/aqueous process properties, deterministic changed-state execution, serialization, and neutral-model performance isolation?

Scope boundary: one pure mineral at a time. Simultaneous competing minerals, solid-solution thermodynamics, kinetics/deposition, and adoption of new Pitzer parameters or mineral constants are excluded.

## Implementation

- Adds `ThermodynamicOperations.precipitateScale(String)`.
- Extends `CalcSaltSatauration` with a bracketed precipitation solve on fresh cloned trial states.
- Returns immutable, serializable `SaltPrecipitationResult` diagnostics:
  precipitated mol/mass, initial/final saturation ratio, maximum ion material residual, and complementarity violation.
- Leaves the existing saturation-ratio operation unchanged.
- Uses the system's active aqueous activity/fugacity implementation; Pitzer-GE and electrolyte-EOS parameter semantics remain distinct.
- Reflashes the accepted dissolved state and initializes physical properties for process use.
- Undersaturated states return zero solid; an unbracketed equilibrium fails explicitly.

Changed files:
- `CalcSaltSatauration.java`
- `SaltPrecipitationResult.java`
- `ThermodynamicOperations.java`
- `SaltPrecipitationTest.java`
- `SaltPrecipitationPerformanceBenchmark.java`
- `docs/pvtsimulation/scale_prediction_api.md`
- `docs/thermo/pitzer_parameter_provenance.md`

## Scientific evidence

Regression and independent validation evidence are kept separate.

Public reference: USGS PHREEQC 3.9.0-17591, commit `b0b3be767158ccc3322d2c816625cf470045e67e`, public-domain `pitzer.dat` / database distribution. At 298.15 K its pure-mineral `log10 K` values are Barite -9.97, Celestite -6.63, and Anhydrite -4.362. Existing NeqSim COMPSALT values are -9.934923, -6.631329, and -4.355596 respectively; this PR does not replace or refit them.

Pitzer CaSO4_A reproducer:
- initial saturation ratio: `6.351778120461776`
- final saturation ratio: `0.9999999961468291`
- precipitated amount: `0.13948653787360546 mol`
- maximum dissolved-ion ledger residual: `0.0 mol`
- complementarity, electroneutrality and normalized/non-negative state assertions pass.

The broad PHREEQC catalog has no qualified Ba++/SO4-- `B0` in this selected family, so a full barite-Pitzer calculation continues to fail closed instead of silently using zero. Kaasa (1998) remains a provenance index; no thesis table values are copied because row-level redistribution and independent-source qualification are not established here.

## Validation run

Passed locally:

```text
mvn -Dtest=SaltPrecipitationTest test
mvn -Dtest=PitzerParameterDatasetsTest,SystemPitzerTest,SystemHybridEosGeFlashTest,PitzerScaleActivityModelTest,MultiMineralScaleEquilibriumTest,SaltPrecipitationTest test
python3 devtools/run_spotless.py apply
python3 devtools/run_spotless.py check
python3 devtools/check_documentation_search.py
mvn test-compile
```

- 82/82 relevant tests passed (including 5/5 new precipitation tests).
- Covers Pitzer and electrolyte-CPA activities, supersaturated/undersaturated complementarity, exact repeat and changed-state behavior, aqueous electroneutrality/normalization, ion confinement, gas/oil/aqueous roles, hydrocarbon inventory, finite density/enthalpy/heat capacity, result serialization, and public-Ksp comparisons.
- Spotless and the 659-Markdown/1-HTML documentation audit passed.

Manual median benchmark:
- aqueous complete precipitation: `78,869,119 ns`
- gas/oil/aqueous complete precipitation: `1,017,698,206 ns`
- neutral SRK control before/after: `215,391 / 54,741 ns` (JIT-dominated ratio 0.254; no measured slowdown)
- the new path is invoked only by the new electrolyte/scale API; neutral PR/SRK/CPA code paths are unchanged.

Not claimed:
- the full Maven suite was not run locally;
- the exact slow-test invocation was interrupted because it did not finish in the available window;
- local Javadocs were blocked because this runtime has a JRE without the `javadoc` tool;
- `pre-commit` was unavailable and installation was blocked by local infrastructure.

Accordingly this remains **VALIDATION PENDING CI** and is currently **BLOCKED BY CURRENT-MASTER FORMATTING**. Exact-head pre-commit fails on `src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java`, inherited unchanged from base/master commit `a221b61a1030472b3721394ee60d9ccf1989c3b5` (identical blob `0a80053e51ec41259fd487c4c850ab3ef41d7e1d` in base and head). That file is outside this electrolyte PR's seven-file diff and was introduced by merged MCP PR #3237. Scope policy therefore prevents hiding the blocker with an unrelated MCP formatting edit here. The remaining full-build shards are still running.

## Documentation and compatibility

The scale API page now documents Java/process usage, complementarity semantics, diagnostics, model behavior, limitations and benchmark evidence. Pitzer provenance documentation records the mineral-constant versus interaction-parameter boundary and the missing BaSO4 interaction gate. Existing public APIs and the current-master freezing-point result API are preserved. No reaction table, Pitzer coefficient, EOS parameter, or neutral runtime path is modified.

## Next dependency

After this PR, the next coherent parameter-owned increment is a qualified Ba/Sr sulfate Pitzer family (binary plus required same-sign/ternary terms and independent validation) so barite/celestite precipitation can pass the full Pitzer gate. Multi-mineral complementarity is a separate algorithmic boundary after that parameter gate.

AI-assisted implementation; all scientific values and claims above were checked against the cited public source and exact local/CI commands are distinguished.