### PR TITLE
[AI-Assisted] docs: use canonical current JavaDoc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ See [VISION_AGENTS.md](VISION_AGENTS.md) and the [Where Does This Go? guide](htt
 
 The Quick Start above shows the core pattern (create a fluid, run a flash, and read properties). For process simulation, add equipment to a `ProcessSystem` and call `run()`; see the [Java Getting Started Guide](docs/java-getting-started.md) for full examples.
 
-**Learn more:** [Java Getting Started Guide](docs/java-getting-started.md) | [JavaDoc](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html) | [Wiki](https://github.com/equinor/neqsim/wiki) | [Colab demo](https://colab.research.google.com/drive/1XkQ_CrVj2gLTtJvXhFQMWALzXii522CL)
+**Learn more:** [Java Getting Started Guide](docs/java-getting-started.md) | [JavaDoc](https://equinor.github.io/neqsim/javadoc/index.html) | [Wiki](https://github.com/equinor/neqsim/wiki) | [Colab demo](https://colab.research.google.com/drive/1XkQ_CrVj2gLTtJvXhFQMWALzXii522CL)
 
 ---
 
@@ -689,7 +689,7 @@ All tests and `./mvnw checkstyle:check` must pass before a PR is merged.
 | **Benchmark gallery** | [docs/benchmarks/](docs/benchmarks/index.md) - validation against NIST, published data |
 | **Reference manual index** | [REFERENCE_MANUAL_INDEX.md](docs/REFERENCE_MANUAL_INDEX.md) (350+ pages) |
 | **MCP tool contract** | [MCP_CONTRACT.md](neqsim-mcp-server/MCP_CONTRACT.md) - stable API for agent builders |
-| **JavaDoc API** | [JavaDoc](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html) |
+| **JavaDoc API** | [JavaDoc](https://equinor.github.io/neqsim/javadoc/index.html) |
 | **Jupyter notebooks** | [examples/notebooks/](examples/notebooks/) (30+ examples) |
 | **Discussion forum** | [GitHub Discussions](https://github.com/equinor/neqsim/discussions) |
 | **Releases** | [GitHub Releases](https://github.com/equinor/neqsim/releases) |

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -44,5 +44,5 @@ Each recipe includes:
 ## API Reference
 
 For complete API documentation, see:
-- **[JavaDoc API](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html)** - All classes and methods
+- **[JavaDoc API](https://equinor.github.io/neqsim/javadoc/index.html)** - All classes and methods
 - **[Reference Manual](../REFERENCE_MANUAL_INDEX.md)** - Comprehensive guides

--- a/docs/cookbook/pipeline-recipes.md
+++ b/docs/cookbook/pipeline-recipes.md
@@ -1326,4 +1326,4 @@ print(f"Total flow: {export.getOutletStream().getFlowRate('kg/hr'):.0f} kg/hr")
 - **[TwoFluidPipe Tutorial](../examples/TwoFluidPipe_Tutorial)** - Complete tutorial with slug tracking
 - **[Pipeline Network Example](../examples/LoopedPipelineNetworkExample)** - Complex network modeling
 - **[Dynamic Simulation Guide](../simulation/dynamic_simulation_guide)** - Transient simulation concepts
-- **[JavaDoc API](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html)** - Complete reference
+- **[JavaDoc API](https://equinor.github.io/neqsim/javadoc/index.html)** - Complete reference

--- a/docs/cookbook/process-recipes.md
+++ b/docs/cookbook/process-recipes.md
@@ -424,4 +424,4 @@ print(f"Adjusted feed flow: {feed.getFlowRate('kg/hr'):.2f} kg/hr")
 
 - **[Process Equipment Documentation](../process/equipment/README.md)** - All equipment types
 - **[Optimization Guide](../process/optimization/README.md)** - Process optimization
-- **[JavaDoc: ProcessSystem](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/process/processmodel/ProcessSystem.html)** - Complete API
+- **[JavaDoc: ProcessSystem](https://equinor.github.io/neqsim/javadoc/neqsim/process/processmodel/ProcessSystem.html)** - Complete API

--- a/docs/cookbook/thermodynamics-recipes.md
+++ b/docs/cookbook/thermodynamics-recipes.md
@@ -314,4 +314,4 @@ changing temperature, pressure, composition, or model settings.
 - **[Reading Fluid Properties Guide](../thermo/reading_fluid_properties)** - Property access and initialization
 - **[Thermodynamic Models](../thermo/thermodynamic_models)** - Model theory and selection
 - **[Phase Envelope Guide](../pvtsimulation/phase_envelope_guide)** - Algorithms, results, and troubleshooting
-- **[JavaDoc: SystemInterface](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/thermo/system/SystemInterface.html)** - Complete API
+- **[JavaDoc: SystemInterface](https://equinor.github.io/neqsim/javadoc/neqsim/thermo/system/SystemInterface.html)** - Complete API

--- a/docs/cookbook/unit-conversion-recipes.md
+++ b/docs/cookbook/unit-conversion-recipes.md
@@ -154,7 +154,7 @@ When a conversion fails or looks implausible:
 
 For errors involving overload selection, stale properties, or phase availability, see the
 [troubleshooting guide](../troubleshooting/index.md). For API signatures, use the
-[current JavaDoc](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html).
+[current JavaDoc](https://equinor.github.io/neqsim/javadoc/index.html).
 
 ## Engineering boundary
 

--- a/docs/development/python_extension_patterns.md
+++ b/docs/development/python_extension_patterns.md
@@ -249,7 +249,7 @@ assert python_tag.getTagNumber() == "20-VG-001"
 
 This proxy only demonstrates the JPype boundary. It is not a process unit and cannot be added to a
 `ProcessSystem`. Before using any proxy in production, read the current
-[NamedInterface JavaDoc](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/util/NamedInterface.html)
+[NamedInterface JavaDoc](https://equinor.github.io/neqsim/javadoc/neqsim/util/NamedInterface.html)
 and the accepting Java API, then test callback lifetime, exceptions, Java threads, and repeated
 execution.
 

--- a/docs/java-getting-started.md
+++ b/docs/java-getting-started.md
@@ -313,7 +313,7 @@ src/
 ## Next steps
 
 - [NeqSim User Documentation](https://equinor.github.io/neqsim/) — Full docs site
-- [JavaDoc API Reference](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html) — Complete API docs
+- [JavaDoc API Reference](https://equinor.github.io/neqsim/javadoc/index.html) — Complete API docs
 - [Java Wiki & examples](https://github.com/equinor/neqsim/wiki) — Usage patterns and guides
 - [Jupyter notebooks](https://github.com/equinor/neqsim/tree/master/examples/notebooks) — 30+ runnable examples
 - [NeqSim Colab demo](https://colab.research.google.com/drive/1XkQ_CrVj2gLTtJvXhFQMWALzXii522CL) — Try NeqSim interactively

--- a/docs/process/equipment/manifold_design.md
+++ b/docs/process/equipment/manifold_design.md
@@ -417,4 +417,4 @@ DNV-ST-F101 and API RP 17A parameters for subsea manifolds.
 
 ## API Reference
 
-See the [JavaDoc API Documentation](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html) for class details.
+See the [JavaDoc API Documentation](https://equinor.github.io/neqsim/javadoc/index.html) for class details.

--- a/docs/quickstart/java-quickstart.md
+++ b/docs/quickstart/java-quickstart.md
@@ -140,11 +140,11 @@ public class FirstProcess {
 - **[Reading Fluid Properties](../thermo/reading_fluid_properties)** - Understanding init levels and property access
 - **[Thermodynamic Models](../thermo/thermodynamic_models)** - Choosing the right equation of state
 - **[Process Equipment](../process/equipment/)** - All available unit operations
-- **[JavaDoc API](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html)** - Complete API reference
+- **[JavaDoc API](https://equinor.github.io/neqsim/javadoc/index.html)** - Complete API reference
 
 ## API Quick Reference
 
-Key interfaces to explore in the [JavaDoc](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html):
+Key interfaces to explore in the [JavaDoc](https://equinor.github.io/neqsim/javadoc/index.html):
 
 | Interface | Purpose |
 |-----------|---------|

--- a/docs/quickstart/python-quickstart.md
+++ b/docs/quickstart/python-quickstart.md
@@ -175,7 +175,7 @@ enthalpy = fluid.getEnthalpy("kJ/kg")
 - **[Reading Fluid Properties](../thermo/reading_fluid_properties)** - Init levels and property access
 - **[Python Examples](../examples/index)** - Jupyter notebook tutorials
 - **[Cookbook](../cookbook/index)** - Quick recipes for common tasks
-- **[JavaDoc API](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html)** - Complete API reference (Java methods work in Python too!)
+- **[JavaDoc API](https://equinor.github.io/neqsim/javadoc/index.html)** - Complete API reference (Java methods work in Python too!)
 
 ## Jupyter Notebook Tips
 

--- a/docs/test_javadoc_links_documentation.py
+++ b/docs/test_javadoc_links_documentation.py
@@ -1,0 +1,111 @@
+"""Regression contracts for the canonical current NeqSim JavaDoc deployment."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LEGACY_PREFIX = "https://equinor.github.io/neqsimhome/javadoc/site/apidocs/"
+CANONICAL_PREFIX = "https://equinor.github.io/neqsim/javadoc/"
+
+EXPECTED_LINK_COUNTS = {
+    "docs/cookbook/index.md": {
+        CANONICAL_PREFIX + "index.html": 1,
+    },
+    "docs/tutorials/learning-paths.md": {
+        CANONICAL_PREFIX + "index.html": 1,
+        CANONICAL_PREFIX + "neqsim/thermo/system/SystemInterface.html": 2,
+        CANONICAL_PREFIX
+        + "neqsim/thermodynamicoperations/ThermodynamicOperations.html": 1,
+        CANONICAL_PREFIX
+        + "neqsim/process/processmodel/ProcessSystem.html": 1,
+        CANONICAL_PREFIX
+        + "neqsim/process/equipment/ProcessEquipmentInterface.html": 2,
+    },
+    "docs/quickstart/java-quickstart.md": {
+        CANONICAL_PREFIX + "index.html": 2,
+    },
+    "README.md": {
+        CANONICAL_PREFIX + "index.html": 2,
+    },
+    "docs/java-getting-started.md": {
+        CANONICAL_PREFIX + "index.html": 1,
+    },
+    "docs/quickstart/python-quickstart.md": {
+        CANONICAL_PREFIX + "index.html": 1,
+    },
+    "docs/cookbook/process-recipes.md": {
+        CANONICAL_PREFIX
+        + "neqsim/process/processmodel/ProcessSystem.html": 1,
+    },
+    "docs/cookbook/unit-conversion-recipes.md": {
+        CANONICAL_PREFIX + "index.html": 1,
+    },
+    "docs/cookbook/thermodynamics-recipes.md": {
+        CANONICAL_PREFIX + "neqsim/thermo/system/SystemInterface.html": 1,
+    },
+    "docs/cookbook/pipeline-recipes.md": {
+        CANONICAL_PREFIX + "index.html": 1,
+    },
+    "docs/process/equipment/manifold_design.md": {
+        CANONICAL_PREFIX + "index.html": 1,
+    },
+    "docs/wiki/field_development_planning.md": {
+        CANONICAL_PREFIX + "index.html": 1,
+    },
+    "docs/development/python_extension_patterns.md": {
+        CANONICAL_PREFIX + "neqsim/util/NamedInterface.html": 1,
+    },
+}
+
+
+class JavaDocLinksDocumentationTest(unittest.TestCase):
+    def _markdown_files(self):
+        files = [ROOT / "README.md"]
+        files.extend(sorted((ROOT / "docs").rglob("*.md")))
+        return files
+
+    def test_legacy_generated_javadoc_deployment_is_not_linked(self):
+        offenders = []
+        for path in self._markdown_files():
+            if LEGACY_PREFIX in path.read_text(encoding="utf-8"):
+                offenders.append(path.relative_to(ROOT).as_posix())
+        self.assertEqual([], offenders)
+
+    def test_all_frozen_links_use_the_canonical_current_targets(self):
+        observed = 0
+        for relative_path, targets in EXPECTED_LINK_COUNTS.items():
+            text = (ROOT / relative_path).read_text(encoding="utf-8")
+            for target, expected_count in targets.items():
+                with self.subTest(path=relative_path, target=target):
+                    self.assertEqual(expected_count, text.count(target))
+                observed += expected_count
+        self.assertEqual(21, observed)
+
+    def test_class_links_preserve_the_generated_package_path(self):
+        class_targets = [
+            target
+            for targets in EXPECTED_LINK_COUNTS.values()
+            for target in targets
+            if target != CANONICAL_PREFIX + "index.html"
+        ]
+        self.assertTrue(class_targets)
+        for target in class_targets:
+            with self.subTest(target=target):
+                self.assertTrue(target.startswith(CANONICAL_PREFIX + "neqsim/"))
+                self.assertTrue(target.endswith(".html"))
+                self.assertNotIn("/site/apidocs/", target)
+
+    def test_documentation_landing_page_owns_the_same_javadoc_root(self):
+        landing = (ROOT / "docs/index.md").read_text(encoding="utf-8")
+        self.assertIn(CANONICAL_PREFIX + "index.html", landing)
+
+    def test_frozen_scope_covers_every_migrated_page(self):
+        self.assertEqual(13, len(EXPECTED_LINK_COUNTS))
+        for relative_path in EXPECTED_LINK_COUNTS:
+            with self.subTest(path=relative_path):
+                self.assertTrue((ROOT / relative_path).is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/tutorials/learning-paths.md
+++ b/docs/tutorials/learning-paths.md
@@ -79,8 +79,8 @@ The AI workflow automates the process around PVT calculations — scoping, runni
 
 ### PVT reference materials
 
-- [JavaDoc: SystemInterface](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/thermo/system/SystemInterface.html)
-- [JavaDoc: ThermodynamicOperations](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/thermodynamicoperations/ThermodynamicOperations.html)
+- [JavaDoc: SystemInterface](https://equinor.github.io/neqsim/javadoc/neqsim/thermo/system/SystemInterface.html)
+- [JavaDoc: ThermodynamicOperations](https://equinor.github.io/neqsim/javadoc/neqsim/thermodynamicoperations/ThermodynamicOperations.html)
 - [Component Database Guide](../thermo/component_database_guide.md)
 
 ---
@@ -132,8 +132,8 @@ The AI workflow automates the work around process simulation — scoping, litera
 
 ### Process reference materials
 
-- [JavaDoc: ProcessSystem](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/process/processmodel/ProcessSystem.html)
-- [JavaDoc: ProcessEquipmentInterface](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/process/equipment/ProcessEquipmentInterface.html)
+- [JavaDoc: ProcessSystem](https://equinor.github.io/neqsim/javadoc/neqsim/process/processmodel/ProcessSystem.html)
+- [JavaDoc: ProcessEquipmentInterface](https://equinor.github.io/neqsim/javadoc/neqsim/process/equipment/ProcessEquipmentInterface.html)
 - [Equipment Index](../process/equipment/README.md)
 
 ---
@@ -150,8 +150,8 @@ The AI workflow automates the work around process simulation — scoping, litera
 
 ### Level 2: Core APIs (2 hours)
 
-1. **[SystemInterface JavaDoc](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/thermo/system/SystemInterface.html)** - Fluid API
-2. **[ProcessEquipmentInterface JavaDoc](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/neqsim/process/equipment/ProcessEquipmentInterface.html)** - Equipment API
+1. **[SystemInterface JavaDoc](https://equinor.github.io/neqsim/javadoc/neqsim/thermo/system/SystemInterface.html)** - Fluid API
+2. **[ProcessEquipmentInterface JavaDoc](https://equinor.github.io/neqsim/javadoc/neqsim/process/equipment/ProcessEquipmentInterface.html)** - Equipment API
 3. **[Test Overview](../wiki/test-overview.md)** - Testing patterns
 
 ### Level 3: Thermodynamic Implementation (2 hours)
@@ -174,7 +174,7 @@ The AI workflow automates the work around process simulation — scoping, litera
 
 ### Developer reference materials
 
-- [Full JavaDoc API](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html)
+- [Full JavaDoc API](https://equinor.github.io/neqsim/javadoc/index.html)
 - [Reference Manual Index](../REFERENCE_MANUAL_INDEX.md)
 - [GitHub Repository](https://github.com/equinor/neqsim)
 

--- a/docs/wiki/field_development_planning.md
+++ b/docs/wiki/field_development_planning.md
@@ -540,5 +540,5 @@ public class FieldDevelopmentExample {
 
 ## API Reference
 
-See the [JavaDoc API Documentation](https://equinor.github.io/neqsimhome/javadoc/site/apidocs/index.html) for complete API details.
+See the [JavaDoc API Documentation](https://equinor.github.io/neqsim/javadoc/index.html) for complete API details.
 


### PR DESCRIPTION
## Summary

Advances #2499 as D088 (rotation scope 7: JavaDoc-facing examples and external links).

Repairs all 21 confirmed stale JavaDoc destinations across the 13 affected guides:

- migrates the legacy generated-site root `https://equinor.github.io/neqsimhome/javadoc/site/apidocs/` to the canonical current deployment `https://equinor.github.io/neqsim/javadoc/`;
- preserves direct package/class destinations for `SystemInterface`, `ThermodynamicOperations`, `ProcessSystem`, `ProcessEquipmentInterface`, and `NamedInterface`;
- aligns README, Java/Python quickstarts, learning paths, cookbook pages, equipment/field-development guides, and Python-extension guidance with the JavaDoc destination advertised by the current documentation landing page; and
- adds a repository-wide regression contract that rejects the legacy JavaDoc origin and freezes all 21 migrated destinations.

## Evidence and root cause

GitHub code search at exact base `a221b61a1030472b3721394ee60d9ccf1989c3b5` found 21 legacy JavaDoc links in exactly 13 Markdown files. The legacy deployment still serves a generated **NeqSim 3.9.1 API**, while the current NeqSim documentation landing page advertises `https://equinor.github.io/neqsim/javadoc/index.html`.

This is therefore a stale-version defect, not a claim that the legacy host is unreachable.

## Frozen scope

Exact base: `a221b61a1030472b3721394ee60d9ccf1989c3b5`

Branch publication head: `99db1bbda4daafbe8203a8744f2a51c8e480024a`

Changed files:

- 13 existing Markdown files containing the 21 legacy destinations
- `docs/test_javadoc_links_documentation.py`

Stop boundary: no code-example text, production Java/Python API, equations, notebooks, images, site layout, generated JavaDoc content, browser rendering, or Huldra work.

Open autonomous PR #3238 does not overlap any frozen file. Portfolio usage at publication is 2 of 10 slots including this draft.

## Validation

Connector-backed exact-branch verification:

- compare against `master`: 14 commits ahead, 0 behind, exactly 14 files;
- all 13 migrated Markdown blobs contain zero legacy JavaDoc destinations;
- all 21 frozen destinations use the canonical current root;
- direct class links preserve the generated package path;
- no code examples, equations, images, or notebooks changed.

The new hermetic Python contract checks:

1. every Markdown file under `docs/` plus `README.md` rejects the legacy JavaDoc origin;
2. all 21 frozen replacements and duplicate counts are exact;
3. direct class links preserve `neqsim/.../*.html` package paths;
4. the documentation landing page owns the same canonical JavaDoc root; and
5. all 13 migrated pages remain present.

## VALIDATION BLOCKED BY EXISTING MASTER FORMATTING

Exact-head hosted results at `99db1bbda4daafbe8203a8744f2a51c8e480024a`:

- build, tests, and JavaDoc passed;
- all five D088 Python contracts passed inside the documentation workflow;
- Jekyll build, search-source audit, generated-search coverage, and search JavaScript checks passed;
- Spotless format-patch workflow passed;
- CodeQL passed; and
- pre-commit failed only because its all-files Spotless hook found a formatting violation in unchanged `src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java` already present on exact base/current `master`. D088 changes no Java file, and the separate D088 Spotless workflow passed.

The pre-commit failure is not attributable to this branch, but the PR is not classified READY TO MERGE while a required check remains red. No speculative out-of-scope MCP formatting change is included.

Documentation impact: JavaDoc-facing documentation now targets the current deployment without changing any technical example or API claim.

Next rotation scope: 8 — recent merged code versus documentation coverage.

AI-assisted documentation repair; repository, external-link, and validation claims above distinguish exact observed evidence from pending CI.