### PR TITLE
[AI-Assisted] docs: repair published links and catalog equipment

### DIFF
--- a/.github/workflows/documentation-search.yml
+++ b/.github/workflows/documentation-search.yml
@@ -11,6 +11,8 @@ on:
     paths:
       - "docs/**"
       - "devtools/check_documentation_search.py"
+      - "devtools/generate_equipment_documentation_catalog.py"
+      - "src/main/java/neqsim/process/equipment/**"
       - ".pre-commit-config.yaml"
       - ".github/workflows/documentation-search.yml"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         name: Documentation Search Coverage
         entry: python devtools/check_documentation_search.py
         language: system
-        files: ^(docs/|devtools/check_documentation_search\.py|\.github/workflows/documentation-search\.yml|\.pre-commit-config\.yaml)
+        files: ^(docs/|devtools/(check_documentation_search|generate_equipment_documentation_catalog)\.py|src/main/java/neqsim/process/equipment/|\.github/workflows/documentation-search\.yml|\.pre-commit-config\.yaml)
         pass_filenames: false
         stages: [pre-push]
         verbose: true

--- a/devtools/check_documentation_search.py
+++ b/devtools/check_documentation_search.py
@@ -7,8 +7,14 @@ import argparse
 import json
 import re
 import sys
+import urllib.parse
 from pathlib import Path
 from typing import Dict, Iterable, List, Sequence, Tuple
+
+try:
+    from devtools import generate_equipment_documentation_catalog as equipment_catalog
+except ModuleNotFoundError:  # Direct execution: python devtools/check_documentation_search.py
+    import generate_equipment_documentation_catalog as equipment_catalog
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -22,6 +28,14 @@ NOTEBOOK_LINK_PATTERN = re.compile(
     r"""(?:\[[^\]]*\]\(\s*|href\s*=\s*["'])
     (?P<target>[^)\s"']+\.ipynb(?:[?#][^)\s"']*)?)""",
     re.IGNORECASE | re.VERBOSE,
+)
+MARKDOWN_LINK_PATTERN = re.compile(
+    r"(?<!!)\[[^\]]*\]\(\s*(?P<target><[^>]+>|[^)\s]+)",
+    re.IGNORECASE,
+)
+INCLUDE_RELATIVE_PATTERN = re.compile(
+    r"{%-?\s*include_relative\s+(?P<target>[^\s%]+)\s*-?%}",
+    re.IGNORECASE,
 )
 
 
@@ -124,6 +138,85 @@ def relative_notebook_link_errors(
     return errors
 
 
+def markdown_link_targets(text: str) -> List[str]:
+    """Return link destinations from Markdown prose, excluding images and code."""
+
+    return [
+        match.group("target").strip("<>")
+        for match in MARKDOWN_LINK_PATTERN.finditer(markdown_prose(text))
+    ]
+
+
+def is_external_link(target: str) -> bool:
+    """Return whether a link uses a URI scheme or protocol-relative URL."""
+
+    return bool(re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", target)) or target.startswith("//")
+
+
+def included_markdown_sources(paths: Iterable[Path]) -> List[Path]:
+    """Return Markdown sources inserted into pages through ``include_relative``."""
+
+    included = set()
+    for path in paths:
+        text = path.read_text(encoding="utf-8-sig")
+        for match in INCLUDE_RELATIVE_PATTERN.finditer(text):
+            target = match.group("target").strip("\"'")
+            included.add((path.parent / target).resolve())
+    return sorted(included)
+
+
+def included_markdown_suffix_errors(path: Path, text: str) -> List[str]:
+    """Reject ``.md`` URLs that Jekyll cannot rewrite after a Liquid include."""
+
+    errors: List[str] = []
+    for target in markdown_link_targets(text):
+        if is_external_link(target) or target.startswith(("#", "{{", "{%")):
+            continue
+        link_path = urllib.parse.unquote(target.split("#", 1)[0].split("?", 1)[0])
+        if link_path.lower().endswith(".md"):
+            errors.append(
+                f"{path.relative_to(ROOT)}: included Markdown link {target} retains a .md "
+                "suffix; use the extensionless published URL"
+            )
+    return errors
+
+
+def internal_document_link_errors(path: Path, text: str) -> List[str]:
+    """Reject relative documentation links whose local source target is missing."""
+
+    errors: List[str] = []
+    for target in markdown_link_targets(text):
+        if is_external_link(target) or target.startswith(("#", "{{", "{%")):
+            continue
+        link_path = urllib.parse.unquote(target.split("#", 1)[0].split("?", 1)[0])
+        if not link_path or any(character in link_path for character in "\\{}"):
+            continue
+        candidate = DOCS / link_path.lstrip("/") if link_path.startswith("/") else path.parent / link_path
+        candidate = candidate.resolve()
+        try:
+            candidate.relative_to(DOCS.resolve())
+        except ValueError:
+            # Repository-source links outside docs are valid but are not published pages.
+            continue
+        candidates = [candidate]
+        if not candidate.suffix:
+            candidates.extend(
+                [
+                    Path(str(candidate) + ".md"),
+                    candidate / "index.md",
+                    candidate / "README.md",
+                    Path(str(candidate) + ".html"),
+                ]
+            )
+        elif candidate.suffix.lower() == ".html":
+            candidates.append(candidate.with_suffix(".md"))
+        if not any(item.exists() for item in candidates):
+            errors.append(
+                f"{path.relative_to(ROOT)}: internal documentation link target does not exist: {target}"
+            )
+    return errors
+
+
 def relative_sources(paths: Iterable[Path]) -> List[str]:
     """Return source paths in the same form emitted by Jekyll's ``page.path``."""
     return [path.relative_to(DOCS).as_posix() for path in paths]
@@ -147,6 +240,33 @@ def source_audit() -> List[str]:
         if not body:
             errors.append(f"{path.relative_to(ROOT)}: documentation body is empty")
         errors.extend(relative_notebook_link_errors(path, body))
+        errors.extend(internal_document_link_errors(path, body))
+
+    for path in included_markdown_sources(markdown):
+        if not path.is_file():
+            errors.append(f"{path.relative_to(ROOT)}: include_relative target does not exist")
+            continue
+        try:
+            _, body = parse_front_matter(path)
+        except ValueError:
+            body = path.read_text(encoding="utf-8-sig")
+        errors.extend(included_markdown_suffix_errors(path, body))
+
+    try:
+        expected_catalog = equipment_catalog.expected_catalog()
+    except ValueError as exc:
+        errors.append(f"equipment catalog generation failed: {exc}")
+    else:
+        actual_catalog = (
+            equipment_catalog.CATALOG.read_text(encoding="utf-8-sig")
+            if equipment_catalog.CATALOG.is_file()
+            else ""
+        )
+        if actual_catalog != expected_catalog:
+            errors.append(
+                "docs/process/equipment/equipment_catalog.md is stale; run "
+                "python devtools/generate_equipment_documentation_catalog.py"
+            )
 
     template = SEARCH_TEMPLATE.read_text(encoding="utf-8")
     required_template_contracts = {

--- a/devtools/generate_equipment_documentation_catalog.py
+++ b/devtools/generate_equipment_documentation_catalog.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Generate the source-backed process-equipment documentation catalog."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SOURCE_ROOT = ROOT / "src" / "main" / "java" / "neqsim" / "process" / "equipment"
+CATALOG = ROOT / "docs" / "process" / "equipment" / "equipment_catalog.md"
+
+
+@dataclass(frozen=True)
+class JavaType:
+    """Small source-level view of one public top-level Java type."""
+
+    qualified_name: str
+    simple_name: str
+    package_name: str
+    source_package: str
+    kind: str
+    is_abstract: bool
+    superclass: Optional[str]
+    interfaces: Tuple[str, ...]
+    imports: Mapping[str, str]
+
+
+PACKAGE_GUIDES: Mapping[str, Tuple[str, str]] = {
+    "absorber": ("[Absorbers and strippers](absorbers)", "Gas absorption, stripping, amine, and TEG contactors"),
+    "adsorber": ("[Adsorbers](adsorbers) and [adsorption beds](adsorption_bed)", "Adsorption beds, mercury removal, and PSA equipment"),
+    "battery": ("[Battery storage](battery_storage)", "Electrical energy storage and balancing"),
+    "blackoil": ("[Black-oil separation](black_oil_separator)", "Black-oil PVT separation in ProcessSystem"),
+    "compressor": ("[Compressors](compressors)", "Compressors, trains, drivers, maps, and anti-surge models"),
+    "diffpressure": ("[Differential-pressure equipment](differential_pressure)", "Orifice and differential-pressure flow equipment"),
+    "distillation": ("[Distillation](distillation)", "Tray, packed, reactive, and shortcut columns"),
+    "ejector": ("[Ejectors](ejectors)", "Motive/suction ejector equipment"),
+    "electrolyzer": ("[Electrolyzers](electrolyzers)", "Water and carbon-dioxide electrolysis"),
+    "energy": ("[Energy conversion equipment](energy_conversion)", "Motors, generators, converters, utility sources, and network solvers"),
+    "expander": ("[Expanders](expanders)", "Turboexpanders and coupled expander-compressor units"),
+    "filter": ("[Filters](filters)", "Particulate, charcoal, and sulfur filters"),
+    "flare": ("[Flares](flares)", "Flare units and stacks"),
+    "heatexchanger": ("[Heat exchangers](heat_exchangers)", "Heaters, coolers, exchangers, evaporators, and dryers"),
+    "lng": ("[LNG cargo ageing](../lng-ageing)", "LNG storage, ageing, boil-off, and transport scenarios"),
+    "manifold": ("[Manifolds](manifolds)", "Multi-inlet production and routing manifolds"),
+    "membrane": ("[Membranes](membranes)", "Membrane separators"),
+    "mixer": ("[Mixers and splitters](mixers_splitters)", "Equilibrium, static, non-equilibrium, and phase mixers"),
+    "network": ("[Networks](networks)", "Pipe, looped, and well-flowline networks"),
+    "pipeline": ("[Pipelines](pipelines)", "Steady and transient single-, two-, and multiphase pipelines"),
+    "powergeneration": ("[Power generation](power_generation)", "Turbines, fuel cells, renewables, and combined-cycle systems"),
+    "pump": ("[Pumps](pumps)", "Centrifugal, ESP, jet, and sucker-rod pumps"),
+    "reactor": ("[Reactors](reactors)", "Equilibrium, kinetic, reforming, sulfur, and bioprocess reactors"),
+    "reservoir": ("[Reservoirs and wells](reservoirs)", "Reservoir, inflow, surveillance, and well-system equipment"),
+    "separator": ("[Separators](separators)", "Phase, solids, cryogenic, and extraction separators"),
+    "solidhandling": ("[Solid handling](solid_handling)", "Biological feedstock preparation and solids handling"),
+    "splitter": ("[Mixers and splitters](mixers_splitters)", "Flow, component, capture, and upgrading splitters"),
+    "stream": ("[Streams](streams)", "Material, equilibrium, virtual, and diagnostic streams"),
+    "subsea": ("[Subsea equipment](subsea_equipment)", "Trees, manifolds, boosters, jumpers, flowlines, and umbilicals"),
+    "tank": ("[Tanks](tanks)", "Storage, LNG, and vessel-depressurization equipment"),
+    "util": ("[Process utilities](util/)", "Adjusters, recycles, calculators, fitters, setters, and utility systems"),
+    "valve": ("[Valves](valves)", "Control, shutdown, relief, rupture-disk, and throttling valves"),
+    "watertreatment": ("[Water treatment](water_treatment)", "Hydrocyclone, flotation, and produced-water treatment trains"),
+}
+
+
+DECLARATION = re.compile(
+    r"public\s+(?P<abstract>abstract\s+)?(?P<kind>class|interface)\s+"
+    r"(?P<name>[A-Za-z_$][\w$]*)(?:\s+extends\s+(?P<extends>[\w.$]+))?"
+    r"(?:\s+implements\s+(?P<implements>[^\{]+))?\s*\{",
+    re.MULTILINE,
+)
+PACKAGE = re.compile(r"^package\s+([\w.]+);", re.MULTILINE)
+IMPORT = re.compile(r"^import\s+([\w.]+);", re.MULTILINE)
+
+
+def read_java_types() -> Dict[str, JavaType]:
+    """Read public top-level classes and interfaces under the equipment package."""
+
+    types: Dict[str, JavaType] = {}
+    for path in sorted(SOURCE_ROOT.rglob("*.java")):
+        text = path.read_text(encoding="utf-8-sig")
+        package_match = PACKAGE.search(text)
+        declaration = DECLARATION.search(text)
+        if package_match is None or declaration is None:
+            continue
+        package_name = package_match.group(1)
+        simple_name = declaration.group("name")
+        imports = {
+            qualified.rsplit(".", 1)[-1]: qualified for qualified in IMPORT.findall(text)
+        }
+        interfaces = tuple(
+            value.strip().split("<", 1)[0]
+            for value in (declaration.group("implements") or "").split(",")
+            if value.strip()
+        )
+        relative = path.relative_to(SOURCE_ROOT)
+        source_package = relative.parts[0] if len(relative.parts) > 1 else "(root)"
+        qualified_name = package_name + "." + simple_name
+        types[qualified_name] = JavaType(
+            qualified_name=qualified_name,
+            simple_name=simple_name,
+            package_name=package_name,
+            source_package=source_package,
+            kind=declaration.group("kind"),
+            is_abstract=bool(declaration.group("abstract")),
+            superclass=declaration.group("extends"),
+            interfaces=interfaces,
+            imports=imports,
+        )
+    return types
+
+
+def resolve_reference(reference: str, owner: JavaType, types: Mapping[str, JavaType]) -> str:
+    """Resolve a source-level superclass or interface reference when possible."""
+
+    plain = reference.strip().split("<", 1)[0]
+    if "." in plain:
+        return plain
+    if plain in owner.imports:
+        return owner.imports[plain]
+    same_package = owner.package_name + "." + plain
+    if same_package in types:
+        return same_package
+    matches = [name for name, java_type in types.items() if java_type.simple_name == plain]
+    return matches[0] if len(matches) == 1 else plain
+
+
+def concrete_equipment(types: Mapping[str, JavaType]) -> List[JavaType]:
+    """Return every non-abstract class that implements the equipment contract."""
+
+    equipment: Set[str] = {
+        "neqsim.process.equipment.ProcessEquipmentInterface",
+        "neqsim.process.equipment.ProcessEquipmentBaseClass",
+    }
+    changed = True
+    while changed:
+        changed = False
+        for qualified_name, java_type in types.items():
+            parents: Iterable[str] = ([java_type.superclass] if java_type.superclass else [])
+            parents = list(parents) + list(java_type.interfaces)
+            if qualified_name not in equipment and any(
+                resolve_reference(parent, java_type, types) in equipment for parent in parents
+            ):
+                equipment.add(qualified_name)
+                changed = True
+    return sorted(
+        (
+            java_type
+            for qualified_name, java_type in types.items()
+            if qualified_name in equipment
+            and java_type.kind == "class"
+            and not java_type.is_abstract
+            and java_type.source_package != "(root)"
+        ),
+        key=lambda java_type: (java_type.source_package, java_type.simple_name),
+    )
+
+
+def render_catalog(equipment: Sequence[JavaType]) -> str:
+    """Render the complete Markdown catalog."""
+
+    grouped: Dict[str, List[JavaType]] = {}
+    for java_type in equipment:
+        grouped.setdefault(java_type.source_package, []).append(java_type)
+    missing_guides = sorted(set(grouped) - set(PACKAGE_GUIDES))
+    if missing_guides:
+        raise ValueError("Equipment source packages need documentation mappings: " + ", ".join(missing_guides))
+
+    lines = [
+        "---",
+        'title: "Complete Process Equipment Catalog"',
+        'description: "Source-backed catalog of every concrete NeqSim ProcessEquipmentInterface implementation, grouped by Java package and linked to its maintained guide."',
+        "---",
+        "",
+        "This catalog is generated from `src/main/java/neqsim/process/equipment`. It lists every public,",
+        "non-abstract class that implements `ProcessEquipmentInterface`, directly or through an equipment",
+        "base class. Helper classes, result records, strategies, enums, and interfaces are intentionally",
+        "excluded from the equipment count.",
+        "",
+        f"**Current source inventory:** {len(equipment)} concrete equipment classes in {len(grouped)} packages.",
+        "",
+        "Regenerate this page after adding or removing equipment:",
+        "",
+        "```text",
+        "python devtools/generate_equipment_documentation_catalog.py",
+        "```",
+        "",
+        "## Equipment by source package",
+        "",
+        "| Source package | Maintained guide | Concrete equipment classes |",
+        "| --- | --- | --- |",
+    ]
+    for source_package in sorted(grouped):
+        guide, purpose = PACKAGE_GUIDES[source_package]
+        classes = ", ".join(f"`{java_type.simple_name}`" for java_type in grouped[source_package])
+        lines.append(
+            f"| `{source_package}` | {guide}<br>{purpose} | {classes} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Equipment-adjacent framework packages",
+            "",
+            "These packages live below `neqsim.process.equipment` but provide shared contracts, metadata,",
+            "or services rather than concrete process units, so they are not included in the equipment count.",
+            "",
+            "| Source package | Documentation | Role |",
+            "| --- | --- | --- |",
+            "| `capacity` | [Capacity constraint framework](../CAPACITY_CONSTRAINT_FRAMEWORK) | Capacity strategies, constraints, bottleneck results, and design data |",
+            "| `failure` | [Failure modes](failure_modes) | Reliability and failure-mode metadata attached to equipment |",
+            "| `iec81346` | [Engineering diagram and identification guide](../../integration/engineering-diagram-document-model) | IEC 81346 reference designations and automatic assignment |",
+            "| `well` | [Well allocation](well_allocation) | Allocation results and production-allocation services |",
+            "",
+            "## Catalog boundary",
+            "",
+            "Controllers and measurement devices implement the broader `ProcessElementInterface` contract and",
+            "are documented separately in [controllers](../controllers) and [measurement devices](measurement_devices).",
+            "Mechanical-design calculators, thermodynamic systems, and process modules are likewise outside this",
+            "equipment-class inventory even when they configure or consume equipment results.",
+            "",
+            "Return to the [equipment guide](./).",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def expected_catalog() -> str:
+    """Return the catalog content implied by the current Java source."""
+
+    return render_catalog(concrete_equipment(read_java_types()))
+
+
+def main(argv: Sequence[str] = ()) -> int:
+    """Generate or check the catalog."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail when the committed catalog is stale")
+    args = parser.parse_args(argv)
+    expected = expected_catalog()
+    if args.check:
+        actual = CATALOG.read_text(encoding="utf-8-sig") if CATALOG.is_file() else ""
+        if actual != expected:
+            print(f"{CATALOG.relative_to(ROOT)} is stale; regenerate it", file=sys.stderr)
+            return 1
+        print(f"Equipment catalog is current: {len(concrete_equipment(read_java_types()))} concrete classes.")
+        return 0
+    CATALOG.write_text(expected, encoding="utf-8")
+    print(f"Generated {CATALOG.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/devtools/test_check_documentation_search.py
+++ b/devtools/test_check_documentation_search.py
@@ -57,5 +57,41 @@ class DocumentationNotebookLinkAuditTest(unittest.TestCase):
         )
 
 
+class DocumentationPageLinkAuditTest(unittest.TestCase):
+    def test_included_markdown_requires_extensionless_links(self) -> None:
+        errors = audit.included_markdown_suffix_errors(
+            audit.DOCS / "process" / "equipment" / "README.md",
+            "[Separators](separators.md) and [external](https://example.com/guide.md)",
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("retains a .md suffix", errors[0])
+
+    def test_existing_extensionless_document_link_is_allowed(self) -> None:
+        errors = audit.internal_document_link_errors(
+            audit.DOCS / "process" / "equipment" / "README.md",
+            "[Separators](separators)",
+        )
+
+        self.assertEqual(errors, [])
+
+    def test_missing_internal_document_link_is_rejected(self) -> None:
+        errors = audit.internal_document_link_errors(
+            audit.DOCS / "process" / "equipment" / "README.md",
+            "[Missing](equipment-page-that-does-not-exist)",
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("target does not exist", errors[0])
+
+    def test_repository_source_link_outside_docs_is_not_treated_as_a_page(self) -> None:
+        errors = audit.internal_document_link_errors(
+            audit.DOCS / "development" / "example.md",
+            "[Agent](../../.github/agents/documentation.agent.md)",
+        )
+
+        self.assertEqual(errors, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/docs/GITHUB_PAGES_SETUP.md
+++ b/docs/GITHUB_PAGES_SETUP.md
@@ -144,7 +144,7 @@ Check the Actions tab in GitHub for build logs. Common issues:
 
 Ensure you're using relative paths without the `/docs` prefix:
 - ✅ `[Thermo](thermo/)`
-- ❌ `[Thermo](/docs/thermo/)`
+- ❌ `[Thermo](/docs/thermo/)` — the `/docs` source-directory prefix is not part of the published URL
 
 ### Images Not Loading
 

--- a/docs/REFERENCE_MANUAL_INDEX.md
+++ b/docs/REFERENCE_MANUAL_INDEX.md
@@ -277,12 +277,15 @@ Fluid characterization handles plus fraction splitting, property estimation, and
 | Streams            | [docs/process/equipment/streams.md](process/equipment/streams.md)                   | Stream models             |
 | Mixers/Splitters   | [docs/process/equipment/mixers_splitters.md](process/equipment/mixers_splitters.md) | Mixer and splitter models |
 | Equipment Overview | [docs/process/equipment/README.md](process/equipment/README.md)                           | Equipment module overview |
+| Complete Equipment Catalog | [docs/process/equipment/equipment_catalog.md](process/equipment/equipment_catalog.md) | Source-generated inventory of every concrete `ProcessEquipmentInterface` class and its maintained guide |
+| Energy Conversion Equipment | [docs/process/equipment/energy_conversion.md](process/equipment/energy_conversion.md) | Motors, generators, converters, typed utility sources and consumers, and energy-network solvers |
 
 ### Chapter 13b: Bio-Processing Unit Operations
 
 | Document             | Path                                                   | Description                                                                                                                                                                                                 |
 | -------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Bio-Processing Guide | [docs/process/bioprocessing.md](process/bioprocessing.md) | **Reactors, fermenters, enzyme treatment, solid-liquid separators, liquid-liquid extraction, multi-effect evaporators, dryers, crystallizers — mathematical models, design equations, simulation examples** |
+| Solid Handling Equipment | [docs/process/equipment/solid_handling.md](process/equipment/solid_handling.md) | Feedstock preparation, dewatering, filtration, pressing, drying, evaporation, crystallization, and mass/energy closure |
 
 ### Chapter 14: Separation Equipment
 
@@ -305,6 +308,7 @@ Fluid characterization handles plus fraction splitting, property estimation, and
 | Membrane Equipment | [docs/process/equipment/membranes.md](process/equipment/membranes.md)             | Membrane equipment                                                                                                                                                                                                 |
 | Filters            | [docs/process/equipment/filters.md](process/equipment/filters.md)                 | Oil and gas filter types, beta-ratio capture, measured/flow-scaled/Ergun pressure drop, dynamic loading, bypass, sulfur `S8` capture, and mechanical design                                                            |
 | Water Treatment    | [docs/process/equipment/water_treatment.md](process/equipment/water_treatment.md) | **Hydrocyclones (physics-based d50, DSD integration, PDR model, liner sizing, OSPAR compliance, ASME VIII mechanical design), GasFlotationUnit (IGF/DGF, per-stage efficiency, reject flow)**, produced water treatment trains, OIW limits |
+| Black-Oil Separator | [docs/process/equipment/black_oil_separator.md](process/equipment/black_oil_separator.md) | `SystemBlackOil` pressure-temperature separation with oil, free-gas, and water products for `ProcessSystem` |
 
 ### Chapter 15: Rotating Equipment
 

--- a/docs/chemicalreactions/README.md
+++ b/docs/chemicalreactions/README.md
@@ -137,7 +137,7 @@ screening trace-reaction trends in CO₂-rich streams. The implementation applie
 stoichiometry, non-negative extent bounds, configurable residence time and material-dependent R8
 kinetics. Its default parameters require calibration before engineering use.
 
-See the [CO₂ impurity kinetics guide](co2_impurity_kinetics_guide.md) for reaction definitions,
+See the [CO₂ impurity kinetics guide](co2_impurity_kinetics_guide) for reaction definitions,
 Java usage, numerical safeguards, and model limitations.
 
 

--- a/docs/examples/BeerBrewing_BioProcess_Simulation.md
+++ b/docs/examples/BeerBrewing_BioProcess_Simulation.md
@@ -2398,7 +2398,7 @@ recipe), here's a recap of the NeqSim `ProcessSystem` we built:
 ### Further Reading
 
 - [NeqSim Bio-Processing Documentation](../process/bioprocessing.md)
-- [NeqSim Thermodynamic Models](../thermo/equations-of-state.md)
+- [NeqSim Thermodynamic Models](../thermo/thermodynamic_models)
 - [CPA Equation of State](https://en.wikipedia.org/wiki/Cubic-plus-association_equation_of_state)
 
 ## Step 17 — Bridging Brew Day and Thermodynamics: ABV from First Principles
@@ -4105,4 +4105,3 @@ density/VLE data (analogous to the glucose fitting shown above) to improve
 multi-sugar phase equilibrium predictions.
 
 *Skaal! — E.C. Dahls G.O.D.S. NEIPA successfully simulated with NeqSim on Grainfather G30v3*
-

--- a/docs/examples/PVT_Simulation_and_Tuning.md
+++ b/docs/examples/PVT_Simulation_and_Tuning.md
@@ -753,5 +753,4 @@ print("="*60)
 
 3. Whitson, C.H., Brulé, M.R. (2000). "Phase Behavior." SPE Monograph Series, Vol. 20.
 
-4. NeqSim Documentation: [docs/fluid_characterization_mathematics.md](../fluid_characterization_mathematics.md)
-
+4. NeqSim Documentation: [Fluid characterization mathematics](../pvtsimulation/fluid_characterization_mathematics)

--- a/docs/examples/ProducedWaterEmissions_Tutorial.md
+++ b/docs/examples/ProducedWaterEmissions_Tutorial.md
@@ -19,7 +19,7 @@ nav_order: 1
 
 This notebook demonstrates comprehensive greenhouse gas emissions calculation (CO₂, methane, nmVOC) from produced water handling systems using NeqSim.
 
-**Reference:** Based on ["Virtual Measurement of Emissions from Produced Water Using an Online Process Simulator"](../GFMW_2023_Emissions_Paper.txt) (GFMW 2023).
+**Reference:** Based on *Virtual Measurement of Emissions from Produced Water Using an Online Process Simulator* (GFMW 2023).
 
 ---
 
@@ -978,7 +978,7 @@ Annual carbon cost: NOK 26,952,680
 - [Norwegian Methods Comparison](NorwegianEmissionMethods_Comparison.md)
 - [NeqSim Documentation](https://equinor.github.io/neqsim/)
 - [neqsim-python GitHub](https://github.com/equinor/neqsim-python)
-- [GFMW 2023 Paper](../GFMW_2023_Emissions_Paper.txt)
+- *Virtual Measurement of Emissions from Produced Water Using an Online Process Simulator* (GFMW 2023)
 
 ### 📞 Support
 
@@ -1182,4 +1182,3 @@ For more information:
 ```
 
 </details>
-

--- a/docs/fielddevelopment/README.md
+++ b/docs/fielddevelopment/README.md
@@ -13,13 +13,13 @@ The high-level helpers are screening tools. They do not by themselves provide a 
 
 | Document | Description |
 |----------|-------------|
-| [DIGITAL_FIELD_TWIN.md](DIGITAL_FIELD_TWIN.md) | **Start here!** Architecture showing how NeqSim integrates all lifecycle phases |
-| [MATHEMATICAL_REFERENCE.md](MATHEMATICAL_REFERENCE.md) | Mathematical foundations for all calculations (EoS, economics, flow) |
-| [API_GUIDE.md](API_GUIDE.md) | Source-anchored concept, screening-KPI, option-ranking, unit, and engineering-boundary guide |
-| [DECISION_ENGINE_WORKFLOWS.md](DECISION_ENGINE_WORKFLOWS.md) | Decision-engine workflows for tiebacks, greenfield concepts, portfolios, process coupling, reservoir exports, and report-ready tables |
-| [HOST_TIE_IN_CAPACITY.md](HOST_TIE_IN_CAPACITY.md) | Host capacity, holdback, process-equipment bottlenecks, and debottleneck decisions for brownfield tiebacks |
-| [INTEGRATED_PRODUCTION_MODELLING.md](INTEGRATED_PRODUCTION_MODELLING.md) | **Reservoir-to-market IPM** &mdash; reservoir drives, well deliverability curves, network solver, gas-lift allocation, well-test matching, artificial-lift pumps, and choke optimisation (GAP/PROSPER/MBAL + Pipesim style) |
-| [FIELD_LIFECYCLE_SIMULATION.md](FIELD_LIFECYCLE_SIMULATION.md) | Time-marching field and area concepts with multi-host routing, facility sizing, product specifications, NPV and break-even |
+| [DIGITAL_FIELD_TWIN.md](DIGITAL_FIELD_TWIN) | **Start here!** Architecture showing how NeqSim integrates all lifecycle phases |
+| [MATHEMATICAL_REFERENCE.md](MATHEMATICAL_REFERENCE) | Mathematical foundations for all calculations (EoS, economics, flow) |
+| [API_GUIDE.md](API_GUIDE) | Source-anchored concept, screening-KPI, option-ranking, unit, and engineering-boundary guide |
+| [DECISION_ENGINE_WORKFLOWS.md](DECISION_ENGINE_WORKFLOWS) | Decision-engine workflows for tiebacks, greenfield concepts, portfolios, process coupling, reservoir exports, and report-ready tables |
+| [HOST_TIE_IN_CAPACITY.md](HOST_TIE_IN_CAPACITY) | Host capacity, holdback, process-equipment bottlenecks, and debottleneck decisions for brownfield tiebacks |
+| [INTEGRATED_PRODUCTION_MODELLING.md](INTEGRATED_PRODUCTION_MODELLING) | **Reservoir-to-market IPM** &mdash; reservoir drives, well deliverability curves, network solver, gas-lift allocation, well-test matching, artificial-lift pumps, and choke optimisation (GAP/PROSPER/MBAL + Pipesim style) |
+| [FIELD_LIFECYCLE_SIMULATION.md](FIELD_LIFECYCLE_SIMULATION) | Time-marching field and area concepts with multi-host routing, facility sizing, product specifications, NPV and break-even |
 
 ---
 
@@ -279,7 +279,7 @@ Depending on the equipment type, the mechanical-design helper can provide:
 - regionalized screening-cost estimates;
 - bill-of-material and JSON-report outputs.
 
-See [SURF Subsea Equipment Guide](../process/SURF_SUBSEA_EQUIPMENT.md) for detailed documentation.
+See [SURF Subsea Equipment Guide](../process/SURF_SUBSEA_EQUIPMENT) for detailed documentation.
 
 ---
 
@@ -287,13 +287,13 @@ See [SURF Subsea Equipment Guide](../process/SURF_SUBSEA_EQUIPMENT.md) for detai
 
 | Topic | Document |
 |-------|----------|
-| Integrated Field Lifecycle Simulation | [FIELD_LIFECYCLE_SIMULATION.md](FIELD_LIFECYCLE_SIMULATION.md) — detailed wells/SURF/process lifetime, multi-host area routing, product specifications, bottlenecks, NPV and break-even |
-| SURF Subsea Equipment | [SURF_SUBSEA_EQUIPMENT.md](../process/SURF_SUBSEA_EQUIPMENT.md) |
-| Late-Life Operations | [LATE_LIFE_OPERATIONS.md](LATE_LIFE_OPERATIONS.md) |
-| Field Development Strategy | [FIELD_DEVELOPMENT_STRATEGY.md](FIELD_DEVELOPMENT_STRATEGY.md) |
-| Integrated Framework | [INTEGRATED_FIELD_DEVELOPMENT_FRAMEWORK.md](INTEGRATED_FIELD_DEVELOPMENT_FRAMEWORK.md) |
-| Decision Engine Workflows | [DECISION_ENGINE_WORKFLOWS.md](DECISION_ENGINE_WORKFLOWS.md) |
-| **Multi-Scenario Production Optimization** | [MULTI_SCENARIO_PRODUCTION_OPTIMIZATION.md](MULTI_SCENARIO_PRODUCTION_OPTIMIZATION.md) |
+| Integrated Field Lifecycle Simulation | [FIELD_LIFECYCLE_SIMULATION.md](FIELD_LIFECYCLE_SIMULATION) — detailed wells/SURF/process lifetime, multi-host area routing, product specifications, bottlenecks, NPV and break-even |
+| SURF Subsea Equipment | [SURF_SUBSEA_EQUIPMENT.md](../process/SURF_SUBSEA_EQUIPMENT) |
+| Late-Life Operations | [LATE_LIFE_OPERATIONS.md](LATE_LIFE_OPERATIONS) |
+| Field Development Strategy | [FIELD_DEVELOPMENT_STRATEGY.md](FIELD_DEVELOPMENT_STRATEGY) |
+| Integrated Framework | [INTEGRATED_FIELD_DEVELOPMENT_FRAMEWORK.md](INTEGRATED_FIELD_DEVELOPMENT_FRAMEWORK) |
+| Decision Engine Workflows | [DECISION_ENGINE_WORKFLOWS.md](DECISION_ENGINE_WORKFLOWS) |
+| **Multi-Scenario Production Optimization** | [MULTI_SCENARIO_PRODUCTION_OPTIMIZATION.md](MULTI_SCENARIO_PRODUCTION_OPTIMIZATION) |
 
 ---
 
@@ -310,10 +310,10 @@ The following developer notebooks import NeqSim Java classes from the workspace 
 
 ## See Also
 
-- [Process Simulation Guide](../wiki/process_simulation.md)
-- [Thermodynamic Models](../thermo/thermodynamic_models.md)
+- [Process Simulation Guide](../wiki/process_simulation)
+- [Thermodynamic Models](../thermo/thermodynamic_models)
 - [Economics Module](../process/economics/)
-- [Reference Manual Index](../REFERENCE_MANUAL_INDEX.md)
+- [Reference Manual Index](../REFERENCE_MANUAL_INDEX)
 
 ---
 
@@ -329,4 +329,4 @@ This agent automatically loads the following skills:
 | `neqsim-subsea-and-wells` | Subsea systems, casing design (API 5C3), SURF costs, tieback analysis |
 | `neqsim-production-optimization` | Decline curves, bottleneck analysis, gas lift, IOR/EOR screening |
 
-See [AI Agents Reference](../integration/ai_agents_reference.md) for the full catalog.
+See [AI Agents Reference](../integration/ai_agents_reference) for the full catalog.

--- a/docs/physical_properties/README.md
+++ b/docs/physical_properties/README.md
@@ -10,11 +10,11 @@ models, and interfacial-property calculations.
 ## Contents
 
 - **Overview** (this page) - Package architecture and basic usage
-- [Viscosity Models](viscosity_models.md) - Dynamic viscosity calculation methods
-- [Thermal Conductivity Models](thermal_conductivity_models.md) - Thermal conductivity methods
-- [Diffusivity Models](diffusivity_models.md) - Binary and multicomponent diffusion coefficients
-- [Interfacial Properties](interfacial_properties.md) - Surface tension and related calculations
-- [Density Models](density_models.md) - Liquid density correlations
+- [Viscosity Models](viscosity_models) - Dynamic viscosity calculation methods
+- [Thermal Conductivity Models](thermal_conductivity_models) - Thermal conductivity methods
+- [Diffusivity Models](diffusivity_models) - Binary and multicomponent diffusion coefficients
+- [Interfacial Properties](interfacial_properties) - Surface tension and related calculations
+- [Density Models](density_models) - Liquid density correlations
 
 ## Calculation workflow
 
@@ -159,18 +159,18 @@ Diffusion coefficients are available from the phase's `PhysicalProperties` objec
 `getDiffusionCoefficient(i, j)` or `getDiffusionCoefficient(component1, component2)` for a
 Maxwell-Stefan binary coefficient. Call `calcEffectiveDiffusionCoefficients()` before reading an
 effective coefficient with `getEffectiveDiffusionCoefficient(...)`. See the
-[diffusivity guide](diffusivity_models.md) for model selection, Fick coefficients, and complete
+[diffusivity guide](diffusivity_models) for model selection, Fick coefficients, and complete
 access patterns.
 
 Surface tension requires two existing phases and an initialized interfacial model. Use phase
 guards and follow the complete examples in the
-[interfacial-properties guide](interfacial_properties.md); do not assume that phase indexes 0 and
+[interfacial-properties guide](interfacial_properties); do not assume that phase indexes 0 and
 1 identify a valid interface.
 
 ## Model tuning
 
 Viscosity tuning parameters are model-specific. The LBC, PFCT/CSP, and advanced friction-theory
-interfaces are documented and tested in the [viscosity guide](viscosity_models.md). Use parameter
+interfaces are documented and tested in the [viscosity guide](viscosity_models). Use parameter
 sets from independent measurements or validated literature, preserve their units and validity
 range, and reinitialize the affected phase after changing them.
 
@@ -234,6 +234,6 @@ The package separates these responsibilities:
 
 ## See also
 
-- [Fluid Creation Guide](../thermo/fluid_creation_guide.md) - Creating thermodynamic systems
-- [Flash Calculations Guide](../thermo/flash_calculations_guide.md) - Phase-equilibrium calculations
-- [Thermodynamic Operations](../thermo/thermodynamic_operations.md) - Thermodynamic calculation workflow
+- [Fluid Creation Guide](../thermo/fluid_creation_guide) - Creating thermodynamic systems
+- [Flash Calculations Guide](../thermo/flash_calculations_guide) - Phase-equilibrium calculations
+- [Thermodynamic Operations](../thermo/thermodynamic_operations) - Thermodynamic calculation workflow

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -43,39 +43,39 @@ This documentation is organized into the following sections:
 | Section | Description |
 |---------|-------------|
 | [equipment/](equipment/) | Equipment documentation (separators, compressors, etc.) |
-| [equipment/adsorption_bed.md](equipment/adsorption_bed.md) | **Adsorption bed** — transient simulation, LDF mass transfer, PSA/TSA cycles |
-| [lng_liquefaction.md](lng_liquefaction.md) | **LNG liquefaction** — closed-loop SMR, C3MR, DMR, and nitrogen-expander templates with common KPIs and literature screening |
-| [mercury_removal.md](mercury_removal.md) | **Mercury removal guard beds** — chemisorption (PuraSpec), bed loading, breakthrough, degradation, mechanical design, cost |
-| [bioprocessing.md](bioprocessing.md) | **Bio-processing** — reactors, fermenters, solid-liquid separators, LLE, evaporators, dryers, crystallizers |
-| [neqsim-studio.md](neqsim-studio.md) | **NeqSim Studio (Python)** — newcomer-friendly process builder: natural language, templates, guided wizard, edit-by-chat, recipe gallery |
+| [equipment/adsorption_bed.md](equipment/adsorption_bed) | **Adsorption bed** — transient simulation, LDF mass transfer, PSA/TSA cycles |
+| [lng_liquefaction.md](lng_liquefaction) | **LNG liquefaction** — closed-loop SMR, C3MR, DMR, and nitrogen-expander templates with common KPIs and literature screening |
+| [mercury_removal.md](mercury_removal) | **Mercury removal guard beds** — chemisorption (PuraSpec), bed loading, breakthrough, degradation, mechanical design, cost |
+| [bioprocessing.md](bioprocessing) | **Bio-processing** — reactors, fermenters, solid-liquid separators, LLE, evaporators, dryers, crystallizers |
+| [neqsim-studio.md](neqsim-studio) | **NeqSim Studio (Python)** — newcomer-friendly process builder: natural language, templates, guided wizard, edit-by-chat, recipe gallery |
 | [processmodel/](processmodel/) | ProcessSystem and flowsheet management |
-| [energy_streams.md](energy_streams.md) | **Energy streams** — typed heat, shaft-work, and electrical ports, unit-aware duties, graph ordering, and energy-driven equipment |
-| [process_json_export_and_e300_fluids.md](process_json_export_and_e300_fluids.md) | **Process JSON export** — self-contained ProcessSystem/ProcessModel JSON for MCP, including E300-equivalent component properties and volume correction |
-| [simulation-hooks-and-events.md](simulation-hooks-and-events.md) | **Lifecycle hooks, event bus, auto-validation** for ProcessSystem and ProcessModel |
-| [model-change-events.md](model-change-events.md) | **Governed model revisions** — versioned change events, idempotent publication, fingerprints, and durable replay |
-| [model-impact-analysis.md](model-impact-analysis.md) | **Cross-model impact analysis** — configurable propagation rules, recalculation order, cycle detection, and reapproval work |
+| [energy_streams.md](energy_streams) | **Energy streams** — typed heat, shaft-work, and electrical ports, unit-aware duties, graph ordering, and energy-driven equipment |
+| [process_json_export_and_e300_fluids.md](process_json_export_and_e300_fluids) | **Process JSON export** — self-contained ProcessSystem/ProcessModel JSON for MCP, including E300-equivalent component properties and volume correction |
+| [simulation-hooks-and-events.md](simulation-hooks-and-events) | **Lifecycle hooks, event bus, auto-validation** for ProcessSystem and ProcessModel |
+| [model-change-events.md](model-change-events) | **Governed model revisions** — versioned change events, idempotent publication, fingerprints, and durable replay |
+| [model-impact-analysis.md](model-impact-analysis) | **Cross-model impact analysis** — configurable propagation rules, recalculation order, cycle detection, and reapproval work |
 | [safety/](safety/) | Safety systems (PSV, ESD, blowdown) |
-| [controllers.md](controllers.md) | Process controllers and logic |
-| [unisim-to-neqsim-conversion.md](unisim-to-neqsim-conversion.md) | **UniSim/HYSYS conversion** — convert `.usc` models to NeqSim with E300 full-fluid transfer and export back to UniSim |
-| [piping_route_builder.md](piping_route_builder.md) | **STID/E3D line-list piping route builder** — convert route tables into serial Beggs-and-Brill hydraulic models and water-hammer screening handoffs |
-| [water_hammer_implementation.md](../wiki/water_hammer_implementation.md) | **Water hammer/liquid hammer screening** — fast valve closure, pump trip, STID route, tagreader event, and MCP runWaterHammer workflow |
-| [operational_evidence_package.md](operational_evidence_package.md) | **Operational evidence package** — combine P&ID/STID references, tagreader values, scenario actions, and bottleneck detection |
-| [exergy-analysis.md](exergy-analysis.md) | **Exergy analysis** — plant-wide destruction hotspots for ProcessSystem and ProcessModel |
-| [production-allocation.md](production-allocation.md) | **Production allocation** — back-allocate metered production to wells/sources via a linear recovery-factor proxy network (handles recycle/reflux) |
-| [k-value-fast-simulation.md](k-value-fast-simulation.md) | **Cached K-value fast simulation** — run one rigorous base-case process, freeze separator K-values and fallback splits, then execute fast source-rate scenarios without repeated EOS flashes |
-| [screening_calculators.md](screening_calculators.md) | **Screening and sizing calculators** — flare radiation (API 521), line sizing/erosion LOF (API RP 14E), flow-induced vibration (AVIFF), pump NPSH, control-valve sizing/noise (IEC 60534), thermowell strength (ASME PTC 19.3), pipeline overpressure protection, orifice metering (GPSA), and crude desalting; with optional process-object bridges |
+| [controllers.md](controllers) | Process controllers and logic |
+| [unisim-to-neqsim-conversion.md](unisim-to-neqsim-conversion) | **UniSim/HYSYS conversion** — convert `.usc` models to NeqSim with E300 full-fluid transfer and export back to UniSim |
+| [piping_route_builder.md](piping_route_builder) | **STID/E3D line-list piping route builder** — convert route tables into serial Beggs-and-Brill hydraulic models and water-hammer screening handoffs |
+| [water_hammer_implementation.md](../wiki/water_hammer_implementation) | **Water hammer/liquid hammer screening** — fast valve closure, pump trip, STID route, tagreader event, and MCP runWaterHammer workflow |
+| [operational_evidence_package.md](operational_evidence_package) | **Operational evidence package** — combine P&ID/STID references, tagreader values, scenario actions, and bottleneck detection |
+| [exergy-analysis.md](exergy-analysis) | **Exergy analysis** — plant-wide destruction hotspots for ProcessSystem and ProcessModel |
+| [production-allocation.md](production-allocation) | **Production allocation** — back-allocate metered production to wells/sources via a linear recovery-factor proxy network (handles recycle/reflux) |
+| [k-value-fast-simulation.md](k-value-fast-simulation) | **Cached K-value fast simulation** — run one rigorous base-case process, freeze separator K-values and fallback splits, then execute fast source-rate scenarios without repeated EOS flashes |
+| [screening_calculators.md](screening_calculators) | **Screening and sizing calculators** — flare radiation (API 521), line sizing/erosion LOF (API RP 14E), flow-induced vibration (AVIFF), pump NPSH, control-valve sizing/noise (IEC 60534), thermowell strength (ASME PTC 19.3), pipeline overpressure protection, orifice metering (GPSA), and crude desalting; with optional process-object bridges |
 
 ### Process Design Guide
 
 | Document | Description |
 |----------|-------------|
-| [process_design_guide.md](process_design_guide.md) | **Complete guide to process design workflow using NeqSim** |
+| [process_design_guide.md](process_design_guide) | **Complete guide to process design workflow using NeqSim** |
 
 ### Design Framework (NEW) ✨
 
 | Document | Description |
 |----------|-------------|
-| [DESIGN_FRAMEWORK.md](DESIGN_FRAMEWORK.md) | **Automated equipment sizing and optimization framework** |
+| [DESIGN_FRAMEWORK.md](DESIGN_FRAMEWORK) | **Automated equipment sizing and optimization framework** |
 
 **Key Features:**
 - `AutoSizeable` interface - Equipment auto-sizing from flow requirements
@@ -88,10 +88,10 @@ This documentation is organized into the following sections:
 
 | Document | Description |
 |----------|-------------|
-| [optimization/OPTIMIZATION_AND_CONSTRAINTS.md](optimization/OPTIMIZATION_AND_CONSTRAINTS.md) | **COMPREHENSIVE: Complete guide to optimization algorithms, constraint types, bottleneck analysis** |
-| [optimization/OPTIMIZATION_OVERVIEW.md](optimization/OPTIMIZATION_OVERVIEW.md) | When to use which optimizer |
-| [optimization/process-researcher.md](optimization/process-researcher.md) | **Process researcher** - generate and rank candidate flowsheets from feed/product targets, including reaction routes |
-| [CAPACITY_CONSTRAINT_FRAMEWORK.md](CAPACITY_CONSTRAINT_FRAMEWORK.md) | Equipment capacity limits and utilization tracking |
+| [optimization/OPTIMIZATION_AND_CONSTRAINTS.md](optimization/OPTIMIZATION_AND_CONSTRAINTS) | **COMPREHENSIVE: Complete guide to optimization algorithms, constraint types, bottleneck analysis** |
+| [optimization/OPTIMIZATION_OVERVIEW.md](optimization/OPTIMIZATION_OVERVIEW) | When to use which optimizer |
+| [optimization/process-researcher.md](optimization/process-researcher) | **Process researcher** - generate and rank candidate flowsheets from feed/product targets, including reaction routes |
+| [CAPACITY_CONSTRAINT_FRAMEWORK.md](CAPACITY_CONSTRAINT_FRAMEWORK) | Equipment capacity limits and utilization tracking |
 
 **Key Features:**
 - Five search algorithms: Binary, Golden-Section, Nelder-Mead, Particle Swarm, Gradient Descent
@@ -107,22 +107,22 @@ This documentation is organized into the following sections:
 | Document | Description |
 |----------|-------------|
 | [corrosion/](corrosion/) | **Corrosion analysis module overview** — NORSOK M-506 CO2 corrosion rate + NORSOK M-001 material selection |
-| [corrosion/norsok_m506_corrosion_rate.md](corrosion/norsok_m506_corrosion_rate.md) | **NORSOK M-506 API** — CO2 corrosion rate prediction with fugacity, pH, correction factors |
-| [corrosion/norsok_m001_material_selection.md](corrosion/norsok_m001_material_selection.md) | **NORSOK M-001 API** — Material grade recommendation, sour service, chloride SCC |
-| [corrosion/pipeline_corrosion_integration.md](corrosion/pipeline_corrosion_integration.md) | **Pipeline integration** — Automated corrosion analysis from process simulation |
+| [corrosion/norsok_m506_corrosion_rate.md](corrosion/norsok_m506_corrosion_rate) | **NORSOK M-506 API** — CO2 corrosion rate prediction with fugacity, pH, correction factors |
+| [corrosion/norsok_m001_material_selection.md](corrosion/norsok_m001_material_selection) | **NORSOK M-001 API** — Material grade recommendation, sour service, chloride SCC |
+| [corrosion/pipeline_corrosion_integration.md](corrosion/pipeline_corrosion_integration) | **Pipeline integration** — Automated corrosion analysis from process simulation |
 
 ### Electrical Design Documentation
 
 | Document | Description |
 |----------|-------------|
-| [electrical-design.md](electrical-design.md) | **Electrical design framework — motor sizing, VFD, cable, transformer, switchgear, hazardous area, equipment-specific designs, plant-wide load analysis** |
+| [electrical-design.md](electrical-design) | **Electrical design framework — motor sizing, VFD, cable, transformer, switchgear, hazardous area, equipment-specific designs, plant-wide load analysis** |
 
 ### Dynamic Simulation
 
 | Document | Description |
 |----------|-------------|
-| [dynamic-simulation.md](dynamic-simulation.md) | **Dynamic simulation helper — auto-instruments a sized steady-state process with transmitters and PID controllers for transient simulation** |
-| [agent-rca-dynamic-fault-benchmark.md](agent-rca-dynamic-fault-benchmark.md) | **AgentRCA dynamic fault benchmark — normal-only evidence and ranked diagnoses for controlled sensor bias, gas leaks, blockage, and imposed multiphase slugging excitation** |
+| [dynamic-simulation.md](dynamic-simulation) | **Dynamic simulation helper — auto-instruments a sized steady-state process with transmitters and PID controllers for transient simulation** |
+| [agent-rca-dynamic-fault-benchmark.md](agent-rca-dynamic-fault-benchmark) | **AgentRCA dynamic fault benchmark — normal-only evidence and ranked diagnoses for controlled sensor bias, gas leaks, blockage, and imposed multiphase slugging excitation** |
 
 **Key Features:**
 - `DynamicProcessHelper` — one-call conversion from steady-state to dynamic
@@ -135,7 +135,7 @@ This documentation is organized into the following sections:
 
 | Document | Description |
 |----------|-------------|
-| [instrument-design.md](instrument-design.md) | **Instrument design framework — ISA-5.1 identification, SIL-rated safety instruments, I/O counting, DCS/SIS cabinet sizing, cost estimation, equipment-specific designs (separator, compressor, heat exchanger, pipeline, valve), plant-wide SystemInstrumentDesign** |
+| [instrument-design.md](instrument-design) | **Instrument design framework — ISA-5.1 identification, SIL-rated safety instruments, I/O counting, DCS/SIS cabinet sizing, cost estimation, equipment-specific designs (separator, compressor, heat exchanger, pipeline, valve), plant-wide SystemInstrumentDesign** |
 
 **Key Features:**
 - Equipment-specific designs: Compressor, Pump, Separator, Heater/Cooler, Pipeline
@@ -147,27 +147,27 @@ This documentation is organized into the following sections:
 
 | Document | Description |
 |----------|-------------|
-| [EQUIPMENT_DESIGN_PARAMETERS.md](EQUIPMENT_DESIGN_PARAMETERS.md) | **Equipment design parameters, autoSize vs MechanicalDesign guide** |
-| [mechanical_design_standards.md](mechanical_design_standards.md) | Design standards (NORSOK, ASME, API, DNV, etc.) |
-| [process_design_standards_program.md](process_design_standards_program.md) | Standards priorities, evidence gates, requirement coverage, and change control |
-| [standard_design_kernel_migration.md](standard_design_kernel_migration.md) | Migrate global editions, metadata factories, mutable calculators, and legacy case execution to typed kernels |
-| [mechanical_design_database.md](mechanical_design_database.md) | Data sources, database schemas, and CSV configuration |
-| [pipeline_mechanical_design.md](pipeline_mechanical_design.md) | Pipeline mechanical design (wall thickness, stress, buckling, corrosion) |
-| [dnv_rp_f109_on_bottom_stability.md](dnv_rp_f109_on_bottom_stability.md) | **DNV-RP-F109 on-bottom stability screening** — typed vertical, transparent absolute-static lateral, and external-response displacement checks with fail-closed readiness |
-| [dnv_st_f101_pipeline_screening.md](dnv_st_f101_pipeline_screening.md) | **Fail-closed DNV-ST-F101:2021 pipeline limit-state screening with explicit review boundary** |
-| [topside_piping_design.md](topside_piping_design.md) | **Topside piping design (velocity, support, vibration per ASME B31.3)** |
-| [riser_mechanical_design.md](riser_mechanical_design.md) | Riser design (catenary, VIV, fatigue per DNV-OS-F201) |
-| [well_mechanical_design.md](well_mechanical_design.md) | **Well casing/tubing design, barrier verification, cost estimation per NORSOK D-010, API 5CT** |
-| [torg_integration.md](torg_integration.md) | Technical Requirements Documents (TORG) integration |
-| [field_development_orchestration.md](field_development_orchestration.md) | Complete design workflow orchestration |
-| [mechanical_design/two_phase_heat_transfer.md](mechanical_design/two_phase_heat_transfer.md) | **Two-phase heat transfer — Shah condensation, Chen/Gungor-Winterton boiling, Friedel/MSH pressure drop, Ebert-Panchal fouling, incremental zone analysis, tube inserts** |
+| [EQUIPMENT_DESIGN_PARAMETERS.md](EQUIPMENT_DESIGN_PARAMETERS) | **Equipment design parameters, autoSize vs MechanicalDesign guide** |
+| [mechanical_design_standards.md](mechanical_design_standards) | Design standards (NORSOK, ASME, API, DNV, etc.) |
+| [process_design_standards_program.md](process_design_standards_program) | Standards priorities, evidence gates, requirement coverage, and change control |
+| [standard_design_kernel_migration.md](standard_design_kernel_migration) | Migrate global editions, metadata factories, mutable calculators, and legacy case execution to typed kernels |
+| [mechanical_design_database.md](mechanical_design_database) | Data sources, database schemas, and CSV configuration |
+| [pipeline_mechanical_design.md](pipeline_mechanical_design) | Pipeline mechanical design (wall thickness, stress, buckling, corrosion) |
+| [dnv_rp_f109_on_bottom_stability.md](dnv_rp_f109_on_bottom_stability) | **DNV-RP-F109 on-bottom stability screening** — typed vertical, transparent absolute-static lateral, and external-response displacement checks with fail-closed readiness |
+| [dnv_st_f101_pipeline_screening.md](dnv_st_f101_pipeline_screening) | **Fail-closed DNV-ST-F101:2021 pipeline limit-state screening with explicit review boundary** |
+| [topside_piping_design.md](topside_piping_design) | **Topside piping design (velocity, support, vibration per ASME B31.3)** |
+| [riser_mechanical_design.md](riser_mechanical_design) | Riser design (catenary, VIV, fatigue per DNV-OS-F201) |
+| [well_mechanical_design.md](well_mechanical_design) | **Well casing/tubing design, barrier verification, cost estimation per NORSOK D-010, API 5CT** |
+| [torg_integration.md](torg_integration) | Technical Requirements Documents (TORG) integration |
+| [field_development_orchestration.md](field_development_orchestration) | Complete design workflow orchestration |
+| [mechanical_design/two_phase_heat_transfer.md](mechanical_design/two_phase_heat_transfer) | **Two-phase heat transfer — Shah condensation, Chen/Gungor-Winterton boiling, Friedel/MSH pressure drop, Ebert-Panchal fouling, incremental zone analysis, tube inserts** |
 
 ### Cost Estimation Framework (NEW) ✨
 
 | Document | Description |
 |----------|-------------|
-| [COST_ESTIMATION_FRAMEWORK.md](COST_ESTIMATION_FRAMEWORK.md) | **Comprehensive capital and operating cost estimation, including scope-safe result reconciliation** |
-| [COST_ESTIMATION_API_REFERENCE.md](COST_ESTIMATION_API_REFERENCE.md) | **Detailed API reference for cost estimation classes and CostEstimateResult output maps** |
+| [COST_ESTIMATION_FRAMEWORK.md](COST_ESTIMATION_FRAMEWORK) | **Comprehensive capital and operating cost estimation, including scope-safe result reconciliation** |
+| [COST_ESTIMATION_API_REFERENCE.md](COST_ESTIMATION_API_REFERENCE) | **Detailed API reference for cost estimation classes and CostEstimateResult output maps** |
 
 **Key Features:**
 - Equipment cost estimation using Turton et al. correlations
@@ -183,48 +183,48 @@ This documentation is organized into the following sections:
 
 | Category | Documentation | Classes |
 |----------|--------------|---------|
-| Streams | [streams.md](equipment/streams.md) | Stream, EnergyStream, VirtualStream |
-| Separators | [separators.md](equipment/separators.md) | Separator, ThreePhaseSeparator, GasScrubber |
-| Heat Exchangers | [heat_exchangers.md](equipment/heat_exchangers.md) | Heater, Cooler, HeatExchanger |
-| Compressors | [compressors.md](equipment/compressors.md) | Compressor, CompressorChart, CompressorWashing |
-| Compressor Deposit / Degradation | [compressor_deposit_degradation.md](compressor_deposit_degradation.md) | CompressorDeposit, DepositMechanism, DepositSource, CompressorDepositProfile, WashFluid, CompressorDepositWash |
-| Compressor Anti-Surge Control | [compressor_antisurge_control.md](equipment/compressor_antisurge_control.md) | AntiSurgeController, CompressorMonitor, ThrottlingValve, Recycle |
-| Pumps | [pumps.md](equipment/pumps.md) | Pump, PumpChart |
-| Expanders | [expanders.md](equipment/expanders.md) | Expander, TurboExpanderCompressor |
-| Valves | [valves.md](equipment/valves.md) | ThrottlingValve, SafetyValve, BlowdownValve |
-| **Choke Collapse Analysis** | [choke-collapse.md](choke-collapse.md) | ChokeCollapseAnalyzer — critical pressure ratio, flashing, cavitation |
-| **Inadvertent Valve Operation** | [inadvertent-valve-operation.md](inadvertent-valve-operation.md) | InadvertentValveOperationAnalyzer — API 521 §4.4.13 / NORSOK P-002 IVO screening |
-| **Well Chokes** | [well_choke_implementation.md](well_choke_implementation.md) | Sachdeva, Gilbert choke models, ThrottlingValve integration |
-| Distillation | [distillation.md](equipment/distillation.md) | DistillationColumn, SimpleTray |
-| Absorbers | [absorbers.md](equipment/absorbers.md) | SimpleAbsorber, SimpleTEGAbsorber |
-| Ejectors | [ejectors.md](equipment/ejectors.md) | Ejector |
-| Membranes | [membranes.md](equipment/membranes.md) | MembraneSeparator |
-| Flares | [flares.md](equipment/flares.md) | Flare, FlareStack |
-| Electrolyzers | [electrolyzers.md](equipment/electrolyzers.md) | Electrolyzer, CO2Electrolyzer |
-| Filters | [filters.md](equipment/filters.md) | Particle, coalescing, strainer, and media filters with dynamic loading and mechanical design |
-| H2S Scavengers | [H2S_scavenger_guide.md](H2S_scavenger_guide.md) | H2S chemical scavenging (triazine, glyoxal, iron sponge) |
-| **Sulfur Recovery** | [sulfur_recovery.md](sulfur_recovery.md) | Integrated Claus furnace, WHB, converters, sulfur condensers, TGTU recycle, incineration, and KPIs |
-| Reactors | [reactors.md](equipment/reactors.md) | GibbsReactor |
-| Pipelines | [pipelines.md](equipment/pipelines.md) | Pipeline, AdiabaticPipe, TopsidePiping, Riser |
-| **Water Hammer Screening** | [water_hammer_implementation.md](../wiki/water_hammer_implementation.md) | WaterHammerPipe, WaterHammerStudy, MCP runWaterHammer |
-| **Piping Route Builder** | [piping_route_builder.md](piping_route_builder.md) | PipingRouteBuilder for STID/E3D line-list route hydraulics |
-| **CO2 Well Analysis** | [co2_injection_well_analysis.md](co2_injection_well_analysis.md) | CO2InjectionWellAnalyzer, ImpurityMonitor, TransientWellbore, CO2FlowCorrections |
-| **LNG Liquefaction** | [lng_liquefaction.md](lng_liquefaction.md) | LNGProcessBuilder, LNGProcessModel, LNGProcessBenchmark, LNGHeatExchanger |
-| **Hydrogen Production** | [hydrogen_production.md](hydrogen_production.md) | SMR/ATR/POX route templates, ReformerFurnace, CatalyticTubeReformer, AutothermalReformer, PartialOxidationReactor, PSACascade, Electrolyzer |
-| Looped Networks | [looped_networks.md](equipment/looped_networks.md) | LoopedPipeNetwork, Hardy Cross solver |
-| Gas Network Operations | [gas_network_operations.md](gas_network_operations.md) | Conservative mixing, coupled hydraulics, quality, optimization, and linepack |
-| Oil Network Operations | [oil_network_operations.md](oil_network_operations.md) | Pumps, assays, tanks, parcels, blends, and cargo scheduling |
-| Tanks | [tanks.md](equipment/tanks.md) | Tank, VesselDepressurization |
-| Wells | [wells.md](equipment/wells.md) | Well equipment |
-| Subsea Trees | [subsea_trees.md](equipment/subsea_trees.md) | SubseaTree, valve control |
-| Subsea Manifolds | [subsea_manifolds.md](equipment/subsea_manifolds.md) | SubseaManifold |
-| Subsea Boosters | [subsea_boosters.md](equipment/subsea_boosters.md) | SubseaBooster, multiphase pumps |
-| Umbilicals | [umbilicals.md](equipment/umbilicals.md) | Umbilical systems |
-| Battery Storage | [battery_storage.md](equipment/battery_storage.md) | BatteryStorage |
-| **Heat Integration** | [heat_integration.md](equipment/heat_integration.md) | PinchAnalysis, HeatStream |
-| **Power Generation** | [power_generation.md](equipment/power_generation.md) | GasTurbine, SteamTurbine, HRSG, CombinedCycleSystem, FuelCell, WindTurbine, SolarPanel |
-| Failure Modes | [failure_modes.md](equipment/failure_modes.md) | EquipmentFailureMode, reliability |
-| Mixers/Splitters | [mixers_splitters.md](equipment/mixers_splitters.md) | Mixer, Splitter |
+| Streams | [streams.md](equipment/streams) | Stream, EnergyStream, VirtualStream |
+| Separators | [separators.md](equipment/separators) | Separator, ThreePhaseSeparator, GasScrubber |
+| Heat Exchangers | [heat_exchangers.md](equipment/heat_exchangers) | Heater, Cooler, HeatExchanger |
+| Compressors | [compressors.md](equipment/compressors) | Compressor, CompressorChart, CompressorWashing |
+| Compressor Deposit / Degradation | [compressor_deposit_degradation.md](compressor_deposit_degradation) | CompressorDeposit, DepositMechanism, DepositSource, CompressorDepositProfile, WashFluid, CompressorDepositWash |
+| Compressor Anti-Surge Control | [compressor_antisurge_control.md](equipment/compressor_antisurge_control) | AntiSurgeController, CompressorMonitor, ThrottlingValve, Recycle |
+| Pumps | [pumps.md](equipment/pumps) | Pump, PumpChart |
+| Expanders | [expanders.md](equipment/expanders) | Expander, TurboExpanderCompressor |
+| Valves | [valves.md](equipment/valves) | ThrottlingValve, SafetyValve, BlowdownValve |
+| **Choke Collapse Analysis** | [choke-collapse.md](choke-collapse) | ChokeCollapseAnalyzer — critical pressure ratio, flashing, cavitation |
+| **Inadvertent Valve Operation** | [inadvertent-valve-operation.md](inadvertent-valve-operation) | InadvertentValveOperationAnalyzer — API 521 §4.4.13 / NORSOK P-002 IVO screening |
+| **Well Chokes** | [well_choke_implementation.md](well_choke_implementation) | Sachdeva, Gilbert choke models, ThrottlingValve integration |
+| Distillation | [distillation.md](equipment/distillation) | DistillationColumn, SimpleTray |
+| Absorbers | [absorbers.md](equipment/absorbers) | SimpleAbsorber, SimpleTEGAbsorber |
+| Ejectors | [ejectors.md](equipment/ejectors) | Ejector |
+| Membranes | [membranes.md](equipment/membranes) | MembraneSeparator |
+| Flares | [flares.md](equipment/flares) | Flare, FlareStack |
+| Electrolyzers | [electrolyzers.md](equipment/electrolyzers) | Electrolyzer, CO2Electrolyzer |
+| Filters | [filters.md](equipment/filters) | Particle, coalescing, strainer, and media filters with dynamic loading and mechanical design |
+| H2S Scavengers | [H2S_scavenger_guide.md](H2S_scavenger_guide) | H2S chemical scavenging (triazine, glyoxal, iron sponge) |
+| **Sulfur Recovery** | [sulfur_recovery.md](sulfur_recovery) | Integrated Claus furnace, WHB, converters, sulfur condensers, TGTU recycle, incineration, and KPIs |
+| Reactors | [reactors.md](equipment/reactors) | GibbsReactor |
+| Pipelines | [pipelines.md](equipment/pipelines) | Pipeline, AdiabaticPipe, TopsidePiping, Riser |
+| **Water Hammer Screening** | [water_hammer_implementation.md](../wiki/water_hammer_implementation) | WaterHammerPipe, WaterHammerStudy, MCP runWaterHammer |
+| **Piping Route Builder** | [piping_route_builder.md](piping_route_builder) | PipingRouteBuilder for STID/E3D line-list route hydraulics |
+| **CO2 Well Analysis** | [co2_injection_well_analysis.md](co2_injection_well_analysis) | CO2InjectionWellAnalyzer, ImpurityMonitor, TransientWellbore, CO2FlowCorrections |
+| **LNG Liquefaction** | [lng_liquefaction.md](lng_liquefaction) | LNGProcessBuilder, LNGProcessModel, LNGProcessBenchmark, LNGHeatExchanger |
+| **Hydrogen Production** | [hydrogen_production.md](hydrogen_production) | SMR/ATR/POX route templates, ReformerFurnace, CatalyticTubeReformer, AutothermalReformer, PartialOxidationReactor, PSACascade, Electrolyzer |
+| Looped Networks | [looped_networks.md](equipment/looped_networks) | LoopedPipeNetwork, Hardy Cross solver |
+| Gas Network Operations | [gas_network_operations.md](gas_network_operations) | Conservative mixing, coupled hydraulics, quality, optimization, and linepack |
+| Oil Network Operations | [oil_network_operations.md](oil_network_operations) | Pumps, assays, tanks, parcels, blends, and cargo scheduling |
+| Tanks | [tanks.md](equipment/tanks) | Tank, VesselDepressurization |
+| Wells | [wells.md](equipment/wells) | Well equipment |
+| Subsea Trees | [subsea_trees.md](equipment/subsea_trees) | SubseaTree, valve control |
+| Subsea Manifolds | [subsea_manifolds.md](equipment/subsea_manifolds) | SubseaManifold |
+| Subsea Boosters | [subsea_boosters.md](equipment/subsea_boosters) | SubseaBooster, multiphase pumps |
+| Umbilicals | [umbilicals.md](equipment/umbilicals) | Umbilical systems |
+| Battery Storage | [battery_storage.md](equipment/battery_storage) | BatteryStorage |
+| **Heat Integration** | [heat_integration.md](equipment/heat_integration) | PinchAnalysis, HeatStream |
+| **Power Generation** | [power_generation.md](equipment/power_generation) | GasTurbine, SteamTurbine, HRSG, CombinedCycleSystem, FuelCell, WindTurbine, SolarPanel |
+| Failure Modes | [failure_modes.md](equipment/failure_modes) | EquipmentFailureMode, reliability |
+| Mixers/Splitters | [mixers_splitters.md](equipment/mixers_splitters) | Mixer, Splitter |
 | Utility | [util/](equipment/util/) | Adjuster, Recycle, Calculator |
 
 ---
@@ -244,8 +244,8 @@ Use the narrowest API that represents the operation being modeled.
 | Flowsheet orchestration | `ProcessSystem` | Named units, topology, execution strategy, convergence, reporting, and transient time |
 | Controls and measurements | `controllerdevice`, `measurementdevice`, `logic` | Controllers, sensors, alarms, and process logic |
 
-See the [equipment index](equipment/README.md) for the current category map and
-[ProcessSystem guide](processmodel/process_system.md) for orchestration details.
+See the [equipment index](equipment/README) for the current category map and
+[ProcessSystem guide](processmodel/process_system) for orchestration details.
 
 ## ProcessSystem
 
@@ -358,7 +358,7 @@ topology-derived execution plan. The complete quick start above executes both ca
 
 ## Choosing Equipment
 
-The [equipment index](equipment/README.md) is the authoritative navigation page for individual
+The [equipment index](equipment/README) is the authoritative navigation page for individual
 unit-operation guides. The complete quick start above is the canonical package example; individual
 guides add equipment-specific constructors, specifications, units, and validation.
 
@@ -377,10 +377,10 @@ been established. Prefer retaining a typed reference when constructing the flows
 
 ## Specifications, Recycles, and Calculators
 
-- Use [adjusters](equipment/util/adjusters.md) for a bounded variable-to-target solve.
-- Use [recycles](equipment/util/recycles.md) to close material loops and document the convergence
+- Use [adjusters](equipment/util/adjusters) for a bounded variable-to-target solve.
+- Use [recycles](equipment/util/recycles) to close material loops and document the convergence
   variable, tolerance, and maximum iterations.
-- Use [calculators and setters](equipment/util/calculators.md) for explicit Java callbacks and
+- Use [calculators and setters](equipment/util/calculators) for explicit Java callbacks and
   supported setter targets. `Calculator` does not parse expression strings.
 - Add each utility object to the same `ProcessSystem` as its dependencies so topology and
   convergence logic can account for it.
@@ -400,7 +400,7 @@ calc.setCalculationMethod((inputs, output) -> {
 process.add(calc);
 ```
 
-The [calculator guide](equipment/util/calculators.md) supplies the imports, complete executable
+The [calculator guide](equipment/util/calculators) supplies the imports, complete executable
 context, supported presets, setter targets, and recycle-coupling boundaries.
 
 ## Transient and Safety Boundaries
@@ -415,12 +415,12 @@ A steady-state flowsheet is not automatically a valid dynamic model. Before adva
    identity, or the configured no-argument helper when that behavior is intentional;
 6. capture results through reports, monitors, or callbacks rather than console printing.
 
-See [dynamic simulation](dynamic-simulation.md) for instrumentation and controller setup.
+See [dynamic simulation](dynamic-simulation) for instrumentation and controller setup.
 
 A `SafetyValve` is constructed from a `StreamInterface`, not a vessel object, and its current
 set-pressure method is `setPressureSpec(double)`; there is no `setSetPressure(...)` API.
-Pressure-relief simulation is not design certification. Use the [valve guide](equipment/valves.md)
-and [safety roadmap](../safety/SAFETY_SIMULATION_ROADMAP.md), record units and scenarios explicitly,
+Pressure-relief simulation is not design certification. Use the [valve guide](equipment/valves)
+and [safety roadmap](../safety/SAFETY_SIMULATION_ROADMAP), record units and scenarios explicitly,
 and obtain the required engineering review.
 
 ## Result Handling
@@ -459,17 +459,17 @@ NeqSim includes foundational infrastructure to support the future of process sim
 | **Emissions Tracking** | [sustainability/](sustainability/) | CO2e accounting, regulatory reporting |
 | **Advisory Systems** | [advisory/](advisory/) | Look-ahead predictions with uncertainty |
 | **ML Integration** | [ml/](ml/) | Surrogate models, physics constraint validation |
-| **Safety Scenarios** | [safety/scenario-generation.md](safety/scenario-generation.md) | Automatic failure scenario generation |
-| **Batch Studies** | [optimization/batch-studies.md](optimization/batch-studies.md) | Parallel parameter studies |
+| **Safety Scenarios** | [safety/scenario-generation.md](safety/scenario-generation) | Automatic failure scenario generation |
+| **Batch Studies** | [optimization/batch-studies.md](optimization/batch-studies) | Parallel parameter studies |
 
-See [Future Infrastructure Overview](future-infrastructure.md) for complete documentation.
+See [Future Infrastructure Overview](future-infrastructure) for complete documentation.
 
 ---
 
 ## Related Documentation
 
 - [Equipment Documentation](equipment/) - Detailed equipment guides
-- [Process Logic Framework](../simulation/process_logic_framework.md) - Logic controllers
-- [Safety Systems](../safety/SAFETY_SIMULATION_ROADMAP.md) - Safety simulation
-- [Alarm System](../safety/alarm_system_guide.md) - Process alarms
-- [Future Infrastructure](future-infrastructure.md) - Digital twin, AI integration, sustainability
+- [Process Logic Framework](../simulation/process_logic_framework) - Logic controllers
+- [Safety Systems](../safety/SAFETY_SIMULATION_ROADMAP) - Safety simulation
+- [Alarm System](../safety/alarm_system_guide) - Process alarms
+- [Future Infrastructure](future-infrastructure) - Digital twin, AI integration, sustainability

--- a/docs/process/equipment/README.md
+++ b/docs/process/equipment/README.md
@@ -4,8 +4,12 @@ description: Source-safe navigation and API ownership for process equipment in N
 ---
 
 Use this index to choose an equipment-specific guide. For an executable, end-to-end flowsheet,
-start with the [process-package quick start](../README.md); it is compiled and run by the
+start with the [process-package quick start](../README); it is compiled and run by the
 documentation regression suite.
+
+The [complete source-backed equipment catalog](equipment_catalog) lists all 234 concrete
+`ProcessEquipmentInterface` implementations on the current source tree. Its generated inventory
+is checked in CI, so a newly added equipment class cannot remain absent from this documentation.
 
 ## Equipment Categories
 
@@ -13,129 +17,157 @@ documentation regression suite.
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Streams | [streams.md](streams.md) | Material and energy streams |
-| Mixers & Splitters | [mixers_splitters.md](mixers_splitters.md) | Stream mixing and splitting |
+| Streams | [streams.md](streams) | Material and energy streams |
+| Mixers & Splitters | [mixers_splitters.md](mixers_splitters) | Stream mixing and splitting |
+| Manifolds | [manifolds.md](manifolds) | Multi-inlet routing and production manifolds |
 
 ### Separation Equipment
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Separators | [separators.md](separators.md) | 2-phase and 3-phase separators, scrubbers |
-| Distillation | [distillation.md](distillation.md) | Distillation columns |
-| Absorbers | [absorbers.md](absorbers.md) | Absorption/stripping columns |
-| Membranes | [membranes.md](membranes.md) | Membrane separation units |
-| Filters | [filters.md](filters.md) | Particulate and charcoal filters |
+| Separators | [separators.md](separators) | 2-phase and 3-phase separators, scrubbers |
+| Separator Entrainment | [separator-entrainment-modeling.md](separator-entrainment-modeling) | Droplet distributions, internals, grade efficiency, and performance calculation |
+| Distillation | [distillation.md](distillation) | Distillation columns |
+| Absorbers | [absorbers.md](absorbers) | Absorption/stripping columns |
+| Adsorbers | [adsorbers.md](adsorbers) | Simplified adsorption equipment |
+| Adsorption Beds | [adsorption_bed.md](adsorption_bed) | Dynamic beds, breakthrough, mercury removal, and PSA |
+| Membranes | [membranes.md](membranes) | Membrane separation units |
+| Filters | [filters.md](filters) | Particulate and charcoal filters |
+| Water Treatment | [water_treatment.md](water_treatment) | Hydrocyclones, flotation, produced-water treatment, and compliance |
+| Black-Oil Separator | [black_oil_separator.md](black_oil_separator) | Pressure-temperature separation of `SystemBlackOil` fluids |
+| Solid Handling | [solid_handling.md](solid_handling) | Feedstock preparation, dewatering, filtration, drying, and crystallization |
 
 ### Heat Transfer Equipment
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Heat Exchangers | [heat_exchangers.md](heat_exchangers.md) | Heaters, coolers, condensers, reboilers |
+| Heat Exchangers | [heat_exchangers.md](heat_exchangers) | Heaters, coolers, condensers, reboilers |
+| Multi-Stream Heat Exchangers | [multistream_heat_exchanger.md](multistream_heat_exchanger) | Composite curves, pinch constraints, and multi-stream matching |
+| LNG Heat Exchanger | [LNGHeatExchanger.md](LNGHeatExchanger) | Brazed-aluminium exchanger model for cryogenic service |
+| Heat Integration | [heat_integration.md](heat_integration) | Heat streams and pinch analysis |
+| Water Cooler and Reboiler | [water_cooler_reboiler.md](water_cooler_reboiler) | Cooling-water and reboiler utilities |
 
 ### Rotating Equipment
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Compressors | [compressors.md](compressors.md) | Gas compression, mechanical losses, seal gas |
-| Compressor Anti-Surge Control | [compressor_antisurge_control.md](compressor_antisurge_control.md) | Dynamic anti-surge recycle, speed/load control, and coordinated pressure-speed-recycle control philosophy |
-| Pumps | [pumps.md](pumps.md) | Liquid pumping |
-| Expanders | [expanders.md](expanders.md) | Power recovery, turboexpanders |
+| Compressors | [compressors.md](compressors) | Gas compression, mechanical losses, seal gas |
+| Compressor Curves | [compressor_curves.md](compressor_curves) | Performance maps, correction, interpolation, and envelopes |
+| Compressor Shaft | [compressor_shaft.md](compressor_shaft) | Multiple compressor bodies on a common-speed shaft |
+| Compressor Anti-Surge Control | [compressor_antisurge_control.md](compressor_antisurge_control) | Dynamic anti-surge recycle, speed/load control, and coordinated pressure-speed-recycle control philosophy |
+| Pumps | [pumps.md](pumps) | Liquid pumping |
+| Expanders | [expanders.md](expanders) | Power recovery, turboexpanders |
 
 ### Flow Control
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Valves | [valves.md](valves.md) | Throttling valves, chokes, safety valves |
+| Valves | [valves.md](valves) | Throttling valves, chokes, safety valves |
+| Control Valves | [control_valves.md](control_valves) | Specialized pressure and level control valves |
 
 ### Reactors
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Reactors (Overview) | [reactors.md](reactors.md) | All reactor types: PFR, CSTR, Gibbs, stoichiometric, ammonia, sulfur, bio-processing |
-| Iron-Sulfide Wall Source | [iron_sulfide_wall_source.md](iron_sulfide_wall_source.md) | Stateful FeS/FeCO3 scale, oxygen ingress, S8 generation, and compressor deposition coupling |
-| Plug Flow Reactor | [plug_flow_reactor.md](plug_flow_reactor.md) | Kinetic PFR with power-law/LHHW/reversible kinetics, catalyst bed, Ergun ΔP, energy modes |
-| Electrolyzers | [electrolyzers.md](electrolyzers.md) | Water and CO₂ electrolysis |
+| Reactors (Overview) | [reactors.md](reactors) | All reactor types: PFR, CSTR, Gibbs, stoichiometric, ammonia, sulfur, bio-processing |
+| Iron-Sulfide Wall Source | [iron_sulfide_wall_source.md](iron_sulfide_wall_source) | Stateful FeS/FeCO3 scale, oxygen ingress, S8 generation, and compressor deposition coupling |
+| Plug Flow Reactor | [plug_flow_reactor.md](plug_flow_reactor) | Kinetic PFR with power-law/LHHW/reversible kinetics, catalyst bed, Ergun ΔP, energy modes |
+| Electrolyzers | [electrolyzers.md](electrolyzers) | Water and CO₂ electrolysis |
 
 ### Ejectors
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Ejectors | [ejectors.md](ejectors.md) | Steam and gas ejectors |
+| Ejectors | [ejectors.md](ejectors) | Steam and gas ejectors |
 
 ### Safety Equipment
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Flares | [flares.md](flares.md) | Flare systems and combustion |
+| Flares | [flares.md](flares) | Flare systems and combustion |
+| Vessel Depressurization | [vessel_depressurization.md](vessel_depressurization) | Blowdown, filling, fire exposure, and transient vessel inventory |
 
 ### Well/Reservoir
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Wells | [wells.md](wells.md) | Production wells, chokes |
-| Reservoirs | [reservoirs.md](reservoirs.md) | Material balance reservoir modeling |
-| Subsea Systems | [subsea_systems.md](subsea_systems.md) | Subsea wells and flowlines |
+| Wells | [wells.md](wells) | Production wells, chokes |
+| Reservoirs | [reservoirs.md](reservoirs) | Material balance reservoir modeling |
+| Production Well Networks | [production_well_networks.md](production_well_networks) | Coupled wells, flowlines, and network constraints |
+| Well Allocation | [well_allocation.md](well_allocation) | Production allocation across wells |
+| Subsea Systems | [subsea_systems.md](subsea_systems) | Subsea wells and flowlines |
 
 ### Subsea Equipment
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Subsea Trees | [subsea_trees.md](subsea_trees.md) | Christmas trees, valve control |
-| Subsea Manifolds | [subsea_manifolds.md](subsea_manifolds.md) | Multi-slot production manifolds |
-| Subsea Boosters | [subsea_boosters.md](subsea_boosters.md) | Multiphase pumps, compressors |
-| Umbilicals | [umbilicals.md](umbilicals.md) | Hydraulic, chemical, electrical supply |
+| Subsea Equipment Overview | [subsea_equipment.md](subsea_equipment) | Complete SURF and subsea equipment selection |
+| Subsea Trees | [subsea_trees.md](subsea_trees) | Christmas trees, valve control |
+| Subsea Manifolds | [subsea_manifolds.md](subsea_manifolds) | Multi-slot production manifolds |
+| Manifold Design | [manifold_design.md](manifold_design) | Mechanical design for topside, onshore, and subsea manifolds |
+| Subsea Boosters | [subsea_boosters.md](subsea_boosters) | Multiphase pumps, compressors |
+| Umbilicals | [umbilicals.md](umbilicals) | Hydraulic, chemical, electrical supply |
 
 ### Pipeline/Network
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Pipelines | [pipelines.md](pipelines.md) | Pipe flow, pressure drop |
-| **Risers** | [pipelines.md#risers](pipelines.md#risers) | **SCR, TTR, Flexible, Lazy-Wave risers** |
-| Networks | [networks.md](networks.md) | Pipeline network modeling |
-| Looped Networks | [looped_networks.md](looped_networks.md) | Hardy Cross solver for loops |
-| Gas Network Operations | [../gas_network_operations.md](../gas_network_operations.md) | Coupled gas quality, optimization, and linepack |
-| Oil Network Operations | [../oil_network_operations.md](../oil_network_operations.md) | Oil pumps, terminal tanks, parcels, and cargo schedules |
-| Manifolds | [manifolds.md](manifolds.md) | Multi-stream routing |
+| Pipelines | [pipelines.md](pipelines) | Pipe flow, pressure drop |
+| Pipeline Simulation | [pipeline_simulation.md](pipeline_simulation) | Model selection, configuration, and execution |
+| Multiphase Correlations | [multiphase_flow_correlations.md](multiphase_flow_correlations) | Pressure-drop, holdup, and flow-regime correlations |
+| **Risers** | [pipelines.md#risers](pipelines#risers) | **SCR, TTR, Flexible, Lazy-Wave risers** |
+| Networks | [networks.md](networks) | Pipeline network modeling |
+| Looped Networks | [looped_networks.md](looped_networks) | Hardy Cross solver for loops |
+| Gas Network Operations | [../gas_network_operations.md](../gas_network_operations) | Coupled gas quality, optimization, and linepack |
+| Oil Network Operations | [../oil_network_operations.md](../oil_network_operations) | Oil pumps, terminal tanks, parcels, and cargo schedules |
 
 ### Flow Measurement
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Differential Pressure | [differential_pressure.md](differential_pressure.md) | Orifice plates, flow measurement |
+| Differential Pressure | [differential_pressure.md](differential_pressure) | Orifice plates, flow measurement |
+| Measurement Devices | [measurement_devices.md](measurement_devices) | Flow, pressure, composition, and condition measurements |
 
 ### Storage
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Tanks | [tanks.md](tanks.md) | Storage tanks, LNG boil-off |
-| Vessel Depressurization | [vessel_depressurization.md](vessel_depressurization.md) | Filling, blowdown, fire cases, CNG/H2 tanks, heat transfer models |
-
-### Gas Treatment
-
-| Equipment | File | Description |
-|-----------|------|-------------|
-| Adsorbers | [adsorbers.md](adsorbers.md) | CO₂ and gas adsorption |
+| Tanks | [tanks.md](tanks) | Storage tanks, LNG boil-off |
+| LNG Cargo Ageing | [../lng-ageing.md](../lng-ageing) | Stratification, boil-off gas, rollover, voyage, and cargo-quality evolution |
 
 ### Power Generation
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Power Equipment | [power_generation.md](power_generation.md) | Gas turbines, fuel cells, renewables |
-| Battery Storage | [battery_storage.md](battery_storage.md) | Energy storage systems |
+| Power Equipment | [power_generation.md](power_generation) | Gas turbines, fuel cells, renewables |
+| Battery Storage | [battery_storage.md](battery_storage) | Energy storage systems |
+| Energy Conversion | [energy_conversion.md](energy_conversion) | Motors, generators, converters, thermal utilities, and energy-network solvers |
 
 ### Utility Equipment
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Adjusters | [util/adjusters.md](util/adjusters.md) | Variable adjustment to meet specs |
-| Recycles | [util/recycles.md](util/recycles.md) | Recycle stream handling |
-| Calculators | [util/calculators.md](util/calculators.md) | Custom calculations and setters |
+| Utility Index | [util/](util/) | Complete utility-equipment navigation |
+| Adjusters | [util/adjusters.md](util/adjusters) | Variable adjustment to meet specs |
+| Recycles | [util/recycles.md](util/recycles) | Recycle stream handling |
+| Calculators | [util/calculators.md](util/calculators) | Custom calculations and setters |
+| Fuel Gas System | [util/fuel_gas_system.md](util/fuel_gas_system) | Fuel-gas supply and balancing |
+| Produced-Water Degassing | [util/produced_water_degassing.md](util/produced_water_degassing) | Degassing-system utility model |
+| Saturators | [util/saturators.md](util/saturators) | Water and component saturation utilities |
+| Stream Fitters | [util/stream_fitters.md](util/stream_fitters) | GOR, MPFM, and production-rate fitting |
+| Utility Air System | [util/utility_air_system.md](util/utility_air_system) | Instrument and plant-air utility modeling |
 
 ### Reliability & Failure
 
 | Equipment | File | Description |
 |-----------|------|-------------|
-| Failure Modes | [failure_modes.md](failure_modes.md) | Equipment failure modeling for risk analysis |
+| Failure Modes | [failure_modes.md](failure_modes) | Equipment failure modeling for risk analysis |
+
+### Complete Source Inventory
+
+| Catalog | Coverage | Description |
+| --- | --- | --- |
+| [Complete equipment catalog](equipment_catalog) | 234 concrete classes in 33 source packages | Generated from the Java inheritance tree and checked against source in CI |
 
 
 ## API Ownership
@@ -170,7 +202,7 @@ method. Follow the selected guide and current Java source for that equipment's:
 
 Add streams and equipment to one `ProcessSystem`, retain typed references, run the process, and
 check conservation plus equipment constraints. The
-[canonical process-package example](../README.md#processsystem) demonstrates this sequence with a
+[canonical process-package example](../README#processsystem) demonstrates this sequence with a
 feed, throttling valve, separator, mass-balance assertion, topology diagnostics, and structured
 reports.
 
@@ -196,9 +228,9 @@ The diagram shows API ownership, not every concrete subtype.
 
 ## Related Documentation
 
-- [Process package](../README.md) — architecture, execution, reports, and the executable quick start
-- [ProcessSystem](../processmodel/process_system.md) — flowsheet orchestration and execution
-- [ProcessModule](../processmodel/process_module.md) — modular process units
-- [Controllers](../controllers.md) — control equipment
-- [Safety systems](../safety/README.md) — safety simulation
+- [Process package](../README) — architecture, execution, reports, and the executable quick start
+- [ProcessSystem](../processmodel/process_system) — flowsheet orchestration and execution
+- [ProcessModule](../processmodel/process_module) — modular process units
+- [Controllers](../controllers) — control equipment
+- [Safety systems](../safety/README) — safety simulation
 - [Engineering documentation](../../engineering/) — controlled design cases and discipline workflows

--- a/docs/process/equipment/black_oil_separator.md
+++ b/docs/process/equipment/black_oil_separator.md
@@ -1,0 +1,47 @@
+---
+title: "Black-Oil Separator Equipment"
+description: "Use BlackOilSeparator with SystemBlackOil in a NeqSim ProcessSystem, including its pressure-temperature specification, outlet systems, units, and model boundary."
+---
+
+`BlackOilSeparator` is the process-equipment bridge for NeqSim's pressure-indexed black-oil
+PVT model. It performs one equilibrium black-oil flash at a specified outlet pressure and
+temperature and can participate in normal `ProcessSystem` execution.
+
+## Model contract
+
+| Item | API or unit |
+| --- | --- |
+| Java class | `neqsim.process.equipment.blackoil.BlackOilSeparator` |
+| Inlet model | `neqsim.blackoil.SystemBlackOil` |
+| Outlet pressure | bar absolute |
+| Outlet temperature | K |
+| Products | `getOilOut()`, `getGasOut()`, and `getWaterOut()` as `SystemBlackOil` objects |
+| Flash evidence | `getLastFlashResult()` and `getResultsMap()` |
+| Process reporting | `toJson()` |
+
+The constructor requires the equipment name, inlet `SystemBlackOil`, outlet pressure, and outlet
+temperature. The model does not use `StreamInterface`: its inlet and three products remain
+black-oil systems containing standard oil, gas, and water totals. Use the compositional
+[separator equipment](separators) when a flowsheet needs component-level material streams.
+
+## Execution and conservation
+
+On each run the unit sets the specified pressure and temperature, flashes the inlet black-oil
+system, and partitions standard totals into oil, free-gas, and water products. A robust workflow
+checks:
+
+1. standard oil, gas, and water closure across the three products;
+2. the `Rs`, `Rv`, `Bo`, `Bg`, and `Bw` values in `BlackOilFlashResult`;
+3. pressure and temperature units before comparing with laboratory or simulator tables;
+4. the PVT-table pressure and temperature validity range.
+
+The temperature is a state label for the selected black-oil table; the underlying table does not
+create an independent continuous temperature correlation. Use separate qualified tables when
+temperature dependence is material.
+
+## Related documentation
+
+- [Black-oil package](../../blackoil/) — table construction, flashes, conversion, and export
+- [Separators](separators) — compositional two- and three-phase process separators
+- [ProcessSystem](../processmodel/process_system) — flowsheet execution and reporting
+- [Complete equipment catalog](equipment_catalog) — every concrete equipment implementation

--- a/docs/process/equipment/energy_conversion.md
+++ b/docs/process/equipment/energy_conversion.md
@@ -1,0 +1,54 @@
+---
+title: "Energy Conversion and Utility Equipment"
+description: "Reference for NeqSim motors, generators, converters, energy-network solvers, thermal utility sources and consumers, and their typed energy-port contracts."
+---
+
+The `neqsim.process.equipment.energy` package supplies process units for conversion and allocation
+of electrical power, shaft work, heat, and chemical energy. These units connect through typed
+`EnergyPort` and `EnergyBus` objects and can be ordered explicitly in a `ProcessSystem` graph.
+
+## Equipment selection
+
+| Equipment | Primary role |
+| --- | --- |
+| `EnergyConverter` | Generic two-domain conversion with efficiency, capacity, idle loss, ramping, and trip state |
+| `LoadMappedEnergyConverter` | Conversion with load-dependent efficiency |
+| `ElectricMotor` | Electrical power to shaft work |
+| `Generator` | Shaft work to electrical power |
+| `Gearbox` | Shaft-work conversion with a speed ratio |
+| `Inverter` | Electrical conversion with voltage and frequency quality |
+| `Transformer` | Electrical conversion with a voltage ratio |
+| `PrimeMover` | Chemical or fuel energy to shaft work |
+| `CommittedEnergyGenerator` | Dispatchable generation with commitment constraints |
+| `ThermalUtilitySource` | Typed heating or cooling utility supply |
+| `ThermalUtilityConsumer` | Temperature-grade-aware thermal utility demand |
+| `EnergyNetworkSolver` | Explicit `ProcessSystem` calculation node for one or more energy buses |
+
+`MotorDriveTrain`, `MotorAssistedDriveTrain`, `CoupledProcessEnergySolver`, and the time-series
+classes are orchestration services rather than equipment units. They coordinate the concrete
+equipment above across shared buses, mechanical shafts, repeated process-energy iterations, or
+time horizons.
+
+## Common contract
+
+Energy equipment uses W internally. Unit-aware public APIs accept the units documented by the
+underlying energy stream or port. Each converter exposes a specification input, a calculated
+useful output, and a calculated heat-loss output. The process graph uses port direction and mode
+to order producers, network solvers, and consumers.
+
+Before using an energy result for design or optimization, check:
+
+- energy conservation across input, useful output, and heat loss;
+- configured efficiency, idle loss, maximum power, and ramp limits;
+- `ValidationResult` setup findings and trip state;
+- energy quality such as utility temperature, electrical frequency, or shaft speed;
+- unmet demand, curtailed supply, and balancing contributions in `EnergyNetworkReport`.
+
+## Related documentation
+
+- [Energy streams and equipment ports](../energy_streams) — connection patterns and energy balances
+- [Energy dispatch](../energy_dispatch) — cost, emissions, and priority dispatch
+- [Energy time series](../energy_time_series) — time-varying supply and demand
+- [Power generation](power_generation) — turbines, fuel cells, renewables, and combined cycles
+- [Battery storage](battery_storage) — state of charge and automatic balancing
+- [Complete equipment catalog](equipment_catalog) — every concrete equipment implementation

--- a/docs/process/equipment/equipment_catalog.md
+++ b/docs/process/equipment/equipment_catalog.md
@@ -1,0 +1,76 @@
+---
+title: "Complete Process Equipment Catalog"
+description: "Source-backed catalog of every concrete NeqSim ProcessEquipmentInterface implementation, grouped by Java package and linked to its maintained guide."
+---
+
+This catalog is generated from `src/main/java/neqsim/process/equipment`. It lists every public,
+non-abstract class that implements `ProcessEquipmentInterface`, directly or through an equipment
+base class. Helper classes, result records, strategies, enums, and interfaces are intentionally
+excluded from the equipment count.
+
+**Current source inventory:** 234 concrete equipment classes in 33 packages.
+
+Regenerate this page after adding or removing equipment:
+
+```text
+python devtools/generate_equipment_documentation_catalog.py
+```
+
+## Equipment by source package
+
+| Source package | Maintained guide | Concrete equipment classes |
+| --- | --- | --- |
+| `absorber` | [Absorbers and strippers](absorbers)<br>Gas absorption, stripping, amine, and TEG contactors | `AbsorptionColumn`, `H2SScavenger`, `RateBasedAbsorber`, `SimpleAbsorber`, `SimpleAmineAbsorber`, `SimpleAmineRegenerator`, `SimpleTEGAbsorber`, `StrippingColumn`, `WaterStripperColumn` |
+| `adsorber` | [Adsorbers](adsorbers) and [adsorption beds](adsorption_bed)<br>Adsorption beds, mercury removal, and PSA equipment | `AdsorptionBed`, `MercuryRemovalBed`, `PSACascade`, `PressureSwingAdsorptionBed`, `SimpleAdsorber` |
+| `battery` | [Battery storage](battery_storage)<br>Electrical energy storage and balancing | `BatteryStorage` |
+| `blackoil` | [Black-oil separation](black_oil_separator)<br>Black-oil PVT separation in ProcessSystem | `BlackOilSeparator` |
+| `compressor` | [Compressors](compressors)<br>Compressors, trains, drivers, maps, and anti-surge models | `Compressor`, `CompressorTrain` |
+| `diffpressure` | [Differential-pressure equipment](differential_pressure)<br>Orifice and differential-pressure flow equipment | `Orifice` |
+| `distillation` | [Distillation](distillation)<br>Tray, packed, reactive, and shortcut columns | `Condenser`, `DistillationColumn`, `PackedColumn`, `RateBasedPackedColumn`, `ReactiveTray`, `Reboiler`, `ScrubColumn`, `ShortcutDistillationColumn`, `SimpleTray`, `VLSolidTray` |
+| `ejector` | [Ejectors](ejectors)<br>Motive/suction ejector equipment | `Ejector` |
+| `electrolyzer` | [Electrolyzers](electrolyzers)<br>Water and carbon-dioxide electrolysis | `CO2Electrolyzer`, `Electrolyzer` |
+| `energy` | [Energy conversion equipment](energy_conversion)<br>Motors, generators, converters, utility sources, and network solvers | `CommittedEnergyGenerator`, `ElectricMotor`, `EnergyConverter`, `EnergyNetworkSolver`, `Gearbox`, `Generator`, `Inverter`, `LoadMappedEnergyConverter`, `PrimeMover`, `ThermalUtilityConsumer`, `ThermalUtilitySource`, `Transformer` |
+| `expander` | [Expanders](expanders)<br>Turboexpanders and coupled expander-compressor units | `Expander`, `ExpanderOld`, `MapTurboExpanderCompressor`, `TurboExpanderCompressor` |
+| `filter` | [Filters](filters)<br>Particulate, charcoal, and sulfur filters | `CharCoalFilter`, `Filter`, `SulfurFilter` |
+| `flare` | [Flares](flares)<br>Flare units and stacks | `Flare`, `FlareStack` |
+| `heatexchanger` | [Heat exchangers](heat_exchangers)<br>Heaters, coolers, exchangers, evaporators, and dryers | `AirCooler`, `Cooler`, `Dryer`, `FiredHeater`, `HeatExchanger`, `Heater`, `LNGHeatExchanger`, `MultiEffectEvaporator`, `MultiStreamHeatExchanger`, `MultiStreamHeatExchanger2`, `NeqHeater`, `ReBoiler`, `SteamHeater`, `WaterCooler` |
+| `lng` | [LNG cargo ageing](../lng-ageing)<br>LNG storage, ageing, boil-off, and transport scenarios | `LNGAgeingScenario` |
+| `manifold` | [Manifolds](manifolds)<br>Multi-inlet production and routing manifolds | `Manifold` |
+| `membrane` | [Membranes](membranes)<br>Membrane separators | `MembraneSeparator` |
+| `mixer` | [Mixers and splitters](mixers_splitters)<br>Equilibrium, static, non-equilibrium, and phase mixers | `Mixer`, `StaticMixer`, `StaticNeqMixer`, `StaticPhaseMixer` |
+| `network` | [Networks](networks)<br>Pipe, looped, and well-flowline networks | `LoopedPipeNetwork`, `PipeFlowNetwork`, `WellFlowlineNetwork` |
+| `pipeline` | [Pipelines](pipelines)<br>Steady and transient single-, two-, and multiphase pipelines | `AdiabaticPipe`, `AdiabaticTwoPhasePipe`, `IncompressiblePipeFlow`, `MultiphasePipe`, `OnePhasePipeLine`, `PipeBeggsAndBrills`, `PipeGray`, `PipeHagedornBrown`, `PipeMukherjeeAndBrill`, `Pipeline`, `Riser`, `SimpleTPoutPipeline`, `TopsidePiping`, `TransientPipe`, `TransientWellbore`, `TubingPerformance`, `TwoFluidPipe`, `TwoPhasePipeLine`, `WaterHammerPipe` |
+| `powergeneration` | [Power generation](power_generation)<br>Turbines, fuel cells, renewables, and combined-cycle systems | `CombinedCycleSystem`, `FuelCell`, `GasTurbine`, `GasTurbineUnit`, `GasTurbineVendorPerformance`, `HRSG`, `OffshoreEnergySystem`, `SolarPanel`, `SteamTurbine`, `WindFarm`, `WindTurbine` |
+| `pump` | [Pumps](pumps)<br>Centrifugal, ESP, jet, and sucker-rod pumps | `ESPPump`, `JetPump`, `Pump`, `SuckerRodPump` |
+| `reactor` | [Reactors](reactors)<br>Equilibrium, kinetic, reforming, sulfur, and bioprocess reactors | `AmmoniaSynthesisReactor`, `AnaerobicDigester`, `AutothermalReformer`, `BiomassGasifier`, `CO2ImpurityKineticReactor`, `CatalyticTubeReformer`, `ClausCatalyticConverter`, `ClausReactionFurnace`, `EnzymeTreatment`, `FermentationReactor`, `Fermenter`, `FurnaceBurner`, `GibbsReactor`, `GibbsReactorCO2`, `IronSulfideOxidationSource`, `PartialOxidationReactor`, `PlugFlowReactor`, `PyrolysisReactor`, `QuenchSection`, `ReactiveWasteHeatBoiler`, `ReformerFurnace`, `StirredTankReactor`, `SubDewPointSulfurReactor`, `SulfurCondenser`, `SulfurDepositionAnalyser`, `SulfurOxidationReactor`, `SulfurRecoveryUnit`, `SyngasBurnerZone`, `TailGasTreatmentUnit`, `ThermalIncinerator`, `WaterGasShiftReactor` |
+| `reservoir` | [Reservoirs and wells](reservoirs)<br>Reservoir, inflow, surveillance, and well-system equipment | `AnnularLeakagePath`, `CementDegradationModel`, `InjectionConformanceMonitor`, `MultiCompartmentReservoir`, `ReservoirCVDsim`, `ReservoirDiffLibsim`, `ReservoirTPsim`, `SimpleReservoir`, `TubingPerformance`, `WellFlow`, `WellSystem` |
+| `separator` | [Separators](separators)<br>Phase, solids, cryogenic, and extraction separators | `CryogenicSeparator`, `Crystallizer`, `EndFlash`, `GasScrubber`, `GasScrubberSimple`, `Hydrocyclone`, `LiquidLiquidExtractor`, `NeqGasScrubber`, `PressureFilter`, `RotaryVacuumFilter`, `ScrewPress`, `Separator`, `SolidsCentrifuge`, `SolidsSeparator`, `ThreePhaseGasScrubber`, `ThreePhaseSeparator`, `TwoPhaseSeparator` |
+| `solidhandling` | [Solid handling](solid_handling)<br>Biological feedstock preparation and solids handling | `BioFeedstockPreparation` |
+| `splitter` | [Mixers and splitters](mixers_splitters)<br>Flow, component, capture, and upgrading splitters | `BiogasUpgrader`, `ComponentCaptureUnit`, `ComponentSplitter`, `Splitter` |
+| `stream` | [Streams](streams)<br>Material, equilibrium, virtual, and diagnostic streams | `EquilibriumStream`, `IronIonSaturationStream`, `NeqStream`, `ScalePotentialCheckStream`, `Stream`, `VirtualStream` |
+| `subsea` | [Subsea equipment](subsea_equipment)<br>Trees, manifolds, boosters, jumpers, flowlines, and umbilicals | `FlexiblePipe`, `FloatingSubstructure`, `MooringSystem`, `PLEM`, `PLET`, `SimpleFlowLine`, `SubseaBooster`, `SubseaJumper`, `SubseaManifold`, `SubseaPowerCable`, `SubseaTree`, `SubseaWell`, `Umbilical` |
+| `tank` | [Tanks](tanks)<br>Storage, LNG, and vessel-depressurization equipment | `LNGTank`, `Tank`, `VesselDepressurization` |
+| `util` | [Process utilities](util/)<br>Adjusters, recycles, calculators, fitters, setters, and utility systems | `Adjuster`, `AntiSurgeCalculator`, `Calculator`, `CompressorShaftCalculator`, `FlowRateAdjuster`, `FlowSetter`, `FuelGasSystem`, `GORfitter`, `MPFMfitter`, `MoleFractionControllerUtil`, `MultiVariableAdjuster`, `NeqSimUnit`, `PressureDrop`, `ProductionRateFitter`, `Recycle`, `SetPoint`, `Setter`, `SpreadsheetBlock`, `StreamSaturatorUtil`, `StreamTransition`, `UnisimCalculator`, `UtilityAirSystem` |
+| `valve` | [Valves](valves)<br>Control, shutdown, relief, rupture-disk, and throttling valves | `BlowdownValve`, `CheckValve`, `ControlValve`, `ESDValve`, `HIPPSValve`, `LevelControlValve`, `PSDValve`, `PressureControlValve`, `RuptureDisk`, `SafetyReliefValve`, `SafetyValve`, `ThrottlingValve` |
+| `watertreatment` | [Water treatment](water_treatment)<br>Hydrocyclone, flotation, and produced-water treatment trains | `GasFlotationUnit`, `Hydrocyclone`, `ProducedWaterTreatmentTrain` |
+
+## Equipment-adjacent framework packages
+
+These packages live below `neqsim.process.equipment` but provide shared contracts, metadata,
+or services rather than concrete process units, so they are not included in the equipment count.
+
+| Source package | Documentation | Role |
+| --- | --- | --- |
+| `capacity` | [Capacity constraint framework](../CAPACITY_CONSTRAINT_FRAMEWORK) | Capacity strategies, constraints, bottleneck results, and design data |
+| `failure` | [Failure modes](failure_modes) | Reliability and failure-mode metadata attached to equipment |
+| `iec81346` | [Engineering diagram and identification guide](../../integration/engineering-diagram-document-model) | IEC 81346 reference designations and automatic assignment |
+| `well` | [Well allocation](well_allocation) | Allocation results and production-allocation services |
+
+## Catalog boundary
+
+Controllers and measurement devices implement the broader `ProcessElementInterface` contract and
+are documented separately in [controllers](../controllers) and [measurement devices](measurement_devices).
+Mechanical-design calculators, thermodynamic systems, and process modules are likewise outside this
+equipment-class inventory even when they configure or consume equipment results.
+
+Return to the [equipment guide](./).

--- a/docs/process/equipment/index.md
+++ b/docs/process/equipment/index.md
@@ -1,6 +1,6 @@
 ---
-title: equipment
-description: equipment documentation for NeqSim
+title: Process Equipment
+description: Complete navigation and source-backed class inventory for NeqSim process equipment.
 ---
 
 {%- include_relative README.md -%}

--- a/docs/process/equipment/solid_handling.md
+++ b/docs/process/equipment/solid_handling.md
@@ -1,0 +1,48 @@
+---
+title: "Solid Handling Equipment"
+description: "Reference for BioFeedstockPreparation and the NeqSim solids-separation equipment used for dewatering, filtration, centrifugation, pressing, drying, and crystallization."
+---
+
+NeqSim represents solid-handling steps through one dedicated feed-preparation unit and several
+solids-separation or thermal-processing units. Select the model according to the material contract:
+`BioFeedstockPreparation` uses a characterized biological feedstock and mass ledger, while the
+separator and heat-exchanger units operate on NeqSim thermodynamic streams.
+
+## Equipment selection
+
+| Equipment | Source package | Role |
+| --- | --- | --- |
+| `BioFeedstockPreparation` | `solidhandling` | Dewatering, size-reduction/handling energy, densification, dry-solids loss, and mass closure |
+| `SolidsSeparator` | `separator` | Base solids/liquid separation model |
+| `SolidsCentrifuge` | `separator` | Centrifugal solids separation |
+| `RotaryVacuumFilter` | `separator` | Vacuum filtration |
+| `PressureFilter` | `separator` | Pressure filtration |
+| `ScrewPress` | `separator` | Mechanical dewatering |
+| `Crystallizer` | `separator` | Solid formation and phase separation |
+| `Dryer` | `heatexchanger` | Thermal moisture removal |
+| `MultiEffectEvaporator` | `heatexchanger` | Staged solvent or water evaporation |
+
+## BioFeedstockPreparation contract
+
+`BioFeedstockPreparation` accepts a `BioFeedstock` characterization and an as-received rate in
+kg/h. Optional specifications set target total-solids mass fraction, prepared bulk density,
+handling and densification energy intensities, water-removal energy, and dry-solids loss.
+
+After execution, inspect prepared feed rate, water removed, dry solids lost, inlet and prepared
+bulk volumes, electrical power, and `getMassClosureFraction()`. The default energy intensities are
+screening assumptions rather than vendor guarantees; replace them with project evidence before
+design use.
+
+## Model boundary
+
+The dedicated feed-preparation model does not create a `StreamInterface` outlet. It produces a
+prepared `BioFeedstock` characterization and report-ready mass/energy results. Connect it to a
+larger study through explicit feedstock data and energy demand. For thermodynamic solid/liquid
+streams, use the separator, crystallizer, dryer, or evaporator models instead.
+
+## Related documentation
+
+- [Bio-processing unit operations](../bioprocessing) — reactors, separators, extraction, drying, and biorefinery examples
+- [Separators](separators) — phase and solids separation equipment
+- [Heat exchangers](heat_exchangers) — dryers and evaporators
+- [Complete equipment catalog](equipment_catalog) — every concrete equipment implementation

--- a/docs/process/safety/README.md
+++ b/docs/process/safety/README.md
@@ -155,12 +155,12 @@ and scenario boundary conditions must also be represented.
 
 ## Relief and fire screening boundary
 
-Use [Relief-Valve Sizing Screening](../../safety/relief_valve_sizing_api.md) for the maintained
+Use [Relief-Valve Sizing Screening](../../safety/relief_valve_sizing_api) for the maintained
 gas, liquid, two-phase, and wetted-fire sizing interfaces. Do not attach an undocumented heat
 input to an arbitrary vessel or infer an API 526 letter from `SafetyValve`; the dynamic equipment
 class does not expose those sizing methods.
 
-Use [Integrated Facility Safety Response](integrated-facility-safety-response.md) when relief,
+Use [Integrated Facility Safety Response](integrated-facility-safety-response) when relief,
 blowdown, flare, compressor trip, process limits, MDMT, and hydrate margin must be reviewed as one
 scenario. Static relief sizing and dynamic transient response answer different questions and
 should both retain method, unit, input-basis, and qualification metadata.
@@ -182,15 +182,15 @@ basis and trace each acceptance criterion to the applicable controlled source.
 
 ## Related documentation
 
-- [Safety documentation index](../../safety/README.md)
-- [Relief-Valve Sizing Screening](../../safety/relief_valve_sizing_api.md)
-- [ESD Dynamic Testing Workflow](../../safety/esd_testing_workflow.md)
-- [HIPPS overview](../../safety/HIPPS_SUMMARY.md)
-- [Closed-loop SIF verification](closed-loop-sif-verification.md)
-- [SIF reliability and degraded modes](sif-reliability-and-degraded-modes.md)
-- [HAZOP/LOPA to draft SRS handoff](hazop-lopa-srs-handoff.md)
-- [Integrated facility safety response](integrated-facility-safety-response.md)
-- [Safety change revalidation and benchmarks](safety-change-revalidation-and-benchmarks.md)
-- [Release and dispersion scenarios](release-dispersion-scenarios.md)
-- [Valve equipment guide](../equipment/valves.md)
-- [Process package overview](../README.md)
+- [Safety documentation index](../../safety/README)
+- [Relief-Valve Sizing Screening](../../safety/relief_valve_sizing_api)
+- [ESD Dynamic Testing Workflow](../../safety/esd_testing_workflow)
+- [HIPPS overview](../../safety/HIPPS_SUMMARY)
+- [Closed-loop SIF verification](closed-loop-sif-verification)
+- [SIF reliability and degraded modes](sif-reliability-and-degraded-modes)
+- [HAZOP/LOPA to draft SRS handoff](hazop-lopa-srs-handoff)
+- [Integrated facility safety response](integrated-facility-safety-response)
+- [Safety change revalidation and benchmarks](safety-change-revalidation-and-benchmarks)
+- [Release and dispersion scenarios](release-dispersion-scenarios)
+- [Valve equipment guide](../equipment/valves)
+- [Process package overview](../README)

--- a/docs/pvtsimulation/README.md
+++ b/docs/pvtsimulation/README.md
@@ -105,12 +105,12 @@ Javadocs before building an automated regression workflow.
 
 ## Related documentation
 
-- [PVT laboratory-test guide](pvt_lab_tests.md)
-- [Phase-envelope guide](phase_envelope_guide.md)
-- [PVT and fluid characterization](../thermo/pvt_fluid_characterization.md)
-- [Eclipse E300 fluid import](eclipse_e300_fluid_import.md)
-- [NeqSim JSON fluid format](json_fluid_format.md)
-- [Black-oil package](../blackoil/README.md)
-- [Reservoir material balance](reservoir_material_balance.md)
-- [Relative-permeability tables](relative_permeability.md)
-- [Flow-assurance screening](flowassurance/README.md)
+- [PVT laboratory-test guide](pvt_lab_tests)
+- [Phase-envelope guide](phase_envelope_guide)
+- [PVT and fluid characterization](../thermo/pvt_fluid_characterization)
+- [Eclipse E300 fluid import](eclipse_e300_fluid_import)
+- [NeqSim JSON fluid format](json_fluid_format)
+- [Black-oil package](../blackoil/README)
+- [Reservoir material balance](reservoir_material_balance)
+- [Relative-permeability tables](relative_permeability)
+- [Flow-assurance screening](flowassurance/README)

--- a/docs/pvtsimulation/flowassurance/README.md
+++ b/docs/pvtsimulation/flowassurance/README.md
@@ -12,14 +12,14 @@ not as design certification.
 
 | Topic | Start here |
 | --- | --- |
-| Integrated study sequence | [Flow-assurance overview](../flow_assurance_overview.md) |
-| Cooldown, simplified corrosion, mineral scale, and wax curves | [Screening-tools guide](flow_assurance_screening_tools.md) |
-| Hydrates | [Hydrate models](../../thermo/hydrate_models.md) |
-| Wax fluid characterization | [Wax characterization](../../thermo/characterization/wax_characterization.md) |
-| Asphaltenes | [Asphaltene modeling](asphaltene_modeling.md) |
-| Sand erosion | [Erosion prediction](erosion_prediction.md) |
-| Emulsions | [Emulsion viscosity](emulsion_viscosity_calculator.md) |
-| High-salinity scale and treatment evidence | [Mineral-scale and chemical-treatment validation](../mineral_scale_chemical_treatment_validation.md) |
+| Integrated study sequence | [Flow-assurance overview](../flow_assurance_overview) |
+| Cooldown, simplified corrosion, mineral scale, and wax curves | [Screening-tools guide](flow_assurance_screening_tools) |
+| Hydrates | [Hydrate models](../../thermo/hydrate_models) |
+| Wax fluid characterization | [Wax characterization](../../thermo/characterization/wax_characterization) |
+| Asphaltenes | [Asphaltene modeling](asphaltene_modeling) |
+| Sand erosion | [Erosion prediction](erosion_prediction) |
+| Emulsions | [Emulsion viscosity](emulsion_viscosity_calculator) |
+| High-salinity scale and treatment evidence | [Mineral-scale and chemical-treatment validation](../mineral_scale_chemical_treatment_validation) |
 
 ## Screening classes
 
@@ -38,11 +38,11 @@ The following classes are in `neqsim.pvtsimulation.flowassurance`.
 | `EmulsionViscosityCalculator` | Effective viscosity and phase-inversion screening |
 
 For process-coupled corrosion and materials workflows in `neqsim.process.corrosion`, see the
-[corrosion analysis module](../../process/corrosion/index.md).
+[corrosion analysis module](../../process/corrosion/index).
 
 ## Canonical executable example
 
-The [screening-tools guide](flow_assurance_screening_tools.md) contains the maintained Java 8
+The [screening-tools guide](flow_assurance_screening_tools) contains the maintained Java 8
 program for cooldown, simplified corrosion, and scale screening, plus the current wax-curve API
 contract. `FlowAssuranceDocumentationTest` executes the documented calls and checks result bounds.
 Keeping one canonical program prevents landing-page fragments from drifting independently.
@@ -56,17 +56,17 @@ larger workflow. The calculators do not add that governance automatically.
 | Need | Class or guide | Notes |
 | --- | --- | --- |
 | Fast empirical screen | `DeBoerAsphalteneScreening` | Requires reservoir pressure, saturation pressure, and in-situ density |
-| CPA stability analysis | `AsphalteneStabilityAnalyzer` | See [CPA calculations](asphaltene_cpa_calculations.md) |
-| Compare available methods | `AsphalteneMethodComparison` or `AsphalteneMultiMethodBenchmark` | See [method comparison](asphaltene_method_comparison.md) |
+| CPA stability analysis | `AsphalteneStabilityAnalyzer` | See [CPA calculations](asphaltene_cpa_calculations) |
+| Compare available methods | `AsphalteneMethodComparison` or `AsphalteneMultiMethodBenchmark` | See [method comparison](asphaltene_method_comparison) |
 | Regular-solution model | `FloryHugginsAsphalteneModel` | Configure and calibrate for the fluid being studied |
 | Refractive-index screen | `RefractiveIndexAsphalteneScreening` | Requires measured or estimated refractive-index inputs |
 | Cubic-EOS characterization | `PedersenAsphalteneCharacterization` | Adds characterized pseudo-components and supports binary-interaction tuning |
-| CPA parameter fitting | `AsphalteneOnsetFitting` | See [parameter fitting](asphaltene_parameter_fitting.md) |
+| CPA parameter fitting | `AsphalteneOnsetFitting` | See [parameter fitting](asphaltene_parameter_fitting) |
 | Pressure-onset flash | `neqsim.thermodynamicoperations.flashops.saturationops.AsphalteneOnsetPressureFlash` | Run the flash object and read `getOnsetPressure()` |
 | Temperature-onset flash | `neqsim.thermodynamicoperations.flashops.saturationops.AsphalteneOnsetTemperatureFlash` | Run the flash object and read its onset result |
 
 For a quick empirical classification, use the maintained
-[De Boer screening guide](asphaltene_deboer_screening.md). The implementation uses absolute
+[De Boer screening guide](asphaltene_deboer_screening). The implementation uses absolute
 reservoir and saturation pressure in bar and in-situ oil density in kg/m3. A flagged case still
 requires measured onset or precipitation data and a calibrated model.
 
@@ -82,14 +82,14 @@ before using it for design decisions.
 
 ## Asphaltene documentation
 
-- [De Boer screening](asphaltene_deboer_screening.md)
-- [CPA calculations](asphaltene_cpa_calculations.md)
-- [Parameter fitting](asphaltene_parameter_fitting.md)
-- [Method comparison](asphaltene_method_comparison.md)
-- [Validation cases](asphaltene_validation.md)
+- [De Boer screening](asphaltene_deboer_screening)
+- [CPA calculations](asphaltene_cpa_calculations)
+- [Parameter fitting](asphaltene_parameter_fitting)
+- [Method comparison](asphaltene_method_comparison)
+- [Validation cases](asphaltene_validation)
 
 ## Related documentation
 
-- [PVT simulation](../README.md)
-- [Thermodynamic models](../../thermo/README.md)
-- [Process simulation](../../process/README.md)
+- [PVT simulation](../README)
+- [Thermodynamic models](../../thermo/README)
+- [Process simulation](../../process/README)

--- a/docs/safety/README.md
+++ b/docs/safety/README.md
@@ -19,69 +19,69 @@ This folder contains guides for implementing safety systems in process simulatio
 
 | Document | Description |
 |----------|-------------|
-| [ESD Dynamic Testing Workflow](esd_testing_workflow.md) | Dynamic ESD testing with process logic, OperationalTagMap/tagreader evidence, and JSON criteria reports |
-| [ESD_BLOWDOWN_SYSTEM.md](ESD_BLOWDOWN_SYSTEM.md) | Complete ESD and blowdown system guide |
-| [PRESSURE_MONITORING_ESD.md](PRESSURE_MONITORING_ESD.md) | Pressure monitoring for ESD |
+| [ESD Dynamic Testing Workflow](esd_testing_workflow) | Dynamic ESD testing with process logic, OperationalTagMap/tagreader evidence, and JSON criteria reports |
+| [ESD_BLOWDOWN_SYSTEM.md](ESD_BLOWDOWN_SYSTEM) | Complete ESD and blowdown system guide |
+| [PRESSURE_MONITORING_ESD.md](PRESSURE_MONITORING_ESD) | Pressure monitoring for ESD |
 
 ### HIPPS (High Integrity Pressure Protection)
 
 | Document | Description |
 |----------|-------------|
-| [HIPPS_SUMMARY.md](HIPPS_SUMMARY.md) | HIPPS overview and summary |
-| [hipps_implementation.md](hipps_implementation.md) | HIPPS implementation details |
-| [hipps_safety_logic.md](hipps_safety_logic.md) | HIPPS safety logic programming |
+| [HIPPS_SUMMARY.md](HIPPS_SUMMARY) | HIPPS overview and summary |
+| [hipps_implementation.md](hipps_implementation) | HIPPS implementation details |
+| [hipps_safety_logic.md](hipps_safety_logic) | HIPPS safety logic programming |
 
 ### Safety Architecture
 
 | Document | Description |
 |----------|-------------|
-| [INTEGRATED_SAFETY_SYSTEMS.md](INTEGRATED_SAFETY_SYSTEMS.md) | Integrated safety systems overview |
-| [layered_safety_architecture.md](layered_safety_architecture.md) | Layered safety architecture (defense in depth) |
-| [sis_logic_implementation.md](sis_logic_implementation.md) | Safety Instrumented Systems (SIS) logic |
-| [integration_safety_chain_tests.md](integration_safety_chain_tests.md) | Safety chain integration testing |
-| [SAFETY_SIMULATION_ROADMAP.md](SAFETY_SIMULATION_ROADMAP.md) | Safety simulation development roadmap |
+| [INTEGRATED_SAFETY_SYSTEMS.md](INTEGRATED_SAFETY_SYSTEMS) | Integrated safety systems overview |
+| [layered_safety_architecture.md](layered_safety_architecture) | Layered safety architecture (defense in depth) |
+| [sis_logic_implementation.md](sis_logic_implementation) | Safety Instrumented Systems (SIS) logic |
+| [integration_safety_chain_tests.md](integration_safety_chain_tests) | Safety chain integration testing |
+| [SAFETY_SIMULATION_ROADMAP.md](SAFETY_SIMULATION_ROADMAP) | Safety simulation development roadmap |
 
 ### Standards Compliance and Hazard Screening
 
 | Document | Description |
 |----------|-------------|
-| [NOG 070 SIL, STS-0131 Gate and ESD Response Time](nog070_sil_sts0131_esd.md) | Pre-determined SIL (NOG 070), aggregated STS-0131 acceptance gate, and IEC 61511 ESD response-time budget |
-| [API 14C SAFE Chart and NORSOK P-002 Compliance](api14c_norsok_p002.md) | API RP 14C / ISO 10418 SAFE chart, NORSOK P-002 flare/blowdown/vent screening, and coupled multi-vessel blowdown header load |
-| [ISO 17776 MAH Bow-Tie and EI AVIFF FIV Screening](mah_bowtie_fiv_screening.md) | Major-accident-hazard bow-tie from the ISO 17776 catalogue and Energy Institute AVIFF flow-induced-vibration screening |
-| [Flare Flame, Hazardous Area and PFP Demand](flare_flame_hazardous_area_pfp.md) | API 537 flare flame/radiation/noise, IEC 60079-10-1 hazardous-area zoning, and API 521 passive-fire-protection demand |
-| [Automated HAZOP from STID and Simulation](automated_hazop_from_stid.md) | End-to-end STID/P&ID, plant data, NeqSim simulation, HAZOP, barrier, and report workflow |
-| [AI-HAZOP Input Data Format](ai_hazop_input_format.md) | Required input-data format for a P&ID Safety Analyser / AI-HAZOP front-end: process model JSON, per-deviation `runHazopScenario` request, DEXPI design-conditions, limit-basis policy, and blocked-outlet overpressure screening |
-| [Open Drain Review with NeqSim Evidence](open_drain_review.md) | NORSOK S-001 Clause 9 review using NeqSim-calculated liquid leak rate, firewater load, density, pressure, and drain capacity plus STID/tagreader evidence |
-| [Barrier Management and SCE Traceability](barrier_management.md) | Evidence-linked PSFs, SCEs, performance standards, and safety-analysis handoffs |
+| [NOG 070 SIL, STS-0131 Gate and ESD Response Time](nog070_sil_sts0131_esd) | Pre-determined SIL (NOG 070), aggregated STS-0131 acceptance gate, and IEC 61511 ESD response-time budget |
+| [API 14C SAFE Chart and NORSOK P-002 Compliance](api14c_norsok_p002) | API RP 14C / ISO 10418 SAFE chart, NORSOK P-002 flare/blowdown/vent screening, and coupled multi-vessel blowdown header load |
+| [ISO 17776 MAH Bow-Tie and EI AVIFF FIV Screening](mah_bowtie_fiv_screening) | Major-accident-hazard bow-tie from the ISO 17776 catalogue and Energy Institute AVIFF flow-induced-vibration screening |
+| [Flare Flame, Hazardous Area and PFP Demand](flare_flame_hazardous_area_pfp) | API 537 flare flame/radiation/noise, IEC 60079-10-1 hazardous-area zoning, and API 521 passive-fire-protection demand |
+| [Automated HAZOP from STID and Simulation](automated_hazop_from_stid) | End-to-end STID/P&ID, plant data, NeqSim simulation, HAZOP, barrier, and report workflow |
+| [AI-HAZOP Input Data Format](ai_hazop_input_format) | Required input-data format for a P&ID Safety Analyser / AI-HAZOP front-end: process model JSON, per-deviation `runHazopScenario` request, DEXPI design-conditions, limit-basis policy, and blocked-outlet overpressure screening |
+| [Open Drain Review with NeqSim Evidence](open_drain_review) | NORSOK S-001 Clause 9 review using NeqSim-calculated liquid leak rate, firewater load, density, pressure, and drain capacity plus STID/tagreader evidence |
+| [Barrier Management and SCE Traceability](barrier_management) | Evidence-linked PSFs, SCEs, performance standards, and safety-analysis handoffs |
 
 ### Fire and Thermal Protection
 
 | Document | Description |
 |----------|-------------|
-| [fire_blowdown_capabilities.md](fire_blowdown_capabilities.md) | Fire case blowdown simulation |
-| [fire_heat_transfer_enhancements.md](fire_heat_transfer_enhancements.md) | Fire heat transfer modeling |
-| [Vessel Thermomechanical Safety](vessel_thermomechanical_safety.md) | Transient non-equilibrium blowdown, fast filling, cryogenic boil-off, composite-wall conduction, and fire/blowdown wall rupture |
-| [Trapped Liquid Fire Rupture](trapped_liquid_fire_rupture.md) | Blocked-in liquid segment fire rupture screening with material, flange, PFP, and source-term handoff |
-| [Blocked-In Liquid Thermal Expansion](blocked_in_liquid_thermal_expansion.md) | Isochoric pressure-rise screening (API 521 §4.4.12) for blocked-in liquid segments, independent of fire exposure |
+| [fire_blowdown_capabilities.md](fire_blowdown_capabilities) | Fire case blowdown simulation |
+| [fire_heat_transfer_enhancements.md](fire_heat_transfer_enhancements) | Fire heat transfer modeling |
+| [Vessel Thermomechanical Safety](vessel_thermomechanical_safety) | Transient non-equilibrium blowdown, fast filling, cryogenic boil-off, composite-wall conduction, and fire/blowdown wall rupture |
+| [Trapped Liquid Fire Rupture](trapped_liquid_fire_rupture) | Blocked-in liquid segment fire rupture screening with material, flange, PFP, and source-term handoff |
+| [Blocked-In Liquid Thermal Expansion](blocked_in_liquid_thermal_expansion) | Isochoric pressure-rise screening (API 521 §4.4.12) for blocked-in liquid segments, independent of fire exposure |
 
 ### Relief Systems
 
 | Document | Description |
 |----------|-------------|
-| [Relief-Valve Sizing Screening](relief_valve_sizing_api.md) | Static gas, liquid, two-phase, and wetted-surface fire screening APIs with explicit SI units and qualification limits |
-| [Trapped Inventory Calculator](trapped_inventory_calculator.md) | Evidence-linked trapped inventory for isolation, blowdown, flare-load, and MDMT screening |
-| [Trapped Liquid Fire Rupture](trapped_liquid_fire_rupture.md) | Fire exposure, thermal expansion, pipe/flange failure screening, PFP demand, and source-term handoff |
-| [Blocked-In Liquid Thermal Expansion](blocked_in_liquid_thermal_expansion.md) | Isochoric pressure-rise screening and simplified beta/kappa relation for blocked-in liquid thermal relief screening |
-| [psv_dynamic_sizing_example.md](psv_dynamic_sizing_example.md) | Pressure Safety Valve dynamic sizing |
-| [Vessel Thermomechanical Safety](vessel_thermomechanical_safety.md) | Dynamic PSV sizing vs steady-state API 521 conservatism, plus blowdown, filling, boil-off, and rupture models |
-| [rupture_disk_dynamic_behavior.md](rupture_disk_dynamic_behavior.md) | Rupture disk dynamic behavior |
+| [Relief-Valve Sizing Screening](relief_valve_sizing_api) | Static gas, liquid, two-phase, and wetted-surface fire screening APIs with explicit SI units and qualification limits |
+| [Trapped Inventory Calculator](trapped_inventory_calculator) | Evidence-linked trapped inventory for isolation, blowdown, flare-load, and MDMT screening |
+| [Trapped Liquid Fire Rupture](trapped_liquid_fire_rupture) | Fire exposure, thermal expansion, pipe/flange failure screening, PFP demand, and source-term handoff |
+| [Blocked-In Liquid Thermal Expansion](blocked_in_liquid_thermal_expansion) | Isochoric pressure-rise screening and simplified beta/kappa relation for blocked-in liquid thermal relief screening |
+| [psv_dynamic_sizing_example.md](psv_dynamic_sizing_example) | Pressure Safety Valve dynamic sizing |
+| [Vessel Thermomechanical Safety](vessel_thermomechanical_safety) | Dynamic PSV sizing vs steady-state API 521 conservatism, plus blowdown, filling, boil-off, and rupture models |
+| [rupture_disk_dynamic_behavior.md](rupture_disk_dynamic_behavior) | Rupture disk dynamic behavior |
 
 ### Alarms
 
 | Document | Description |
 |----------|-------------|
-| [alarm_system_guide.md](alarm_system_guide.md) | Alarm system implementation guide |
-| [alarm_triggered_logic_example.md](alarm_triggered_logic_example.md) | Alarm-triggered logic examples |
+| [alarm_system_guide.md](alarm_system_guide) | Alarm system implementation guide |
+| [alarm_triggered_logic_example.md](alarm_triggered_logic_example) | Alarm-triggered logic examples |
 
 ---
 
@@ -89,5 +89,5 @@ This folder contains guides for implementing safety systems in process simulatio
 
 - [Process Package](../process/) - Process simulation overview
 - [Process Safety](../process/safety/) - Safety equipment classes
-- [Controllers](../process/controllers.md) - Controller devices
+- [Controllers](../process/controllers) - Controller devices
 

--- a/docs/simulation/README.md
+++ b/docs/simulation/README.md
@@ -19,54 +19,54 @@ This folder contains guides for advanced process simulation topics including pro
 
 | Document | Description |
 |----------|-------------|
-| [process_logic_framework.md](process_logic_framework.md) | Process logic framework architecture |
-| [advanced_process_logic.md](advanced_process_logic.md) | Advanced logic patterns |
-| [ProcessLogicEnhancements.md](ProcessLogicEnhancements.md) | Logic enhancements |
-| [process_logic_implementation_summary.md](process_logic_implementation_summary.md) | Implementation summary |
-| [RuntimeLogicFlexibility.md](RuntimeLogicFlexibility.md) | Runtime logic flexibility |
-| [process_calculator.md](process_calculator.md) | Process calculators |
+| [process_logic_framework.md](process_logic_framework) | Process logic framework architecture |
+| [advanced_process_logic.md](advanced_process_logic) | Advanced logic patterns |
+| [ProcessLogicEnhancements.md](ProcessLogicEnhancements) | Logic enhancements |
+| [process_logic_implementation_summary.md](process_logic_implementation_summary) | Implementation summary |
+| [RuntimeLogicFlexibility.md](RuntimeLogicFlexibility) | Runtime logic flexibility |
+| [process_calculator.md](process_calculator) | Process calculators |
 
 ### Dynamic & Transient Simulation
 
 | Document | Description |
 |----------|-------------|
-| [dynamic_simulation_guide.md](dynamic_simulation_guide.md) | **Comprehensive dynamic/transient simulation guide** |
-| [derivatives_and_gradients.md](derivatives_and_gradients.md) | Derivatives and gradients for dynamic systems |
+| [dynamic_simulation_guide.md](dynamic_simulation_guide) | **Comprehensive dynamic/transient simulation guide** |
+| [derivatives_and_gradients.md](derivatives_and_gradients) | Derivatives and gradients for dynamic systems |
 
 ### Simulation Techniques
 
 | Document | Description |
 |----------|-------------|
-| [process_serialization.md](process_serialization.md) | **Saving and loading process models** |
-| [parallel_process_simulation.md](parallel_process_simulation.md) | Parallel and multi-threaded simulation |
-| [graph_based_process_simulation.md](graph_based_process_simulation.md) | Graph-based process simulation |
-| [recycle_acceleration_guide.md](recycle_acceleration_guide.md) | Recycle convergence acceleration |
-| [differentiable_thermodynamics.md](differentiable_thermodynamics.md) | Auto-differentiation for optimization |
-| [INTEGRATED_WORKFLOW_GUIDE.md](INTEGRATED_WORKFLOW_GUIDE.md) | Integrated workflow guide |
+| [process_serialization.md](process_serialization) | **Saving and loading process models** |
+| [parallel_process_simulation.md](parallel_process_simulation) | Parallel and multi-threaded simulation |
+| [graph_based_process_simulation.md](graph_based_process_simulation) | Graph-based process simulation |
+| [recycle_acceleration_guide.md](recycle_acceleration_guide) | Recycle convergence acceleration |
+| [differentiable_thermodynamics.md](differentiable_thermodynamics) | Auto-differentiation for optimization |
+| [INTEGRATED_WORKFLOW_GUIDE.md](INTEGRATED_WORKFLOW_GUIDE) | Integrated workflow guide |
 
 
 ### Process Automation Deep Dives
 
 | Document | Description |
 |----------|-------------|
-| [automation/automation_foundations.md](automation/automation_foundations.md) | Addressing, variable catalogs, unit handling, and safe accessor schema |
-| [automation/automation_integrations.md](automation/automation_integrations.md) | Multi-area patterns plus optimizer and digital-twin integration |
-| [automation/automation_operations.md](automation/automation_operations.md) | Diagnostics, bounds validation, and troubleshooting playbook |
+| [automation/automation_foundations.md](automation/automation_foundations) | Addressing, variable catalogs, unit handling, and safe accessor schema |
+| [automation/automation_integrations.md](automation/automation_integrations) | Multi-area patterns plus optimizer and digital-twin integration |
+| [automation/automation_operations.md](automation/automation_operations) | Diagnostics, bounds validation, and troubleshooting playbook |
 
 ### Equipment Modeling
 
 | Document | Description |
 |----------|-------------|
-| [turboexpander_compressor_model.md](turboexpander_compressor_model.md) | Turboexpander and compressor modeling |
-| [equipment_factory.md](equipment_factory.md) | Equipment factory patterns |
+| [turboexpander_compressor_model.md](turboexpander_compressor_model) | Turboexpander and compressor modeling |
+| [equipment_factory.md](equipment_factory) | Equipment factory patterns |
 
 ### Well and Reservoir
 
 | Document | Description |
 |----------|-------------|
-| [well_simulation_guide.md](well_simulation_guide.md) | Well simulation guide |
-| [well_and_choke_simulation.md](well_and_choke_simulation.md) | Choke valve simulation |
-| [field_development_engine.md](field_development_engine.md) | Field development engine |
+| [well_simulation_guide.md](well_simulation_guide) | Well simulation guide |
+| [well_and_choke_simulation.md](well_and_choke_simulation) | Choke valve simulation |
+| [field_development_engine.md](field_development_engine) | Field development engine |
 
 ---
 

--- a/docs/standards/README.md
+++ b/docs/standards/README.md
@@ -12,13 +12,13 @@ analysis, a certified laboratory method, or the governing contract.
 
 | Need | NeqSim class | Guide |
 | --- | --- | --- |
-| Calorific value, relative density, and Wobbe index | `Standard_ISO6976` or `Standard_ISO6976_2016` | [ISO 6976](iso6976_calorific_values.md) |
-| LNG density from composition | `Standard_ISO6578` | [ISO 6578](iso6578_lng_density.md) |
-| Water or hydrocarbon dew point | `Draft_ISO18453` or `BestPracticeHydrocarbonDewPoint` | [Dew-point methods](dew_point_standards.md) |
-| CNG methane number and motor octane number | `Standard_ISO15403` | [ISO 15403](iso15403_cng_quality.md) |
-| Simulated crude-oil vapour pressure | `Standard_ASTM_D6377` | [ASTM D6377](astm_d6377_rvp.md) |
-| Other simulated oil-quality properties | Classes in `neqsim.standards.oilquality` | [Oil-quality methods](oil_quality_standards.md) |
-| Delivery-point specification checks | `BaseContract` and `ContractSpecification` | [Sales contracts](sales_contracts.md) |
+| Calorific value, relative density, and Wobbe index | `Standard_ISO6976` or `Standard_ISO6976_2016` | [ISO 6976](iso6976_calorific_values) |
+| LNG density from composition | `Standard_ISO6578` | [ISO 6578](iso6578_lng_density) |
+| Water or hydrocarbon dew point | `Draft_ISO18453` or `BestPracticeHydrocarbonDewPoint` | [Dew-point methods](dew_point_standards) |
+| CNG methane number and motor octane number | `Standard_ISO15403` | [ISO 15403](iso15403_cng_quality) |
+| Simulated crude-oil vapour pressure | `Standard_ASTM_D6377` | [ASTM D6377](astm_d6377_rvp) |
+| Other simulated oil-quality properties | Classes in `neqsim.standards.oilquality` | [Oil-quality methods](oil_quality_standards) |
+| Delivery-point specification checks | `BaseContract` and `ContractSpecification` | [Sales contracts](sales_contracts) |
 
 Use the edition and reference conditions named by the applicable contract or
 regulation. A class name identifies the implemented calculation route; it is not

--- a/docs/test_equipment_catalog.py
+++ b/docs/test_equipment_catalog.py
@@ -1,0 +1,39 @@
+"""Regression tests for complete process-equipment documentation coverage."""
+
+import unittest
+
+from devtools import generate_equipment_documentation_catalog as catalog
+
+
+class EquipmentDocumentationCatalogTest(unittest.TestCase):
+    def test_catalog_matches_current_equipment_source(self) -> None:
+        self.assertEqual(
+            catalog.CATALOG.read_text(encoding="utf-8-sig"),
+            catalog.expected_catalog(),
+        )
+
+    def test_inventory_covers_representative_equipment_families(self) -> None:
+        equipment = catalog.concrete_equipment(catalog.read_java_types())
+        qualified_names = {java_type.qualified_name for java_type in equipment}
+
+        self.assertGreater(len(equipment), 0)
+        self.assertIn(
+            "neqsim.process.equipment.blackoil.BlackOilSeparator",
+            qualified_names,
+        )
+        self.assertIn(
+            "neqsim.process.equipment.energy.EnergyNetworkSolver",
+            qualified_names,
+        )
+        self.assertIn(
+            "neqsim.process.equipment.solidhandling.BioFeedstockPreparation",
+            qualified_names,
+        )
+        self.assertNotIn(
+            "neqsim.process.equipment.capacity.CapacityConstraint",
+            qualified_names,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/test_fielddevelopment_overview_documentation.py
+++ b/docs/test_fielddevelopment_overview_documentation.py
@@ -56,6 +56,14 @@ def resolve_internal_target(source_path, destination):
     candidates = [raw_target]
     if target.endswith("/"):
         candidates = [raw_target / "README.md", raw_target / "index.md"]
+    elif not Path(target).suffix:
+        candidates.extend(
+            (
+                Path("{}.md".format(raw_target)),
+                raw_target / "README.md",
+                raw_target / "index.md",
+            )
+        )
 
     for candidate in candidates:
         if candidate.is_file():

--- a/docs/test_flow_assurance_screening_tools_documentation.py
+++ b/docs/test_flow_assurance_screening_tools_documentation.py
@@ -89,9 +89,11 @@ class FlowAssuranceScreeningToolsDocumentationTest(unittest.TestCase):
                 if target.startswith(("http://", "https://", "#")):
                     continue
                 path_part = target.split("#", 1)[0]
-                self.assertTrue(path_part.endswith(".md"), target)
-                source_path = (source.parent / path_part).resolve()
-                self.assertTrue(source_path.exists(), target)
+                raw_path = (source.parent / path_part).resolve()
+                source_paths = [raw_path]
+                if not Path(path_part).suffix:
+                    source_paths.append(Path("{}.md".format(raw_path)))
+                self.assertTrue(any(path.exists() for path in source_paths), target)
 
     def test_engineering_boundaries_and_executable_coverage_are_explicit(self):
         required = (
@@ -117,7 +119,7 @@ class FlowAssuranceScreeningToolsDocumentationTest(unittest.TestCase):
 
     def test_landing_points_to_one_canonical_screening_example(self):
         self.assertIn(
-            "[screening-tools guide](flow_assurance_screening_tools.md)", self.landing
+            "[screening-tools guide](flow_assurance_screening_tools)", self.landing
         )
         self.assertIn("FlowAssuranceDocumentationTest", self.landing)
         self.assertNotIn("## Quick start: De Boer", self.landing)

--- a/docs/test_iso15403_documentation.py
+++ b/docs/test_iso15403_documentation.py
@@ -125,7 +125,7 @@ class Iso15403DocumentationContractTest(unittest.TestCase):
     def test_page_is_discoverable_from_both_indexes(self):
         standards_index = STANDARDS_INDEX.read_text(encoding="utf-8")
         reference_index = REFERENCE_INDEX.read_text(encoding="utf-8")
-        self.assertIn("iso15403_cng_quality.md", standards_index)
+        self.assertIn("iso15403_cng_quality", standards_index)
         self.assertIn("standards/iso15403_cng_quality", reference_index)
 
 

--- a/docs/test_oil_quality_standards_documentation.py
+++ b/docs/test_oil_quality_standards_documentation.py
@@ -184,7 +184,7 @@ class OilQualityStandardsDocumentationContractTest(unittest.TestCase):
         )
 
     def test_standards_indexes_discover_the_guide(self):
-        link = "[Oil-quality methods](oil_quality_standards.md)"
+        link = "[Oil-quality methods](oil_quality_standards)"
         self.assertIn(link, self.standards_index)
         self.assertIn("standards/oil_quality_standards.md", self.reference_index)
 

--- a/docs/test_phase_package_documentation.py
+++ b/docs/test_phase_package_documentation.py
@@ -55,11 +55,21 @@ def resolve_internal_target(source_path: Path, destination: str) -> tuple[Path, 
     if not target:
         return source_path, fragment
     target_path = (source_path.parent / target).resolve()
-    if not target_path.is_file():
+    candidates = [target_path]
+    if not Path(target).suffix:
+        candidates.extend(
+            (
+                Path("{}.md".format(target_path)),
+                target_path / "README.md",
+                target_path / "index.md",
+            )
+        )
+    resolved_path = next((path for path in candidates if path.is_file()), None)
+    if resolved_path is None:
         raise AssertionError(
             "Unresolved link from {}: {}".format(source_path, destination)
         )
-    return target_path, fragment
+    return resolved_path, fragment
 
 
 class PhasePackageDocumentationContractTest(unittest.TestCase):
@@ -81,9 +91,7 @@ class PhasePackageDocumentationContractTest(unittest.TestCase):
         for destination in markdown_links.findall(guide):
             if destination.startswith(("http://", "https://", "mailto:")):
                 continue
-            target, _, fragment = destination.partition("#")
-            if target:
-                assert target.endswith(".md")
+            _target, _, fragment = destination.partition("#")
             target_path, resolved_fragment = resolve_internal_target(
                 GUIDE,
                 destination,

--- a/docs/test_physical_properties_navigation.py
+++ b/docs/test_physical_properties_navigation.py
@@ -45,6 +45,14 @@ def resolve_internal_target(source_path, destination):
         candidates.extend((raw_target / "README.md", raw_target / "index.md"))
     else:
         candidates.append(raw_target)
+        if not Path(target).suffix:
+            candidates.extend(
+                (
+                    Path("{}.md".format(raw_target)),
+                    raw_target / "README.md",
+                    raw_target / "index.md",
+                )
+            )
 
     for candidate in candidates:
         if candidate.is_file():
@@ -148,7 +156,7 @@ class PhysicalPropertiesDocumentationContractTest(unittest.TestCase):
 
         self.assertNotIn("setMixingRule(7)", self.documents[THERMO_OVERVIEW])
         self.assertIn(
-            "../physical_properties/README.md",
+            "../physical_properties/README",
             self.documents[THERMO_INDEX],
         )
 

--- a/docs/test_process_overview_documentation.py
+++ b/docs/test_process_overview_documentation.py
@@ -66,6 +66,14 @@ def resolve_internal_target(source_path, destination):
     candidates = [raw_target]
     if target.endswith("/"):
         candidates = [raw_target / "README.md", raw_target / "index.md"]
+    elif not Path(target).suffix:
+        candidates.extend(
+            (
+                Path("{}.md".format(raw_target)),
+                raw_target / "README.md",
+                raw_target / "index.md",
+            )
+        )
 
     for candidate in candidates:
         if candidate.is_file():
@@ -127,17 +135,11 @@ class ProcessOverviewDocumentationContractTest(unittest.TestCase):
                 ):
                     continue
 
-                target, _, fragment = destination.partition("#")
+                _target, _, fragment = destination.partition("#")
                 with self.subTest(
                     source_path=source_path,
                     destination=destination,
                 ):
-                    if target and not target.endswith("/"):
-                        self.assertTrue(
-                            target.endswith(".md"),
-                            "Documentation source links must include .md",
-                        )
-
                     target_path, resolved_fragment = resolve_internal_target(
                         source_path,
                         destination,
@@ -253,7 +255,7 @@ class ProcessOverviewDocumentationContractTest(unittest.TestCase):
             self.overview,
         )
         self.assertIn(
-            "[process-package quick start](../README.md)",
+            "[process-package quick start](../README)",
             self.equipment_overview,
         )
 

--- a/docs/test_process_safety_overview_documentation.py
+++ b/docs/test_process_safety_overview_documentation.py
@@ -50,6 +50,14 @@ def resolve_internal_target(source_path, destination):
     candidates = [raw_target]
     if target.endswith("/"):
         candidates = [raw_target / "README.md", raw_target / "index.md"]
+    elif not Path(target).suffix:
+        candidates.extend(
+            (
+                Path("{}.md".format(raw_target)),
+                raw_target / "README.md",
+                raw_target / "index.md",
+            )
+        )
 
     for candidate in candidates:
         if candidate.is_file():
@@ -87,10 +95,8 @@ class ProcessSafetyOverviewDocumentationContractTest(unittest.TestCase):
         for destination in markdown_links.findall(self.overview):
             if destination.startswith(("http://", "https://", "mailto:")):
                 continue
-            target, _, fragment = destination.partition("#")
+            _target, _, fragment = destination.partition("#")
             with self.subTest(destination=destination):
-                if target and not target.endswith("/"):
-                    self.assertTrue(target.endswith(".md"))
                 target_path, resolved_fragment = resolve_internal_target(
                     OVERVIEW,
                     destination,

--- a/docs/test_relief_valve_sizing_documentation.py
+++ b/docs/test_relief_valve_sizing_documentation.py
@@ -127,7 +127,7 @@ class ReliefValveSizingDocumentationContractTest(unittest.TestCase):
 
     def test_safety_index_discovers_the_guide(self):
         self.assertIn(
-            "[Relief-Valve Sizing Screening](relief_valve_sizing_api.md)",
+            "[Relief-Valve Sizing Screening](relief_valve_sizing_api)",
             self.safety_index,
         )
 

--- a/docs/test_sales_contracts_documentation.py
+++ b/docs/test_sales_contracts_documentation.py
@@ -164,7 +164,7 @@ class SalesContractsDocumentationContractTest(unittest.TestCase):
     def test_existing_indexes_discover_the_guide(self):
         standards_index = STANDARDS_INDEX.read_text(encoding="utf-8")
         reference_index = REFERENCE_INDEX.read_text(encoding="utf-8")
-        self.assertIn("[Sales contracts](sales_contracts.md)", standards_index)
+        self.assertIn("[Sales contracts](sales_contracts)", standards_index)
         self.assertIn("standards/sales_contracts.md", reference_index)
 
 

--- a/docs/thermo/README.md
+++ b/docs/thermo/README.md
@@ -36,45 +36,45 @@ thermo/
 
 ### Core Guides
 
-- [Thermodynamic Models Guide](thermodynamic_models.md): **Comprehensive overview** of all thermodynamic models in NeqSim, including equations of state, CPA, reference equations (GERG-2008, EOS-CG), activity coefficient models, electrolyte models, and the auto-select feature. Covers theory, usage, and model selection guidelines.
-- [Mercury Thermodynamics](mercury_thermodynamics.md): **Mercury-focused workflow** for SRK-TwuCoon-Statoil-EOS, TPflash setup, INTER-table usage, and thesis-linked correlation guidance.
-- [Søreide-Whitson Model](SoreideWhitsonModel.md): **Gas solubility in brine** - Modified Peng-Robinson EoS with salinity-dependent alpha function for water. Essential for produced water emission calculations and used in **NeqSimLive**. Includes mathematical formulation, salt type coefficients, validation data, and literature references.
-- [Fluid Creation Guide](fluid_creation_guide.md): **Comprehensive guide** to creating fluids in NeqSim, including all available equations of state, mixing rules, and model selection guidelines.
-- [Mixing Rules Guide](mixing_rules_guide.md): **Detailed documentation** on mixing rules, including mathematical formulations, binary interaction parameters, and usage examples for different applications.
-- [Flash Calculations Guide](flash_calculations_guide.md): **Comprehensive documentation** of flash calculations available via ThermodynamicOperations, including TP, PH, PS, VU flashes, saturation calculations, and hydrate equilibria.
-- [Reactive Flash](reactive_flash.md): **Simultaneous chemical and phase equilibrium** using the Modified RAND method. Covers reactive TP and PH flash for systems with gas-phase reactions, ionic equilibria, and multiphase reactive systems.
-- [Hydrate Models Guide](hydrate_models.md): **Comprehensive documentation** of gas hydrate thermodynamic models, including van der Waals-Platteeuw theory, Structure I/II hydrates, CPA and PVTsim implementations, and inhibitor modeling.
-- [Electrolyte CPA Model](ElectrolyteCPAModel.md): **Detailed documentation** of the electrolyte CPA model, including Fürst electrostatic contributions, validation data, and usage examples.
-- [Pitzer Parameter Provenance and Coverage](pitzer_parameter_provenance.md): **Dataset and safety reference** for Pitzer equation conventions, source/licensing comparisons, mixed-ion coverage diagnostics, and parameter-adoption gates.
+- [Thermodynamic Models Guide](thermodynamic_models): **Comprehensive overview** of all thermodynamic models in NeqSim, including equations of state, CPA, reference equations (GERG-2008, EOS-CG), activity coefficient models, electrolyte models, and the auto-select feature. Covers theory, usage, and model selection guidelines.
+- [Mercury Thermodynamics](mercury_thermodynamics): **Mercury-focused workflow** for SRK-TwuCoon-Statoil-EOS, TPflash setup, INTER-table usage, and thesis-linked correlation guidance.
+- [Søreide-Whitson Model](SoreideWhitsonModel): **Gas solubility in brine** - Modified Peng-Robinson EoS with salinity-dependent alpha function for water. Essential for produced water emission calculations and used in **NeqSimLive**. Includes mathematical formulation, salt type coefficients, validation data, and literature references.
+- [Fluid Creation Guide](fluid_creation_guide): **Comprehensive guide** to creating fluids in NeqSim, including all available equations of state, mixing rules, and model selection guidelines.
+- [Mixing Rules Guide](mixing_rules_guide): **Detailed documentation** on mixing rules, including mathematical formulations, binary interaction parameters, and usage examples for different applications.
+- [Flash Calculations Guide](flash_calculations_guide): **Comprehensive documentation** of flash calculations available via ThermodynamicOperations, including TP, PH, PS, VU flashes, saturation calculations, and hydrate equilibria.
+- [Reactive Flash](reactive_flash): **Simultaneous chemical and phase equilibrium** using the Modified RAND method. Covers reactive TP and PH flash for systems with gas-phase reactions, ionic equilibria, and multiphase reactive systems.
+- [Hydrate Models Guide](hydrate_models): **Comprehensive documentation** of gas hydrate thermodynamic models, including van der Waals-Platteeuw theory, Structure I/II hydrates, CPA and PVTsim implementations, and inhibitor modeling.
+- [Electrolyte CPA Model](ElectrolyteCPAModel): **Detailed documentation** of the electrolyte CPA model, including Fürst electrostatic contributions, validation data, and usage examples.
+- [Pitzer Parameter Provenance and Coverage](pitzer_parameter_provenance): **Dataset and safety reference** for Pitzer equation conventions, source/licensing comparisons, mixed-ion coverage diagnostics, and parameter-adoption gates.
 
 ### Database Documentation
 
-- [Component Database Guide](component_database_guide.md): **Detailed documentation** of the COMP pure component parameters database, including parameter descriptions, units, and links to thermodynamic models.
-- [INTER Table Guide](inter_table_guide.md): **Detailed documentation** of the INTER binary interaction parameters database, including column reference for all EoS, CPA, Huron-Vidal, Wong-Sandler, and NRTL parameters.
+- [Component Database Guide](component_database_guide): **Detailed documentation** of the COMP pure component parameters database, including parameter descriptions, units, and links to thermodynamic models.
+- [INTER Table Guide](inter_table_guide): **Detailed documentation** of the INTER binary interaction parameters database, including column reference for all EoS, CPA, Huron-Vidal, Wong-Sandler, and NRTL parameters.
 
 ### Reference Documentation
 
-- [Mathematical Models](mathematical_models.md): Equations of state, activity-coefficient formulations, and transport correlations available in NeqSim.
-- [GERG-2008 and EOS-CG](gerg2008_eoscg.md): Detailed guide to the reference equations of state for natural gas and CCS applications.
+- [Mathematical Models](mathematical_models): Equations of state, activity-coefficient formulations, and transport correlations available in NeqSim.
+- [GERG-2008 and EOS-CG](gerg2008_eoscg): Detailed guide to the reference equations of state for natural gas and CCS applications.
 
 ### Acid Gas and Sour Fluid Modeling
 
-- [H2S Distribution Guide](H2S_distribution_guide.md): **H2S phase distribution modeling** between gas, oil, and water using SRK, PR, CPA, and Electrolyte-CPA equations of state. Covers acid-base chemistry, pH effects, and salinity impacts.
-- [H2S Distribution Modeling (Detailed)](H2S_DISTRIBUTION_MODELING.md): **Comprehensive H2S modeling** including chemical reactions, model selection guidance, and validation examples.
-- [Amine CO2 Solubility (Kent-Eisenberg)](amine_co2_solubility.md): **Screening-level CO2 solubility** in aqueous MEA / DEA / MDEA / activated-MDEA solvents using the Kent-Eisenberg apparent-equilibrium-constant model. Covers the validated screening API, validation status, equations, and usage examples.
+- [H2S Distribution Guide](H2S_distribution_guide): **H2S phase distribution modeling** between gas, oil, and water using SRK, PR, CPA, and Electrolyte-CPA equations of state. Covers acid-base chemistry, pH effects, and salinity impacts.
+- [H2S Distribution Modeling (Detailed)](H2S_DISTRIBUTION_MODELING): **Comprehensive H2S modeling** including chemical reactions, model selection guidance, and validation examples.
+- [Amine CO2 Solubility (Kent-Eisenberg)](amine_co2_solubility): **Screening-level CO2 solubility** in aqueous MEA / DEA / MDEA / activated-MDEA solvents using the Kent-Eisenberg apparent-equilibrium-constant model. Covers the validated screening API, validation status, equations, and usage examples.
 
 ### Application Guides
 
-- [Thermodynamic Workflows](thermodynamic_workflows.md): How to set up systems, select models, and perform common equilibrium calculations.
-- [Adsorption Isotherm Models](adsorption_isotherms.md): **Complete reference** for all adsorption isotherm models — Langmuir, Extended Langmuir, BET, Freundlich, Sips, DRA potential theory, capillary condensation, and the parameter database.
-- [PVT and Fluid Characterization](pvt_fluid_characterization.md): Building realistic fluid descriptions, including heavy-end handling and lab-data reconciliation.
-- [Thermodynamic Operations](thermodynamic_operations.md): Flash calculations, phase envelopes, and other process-centric operations.
-- [Physical Properties](physical_properties.md): Thermodynamic/transport API boundaries and links to the maintained [physical-properties package guide](../physical_properties/README.md).
-- [Attainable Metastability — Volume Balancing Method](attainable_metastability.md): **Superheat / pressure-undershoot limit of a rapidly depressurising liquid** (Log, 2025). Rarefaction-outflow vs. Plesset-Zwick bubble-growth balance, the `n_bub` tuning parameter, and a CO₂ blowdown example.
+- [Thermodynamic Workflows](thermodynamic_workflows): How to set up systems, select models, and perform common equilibrium calculations.
+- [Adsorption Isotherm Models](adsorption_isotherms): **Complete reference** for all adsorption isotherm models — Langmuir, Extended Langmuir, BET, Freundlich, Sips, DRA potential theory, capillary condensation, and the parameter database.
+- [PVT and Fluid Characterization](pvt_fluid_characterization): Building realistic fluid descriptions, including heavy-end handling and lab-data reconciliation.
+- [Thermodynamic Operations](thermodynamic_operations): Flash calculations, phase envelopes, and other process-centric operations.
+- [Physical Properties](physical_properties): Thermodynamic/transport API boundaries and links to the maintained [physical-properties package guide](../physical_properties/README).
+- [Attainable Metastability — Volume Balancing Method](attainable_metastability): **Superheat / pressure-undershoot limit of a rapidly depressurising liquid** (Log, 2025). Rarefaction-outflow vs. Plesset-Zwick bubble-growth balance, the `n_bub` tuning parameter, and a CO₂ blowdown example.
 
 ---
 
 Examples are written for the Java API unless a page says otherwise. Python uses the
 NeqSim gateway and different import conventions; follow the
-[Python quickstart](../quickstart/python-quickstart.md) rather than translating Java
+[Python quickstart](../quickstart/python-quickstart) rather than translating Java
 syntax literally.

--- a/docs/thermo/phase/README.md
+++ b/docs/thermo/phase/README.md
@@ -97,7 +97,7 @@ Use the following sequence for phase-equilibrium and property work:
 `TPflash()` determines the equilibrium phase split. `initProperties()` initializes the
 thermodynamic state and the selected physical-property models. Diffusion is not exposed as a
 zero-argument method on `PhaseInterface`; use the initialized physical-properties API described in
-the [physical-properties guide](../../physical_properties/README.md).
+the [physical-properties guide](../../physical_properties/README).
 
 ## Phase types and safe lookup
 
@@ -168,7 +168,7 @@ internal conventions and are less clear in examples.
 Generic phase objects do not expose `getdZdT()`, `getdZdP()`, excess enthalpy/entropy/volume,
 or component fugacity-derivative getters under the names previously shown on this page. Do not
 build workflows around those names. For equilibrium and state-function calculations, use the
-supported operations in the [thermodynamic operations guide](../thermodynamic_operations.md).
+supported operations in the [thermodynamic operations guide](../thermodynamic_operations).
 
 ## Aqueous phases
 
@@ -193,14 +193,14 @@ Additional phases appear only when the corresponding model and calculation are e
 
 - **Hydrate:** configure hydrate checking, run a hydrate-specific operation, then use
   `fluid.hasHydratePhase()`, `fluid.getHydratePhase()`, and
-  `fluid.getHydrateFraction()`. See [hydrate flash operations](../../thermodynamicoperations/hydrate_flash_operations.md)
-  and [hydrate models](../hydrate_models.md).
+  `fluid.getHydrateFraction()`. See [hydrate flash operations](../../thermodynamicoperations/hydrate_flash_operations)
+  and [hydrate models](../hydrate_models).
 - **Wax and generic solids:** use the relevant solid/wax configuration and operation, then inspect
   `hasPhaseType(PhaseType.WAX)` or `hasPhaseType(PhaseType.SOLID)`. There is no generic
   `setWaxCheck()` or `hasWax()` pair on `SystemInterface`.
 - **Asphaltene:** inspect `PhaseType.ASPHALTENE` or
   `PhaseType.LIQUID_ASPHALTENE` after the selected characterization/equilibrium workflow. See
-  [asphaltene characterization](../characterization/asphaltene_characterization.md). Density,
+  [asphaltene characterization](../characterization/asphaltene_characterization). Density,
   viscosity, and phase fraction are calculated results, not fixed constants.
 
 Do not infer a formation temperature from a phase object. Formation-temperature and stability
@@ -215,9 +215,9 @@ the exact interface or implementation used.
 
 ## Related documentation
 
-- [Fluid creation guide](../fluid_creation_guide.md)
-- [Thermodynamic models](../thermodynamic_models.md)
-- [Thermodynamic operations](../thermodynamic_operations.md)
-- [Physical-properties guide](../../physical_properties/README.md)
-- [Hydrate models](../hydrate_models.md)
-- [Asphaltene characterization](../characterization/asphaltene_characterization.md)
+- [Fluid creation guide](../fluid_creation_guide)
+- [Thermodynamic models](../thermodynamic_models)
+- [Thermodynamic operations](../thermodynamic_operations)
+- [Physical-properties guide](../../physical_properties/README)
+- [Hydrate models](../hydrate_models)
+- [Asphaltene characterization](../characterization/asphaltene_characterization)

--- a/docs/thermodynamicoperations/README.md
+++ b/docs/thermodynamicoperations/README.md
@@ -95,7 +95,7 @@ The same facade provides the following public operations:
 Solid checking is a fluid configuration used by `TPflash()`; there is no public
 `TPsolidflash()` method on `ThermodynamicOperations`. Hydrate calculations also
 require a fluid model and components suitable for hydrate equilibrium. See the
-[thermodynamic model guide](../thermo/thermodynamic_models.md) before selecting an
+[thermodynamic model guide](../thermo/thermodynamic_models) before selecting an
 equation of state.
 
 ## PT phase envelope
@@ -158,7 +158,7 @@ if (Math.abs(compositionSum - 1.0) > 1.0e-10) {
 
 There are no `setChemicalReactions(true)` or `calcChemicalEquilibrium()` methods
 on these public interfaces. For reaction selection, phase constraints, and
-reactive PH/PS operations, see the [reactive flash guide](../thermo/reactive_flash.md).
+reactive PH/PS operations, see the [reactive flash guide](../thermo/reactive_flash).
 
 ## Convergence and result checks
 
@@ -182,8 +182,8 @@ example previously shown on this page.
 
 ## Related documentation
 
-- [Thermodynamics overview](../thermo/README.md)
-- [Reading fluid properties](../thermo/reading_fluid_properties.md)
-- [Thermodynamic model selection](../thermo/thermodynamic_models.md)
-- [Reactive flash calculations](../thermo/reactive_flash.md)
-- [Thermodynamics cookbook recipes](../cookbook/thermodynamics-recipes.md)
+- [Thermodynamics overview](../thermo/README)
+- [Reading fluid properties](../thermo/reading_fluid_properties)
+- [Thermodynamic model selection](../thermo/thermodynamic_models)
+- [Reactive flash calculations](../thermo/reactive_flash)
+- [Thermodynamics cookbook recipes](../cookbook/thermodynamics-recipes)

--- a/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
@@ -254,16 +254,15 @@ public final class McpEvidenceInventory {
    */
   private static JsonObject buildContractPromotionCandidates() {
     JsonObject candidates = new JsonObject();
-    candidates.add("searchComponents",
-        contractPromotionCandidate("NOT_APPLICABLE_NON_NUMERICAL_COMPONENT_CATALOG_LOOKUP",
-            new String[] { "src/main/java/neqsim/mcp/runners/ComponentQuery.java",
-                "src/test/java/neqsim/mcp/runners/ComponentQueryTest.java", "neqsim-mcp-server/test_mcp_server.py" },
-            "Component-name lookup, substring search, empty-query enumeration, typo handling, and no-match behavior are directly tested, including real-protocol retrieval; catalog lookup does not validate thermodynamic calculations or component-property models"));
-    candidates.add("queryDataCatalog",
-        contractPromotionCandidate("NOT_APPLICABLE_NON_NUMERICAL_DATA_CATALOG_DISCOVERY",
-            new String[] { "src/main/java/neqsim/mcp/runners/DataCatalogRunner.java",
-                "src/test/java/neqsim/mcp/runners/DataCatalogRunnerTest.java", "neqsim-mcp-server/test_mcp_server.py" },
-            "Read-only catalog dispatch and representative component-family, EOS-model, component-property, and real-protocol catalog retrieval are tested; database contents, standards applicability, EOS accuracy, and material or design decisions are not validated by this evidence"));
+    candidates.add("searchComponents", contractPromotionCandidate(
+        "NOT_APPLICABLE_NON_NUMERICAL_COMPONENT_CATALOG_LOOKUP",
+        new String[] { "src/main/java/neqsim/mcp/runners/ComponentQuery.java",
+            "src/test/java/neqsim/mcp/runners/ComponentQueryTest.java", "neqsim-mcp-server/test_mcp_server.py" },
+        "Component-name lookup, substring search, empty-query enumeration, typo handling, and no-match behavior are directly tested, including real-protocol retrieval; catalog lookup does not validate thermodynamic calculations or component-property models"));
+    candidates.add("queryDataCatalog", contractPromotionCandidate("NOT_APPLICABLE_NON_NUMERICAL_DATA_CATALOG_DISCOVERY",
+        new String[] { "src/main/java/neqsim/mcp/runners/DataCatalogRunner.java",
+            "src/test/java/neqsim/mcp/runners/DataCatalogRunnerTest.java", "neqsim-mcp-server/test_mcp_server.py" },
+        "Read-only catalog dispatch and representative component-family, EOS-model, component-property, and real-protocol catalog retrieval are tested; database contents, standards applicability, EOS accuracy, and material or design decisions are not validated by this evidence"));
     return candidates;
   }
 


### PR DESCRIPTION
## Summary

- replace `.md` destinations in README sources inserted with Liquid `include_relative`, fixing published GitHub Pages 404s such as `/process/equipment/separators.md`
- expand the process-equipment landing page and add a generated, source-backed catalog covering all 234 concrete `ProcessEquipmentInterface` implementations across 33 packages
- add focused pages for black-oil separation, energy conversion, and solid handling; link all existing equipment guides from the landing page
- extend the documentation audit to reject missing internal targets and published `.md` URLs in included Markdown, and wire equipment-source changes into CI/pre-push coverage
- repair additional broken internal references found by the repository-wide audit
- apply Spotless's formatting-only correction to the newly merged `McpEvidenceInventory.java`; there is no Java behavior change

## Validation

- `python -m unittest discover -s docs -p 'test_*.py' -v` — 163 tests passed
- `python -m unittest devtools.test_check_documentation_search -v` — 8 tests passed
- `python devtools/generate_equipment_documentation_catalog.py --check` — 234 concrete classes cataloged
- `python devtools/check_documentation_search.py` — 663 Markdown pages and 1 standalone HTML page audited
- `python devtools/run_spotless.py apply` — passed with no remaining changes
- `python devtools/run_spotless.py check` — passed
- `pre-commit run --all-files --hook-stage pre-commit` — passed
- `pre-commit run --all-files --hook-stage pre-push` — passed
- `node --check docs/assets/js/search.js` — passed
- `git diff --check origin/master...HEAD` — passed
- GitHub Actions **Documentation search coverage** — Jekyll build, generated-site audit, documentation tests, and JavaScript syntax check passed

## Documentation impact

Updates the equipment hub, reference index, affected package landing pages, GitHub Pages setup guide, and three previously broken example links. Adds generated catalog maintenance coverage so new equipment packages cannot silently remain undocumented.

## Contribution checklist

- [ ] `./mvnw test` — not run locally; this is documentation/tooling work with one Spotless-only Java formatting change
- [x] Formatting verified with Spotless
- [x] Relevant docs/README files updated
- [ ] Associated issue/discussion — none supplied
- [ ] CODEOWNERS/domain review — pending while this PR is a draft
- [x] NRC/migration note not required; no public API contract changes
