### PR TITLE
[AI-Assisted] test(mcp): qualify validation-profile protocol contract

### DIFF
--- a/.github/workflows/mcp_protocol_qualification.yml
+++ b/.github/workflows/mcp_protocol_qualification.yml
@@ -28,8 +28,8 @@ on:
       - '.github/workflows/mcp_protocol_qualification.yml'
 
 jobs:
-  inspect_api_contract:
-    name: Qualify inspectApi over packaged MCP
+  phase0_contracts:
+    name: Qualify focused contracts over packaged MCP
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -60,3 +60,6 @@ jobs:
 
       - name: Run focused real-MCP API-inspection qualification
         run: cd neqsim-mcp-server && python test_inspect_api_protocol.py
+
+      - name: Run focused real-MCP validation-profile qualification
+        run: cd neqsim-mcp-server && python test_validation_profile_protocol.py

--- a/neqsim-mcp-server/docs/evidence/VALIDATION_PROFILE_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/VALIDATION_PROFILE_CONTRACT.md
@@ -12,11 +12,13 @@ The runner has five built-in profiles (`ncs`, `ukcs`, `gom`, `brazil`, and `gene
 
 ## Focused contract evidence
 
-- `src/test/java/neqsim/mcp/runners/ValidationProfileRunnerTest.java` checks built-in discovery, profile details, equipment-standard retrieval, a create/activate/read/delete custom-profile lifecycle with state restoration, and fail-closed mutation errors.
-- `neqsim-mcp-server/test_validation_profile_protocol.py` starts the packaged MCP server over STDIO and repeats the bounded discovery/lifecycle/fail-closed contract through real `tools/call` requests.
+- `src/test/java/neqsim/mcp/runners/ValidationProfileRunnerTest.java` checks built-in discovery, profile details, equipment-standard retrieval, the `validateWithProfile` response shape and profile/standards/design-factor metadata, a create/activate/read/delete custom-profile lifecycle with state restoration, and fail-closed mutation errors.
+- `neqsim-mcp-server/test_validation_profile_protocol.py` starts the packaged MCP server over STDIO and repeats the bounded discovery, validation-metadata, lifecycle, and fail-closed contract through real `tools/call` requests.
 - `.github/workflows/mcp_protocol_qualification.yml` builds the exact NeqSim core and MCP package with Java 21 and executes the focused protocol qualification on relevant PRs and `master` pushes with read-only repository permissions.
 
 The packaged qualification uses an isolated synthetic profile name and restores/deletes its process-local state before server shutdown. It does not persist a profile to disk, write to a plant system, or alter another client or tenant.
+
+The `validateWithProfile` checks are intentionally structural only: they prove that the underlying validator verdict remains visible and that the selected profile name, applicable-standards array, and required-design-factor object survive the runner and MCP response path. They do not assert that any listed standard, threshold, factor, or engineering verdict is correct for a real facility.
 
 ## Evidence that is not established
 

--- a/neqsim-mcp-server/docs/evidence/VALIDATION_PROFILE_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/VALIDATION_PROFILE_CONTRACT.md
@@ -1,0 +1,29 @@
+# Phase 0 validation-profile contract evidence
+
+This note records bounded Phase 0 software-contract evidence for the existing `manageValidationProfile` MCP tool. It does not promote the tool's trust classification and it is not scientific, regulatory, authorization, or plant-control validation.
+
+## Existing implementation boundary
+
+`ValidationProfileRunner` exposes eight actions: `listProfiles`, `getProfile`, `setActiveProfile`, `createProfile`, `deleteProfile`, `validateWithProfile`, `getActiveProfile`, and `getStandardsForEquipment`.
+
+The runner has five built-in profiles (`ncs`, `ukcs`, `gom`, `brazil`, and `generic`) plus process-local custom profiles. Custom profiles are stored in memory, the active profile is process-local mutable state, deleting the active custom profile recovers to `generic`, built-in profiles cannot be deleted, and unknown profile/action requests return structured error entries.
+
+`IndustrialProfile` classifies `manageValidationProfile` as an experimental `PLATFORM` tool. It is therefore available in the default single-engineer desktop profile but blocked from deployment modes that exclude experimental/platform operations. This evidence does not relax those governance rules.
+
+## Focused contract evidence
+
+- `src/test/java/neqsim/mcp/runners/ValidationProfileRunnerTest.java` checks built-in discovery, profile details, equipment-standard retrieval, a create/activate/read/delete custom-profile lifecycle with state restoration, and fail-closed mutation errors.
+- `neqsim-mcp-server/test_validation_profile_protocol.py` starts the packaged MCP server over STDIO and repeats the bounded discovery/lifecycle/fail-closed contract through real `tools/call` requests.
+- `.github/workflows/mcp_protocol_qualification.yml` builds the exact NeqSim core and MCP package with Java 21 and executes the focused protocol qualification on relevant PRs and `master` pushes with read-only repository permissions.
+
+The packaged qualification uses an isolated synthetic profile name and restores/deletes its process-local state before server shutdown. It does not persist a profile to disk, write to a plant system, or alter another client or tenant.
+
+## Evidence that is not established
+
+This contract evidence does **not** establish that the named standards are complete, current, legally applicable, licensed for redistribution, or sufficient for a particular facility or jurisdiction. It does not certify any engineering result produced by `validateWithProfile`, prove external identity or authorization, prove cross-process durability, prove multi-tenant isolation for a deployment, or grant accountable engineering approval.
+
+The `manageValidationProfile` trust record remains unchanged until the machine-readable Phase 0 inventory and the primary packaged-protocol accounting are updated atomically on one validated exact head. Existing `BenchmarkTrust` numerical/scientific accounting is unaffected.
+
+## Owner-roadmap boundary
+
+No thermodynamic, process, pipeline, dynamics, DEXPI/P&ID, production-optimization, schema, response-envelope, or live-control behavior changes in this evidence increment. The canonical NeqSim model and all specialist owner roadmaps remain authoritative.

--- a/neqsim-mcp-server/test_validation_profile_protocol.py
+++ b/neqsim-mcp-server/test_validation_profile_protocol.py
@@ -1,0 +1,230 @@
+"""Focused real-MCP qualification for manageValidationProfile.
+
+This dependency-free harness starts the packaged NeqSim MCP server over STDIO and
+checks built-in profile discovery, an isolated custom-profile lifecycle, and
+fail-closed error behavior. It qualifies software-contract behavior only; it
+is not scientific, regulatory, authorization, or plant-control validation.
+"""
+import json
+import subprocess
+import sys
+import time
+
+JAR = "target/neqsim-mcp-server-1.0.0-SNAPSHOT-runner.jar"
+PROFILE_NAME = "phase0-protocol-profile"
+
+
+class McpClient:
+    """Minimal line-delimited JSON-RPC MCP client for exact packaged-server tests."""
+
+    def __init__(self):
+        self.proc = None
+        self.message_id = 0
+
+    def next_id(self):
+        self.message_id += 1
+        return self.message_id
+
+    def send(self, message):
+        self.proc.stdin.write(json.dumps(message) + "\n")
+        self.proc.stdin.flush()
+
+    def receive(self):
+        line = self.proc.stdout.readline()
+        if not line:
+            stderr = self.proc.stderr.read() if self.proc and self.proc.stderr else ""
+            raise RuntimeError("MCP server closed stdout unexpectedly: " + stderr)
+        return json.loads(line)
+
+    def start(self):
+        self.proc = subprocess.Popen(
+            ["java", "-jar", JAR],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "neqsim-validation-profile-test", "version": "1.0"},
+                },
+            }
+        )
+        response = self.receive()
+        require("result" in response, "MCP initialize did not return a result", response)
+        self.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        time.sleep(0.2)
+
+    def call_tool(self, name, arguments):
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            }
+        )
+        response = self.receive()
+        content = response.get("result", {}).get("content", [])
+        require(content, "MCP tool call returned no content", response)
+        text = content[0].get("text", "")
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as error:
+            raise AssertionError(f"MCP tool returned non-JSON content: {error}: {text}")
+
+    def validation_profile(self, request):
+        return self.call_tool(
+            "manageValidationProfile", {"profileJson": json.dumps(request)}
+        )
+
+    def close(self):
+        if self.proc is None:
+            return
+        if self.proc.stdin:
+            self.proc.stdin.close()
+        try:
+            self.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.proc.terminate()
+            self.proc.wait(timeout=10)
+        self.proc = None
+
+
+def require(condition, message, detail=None):
+    """Raise a compact assertion with JSON detail when a protocol contract fails."""
+    if condition:
+        return
+    suffix = ""
+    if detail is not None:
+        suffix = "\n" + json.dumps(detail, indent=2, sort_keys=True)
+    raise AssertionError(message + suffix)
+
+
+def payload(response):
+    """Return domain data while retaining standardized envelope state."""
+    data = response.get("data") if isinstance(response, dict) else None
+    if not isinstance(data, dict):
+        return response
+    merged = dict(data)
+    for key in ("status", "message", "tool", "errors"):
+        if key in response:
+            merged.setdefault(key, response[key])
+    return merged
+
+
+def error_codes(response):
+    """Collect runner or standardized-envelope error codes without assuming nesting."""
+    data = payload(response)
+    errors = data.get("errors", []) if isinstance(data, dict) else []
+    return [item.get("code") for item in errors if isinstance(item, dict)]
+
+
+def test_builtin_profile_discovery(client):
+    result = client.validation_profile({"action": "listProfiles"})
+    data = payload(result)
+    require(data.get("status") == "success", "listProfiles failed", result)
+    profiles = data.get("profiles", [])
+    names = {item.get("name") for item in profiles if isinstance(item, dict)}
+    require({"ncs", "ukcs", "gom", "brazil", "generic"}.issubset(names),
+            "built-in validation profiles drifted", result)
+    require(data.get("totalCount", 0) >= 5, "profile count omitted built-ins", result)
+
+    ncs = payload(client.validation_profile({"action": "getProfile", "profileName": "ncs"}))
+    require(ncs.get("status") == "success", "getProfile(ncs) failed", ncs)
+    require(ncs.get("name") == "ncs", "getProfile lost requested name", ncs)
+    require(ncs.get("type") == "built-in", "ncs should remain built-in", ncs)
+    profile = ncs.get("profile", {})
+    require(isinstance(profile.get("standards"), list), "ncs standards missing", ncs)
+
+
+def test_custom_profile_lifecycle(client):
+    client.validation_profile({"action": "deleteProfile", "profileName": PROFILE_NAME})
+    created = payload(
+        client.validation_profile(
+            {
+                "action": "createProfile",
+                "profileName": PROFILE_NAME,
+                "basedOn": "generic",
+                "description": "Phase 0 packaged protocol fixture",
+            }
+        )
+    )
+    require(created.get("status") == "success", "createProfile failed", created)
+    require(created.get("profileName") == PROFILE_NAME, "created profile identity drifted", created)
+
+    activated = payload(
+        client.validation_profile({"action": "setActiveProfile", "profileName": PROFILE_NAME})
+    )
+    require(activated.get("status") == "success", "setActiveProfile failed", activated)
+    require(activated.get("activeProfile") == PROFILE_NAME, "active profile did not change", activated)
+
+    active = payload(client.validation_profile({"action": "getActiveProfile"}))
+    require(active.get("status") == "success", "getActiveProfile failed", active)
+    require(active.get("activeProfile") == PROFILE_NAME, "active profile identity was not retained", active)
+    require(active.get("type") == "custom", "custom profile type was not retained", active)
+    require(
+        active.get("profile", {}).get("description") == "Phase 0 packaged protocol fixture",
+        "custom profile payload drifted",
+        active,
+    )
+
+    standards = payload(
+        client.validation_profile(
+            {"action": "getStandardsForEquipment", "equipmentType": "separator"}
+        )
+    )
+    require(standards.get("status") == "success", "equipment standards lookup failed", standards)
+    require(standards.get("equipmentType") == "separator", "equipment identity drifted", standards)
+    require(isinstance(standards.get("standards"), list), "equipment standards missing", standards)
+
+    deleted = payload(
+        client.validation_profile({"action": "deleteProfile", "profileName": PROFILE_NAME})
+    )
+    require(deleted.get("status") == "success", "deleteProfile failed", deleted)
+    require(deleted.get("deleted") is True, "custom profile was not deleted", deleted)
+    require(deleted.get("activeProfile") == "generic", "deleting active custom profile did not recover to generic", deleted)
+
+
+def test_mutation_errors_fail_closed(client):
+    reserved = client.validation_profile({"action": "deleteProfile", "profileName": "generic"})
+    require(payload(reserved).get("status") == "error", "built-in profile deletion was not rejected", reserved)
+    require("CANNOT_DELETE" in error_codes(reserved), "built-in deletion error code drifted", reserved)
+
+    missing = client.validation_profile(
+        {"action": "setActiveProfile", "profileName": "does-not-exist-phase0"}
+    )
+    require(payload(missing).get("status") == "error", "unknown profile activation was not rejected", missing)
+    require("PROFILE_NOT_FOUND" in error_codes(missing), "unknown-profile error code drifted", missing)
+
+    unknown = client.validation_profile({"action": "unsupported-phase0-action"})
+    require(payload(unknown).get("status") == "error", "unknown action was not rejected", unknown)
+    require("UNKNOWN_ACTION" in error_codes(unknown), "unknown-action error code drifted", unknown)
+
+
+def main():
+    client = McpClient()
+    try:
+        client.start()
+        test_builtin_profile_discovery(client)
+        test_custom_profile_lifecycle(client)
+        test_mutation_errors_fail_closed(client)
+    finally:
+        try:
+            if client.proc is not None:
+                client.validation_profile({"action": "deleteProfile", "profileName": PROFILE_NAME})
+                client.validation_profile({"action": "setActiveProfile", "profileName": "generic"})
+        finally:
+            client.close()
+    print("manageValidationProfile real-MCP qualification: 3/3 scenarios passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/neqsim-mcp-server/test_validation_profile_protocol.py
+++ b/neqsim-mcp-server/test_validation_profile_protocol.py
@@ -1,8 +1,8 @@
 """Focused real-MCP qualification for manageValidationProfile.
 
 This dependency-free harness starts the packaged NeqSim MCP server over STDIO and
-checks built-in profile discovery, an isolated custom-profile lifecycle, and
-fail-closed error behavior. It qualifies software-contract behavior only; it
+checks built-in profile discovery, bounded validation metadata, an isolated custom-profile lifecycle,
+and fail-closed error behavior. It qualifies software-contract behavior only; it
 is not scientific, regulatory, authorization, or plant-control validation.
 """
 import json
@@ -144,6 +144,21 @@ def test_builtin_profile_discovery(client):
     require(isinstance(profile.get("standards"), list), "ncs standards missing", ncs)
 
 
+def test_validation_metadata_is_preserved(client):
+    result = client.validation_profile(
+        {"action": "validateWithProfile", "profileName": "generic"}
+    )
+    data = payload(result)
+    require("verdict" in data, "validator verdict was omitted", result)
+    require(
+        data.get("validationProfile") == "generic",
+        "validation profile provenance drifted",
+        result,
+    )
+    require(isinstance(data.get("applicableStandards"), list), "standards metadata missing", result)
+    require(isinstance(data.get("requiredDesignFactors"), dict), "design-factor metadata missing", result)
+
+
 def test_custom_profile_lifecycle(client):
     client.validation_profile({"action": "deleteProfile", "profileName": PROFILE_NAME})
     created = payload(
@@ -213,6 +228,7 @@ def main():
     try:
         client.start()
         test_builtin_profile_discovery(client)
+        test_validation_metadata_is_preserved(client)
         test_custom_profile_lifecycle(client)
         test_mutation_errors_fail_closed(client)
     finally:
@@ -222,7 +238,7 @@ def main():
                 client.validation_profile({"action": "setActiveProfile", "profileName": "generic"})
         finally:
             client.close()
-    print("manageValidationProfile real-MCP qualification: 3/3 scenarios passed")
+    print("manageValidationProfile real-MCP qualification: 4/4 scenarios passed")
     return 0
 
 

--- a/src/test/java/neqsim/mcp/runners/ValidationProfileRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/ValidationProfileRunnerTest.java
@@ -115,20 +115,24 @@ class ValidationProfileRunnerTest {
         ValidationProfileRunner.run("{\"action\":\"deleteProfile\",\"profileName\":\"generic\"}"))
         .getAsJsonObject();
     assertEquals("error", reservedDelete.get("status").getAsString());
-    assertEquals("CANNOT_DELETE", reservedDelete.get("errorCode").getAsString());
+    assertEquals("CANNOT_DELETE",
+        reservedDelete.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
 
     JsonObject missingProfile = JsonParser.parseString(
         ValidationProfileRunner.run("{\"action\":\"setActiveProfile\",\"profileName\":\"does-not-exist\"}"))
         .getAsJsonObject();
     assertEquals("error", missingProfile.get("status").getAsString());
-    assertEquals("PROFILE_NOT_FOUND", missingProfile.get("errorCode").getAsString());
+    assertEquals("PROFILE_NOT_FOUND",
+        missingProfile.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
 
     JsonObject unknownAction = JsonParser
         .parseString(ValidationProfileRunner.run("{\"action\":\"unsupported-phase0-action\"}"))
         .getAsJsonObject();
     assertEquals("error", unknownAction.get("status").getAsString());
-    assertEquals("UNKNOWN_ACTION", unknownAction.get("errorCode").getAsString());
-    assertFalse(unknownAction.get("message").getAsString().isEmpty());
+    JsonObject error = unknownAction.getAsJsonArray("errors").get(0).getAsJsonObject();
+    assertEquals("UNKNOWN_ACTION", error.get("code").getAsString());
+    assertFalse(error.get("message").getAsString().isEmpty());
+    assertFalse(error.get("remediation").getAsString().isEmpty());
   }
 
   @Test

--- a/src/test/java/neqsim/mcp/runners/ValidationProfileRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/ValidationProfileRunnerTest.java
@@ -70,20 +70,21 @@ class ValidationProfileRunnerTest {
     ValidationProfileRunner.run("{\"action\":\"setActiveProfile\",\"profileName\":\"generic\"}");
     try {
       JsonObject cleanup = JsonParser
-          .parseString(ValidationProfileRunner.run("{\"action\":\"deleteProfile\",\"profileName\":\"" + profileName
-              + "\"}"))
+          .parseString(
+              ValidationProfileRunner.run("{\"action\":\"deleteProfile\",\"profileName\":\"" + profileName + "\"}"))
           .getAsJsonObject();
       assertEquals("success", cleanup.get("status").getAsString());
 
-      JsonObject created = JsonParser.parseString(ValidationProfileRunner.run(
-          "{\"action\":\"createProfile\",\"profileName\":\"" + profileName
+      JsonObject created = JsonParser
+          .parseString(ValidationProfileRunner.run("{\"action\":\"createProfile\",\"profileName\":\"" + profileName
               + "\",\"basedOn\":\"generic\",\"description\":\"Phase 0 contract fixture\"}"))
           .getAsJsonObject();
       assertEquals("success", created.get("status").getAsString());
       assertEquals(profileName, created.get("profileName").getAsString());
 
-      JsonObject activated = JsonParser.parseString(ValidationProfileRunner.run(
-          "{\"action\":\"setActiveProfile\",\"profileName\":\"" + profileName + "\"}"))
+      JsonObject activated = JsonParser
+          .parseString(
+              ValidationProfileRunner.run("{\"action\":\"setActiveProfile\",\"profileName\":\"" + profileName + "\"}"))
           .getAsJsonObject();
       assertEquals("success", activated.get("status").getAsString());
       assertEquals(profileName, activated.get("activeProfile").getAsString());
@@ -95,38 +96,38 @@ class ValidationProfileRunnerTest {
       assertEquals("custom", active.get("type").getAsString());
       assertEquals("Phase 0 contract fixture", active.getAsJsonObject("profile").get("description").getAsString());
 
-      JsonObject deleted = JsonParser.parseString(ValidationProfileRunner.run(
-          "{\"action\":\"deleteProfile\",\"profileName\":\"" + profileName + "\"}"))
+      JsonObject deleted = JsonParser
+          .parseString(
+              ValidationProfileRunner.run("{\"action\":\"deleteProfile\",\"profileName\":\"" + profileName + "\"}"))
           .getAsJsonObject();
       assertEquals("success", deleted.get("status").getAsString());
       assertTrue(deleted.get("deleted").getAsBoolean());
       assertEquals("generic", deleted.get("activeProfile").getAsString());
     } finally {
-      ValidationProfileRunner.run(
-          "{\"action\":\"deleteProfile\",\"profileName\":\"" + profileName + "\"}");
+      ValidationProfileRunner.run("{\"action\":\"deleteProfile\",\"profileName\":\"" + profileName + "\"}");
       ValidationProfileRunner.run("{\"action\":\"setActiveProfile\",\"profileName\":\"generic\"}");
     }
   }
 
   @Test
   void testMutationErrorsFailClosed() {
-    JsonObject reservedDelete = JsonParser.parseString(
-        ValidationProfileRunner.run("{\"action\":\"deleteProfile\",\"profileName\":\"generic\"}"))
+    JsonObject reservedDelete = JsonParser
+        .parseString(ValidationProfileRunner.run("{\"action\":\"deleteProfile\",\"profileName\":\"generic\"}"))
         .getAsJsonObject();
     assertEquals("error", reservedDelete.get("status").getAsString());
     assertEquals("CANNOT_DELETE",
         reservedDelete.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
 
-    JsonObject missingProfile = JsonParser.parseString(
-        ValidationProfileRunner.run("{\"action\":\"setActiveProfile\",\"profileName\":\"does-not-exist\"}"))
+    JsonObject missingProfile = JsonParser
+        .parseString(
+            ValidationProfileRunner.run("{\"action\":\"setActiveProfile\",\"profileName\":\"does-not-exist\"}"))
         .getAsJsonObject();
     assertEquals("error", missingProfile.get("status").getAsString());
     assertEquals("PROFILE_NOT_FOUND",
         missingProfile.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
 
     JsonObject unknownAction = JsonParser
-        .parseString(ValidationProfileRunner.run("{\"action\":\"unsupported-phase0-action\"}"))
-        .getAsJsonObject();
+        .parseString(ValidationProfileRunner.run("{\"action\":\"unsupported-phase0-action\"}")).getAsJsonObject();
     assertEquals("error", unknownAction.get("status").getAsString());
     JsonObject error = unknownAction.getAsJsonArray("errors").get(0).getAsJsonObject();
     assertEquals("UNKNOWN_ACTION", error.get("code").getAsString());

--- a/src/test/java/neqsim/mcp/runners/ValidationProfileRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/ValidationProfileRunnerTest.java
@@ -1,6 +1,7 @@
 package neqsim.mcp.runners;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,10 @@ class ValidationProfileRunnerTest {
     JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
     assertEquals("success", obj.get("status").getAsString(), "List profiles failed: " + result);
     assertTrue(obj.has("profiles"), "Should list profiles");
+    assertTrue(obj.get("totalCount").getAsInt() >= 5, "Should include all built-in profiles");
+    String profiles = obj.getAsJsonArray("profiles").toString();
+    assertTrue(profiles.contains("ncs"));
+    assertTrue(profiles.contains("generic"));
   }
 
   @Test
@@ -32,6 +37,9 @@ class ValidationProfileRunnerTest {
     assertNotNull(result);
     JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
     assertEquals("success", obj.get("status").getAsString(), "Get profile failed: " + result);
+    assertEquals("ncs", obj.get("name").getAsString());
+    assertEquals("built-in", obj.get("type").getAsString());
+    assertTrue(obj.getAsJsonObject("profile").has("standards"));
   }
 
   @Test
@@ -41,6 +49,8 @@ class ValidationProfileRunnerTest {
     assertNotNull(result);
     JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
     assertEquals("success", obj.get("status").getAsString(), "Get active profile failed: " + result);
+    assertTrue(obj.has("activeProfile"));
+    assertTrue(obj.has("profile"));
   }
 
   @Test
@@ -50,6 +60,75 @@ class ValidationProfileRunnerTest {
     assertNotNull(result);
     JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
     assertEquals("success", obj.get("status").getAsString(), "Equipment standards failed: " + result);
+    assertEquals("separator", obj.get("equipmentType").getAsString());
+    assertTrue(obj.has("standards"));
+  }
+
+  @Test
+  void testCustomProfileLifecycleIsExplicitAndRecoverable() {
+    String originalProfile = ValidationProfileRunner.getActiveProfileName();
+    String profileName = "phase0-contract-profile";
+    try {
+      JsonObject cleanup = JsonParser
+          .parseString(ValidationProfileRunner.run("{\"action\":\"deleteProfile\",\"profileName\":\"" + profileName
+              + "\"}"))
+          .getAsJsonObject();
+      assertEquals("success", cleanup.get("status").getAsString());
+
+      JsonObject created = JsonParser.parseString(ValidationProfileRunner.run(
+          "{\"action\":\"createProfile\",\"profileName\":\"" + profileName
+              + "\",\"basedOn\":\"generic\",\"description\":\"Phase 0 contract fixture\"}"))
+          .getAsJsonObject();
+      assertEquals("success", created.get("status").getAsString());
+      assertEquals(profileName, created.get("profileName").getAsString());
+
+      JsonObject activated = JsonParser.parseString(ValidationProfileRunner.run(
+          "{\"action\":\"setActiveProfile\",\"profileName\":\"" + profileName + "\"}"))
+          .getAsJsonObject();
+      assertEquals("success", activated.get("status").getAsString());
+      assertEquals(profileName, activated.get("activeProfile").getAsString());
+
+      JsonObject active = JsonParser.parseString(ValidationProfileRunner.run("{\"action\":\"getActiveProfile\"}"))
+          .getAsJsonObject();
+      assertEquals("success", active.get("status").getAsString());
+      assertEquals(profileName, active.get("activeProfile").getAsString());
+      assertEquals("custom", active.get("type").getAsString());
+      assertEquals("Phase 0 contract fixture", active.getAsJsonObject("profile").get("description").getAsString());
+
+      JsonObject deleted = JsonParser.parseString(ValidationProfileRunner.run(
+          "{\"action\":\"deleteProfile\",\"profileName\":\"" + profileName + "\"}"))
+          .getAsJsonObject();
+      assertEquals("success", deleted.get("status").getAsString());
+      assertTrue(deleted.get("deleted").getAsBoolean());
+      assertEquals("generic", deleted.get("activeProfile").getAsString());
+    } finally {
+      ValidationProfileRunner.run(
+          "{\"action\":\"deleteProfile\",\"profileName\":\"" + profileName + "\"}");
+      ValidationProfileRunner.run(
+          "{\"action\":\"setActiveProfile\",\"profileName\":\"" + originalProfile + "\"}");
+    }
+  }
+
+  @Test
+  void testMutationErrorsFailClosed() {
+    JsonObject reservedDelete = JsonParser.parseString(
+        ValidationProfileRunner.run("{\"action\":\"deleteProfile\",\"profileName\":\"generic\"}"))
+        .getAsJsonObject();
+    assertEquals("error", reservedDelete.get("status").getAsString());
+    assertEquals("CANNOT_DELETE", reservedDelete.get("errorCode").getAsString());
+
+    JsonObject missingProfile = JsonParser.parseString(
+        ValidationProfileRunner.run("{\"action\":\"setActiveProfile\",\"profileName\":\"does-not-exist\"}"))
+        .getAsJsonObject();
+    assertEquals("error", missingProfile.get("status").getAsString());
+    assertEquals("PROFILE_NOT_FOUND", missingProfile.get("errorCode").getAsString());
+
+    JsonObject unknownAction = JsonParser
+        .parseString(ValidationProfileRunner.run("{\"action\":\"unsupported-phase0-action\"}"))
+        .getAsJsonObject();
+    assertEquals("error", unknownAction.get("status").getAsString());
+    assertEquals("UNKNOWN_ACTION", unknownAction.get("errorCode").getAsString());
+    assertFalse(unknownAction.get("message").getAsString().isEmpty());
   }
 
   @Test

--- a/src/test/java/neqsim/mcp/runners/ValidationProfileRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/ValidationProfileRunnerTest.java
@@ -66,8 +66,8 @@ class ValidationProfileRunnerTest {
 
   @Test
   void testCustomProfileLifecycleIsExplicitAndRecoverable() {
-    String originalProfile = ValidationProfileRunner.getActiveProfileName();
     String profileName = "phase0-contract-profile";
+    ValidationProfileRunner.run("{\"action\":\"setActiveProfile\",\"profileName\":\"generic\"}");
     try {
       JsonObject cleanup = JsonParser
           .parseString(ValidationProfileRunner.run("{\"action\":\"deleteProfile\",\"profileName\":\"" + profileName
@@ -104,8 +104,7 @@ class ValidationProfileRunnerTest {
     } finally {
       ValidationProfileRunner.run(
           "{\"action\":\"deleteProfile\",\"profileName\":\"" + profileName + "\"}");
-      ValidationProfileRunner.run(
-          "{\"action\":\"setActiveProfile\",\"profileName\":\"" + originalProfile + "\"}");
+      ValidationProfileRunner.run("{\"action\":\"setActiveProfile\",\"profileName\":\"generic\"}");
     }
   }
 

--- a/src/test/java/neqsim/mcp/runners/ValidationProfileRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/ValidationProfileRunnerTest.java
@@ -65,6 +65,16 @@ class ValidationProfileRunnerTest {
   }
 
   @Test
+  void testValidateWithProfileReturnsProfileMetadata() {
+    String json = "{\"action\":\"validateWithProfile\",\"profileName\":\"generic\"}";
+    JsonObject obj = JsonParser.parseString(ValidationProfileRunner.run(json)).getAsJsonObject();
+    assertTrue(obj.has("verdict"), "Validator verdict should remain visible");
+    assertEquals("generic", obj.get("validationProfile").getAsString());
+    assertTrue(obj.has("applicableStandards"));
+    assertTrue(obj.has("requiredDesignFactors"));
+  }
+
+  @Test
   void testCustomProfileLifecycleIsExplicitAndRecoverable() {
     String profileName = "phase0-contract-profile";
     ValidationProfileRunner.run("{\"action\":\"setActiveProfile\",\"profileName\":\"generic\"}");


### PR DESCRIPTION
## Summary

Advances #3153 Phase 0 from exact branch-creation base `a5393a1fb212377944eff4e757907c50bcb62c5e` by qualifying the existing `manageValidationProfile` software contract across the core runner and packaged MCP transport.

Exact current head: `a7d6944621b9abc01b3ea221208f18228b360b76`.

- strengthens `ValidationProfileRunnerTest` with deterministic built-in discovery, structural `validateWithProfile` metadata checks, an isolated custom-profile create/activate/read/delete lifecycle, default-`generic` recovery, equipment-standard retrieval, and structured fail-closed mutation errors;
- adds `neqsim-mcp-server/test_validation_profile_protocol.py`, a dependency-free real-MCP STDIO qualification covering built-in discovery, bounded validation metadata, isolated custom-profile lifecycle, and rejection of built-in deletion, unknown profile activation, and unknown actions;
- extends the existing read-only `MCP protocol qualification` workflow to run the validation-profile harness after building the exact Java 21 core and packaged MCP server;
- adds `docs/evidence/VALIDATION_PROFILE_CONTRACT.md` with explicit governance, persistence, regulatory, authorization, and engineering-validation boundaries.

This PR deliberately does **not** promote `manageValidationProfile` or change the Phase 0 trust accounting. Current accounting remains `20 EXPLICIT_TRUST + 9 CONTRACT_TESTED + 42 CONFIRMED_GAP`; `BenchmarkTrust` numerical/scientific accounting is unchanged.

## Scope / safety boundary

`manageValidationProfile` remains an experimental `PLATFORM` tool under `IndustrialProfile`; this evidence does not relax deployment-profile access rules. Custom profiles are process-local mutable state, and both Java and packaged-protocol lifecycle fixtures use synthetic names and restore `generic`/delete the fixture before completion.

The `validateWithProfile` assertions are structural only: they prove that a validator verdict remains visible and that `validationProfile`, `applicableStandards`, and `requiredDesignFactors` survive the runner and packaged MCP response path. They do **not** validate the engineering correctness, currency, legal applicability, or licensing status of any named standard, threshold, design factor, or validator verdict.

The profile names and embedded standards metadata are not claimed to be complete, current, legally applicable, licensed for redistribution, or sufficient for any facility/jurisdiction. This PR does not grant external authorization, prove multi-tenant deployment isolation or restart durability, or imply accountable engineering approval.

No thermodynamic, process, pipeline, dynamics, DEXPI/P&ID, production-optimization, public MCP tool/input schema, stable response-envelope, security-policy, live-plant write, or control behavior changes.

## Validation

**READY TO MERGE for exact head `a7d6944621b9abc01b3ea221208f18228b360b76`.** This classification grants no merge authority; the PR remains draft.

Hosted exact-head GitHub validation is complete and successful:

- `MCP protocol qualification`: passed; exact Java 21 core/package build plus `inspectApi` **3/3** and `manageValidationProfile` **4/4** real-MCP scenarios;
- `Pre-commit checks`: passed;
- `Spotless format patch`: passed, with no outstanding formatter change;
- `CodeQL Security Analysis`: passed;
- `Run build, test and javadoc`: passed, including Javadocs, agent/skill cross-reference validation, fast tests, and all slow-test shards.

The single optional local checkout attempt in the implementation run was infrastructure-blocked by DNS (`Could not resolve host: github.com`), so no local Maven/JDK/Spotless/Python/pre-commit/Javadocs pass is claimed.

Current `master` has advanced to `5eea490cce2ff6a58a3eaf2a2fbdec3f89404e6a` only through an unrelated `devtools/generate_sources_md.py` PDM/Rigga source-classification change. This PR remains mergeable. Per campaign policy, the branch was not synchronized with master merely because master moved.

Repository instructions were rechecked; the tests use no post-Java-8 language/library features.

## Documentation impact

Adds one bounded evidence note under `neqsim-mcp-server/docs/evidence/` and keeps it synchronized with the focused Java/protocol coverage. No public invocation contract changes, so README/MCP_CONTRACT/API_REFERENCE and companion agent/skill contracts do not require synchronized changes in this increment.

## Stop boundary / next dependency

The first deferred Phase 0 dependency remains the atomic `inspectApi` promotion: update the machine-readable coverage status and primary packaged-protocol accounting together from 20/9/42 to 20/10/41 on one exact validated head. This PR does not substitute validation-profile evidence for that promotion; it prepares another defensible non-numerical contract for later classification only after its own merge and current-master re-audit.

AI-assisted contribution; no unrun check is claimed as passed.