### PR TITLE
[AI-Assisted] Equilibrate competing electrolyte scale minerals

### DIFF
--- a/docs/pvtsimulation/scale_prediction_api.md
+++ b/docs/pvtsimulation/scale_prediction_api.md
@@ -249,10 +249,61 @@ composition is reflashed and physical properties are reinitialised. Consequently
 fluid can continue through `Stream`, `Heater`, and `ProcessSystem` calculations. Ions remain in the
 aqueous phase, while gas and oil phases retain their EOS roles.
 
-This API is a single-pure-mineral equilibrium operation. Callers should require a complementarity
-residual such as `solid.getComplementarityViolation() <= 1e-5` and independently check total and
-elemental balances. It does not yet solve simultaneous competition among several solid phases,
-solid solutions, nucleation, kinetics, deposition, or inhibitor performance. A Pitzer calculation
+Callers should require a complementarity residual such as
+`solid.getComplementarityViolation() <= 1e-5` and independently check total and elemental balances.
+
+### Simultaneous competing pure minerals
+
+`ThermodynamicOperations.precipitateScales(String...)` enforces non-negative pure-solid amounts and
+aqueous saturation complementarity for several named COMPSALT minerals. The active set precipitates
+supersaturated minerals and redissolves an undersaturated present mineral. Names are sorted before
+iteration, so caller ordering cannot select a different solid topology.
+
+```java
+MultiSaltPrecipitationResult scales =
+    operations.precipitateScales("CaSO4_A", "CaSO4_G");
+
+SaltPrecipitationResult anhydrite = scales.getMineralResult("CaSO4_A");
+SaltPrecipitationResult gypsumCorrelation = scales.getMineralResult("CaSO4_G");
+double complementarity = scales.getMaximumComplementarityViolation();
+double componentBalanceMol = scales.getMaximumComponentBalanceResidualMoles();
+```
+
+The returned ledger is absolute for that call and is not inserted into the NeqSim phase list. Carry
+it with the residual fluid. After a heater, pressure change, dilution, or composition change, pass
+the same ledger back so available solids can dissolve as well as precipitate:
+
+```java
+MultiSaltPrecipitationResult updatedScales =
+    new ThermodynamicOperations(changedFluid).equilibrateScales(scales);
+```
+
+The continuation API conserves dissolved plus ledgered formula units and fails closed if the
+bounded active set cannot reach `1e-6` log10-SR complementarity or `1e-10 mol` component balance.
+The result reports the update count, maximum complementarity violation, component-ledger residual,
+per-mineral saturation ratios and non-negative amounts. It is serializable and its mineral map is
+defensively immutable for Java and Python process workflows. A thermodynamic system remains mutable
+and must not be shared between threads. Sequential clones are deterministic, and independently
+constructed systems are covered by a parallel determinism regression. Concurrent use of clones from
+one Pitzer instance is not qualified because current shared Pitzer internals can race; construct each
+parallel system independently until that separate prerequisite is resolved.
+
+The deterministic regression uses the two existing calcium-sulfate COMPSALT correlations because
+they share the same dissolved ions: the lower-Ksp `CaSO4_G` correlation must displace
+`CaSO4_A`, independent of caller order. A separate dilution continuation proves that an existing
+solid can redissolve without stale-state carryover. This proves the active-set algorithm; it is not
+independent validation of gypsum hydration thermodynamics. COMPSALT represents
+the aqueous ion reaction and does not explicitly include crystallization-water activity or mass,
+so hydrated-mineral standard-state treatment remains outside this API's qualified scope.
+
+The process-system test carries the solid ledger beside the residual fluid through a
+`Stream -> Heater -> ProcessSystem` calculation, then re-equilibrates it at the outlet. Fluid-phase
+density, enthalpy and heat capacity remain finite and ions remain aqueous. Solid density, enthalpy,
+heat capacity and heat of precipitation are not yet represented, so rigorous process energy balances
+with a material solid stream remain a separate model/property boundary.
+
+Neither pure-mineral API solves solid solutions, nucleation, kinetics, deposition, or inhibitor
+performance. A Pitzer calculation
 must first select a parameter dataset complete for its active aqueous topology. Missing binary,
 same-sign, ternary, or neutral interactions remain an error; they are not silently set to zero.
 
@@ -261,7 +312,15 @@ control. On OpenJDK 17 in the development container, its median fresh-system cal
 78.9 ms for aqueous anhydrite precipitation and 1.018 s for the complete gas-oil-aqueous case.
 The unchanged neutral SRK control measured 0.215 ms before and 0.055 ms after the Pitzer batches
 (ratio 0.254, reflecting JIT warmup rather than a regression). This operation is invoked only by
-`precipitateScale`; neutral PR/SRK/CPA calculations execute no new branch or allocation.
+`precipitateScale` or `precipitateScales`; neutral PR/SRK/CPA calculations execute no new branch or
+allocation.
+
+With simultaneous `CaSO4_A`/`CaSO4_G` enabled in the same benchmark, median fresh-system times were
+80.5 ms for the aqueous calculation and 1.206 s for gas-oil-aqueous. The active set required one
+solid update, reached `9.995e-9` maximum log10-SR complementarity violation, and closed the component
+ledger to reported machine zero. The unchanged neutral SRK control measured 0.205 ms before and
+0.049 ms after the electrolyte batches (ratio 0.238, JIT dominated). Timings are diagnostic and not
+portable hardware guarantees.
 
 ### Reaction-level saturation diagnostics
 

--- a/docs/thermo/pitzer_parameter_provenance.md
+++ b/docs/thermo/pitzer_parameter_provenance.md
@@ -280,6 +280,27 @@ agreement does not qualify its missing aqueous interaction family. A redistribut
 Ba/Sr sulfate family with binary and all required mixed-brine terms plus held-out solubility or
 saturation evidence is the next parameter dependency.
 
+`ThermodynamicOperations.precipitateScales` adds a model-neutral orchestration layer for competing
+pure COMPSALT minerals. It does not merge parameter semantics: `SystemPitzer` continues to evaluate
+molality-scale activities from the explicitly selected PHREEQC family, while electrolyte EOS
+systems continue to use their own aqueous fugacity/activity implementation. No Pitzer interaction
+is copied into an EOS or reaction table.
+
+The active set owns an external, non-negative pure-solid ledger, precipitates supersaturated
+minerals, and redissolves undersaturated present minerals until the maximum complementarity
+violation is at most `1e-6` log10-SR. It fails closed on non-convergence and on a dissolved-plus-solid
+component residual above `1e-10 mol`. A continuation API accepts the previous ledger after a T/P or
+composition change, preventing a stale solid state in process sequences.
+
+The algorithmic regression uses `CaSO4_A` and `CaSO4_G`, whose unmodified COMPSALT correlations at
+298.15 K give log10 Ksp values `-4.355596` and `-4.578529`, respectively. Because both consume one
+Ca++ and one SO4--, the lower-Ksp correlation must be present and the higher-Ksp phase absent,
+independent of input order. This is an internal complementarity/topology regression, separate from
+the PHREEQC anhydrite Ksp comparison and from fitted-data validation. The `CaSO4_G` COMPSALT row
+does not explicitly represent crystallization-water activity or mass; therefore the regression does
+not qualify gypsum hydration thermodynamics, and that standard-state extension remains a distinct
+parameter/model boundary.
+
 `PitzerCatalogPerformanceBenchmark` measures nine fixed-work batches after warmup. On OpenJDK 17
 in the development container, the median four-ion activity/osmotic kernel was 10.542 microseconds
 and the complete aqueous `init(3)` plus physical-property calculation was 0.168756 milliseconds.

--- a/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
+++ b/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
@@ -62,6 +62,8 @@ import neqsim.thermodynamicoperations.flashops.saturationops.HydrateFormationPre
 import neqsim.thermodynamicoperations.flashops.saturationops.HydrateFormationTemperatureFlash;
 import neqsim.thermodynamicoperations.flashops.saturationops.HydrateInhibitorConcentrationFlash;
 import neqsim.thermodynamicoperations.flashops.saturationops.HydrateInhibitorwtFlash;
+import neqsim.thermodynamicoperations.flashops.saturationops.MultiSaltPrecipitation;
+import neqsim.thermodynamicoperations.flashops.saturationops.MultiSaltPrecipitationResult;
 import neqsim.thermodynamicoperations.flashops.saturationops.SolidComplexTemperatureCalc;
 import neqsim.thermodynamicoperations.flashops.saturationops.SaltPrecipitationResult;
 import neqsim.thermodynamicoperations.flashops.saturationops.WATcalc;
@@ -1295,6 +1297,31 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
     CalcSaltSatauration saltOperation = new CalcSaltSatauration(system, saltName);
     operation = saltOperation;
     return saltOperation.precipitate();
+  }
+
+  /**
+   * Equilibrates several competing pure COMPSALT minerals against the active aqueous model.
+   *
+   * <p>
+   * The dissolved system is updated and reflashed after each active-set adjustment. The immutable result contains the
+   * non-negative pure-solid material ledger; solids are not inserted as NeqSim phases.
+   * </p>
+   *
+   * @param saltNames unique COMPSALT mineral names
+   * @return simultaneous precipitation/dissolution result and convergence diagnostics
+   */
+  public MultiSaltPrecipitationResult precipitateScales(String... saltNames) {
+    return new MultiSaltPrecipitation(system, saltNames).solve();
+  }
+
+  /**
+   * Re-equilibrates an existing pure-mineral ledger after temperature, pressure, or composition changes.
+   *
+   * @param previousResult previous simultaneous-mineral result whose solid inventory accompanies this fluid
+   * @return updated absolute solid ledger and convergence diagnostics
+   */
+  public MultiSaltPrecipitationResult equilibrateScales(MultiSaltPrecipitationResult previousResult) {
+    return new MultiSaltPrecipitation(system, previousResult).solve();
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalcSaltSatauration.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalcSaltSatauration.java
@@ -20,6 +20,7 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
   static Logger logger = LogManager.getLogger(CalcSaltSatauration.class);
 
   String saltName;
+  private transient SaltData saltDataCache;
 
   /**
    * Constructor for calcSaltSatauration.
@@ -206,11 +207,117 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
         initialSaturationRatio, finalSaturationRatio, maximumBalanceResidual);
   }
 
+  /**
+   * Returns the current activity-based saturation ratio after a complete TP flash.
+   *
+   * @return current ion-activity product divided by the COMPSALT solubility product
+   */
+  double getCurrentSaturationRatio() {
+    SaltData saltData = readSaltData();
+    ensureSaltIonsPresent(saltData);
+    initialisePrecipitationSystem();
+    return calculateSaturationRatio(saltData, getAqueousPhaseNumber());
+  }
+
+  /**
+   * Dissolves at most the supplied amount of an existing pure-solid ledger.
+   *
+   * <p>
+   * If all available solid can dissolve while the aqueous phase remains undersaturated, the full amount is returned.
+   * Otherwise a clone-isolated bisection adds just enough stoichiometric ions to restore saturation equilibrium.
+   * </p>
+   *
+   * @param availableSolidMoles available pure-solid formula units in mol
+   * @return formula units dissolved in mol
+   */
+  double dissolve(double availableSolidMoles) {
+    if (!(availableSolidMoles > 0.0) || !Double.isFinite(availableSolidMoles)) {
+      throw new IllegalArgumentException("Available solid amount must be finite and positive for " + saltName);
+    }
+    SaltData saltData = readSaltData();
+    ensureSaltIonsPresent(saltData);
+    initialisePrecipitationSystem();
+    double initialSaturationRatio = calculateSaturationRatio(saltData, getAqueousPhaseNumber());
+    if (initialSaturationRatio >= 1.0) {
+      return 0.0;
+    }
+
+    SystemInterface baseSystem = system.clone();
+    double upperSaturationRatio = calculateSaturationRatioForDissolution(baseSystem, saltData, availableSolidMoles);
+    double acceptedDissolution;
+    if (upperSaturationRatio <= 1.0) {
+      acceptedDissolution = availableSolidMoles;
+    } else {
+      double lowerDissolution = 0.0;
+      double upperDissolution = availableSolidMoles;
+      acceptedDissolution = Double.NaN;
+      for (int iteration = 0; iteration < 100; iteration++) {
+        double trialDissolution = 0.5 * (lowerDissolution + upperDissolution);
+        double trialSaturationRatio = calculateSaturationRatioForDissolution(baseSystem, saltData, trialDissolution);
+        acceptedDissolution = trialDissolution;
+        if (Math.abs(Math.log10(trialSaturationRatio)) <= 1.0e-8) {
+          break;
+        }
+        if (trialSaturationRatio < 1.0) {
+          lowerDissolution = trialDissolution;
+        } else {
+          upperDissolution = trialDissolution;
+        }
+      }
+    }
+
+    addSaltAmount(saltData, acceptedDissolution);
+    initialisePrecipitationSystem();
+    return acceptedDissolution;
+  }
+
+  /** @return first COMPSALT ion name */
+  String getIon1Name() {
+    return readSaltData().name1;
+  }
+
+  /** @return second COMPSALT ion name */
+  String getIon2Name() {
+    return readSaltData().name2;
+  }
+
+  /** @return first-ion stoichiometric coefficient per formula unit */
+  double getIon1Stoichiometry() {
+    return readSaltData().stoc1;
+  }
+
+  /** @return second-ion stoichiometric coefficient per formula unit */
+  double getIon2Stoichiometry() {
+    return readSaltData().stoc2;
+  }
+
+  /** @return pure-solid molar mass in grams per mole of formula units */
+  double getSolidMolarMassGrams() {
+    SaltData saltData = readSaltData();
+    ensureSaltIonsPresent(saltData);
+    return 1000.0 * (saltData.stoc1 * system.getComponent(saltData.name1).getMolarMass()
+        + saltData.stoc2 * system.getComponent(saltData.name2).getMolarMass());
+  }
+
   private double calculateSaturationRatioForRemoval(SystemInterface baseSystem, SaltData saltData, double saltAmount) {
     SystemInterface originalSystem = system;
     try {
       system = createTrialSystem(baseSystem);
       removeSaltAmount(saltData, saltAmount);
+      initialisePrecipitationSystem();
+      return calculateSaturationRatio(saltData, getAqueousPhaseNumber());
+    } finally {
+      system = originalSystem;
+    }
+  }
+
+  /** Evaluates dissolution on a fresh clone using the same full-flash path as precipitation. */
+  private double calculateSaturationRatioForDissolution(SystemInterface baseSystem, SaltData saltData,
+      double saltAmount) {
+    SystemInterface originalSystem = system;
+    try {
+      system = createTrialSystem(baseSystem);
+      addSaltAmount(saltData, saltAmount);
       initialisePrecipitationSystem();
       return calculateSaturationRatio(saltData, getAqueousPhaseNumber());
     } finally {
@@ -244,6 +351,9 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
    * @return salt data for the requested salt
    */
   private SaltData readSaltData() {
+    if (saltDataCache != null) {
+      return saltDataCache;
+    }
     try (neqsim.util.database.NeqSimDataBase database = new neqsim.util.database.NeqSimDataBase();
         java.sql.ResultSet dataSet = database
             .getResultSet("SELECT * FROM compsalt WHERE SaltName='" + saltName + "'")) {
@@ -261,6 +371,7 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
       data.kspwater4 = Double.parseDouble(dataSet.getString("Kspwater4"));
       data.kspwater5 = Double.parseDouble(dataSet.getString("Kspwater5"));
       data.vdelta = Double.parseDouble(dataSet.getString("Vdelta"));
+      saltDataCache = data;
       return data;
     } catch (RuntimeException ex) {
       throw ex;

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/MultiSaltPrecipitation.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/MultiSaltPrecipitation.java
@@ -1,0 +1,243 @@
+package neqsim.thermodynamicoperations.flashops.saturationops;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import neqsim.thermo.system.SystemInterface;
+
+/**
+ * Active-set equilibrium for competing pure COMPSALT minerals.
+ *
+ * <p>
+ * The operation owns an external non-negative solid ledger. It repeatedly precipitates the most supersaturated mineral
+ * or redissolves the most undersaturated present mineral, always using the active thermodynamic system's aqueous
+ * activities. Mineral names are sorted so the result is independent of caller ordering.
+ * </p>
+ */
+public final class MultiSaltPrecipitation {
+  private static final double COMPLEMENTARITY_TOLERANCE = 1.0e-6;
+  private static final double BALANCE_TOLERANCE_MOLES = 1.0e-10;
+  private static final double SOLID_ZERO_TOLERANCE_MOLES = 1.0e-14;
+  private static final int MAXIMUM_UPDATES = 100;
+
+  private final SystemInterface system;
+  private final List<String> mineralNames;
+  private final Map<String, CalcSaltSatauration> operations = new LinkedHashMap<String, CalcSaltSatauration>();
+  private final Map<String, Double> startingSolidMoles = new LinkedHashMap<String, Double>();
+
+  /**
+   * Creates a simultaneous pure-mineral equilibrium operation.
+   *
+   * @param system thermodynamic system whose dissolved state will be updated
+   * @param requestedMineralNames unique COMPSALT mineral names
+   * @throws IllegalArgumentException if no mineral is supplied or a name is blank or duplicated
+   */
+  public MultiSaltPrecipitation(SystemInterface system, String... requestedMineralNames) {
+    this(system, null, requestedMineralNames);
+  }
+
+  /**
+   * Creates a continuation operation with an existing non-negative pure-solid ledger.
+   *
+   * @param system thermodynamic system containing the matching residual dissolved inventory
+   * @param previousResult previous simultaneous-mineral result to re-equilibrate after a state change
+   * @throws IllegalArgumentException if the result is null or contains an invalid solid amount
+   */
+  public MultiSaltPrecipitation(SystemInterface system, MultiSaltPrecipitationResult previousResult) {
+    this(system, requirePreviousResult(previousResult),
+        previousResult.getMineralResults().keySet().toArray(new String[previousResult.getMineralResults().size()]));
+  }
+
+  /** Shared constructor for fresh and continuation operations. */
+  private MultiSaltPrecipitation(SystemInterface system, MultiSaltPrecipitationResult previousResult,
+      String... requestedMineralNames) {
+    if (system == null) {
+      throw new IllegalArgumentException("Thermodynamic system cannot be null");
+    }
+    if (requestedMineralNames == null || requestedMineralNames.length == 0) {
+      throw new IllegalArgumentException("At least one COMPSALT mineral must be supplied");
+    }
+    Set<String> uniqueNames = new LinkedHashSet<String>();
+    for (String name : requestedMineralNames) {
+      if (name == null || name.trim().isEmpty()) {
+        throw new IllegalArgumentException("COMPSALT mineral names cannot be blank");
+      }
+      if (!uniqueNames.add(name)) {
+        throw new IllegalArgumentException("Duplicate COMPSALT mineral name: " + name);
+      }
+    }
+    this.system = system;
+    this.mineralNames = new ArrayList<String>(uniqueNames);
+    Collections.sort(this.mineralNames);
+    for (String name : this.mineralNames) {
+      operations.put(name, new CalcSaltSatauration(system, name));
+      double startingAmount = previousResult == null ? 0.0
+          : previousResult.getMineralResult(name).getPrecipitatedMoles();
+      if (!Double.isFinite(startingAmount) || startingAmount < 0.0) {
+        throw new IllegalArgumentException("Existing solid amount must be finite and non-negative for " + name);
+      }
+      startingSolidMoles.put(name, startingAmount);
+    }
+  }
+
+  /** Validates and returns a continuation result for constructor chaining. */
+  private static MultiSaltPrecipitationResult requirePreviousResult(MultiSaltPrecipitationResult previousResult) {
+    if (previousResult == null) {
+      throw new IllegalArgumentException("Previous simultaneous-mineral result cannot be null");
+    }
+    return previousResult;
+  }
+
+  /**
+   * Solves precipitation/dissolution complementarity for all requested minerals.
+   *
+   * @return immutable final solid ledger and convergence diagnostics
+   * @throws IllegalStateException if complementarity or the component ledger does not converge
+   */
+  public MultiSaltPrecipitationResult solve() {
+    Map<String, Double> initialSaturationRatios = new LinkedHashMap<String, Double>();
+    Map<String, Double> solidMoles = new LinkedHashMap<String, Double>();
+    Map<String, Double> initialComponentMoles = new LinkedHashMap<String, Double>();
+    for (String name : mineralNames) {
+      CalcSaltSatauration mineralOperation = operations.get(name);
+      initialSaturationRatios.put(name, mineralOperation.getCurrentSaturationRatio());
+      solidMoles.put(name, startingSolidMoles.get(name));
+      rememberInitialComponent(initialComponentMoles, mineralOperation.getIon1Name());
+      rememberInitialComponent(initialComponentMoles, mineralOperation.getIon2Name());
+    }
+    addStartingSolidsToInitialLedger(initialComponentMoles);
+
+    int updates = 0;
+    while (updates < MAXIMUM_UPDATES) {
+      Violation largestViolation = findLargestViolation(solidMoles);
+      if (largestViolation.value <= COMPLEMENTARITY_TOLERANCE) {
+        break;
+      }
+
+      CalcSaltSatauration mineralOperation = operations.get(largestViolation.mineralName);
+      double previousSolidMoles = solidMoles.get(largestViolation.mineralName);
+      double updatedSolidMoles;
+      if (largestViolation.saturationRatio > 1.0) {
+        SaltPrecipitationResult increment = mineralOperation.precipitate();
+        updatedSolidMoles = previousSolidMoles + increment.getPrecipitatedMoles();
+      } else {
+        double dissolvedMoles = mineralOperation.dissolve(previousSolidMoles);
+        updatedSolidMoles = Math.max(0.0, previousSolidMoles - dissolvedMoles);
+      }
+      if (Math.abs(updatedSolidMoles - previousSolidMoles) <= SOLID_ZERO_TOLERANCE_MOLES) {
+        throw new IllegalStateException("Mineral complementarity stalled for " + largestViolation.mineralName
+            + " at SR=" + largestViolation.saturationRatio);
+      }
+      solidMoles.put(largestViolation.mineralName, updatedSolidMoles);
+      updates++;
+    }
+
+    Violation finalViolation = findLargestViolation(solidMoles);
+    if (finalViolation.value > COMPLEMENTARITY_TOLERANCE) {
+      throw new IllegalStateException("Pure-mineral complementarity did not converge in " + MAXIMUM_UPDATES
+          + " updates; maximum violation=" + finalViolation.value + " for " + finalViolation.mineralName);
+    }
+
+    double balanceResidual = calculateMaximumBalanceResidual(initialComponentMoles, solidMoles);
+    if (balanceResidual > BALANCE_TOLERANCE_MOLES) {
+      throw new IllegalStateException(
+          "Pure-mineral component ledger did not close; residual=" + balanceResidual + " mol");
+    }
+
+    Map<String, SaltPrecipitationResult> mineralResults = new LinkedHashMap<String, SaltPrecipitationResult>();
+    for (String name : mineralNames) {
+      CalcSaltSatauration mineralOperation = operations.get(name);
+      double finalSaturationRatio = mineralOperation.getCurrentSaturationRatio();
+      double amount = solidMoles.get(name);
+      if (amount <= SOLID_ZERO_TOLERANCE_MOLES) {
+        amount = 0.0;
+      }
+      mineralResults.put(name,
+          new SaltPrecipitationResult(name, amount, amount * mineralOperation.getSolidMolarMassGrams(),
+              initialSaturationRatios.get(name), finalSaturationRatio, balanceResidual));
+    }
+    return new MultiSaltPrecipitationResult(mineralResults, updates, finalViolation.value, balanceResidual);
+  }
+
+  /** Records the initial dissolved amount for one component exactly once. */
+  private void rememberInitialComponent(Map<String, Double> initialComponentMoles, String componentName) {
+    if (!initialComponentMoles.containsKey(componentName)) {
+      initialComponentMoles.put(componentName, system.getComponent(componentName).getNumberOfmoles());
+    }
+  }
+
+  /** Adds the supplied starting solids to the conserved overall component inventory. */
+  private void addStartingSolidsToInitialLedger(Map<String, Double> initialComponentMoles) {
+    for (String name : mineralNames) {
+      CalcSaltSatauration mineralOperation = operations.get(name);
+      double amount = startingSolidMoles.get(name);
+      initialComponentMoles.put(mineralOperation.getIon1Name(),
+          initialComponentMoles.get(mineralOperation.getIon1Name()) + mineralOperation.getIon1Stoichiometry() * amount);
+      initialComponentMoles.put(mineralOperation.getIon2Name(),
+          initialComponentMoles.get(mineralOperation.getIon2Name()) + mineralOperation.getIon2Stoichiometry() * amount);
+    }
+  }
+
+  /** Finds the largest KKT complementarity violation in deterministic mineral order. */
+  private Violation findLargestViolation(Map<String, Double> solidMoles) {
+    Violation largest = new Violation(mineralNames.get(0), 0.0, 0.0);
+    for (String name : mineralNames) {
+      double saturationRatio = operations.get(name).getCurrentSaturationRatio();
+      if (!Double.isFinite(saturationRatio) || saturationRatio < 0.0) {
+        throw new IllegalStateException("Invalid saturation ratio for " + name + ": " + saturationRatio);
+      }
+      double logarithmicSaturation = saturationRatio > 0.0 ? Math.log10(saturationRatio) : Double.NEGATIVE_INFINITY;
+      double violation = solidMoles.get(name) > SOLID_ZERO_TOLERANCE_MOLES ? Math.abs(logarithmicSaturation)
+          : Math.max(logarithmicSaturation, 0.0);
+      if (violation > largest.value) {
+        largest = new Violation(name, saturationRatio, violation);
+      }
+    }
+    return largest;
+  }
+
+  /** Calculates the maximum component ledger residual across all mineral ions. */
+  private double calculateMaximumBalanceResidual(Map<String, Double> initialComponentMoles,
+      Map<String, Double> solidMoles) {
+    Map<String, Double> solidComponentMoles = new LinkedHashMap<String, Double>();
+    for (String name : mineralNames) {
+      CalcSaltSatauration mineralOperation = operations.get(name);
+      addToComponentLedger(solidComponentMoles, mineralOperation.getIon1Name(),
+          mineralOperation.getIon1Stoichiometry() * solidMoles.get(name));
+      addToComponentLedger(solidComponentMoles, mineralOperation.getIon2Name(),
+          mineralOperation.getIon2Stoichiometry() * solidMoles.get(name));
+    }
+
+    double maximumResidual = 0.0;
+    for (Map.Entry<String, Double> initial : initialComponentMoles.entrySet()) {
+      double dissolved = system.getComponent(initial.getKey()).getNumberOfmoles();
+      Double solid = solidComponentMoles.get(initial.getKey());
+      double residual = initial.getValue() - dissolved - (solid == null ? 0.0 : solid.doubleValue());
+      maximumResidual = Math.max(maximumResidual, Math.abs(residual));
+    }
+    return maximumResidual;
+  }
+
+  /** Adds a component amount to the solid material ledger. */
+  private static void addToComponentLedger(Map<String, Double> ledger, String componentName, double amount) {
+    Double previous = ledger.get(componentName);
+    ledger.put(componentName, (previous == null ? 0.0 : previous.doubleValue()) + amount);
+  }
+
+  /** One mineral's current complementarity violation. */
+  private static final class Violation {
+    private final String mineralName;
+    private final double saturationRatio;
+    private final double value;
+
+    private Violation(String mineralName, double saturationRatio, double value) {
+      this.mineralName = mineralName;
+      this.saturationRatio = saturationRatio;
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/MultiSaltPrecipitationResult.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/MultiSaltPrecipitationResult.java
@@ -1,0 +1,82 @@
+package neqsim.thermodynamicoperations.flashops.saturationops;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Immutable diagnostics and pure-solid ledger from simultaneous mineral equilibration. */
+public final class MultiSaltPrecipitationResult implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final Map<String, SaltPrecipitationResult> mineralResults;
+  private final int equilibriumUpdates;
+  private final double maximumComplementarityViolation;
+  private final double maximumComponentBalanceResidualMoles;
+
+  MultiSaltPrecipitationResult(Map<String, SaltPrecipitationResult> mineralResults, int equilibriumUpdates,
+      double maximumComplementarityViolation, double maximumComponentBalanceResidualMoles) {
+    this.mineralResults = Collections
+        .unmodifiableMap(new LinkedHashMap<String, SaltPrecipitationResult>(mineralResults));
+    this.equilibriumUpdates = equilibriumUpdates;
+    this.maximumComplementarityViolation = maximumComplementarityViolation;
+    this.maximumComponentBalanceResidualMoles = maximumComponentBalanceResidualMoles;
+  }
+
+  /**
+   * Returns an immutable defensive copy of the per-mineral solid ledger.
+   *
+   * @return mineral-name keyed precipitation results in deterministic order
+   */
+  public Map<String, SaltPrecipitationResult> getMineralResults() {
+    return Collections.unmodifiableMap(new LinkedHashMap<String, SaltPrecipitationResult>(mineralResults));
+  }
+
+  /**
+   * Returns one mineral result.
+   *
+   * @param mineralName COMPSALT mineral name
+   * @return immutable mineral result
+   * @throws IllegalArgumentException if the mineral was not requested
+   */
+  public SaltPrecipitationResult getMineralResult(String mineralName) {
+    SaltPrecipitationResult result = mineralResults.get(mineralName);
+    if (result == null) {
+      throw new IllegalArgumentException("Mineral was not included in the equilibrium: " + mineralName);
+    }
+    return result;
+  }
+
+  /** @return number of precipitation or dissolution updates */
+  public int getEquilibriumUpdates() {
+    return equilibriumUpdates;
+  }
+
+  /** @return maximum pure-mineral complementarity violation in log10 saturation-ratio units */
+  public double getMaximumComplementarityViolation() {
+    return maximumComplementarityViolation;
+  }
+
+  /** @return maximum absolute component ledger residual in mol */
+  public double getMaximumComponentBalanceResidualMoles() {
+    return maximumComponentBalanceResidualMoles;
+  }
+
+  /**
+   * Returns the total dissolved-ion formula mass represented by the solid ledger.
+   *
+   * <p>
+   * COMPSALT rows do not explicitly encode crystallization water. Hydrated-solid mass therefore requires a separately
+   * qualified solid standard-state model and is outside this diagnostic.
+   * </p>
+   *
+   * @return total COMPSALT ion-formula mass in g
+   */
+  public double getTotalPrecipitatedMassGrams() {
+    double totalMass = 0.0;
+    for (SaltPrecipitationResult result : mineralResults.values()) {
+      totalMass += result.getPrecipitatedMassGrams();
+    }
+    return totalMass;
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/MultiSaltPrecipitationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/MultiSaltPrecipitationTest.java
@@ -1,0 +1,233 @@
+package neqsim.thermodynamicoperations.flashops.saturationops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.phase.PhaseInterface;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPitzer;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Scientific, continuation, and process tests for competing pure-mineral equilibrium. */
+class MultiSaltPrecipitationTest extends neqsim.NeqSimTest {
+
+  @Test
+  void competingCalciumSulfatePolymorphsSelectLowerKspIndependentOfInputOrder() {
+    SystemPitzer forwardSystem = createPitzerBrine(false);
+    double initialCalcium = forwardSystem.getComponent("Ca++").getNumberOfmoles();
+    double initialSulfate = forwardSystem.getComponent("SO4--").getNumberOfmoles();
+    MultiSaltPrecipitationResult forward = new ThermodynamicOperations(forwardSystem).precipitateScales("CaSO4_A",
+        "CaSO4_G");
+
+    assertStableGypsumTopology(forward);
+    assertEquals(initialCalcium,
+        forwardSystem.getComponent("Ca++").getNumberOfmoles()
+            + forward.getMineralResult("CaSO4_A").getPrecipitatedMoles()
+            + forward.getMineralResult("CaSO4_G").getPrecipitatedMoles(),
+        1.0e-10);
+    assertEquals(initialSulfate,
+        forwardSystem.getComponent("SO4--").getNumberOfmoles()
+            + forward.getMineralResult("CaSO4_A").getPrecipitatedMoles()
+            + forward.getMineralResult("CaSO4_G").getPrecipitatedMoles(),
+        1.0e-10);
+    assertAqueousChargeAndPhaseState(forwardSystem);
+
+    SystemPitzer reverseSystem = createPitzerBrine(false);
+    MultiSaltPrecipitationResult reverse = new ThermodynamicOperations(reverseSystem).precipitateScales("CaSO4_G",
+        "CaSO4_A");
+    assertStableGypsumTopology(reverse);
+    assertEquals(forward.getMineralResult("CaSO4_G").getPrecipitatedMoles(),
+        reverse.getMineralResult("CaSO4_G").getPrecipitatedMoles(), 1.0e-10);
+    assertEquals(forwardSystem.getComponent("Ca++").getNumberOfmoles(),
+        reverseSystem.getComponent("Ca++").getNumberOfmoles(), 1.0e-10);
+  }
+
+  @Test
+  void existingSolidLedgerIsRepeatableAndRedissolvesAfterDilution() {
+    SystemPitzer system = createPitzerBrine(false);
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+    MultiSaltPrecipitationResult initial = operations.precipitateScales("CaSO4_A", "CaSO4_G");
+
+    MultiSaltPrecipitationResult repeated = operations.equilibrateScales(initial);
+    assertEquals(initial.getMineralResult("CaSO4_G").getPrecipitatedMoles(),
+        repeated.getMineralResult("CaSO4_G").getPrecipitatedMoles(), 1.0e-10);
+    assertTrue(repeated.getMaximumComplementarityViolation() <= 1.0e-6);
+
+    system.addComponent("water", 55.508);
+    system.init(0);
+    MultiSaltPrecipitationResult diluted = operations.equilibrateScales(repeated);
+    assertTrue(diluted.getMineralResult("CaSO4_G").getPrecipitatedMoles() < repeated.getMineralResult("CaSO4_G")
+        .getPrecipitatedMoles());
+    assertTrue(diluted.getMaximumComplementarityViolation() <= 1.0e-6);
+    assertTrue(diluted.getMaximumComponentBalanceResidualMoles() <= 1.0e-10);
+    assertAqueousChargeAndPhaseState(system);
+  }
+
+  @Test
+  void gasOilAqueousResultRemainsProcessComposableAndSerializable() throws Exception {
+    SystemPitzer system = createPitzerBrine(true);
+    MultiSaltPrecipitationResult result = new ThermodynamicOperations(system).precipitateScales("CaSO4_A", "CaSO4_G");
+
+    Stream feed = new Stream("scale-equilibrated feed", system);
+    Heater heater = new Heater("electrolyte heater", feed);
+    heater.setOutTemperature(308.15);
+    ProcessSystem process = new ProcessSystem("multi-mineral electrolyte process smoke test");
+    process.add(feed);
+    process.add(heater);
+    process.run();
+
+    SystemInterface outlet = heater.getOutletStream().getThermoSystem();
+    assertEquals(system.getTotalNumberOfMoles(), outlet.getTotalNumberOfMoles(), 1.0e-10);
+    assertEquals(outlet.getEnthalpy() - feed.getFluid().getEnthalpy(), heater.getDuty(),
+        Math.max(1.0e-6, Math.abs(heater.getDuty()) * 1.0e-12));
+    assertTrue(outlet.hasPhaseType("gas"));
+    assertTrue(outlet.hasPhaseType("oil"));
+    assertTrue(outlet.hasPhaseType("aqueous"));
+    assertFinitePropertiesAndIonConfinement(outlet);
+    MultiSaltPrecipitationResult outletResult = new ThermodynamicOperations(outlet).equilibrateScales(result);
+    assertTrue(outletResult.getMaximumComplementarityViolation() <= 1.0e-6);
+    assertTrue(outletResult.getMaximumComponentBalanceResidualMoles() <= 1.0e-10);
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(outletResult);
+    }
+    MultiSaltPrecipitationResult restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored = (MultiSaltPrecipitationResult) input.readObject();
+    }
+    assertEquals(outletResult.getTotalPrecipitatedMassGrams(), restored.getTotalPrecipitatedMassGrams(), 0.0);
+    Map<String, SaltPrecipitationResult> defensiveResults = restored.getMineralResults();
+    assertThrows(UnsupportedOperationException.class,
+        () -> defensiveResults.put("unexpected", restored.getMineralResult("CaSO4_G")));
+  }
+
+  @Test
+  void clonesAreDeterministicAndIndependentSystemsCanRunInParallel() throws Exception {
+    SystemPitzer baseSystem = createPitzerBrine(false);
+    SystemInterface firstSystem = baseSystem.clone();
+    SystemInterface secondSystem = baseSystem.clone();
+    MultiSaltPrecipitationResult firstCloneResult = new ThermodynamicOperations(firstSystem)
+        .precipitateScales("CaSO4_A", "CaSO4_G");
+    MultiSaltPrecipitationResult secondCloneResult = new ThermodynamicOperations(secondSystem)
+        .precipitateScales("CaSO4_G", "CaSO4_A");
+    assertStableGypsumTopology(firstCloneResult);
+    assertStableGypsumTopology(secondCloneResult);
+    assertEquals(firstCloneResult.getMineralResult("CaSO4_G").getPrecipitatedMoles(),
+        secondCloneResult.getMineralResult("CaSO4_G").getPrecipitatedMoles(), 1.0e-10);
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<MultiSaltPrecipitationResult> first = executor
+          .submit(() -> new ThermodynamicOperations(createPitzerBrine(false)).precipitateScales("CaSO4_A", "CaSO4_G"));
+      Future<MultiSaltPrecipitationResult> second = executor
+          .submit(() -> new ThermodynamicOperations(createPitzerBrine(false)).precipitateScales("CaSO4_G", "CaSO4_A"));
+      MultiSaltPrecipitationResult firstResult = first.get();
+      MultiSaltPrecipitationResult secondResult = second.get();
+      assertStableGypsumTopology(firstResult);
+      assertStableGypsumTopology(secondResult);
+      assertEquals(firstResult.getMineralResult("CaSO4_G").getPrecipitatedMoles(),
+          secondResult.getMineralResult("CaSO4_G").getPrecipitatedMoles(), 1.0e-10);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void electrolyteEosUsesItsOwnActivitiesAndInvalidRequestsFailClosed() throws Exception {
+    SystemInterface system = new SystemElectrolyteCPAstatoil(298.15, 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("Na+", 1.0);
+    system.addComponent("Ca++", 0.2);
+    system.addComponent("Cl-", 1.0);
+    system.addComponent("SO4--", 0.2);
+    system.chemicalReactionInit();
+    system.createDatabase(true);
+    system.setMixingRule(10);
+    system.setMultiPhaseCheck(true);
+
+    MultiSaltPrecipitationResult result = new ThermodynamicOperations(system).precipitateScales("CaSO4_A", "CaSO4_G");
+    assertStableGypsumTopology(result);
+    assertTrue(result.getMaximumComponentBalanceResidualMoles() <= 1.0e-10);
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+    assertThrows(IllegalArgumentException.class, () -> operations.precipitateScales("CaSO4_A", "CaSO4_A"));
+    assertThrows(IllegalArgumentException.class, () -> operations.precipitateScales("NOT_A_COMPSALT_MINERAL"));
+  }
+
+  private static void assertStableGypsumTopology(MultiSaltPrecipitationResult result) {
+    SaltPrecipitationResult anhydrite = result.getMineralResult("CaSO4_A");
+    SaltPrecipitationResult gypsum = result.getMineralResult("CaSO4_G");
+    assertFalse(anhydrite.hasPrecipitatedSolid());
+    assertTrue(anhydrite.getFinalSaturationRatio() < 1.0);
+    assertTrue(gypsum.hasPrecipitatedSolid());
+    assertEquals(1.0, gypsum.getFinalSaturationRatio(), 1.0e-6);
+    assertTrue(result.getMaximumComplementarityViolation() <= 1.0e-6);
+    assertTrue(result.getMaximumComponentBalanceResidualMoles() <= 1.0e-10);
+  }
+
+  private static SystemPitzer createPitzerBrine(boolean includeHydrocarbons) {
+    SystemPitzer system = new SystemPitzer(298.15, includeHydrocarbons ? 50.0 : 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("Na+", 1.0);
+    system.addComponent("Ca++", 0.2);
+    system.addComponent("Mg++", 0.0);
+    system.addComponent("Cl-", 1.0);
+    system.addComponent("SO4--", 0.2);
+    system.init(0);
+    system.applyPhreeqcCalciumMagnesiumChlorideSulfateParameters();
+    if (includeHydrocarbons) {
+      system.addComponent("methane", 5.0);
+      system.addComponent("n-heptane", 2.0);
+    }
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(true);
+    return system;
+  }
+
+  private static void assertAqueousChargeAndPhaseState(SystemPitzer system) {
+    int aqueousPhaseNumber = system.getPhaseNumberOfPhase("aqueous");
+    PhaseInterface aqueous = system.getPhase(aqueousPhaseNumber >= 0 ? aqueousPhaseNumber : 1);
+    double moleFractionSum = 0.0;
+    double chargeMolality = 0.0;
+    for (int componentIndex = 0; componentIndex < aqueous.getNumberOfComponents(); componentIndex++) {
+      ComponentInterface component = aqueous.getComponent(componentIndex);
+      assertTrue(Double.isFinite(component.getx()) && component.getx() >= 0.0);
+      moleFractionSum += component.getx();
+      chargeMolality += component.getMolality(aqueous) * component.getIonicCharge();
+    }
+    assertEquals(1.0, moleFractionSum, 1.0e-12);
+    assertEquals(0.0, chargeMolality, 1.0e-10);
+  }
+
+  private static void assertFinitePropertiesAndIonConfinement(SystemInterface system) {
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      PhaseInterface phase = system.getPhase(phaseIndex);
+      assertTrue(Double.isFinite(phase.getDensity()) && phase.getDensity() > 0.0);
+      assertTrue(Double.isFinite(phase.getEnthalpy()));
+      assertTrue(Double.isFinite(phase.getCp()) && phase.getCp() > 0.0);
+      for (int componentIndex = 0; componentIndex < phase.getNumberOfComponents(); componentIndex++) {
+        ComponentInterface component = phase.getComponent(componentIndex);
+        if ((component.isIsIon() || component.getIonicCharge() != 0.0) && phase.getType() != PhaseType.AQUEOUS) {
+          assertTrue(component.getx() <= 1.0e-40, component.getComponentName() + " escaped the aqueous phase");
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltPrecipitationPerformanceBenchmark.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltPrecipitationPerformanceBenchmark.java
@@ -33,11 +33,15 @@ public final class SaltPrecipitationPerformanceBenchmark {
     }
     long aqueousPrecipitation = medianBatches(() -> precipitationChecksum(false), 2);
     long multiphasePrecipitation = medianBatches(() -> precipitationChecksum(true), 2);
+    long simultaneousAqueousPrecipitation = medianBatches(() -> simultaneousPrecipitationChecksum(false), 2);
+    long simultaneousMultiphasePrecipitation = medianBatches(() -> simultaneousPrecipitationChecksum(true), 2);
     long neutralAfter = medianBatches(() -> neutralFlashChecksum(neutral), 20);
 
     SaltPrecipitationResult evidence = precipitate(false);
     LOGGER.info("aqueousPrecipitationNs={}", aqueousPrecipitation);
     LOGGER.info("gasOilAqueousPrecipitationNs={}", multiphasePrecipitation);
+    LOGGER.info("simultaneousAqueousPrecipitationNs={}", simultaneousAqueousPrecipitation);
+    LOGGER.info("simultaneousGasOilAqueousPrecipitationNs={}", simultaneousMultiphasePrecipitation);
     LOGGER.info("neutralSrkBeforeNs={}", neutralBefore);
     LOGGER.info("neutralSrkAfterNs={}", neutralAfter);
     LOGGER.info("neutralSrkRatio={}", (double) neutralAfter / neutralBefore);
@@ -45,6 +49,10 @@ public final class SaltPrecipitationPerformanceBenchmark {
     LOGGER.info("finalSaturationRatio={}", evidence.getFinalSaturationRatio());
     LOGGER.info("precipitatedMoles={}", evidence.getPrecipitatedMoles());
     LOGGER.info("ionBalanceResidualMoles={}", evidence.getMaximumIonBalanceResidualMoles());
+    MultiSaltPrecipitationResult simultaneousEvidence = precipitateSimultaneously(false);
+    LOGGER.info("simultaneousEquilibriumUpdates={}", simultaneousEvidence.getEquilibriumUpdates());
+    LOGGER.info("simultaneousComplementarityViolation={}", simultaneousEvidence.getMaximumComplementarityViolation());
+    LOGGER.info("simultaneousBalanceResidualMoles={}", simultaneousEvidence.getMaximumComponentBalanceResidualMoles());
     if (!Double.isFinite(sink)) {
       throw new IllegalStateException("Benchmark checksum is not finite");
     }
@@ -72,6 +80,17 @@ public final class SaltPrecipitationPerformanceBenchmark {
   private static SaltPrecipitationResult precipitate(boolean includeHydrocarbons) {
     SystemPitzer system = createPitzerSystem(includeHydrocarbons);
     return new ThermodynamicOperations(system).precipitateScale("CaSO4_A");
+  }
+
+  private static double simultaneousPrecipitationChecksum(boolean includeHydrocarbons) {
+    MultiSaltPrecipitationResult result = precipitateSimultaneously(includeHydrocarbons);
+    return result.getTotalPrecipitatedMassGrams() + result.getMaximumComplementarityViolation()
+        + result.getMaximumComponentBalanceResidualMoles();
+  }
+
+  private static MultiSaltPrecipitationResult precipitateSimultaneously(boolean includeHydrocarbons) {
+    SystemPitzer system = createPitzerSystem(includeHydrocarbons);
+    return new ThermodynamicOperations(system).precipitateScales("CaSO4_A", "CaSO4_G");
   }
 
   private static double neutralFlashChecksum(SystemSrkEos system) {

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltPrecipitationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltPrecipitationTest.java
@@ -140,6 +140,7 @@ class SaltPrecipitationTest extends neqsim.NeqSimTest {
     assertSaturationLogKMatchesPhreeqc("BaSO4", -9.97, 0.04);
     assertSaturationLogKMatchesPhreeqc("SrSO4", -6.63, 0.01);
     assertSaturationLogKMatchesPhreeqc("CaSO4_A", -4.362, 0.01);
+    assertSaturationLogKMatchesPhreeqc("CaSO4_G", -4.58, 0.01);
   }
 
   private static SystemPitzer createCalciumSulphateBrine(boolean includeHydrocarbons, double scaleIonMolality) {


### PR DESCRIPTION
## Scientific question

Can NeqSim equilibrate several competing pure COMPSALT minerals against the **active aqueous activity model** in a gas/oil/aqueous electrolyte system, preserve an external non-negative solid ledger across state changes, and expose process-usable diagnostics without changing neutral EOS paths?

Closes one algorithmic boundary in #3144. Generic TP-flash work remains with #2937, reactive absorber equipment with #205, and salt input/API work with #448.

## Frozen scope

- Models: legacy Pitzer GE and electrolyte EOS, each using its own aqueous activities.
- Mineral data: existing COMPSALT rows only; no new Pitzer parameter or reaction/mineral constant.
- Basis: dissolved component moles plus an external pure-solid formula-unit ledger.
- Solver: deterministic active set, sorted mineral identity, precipitation and redissolution.
- Acceptance: maximum complementarity violation `<= 1e-6` in log10(SR), component balance `<= 1e-10 mol`, non-negative solids, fail-closed invalid inputs/nonconvergence.
- Stop boundary: pure minerals only. No solid solutions, kinetics, deposition, inhibitor model, new hydrated-solid standard state, or generic flash changes.

## Changes

- Adds `precipitateScales(String...)` and continuation API `equilibrateScales(previousResult)`.
- Adds immutable/serializable `MultiSaltPrecipitationResult` with per-mineral ledger, update count, complementarity, balance, and ion-formula mass.
- Reuses the existing activity-consistent single-mineral kernel and adds bounded redissolution.
- Adds gas/oil/aqueous `Stream -> Heater -> ProcessSystem` coverage with ion confinement, fugacity/mass closure, density, enthalpy, and heat capacity.
- Adds Pitzer and electrolyte-EOS regressions, deterministic ordering, stale-state continuation, serialization, defensive-copy, invalid-input, and independently constructed parallel-system coverage.
- Extends the benchmark and user/provenance documentation.

## Scientific and source evidence

- Existing COMPSALT `CaSO4_A` and `CaSO4_G` correlations provide a deterministic competing-topology regression. At 298.15 K, `log10 Ksp = -4.355595801363142` and `-4.5785292971546`; the lower-Ksp `CaSO4_G` topology remains and `CaSO4_A` is absent, independent of caller order.
- Existing PHREEQC gypsum `log K = -4.58` is reproduced within 0.01 as a separate public-domain comparison.
- Parameter provenance remains pinned to USGS PHREEQC 3.9.0-17591 and PHRQPITZ. The source matrix is updated in `docs/thermo/pitzer_parameter_provenance.md`.
- Kaasa (1998) remains provenance/index evidence only. No thesis numerical value is copied or adopted; redistribution, row lineage, and independent agreement remain mandatory.
- No parameter was fitted or changed.

The `CaSO4_G` COMPSALT row does not explicitly encode crystallization-water activity or mass. This is therefore algorithm/topology evidence, not independent validation of gypsum hydration thermodynamics.

## Validation

Local final tree:

- Focused Java 17: **10/10 passed**.
- Broader Pitzer/electrolyte matrix: **87/87 passed**.
- Java 8 source/target compatibility on JDK 17: **10/10 passed**.
- Spotless apply/check: passed.
- Documentation search audit: **659 Markdown + 1 standalone HTML passed**.
- Actual Java 8 runtime: **VALIDATION PENDING CI**.
- Javadocs: **VALIDATION PENDING CI** (local runtime has no `javadoc` executable).
- Pre-commit executable was unavailable locally; equivalent direct formatting, tests, and documentation gates were run.

Numerical regression:

- competing-mineral updates: `1`
- maximum complementarity: `9.994581301690431e-9`
- maximum component-balance residual: `0.0 mol`
- single CaSO4 final SR: `0.9999999961468291`
- single CaSO4 precipitated: `0.13948653787360546 mol`

Representative fresh-system timings:

- single aqueous: `72.18 ms`
- simultaneous aqueous: `80.50 ms`
- single gas/oil/aqueous: `883.12 ms`
- simultaneous gas/oil/aqueous: `1206.05 ms`
- neutral SRK control after/before ratio: `0.238` (JIT-dominated; no slowdown observed)

## Compatibility and limitations

All new runtime work is opt-in through the new multi-mineral API. Neutral PR/SRK/CPA and non-ionic calculations execute no new branch.

Sequential Pitzer clones are deterministic, but concurrent use of clones from one Pitzer instance is not qualified because existing shared Pitzer internals can race. Parallel regressions use independently constructed systems. Resolving shared Pitzer clone internals is a separate prerequisite.

## Status

**DRAFT — VALIDATION PENDING CI**

Please do not merge until exact-head hosted checks complete.