### PR TITLE
[AI-Assisted] fix(tpflash): stabilize rich gas cricondenbar endpoints

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -2186,3 +2186,47 @@ probe (20 warmups and five blocks of 60 flashes), the corrected SRK 180 K/50 bar
 a median 14.25 ms/flash for the invalid endpoint to 18.20 ms/flash for the accepted equilibrium.
 The screen-excluded SRK 300 K/100 bar trace-heavy control was 10.98 versus 10.88 ms/flash, within
 run-to-run noise. No speedup is claimed, and common flashes return before the new refinement.
+
+### Near-cricondenbar rich-gas endpoint refinement
+
+An ordinary SRK or PR flash near a rich natural gas's cricondenbar can retain a local cubic root or
+collapse a valid gas/oil split even when the explicit multiphase path finds a conservative,
+fugacity-equal, lower-Gibbs equilibrium. The private performance screen is limited to 50--200 bar,
+neutral water-free feeds containing at least four active hydrocarbons, at least 0.90 total
+hydrocarbon, at least 0.30 methane, at least 0.05 condensable hydrocarbon, no more than 0.05 carbon
+dioxide, and a hydrocarbon critical-temperature span of at least 250 K. Other active components
+must be inert. These conditions select only whether to run the established reciprocal stability
+flash; thermodynamic acceptance remains authoritative.
+
+The qualification fluid contains nitrogen, carbon dioxide, methane through n-hexane and uses the
+classic mixing rule. Deterministic failures included:
+
+| EOS | Temperature (K) | Pressure (bara) | Ordinary result before refinement | Maximum log-fugacity residual before refinement | Lower-Gibbs result (J) |
+| --- | ---: | ---: | --- | ---: | ---: |
+| SRK | 273.15 | 100 | GAS+OIL | 1.30055e-2 | 626518.842 |
+| SRK | 283.15 | 100 | GAS+OIL | 1.51337e-2 | 670464.297 |
+| PR | 268.15 | 95 | GAS+OIL | 8.42662e-2 | 586168.078 |
+| PR | 273.15 | 100 | GAS only; material residual 9.88469e-4 | not applicable | 614120.253 |
+| PR | 278.15 | 100 | GAS+OIL | 5.2598e-3 | 636403.262 |
+| PR | 283.15 | 100 | GAS+OIL | 3.1720e-3 | 657662.282 |
+
+The reciprocal candidate must contain one or two neutral fluid phases, remain bounded and
+normalized, close component material balance below `1e-10`, close maximum log-fugacity residual
+below `1e-8`, and lower Gibbs energy beyond the existing allowance. Complete initialized phase
+objects preserve the accepted cubic roots during transfer. A final maximum of five bounded beta
+updates targets a tighter `1e-10` log-fugacity residual without changing the selected active set;
+failure, Gibbs increase, or lost closure restores the complete accepted candidate. Final one-phase
+states are normalized to beta one and `x = z`.
+
+Focused SRK/PR regressions cover the six states above, poor initial beta values, deterministic
+repeats, changed-temperature and return-to-state execution, gas/oil appearance, single-phase
+disappearance, material balance, fugacity equality, phase normalization, bounded compositions,
+compressibility factor, density, and ordinary/multiphase agreement. The near-critical comparison
+uses `1e-7` for beta and composition because phase fraction is ill-conditioned at the boundary;
+the independent conservation and fugacity gates remain `1e-10` and `1e-8` respectively.
+
+This is a correctness fallback, not a speed optimization. Valid nonqualifying flashes perform no
+additional thermodynamic solve. A qualifying invalid endpoint performs one reciprocal flash and at
+most five beta updates; qualifying endpoints that already meet the equilibrium gate return after
+an allocation-free composition screen and residual audit. No public API, model parameter, unit, or
+default changes.

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -102,6 +102,8 @@ public class TPflash extends Flash {
   private static final double MAX_FINAL_EQUILIBRIUM_REFINEMENT_RESIDUAL = 1.0e-5;
   /** Maximum multiphase beta updates used to repair an invalid neutral two-phase endpoint. */
   private static final int MAX_FINAL_BETA_REFINEMENT_ITERATIONS = 20;
+  private static final int MAX_NEAR_CRITICAL_BETA_REFINEMENT_ITERATIONS = 5;
+  private static final double NEAR_CRITICAL_EQUILIBRIUM_TOLERANCE = 1.0e-10;
   /** Maximum beta updates used by the rare large-volatility hydrocarbon root refinement. */
   private static final int MAX_LARGE_VOLATILITY_REFINEMENT_ITERATIONS = 160;
   /** Tight closure target for the rare large-volatility hydrocarbon root refinement. */
@@ -899,7 +901,8 @@ public class TPflash extends Flash {
         normalizeUnchangedStableSinglePhaseEndpoint(stableSinglePhaseType, stableSinglePhaseZ,
             stableSinglePhaseComposition);
         rescueSinglePhaseMultiphaseEndpoint();
-        normalizeSourGasSinglePhaseEndpoint();
+        normalizeQualifiedNeutralSinglePhaseEndpoint();
+        polishNearCriticalNeutralTwoPhaseEndpoint();
         return;
       }
     }
@@ -1126,7 +1129,8 @@ public class TPflash extends Flash {
     rescueSinglePhaseMultiphaseEndpoint();
     restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(balancedWaterRichInput);
     restoreLowerGibbsReferenceAfterSinglePhaseCollapse(balancedWaterRichInput);
-    normalizeSourGasSinglePhaseEndpoint();
+    normalizeQualifiedNeutralSinglePhaseEndpoint();
+    polishNearCriticalNeutralTwoPhaseEndpoint();
     refineIonicGasAqueousEndpoint();
 
     // TPmultiflash already finalized coupled chemistry on a multiphase configuration. For an
@@ -1476,19 +1480,19 @@ public class TPflash extends Flash {
    * <p>
    * The ordinary two-phase flash can converge to a local gas/liquid or liquid-only stationary point even though
    * Michelsen tangent-plane stability analysis finds a lower-Gibbs two-phase equilibrium. A cheap feed-composition
-   * screen limits the extra stability flash to strongly asymmetric neutral mixtures with substantial non-hydrocarbon
-   * content at temperatures where liquid-liquid instability is plausible.
+   * screen limits the extra stability flash to independently qualified sour-gas and near-cricondenbar rich-gas
+   * families.
    * </p>
    *
    * <p>
    * The accepted candidate must contain exactly two neutral fluid phases, close material balance and fugacity equality,
    * and lower Gibbs energy. Chemical/electrolyte, aqueous, solid, wax, and compositions outside the instability screen
-   * remain on the existing fast path. A screened single-phase sour-gas endpoint is normalized to the feed before its
-   * Gibbs energy is compared, because an incipient phase composition is not a valid one-phase reference state.
+   * remain on the existing fast path. A screened single-phase endpoint is normalized to the feed before its Gibbs
+   * energy is compared, because an incipient phase composition is not a valid one-phase reference state.
    * </p>
    */
   private void rescueLowerGibbsNeutralEndpoint() {
-    if (!isSourGasConsistencyRefinementCase()) {
+    if (!isQualifiedNeutralConsistencyRefinementCase()) {
       return;
     }
     if (system.doMultiPhaseCheck() || system.getNumberOfPhases() < 1 || system.getNumberOfPhases() > 2
@@ -1505,18 +1509,22 @@ public class TPflash extends Flash {
       hasGasPhase |= phaseType == PhaseType.GAS;
     }
     if (system.getNumberOfPhases() == 1) {
-      if (!hasPotentialAsymmetricNeutralInstability(MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN)
+      if ((!isNearCriticalRichGasRefinementCase()
+          && !hasPotentialAsymmetricNeutralInstability(MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN))
           || !hasPotentialMultiphaseEndpoint(system.getPhase(0).getType())) {
         return;
       }
     } else {
+      if (isNearCriticalRichGasRefinementCase() && !isSourGasConsistencyRefinementCase()) {
+        return;
+      }
       if (!hasGasPhase || !hasPotentialLiquidLiquidInstability() || !hasPotentialCompetingNeutralMinimum()) {
         return;
       }
     }
 
     if (system.getNumberOfPhases() == 1) {
-      normalizeSourGasSinglePhaseEndpoint();
+      normalizeQualifiedNeutralSinglePhaseEndpoint();
     } else {
       system.init(1);
     }
@@ -1556,7 +1564,11 @@ public class TPflash extends Flash {
             && isLowerGibbsMultiphaseCandidate(candidate, referenceGibbsEnergy);
       }
       if (accepted) {
-        copyNeutralFlashStatePreservingRoots(candidate);
+        if (isNearCriticalRichGasRefinementCase()) {
+          copyConvergedNeutralFlashState(candidate);
+        } else {
+          copyNeutralFlashStatePreservingRoots(candidate);
+        }
       }
     } catch (Exception ex) {
       logger.debug("Neutral endpoint stability refinement failed: {}", ex.getMessage());
@@ -2128,12 +2140,12 @@ public class TPflash extends Flash {
    *
    * <p>
    * Post-convergence phase-root selection can leave a gas/oil split with valid material balance but component
-   * fugacities outside the flash tolerance. The refinement is attempted only for a qualified sour-gas endpoint or a
-   * high-pressure hydrogen/hydrocarbon endpoint with an incipient phase, or a high-pressure hydrocarbon endpoint with a
-   * large critical-temperature span. It retains the selected active set and accepts the result only when phase
-   * fractions, compositions, material balance, fugacity equality, and Gibbs energy pass the existing strict checks. A
-   * reciprocal ordinary/multiphase trial can recover a lower cubic root; otherwise the complete two-phase iteration
-   * state is restored.
+   * fugacities outside the flash tolerance. The refinement is attempted only for a qualified sour-gas or
+   * near-cricondenbar rich-gas endpoint, a high-pressure hydrogen/hydrocarbon endpoint with an incipient phase, or a
+   * high-pressure hydrocarbon endpoint with a large critical-temperature span. It retains the selected active set and
+   * accepts the result only when phase fractions, compositions, material balance, fugacity equality, and Gibbs energy
+   * pass the existing strict checks. A reciprocal ordinary/multiphase trial can recover a lower cubic root; otherwise
+   * the complete two-phase iteration state is restored.
    * </p>
    */
   private void refineInvalidNeutralTwoPhaseEndpoint() {
@@ -2150,7 +2162,7 @@ public class TPflash extends Flash {
 
     boolean hydrogenBoundaryCase = isHydrogenHydrocarbonBoundaryRefinementCase();
     boolean largeVolatilityHydrocarbonCase = isLargeVolatilityHydrocarbonRefinementCase();
-    if (!isSourGasConsistencyRefinementCase() && !hydrogenBoundaryCase && !largeVolatilityHydrocarbonCase) {
+    if (!isQualifiedNeutralConsistencyRefinementCase() && !hydrogenBoundaryCase && !largeVolatilityHydrocarbonCase) {
       return;
     }
 
@@ -2217,7 +2229,11 @@ public class TPflash extends Flash {
           && (referenceMaterialBalanceInvalid
               || candidate.getGibbsEnergy() < referenceState.gibbsEnergy - gibbsTolerance
               || replacesInvalidIncipientPhase)) {
-        copyNeutralFlashStatePreservingRoots(candidate);
+        if (isNearCriticalRichGasRefinementCase()) {
+          copyConvergedNeutralFlashState(candidate);
+        } else {
+          copyNeutralFlashStatePreservingRoots(candidate);
+        }
       }
     } catch (Exception ex) {
       logger.debug("Final neutral two-phase cross-algorithm refinement failed: {}", ex.getMessage());
@@ -2323,6 +2339,27 @@ public class TPflash extends Flash {
       system.setPhaseType(phaseIndex, rootTypes[phaseIndex]);
     }
     system.init(1);
+  }
+
+  /**
+   * Copies the active phase objects and fractions of an accepted near-critical neutral endpoint.
+   *
+   * <p>
+   * Reconstructing phases from public labels can select a different cubic root near the cricondenbar. Copying the
+   * complete initialized objects preserves the accepted roots until the guarded final beta polish runs after all other
+   * endpoint processing.
+   * </p>
+   *
+   * @param source accepted near-critical candidate
+   */
+  private void copyConvergedNeutralFlashState(SystemInterface source) {
+    system.setNumberOfPhases(source.getNumberOfPhases());
+    for (int phaseIndex = 0; phaseIndex < source.getNumberOfPhases(); phaseIndex++) {
+      system.setPhaseIndex(phaseIndex, phaseIndex);
+      system.setPhase(source.getPhase(phaseIndex).clone(), phaseIndex);
+      system.setPhaseType(phaseIndex, source.getPhase(phaseIndex).getType());
+      system.setBeta(phaseIndex, source.getBeta(phaseIndex));
+    }
   }
 
   /**
@@ -2439,6 +2476,73 @@ public class TPflash extends Flash {
   }
 
   /**
+   * Checks whether the feed is a rich natural-gas mixture near a high-pressure cubic-EOS phase boundary.
+   *
+   * <p>
+   * The screen permits hydrocarbons, inert components, and at most five mole percent carbon dioxide. It requires a
+   * methane-rich feed, at least four active hydrocarbons, a condensable hydrocarbon inventory, and a critical-
+   * temperature span large enough to support a distinct gas/liquid split. The subsequent reciprocal flash still has to
+   * close material balance and fugacity equality and lower Gibbs energy, so this method is only a performance gate.
+   * </p>
+   *
+   * @return true when a guarded ordinary/multiphase consistency refinement is justified
+   */
+  private boolean isNearCriticalRichGasRefinementCase() {
+    if (system.getPressure() < 50.0 || system.getPressure() > 200.0 || system.getNumberOfPhases() < 1
+        || system.getNumberOfPhases() > 2) {
+      return false;
+    }
+    int activeHydrocarbons = 0;
+    double hydrocarbonFraction = 0.0;
+    double methaneFraction = 0.0;
+    double condensableHydrocarbonFraction = 0.0;
+    double carbonDioxideFraction = 0.0;
+    double minimumHydrocarbonCriticalTemperature = Double.POSITIVE_INFINITY;
+    double maximumHydrocarbonCriticalTemperature = Double.NEGATIVE_INFINITY;
+    for (int componentIndex = 0; componentIndex < system.getPhase(0).getNumberOfComponents(); componentIndex++) {
+      neqsim.thermo.component.ComponentInterface component = system.getPhase(0).getComponent(componentIndex);
+      double feedFraction = component.getz();
+      if (feedFraction <= 1.0e-50) {
+        continue;
+      }
+      String componentName = component.getComponentName();
+      if ("water".equalsIgnoreCase(componentName) || component.getIonicCharge() != 0 || component.isIsIon()) {
+        return false;
+      }
+      if (component.isHydrocarbon()) {
+        activeHydrocarbons++;
+        hydrocarbonFraction += feedFraction;
+        if ("methane".equalsIgnoreCase(componentName)) {
+          methaneFraction += feedFraction;
+        }
+        double criticalTemperature = component.getTC();
+        minimumHydrocarbonCriticalTemperature = Math.min(minimumHydrocarbonCriticalTemperature, criticalTemperature);
+        maximumHydrocarbonCriticalTemperature = Math.max(maximumHydrocarbonCriticalTemperature, criticalTemperature);
+        if (criticalTemperature > system.getTemperature() + MULTIPHASE_ENDPOINT_CRITICAL_TEMPERATURE_MARGIN) {
+          condensableHydrocarbonFraction += feedFraction;
+        }
+      } else if ("CO2".equalsIgnoreCase(componentName)) {
+        carbonDioxideFraction += feedFraction;
+      } else if (!component.isInert()) {
+        return false;
+      }
+    }
+    return activeHydrocarbons >= 4 && hydrocarbonFraction >= 0.90 && methaneFraction >= 0.30
+        && carbonDioxideFraction <= 0.05 && condensableHydrocarbonFraction >= 0.05
+        && maximumHydrocarbonCriticalTemperature - minimumHydrocarbonCriticalTemperature >= 250.0;
+  }
+
+  /**
+   * Combines the independently qualified neutral endpoint families that use the same strict reciprocal acceptance
+   * gates.
+   *
+   * @return true for a supported sour-gas or near-critical rich-gas endpoint
+   */
+  private boolean isQualifiedNeutralConsistencyRefinementCase() {
+    return isSourGasConsistencyRefinementCase() || isNearCriticalRichGasRefinementCase();
+  }
+
+  /**
    * Screens a high-pressure hydrogen/hydrocarbon endpoint with an incipient second phase.
    *
    * <p>
@@ -2515,7 +2619,7 @@ public class TPflash extends Flash {
   }
 
   /**
-   * Restores exact material closure for a final single-phase sour-gas endpoint.
+   * Restores exact material closure for a final qualified neutral single-phase endpoint.
    *
    * <p>
    * A collapsed trial phase can leave its incipient composition and a beta infinitesimally below unity in the active
@@ -2523,13 +2627,56 @@ public class TPflash extends Flash {
    * allocation-free finalization step and leaves the already-selected cubic root unchanged.
    * </p>
    */
-  private void normalizeSourGasSinglePhaseEndpoint() {
-    if (!isSourGasConsistencyRefinementCase() || system.getNumberOfPhases() != 1) {
+  private void normalizeQualifiedNeutralSinglePhaseEndpoint() {
+    if (!isQualifiedNeutralConsistencyRefinementCase() || system.getNumberOfPhases() != 1) {
       return;
     }
     system.setBeta(0, 1.0);
     resetSinglePhaseCompositionToFeed();
     system.init(1, 0);
+  }
+
+  /**
+   * Applies the tight final beta polish after all ordinary endpoint post-processing.
+   *
+   * <p>
+   * Phase cleanup performed after an accepted reciprocal flash can reopen a small near-critical fugacity residual. This
+   * last bounded update is restricted to the qualified rich-gas family and restores the complete pre-polish state
+   * unless material balance, the selected active set, Gibbs energy, and a {@code 1e-10} log-fugacity target all pass.
+   * </p>
+   */
+  private void polishNearCriticalNeutralTwoPhaseEndpoint() {
+    if (system.doMultiPhaseCheck() || !isNearCriticalRichGasRefinementCase() || system.getNumberOfPhases() != 2) {
+      return;
+    }
+    system.init(1);
+    double initialResidual = maximumLogFugacityResidual(system.getPhase(0), system.getPhase(1));
+    if (!Double.isFinite(initialResidual) || initialResidual < NEAR_CRITICAL_EQUILIBRIUM_TOLERANCE
+        || initialResidual >= PHASE_ROOT_EQUILIBRIUM_TOLERANCE) {
+      return;
+    }
+    BalancedTwoPhaseState referenceState = new BalancedTwoPhaseState(system);
+    try {
+      TPmultiflash endpointSolver = new TPmultiflash(system, false);
+      endpointSolver.setDoubleArrays();
+      for (int refinement = 0; refinement < MAX_NEAR_CRITICAL_BETA_REFINEMENT_ITERATIONS
+          && maximumLogFugacityResidual(system.getPhase(0),
+              system.getPhase(1)) >= NEAR_CRITICAL_EQUILIBRIUM_TOLERANCE; refinement++) {
+        endpointSolver.solveBeta();
+      }
+      system.orderByDensity();
+      system.init(1);
+      double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceState.gibbsEnergy) * 1.0e-8);
+      if (!isBalancedEquilibriumCandidate(system)
+          || maximumLogFugacityResidual(system.getPhase(0), system.getPhase(1)) >= NEAR_CRITICAL_EQUILIBRIUM_TOLERANCE
+          || !preservesTwoPhaseActiveSet(system, referenceState.phaseTypes)
+          || system.getGibbsEnergy() > referenceState.gibbsEnergy + gibbsTolerance) {
+        restoreTwoPhaseIterationState(referenceState);
+      }
+    } catch (Exception ex) {
+      restoreTwoPhaseIterationState(referenceState);
+      logger.debug("Final near-critical neutral endpoint polishing failed: {}", ex.getMessage());
+    }
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -102,7 +102,9 @@ public class TPflash extends Flash {
   private static final double MAX_FINAL_EQUILIBRIUM_REFINEMENT_RESIDUAL = 1.0e-5;
   /** Maximum multiphase beta updates used to repair an invalid neutral two-phase endpoint. */
   private static final int MAX_FINAL_BETA_REFINEMENT_ITERATIONS = 20;
+  /** Maximum beta updates used for final near-critical rich-gas polishing. */
   private static final int MAX_NEAR_CRITICAL_BETA_REFINEMENT_ITERATIONS = 5;
+  /** Tight log-fugacity target for final near-critical rich-gas polishing. */
   private static final double NEAR_CRITICAL_EQUILIBRIUM_TOLERANCE = 1.0e-10;
   /** Maximum beta updates used by the rare large-volatility hydrocarbon root refinement. */
   private static final int MAX_LARGE_VOLATILITY_REFINEMENT_ITERATIONS = 160;

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashNearCricondenbarConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashNearCricondenbarConsistencyTest.java
@@ -1,0 +1,221 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Arrays;
+import java.util.Comparator;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Qualification of rich-gas SRK/PR flashes near the cricondenbar. */
+class TPflashNearCricondenbarConsistencyTest extends neqsim.NeqSimTest {
+  private static final double MATERIAL_BALANCE_TOLERANCE = 1.0e-10;
+  private static final double FUGACITY_TOLERANCE = 1.0e-8;
+  private static final double STATE_TOLERANCE = 1.0e-7;
+  private static final Case[] REGRESSION_CASES = { new Case(Eos.SRK, 273.15, 100.0), new Case(Eos.SRK, 283.15, 100.0),
+      new Case(Eos.PR, 268.15, 95.0), new Case(Eos.PR, 273.15, 100.0), new Case(Eos.PR, 278.15, 100.0),
+      new Case(Eos.PR, 283.15, 100.0) };
+
+  @Test
+  void nearCricondenbarEndpointsCloseAndAgreeAcrossAlgorithms() {
+    for (Case regression : REGRESSION_CASES) {
+      SystemInterface ordinary = flash(createSystem(regression, false), false);
+      SystemInterface multiphase = flash(createSystem(regression, true), false);
+
+      assertEquals(2, ordinary.getNumberOfPhases(), regression.label());
+      assertEquivalent(ordinary, multiphase, regression.label(), STATE_TOLERANCE);
+      assertTrue(maximumFugacityResidual(ordinary) < 1.0e-10,
+          regression.label() + " polished ordinary fugacity residual " + maximumFugacityResidual(ordinary));
+    }
+  }
+
+  @Test
+  void poorInitializationRepeatsAndChangedStateRemainDeterministic() {
+    for (Case regression : new Case[] { new Case(Eos.SRK, 283.15, 100.0), new Case(Eos.PR, 273.15, 100.0) }) {
+      for (boolean multiphase : new boolean[] { false, true }) {
+        SystemInterface reference = flash(createSystem(regression, multiphase), false);
+        SystemInterface poorGuess = flash(createSystem(regression, multiphase), true);
+        assertEquivalent(reference, poorGuess, regression.label() + " poor initialization", STATE_TOLERANCE);
+
+        SystemInterface repeatedReference = reference.clone();
+        flash(reference, false);
+        assertEquivalent(repeatedReference, reference, regression.label() + " repeat", STATE_TOLERANCE);
+
+        Case changedCase = regression.withTemperature(regression.temperature + 0.25);
+        reference.setTemperature(changedCase.temperature, "K");
+        flash(reference, false);
+        SystemInterface changedReference = flash(createSystem(changedCase, multiphase), false);
+        assertEquivalent(changedReference, reference, regression.label() + " changed temperature", STATE_TOLERANCE);
+
+        reference.setTemperature(regression.temperature, "K");
+        flash(reference, false);
+        SystemInterface returnedReference = flash(createSystem(regression, multiphase), false);
+        assertEquivalent(returnedReference, reference, regression.label() + " return to state", STATE_TOLERANCE);
+      }
+    }
+  }
+
+  @Test
+  void phaseAppearanceAndDisappearanceRemainContinuous() {
+    Case[][] transitions = { { new Case(Eos.SRK, 293.15, 100.0), new Case(Eos.SRK, 303.15, 100.0) },
+        { new Case(Eos.PR, 288.15, 100.0), new Case(Eos.PR, 293.15, 100.0) } };
+    for (Case[] transition : transitions) {
+      SystemInterface twoPhase = flash(createSystem(transition[0], false), false);
+      SystemInterface twoPhaseMultiphase = flash(createSystem(transition[0], true), false);
+      assertEquals(2, twoPhase.getNumberOfPhases(), transition[0].label());
+      assertEquivalent(twoPhase, twoPhaseMultiphase, transition[0].label(), STATE_TOLERANCE);
+
+      SystemInterface onePhase = flash(createSystem(transition[1], false), false);
+      SystemInterface onePhaseMultiphase = flash(createSystem(transition[1], true), false);
+      assertEquals(1, onePhase.getNumberOfPhases(), transition[1].label());
+      assertEquivalent(onePhase, onePhaseMultiphase, transition[1].label(), 1.0e-12);
+      assertEquals(1.0, onePhase.getBeta(0), 0.0, transition[1].label());
+      for (int component = 0; component < onePhase.getPhase(0).getNumberOfComponents(); component++) {
+        assertEquals(onePhase.getPhase(0).getComponent(component).getz(),
+            onePhase.getPhase(0).getComponent(component).getx(), 1.0e-12, transition[1].label());
+      }
+    }
+
+    for (Eos eos : Eos.values()) {
+      Case pressureControl = new Case(eos, 273.15, 105.0);
+      SystemInterface ordinary = flash(createSystem(pressureControl, false), false);
+      SystemInterface multiphase = flash(createSystem(pressureControl, true), false);
+      assertEquals(1, ordinary.getNumberOfPhases(), pressureControl.label());
+      assertEquivalent(ordinary, multiphase, pressureControl.label(), 1.0e-12);
+    }
+  }
+
+  private static SystemInterface createSystem(Case testCase, boolean multiphase) {
+    SystemInterface system = testCase.eos == Eos.PR ? new SystemPrEos(testCase.temperature, testCase.pressure)
+        : new SystemSrkEos(testCase.temperature, testCase.pressure);
+    system.addComponent("nitrogen", 3.43);
+    system.addComponent("CO2", 0.34);
+    system.addComponent("methane", 62.51);
+    system.addComponent("ethane", 15.65);
+    system.addComponent("propane", 13.22);
+    system.addComponent("i-butane", 1.61);
+    system.addComponent("n-butane", 2.48);
+    system.addComponent("i-pentane", 0.35);
+    system.addComponent("n-pentane", 0.29);
+    system.addComponent("n-hexane", 0.12);
+    system.setMixingRule(2);
+    system.setMultiPhaseCheck(multiphase);
+    return system;
+  }
+
+  private static SystemInterface flash(SystemInterface system, boolean poorGuess) {
+    if (poorGuess) {
+      system.setBeta(0, 1.0e-10);
+      system.setBeta(1, 1.0 - 1.0e-10);
+    }
+    new ThermodynamicOperations(system).TPflash();
+    system.init(1);
+    return system;
+  }
+
+  private static void assertEquivalent(SystemInterface expected, SystemInterface actual, String label,
+      double stateTolerance) {
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases(), label);
+    assertClosure(expected, label + " reference");
+    assertClosure(actual, label + " comparison");
+    Integer[] expectedOrder = phaseOrder(expected);
+    Integer[] actualOrder = phaseOrder(actual);
+    for (int orderedPhase = 0; orderedPhase < expectedOrder.length; orderedPhase++) {
+      int expectedPhase = expectedOrder[orderedPhase];
+      int actualPhase = actualOrder[orderedPhase];
+      assertEquals(expected.getPhase(expectedPhase).getType(), actual.getPhase(actualPhase).getType(), label);
+      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), stateTolerance, label);
+      assertEquals(expected.getPhase(expectedPhase).getZ(), actual.getPhase(actualPhase).getZ(), stateTolerance, label);
+      assertEquals(expected.getPhase(expectedPhase).getDensity(), actual.getPhase(actualPhase).getDensity(),
+          Math.max(1.0e-8, stateTolerance * expected.getPhase(expectedPhase).getDensity()), label);
+      for (int component = 0; component < expected.getPhase(expectedPhase).getNumberOfComponents(); component++) {
+        assertEquals(expected.getPhase(expectedPhase).getComponent(component).getx(),
+            actual.getPhase(actualPhase).getComponent(component).getx(), stateTolerance, label);
+      }
+    }
+    assertEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(),
+        Math.max(1.0e-7, stateTolerance * Math.abs(expected.getGibbsEnergy())), label);
+  }
+
+  private static Integer[] phaseOrder(SystemInterface system) {
+    Integer[] order = new Integer[system.getNumberOfPhases()];
+    Arrays.setAll(order, index -> index);
+    Arrays.sort(order, Comparator.comparingDouble(index -> system.getPhase(index).getDensity()));
+    return order;
+  }
+
+  private static void assertClosure(SystemInterface system, String label) {
+    double betaSum = 0.0;
+    int componentCount = system.getPhase(0).getNumberOfComponents();
+    for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+      double beta = system.getBeta(phase);
+      assertTrue(Double.isFinite(beta) && beta >= 0.0 && beta <= 1.0, label);
+      betaSum += beta;
+      double compositionSum = 0.0;
+      for (int component = 0; component < componentCount; component++) {
+        double composition = system.getPhase(phase).getComponent(component).getx();
+        assertTrue(Double.isFinite(composition) && composition >= 0.0 && composition <= 1.0, label);
+        compositionSum += composition;
+      }
+      assertEquals(1.0, compositionSum, 1.0e-12, label);
+      assertTrue(Double.isFinite(system.getPhase(phase).getZ()) && system.getPhase(phase).getZ() > 0.0, label);
+    }
+    assertEquals(1.0, betaSum, 1.0e-12, label);
+
+    double maximumMaterialBalanceResidual = 0.0;
+    for (int component = 0; component < componentCount; component++) {
+      double recovered = 0.0;
+      for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+        recovered += system.getBeta(phase) * system.getPhase(phase).getComponent(component).getx();
+      }
+      maximumMaterialBalanceResidual = Math.max(maximumMaterialBalanceResidual,
+          Math.abs(system.getPhase(0).getComponent(component).getz() - recovered));
+    }
+    assertTrue(maximumMaterialBalanceResidual < MATERIAL_BALANCE_TOLERANCE,
+        label + " material balance residual " + maximumMaterialBalanceResidual);
+
+    if (system.getNumberOfPhases() == 2) {
+      double maximumFugacityResidual = maximumFugacityResidual(system);
+      assertTrue(maximumFugacityResidual < FUGACITY_TOLERANCE, label + " fugacity residual " + maximumFugacityResidual);
+    }
+  }
+
+  private static double maximumFugacityResidual(SystemInterface system) {
+    double maximumResidual = 0.0;
+    for (int component = 0; component < system.getPhase(0).getNumberOfComponents(); component++) {
+      double first = system.getPhase(0).getComponent(component).getx()
+          * system.getPhase(0).getComponent(component).getFugacityCoefficient();
+      double second = system.getPhase(1).getComponent(component).getx()
+          * system.getPhase(1).getComponent(component).getFugacityCoefficient();
+      maximumResidual = Math.max(maximumResidual, Math.abs(Math.log(first / second)));
+    }
+    return maximumResidual;
+  }
+
+  private enum Eos {
+    SRK, PR
+  }
+
+  private static final class Case {
+    private final Eos eos;
+    private final double temperature;
+    private final double pressure;
+
+    private Case(Eos eos, double temperature, double pressure) {
+      this.eos = eos;
+      this.temperature = temperature;
+      this.pressure = pressure;
+    }
+
+    private Case withTemperature(double changedTemperature) {
+      return new Case(eos, changedTemperature, pressure);
+    }
+
+    private String label() {
+      return eos + " rich gas at " + temperature + " K, " + pressure + " bara";
+    }
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashNearCricondenbarConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashNearCricondenbarConsistencyTest.java
@@ -88,6 +88,16 @@ class TPflashNearCricondenbarConsistencyTest extends neqsim.NeqSimTest {
     }
   }
 
+  @Test
+  void lowPressureScreenExcludedControlRemainsCrossAlgorithmConsistent() {
+    for (Eos eos : Eos.values()) {
+      Case control = new Case(eos, 273.15, 20.0);
+      SystemInterface ordinary = flash(createSystem(control, false), false);
+      SystemInterface multiphase = flash(createSystem(control, true), false);
+      assertEquivalent(ordinary, multiphase, control.label(), 1.0e-10);
+    }
+  }
+
   private static SystemInterface createSystem(Case testCase, boolean multiphase) {
     SystemInterface system = testCase.eos == Eos.PR ? new SystemPrEos(testCase.temperature, testCase.pressure)
         : new SystemSrkEos(testCase.temperature, testCase.pressure);


### PR DESCRIPTION
## Engineering question

Can ordinary SRK and PR TP flashes return the same conservative, fugacity-equal lower-Gibbs rich-gas equilibrium as the explicit multiphase path near the cricondenbar, including phase appearance/disappearance and reused-state execution?

Advances #2937.

## Verified master defect

Exact base: `5eea490cce2ff6a58a3eaf2a2fbdec3f89404e6a`.

For a nitrogen/CO2/C1-C6 rich gas with classic mixing rule, ordinary flashes deterministically retained higher-Gibbs or wrong-topology endpoints:

- SRK, 100 bara / 273.15 K: maximum log-fugacity residual `1.30055e-2`
- SRK, 100 bara / 283.15 K: `1.51337e-2`
- PR, 95 bara / 268.15 K: `8.42662e-2`
- PR, 100 bara / 273.15 K: collapsed to one GAS phase with material residual `9.88469e-4`
- PR, 100 bara / 278.15 K: log-fugacity residual `5.2598e-3`
- PR, 100 bara / 283.15 K: `3.1720e-3`

The explicit multiphase path returned GAS+OIL equilibria with log-fugacity residuals of order `1e-13` and lower Gibbs energy.

## Change

- add a private composition/pressure performance screen for neutral water-free, methane-rich C1-C6/inert feeds near a high-pressure cubic-EOS boundary;
- use the established reciprocal stability flash only inside that qualified family;
- accept a candidate only with bounded normalized phases, material balance below `1e-10`, log-fugacity residual below `1e-8`, and lower Gibbs energy;
- preserve accepted cubic roots by transferring complete initialized phase objects;
- run at most five final beta updates to target `1e-10` fugacity closure after endpoint cleanup;
- restore the complete pre-polish state on failure, active-set change, lost closure, or Gibbs increase;
- normalize accepted one-phase endpoints to beta one and `x = z`.

No public API, EOS parameter, mixing rule, unit, or default changes.

## Regression matrix

The new SRK/PR test covers:

- all six reproduced failures;
- ordinary versus explicit-multiphase topology and state;
- material balance, fugacity equality, bounded and normalized beta/compositions, Z, density, and Gibbs energy;
- deliberately poor beta initialization;
- exact repeats;
- changed-temperature and return-to-state execution;
- gas/oil appearance and single-phase disappearance;
- 105 bara one-phase pressure controls;
- 20 bara SRK/PR screen-excluded controls.

Near the phase boundary, beta/composition agreement uses `1e-7` because phase fraction is ill-conditioned; the independent conservation and equilibrium gates remain `1e-10` and `1e-8`. Corrected ordinary regression endpoints are additionally required below `1e-10` log-fugacity residual.

## Performance control

This is a correctness fallback, not a speed optimization. Nonqualifying flashes do not run another thermodynamic solve. A qualifying invalid endpoint performs one reciprocal flash and at most five beta updates; an already-valid qualifying endpoint returns after an allocation-free component screen and residual audit. No speedup is claimed.

## Local validation

- `TPflashNearCricondenbarConsistencyTest`: 4/4 passed
- focused plus adjacent `TPflashLargeVolatilityHydrocarbonConsistencyTest`, `TPflashCubicRootSelectionTest`, `TPflashSourGasConsistencyTest`, and `TPFlashTest`: passed
- `python devtools/run_spotless.py check`: passed
- `python devtools/check_documentation_search.py`: passed (666 Markdown pages and 1 standalone HTML page)
- repository `pre-commit` was installed in a task-specific environment but could not run because the exact-source archive intentionally has no `.git` metadata; the direct mandatory gates above passed and hosted pre-commit remains authoritative

## Documentation impact

Updated the TPflash algorithm guide with the qualified feed/pressure range, six baseline failures, acceptance/rollback gates, units, state tolerance rationale, validation coverage, performance boundary, and lack of public-API/default changes.

## Status and stop boundary

**VALIDATION PENDING CI** at exact head `069aaa609981d8881dc5ca2c56b6d277abd663ba`. Hosted PaperLab, Spotless, pre-commit, Java 21 Javadoc, and agent-skill cross-reference checks passed. CodeQL, documentation, Java 21 fast tests, and all four slow shards are active with no reported failures. No pending gate is claimed as passed.

Frozen scope is neutral rich-gas SRK/PR endpoint selection and finalization near the cricondenbar. This PR does not alter saturation-search algorithms (#3269/#3271), electrolyte/Pitzer defaults (#3144), CPA parameterization, genuine three-phase algorithms, Column Solver, Process Performance, or Huldra work.