### PR TITLE
[AI-Assisted] test(mcp): qualify progress retrieval contract evidence

### DIFF
--- a/neqsim-mcp-server/docs/evidence/PROGRESS_RETRIEVAL_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/PROGRESS_RETRIEVAL_CONTRACT.md
@@ -1,0 +1,19 @@
+# Phase 0 progress-retrieval contract evidence
+
+This note records bounded Phase 0 evidence for the existing `getProgress` MCP tool. It is an evidence artifact, not an additional MCP guide and not a scientific benchmark.
+
+## Evidence currently present
+
+- `src/main/java/neqsim/mcp/runners/ProgressTracker.java` implements bounded in-memory progress state, active-operation listing, point retrieval, milestone retention, completion, failure state, and old-operation eviction.
+- `src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java` now exercises a complete progress lifecycle: active discovery, a 50% update, milestone retrieval, completion at 100%, removal from the active list, and an explicit error for an unknown operation ID.
+- `neqsim-mcp-server/test_mcp_server.py` already invokes `getProgress` through the real MCP JSON-RPC transport with `action=listActive`.
+
+## Trust boundary
+
+The evidence supports only the software contract for advisory progress retrieval. It does not prove that an underlying calculation is correct, converged, scientifically validated, cancellable, or safe for plant control. It does not establish external authorization, cross-tenant isolation for a particular deployment, durability across process restarts, or delivery guarantees for every long-running runner.
+
+`getProgress` remains a `CONFIRMED_GAP` in the current Phase 0 trust-coverage accounting. This increment deliberately does not change the frozen `20 EXPLICIT_TRUST + 6 CONTRACT_TESTED + 45 CONFIRMED_GAP` classification or the packaged protocol accounting. A future promotion to `CONTRACT_TESTED` must update the machine-readable inventory and exact protocol expectation together on one validated head.
+
+## Owner-roadmap boundary
+
+This evidence note changes no process, thermodynamic, pipeline, dynamic, optimization, DEXPI/P&ID, or facility-model behavior. It introduces no MCP-only simulator and no live-plant write or control path.

--- a/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
+++ b/src/test/java/neqsim/mcp/runners/McpEvidenceInventoryFoundationTests.java
@@ -158,6 +158,37 @@ class McpEvidenceInventoryFoundationTests {
   }
 
   @Test
+  void testProgressRetrievalContractIsBoundedAndReadOnly() {
+    String operationId = ProgressTracker.start("phase0-progress-contract", 2);
+
+    JsonObject active = JsonParser.parseString(ProgressTracker.listActive()).getAsJsonObject();
+    assertEquals("success", active.get("status").getAsString());
+    assertTrue(active.getAsJsonArray("operations").toString().contains(operationId));
+
+    ProgressTracker.update(operationId, 1, "half complete");
+    JsonObject progress = JsonParser.parseString(ProgressTracker.getProgress(operationId)).getAsJsonObject();
+    assertEquals(operationId, progress.get("operationId").getAsString());
+    assertEquals("phase0-progress-contract", progress.get("operationType").getAsString());
+    assertEquals(2, progress.get("totalSteps").getAsInt());
+    assertEquals(1, progress.get("currentStep").getAsInt());
+    assertEquals(50, progress.get("percentComplete").getAsInt());
+    assertFalse(progress.get("completed").getAsBoolean());
+    assertTrue(progress.getAsJsonArray("recentMilestones").toString().contains("half complete"));
+
+    ProgressTracker.complete(operationId, "complete");
+    JsonObject completed = JsonParser.parseString(ProgressTracker.getProgress(operationId)).getAsJsonObject();
+    assertEquals(100, completed.get("percentComplete").getAsInt());
+    assertTrue(completed.get("completed").getAsBoolean());
+    assertFalse(completed.get("failed").getAsBoolean());
+
+    JsonObject after = JsonParser.parseString(ProgressTracker.listActive()).getAsJsonObject();
+    assertFalse(after.getAsJsonArray("operations").toString().contains(operationId));
+
+    JsonObject missing = JsonParser.parseString(ProgressTracker.getProgress("missing-phase0-operation")).getAsJsonObject();
+    assertEquals("error", missing.get("status").getAsString());
+  }
+
+  @Test
   void testPhase0EvidenceIsDiscoverableThroughCapabilities() {
     JsonObject capabilities = JsonParser.parseString(CapabilitiesRunner.getCapabilities()).getAsJsonObject();
     JsonObject inventory = capabilities.getAsJsonObject("phase0EvidenceInventory");


### PR DESCRIPTION
## Summary

Advances #3153 Phase 0 on exact current-master base `a266d236136391cd810d2bc599851f9b73769ff0` by closing the missing focused core-regression prerequisite for the existing non-numerical `getProgress` contract.

- extends the existing Phase 0 foundation regression with a bounded `ProgressTracker` lifecycle check: active discovery, 50% progress/milestone retrieval, successful completion, removal from the active list, and explicit unknown-operation failure;
- records the evidence boundary in `neqsim-mcp-server/docs/evidence/PROGRESS_RETRIEVAL_CONTRACT.md`;
- reuses the already-existing real-MCP `getProgress(action=listActive)` protocol scenario as transport evidence;
- deliberately leaves `getProgress` as `CONFIRMED_GAP` and preserves the current `20 EXPLICIT_TRUST + 6 CONTRACT_TESTED + 45 CONFIRMED_GAP` accounting. A later classification promotion must update machine-readable accounting and the packaged protocol expectation atomically on one validated head.

No thermodynamic, process, pipeline, dynamics, DEXPI/P&ID, optimization, schema, tool-name, response-envelope, deployment-profile, security-policy, live-plant, or control behavior changes.

## Validation

`VALIDATION PENDING CI`

The single permitted local supporting network attempt was infrastructure-blocked by DNS, so no local Maven/JDK/Spotless/pre-commit/Javadocs result is claimed. GitHub source inspection established that `ProgressTracker` is bounded to at most 20 retained milestones per operation and evicts old completed operations when the registry exceeds 100 entries; the new regression does not assert exact global active counts, so it remains isolated from unrelated progress operations.

Hosted exact-head CI is authoritative follow-up validation.

## Documentation impact

Adds one bounded evidence note under `neqsim-mcp-server/docs/evidence/`. It is explicitly an evidence artifact rather than an additional MCP guide, so the existing eight-guide Phase 0 inventory is unchanged. No companion agent/skill handoff is required because invocation contracts are unchanged.

## Stop boundary / next dependency

This PR stops at software-contract evidence for advisory progress retrieval. It does not claim correctness, convergence, cancellation, durability, scientific validation, tenant isolation for a deployment, or plant authority for the underlying calculation.

After merge and current-master re-audit, the deferred `searchComponents` / `queryDataCatalog` promotion remains first: move the frozen classification from 6/45 to 8/43 only together with its packaged protocol accounting. `getProgress` can then be considered for promotion once its machine-readable inventory/protocol accounting is updated on the same validated head.

AI-assisted contribution; I reviewed the repository instructions and the exact source behavior described above.