### PR TITLE
[AI-Assisted] fix(pitzer): keep automatic catalog for hydrocarbon brines

### DIFF
--- a/docs/thermo/pitzer_parameter_provenance.md
+++ b/docs/thermo/pitzer_parameter_provenance.md
@@ -15,8 +15,10 @@ derived and reviewed equation mapping.
 
 New `SystemPitzer` phases use a catalog-first default: on the first Pitzer activity/property
 evaluation, NeqSim selects the complete bundled PHREEQC topology when every required active aqueous
-interaction exists. Hydrocarbons remain on the EOS role phases and do not create aqueous neutral-
-interaction requirements. Other non-hydrocarbon aqueous neutrals still require explicit complete
+interaction exists. EOS-role pure hydrocarbons are identified by molecular formula as well as
+component-type metadata and do not create aqueous neutral-interaction requirements; this includes
+normal database components such as methane whose GE-phase type is not reliably `HC`. Other
+non-hydrocarbon aqueous neutrals still require explicit complete
 `lambda` and `zeta` families. If the catalog is incomplete, loading falls back to the historical
 binary table; mixed primary-salt coverage then still fails closed on missing binary, `theta`, or
 `psi` rows. No missing interaction is silently converted to zero. Call

--- a/src/main/java/neqsim/thermo/phase/PhasePitzer.java
+++ b/src/main/java/neqsim/thermo/phase/PhasePitzer.java
@@ -1867,7 +1867,8 @@ public class PhasePitzer extends PhaseGE {
 
   private boolean isNeutralSolute(int index) {
     return Math.abs(getComponent(index).getIonicCharge()) < 0.5 && !"water".equalsIgnoreCase(componentName(index))
-        && (!excludeHydrocarbonsFromNeutralPitzerTopology || !getComponent(index).isHydrocarbon());
+        && (!excludeHydrocarbonsFromNeutralPitzerTopology
+            || !PitzerParameterDatasets.isHydrocarbonForAutomaticCatalog(getComponent(index)));
   }
 
   private void validateNeutralParameterCoverageOncePerState() {

--- a/src/main/java/neqsim/thermo/phase/PitzerParameterDatasets.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerParameterDatasets.java
@@ -291,12 +291,44 @@ public final class PitzerParameterDatasets {
       if (phase.getComponent(component).getNumberOfMolesInPhase() <= 1.0e-20
           || Math.abs(phase.getComponent(component).getIonicCharge()) >= 0.5
           || "water".equalsIgnoreCase(phase.getComponent(component).getComponentName())
-          || (excludeHydrocarbons && phase.getComponent(component).isHydrocarbon())) {
+          || (excludeHydrocarbons && isHydrocarbonForAutomaticCatalog(phase.getComponent(component)))) {
         continue;
       }
       neutrals.add(component);
     }
     return neutrals;
+  }
+
+  /**
+   * Identifies EOS-role hydrocarbons without relying only on the mutable component-type flag.
+   *
+   * <p>
+   * Normal database components such as methane can retain component type {@code normal} in a GE phase. Their molecular
+   * formula remains an unambiguous discriminator: a pure hydrocarbon contains carbon and hydrogen only. Explicit
+   * neutral Pitzer datasets are unaffected; this helper is used only by automatic catalog selection.
+   * </p>
+   */
+  static boolean isHydrocarbonForAutomaticCatalog(neqsim.thermo.component.ComponentInterface component) {
+    if (component.isHydrocarbon() || component.isIsTBPfraction()) {
+      return true;
+    }
+    String formula = component.getFormulae();
+    if (formula == null || formula.isEmpty()) {
+      return false;
+    }
+    boolean carbon = false;
+    boolean hydrogen = false;
+    for (int index = 0; index < formula.length(); index++) {
+      char character = formula.charAt(index);
+      if (character == 'C') {
+        carbon = true;
+      } else if (character == 'H') {
+        hydrogen = true;
+      } else if (!Character.isDigit(character)) {
+        return false;
+      }
+    }
+    return carbon && hydrogen;
   }
 
   private static void applyValidatedCatalog(PhasePitzer phase, PhreeqcPitzerParameterCatalog catalog,

--- a/src/test/java/neqsim/thermo/phase/PitzerParameterDatasetsTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerParameterDatasetsTest.java
@@ -333,6 +333,29 @@ class PitzerParameterDatasetsTest extends neqsim.NeqSimTest {
   }
 
   @Test
+  void automaticCatalogIgnoresEosRoleHydrocarbonFormulaAndKeepsLegacyOptOut() {
+    SystemPitzer automatic = createMethaneSodiumChlorideSystem(false);
+    PhasePitzer automaticPhase = (PhasePitzer) automatic.getGeLiquidPhase();
+
+    assertTrue(Double.isFinite(automaticPhase.getOsmoticCoefficientOfWater()));
+    double sodiumLogGamma = componentLogGamma(automaticPhase, "Na+");
+    assertTrue(Double.isFinite(sodiumLogGamma));
+    assertEquals(PitzerParameterDatasets.PHREEQC_PITZER_CATALOG_ID, automaticPhase.getParameterDatasetId());
+    assertTrue(automaticPhase.getPitzerParameterCoverage().isComplete());
+    assertTrue(automaticPhase.auditNeutralPitzerParameterCoverage().isComplete());
+    assertTrue(PitzerParameterDatasets
+        .isHydrocarbonForAutomaticCatalog(automaticPhase.getComponent("methane")));
+    assertFalse(PitzerParameterDatasets
+        .isHydrocarbonForAutomaticCatalog(automaticPhase.getComponent("water")));
+
+    SystemPitzer legacy = createMethaneSodiumChlorideSystem(true);
+    PhasePitzer legacyPhase = (PhasePitzer) legacy.getGeLiquidPhase();
+    assertTrue(Double.isFinite(legacyPhase.getOsmoticCoefficientOfWater()));
+    assertTrue(Double.isFinite(componentLogGamma(legacyPhase, "Na+")));
+    assertEquals(PhasePitzer.DEFAULT_PARAMETER_DATASET_ID, legacyPhase.getParameterDatasetId());
+  }
+
+  @Test
   void completeCalciumMagnesiumChlorideSulfateFamilyIsApplied() {
     SystemPitzer system = createCalciumMagnesiumChlorideSulfateSystem(REFERENCE_TEMPERATURE, 0.2, 0.3, 0.4, 0.3);
     system.applyPhreeqcCalciumMagnesiumChlorideSulfateParameters();
@@ -637,6 +660,20 @@ class PitzerParameterDatasetsTest extends neqsim.NeqSimTest {
     system.addComponent("Mg++", magnesiumMolality);
     system.addComponent("Cl-", chlorideMolality);
     system.addComponent("SO4--", sulfateMolality);
+    system.setMixingRule("classic");
+    system.init(0);
+    return system;
+  }
+
+  private static SystemPitzer createMethaneSodiumChlorideSystem(boolean legacy) {
+    SystemPitzer system = new SystemPitzer(REFERENCE_TEMPERATURE, 100.0);
+    if (legacy) {
+      system.useLegacyPitzerParameters();
+    }
+    system.addComponent("methane", 1.0);
+    system.addComponent("water", 55.508);
+    system.addComponent("Na+", 1.0);
+    system.addComponent("Cl-", 1.0);
     system.setMixingRule("classic");
     system.init(0);
     return system;

--- a/src/test/java/neqsim/thermo/phase/PitzerParameterDatasetsTest.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerParameterDatasetsTest.java
@@ -343,10 +343,8 @@ class PitzerParameterDatasetsTest extends neqsim.NeqSimTest {
     assertEquals(PitzerParameterDatasets.PHREEQC_PITZER_CATALOG_ID, automaticPhase.getParameterDatasetId());
     assertTrue(automaticPhase.getPitzerParameterCoverage().isComplete());
     assertTrue(automaticPhase.auditNeutralPitzerParameterCoverage().isComplete());
-    assertTrue(PitzerParameterDatasets
-        .isHydrocarbonForAutomaticCatalog(automaticPhase.getComponent("methane")));
-    assertFalse(PitzerParameterDatasets
-        .isHydrocarbonForAutomaticCatalog(automaticPhase.getComponent("water")));
+    assertTrue(PitzerParameterDatasets.isHydrocarbonForAutomaticCatalog(automaticPhase.getComponent("methane")));
+    assertFalse(PitzerParameterDatasets.isHydrocarbonForAutomaticCatalog(automaticPhase.getComponent("water")));
 
     SystemPitzer legacy = createMethaneSodiumChlorideSystem(true);
     PhasePitzer legacyPhase = (PhasePitzer) legacy.getGeLiquidPhase();


### PR DESCRIPTION
## Scientific question

Can `SystemPitzer` keep its automatic, complete PHREEQC parameter catalog for a raw hydrocarbon/brine inventory when normal database hydrocarbons (notably methane) retain GE-phase component type `normal`, without weakening missing-parameter checks for polar/reactive neutrals?

Issue: #3144

## Frozen scope

- **Base/master:** `5eea490cce2ff6a58a3eaf2a2fbdec3f89404e6a`
- **Exact head:** `4a93ab3a563b6df60fb7841a74330b40ff6bbe82`
- **Model:** `SystemPitzer` hybrid SRK/Pitzer, classic mixing rule
- **Reproducer:** methane + water + Na+ + Cl−, 298.15 K, 100 bara, overall mole input, no reactions
- **Acceptance:** automatic PHREEQC catalog identity; finite ion activity/osmotic output; complete ionic and neutral coverage; methane classified as EOS-role hydrocarbon while water is not; explicit legacy opt-out remains legacy
- **Compatibility/performance risk:** setup-time classification only; no new work in neutral PR/SRK/CPA or electrolyte-EOS kernels
- **Stop boundary:** no coefficient, reaction/mineral table, generic TP-flash, hydrate solver, salt-input API, absorber-equipment, or parameter-fitting change

## Current-master defect

On unmodified master the reproducer falls back silently to `neqsim-legacy-pitzer-parameters-v1`. The automatic topology treats methane as an aqueous neutral because `ComponentInterface.isHydrocarbon()` is false for this normal database component, then rejects the PHREEQC catalog for missing `LAMBDA(methane,methane)`.

That defeats the catalog-first default for the raw gas/brine inventories used by electrolyte saturation, VLE/VLLE, and hydrate workflows.

## Change

- Classify EOS-role pure hydrocarbons for **automatic catalog topology only** using existing hydrocarbon/TBP metadata plus a strict C/H-only molecular-formula check.
- Reuse the same classification in the runtime neutral-coverage audit.
- Keep polar/reactive neutrals fail-closed and preserve `SystemPitzer.useLegacyPitzerParameters()`.
- Document the automatic default and the methane component-metadata case.
- Add a focused methane/NaCl regression covering automatic and explicit-legacy paths.

No Pitzer coefficient, equation, temperature function, dataset identity, tolerance, or source row changed.

## Validation

Run locally against the exact source overlay:

```text
./mvnw -q -DskipTests spotless:check
./mvnw -q -Dtest=PitzerParameterDatasetsTest,ElectrolytePhaseBoundaryFlashTest test
./mvnw -q -Dtest=PitzerParameterDatasetsTest,PitzerParameterCoverageTest,PitzerNeutralInteractionTest,PitzerElectrostaticMixingTest,PitzerTemperatureFunctionTest,SystemPitzerTest,ElectrolytePhaseBoundaryFlashTest test
documentation search: 660 Markdown files + 1 standalone HTML
```

Results:

- focused catalog + electrolyte-boundary matrix: **27/27 passed**
- broader Pitzer/VLE matrix: **76/76 passed**
- Spotless: **passed**
- documentation search: **passed**
- local `pre-commit` executable: unavailable and not claimed
- hosted pre-commit first attempt identified two Spotless-wrapped assertions; exact correction is committed at this head
- exact-head hosted pre-commit, Spotless patch, and PaperLab: **passed**
- exact-head Java 21 Ubuntu/Windows tests, all four Java 21 slow shards, Java 8 Ubuntu/Windows tests, Javadocs, documentation search, CodeQL, hosted pre-commit, Spotless patch, and PaperLab: **passed**

Microbenchmark (warm local JVM; report raw values because JIT noise dominates the neutral control):

```text
pitzerCatalogKernelNs=7134
pitzerCompletePropertyNs=174445
neutralSrkBeforeCatalogNs=49474
neutralSrkAfterCatalogNs=22165
neutralSrkRatio=0.448
```

The production change is catalog setup-only. The neutral SRK control shows no slowdown; this does not claim statistical precision beyond the absence of a practical regression.

## Scientific provenance and validation separation

The parameter values remain the bundled USGS PHREEQC 3.9.0 public-domain catalog at commit `b0b3be767158ccc3322d2c816625cf470045e67e`; the exact source-comparison matrix, equation mapping, species/standard-state conventions, ranges, licensing, conflicts, and held-out validation are retained in [Pitzer parameter provenance and coverage](https://github.com/equinor/neqsim/blob/4a93ab3a563b6df60fb7841a74330b40ff6bbe82/docs/thermo/pitzer_parameter_provenance.md).

Primary/authoritative references remain:

- Pitzer & Mayorga, [DOI 10.1021/j100621a026](https://doi.org/10.1021/j100621a026)
- Plummer et al., PHRQPITZ, [USGS WRI 88-4153](https://doi.org/10.3133/wri884153)
- [USGS PHREEQC](https://github.com/usgs-coupled/phreeqc3) public-domain source

Kaasa (1998) remains a provenance index only. No thesis table value is copied or adopted here; the previously identified CH4 `lambda`/`zeta` family still lacks redistribution-clear, independent row validation. The adopted NaCl ionic family and exact NeqSim convention mapping are unchanged.

## Known limitations / real review boundaries

- This fixes default catalog selection, not hydrocarbon/brine VLE or hydrate accuracy itself.
- A temporary diagnostic found the existing Pitzer hydrate calculation has a physically suspect uninhibited absolute boundary despite the expected NaCl inhibition trend; no hydrate accuracy claim or test is included.
- Reactive electrolyte VLE/VLLE remains blocked by the separately documented reaction-solver failure to satisfy electroneutrality, elemental balance, non-negativity, and reaction closure together.
- Generic TP flash remains coordinated with #2937, reactive absorber equipment with #205, and salt input/API with #448.
- Next parameter dependency is a complete, redistributable Ba/Sr sulfate family for barite/celestite scale work.

**Status: READY TO MERGE on exact head `4a93ab3a563b6df60fb7841a74330b40ff6bbe82`.** The pull request intentionally remains draft; this is a campaign readiness classification, not merge or review-state authority.