### PR TITLE
[AI-Assisted] docs: correct thermodynamic workflow APIs

### DIFF
--- a/docs/test_thermodynamic_workflows_documentation.py
+++ b/docs/test_thermodynamic_workflows_documentation.py
@@ -12,6 +12,7 @@ class ThermodynamicWorkflowsDocumentationTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.guide = GUIDE.read_text(encoding="utf-8")
+        cls.guide_prose = " ".join(cls.guide.split()).lower()
 
     def test_front_matter_is_complete_without_duplicate_h1(self):
         self.assertTrue(self.guide.startswith("---\ntitle:"))
@@ -45,7 +46,7 @@ class ThermodynamicWorkflowsDocumentationTest(unittest.TestCase):
             "do not have the same characterization semantics",
         ):
             with self.subTest(contract=contract):
-                self.assertIn(contract, self.guide)
+                self.assertIn(" ".join(contract.split()).lower(), self.guide_prose)
         self.assertNotIn("enable access to component data", self.guide)
         self.assertNotIn("Always call `createDatabase(true)` before", self.guide)
 
@@ -97,7 +98,7 @@ class ThermodynamicWorkflowsDocumentationTest(unittest.TestCase):
             "Molar mass and Z-factor alone do not validate",
         ):
             with self.subTest(contract=contract):
-                self.assertIn(contract, self.guide)
+                self.assertIn(" ".join(contract.split()).lower(), self.guide_prose)
 
     def test_clone_is_independent_and_not_presented_as_json_export(self):
         for contract in (

--- a/docs/test_thermodynamic_workflows_documentation.py
+++ b/docs/test_thermodynamic_workflows_documentation.py
@@ -1,0 +1,143 @@
+"""Regression contracts for the source-verified thermodynamic workflow guide."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDE = ROOT / "docs" / "thermo" / "thermodynamic_workflows.md"
+
+
+class ThermodynamicWorkflowsDocumentationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+
+    def test_front_matter_is_complete_without_duplicate_h1(self):
+        self.assertTrue(self.guide.startswith("---\ntitle:"))
+        front_matter = self.guide.split("---", 2)[1]
+        self.assertIn('description: "', front_matter)
+        self.assertIn('keywords: "', front_matter)
+        self.assertNotRegex(self.guide.split("---", 2)[2], r"(?m)^# ")
+
+    def test_tbp_arguments_and_units_match_system_interface(self):
+        self.assertIn(
+            'fluid.addTBPfraction("C10", 0.10, 0.134, 0.792);',
+            self.guide,
+        )
+        self.assertIn("molar mass [kg/mol], specific gravity [-]", self.guide)
+        self.assertNotIn('addTBPfraction("C7+", 0.10, 0.45, 8.0)', self.guide)
+
+        source = (
+            ROOT / "src/main/java/neqsim/thermo/system/SystemInterface.java"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "addTBPfraction(String componentName, double numberOfMoles, "
+            "double molarMass, double density)",
+            source.replace("\n", " "),
+        )
+
+    def test_database_and_plus_fraction_semantics_are_explicit(self):
+        for contract in (
+            "temporary component and interaction tables",
+            "does not infer the molar mass or density",
+            "Use `addPlusFraction(...)` for an unresolved plus fraction",
+            "do not have the same characterization semantics",
+        ):
+            with self.subTest(contract=contract):
+                self.assertIn(contract, self.guide)
+        self.assertNotIn("enable access to component data", self.guide)
+        self.assertNotIn("Always call `createDatabase(true)` before", self.guide)
+
+    def test_mixing_rule_guidance_matches_current_enum(self):
+        enum_source = (
+            ROOT / "src/main/java/neqsim/thermo/mixingrule/EosMixingRuleType.java"
+        ).read_text(encoding="utf-8")
+        self.assertIn("NO(1)", enum_source)
+        self.assertIn("CLASSIC(2)", enum_source)
+        self.assertIn('setMixingRule("classic")', self.guide)
+        self.assertIn("legacy value 1 is the", self.guide)
+        self.assertIn("all binary interaction parameters set to zero", self.guide)
+        for stale_mapping in (
+            "`setMixingRule(2)`: Huron",
+            "`setMixingRule(4)`: Wong",
+            "`setMixingRule(7)`: Simplified",
+        ):
+            with self.subTest(stale_mapping=stale_mapping):
+                self.assertNotIn(stale_mapping, self.guide)
+
+    def test_flash_operations_are_anchored_in_current_source(self):
+        source = (
+            ROOT
+            / "src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java"
+        ).read_text(encoding="utf-8")
+        for signature in (
+            "void TPflash()",
+            "void PHflash(double Hspec, String enthalpyUnit)",
+            "void PSflash(double Sspec, String unit)",
+            "void dewPointTemperatureFlash()",
+            "void bubblePointPressureFlash()",
+            "void calcPTphaseEnvelope()",
+        ):
+            with self.subTest(signature=signature):
+                self.assertIn(signature, source)
+        self.assertNotIn("calcPseudocriticalTemperature()", self.guide)
+        self.assertIn(
+            "there is no\ngeneral `ThermodynamicOperations.calcChemicalEquilibrium()`",
+            self.guide,
+        )
+
+    def test_units_state_mutation_and_validation_boundaries_are_explicit(self):
+        for contract in (
+            'PHflash(hSpec, "J/kg")',
+            'PSflash(sSpec, "J/kgK")',
+            "use total extensive specifications",
+            "operations update\nthat fluid's state",
+            "phase indexes can change",
+            "Molar mass and Z-factor alone do not validate",
+        ):
+            with self.subTest(contract=contract):
+                self.assertIn(contract, self.guide)
+
+    def test_clone_is_independent_and_not_presented_as_json_export(self):
+        for contract in (
+            "SystemInterface sweepCase = fluid.clone();",
+            'sweepCase.setTemperature(280.0, "K");',
+            'sweepCase.setPressure(10.0, "bara");',
+            "Cloning is not JSON export",
+            "original remains at its prior temperature and pressure",
+        ):
+            with self.subTest(contract=contract):
+                self.assertIn(contract, self.guide)
+        self.assertNotIn("Export an EOS state to JSON", self.guide)
+
+    def test_complete_example_and_clone_have_executable_java_regressions(self):
+        source = (
+            ROOT
+            / "src/test/java/neqsim/thermo/ThermodynamicWorkflowsDocumentationTest.java"
+        ).read_text(encoding="utf-8")
+        for contract in (
+            "buildFlashAndReadExample",
+            "cloneSweepKeepsOriginalState",
+            'addTBPfraction("C10", 0.10, 0.134, 0.792)',
+            'setMixingRule("classic")',
+            "operations.TPflash()",
+            "sweepOperations.TPflash()",
+        ):
+            with self.subTest(contract=contract):
+                self.assertIn(contract, source)
+
+    def test_changed_internal_links_resolve(self):
+        for relative_target in (
+            "fluid_creation_guide.md",
+            "../pvtsimulation/phase_envelope_guide.md",
+            "reactive_flash.md",
+            "reading_fluid_properties.md",
+        ):
+            resolved = (GUIDE.parent / relative_target).resolve()
+            with self.subTest(target=relative_target):
+                self.assertTrue(resolved.is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/thermo/thermodynamic_workflows.md
+++ b/docs/thermo/thermodynamic_workflows.md
@@ -1,58 +1,130 @@
 ---
 title: "Thermodynamic Workflows"
-description: "Use these recipes to configure fluids and run equilibrium calculations with NeqSim. The Java snippets mirror the workflow used in other language bindings."
+description: "Build, characterize, flash, inspect, and clone NeqSim fluids with source-verified Java APIs and explicit units."
+keywords: "thermodynamic workflow, TPflash, PHflash, PSflash, TBP fraction, mixing rule, phase envelope, fluid clone"
 ---
 
-# Thermodynamic Workflows
+Use the workflow below when a calculation needs a characterized fluid, a defined equilibrium
+specification, and reusable results. Temperature is in K and pressure is absolute bara unless an
+API call supplies another unit explicitly.
 
-Use these recipes to configure fluids and run equilibrium calculations with NeqSim. The Java snippets mirror the workflow used in other language bindings.
+## Build and flash a characterized fluid
 
-## 1. Build a Fluid
+This complete example adds ordinary database components and one TBP pseudo-component, loads the
+mixture interaction parameters, performs a TP flash, and initializes properties:
+
 ```java
-SystemInterface fluid = new SystemPrEos(313.15, 80.0);
-fluid.addComponent("methane", 0.85);
-fluid.addComponent("ethane", 0.05);
-fluid.addTBPfraction("C7+", 0.10, 0.45, 8.0); // name, moles, density [g/cc], MW
-fluid.createDatabase(true); // enable access to component data
-fluid.setMixingRule(1); // classical van der Waals mixing rule
-fluid.init(0);
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+public final class ThermodynamicWorkflowExample {
+  private ThermodynamicWorkflowExample() {}
+
+  public static void main(String[] args) {
+    SystemInterface fluid = new SystemPrEos(313.15, 80.0);
+    fluid.addComponent("methane", 0.85);
+    fluid.addComponent("ethane", 0.05);
+
+    // name, moles, molar mass [kg/mol], specific gravity [-]
+    fluid.addTBPfraction("C10", 0.10, 0.134, 0.792);
+
+    // Rebuild the temporary component/interaction tables after the component list is complete.
+    fluid.createDatabase(true);
+    fluid.setMixingRule("classic");
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+    operations.TPflash();
+    fluid.initProperties();
+
+    System.out.printf("T = %.2f K%n", fluid.getTemperature("K"));
+    System.out.printf("P = %.2f bara%n", fluid.getPressure("bara"));
+    System.out.printf("phases = %d%n", fluid.getNumberOfPhases());
+    System.out.printf("density = %.3f kg/m3%n", fluid.getDensity("kg/m3"));
+    System.out.printf("molar mass = %.3f g/mol%n", fluid.getMolarMass() * 1000.0);
+  }
+}
 ```
 
-Tips:
-- Always call `createDatabase(true)` before adding TBP fractions so critical properties and acentric factors are filled automatically.
-- Use `addPlusFraction` for simpler heavy-end inputs, or `addFluid` to merge two existing systems.
+`addTBPfraction(name, moles, molarMass, density)` expects molar mass in kg/mol and
+specific gravity (numerically equal to g/cm3) in its fourth argument. Values above 1.5 in the
+density position are interpreted as kg/m3 and divided by 1000. Use `addPlusFraction(...)` for an
+unresolved plus fraction; a TBP cut and a plus fraction do not have the same characterization
+semantics.
 
-## 2. Choose a Model and Mixing Rule
-- `setMixingRule(1)`: classical quadratic kij.
-- `setMixingRule(2)`: Huron–Vidal (gamma-phi) coupling.
-- `setMixingRule(4)`: Wong–Sandler (NRTL-based) coupling.
-- `setMixingRule(7)`: Simplified CPA cross-association rules.
+`createDatabase(true)` rebuilds NeqSim's temporary component and interaction tables for the
+current component list. It does not switch on a separate database service and it does not infer
+the molar mass or density of a TBP fraction.
 
-For lean gas, start with PR and kij from correlations; for rich liquids or polar systems, move to SRK-Twu + Huron–Vidal or CPA-SRK.
+## Choose the thermodynamic model and mixing rule separately
 
-## 3. Run Thermodynamic Operations
-Instantiate `ThermodynamicOperations` with the configured fluid to access flash and envelope tools:
+The system class selects the thermodynamic model. The mixing rule controls how mixture parameters
+are combined. In the example, `SystemPrEos` selects Peng-Robinson and
+`setMixingRule("classic")` selects the database-backed classic rule
+(`EosMixingRuleType.CLASSIC`, legacy value 2).
+
+Prefer named mixing rules over raw legacy integers. The maintained
+[fluid-creation guide](fluid_creation_guide.md#8-mixing-rules) lists the current names, numeric
+compatibility values, and model-specific recommendations. In particular, legacy value 1 is the
+no-interaction rule with all binary interaction parameters set to zero; it is not the
+database-backed classic rule.
+
+## Select an equilibrium specification
+
+Create one `ThermodynamicOperations` instance for the fluid being calculated. Operations update
+that fluid's state.
+
+| Engineering specification | Source-verified operation | Important basis |
+|---|---|---|
+| Temperature and pressure | `operations.TPflash()` | Set T and absolute P on the fluid first |
+| Pressure and enthalpy | `operations.PHflash(hSpec, "J/kg")` | Set absolute P first and state the enthalpy unit |
+| Pressure and entropy | `operations.PSflash(sSpec, "J/kgK")` | Set absolute P first and state the entropy unit |
+| Dew-point temperature | `operations.dewPointTemperatureFlash()` | Uses the current composition and pressure; updates T |
+| Bubble-point pressure | `operations.bubblePointPressureFlash()` | Uses the current composition and temperature; updates P |
+| PT phase envelope | `operations.calcPTphaseEnvelope()` | Use the dedicated result accessors and inspect convergence |
+
+The one-argument PH and PS overloads use total extensive specifications. Prefer the unit-aware
+overloads in user-facing workflows so a molar, mass, or total basis cannot be confused. Saturation
+and phase-envelope calculations can fail or become supercritical for some compositions and
+starting states; handle exceptions and validate the returned state. See the
+[phase-envelope guide](../pvtsimulation/phase_envelope_guide.md) for envelope-specific setup and
+result handling.
+
+Chemical and phase equilibrium require their dedicated model setup and operations; there is no
+general `ThermodynamicOperations.calcChemicalEquilibrium()` entry point. Start with the
+[reactive-flash guide](reactive_flash.md) for supported reactive workflows.
+
+## Clone independent states for sweeps
+
+Clone a configured and flashed fluid before changing a sweep condition. The clone owns an
+independent thermodynamic state; the original remains at its prior temperature and pressure.
+
 ```java
-ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-ops.TPflash();
-fluid.initProperties();
-System.out.println("Vapor fraction: " + fluid.getPhaseFraction("gas", "mole"));
-```
-Common operations include:
-- `PHflash(enthalpy)`, `PSflash(entropy)` for process simulators (set pressure on the fluid before calling).
-- `dewPointTemperatureFlash()` and `bubblePointPressureFlash()` for PVT lab matches.
-- `calcPTphaseEnvelope()` and `calcPseudocriticalTemperature()` for compositional screening.
+SystemInterface sweepCase = fluid.clone();
+sweepCase.setTemperature(280.0, "K");
+sweepCase.setPressure(10.0, "bara");
 
-## 4. Save and Reuse States
-Export an EOS state to JSON or clone fluids when sweeping conditions:
-```java
-SystemInterface clone = fluid.clone();
-clone.setTemperature(280.0);
-clone.setPressure(10.0);
-new ThermodynamicOperations(clone).TPflash();
+ThermodynamicOperations sweepOperations = new ThermodynamicOperations(sweepCase);
+sweepOperations.TPflash();
+sweepCase.initProperties();
 ```
 
-## 5. Debugging and Validation
-- Call `display()` on the fluid to dump compositions, kij values, and phase properties.
-- Use `calcChemicalEquilibrium()` after setting reaction stoichiometry to couple reactions into flashes.
-- Compare `getMolarMass()` and `getZ()` against lab PVT data to verify characterization accuracy.
+Cloning is not JSON export. If a workflow needs persistent or transferable state, select and
+validate a serialization format explicitly rather than treating a clone as a stored artifact.
+
+## Read, diagnose, and validate results
+
+- Call `initProperties()` after the flash before reading density or transport properties.
+- Prefer phase names or `PhaseType` and check phase existence; phase indexes can change after a
+  new equilibrium calculation.
+- Use `prettyPrint()` for a human-readable state table. Do not assume it reports every binary
+  interaction parameter.
+- Keep pressure basis and every enthalpy, entropy, density, and flow unit explicit.
+- Validate the quantities relevant to the experiment or process: density and compressibility,
+  saturation pressure/temperature, CCE or differential-liberation volumes, phase amounts and
+  compositions, and material/energy closure. Molar mass and Z-factor alone do not validate a
+  characterized petroleum fluid.
+- Compare changed-state sweeps against the untouched original to detect accidental state reuse.
+
+For the complete property initialization and phase-access contract, continue with
+[Reading Fluid Properties](reading_fluid_properties.md).

--- a/src/test/java/neqsim/thermo/ThermodynamicWorkflowsDocumentationTest.java
+++ b/src/test/java/neqsim/thermo/ThermodynamicWorkflowsDocumentationTest.java
@@ -1,0 +1,62 @@
+package neqsim.thermo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Executes the examples in docs/thermo/thermodynamic_workflows.md. */
+class ThermodynamicWorkflowsDocumentationTest {
+
+  private SystemInterface buildAndFlashFluid() {
+    SystemInterface fluid = new SystemPrEos(313.15, 80.0);
+    fluid.addComponent("methane", 0.85);
+    fluid.addComponent("ethane", 0.05);
+    fluid.addTBPfraction("C10", 0.10, 0.134, 0.792);
+    fluid.createDatabase(true);
+    fluid.setMixingRule("classic");
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+    operations.TPflash();
+    fluid.initProperties();
+    return fluid;
+  }
+
+  /** Execute the complete characterized-fluid TP-flash example. */
+  @Test
+  void buildFlashAndReadExample() {
+    SystemInterface fluid = buildAndFlashFluid();
+
+    assertEquals(1.0, fluid.getTotalNumberOfMoles(), 1.0e-12);
+    assertEquals(313.15, fluid.getTemperature("K"), 1.0e-10);
+    assertEquals(80.0, fluid.getPressure("bara"), 1.0e-10);
+    assertTrue(fluid.getNumberOfPhases() >= 1);
+    assertTrue(Double.isFinite(fluid.getDensity("kg/m3")));
+    assertTrue(fluid.getDensity("kg/m3") > 0.0);
+    assertTrue(fluid.getMolarMass() > 0.0);
+  }
+
+  /** Prove the documented changed-state clone does not mutate the original fluid. */
+  @Test
+  void cloneSweepKeepsOriginalState() {
+    SystemInterface fluid = buildAndFlashFluid();
+    SystemInterface sweepCase = fluid.clone();
+    assertNotSame(fluid, sweepCase);
+
+    sweepCase.setTemperature(280.0, "K");
+    sweepCase.setPressure(10.0, "bara");
+    ThermodynamicOperations sweepOperations = new ThermodynamicOperations(sweepCase);
+    sweepOperations.TPflash();
+    sweepCase.initProperties();
+
+    assertEquals(313.15, fluid.getTemperature("K"), 1.0e-10);
+    assertEquals(80.0, fluid.getPressure("bara"), 1.0e-10);
+    assertEquals(280.0, sweepCase.getTemperature("K"), 1.0e-10);
+    assertEquals(10.0, sweepCase.getPressure("bara"), 1.0e-10);
+    assertTrue(Double.isFinite(sweepCase.getDensity("kg/m3")));
+    assertTrue(sweepCase.getDensity("kg/m3") > 0.0);
+  }
+}


### PR DESCRIPTION
## Summary

- correct the characterized-fluid example's TBP argument order, physical values, database-table semantics, and mixing-rule selection
- replace four wrong legacy mixing-rule mappings and two nonexistent thermodynamic operations with current source-verified APIs
- make flash bases, state mutation, cloning, diagnostics, and PVT validation boundaries explicit
- add nine documentation/source/navigation contracts and two executable Java regressions

## Frozen documentation contract

**Campaign:** #2499, D091, rotation scope 2 — thermo, fluids, phase equilibrium, and physical properties.

**Exact base:** `60fc3a25423488995077f299934efe00f59018a9`

**Exact head:** `9062bc7d73b30eee5b80310a2c8bff9b7e3e8be1`

**Frozen files:**

- `docs/thermo/thermodynamic_workflows.md`
- `docs/test_thermodynamic_workflows_documentation.py`
- `src/test/java/neqsim/thermo/ThermodynamicWorkflowsDocumentationTest.java`

**Confirmed defects:** 18 total: reversed TBP parameter labels, invalid density and misleading plus-fraction naming, contradictory/incorrect database guidance, four incorrect mixing-rule mappings, an unsafe model-selection shortcut, ambiguous PH/PS bases, two nonexistent operations, clone presented as JSON export, overstated diagnostic output, incomplete validation guidance, and a non-executable partial example.

**Acceptance criteria:** the complete Java workflow compiles and runs; TBP values and units match `SystemInterface`; mixing rules match `EosMixingRuleType`; every named operation exists on current `ThermodynamicOperations`; PH/PS units and state mutation are explicit; clone independence is executed; all changed internal links resolve.

**Stop boundary:** no production thermodynamic code, algorithm changes, electrolyte phase-boundary scope from #3260, new model recommendations, persistent serialization implementation, notebook, external dataset, or Huldra work.

## Validation

Connector-side exact-tree checks passed:

- exact base-to-head comparison: 4 commits ahead, 0 behind, exactly 3 frozen files
- all six documented flash/saturation/envelope signatures exist in current source
- documented TBP signature and `NO(1)` / `CLASSIC(2)` mappings match current source
- invalid TBP call, stale mixing-rule mappings, and nonexistent pseudocritical operation are absent
- guide has valid front matter, no duplicate body H1, named mixing rule, explicit units, and four repository-resolving internal targets
- nine Python documentation contracts and two Java regressions are present
- the first documentation run exposed four whitespace/case-fragile prose assertions; exact head `9062bc7` normalizes only prose matching while preserving exact API/source checks

Exact-head hosted CI:

- **PASS:** documentation contracts, Jekyll build/search coverage, pre-commit, Spotless, CodeQL, Javadocs
- **PASS:** Java 21 Ubuntu fast tests, Java 21 Windows tests, and slow-test shards 2–4
- **UNRELATED BASE FAILURE:** slow shard 1 fails only `SevereSluggingExperimentalBenchmarkTest.reproducesTheLiquidCycleAndTheRiserPressureSwing`; the same failure is reproduced on exact base `60fc3a2` and is owned by active #3258
- **PENDING:** Java 8 Ubuntu and Windows jobs

**VALIDATION PENDING CI**

No local Python, Java, Maven, Spotless, pre-commit, or Jekyll execution is claimed.

## Documentation impact

Documentation is the implementation. The Java file provides tightly coupled executable coverage; no production API or runtime behavior changes.

Refs #2499
