### PR TITLE
[AI-Assisted] docs: make reference-index maintenance truthful

### DIFF
--- a/docs/REFERENCE_MANUAL_INDEX.md
+++ b/docs/REFERENCE_MANUAL_INDEX.md
@@ -778,7 +778,7 @@ Comprehensive operational risk simulation framework for equipment failure analys
 | **Reliability Data Guide**     | [docs/risk/RELIABILITY_DATA_GUIDE.md](risk/RELIABILITY_DATA_GUIDE.md)                 | Multi-source reliability data (IOGP/SINTEF, CCPS, IEEE 493, Lees, OREDA), CSV format  |
 | **Physics-Based Integration**  | [docs/risk/PHYSICS_BASED_RISK_INTEGRATION.md](risk/PHYSICS_BASED_RISK_INTEGRATION.md) | **Integration of physics-based models with risk simulation for dynamic failure analysis** |
 
-### Chapter 35a: Advanced Risk Framework (**NEW**)
+### Chapter 35a: Advanced Risk Framework
 
 Extended risk analysis capabilities implementing P1-P7 priority improvements for oil & gas industry applications.
 
@@ -1028,8 +1028,8 @@ hypothesis scoring with OREDA, historian, STID, and NeqSim simulation verificati
 | Document                          | Path                                                                                                                       | Description                                                             |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | Field Development Overview        | [docs/fielddevelopment/README.md](fielddevelopment/README.md)                                                                       | Field development module overview                                       |
-| **Digital Field Twin**            | [docs/fielddevelopment/DIGITAL_FIELD_TWIN.md](fielddevelopment/DIGITAL_FIELD_TWIN.md)                                         | **NEW** Comprehensive architecture for lifecycle consistency            |
-| **Mathematical Reference**        | [docs/fielddevelopment/MATHEMATICAL_REFERENCE.md](fielddevelopment/MATHEMATICAL_REFERENCE.md)                                 | **NEW** Mathematical foundations for all calculations                   |
+| **Digital Field Twin**            | [docs/fielddevelopment/DIGITAL_FIELD_TWIN.md](fielddevelopment/DIGITAL_FIELD_TWIN.md)                                         | Comprehensive architecture for lifecycle consistency            |
+| **Mathematical Reference**        | [docs/fielddevelopment/MATHEMATICAL_REFERENCE.md](fielddevelopment/MATHEMATICAL_REFERENCE.md)                                 | Mathematical foundations for all calculations                   |
 | Field Development API Guide      | [docs/fielddevelopment/API_GUIDE.md](fielddevelopment/API_GUIDE.md)                                                           | Current concept inputs, screening KPIs, option ranking, units, and boundaries |
 | **Integrated Framework**          | [docs/fielddevelopment/INTEGRATED_FIELD_DEVELOPMENT_FRAMEWORK.md](fielddevelopment/INTEGRATED_FIELD_DEVELOPMENT_FRAMEWORK.md) | PVT→Reservoir→Well→Process integration guide                            |
 | **Decision Engine Workflows**      | [docs/fielddevelopment/DECISION_ENGINE_WORKFLOWS.md](fielddevelopment/DECISION_ENGINE_WORKFLOWS.md)                           | Tieback, greenfield, portfolio, process, reservoir, and reporting workflows |
@@ -1120,9 +1120,9 @@ hypothesis scoring with OREDA, historian, STID, and NeqSim simulation verificati
 | **Field Development Decision Engine**     | [examples/notebooks/field_development_decision_engine.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/field_development_decision_engine.ipynb) | **Concept templates, lifecycle emissions, MCDA ranking, portfolio optimization, and report-ready tables** |
 | **Field Development Process Coupling**    | [examples/notebooks/field_development_process_reservoir_coupling.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/field_development_process_reservoir_coupling.ipynb) | **Tieback route networks, gathering allocation, process utility generation, and VFP/schedule export** |
 | **Host Tie-In Capacity and Holdback**     | [examples/notebooks/host_tie_in_capacity_and_holdback.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/host_tie_in_capacity_and_holdback.ipynb) | **Brownfield host capacity, satellite holdback, process-equipment bottlenecks, and debottleneck value** |
-| **Multi-Scenario VFP Tutorial**           | [docs/examples/MultiScenarioVFP_Tutorial.ipynb](examples/MultiScenarioVFP_Tutorial.md)                            | **VFP generation with varying GOR/water cut scenarios**                                                            |
-| **Production System Bottleneck Analysis** | [docs/examples/ProductionSystem_BottleneckAnalysis.ipynb](examples/ProductionSystem_BottleneckAnalysis.md)        | **Multi-well system optimization, bottleneck identification, and well prioritization**                             |
-| **Integrated Production & Risk Analysis** | [docs/examples/IntegratedProductionRiskAnalysis.ipynb](examples/IntegratedProductionRiskAnalysis.md)              | **Complete operational workflow combining bottleneck analysis with risk simulation, Monte Carlo, and risk matrix** |
+| **Multi-Scenario VFP Tutorial**           | [docs/examples/MultiScenarioVFP_Tutorial.md](examples/MultiScenarioVFP_Tutorial.md)                            | **VFP generation with varying GOR/water cut scenarios**                                                            |
+| **Production System Bottleneck Analysis** | [docs/examples/ProductionSystem_BottleneckAnalysis.md](examples/ProductionSystem_BottleneckAnalysis.md)        | **Multi-well system optimization, bottleneck identification, and well prioritization**                             |
+| **Integrated Production & Risk Analysis** | [docs/examples/IntegratedProductionRiskAnalysis.md](examples/IntegratedProductionRiskAnalysis.md)              | **Complete operational workflow combining bottleneck analysis with risk simulation, Monte Carlo, and risk matrix** |
 | **LNG Heat Exchanger Demo**               | [examples/notebooks/LNGHeatExchanger_ComprehensiveDemo.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/LNGHeatExchanger_ComprehensiveDemo.ipynb) | **Comprehensive BAHX demo: composite curves, exergy, adaptive zones, Manglik-Bergles, transient cool-down, core sizing, freeze-out, maldistribution, mechanical design, cost estimation, SMR cycle** |
 | **LNG Ageing Basics**                     | [examples/notebooks/lng_ageing_basics.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/lng_ageing_basics.ipynb)                                   | **Single-tank LNG ageing simulation: composition evolution, BOG, Wobbe index, voyage profiles** |
 | **LNG Ageing Advanced**                   | [examples/notebooks/lng_ageing_advanced.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/lng_ageing_advanced.ipynb)                               | **Advanced LNG ageing: tank geometry, sloshing, methane number, rollover detection, multi-zone heat transfer** |
@@ -1141,7 +1141,7 @@ hypothesis scoring with OREDA, historian, STID, and NeqSim simulation verificati
 
 | Document               | Path                                                                            | Description                                          |
 | ---------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| **GitHub Pages Setup** | [docs/GITHUB_PAGES_SETUP.md](GITHUB_PAGES_SETUP.md)                                | **NEW** Enable GitHub Pages for hosted documentation |
+| **GitHub Pages Setup** | [docs/GITHUB_PAGES_SETUP.md](GITHUB_PAGES_SETUP.md)                                | Enable GitHub Pages for hosted documentation |
 | Reference Manual       | [docs/manual/neqsim_reference_manual.html](manual/neqsim_reference_manual.html) | Interactive reference manual                         |
 | Documentation Index    | [docs/index.md](index.md)                                                          | GitHub Pages home page                               |
 
@@ -1184,28 +1184,34 @@ hypothesis scoring with OREDA, historian, STID, and NeqSim simulation verificati
 | --------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | Utilities                   | [docs/util/README.md](util/README.md)                                                 | Utility functions                                                                    |
 | Unit Conversion             | [docs/util/unit_conversion.md](util/unit_conversion.md)                         | Unit conversion guide                                                                |
-| **Unit Conversion Recipes** | [docs/cookbook/unit-conversion-recipes.md](cookbook/unit-conversion-recipes.md) | **NEW** Quick reference for all supported unit strings                               |
-| **Optimizer Guide**         | [docs/util/optimizer_guide.md](util/optimizer_guide.md)                         | **NEW** Comprehensive optimization framework with BFGS, Pareto, sensitivity analysis |
+| **Unit Conversion Recipes** | [docs/cookbook/unit-conversion-recipes.md](cookbook/unit-conversion-recipes.md) | Quick reference for all supported unit strings                               |
+| **Optimizer Guide**         | [docs/util/optimizer_guide.md](util/optimizer_guide.md)                         | Comprehensive optimization framework with BFGS, Pareto, sensitivity analysis |
+
+### Appendix E: Wiki Reference
+
+| Document      | Path                         | Description        |
+| ------------- | ---------------------------- | ------------------ |
+| Wiki Overview | [docs/wiki/README.md](wiki/README.md) | Wiki documentation |
 
 ### Appendix F: Process Design Templates
 
 | Document            | Path                                                                     | Description                                                                 |
 | ------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
-| **Templates Guide** | [docs/process/design/templates_guide.md](process/design/templates_guide.md) | **NEW** Pre-built process templates (compression, dehydration, CO2 capture) |
+| **Templates Guide** | [docs/process/design/templates_guide.md](process/design/templates_guide.md) | Pre-built process templates (compression, dehydration, CO2 capture) |
 
 ### Appendix G: Mechanical Design Standards
 
 | Document                | Path                                                                                                   | Description                                                 |
 | ----------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
-| **TEMA Standard Guide** | [docs/process/mechanical_design/tema_standard_guide.md](process/mechanical_design/tema_standard_guide.md) | **NEW** TEMA shell and tube heat exchanger design standards |
-| **Thermal-Hydraulic Design** | [docs/process/mechanical_design/thermal_hydraulic_design.md](process/mechanical_design/thermal_hydraulic_design.md) | **NEW** Tube/shell HTC (Gnielinski, Kern, Bell-Delaware), overall U, pressure drops, LMTD correction, vibration screening, rating mode |
-| **Two-Phase Heat Transfer** | [docs/process/mechanical_design/two_phase_heat_transfer.md](process/mechanical_design/two_phase_heat_transfer.md) | **NEW** Shah condensation, Chen/Gungor-Winterton boiling, Friedel/MSH two-phase pressure drop, Ebert-Panchal fouling, incremental zone analysis, tube inserts |
+| **TEMA Standard Guide** | [docs/process/mechanical_design/tema_standard_guide.md](process/mechanical_design/tema_standard_guide.md) | TEMA shell and tube heat exchanger design standards |
+| **Thermal-Hydraulic Design** | [docs/process/mechanical_design/thermal_hydraulic_design.md](process/mechanical_design/thermal_hydraulic_design.md) | Tube/shell HTC (Gnielinski, Kern, Bell-Delaware), overall U, pressure drops, LMTD correction, vibration screening, rating mode |
+| **Two-Phase Heat Transfer** | [docs/process/mechanical_design/two_phase_heat_transfer.md](process/mechanical_design/two_phase_heat_transfer.md) | Shah condensation, Chen/Gungor-Winterton boiling, Friedel/MSH two-phase pressure drop, Ebert-Panchal fouling, incremental zone analysis, tube inserts |
 
 ### Appendix H: Cookbook (Quick Recipes)
 
 | Document               | Path                                                                       | Description                                         |
 | ---------------------- | -------------------------------------------------------------------------- | --------------------------------------------------- |
-| **Cookbook Index**     | [docs/cookbook/index.md](cookbook/index.md)                                   | **NEW** Quick copy-paste recipes for common tasks   |
+| **Cookbook Index**     | [docs/cookbook/index.md](cookbook/index.md)                                   | Quick copy-paste recipes for common tasks   |
 | Thermodynamics Recipes | [docs/cookbook/thermodynamics-recipes.md](cookbook/thermodynamics-recipes.md) | Fluids, flash, properties, phase envelopes          |
 | Process Recipes        | [docs/cookbook/process-recipes.md](cookbook/process-recipes.md)               | Separators, compressors, heat exchangers            |
 | Pipeline Recipes       | [docs/cookbook/pipeline-recipes.md](cookbook/pipeline-recipes.md)             | Pressure drop, multiphase flow                      |
@@ -1215,41 +1221,17 @@ hypothesis scoring with OREDA, historian, STID, and NeqSim simulation verificati
 
 | Document                  | Path                                                   | Description                          |
 | ------------------------- | ------------------------------------------------------ | ------------------------------------ |
-| **Troubleshooting Guide** | [docs/troubleshooting/index.md](troubleshooting/index.md) | **NEW** Solutions to common problems |
+| **Troubleshooting Guide** | [docs/troubleshooting/index.md](troubleshooting/index.md) | Solutions to common problems |
 
-### Appendix E: Wiki Reference
+## Index coverage and maintenance
 
-| Document      | Path                         | Description        |
-| ------------- | ---------------------------- | ------------------ |
-| Wiki Overview | [docs/wiki/README.md](wiki/README.md) | Wiki documentation |
+This page is a curated navigation surface, not a hand-counted inventory. Repository CI builds the
+search index from every publishable documentation source and reports the audited Markdown and
+standalone HTML totals. Use [Documentation Search](search/index.md) when a topic is not listed
+here.
 
----
-
-## Document Statistics
-
-| Category               | Count   |
-| ---------------------- | ------- |
-| Wiki/Tutorials         | 60      |
-| Thermodynamics         | 26      |
-| Process Simulation     | 49      |
-| Safety Systems         | 18      |
-| **Risk Simulation**    | **13**  |
-| Field Development      | 11      |
-| Integration/AI         | 12      |
-| Pipeline/Flow          | 17      |
-| PVT/Reservoir          | 15      |
-| Standards              | 6       |
-| Development            | 11      |
-| Statistics             | 4       |
-| Examples               | 19      |
-| **Optimization**       | **5**   |
-| **Templates & Design** | **2**   |
-| **Quickstart Guides**  | **4**   |
-| **Cookbook**           | **6**   |
-| **Tutorials/Learning** | **2**   |
-| **Troubleshooting**    | **1**   |
-| Other                  | 24      |
-| **Total**              | **303** |
+The index is maintained by topic and source path. Entries do not carry date-sensitive "new"
+badges; version history and merge dates remain available in Git.
 
 ---
 
@@ -1266,4 +1248,4 @@ hypothesis scoring with OREDA, historian, STID, and NeqSim simulation verificati
 
 ---
 
-*This index was updated after comprehensive documentation review. Last updated: February 2026*
+*Curated index entries are validated against repository source paths by CI.*

--- a/docs/REFERENCE_MANUAL_INDEX.md
+++ b/docs/REFERENCE_MANUAL_INDEX.md
@@ -1227,8 +1227,7 @@ hypothesis scoring with OREDA, historian, STID, and NeqSim simulation verificati
 
 This page is a curated navigation surface, not a hand-counted inventory. Repository CI builds the
 search index from every publishable documentation source and reports the audited Markdown and
-standalone HTML totals. Use [Documentation Search](search/index.md) when a topic is not listed
-here.
+standalone HTML totals. Use the site search when a topic is not listed here.
 
 The index is maintained by topic and source path. Entries do not carry date-sensitive "new"
 badges; version history and merge dates remain available in Git.

--- a/docs/test_reference_manual_index_documentation.py
+++ b/docs/test_reference_manual_index_documentation.py
@@ -54,6 +54,35 @@ class ReferenceManualIndexDocumentationTest(unittest.TestCase):
                 failures.append("{} -> {}".format(target, resolved.relative_to(ROOT)))
         self.assertEqual([], failures)
 
+    def test_maintenance_claims_are_generated_not_date_or_count_bound(self):
+        self.assertIn("not a hand-counted inventory", self.index)
+        self.assertIn("reports the audited Markdown", self.index)
+        self.assertNotIn("## Document Statistics", self.index)
+        self.assertNotIn("**NEW**", self.index)
+        self.assertNotIn("Last updated:", self.index)
+
+    def test_appendices_are_in_alphabetical_navigation_order(self):
+        appendices = re.findall(r"(?m)^### Appendix ([A-Z]):", self.index)
+        self.assertEqual(list("ABCDEFGHI"), appendices)
+
+    def test_source_path_labels_match_their_internal_targets(self):
+        source_links = re.findall(r"\\[([^\\]]+)\\]\\(([^)\\s]+)\\)", self.index)
+        checked = 0
+        mismatches = []
+        for label, target in source_links:
+            if not label.startswith("docs/"):
+                continue
+            path_text = target.split("#", 1)[0].split("?", 1)[0]
+            if re.match(r"^[a-z][a-z0-9+.-]*:", path_text, re.IGNORECASE):
+                continue
+            checked += 1
+            expected = label[len("docs/") :]
+            actual = unquote(path_text)
+            if expected != actual:
+                mismatches.append("{} -> {}".format(label, target))
+        self.assertGreater(checked, 600)
+        self.assertEqual([], mismatches)
+
     def test_fragment_and_landing_targets_are_source_safe(self):
         self.assertIn(
             "(process/plant-data-tagreader.md#step-5-neqsimapi-cloud-rest)",

--- a/docs/test_reference_manual_index_documentation.py
+++ b/docs/test_reference_manual_index_documentation.py
@@ -77,7 +77,7 @@ class ReferenceManualIndexDocumentationTest(unittest.TestCase):
                 continue
             checked += 1
             expected = label[len("docs/") :]
-            actual = unquote(path_text)
+            actual = unquote(target)
             if expected != actual:
                 mismatches.append("{} -> {}".format(label, target))
         self.assertGreater(checked, 600)

--- a/docs/test_reference_manual_index_documentation.py
+++ b/docs/test_reference_manual_index_documentation.py
@@ -66,7 +66,7 @@ class ReferenceManualIndexDocumentationTest(unittest.TestCase):
         self.assertEqual(list("ABCDEFGHI"), appendices)
 
     def test_source_path_labels_match_their_internal_targets(self):
-        source_links = re.findall(r"\\[([^\\]]+)\\]\\(([^)\\s]+)\\)", self.index)
+        source_links = re.findall(r"\[([^\]]+)\]\(([^)\s]+)\)", self.index)
         checked = 0
         mismatches = []
         for label, target in source_links:


### PR DESCRIPTION
## Summary

- remove 12 stale `NEW` markers and replace the hand-maintained document-count/date claims with durable CI-backed maintenance guidance
- correct three displayed notebook source paths that actually target rendered Markdown sources
- restore alphabetical appendix navigation and add regression coverage for maintenance claims, appendix order, and displayed source/target agreement

## Frozen documentation contract

**Campaign:** #2499, D090, rotation scope 1 — landing pages, navigation, indexes, and internal links.

**Exact base:** `a85d255bc4f0b63b3f3b6009042e9ad17bb09117`

**Exact head:** `5681570d2321dd504569169c2cc28d3ad1546ea9`

**Confirmed defects:** 18 total: 12 stale date-sensitive badges, 3 displayed-source/target mismatches, 1 stale hand-counted statistics block, 1 appendix-order defect, and 1 stale update date.

**Acceptance criteria:** no date-sensitive `NEW`/last-updated claims; no hand-maintained repository totals; appendices A–I in order; every displayed `docs/...` source path agrees with its complete internal target; existing explicit-source and repository-resolution contracts remain active.

**Stop boundary:** no broad content reorganization, generated search implementation, production code, notebooks, equations, external-link migration, or Huldra work.

## Validation

**READY TO MERGE** at exact head `5681570d2321dd504569169c2cc28d3ad1546ea9`.

GitHub exact-head workflows:

- Documentation search coverage: passed — source contracts, all 8 documentation contracts, Jekyll build, generated search coverage, and search JavaScript syntax
- Pre-commit checks: passed
- Spotless format patch: passed
- CodeQL Security Analysis: passed
- Build/test/Javadocs workflow: passed its applicable documentation-only gates; change detection and agent-skill cross-references passed, while Java test/Javadoc jobs were correctly skipped because neither Java nor XML changed

Final connector audit:

- 5 commits ahead, 0 behind, mergeable, exactly 2 frozen files
- 611 displayed `docs/...` source labels match their complete relative targets
- appendix headings are exactly A–I
- no `**NEW**`, `Last updated:`, `## Document Statistics`, duplicate body H1, or invented search source link remains
- no reviews or unresolved inline threads

No local Python, Jekyll, pre-commit, Spotless, Maven, or Java execution is claimed; validation above is from GitHub on the exact head.

## Documentation impact

Documentation is the implementation. Updated:

- `docs/REFERENCE_MANUAL_INDEX.md`
- `docs/test_reference_manual_index_documentation.py`

No public API, runtime behavior, units, models, examples, or notebooks change.

Refs #2499
