### PR TITLE
[AI-Assisted] Package multi-area DEXPI Process exchanges

### DIFF
--- a/docs/integration/dexpi-20-conformance.md
+++ b/docs/integration/dexpi-20-conformance.md
@@ -82,10 +82,39 @@ DEXPI Process. A missing or incompatible node omits that individual quantity and
 `DEXPI_PROCESS_OPERATING_VALUE_MISSING`; it never falls back to a live stream read. The established
 four-argument overload remains topology-only and retains its existing XML and report shape.
 
-The assessed path reports energy and signal connections, multi-area `ProcessModel` hierarchy,
-controlled document/sheet semantics, and drawing graphics as unsupported scopes. These warnings do
-not hide a supported material-topology error; missing, unexpected, unresolved-port, and reused-port
-findings are errors.
+## Multi-area ProcessModel package
+
+`Dexpi20ProcessModelPackageWriter.writeAndAssess(...)` provides a bounded multi-area delivery
+container without inventing a DEXPI whole-plant hierarchy:
+
+```java
+File processPackage = new File("facility-process-model.zip");
+Dexpi20ProcessModelPackageWriter.Report packageReport =
+    Dexpi20ProcessModelPackageWriter.writeAndAssess(
+        processModel, processPackage, "PLANT-001", "A");
+if (!packageReport.isComplete()) {
+  throw new IllegalStateException(packageReport.toJson());
+}
+```
+
+The deterministic ZIP contains one independently schema/profile/topology-assessed native DEXPI
+Process XML file per named `ProcessModel` area and a NeqSim `manifest.json`. The manifest pins the
+canonical plant fingerprint, stable area and connection IDs, source revision, file SHA-256 values,
+and structured loss diagnostics. An optional operating-case overload uses the same case-matched
+canonical calculation-node rules as the single-area assessed exporter.
+
+Cross-area material connections are preserved as `MANIFEST_ONLY_CROSS_AREA`. Energy and
+information connections are preserved as `MANIFEST_ONLY_NOT_MAPPED_TO_NATIVE_PROCESS`. They are
+therefore explicit plant-wide semantic evidence, but are not claimed to be native DEXPI Process
+relationships. Controlled documents/sheets and graphics remain separate projections. The package
+reports `nativeWholePlantDexpiExchange=false`, `approvalStatus=REVIEW_REQUIRED`, and
+`fitnessForConstruction=false`; it is not a new DEXPI profile, standards-conformance claim, or
+drawing approval.
+
+The single-area assessed path reports energy and signal connections, multi-area `ProcessModel`
+hierarchy, controlled document/sheet semantics, and drawing graphics as unsupported scopes. These
+warnings do not hide a supported material-topology error; missing, unexpected, unresolved-port, and
+reused-port findings are errors.
 
 Each process connection has a dedicated source and target `MaterialPort`. The ports and
 `Process.Stream` carry reciprocal references, stable identifiers, nominal directions, and explicit
@@ -149,6 +178,9 @@ Record that separate evidence through `DexpiToolQualificationRunner` and
 - Retain the canonical topology fingerprint, structured topology report, operating-case identifier
   and value-source evidence, and source model revision beside the XML and conformance report when
   using the opt-in operating-case overload of `writeAndAssessTopology(...)`.
+- For a multi-area package, retain the ZIP and manifest SHA-256 values and review every manifest-only
+  cross-area, energy, and information diagnostic; do not treat package completeness as native
+  whole-plant DEXPI coverage.
 - Treat graphics, project standard-library restrictions, vendor extensions, and CAE certification as
   separate qualification scopes.
 

--- a/docs/integration/dexpi-pid-current-master-audit.md
+++ b/docs/integration/dexpi-pid-current-master-audit.md
@@ -31,7 +31,7 @@ test, fixture, example, and qualification surfaces required by issue #2899.
 | Proteus-compatible export | `processmodel.dexpi.DexpiXmlWriter`, compatibility facade `processmodel.DexpiXmlWriter` | `ProcessSystem`, `ProcessModel`, pyDEXPI namespace-omitted output, layout and compatibility sheets | Not native DEXPI 2.0; sheets are not a controlled drawing set |
 | Proteus-compatible import | `DexpiXmlReader`, `DexpiTopologyResolver`, `DexpiEquipmentFactory`, `DexpiSimulationBuilder` | Equipment, nozzles, piping segments, instruments, mappings, and a runnable process scaffold | Imported topology still requires fluid, cases, specifications, dynamics, and accountable review |
 | Native DEXPI 2.0 Plant | `Dexpi20XmlWriter`, `Dexpi20EngineeringMaterializer` | Core/Plant items, piping, nozzles, instrumentation, safeguards, boundaries, and representations | Plant exchange is not Process/PFD exchange or a DEXPI EV certificate |
-| Native DEXPI 2.0 Process | `Dexpi20ProcessModelWriter`, `Dexpi20ProcessTopologyAssessment` | Process steps, explicit material ports, streams, selected physical quantities, canonical topology assessment | Assessed canonical export is currently `ProcessSystem` material-focused; multi-area, graphics, energy, signal, and document scopes remain diagnosed gaps |
+| Native DEXPI 2.0 Process | `Dexpi20ProcessModelWriter`, `Dexpi20ProcessTopologyAssessment`, `Dexpi20ProcessModelPackageWriter` | Process steps, explicit material ports, streams, selected physical quantities, canonical topology assessment, and deterministic assessed per-area packages | The multi-area ZIP manifest preserves cross-area material plus energy/information identity as explicit manifest-only evidence; it is not native whole-plant DEXPI, and graphics/document scopes remain separate |
 | Common model helpers | `DexpiMetadata`, `DexpiStream`, `DexpiProcessUnit`, `DexpiInstrumentInfo`, `DexpiStreamUtils`, `DexpiServiceClassifier`, `NorsokLineNumber` | Metadata, supported object classification, line/tag helpers, and compatibility DTOs | These helpers do not constitute a shared immutable drawing/document model |
 | Round-trip profile | `DexpiRoundTripProfile`, `EngineeringDexpiRoundTripQualifier` | Internal structural identity/reference comparison and explicit qualification status | Internal round trip is weaker than named-product import/export evidence |
 
@@ -75,6 +75,7 @@ Run the current DEXPI/P&ID baseline with the repository Maven wrapper. The focus
 
 ```text
 Dexpi20ProcessModelWriterTest
+Dexpi20ProcessModelPackageWriterTest
 Dexpi20SemanticValidatorTest
 DexpiXmlWriterTest
 DexpiXmlReaderTest
@@ -121,7 +122,7 @@ proposal boundaries from fresh models.
 | `professional_process_flow_diagrams.ipynb` | Simulator Graphviz views and Proteus/pyDEXPI rendering | Not a native professional PFD or standards qualification |
 | `dexpi_pid_visualization.ipynb` | DEXPI visualization and internal round-trip evidence | External renderer/tool qualification remains environment-specific |
 | `dexpi_engineering_full_processsystem.ipynb` | Governed `ProcessSystem` engineering/DEXPI package | Does not qualify a multi-sheet accountable P&ID |
-| `dexpi_engineering_processmodel.ipynb` | Multi-area engineering package | Native DEXPI Process multi-area document exchange remains a gap |
+| `dexpi_engineering_processmodel.ipynb` | Multi-area engineering package | Deterministic per-area native Process packaging is available; notebook adoption and native whole-plant/document semantics remain gaps |
 | `complete_pid_design_synthesis.ipynb` | Governed P&ID proposal synthesis and completeness | Proposal state; not discipline approval |
 | `process_to_engineering_simulator.ipynb` | End-to-end calculated engineering package | Not the NeqSim-Colab acceptance notebook |
 | NeqSim-Colab `dexpi_safety_study_workflow.ipynb` | User-facing Proteus/native profile selection, SIS/HIPPS evidence, HAZOP/cause-effect preparation, completeness and traceability | Current saved run uses released NeqSim 3.17.0; it does not yet exercise current-master canonical operating values, realistic multi-area/cross-sheet content, revision delta, or a native professional drawing set |
@@ -167,7 +168,7 @@ licensed standards, a named external tool, or accountable engineering review.
 | Phase 0 golden simple, branched, and multi-area cases | Present | Synthetic public executable cases pin material conservation, canonical topology/identity, supported native Process/Plant exchange, Proteus compatibility, legacy DOT, and governed P&ID proposal boundaries; unsupported native multi-area/document/graphics and SVG/PDF scopes remain structured limitations |
 | Stable identities and relationships | Partial | Canonical plant/area/equipment/port/connection IDs and governed engineering identities exist; detailed nozzles, piping, instruments, loops, safeguards, boundaries, and drawing objects do not yet share one qualified model |
 | State, units, case, and provenance separation | Partial | Canonical calculated operating values and governed design/evidence states exist; the full P&ID/document profile is not uniformly projected |
-| Deterministic ProcessSystem/ProcessModel export | Partial | Canonical topology and existing exporters are deterministic in their tested subsets; native DEXPI Process lacks multi-area export |
+| Deterministic ProcessSystem/ProcessModel export | Partial | Canonical topology and native Process exports are deterministic in tested subsets; `ProcessModel` packaging adds assessed area XML, hashes, and a plant manifest, while cross-area/energy/information semantics remain manifest-only rather than native whole-plant DEXPI |
 | Export-import-export semantic equivalence and loss | Partial | Internal structural qualifiers and canonical material comparisons exist; full Plant/Process/P&ID round trip and machine-readable loss coverage remain incomplete |
 | Schema/API compatibility and migration | Partial | Compatibility facades and byte-equivalent tested paths exist; no comprehensive versioned package migration suite covers every serialized artifact |
 | Revision semantic diff/impact | Partial | Engineering graph/package revision impact exists; affected drawing/sheet/register/study completeness is not yet end-to-end |
@@ -194,8 +195,8 @@ blocked on a controlled choice between an exchange-neutral reviewed symbol proje
 legally distributable DEXPI profile-symbol catalogue. Empty placeholder representation groups and
 invented standards mappings are not acceptable substitutes.
 
-Independent remaining work includes native Process multi-area and energy/information scope,
-end-to-end revision/MOC impact, broader P&ID object coverage, a reviewed visual-reference corpus,
+Independent remaining work includes native whole-plant Process hierarchy and native energy/information mappings beyond
+manifest-only package evidence, end-to-end revision/MOC impact, broader P&ID object coverage, a reviewed visual-reference corpus,
 fresh exact-version external DEXPIViewer execution, and named commercial-CAE qualification. These
 items must retain legacy DOT/Graphviz, native DEXPI 2.0, and Proteus/P&ID compatibility and must not
 be reported as standards conformance or drawing approval without accountable evidence.

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageWriter.java
@@ -1,0 +1,609 @@
+package neqsim.process.processmodel.dexpi;
+
+import com.google.gson.GsonBuilder;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import neqsim.process.engineering.model.EngineeringGraph;
+import neqsim.process.engineering.model.EngineeringNode;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.process.processmodel.diagram.ProcessDiagramGraphAdapter;
+
+/**
+ * Writes a deterministic multi-area NeqSim package containing native DEXPI 2.0 Process exchanges.
+ *
+ * <p>
+ * DEXPI Process files remain independently schema/profile assessed, one per {@link ProcessSystem} area. A NeqSim
+ * manifest preserves the plant-wide canonical graph fingerprint, stable area identities and cross-area connection
+ * identities. The package is not a new DEXPI profile and does not claim that manifest-only connections are present in
+ * a native whole-plant DEXPI model.
+ * </p>
+ */
+public final class Dexpi20ProcessModelPackageWriter {
+  private static final String MANIFEST_ENTRY = "manifest.json";
+  private static final String SCHEMA_VERSION = "neqsim_dexpi_2_0_process_model_package.v1";
+
+  private Dexpi20ProcessModelPackageWriter() {
+  }
+
+  /** Severity of one package-level diagnostic. */
+  public enum Severity {
+    /** Informational evidence about the bounded package representation. */
+    INFO,
+    /** Explicit retained limitation or manifest-only relationship. */
+    WARNING,
+    /** Invalid canonical or per-area exchange evidence. */
+    ERROR
+  }
+
+  /** Immutable package diagnostic. */
+  public static final class Diagnostic implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Severity severity;
+    private final String code;
+    private final String message;
+    private final String subject;
+
+    Diagnostic(Severity severity, String code, String message, String subject) {
+      this.severity = severity;
+      this.code = code;
+      this.message = message;
+      this.subject = subject == null ? "" : subject;
+    }
+
+    public Severity getSeverity() {
+      return severity;
+    }
+
+    public String getCode() {
+      return code;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public String getSubject() {
+      return subject;
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("severity", severity.name());
+      result.put("code", code);
+      result.put("message", message);
+      result.put("subject", subject);
+      return result;
+    }
+  }
+
+  /** One native per-area DEXPI Process exchange in the package. */
+  public static final class AreaExchange implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String areaName;
+    private final String areaId;
+    private final String processSystemName;
+    private final String entryName;
+    private final String fileSha256;
+    private final Dexpi20ProcessTopologyAssessment.Report assessment;
+
+    AreaExchange(String areaName, String areaId, String processSystemName, String entryName, String fileSha256,
+        Dexpi20ProcessTopologyAssessment.Report assessment) {
+      this.areaName = areaName;
+      this.areaId = areaId;
+      this.processSystemName = processSystemName;
+      this.entryName = entryName;
+      this.fileSha256 = fileSha256;
+      this.assessment = assessment;
+    }
+
+    public String getAreaName() {
+      return areaName;
+    }
+
+    public String getAreaId() {
+      return areaId;
+    }
+
+    public String getProcessSystemName() {
+      return processSystemName;
+    }
+
+    public String getEntryName() {
+      return entryName;
+    }
+
+    public String getFileSha256() {
+      return fileSha256;
+    }
+
+    public Dexpi20ProcessTopologyAssessment.Report getAssessment() {
+      return assessment;
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("areaName", areaName);
+      result.put("areaId", areaId);
+      result.put("processSystemName", processSystemName);
+      result.put("entryName", entryName);
+      result.put("fileSha256", fileSha256);
+      result.put("schemaProfileAndSupportedTopologyValid",
+          Boolean.valueOf(assessment.isSchemaProfileAndSupportedTopologyValid()));
+      result.put("assessment", assessment.toMap());
+      return result;
+    }
+  }
+
+  /** One canonical plant-wide material, energy or information connection. */
+  public static final class ConnectionRecord implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String connectionId;
+    private final String externalKey;
+    private final String connectionType;
+    private final String sourceArea;
+    private final String targetArea;
+    private final String sourceEquipment;
+    private final String targetEquipment;
+    private final String sourcePort;
+    private final String targetPort;
+    private final String carriedObjectName;
+    private final boolean crossArea;
+    private final boolean recycle;
+    private final String exchangeStatus;
+
+    ConnectionRecord(EngineeringNode node) {
+      connectionId = node.getId();
+      externalKey = node.getExternalKey();
+      connectionType = property(node, "connectionType");
+      sourceArea = property(node, "sourceArea");
+      targetArea = property(node, "targetArea");
+      sourceEquipment = property(node, "sourceEquipment");
+      targetEquipment = property(node, "targetEquipment");
+      sourcePort = property(node, "sourcePort");
+      targetPort = property(node, "targetPort");
+      carriedObjectName = property(node, "carriedObjectName");
+      crossArea = booleanProperty(node, "crossArea");
+      recycle = booleanProperty(node, "recycle");
+      exchangeStatus = "MATERIAL".equals(connectionType)
+          ? crossArea ? "MANIFEST_ONLY_CROSS_AREA" : "ASSESSED_AREA_DEXPI"
+          : "MANIFEST_ONLY_NOT_MAPPED_TO_NATIVE_PROCESS";
+    }
+
+    public String getConnectionId() {
+      return connectionId;
+    }
+
+    public String getConnectionType() {
+      return connectionType;
+    }
+
+    public String getSourceArea() {
+      return sourceArea;
+    }
+
+    public String getTargetArea() {
+      return targetArea;
+    }
+
+    public boolean isCrossArea() {
+      return crossArea;
+    }
+
+    public String getExchangeStatus() {
+      return exchangeStatus;
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("connectionId", connectionId);
+      result.put("externalKey", externalKey);
+      result.put("connectionType", connectionType);
+      result.put("sourceArea", sourceArea);
+      result.put("targetArea", targetArea);
+      result.put("sourceEquipment", sourceEquipment);
+      result.put("targetEquipment", targetEquipment);
+      result.put("sourcePort", sourcePort);
+      result.put("targetPort", targetPort);
+      result.put("carriedObjectName", carriedObjectName);
+      result.put("crossArea", Boolean.valueOf(crossArea));
+      result.put("recycle", Boolean.valueOf(recycle));
+      result.put("exchangeStatus", exchangeStatus);
+      return result;
+    }
+  }
+
+  /** Immutable evidence for one deterministic multi-area package. */
+  public static final class Report implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String plantId;
+    private final String revision;
+    private final String operatingCaseId;
+    private final String canonicalFingerprint;
+    private final List<AreaExchange> areaExchanges;
+    private final List<ConnectionRecord> connections;
+    private final List<Diagnostic> diagnostics;
+    private final String packageFileSha256;
+    private final String manifestSha256;
+
+    Report(String plantId, String revision, String operatingCaseId, String canonicalFingerprint,
+        List<AreaExchange> areaExchanges, List<ConnectionRecord> connections, List<Diagnostic> diagnostics,
+        String packageFileSha256, String manifestSha256) {
+      this.plantId = plantId;
+      this.revision = revision;
+      this.operatingCaseId = operatingCaseId;
+      this.canonicalFingerprint = canonicalFingerprint;
+      this.areaExchanges = Collections.unmodifiableList(new ArrayList<AreaExchange>(areaExchanges));
+      this.connections = Collections.unmodifiableList(new ArrayList<ConnectionRecord>(connections));
+      this.diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+      this.packageFileSha256 = packageFileSha256;
+      this.manifestSha256 = manifestSha256;
+    }
+
+    public String getCanonicalFingerprint() {
+      return canonicalFingerprint;
+    }
+
+    public List<AreaExchange> getAreaExchanges() {
+      return areaExchanges;
+    }
+
+    public List<ConnectionRecord> getConnections() {
+      return connections;
+    }
+
+    public List<Diagnostic> getDiagnostics() {
+      return diagnostics;
+    }
+
+    public String getPackageFileSha256() {
+      return packageFileSha256;
+    }
+
+    public String getManifestSha256() {
+      return manifestSha256;
+    }
+
+    /**
+     * Returns whether every area exchange and the canonical package evidence passed its bounded gates.
+     *
+     * @return true when no package error exists and every area assessment passes
+     */
+    public boolean isComplete() {
+      for (AreaExchange area : areaExchanges) {
+        if (!area.getAssessment().isSchemaProfileAndSupportedTopologyValid()) {
+          return false;
+        }
+      }
+      for (Diagnostic diagnostic : diagnostics) {
+        if (diagnostic.getSeverity() == Severity.ERROR) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    /**
+     * Returns false because the ZIP manifest is a NeqSim container, not an official DEXPI whole-plant profile.
+     *
+     * @return always false
+     */
+    public boolean isNativeWholePlantDexpiExchange() {
+      return false;
+    }
+
+    /** Returns the deterministic embedded manifest without the enclosing archive fingerprints. */
+    public String toManifestJson() {
+      return new GsonBuilder().setPrettyPrinting().create().toJson(manifestMap());
+    }
+
+    /** Returns deterministic report JSON including the exact archive and manifest fingerprints. */
+    public String toJson() {
+      return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = manifestMap();
+      result.put("manifestSha256", manifestSha256);
+      result.put("packageFileSha256", packageFileSha256);
+      return result;
+    }
+
+    private Map<String, Object> manifestMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("schemaVersion", SCHEMA_VERSION);
+      result.put("packageFormat", "NEQSIM_DETERMINISTIC_ZIP_WITH_NATIVE_DEXPI_AREA_FILES");
+      result.put("manifestEntry", MANIFEST_ENTRY);
+      result.put("plantId", plantId);
+      result.put("revision", revision);
+      if (operatingCaseId != null) {
+        result.put("operatingCaseId", operatingCaseId);
+      }
+      result.put("canonicalFingerprint", canonicalFingerprint);
+      result.put("engineeringState", "CALCULATED");
+      result.put("approvalStatus", "REVIEW_REQUIRED");
+      result.put("fitnessForConstruction", Boolean.FALSE);
+      result.put("nativeWholePlantDexpiExchange", Boolean.FALSE);
+      List<Map<String, Object>> areaMaps = new ArrayList<Map<String, Object>>();
+      for (AreaExchange area : areaExchanges) {
+        areaMaps.add(area.toMap());
+      }
+      result.put("areaExchanges", areaMaps);
+      List<Map<String, Object>> connectionMaps = new ArrayList<Map<String, Object>>();
+      for (ConnectionRecord connection : connections) {
+        connectionMaps.add(connection.toMap());
+      }
+      result.put("connections", connectionMaps);
+      List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
+      for (Diagnostic diagnostic : diagnostics) {
+        diagnosticMaps.add(diagnostic.toMap());
+      }
+      result.put("diagnostics", diagnosticMaps);
+      result.put("completeWithinDeclaredScope", Boolean.valueOf(isComplete()));
+      return result;
+    }
+  }
+
+  /**
+   * Writes topology-only area exchanges and a plant-wide manifest.
+   *
+   * @param processModel source multi-area model
+   * @param packageFile destination ZIP file
+   * @param plantId controlled plant or project identifier
+   * @param revision controlled source-model revision
+   * @return deterministic package evidence
+   * @throws IOException if an area exchange or archive cannot be written
+   */
+  public static Report writeAndAssess(ProcessModel processModel, File packageFile, String plantId, String revision)
+      throws IOException {
+    return writeAndAssess(processModel, packageFile, plantId, revision, null);
+  }
+
+  /**
+   * Writes area exchanges with selected canonical operating values and a plant-wide manifest.
+   *
+   * @param processModel source multi-area model with successfully run areas
+   * @param packageFile destination ZIP file
+   * @param plantId controlled plant or project identifier
+   * @param revision controlled source-model revision
+   * @param operatingCaseId stable plant-wide operating-case identifier
+   * @return deterministic package evidence
+   * @throws IOException if an area exchange or archive cannot be written
+   */
+  public static Report writeAndAssess(ProcessModel processModel, File packageFile, String plantId, String revision,
+      String operatingCaseId) throws IOException {
+    if (processModel == null || packageFile == null) {
+      throw new IllegalArgumentException("processModel and packageFile must not be null");
+    }
+    String controlledPlantId = requireText(plantId, "plantId");
+    String controlledRevision = requireText(revision, "revision");
+    String controlledCaseId = operatingCaseId == null ? null : requireText(operatingCaseId, "operatingCaseId");
+    ProcessDiagramGraphAdapter.Result canonical = controlledCaseId == null
+        ? ProcessDiagramGraphAdapter.fromProcessModel(processModel, controlledPlantId, controlledRevision)
+        : ProcessDiagramGraphAdapter.fromProcessModel(processModel, controlledPlantId, controlledRevision,
+            controlledCaseId);
+
+    List<String> areaNames = new ArrayList<String>(processModel.getProcessSystemNames());
+    Collections.sort(areaNames);
+    if (areaNames.isEmpty()) {
+      throw new IllegalArgumentException("DEXPI ProcessModel package requires at least one process area");
+    }
+
+    Map<String, byte[]> entries = new TreeMap<String, byte[]>();
+    List<AreaExchange> areas = new ArrayList<AreaExchange>();
+    List<Diagnostic> diagnostics = adapterDiagnostics(canonical);
+    for (String areaName : areaNames) {
+      ProcessSystem area = processModel.get(areaName);
+      if (area == null) {
+        diagnostics.add(error("DEXPI_PROCESS_PACKAGE_AREA_MISSING", "ProcessModel area could not be resolved",
+            areaName));
+        continue;
+      }
+      String entryName = areaEntryName(controlledPlantId, areaName);
+      Path temporaryFile = Files.createTempFile("neqsim-dexpi-process-area-", ".xml");
+      try {
+        Dexpi20ProcessTopologyAssessment.Report assessment = controlledCaseId == null
+            ? Dexpi20ProcessModelWriter.writeAndAssessTopology(area, temporaryFile.toFile(),
+                controlledPlantId + "/" + areaName, controlledRevision)
+            : Dexpi20ProcessModelWriter.writeAndAssessTopology(area, temporaryFile.toFile(),
+                controlledPlantId + "/" + areaName, controlledRevision, controlledCaseId);
+        byte[] xml = Files.readAllBytes(temporaryFile);
+        entries.put(entryName, xml);
+        areas.add(new AreaExchange(areaName, areaId(canonical.getGraph(), areaName), area.getName(), entryName,
+            sha256(xml), assessment));
+        if (!assessment.isSchemaProfileAndSupportedTopologyValid()) {
+          diagnostics.add(error("DEXPI_PROCESS_PACKAGE_AREA_ASSESSMENT_FAILED",
+              "Area DEXPI Process exchange failed schema/profile or supported-topology assessment", areaName));
+        }
+      } finally {
+        Files.deleteIfExists(temporaryFile);
+      }
+    }
+
+    List<ConnectionRecord> connections = connectionRecords(canonical.getGraph(), diagnostics);
+    diagnostics.add(new Diagnostic(Severity.INFO, "DEXPI_PROCESS_PACKAGE_NOT_NATIVE_WHOLE_PLANT_PROFILE",
+        "The ZIP and manifest are a NeqSim container around independently assessed native DEXPI area files",
+        controlledPlantId));
+    diagnostics.add(new Diagnostic(Severity.WARNING, "DEXPI_PROCESS_PACKAGE_DOCUMENT_SEMANTICS_NOT_INCLUDED",
+        "Controlled drawing/document/sheet semantics remain a separate projection", controlledPlantId));
+    diagnostics.add(new Diagnostic(Severity.WARNING, "DEXPI_PROCESS_PACKAGE_GRAPHICS_NOT_INCLUDED",
+        "Graphical projection remains a separate DEXPI Core or native SVG/PDF artifact", controlledPlantId));
+    sortDiagnostics(diagnostics);
+
+    Report manifestReport = new Report(controlledPlantId, controlledRevision, controlledCaseId,
+        canonical.getFingerprint(), areas, connections, diagnostics, "", "");
+    byte[] manifest = manifestReport.toManifestJson().getBytes(StandardCharsets.UTF_8);
+    entries.put(MANIFEST_ENTRY, manifest);
+    writeArchive(packageFile.toPath(), entries);
+    return new Report(controlledPlantId, controlledRevision, controlledCaseId, canonical.getFingerprint(), areas,
+        connections, diagnostics, sha256(Files.readAllBytes(packageFile.toPath())), sha256(manifest));
+  }
+
+  private static List<Diagnostic> adapterDiagnostics(ProcessDiagramGraphAdapter.Result canonical) {
+    List<Diagnostic> result = new ArrayList<Diagnostic>();
+    for (ProcessDiagramGraphAdapter.Diagnostic diagnostic : canonical.getDiagnostics()) {
+      Severity severity = diagnostic.getSeverity() == ProcessDiagramGraphAdapter.Severity.ERROR ? Severity.ERROR
+          : diagnostic.getSeverity() == ProcessDiagramGraphAdapter.Severity.WARNING ? Severity.WARNING
+              : Severity.INFO;
+      String subject = diagnostic.getArea();
+      if (!diagnostic.getSubject().isEmpty()) {
+        subject = subject.isEmpty() ? diagnostic.getSubject() : subject + "/" + diagnostic.getSubject();
+      }
+      result.add(new Diagnostic(severity, diagnostic.getCode(), diagnostic.getMessage(), subject));
+    }
+    return result;
+  }
+
+  private static List<ConnectionRecord> connectionRecords(EngineeringGraph graph, List<Diagnostic> diagnostics) {
+    List<ConnectionRecord> result = new ArrayList<ConnectionRecord>();
+    for (EngineeringNode node : graph.getNodes().values()) {
+      if (node.getKind() != EngineeringNode.Kind.PIPE_SEGMENT
+          && node.getKind() != EngineeringNode.Kind.ENERGY_CONNECTION
+          && node.getKind() != EngineeringNode.Kind.SIGNAL_CONNECTION) {
+        continue;
+      }
+      ConnectionRecord record = new ConnectionRecord(node);
+      result.add(record);
+      if (record.isCrossArea() && "MATERIAL".equals(record.getConnectionType())) {
+        diagnostics.add(new Diagnostic(Severity.WARNING, "DEXPI_PROCESS_PACKAGE_CROSS_AREA_CONNECTION_MANIFEST_ONLY",
+            "Cross-area material identity is preserved in the package manifest, not as one native DEXPI connection",
+            record.getConnectionId()));
+      } else if ("ENERGY".equals(record.getConnectionType())) {
+        diagnostics.add(new Diagnostic(Severity.WARNING, "DEXPI_PROCESS_PACKAGE_ENERGY_CONNECTION_MANIFEST_ONLY",
+            "Energy connection is preserved in the package manifest but is not mapped to native DEXPI Process",
+            record.getConnectionId()));
+      } else if ("SIGNAL".equals(record.getConnectionType())) {
+        diagnostics.add(new Diagnostic(Severity.WARNING, "DEXPI_PROCESS_PACKAGE_SIGNAL_CONNECTION_MANIFEST_ONLY",
+            "Information connection is preserved in the package manifest but is not mapped to native DEXPI Process",
+            record.getConnectionId()));
+      }
+    }
+    Collections.sort(result, new Comparator<ConnectionRecord>() {
+      @Override
+      public int compare(ConnectionRecord first, ConnectionRecord second) {
+        return first.getConnectionId().compareTo(second.getConnectionId());
+      }
+    });
+    return result;
+  }
+
+  private static String areaId(EngineeringGraph graph, String areaName) {
+    for (EngineeringNode node : graph.getNodes().values()) {
+      if (node.getKind() == EngineeringNode.Kind.AREA && areaName.equals(property(node, "areaName"))) {
+        return node.getId();
+      }
+    }
+    return "";
+  }
+
+  private static String areaEntryName(String plantId, String areaName) {
+    return "areas/" + safeSegment(areaName) + "-" + shortHash(plantId + "/" + areaName)
+        + ".process.dexpi.xml";
+  }
+
+  private static String safeSegment(String value) {
+    String result = value.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]+", "-").replaceAll("(^-+|-+$)", "");
+    return result.isEmpty() ? "area" : result;
+  }
+
+  private static String shortHash(String value) {
+    return sha256(value.getBytes(StandardCharsets.UTF_8)).substring(0, 12);
+  }
+
+  private static void writeArchive(Path file, Map<String, byte[]> entries) throws IOException {
+    Path absolute = file.toAbsolutePath();
+    Path parent = absolute.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    FileOutputStream output = new FileOutputStream(file.toFile());
+    try {
+      ZipOutputStream archive = new ZipOutputStream(output, StandardCharsets.UTF_8);
+      try {
+        for (Map.Entry<String, byte[]> item : entries.entrySet()) {
+          CRC32 crc = new CRC32();
+          crc.update(item.getValue());
+          ZipEntry entry = new ZipEntry(item.getKey());
+          entry.setMethod(ZipEntry.STORED);
+          entry.setSize(item.getValue().length);
+          entry.setCompressedSize(item.getValue().length);
+          entry.setCrc(crc.getValue());
+          entry.setTime(0L);
+          archive.putNextEntry(entry);
+          archive.write(item.getValue());
+          archive.closeEntry();
+        }
+      } finally {
+        archive.close();
+      }
+    } finally {
+      output.close();
+    }
+  }
+
+  private static void sortDiagnostics(List<Diagnostic> diagnostics) {
+    Collections.sort(diagnostics, new Comparator<Diagnostic>() {
+      @Override
+      public int compare(Diagnostic first, Diagnostic second) {
+        int bySeverity = first.getSeverity().compareTo(second.getSeverity());
+        if (bySeverity != 0) {
+          return bySeverity;
+        }
+        int byCode = first.getCode().compareTo(second.getCode());
+        return byCode == 0 ? first.getSubject().compareTo(second.getSubject()) : byCode;
+      }
+    });
+  }
+
+  private static String property(EngineeringNode node, String name) {
+    Object value = node.getProperties().get(name);
+    return value == null ? "" : String.valueOf(value);
+  }
+
+  private static boolean booleanProperty(EngineeringNode node, String name) {
+    Object value = node.getProperties().get(name);
+    return value instanceof Boolean ? ((Boolean) value).booleanValue() : Boolean.parseBoolean(String.valueOf(value));
+  }
+
+  private static String sha256(byte[] bytes) {
+    try {
+      byte[] digest = MessageDigest.getInstance("SHA-256").digest(bytes);
+      StringBuilder result = new StringBuilder();
+      for (byte value : digest) {
+        result.append(String.format(Locale.ROOT, "%02x", Integer.valueOf(value & 255)));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is required by every supported Java runtime", exception);
+    }
+  }
+
+  private static String requireText(String value, String name) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private static Diagnostic error(String code, String message, String subject) {
+    return new Diagnostic(Severity.ERROR, code, message, subject);
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageWriter.java
@@ -33,8 +33,8 @@ import neqsim.process.processmodel.diagram.ProcessDiagramGraphAdapter;
  * <p>
  * DEXPI Process files remain independently schema/profile assessed, one per {@link ProcessSystem} area. A NeqSim
  * manifest preserves the plant-wide canonical graph fingerprint, stable area identities and cross-area connection
- * identities. The package is not a new DEXPI profile and does not claim that manifest-only connections are present in
- * a native whole-plant DEXPI model.
+ * identities. The package is not a new DEXPI profile and does not claim that manifest-only connections are present in a
+ * native whole-plant DEXPI model.
  * </p>
  */
 public final class Dexpi20ProcessModelPackageWriter {
@@ -431,8 +431,8 @@ public final class Dexpi20ProcessModelPackageWriter {
     for (String areaName : areaNames) {
       ProcessSystem area = processModel.get(areaName);
       if (area == null) {
-        diagnostics.add(error("DEXPI_PROCESS_PACKAGE_AREA_MISSING", "ProcessModel area could not be resolved",
-            areaName));
+        diagnostics
+            .add(error("DEXPI_PROCESS_PACKAGE_AREA_MISSING", "ProcessModel area could not be resolved", areaName));
         continue;
       }
       String entryName = areaEntryName(controlledPlantId, areaName);
@@ -483,8 +483,7 @@ public final class Dexpi20ProcessModelPackageWriter {
     List<Diagnostic> result = new ArrayList<Diagnostic>();
     for (ProcessDiagramGraphAdapter.Diagnostic diagnostic : canonical.getDiagnostics()) {
       Severity severity = diagnostic.getSeverity() == ProcessDiagramGraphAdapter.Severity.ERROR ? Severity.ERROR
-          : diagnostic.getSeverity() == ProcessDiagramGraphAdapter.Severity.WARNING ? Severity.WARNING
-              : Severity.INFO;
+          : diagnostic.getSeverity() == ProcessDiagramGraphAdapter.Severity.WARNING ? Severity.WARNING : Severity.INFO;
       String subject = diagnostic.getArea();
       if (!diagnostic.getSubject().isEmpty()) {
         subject = subject.isEmpty() ? diagnostic.getSubject() : subject + "/" + diagnostic.getSubject();
@@ -537,8 +536,7 @@ public final class Dexpi20ProcessModelPackageWriter {
   }
 
   private static String areaEntryName(String plantId, String areaName) {
-    return "areas/" + safeSegment(areaName) + "-" + shortHash(plantId + "/" + areaName)
-        + ".process.dexpi.xml";
+    return "areas/" + safeSegment(areaName) + "-" + shortHash(plantId + "/" + areaName) + ".process.dexpi.xml";
   }
 
   private static String safeSegment(String value) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageWriter.java
@@ -258,8 +258,24 @@ public final class Dexpi20ProcessModelPackageWriter {
       this.manifestSha256 = manifestSha256;
     }
 
+    /** @return canonical plant-wide engineering-graph SHA-256 fingerprint */
     public String getCanonicalFingerprint() {
       return canonicalFingerprint;
+    }
+
+    /** @return controlled plant or project identifier */
+    public String getPlantId() {
+      return plantId;
+    }
+
+    /** @return controlled source-model revision */
+    public String getRevision() {
+      return revision;
+    }
+
+    /** @return operating-case identifier, or {@code null} for topology-only output */
+    public String getOperatingCaseId() {
+      return operatingCaseId;
     }
 
     public List<AreaExchange> getAreaExchanges() {
@@ -331,6 +347,8 @@ public final class Dexpi20ProcessModelPackageWriter {
       Map<String, Object> result = new LinkedHashMap<String, Object>();
       result.put("schemaVersion", SCHEMA_VERSION);
       result.put("packageFormat", "NEQSIM_DETERMINISTIC_ZIP_WITH_NATIVE_DEXPI_AREA_FILES");
+      result.put("dexpiVersion", "2.0.0");
+      result.put("dexpiModel", "Process");
       result.put("manifestEntry", MANIFEST_ENTRY);
       result.put("plantId", plantId);
       result.put("revision", revision);
@@ -427,8 +445,12 @@ public final class Dexpi20ProcessModelPackageWriter {
                 controlledPlantId + "/" + areaName, controlledRevision, controlledCaseId);
         byte[] xml = Files.readAllBytes(temporaryFile);
         entries.put(entryName, xml);
-        areas.add(new AreaExchange(areaName, areaId(canonical.getGraph(), areaName), area.getName(), entryName,
-            sha256(xml), assessment));
+        String stableAreaId = areaId(canonical.getGraph(), areaName);
+        areas.add(new AreaExchange(areaName, stableAreaId, area.getName(), entryName, sha256(xml), assessment));
+        if (stableAreaId.isEmpty()) {
+          diagnostics.add(error("DEXPI_PROCESS_PACKAGE_AREA_ID_MISSING",
+              "Canonical ProcessModel snapshot did not expose a stable area identity", areaName));
+        }
         if (!assessment.isSchemaProfileAndSupportedTopologyValid()) {
           diagnostics.add(error("DEXPI_PROCESS_PACKAGE_AREA_ASSESSMENT_FAILED",
               "Area DEXPI Process exchange failed schema/profile or supported-topology assessment", areaName));

--- a/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
@@ -18,6 +18,8 @@
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessTopologyAssessment} - Canonical material-topology
  * projection, canonical operating-value provenance, and structured scope evidence for assessed native Process
  * exchange</li>
+ * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessModelPackageWriter} - Deterministic multi-area package
+ * of assessed native Process exchanges and explicit plant-wide manifest-only connection evidence</li>
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20GraphicalProjectionWriter} - Opt-in native DEXPI Core graphical
  * projection</li>
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20GraphicalProjectionAssessment} - Deterministic inspection of

--- a/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
@@ -18,8 +18,8 @@
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessTopologyAssessment} - Canonical material-topology
  * projection, canonical operating-value provenance, and structured scope evidence for assessed native Process
  * exchange</li>
- * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessModelPackageWriter} - Deterministic multi-area package
- * of assessed native Process exchanges and explicit plant-wide manifest-only connection evidence</li>
+ * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessModelPackageWriter} - Deterministic multi-area package of
+ * assessed native Process exchanges and explicit plant-wide manifest-only connection evidence</li>
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20GraphicalProjectionWriter} - Opt-in native DEXPI Core graphical
  * projection</li>
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20GraphicalProjectionAssessment} - Deterministic inspection of

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageWriterTest.java
@@ -1,0 +1,181 @@
+package neqsim.process.processmodel.dexpi;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import neqsim.process.processmodel.ProcessConnection;
+import neqsim.process.processmodel.ProcessModel;
+import neqsim.process.processmodel.diagram.EngineeringDiagramReferenceFixtures;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class Dexpi20ProcessModelPackageWriterTest {
+  @TempDir Path temporaryDirectory;
+
+  @Test
+  void writesDeterministicAssessedAreaPackageWithPlantWideConnectionEvidence() throws IOException {
+    EngineeringDiagramReferenceFixtures.ModelCase fixture =
+        EngineeringDiagramReferenceFixtures.multiAreaFacility();
+    fixture.getProcessModel().get("Inlet").connect("30-XV-001", "energyOut", "30-VA-001",
+        "energyIn", ProcessConnection.ConnectionType.ENERGY);
+    fixture.getProcessModel().get("Inlet").connect("30-VA-001", "signalOut", "30-SP-001",
+        "signalIn", ProcessConnection.ConnectionType.SIGNAL);
+
+    File first = temporaryDirectory.resolve("first.zip").toFile();
+    File second = temporaryDirectory.resolve("second.zip").toFile();
+    Dexpi20ProcessModelPackageWriter.Report firstReport =
+        Dexpi20ProcessModelPackageWriter.writeAndAssess(fixture.getProcessModel(), first,
+            "PLANT-30", "REV-A");
+    Dexpi20ProcessModelPackageWriter.Report secondReport =
+        Dexpi20ProcessModelPackageWriter.writeAndAssess(fixture.getProcessModel(), second,
+            "PLANT-30", "REV-A");
+
+    assertArrayEquals(Files.readAllBytes(first.toPath()), Files.readAllBytes(second.toPath()));
+    assertEquals(firstReport.toJson(), secondReport.toJson());
+    assertTrue(firstReport.isComplete(), firstReport.toJson());
+    assertFalse(firstReport.isNativeWholePlantDexpiExchange());
+    assertEquals(4, firstReport.getAreaExchanges().size());
+    assertEquals(9, firstReport.getConnections().size());
+    assertEquals(64, firstReport.getCanonicalFingerprint().length());
+    assertEquals(64, firstReport.getManifestSha256().length());
+    assertEquals(64, firstReport.getPackageFileSha256().length());
+
+    for (Dexpi20ProcessModelPackageWriter.AreaExchange area : firstReport.getAreaExchanges()) {
+      assertFalse(area.getAreaId().isEmpty());
+      assertEquals(64, area.getFileSha256().length());
+      assertTrue(area.getAssessment().isSchemaProfileAndSupportedTopologyValid(),
+          area.getAssessment().toJson());
+    }
+    assertEquals(7, connectionCount(firstReport, "MATERIAL"));
+    assertEquals(1, connectionCount(firstReport, "ENERGY"));
+    assertEquals(1, connectionCount(firstReport, "SIGNAL"));
+    assertEquals(3, connectionStatusCount(firstReport, "MANIFEST_ONLY_CROSS_AREA"));
+    assertEquals(2,
+        connectionStatusCount(firstReport, "MANIFEST_ONLY_NOT_MAPPED_TO_NATIVE_PROCESS"));
+    assertTrue(hasDiagnostic(firstReport,
+        "DEXPI_PROCESS_PACKAGE_CROSS_AREA_CONNECTION_MANIFEST_ONLY"));
+    assertTrue(hasDiagnostic(firstReport, "DEXPI_PROCESS_PACKAGE_ENERGY_CONNECTION_MANIFEST_ONLY"));
+    assertTrue(hasDiagnostic(firstReport, "DEXPI_PROCESS_PACKAGE_SIGNAL_CONNECTION_MANIFEST_ONLY"));
+    assertTrue(hasDiagnostic(firstReport, "DEXPI_PROCESS_PACKAGE_NOT_NATIVE_WHOLE_PLANT_PROFILE"));
+
+    List<String> entries = zipEntries(first.toPath());
+    assertEquals(5, entries.size());
+    assertTrue(entries.get(0).startsWith("areas/compression-"));
+    assertTrue(entries.get(3).startsWith("areas/inlet-"));
+    assertEquals("manifest.json", entries.get(4));
+    String manifest = zipEntry(first.toPath(), "manifest.json");
+    assertTrue(manifest.contains("\"nativeWholePlantDexpiExchange\": false"));
+    assertTrue(manifest.contains("\"approvalStatus\": \"REVIEW_REQUIRED\""));
+    assertTrue(manifest.contains("\"fitnessForConstruction\": false"));
+    assertTrue(manifest.contains("\"canonicalFingerprint\": \""
+        + firstReport.getCanonicalFingerprint() + "\""));
+  }
+
+  @Test
+  void controlledInputsAndAtLeastOneAreaAreRequired() {
+    Path output = temporaryDirectory.resolve("invalid.zip");
+    assertThrows(IllegalArgumentException.class,
+        () -> Dexpi20ProcessModelPackageWriter.writeAndAssess(null, output.toFile(), "P", "R"));
+    assertThrows(IllegalArgumentException.class,
+        () -> Dexpi20ProcessModelPackageWriter.writeAndAssess(new ProcessModel(), output.toFile(),
+            "P", "R"));
+    assertThrows(IllegalArgumentException.class,
+        () -> Dexpi20ProcessModelPackageWriter.writeAndAssess(new ProcessModel(), output.toFile(),
+            " ", "R"));
+  }
+
+  @Test
+  void differentControlledRevisionChangesPackageEvidence() throws IOException {
+    ProcessModel model = EngineeringDiagramReferenceFixtures.multiAreaFacility().getProcessModel();
+    File first = temporaryDirectory.resolve("revision-a.zip").toFile();
+    File second = temporaryDirectory.resolve("revision-b.zip").toFile();
+    Dexpi20ProcessModelPackageWriter.Report firstReport =
+        Dexpi20ProcessModelPackageWriter.writeAndAssess(model, first, "PLANT-30", "REV-A");
+    Dexpi20ProcessModelPackageWriter.Report secondReport =
+        Dexpi20ProcessModelPackageWriter.writeAndAssess(model, second, "PLANT-30", "REV-B");
+
+    assertNotEquals(firstReport.getCanonicalFingerprint(), secondReport.getCanonicalFingerprint());
+    assertNotEquals(firstReport.getPackageFileSha256(), secondReport.getPackageFileSha256());
+  }
+
+  private static long connectionCount(Dexpi20ProcessModelPackageWriter.Report report, String type) {
+    long count = 0L;
+    for (Dexpi20ProcessModelPackageWriter.ConnectionRecord connection : report.getConnections()) {
+      if (type.equals(connection.getConnectionType())) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static long connectionStatusCount(Dexpi20ProcessModelPackageWriter.Report report,
+      String status) {
+    long count = 0L;
+    for (Dexpi20ProcessModelPackageWriter.ConnectionRecord connection : report.getConnections()) {
+      if (status.equals(connection.getExchangeStatus())) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static boolean hasDiagnostic(Dexpi20ProcessModelPackageWriter.Report report, String code) {
+    for (Dexpi20ProcessModelPackageWriter.Diagnostic diagnostic : report.getDiagnostics()) {
+      if (code.equals(diagnostic.getCode())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static List<String> zipEntries(Path file) throws IOException {
+    List<String> entries = new ArrayList<String>();
+    ZipInputStream input = new ZipInputStream(Files.newInputStream(file));
+    try {
+      ZipEntry entry;
+      while ((entry = input.getNextEntry()) != null) {
+        entries.add(entry.getName());
+      }
+    } finally {
+      input.close();
+    }
+    Collections.sort(entries);
+    return entries;
+  }
+
+  private static String zipEntry(Path file, String requestedName) throws IOException {
+    ZipInputStream input = new ZipInputStream(Files.newInputStream(file));
+    try {
+      ZipEntry entry;
+      while ((entry = input.getNextEntry()) != null) {
+        if (!requestedName.equals(entry.getName())) {
+          continue;
+        }
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        int count;
+        while ((count = input.read(buffer)) != -1) {
+          output.write(buffer, 0, count);
+        }
+        return new String(output.toByteArray(), java.nio.charset.StandardCharsets.UTF_8);
+      }
+    } finally {
+      input.close();
+    }
+    throw new AssertionError("ZIP entry not found: " + requestedName);
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageWriterTest.java
@@ -25,25 +25,23 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class Dexpi20ProcessModelPackageWriterTest {
-  @TempDir Path temporaryDirectory;
+  @TempDir
+  Path temporaryDirectory;
 
   @Test
   void writesDeterministicAssessedAreaPackageWithPlantWideConnectionEvidence() throws IOException {
-    EngineeringDiagramReferenceFixtures.ModelCase fixture =
-        EngineeringDiagramReferenceFixtures.multiAreaFacility();
-    fixture.getProcessModel().get("Inlet").connect("30-XV-001", "energyOut", "30-VA-001",
-        "energyIn", ProcessConnection.ConnectionType.ENERGY);
-    fixture.getProcessModel().get("Inlet").connect("30-VA-001", "signalOut", "30-SP-001",
-        "signalIn", ProcessConnection.ConnectionType.SIGNAL);
+    EngineeringDiagramReferenceFixtures.ModelCase fixture = EngineeringDiagramReferenceFixtures.multiAreaFacility();
+    fixture.getProcessModel().get("Inlet").connect("30-XV-001", "energyOut", "30-VA-001", "energyIn",
+        ProcessConnection.ConnectionType.ENERGY);
+    fixture.getProcessModel().get("Inlet").connect("30-VA-001", "signalOut", "30-SP-001", "signalIn",
+        ProcessConnection.ConnectionType.SIGNAL);
 
     File first = temporaryDirectory.resolve("first.zip").toFile();
     File second = temporaryDirectory.resolve("second.zip").toFile();
-    Dexpi20ProcessModelPackageWriter.Report firstReport =
-        Dexpi20ProcessModelPackageWriter.writeAndAssess(fixture.getProcessModel(), first,
-            "PLANT-30", "REV-A");
-    Dexpi20ProcessModelPackageWriter.Report secondReport =
-        Dexpi20ProcessModelPackageWriter.writeAndAssess(fixture.getProcessModel(), second,
-            "PLANT-30", "REV-A");
+    Dexpi20ProcessModelPackageWriter.Report firstReport = Dexpi20ProcessModelPackageWriter
+        .writeAndAssess(fixture.getProcessModel(), first, "PLANT-30", "REV-A");
+    Dexpi20ProcessModelPackageWriter.Report secondReport = Dexpi20ProcessModelPackageWriter
+        .writeAndAssess(fixture.getProcessModel(), second, "PLANT-30", "REV-A");
 
     assertArrayEquals(Files.readAllBytes(first.toPath()), Files.readAllBytes(second.toPath()));
     assertEquals(firstReport.toJson(), secondReport.toJson());
@@ -61,17 +59,14 @@ class Dexpi20ProcessModelPackageWriterTest {
     for (Dexpi20ProcessModelPackageWriter.AreaExchange area : firstReport.getAreaExchanges()) {
       assertFalse(area.getAreaId().isEmpty());
       assertEquals(64, area.getFileSha256().length());
-      assertTrue(area.getAssessment().isSchemaProfileAndSupportedTopologyValid(),
-          area.getAssessment().toJson());
+      assertTrue(area.getAssessment().isSchemaProfileAndSupportedTopologyValid(), area.getAssessment().toJson());
     }
     assertEquals(7, connectionCount(firstReport, "MATERIAL"));
     assertEquals(1, connectionCount(firstReport, "ENERGY"));
     assertEquals(1, connectionCount(firstReport, "SIGNAL"));
     assertEquals(3, connectionStatusCount(firstReport, "MANIFEST_ONLY_CROSS_AREA"));
-    assertEquals(2,
-        connectionStatusCount(firstReport, "MANIFEST_ONLY_NOT_MAPPED_TO_NATIVE_PROCESS"));
-    assertTrue(hasDiagnostic(firstReport,
-        "DEXPI_PROCESS_PACKAGE_CROSS_AREA_CONNECTION_MANIFEST_ONLY"));
+    assertEquals(2, connectionStatusCount(firstReport, "MANIFEST_ONLY_NOT_MAPPED_TO_NATIVE_PROCESS"));
+    assertTrue(hasDiagnostic(firstReport, "DEXPI_PROCESS_PACKAGE_CROSS_AREA_CONNECTION_MANIFEST_ONLY"));
     assertTrue(hasDiagnostic(firstReport, "DEXPI_PROCESS_PACKAGE_ENERGY_CONNECTION_MANIFEST_ONLY"));
     assertTrue(hasDiagnostic(firstReport, "DEXPI_PROCESS_PACKAGE_SIGNAL_CONNECTION_MANIFEST_ONLY"));
     assertTrue(hasDiagnostic(firstReport, "DEXPI_PROCESS_PACKAGE_NOT_NATIVE_WHOLE_PLANT_PROFILE"));
@@ -87,8 +82,7 @@ class Dexpi20ProcessModelPackageWriterTest {
     assertTrue(manifest.contains("\"dexpiModel\": \"Process\""));
     assertTrue(manifest.contains("\"approvalStatus\": \"REVIEW_REQUIRED\""));
     assertTrue(manifest.contains("\"fitnessForConstruction\": false"));
-    assertTrue(manifest.contains("\"canonicalFingerprint\": \""
-        + firstReport.getCanonicalFingerprint() + "\""));
+    assertTrue(manifest.contains("\"canonicalFingerprint\": \"" + firstReport.getCanonicalFingerprint() + "\""));
   }
 
   @Test
@@ -97,11 +91,9 @@ class Dexpi20ProcessModelPackageWriterTest {
     assertThrows(IllegalArgumentException.class,
         () -> Dexpi20ProcessModelPackageWriter.writeAndAssess(null, output.toFile(), "P", "R"));
     assertThrows(IllegalArgumentException.class,
-        () -> Dexpi20ProcessModelPackageWriter.writeAndAssess(new ProcessModel(), output.toFile(),
-            "P", "R"));
+        () -> Dexpi20ProcessModelPackageWriter.writeAndAssess(new ProcessModel(), output.toFile(), "P", "R"));
     assertThrows(IllegalArgumentException.class,
-        () -> Dexpi20ProcessModelPackageWriter.writeAndAssess(new ProcessModel(), output.toFile(),
-            " ", "R"));
+        () -> Dexpi20ProcessModelPackageWriter.writeAndAssess(new ProcessModel(), output.toFile(), " ", "R"));
   }
 
   @Test
@@ -109,10 +101,10 @@ class Dexpi20ProcessModelPackageWriterTest {
     ProcessModel model = EngineeringDiagramReferenceFixtures.multiAreaFacility().getProcessModel();
     File first = temporaryDirectory.resolve("revision-a.zip").toFile();
     File second = temporaryDirectory.resolve("revision-b.zip").toFile();
-    Dexpi20ProcessModelPackageWriter.Report firstReport =
-        Dexpi20ProcessModelPackageWriter.writeAndAssess(model, first, "PLANT-30", "REV-A");
-    Dexpi20ProcessModelPackageWriter.Report secondReport =
-        Dexpi20ProcessModelPackageWriter.writeAndAssess(model, second, "PLANT-30", "REV-B");
+    Dexpi20ProcessModelPackageWriter.Report firstReport = Dexpi20ProcessModelPackageWriter.writeAndAssess(model, first,
+        "PLANT-30", "REV-A");
+    Dexpi20ProcessModelPackageWriter.Report secondReport = Dexpi20ProcessModelPackageWriter.writeAndAssess(model,
+        second, "PLANT-30", "REV-B");
 
     assertNotEquals(firstReport.getCanonicalFingerprint(), secondReport.getCanonicalFingerprint());
     assertNotEquals(firstReport.getPackageFileSha256(), secondReport.getPackageFileSha256());
@@ -128,8 +120,7 @@ class Dexpi20ProcessModelPackageWriterTest {
     return count;
   }
 
-  private static long connectionStatusCount(Dexpi20ProcessModelPackageWriter.Report report,
-      String status) {
+  private static long connectionStatusCount(Dexpi20ProcessModelPackageWriter.Report report, String status) {
     long count = 0L;
     for (Dexpi20ProcessModelPackageWriter.ConnectionRecord connection : report.getConnections()) {
       if (status.equals(connection.getExchangeStatus())) {

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageWriterTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -48,6 +49,9 @@ class Dexpi20ProcessModelPackageWriterTest {
     assertEquals(firstReport.toJson(), secondReport.toJson());
     assertTrue(firstReport.isComplete(), firstReport.toJson());
     assertFalse(firstReport.isNativeWholePlantDexpiExchange());
+    assertEquals("PLANT-30", firstReport.getPlantId());
+    assertEquals("REV-A", firstReport.getRevision());
+    assertNull(firstReport.getOperatingCaseId());
     assertEquals(4, firstReport.getAreaExchanges().size());
     assertEquals(9, firstReport.getConnections().size());
     assertEquals(64, firstReport.getCanonicalFingerprint().length());
@@ -79,6 +83,8 @@ class Dexpi20ProcessModelPackageWriterTest {
     assertEquals("manifest.json", entries.get(4));
     String manifest = zipEntry(first.toPath(), "manifest.json");
     assertTrue(manifest.contains("\"nativeWholePlantDexpiExchange\": false"));
+    assertTrue(manifest.contains("\"dexpiVersion\": \"2.0.0\""));
+    assertTrue(manifest.contains("\"dexpiModel\": \"Process\""));
     assertTrue(manifest.contains("\"approvalStatus\": \"REVIEW_REQUIRED\""));
     assertTrue(manifest.contains("\"fitnessForConstruction\": false"));
     assertTrue(manifest.contains("\"canonicalFingerprint\": \""


### PR DESCRIPTION
## Summary

Advances #1332 and #2899 as one engineering-diagram lane by adding the first bounded multi-area native DEXPI Process delivery package.

This PR adds `Dexpi20ProcessModelPackageWriter`, which:

- emits one independently schema/profile/topology-assessed native DEXPI 2.0 Process XML file per named `ProcessModel` area;
- writes a deterministic NeqSim ZIP and `manifest.json` with controlled plant/revision/case metadata, canonical graph fingerprint, stable area and connection identities, and SHA-256 evidence;
- preserves plant-wide material, energy, and information connections without inventing an unsupported DEXPI hierarchy;
- marks cross-area material as `MANIFEST_ONLY_CROSS_AREA` and energy/information as `MANIFEST_ONLY_NOT_MAPPED_TO_NATIVE_PROCESS`;
- fails closed on per-area assessment failure, canonical adapter errors, or missing stable area identity;
- states `nativeWholePlantDexpiExchange=false`, `approvalStatus=REVIEW_REQUIRED`, and `fitnessForConstruction=false`.

## Scope boundary

This is a deterministic NeqSim container around native per-area DEXPI Process exchanges. It is not a new DEXPI profile and does not claim native whole-plant DEXPI, ISO 10628 conformance, external-validator cleanliness, CAE qualification, or drawing approval. Controlled document/sheet semantics and graphical projections remain separate. Legacy DOT/Graphviz, native SVG/PDF, existing single-`ProcessSystem` DEXPI APIs and bytes, and Proteus/DEXPI P&ID workflows are unchanged.

No Huldra or public-manufacturing dataset content was fetched, transformed, or published.

## Regression coverage

`Dexpi20ProcessModelPackageWriterTest` covers:

- byte-identical repeated ZIP and JSON output;
- four independently assessed synthetic public areas;
- seven material, one energy, and one signal connection with explicit exchange status;
- three cross-area material identities;
- stable area/file/package/manifest fingerprints;
- archive inventory and governance flags;
- controlled revision sensitivity;
- fail-closed null, blank, and empty-model input.

Documentation and package Javadocs explain use, provenance, compatibility, and retained losses.

## Validation

**VALIDATION PENDING CI**

The branch was assembled from exact GitHub master `727410035fd6a0e2fd6b357a70a5418c0b8537b1` through the connected GitHub repository API. This workspace did not provide a local checkout, Maven wrapper, Spotless, pre-commit, or documentation toolchain, so no local test or formatting result is claimed. GitHub CI is the authoritative validator for exact head `54c351a981f1110bafd08af9376e482ec96fa736`.

The first hosted pre-commit run identified only Spotless drift; its documentation search check passed. The dedicated Spotless workflow published formatter artifact `spotless-format-patch` (SHA-256 `d0ce8660443b1786ea5f7e6be598df232d7c0188a8b55e52bfa23840b9f95a73`). That patch was applied exactly: the three resulting Git blob SHAs are `cd6df7a71bfc1d22471dffe0a4d58ac8583b064c`, `8839b4a7578d1549c4e871f3bc2b24af036fabd9`, and `cc512b880bcce93d66a294e966842ff15b7d15cf`. Replacement exact-head Spotless, pre-commit (including documentation source audit), PaperLab, standalone documentation, CodeQL, the engineering notebook, and Java 21 Javadocs/main compilation pass. The broad Java fast and four-way slow test matrix remains in progress.

## Review focus

1. Whether the container boundary is explicit enough to prevent a whole-plant DEXPI inference.
2. Deterministic ZIP and manifest evidence.
3. Fail-closed per-area assessment and stable identity handling.
4. Manifest-only loss diagnostics for cross-area, energy, information, document, and graphics scopes.
