### PR TITLE
[AI-Assisted] docs: correct separator construction and design APIs

### DIFF
--- a/docs/process/equipment/separators.md
+++ b/docs/process/equipment/separators.md
@@ -4,11 +4,10 @@ description: "Documentation for separator equipment in NeqSim process simulation
 keywords: "separator, two-phase, three-phase, gas-oil-water, test separator, scrubber, knockout drum, flash drum, liquid level, entrainment"
 ---
 
-# Separator Equipment
-
 Documentation for separator equipment in NeqSim process simulation.
 
 ## Table of Contents
+
 - [Overview](#overview)
 - [Separator Types](#separator-types)
 - [Three-Phase Separator in Detail](#three-phase-separator-in-detail)
@@ -46,13 +45,14 @@ Documentation for separator equipment in NeqSim process simulation.
 
 ```java
 import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.StreamInterface;
 
 Separator separator = new Separator("V-100", inletStream);
 separator.run();
 
 // Get outlet streams
-Stream gasOut = separator.getGasOutStream();
-Stream liquidOut = separator.getLiquidOutStream();
+StreamInterface gasOut = separator.getGasOutStream();
+StreamInterface liquidOut = separator.getLiquidOutStream();
 
 // Properties
 double gasRate = gasOut.getFlowRate("kg/hr");
@@ -64,32 +64,38 @@ double liquidLevel = separator.getLiquidLevel();
 
 ```java
 import neqsim.process.equipment.separator.ThreePhaseSeparator;
+import neqsim.process.equipment.stream.StreamInterface;
 
 ThreePhaseSeparator separator = new ThreePhaseSeparator("V-200", inletStream);
 separator.run();
 
 // Get outlet streams
-Stream gasOut = separator.getGasOutStream();
-Stream oilOut = separator.getOilOutStream();
-Stream waterOut = separator.getWaterOutStream();
+StreamInterface gasOut = separator.getGasOutStream();
+StreamInterface oilOut = separator.getOilOutStream();
+StreamInterface waterOut = separator.getWaterOutStream();
 
-// Water cut
-double waterCut = separator.getWaterCut();
+// Produced-liquid water mass fraction (explicit basis)
+double waterMassFlow = waterOut.getFlowRate("kg/hr");
+double oilMassFlow = oilOut.getFlowRate("kg/hr");
+double producedLiquidMassFlow = oilMassFlow + waterMassFlow;
+double producedLiquidWaterMassFraction =
+    producedLiquidMassFlow > 0.0 ? waterMassFlow / producedLiquidMassFlow : 0.0;
 ```
 
 ### Gas Scrubber
 
 ```java
 import neqsim.process.equipment.separator.GasScrubber;
+import neqsim.process.equipment.stream.StreamInterface;
 
 GasScrubber scrubber = new GasScrubber("Inlet Scrubber", gasStream);
 scrubber.run();
 
 // Dry gas output
-Stream dryGas = scrubber.getGasOutStream();
+StreamInterface dryGas = scrubber.getGasOutStream();
 
 // Condensate removal
-Stream condensate = scrubber.getLiquidOutStream();
+StreamInterface condensate = scrubber.getLiquidOutStream();
 ```
 
 > **Note:** Gas scrubbers automatically use K-value only constraints (`useGasScrubberConstraints()`).
@@ -99,7 +105,7 @@ Stream condensate = scrubber.getLiquidOutStream();
 
 ## Three-Phase Separator in Detail
 
-The `ThreePhaseSeparator` extends `Separator` and separates a multiphase feed into three outlet streams: gas, oil, and water (aqueous). It requires the fluid to have `setMultiPhaseCheck(true)` so the thermodynamic flash produces distinct oil and aqueous phases.
+The `ThreePhaseSeparator` extends `Separator` and separates a multiphase feed into three outlet streams: gas, oil, and water (aqueous). During `run()`, it temporarily enables the thermodynamic multiphase check for its internal flash and restores the cloned fluid setting afterward. Calling `setMultiPhaseCheck(true)` on the feed is therefore not a separator prerequisite; use it when the upstream feed itself must be initialized or inspected as multiphase. Distinct oil and aqueous phases still depend on the selected thermodynamic model, composition, temperature, and pressure.
 
 ### Creating a Three-Phase Separator
 
@@ -114,7 +120,7 @@ fluid.addComponent("methane", 72.0);
 fluid.addComponent("n-heptane", 14.0);
 fluid.addComponent("water", 40.0);
 fluid.setMixingRule(10);
-fluid.setMultiPhaseCheck(true);  // REQUIRED for three-phase separation
+fluid.setMultiPhaseCheck(true);  // Optional here; useful for inspecting the feed phases
 
 Stream feed = new Stream("Feed", fluid);
 feed.setTemperature(72.0, "C");
@@ -163,7 +169,7 @@ process.add(oilHeater);
 
 // Water to treatment
 ThrottlingValve waterValve = new ThrottlingValve("Water Valve", separator.getWaterOutStream());
-waterValve.setOutletPressure(1.01325);
+waterValve.setOutletPressure(1.01325, "bara");
 process.add(waterValve);
 
 process.run();
@@ -321,7 +327,7 @@ wellStream.setPressure(120.0, "bara");
 
 // Inlet choke
 ThrottlingValve chokeValve = new ThrottlingValve("Inlet Choke", wellStream);
-chokeValve.setOutletPressure(35.0);
+chokeValve.setOutletPressure(35.0, "bara");
 
 // 1st stage separator with entrainment
 ThreePhaseSeparator hpSep = new ThreePhaseSeparator("HP Separator", chokeValve.getOutletStream());
@@ -333,7 +339,7 @@ Heater oilHeater = new Heater("Oil Heater", hpSep.getOilOutStream());
 oilHeater.setOutTemperature(85.0, "C");
 
 ThrottlingValve mpValve = new ThrottlingValve("MP Valve", oilHeater.getOutletStream());
-mpValve.setOutletPressure(7.0);
+mpValve.setOutletPressure(7.0, "bara");
 
 // 2nd stage separator
 ThreePhaseSeparator mpSep = new ThreePhaseSeparator("MP Separator", mpValve.getOutletStream());
@@ -341,7 +347,7 @@ mpSep.setEntrainment(0.003, "mass", "product", "aqueous", "oil");
 
 // Water treatment
 ThrottlingValve waterValve = new ThrottlingValve("Water DP Valve", hpSep.getWaterOutStream());
-waterValve.setOutletPressure(1.01325);
+waterValve.setOutletPressure(1.01325, "bara");
 Separator waterDegasser = new Separator("Water Degasser", waterValve.getOutletStream());
 
 // Build and run process
@@ -422,11 +428,18 @@ Horizontal separators have specific geometry parameters for sizing and level cal
 
 ### Vessel Geometry
 
-| Parameter         | Method                       | Description                                   | Unit |
-| ----------------- | ---------------------------- | --------------------------------------------- | ---- |
-| Internal Diameter | `setInternalDiameter(value)` | Vessel ID (meters)                            | m    |
-| Length            | `setLength(value, unit)`     | Tan-to-tan length                             | m    |
-| L/D Ratio         | `getLengthDiameterRatio()`   | Length to diameter ratio (design target: 3-5) | -    |
+| Parameter         | Method                                         | Description                                   | Unit |
+| ----------------- | ---------------------------------------------- | --------------------------------------------- | ---- |
+| Internal Diameter | `setInternalDiameter(value)`                   | Vessel ID                                     | m    |
+| Length            | `setSeparatorLength(value)`                    | Tan-to-tan length                             | m    |
+| L/D Ratio         | `getSeparatorLength() / getInternalDiameter()` | Derived length-to-diameter ratio              | -    |
+
+```java
+separator.setInternalDiameter(2.5);
+separator.setSeparatorLength(10.0);
+double lengthDiameterRatio =
+    separator.getSeparatorLength() / separator.getInternalDiameter();
+```
 
 ### Liquid Levels (Horizontal Separators)
 
@@ -434,24 +447,23 @@ Liquid levels are defined as percentages of internal diameter (ID). The mechanic
 
 | Level | Method      | Description                             | Default % of ID |
 | ----- | ----------- | --------------------------------------- | --------------- |
-| HHLL  | `getHHLL()` | High-High Liquid Level (alarm/shutdown) | 75%             |
+| HHLL  | `getHHLL()` | High-High Liquid Level (alarm/shutdown) | 80%             |
 | HLL   | `getHLL()`  | High Liquid Level (K-value reference)   | 70%             |
 | NLL   | `getNLL()`  | Normal Liquid Level (design point)      | 50%             |
 | LLL   | `getLLL()`  | Low Liquid Level (control warning)      | 30%             |
-| LLLL  | `getLLLL()` | Low-Low Liquid Level (alarm/shutdown)   | 25%             |
+| LLLL  | `getLLLL()` | Low-Low Liquid Level (alarm/shutdown)   | 15%             |
 
 ```java
 // Configure liquid levels (percentage of internal diameter)
 SeparatorMechanicalDesign design = (SeparatorMechanicalDesign) separator.getMechanicalDesign();
-design.setHHLLFraction(0.75);  // 75% of ID
+design.setHHLLFraction(0.80);  // 80% of ID
 design.setHLLFraction(0.70);   // 70% of ID
 design.setNLLFraction(0.50);   // 50% of ID
 design.setLLLFraction(0.30);   // 30% of ID
-design.setLLLLFraction(0.25);  // 25% of ID
+design.setLLLLFraction(0.15);  // 15% of ID
 
-// Calculate and retrieve absolute levels
-design.calcDesign();
-double hhlAbsolute = design.getHHLL();  // in meters
+// Retrieve absolute levels; the getters return meters.
+double hhllAbsolute = design.getHHLL();
 double hllAbsolute = design.getHLL();
 ```
 
@@ -461,38 +473,37 @@ For horizontal separators, effective lengths define zones for gas-liquid separat
 
 | Parameter               | Method                       | Description                                        |
 | ----------------------- | ---------------------------- | -------------------------------------------------- |
-| Gas Effective Length    | `getGasEffectiveLength()`    | Length for gas separation (inlet to outlet nozzle) |
-| Liquid Effective Length | `getLiquidEffectiveLength()` | Length for liquid settling                         |
+| Gas Effective Length    | `getEffectiveLengthGas()`    | Length for gas separation (inlet to outlet nozzle) |
+| Liquid Effective Length | `getEffectiveLengthLiquid()` | Length for liquid settling                         |
 
 ```java
 // Get effective lengths for capacity calculations
-double Leff_gas = separator.getMechanicalDesign().getGasEffectiveLength();
-double Leff_liquid = separator.getMechanicalDesign().getLiquidEffectiveLength();
+SeparatorMechanicalDesign design = separator.getMechanicalDesign();
+double effectiveGasLength = design.getEffectiveLengthGas();
+double effectiveLiquidLength = design.getEffectiveLengthLiquid();
 ```
 
 ### Pre-Designed Separator Setup
 
-For existing/pre-designed separators, use the convenience methods:
+Pre-designed geometry is configured on `SeparatorMechanicalDesign`. Set the process-equipment geometry as well when runtime or dynamic vessel holdup uses the imported dimensions. All values below are in meters.
 
 ```java
-// Option 1: Set from existing design
-separator.setFromExistingDesign(
-    2.5,    // internal diameter [m]
-    10.0,   // length (tan-to-tan) [m]
-    0.70,   // HLL fraction (% of ID)
-    0.50,   // NLL fraction (% of ID)
-    8.0,    // liquid effective length [m]
-    9.0     // gas effective length [m]
-);
+SeparatorMechanicalDesign design = separator.getMechanicalDesign();
 
-// Option 2: Alternative design specification
-separator.setFromDesignSpec(
-    2.5,    // internal diameter [m]
-    10.0,   // length [m]
-    0.70,   // HLL fraction
-    0.50    // NLL fraction
-);
-// Effective lengths default to 80% and 90% of total length
+// Runtime/dynamic vessel geometry
+separator.setInternalDiameter(2.5);
+separator.setSeparatorLength(10.0);
+
+// Complete existing design: ID, tan-to-tan length, wall thickness,
+// liquid/gas effective lengths, then inlet/gas/oil/water nozzle IDs.
+design.setFromExistingDesign(
+    2.5, 10.0, 0.025, 8.0, 9.0, 0.50, 0.45, 0.35, 0.30);
+
+// Alternative design specification: ID, length, effective lengths, inlet nozzle,
+// HHLL, HLL, NLL, LLL, weir, HIL, NIL, and LIL absolute heights.
+design.setFromDesignSpec(
+    2.5, 10.0, 8.0, 9.0, 0.50,
+    2.00, 1.75, 1.25, 0.75, 0.625, 0.60, 0.50, 0.35);
 ```
 
 ---
@@ -501,26 +512,25 @@ separator.setFromDesignSpec(
 
 Three-phase separators have additional interface level parameters for oil-water separation.
 
+Fresh mechanical-design objects use the interface defaults below. Calling `calculateDefaultLevelFractions()` explicitly changes HIL, NIL, and LIL to 24%, 21%, and 14% of ID, respectively.
+
 ### Interface Levels
 
 | Level | Method     | Description                           | Default % of ID |
 | ----- | ---------- | ------------------------------------- | --------------- |
-| HIL   | `getHIL()` | High Interface Level                  | 45%             |
-| NIL   | `getNIL()` | Normal Interface Level (design point) | 40%             |
-| LIL   | `getLIL()` | Low Interface Level                   | 35%             |
+| HIL   | `getHIL()` | High Interface Level                  | 25%             |
+| NIL   | `getNIL()` | Normal Interface Level (design point) | 20%             |
+| LIL   | `getLIL()` | Low Interface Level                   | 15%             |
 
 ```java
 // Configure interface levels
 SeparatorMechanicalDesign design = (SeparatorMechanicalDesign) separator.getMechanicalDesign();
-design.setHILFraction(0.45);  // 45% of ID
-design.setNILFraction(0.40);  // 40% of ID
-design.setLILFraction(0.35);  // 35% of ID
+design.setHILFraction(0.25);  // 25% of ID
+design.setNILFraction(0.20);  // 20% of ID
+design.setLILFraction(0.15);  // 15% of ID
 
-// Calculate designs
-design.calcDesign();
-
-// Get absolute interface levels
-double nilAbsolute = design.getNIL();  // in meters
+// Get the absolute interface level in meters.
+double nilAbsolute = design.getNIL();
 ```
 
 ### Weir Configuration
@@ -528,8 +538,8 @@ double nilAbsolute = design.getNIL();  // in meters
 Three-phase separators typically use a weir to maintain the oil-water interface.
 
 ```java
-// Set weir height (typically at or slightly above NIL)
-design.setWeirHeight(design.getNIL() * 1.05);  // 5% above NIL
+// Set an absolute weir height for design and dynamic overflow control.
+design.setWeirHeightAbsolute(design.getNIL() * 1.05);  // 5% above NIL
 ```
 
 ### Three-Phase Specific Calculations
@@ -540,13 +550,14 @@ separator.setInternalDiameter(2.5);  // meters
 separator.setSeparatorLength(12.0);  // meters
 separator.run();
 
-// Oil retention time (from NLL to NIL)
+// Oil retention time for the layer between NIL (interface) and NLL (oil surface)
 double oilRetention = separator.calcOilRetentionTime();  // minutes
 
-// Water retention time (from NIL to vessel bottom)
+// Water retention time for the layer below NIL
 double waterRetention = separator.calcWaterRetentionTime();  // minutes
 
-// Interface settling time
+// Screening time for a fixed 150 µm water droplet settling through the oil layer
+// with the Stokes-law expression implemented by the current model
 double settlingTime = separator.calcInterfaceSettlingTime();  // minutes
 ```
 
@@ -993,6 +1004,7 @@ Example JSON output:
 ```java
 import neqsim.process.equipment.separator.ThreePhaseSeparator;
 import neqsim.process.equipment.stream.Stream;
+import neqsim.process.mechanicaldesign.separator.SeparatorMechanicalDesign;
 import neqsim.thermo.system.SystemSrkEos;
 
 // Create feed
@@ -1009,14 +1021,11 @@ feed.run();
 
 // Create separator with pre-designed dimensions
 ThreePhaseSeparator separator = new ThreePhaseSeparator("Production Sep", feed);
-separator.setFromExistingDesign(
-    2.5,    // ID [m]
-    10.0,   // Length [m]
-    0.70,   // HLL fraction
-    0.50,   // NLL fraction
-    8.0,    // Liquid Leff [m]
-    9.0     // Gas Leff [m]
-);
+separator.setInternalDiameter(2.5);
+separator.setSeparatorLength(10.0);
+SeparatorMechanicalDesign design = separator.getMechanicalDesign();
+design.setFromExistingDesign(
+    2.5, 10.0, 0.025, 8.0, 9.0, 0.50, 0.45, 0.35, 0.30);
 
 // Apply Equinor TR3500 constraints
 separator.useEquinorConstraints();

--- a/docs/test_separator_core_documentation.py
+++ b/docs/test_separator_core_documentation.py
@@ -37,7 +37,10 @@ class SeparatorCoreDocumentationTest(unittest.TestCase):
     def test_front_matter_has_no_duplicate_body_h1(self):
         self.assertTrue(self.guide.startswith("---\ntitle:"))
         body = self.guide.split("---", 2)[2]
-        self.assertNotRegex(body, r"(?m)^# ")
+        body_without_fenced_code = re.sub(
+            r"```.*?```", "", body, flags=re.DOTALL
+        )
+        self.assertNotRegex(body_without_fenced_code, r"(?m)^# ")
 
     def test_outlet_examples_use_declared_stream_interface_types(self):
         for source_contract in (

--- a/docs/test_separator_core_documentation.py
+++ b/docs/test_separator_core_documentation.py
@@ -1,0 +1,188 @@
+"""Regression contracts for the source-verified separator equipment guide."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDE = ROOT / "docs" / "process" / "equipment" / "separators.md"
+SEPARATOR_SOURCE = (
+    ROOT
+    / "src/main/java/neqsim/process/equipment/separator/Separator.java"
+)
+THREE_PHASE_SOURCE = (
+    ROOT
+    / "src/main/java/neqsim/process/equipment/separator/ThreePhaseSeparator.java"
+)
+DESIGN_SOURCE = (
+    ROOT
+    / (
+        "src/main/java/neqsim/process/mechanicaldesign/separator/"
+        "SeparatorMechanicalDesign.java"
+    )
+)
+
+
+class SeparatorCoreDocumentationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+        cls.guide_prose = " ".join(cls.guide.split()).lower()
+        cls.separator_source = SEPARATOR_SOURCE.read_text(encoding="utf-8")
+        cls.three_phase_source = THREE_PHASE_SOURCE.read_text(encoding="utf-8")
+        cls.design_source = DESIGN_SOURCE.read_text(encoding="utf-8")
+        cls.normalized_design_source = " ".join(cls.design_source.split())
+
+    def test_front_matter_has_no_duplicate_body_h1(self):
+        self.assertTrue(self.guide.startswith("---\ntitle:"))
+        body = self.guide.split("---", 2)[2]
+        self.assertNotRegex(body, r"(?m)^# ")
+
+    def test_outlet_examples_use_declared_stream_interface_types(self):
+        for source_contract in (
+            "public StreamInterface getGasOutStream()",
+            "public StreamInterface getLiquidOutStream()",
+        ):
+            with self.subTest(source_contract=source_contract):
+                self.assertIn(source_contract, self.separator_source)
+        for source_contract in (
+            "public StreamInterface getOilOutStream()",
+            "public StreamInterface getWaterOutStream()",
+        ):
+            with self.subTest(source_contract=source_contract):
+                self.assertIn(source_contract, self.three_phase_source)
+        for guide_contract in (
+            "StreamInterface gasOut = separator.getGasOutStream();",
+            "StreamInterface oilOut = separator.getOilOutStream();",
+            "StreamInterface waterOut = separator.getWaterOutStream();",
+            "StreamInterface dryGas = scrubber.getGasOutStream();",
+            "StreamInterface condensate = scrubber.getLiquidOutStream();",
+        ):
+            with self.subTest(guide_contract=guide_contract):
+                self.assertIn(guide_contract, self.guide)
+
+    def test_water_fraction_has_an_explicit_mass_basis(self):
+        self.assertNotIn("getWaterCut()", self.guide)
+        self.assertIn("producedLiquidWaterMassFraction", self.guide)
+        self.assertIn('waterOut.getFlowRate("kg/hr")', self.guide)
+        self.assertIn('oilOut.getFlowRate("kg/hr")', self.guide)
+        self.assertIn("producedLiquidMassFlow > 0.0", self.guide)
+
+    def test_multiphase_check_is_not_documented_as_a_prerequisite(self):
+        for source_contract in (
+            "if (!thermoSystem2.doMultiPhaseCheck())",
+            "thermoSystem2.setMultiPhaseCheck(true)",
+            "thermoSystem2.setMultiPhaseCheck(false)",
+        ):
+            with self.subTest(source_contract=source_contract):
+                self.assertIn(source_contract, self.three_phase_source)
+        self.assertIn("not a separator prerequisite", self.guide_prose)
+        self.assertNotIn("REQUIRED for three-phase separation", self.guide)
+
+    def test_pressure_examples_use_explicit_bara_units(self):
+        for contract in (
+            'setOutletPressure(1.01325, "bara")',
+            'setOutletPressure(35.0, "bara")',
+            'setOutletPressure(7.0, "bara")',
+            'setOutletPressure(5.0, "bara")',
+        ):
+            with self.subTest(contract=contract):
+                self.assertIn(contract, self.guide)
+        self.assertIsNone(
+            re.search(r"setOutletPressure\([^,\n]+\);", self.guide)
+        )
+
+    def test_geometry_and_effective_length_apis_match_source(self):
+        for stale_api in (
+            "setLength(value, unit)",
+            "getLengthDiameterRatio()",
+            "getGasEffectiveLength()",
+            "getLiquidEffectiveLength()",
+        ):
+            with self.subTest(stale_api=stale_api):
+                self.assertNotIn(stale_api, self.guide)
+        for source_contract in (
+            "public double getEffectiveLengthGas()",
+            "public double getEffectiveLengthLiquid()",
+        ):
+            with self.subTest(source_contract=source_contract):
+                self.assertIn(source_contract, self.design_source)
+        self.assertIn("separator.setSeparatorLength(10.0);", self.guide)
+        self.assertIn(
+            "separator.getSeparatorLength() / separator.getInternalDiameter()",
+            self.guide,
+        )
+
+    def test_imported_design_examples_use_current_owner_and_signatures(self):
+        existing_signature = (
+            "public void setFromExistingDesign(double id, double tanTanLength, "
+            "double wallThick, double lEffLiquid, double lEffGas, double "
+            "inletNozzle, double gasNozzle, double oilNozzle, "
+            "double waterNozzle)"
+        )
+        spec_signature = (
+            "public void setFromDesignSpec(double id, double length, "
+            "double lEffLiquid, double lEffGas, double inletNozzleId, "
+            "double hhll, double hll, double nll, double lll, double weir, "
+            "double hil, double nil, double lil)"
+        )
+        self.assertIn(existing_signature, self.normalized_design_source)
+        self.assertIn(spec_signature, self.normalized_design_source)
+        self.assertIn("design.setFromExistingDesign(", self.guide)
+        self.assertIn("design.setFromDesignSpec(", self.guide)
+        self.assertNotIn("separator.setFromExistingDesign(", self.guide)
+        self.assertNotIn("separator.setFromDesignSpec(", self.guide)
+
+    def test_level_defaults_weir_and_retention_basis_match_source(self):
+        for source_contract in (
+            "private double hhllFraction = 0.80;",
+            "private double llllFraction = 0.15;",
+            "private double hilFraction = 0.25;",
+            "private double nilFraction = 0.20;",
+            "private double lilFraction = 0.15;",
+            "public void setWeirHeightAbsolute(double height)",
+        ):
+            with self.subTest(source_contract=source_contract):
+                self.assertIn(source_contract, self.design_source)
+        for guide_contract in (
+            "| HHLL  | `getHHLL()` | High-High Liquid Level "
+            "(alarm/shutdown) | 80%",
+            "| LLLL  | `getLLLL()` | Low-Low Liquid Level "
+            "(alarm/shutdown)   | 15%",
+            "design.setWeirHeightAbsolute(",
+            "between NIL (interface) and NLL (oil surface)",
+            "fixed 150 µm water droplet",
+            "Stokes-law expression",
+        ):
+            with self.subTest(guide_contract=guide_contract):
+                self.assertIn(guide_contract, self.guide)
+        self.assertIn("double dropletDiameter = 150e-6;", self.three_phase_source)
+
+    def test_current_examples_have_executable_java_regressions(self):
+        java_test = (
+            ROOT
+            / (
+                "src/test/java/neqsim/process/equipment/separator/"
+                "SeparatorGuideDocumentationTest.java"
+            )
+        ).read_text(encoding="utf-8")
+        for contract in (
+            "threePhaseExampleUsesCurrentOutletAndMassFractionApis",
+            "mechanicalDesignExampleUsesCurrentGeometryApis",
+            "StreamInterface gasOut",
+            "producedLiquidWaterMassFraction",
+            "design.setFromExistingDesign(",
+            "design.setFromDesignSpec(",
+            "design.setWeirHeightAbsolute(",
+        ):
+            with self.subTest(contract=contract):
+                self.assertIn(contract, java_test)
+
+    def test_related_separator_guide_resolves(self):
+        target = GUIDE.parent / "separator-entrainment-modeling.md"
+        self.assertTrue(target.is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test/java/neqsim/process/equipment/separator/SeparatorGuideDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/separator/SeparatorGuideDocumentationTest.java
@@ -51,13 +51,11 @@ class SeparatorGuideDocumentationTest {
     double producedLiquidMassFlow = oilMassFlow + waterMassFlow;
     assertTrue(producedLiquidMassFlow > 0.0);
 
-    double producedLiquidWaterMassFraction =
-        waterMassFlow / producedLiquidMassFlow;
+    double producedLiquidWaterMassFraction = waterMassFlow / producedLiquidMassFlow;
     assertTrue(producedLiquidWaterMassFraction >= 0.0);
     assertTrue(producedLiquidWaterMassFraction <= 1.0);
 
-    double outletMassFlow =
-        gasOut.getFlowRate("kg/hr") + oilMassFlow + waterMassFlow;
+    double outletMassFlow = gasOut.getFlowRate("kg/hr") + oilMassFlow + waterMassFlow;
     double inletMassFlow = feed.getFlowRate("kg/hr");
     assertEquals(inletMassFlow, outletMassFlow, inletMassFlow * 1.0e-5);
   }
@@ -76,17 +74,12 @@ class SeparatorGuideDocumentationTest {
     assertEquals(0.20, design.getNILFraction(), 1.0e-12);
     assertEquals(0.15, design.getLILFraction(), 1.0e-12);
 
-    design.setFromExistingDesign(
-        2.5, 10.0, 0.025, 8.0, 9.0, 0.50, 0.45, 0.35, 0.30);
-    assertEquals(4.0,
-        separator.getSeparatorLength() / separator.getInternalDiameter(),
-        1.0e-12);
+    design.setFromExistingDesign(2.5, 10.0, 0.025, 8.0, 9.0, 0.50, 0.45, 0.35, 0.30);
+    assertEquals(4.0, separator.getSeparatorLength() / separator.getInternalDiameter(), 1.0e-12);
     assertEquals(8.0, design.getEffectiveLengthLiquid(), 1.0e-12);
     assertEquals(9.0, design.getEffectiveLengthGas(), 1.0e-12);
 
-    design.setFromDesignSpec(
-        2.5, 10.0, 8.0, 9.0, 0.50,
-        2.00, 1.75, 1.25, 0.75, 0.625, 0.60, 0.50, 0.35);
+    design.setFromDesignSpec(2.5, 10.0, 8.0, 9.0, 0.50, 2.00, 1.75, 1.25, 0.75, 0.625, 0.60, 0.50, 0.35);
     assertEquals(2.00, design.getHHLL(), 1.0e-12);
     assertEquals(1.25, design.getNLL(), 1.0e-12);
     assertEquals(0.50, design.getNIL(), 1.0e-12);

--- a/src/test/java/neqsim/process/equipment/separator/SeparatorGuideDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/separator/SeparatorGuideDocumentationTest.java
@@ -1,0 +1,98 @@
+package neqsim.process.equipment.separator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.mechanicaldesign.separator.SeparatorMechanicalDesign;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkCPAstatoil;
+
+/** Executes the core examples in docs/process/equipment/separators.md. */
+class SeparatorGuideDocumentationTest {
+
+  private Stream createThreePhaseFeed() {
+    SystemInterface fluid = new SystemSrkCPAstatoil(273.15 + 42.0, 10.0);
+    fluid.addComponent("methane", 72.0);
+    fluid.addComponent("n-heptane", 14.0);
+    fluid.addComponent("water", 40.0);
+    fluid.setMixingRule(10);
+
+    Stream feed = new Stream("Feed", fluid);
+    feed.setTemperature(72.0, "C");
+    feed.setPressure(10.7, "bara");
+    feed.setFlowRate(720.0, "kg/hr");
+    feed.run();
+    return feed;
+  }
+
+  /** Prove the documented outlets and explicit produced-liquid water fraction execute. */
+  @Test
+  void threePhaseExampleUsesCurrentOutletAndMassFractionApis() {
+    Stream feed = createThreePhaseFeed();
+    assertFalse(feed.getFluid().doMultiPhaseCheck());
+
+    ThreePhaseSeparator separator = new ThreePhaseSeparator("1st Stage Sep", feed);
+    separator.run();
+
+    StreamInterface gasOut = separator.getGasOutStream();
+    StreamInterface oilOut = separator.getOilOutStream();
+    StreamInterface waterOut = separator.getWaterOutStream();
+    assertNotNull(gasOut);
+    assertNotNull(oilOut);
+    assertNotNull(waterOut);
+    assertFalse(feed.getFluid().doMultiPhaseCheck());
+
+    double waterMassFlow = waterOut.getFlowRate("kg/hr");
+    double oilMassFlow = oilOut.getFlowRate("kg/hr");
+    double producedLiquidMassFlow = oilMassFlow + waterMassFlow;
+    assertTrue(producedLiquidMassFlow > 0.0);
+
+    double producedLiquidWaterMassFraction =
+        waterMassFlow / producedLiquidMassFlow;
+    assertTrue(producedLiquidWaterMassFraction >= 0.0);
+    assertTrue(producedLiquidWaterMassFraction <= 1.0);
+
+    double outletMassFlow =
+        gasOut.getFlowRate("kg/hr") + oilMassFlow + waterMassFlow;
+    double inletMassFlow = feed.getFlowRate("kg/hr");
+    assertEquals(inletMassFlow, outletMassFlow, inletMassFlow * 1.0e-5);
+  }
+
+  /** Prove the documented vessel and imported mechanical-design APIs execute. */
+  @Test
+  void mechanicalDesignExampleUsesCurrentGeometryApis() {
+    ThreePhaseSeparator separator = new ThreePhaseSeparator("Production Sep");
+    separator.setInternalDiameter(2.5);
+    separator.setSeparatorLength(10.0);
+
+    SeparatorMechanicalDesign design = separator.getMechanicalDesign();
+    assertEquals(0.80, design.getHHLLFraction(), 1.0e-12);
+    assertEquals(0.15, design.getLLLLFraction(), 1.0e-12);
+    assertEquals(0.25, design.getHILFraction(), 1.0e-12);
+    assertEquals(0.20, design.getNILFraction(), 1.0e-12);
+    assertEquals(0.15, design.getLILFraction(), 1.0e-12);
+
+    design.setFromExistingDesign(
+        2.5, 10.0, 0.025, 8.0, 9.0, 0.50, 0.45, 0.35, 0.30);
+    assertEquals(4.0,
+        separator.getSeparatorLength() / separator.getInternalDiameter(),
+        1.0e-12);
+    assertEquals(8.0, design.getEffectiveLengthLiquid(), 1.0e-12);
+    assertEquals(9.0, design.getEffectiveLengthGas(), 1.0e-12);
+
+    design.setFromDesignSpec(
+        2.5, 10.0, 8.0, 9.0, 0.50,
+        2.00, 1.75, 1.25, 0.75, 0.625, 0.60, 0.50, 0.35);
+    assertEquals(2.00, design.getHHLL(), 1.0e-12);
+    assertEquals(1.25, design.getNLL(), 1.0e-12);
+    assertEquals(0.50, design.getNIL(), 1.0e-12);
+
+    design.setWeirHeightAbsolute(design.getNIL() * 1.05);
+    assertEquals(0.525, design.getWeirHeightAbsolute(), 1.0e-12);
+    assertEquals(0.525, separator.getWeirHeight(), 1.0e-12);
+  }
+}


### PR DESCRIPTION
## Summary

- correct separator, three-phase separator, and gas-scrubber outlet examples to use the declared `StreamInterface` return type
- replace the nonexistent water-cut getter with an explicit produced-liquid water mass fraction and document the separator's internal multiphase-flash behavior
- make pressure units explicit and align geometry, effective-length, imported-design, level-default, weir, and retention-time guidance with current source
- add ten source/documentation contracts and two executable Java regressions

## Campaign

Advances documentation-quality campaign #2499 as D092.

Frozen scope: `docs/process/equipment/separators.md` core construction, topology, runtime geometry, and mechanical-design examples, plus tightly coupled regression coverage.

Stop boundary: no separator production-code changes; no performance-model, auto-sizing, standards, notebook, PFD/DEXPI, electrolyte, or Huldra work.

Exact base: `c7fc360609e5152f5f21d3f4c711d6683c748a5a`  
Exact head: `68f33a3c07a3255eb88604e938181a22f7ff0921`

## Validation

**VALIDATION PENDING CI**

Passed on the exact head:

- documentation contracts, Jekyll build, search-index validation, and link checks
- Spotless
- pre-commit
- Javadocs on Java 21
- CodeQL
- agent-skill cross-reference validation
- all four Java 21 slow-test shards on Ubuntu

Still running on the exact head:

- Java 21 fast tests on Ubuntu
- Java 21 tests on Windows

Connector-backed source and diff checks:

- exact source inspection at the base SHA for `Separator`, `ThreePhaseSeparator`, `GasScrubber`, and `SeparatorMechanicalDesign`
- 42 static source/documentation contract assertions
- exact frozen diff inspection: 3 files, 5 commits ahead of the frozen base

Attributable CI findings repaired on this branch:

- documentation contract now excludes fenced code before checking for a duplicate body H1
- executable Java coverage formatted exactly as required by Spotless

Current master is two commits ahead of the frozen base. Their verified three-file delta is confined to `devtools/install_agent.py`, `devtools/test_install_agent.py`, and `docs/integration/agents_and_skills_setup.md`; it does not overlap this PR's three frozen files. The PR is mergeable. No running check is claimed as passed until it completes on this exact head.

## Documentation impact

Documentation impact: direct and complete for the frozen separator-core batch. The guide now states the current public APIs, explicit units, default level fractions, phase-basis calculation, runtime/design geometry boundary, and fixed-droplet screening limitation.

## Review notes

The `ThreePhaseSeparator` regression intentionally leaves the feed's multiphase-check flag disabled. It proves that `run()` performs its documented temporary internal multiphase flash without mutating the feed setting, while still accounting for gas, oil, and water outlet mass.

The PR remains draft. No merge, ready-for-review transition, or Huldra work is part of this batch.
