### PR TITLE
[AI-Assisted] Read assessed multi-area DEXPI Process packages

### DIFF
--- a/docs/integration/dexpi-20-conformance.md
+++ b/docs/integration/dexpi-20-conformance.md
@@ -129,6 +129,25 @@ import, and NeqSim supported-profile assessment for each XML. A restarted packag
 `REVIEW_REQUIRED`, `fitnessForConstruction=false`, or
 `nativeWholePlantDexpiExchange=false`; altered approval fields fail closed.
 
+After assessment, use the bounded reader when a caller needs exact per-area XML and connection
+evidence without extracting archive paths or trusting the embedded manifest:
+
+```java
+Dexpi20ProcessModelPackageReader.Snapshot snapshot =
+    Dexpi20ProcessModelPackageReader.read(processPackage);
+for (Dexpi20ProcessModelPackageReader.AreaDocument area : snapshot.getAreaDocuments()) {
+  byte[] exactAssessedXml = area.getXmlBytes();
+  // Pass the defensive copy to a controlled DEXPI Process consumer.
+}
+```
+
+`read(...)` reassesses first, captures the archive only within the bounded package size, and
+requires the captured bytes to match the assessment SHA-256 before exposing content. The serializable
+snapshot retains plant/revision/case provenance, package and manifest fingerprints, defensive exact
+area XML, and immutable material/energy/signal connection evidence. It deliberately does not extract
+files, reconstruct or execute a `ProcessModel`, reinterpret manifest-only connections as native
+DEXPI Process relationships, or change the engineering approval state.
+
 The single-area assessed path reports energy and signal connections, multi-area `ProcessModel`
 hierarchy, controlled document/sheet semantics, and drawing graphics as unsupported scopes. These
 warnings do not hide a supported material-topology error; missing, unexpected, unresolved-port, and

--- a/docs/integration/dexpi-pid-current-master-audit.md
+++ b/docs/integration/dexpi-pid-current-master-audit.md
@@ -31,7 +31,7 @@ test, fixture, example, and qualification surfaces required by issue #2899.
 | Proteus-compatible export | `processmodel.dexpi.DexpiXmlWriter`, compatibility facade `processmodel.DexpiXmlWriter` | `ProcessSystem`, `ProcessModel`, pyDEXPI namespace-omitted output, layout and compatibility sheets | Not native DEXPI 2.0; sheets are not a controlled drawing set |
 | Proteus-compatible import | `DexpiXmlReader`, `DexpiTopologyResolver`, `DexpiEquipmentFactory`, `DexpiSimulationBuilder` | Equipment, nozzles, piping segments, instruments, mappings, and a runnable process scaffold | Imported topology still requires fluid, cases, specifications, dynamics, and accountable review |
 | Native DEXPI 2.0 Plant | `Dexpi20XmlWriter`, `Dexpi20EngineeringMaterializer` | Core/Plant items, piping, nozzles, instrumentation, safeguards, boundaries, and representations | Plant exchange is not Process/PFD exchange or a DEXPI EV certificate |
-| Native DEXPI 2.0 Process | `Dexpi20ProcessModelWriter`, `Dexpi20ProcessTopologyAssessment`, `Dexpi20ProcessModelPackageWriter`, `Dexpi20ProcessModelPackageAssessment` | Process steps, explicit material ports, streams, selected physical quantities, canonical topology assessment, and deterministic assessed per-area packages | The multi-area ZIP manifest preserves cross-area material plus energy/information identity as explicit manifest-only evidence; it is not native whole-plant DEXPI, and graphics/document scopes remain separate |
+| Native DEXPI 2.0 Process | `Dexpi20ProcessModelWriter`, `Dexpi20ProcessTopologyAssessment`, `Dexpi20ProcessModelPackageWriter`, `Dexpi20ProcessModelPackageAssessment`, `Dexpi20ProcessModelPackageReader` | Process steps, explicit material ports, streams, selected physical quantities, canonical topology assessment, deterministic assessed per-area packages, and immutable exact-content intake snapshots | The reader exposes defensive per-area XML plus assessed material/energy/information connection evidence; it does not reconstruct a `ProcessModel`, promote manifest-only relationships to native whole-plant DEXPI, or combine graphics/document scopes |
 | Common model helpers | `DexpiMetadata`, `DexpiStream`, `DexpiProcessUnit`, `DexpiInstrumentInfo`, `DexpiStreamUtils`, `DexpiServiceClassifier`, `NorsokLineNumber` | Metadata, supported object classification, line/tag helpers, and compatibility DTOs | These helpers do not constitute a shared immutable drawing/document model |
 | Round-trip profile | `DexpiRoundTripProfile`, `EngineeringDexpiRoundTripQualifier` | Internal structural identity/reference comparison and explicit qualification status | Internal round trip is weaker than named-product import/export evidence |
 
@@ -76,6 +76,8 @@ Run the current DEXPI/P&ID baseline with the repository Maven wrapper. The focus
 ```text
 Dexpi20ProcessModelWriterTest
 Dexpi20ProcessModelPackageWriterTest
+Dexpi20ProcessModelPackageAssessmentTest
+Dexpi20ProcessModelPackageReaderTest
 Dexpi20SemanticValidatorTest
 DexpiXmlWriterTest
 DexpiXmlReaderTest
@@ -168,8 +170,8 @@ licensed standards, a named external tool, or accountable engineering review.
 | Phase 0 golden simple, branched, and multi-area cases | Present | Synthetic public executable cases pin material conservation, canonical topology/identity, supported native Process/Plant exchange, Proteus compatibility, legacy DOT, and governed P&ID proposal boundaries; unsupported native multi-area/document/graphics and SVG/PDF scopes remain structured limitations |
 | Stable identities and relationships | Partial | Canonical plant/area/equipment/port/connection IDs and governed engineering identities exist; detailed nozzles, piping, instruments, loops, safeguards, boundaries, and drawing objects do not yet share one qualified model |
 | State, units, case, and provenance separation | Partial | Canonical calculated operating values and governed design/evidence states exist; the full P&ID/document profile is not uniformly projected |
-| Deterministic ProcessSystem/ProcessModel export | Partial | Canonical topology and native Process exports are deterministic in tested subsets; `ProcessModel` packaging adds assessed area XML, hashes, a plant manifest, and fail-closed offline intake reassessment, while cross-area/energy/information semantics remain manifest-only rather than native whole-plant DEXPI |
-| Export-import-export semantic equivalence and loss | Partial | Internal structural qualifiers and canonical material comparisons exist; full Plant/Process/P&ID round trip and machine-readable loss coverage remain incomplete |
+| Deterministic ProcessSystem/ProcessModel export | Partial | Canonical topology and native Process exports are deterministic in tested subsets; `ProcessModel` packaging adds assessed area XML, hashes, a plant manifest, fail-closed offline reassessment, and a serializable exact-content intake snapshot, while cross-area/energy/information semantics remain manifest-only rather than native whole-plant DEXPI |
+| Export-import-export semantic equivalence and loss | Partial | Assessed package intake now preserves exact per-area XML and independently validated connection/loss status without path extraction; no runnable `ProcessModel` reconstruction is inferred, and full Plant/Process/P&ID round trip remains incomplete |
 | Schema/API compatibility and migration | Partial | Compatibility facades and byte-equivalent tested paths exist; no comprehensive versioned package migration suite covers every serialized artifact |
 | Revision semantic diff/impact | Partial | Engineering graph/package revision impact exists; affected drawing/sheet/register/study completeness is not yet end-to-end |
 | Professional symbols and project conventions | Partial/external | Proteus shapes, ISA/NORSOK tag helpers and proposal rules exist; a licensed ISO 10628/14617 mapping and reviewed vector catalog remain external/gap |
@@ -180,7 +182,7 @@ licensed standards, a named external tool, or accountable engineering review.
 | Detailed P&ID object coverage | Partial | Governed proposal rules cover important controls and safeguards; complete nozzle, fitting, reducer, drain/vent, bypass, blind, valve, analyzer, package, and line-design evidence is not uniform |
 | Simulation-backed engineering enrichment | Partial | Coordinated cases, registers, calculations, DEXPI packages and selected canonical stream values exist; governing envelopes and all equipment/design selections are not uniformly linked through the exchange |
 | DEXPI-centred study audits | Partial | Completeness, HAZOP preparation, SIS/HIPPS and qualification evidence exist; revision/MOC deltas and reusable selected-object study hooks are incomplete |
-| Java/Python engineer usability | Partial | Java writers/compilers and Python/Colab examples exist; one concise model-to-package-to-drawing-to-study API is not yet qualified |
+| Java/Python engineer usability | Partial | Java writers/compilers and a Java/Python-composable assessed package snapshot exist alongside Python/Colab examples; one concise model-to-package-to-drawing-to-study API is not yet qualified |
 | Public DEXPI/pyDEXPI validation | Partial | Bundled schema, a pinned DEXPIViewer runner/baseline, pyDEXPI import helper, and internal fixtures exist; the reviewed external baseline is not clean and exact-version execution must be rerun per release/reference case |
 | Commercial CAE qualification | External | Evidence template exists; observed named-product/version import, export, semantic diff and accountable review are mandatory |
 | Executed reference workflows | Partial | Saved notebooks and CI workflows exist; the full realistic multi-area, recycle, isolation, relief, flare, cross-sheet, revision-delta acceptance workflow remains a gap |
@@ -195,8 +197,9 @@ blocked on a controlled choice between an exchange-neutral reviewed symbol proje
 legally distributable DEXPI profile-symbol catalogue. Empty placeholder representation groups and
 invented standards mappings are not acceptable substitutes.
 
-Independent remaining work includes native whole-plant Process hierarchy and native energy/information mappings beyond
-manifest-only package evidence, end-to-end revision/MOC impact, broader P&ID object coverage, a reviewed visual-reference corpus,
+Independent remaining work includes reviewed reconstruction of assessed area exchanges into a runnable model, native
+whole-plant Process hierarchy and native energy/information mappings beyond manifest-only package evidence, end-to-end
+revision/MOC impact, broader P&ID object coverage, a reviewed visual-reference corpus,
 fresh exact-version external DEXPIViewer execution, and named commercial-CAE qualification. These
 items must retain legacy DOT/Graphviz, native DEXPI 2.0, and Proteus/P&ID compatibility and must not
 be reported as standards conformance or drawing approval without accountable evidence.

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageAssessment.java
@@ -285,8 +285,7 @@ public final class Dexpi20ProcessModelPackageAssessment {
       this.operatingCaseId = operatingCaseId;
       this.canonicalFingerprint = canonicalFingerprint;
       this.areaEvidence = Collections.unmodifiableList(new ArrayList<AreaEvidence>(areaEvidence));
-      this.connectionEvidence =
-          Collections.unmodifiableList(new ArrayList<ConnectionEvidence>(connectionEvidence));
+      this.connectionEvidence = Collections.unmodifiableList(new ArrayList<ConnectionEvidence>(connectionEvidence));
       this.diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
     }
 

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageAssessment.java
@@ -170,6 +170,98 @@ public final class Dexpi20ProcessModelPackageAssessment {
     }
   }
 
+  /** Independently verified evidence for one declared plant-wide connection. */
+  public static final class ConnectionEvidence implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String connectionId;
+    private final String connectionType;
+    private final String sourceArea;
+    private final String targetArea;
+    private final String sourceEquipment;
+    private final String targetEquipment;
+    private final String sourcePort;
+    private final String targetPort;
+    private final boolean crossArea;
+    private final boolean recycle;
+    private final String exchangeStatus;
+
+    ConnectionEvidence(String connectionId, String connectionType, String sourceArea, String targetArea,
+        String sourceEquipment, String targetEquipment, String sourcePort, String targetPort, boolean crossArea,
+        boolean recycle, String exchangeStatus) {
+      this.connectionId = connectionId;
+      this.connectionType = connectionType;
+      this.sourceArea = sourceArea;
+      this.targetArea = targetArea;
+      this.sourceEquipment = sourceEquipment;
+      this.targetEquipment = targetEquipment;
+      this.sourcePort = sourcePort;
+      this.targetPort = targetPort;
+      this.crossArea = crossArea;
+      this.recycle = recycle;
+      this.exchangeStatus = exchangeStatus;
+    }
+
+    public String getConnectionId() {
+      return connectionId;
+    }
+
+    public String getConnectionType() {
+      return connectionType;
+    }
+
+    public String getSourceArea() {
+      return sourceArea;
+    }
+
+    public String getTargetArea() {
+      return targetArea;
+    }
+
+    public String getSourceEquipment() {
+      return sourceEquipment;
+    }
+
+    public String getTargetEquipment() {
+      return targetEquipment;
+    }
+
+    public String getSourcePort() {
+      return sourcePort;
+    }
+
+    public String getTargetPort() {
+      return targetPort;
+    }
+
+    public boolean isCrossArea() {
+      return crossArea;
+    }
+
+    public boolean isRecycle() {
+      return recycle;
+    }
+
+    public String getExchangeStatus() {
+      return exchangeStatus;
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("connectionId", connectionId);
+      result.put("connectionType", connectionType);
+      result.put("sourceArea", sourceArea);
+      result.put("targetArea", targetArea);
+      result.put("sourceEquipment", sourceEquipment);
+      result.put("targetEquipment", targetEquipment);
+      result.put("sourcePort", sourcePort);
+      result.put("targetPort", targetPort);
+      result.put("crossArea", Boolean.valueOf(crossArea));
+      result.put("recycle", Boolean.valueOf(recycle));
+      result.put("exchangeStatus", exchangeStatus);
+      return result;
+    }
+  }
+
   /** Immutable independent assessment of one package file. */
   public static final class Report implements Serializable {
     private static final long serialVersionUID = 1000L;
@@ -180,10 +272,12 @@ public final class Dexpi20ProcessModelPackageAssessment {
     private final String operatingCaseId;
     private final String canonicalFingerprint;
     private final List<AreaEvidence> areaEvidence;
+    private final List<ConnectionEvidence> connectionEvidence;
     private final List<Diagnostic> diagnostics;
 
     Report(String packageFileSha256, String manifestSha256, String plantId, String revision, String operatingCaseId,
-        String canonicalFingerprint, List<AreaEvidence> areaEvidence, List<Diagnostic> diagnostics) {
+        String canonicalFingerprint, List<AreaEvidence> areaEvidence, List<ConnectionEvidence> connectionEvidence,
+        List<Diagnostic> diagnostics) {
       this.packageFileSha256 = packageFileSha256;
       this.manifestSha256 = manifestSha256;
       this.plantId = plantId;
@@ -191,6 +285,8 @@ public final class Dexpi20ProcessModelPackageAssessment {
       this.operatingCaseId = operatingCaseId;
       this.canonicalFingerprint = canonicalFingerprint;
       this.areaEvidence = Collections.unmodifiableList(new ArrayList<AreaEvidence>(areaEvidence));
+      this.connectionEvidence =
+          Collections.unmodifiableList(new ArrayList<ConnectionEvidence>(connectionEvidence));
       this.diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
     }
 
@@ -220,6 +316,10 @@ public final class Dexpi20ProcessModelPackageAssessment {
 
     public List<AreaEvidence> getAreaEvidence() {
       return areaEvidence;
+    }
+
+    public List<ConnectionEvidence> getConnectionEvidence() {
+      return connectionEvidence;
     }
 
     public List<Diagnostic> getDiagnostics() {
@@ -265,6 +365,11 @@ public final class Dexpi20ProcessModelPackageAssessment {
         areas.add(area.toMap());
       }
       result.put("areaEvidence", areas);
+      List<Map<String, Object>> connections = new ArrayList<Map<String, Object>>();
+      for (ConnectionEvidence connection : connectionEvidence) {
+        connections.add(connection.toMap());
+      }
+      result.put("connectionEvidence", connections);
       List<Map<String, Object>> findings = new ArrayList<Map<String, Object>>();
       for (Diagnostic diagnostic : diagnostics) {
         findings.add(diagnostic.toMap());
@@ -304,7 +409,8 @@ public final class Dexpi20ProcessModelPackageAssessment {
       diagnostics.add(
           error("DEXPI_PROCESS_PACKAGE_MANIFEST_MISSING", "Package does not contain manifest.json", MANIFEST_ENTRY));
       sortDiagnostics(diagnostics);
-      return new Report(packageSha, "", "", "", null, "", Collections.<AreaEvidence>emptyList(), diagnostics);
+      return new Report(packageSha, "", "", "", null, "", Collections.<AreaEvidence>emptyList(),
+          Collections.<ConnectionEvidence>emptyList(), diagnostics);
     }
 
     String manifestSha = sha256(new ByteArrayInputStream(manifestBytes));
@@ -318,7 +424,8 @@ public final class Dexpi20ProcessModelPackageAssessment {
       diagnostics.add(error("DEXPI_PROCESS_PACKAGE_MANIFEST_INVALID_JSON",
           "Package manifest is not valid JSON: " + exception.getMessage(), MANIFEST_ENTRY));
       sortDiagnostics(diagnostics);
-      return new Report(packageSha, manifestSha, "", "", null, "", Collections.<AreaEvidence>emptyList(), diagnostics);
+      return new Report(packageSha, manifestSha, "", "", null, "", Collections.<AreaEvidence>emptyList(),
+          Collections.<ConnectionEvidence>emptyList(), diagnostics);
     }
 
     String plantId = requiredText(manifest, "plantId", diagnostics);
@@ -331,11 +438,11 @@ public final class Dexpi20ProcessModelPackageAssessment {
     Set<String> areaNames = new LinkedHashSet<String>();
     Set<String> areaIds = new LinkedHashSet<String>();
     List<AreaEvidence> areas = assessAreas(manifest, entries, declaredAreaEntries, areaNames, areaIds, diagnostics);
-    verifyConnections(manifest, areaNames, diagnostics);
+    List<ConnectionEvidence> connections = verifyConnections(manifest, areaNames, diagnostics);
     verifyDeclaredEntries(entries.keySet(), declaredAreaEntries, diagnostics);
     sortDiagnostics(diagnostics);
     return new Report(packageSha, manifestSha, plantId, revision, operatingCaseId, canonicalFingerprint, areas,
-        diagnostics);
+        connections, diagnostics);
   }
 
   private static Map<String, byte[]> readArchive(Path packagePath, List<Diagnostic> diagnostics) throws IOException {
@@ -518,10 +625,12 @@ public final class Dexpi20ProcessModelPackageAssessment {
     }
   }
 
-  private static void verifyConnections(JsonObject manifest, Set<String> areaNames, List<Diagnostic> diagnostics) {
+  private static List<ConnectionEvidence> verifyConnections(JsonObject manifest, Set<String> areaNames,
+      List<Diagnostic> diagnostics) {
+    List<ConnectionEvidence> result = new ArrayList<ConnectionEvidence>();
     JsonArray connections = requiredArray(manifest, "connections", diagnostics);
     if (connections == null) {
-      return;
+      return result;
     }
     Set<String> ids = new LinkedHashSet<String>();
     Set<String> manifestDiagnosticKeys = manifestDiagnosticKeys(manifest);
@@ -538,13 +647,13 @@ public final class Dexpi20ProcessModelPackageAssessment {
       String type = requiredText(connection, "connectionType", diagnostics, id);
       String sourceArea = requiredText(connection, "sourceArea", diagnostics, id);
       String targetArea = requiredText(connection, "targetArea", diagnostics, id);
-      requiredText(connection, "sourceEquipment", diagnostics, id);
-      requiredText(connection, "targetEquipment", diagnostics, id);
-      requiredText(connection, "sourcePort", diagnostics, id);
-      requiredText(connection, "targetPort", diagnostics, id);
+      String sourceEquipment = requiredText(connection, "sourceEquipment", diagnostics, id);
+      String targetEquipment = requiredText(connection, "targetEquipment", diagnostics, id);
+      String sourcePort = requiredText(connection, "sourcePort", diagnostics, id);
+      String targetPort = requiredText(connection, "targetPort", diagnostics, id);
       String status = requiredText(connection, "exchangeStatus", diagnostics, id);
       Boolean crossArea = requiredBoolean(connection, "crossArea", diagnostics, id);
-      requiredBoolean(connection, "recycle", diagnostics, id);
+      Boolean recycle = requiredBoolean(connection, "recycle", diagnostics, id);
       addUnique(ids, id, "DEXPI_PROCESS_PACKAGE_DUPLICATE_CONNECTION_ID", diagnostics);
       if (!areaNames.contains(sourceArea) || !areaNames.contains(targetArea)) {
         diagnostics.add(error("DEXPI_PROCESS_PACKAGE_CONNECTION_AREA_UNKNOWN",
@@ -563,7 +672,16 @@ public final class Dexpi20ProcessModelPackageAssessment {
         diagnostics.add(error("DEXPI_PROCESS_PACKAGE_CONNECTION_LOSS_DIAGNOSTIC_MISSING",
             "Manifest-only connection has no matching structured loss diagnostic", id));
       }
+      result.add(new ConnectionEvidence(id, type, sourceArea, targetArea, sourceEquipment, targetEquipment, sourcePort,
+          targetPort, Boolean.TRUE.equals(crossArea), Boolean.TRUE.equals(recycle), status));
     }
+    Collections.sort(result, new Comparator<ConnectionEvidence>() {
+      @Override
+      public int compare(ConnectionEvidence first, ConnectionEvidence second) {
+        return first.getConnectionId().compareTo(second.getConnectionId());
+      }
+    });
+    return result;
   }
 
   private static String expectedConnectionStatus(String type, boolean crossArea) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageAssessment.java
@@ -314,15 +314,15 @@ public final class Dexpi20ProcessModelPackageAssessment {
     }
 
     public List<AreaEvidence> getAreaEvidence() {
-      return areaEvidence;
+      return Collections.unmodifiableList(new ArrayList<AreaEvidence>(areaEvidence));
     }
 
     public List<ConnectionEvidence> getConnectionEvidence() {
-      return connectionEvidence;
+      return Collections.unmodifiableList(new ArrayList<ConnectionEvidence>(connectionEvidence));
     }
 
     public List<Diagnostic> getDiagnostics() {
-      return diagnostics;
+      return Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
     }
 
     /** @return true when the independently assessed archive and declared contents have no error */

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReader.java
@@ -157,9 +157,8 @@ public final class Dexpi20ProcessModelPackageReader {
     }
 
     public List<Dexpi20ProcessModelPackageAssessment.ConnectionEvidence> getConnectionEvidence() {
-      return Collections.unmodifiableList(
-          new ArrayList<Dexpi20ProcessModelPackageAssessment.ConnectionEvidence>(
-              assessmentReport.getConnectionEvidence()));
+      return Collections.unmodifiableList(new ArrayList<Dexpi20ProcessModelPackageAssessment.ConnectionEvidence>(
+          assessmentReport.getConnectionEvidence()));
     }
 
     /** @return always {@code REVIEW_REQUIRED} */

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReader.java
@@ -230,8 +230,7 @@ public final class Dexpi20ProcessModelPackageReader {
       throw new IOException("DEXPI ProcessModel package exceeds the bounded file-size limit");
     }
 
-    Dexpi20ProcessModelPackageAssessment.Report assessment =
-        Dexpi20ProcessModelPackageAssessment.assess(packageFile);
+    Dexpi20ProcessModelPackageAssessment.Report assessment = Dexpi20ProcessModelPackageAssessment.assess(packageFile);
     if (!assessment.isValid()) {
       throw new InvalidPackageException(assessment);
     }
@@ -265,8 +264,7 @@ public final class Dexpi20ProcessModelPackageReader {
 
   private static List<AreaDocument> readAreaDocuments(byte[] archiveBytes,
       Dexpi20ProcessModelPackageAssessment.Report assessment) throws IOException {
-    Map<String, Dexpi20ProcessModelPackageAssessment.AreaEvidence> expected =
-        new LinkedHashMap<String, Dexpi20ProcessModelPackageAssessment.AreaEvidence>();
+    Map<String, Dexpi20ProcessModelPackageAssessment.AreaEvidence> expected = new LinkedHashMap<String, Dexpi20ProcessModelPackageAssessment.AreaEvidence>();
     for (Dexpi20ProcessModelPackageAssessment.AreaEvidence area : assessment.getAreaEvidence()) {
       expected.put(area.getEntryName(), area);
     }

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReader.java
@@ -5,6 +5,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -235,11 +236,31 @@ public final class Dexpi20ProcessModelPackageReader {
       throw new InvalidPackageException(assessment);
     }
 
-    byte[] archiveBytes = Files.readAllBytes(path);
+    byte[] archiveBytes = readBoundedFile(path);
     if (!assessment.getPackageFileSha256().equals(sha256(archiveBytes))) {
       throw new IOException("DEXPI ProcessModel package changed during assessed intake");
     }
     return new Snapshot(assessment, readAreaDocuments(archiveBytes, assessment));
+  }
+
+  private static byte[] readBoundedFile(Path path) throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    InputStream input = Files.newInputStream(path);
+    try {
+      byte[] buffer = new byte[8192];
+      long total = 0L;
+      int count;
+      while ((count = input.read(buffer)) != -1) {
+        total += count;
+        if (total > MAX_PACKAGE_FILE_BYTES) {
+          throw new IOException("DEXPI ProcessModel package exceeds the bounded file-size limit");
+        }
+        output.write(buffer, 0, count);
+      }
+    } finally {
+      input.close();
+    }
+    return output.toByteArray();
   }
 
   private static List<AreaDocument> readAreaDocuments(byte[] archiveBytes,

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReader.java
@@ -1,0 +1,305 @@
+package neqsim.process.processmodel.dexpi;
+
+import com.google.gson.GsonBuilder;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Reads independently assessed NeqSim multi-area DEXPI Process packages without extracting archive paths.
+ *
+ * <p>
+ * The reader first applies {@link Dexpi20ProcessModelPackageAssessment}, captures the exact assessed archive bytes, and
+ * refuses to expose content unless both reads have the same SHA-256 fingerprint. The returned snapshot contains
+ * defensive copies of the native per-area DEXPI 2.0 Process XML and the independently validated plant-wide connection
+ * evidence. It does not reconstruct or execute a {@code ProcessModel}, invent native whole-plant DEXPI relationships,
+ * or weaken the mandatory engineering-review boundary.
+ * </p>
+ */
+public final class Dexpi20ProcessModelPackageReader {
+  private static final long MAX_PACKAGE_FILE_BYTES = 256L * 1024L * 1024L;
+  private static final long MAX_AREA_XML_BYTES = 64L * 1024L * 1024L;
+
+  private Dexpi20ProcessModelPackageReader() {
+  }
+
+  /** Checked failure carrying deterministic assessment evidence for an invalid package. */
+  public static final class InvalidPackageException extends IOException {
+    private static final long serialVersionUID = 1000L;
+    private final Dexpi20ProcessModelPackageAssessment.Report assessmentReport;
+
+    InvalidPackageException(Dexpi20ProcessModelPackageAssessment.Report assessmentReport) {
+      super("DEXPI ProcessModel package failed independent assessment");
+      this.assessmentReport = assessmentReport;
+    }
+
+    /** @return immutable fail-closed assessment report */
+    public Dexpi20ProcessModelPackageAssessment.Report getAssessmentReport() {
+      return assessmentReport;
+    }
+  }
+
+  /** Immutable native DEXPI Process document for one assessed area. */
+  public static final class AreaDocument implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String areaName;
+    private final String areaId;
+    private final String entryName;
+    private final String fileSha256;
+    private final byte[] xmlBytes;
+
+    AreaDocument(Dexpi20ProcessModelPackageAssessment.AreaEvidence evidence, byte[] xmlBytes) {
+      this.areaName = evidence.getAreaName();
+      this.areaId = evidence.getAreaId();
+      this.entryName = evidence.getEntryName();
+      this.fileSha256 = evidence.getActualFileSha256();
+      this.xmlBytes = xmlBytes.clone();
+    }
+
+    public String getAreaName() {
+      return areaName;
+    }
+
+    public String getAreaId() {
+      return areaId;
+    }
+
+    public String getEntryName() {
+      return entryName;
+    }
+
+    public String getFileSha256() {
+      return fileSha256;
+    }
+
+    /** @return a defensive copy of the exact assessed XML bytes */
+    public byte[] getXmlBytes() {
+      return xmlBytes.clone();
+    }
+
+    /** @return the exact assessed XML decoded as UTF-8 */
+    public String getXmlUtf8() {
+      return new String(xmlBytes, StandardCharsets.UTF_8);
+    }
+
+    public int getByteLength() {
+      return xmlBytes.length;
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("areaName", areaName);
+      result.put("areaId", areaId);
+      result.put("entryName", entryName);
+      result.put("fileSha256", fileSha256);
+      result.put("byteLength", Integer.valueOf(xmlBytes.length));
+      return result;
+    }
+  }
+
+  /** Immutable restart snapshot of one valid assessed package. */
+  public static final class Snapshot implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Dexpi20ProcessModelPackageAssessment.Report assessmentReport;
+    private final List<AreaDocument> areaDocuments;
+
+    Snapshot(Dexpi20ProcessModelPackageAssessment.Report assessmentReport, List<AreaDocument> areaDocuments) {
+      this.assessmentReport = assessmentReport;
+      this.areaDocuments = Collections.unmodifiableList(new ArrayList<AreaDocument>(areaDocuments));
+    }
+
+    public Dexpi20ProcessModelPackageAssessment.Report getAssessmentReport() {
+      return assessmentReport;
+    }
+
+    public String getPackageFileSha256() {
+      return assessmentReport.getPackageFileSha256();
+    }
+
+    public String getManifestSha256() {
+      return assessmentReport.getManifestSha256();
+    }
+
+    public String getPlantId() {
+      return assessmentReport.getPlantId();
+    }
+
+    public String getRevision() {
+      return assessmentReport.getRevision();
+    }
+
+    public String getOperatingCaseId() {
+      return assessmentReport.getOperatingCaseId();
+    }
+
+    public String getCanonicalFingerprint() {
+      return assessmentReport.getCanonicalFingerprint();
+    }
+
+    public List<AreaDocument> getAreaDocuments() {
+      return areaDocuments;
+    }
+
+    public List<Dexpi20ProcessModelPackageAssessment.ConnectionEvidence> getConnectionEvidence() {
+      return assessmentReport.getConnectionEvidence();
+    }
+
+    /** @return always {@code REVIEW_REQUIRED} */
+    public String getApprovalStatus() {
+      return "REVIEW_REQUIRED";
+    }
+
+    /** @return always false */
+    public boolean isFitnessForConstruction() {
+      return false;
+    }
+
+    /** @return always false */
+    public boolean isNativeWholePlantDexpiExchange() {
+      return false;
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("schemaVersion", "neqsim_dexpi_2_0_process_model_package_snapshot.v1");
+      result.put("packageFileSha256", getPackageFileSha256());
+      result.put("manifestSha256", getManifestSha256());
+      result.put("plantId", getPlantId());
+      result.put("revision", getRevision());
+      if (getOperatingCaseId() != null) {
+        result.put("operatingCaseId", getOperatingCaseId());
+      }
+      result.put("canonicalFingerprint", getCanonicalFingerprint());
+      result.put("approvalStatus", getApprovalStatus());
+      result.put("fitnessForConstruction", Boolean.FALSE);
+      result.put("nativeWholePlantDexpiExchange", Boolean.FALSE);
+      List<Map<String, Object>> areas = new ArrayList<Map<String, Object>>();
+      for (AreaDocument area : areaDocuments) {
+        areas.add(area.toMap());
+      }
+      result.put("areaDocuments", areas);
+      List<Map<String, Object>> connections = new ArrayList<Map<String, Object>>();
+      for (Dexpi20ProcessModelPackageAssessment.ConnectionEvidence connection : getConnectionEvidence()) {
+        connections.add(connection.toMap());
+      }
+      result.put("connectionEvidence", connections);
+      result.put("contentScope", "Exact assessed native per-area DEXPI Process XML and validated manifest connections");
+      result.put("executionStatus", "NOT_RECONSTRUCTED_OR_EXECUTED");
+      return result;
+    }
+
+    public String toJson() {
+      return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+    }
+  }
+
+  /**
+   * Reads one package into an immutable assessed snapshot.
+   *
+   * @param packageFile package written by {@link Dexpi20ProcessModelPackageWriter}
+   * @return immutable exact-content snapshot
+   * @throws InvalidPackageException when independent assessment finds an invalid package
+   * @throws IOException when the file changes during intake or cannot be read within the bounded size
+   */
+  public static Snapshot read(File packageFile) throws IOException {
+    if (packageFile == null) {
+      throw new IllegalArgumentException("packageFile must not be null");
+    }
+    Path path = packageFile.toPath();
+    if (!Files.isRegularFile(path)) {
+      throw new IOException("DEXPI ProcessModel package is not a regular file: " + path);
+    }
+    long fileSize = Files.size(path);
+    if (fileSize > MAX_PACKAGE_FILE_BYTES) {
+      throw new IOException("DEXPI ProcessModel package exceeds the bounded file-size limit");
+    }
+
+    Dexpi20ProcessModelPackageAssessment.Report assessment =
+        Dexpi20ProcessModelPackageAssessment.assess(packageFile);
+    if (!assessment.isValid()) {
+      throw new InvalidPackageException(assessment);
+    }
+
+    byte[] archiveBytes = Files.readAllBytes(path);
+    if (!assessment.getPackageFileSha256().equals(sha256(archiveBytes))) {
+      throw new IOException("DEXPI ProcessModel package changed during assessed intake");
+    }
+    return new Snapshot(assessment, readAreaDocuments(archiveBytes, assessment));
+  }
+
+  private static List<AreaDocument> readAreaDocuments(byte[] archiveBytes,
+      Dexpi20ProcessModelPackageAssessment.Report assessment) throws IOException {
+    Map<String, Dexpi20ProcessModelPackageAssessment.AreaEvidence> expected =
+        new LinkedHashMap<String, Dexpi20ProcessModelPackageAssessment.AreaEvidence>();
+    for (Dexpi20ProcessModelPackageAssessment.AreaEvidence area : assessment.getAreaEvidence()) {
+      expected.put(area.getEntryName(), area);
+    }
+    Map<String, byte[]> found = new LinkedHashMap<String, byte[]>();
+    ZipInputStream input = new ZipInputStream(new ByteArrayInputStream(archiveBytes), StandardCharsets.UTF_8);
+    try {
+      ZipEntry entry;
+      byte[] buffer = new byte[8192];
+      while ((entry = input.getNextEntry()) != null) {
+        Dexpi20ProcessModelPackageAssessment.AreaEvidence area = expected.get(entry.getName());
+        if (area == null) {
+          while (input.read(buffer) != -1) {
+            // Consume assessed non-area entries without exposing them.
+          }
+          continue;
+        }
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        long countForEntry = 0L;
+        int count;
+        while ((count = input.read(buffer)) != -1) {
+          countForEntry += count;
+          if (countForEntry > MAX_AREA_XML_BYTES) {
+            throw new IOException("Assessed area XML exceeds the bounded reader limit: " + entry.getName());
+          }
+          output.write(buffer, 0, count);
+        }
+        found.put(entry.getName(), output.toByteArray());
+      }
+    } finally {
+      input.close();
+    }
+
+    List<AreaDocument> result = new ArrayList<AreaDocument>();
+    for (Dexpi20ProcessModelPackageAssessment.AreaEvidence area : assessment.getAreaEvidence()) {
+      byte[] xml = found.get(area.getEntryName());
+      if (xml == null || !area.getActualFileSha256().equals(sha256(xml))) {
+        throw new IOException("Assessed area XML changed or is unavailable: " + area.getEntryName());
+      }
+      result.add(new AreaDocument(area, xml));
+    }
+    return result;
+  }
+
+  private static String sha256(byte[] bytes) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      digest.update(bytes);
+      StringBuilder result = new StringBuilder();
+      for (byte value : digest.digest()) {
+        result.append(String.format(Locale.ROOT, "%02x", Integer.valueOf(value & 255)));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is required by every supported Java runtime", exception);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReader.java
@@ -153,11 +153,13 @@ public final class Dexpi20ProcessModelPackageReader {
     }
 
     public List<AreaDocument> getAreaDocuments() {
-      return areaDocuments;
+      return Collections.unmodifiableList(new ArrayList<AreaDocument>(areaDocuments));
     }
 
     public List<Dexpi20ProcessModelPackageAssessment.ConnectionEvidence> getConnectionEvidence() {
-      return assessmentReport.getConnectionEvidence();
+      return Collections.unmodifiableList(
+          new ArrayList<Dexpi20ProcessModelPackageAssessment.ConnectionEvidence>(
+              assessmentReport.getConnectionEvidence()));
     }
 
     /** @return always {@code REVIEW_REQUIRED} */

--- a/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
@@ -22,6 +22,8 @@
  * assessed native Process exchanges and explicit plant-wide manifest-only connection evidence</li>
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessModelPackageAssessment} - Offline, fail-closed package
  * integrity, engineering-boundary, identity, loss-status, hash, and per-area conformance assessment</li>
+ * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessModelPackageReader} - Immutable intake snapshot with
+ * defensive exact-area XML and independently assessed connection evidence</li>
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20GraphicalProjectionWriter} - Opt-in native DEXPI Core graphical
  * projection</li>
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20GraphicalProjectionAssessment} - Deterministic inspection of

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReaderTest.java
@@ -67,8 +67,8 @@ class Dexpi20ProcessModelPackageReaderTest {
 
   @Test
   void returnsDefensiveSerializableRestartSnapshot() throws IOException, ClassNotFoundException {
-    Dexpi20ProcessModelPackageReader.Snapshot snapshot =
-        Dexpi20ProcessModelPackageReader.read(writeReferencePackage("restart.zip"));
+    Dexpi20ProcessModelPackageReader.Snapshot snapshot = Dexpi20ProcessModelPackageReader
+        .read(writeReferencePackage("restart.zip"));
     Dexpi20ProcessModelPackageReader.AreaDocument area = snapshot.getAreaDocuments().get(0);
     byte[] changed = area.getXmlBytes();
     byte originalFirstByte = changed[0];
@@ -78,8 +78,7 @@ class Dexpi20ProcessModelPackageReaderTest {
     assertNotEquals(changed[0], area.getXmlBytes()[0]);
     assertThrows(UnsupportedOperationException.class,
         () -> snapshot.getAreaDocuments().add(snapshot.getAreaDocuments().get(0)));
-    assertThrows(UnsupportedOperationException.class,
-        () -> snapshot.getConnectionEvidence().clear());
+    assertThrows(UnsupportedOperationException.class, () -> snapshot.getConnectionEvidence().clear());
 
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     ObjectOutputStream output = new ObjectOutputStream(bytes);
@@ -120,9 +119,9 @@ class Dexpi20ProcessModelPackageReaderTest {
       output.close();
     }
 
-    Dexpi20ProcessModelPackageReader.InvalidPackageException exception =
-        assertThrows(Dexpi20ProcessModelPackageReader.InvalidPackageException.class,
-            () -> Dexpi20ProcessModelPackageReader.read(invalid.toFile()));
+    Dexpi20ProcessModelPackageReader.InvalidPackageException exception = assertThrows(
+        Dexpi20ProcessModelPackageReader.InvalidPackageException.class,
+        () -> Dexpi20ProcessModelPackageReader.read(invalid.toFile()));
 
     assertFalse(exception.getAssessmentReport().isValid());
     assertTrue(exception.getAssessmentReport().toJson().contains("DEXPI_PROCESS_PACKAGE_UNSAFE_ENTRY_NAME"));

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReaderTest.java
@@ -79,10 +79,8 @@ class Dexpi20ProcessModelPackageReaderTest {
     assertThrows(UnsupportedOperationException.class,
         () -> snapshot.getAreaDocuments().add(snapshot.getAreaDocuments().get(0)));
     assertThrows(UnsupportedOperationException.class, () -> snapshot.getConnectionEvidence().clear());
-    assertThrows(UnsupportedOperationException.class,
-        () -> snapshot.getAssessmentReport().getAreaEvidence().clear());
-    assertThrows(UnsupportedOperationException.class,
-        () -> snapshot.getAssessmentReport().getDiagnostics().clear());
+    assertThrows(UnsupportedOperationException.class, () -> snapshot.getAssessmentReport().getAreaEvidence().clear());
+    assertThrows(UnsupportedOperationException.class, () -> snapshot.getAssessmentReport().getDiagnostics().clear());
 
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     ObjectOutputStream output = new ObjectOutputStream(bytes);

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReaderTest.java
@@ -1,0 +1,144 @@
+package neqsim.process.processmodel.dexpi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import neqsim.process.processmodel.ProcessConnection;
+import neqsim.process.processmodel.diagram.EngineeringDiagramReferenceFixtures;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class Dexpi20ProcessModelPackageReaderTest {
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void readsExactAssessedAreaDocumentsAndConnectionEvidence() throws IOException {
+    File packageFile = writeReferencePackage("facility.zip");
+
+    Dexpi20ProcessModelPackageReader.Snapshot first = Dexpi20ProcessModelPackageReader.read(packageFile);
+    Dexpi20ProcessModelPackageReader.Snapshot second = Dexpi20ProcessModelPackageReader.read(packageFile);
+
+    assertEquals("PLANT-30", first.getPlantId());
+    assertEquals("REV-A", first.getRevision());
+    assertEquals(64, first.getPackageFileSha256().length());
+    assertEquals(64, first.getManifestSha256().length());
+    assertEquals(64, first.getCanonicalFingerprint().length());
+    assertEquals("REVIEW_REQUIRED", first.getApprovalStatus());
+    assertFalse(first.isFitnessForConstruction());
+    assertFalse(first.isNativeWholePlantDexpiExchange());
+    assertEquals(4, first.getAreaDocuments().size());
+    assertEquals(first.toJson(), second.toJson());
+
+    for (Dexpi20ProcessModelPackageReader.AreaDocument area : first.getAreaDocuments()) {
+      assertEquals(64, area.getFileSha256().length());
+      assertTrue(area.getByteLength() > 0);
+      assertTrue(area.getXmlUtf8().contains("<Model"));
+    }
+
+    Set<String> connectionTypes = new LinkedHashSet<String>();
+    for (Dexpi20ProcessModelPackageAssessment.ConnectionEvidence connection : first.getConnectionEvidence()) {
+      connectionTypes.add(connection.getConnectionType());
+      assertFalse(connection.getConnectionId().isEmpty());
+      assertFalse(connection.getSourcePort().isEmpty());
+      assertFalse(connection.getTargetPort().isEmpty());
+    }
+    assertTrue(connectionTypes.contains("MATERIAL"));
+    assertTrue(connectionTypes.contains("ENERGY"));
+    assertTrue(connectionTypes.contains("SIGNAL"));
+  }
+
+  @Test
+  void returnsDefensiveSerializableRestartSnapshot() throws IOException, ClassNotFoundException {
+    Dexpi20ProcessModelPackageReader.Snapshot snapshot =
+        Dexpi20ProcessModelPackageReader.read(writeReferencePackage("restart.zip"));
+    Dexpi20ProcessModelPackageReader.AreaDocument area = snapshot.getAreaDocuments().get(0);
+    byte[] changed = area.getXmlBytes();
+    byte originalFirstByte = changed[0];
+    changed[0] = (byte) (changed[0] + 1);
+
+    assertEquals(originalFirstByte, area.getXmlBytes()[0]);
+    assertNotEquals(changed[0], area.getXmlBytes()[0]);
+    assertThrows(UnsupportedOperationException.class,
+        () -> snapshot.getAreaDocuments().add(snapshot.getAreaDocuments().get(0)));
+    assertThrows(UnsupportedOperationException.class,
+        () -> snapshot.getConnectionEvidence().clear());
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream output = new ObjectOutputStream(bytes);
+    try {
+      output.writeObject(snapshot);
+    } finally {
+      output.close();
+    }
+    ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    Dexpi20ProcessModelPackageReader.Snapshot restored;
+    try {
+      restored = (Dexpi20ProcessModelPackageReader.Snapshot) input.readObject();
+    } finally {
+      input.close();
+    }
+    assertEquals(snapshot.toJson(), restored.toJson());
+    assertEquals(area.getXmlUtf8(), restored.getAreaDocuments().get(0).getXmlUtf8());
+  }
+
+  @Test
+  void failsClosedBeforeExposingInvalidOrUnsafeArchiveContent() throws IOException {
+    Path invalid = temporaryDirectory.resolve("invalid.zip");
+    ZipOutputStream output = new ZipOutputStream(Files.newOutputStream(invalid), StandardCharsets.UTF_8);
+    try {
+      byte[] bytes = "not DEXPI".getBytes(StandardCharsets.UTF_8);
+      CRC32 crc = new CRC32();
+      crc.update(bytes);
+      ZipEntry entry = new ZipEntry("../escaped.xml");
+      entry.setMethod(ZipEntry.STORED);
+      entry.setSize(bytes.length);
+      entry.setCompressedSize(bytes.length);
+      entry.setCrc(crc.getValue());
+      entry.setTime(0L);
+      output.putNextEntry(entry);
+      output.write(bytes);
+      output.closeEntry();
+    } finally {
+      output.close();
+    }
+
+    Dexpi20ProcessModelPackageReader.InvalidPackageException exception =
+        assertThrows(Dexpi20ProcessModelPackageReader.InvalidPackageException.class,
+            () -> Dexpi20ProcessModelPackageReader.read(invalid.toFile()));
+
+    assertFalse(exception.getAssessmentReport().isValid());
+    assertTrue(exception.getAssessmentReport().toJson().contains("DEXPI_PROCESS_PACKAGE_UNSAFE_ENTRY_NAME"));
+    assertFalse(Files.exists(temporaryDirectory.getParent().resolve("escaped.xml")));
+    assertThrows(IllegalArgumentException.class, () -> Dexpi20ProcessModelPackageReader.read(null));
+  }
+
+  private File writeReferencePackage(String name) throws IOException {
+    EngineeringDiagramReferenceFixtures.ModelCase fixture = EngineeringDiagramReferenceFixtures.multiAreaFacility();
+    fixture.getProcessModel().get("Inlet").connect("30-XV-001", "energyOut", "30-VA-001", "energyIn",
+        ProcessConnection.ConnectionType.ENERGY);
+    fixture.getProcessModel().get("Inlet").connect("30-VA-001", "signalOut", "30-SP-001", "signalIn",
+        ProcessConnection.ConnectionType.SIGNAL);
+    File packageFile = temporaryDirectory.resolve(name).toFile();
+    Dexpi20ProcessModelPackageWriter.writeAndAssess(fixture.getProcessModel(), packageFile, "PLANT-30", "REV-A");
+    return packageFile;
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReaderTest.java
@@ -79,6 +79,10 @@ class Dexpi20ProcessModelPackageReaderTest {
     assertThrows(UnsupportedOperationException.class,
         () -> snapshot.getAreaDocuments().add(snapshot.getAreaDocuments().get(0)));
     assertThrows(UnsupportedOperationException.class, () -> snapshot.getConnectionEvidence().clear());
+    assertThrows(UnsupportedOperationException.class,
+        () -> snapshot.getAssessmentReport().getAreaEvidence().clear());
+    assertThrows(UnsupportedOperationException.class,
+        () -> snapshot.getAssessmentReport().getDiagnostics().clear());
 
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     ObjectOutputStream output = new ObjectOutputStream(bytes);

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageReaderTest.java
@@ -16,7 +16,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;


### PR DESCRIPTION
## Engineering question

Can a downstream Java or Python caller consume a deterministic multi-area DEXPI Process package as exact, restartable assessed content without trusting the manifest, extracting archive paths, reconstructing an unreviewed simulation model, or weakening the engineering-approval boundary?

Advances #1332 and #2899 as one shared engineering-diagram lane.

## Change

- extend the independent package assessment with immutable, deterministically ordered material/energy/signal connection evidence;
- add `Dexpi20ProcessModelPackageReader.read(...)`, which assesses first and refuses invalid packages before exposing content;
- capture package bytes through a 256 MiB bounded read and require their SHA-256 to match the independent assessment, closing the assessment/read mutation window;
- expose serializable snapshot metadata, defensive exact per-area DEXPI Process XML, stable area IDs, hashes, and validated connection endpoints/status;
- retain `REVIEW_REQUIRED`, `fitnessForConstruction=false`, and `nativeWholePlantDexpiExchange=false`;
- update package Javadocs, intake guidance, and the current-master capability audit.

## Regression coverage

`Dexpi20ProcessModelPackageReaderTest` covers:

- exact stable plant/revision/fingerprint/hash evidence;
- all per-area XML as defensive UTF-8/byte copies;
- material, energy, and signal connection evidence;
- deterministic JSON across repeated intake;
- unmodifiable collections and Java serialization/restart;
- fail-closed invalid/unsafe archive handling with no path extraction;
- null input rejection.

Existing `Dexpi20ProcessModelPackageAssessmentTest` continues to cover changed area bytes, weakened approval fields, unsafe/undeclared entries, and missing manifests.

## Compatibility and stop boundary

This is additive. It does not change writer output, legacy DOT/Graphviz, native SVG/PDF rendering, Proteus/P&ID paths, the existing ProcessSystem APIs, or classic output bytes. It does not reconstruct or execute a `ProcessModel`, infer native whole-plant hierarchy, map manifest-only energy/information relationships into DEXPI Process, introduce symbols, or claim standards conformance, external-validator qualification, drawing approval, or fitness for construction.

The next reconstruction/native-whole-plant step requires a reviewed semantic mapping and is intentionally outside this PR. No Huldra or public-dataset content was accessed or added.

## Documentation impact

Updated the DEXPI 2.0 conformance guide, package-level Javadocs, and current-master audit with the exact intake API, security/integrity behavior, restartable evidence, and explicit limitations. No notebook was changed, so notebook execution/rendering gates are not triggered.

## Validation

**VALIDATION PENDING CI** at exact head `a5725d57253726be32c8bae169fa4a75c6490f2d`.

The exact initial and review-fix Spotless artifacts are applied. Code-quality review requested explicit defensive copies at the public list getters; the bounded fix and additional mutation regressions are present and both threads are resolved. This head passes clean Spotless (5,108 files, zero changes), pre-commit, PaperLab, the engineering notebook, and Java 21 Javadocs/main compilation. Documentation search, CodeQL, Java 21 Ubuntu/Windows fast tests, and all four slow shards remain active; none is claimed as passed.

Local validation was unavailable because this run used exact GitHub source without a local repository checkout. GitHub CI is authoritative; attributable failures will be repaired on this draft branch.