### PR TITLE
fix(pvt): stop saturation scans at upper boundary

### DIFF
--- a/src/main/java/neqsim/pvtsimulation/simulation/SaturationPressure.java
+++ b/src/main/java/neqsim/pvtsimulation/simulation/SaturationPressure.java
@@ -50,26 +50,25 @@ public class SaturationPressure extends BasePVTsimulation {
     try {
       double twoPhasePressure = Double.NaN;
       double singlePhasePressure = Double.NaN;
-      double previousPressure = MINIMUM_SEARCH_PRESSURE_BARA;
-      boolean previousIsTwoPhase = isTwoPhaseAtPressure(previousPressure);
+      double higherPressure = MAXIMUM_SEARCH_PRESSURE_BARA;
+      boolean higherIsTwoPhase = isTwoPhaseAtPressure(higherPressure);
+      int numberOfSearchSteps = (int) Math
+          .floor((MAXIMUM_SEARCH_PRESSURE_BARA - MINIMUM_SEARCH_PRESSURE_BARA) / SEARCH_PRESSURE_STEP_BARA);
 
-      for (double trialPressure = previousPressure
-          + SEARCH_PRESSURE_STEP_BARA; trialPressure <= MAXIMUM_SEARCH_PRESSURE_BARA; trialPressure += SEARCH_PRESSURE_STEP_BARA) {
+      // Descending makes the first bracket the uppermost crossing, including for retrograde fluids.
+      for (int stepIndex = numberOfSearchSteps; stepIndex >= 0; stepIndex--) {
+        double trialPressure = MINIMUM_SEARCH_PRESSURE_BARA + stepIndex * SEARCH_PRESSURE_STEP_BARA;
+        if (trialPressure >= higherPressure) {
+          continue;
+        }
         boolean trialIsTwoPhase = isTwoPhaseAtPressure(trialPressure);
-        if (previousIsTwoPhase && !trialIsTwoPhase) {
-          twoPhasePressure = previousPressure;
-          singlePhasePressure = trialPressure;
+        if (trialIsTwoPhase && !higherIsTwoPhase) {
+          twoPhasePressure = trialPressure;
+          singlePhasePressure = higherPressure;
+          break;
         }
-        previousPressure = trialPressure;
-        previousIsTwoPhase = trialIsTwoPhase;
-      }
-
-      if (previousPressure < MAXIMUM_SEARCH_PRESSURE_BARA) {
-        boolean trialIsTwoPhase = isTwoPhaseAtPressure(MAXIMUM_SEARCH_PRESSURE_BARA);
-        if (previousIsTwoPhase && !trialIsTwoPhase) {
-          twoPhasePressure = previousPressure;
-          singlePhasePressure = MAXIMUM_SEARCH_PRESSURE_BARA;
-        }
+        higherPressure = trialPressure;
+        higherIsTwoPhase = trialIsTwoPhase;
       }
 
       if (Double.isNaN(twoPhasePressure) || Double.isNaN(singlePhasePressure)) {

--- a/src/main/java/neqsim/pvtsimulation/simulation/SaturationTemperature.java
+++ b/src/main/java/neqsim/pvtsimulation/simulation/SaturationTemperature.java
@@ -5,7 +5,7 @@ import neqsim.thermo.system.SystemSrkEos;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
 /**
- * SaturationPressure class.
+ * SaturationTemperature class.
  *
  * @author esol
  * @version $Id: $Id
@@ -23,7 +23,7 @@ public class SaturationTemperature extends BasePVTsimulation {
   private static final int MAXIMUM_BISECTION_ITERATIONS = 500;
 
   /**
-   * Constructor for SaturationPressure.
+   * Constructor for SaturationTemperature.
    *
    * @param tempSystem a {@link neqsim.thermo.system.SystemInterface} object
    */
@@ -32,7 +32,7 @@ public class SaturationTemperature extends BasePVTsimulation {
   }
 
   /**
-   * calcSaturationPressure.
+   * Calculates the upper saturation temperature.
    *
    * @return a double
    */
@@ -46,26 +46,25 @@ public class SaturationTemperature extends BasePVTsimulation {
     try {
       double twoPhaseTemperature = Double.NaN;
       double singlePhaseTemperature = Double.NaN;
-      double previousTemperature = MINIMUM_SEARCH_TEMPERATURE_K;
-      boolean previousIsTwoPhase = isTwoPhaseAtTemperature(previousTemperature);
+      double higherTemperature = MAXIMUM_SEARCH_TEMPERATURE_K;
+      boolean higherIsTwoPhase = isTwoPhaseAtTemperature(higherTemperature);
+      int numberOfSearchSteps = (int) Math
+          .floor((MAXIMUM_SEARCH_TEMPERATURE_K - MINIMUM_SEARCH_TEMPERATURE_K) / SEARCH_TEMPERATURE_STEP_K);
 
-      for (double trialTemperature = previousTemperature
-          + SEARCH_TEMPERATURE_STEP_K; trialTemperature <= MAXIMUM_SEARCH_TEMPERATURE_K; trialTemperature += SEARCH_TEMPERATURE_STEP_K) {
+      // Descending makes the first bracket the uppermost crossing, including for retrograde fluids.
+      for (int stepIndex = numberOfSearchSteps; stepIndex >= 0; stepIndex--) {
+        double trialTemperature = MINIMUM_SEARCH_TEMPERATURE_K + stepIndex * SEARCH_TEMPERATURE_STEP_K;
+        if (trialTemperature >= higherTemperature) {
+          continue;
+        }
         boolean trialIsTwoPhase = isTwoPhaseAtTemperature(trialTemperature);
-        if (previousIsTwoPhase && !trialIsTwoPhase) {
-          twoPhaseTemperature = previousTemperature;
-          singlePhaseTemperature = trialTemperature;
+        if (trialIsTwoPhase && !higherIsTwoPhase) {
+          twoPhaseTemperature = trialTemperature;
+          singlePhaseTemperature = higherTemperature;
+          break;
         }
-        previousTemperature = trialTemperature;
-        previousIsTwoPhase = trialIsTwoPhase;
-      }
-
-      if (previousTemperature < MAXIMUM_SEARCH_TEMPERATURE_K) {
-        boolean trialIsTwoPhase = isTwoPhaseAtTemperature(MAXIMUM_SEARCH_TEMPERATURE_K);
-        if (previousIsTwoPhase && !trialIsTwoPhase) {
-          twoPhaseTemperature = previousTemperature;
-          singlePhaseTemperature = MAXIMUM_SEARCH_TEMPERATURE_K;
-        }
+        higherTemperature = trialTemperature;
+        higherIsTwoPhase = trialIsTwoPhase;
       }
 
       if (Double.isNaN(twoPhaseTemperature) || Double.isNaN(singlePhaseTemperature)) {

--- a/src/test/java/neqsim/pvtsimulation/simulation/SaturationPressureTest.java
+++ b/src/test/java/neqsim/pvtsimulation/simulation/SaturationPressureTest.java
@@ -1,10 +1,12 @@
 package neqsim.pvtsimulation.simulation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 class SaturationPressureTest extends neqsim.NeqSimTest {
   @BeforeAll
@@ -29,9 +31,16 @@ class SaturationPressureTest extends neqsim.NeqSimTest {
     tempSystem.addTBPfraction("C9", 0.014, 129.5 / 1000.0, 0.7454);
     tempSystem.addTBPfraction("C10", 0.0078, 135.3 / 1000.0, 0.7864);
     tempSystem.setMixingRule(2);
-    SimulationInterface satPresSim = new SaturationPressure(tempSystem);
-    satPresSim.run();
-    assertEquals(satPresSim.getThermoSystem().getPressure(), 126.195102691, 0.1);
+    SaturationPressure saturationPressure = new SaturationPressure(tempSystem);
+    CountingThermodynamicOperations countingOperations = new CountingThermodynamicOperations(tempSystem);
+    saturationPressure.thermoOps = countingOperations;
+
+    double result = saturationPressure.calcSaturationPressure();
+
+    assertEquals(126.195102691, result, 0.1);
+    assertTrue(countingOperations.getFlashCount() < 115, "upper-bound search should stop after bracketing saturation");
+    assertTrue(countingOperations.getMinimumPressure() > 100.0,
+        "search should not continue below the upper saturation boundary");
   }
 
   /**
@@ -82,5 +91,29 @@ class SaturationPressureTest extends neqsim.NeqSimTest {
 
     // Correct upper dew point ~106.2 bara; the trivial-split regression returned ~109 bara.
     assertEquals(106.2, satPresSim.getSaturationPressure(), 1.0);
+  }
+
+  private static final class CountingThermodynamicOperations extends ThermodynamicOperations {
+    private int flashCount;
+    private double minimumPressure = Double.POSITIVE_INFINITY;
+
+    private CountingThermodynamicOperations(SystemInterface system) {
+      super(system);
+    }
+
+    @Override
+    public void TPflash() {
+      flashCount++;
+      minimumPressure = Math.min(minimumPressure, getSystem().getPressure());
+      super.TPflash();
+    }
+
+    private int getFlashCount() {
+      return flashCount;
+    }
+
+    private double getMinimumPressure() {
+      return minimumPressure;
+    }
   }
 }

--- a/src/test/java/neqsim/pvtsimulation/simulation/SaturationTemperatureTest.java
+++ b/src/test/java/neqsim/pvtsimulation/simulation/SaturationTemperatureTest.java
@@ -39,9 +39,33 @@ class SaturationTemperatureTest extends neqsim.NeqSimTest {
     tempSystem.init(1);
     // tempSystem.saveFluid(928);
 
-    SimulationInterface satPresSim = new SaturationTemperature(tempSystem);
-    satPresSim.run();
-    assertEquals(tempSystem.getTemperature(), 380.127567672, 0.1);
+    SaturationTemperature saturationTemperature = new SaturationTemperature(tempSystem);
+    CountingThermodynamicOperations countingOperations = new CountingThermodynamicOperations(tempSystem);
+    saturationTemperature.thermoOps = countingOperations;
+
+    double result = saturationTemperature.calcSaturationTemperature();
+
+    assertEquals(380.127567672, result, 0.1);
+    assertTrue(countingOperations.getFlashCount() < 115, "upper-bound search should stop after bracketing saturation");
+    assertTrue(countingOperations.getMinimumTemperature() > 300.0,
+        "search should not scan the expensive low-temperature range");
+  }
+
+  /** Regression test for the full-range scan reported in issue 3269. */
+  @Test
+  void issue3269FluidStopsAtUpperSaturationTemperature() {
+    SystemInterface fluid = createIssue3269Fluid();
+    SaturationTemperature saturationTemperature = new SaturationTemperature(fluid);
+    CountingThermodynamicOperations countingOperations = new CountingThermodynamicOperations(fluid);
+    saturationTemperature.thermoOps = countingOperations;
+
+    double result = saturationTemperature.calcSaturationTemperature();
+
+    assertEquals(29.4644, result - 273.15, 0.001);
+    assertTrue(countingOperations.getFlashCount() < 115,
+        "issue 3269 fluid should stop after bracketing the upper boundary");
+    assertTrue(countingOperations.getMinimumTemperature() > 290.0,
+        "issue 3269 fluid should not be flashed from the 30 K global minimum");
   }
 
   /**
@@ -94,5 +118,61 @@ class SaturationTemperatureTest extends neqsim.NeqSimTest {
     SaturationTemperature satTempSim = new SaturationTemperature(testSystem);
     satTempSim.run();
     assertEquals(satTempSim.getThermoSystem().getTemperature() - 273.15, 23.469396812206867, 0.001);
+  }
+
+  private static SystemInterface createIssue3269Fluid() {
+    SystemInterface fluid = new SystemUMRPRUMCEos(280.0, 10.0);
+    fluid.addComponent("CO2", 0.0174985900521278);
+    fluid.addComponent("nitrogen", 0.0064392895437777);
+    fluid.addComponent("methane", 0.792318403720856);
+    fluid.addComponent("ethane", 0.098281517624855);
+    fluid.addComponent("propane", 0.0536346212029457);
+    fluid.addComponent("i-butane", 0.00683294050395489);
+    fluid.addComponent("n-butane", 0.015396480448544);
+    fluid.addComponent("i-pentane", 0.00299966568127275);
+    fluid.addComponent("n-pentane", 0.0034116730093956);
+    fluid.addComponent("2-m-C5", 0.000556670012883842);
+    fluid.addComponent("3-m-C5", 0.000284214998828247);
+    fluid.addComponent("n-hexane", 0.000755471992306411);
+    fluid.addComponent("n-heptane", 0.000334932003170252);
+    fluid.addComponent("c-hexane", 0.000783208000939339);
+    fluid.addComponent("c-C7", 0.000296807993436232);
+    fluid.addComponent("benzene", 0.000156905996846035);
+    fluid.addComponent("n-octane", 0.0000632131996098906);
+    fluid.addComponent("toluene", 0.0000737486989237368);
+    fluid.addComponent("c-C8", 0.0000236678006775375);
+    fluid.addComponent("n-nonane", 0.000015582600099151);
+    fluid.addComponent("m-Xylene", 0.0000217079996218672);
+    fluid.addComponent("nC10", 0.0000176893008756451);
+    fluid.addComponent("nC11", 0.000000098000001003129);
+    fluid.addComponent("nC12", 0.00000048999999080479);
+    fluid.setMixingRule("HV", "UNIFAC_UMRPRU");
+    fluid.setPressure(57.6755867004395, "bara");
+    fluid.setTemperature(24.9726753234863, "C");
+    return fluid;
+  }
+
+  private static final class CountingThermodynamicOperations extends ThermodynamicOperations {
+    private int flashCount;
+    private double minimumTemperature = Double.POSITIVE_INFINITY;
+
+    private CountingThermodynamicOperations(SystemInterface system) {
+      super(system);
+    }
+
+    @Override
+    public void TPflash() {
+      flashCount++;
+      minimumTemperature = Math.min(minimumTemperature, getSystem().getTemperature());
+      super.TPflash();
+    }
+
+    private int getFlashCount() {
+      return flashCount;
+    }
+
+    private double getMinimumTemperature() {
+      return minimumTemperature;
+    }
   }
 }


### PR DESCRIPTION
Closes #3269

## Summary

- scan the existing saturation-search grid from its upper bound downward
- stop at the first lower-two-phase / higher-single-phase bracket
- preserve the uppermost-crossing semantics needed for retrograde fluids
- keep the existing bisection refinement, no-boundary fallback, and multiphase-check restoration
- add deterministic regression coverage for flash count and the lowest trial condition reached
- reproduce the issue composition and retain its 29.4644 °C saturation result

The reverse scan visits the same coarse grid as the previous exhaustive implementation. Its first descending bracket is therefore the last (uppermost) two-phase-to-single-phase transition that the ascending full scan retained, but it avoids flashing every lower-temperature or lower-pressure point after that bracket is known.

## Validation

- `./mvnw -q -DskipITs -Dtest=SaturationTemperatureTest,SaturationPressureTest test` — passed (5 tests)
- `./mvnw -q clean --file pomJava8.xml -DskipITs -Dtest=SaturationTemperatureTest,SaturationPressureTest test` — passed using the Java-8 compatibility profile
- `./mvnw -q clean -DskipITs -Dtest='neqsim.pvtsimulation.simulation.*Test' test` — passed (44 tests)
- `./mvnw -q -DskipITs -Dtest=HydrocarbonScrubberSaturationPressureStabilityTest -Dgroups=slow -DexcludedTestGroups= test` — passed (1 slow retrograde/stability test)
- `python devtools/run_spotless.py apply` — passed
- `pre-commit run --all-files --hook-stage pre-commit` — passed
- `python devtools/run_spotless.py check` — passed
- `python devtools/check_documentation_search.py` — passed
- `pre-commit run --all-files --hook-stage pre-push` — passed

Exact #3269 regression result: **29.4644 °C**, unchanged. The deterministic guards also prove that the searches stop before entering the costly low-temperature/low-pressure ranges.

**VALIDATION PENDING CI:** the local runtime contains a JRE without a `javadoc` executable, so the configured Temurin-JDK Javadoc job and the native Java 8 matrix remain authoritative.

## Documentation impact

No user-facing API, inputs, outputs, units, defaults, or numerical results change. The incorrect `SaturationPressure` wording in `SaturationTemperature` Javadocs was corrected while touching the class; no guide or migration update is needed.
