### PR TITLE
docs: repair two-fluid transient pipeline recipes

### DIFF
--- a/docs/cookbook/pipeline-recipes.md
+++ b/docs/cookbook/pipeline-recipes.md
@@ -1159,7 +1159,7 @@ A comprehensive reference for the TwoFluidPipe model covering all flow types, bo
 | Method | Description |
 |--------|-------------|
 | `setEnableAdaptiveTimestepping(boolean)` | Enable/disable OLGA-style adaptive dt |
-| `setAdaptiveMaxPressure(double)` | Pressure ceiling (bar) — reject step if exceeded |
+| `setAdaptiveMaxPressure(double)` | Pressure ceiling (bara) — reject step if exceeded |
 | `getAdaptiveDtFactor()` | Current dt multiplier (1.0 = full CFL) |
 | `isAdaptiveTimesteppingEnabled()` | Query state |
 

--- a/docs/cookbook/pipeline-recipes.md
+++ b/docs/cookbook/pipeline-recipes.md
@@ -1059,7 +1059,6 @@ pipe.setNumberOfSections(200)
 
 # Enable slug tracking (Lagrangian OLGA-style)
 pipe.setSlugTrackingMode(TwoFluidPipe.SlugTrackingMode.LAGRANGIAN)
-pipe.setSlugTrackingMode(TwoFluidPipe.SlugTrackingMode.LAGRANGIAN)
 
 # Configure Lagrangian tracker for terrain and hydrodynamic slugs
 pipe.configureLagrangianSlugTracking(True, True, True)

--- a/docs/cookbook/pipeline-recipes.md
+++ b/docs/cookbook/pipeline-recipes.md
@@ -3,9 +3,10 @@ title: Pipeline Recipes
 description: Quick recipes for pipeline simulation in NeqSim - pressure drop, multiphase flow, drift-flux, two-fluid, slug tracking, three-phase flow, transient dynamics, and terrain effects.
 ---
 
-# Pipeline Recipes
-
-Copy-paste solutions for pipeline calculations and multiphase flow.
+Copy-paste solutions for pipeline calculations and multiphase flow. Treat the
+transient and multiphase recipes as model-screening workflows: verify convergence,
+conservation, mesh and time-step sensitivity, boundary conditions, and validation
+against suitable data before using their results for an engineering decision.
 
 ## Table of Contents
 
@@ -81,7 +82,7 @@ process.run()
 
 # Multiphase results
 print(f"Outlet pressure: {pipe.getOutletStream().getPressure():.2f} bara")
-print(f"Liquid holdup: {pipe.getPressureDrop():.2f} bar")  # Total DP
+print(f"Pressure drop: {pipe.getPressureDrop():.2f} bar")
 ```
 
 ### Two-Fluid Model (Detailed)
@@ -262,7 +263,7 @@ for rate in flow_rates:
 `TwoFluidPipe` solves separate momentum equations for gas and liquid phases with transient time-stepping:
 
 ```python
-import uuid
+from java.util import UUID
 
 TwoFluidPipe = jneqsim.process.equipment.pipeline.TwoFluidPipe
 
@@ -290,10 +291,16 @@ pipe.setSurfaceTemperature(4.0, "C")   # Ambient
 
 # Initialize steady-state
 pipe.run()
+if not pipe.isSteadyStateConverged():
+    if pipe.isSteadyStatePressureFloorLimited():
+        raise RuntimeError("The requested rate is not deliverable")
+    if pipe.isSteadyStateWallClockLimited():
+        raise RuntimeError("Steady initialization hit its wall-clock limit")
+    raise RuntimeError("Steady initialization did not converge")
 print(f"Steady-state liquid inventory: {pipe.getLiquidInventory('m3'):.2f} m³")
 
 # Run transient simulation
-run_id = str(uuid.uuid4())
+run_id = UUID.randomUUID()
 dt = 0.5        # 0.5 second time step
 t_end = 300.0   # 5 minutes total
 
@@ -310,7 +317,19 @@ while time < t_end:
 # Final results
 print(f"Final liquid inventory: {pipe.getLiquidInventory('m3'):.2f} m³")
 print(f"Outlet pressure: {pipe.getOutletStream().getPressure():.2f} bara")
+
+balance = pipe.getLastMassBalanceReport()
+if balance is None:
+    raise RuntimeError("No transient mass-balance report was produced")
+MassPhase = jneqsim.process.equipment.pipeline.TwoFluidMassBalanceReport.Phase
+if not balance.isWithinTolerance(MassPhase.TOTAL, 1.0e-7, 1.0e-8):
+    raise RuntimeError("Transient total-mass balance did not close")
 ```
+
+`runTransient(double, UUID)` requires the Java `UUID` used above; a Python UUID
+or string does not satisfy the overload. The example tolerances are diagnostic
+values for this fixture, not universal solver criteria. Inspect phase-resolved
+residuals and the accepted substep count for the study at hand.
 
 ### Key Parameters for Dynamic Simulation
 
@@ -344,12 +363,13 @@ tf.run()
 dp_bb = inlet.getPressure() - bb.getOutletStream().getPressure()
 dp_tf = inlet.getPressure() - tf.getOutletStream().getPressure()
 print(f"BB dP: {dp_bb:.3f} bar, TF dP: {dp_tf:.3f} bar, ratio: {dp_tf/dp_bb:.2f}")
-# Expect ratio 0.8-1.3 for typical two-phase horizontal flow
+# Do not apply a universal ratio; qualify both models against the same case and data
 ```
 
-> **Note:** For single-phase gas, the ratio should be ~0.98 (excellent agreement).
-> For two-phase flow, agreement varies with gas fraction — ratios of 0.8–1.3 are
-> within typical engineering accuracy for different multiphase correlations.
+> **Interpretation:** Agreement between two NeqSim implementations is a diagnostic, not
+> independent validation. Align fluid, boundary conditions, heat transfer, elevation,
+> discretization, and convergence gates; then compare with measured pressure,
+> temperature, liquid inventory, and flow-regime evidence.
 
 ---
 
@@ -401,7 +421,7 @@ print(f"Average oil holdup: {sum(oil_holdup)/len(oil_holdup):.4f}")
 For detailed slug dynamics, use the Lagrangian slug tracker:
 
 ```python
-import uuid
+from java.util import UUID
 
 # Configure pipe for slug tracking
 pipe = TwoFluidPipe("Slugging Pipeline", inlet)
@@ -410,7 +430,7 @@ pipe.setDiameter(0.15)           # 150 mm (promotes slugging)
 pipe.setNumberOfSections(400)    # Fine grid for slug resolution
 
 # Enable Lagrangian slug tracking
-pipe.setEnableSlugTracking(True)
+pipe.setSlugTrackingMode(TwoFluidPipe.SlugTrackingMode.LAGRANGIAN)
 
 # Set terrain to promote terrain-induced slugging
 elevations = []
@@ -426,19 +446,24 @@ pipe.setElevationProfile(elevations)
 pipe.run()
 
 # Run transient to observe slug development
-run_id = str(uuid.uuid4())
+run_id = UUID.randomUUID()
 for step in range(600):  # 5 minutes @ 0.5s steps
     pipe.runTransient(0.5, run_id)
 
     # Monitor slugs every 30 seconds
     if step % 60 == 0:
-        slug_count = pipe.getSlugTracker().getSlugCount()
-        avg_slug_length = pipe.getSlugTracker().getAverageSlugLength()
-        slug_frequency = pipe.getSlugTracker().getSlugFrequency()
+        slug_count = pipe.getLagrangianSlugTracker().getSlugCount()
+        avg_slug_length = pipe.getLagrangianSlugTracker().getAverageSlugLength()
+        slug_frequency = pipe.getLagrangianSlugTracker().getSlugFrequency()
         print(f"Time: {step*0.5:.0f}s - Slugs: {slug_count}, "
               f"Avg length: {avg_slug_length:.1f}m, "
               f"Frequency: {slug_frequency:.3f} Hz")
 ```
+
+The default tracker mode is Lagrangian, so its statistics must be read through
+`getLagrangianSlugTracker()`. If `SlugTrackingMode.SIMPLIFIED` is selected,
+use `getSlugTracker()` instead. A zero count is a valid outcome when the selected
+initiation criteria are not met; do not change the case merely to force a slug.
 
 ### Three-Phase Capabilities Summary
 
@@ -659,8 +684,8 @@ pipe = TwoFluidPipe("Flowline-Riser", feed)
 pipe.setLength(5400.0)
 pipe.setDiameter(0.2032)
 
-# Set elevation profile FIRST
-elevation = [...]  # must be set before generateRefinedMesh
+# Set an explicit elevation profile first
+elevation = [0.0] * 100
 pipe.setElevationProfile(elevation)
 
 # Generate refined mesh: 100 base sections, 4x refinement at steep sections
@@ -697,7 +722,7 @@ per macro timestep.
 
 ### Adaptive Timestepping (TwoFluidPipe)
 
-OLGA-style adaptive timestepping provides robustness for challenging geometries (risers, S-bends):
+NeqSim's adaptive transient step control can improve numerical robustness for challenging geometries such as risers and S-bends:
 
 ```python
 pipe = TwoFluidPipe("Subsea Line", feed)
@@ -707,12 +732,13 @@ pipe.setElevationProfile(elevation)
 
 # Enable adaptive timestepping
 pipe.setEnableAdaptiveTimestepping(True)
-pipe.setAdaptiveMaxPressure(200.0)  # bar — reject step if exceeded
+pipe.setAdaptiveMaxPressure(200.0)  # bara — reject a step if exceeded
 
 # Run transient
-import java.util.UUID as UUID
+from java.util import UUID
 run_id = UUID.randomUUID()
-for step in range(n_steps):
+dt = 0.1
+for step in range(10):
     pipe.runTransient(dt, run_id)
     dt_factor = pipe.getAdaptiveDtFactor()  # 1.0 = full CFL, <1 = reduced
 ```
@@ -720,13 +746,13 @@ for step in range(n_steps):
 | Parameter | Method | Default | Description |
 |-----------|--------|---------|-------------|
 | Enable | `setEnableAdaptiveTimestepping(bool)` | `False` | Turn on/off |
-| Pressure ceiling | `setAdaptiveMaxPressure(bar)` | 1000 | Reject step if any section exceeds |
+| Pressure ceiling | `setAdaptiveMaxPressure(bara)` | 1000 | Reject a step if any section exceeds the configured absolute pressure |
 | Monitor | `getAdaptiveDtFactor()` | — | Current dt multiplier (1.0 = full CFL) |
 | Check | `isAdaptiveTimesteppingEnabled()` | — | Query state |
 
 The algorithm: (1) per-step CFL recompute from current velocities, (2) NaN/negative mass
 detection with state rollback, (3) pressure/velocity ceiling checks, (4) gradual dt recovery
-(x1.02 growth per stable step back to 1.0).
+(×1.05 growth per stable step back to 1.0).
 
 ---
 
@@ -785,7 +811,7 @@ outlet_bc = pipe.getOutletBoundaryCondition()
 ### Transient Simulation with Changing Flow Rate
 
 ```python
-import uuid
+from java.util import UUID
 
 # Configure pipe with explicit flow BC
 pipe = TwoFluidPipe("Flowline", inlet_stream)
@@ -802,7 +828,7 @@ pipe.setOutletPressure(30.0, "bara")
 pipe.run()
 
 # Transient loop with flow ramp-up
-run_id = str(uuid.uuid4())
+run_id = UUID.randomUUID()
 for t in range(120):  # 2 minutes
     # Ramp flow from 20 to 50 kg/s over first 60s
     if t < 60:
@@ -852,7 +878,7 @@ print(f"Computed outlet mass flow: {outlet.getFlowRate('kg/sec'):.2f} kg/s")
 Use the `CLOSED` boundary condition or convenience methods for shut-in and pressure surge analysis:
 
 ```python
-import uuid
+from java.util import UUID
 
 pipe = TwoFluidPipe("Pipeline", inlet_stream)
 pipe.setLength(10000)
@@ -868,7 +894,7 @@ print(f"Initial inlet pressure: {initial_P_inlet:.2f} bara")
 # --- Shut-in scenario: close outlet valve ---
 pipe.closeOutlet()  # Convenience method (or: BoundaryCondition.CLOSED)
 
-run_id = str(uuid.uuid4())
+run_id = UUID.randomUUID()
 for t in range(60):  # 1 minute transient
     pipe.runTransient(1.0, run_id)
 
@@ -907,7 +933,7 @@ pipe.closeInlet()
 pipe.openOutlet(1.0, "bara")  # Vent to atmospheric
 
 # Monitor depressurization
-run_id = str(uuid.uuid4())
+run_id = UUID.randomUUID()
 for t in range(300):  # 5 minutes
     pipe.runTransient(1.0, run_id)
 
@@ -1032,7 +1058,7 @@ pipe.setDiameter(0.15)
 pipe.setNumberOfSections(200)
 
 # Enable slug tracking (Lagrangian OLGA-style)
-pipe.setEnableSlugTracking(True)
+pipe.setSlugTrackingMode(TwoFluidPipe.SlugTrackingMode.LAGRANGIAN)
 pipe.setSlugTrackingMode(TwoFluidPipe.SlugTrackingMode.LAGRANGIAN)
 
 # Configure Lagrangian tracker for terrain and hydrodynamic slugs

--- a/docs/test_pipeline_transient_recipes_documentation.py
+++ b/docs/test_pipeline_transient_recipes_documentation.py
@@ -1,0 +1,129 @@
+"""Contracts for the TwoFluidPipe transient and slug-tracking cookbook batch."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDE = ROOT / "docs" / "cookbook" / "pipeline-recipes.md"
+PIPELINE_SOURCE = (
+    ROOT
+    / "src"
+    / "main"
+    / "java"
+    / "neqsim"
+    / "process"
+    / "equipment"
+    / "pipeline"
+)
+TWO_FLUID_SOURCE = PIPELINE_SOURCE / "TwoFluidPipe.java"
+MASS_REPORT_SOURCE = PIPELINE_SOURCE / "TwoFluidMassBalanceReport.java"
+LAGRANGIAN_SOURCE = (
+    PIPELINE_SOURCE
+    / "twophasepipe"
+    / "LagrangianSlugTracker.java"
+)
+JAVA_REGRESSION = (
+    ROOT
+    / "src"
+    / "test"
+    / "java"
+    / "neqsim"
+    / "process"
+    / "equipment"
+    / "pipeline"
+    / "PipelineTransientRecipesDocumentationTest.java"
+)
+
+
+class PipelineTransientRecipesDocumentationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+        cls.two_fluid_source = TWO_FLUID_SOURCE.read_text(encoding="utf-8")
+        cls.mass_report_source = MASS_REPORT_SOURCE.read_text(encoding="utf-8")
+        cls.lagrangian_source = LAGRANGIAN_SOURCE.read_text(encoding="utf-8")
+        cls.java_regression = JAVA_REGRESSION.read_text(encoding="utf-8")
+
+    def test_front_matter_has_no_duplicate_h1(self):
+        self.assertTrue(self.guide.startswith("---\ntitle:"))
+        body = self.guide.split("---", 2)[2]
+        body_without_fences = re.sub(
+            r"[\x60]{3}.*?[\x60]{3}",
+            "",
+            body,
+            flags=re.DOTALL,
+        )
+        self.assertNotRegex(body_without_fences, r"(?m)^# ")
+
+    def test_transient_recipe_uses_java_uuid_overload(self):
+        self.assertIn(
+            "public void runTransient(double dt, UUID id)",
+            self.two_fluid_source,
+        )
+        self.assertIn("from java.util import UUID", self.guide)
+        self.assertIn("UUID.randomUUID()", self.guide)
+        self.assertNotIn("str(uuid.uuid4())", self.guide)
+        self.assertNotIn("import uuid", self.guide)
+
+    def test_transient_recipe_fails_closed_and_checks_mass_balance(self):
+        for token in (
+            "isSteadyStateConverged()",
+            "isSteadyStatePressureFloorLimited()",
+            "isSteadyStateWallClockLimited()",
+            "getLastMassBalanceReport()",
+            "MassPhase.TOTAL",
+            "isWithinTolerance(",
+        ):
+            self.assertIn(token, self.guide)
+        for token in (
+            "getRelativeResidual(Phase phase)",
+            "isWithinTolerance(Phase phase",
+        ):
+            self.assertIn(token, self.mass_report_source)
+
+    def test_lagrangian_mode_uses_matching_tracker(self):
+        for token in (
+            "SlugTrackingMode.LAGRANGIAN",
+            "getLagrangianSlugTracker()",
+        ):
+            self.assertIn(token, self.guide)
+            self.assertIn(token.split("()", 1)[0], self.two_fluid_source)
+        for token in (
+            "getSlugCount()",
+            "getAverageSlugLength()",
+            "getSlugFrequency()",
+        ):
+            self.assertIn(token, self.guide)
+            self.assertIn(token, self.lagrangian_source)
+        self.assertNotIn("getSlugTracker().getSlugCount()", self.guide)
+
+    def test_adaptive_step_contract_matches_source(self):
+        self.assertIn("ADAPTIVE_DT_GROWTH = 1.05", self.two_fluid_source)
+        self.assertIn("×1.05 growth", self.guide)
+        self.assertIn(
+            "setAdaptiveMaxPressure(200.0)  # bara",
+            self.guide,
+        )
+        self.assertNotIn("x1.02 growth", self.guide)
+
+    def test_comparison_has_no_universal_acceptance_ratio(self):
+        self.assertIn(
+            "Do not apply a universal ratio",
+            self.guide,
+        )
+        for stale_claim in ("ratio 0.8-1.3", "~0.98"):
+            self.assertNotIn(stale_claim, self.guide)
+
+    def test_java_regression_executes_documented_contracts(self):
+        for token in (
+            "documentedTransientUsesJavaUuidAndClosesMassBalance",
+            "documentedLagrangianModeUsesMatchingTracker",
+            "documentedThreePhaseProfilesAreBounded",
+        ):
+            self.assertIn(token, self.java_regression)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test/java/neqsim/process/equipment/pipeline/PipelineTransientRecipesDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/PipelineTransientRecipesDocumentationTest.java
@@ -36,8 +36,7 @@ class PipelineTransientRecipesDocumentationTest extends NeqSimTest {
     TwoFluidMassBalanceReport balance = pipe.getLastMassBalanceReport();
     assertNotNull(balance);
     assertTrue(balance.getAcceptedSubsteps() > 0);
-    assertTrue(balance.isWithinTolerance(Phase.TOTAL, ABSOLUTE_BALANCE_TOLERANCE_KG,
-        RELATIVE_BALANCE_TOLERANCE));
+    assertTrue(balance.isWithinTolerance(Phase.TOTAL, ABSOLUTE_BALANCE_TOLERANCE_KG, RELATIVE_BALANCE_TOLERANCE));
     assertTrue(Double.isFinite(balance.getRelativeResidual(Phase.TOTAL)));
   }
 

--- a/src/test/java/neqsim/process/equipment/pipeline/PipelineTransientRecipesDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/PipelineTransientRecipesDocumentationTest.java
@@ -26,6 +26,7 @@ class PipelineTransientRecipesDocumentationTest extends NeqSimTest {
     pipe.setEnableSlugTracking(false);
     pipe.run();
 
+    assertTrue(pipe.isSteadyStateConverged());
     assertFalse(pipe.isSteadyStatePressureFloorLimited());
     assertFalse(pipe.isSteadyStateWallClockLimited());
 

--- a/src/test/java/neqsim/process/equipment/pipeline/PipelineTransientRecipesDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/PipelineTransientRecipesDocumentationTest.java
@@ -22,11 +22,12 @@ class PipelineTransientRecipesDocumentationTest extends NeqSimTest {
 
   @Test
   void documentedTransientUsesJavaUuidAndClosesMassBalance() {
-    TwoFluidPipe pipe = createPipe("documented-transient", 8);
+    TwoFluidPipe pipe = createConvergedTransientPipe();
     pipe.setEnableSlugTracking(false);
     pipe.run();
 
-    assertTrue(pipe.isSteadyStateConverged());
+    assertTrue(pipe.isSteadyStateConverged(), "iterations=" + pipe.getSteadyStateIterationsUsed() + ", pressureFloor="
+        + pipe.isSteadyStatePressureFloorLimited() + ", wallClock=" + pipe.isSteadyStateWallClockLimited());
     assertFalse(pipe.isSteadyStatePressureFloorLimited());
     assertFalse(pipe.isSteadyStateWallClockLimited());
 
@@ -101,6 +102,34 @@ class PipelineTransientRecipesDocumentationTest extends NeqSimTest {
     pipe.setEnableAdaptiveTimestepping(false);
     pipe.setThermodynamicUpdateInterval(Integer.MAX_VALUE);
     pipe.setSteadyStateMaxWallClockTime(10.0);
+    return pipe;
+  }
+
+  private static TwoFluidPipe createConvergedTransientPipe() {
+    SystemInterface fluid = new SystemSrkEos(303.15, 150.0);
+    fluid.addComponent("methane", 0.92);
+    fluid.addComponent("ethane", 0.05);
+    fluid.addComponent("propane", 0.03);
+    fluid.setMixingRule("classic");
+
+    Stream inlet = new Stream("documented-transient-inlet", fluid);
+    inlet.setFlowRate(200000.0, "kg/hr");
+    inlet.setTemperature(30.0, "C");
+    inlet.setPressure(150.0, "bara");
+    inlet.run();
+
+    int sections = 40;
+    TwoFluidPipe pipe = new TwoFluidPipe("documented-transient-pipe", inlet);
+    pipe.setLength(30000.0);
+    pipe.setDiameter(0.30);
+    pipe.setRoughness(4.5e-5);
+    pipe.setNumberOfSections(sections);
+    pipe.setElevationProfile(new double[sections + 1]);
+    pipe.setIncludeEnergyEquation(false);
+    pipe.setEnableTerrainTracking(false);
+    pipe.setEnableAdaptiveTimestepping(false);
+    pipe.setEnableSlugTracking(false);
+    pipe.setThermodynamicUpdateInterval(Integer.MAX_VALUE);
     return pipe;
   }
 }

--- a/src/test/java/neqsim/process/equipment/pipeline/PipelineTransientRecipesDocumentationTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/PipelineTransientRecipesDocumentationTest.java
@@ -1,0 +1,106 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport.Phase;
+import neqsim.process.equipment.pipeline.TwoFluidPipe.SlugTrackingMode;
+import neqsim.process.equipment.pipeline.twophasepipe.LagrangianSlugTracker;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Executes the transient and slug-tracking contracts in the pipeline cookbook. */
+class PipelineTransientRecipesDocumentationTest extends NeqSimTest {
+  private static final double ABSOLUTE_BALANCE_TOLERANCE_KG = 1.0e-7;
+  private static final double RELATIVE_BALANCE_TOLERANCE = 1.0e-8;
+
+  @Test
+  void documentedTransientUsesJavaUuidAndClosesMassBalance() {
+    TwoFluidPipe pipe = createPipe("documented-transient", 8);
+    pipe.setEnableSlugTracking(false);
+    pipe.run();
+
+    assertFalse(pipe.isSteadyStatePressureFloorLimited());
+    assertFalse(pipe.isSteadyStateWallClockLimited());
+
+    UUID runId = UUID.fromString("00000000-0000-0000-0000-00000000d095");
+    pipe.runTransient(1.0e-3, runId);
+
+    TwoFluidMassBalanceReport balance = pipe.getLastMassBalanceReport();
+    assertNotNull(balance);
+    assertTrue(balance.getAcceptedSubsteps() > 0);
+    assertTrue(balance.isWithinTolerance(Phase.TOTAL, ABSOLUTE_BALANCE_TOLERANCE_KG,
+        RELATIVE_BALANCE_TOLERANCE));
+    assertTrue(Double.isFinite(balance.getRelativeResidual(Phase.TOTAL)));
+  }
+
+  @Test
+  void documentedLagrangianModeUsesMatchingTracker() {
+    TwoFluidPipe pipe = createPipe("documented-lagrangian", 12);
+    pipe.setSlugTrackingMode(SlugTrackingMode.LAGRANGIAN);
+    pipe.configureLagrangianSlugTracking(true, true, true);
+
+    assertEquals(SlugTrackingMode.LAGRANGIAN, pipe.getSlugTrackingMode());
+    LagrangianSlugTracker tracker = pipe.getLagrangianSlugTracker();
+    assertNotNull(tracker);
+    assertTrue(tracker.getSlugCount() >= 0);
+    assertTrue(tracker.getAverageSlugLength() >= 0.0);
+    assertTrue(tracker.getSlugFrequency() >= 0.0);
+    assertNotNull(pipe.getSlugTrackingStatisticsJson());
+  }
+
+  @Test
+  void documentedThreePhaseProfilesAreBounded() {
+    TwoFluidPipe pipe = createPipe("documented-three-phase", 8);
+    pipe.setEnableSlugTracking(false);
+    pipe.run();
+
+    double[] oilHoldup = pipe.getOilHoldupProfile();
+    double[] waterHoldup = pipe.getWaterHoldupProfile();
+
+    assertEquals(8, oilHoldup.length);
+    assertEquals(8, waterHoldup.length);
+    for (int section = 0; section < oilHoldup.length; section++) {
+      assertTrue(oilHoldup[section] >= 0.0 && oilHoldup[section] <= 1.0);
+      assertTrue(waterHoldup[section] >= 0.0 && waterHoldup[section] <= 1.0);
+      assertTrue(oilHoldup[section] + waterHoldup[section] <= 1.0 + 1.0e-12);
+    }
+  }
+
+  private static TwoFluidPipe createPipe(String name, int sections) {
+    SystemInterface fluid = new SystemSrkEos(293.15, 80.0);
+    fluid.addComponent("methane", 0.80);
+    fluid.addComponent("ethane", 0.06);
+    fluid.addComponent("propane", 0.04);
+    fluid.addComponent("n-pentane", 0.03);
+    fluid.addComponent("n-heptane", 0.02);
+    fluid.addComponent("nC10", 0.02);
+    fluid.addComponent("water", 0.03);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    Stream inlet = new Stream(name + "-inlet", fluid);
+    inlet.setFlowRate(6.0, "kg/sec");
+    inlet.setTemperature(20.0, "C");
+    inlet.setPressure(80.0, "bara");
+    inlet.run();
+
+    TwoFluidPipe pipe = new TwoFluidPipe(name + "-pipe", inlet);
+    pipe.setLength(300.0);
+    pipe.setDiameter(0.15);
+    pipe.setRoughness(1.0e-5);
+    pipe.setNumberOfSections(sections);
+    pipe.setElevationProfile(new double[sections]);
+    pipe.setOutletPressure(60.0, "bara");
+    pipe.setEnableAdaptiveTimestepping(false);
+    pipe.setThermodynamicUpdateInterval(Integer.MAX_VALUE);
+    pipe.setSteadyStateMaxWallClockTime(10.0);
+    return pipe;
+  }
+}


### PR DESCRIPTION
## Summary

Advances documentation-quality campaign #2499 with bounded batch **D095** for the TwoFluidPipe transient, slug-tracking, adaptive-timestep, and three-phase pipeline cookbook recipes.

### Documentation repairs

- remove the duplicate top-level heading after front matter;
- stop labeling Beggs–Brill pressure drop as liquid holdup;
- use `java.util.UUID` for the documented `runTransient(double, UUID)` overload;
- fail closed when steady-state initialization is unconverged, pressure-floor limited, or wall-clock limited;
- inspect the discrete transient mass-balance report after stepping;
- select the Lagrangian tracker explicitly and read statistics from the matching tracker;
- explain that zero detected slugs can be a valid result;
- replace unsupported Java-style alias imports and undefined adaptive-step placeholders with complete Python examples;
- document `setAdaptiveMaxPressure` in bara and the source-defined ×1.05 growth factor;
- remove universal cross-model acceptance ratios and qualify comparisons against aligned cases and data.

### Regression coverage

- add seven source-linked documentation contract groups;
- add three focused Java regressions for the UUID/mass-balance path, Lagrangian tracker API, and bounded three-phase profiles.

## Frozen scope

1. `docs/cookbook/pipeline-recipes.md`
2. `docs/test_pipeline_transient_recipes_documentation.py`
3. `src/test/java/neqsim/process/equipment/pipeline/PipelineTransientRecipesDocumentationTest.java`

No production code, notebook, dependency, or Huldra dataset changes are included.

## Validation

**VALIDATION PENDING CI** on exact head `fd96f377dab77f3484dc7c3b2efa86b8082e281f`.

The previous head failed its own Java 21 Ubuntu contract at
`PipelineTransientRecipesDocumentationTest.documentedTransientUsesJavaUuidAndClosesMassBalance`.
The original multiphase test fixture exhausted all 159 steady-state iterations without reaching the
pressure floor or wall-clock limit, so it could not validly exercise the documented fail-closed
precondition.

The test-only repair isolates the UUID and transient mass-balance contract on the repository's
independently covered convergent lean-gas case. The multiphase three-phase-profile and Lagrangian
slug-tracker fixtures remain unchanged.

Exact-content local validation:

- `PipelineTransientRecipesDocumentationTest`: 3/3 passed;
- Spotless apply/check, documentation-search audit (666 Markdown + 1 HTML), and `git diff --check`: passed;
- local `pre-commit` executable is unavailable.

The prior head passed Spotless, pre-commit, Javadocs, documentation search, CodeQL, and all four
slow-test shards. Fresh hosted checks for this repair are pending; no pending check is claimed as
passed.

Closes no issue; contributes to #2499.
