### PR TITLE
[AI-Assisted] docs: repair safety hub navigation

### DIFF
--- a/docs/process/safety/README.md
+++ b/docs/process/safety/README.md
@@ -155,12 +155,12 @@ and scenario boundary conditions must also be represented.
 
 ## Relief and fire screening boundary
 
-Use [Relief-Valve Sizing Screening](../../safety/relief_valve_sizing_api.md) for the maintained
+Use [Relief-Valve Sizing Screening](../../safety/relief_valve_sizing_api) for the maintained
 gas, liquid, two-phase, and wetted-fire sizing interfaces. Do not attach an undocumented heat
 input to an arbitrary vessel or infer an API 526 letter from `SafetyValve`; the dynamic equipment
 class does not expose those sizing methods.
 
-Use [Integrated Facility Safety Response](integrated-facility-safety-response.md) when relief,
+Use [Integrated Facility Safety Response](integrated-facility-safety-response) when relief,
 blowdown, flare, compressor trip, process limits, MDMT, and hydrate margin must be reviewed as one
 scenario. Static relief sizing and dynamic transient response answer different questions and
 should both retain method, unit, input-basis, and qualification metadata.
@@ -182,15 +182,15 @@ basis and trace each acceptance criterion to the applicable controlled source.
 
 ## Related documentation
 
-- [Safety documentation index](../../safety/README.md)
-- [Relief-Valve Sizing Screening](../../safety/relief_valve_sizing_api.md)
-- [ESD Dynamic Testing Workflow](../../safety/esd_testing_workflow.md)
-- [HIPPS overview](../../safety/HIPPS_SUMMARY.md)
-- [Closed-loop SIF verification](closed-loop-sif-verification.md)
-- [SIF reliability and degraded modes](sif-reliability-and-degraded-modes.md)
-- [HAZOP/LOPA to draft SRS handoff](hazop-lopa-srs-handoff.md)
-- [Integrated facility safety response](integrated-facility-safety-response.md)
-- [Safety change revalidation and benchmarks](safety-change-revalidation-and-benchmarks.md)
-- [Release and dispersion scenarios](release-dispersion-scenarios.md)
-- [Valve equipment guide](../equipment/valves.md)
-- [Process package overview](../README.md)
+- [Safety documentation index](../../safety/README)
+- [Relief-Valve Sizing Screening](../../safety/relief_valve_sizing_api)
+- [ESD Dynamic Testing Workflow](../../safety/esd_testing_workflow)
+- [HIPPS overview](../../safety/HIPPS_SUMMARY)
+- [Closed-loop SIF verification](closed-loop-sif-verification)
+- [SIF reliability and degraded modes](sif-reliability-and-degraded-modes)
+- [HAZOP/LOPA to draft SRS handoff](hazop-lopa-srs-handoff)
+- [Integrated facility safety response](integrated-facility-safety-response)
+- [Safety change revalidation and benchmarks](safety-change-revalidation-and-benchmarks)
+- [Release and dispersion scenarios](release-dispersion-scenarios)
+- [Valve equipment guide](../equipment/valves)
+- [Process package overview](../README)

--- a/docs/process/safety/README.md
+++ b/docs/process/safety/README.md
@@ -155,12 +155,12 @@ and scenario boundary conditions must also be represented.
 
 ## Relief and fire screening boundary
 
-Use [Relief-Valve Sizing Screening](../../safety/relief_valve_sizing_api) for the maintained
+Use [Relief-Valve Sizing Screening](../../safety/relief_valve_sizing_api.md) for the maintained
 gas, liquid, two-phase, and wetted-fire sizing interfaces. Do not attach an undocumented heat
 input to an arbitrary vessel or infer an API 526 letter from `SafetyValve`; the dynamic equipment
 class does not expose those sizing methods.
 
-Use [Integrated Facility Safety Response](integrated-facility-safety-response) when relief,
+Use [Integrated Facility Safety Response](integrated-facility-safety-response.md) when relief,
 blowdown, flare, compressor trip, process limits, MDMT, and hydrate margin must be reviewed as one
 scenario. Static relief sizing and dynamic transient response answer different questions and
 should both retain method, unit, input-basis, and qualification metadata.
@@ -182,15 +182,15 @@ basis and trace each acceptance criterion to the applicable controlled source.
 
 ## Related documentation
 
-- [Safety documentation index](../../safety/README)
-- [Relief-Valve Sizing Screening](../../safety/relief_valve_sizing_api)
-- [ESD Dynamic Testing Workflow](../../safety/esd_testing_workflow)
-- [HIPPS overview](../../safety/HIPPS_SUMMARY)
-- [Closed-loop SIF verification](closed-loop-sif-verification)
-- [SIF reliability and degraded modes](sif-reliability-and-degraded-modes)
-- [HAZOP/LOPA to draft SRS handoff](hazop-lopa-srs-handoff)
-- [Integrated facility safety response](integrated-facility-safety-response)
-- [Safety change revalidation and benchmarks](safety-change-revalidation-and-benchmarks)
-- [Release and dispersion scenarios](release-dispersion-scenarios)
-- [Valve equipment guide](../equipment/valves)
-- [Process package overview](../README)
+- [Safety documentation index](../../safety/README.md)
+- [Relief-Valve Sizing Screening](../../safety/relief_valve_sizing_api.md)
+- [ESD Dynamic Testing Workflow](../../safety/esd_testing_workflow.md)
+- [HIPPS overview](../../safety/HIPPS_SUMMARY.md)
+- [Closed-loop SIF verification](closed-loop-sif-verification.md)
+- [SIF reliability and degraded modes](sif-reliability-and-degraded-modes.md)
+- [HAZOP/LOPA to draft SRS handoff](hazop-lopa-srs-handoff.md)
+- [Integrated facility safety response](integrated-facility-safety-response.md)
+- [Safety change revalidation and benchmarks](safety-change-revalidation-and-benchmarks.md)
+- [Release and dispersion scenarios](release-dispersion-scenarios.md)
+- [Valve equipment guide](../equipment/valves.md)
+- [Process package overview](../README.md)

--- a/docs/safety/README.md
+++ b/docs/safety/README.md
@@ -5,7 +5,7 @@ keywords: "safety, SIS, ESD, HIPPS, blowdown, depressurization, relief valve, PS
 ---
 
 Use this hub to choose the safety-analysis layer that matches the engineering question. The
-[process-safety API overview](../process/safety/README.md) explains current equipment, logic,
+[process-safety API overview](../process/safety/README) explains current equipment, logic,
 scenario-runner, units, and lifecycle boundaries. The guides below provide focused workflows and
 screening methods.
 
@@ -17,92 +17,92 @@ accountable review remain mandatory.
 
 | Need | Guide |
 | --- | --- |
-| Choose equipment, logic, or scenario APIs | [Process-safety API overview](../process/safety/README.md) |
-| Size or screen relief devices | [Relief-valve sizing screening](relief_valve_sizing_api.md) |
-| Test ESD logic dynamically | [ESD dynamic testing workflow](esd_testing_workflow.md) |
-| Model HIPPS voting and action | [HIPPS implementation](hipps_implementation.md) |
-| Generate safety scenarios | [Safety scenario generation](../process/safety/scenario-generation.md) |
-| Review releases and consequence inputs | [Release and dispersion scenarios](../process/safety/release-dispersion-scenarios.md) |
-| Trace barriers and safety-critical elements | [Barrier management and SCE traceability](barrier_management.md) |
+| Choose equipment, logic, or scenario APIs | [Process-safety API overview](../process/safety/README) |
+| Size or screen relief devices | [Relief-valve sizing screening](relief_valve_sizing_api) |
+| Test ESD logic dynamically | [ESD dynamic testing workflow](esd_testing_workflow) |
+| Model HIPPS voting and action | [HIPPS implementation](hipps_implementation) |
+| Generate safety scenarios | [Safety scenario generation](../process/safety/scenario-generation) |
+| Review releases and consequence inputs | [Release and dispersion scenarios](../process/safety/release-dispersion-scenarios) |
+| Trace barriers and safety-critical elements | [Barrier management and SCE traceability](barrier_management) |
 
 ## Emergency shutdown and blowdown
 
 | Document | Description |
 | --- | --- |
-| [ESD dynamic testing workflow](esd_testing_workflow.md) | Dynamic ESD testing with process logic, OperationalTagMap/tagreader evidence, and JSON criteria reports |
-| [ESD and blowdown system](ESD_BLOWDOWN_SYSTEM.md) | Complete ESD and blowdown-system guide |
-| [Pressure monitoring for ESD](PRESSURE_MONITORING_ESD.md) | Pressure monitoring and shutdown logic |
-| [API 521 depressurization workflow](depressurization_per_API_521.md) | Dynamic depressurization screening and API 521 interpretation boundary |
-| [Integrated safety systems](INTEGRATED_SAFETY_SYSTEMS.md) | Integrated shutdown, isolation, blowdown, and relief overview |
+| [ESD dynamic testing workflow](esd_testing_workflow) | Dynamic ESD testing with process logic, OperationalTagMap/tagreader evidence, and JSON criteria reports |
+| [ESD and blowdown system](ESD_BLOWDOWN_SYSTEM) | Complete ESD and blowdown-system guide |
+| [Pressure monitoring for ESD](PRESSURE_MONITORING_ESD) | Pressure monitoring and shutdown logic |
+| [API 521 depressurization workflow](depressurization_per_API_521) | Dynamic depressurization screening and API 521 interpretation boundary |
+| [Integrated safety systems](INTEGRATED_SAFETY_SYSTEMS) | Integrated shutdown, isolation, blowdown, and relief overview |
 
 ## HIPPS and safety-instrumented functions
 
 | Document | Description |
 | --- | --- |
-| [HIPPS overview](HIPPS_SUMMARY.md) | HIPPS concepts, voting, and implementation map |
-| [HIPPS implementation](hipps_implementation.md) | Detector, voting, logic, and final-action workflow |
-| [HIPPS safety logic](hipps_safety_logic.md) | Safety-logic programming and state behavior |
-| [SIS logic implementation](sis_logic_implementation.md) | Safety-instrumented-system logic |
-| [NOG 070 SIL, STS-0131 gate, and ESD response time](nog070_sil_sts0131_esd.md) | Predetermined SIL, acceptance gate, and response-time budget |
-| [Safety-chain integration tests](integration_safety_chain_tests.md) | Integrated safety-chain verification |
+| [HIPPS overview](HIPPS_SUMMARY) | HIPPS concepts, voting, and implementation map |
+| [HIPPS implementation](hipps_implementation) | Detector, voting, logic, and final-action workflow |
+| [HIPPS safety logic](hipps_safety_logic) | Safety-logic programming and state behavior |
+| [SIS logic implementation](sis_logic_implementation) | Safety-instrumented-system logic |
+| [NOG 070 SIL, STS-0131 gate, and ESD response time](nog070_sil_sts0131_esd) | Predetermined SIL, acceptance gate, and response-time budget |
+| [Safety-chain integration tests](integration_safety_chain_tests) | Integrated safety-chain verification |
 
 ## Hazard identification, risk, and barriers
 
 | Document | Description |
 | --- | --- |
-| [HAZOP guide](HAZOP.md) | Hazard-and-operability study structure and guidewords |
-| [Automated HAZOP from STID and simulation](automated_hazop_from_stid.md) | STID/P&ID, plant data, simulation, HAZOP, barrier, and report workflow |
-| [AI-HAZOP input-data format](ai_hazop_input_format.md) | Required process, deviation, design-condition, and limit-basis inputs |
-| [FMEA guide](FMEA.md) | Failure-mode and effects analysis workflow |
-| [Event and fault trees](event_fault_trees.md) | Event-tree and fault-tree modeling |
-| [Layered safety architecture](layered_safety_architecture.md) | Defense-in-depth and protection-layer structure |
-| [Barrier management and SCE traceability](barrier_management.md) | Evidence-linked PSFs, SCEs, performance standards, and analysis handoffs |
-| [ISO 17776 MAH bow-tie and EI AVIFF FIV screening](mah_bowtie_fiv_screening.md) | Major-accident-hazard bow-tie and flow-induced-vibration screening |
-| [Safety simulation roadmap](SAFETY_SIMULATION_ROADMAP.md) | Maintained capability and development roadmap |
+| [HAZOP guide](HAZOP) | Hazard-and-operability study structure and guidewords |
+| [Automated HAZOP from STID and simulation](automated_hazop_from_stid) | STID/P&ID, plant data, simulation, HAZOP, barrier, and report workflow |
+| [AI-HAZOP input-data format](ai_hazop_input_format) | Required process, deviation, design-condition, and limit-basis inputs |
+| [FMEA guide](FMEA) | Failure-mode and effects analysis workflow |
+| [Event and fault trees](event_fault_trees) | Event-tree and fault-tree modeling |
+| [Layered safety architecture](layered_safety_architecture) | Defense-in-depth and protection-layer structure |
+| [Barrier management and SCE traceability](barrier_management) | Evidence-linked PSFs, SCEs, performance standards, and analysis handoffs |
+| [ISO 17776 MAH bow-tie and EI AVIFF FIV screening](mah_bowtie_fiv_screening) | Major-accident-hazard bow-tie and flow-induced-vibration screening |
+| [Safety simulation roadmap](SAFETY_SIMULATION_ROADMAP) | Maintained capability and development roadmap |
 
 ## Standards and facility screening
 
 | Document | Description |
 | --- | --- |
-| [API RP 14C SAFE chart and NORSOK P-002 compliance](api14c_norsok_p002.md) | SAFE chart, flare/blowdown/vent screening, and multi-vessel header load |
-| [Flare flame, hazardous area, and PFP demand](flare_flame_hazardous_area_pfp.md) | API 537, IEC 60079-10-1, and API 521 screening |
-| [Open-drain review with NeqSim evidence](open_drain_review.md) | NORSOK S-001 open-drain review using calculated leak and firewater loads |
-| [Minimum design metal temperature assessment](mdmt_assessment.md) | MDMT evidence and low-temperature screening |
+| [API RP 14C SAFE chart and NORSOK P-002 compliance](api14c_norsok_p002) | SAFE chart, flare/blowdown/vent screening, and multi-vessel header load |
+| [Flare flame, hazardous area, and PFP demand](flare_flame_hazardous_area_pfp) | API 537, IEC 60079-10-1, and API 521 screening |
+| [Open-drain review with NeqSim evidence](open_drain_review) | NORSOK S-001 open-drain review using calculated leak and firewater loads |
+| [Minimum design metal temperature assessment](mdmt_assessment) | MDMT evidence and low-temperature screening |
 
 ## Relief systems and trapped inventory
 
 | Document | Description |
 | --- | --- |
-| [Relief-valve sizing screening](relief_valve_sizing_api.md) | Static gas, liquid, two-phase, and wetted-fire sizing APIs with explicit SI units |
-| [PSV dynamic sizing example](psv_dynamic_sizing_example.md) | Pressure-safety-valve dynamic sizing workflow |
-| [Rupture-disk dynamic behavior](rupture_disk_dynamic_behavior.md) | Burst, opening, flow, and reset-state behavior |
-| [Trapped inventory calculator](trapped_inventory_calculator.md) | Evidence-linked isolation inventory for blowdown, flare-load, and MDMT screening |
-| [Blocked-in liquid thermal expansion](blocked_in_liquid_thermal_expansion.md) | Isochoric pressure-rise and thermal-relief screening |
-| [Trapped liquid fire rupture](trapped_liquid_fire_rupture.md) | Fire exposure, expansion, failure screening, PFP demand, and source-term handoff |
-| [Vessel thermomechanical safety](vessel_thermomechanical_safety.md) | Blowdown, filling, boil-off, composite-wall conduction, and rupture models |
+| [Relief-valve sizing screening](relief_valve_sizing_api) | Static gas, liquid, two-phase, and wetted-fire sizing APIs with explicit SI units |
+| [PSV dynamic sizing example](psv_dynamic_sizing_example) | Pressure-safety-valve dynamic sizing workflow |
+| [Rupture-disk dynamic behavior](rupture_disk_dynamic_behavior) | Burst, opening, flow, and reset-state behavior |
+| [Trapped inventory calculator](trapped_inventory_calculator) | Evidence-linked isolation inventory for blowdown, flare-load, and MDMT screening |
+| [Blocked-in liquid thermal expansion](blocked_in_liquid_thermal_expansion) | Isochoric pressure-rise and thermal-relief screening |
+| [Trapped liquid fire rupture](trapped_liquid_fire_rupture) | Fire exposure, expansion, failure screening, PFP demand, and source-term handoff |
+| [Vessel thermomechanical safety](vessel_thermomechanical_safety) | Blowdown, filling, boil-off, composite-wall conduction, and rupture models |
 
 ## Fire, release, and consequence
 
 | Document | Description |
 | --- | --- |
-| [Fire-case blowdown capabilities](fire_blowdown_capabilities.md) | Fire-exposed blowdown simulation |
-| [Fire heat-transfer enhancements](fire_heat_transfer_enhancements.md) | Fire heat flux and wall heat-transfer modeling |
-| [Dispersion and consequence](dispersion_and_consequence.md) | Source-term, dispersion, radiation, and consequence-analysis handoff |
-| [Release and dispersion scenarios](../process/safety/release-dispersion-scenarios.md) | Structured release scenarios with explicit inputs and limitations |
-| [Vessel thermomechanical safety](vessel_thermomechanical_safety.md) | Dynamic PSV screening and thermomechanical response |
-| [Trapped liquid fire rupture](trapped_liquid_fire_rupture.md) | Blocked-in liquid fire and rupture screening |
+| [Fire-case blowdown capabilities](fire_blowdown_capabilities) | Fire-exposed blowdown simulation |
+| [Fire heat-transfer enhancements](fire_heat_transfer_enhancements) | Fire heat flux and wall heat-transfer modeling |
+| [Dispersion and consequence](dispersion_and_consequence) | Source-term, dispersion, radiation, and consequence-analysis handoff |
+| [Release and dispersion scenarios](../process/safety/release-dispersion-scenarios) | Structured release scenarios with explicit inputs and limitations |
+| [Vessel thermomechanical safety](vessel_thermomechanical_safety) | Dynamic PSV screening and thermomechanical response |
+| [Trapped liquid fire rupture](trapped_liquid_fire_rupture) | Blocked-in liquid fire and rupture screening |
 
 ## Alarms and architecture
 
 | Document | Description |
 | --- | --- |
-| [Alarm-system guide](alarm_system_guide.md) | Alarm configuration and behavior |
-| [Alarm-triggered logic examples](alarm_triggered_logic_example.md) | Alarm-driven process logic |
-| [Integrated safety systems](INTEGRATED_SAFETY_SYSTEMS.md) | Facility safety-system overview |
-| [Layered safety architecture](layered_safety_architecture.md) | Independent protection layers and defense in depth |
+| [Alarm-system guide](alarm_system_guide) | Alarm configuration and behavior |
+| [Alarm-triggered logic examples](alarm_triggered_logic_example) | Alarm-driven process logic |
+| [Integrated safety systems](INTEGRATED_SAFETY_SYSTEMS) | Facility safety-system overview |
+| [Layered safety architecture](layered_safety_architecture) | Independent protection layers and defense in depth |
 
 ## Related documentation
 
-- [Process package overview](../process/README.md)
-- [Process-safety API overview](../process/safety/README.md)
-- [Controller devices](../process/controllers.md)
+- [Process package overview](../process/README)
+- [Process-safety API overview](../process/safety/README)
+- [Controller devices](../process/controllers)

--- a/docs/safety/README.md
+++ b/docs/safety/README.md
@@ -1,93 +1,108 @@
 ---
 title: Safety Systems Documentation
-description: Documentation for safety-related features and systems in NeqSim.
+description: Navigation for NeqSim process-safety, relief, ESD, HIPPS, risk, consequence, and barrier-analysis guides.
+keywords: "safety, SIS, ESD, HIPPS, blowdown, depressurization, relief valve, PSV, API 520, API 521, fire case, source term, consequence, HAZOP, LOPA, alarm, trip"
 ---
 
-Documentation for safety-related features and systems in NeqSim.
+Use this hub to choose the safety-analysis layer that matches the engineering question. The
+[process-safety API overview](../process/safety/README.md) explains current equipment, logic,
+scenario-runner, units, and lifecycle boundaries. The guides below provide focused workflows and
+screening methods.
 
----
+NeqSim results are engineering evidence, not approval. Project-specific hazards, design
+conditions, standards editions, safeguard independence, uncertainty, acceptance criteria, and
+accountable review remain mandatory.
 
-## Overview
+## Start here
 
-This folder contains guides for implementing safety systems in process simulations, including Emergency Shutdown (ESD), High Integrity Pressure Protection Systems (HIPPS), blowdown analysis, and alarm management.
+| Need | Guide |
+| --- | --- |
+| Choose equipment, logic, or scenario APIs | [Process-safety API overview](../process/safety/README.md) |
+| Size or screen relief devices | [Relief-valve sizing screening](relief_valve_sizing_api.md) |
+| Test ESD logic dynamically | [ESD dynamic testing workflow](esd_testing_workflow.md) |
+| Model HIPPS voting and action | [HIPPS implementation](hipps_implementation.md) |
+| Generate safety scenarios | [Safety scenario generation](../process/safety/scenario-generation.md) |
+| Review releases and consequence inputs | [Release and dispersion scenarios](../process/safety/release-dispersion-scenarios.md) |
+| Trace barriers and safety-critical elements | [Barrier management and SCE traceability](barrier_management.md) |
 
----
-
-## Documentation Index
-
-### Emergency Shutdown (ESD)
-
-| Document | Description |
-|----------|-------------|
-| [ESD Dynamic Testing Workflow](esd_testing_workflow) | Dynamic ESD testing with process logic, OperationalTagMap/tagreader evidence, and JSON criteria reports |
-| [ESD_BLOWDOWN_SYSTEM.md](ESD_BLOWDOWN_SYSTEM) | Complete ESD and blowdown system guide |
-| [PRESSURE_MONITORING_ESD.md](PRESSURE_MONITORING_ESD) | Pressure monitoring for ESD |
-
-### HIPPS (High Integrity Pressure Protection)
-
-| Document | Description |
-|----------|-------------|
-| [HIPPS_SUMMARY.md](HIPPS_SUMMARY) | HIPPS overview and summary |
-| [hipps_implementation.md](hipps_implementation) | HIPPS implementation details |
-| [hipps_safety_logic.md](hipps_safety_logic) | HIPPS safety logic programming |
-
-### Safety Architecture
+## Emergency shutdown and blowdown
 
 | Document | Description |
-|----------|-------------|
-| [INTEGRATED_SAFETY_SYSTEMS.md](INTEGRATED_SAFETY_SYSTEMS) | Integrated safety systems overview |
-| [layered_safety_architecture.md](layered_safety_architecture) | Layered safety architecture (defense in depth) |
-| [sis_logic_implementation.md](sis_logic_implementation) | Safety Instrumented Systems (SIS) logic |
-| [integration_safety_chain_tests.md](integration_safety_chain_tests) | Safety chain integration testing |
-| [SAFETY_SIMULATION_ROADMAP.md](SAFETY_SIMULATION_ROADMAP) | Safety simulation development roadmap |
+| --- | --- |
+| [ESD dynamic testing workflow](esd_testing_workflow.md) | Dynamic ESD testing with process logic, OperationalTagMap/tagreader evidence, and JSON criteria reports |
+| [ESD and blowdown system](ESD_BLOWDOWN_SYSTEM.md) | Complete ESD and blowdown-system guide |
+| [Pressure monitoring for ESD](PRESSURE_MONITORING_ESD.md) | Pressure monitoring and shutdown logic |
+| [API 521 depressurization workflow](depressurization_per_API_521.md) | Dynamic depressurization screening and API 521 interpretation boundary |
+| [Integrated safety systems](INTEGRATED_SAFETY_SYSTEMS.md) | Integrated shutdown, isolation, blowdown, and relief overview |
 
-### Standards Compliance and Hazard Screening
-
-| Document | Description |
-|----------|-------------|
-| [NOG 070 SIL, STS-0131 Gate and ESD Response Time](nog070_sil_sts0131_esd) | Pre-determined SIL (NOG 070), aggregated STS-0131 acceptance gate, and IEC 61511 ESD response-time budget |
-| [API 14C SAFE Chart and NORSOK P-002 Compliance](api14c_norsok_p002) | API RP 14C / ISO 10418 SAFE chart, NORSOK P-002 flare/blowdown/vent screening, and coupled multi-vessel blowdown header load |
-| [ISO 17776 MAH Bow-Tie and EI AVIFF FIV Screening](mah_bowtie_fiv_screening) | Major-accident-hazard bow-tie from the ISO 17776 catalogue and Energy Institute AVIFF flow-induced-vibration screening |
-| [Flare Flame, Hazardous Area and PFP Demand](flare_flame_hazardous_area_pfp) | API 537 flare flame/radiation/noise, IEC 60079-10-1 hazardous-area zoning, and API 521 passive-fire-protection demand |
-| [Automated HAZOP from STID and Simulation](automated_hazop_from_stid) | End-to-end STID/P&ID, plant data, NeqSim simulation, HAZOP, barrier, and report workflow |
-| [AI-HAZOP Input Data Format](ai_hazop_input_format) | Required input-data format for a P&ID Safety Analyser / AI-HAZOP front-end: process model JSON, per-deviation `runHazopScenario` request, DEXPI design-conditions, limit-basis policy, and blocked-outlet overpressure screening |
-| [Open Drain Review with NeqSim Evidence](open_drain_review) | NORSOK S-001 Clause 9 review using NeqSim-calculated liquid leak rate, firewater load, density, pressure, and drain capacity plus STID/tagreader evidence |
-| [Barrier Management and SCE Traceability](barrier_management) | Evidence-linked PSFs, SCEs, performance standards, and safety-analysis handoffs |
-
-### Fire and Thermal Protection
+## HIPPS and safety-instrumented functions
 
 | Document | Description |
-|----------|-------------|
-| [fire_blowdown_capabilities.md](fire_blowdown_capabilities) | Fire case blowdown simulation |
-| [fire_heat_transfer_enhancements.md](fire_heat_transfer_enhancements) | Fire heat transfer modeling |
-| [Vessel Thermomechanical Safety](vessel_thermomechanical_safety) | Transient non-equilibrium blowdown, fast filling, cryogenic boil-off, composite-wall conduction, and fire/blowdown wall rupture |
-| [Trapped Liquid Fire Rupture](trapped_liquid_fire_rupture) | Blocked-in liquid segment fire rupture screening with material, flange, PFP, and source-term handoff |
-| [Blocked-In Liquid Thermal Expansion](blocked_in_liquid_thermal_expansion) | Isochoric pressure-rise screening (API 521 §4.4.12) for blocked-in liquid segments, independent of fire exposure |
+| --- | --- |
+| [HIPPS overview](HIPPS_SUMMARY.md) | HIPPS concepts, voting, and implementation map |
+| [HIPPS implementation](hipps_implementation.md) | Detector, voting, logic, and final-action workflow |
+| [HIPPS safety logic](hipps_safety_logic.md) | Safety-logic programming and state behavior |
+| [SIS logic implementation](sis_logic_implementation.md) | Safety-instrumented-system logic |
+| [NOG 070 SIL, STS-0131 gate, and ESD response time](nog070_sil_sts0131_esd.md) | Predetermined SIL, acceptance gate, and response-time budget |
+| [Safety-chain integration tests](integration_safety_chain_tests.md) | Integrated safety-chain verification |
 
-### Relief Systems
-
-| Document | Description |
-|----------|-------------|
-| [Relief-Valve Sizing Screening](relief_valve_sizing_api) | Static gas, liquid, two-phase, and wetted-surface fire screening APIs with explicit SI units and qualification limits |
-| [Trapped Inventory Calculator](trapped_inventory_calculator) | Evidence-linked trapped inventory for isolation, blowdown, flare-load, and MDMT screening |
-| [Trapped Liquid Fire Rupture](trapped_liquid_fire_rupture) | Fire exposure, thermal expansion, pipe/flange failure screening, PFP demand, and source-term handoff |
-| [Blocked-In Liquid Thermal Expansion](blocked_in_liquid_thermal_expansion) | Isochoric pressure-rise screening and simplified beta/kappa relation for blocked-in liquid thermal relief screening |
-| [psv_dynamic_sizing_example.md](psv_dynamic_sizing_example) | Pressure Safety Valve dynamic sizing |
-| [Vessel Thermomechanical Safety](vessel_thermomechanical_safety) | Dynamic PSV sizing vs steady-state API 521 conservatism, plus blowdown, filling, boil-off, and rupture models |
-| [rupture_disk_dynamic_behavior.md](rupture_disk_dynamic_behavior) | Rupture disk dynamic behavior |
-
-### Alarms
+## Hazard identification, risk, and barriers
 
 | Document | Description |
-|----------|-------------|
-| [alarm_system_guide.md](alarm_system_guide) | Alarm system implementation guide |
-| [alarm_triggered_logic_example.md](alarm_triggered_logic_example) | Alarm-triggered logic examples |
+| --- | --- |
+| [HAZOP guide](HAZOP.md) | Hazard-and-operability study structure and guidewords |
+| [Automated HAZOP from STID and simulation](automated_hazop_from_stid.md) | STID/P&ID, plant data, simulation, HAZOP, barrier, and report workflow |
+| [AI-HAZOP input-data format](ai_hazop_input_format.md) | Required process, deviation, design-condition, and limit-basis inputs |
+| [FMEA guide](FMEA.md) | Failure-mode and effects analysis workflow |
+| [Event and fault trees](event_fault_trees.md) | Event-tree and fault-tree modeling |
+| [Layered safety architecture](layered_safety_architecture.md) | Defense-in-depth and protection-layer structure |
+| [Barrier management and SCE traceability](barrier_management.md) | Evidence-linked PSFs, SCEs, performance standards, and analysis handoffs |
+| [ISO 17776 MAH bow-tie and EI AVIFF FIV screening](mah_bowtie_fiv_screening.md) | Major-accident-hazard bow-tie and flow-induced-vibration screening |
+| [Safety simulation roadmap](SAFETY_SIMULATION_ROADMAP.md) | Maintained capability and development roadmap |
 
----
+## Standards and facility screening
 
-## Related Documentation
+| Document | Description |
+| --- | --- |
+| [API RP 14C SAFE chart and NORSOK P-002 compliance](api14c_norsok_p002.md) | SAFE chart, flare/blowdown/vent screening, and multi-vessel header load |
+| [Flare flame, hazardous area, and PFP demand](flare_flame_hazardous_area_pfp.md) | API 537, IEC 60079-10-1, and API 521 screening |
+| [Open-drain review with NeqSim evidence](open_drain_review.md) | NORSOK S-001 open-drain review using calculated leak and firewater loads |
+| [Minimum design metal temperature assessment](mdmt_assessment.md) | MDMT evidence and low-temperature screening |
 
-- [Process Package](../process/) - Process simulation overview
-- [Process Safety](../process/safety/) - Safety equipment classes
-- [Controllers](../process/controllers) - Controller devices
+## Relief systems and trapped inventory
 
+| Document | Description |
+| --- | --- |
+| [Relief-valve sizing screening](relief_valve_sizing_api.md) | Static gas, liquid, two-phase, and wetted-fire sizing APIs with explicit SI units |
+| [PSV dynamic sizing example](psv_dynamic_sizing_example.md) | Pressure-safety-valve dynamic sizing workflow |
+| [Rupture-disk dynamic behavior](rupture_disk_dynamic_behavior.md) | Burst, opening, flow, and reset-state behavior |
+| [Trapped inventory calculator](trapped_inventory_calculator.md) | Evidence-linked isolation inventory for blowdown, flare-load, and MDMT screening |
+| [Blocked-in liquid thermal expansion](blocked_in_liquid_thermal_expansion.md) | Isochoric pressure-rise and thermal-relief screening |
+| [Trapped liquid fire rupture](trapped_liquid_fire_rupture.md) | Fire exposure, expansion, failure screening, PFP demand, and source-term handoff |
+| [Vessel thermomechanical safety](vessel_thermomechanical_safety.md) | Blowdown, filling, boil-off, composite-wall conduction, and rupture models |
+
+## Fire, release, and consequence
+
+| Document | Description |
+| --- | --- |
+| [Fire-case blowdown capabilities](fire_blowdown_capabilities.md) | Fire-exposed blowdown simulation |
+| [Fire heat-transfer enhancements](fire_heat_transfer_enhancements.md) | Fire heat flux and wall heat-transfer modeling |
+| [Dispersion and consequence](dispersion_and_consequence.md) | Source-term, dispersion, radiation, and consequence-analysis handoff |
+| [Release and dispersion scenarios](../process/safety/release-dispersion-scenarios.md) | Structured release scenarios with explicit inputs and limitations |
+| [Vessel thermomechanical safety](vessel_thermomechanical_safety.md) | Dynamic PSV screening and thermomechanical response |
+| [Trapped liquid fire rupture](trapped_liquid_fire_rupture.md) | Blocked-in liquid fire and rupture screening |
+
+## Alarms and architecture
+
+| Document | Description |
+| --- | --- |
+| [Alarm-system guide](alarm_system_guide.md) | Alarm configuration and behavior |
+| [Alarm-triggered logic examples](alarm_triggered_logic_example.md) | Alarm-driven process logic |
+| [Integrated safety systems](INTEGRATED_SAFETY_SYSTEMS.md) | Facility safety-system overview |
+| [Layered safety architecture](layered_safety_architecture.md) | Independent protection layers and defense in depth |
+
+## Related documentation
+
+- [Process package overview](../process/README.md)
+- [Process-safety API overview](../process/safety/README.md)
+- [Controller devices](../process/controllers.md)

--- a/docs/safety/README.md
+++ b/docs/safety/README.md
@@ -18,7 +18,7 @@ accountable review remain mandatory.
 | Need | Guide |
 | --- | --- |
 | Choose equipment, logic, or scenario APIs | [Process-safety API overview](../process/safety/README) |
-| Size or screen relief devices | [Relief-valve sizing screening](relief_valve_sizing_api) |
+| Size or screen relief devices | [Relief-Valve Sizing Screening](relief_valve_sizing_api) |
 | Test ESD logic dynamically | [ESD dynamic testing workflow](esd_testing_workflow) |
 | Model HIPPS voting and action | [HIPPS implementation](hipps_implementation) |
 | Generate safety scenarios | [Safety scenario generation](../process/safety/scenario-generation) |
@@ -73,7 +73,7 @@ accountable review remain mandatory.
 
 | Document | Description |
 | --- | --- |
-| [Relief-valve sizing screening](relief_valve_sizing_api) | Static gas, liquid, two-phase, and wetted-fire sizing APIs with explicit SI units |
+| [Relief-Valve Sizing Screening](relief_valve_sizing_api) | Static gas, liquid, two-phase, and wetted-fire sizing APIs with explicit SI units |
 | [PSV dynamic sizing example](psv_dynamic_sizing_example) | Pressure-safety-valve dynamic sizing workflow |
 | [Rupture-disk dynamic behavior](rupture_disk_dynamic_behavior) | Burst, opening, flow, and reset-state behavior |
 | [Trapped inventory calculator](trapped_inventory_calculator) | Evidence-linked isolation inventory for blowdown, flare-load, and MDMT screening |

--- a/docs/test_safety_hub_navigation.py
+++ b/docs/test_safety_hub_navigation.py
@@ -30,14 +30,14 @@ class SafetyHubNavigationTest(unittest.TestCase):
                 )
                 self.assertNotRegex(body_without_fences, r"(?m)^# ")
 
-    def test_local_links_use_explicit_markdown_targets(self):
+    def test_included_hubs_use_extensionless_published_targets(self):
         for path, content in self.hubs.items():
             for target in re.findall(r"\[[^\]]+\]\(([^)]+)\)", content):
                 target_path = target.split("#", 1)[0]
                 if "://" in target_path or target_path.startswith("#"):
                     continue
                 with self.subTest(path=path, target=target):
-                    self.assertTrue(target_path.endswith(".md"))
+                    self.assertFalse(target_path.endswith(".md"))
 
     def test_every_local_target_resolves(self):
         for path, content in self.hubs.items():
@@ -45,7 +45,7 @@ class SafetyHubNavigationTest(unittest.TestCase):
                 target_path = target.split("#", 1)[0]
                 if "://" in target_path or target_path.startswith("#"):
                     continue
-                resolved = (path.parent / target_path).resolve()
+                resolved = (path.parent / (target_path + ".md")).resolve()
                 with self.subTest(path=path, target=target):
                     self.assertTrue(resolved.is_file(), resolved)
 
@@ -57,24 +57,24 @@ class SafetyHubNavigationTest(unittest.TestCase):
     def test_safety_hub_exposes_core_risk_and_consequence_guides(self):
         safety_hub = self.hubs[SAFETY_HUB]
         for target in (
-            "HAZOP.md",
-            "FMEA.md",
-            "event_fault_trees.md",
-            "depressurization_per_API_521.md",
-            "mdmt_assessment.md",
-            "dispersion_and_consequence.md",
-            "../process/safety/scenario-generation.md",
-            "../process/safety/release-dispersion-scenarios.md",
+            "HAZOP",
+            "FMEA",
+            "event_fault_trees",
+            "depressurization_per_API_521",
+            "mdmt_assessment",
+            "dispersion_and_consequence",
+            "../process/safety/scenario-generation",
+            "../process/safety/release-dispersion-scenarios",
         ):
             with self.subTest(target=target):
                 self.assertIn(f"]({target})", safety_hub)
 
     def test_hubs_cross_link_and_remain_indexed(self):
         self.assertIn(
-            "](../process/safety/README.md)", self.hubs[SAFETY_HUB]
+            "](../process/safety/README)", self.hubs[SAFETY_HUB]
         )
         self.assertIn(
-            "](../../safety/README.md)", self.hubs[PROCESS_SAFETY_HUB]
+            "](../../safety/README)", self.hubs[PROCESS_SAFETY_HUB]
         )
         self.assertIn(
             "[docs/safety/README.md](safety/README.md)", self.reference_index

--- a/docs/test_safety_hub_navigation.py
+++ b/docs/test_safety_hub_navigation.py
@@ -1,0 +1,89 @@
+"""Regression contracts for the safety documentation hubs."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SAFETY_HUB = ROOT / "docs" / "safety" / "README.md"
+PROCESS_SAFETY_HUB = ROOT / "docs" / "process" / "safety" / "README.md"
+REFERENCE_INDEX = ROOT / "docs" / "REFERENCE_MANUAL_INDEX.md"
+
+
+class SafetyHubNavigationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.hubs = {
+            SAFETY_HUB: SAFETY_HUB.read_text(encoding="utf-8"),
+            PROCESS_SAFETY_HUB: PROCESS_SAFETY_HUB.read_text(encoding="utf-8"),
+        }
+        cls.reference_index = REFERENCE_INDEX.read_text(encoding="utf-8")
+
+    def test_hubs_have_front_matter_without_duplicate_body_h1(self):
+        for path, content in self.hubs.items():
+            with self.subTest(path=path):
+                self.assertTrue(content.startswith("---\ntitle:"))
+                body = content.split("---", 2)[2]
+                body_without_fences = re.sub(
+                    r"```.*?```", "", body, flags=re.DOTALL
+                )
+                self.assertNotRegex(body_without_fences, r"(?m)^# ")
+
+    def test_local_links_use_explicit_markdown_targets(self):
+        for path, content in self.hubs.items():
+            for target in re.findall(r"\[[^\]]+\]\(([^)]+)\)", content):
+                target_path = target.split("#", 1)[0]
+                if "://" in target_path or target_path.startswith("#"):
+                    continue
+                with self.subTest(path=path, target=target):
+                    self.assertTrue(target_path.endswith(".md"))
+
+    def test_every_local_target_resolves(self):
+        for path, content in self.hubs.items():
+            for target in re.findall(r"\[[^\]]+\]\(([^)]+)\)", content):
+                target_path = target.split("#", 1)[0]
+                if "://" in target_path or target_path.startswith("#"):
+                    continue
+                resolved = (path.parent / target_path).resolve()
+                with self.subTest(path=path, target=target):
+                    self.assertTrue(resolved.is_file(), resolved)
+
+    def test_link_labels_are_human_readable(self):
+        for path, content in self.hubs.items():
+            with self.subTest(path=path):
+                self.assertIsNone(re.search(r"\[[^\]]+\.md\]\(", content))
+
+    def test_safety_hub_exposes_core_risk_and_consequence_guides(self):
+        safety_hub = self.hubs[SAFETY_HUB]
+        for target in (
+            "HAZOP.md",
+            "FMEA.md",
+            "event_fault_trees.md",
+            "depressurization_per_API_521.md",
+            "mdmt_assessment.md",
+            "dispersion_and_consequence.md",
+            "../process/safety/scenario-generation.md",
+            "../process/safety/release-dispersion-scenarios.md",
+        ):
+            with self.subTest(target=target):
+                self.assertIn(f"]({target})", safety_hub)
+
+    def test_hubs_cross_link_and_remain_indexed(self):
+        self.assertIn(
+            "](../process/safety/README.md)", self.hubs[SAFETY_HUB]
+        )
+        self.assertIn(
+            "](../../safety/README.md)", self.hubs[PROCESS_SAFETY_HUB]
+        )
+        self.assertIn(
+            "[docs/safety/README.md](safety/README.md)", self.reference_index
+        )
+        self.assertIn(
+            "[docs/process/safety/README.md](process/safety/README.md)",
+            self.reference_index,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace 16 raw filename labels with human-readable safety topics
- surface eight existing HAZOP, FMEA, event/fault-tree, depressurization, MDMT, dispersion, and scenario guides from the primary safety hub
- reorganize the hub into task-oriented ESD/blowdown, HIPPS/SIF, risk/barrier, standards, relief, consequence, and alarm sections
- add six included-page navigation contracts covering structure, published URL form, target resolution, readable labels, cross-linking, and reference-index discoverability

## Campaign

Advances documentation-quality campaign #2499 as D093.

Rotation scope: 4 — engineering design and safety. DEXPI/PFD content is excluded because it belongs to the separate diagram campaign.

Frozen scope:

- `docs/safety/README.md`
- `docs/test_safety_hub_navigation.py`

Stop boundary: no production code, safety-model behavior, standards interpretation, DEXPI/PFD, field-development, notebook, equation, image, browser-rendering, or Huldra work.

Exact base: `5eea490cce2ff6a58a3eaf2a2fbdec3f89404e6a`  
Exact head: `11921bed2104cd825ab604e5d97ae54bded11b69`

## Validation

**READY TO MERGE**

Connector-backed checks completed on the exact head:

- 66 local links inspected across the updated safety hub and unchanged process-safety hub
- all 48 unique repository target files resolve
- all included-page targets use the extensionless published-URL form required by repository CI
- zero raw `.md` filename labels remain
- front matter is present and neither hub has a duplicate body H1
- all eight newly surfaced risk/consequence guides resolve
- hub cross-links and both reference-index entries resolve
- `docs/process/safety/README.md` is byte-identical to `master` at blob `1c66f9bed9be075ec9cf8617d2c904b282690287`
- Python regression-contract syntax passes
- exact diff: 2 frozen files, 7 commits ahead, 0 behind

All five exact-head GitHub workflows pass:

- documentation contracts, Jekyll build, search-index validation, and link checks
- build, tests, and Javadocs
- pre-commit
- Spotless
- CodeQL

Two attributable compatibility findings from earlier heads were repaired: the included-page URL form and the established `Relief-Valve Sizing Screening` discoverability label.

## Documentation impact

Documentation impact: direct and complete for this frozen navigation batch. The safety landing page now gives readers a task-oriented route to maintained analysis guides while retaining explicit engineering-review boundaries.

The executable Java quick start and its regression in the process-safety hub are untouched.

## Review notes

No comments, reviews, or unresolved threads. The branch is mergeable and zero commits behind `master`.

The branch does not alter standards claims or safety calculations. It exposes existing maintained guides and preserves existing contract-sensitive link conventions.

The PR remains draft. No merge, ready-for-review transition, or Huldra work is authorized.
