### PR TITLE
[AI-Assisted] fix(mcp): restore merged Phase 0 CI baseline

### DIFF
--- a/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
@@ -254,16 +254,15 @@ public final class McpEvidenceInventory {
    */
   private static JsonObject buildContractPromotionCandidates() {
     JsonObject candidates = new JsonObject();
-    candidates.add("searchComponents",
-        contractPromotionCandidate("NOT_APPLICABLE_NON_NUMERICAL_COMPONENT_CATALOG_LOOKUP",
-            new String[] { "src/main/java/neqsim/mcp/runners/ComponentQuery.java",
-                "src/test/java/neqsim/mcp/runners/ComponentQueryTest.java", "neqsim-mcp-server/test_mcp_server.py" },
-            "Component-name lookup, substring search, empty-query enumeration, typo handling, and no-match behavior are directly tested, including real-protocol retrieval; catalog lookup does not validate thermodynamic calculations or component-property models"));
-    candidates.add("queryDataCatalog",
-        contractPromotionCandidate("NOT_APPLICABLE_NON_NUMERICAL_DATA_CATALOG_DISCOVERY",
-            new String[] { "src/main/java/neqsim/mcp/runners/DataCatalogRunner.java",
-                "src/test/java/neqsim/mcp/runners/DataCatalogRunnerTest.java", "neqsim-mcp-server/test_mcp_server.py" },
-            "Read-only catalog dispatch and representative component-family, EOS-model, component-property, and real-protocol catalog retrieval are tested; database contents, standards applicability, EOS accuracy, and material or design decisions are not validated by this evidence"));
+    candidates.add("searchComponents", contractPromotionCandidate(
+        "NOT_APPLICABLE_NON_NUMERICAL_COMPONENT_CATALOG_LOOKUP",
+        new String[] { "src/main/java/neqsim/mcp/runners/ComponentQuery.java",
+            "src/test/java/neqsim/mcp/runners/ComponentQueryTest.java", "neqsim-mcp-server/test_mcp_server.py" },
+        "Component-name lookup, substring search, empty-query enumeration, typo handling, and no-match behavior are directly tested, including real-protocol retrieval; catalog lookup does not validate thermodynamic calculations or component-property models"));
+    candidates.add("queryDataCatalog", contractPromotionCandidate("NOT_APPLICABLE_NON_NUMERICAL_DATA_CATALOG_DISCOVERY",
+        new String[] { "src/main/java/neqsim/mcp/runners/DataCatalogRunner.java",
+            "src/test/java/neqsim/mcp/runners/DataCatalogRunnerTest.java", "neqsim-mcp-server/test_mcp_server.py" },
+        "Read-only catalog dispatch and representative component-family, EOS-model, component-property, and real-protocol catalog retrieval are tested; database contents, standards applicability, EOS accuracy, and material or design decisions are not validated by this evidence"));
     return candidates;
   }
 

--- a/src/test/java/neqsim/mcp/runners/McpAcceptanceBaselineRunnerTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpAcceptanceBaselineRunnerTests.java
@@ -20,7 +20,7 @@ class McpAcceptanceBaselineRunnerTests {
     assertFalse(contract.get("scientificValidationComplete").getAsBoolean());
 
     JsonObject inventory = McpEvidenceInventory.build();
-    assertEquals("1.8", inventory.get("inventoryVersion").getAsString());
+    assertEquals("1.9", inventory.get("inventoryVersion").getAsString());
     assertTrue(inventory.has("acceptanceBaselineContract"));
     assertFalse(inventory.get("complete").getAsBoolean());
   }


### PR DESCRIPTION
## Summary

Advances #3153 by repairing two deterministic current-master regressions introduced by merged MCP PR #3237 before the next Phase 0 trust-classification increment.

- applies the exact hosted Spotless formatting patch to `McpEvidenceInventory.java`;
- aligns `McpAcceptanceBaselineRunnerTests` with the inventory version (`1.9`) already published by current master;
- leaves the current `20 EXPLICIT_TRUST + 6 CONTRACT_TESTED + 45 CONFIRMED_GAP` accounting and the two read-only promotion candidates unchanged;
- changes no MCP tool, schema, response envelope, thermodynamic/process calculation, facility model, safety policy, or plant-control behavior.

Exact branch base: `a221b61a1030472b3721394ee60d9ccf1989c3b5` (merged #3237)  
Exact publication head: `08c2c1a741b9d12ba2643f6adbb3ded8a20c5496`

## Verified root causes

Merged #3237 exact head `4291b6162e659ed3ec48283b6a3252f21943b411` completed with:

- Spotless-format artifact available;
- pre-commit workflow failure;
- Java 21 fast-test workflow failure.

The hosted Spotless artifact changes only the two call-formatting blocks in `McpEvidenceInventory.java`. This PR writes exactly that formatted file; its resulting blob is `5800cbade2456e6b5ae1532c25b5635e0fc954b7`, matching the hosted formatter target.

Current master also has a direct contract mismatch: `McpEvidenceInventory.build()` reports inventory version `1.9`, `McpEvidenceInventoryFoundationTests` expects `1.9`, while `McpAcceptanceBaselineRunnerTests` still expects `1.8`. This PR changes only that stale assertion to `1.9`; no test is weakened or bypassed.

## Scope / dependency boundary

This is a current-master CI-baseline repair and not the deferred catalog-promotion increment. `searchComponents` and `queryDataCatalog` remain `CONFIRMED_GAP` with `promotionReady=false`. Their next dependency remains the atomic update of Java classification accounting plus packaged MCP protocol expectations on one exact validated head.

Owner-roadmap boundaries remain unchanged: DEXPI/P&ID #2899, dynamics #2911, flash/stability #2937, generic process performance #2939, and production optimization #2941/#3154.

## Validation

Hosted exact-head CI completed successfully at `08c2c1a741b9d12ba2643f6adbb3ded8a20c5496`:

- Run build, test and javadoc #10706: Java 21 fast tests on Ubuntu and Windows, all four Java 21 slow-test shards, Java 8 full tests on Ubuntu and Windows, Javadocs, and agent-skill cross-reference validation passed;
- Spotless format patch #3017 passed;
- pre-commit checks #3463 passed;
- CodeQL Security Analysis #7299 passed;
- PaperLab Replication Gate #3505 passed.

The Windows/Java 8 full suite that reproduced the reported `expected: <1.8> but was: <1.9>` master failure now passes.

Connector-backed exact-source validation also confirms:

- branch is exactly two commits ahead / zero behind base;
- final diff is exactly two MCP files;
- the formatted `McpEvidenceInventory.java` blob exactly matches the hosted #3237 Spotless artifact target;
- the acceptance-baseline change is the single stale version assertion `1.8 -> 1.9`.

No repository-local Maven, Java/JDK, Spotless, pre-commit, Javadoc, or packaged MCP execution is claimed; hosted exact-head CI is the validation authority for this repair.

## Documentation impact

None. This restores internal formatting and regression alignment only; public MCP usage, units, schemas, examples, response contracts, advisory boundaries, and agent/skill invocation contracts do not change.

## Next dependency

After this repair is validated/merged, atomically promote the already evidence-qualified read-only `searchComponents` and `queryDataCatalog` contracts together with the packaged protocol 6/45 accounting update, without introducing scientific benchmark claims.

AI-assisted implementation. No unrun check is claimed as passed.