### PR TITLE
[AI-Assisted] Compare assessed DEXPI package revisions

### DIFF
--- a/docs/integration/dexpi-20-conformance.md
+++ b/docs/integration/dexpi-20-conformance.md
@@ -148,6 +148,26 @@ area XML, and immutable material/energy/signal connection evidence. It deliberat
 files, reconstruct or execute a `ProcessModel`, reinterpret manifest-only connections as native
 DEXPI Process relationships, or change the engineering approval state.
 
+Compare two valid snapshots when a controlled revision needs machine-readable intake evidence:
+
+```java
+Dexpi20ProcessModelPackageRevisionImpact impact =
+    Dexpi20ProcessModelPackageRevisionImpact.compare(baselineSnapshot, revisedSnapshot);
+if (!impact.isConnectionTopologyEquivalent()) {
+  Files.write(Paths.get("facility-process-model.revision-impact.json"),
+      impact.toJson().getBytes(StandardCharsets.UTF_8));
+}
+```
+
+The revision-impact report classifies every stable area and material/energy/signal connection as
+`ADDED`, `REMOVED`, `MODIFIED`, or `UNCHANGED`. Exact package, manifest, canonical, and
+per-area XML SHA-256 evidence remains separate from stable area-identity and assessed connection
+equivalence. This prevents a controlled revision or case change from being mislabeled as a
+topology change while still retaining byte-level document evidence. Comparison requires the same
+plant identity and always returns `REVIEW_REQUIRED`,
+`engineeringReviewRequired=true`, `fitnessForConstruction=false`, and
+`nativeWholePlantDexpiExchange=false`; it is revision evidence, not an MOC decision or approval.
+
 The single-area assessed path reports energy and signal connections, multi-area `ProcessModel`
 hierarchy, controlled document/sheet semantics, and drawing graphics as unsupported scopes. These
 warnings do not hide a supported material-topology error; missing, unexpected, unresolved-port, and

--- a/docs/integration/dexpi-pid-current-master-audit.md
+++ b/docs/integration/dexpi-pid-current-master-audit.md
@@ -31,7 +31,7 @@ test, fixture, example, and qualification surfaces required by issue #2899.
 | Proteus-compatible export | `processmodel.dexpi.DexpiXmlWriter`, compatibility facade `processmodel.DexpiXmlWriter` | `ProcessSystem`, `ProcessModel`, pyDEXPI namespace-omitted output, layout and compatibility sheets | Not native DEXPI 2.0; sheets are not a controlled drawing set |
 | Proteus-compatible import | `DexpiXmlReader`, `DexpiTopologyResolver`, `DexpiEquipmentFactory`, `DexpiSimulationBuilder` | Equipment, nozzles, piping segments, instruments, mappings, and a runnable process scaffold | Imported topology still requires fluid, cases, specifications, dynamics, and accountable review |
 | Native DEXPI 2.0 Plant | `Dexpi20XmlWriter`, `Dexpi20EngineeringMaterializer` | Core/Plant items, piping, nozzles, instrumentation, safeguards, boundaries, and representations | Plant exchange is not Process/PFD exchange or a DEXPI EV certificate |
-| Native DEXPI 2.0 Process | `Dexpi20ProcessModelWriter`, `Dexpi20ProcessTopologyAssessment`, `Dexpi20ProcessModelPackageWriter`, `Dexpi20ProcessModelPackageAssessment`, `Dexpi20ProcessModelPackageReader` | Process steps, explicit material ports, streams, selected physical quantities, canonical topology assessment, deterministic assessed per-area packages, and immutable exact-content intake snapshots | The reader exposes defensive per-area XML plus assessed material/energy/information connection evidence; it does not reconstruct a `ProcessModel`, promote manifest-only relationships to native whole-plant DEXPI, or combine graphics/document scopes |
+| Native DEXPI 2.0 Process | `Dexpi20ProcessModelWriter`, `Dexpi20ProcessTopologyAssessment`, `Dexpi20ProcessModelPackageWriter`, `Dexpi20ProcessModelPackageAssessment`, `Dexpi20ProcessModelPackageReader`, `Dexpi20ProcessModelPackageRevisionImpact` | Process steps, explicit material ports, streams, selected physical quantities, canonical topology assessment, deterministic assessed per-area packages, immutable exact-content intake snapshots, and package-to-package area/connection revision evidence | Intake and revision APIs expose defensive per-area XML plus assessed material/energy/information connection evidence; they do not reconstruct a `ProcessModel`, promote manifest-only relationships to native whole-plant DEXPI, decide MOC, or combine graphics/document scopes |
 | Common model helpers | `DexpiMetadata`, `DexpiStream`, `DexpiProcessUnit`, `DexpiInstrumentInfo`, `DexpiStreamUtils`, `DexpiServiceClassifier`, `NorsokLineNumber` | Metadata, supported object classification, line/tag helpers, and compatibility DTOs | These helpers do not constitute a shared immutable drawing/document model |
 | Round-trip profile | `DexpiRoundTripProfile`, `EngineeringDexpiRoundTripQualifier` | Internal structural identity/reference comparison and explicit qualification status | Internal round trip is weaker than named-product import/export evidence |
 
@@ -78,6 +78,7 @@ Dexpi20ProcessModelWriterTest
 Dexpi20ProcessModelPackageWriterTest
 Dexpi20ProcessModelPackageAssessmentTest
 Dexpi20ProcessModelPackageReaderTest
+Dexpi20ProcessModelPackageRevisionImpactTest
 Dexpi20SemanticValidatorTest
 DexpiXmlWriterTest
 DexpiXmlReaderTest
@@ -173,7 +174,7 @@ licensed standards, a named external tool, or accountable engineering review.
 | Deterministic ProcessSystem/ProcessModel export | Partial | Canonical topology and native Process exports are deterministic in tested subsets; `ProcessModel` packaging adds assessed area XML, hashes, a plant manifest, fail-closed offline reassessment, and a serializable exact-content intake snapshot, while cross-area/energy/information semantics remain manifest-only rather than native whole-plant DEXPI |
 | Export-import-export semantic equivalence and loss | Partial | Assessed package intake now preserves exact per-area XML and independently validated connection/loss status without path extraction; no runnable `ProcessModel` reconstruction is inferred, and full Plant/Process/P&ID round trip remains incomplete |
 | Schema/API compatibility and migration | Partial | Compatibility facades and byte-equivalent tested paths exist; no comprehensive versioned package migration suite covers every serialized artifact |
-| Revision semantic diff/impact | Partial | Engineering graph/package revision impact exists; affected drawing/sheet/register/study completeness is not yet end-to-end |
+| Revision semantic diff/impact | Partial | Controlled document-set semantic-object impact and assessed multi-area package area/connection impact now exist with deterministic JSON and review-required boundaries; cross-artifact drawing/sheet/register/study completeness is not yet end-to-end |
 | Professional symbols and project conventions | Partial/external | Proteus shapes, ISA/NORSOK tag helpers and proposal rules exist; a licensed ISO 10628/14617 mapping and reviewed vector catalog remain external/gap |
 | Native DEXPI Core graphical projection | Assessed supported subset | The opt-in exchange-neutral adapter emits non-empty Core Diagram/RepresentationGroup structures with generic Polygon, PolyLine, and Text primitives. `Dexpi20GraphicalProjectionAssessment` verifies stable represented identities, mapped geometry/style, diagram metadata/bounds, exact-file SHA-256 provenance, and explicit losses; no Profile/SymbolUsage, clean external-validator, standards, or approval claim is made |
 | Multi-sheet documents and off-page references | Implemented foundation | `EngineeringDiagramDocumentSet` owns deterministic drawing/sheet IDs, controlled references, paired off-page connectors, zones, revision/status metadata, validation, and restartable layout overrides; accountable completeness and project-specific approval remain external |
@@ -198,8 +199,7 @@ legally distributable DEXPI profile-symbol catalogue. Empty placeholder represen
 invented standards mappings are not acceptable substitutes.
 
 Independent remaining work includes reviewed reconstruction of assessed area exchanges into a runnable model, native
-whole-plant Process hierarchy and native energy/information mappings beyond manifest-only package evidence, end-to-end
-revision/MOC impact, broader P&ID object coverage, a reviewed visual-reference corpus,
+whole-plant Process hierarchy and native energy/information mappings beyond manifest-only package evidence, cross-artifact drawing/register/study revision-MOC impact, broader P&ID object coverage, a reviewed visual-reference corpus,
 fresh exact-version external DEXPIViewer execution, and named commercial-CAE qualification. These
 items must retain legacy DOT/Graphviz, native DEXPI 2.0, and Proteus/P&ID compatibility and must not
 be reported as standards conformance or drawing approval without accountable evidence.

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpact.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpact.java
@@ -1,0 +1,635 @@
+package neqsim.process.processmodel.dexpi;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * Deterministic revision-impact evidence between two valid assessed multi-area DEXPI Process
+ * packages.
+ *
+ * <p>
+ * The comparison operates only on immutable snapshots returned by
+ * {@link Dexpi20ProcessModelPackageReader}. It distinguishes exact package-byte changes,
+ * per-area native DEXPI Process document changes, stable area-identity changes, and plant-wide
+ * material, energy, or signal connection changes. It does not reconstruct or execute a process
+ * model, infer native whole-plant DEXPI relationships, approve a drawing, or determine fitness for
+ * construction.
+ * </p>
+ */
+public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private static final Gson GSON = new Gson();
+  public static final String SCHEMA_VERSION =
+      "neqsim_dexpi_2_0_process_model_package_revision_impact.v1";
+
+  /** Overall comparison status. */
+  public enum Status {
+    /** Package content and assessed evidence are unchanged. */
+    UNCHANGED,
+    /** At least one area document, identity, or connection changed. */
+    CHANGED
+  }
+
+  /** Per-identity comparison outcome. */
+  public enum ChangeType {
+    /** Identity exists only in the revised package. */
+    ADDED,
+    /** Identity exists only in the baseline package. */
+    REMOVED,
+    /** Identity exists in both packages but assessed content changed. */
+    MODIFIED,
+    /** Identity and assessed content are unchanged. */
+    UNCHANGED
+  }
+
+  /** Immutable state of one assessed area document. */
+  public static final class AreaState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String areaId;
+    private final String areaName;
+    private final String entryName;
+    private final String fileSha256;
+    private final int byteLength;
+
+    AreaState(Dexpi20ProcessModelPackageReader.AreaDocument area) {
+      areaId = area.getAreaId();
+      areaName = area.getAreaName();
+      entryName = area.getEntryName();
+      fileSha256 = area.getFileSha256();
+      byteLength = area.getByteLength();
+    }
+
+    public String getAreaId() {
+      return areaId;
+    }
+
+    public String getAreaName() {
+      return areaName;
+    }
+
+    public String getEntryName() {
+      return entryName;
+    }
+
+    public String getFileSha256() {
+      return fileSha256;
+    }
+
+    public int getByteLength() {
+      return byteLength;
+    }
+
+    /** @return deterministic machine-readable area state */
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("areaId", areaId);
+      result.put("areaName", areaName);
+      result.put("entryName", entryName);
+      result.put("fileSha256", fileSha256);
+      result.put("byteLength", Integer.valueOf(byteLength));
+      return result;
+    }
+
+    boolean sameAs(AreaState other) {
+      return other != null && sameText(areaId, other.areaId) && sameText(areaName, other.areaName)
+          && sameText(entryName, other.entryName) && sameText(fileSha256, other.fileSha256)
+          && byteLength == other.byteLength;
+    }
+  }
+
+  /** Immutable state of one assessed plant-wide connection. */
+  public static final class ConnectionState implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String connectionId;
+    private final String connectionType;
+    private final String sourceArea;
+    private final String targetArea;
+    private final String sourceEquipment;
+    private final String targetEquipment;
+    private final String sourcePort;
+    private final String targetPort;
+    private final boolean crossArea;
+    private final boolean recycle;
+    private final String exchangeStatus;
+
+    ConnectionState(Dexpi20ProcessModelPackageAssessment.ConnectionEvidence connection) {
+      connectionId = connection.getConnectionId();
+      connectionType = connection.getConnectionType();
+      sourceArea = connection.getSourceArea();
+      targetArea = connection.getTargetArea();
+      sourceEquipment = connection.getSourceEquipment();
+      targetEquipment = connection.getTargetEquipment();
+      sourcePort = connection.getSourcePort();
+      targetPort = connection.getTargetPort();
+      crossArea = connection.isCrossArea();
+      recycle = connection.isRecycle();
+      exchangeStatus = connection.getExchangeStatus();
+    }
+
+    public String getConnectionId() {
+      return connectionId;
+    }
+
+    public String getConnectionType() {
+      return connectionType;
+    }
+
+    public String getSourceArea() {
+      return sourceArea;
+    }
+
+    public String getTargetArea() {
+      return targetArea;
+    }
+
+    public String getSourceEquipment() {
+      return sourceEquipment;
+    }
+
+    public String getTargetEquipment() {
+      return targetEquipment;
+    }
+
+    public String getSourcePort() {
+      return sourcePort;
+    }
+
+    public String getTargetPort() {
+      return targetPort;
+    }
+
+    public boolean isCrossArea() {
+      return crossArea;
+    }
+
+    public boolean isRecycle() {
+      return recycle;
+    }
+
+    public String getExchangeStatus() {
+      return exchangeStatus;
+    }
+
+    /** @return deterministic machine-readable connection state */
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("connectionId", connectionId);
+      result.put("connectionType", connectionType);
+      result.put("sourceArea", sourceArea);
+      result.put("targetArea", targetArea);
+      result.put("sourceEquipment", sourceEquipment);
+      result.put("targetEquipment", targetEquipment);
+      result.put("sourcePort", sourcePort);
+      result.put("targetPort", targetPort);
+      result.put("crossArea", Boolean.valueOf(crossArea));
+      result.put("recycle", Boolean.valueOf(recycle));
+      result.put("exchangeStatus", exchangeStatus);
+      return result;
+    }
+
+    boolean sameAs(ConnectionState other) {
+      return other != null && sameText(connectionId, other.connectionId)
+          && sameText(connectionType, other.connectionType) && sameText(sourceArea, other.sourceArea)
+          && sameText(targetArea, other.targetArea)
+          && sameText(sourceEquipment, other.sourceEquipment)
+          && sameText(targetEquipment, other.targetEquipment)
+          && sameText(sourcePort, other.sourcePort) && sameText(targetPort, other.targetPort)
+          && crossArea == other.crossArea && recycle == other.recycle
+          && sameText(exchangeStatus, other.exchangeStatus);
+    }
+  }
+
+  /** Immutable revision delta for one stable area identity. */
+  public static final class AreaChange implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String areaId;
+    private final ChangeType changeType;
+    private final AreaState baseline;
+    private final AreaState revised;
+
+    AreaChange(String areaId, ChangeType changeType, AreaState baseline, AreaState revised) {
+      this.areaId = areaId;
+      this.changeType = changeType;
+      this.baseline = baseline;
+      this.revised = revised;
+    }
+
+    public String getAreaId() {
+      return areaId;
+    }
+
+    public ChangeType getChangeType() {
+      return changeType;
+    }
+
+    public AreaState getBaseline() {
+      return baseline;
+    }
+
+    public AreaState getRevised() {
+      return revised;
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("areaId", areaId);
+      result.put("changeType", changeType.name());
+      result.put("baseline", baseline == null ? null : baseline.toMap());
+      result.put("revised", revised == null ? null : revised.toMap());
+      return result;
+    }
+  }
+
+  /** Immutable revision delta for one stable plant-wide connection identity. */
+  public static final class ConnectionChange implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String connectionId;
+    private final ChangeType changeType;
+    private final ConnectionState baseline;
+    private final ConnectionState revised;
+
+    ConnectionChange(String connectionId, ChangeType changeType, ConnectionState baseline,
+        ConnectionState revised) {
+      this.connectionId = connectionId;
+      this.changeType = changeType;
+      this.baseline = baseline;
+      this.revised = revised;
+    }
+
+    public String getConnectionId() {
+      return connectionId;
+    }
+
+    public ChangeType getChangeType() {
+      return changeType;
+    }
+
+    public ConnectionState getBaseline() {
+      return baseline;
+    }
+
+    public ConnectionState getRevised() {
+      return revised;
+    }
+
+    Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("connectionId", connectionId);
+      result.put("changeType", changeType.name());
+      result.put("baseline", baseline == null ? null : baseline.toMap());
+      result.put("revised", revised == null ? null : revised.toMap());
+      return result;
+    }
+  }
+
+  private final String plantId;
+  private final String baselineRevision;
+  private final String revisedRevision;
+  private final String baselineOperatingCaseId;
+  private final String revisedOperatingCaseId;
+  private final String baselinePackageFileSha256;
+  private final String revisedPackageFileSha256;
+  private final String baselineManifestSha256;
+  private final String revisedManifestSha256;
+  private final String baselineCanonicalFingerprint;
+  private final String revisedCanonicalFingerprint;
+  private final List<AreaChange> areaChanges;
+  private final List<ConnectionChange> connectionChanges;
+  private final Status status;
+
+  private Dexpi20ProcessModelPackageRevisionImpact(
+      Dexpi20ProcessModelPackageReader.Snapshot baseline,
+      Dexpi20ProcessModelPackageReader.Snapshot revised, List<AreaChange> areaChanges,
+      List<ConnectionChange> connectionChanges) {
+    plantId = baseline.getPlantId();
+    baselineRevision = baseline.getRevision();
+    revisedRevision = revised.getRevision();
+    baselineOperatingCaseId = baseline.getOperatingCaseId();
+    revisedOperatingCaseId = revised.getOperatingCaseId();
+    baselinePackageFileSha256 = baseline.getPackageFileSha256();
+    revisedPackageFileSha256 = revised.getPackageFileSha256();
+    baselineManifestSha256 = baseline.getManifestSha256();
+    revisedManifestSha256 = revised.getManifestSha256();
+    baselineCanonicalFingerprint = baseline.getCanonicalFingerprint();
+    revisedCanonicalFingerprint = revised.getCanonicalFingerprint();
+    this.areaChanges = immutableAreaChanges(areaChanges);
+    this.connectionChanges = immutableConnectionChanges(connectionChanges);
+    status = countChangedAreas(areaChanges) == 0 && countChangedConnections(connectionChanges) == 0
+        && sameText(baselinePackageFileSha256, revisedPackageFileSha256) ? Status.UNCHANGED
+            : Status.CHANGED;
+  }
+
+  /**
+   * Compares two valid assessed snapshots for the same controlled plant identity.
+   *
+   * @param baseline immutable baseline package snapshot
+   * @param revised immutable revised package snapshot
+   * @return deterministic package revision impact
+   */
+  public static Dexpi20ProcessModelPackageRevisionImpact compare(
+      Dexpi20ProcessModelPackageReader.Snapshot baseline,
+      Dexpi20ProcessModelPackageReader.Snapshot revised) {
+    if (baseline == null || revised == null) {
+      throw new IllegalArgumentException("baseline and revised must not be null");
+    }
+    if (!sameText(baseline.getPlantId(), revised.getPlantId())) {
+      throw new IllegalArgumentException("Package revision impact requires the same plant identity");
+    }
+
+    Map<String, AreaState> baselineAreas = areasById(baseline);
+    Map<String, AreaState> revisedAreas = areasById(revised);
+    Set<String> areaIds = new TreeSet<String>();
+    areaIds.addAll(baselineAreas.keySet());
+    areaIds.addAll(revisedAreas.keySet());
+    List<AreaChange> areas = new ArrayList<AreaChange>();
+    for (String areaId : areaIds) {
+      AreaState before = baselineAreas.get(areaId);
+      AreaState after = revisedAreas.get(areaId);
+      areas.add(new AreaChange(areaId, changeType(before, after), before, after));
+    }
+
+    Map<String, ConnectionState> baselineConnections = connectionsById(baseline);
+    Map<String, ConnectionState> revisedConnections = connectionsById(revised);
+    Set<String> connectionIds = new TreeSet<String>();
+    connectionIds.addAll(baselineConnections.keySet());
+    connectionIds.addAll(revisedConnections.keySet());
+    List<ConnectionChange> connections = new ArrayList<ConnectionChange>();
+    for (String connectionId : connectionIds) {
+      ConnectionState before = baselineConnections.get(connectionId);
+      ConnectionState after = revisedConnections.get(connectionId);
+      connections
+          .add(new ConnectionChange(connectionId, changeType(before, after), before, after));
+    }
+    return new Dexpi20ProcessModelPackageRevisionImpact(baseline, revised, areas, connections);
+  }
+
+  public String getPlantId() {
+    return plantId;
+  }
+
+  public String getBaselineRevision() {
+    return baselineRevision;
+  }
+
+  public String getRevisedRevision() {
+    return revisedRevision;
+  }
+
+  public String getBaselineOperatingCaseId() {
+    return baselineOperatingCaseId;
+  }
+
+  public String getRevisedOperatingCaseId() {
+    return revisedOperatingCaseId;
+  }
+
+  public String getBaselinePackageFileSha256() {
+    return baselinePackageFileSha256;
+  }
+
+  public String getRevisedPackageFileSha256() {
+    return revisedPackageFileSha256;
+  }
+
+  public String getBaselineManifestSha256() {
+    return baselineManifestSha256;
+  }
+
+  public String getRevisedManifestSha256() {
+    return revisedManifestSha256;
+  }
+
+  public String getBaselineCanonicalFingerprint() {
+    return baselineCanonicalFingerprint;
+  }
+
+  public String getRevisedCanonicalFingerprint() {
+    return revisedCanonicalFingerprint;
+  }
+
+  public Status getStatus() {
+    return status;
+  }
+
+  public List<AreaChange> getAreaChanges() {
+    return immutableAreaChanges(areaChanges);
+  }
+
+  public List<ConnectionChange> getConnectionChanges() {
+    return immutableConnectionChanges(connectionChanges);
+  }
+
+  public int getChangedAreaCount() {
+    return countChangedAreas(areaChanges);
+  }
+
+  public int getChangedConnectionCount() {
+    return countChangedConnections(connectionChanges);
+  }
+
+  public boolean isExactPackageMatch() {
+    return sameText(baselinePackageFileSha256, revisedPackageFileSha256);
+  }
+
+  /**
+   * Reports whether the stable area identity set is unchanged.
+   *
+   * <p>
+   * Area XML may still differ when this method returns true.
+   * </p>
+   *
+   * @return true when no area identity was added or removed
+   */
+  public boolean isAreaIdentitySetEquivalent() {
+    for (AreaChange change : areaChanges) {
+      if (change.getChangeType() == ChangeType.ADDED
+          || change.getChangeType() == ChangeType.REMOVED) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Reports whether all assessed material, energy, and signal connection evidence is unchanged.
+   *
+   * @return true when no connection was added, removed, or modified
+   */
+  public boolean isConnectionTopologyEquivalent() {
+    return countChangedConnections(connectionChanges) == 0;
+  }
+
+  /** @return always {@code REVIEW_REQUIRED} */
+  public String getApprovalStatus() {
+    return "REVIEW_REQUIRED";
+  }
+
+  /** @return always true; software evidence cannot approve an engineering revision */
+  public boolean isEngineeringReviewRequired() {
+    return true;
+  }
+
+  /** @return always false */
+  public boolean isFitnessForConstruction() {
+    return false;
+  }
+
+  /** @return always false */
+  public boolean isNativeWholePlantDexpiExchange() {
+    return false;
+  }
+
+  /** @return deterministic machine-readable revision-impact representation */
+  public Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("schemaVersion", SCHEMA_VERSION);
+    result.put("plantId", plantId);
+    result.put("baselineRevision", baselineRevision);
+    result.put("revisedRevision", revisedRevision);
+    if (baselineOperatingCaseId != null) {
+      result.put("baselineOperatingCaseId", baselineOperatingCaseId);
+    }
+    if (revisedOperatingCaseId != null) {
+      result.put("revisedOperatingCaseId", revisedOperatingCaseId);
+    }
+    result.put("baselinePackageFileSha256", baselinePackageFileSha256);
+    result.put("revisedPackageFileSha256", revisedPackageFileSha256);
+    result.put("baselineManifestSha256", baselineManifestSha256);
+    result.put("revisedManifestSha256", revisedManifestSha256);
+    result.put("baselineCanonicalFingerprint", baselineCanonicalFingerprint);
+    result.put("revisedCanonicalFingerprint", revisedCanonicalFingerprint);
+    result.put("status", status.name());
+    result.put("exactPackageMatch", Boolean.valueOf(isExactPackageMatch()));
+    result.put("areaIdentitySetEquivalent", Boolean.valueOf(isAreaIdentitySetEquivalent()));
+    result.put("connectionTopologyEquivalent",
+        Boolean.valueOf(isConnectionTopologyEquivalent()));
+    result.put("changedAreaCount", Integer.valueOf(getChangedAreaCount()));
+    result.put("changedConnectionCount", Integer.valueOf(getChangedConnectionCount()));
+    List<Map<String, Object>> areas = new ArrayList<Map<String, Object>>();
+    for (AreaChange change : areaChanges) {
+      areas.add(change.toMap());
+    }
+    result.put("areaChanges", areas);
+    List<Map<String, Object>> connections = new ArrayList<Map<String, Object>>();
+    for (ConnectionChange change : connectionChanges) {
+      connections.add(change.toMap());
+    }
+    result.put("connectionChanges", connections);
+    result.put("approvalStatus", getApprovalStatus());
+    result.put("engineeringReviewRequired", Boolean.TRUE);
+    result.put("fitnessForConstruction", Boolean.FALSE);
+    result.put("nativeWholePlantDexpiExchange", Boolean.FALSE);
+    result.put("scope",
+        "Exact assessed package, per-area native DEXPI Process document, stable area identity, "
+            + "and manifest connection revision evidence");
+    result.put("fingerprint", fingerprint(result));
+    return result;
+  }
+
+  /** @return pretty-printed deterministic JSON */
+  public String toJson() {
+    return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+  }
+
+  private static Map<String, AreaState> areasById(
+      Dexpi20ProcessModelPackageReader.Snapshot snapshot) {
+    Map<String, AreaState> result = new TreeMap<String, AreaState>();
+    for (Dexpi20ProcessModelPackageReader.AreaDocument area : snapshot.getAreaDocuments()) {
+      result.put(area.getAreaId(), new AreaState(area));
+    }
+    return result;
+  }
+
+  private static Map<String, ConnectionState> connectionsById(
+      Dexpi20ProcessModelPackageReader.Snapshot snapshot) {
+    Map<String, ConnectionState> result = new TreeMap<String, ConnectionState>();
+    for (Dexpi20ProcessModelPackageAssessment.ConnectionEvidence connection : snapshot
+        .getConnectionEvidence()) {
+      result.put(connection.getConnectionId(), new ConnectionState(connection));
+    }
+    return result;
+  }
+
+  private static ChangeType changeType(AreaState baseline, AreaState revised) {
+    if (baseline == null) {
+      return ChangeType.ADDED;
+    }
+    if (revised == null) {
+      return ChangeType.REMOVED;
+    }
+    return baseline.sameAs(revised) ? ChangeType.UNCHANGED : ChangeType.MODIFIED;
+  }
+
+  private static ChangeType changeType(ConnectionState baseline, ConnectionState revised) {
+    if (baseline == null) {
+      return ChangeType.ADDED;
+    }
+    if (revised == null) {
+      return ChangeType.REMOVED;
+    }
+    return baseline.sameAs(revised) ? ChangeType.UNCHANGED : ChangeType.MODIFIED;
+  }
+
+  private static int countChangedAreas(List<AreaChange> changes) {
+    int count = 0;
+    for (AreaChange change : changes) {
+      if (change.getChangeType() != ChangeType.UNCHANGED) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static int countChangedConnections(List<ConnectionChange> changes) {
+    int count = 0;
+    for (ConnectionChange change : changes) {
+      if (change.getChangeType() != ChangeType.UNCHANGED) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static List<AreaChange> immutableAreaChanges(List<AreaChange> changes) {
+    return Collections.unmodifiableList(new ArrayList<AreaChange>(changes));
+  }
+
+  private static List<ConnectionChange> immutableConnectionChanges(
+      List<ConnectionChange> changes) {
+    return Collections.unmodifiableList(new ArrayList<ConnectionChange>(changes));
+  }
+
+  private static boolean sameText(String first, String second) {
+    return first == null ? second == null : first.equals(second);
+  }
+
+  private static String fingerprint(Map<String, Object> map) {
+    Map<String, Object> content = new LinkedHashMap<String, Object>(map);
+    content.remove("fingerprint");
+    byte[] bytes = GSON.toJson(content).getBytes(StandardCharsets.UTF_8);
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(bytes);
+      StringBuilder result = new StringBuilder();
+      for (byte value : hash) {
+        result.append(String.format(Locale.ROOT, "%02x", value & 0xff));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is not available", exception);
+    }
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpact.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpact.java
@@ -615,4 +615,3 @@ public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializa
     }
   }
 }
-

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpact.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpact.java
@@ -35,7 +35,7 @@ public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializa
   public enum Status {
     /** Package content and assessed evidence are unchanged. */
     UNCHANGED,
-    /** At least one area document, identity, or connection changed. */
+    /** Package content or at least one area document, identity, or connection changed. */
     CHANGED
   }
 

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpact.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpact.java
@@ -17,23 +17,19 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 
 /**
- * Deterministic revision-impact evidence between two valid assessed multi-area DEXPI Process
- * packages.
+ * Deterministic revision-impact evidence between two valid assessed multi-area DEXPI Process packages.
  *
  * <p>
- * The comparison operates only on immutable snapshots returned by
- * {@link Dexpi20ProcessModelPackageReader}. It distinguishes exact package-byte changes,
- * per-area native DEXPI Process document changes, stable area-identity changes, and plant-wide
- * material, energy, or signal connection changes. It does not reconstruct or execute a process
- * model, infer native whole-plant DEXPI relationships, approve a drawing, or determine fitness for
- * construction.
+ * The comparison operates only on immutable snapshots returned by {@link Dexpi20ProcessModelPackageReader}. It
+ * distinguishes exact package-byte changes, per-area native DEXPI Process document changes, stable area-identity
+ * changes, and plant-wide material, energy, or signal connection changes. It does not reconstruct or execute a process
+ * model, infer native whole-plant DEXPI relationships, approve a drawing, or determine fitness for construction.
  * </p>
  */
 public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializable {
   private static final long serialVersionUID = 1000L;
   private static final Gson GSON = new Gson();
-  public static final String SCHEMA_VERSION =
-      "neqsim_dexpi_2_0_process_model_package_revision_impact.v1";
+  public static final String SCHEMA_VERSION = "neqsim_dexpi_2_0_process_model_package_revision_impact.v1";
 
   /** Overall comparison status. */
   public enum Status {
@@ -203,11 +199,9 @@ public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializa
     boolean sameAs(ConnectionState other) {
       return other != null && sameText(connectionId, other.connectionId)
           && sameText(connectionType, other.connectionType) && sameText(sourceArea, other.sourceArea)
-          && sameText(targetArea, other.targetArea)
-          && sameText(sourceEquipment, other.sourceEquipment)
-          && sameText(targetEquipment, other.targetEquipment)
-          && sameText(sourcePort, other.sourcePort) && sameText(targetPort, other.targetPort)
-          && crossArea == other.crossArea && recycle == other.recycle
+          && sameText(targetArea, other.targetArea) && sameText(sourceEquipment, other.sourceEquipment)
+          && sameText(targetEquipment, other.targetEquipment) && sameText(sourcePort, other.sourcePort)
+          && sameText(targetPort, other.targetPort) && crossArea == other.crossArea && recycle == other.recycle
           && sameText(exchangeStatus, other.exchangeStatus);
     }
   }
@@ -261,8 +255,7 @@ public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializa
     private final ConnectionState baseline;
     private final ConnectionState revised;
 
-    ConnectionChange(String connectionId, ChangeType changeType, ConnectionState baseline,
-        ConnectionState revised) {
+    ConnectionChange(String connectionId, ChangeType changeType, ConnectionState baseline, ConnectionState revised) {
       this.connectionId = connectionId;
       this.changeType = changeType;
       this.baseline = baseline;
@@ -310,8 +303,7 @@ public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializa
   private final List<ConnectionChange> connectionChanges;
   private final Status status;
 
-  private Dexpi20ProcessModelPackageRevisionImpact(
-      Dexpi20ProcessModelPackageReader.Snapshot baseline,
+  private Dexpi20ProcessModelPackageRevisionImpact(Dexpi20ProcessModelPackageReader.Snapshot baseline,
       Dexpi20ProcessModelPackageReader.Snapshot revised, List<AreaChange> areaChanges,
       List<ConnectionChange> connectionChanges) {
     plantId = baseline.getPlantId();
@@ -328,8 +320,7 @@ public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializa
     this.areaChanges = immutableAreaChanges(areaChanges);
     this.connectionChanges = immutableConnectionChanges(connectionChanges);
     status = countChangedAreas(areaChanges) == 0 && countChangedConnections(connectionChanges) == 0
-        && sameText(baselinePackageFileSha256, revisedPackageFileSha256) ? Status.UNCHANGED
-            : Status.CHANGED;
+        && sameText(baselinePackageFileSha256, revisedPackageFileSha256) ? Status.UNCHANGED : Status.CHANGED;
   }
 
   /**
@@ -339,8 +330,7 @@ public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializa
    * @param revised immutable revised package snapshot
    * @return deterministic package revision impact
    */
-  public static Dexpi20ProcessModelPackageRevisionImpact compare(
-      Dexpi20ProcessModelPackageReader.Snapshot baseline,
+  public static Dexpi20ProcessModelPackageRevisionImpact compare(Dexpi20ProcessModelPackageReader.Snapshot baseline,
       Dexpi20ProcessModelPackageReader.Snapshot revised) {
     if (baseline == null || revised == null) {
       throw new IllegalArgumentException("baseline and revised must not be null");
@@ -370,8 +360,7 @@ public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializa
     for (String connectionId : connectionIds) {
       ConnectionState before = baselineConnections.get(connectionId);
       ConnectionState after = revisedConnections.get(connectionId);
-      connections
-          .add(new ConnectionChange(connectionId, changeType(before, after), before, after));
+      connections.add(new ConnectionChange(connectionId, changeType(before, after), before, after));
     }
     return new Dexpi20ProcessModelPackageRevisionImpact(baseline, revised, areas, connections);
   }
@@ -455,8 +444,7 @@ public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializa
    */
   public boolean isAreaIdentitySetEquivalent() {
     for (AreaChange change : areaChanges) {
-      if (change.getChangeType() == ChangeType.ADDED
-          || change.getChangeType() == ChangeType.REMOVED) {
+      if (change.getChangeType() == ChangeType.ADDED || change.getChangeType() == ChangeType.REMOVED) {
         return false;
       }
     }
@@ -514,8 +502,7 @@ public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializa
     result.put("status", status.name());
     result.put("exactPackageMatch", Boolean.valueOf(isExactPackageMatch()));
     result.put("areaIdentitySetEquivalent", Boolean.valueOf(isAreaIdentitySetEquivalent()));
-    result.put("connectionTopologyEquivalent",
-        Boolean.valueOf(isConnectionTopologyEquivalent()));
+    result.put("connectionTopologyEquivalent", Boolean.valueOf(isConnectionTopologyEquivalent()));
     result.put("changedAreaCount", Integer.valueOf(getChangedAreaCount()));
     result.put("changedConnectionCount", Integer.valueOf(getChangedConnectionCount()));
     List<Map<String, Object>> areas = new ArrayList<Map<String, Object>>();
@@ -532,9 +519,8 @@ public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializa
     result.put("engineeringReviewRequired", Boolean.TRUE);
     result.put("fitnessForConstruction", Boolean.FALSE);
     result.put("nativeWholePlantDexpiExchange", Boolean.FALSE);
-    result.put("scope",
-        "Exact assessed package, per-area native DEXPI Process document, stable area identity, "
-            + "and manifest connection revision evidence");
+    result.put("scope", "Exact assessed package, per-area native DEXPI Process document, stable area identity, "
+        + "and manifest connection revision evidence");
     result.put("fingerprint", fingerprint(result));
     return result;
   }
@@ -544,8 +530,7 @@ public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializa
     return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
   }
 
-  private static Map<String, AreaState> areasById(
-      Dexpi20ProcessModelPackageReader.Snapshot snapshot) {
+  private static Map<String, AreaState> areasById(Dexpi20ProcessModelPackageReader.Snapshot snapshot) {
     Map<String, AreaState> result = new TreeMap<String, AreaState>();
     for (Dexpi20ProcessModelPackageReader.AreaDocument area : snapshot.getAreaDocuments()) {
       result.put(area.getAreaId(), new AreaState(area));
@@ -553,11 +538,9 @@ public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializa
     return result;
   }
 
-  private static Map<String, ConnectionState> connectionsById(
-      Dexpi20ProcessModelPackageReader.Snapshot snapshot) {
+  private static Map<String, ConnectionState> connectionsById(Dexpi20ProcessModelPackageReader.Snapshot snapshot) {
     Map<String, ConnectionState> result = new TreeMap<String, ConnectionState>();
-    for (Dexpi20ProcessModelPackageAssessment.ConnectionEvidence connection : snapshot
-        .getConnectionEvidence()) {
+    for (Dexpi20ProcessModelPackageAssessment.ConnectionEvidence connection : snapshot.getConnectionEvidence()) {
       result.put(connection.getConnectionId(), new ConnectionState(connection));
     }
     return result;
@@ -607,8 +590,7 @@ public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializa
     return Collections.unmodifiableList(new ArrayList<AreaChange>(changes));
   }
 
-  private static List<ConnectionChange> immutableConnectionChanges(
-      List<ConnectionChange> changes) {
+  private static List<ConnectionChange> immutableConnectionChanges(List<ConnectionChange> changes) {
     return Collections.unmodifiableList(new ArrayList<ConnectionChange>(changes));
   }
 
@@ -633,3 +615,4 @@ public final class Dexpi20ProcessModelPackageRevisionImpact implements Serializa
     }
   }
 }
+

--- a/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
@@ -24,6 +24,8 @@
  * integrity, engineering-boundary, identity, loss-status, hash, and per-area conformance assessment</li>
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessModelPackageReader} - Immutable intake snapshot with
  * defensive exact-area XML and independently assessed connection evidence</li>
+ * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20ProcessModelPackageRevisionImpact} - Deterministic assessed
+ * package, area-document, and material/energy/signal connection revision evidence</li>
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20GraphicalProjectionWriter} - Opt-in native DEXPI Core graphical
  * projection</li>
  * <li>{@link neqsim.process.processmodel.dexpi.Dexpi20GraphicalProjectionAssessment} - Deterministic inspection of

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpactTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpactTest.java
@@ -25,13 +25,12 @@ class Dexpi20ProcessModelPackageRevisionImpactTest {
   @Test
   void reportsIdenticalSnapshotAsUnchangedAndDeterministic() throws IOException {
     EngineeringDiagramReferenceFixtures.ModelCase fixture = referenceFixture();
-    Dexpi20ProcessModelPackageReader.Snapshot snapshot =
-        writeAndRead(fixture, "same.zip", "PLANT-30", "REV-A");
+    Dexpi20ProcessModelPackageReader.Snapshot snapshot = writeAndRead(fixture, "same.zip", "PLANT-30", "REV-A");
 
-    Dexpi20ProcessModelPackageRevisionImpact first =
-        Dexpi20ProcessModelPackageRevisionImpact.compare(snapshot, snapshot);
-    Dexpi20ProcessModelPackageRevisionImpact second =
-        Dexpi20ProcessModelPackageRevisionImpact.compare(snapshot, snapshot);
+    Dexpi20ProcessModelPackageRevisionImpact first = Dexpi20ProcessModelPackageRevisionImpact.compare(snapshot,
+        snapshot);
+    Dexpi20ProcessModelPackageRevisionImpact second = Dexpi20ProcessModelPackageRevisionImpact.compare(snapshot,
+        snapshot);
 
     assertEquals(Dexpi20ProcessModelPackageRevisionImpact.Status.UNCHANGED, first.getStatus());
     assertTrue(first.isExactPackageMatch());
@@ -50,13 +49,11 @@ class Dexpi20ProcessModelPackageRevisionImpactTest {
   @Test
   void separatesDocumentRevisionFromConnectionTopology() throws IOException {
     EngineeringDiagramReferenceFixtures.ModelCase fixture = referenceFixture();
-    Dexpi20ProcessModelPackageReader.Snapshot baseline =
-        writeAndRead(fixture, "revision-a.zip", "PLANT-30", "REV-A");
-    Dexpi20ProcessModelPackageReader.Snapshot revised =
-        writeAndRead(fixture, "revision-b.zip", "PLANT-30", "REV-B");
+    Dexpi20ProcessModelPackageReader.Snapshot baseline = writeAndRead(fixture, "revision-a.zip", "PLANT-30", "REV-A");
+    Dexpi20ProcessModelPackageReader.Snapshot revised = writeAndRead(fixture, "revision-b.zip", "PLANT-30", "REV-B");
 
-    Dexpi20ProcessModelPackageRevisionImpact impact =
-        Dexpi20ProcessModelPackageRevisionImpact.compare(baseline, revised);
+    Dexpi20ProcessModelPackageRevisionImpact impact = Dexpi20ProcessModelPackageRevisionImpact.compare(baseline,
+        revised);
 
     assertEquals(Dexpi20ProcessModelPackageRevisionImpact.Status.CHANGED, impact.getStatus());
     assertEquals("REV-A", impact.getBaselineRevision());
@@ -67,55 +64,46 @@ class Dexpi20ProcessModelPackageRevisionImpactTest {
     assertEquals(4, impact.getChangedAreaCount());
     assertEquals(0, impact.getChangedConnectionCount());
     for (Dexpi20ProcessModelPackageRevisionImpact.AreaChange change : impact.getAreaChanges()) {
-      assertEquals(Dexpi20ProcessModelPackageRevisionImpact.ChangeType.MODIFIED,
-          change.getChangeType());
+      assertEquals(Dexpi20ProcessModelPackageRevisionImpact.ChangeType.MODIFIED, change.getChangeType());
       assertEquals(change.getBaseline().getAreaId(), change.getRevised().getAreaId());
-      assertNotEquals(change.getBaseline().getFileSha256(),
-          change.getRevised().getFileSha256());
+      assertNotEquals(change.getBaseline().getFileSha256(), change.getRevised().getFileSha256());
     }
   }
 
   @Test
   void detectsAddedSignalConnectionWithStableEvidence() throws IOException {
     EngineeringDiagramReferenceFixtures.ModelCase fixture = referenceFixture();
-    Dexpi20ProcessModelPackageReader.Snapshot baseline =
-        writeAndRead(fixture, "connection-a.zip", "PLANT-30", "REV-A");
+    Dexpi20ProcessModelPackageReader.Snapshot baseline = writeAndRead(fixture, "connection-a.zip", "PLANT-30", "REV-A");
 
-    fixture.getProcessModel().get("Inlet").connect("30-XV-001", "signalOut2", "30-SP-001",
-        "signalIn2", ProcessConnection.ConnectionType.SIGNAL);
-    Dexpi20ProcessModelPackageReader.Snapshot revised =
-        writeAndRead(fixture, "connection-b.zip", "PLANT-30", "REV-B");
+    fixture.getProcessModel().get("Inlet").connect("30-XV-001", "signalOut2", "30-SP-001", "signalIn2",
+        ProcessConnection.ConnectionType.SIGNAL);
+    Dexpi20ProcessModelPackageReader.Snapshot revised = writeAndRead(fixture, "connection-b.zip", "PLANT-30", "REV-B");
 
-    Dexpi20ProcessModelPackageRevisionImpact impact =
-        Dexpi20ProcessModelPackageRevisionImpact.compare(baseline, revised);
+    Dexpi20ProcessModelPackageRevisionImpact impact = Dexpi20ProcessModelPackageRevisionImpact.compare(baseline,
+        revised);
 
     assertFalse(impact.isConnectionTopologyEquivalent());
     assertEquals(1, impact.getChangedConnectionCount());
     int addedSignalConnections = 0;
-    for (Dexpi20ProcessModelPackageRevisionImpact.ConnectionChange change : impact
-        .getConnectionChanges()) {
+    for (Dexpi20ProcessModelPackageRevisionImpact.ConnectionChange change : impact.getConnectionChanges()) {
       if (change.getChangeType() == Dexpi20ProcessModelPackageRevisionImpact.ChangeType.ADDED) {
         addedSignalConnections++;
         assertEquals("SIGNAL", change.getRevised().getConnectionType());
         assertEquals("signalOut2", change.getRevised().getSourcePort());
         assertEquals("signalIn2", change.getRevised().getTargetPort());
-        assertEquals("MANIFEST_ONLY_NOT_MAPPED_TO_NATIVE_PROCESS",
-            change.getRevised().getExchangeStatus());
+        assertEquals("MANIFEST_ONLY_NOT_MAPPED_TO_NATIVE_PROCESS", change.getRevised().getExchangeStatus());
       }
     }
     assertEquals(1, addedSignalConnections);
   }
 
   @Test
-  void remainsSerializableDefensiveAndPlantScoped()
-      throws IOException, ClassNotFoundException {
+  void remainsSerializableDefensiveAndPlantScoped() throws IOException, ClassNotFoundException {
     EngineeringDiagramReferenceFixtures.ModelCase fixture = referenceFixture();
-    Dexpi20ProcessModelPackageReader.Snapshot baseline =
-        writeAndRead(fixture, "restart-a.zip", "PLANT-30", "REV-A");
-    Dexpi20ProcessModelPackageReader.Snapshot revised =
-        writeAndRead(fixture, "restart-b.zip", "PLANT-30", "REV-B");
-    Dexpi20ProcessModelPackageRevisionImpact impact =
-        Dexpi20ProcessModelPackageRevisionImpact.compare(baseline, revised);
+    Dexpi20ProcessModelPackageReader.Snapshot baseline = writeAndRead(fixture, "restart-a.zip", "PLANT-30", "REV-A");
+    Dexpi20ProcessModelPackageReader.Snapshot revised = writeAndRead(fixture, "restart-b.zip", "PLANT-30", "REV-B");
+    Dexpi20ProcessModelPackageRevisionImpact impact = Dexpi20ProcessModelPackageRevisionImpact.compare(baseline,
+        revised);
 
     assertThrows(UnsupportedOperationException.class, () -> impact.getAreaChanges().clear());
     assertThrows(UnsupportedOperationException.class, () -> impact.getConnectionChanges().clear());
@@ -127,8 +115,7 @@ class Dexpi20ProcessModelPackageRevisionImpactTest {
     } finally {
       output.close();
     }
-    ObjectInputStream input =
-        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
     Dexpi20ProcessModelPackageRevisionImpact restored;
     try {
       restored = (Dexpi20ProcessModelPackageRevisionImpact) input.readObject();
@@ -138,30 +125,27 @@ class Dexpi20ProcessModelPackageRevisionImpactTest {
     assertEquals(impact.toJson(), restored.toJson());
 
     EngineeringDiagramReferenceFixtures.ModelCase otherFixture = referenceFixture();
-    Dexpi20ProcessModelPackageReader.Snapshot otherPlant =
-        writeAndRead(otherFixture, "other-plant.zip", "PLANT-31", "REV-B");
+    Dexpi20ProcessModelPackageReader.Snapshot otherPlant = writeAndRead(otherFixture, "other-plant.zip", "PLANT-31",
+        "REV-B");
     assertThrows(IllegalArgumentException.class,
         () -> Dexpi20ProcessModelPackageRevisionImpact.compare(baseline, otherPlant));
-    assertThrows(IllegalArgumentException.class,
-        () -> Dexpi20ProcessModelPackageRevisionImpact.compare(null, revised));
+    assertThrows(IllegalArgumentException.class, () -> Dexpi20ProcessModelPackageRevisionImpact.compare(null, revised));
   }
 
   private EngineeringDiagramReferenceFixtures.ModelCase referenceFixture() {
-    EngineeringDiagramReferenceFixtures.ModelCase fixture =
-        EngineeringDiagramReferenceFixtures.multiAreaFacility();
-    fixture.getProcessModel().get("Inlet").connect("30-XV-001", "energyOut", "30-VA-001",
-        "energyIn", ProcessConnection.ConnectionType.ENERGY);
-    fixture.getProcessModel().get("Inlet").connect("30-VA-001", "signalOut", "30-SP-001",
-        "signalIn", ProcessConnection.ConnectionType.SIGNAL);
+    EngineeringDiagramReferenceFixtures.ModelCase fixture = EngineeringDiagramReferenceFixtures.multiAreaFacility();
+    fixture.getProcessModel().get("Inlet").connect("30-XV-001", "energyOut", "30-VA-001", "energyIn",
+        ProcessConnection.ConnectionType.ENERGY);
+    fixture.getProcessModel().get("Inlet").connect("30-VA-001", "signalOut", "30-SP-001", "signalIn",
+        ProcessConnection.ConnectionType.SIGNAL);
     return fixture;
   }
 
-  private Dexpi20ProcessModelPackageReader.Snapshot writeAndRead(
-      EngineeringDiagramReferenceFixtures.ModelCase fixture, String fileName, String plantId,
-      String revision) throws IOException {
+  private Dexpi20ProcessModelPackageReader.Snapshot writeAndRead(EngineeringDiagramReferenceFixtures.ModelCase fixture,
+      String fileName, String plantId, String revision) throws IOException {
     File packageFile = temporaryDirectory.resolve(fileName).toFile();
-    Dexpi20ProcessModelPackageWriter.writeAndAssess(fixture.getProcessModel(), packageFile, plantId,
-        revision);
+    Dexpi20ProcessModelPackageWriter.writeAndAssess(fixture.getProcessModel(), packageFile, plantId, revision);
     return Dexpi20ProcessModelPackageReader.read(packageFile);
   }
 }
+

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpactTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpactTest.java
@@ -47,7 +47,7 @@ class Dexpi20ProcessModelPackageRevisionImpactTest {
   }
 
   @Test
-  void separatesDocumentRevisionFromConnectionTopology() throws IOException {
+  void separatesPackageRevisionFromAreaAndConnectionTopology() throws IOException {
     EngineeringDiagramReferenceFixtures.ModelCase fixture = referenceFixture();
     Dexpi20ProcessModelPackageReader.Snapshot baseline = writeAndRead(fixture, "revision-a.zip", "PLANT-30", "REV-A");
     Dexpi20ProcessModelPackageReader.Snapshot revised = writeAndRead(fixture, "revision-b.zip", "PLANT-30", "REV-B");
@@ -59,14 +59,16 @@ class Dexpi20ProcessModelPackageRevisionImpactTest {
     assertEquals("REV-A", impact.getBaselineRevision());
     assertEquals("REV-B", impact.getRevisedRevision());
     assertFalse(impact.isExactPackageMatch());
+    assertNotEquals(impact.getBaselineManifestSha256(), impact.getRevisedManifestSha256());
     assertTrue(impact.isAreaIdentitySetEquivalent());
     assertTrue(impact.isConnectionTopologyEquivalent());
-    assertEquals(4, impact.getChangedAreaCount());
+    assertEquals(0, impact.getChangedAreaCount());
     assertEquals(0, impact.getChangedConnectionCount());
+    assertEquals(4, impact.getAreaChanges().size());
     for (Dexpi20ProcessModelPackageRevisionImpact.AreaChange change : impact.getAreaChanges()) {
-      assertEquals(Dexpi20ProcessModelPackageRevisionImpact.ChangeType.MODIFIED, change.getChangeType());
+      assertEquals(Dexpi20ProcessModelPackageRevisionImpact.ChangeType.UNCHANGED, change.getChangeType());
       assertEquals(change.getBaseline().getAreaId(), change.getRevised().getAreaId());
-      assertNotEquals(change.getBaseline().getFileSha256(), change.getRevised().getFileSha256());
+      assertEquals(change.getBaseline().getFileSha256(), change.getRevised().getFileSha256());
     }
   }
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpactTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpactTest.java
@@ -1,0 +1,167 @@
+package neqsim.process.processmodel.dexpi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Path;
+import neqsim.process.processmodel.ProcessConnection;
+import neqsim.process.processmodel.diagram.EngineeringDiagramReferenceFixtures;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class Dexpi20ProcessModelPackageRevisionImpactTest {
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void reportsIdenticalSnapshotAsUnchangedAndDeterministic() throws IOException {
+    EngineeringDiagramReferenceFixtures.ModelCase fixture = referenceFixture();
+    Dexpi20ProcessModelPackageReader.Snapshot snapshot =
+        writeAndRead(fixture, "same.zip", "PLANT-30", "REV-A");
+
+    Dexpi20ProcessModelPackageRevisionImpact first =
+        Dexpi20ProcessModelPackageRevisionImpact.compare(snapshot, snapshot);
+    Dexpi20ProcessModelPackageRevisionImpact second =
+        Dexpi20ProcessModelPackageRevisionImpact.compare(snapshot, snapshot);
+
+    assertEquals(Dexpi20ProcessModelPackageRevisionImpact.Status.UNCHANGED, first.getStatus());
+    assertTrue(first.isExactPackageMatch());
+    assertTrue(first.isAreaIdentitySetEquivalent());
+    assertTrue(first.isConnectionTopologyEquivalent());
+    assertEquals(0, first.getChangedAreaCount());
+    assertEquals(0, first.getChangedConnectionCount());
+    assertEquals(first.toJson(), second.toJson());
+    assertEquals(64, String.valueOf(first.toMap().get("fingerprint")).length());
+    assertEquals("REVIEW_REQUIRED", first.getApprovalStatus());
+    assertTrue(first.isEngineeringReviewRequired());
+    assertFalse(first.isFitnessForConstruction());
+    assertFalse(first.isNativeWholePlantDexpiExchange());
+  }
+
+  @Test
+  void separatesDocumentRevisionFromConnectionTopology() throws IOException {
+    EngineeringDiagramReferenceFixtures.ModelCase fixture = referenceFixture();
+    Dexpi20ProcessModelPackageReader.Snapshot baseline =
+        writeAndRead(fixture, "revision-a.zip", "PLANT-30", "REV-A");
+    Dexpi20ProcessModelPackageReader.Snapshot revised =
+        writeAndRead(fixture, "revision-b.zip", "PLANT-30", "REV-B");
+
+    Dexpi20ProcessModelPackageRevisionImpact impact =
+        Dexpi20ProcessModelPackageRevisionImpact.compare(baseline, revised);
+
+    assertEquals(Dexpi20ProcessModelPackageRevisionImpact.Status.CHANGED, impact.getStatus());
+    assertEquals("REV-A", impact.getBaselineRevision());
+    assertEquals("REV-B", impact.getRevisedRevision());
+    assertFalse(impact.isExactPackageMatch());
+    assertTrue(impact.isAreaIdentitySetEquivalent());
+    assertTrue(impact.isConnectionTopologyEquivalent());
+    assertEquals(4, impact.getChangedAreaCount());
+    assertEquals(0, impact.getChangedConnectionCount());
+    for (Dexpi20ProcessModelPackageRevisionImpact.AreaChange change : impact.getAreaChanges()) {
+      assertEquals(Dexpi20ProcessModelPackageRevisionImpact.ChangeType.MODIFIED,
+          change.getChangeType());
+      assertEquals(change.getBaseline().getAreaId(), change.getRevised().getAreaId());
+      assertNotEquals(change.getBaseline().getFileSha256(),
+          change.getRevised().getFileSha256());
+    }
+  }
+
+  @Test
+  void detectsAddedSignalConnectionWithStableEvidence() throws IOException {
+    EngineeringDiagramReferenceFixtures.ModelCase fixture = referenceFixture();
+    Dexpi20ProcessModelPackageReader.Snapshot baseline =
+        writeAndRead(fixture, "connection-a.zip", "PLANT-30", "REV-A");
+
+    fixture.getProcessModel().get("Inlet").connect("30-XV-001", "signalOut2", "30-SP-001",
+        "signalIn2", ProcessConnection.ConnectionType.SIGNAL);
+    Dexpi20ProcessModelPackageReader.Snapshot revised =
+        writeAndRead(fixture, "connection-b.zip", "PLANT-30", "REV-B");
+
+    Dexpi20ProcessModelPackageRevisionImpact impact =
+        Dexpi20ProcessModelPackageRevisionImpact.compare(baseline, revised);
+
+    assertFalse(impact.isConnectionTopologyEquivalent());
+    assertEquals(1, impact.getChangedConnectionCount());
+    int addedSignalConnections = 0;
+    for (Dexpi20ProcessModelPackageRevisionImpact.ConnectionChange change : impact
+        .getConnectionChanges()) {
+      if (change.getChangeType() == Dexpi20ProcessModelPackageRevisionImpact.ChangeType.ADDED) {
+        addedSignalConnections++;
+        assertEquals("SIGNAL", change.getRevised().getConnectionType());
+        assertEquals("signalOut2", change.getRevised().getSourcePort());
+        assertEquals("signalIn2", change.getRevised().getTargetPort());
+        assertEquals("MANIFEST_ONLY_NOT_MAPPED_TO_NATIVE_PROCESS",
+            change.getRevised().getExchangeStatus());
+      }
+    }
+    assertEquals(1, addedSignalConnections);
+  }
+
+  @Test
+  void remainsSerializableDefensiveAndPlantScoped()
+      throws IOException, ClassNotFoundException {
+    EngineeringDiagramReferenceFixtures.ModelCase fixture = referenceFixture();
+    Dexpi20ProcessModelPackageReader.Snapshot baseline =
+        writeAndRead(fixture, "restart-a.zip", "PLANT-30", "REV-A");
+    Dexpi20ProcessModelPackageReader.Snapshot revised =
+        writeAndRead(fixture, "restart-b.zip", "PLANT-30", "REV-B");
+    Dexpi20ProcessModelPackageRevisionImpact impact =
+        Dexpi20ProcessModelPackageRevisionImpact.compare(baseline, revised);
+
+    assertThrows(UnsupportedOperationException.class, () -> impact.getAreaChanges().clear());
+    assertThrows(UnsupportedOperationException.class, () -> impact.getConnectionChanges().clear());
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream output = new ObjectOutputStream(bytes);
+    try {
+      output.writeObject(impact);
+    } finally {
+      output.close();
+    }
+    ObjectInputStream input =
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    Dexpi20ProcessModelPackageRevisionImpact restored;
+    try {
+      restored = (Dexpi20ProcessModelPackageRevisionImpact) input.readObject();
+    } finally {
+      input.close();
+    }
+    assertEquals(impact.toJson(), restored.toJson());
+
+    EngineeringDiagramReferenceFixtures.ModelCase otherFixture = referenceFixture();
+    Dexpi20ProcessModelPackageReader.Snapshot otherPlant =
+        writeAndRead(otherFixture, "other-plant.zip", "PLANT-31", "REV-B");
+    assertThrows(IllegalArgumentException.class,
+        () -> Dexpi20ProcessModelPackageRevisionImpact.compare(baseline, otherPlant));
+    assertThrows(IllegalArgumentException.class,
+        () -> Dexpi20ProcessModelPackageRevisionImpact.compare(null, revised));
+  }
+
+  private EngineeringDiagramReferenceFixtures.ModelCase referenceFixture() {
+    EngineeringDiagramReferenceFixtures.ModelCase fixture =
+        EngineeringDiagramReferenceFixtures.multiAreaFacility();
+    fixture.getProcessModel().get("Inlet").connect("30-XV-001", "energyOut", "30-VA-001",
+        "energyIn", ProcessConnection.ConnectionType.ENERGY);
+    fixture.getProcessModel().get("Inlet").connect("30-VA-001", "signalOut", "30-SP-001",
+        "signalIn", ProcessConnection.ConnectionType.SIGNAL);
+    return fixture;
+  }
+
+  private Dexpi20ProcessModelPackageReader.Snapshot writeAndRead(
+      EngineeringDiagramReferenceFixtures.ModelCase fixture, String fileName, String plantId,
+      String revision) throws IOException {
+    File packageFile = temporaryDirectory.resolve(fileName).toFile();
+    Dexpi20ProcessModelPackageWriter.writeAndAssess(fixture.getProcessModel(), packageFile, plantId,
+        revision);
+    return Dexpi20ProcessModelPackageReader.read(packageFile);
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpactTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelPackageRevisionImpactTest.java
@@ -148,4 +148,3 @@ class Dexpi20ProcessModelPackageRevisionImpactTest {
     return Dexpi20ProcessModelPackageReader.read(packageFile);
   }
 }
-


### PR DESCRIPTION
## Engineering question

Can two independently assessed multi-area DEXPI Process packages produce deterministic, restartable revision evidence that separates exact document-byte changes from stable area-identity and material/energy/signal connection changes without reconstructing an unreviewed simulation model or weakening the engineering-approval boundary?

Advances #1332 and #2899 as one shared engineering-diagram lane.

## Change

- add `Dexpi20ProcessModelPackageRevisionImpact.compare(...)` for valid immutable package-reader snapshots;
- classify every stable area and plant-wide material/energy/signal connection as `ADDED`, `REMOVED`, `MODIFIED`, or `UNCHANGED`;
- retain baseline/revised revision, optional operating case, package, manifest, canonical, and per-area XML SHA-256 evidence;
- distinguish exact package equality, stable area-identity-set equivalence, and assessed connection-topology equivalence;
- emit deterministic JSON with its own SHA-256 fingerprint and Java-serializable immutable state;
- fail closed when plant identities differ and retain `REVIEW_REQUIRED`, `engineeringReviewRequired=true`, `fitnessForConstruction=false`, and `nativeWholePlantDexpiExchange=false`;
- document the API and reconcile the current-master capability audit.

## Regression coverage

`Dexpi20ProcessModelPackageRevisionImpactTest` covers:

- identical snapshots and deterministic fingerprints;
- a revision-only package change where manifest/package hashes change while identical native area documents and assessed connections remain unchanged;
- one added signal connection with exact endpoints and manifest-only exchange status;
- defensive collections, Java serialization/restart, different-plant rejection, and null rejection.

## Compatibility and stop boundary

This is additive. It does not change package writer/reader bytes, legacy DOT/Graphviz, native SVG/PDF rendering, DEXPI Process or Plant serialization, Proteus/P&ID paths, public ProcessSystem/ProcessModel behavior, or Classic output. It does not reconstruct or execute a ProcessModel, infer native whole-plant DEXPI relationships, decide MOC, qualify a CAE tool, approve a drawing, or claim standards conformance.

Cross-artifact propagation into controlled drawing/sheet/register/study completeness remains separate work. No Huldra or public-dataset content was accessed or added.

## Documentation impact

Updated package Javadocs, the DEXPI 2.0 conformance guide, and the current-master audit with the exact comparison semantics, machine-readable evidence, and explicit approval limitations. No notebook changed, so notebook execution/rendering gates are not triggered.

## Validation

**VALIDATION BLOCKED BY UPSTREAM MASTER TEST** at exact head `278a4e2b5cd33f41332e4aeaaa2080e2558e961c`.

Local validation on the exact resulting feature content:

- `Dexpi20ProcessModelPackageRevisionImpactTest`: 4/4 passed;
- Spotless apply twice without further drift, Spotless check, documentation-search audit (666 Markdown + 1 HTML page), and `git diff --check`: passed;
- local pre-commit was not run because the executable is unavailable.

Hosted exact-head results:

- Spotless, pre-commit, documentation search, CodeQL, PaperLab, and the process-to-engineering notebook pass;
- Java 21 Javadocs/main compilation, Ubuntu and Windows fast-test jobs, and all four Java 21 slow-test shards pass;
- the notebook's first attempt stopped before compilation because Maven Central returned HTTP 429 for `maven-resources-plugin:3.4.0`; the failed-job-only retry passed without a source change;
- Java 8 Ubuntu reaches 12,338 tests and fails only the unchanged `TPflashCubicRootSelectionTest.ordinaryAndMultiphaseFlashSelectSameLowestGibbsCubicRoots` beta comparison (`0.0068049286679049414` versus `0.006804926803270682`). None of this PR's five changed files is in TP flash code or tests. The separate active repair is [#3279](https://github.com/equinor/neqsim/pull/3279), so no diagram source was changed for this upstream failure;
- Java 8 Windows remains in progress. No pending check is claimed as passed.

The PR remains draft, mergeable, with no reviews or unresolved threads. It is not classified READY TO MERGE while the authoritative workflow is red/pending.

Base inspected before publication: `78a12469d97d8a754a9f2d97318bb3d819cdf47b`.