### PR TITLE
[AI-Assisted] Fix aqueous gas-to-liquid cubic-root transition

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -242,6 +242,11 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │     → Replace only with a lower-Gibbs root that already satisfies                │
 │       max |Δ ln(fᵢ)| < 1e-8; phase fractions and compositions stay unchanged     │
 │                                                                                 │
+│  IF multiphase, neutral GAS+AQUEOUS has a lower alternate cubic root:            │
+│     → Evaluate one ordinary candidate from the unchanged feed                    │
+│     → Accept exactly one AQUEOUS plus one GAS/OIL/LIQUID phase; the cubic root   │
+│       may change label only when balance, fugacity, and lower-Gibbs gates pass    │
+│                                                                                 │
 │  IF a final neutral two-phase aqueous endpoint with water feed ≥ 0.01 fails:     │
 │     → Audit max |Δzᵢ| and max |Δ ln(fᵢ)| against 1e-8                            │
 │     → Retain the selected two-phase active set and run at most three              │
@@ -298,7 +303,7 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | CPA one-phase aqueous-stability screen | water feed `< 0.01`, one ordinary phase, CPA model, and `f_water / p_water_sat >= 0.8` | Use the fugacity ratio only as a conservative performance gate for the existing aqueous TPD trial. When the trial adds one phase, rebuild the two-phase active set and require beta-solver residual `< 1e-10`, phase normalization, `1e-8` material/fugacity checks, distinct compositions, and a Gibbs reduction larger than `max(1e-8 J, 1e-12 abs(G))`. The tighter Gibbs tolerance retains independently converged incipient aqueous fractions without treating the saturation screen itself as a stability criterion. |
 | Water-rich material-balance tolerance | 1e-8 in `max abs(Delta z_i)` | Reject a non-conservative reference before comparing feasible Gibbs minima |
 | Dry cubic-root screen and acceptance | Screen normally ordered GAS+OIL endpoints when `max abs(Delta ln(f_i)) >= 1e-8`; accept below `1e-8` | Evaluate both roots for one phase at a time and retain a lower-Gibbs root seed only when the resulting unchanged composition split restores fugacity equality. Inverted mean-molar-mass order retains the paired-root comparison. |
-| Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality |
+| Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Ordinary flashes accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality. A multiphase GAS+AQUEOUS endpoint may replay a lower-Gibbs ordinary candidate containing exactly one AQUEOUS and one cubic GAS/OIL/LIQUID phase, so a valid gas-to-oil root transition is not rejected by its new label. The candidate must additionally retain normalized positive phases, distinct compositions, and component balance below `1e-8`. |
 | Stable-single-phase aqueous-seed gate | `1e-8` in phase-composition normalization | Reject only a structurally invalid aqueous trial whose composition is non-finite, out of `[0, 1]`, or unnormalized; leave normalized endpoints to model-specific convergence and refinement paths |
 | Post-removal aqueous recovery | `1e-8` in `max abs(Delta z_i)` and `max abs(Delta ln(f_i))` | Restore a balanced neutral two-phase aqueous reference only when a rejected third-phase trial leaves the final two-phase endpoint infeasible; genuine three-phase and already feasible endpoints are retained |
 | Final aqueous active-set refinement | water feed `>= 0.01`, or an active aqueous split with `max abs(Delta z_i) > 1e-8`; at most 3 beta refinements; `1e-8` in phase normalization, `max abs(Delta z_i)`, and `max abs(Delta ln(f_i))` | Preserve the selected neutral two-phase active set while correcting stale beta/compositions after phase cleanup or root selection. Trace-water bypass does not run phase search. Roll back unless the result is feasible; also require no Gibbs increase when the reference material balance was valid. |
@@ -1802,13 +1807,14 @@ Commercial process simulators do not publish all implementation details, but pub
   Gibbs energy by more than `max(1e-8 J, 1e-12 abs(G))`. Stable polar aqueous endpoints without condensable
   hydrocarbons stay on the ordinary fast path. Chemical, ionic, solid, wax, and explicit-multiphase calculations are
   excluded.
-- The same strict gate is reciprocal for a water-rich multiphase GAS+AQUEOUS endpoint. If phase-appearance cleanup
-  returns that phase set with a non-finite or at-least `1e-8` log-fugacity residual, one cold ordinary candidate is
-  evaluated from the unchanged feed. It replaces the multiphase endpoint only when it is independently feasible and
-  lowers extensive Gibbs energy beyond `max(1e-6 J, 1e-8 abs(G))`. The accepted ordinary calculation is repeated on the
-  live system to rebuild the cubic/aqueous storage mapping; a recursion guard prevents fallback ping-pong. Genuine
-  OIL+AQUEOUS liquid-liquid endpoints, already-feasible multiphase states, and dry systems do not run the additional
-  flash.
+- The same strict gate is reciprocal for a water-rich multiphase GAS+AQUEOUS endpoint. If its gas phase has a
+  lower-Gibbs alternate cubic root, one ordinary candidate is evaluated from the unchanged feed. It replaces the
+  multiphase endpoint only when it contains exactly one AQUEOUS and one cubic GAS/OIL/LIQUID phase, is independently
+  feasible, and lowers extensive Gibbs energy beyond `max(1e-6 J, 1e-8 abs(G))`. Allowing the cubic phase identity to
+  change prevents a stable liquid root from being rejected merely because the reference endpoint called the same
+  phase GAS. The accepted ordinary calculation is repeated on the live system to rebuild the cubic/aqueous storage
+  mapping; a recursion guard prevents fallback ping-pong. Genuine three-phase endpoints, chemical/electrolyte systems,
+  solid/wax calculations, and dry systems do not run the additional flash.
 - For a neutral non-CPA water-rich asymmetric feed, ordinary and explicit-multiphase calculations retain the cold
   pre-iteration state instead of relying on a clone of a final endpoint. A post-flash clone can preserve collapsed
   phase-storage and cubic-root history even after beta and compositions are reset, causing it to revisit a rejected

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -3575,10 +3575,11 @@ public class TPflash extends Flash {
    * {@link TPmultiflash} can converge a balanced gas/aqueous split on a higher-Gibbs cubic root while the ordinary
    * two-phase path reaches the lower root and a slightly adjusted equilibrium composition. A cheap alternate-root
    * comparison screens the converged gas phase before any retry. Only a lower root beyond numerical noise starts an
-   * ordinary TP flash on a clone; the candidate is replayed on the live system only when it retains exactly gas and
-   * aqueous phases, passes the existing strict phase-fraction, normalization, material-balance, distinct-composition,
-   * and fugacity checks, and lowers total extensive Gibbs energy beyond the same tolerance. Three-phase results and
-   * chemical, electrolyte, solid, and wax calculations remain on their existing paths.
+   * ordinary TP flash on a clone; the candidate is replayed on the live system only when it retains exactly one aqueous
+   * phase and one cubic fluid phase. The cubic phase may change from gas to oil/liquid when the alternate root is
+   * stable. The candidate must still pass the existing strict phase-fraction, normalization, material-balance,
+   * distinct-composition, and fugacity checks, and lower total extensive Gibbs energy beyond the same tolerance.
+   * Three-phase results and chemical, electrolyte, solid, and wax calculations remain on their existing paths.
    * </p>
    */
   private void rescueLowerGibbsMultiphaseAqueousRoot() {
@@ -3597,10 +3598,7 @@ public class TPflash extends Flash {
       candidate.setMultiPhaseCheck(false);
       new TPflash(candidate, false).run();
       candidate.init(1);
-      double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceGibbsEnergy) * 1.0e-8);
-      if (candidate.getNumberOfPhases() == 2 && candidate.hasPhaseType(PhaseType.GAS)
-          && candidate.hasPhaseType(PhaseType.AQUEOUS) && isBalancedEquilibriumCandidate(candidate)
-          && candidate.getGibbsEnergy() < referenceGibbsEnergy - gibbsTolerance) {
+      if (isLowerGibbsMultiphaseAqueousRootCandidate(candidate, referenceGibbsEnergy)) {
         runAcceptedOrdinaryWaterRichFallback(candidate);
       }
     } catch (Exception ex) {
@@ -3608,6 +3606,34 @@ public class TPflash extends Flash {
     } finally {
       MULTIPHASE_RESCUE_ACTIVE.set(Boolean.FALSE);
     }
+  }
+
+  /**
+   * Checks an ordinary candidate for the reciprocal multiphase aqueous-root rescue.
+   *
+   * @param candidate ordinary TP flash candidate
+   * @param referenceGibbsEnergy Gibbs energy of the multiphase reference endpoint
+   * @return true when the candidate retains the expected topology, is feasible, and lowers Gibbs energy
+   */
+  boolean isLowerGibbsMultiphaseAqueousRootCandidate(SystemInterface candidate, double referenceGibbsEnergy) {
+    if (candidate.getNumberOfPhases() != 2 || !candidate.hasPhaseType(PhaseType.AQUEOUS)) {
+      return false;
+    }
+    int aqueousPhaseCount = 0;
+    int cubicFluidPhaseCount = 0;
+    for (int phaseIndex = 0; phaseIndex < candidate.getNumberOfPhases(); phaseIndex++) {
+      PhaseType phaseType = candidate.getPhase(phaseIndex).getType();
+      if (phaseType == PhaseType.AQUEOUS) {
+        aqueousPhaseCount++;
+      } else if (phaseType == PhaseType.GAS || phaseType == PhaseType.OIL || phaseType == PhaseType.LIQUID) {
+        cubicFluidPhaseCount++;
+      } else {
+        return false;
+      }
+    }
+    double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceGibbsEnergy) * 1.0e-8);
+    return aqueousPhaseCount == 1 && cubicFluidPhaseCount == 1 && isBalancedEquilibriumCandidate(candidate)
+        && candidate.getGibbsEnergy() < referenceGibbsEnergy - gibbsTolerance;
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousRootTransitionCandidateTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousRootTransitionCandidateTest.java
@@ -1,0 +1,104 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermo.system.SystemPrEos1978;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class TPflashAqueousRootTransitionCandidateTest {
+  @Test
+  void acceptsLowerGibbsOilAqueousCandidateAcrossSeparatorPressures() {
+    for (double pressureBara : new double[] { 2.10, 1.62, 1.20, 0.74 }) {
+      SystemInterface candidate = createOilAqueousCandidate(pressureBara);
+      TPflash flash = new TPflash(candidate.clone(), false);
+      double referenceGibbsEnergy = candidate.getGibbsEnergy() + 1.0;
+
+      assertTrue(candidate.hasPhaseType(PhaseType.OIL));
+      assertTrue(candidate.hasPhaseType(PhaseType.AQUEOUS));
+      assertTrue(flash.isLowerGibbsMultiphaseAqueousRootCandidate(candidate, referenceGibbsEnergy),
+          "lower-Gibbs OIL+AQUEOUS candidate was rejected at " + pressureBara + " bara");
+      assertFalse(flash.isLowerGibbsMultiphaseAqueousRootCandidate(candidate, candidate.getGibbsEnergy() - 1.0),
+          "higher-Gibbs candidate was accepted at " + pressureBara + " bara");
+    }
+  }
+
+  @Test
+  void acceptsGasAqueousCandidateButRejectsOtherPhaseTopologies() {
+    SystemInterface gasAqueous = createSrkCandidate(260.0, 100.0);
+    TPflash flash = new TPflash(gasAqueous.clone(), false);
+
+    assertTrue(flash.isLowerGibbsMultiphaseAqueousRootCandidate(gasAqueous, gasAqueous.getGibbsEnergy() + 1.0));
+
+    SystemInterface threePhase = createSrkCandidate(255.0, 90.0);
+    assertFalse(flash.isLowerGibbsMultiphaseAqueousRootCandidate(threePhase, threePhase.getGibbsEnergy() + 1.0));
+
+    SystemInterface dryGasOil = createDryGasOilCandidate();
+    assertTrue(dryGasOil.hasPhaseType(PhaseType.GAS));
+    assertTrue(dryGasOil.hasPhaseType(PhaseType.OIL));
+    assertFalse(flash.isLowerGibbsMultiphaseAqueousRootCandidate(dryGasOil, dryGasOil.getGibbsEnergy() + 1.0));
+  }
+
+  private SystemInterface createDryGasOilCandidate() {
+    SystemInterface system = new SystemPrEos(220.0, 100.0);
+    system.addComponent("methane", 0.72);
+    system.addComponent("ethane", 0.08);
+    system.addComponent("propane", 0.05);
+    system.addComponent("n-heptane", 0.10);
+    system.addComponent("nC10", 0.05);
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(true);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(3);
+    return system;
+  }
+
+  private SystemInterface createOilAqueousCandidate(double pressureBara) {
+    SystemInterface feed = new SystemPrEos1978(273.15 + 30.0, pressureBara);
+    addSeparatorFeed(feed);
+    feed.setMixingRule("classic");
+    feed.setMultiPhaseCheck(true);
+    new ThermodynamicOperations(feed).TPflash();
+
+    SystemInterface candidate = feed.phaseToSystem(feed.getPhaseNumberOfPhase(PhaseType.OIL),
+        feed.getPhaseNumberOfPhase(PhaseType.AQUEOUS));
+    candidate.setMultiPhaseCheck(true);
+    candidate.setTemperature(273.15 + 30.0);
+    candidate.setPressure(pressureBara, "bara");
+    new ThermodynamicOperations(candidate).TPflash();
+    candidate.init(3);
+    return candidate;
+  }
+
+  private SystemInterface createSrkCandidate(double temperatureK, double pressureBara) {
+    SystemInterface system = new SystemSrkEos(temperatureK, pressureBara);
+    system.addComponent("CO2", 0.543865141103918);
+    system.addComponent("methane", 0.2937712952303271);
+    system.addComponent("ethane", 0.07010605470616459);
+    system.addComponent("water", 0.09225750895959021);
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(true);
+    new ThermodynamicOperations(system).TPflash();
+    system.init(3);
+    return system;
+  }
+
+  private void addSeparatorFeed(SystemInterface system) {
+    system.addComponent("methane", 0.0034);
+    system.addComponent("ethane", 0.0038);
+    system.addComponent("propane", 0.0406);
+    system.addComponent("i-butane", 0.0339);
+    system.addComponent("n-butane", 0.1114);
+    system.addComponent("i-pentane", 0.0536);
+    system.addComponent("n-pentane", 0.0733);
+    system.addComponent("n-hexane", 0.0681);
+    system.addComponent("n-heptane", 0.0637);
+    system.addComponent("n-octane", 0.0365);
+    system.addComponent("nC10", 0.0172);
+    system.addComponent("water", 0.4945);
+  }
+}


### PR DESCRIPTION
## Summary

- accept a reciprocal aqueous-root candidate when it contains exactly one `AQUEOUS` phase and one cubic `GAS`, `OIL`, or `LIQUID` phase
- preserve the existing positive/normalized phase, distinct-composition, material-balance, fugacity-equality, and lower-Gibbs acceptance gates
- document the permitted gas-to-oil phase-identity transition and its safeguards

## Root cause and scope

The multiphase rescue correctly detects a lower alternate cubic root in a neutral `GAS+AQUEOUS` endpoint and evaluates an ordinary TP-flash candidate from the unchanged feed. Its final acceptance condition nevertheless required that the candidate still be `GAS+AQUEOUS`. A thermodynamically valid candidate whose cubic phase changes to the stable liquid root (`OIL+AQUEOUS`) was therefore discarded solely because its phase label changed.

This is broader than one scrubber characterization: it affects neutral SRK/PR-family water-bearing endpoints whenever the reciprocal calculation crosses the cubic gas/liquid root identity. The only other hard `GAS+AQUEOUS` gate found in `TPflash` belongs to the ionic gas/aqueous closure and is intentionally unchanged.

The exact 3.16.0→3.17.0 introducing commit cannot be proven without the proprietary E300 characterization. Public PR78 characterizations with the issue compositions do not reproduce the release flip, which confirms that pseudo-component properties/BIPs are part of the trigger. The current-master rejection is deterministic and directly covered here.

## Verification

The new regression test failed before the topology fix because balanced, lower-Gibbs `OIL+AQUEOUS` candidates were rejected. It now covers:

- PR78 oil/aqueous candidates at 2.10, 1.62, 1.20, and 0.74 bara
- retained `GAS+AQUEOUS` acceptance
- rejection of higher-Gibbs, dry `GAS+OIL`, and genuine three-phase candidates

Validation completed locally:

- all 32 `TPflash`/`TPFlash` test classes
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`

## Documentation impact

`docs/thermodynamicoperations/TPflash_algorithm.md` now describes the reciprocal aqueous cubic-root transition and its unchanged thermodynamic gates.

Relates to #3274. Exact asset-case verification is requested on the issue before it is closed.