### PR TITLE
[AI-Assisted] test: fix master build portability regressions

### DIFF
--- a/src/test/java/neqsim/mcp/runners/StatePersistenceRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/StatePersistenceRunnerTest.java
@@ -2,8 +2,10 @@ package neqsim.mcp.runners;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
@@ -25,12 +27,31 @@ class StatePersistenceRunnerTest {
   }
 
   @Test
-  void testListStates() {
-    String json = "{\"action\": \"list\"}";
-    String result = StatePersistenceRunner.run(json);
-    assertNotNull(result);
-    JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
-    assertEquals("success", obj.get("status").getAsString(), "List states failed: " + result);
+  void testListStates(@TempDir Path temporaryDirectory) {
+    String allowExternalProperty = "neqsim.mcp.allowExternalStateDir";
+    String previousAllowExternal = System.getProperty(allowExternalProperty);
+    System.setProperty(allowExternalProperty, "true");
+    try {
+      JsonObject configureInput = new JsonObject();
+      configureInput.addProperty("action", "setStorageDir");
+      configureInput.addProperty("directory", temporaryDirectory.resolve("saved_simulations").toString());
+      String configureResult = StatePersistenceRunner.run(configureInput.toString());
+      JsonObject configureObject = JsonParser.parseString(configureResult).getAsJsonObject();
+      assertEquals("success", configureObject.get("status").getAsString(),
+          "Configure temporary storage failed: " + configureResult);
+
+      String result = StatePersistenceRunner.run("{\"action\": \"list\"}");
+      assertNotNull(result);
+      JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
+      assertEquals("success", obj.get("status").getAsString(), "List states failed: " + result);
+      assertEquals(0, obj.get("count").getAsInt());
+    } finally {
+      if (previousAllowExternal == null) {
+        System.clearProperty(allowExternalProperty);
+      } else {
+        System.setProperty(allowExternalProperty, previousAllowExternal);
+      }
+    }
   }
 
   @Test

--- a/src/test/java/neqsim/thermo/system/SystemEOSCGEosCO2SoundSpeedTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemEOSCGEosCO2SoundSpeedTest.java
@@ -18,12 +18,6 @@ public class SystemEOSCGEosCO2SoundSpeedTest extends neqsim.NeqSimTest {
 
     SystemInterface system = new SystemEOSCGEos(temperature, pressure);
     system.addComponent("CO2", 1.0);
-    system.setMixingRule("classic"); // EOS-CG might have its own mixing rule handling, but setting
-    // classic is often safe or ignored if not relevant.
-    // Actually EOS-CG is a specific model, maybe I shouldn't set mixing rule if it defaults
-    // correctly.
-    // Let's check SystemEOSCGEos constructor or init.
-    // The existing test SystemEOSCGEosThermodynamicConsistencyTest doesn't set mixing rule.
 
     ThermodynamicOperations ops = new ThermodynamicOperations(system);
     ops.TPflash();


### PR DESCRIPTION
## Summary

- isolate the MCP state-listing test in a JUnit temporary directory instead of writing below `user.home`
- restore the external-storage system-property override after the test
- keep the pure-CO2 EOS-CG sound-speed test on the model's native setup by removing the unrelated `classic` mixing-rule override

## Root cause

The current fast-suite baseline exposed two deterministic portability failures:

1. `StatePersistenceRunnerTest.testListStates` assumed the process home directory was writable and failed when `/root/.neqsim` was read-only.
2. `SystemEOSCGEosCO2SoundSpeedTest.testCO2SoundSpeed` applied a cubic-EOS mixing rule to EOS-CG; on the local Java 17 build this drove the TP flash to a NaN pressure before sound speed could be evaluated.

Both changes are test-only. They do not change NeqSim production APIs, thermodynamic calculations, or reference results.

## Validation

- `./mvnw -B test -DskipITs -Djacoco.skip=true -ntp`
  - baseline: 12,322 tests; exactly these two failures; 215 skipped
- `./mvnw -B test -Dtest=SystemEOSCGEosCO2SoundSpeedTest,StatePersistenceRunnerTest -Djacoco.skip=true -ntp`
  - 10 tests, 0 failures/errors
- `./mvnw -B test --file pomJava8.xml -Dtest=SystemEOSCGEosCO2SoundSpeedTest,StatePersistenceRunnerTest -Djacoco.skip=true -ntp`
  - 10 tests, 0 failures/errors; Java 8 bytecode compilation passed
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- `git diff --check`

## Documentation impact

None. This is test isolation/setup only; no public behavior or documented workflow changed.