### PR TITLE
[AI-Assisted] feat(dexpi): assess graphical projection export equivalence

### DIFF
--- a/docs/integration/dexpi-engineering-generation.md
+++ b/docs/integration/dexpi-engineering-generation.md
@@ -758,3 +758,34 @@ The focused regression compiles this API and verifies deterministic XML, real `R
 references, all four exchange-neutral primitive mappings, loss diagnostics, and rejection of empty
 `RepresentationGroup` placeholders. External DEXPIViewer has not been rerun for this adapter, so
 no clean-validation or interoperability claim is made.
+
+### Inspect supported graphical export equivalence
+
+`Dexpi20GraphicalProjectionAssessment` compares the controlled source projection with the exact
+native DEXPI XML bytes after export. The report records the inspected file's full SHA-256, stable
+primitive identities, represented external keys, mapped geometry and styles, diagram metadata and
+bounds, and explicit deterministic approximations. It fails closed for missing, unexpected,
+duplicate, unresolved, or changed supported content.
+
+```java
+Dexpi20GraphicalProjectionReport exportReport = Dexpi20GraphicalProjectionWriter.write(
+    processSystem,
+    projection,
+    outputFile,
+    Dexpi20PlantExportOptions.builder(metadata).build());
+
+Dexpi20GraphicalProjectionAssessment.Report assessment =
+    Dexpi20GraphicalProjectionAssessment.assess(projection, outputFile.toPath());
+
+if (!exportReport.isComplete() || !assessment.isSupportedProjectionEquivalent()) {
+  throw new IllegalStateException(assessment.toJson());
+}
+```
+
+This assessment verifies only the generic Core mapping that NeqSim supports. Solid polygon fill
+retains its state but not its source colour, numeric dash arrays map to the generic `Dash`
+enumeration, and required missing colours fall back to black; each confirmed approximation remains
+a warning in the machine-readable evidence. The assessment is not a DEXPI reader, profile-symbol
+qualification, external-validator result, ISO 10628 claim, or accountable drawing approval.
+Negative regressions corrupt a stable primitive identity and a `Represents` reference to prove that
+the gate detects semantic damage rather than merely accepting parseable XML.

--- a/docs/integration/dexpi-pid-current-master-audit.md
+++ b/docs/integration/dexpi-pid-current-master-audit.md
@@ -172,10 +172,10 @@ licensed standards, a named external tool, or accountable engineering review.
 | Schema/API compatibility and migration | Partial | Compatibility facades and byte-equivalent tested paths exist; no comprehensive versioned package migration suite covers every serialized artifact |
 | Revision semantic diff/impact | Partial | Engineering graph/package revision impact exists; affected drawing/sheet/register/study completeness is not yet end-to-end |
 | Professional symbols and project conventions | Partial/external | Proteus shapes, ISA/NORSOK tag helpers and proposal rules exist; a licensed ISO 10628/14617 mapping and reviewed vector catalog remain external/gap |
-| Native DEXPI Core graphical projection | Partial | The opt-in exchange-neutral adapter emits non-empty Core Diagram/RepresentationGroup structures with generic Polygon, PolyLine, and Text primitives and structured mapping/loss reports; no Profile/SymbolUsage, clean external-validator, standards, or approval claim is made |
-| Multi-sheet documents and off-page references | Gap | Compatibility per-area sheets and off-page graphics exist, but no controlled document/drawing/sheet identity, paired connector, zone reference, completeness, or persistent override model exists |
-| Professional native SVG/PDF | Gap | Current SVG/PDF paths depend on Graphviz or external/tool-specific rendering; no shared deterministic native renderer is qualified |
-| Drawing-quality metrics and visual regression | Partial | Structural/routing tests exist; normalized native SVG/PDF collision, clipping, label, and readability gates do not |
+| Native DEXPI Core graphical projection | Assessed supported subset | The opt-in exchange-neutral adapter emits non-empty Core Diagram/RepresentationGroup structures with generic Polygon, PolyLine, and Text primitives. `Dexpi20GraphicalProjectionAssessment` verifies stable represented identities, mapped geometry/style, diagram metadata/bounds, exact-file SHA-256 provenance, and explicit losses; no Profile/SymbolUsage, clean external-validator, standards, or approval claim is made |
+| Multi-sheet documents and off-page references | Implemented foundation | `EngineeringDiagramDocumentSet` owns deterministic drawing/sheet IDs, controlled references, paired off-page connectors, zones, revision/status metadata, validation, and restartable layout overrides; accountable completeness and project-specific approval remain external |
+| Professional native SVG/PDF | Implemented foundation | `NativeEngineeringDiagramRenderer` produces deterministic opt-in SVG/PDF from the shared document model with fixed-port orthogonal routing, parallel lanes, title/revision fields, off-page connectors, and diagnostics while legacy Graphviz remains unchanged |
+| Drawing-quality metrics and visual regression | Partial | Native rendering reports collision, clearance, bounds, routing, label, and off-page findings with deterministic regressions; a broader reviewed symbol/readability reference corpus remains incomplete |
 | Detailed P&ID object coverage | Partial | Governed proposal rules cover important controls and safeguards; complete nozzle, fitting, reducer, drain/vent, bypass, blind, valve, analyzer, package, and line-design evidence is not uniform |
 | Simulation-backed engineering enrichment | Partial | Coordinated cases, registers, calculations, DEXPI packages and selected canonical stream values exist; governing envelopes and all equipment/design selections are not uniformly linked through the exchange |
 | DEXPI-centred study audits | Partial | Completeness, HAZOP preparation, SIS/HIPPS and qualification evidence exist; revision/MOC deltas and reusable selected-object study hooks are incomplete |
@@ -187,8 +187,15 @@ licensed standards, a named external tool, or accountable engineering review.
 
 ## Dependency-ordered next work
 
-After this reference-case baseline is merged and its exact-head CI is recorded, the shared lane can
-start the Phase 1 immutable diagram/document model. That model must own stable
-document/drawing/sheet IDs, views of one semantic plant, paired off-page references,
-revision/status metadata, persistent layout decisions, and structured loss diagnostics while
-leaving legacy DOT/Graphviz, native DEXPI 2.0, and Proteus/P&ID APIs unchanged.
+The immutable diagram/document model, deterministic native SVG/PDF renderer, fixed-port routing,
+exchange-neutral graphical projection, generic DEXPI Core adapter, and supported-content
+export-inspection assessment now form the merged dependency chain. The next graphical tranche is
+blocked on a controlled choice between an exchange-neutral reviewed symbol projection and a pinned,
+legally distributable DEXPI profile-symbol catalogue. Empty placeholder representation groups and
+invented standards mappings are not acceptable substitutes.
+
+Independent remaining work includes native Process multi-area and energy/information scope,
+end-to-end revision/MOC impact, broader P&ID object coverage, a reviewed visual-reference corpus,
+fresh exact-version external DEXPIViewer execution, and named commercial-CAE qualification. These
+items must retain legacy DOT/Graphviz, native DEXPI 2.0, and Proteus/P&ID compatibility and must not
+be reported as standards conformance or drawing approval without accountable evidence.

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20GraphicalProjectionAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20GraphicalProjectionAssessment.java
@@ -106,9 +106,8 @@ public final class Dexpi20GraphicalProjectionAssessment {
     private final int matchedPrimitiveCount;
     private final List<Diagnostic> diagnostics;
 
-    Report(EngineeringGraphicalProjection projection, String inspectedFileSha256,
-        Map<String, String> expected, Map<String, String> exported, int matchedPrimitiveCount,
-        List<Diagnostic> diagnostics) {
+    Report(EngineeringGraphicalProjection projection, String inspectedFileSha256, Map<String, String> expected,
+        Map<String, String> exported, int matchedPrimitiveCount, List<Diagnostic> diagnostics) {
       this.sourceGraphFingerprint = projection.getSourceGraphFingerprint();
       this.sourceReference = projection.getSourceReference();
       this.revision = projection.getRevision();
@@ -347,8 +346,7 @@ public final class Dexpi20GraphicalProjectionAssessment {
     return result.toString();
   }
 
-  private static int compare(Map<String, String> expected, Map<String, String> exported,
-      List<Diagnostic> diagnostics) {
+  private static int compare(Map<String, String> expected, Map<String, String> exported, List<Diagnostic> diagnostics) {
     Set<String> ids = new LinkedHashSet<String>();
     ids.addAll(expected.keySet());
     ids.addAll(exported.keySet());
@@ -372,8 +370,8 @@ public final class Dexpi20GraphicalProjectionAssessment {
 
   private static void assessDiagram(Document document, EngineeringGraphicalProjection projection,
       List<Diagnostic> diagnostics) {
-    String id = "Diagram_" + Dexpi20GraphicalProjectionWriter
-        .digest(projection.getProjectId() + ":" + projection.getRevision());
+    String id = "Diagram_"
+        + Dexpi20GraphicalProjectionWriter.digest(projection.getProjectId() + ":" + projection.getRevision());
     Element diagram = objectById(document, id);
     if (diagram == null || !"Core/Diagram.Diagram".equals(diagram.getAttribute("type"))) {
       diagnostics.add(error("DEXPI_GRAPHICS_DIAGRAM_MISSING",
@@ -387,8 +385,8 @@ public final class Dexpi20GraphicalProjectionAssessment {
           "Diagram name does not retain project, revision, and controlled source reference", id));
     }
     double[] expected = bounds(projection.getPrimitives());
-    double[] actual = new double[] {directDouble(diagram, "MinX"), directDouble(diagram, "MinY"),
-        directDouble(diagram, "MaxX"), directDouble(diagram, "MaxY")};
+    double[] actual = new double[] { directDouble(diagram, "MinX"), directDouble(diagram, "MinY"),
+        directDouble(diagram, "MaxX"), directDouble(diagram, "MaxY") };
     for (int index = 0; index < expected.length; index++) {
       if (Double.compare(expected[index], actual[index]) != 0) {
         diagnostics.add(error("DEXPI_GRAPHICS_DIAGRAM_BOUNDS_MISMATCH",
@@ -641,7 +639,7 @@ public final class Dexpi20GraphicalProjectionAssessment {
         maxY = Math.max(maxY, value.getY());
       }
     }
-    return new double[] {minX - 10.0, minY - 10.0, maxX + 10.0, maxY + 10.0};
+    return new double[] { minX - 10.0, minY - 10.0, maxX + 10.0, maxY + 10.0 };
   }
 
   private static Diagnostic warning(String code, String message, String subjectId) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20GraphicalProjectionAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20GraphicalProjectionAssessment.java
@@ -1,0 +1,683 @@
+package neqsim.process.processmodel.dexpi;
+
+import com.google.gson.GsonBuilder;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection.Point;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection.Primitive;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection.PrimitiveType;
+
+/**
+ * Assesses whether supported generic graphical content survives native DEXPI 2.0 serialization.
+ *
+ * <p>
+ * This is an internal export-inspection check, not a DEXPI profile, external-tool, standards-conformance, or drawing
+ * approval claim. It compares stable primitive identities, represented-object references, mapped geometry and mapped
+ * styles. Deliberately lossy mappings remain explicit diagnostics.
+ * </p>
+ */
+public final class Dexpi20GraphicalProjectionAssessment {
+  private static final String SCHEMA_VERSION = "neqsim_dexpi_2_0_graphical_projection_assessment.v1";
+
+  private Dexpi20GraphicalProjectionAssessment() {
+  }
+
+  /** Severity of one graphical-equivalence diagnostic. */
+  public enum Severity {
+    /** Informational evidence that does not affect supported equivalence. */
+    INFO,
+    /** Confirmed deterministic approximation or retained graphical loss. */
+    WARNING,
+    /** Missing, unexpected, ambiguous, or changed supported content. */
+    ERROR
+  }
+
+  /** Immutable graphical-equivalence diagnostic. */
+  public static final class Diagnostic implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Severity severity;
+    private final String code;
+    private final String message;
+    private final String subjectId;
+
+    Diagnostic(Severity severity, String code, String message, String subjectId) {
+      this.severity = severity;
+      this.code = code;
+      this.message = message;
+      this.subjectId = subjectId == null ? "" : subjectId;
+    }
+
+    public Severity getSeverity() {
+      return severity;
+    }
+
+    public String getCode() {
+      return code;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public String getSubjectId() {
+      return subjectId;
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("severity", severity.name());
+      result.put("code", code);
+      result.put("message", message);
+      result.put("subjectId", subjectId);
+      return result;
+    }
+  }
+
+  /** Deterministic evidence for supported graphical export equivalence. */
+  public static final class Report implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String sourceGraphFingerprint;
+    private final String sourceReference;
+    private final String revision;
+    private final String inspectedFileSha256;
+    private final Map<String, String> expectedPrimitiveSignatures;
+    private final Map<String, String> exportedPrimitiveSignatures;
+    private final int matchedPrimitiveCount;
+    private final List<Diagnostic> diagnostics;
+
+    Report(EngineeringGraphicalProjection projection, String inspectedFileSha256,
+        Map<String, String> expected, Map<String, String> exported, int matchedPrimitiveCount,
+        List<Diagnostic> diagnostics) {
+      this.sourceGraphFingerprint = projection.getSourceGraphFingerprint();
+      this.sourceReference = projection.getSourceReference();
+      this.revision = projection.getRevision();
+      this.inspectedFileSha256 = inspectedFileSha256;
+      this.expectedPrimitiveSignatures = immutableMap(expected);
+      this.exportedPrimitiveSignatures = immutableMap(exported);
+      this.matchedPrimitiveCount = matchedPrimitiveCount;
+      this.diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+    }
+
+    public String getSourceGraphFingerprint() {
+      return sourceGraphFingerprint;
+    }
+
+    public String getSourceReference() {
+      return sourceReference;
+    }
+
+    public String getRevision() {
+      return revision;
+    }
+
+    /**
+     * Returns the full SHA-256 of the exact inspected DEXPI XML bytes.
+     *
+     * @return lower-case hexadecimal SHA-256
+     */
+    public String getInspectedFileSha256() {
+      return inspectedFileSha256;
+    }
+
+    public Map<String, String> getExpectedPrimitiveSignatures() {
+      return expectedPrimitiveSignatures;
+    }
+
+    public Map<String, String> getExportedPrimitiveSignatures() {
+      return exportedPrimitiveSignatures;
+    }
+
+    public int getMatchedPrimitiveCount() {
+      return matchedPrimitiveCount;
+    }
+
+    public List<Diagnostic> getDiagnostics() {
+      return diagnostics;
+    }
+
+    /**
+     * Returns whether every supported projected primitive survived with equivalent mapped semantics.
+     *
+     * @return true when there are no equivalence errors
+     */
+    public boolean isSupportedProjectionEquivalent() {
+      for (Diagnostic diagnostic : diagnostics) {
+        if (diagnostic.getSeverity() == Severity.ERROR) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    /**
+     * Returns deterministic machine-readable assessment evidence.
+     *
+     * @return key-ordered evidence map
+     */
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("schemaVersion", SCHEMA_VERSION);
+      result.put("sourceGraphFingerprint", sourceGraphFingerprint);
+      result.put("sourceReference", sourceReference);
+      result.put("revision", revision);
+      result.put("inspectedFileSha256", inspectedFileSha256);
+      result.put("engineeringState", "CALCULATED_GRAPHICS");
+      result.put("approvalStatus", "REVIEW_REQUIRED");
+      result.put("expectedPrimitiveSignatures", expectedPrimitiveSignatures);
+      result.put("exportedPrimitiveSignatures", exportedPrimitiveSignatures);
+      result.put("expectedPrimitiveCount", Integer.valueOf(expectedPrimitiveSignatures.size()));
+      result.put("exportedPrimitiveCount", Integer.valueOf(exportedPrimitiveSignatures.size()));
+      result.put("matchedPrimitiveCount", Integer.valueOf(matchedPrimitiveCount));
+      List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
+      for (Diagnostic diagnostic : diagnostics) {
+        diagnosticMaps.add(diagnostic.toMap());
+      }
+      result.put("diagnostics", diagnosticMaps);
+      result.put("supportedProjectionEquivalent", Boolean.valueOf(isSupportedProjectionEquivalent()));
+      return result;
+    }
+
+    /**
+     * Returns deterministic pretty-printed JSON evidence.
+     *
+     * @return JSON assessment
+     */
+    public String toJson() {
+      return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+    }
+
+    private static Map<String, String> immutableMap(Map<String, String> source) {
+      return Collections.unmodifiableMap(new LinkedHashMap<String, String>(new TreeMap<String, String>(source)));
+    }
+  }
+
+  /**
+   * Inspects one native DEXPI 2.0 file against the projection that drove its graphical export.
+   *
+   * @param projection controlled source projection
+   * @param file native DEXPI 2.0 file to inspect
+   * @return deterministic supported-content equivalence evidence
+   * @throws IOException when the file cannot be parsed
+   */
+  public static Report assess(EngineeringGraphicalProjection projection, Path file) throws IOException {
+    if (projection == null || file == null) {
+      throw new IllegalArgumentException("projection and file must not be null");
+    }
+    Document document = parse(file);
+    List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
+    Map<String, String> expected = expectedSignatures(projection, diagnostics);
+    Map<String, String> exported = exportedSignatures(document, diagnostics);
+    assessDiagram(document, projection, diagnostics);
+    int matched = compare(expected, exported, diagnostics);
+    Collections.sort(diagnostics, new Comparator<Diagnostic>() {
+      @Override
+      public int compare(Diagnostic left, Diagnostic right) {
+        int bySeverity = left.getSeverity().compareTo(right.getSeverity());
+        if (bySeverity != 0) {
+          return bySeverity;
+        }
+        int byCode = left.getCode().compareTo(right.getCode());
+        return byCode == 0 ? left.getSubjectId().compareTo(right.getSubjectId()) : byCode;
+      }
+    });
+    return new Report(projection, sha256(file), expected, exported, matched, diagnostics);
+  }
+
+  private static Map<String, String> expectedSignatures(EngineeringGraphicalProjection projection,
+      List<Diagnostic> diagnostics) {
+    Map<String, String> result = new TreeMap<String, String>();
+    for (Primitive primitive : projection.getPrimitives()) {
+      String id = "GraphicalPrimitive_" + Dexpi20GraphicalProjectionWriter.digest(primitive.getId());
+      if (result.put(id, expectedSignature(primitive, diagnostics)) != null) {
+        diagnostics.add(error("DEXPI_GRAPHICS_EXPECTED_ID_COLLISION",
+            "Two projection primitives resolve to the same stable DEXPI identity", primitive.getId()));
+      }
+    }
+    return result;
+  }
+
+  private static String expectedSignature(Primitive primitive, List<Diagnostic> diagnostics) {
+    StringBuilder result = new StringBuilder();
+    result.append(primitive.getRepresentedExternalKey()).append('|');
+    if (primitive.getType() == PrimitiveType.TEXT) {
+      result.append("Core/Diagram.Text|");
+      result.append(point(primitive.getX(), primitive.getY())).append('|');
+      result.append(primitive.getText()).append('|');
+      result.append(number(primitive.getSize())).append('|');
+      result.append(textAlignment(primitive.getTextAnchor())).append('|');
+      result.append(color("none".equals(primitive.getFillColor()) ? "#000000" : primitive.getFillColor()));
+      if ("none".equals(primitive.getFillColor())) {
+        diagnostics.add(warning("DEXPI_GRAPHICS_COLOR_FALLBACK_CONFIRMED",
+            "DEXPI Core requires text color, so projection color none maps to black", primitive.getId()));
+      }
+      return result.toString();
+    }
+    if (primitive.getType() == PrimitiveType.POLYLINE) {
+      result.append("Core/Diagram.PolyLine|");
+      result.append(points(primitive.getPoints())).append('|');
+    } else {
+      result.append("Core/Diagram.Polygon|");
+      result.append(points(polygonPoints(primitive))).append('|');
+      result.append("none".equals(primitive.getFillColor()) ? "Transparent" : "Solid").append('|');
+      if (!"none".equals(primitive.getFillColor())) {
+        diagnostics.add(warning("DEXPI_GRAPHICS_FILL_COLOR_LOSS_CONFIRMED",
+            "DEXPI Core Polygon retains solid fill state but not the projection fill color", primitive.getId()));
+      }
+    }
+    result.append(color("none".equals(primitive.getStrokeColor()) ? "#000000" : primitive.getStrokeColor()))
+        .append('|');
+    result.append(primitive.getDashPattern().isEmpty() ? "Solid" : "Dash").append('|');
+    result.append(number(primitive.getStrokeWidth()));
+    if (!primitive.getDashPattern().isEmpty()) {
+      diagnostics.add(warning("DEXPI_GRAPHICS_DASH_APPROXIMATION_CONFIRMED",
+          "Numeric projection dash pattern maps to the generic DEXPI Dash enumeration", primitive.getId()));
+    }
+    return result.toString();
+  }
+
+  private static Map<String, String> exportedSignatures(Document document, List<Diagnostic> diagnostics) {
+    Map<String, String> objectKeys = representedExternalKeys(document);
+    Map<Element, String> groupKeys = representationGroupKeys(document, objectKeys, diagnostics);
+    Map<String, String> result = new TreeMap<String, String>();
+    NodeList objects = document.getElementsByTagName("Object");
+    for (int index = 0; index < objects.getLength(); index++) {
+      Element object = (Element) objects.item(index);
+      String id = object.getAttribute("id");
+      if (!id.startsWith("GraphicalPrimitive_")) {
+        continue;
+      }
+      Element group = ancestor(object, "Core/Diagram.RepresentationGroup");
+      String externalKey = group == null ? "" : groupKeys.get(group);
+      if (group == null || externalKey == null || externalKey.isEmpty()) {
+        diagnostics.add(error("DEXPI_GRAPHICS_PRIMITIVE_GROUP_UNRESOLVED",
+            "Graphical primitive does not resolve through a representation group to one exported object", id));
+        externalKey = "";
+      }
+      String previous = result.put(id, exportedSignature(object, externalKey));
+      if (previous != null) {
+        diagnostics.add(error("DEXPI_GRAPHICS_EXPORTED_ID_DUPLICATE",
+            "DEXPI document contains duplicate graphical primitive identities", id));
+      }
+    }
+    return result;
+  }
+
+  private static String exportedSignature(Element primitive, String externalKey) {
+    String type = primitive.getAttribute("type");
+    StringBuilder result = new StringBuilder();
+    result.append(externalKey).append('|').append(type).append('|');
+    if ("Core/Diagram.Text".equals(type)) {
+      Element position = directAggregate(primitive, "Position");
+      result.append(point(directDouble(position, "X"), directDouble(position, "Y"))).append('|');
+      result.append(directString(primitive, "Text")).append('|');
+      result.append(number(directDouble(primitive, "Size"))).append('|');
+      result.append(referenceName(directDataReference(primitive, "Alignment"))).append('|');
+      result.append(readColor(directAggregate(primitive, "Color")));
+      return result.toString();
+    }
+    result.append(readPoints(primitive)).append('|');
+    if ("Core/Diagram.Polygon".equals(type)) {
+      result.append(referenceName(directDataReference(primitive, "FillStyle"))).append('|');
+    }
+    Element stroke = directAggregate(primitive, "Stroke");
+    result.append(readColor(directAggregate(stroke, "Color"))).append('|');
+    result.append(referenceName(directDataReference(stroke, "DashStyle"))).append('|');
+    result.append(number(directDouble(stroke, "Width")));
+    return result.toString();
+  }
+
+  private static int compare(Map<String, String> expected, Map<String, String> exported,
+      List<Diagnostic> diagnostics) {
+    Set<String> ids = new LinkedHashSet<String>();
+    ids.addAll(expected.keySet());
+    ids.addAll(exported.keySet());
+    int matched = 0;
+    for (String id : ids) {
+      if (!expected.containsKey(id)) {
+        diagnostics.add(error("DEXPI_GRAPHICS_PRIMITIVE_UNEXPECTED",
+            "DEXPI document contains a graphical primitive absent from the source projection", id));
+      } else if (!exported.containsKey(id)) {
+        diagnostics.add(error("DEXPI_GRAPHICS_PRIMITIVE_MISSING",
+            "Source projection primitive is absent from the DEXPI document", id));
+      } else if (!expected.get(id).equals(exported.get(id))) {
+        diagnostics.add(error("DEXPI_GRAPHICS_PRIMITIVE_MISMATCH",
+            "Represented identity, mapped geometry, or mapped style differs from the source projection", id));
+      } else {
+        matched++;
+      }
+    }
+    return matched;
+  }
+
+  private static void assessDiagram(Document document, EngineeringGraphicalProjection projection,
+      List<Diagnostic> diagnostics) {
+    String id = "Diagram_" + Dexpi20GraphicalProjectionWriter
+        .digest(projection.getProjectId() + ":" + projection.getRevision());
+    Element diagram = objectById(document, id);
+    if (diagram == null || !"Core/Diagram.Diagram".equals(diagram.getAttribute("type"))) {
+      diagnostics.add(error("DEXPI_GRAPHICS_DIAGRAM_MISSING",
+          "Expected stable Core Diagram identity is absent from the DEXPI document", id));
+      return;
+    }
+    String expectedName = projection.getProjectId() + " " + projection.getRevision() + " "
+        + projection.getSourceReference();
+    if (!expectedName.equals(directString(diagram, "Name"))) {
+      diagnostics.add(error("DEXPI_GRAPHICS_DIAGRAM_METADATA_MISMATCH",
+          "Diagram name does not retain project, revision, and controlled source reference", id));
+    }
+    double[] expected = bounds(projection.getPrimitives());
+    double[] actual = new double[] {directDouble(diagram, "MinX"), directDouble(diagram, "MinY"),
+        directDouble(diagram, "MaxX"), directDouble(diagram, "MaxY")};
+    for (int index = 0; index < expected.length; index++) {
+      if (Double.compare(expected[index], actual[index]) != 0) {
+        diagnostics.add(error("DEXPI_GRAPHICS_DIAGRAM_BOUNDS_MISMATCH",
+            "Diagram bounds differ from the supported source projection", id));
+        break;
+      }
+    }
+  }
+
+  private static Map<Element, String> representationGroupKeys(Document document, Map<String, String> objectKeys,
+      List<Diagnostic> diagnostics) {
+    Map<Element, String> result = new LinkedHashMap<Element, String>();
+    NodeList objects = document.getElementsByTagName("Object");
+    for (int index = 0; index < objects.getLength(); index++) {
+      Element object = (Element) objects.item(index);
+      if (!"Core/Diagram.RepresentationGroup".equals(object.getAttribute("type"))) {
+        continue;
+      }
+      String representedId = directReference(object, "Represents");
+      String externalKey = objectKeys.get(representedId);
+      if (externalKey == null || externalKey.isEmpty()) {
+        diagnostics.add(error("DEXPI_GRAPHICS_GROUP_REPRESENTS_UNRESOLVED",
+            "Representation group does not resolve to one tagged exported conceptual object",
+            object.getAttribute("id")));
+        externalKey = "";
+      }
+      result.put(object, externalKey);
+    }
+    return result;
+  }
+
+  private static Map<String, String> representedExternalKeys(Document document) {
+    Map<String, String> result = new LinkedHashMap<String, String>();
+    NodeList objects = document.getElementsByTagName("Object");
+    for (int index = 0; index < objects.getLength(); index++) {
+      Element object = (Element) objects.item(index);
+      String id = object.getAttribute("id");
+      String key = firstText(object, "TagName", "PipeConnectorNumber", "LineNumber");
+      if (!id.isEmpty() && !key.isEmpty()) {
+        result.put(id, key);
+      }
+    }
+    return result;
+  }
+
+  private static String firstText(Element object, String... properties) {
+    for (String property : properties) {
+      String value = directString(object, property);
+      if (!value.isEmpty()) {
+        return value;
+      }
+    }
+    return "";
+  }
+
+  private static Element ancestor(Element source, String type) {
+    for (Node node = source.getParentNode(); node != null; node = node.getParentNode()) {
+      if (node instanceof Element && "Object".equals(((Element) node).getTagName())
+          && type.equals(((Element) node).getAttribute("type"))) {
+        return (Element) node;
+      }
+    }
+    return null;
+  }
+
+  private static Element objectById(Document document, String id) {
+    NodeList objects = document.getElementsByTagName("Object");
+    for (int index = 0; index < objects.getLength(); index++) {
+      Element object = (Element) objects.item(index);
+      if (id.equals(object.getAttribute("id"))) {
+        return object;
+      }
+    }
+    return null;
+  }
+
+  private static String directReference(Element parent, String property) {
+    if (parent == null) {
+      return "";
+    }
+    for (Node child = parent.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (child instanceof Element && "References".equals(((Element) child).getTagName())
+          && property.equals(((Element) child).getAttribute("property"))) {
+        return ((Element) child).getAttribute("objects").replaceFirst("^#", "");
+      }
+    }
+    return "";
+  }
+
+  private static String directString(Element parent, String property) {
+    Element data = directData(parent, property);
+    if (data == null) {
+      return "";
+    }
+    NodeList values = data.getElementsByTagName("String");
+    return values.getLength() == 0 ? "" : values.item(0).getTextContent();
+  }
+
+  private static double directDouble(Element parent, String property) {
+    Element data = directData(parent, property);
+    if (data == null) {
+      return Double.NaN;
+    }
+    NodeList values = data.getElementsByTagName("Double");
+    if (values.getLength() == 0) {
+      return Double.NaN;
+    }
+    try {
+      return Double.parseDouble(values.item(0).getTextContent());
+    } catch (NumberFormatException exception) {
+      return Double.NaN;
+    }
+  }
+
+  private static Element directAggregate(Element parent, String property) {
+    Element data = directData(parent, property);
+    if (data == null) {
+      return null;
+    }
+    for (Node child = data.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (child instanceof Element && "AggregatedDataValue".equals(((Element) child).getTagName())) {
+        return (Element) child;
+      }
+    }
+    return null;
+  }
+
+  private static String directDataReference(Element parent, String property) {
+    Element data = directData(parent, property);
+    if (data == null) {
+      return "";
+    }
+    NodeList values = data.getElementsByTagName("DataReference");
+    return values.getLength() == 0 ? "" : ((Element) values.item(0)).getAttribute("data");
+  }
+
+  private static Element directData(Element parent, String property) {
+    if (parent == null) {
+      return null;
+    }
+    for (Node child = parent.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (child instanceof Element && "Data".equals(((Element) child).getTagName())
+          && property.equals(((Element) child).getAttribute("property"))) {
+        return (Element) child;
+      }
+    }
+    return null;
+  }
+
+  private static String readPoints(Element primitive) {
+    Element data = directData(primitive, "Points");
+    if (data == null) {
+      return "";
+    }
+    List<Point> points = new ArrayList<Point>();
+    for (Node child = data.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (child instanceof Element && "AggregatedDataValue".equals(((Element) child).getTagName())) {
+        Element value = (Element) child;
+        points.add(new Point(directDouble(value, "X"), directDouble(value, "Y")));
+      }
+    }
+    return points(points);
+  }
+
+  private static String readColor(Element value) {
+    int red = directInteger(value, "R");
+    int green = directInteger(value, "G");
+    int blue = directInteger(value, "B");
+    if (red < 0 || green < 0 || blue < 0 || red > 255 || green > 255 || blue > 255) {
+      return "invalid";
+    }
+    return String.format(java.util.Locale.ROOT, "#%02x%02x%02x", Integer.valueOf(red), Integer.valueOf(green),
+        Integer.valueOf(blue));
+  }
+
+  private static int directInteger(Element parent, String property) {
+    Element data = directData(parent, property);
+    if (data == null) {
+      return -1;
+    }
+    NodeList values = data.getElementsByTagName("Integer");
+    if (values.getLength() == 0) {
+      return -1;
+    }
+    try {
+      return Integer.parseInt(values.item(0).getTextContent());
+    } catch (NumberFormatException exception) {
+      return -1;
+    }
+  }
+
+  private static List<Point> polygonPoints(Primitive primitive) {
+    if (primitive.getType() != PrimitiveType.RECTANGLE) {
+      return primitive.getPoints();
+    }
+    List<Point> points = new ArrayList<Point>();
+    points.add(new Point(primitive.getX(), primitive.getY()));
+    points.add(new Point(primitive.getX() + primitive.getWidth(), primitive.getY()));
+    points.add(new Point(primitive.getX() + primitive.getWidth(), primitive.getY() + primitive.getHeight()));
+    points.add(new Point(primitive.getX(), primitive.getY() + primitive.getHeight()));
+    return points;
+  }
+
+  private static String points(List<Point> values) {
+    StringBuilder result = new StringBuilder();
+    for (Point value : values) {
+      if (result.length() > 0) {
+        result.append(';');
+      }
+      result.append(point(value.getX(), value.getY()));
+    }
+    return result.toString();
+  }
+
+  private static String point(double x, double y) {
+    return number(x) + ',' + number(y);
+  }
+
+  private static String number(double value) {
+    return Double.toString(value == 0.0 ? 0.0 : value);
+  }
+
+  private static String color(String value) {
+    return value.toLowerCase(java.util.Locale.ROOT);
+  }
+
+  private static String textAlignment(String anchor) {
+    return "middle".equals(anchor) ? "CenterCenter" : "end".equals(anchor) ? "RightCenter" : "LeftCenter";
+  }
+
+  private static String referenceName(String value) {
+    int separator = value.lastIndexOf('.');
+    return separator < 0 ? value : value.substring(separator + 1);
+  }
+
+  private static double[] bounds(List<Primitive> primitives) {
+    double minX = Double.POSITIVE_INFINITY;
+    double minY = Double.POSITIVE_INFINITY;
+    double maxX = Double.NEGATIVE_INFINITY;
+    double maxY = Double.NEGATIVE_INFINITY;
+    for (Primitive primitive : primitives) {
+      List<Point> values = primitive.getType() == PrimitiveType.RECTANGLE ? polygonPoints(primitive)
+          : primitive.getType() == PrimitiveType.TEXT
+              ? Collections.singletonList(new Point(primitive.getX(), primitive.getY()))
+              : primitive.getPoints();
+      for (Point value : values) {
+        minX = Math.min(minX, value.getX());
+        minY = Math.min(minY, value.getY());
+        maxX = Math.max(maxX, value.getX());
+        maxY = Math.max(maxY, value.getY());
+      }
+    }
+    return new double[] {minX - 10.0, minY - 10.0, maxX + 10.0, maxY + 10.0};
+  }
+
+  private static Diagnostic warning(String code, String message, String subjectId) {
+    return new Diagnostic(Severity.WARNING, code, message, subjectId);
+  }
+
+  private static Diagnostic error(String code, String message, String subjectId) {
+    return new Diagnostic(Severity.ERROR, code, message, subjectId);
+  }
+
+  private static String sha256(Path file) throws IOException {
+    try {
+      byte[] bytes = MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(file));
+      StringBuilder result = new StringBuilder();
+      for (byte value : bytes) {
+        result.append(String.format(java.util.Locale.ROOT, "%02x", Integer.valueOf(value & 255)));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is required by every supported Java runtime", exception);
+    }
+  }
+
+  private static Document parse(Path file) throws IOException {
+    try {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      factory.setXIncludeAware(false);
+      factory.setExpandEntityReferences(false);
+      return factory.newDocumentBuilder().parse(file.toFile());
+    } catch (ParserConfigurationException exception) {
+      throw new IOException("Could not configure DEXPI graphical-projection assessment", exception);
+    } catch (SAXException exception) {
+      throw new IOException("Could not parse DEXPI graphical-projection assessment input", exception);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20GraphicalProjectionWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20GraphicalProjectionWriter.java
@@ -468,7 +468,7 @@ public final class Dexpi20GraphicalProjectionWriter {
     return null;
   }
 
-  private static String digest(String value) {
+  static String digest(String value) {
     try {
       byte[] bytes = MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
       StringBuilder result = new StringBuilder();

--- a/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
@@ -18,6 +18,10 @@
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessTopologyAssessment} - Canonical material-topology
  * projection, canonical operating-value provenance, and structured scope evidence for assessed native Process
  * exchange</li>
+ * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20GraphicalProjectionWriter} - Opt-in native DEXPI Core
+ * graphical projection</li>
+ * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20GraphicalProjectionAssessment} - Deterministic inspection of
+ * stable represented identities, mapped geometry, styles, bounds, and retained graphical losses</li>
  * </ul>
  *
  * <h2>Usage Example</h2>

--- a/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
@@ -18,8 +18,8 @@
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessTopologyAssessment} - Canonical material-topology
  * projection, canonical operating-value provenance, and structured scope evidence for assessed native Process
  * exchange</li>
- * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20GraphicalProjectionWriter} - Opt-in native DEXPI Core
- * graphical projection</li>
+ * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20GraphicalProjectionWriter} - Opt-in native DEXPI Core graphical
+ * projection</li>
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20GraphicalProjectionAssessment} - Deterministic inspection of
  * stable represented identities, mapped geometry, styles, bounds, and retained graphical losses</li>
  * </ul>

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20GraphicalProjectionAssessmentTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20GraphicalProjectionAssessmentTest.java
@@ -1,0 +1,195 @@
+package neqsim.process.processmodel.dexpi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import neqsim.NeqSimTest;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection.Point;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection.Primitive;
+import neqsim.process.engineering.model.EngineeringGraphicalProjection.VerificationStatus;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests deterministic DEXPI Core graphical export-inspection equivalence. */
+public class Dexpi20GraphicalProjectionAssessmentTest extends NeqSimTest {
+  @TempDir
+  Path temporaryDirectory;
+
+  /** Verifies mapped identity, geometry, style, metadata, bounds, and deterministic evidence. */
+  @Test
+  public void assessesSupportedProjectionEquivalence() throws Exception {
+    ProcessSystem process = process();
+    EngineeringGraphicalProjection projection = projection();
+    Path file = temporaryDirectory.resolve("graphical-assessment.dexpi.xml");
+
+    Dexpi20GraphicalProjectionReport exportReport = Dexpi20GraphicalProjectionWriter.write(process, projection,
+        file.toFile(), options());
+    Dexpi20GraphicalProjectionAssessment.Report first = Dexpi20GraphicalProjectionAssessment.assess(projection, file);
+    Dexpi20GraphicalProjectionAssessment.Report second = Dexpi20GraphicalProjectionAssessment.assess(projection, file);
+
+    assertTrue(exportReport.isComplete());
+    assertTrue(first.isSupportedProjectionEquivalent());
+    assertEquals(4, first.getExpectedPrimitiveSignatures().size());
+    assertEquals(4, first.getExportedPrimitiveSignatures().size());
+    assertEquals(4, first.getMatchedPrimitiveCount());
+    assertEquals(64, first.getInspectedFileSha256().length());
+    assertEquals(first.toJson(), second.toJson());
+    assertTrue(first.toJson().contains(first.getInspectedFileSha256()));
+    assertTrue(first.getDiagnostics().stream()
+        .anyMatch(item -> "DEXPI_GRAPHICS_FILL_COLOR_LOSS_CONFIRMED".equals(item.getCode())));
+    assertTrue(first.getDiagnostics().stream()
+        .anyMatch(item -> "DEXPI_GRAPHICS_DASH_APPROXIMATION_CONFIRMED".equals(item.getCode())));
+    assertTrue(first.toJson().contains("\"approvalStatus\": \"REVIEW_REQUIRED\""));
+  }
+
+  /** Verifies fail-closed detection of missing and unexpected stable primitive identities. */
+  @Test
+  public void detectsCorruptedPrimitiveIdentity() throws Exception {
+    EngineeringGraphicalProjection projection = projection();
+    Path file = temporaryDirectory.resolve("graphical-corrupt-id.dexpi.xml");
+    Dexpi20GraphicalProjectionWriter.write(process(), projection, file.toFile(), options());
+    Document document = parse(file);
+    Element primitive = firstObjectWithIdPrefix(document, "GraphicalPrimitive_");
+    primitive.setAttribute("id", "GraphicalPrimitive_unexpected");
+    write(document, file);
+
+    Dexpi20GraphicalProjectionAssessment.Report report = Dexpi20GraphicalProjectionAssessment.assess(projection, file);
+
+    assertFalse(report.isSupportedProjectionEquivalent());
+    assertEquals(3, report.getMatchedPrimitiveCount());
+    assertTrue(report.getDiagnostics().stream()
+        .anyMatch(item -> "DEXPI_GRAPHICS_PRIMITIVE_MISSING".equals(item.getCode())));
+    assertTrue(report.getDiagnostics().stream()
+        .anyMatch(item -> "DEXPI_GRAPHICS_PRIMITIVE_UNEXPECTED".equals(item.getCode())));
+  }
+
+  /** Verifies fail-closed detection of a broken represented-object reference. */
+  @Test
+  public void detectsBrokenRepresentationReference() throws Exception {
+    EngineeringGraphicalProjection projection = projection();
+    Path file = temporaryDirectory.resolve("graphical-corrupt-reference.dexpi.xml");
+    Dexpi20GraphicalProjectionWriter.write(process(), projection, file.toFile(), options());
+    Document document = parse(file);
+    Element group = firstObject(document, "Core/Diagram.RepresentationGroup");
+    directReference(group, "Represents").setAttribute("objects", "#MissingConceptualObject");
+    write(document, file);
+
+    Dexpi20GraphicalProjectionAssessment.Report report = Dexpi20GraphicalProjectionAssessment.assess(projection, file);
+
+    assertFalse(report.isSupportedProjectionEquivalent());
+    assertTrue(report.getDiagnostics().stream()
+        .anyMatch(item -> "DEXPI_GRAPHICS_GROUP_REPRESENTS_UNRESOLVED".equals(item.getCode())));
+    assertTrue(report.getDiagnostics().stream()
+        .anyMatch(item -> "DEXPI_GRAPHICS_PRIMITIVE_GROUP_UNRESOLVED".equals(item.getCode())));
+  }
+
+  private static EngineeringGraphicalProjection projection() {
+    Primitive rectangle = Primitive.rectangle("separator:shape", "equipment:separator", "10-VA-001", 10.0, 20.0,
+        28.0, 14.0, "#123456", "#abcdef", 0.8);
+    Primitive polygon = Primitive.polygon("separator:proposal", "equipment:separator", "10-VA-001",
+        Arrays.asList(new Point(20.0, 18.0), new Point(24.0, 22.0), new Point(20.0, 26.0)), "#654321", "none",
+        0.6);
+    Primitive route = Primitive.polyline("separator:route", "equipment:separator", "10-VA-001",
+        Arrays.asList(new Point(5.0, 20.0), new Point(10.0, 20.0)), "#2563eb", 0.8, "4 2", false);
+    Primitive label = Primitive.text("separator:label", "equipment:separator", "10-VA-001", 24.0, 27.0, 3.0,
+        "10-VA-001", "#111827", "middle");
+    return new EngineeringGraphicalProjection("synthetic-plant", "A", "graph-fingerprint", "DOC-PFD-001",
+        VerificationStatus.PROPOSAL, Arrays.asList(rectangle, polygon, route, label),
+        Collections.<EngineeringGraphicalProjection.Diagnostic>emptyList());
+  }
+
+  private static Dexpi20PlantExportOptions options() {
+    Dexpi20PlantExportMetadata metadata = Dexpi20PlantExportMetadata
+        .builder("2026-08-25T20:00:00Z", "NeqSim", "Equinor", "3.18.0")
+        .plantProperty(Dexpi20PlantExportMetadata.PlantProperty.PROCESS_PLANT_NAME,
+            "Synthetic graphical assessment regression plant")
+        .build();
+    return Dexpi20PlantExportOptions.builder(metadata).build();
+  }
+
+  private static ProcessSystem process() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 40.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("n-heptane", 0.2);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("10-FEED-001", fluid);
+    Separator separator = new Separator("10-VA-001", feed);
+    Compressor compressor = new Compressor("10-KA-001", separator.getGasOutStream());
+    ProcessSystem process = new ProcessSystem("DEXPI graphical assessment test");
+    process.add(feed);
+    process.add(separator);
+    process.add(compressor);
+    return process;
+  }
+
+  private static Document parse(Path file) throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setXIncludeAware(false);
+    factory.setExpandEntityReferences(false);
+    return factory.newDocumentBuilder().parse(file.toFile());
+  }
+
+  private static void write(Document document, Path file) throws Exception {
+    TransformerFactory factory = TransformerFactory.newInstance();
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    Transformer transformer = factory.newTransformer();
+    transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+    transformer.transform(new DOMSource(document), new StreamResult(file.toFile()));
+  }
+
+  private static Element firstObject(Document document, String type) {
+    NodeList objects = document.getElementsByTagName("Object");
+    for (int index = 0; index < objects.getLength(); index++) {
+      Element object = (Element) objects.item(index);
+      if (type.equals(object.getAttribute("type"))) {
+        return object;
+      }
+    }
+    throw new AssertionError("Missing object type " + type);
+  }
+
+  private static Element firstObjectWithIdPrefix(Document document, String prefix) {
+    NodeList objects = document.getElementsByTagName("Object");
+    for (int index = 0; index < objects.getLength(); index++) {
+      Element object = (Element) objects.item(index);
+      if (object.getAttribute("id").startsWith(prefix)) {
+        return object;
+      }
+    }
+    throw new AssertionError("Missing object id prefix " + prefix);
+  }
+
+  private static Element directReference(Element object, String property) {
+    for (Node child = object.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (child instanceof Element && "References".equals(((Element) child).getTagName())
+          && property.equals(((Element) child).getAttribute("property"))) {
+        return (Element) child;
+      }
+    }
+    throw new AssertionError("Missing reference property " + property);
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20GraphicalProjectionAssessmentTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20GraphicalProjectionAssessmentTest.java
@@ -78,8 +78,8 @@ public class Dexpi20GraphicalProjectionAssessmentTest extends NeqSimTest {
 
     assertFalse(report.isSupportedProjectionEquivalent());
     assertEquals(3, report.getMatchedPrimitiveCount());
-    assertTrue(report.getDiagnostics().stream()
-        .anyMatch(item -> "DEXPI_GRAPHICS_PRIMITIVE_MISSING".equals(item.getCode())));
+    assertTrue(
+        report.getDiagnostics().stream().anyMatch(item -> "DEXPI_GRAPHICS_PRIMITIVE_MISSING".equals(item.getCode())));
     assertTrue(report.getDiagnostics().stream()
         .anyMatch(item -> "DEXPI_GRAPHICS_PRIMITIVE_UNEXPECTED".equals(item.getCode())));
   }
@@ -105,11 +105,10 @@ public class Dexpi20GraphicalProjectionAssessmentTest extends NeqSimTest {
   }
 
   private static EngineeringGraphicalProjection projection() {
-    Primitive rectangle = Primitive.rectangle("separator:shape", "equipment:separator", "10-VA-001", 10.0, 20.0,
-        28.0, 14.0, "#123456", "#abcdef", 0.8);
+    Primitive rectangle = Primitive.rectangle("separator:shape", "equipment:separator", "10-VA-001", 10.0, 20.0, 28.0,
+        14.0, "#123456", "#abcdef", 0.8);
     Primitive polygon = Primitive.polygon("separator:proposal", "equipment:separator", "10-VA-001",
-        Arrays.asList(new Point(20.0, 18.0), new Point(24.0, 22.0), new Point(20.0, 26.0)), "#654321", "none",
-        0.6);
+        Arrays.asList(new Point(20.0, 18.0), new Point(24.0, 22.0), new Point(20.0, 26.0)), "#654321", "none", 0.6);
     Primitive route = Primitive.polyline("separator:route", "equipment:separator", "10-VA-001",
         Arrays.asList(new Point(5.0, 20.0), new Point(10.0, 20.0)), "#2563eb", 0.8, "4 2", false);
     Primitive label = Primitive.text("separator:label", "equipment:separator", "10-VA-001", 24.0, 27.0, 3.0,


### PR DESCRIPTION
## Summary

Adds deterministic, fail-closed inspection of the supported generic DEXPI 2.0 Core graphical projection.

- compares stable graphical primitive identities and represented conceptual-object keys
- compares mapped rectangle/polygon/polyline/text geometry and mapped style
- verifies stable Diagram identity, controlled name, and deterministic bounds
- fingerprints the exact inspected XML bytes with full SHA-256 provenance
- retains explicit warnings for fill-colour loss, numeric-dash approximation, and required colour fallback
- emits ordered machine-readable JSON with expected/exported signatures and matched counts
- proves negative detection by corrupting a primitive identity and a `Represents` reference

The assessment is deliberately bounded to NeqSim's supported generic Core mapping. It is not a DEXPI reader, profile-symbol qualification, clean external-validator result, ISO 10628 claim, or accountable drawing approval.

## Compatibility

- Existing `Dexpi20GraphicalProjectionWriter` overloads and XML output are unchanged.
- The writer's stable digest helper becomes package-private solely so the adjacent assessment derives the exact same internal IDs.
- Legacy DOT/Graphviz, native SVG/PDF, DEXPI Process, native Plant compatibility paths, and Proteus/P&ID APIs are unchanged.
- No external dataset or licensed symbol content is included.

## Tests

Focused regressions cover:

1. supported export equivalence, exact-file SHA-256 evidence, deterministic JSON, all four primitive mappings, and confirmed loss warnings;
2. missing/unexpected stable identity detection after XML corruption;
3. unresolved representation-group and primitive references after `Represents` corruption.

**READY TO MERGE — MAINTAINER ACTION REQUIRED**

All seven GitHub Actions workflows pass on exact head `a41c4f014bfbea9d3095cf02ef0ab856d4da61b7`:

- Spotless and pre-commit;
- documentation search/build;
- PaperLab and the process-to-engineering notebook;
- CodeQL;
- Java 8 tests on Ubuntu and Windows;
- Java 21 tests on Ubuntu and Windows, all four slow-test shards, and Javadocs.

GitHub reports the draft PR mergeable with no reviews or unresolved review threads. The branch is two commits behind current master `60fc3a25423488995077f299934efe00f59018a9`; those intervening changes do not overlap the six-file PR diff, and no rebase or force-push was performed. The PR remains draft for maintainer control.

This connector-only workspace has no repository checkout, JDK, Maven, Spotless runtime, or pre-commit executable. Therefore no local result is claimed; GitHub Actions on the exact PR head is the authoritative validation evidence.

## Documentation impact

Updated:

- DEXPI engineering guide with the assessment API, gate semantics, evidence, and limitations;
- DEXPI package Javadocs with the writer and assessment entry points;
- current-master DEXPI/P&ID audit to reconcile the merged document-set/native-renderer foundation and the new assessed graphical subset.

## Scope boundary

This PR stops before profile symbols, licensed standards mappings, external DEXPIViewer execution, commercial CAE qualification, or accountable P&ID approval.

Base: `ac61c08e1f6bd049673f13916cdef70c6102a6cf`  
Head: `a41c4f014bfbea9d3095cf02ef0ab856d4da61b7`

Refs #1332
Refs #2899
