### PR TITLE
docs: repair generated notebook page metadata

### DIFF
--- a/docs/convert_notebooks.py
+++ b/docs/convert_notebooks.py
@@ -57,6 +57,20 @@ def get_notebook_documentation_metadata(notebook, notebook_name):
         documentation_metadata.update(notebook_metadata)
     return documentation_metadata
 
+
+def get_first_markdown_h1(notebook):
+    """Return the first notebook-owned level-one heading, if present."""
+
+    for cell in notebook.get("cells", []):
+        if cell.get("cell_type") != "markdown":
+            continue
+        source = "".join(cell.get("source", []))
+        match = re.search(r"(?m)^#\\s+(.+?)\\s*$", source)
+        if match:
+            return match.group(1).strip()
+    return None
+
+
 # Ensure Unicode output works on Windows consoles (cp1252 by default).
 for _stream in (sys.stdout, sys.stderr):
     try:
@@ -107,17 +121,21 @@ def notebook_to_markdown(notebook_path):
         nb,
         notebook_name,
     )
-    title = documentation_metadata.get(
-        'title',
-        notebook_name.replace('_', ' ').replace('-', ' '),
+    default_title = (
+        get_first_markdown_h1(nb)
+        or notebook_name.replace('_', ' ').replace('-', ' ')
     )
+    title = documentation_metadata.get('title', default_title)
     description = documentation_metadata.get(
         'description',
-        'Jupyter notebook tutorial for NeqSim',
+        (
+            f"Notebook for {title}, including NeqSim Python examples "
+            "and workflow context."
+        ),
     )
     generated_title = (
         f"# {title}\n\n"
-        if documentation_metadata.get('show_generated_title', True)
+        if documentation_metadata.get('show_generated_title', False)
         else ''
     )
     colab_link_text = documentation_metadata.get(
@@ -126,7 +144,7 @@ def notebook_to_markdown(notebook_path):
     )
     strip_first_h1 = documentation_metadata.get(
         'strip_first_h1',
-        documentation_metadata.get('strip_notebook_title', False),
+        documentation_metadata.get('strip_notebook_title', True),
     )
     title_yaml = json.dumps(str(title), ensure_ascii=False)
     description_yaml = json.dumps(str(description), ensure_ascii=False)
@@ -154,24 +172,23 @@ nav_order: 1
 """
 
     markdown_content = []
-    first_markdown_cell_seen = False
+    first_h1_stripped = False
 
     for cell in nb.get('cells', []):
         cell_type = cell.get('cell_type', '')
         source = ''.join(cell.get('source', []))
 
         if cell_type == 'markdown':
-            if not first_markdown_cell_seen:
-                first_markdown_cell_seen = True
-                if strip_first_h1:
-                    # The Jekyll page title is supplied by front matter. Keep the
-                    # notebook's H1 for Colab while avoiding a duplicate page H1.
-                    source = re.sub(
-                        r'\A# [^\r\n]*(?:\r?\n){0,2}',
-                        '',
-                        source,
-                        count=1,
-                    )
+            if strip_first_h1 and not first_h1_stripped:
+                # The Jekyll page title is supplied by front matter. Keep the
+                # notebook's H1 for Colab while avoiding a duplicate page H1.
+                source, replacements = re.subn(
+                    r'(?m)^# [^\r\n]*(?:\r?\n){0,2}',
+                    '',
+                    source,
+                    count=1,
+                )
+                first_h1_stripped = replacements == 1
             # Add markdown content directly
             markdown_content.append(source)
             markdown_content.append('\n\n')

--- a/docs/convert_notebooks.py
+++ b/docs/convert_notebooks.py
@@ -65,7 +65,7 @@ def get_first_markdown_h1(notebook):
         if cell.get("cell_type") != "markdown":
             continue
         source = "".join(cell.get("source", []))
-        match = re.search(r"(?m)^#\\s+(.+?)\\s*$", source)
+        match = re.search(r"(?m)^#\s+(.+?)\s*$", source)
         if match:
             return match.group(1).strip()
     return None

--- a/docs/examples/AIPlatformIntegration.md
+++ b/docs/examples/AIPlatformIntegration.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "AIPlatformIntegration"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "NeqSim AI Platform Integration"
+description: "Notebook for NeqSim AI Platform Integration, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# AIPlatformIntegration
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`AIPlatformIntegration.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/AIPlatformIntegration.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# NeqSim AI Platform Integration
 
 This notebook demonstrates how to integrate NeqSim's thermodynamic and process simulation capabilities with AI-based production optimization platforms using the **Direct Java Access** method.
 

--- a/docs/examples/AdvancedRiskFramework_Tutorial.md
+++ b/docs/examples/AdvancedRiskFramework_Tutorial.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "AdvancedRiskFramework Tutorial"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "NeqSim Advanced Risk Framework Tutorial"
+description: "Notebook for NeqSim Advanced Risk Framework Tutorial, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# AdvancedRiskFramework Tutorial
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`AdvancedRiskFramework_Tutorial.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/AdvancedRiskFramework_Tutorial.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# NeqSim Advanced Risk Framework Tutorial
 
 This notebook demonstrates the advanced risk analysis capabilities of NeqSim, including:
 

--- a/docs/examples/BeerBrewing_BioProcess_Simulation.md
+++ b/docs/examples/BeerBrewing_BioProcess_Simulation.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "BeerBrewing BioProcess Simulation"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "Beer Brewing Process Simulation with NeqSim Bio-Processing"
+description: "Notebook for Beer Brewing Process Simulation with NeqSim Bio-Processing, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# BeerBrewing BioProcess Simulation
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`BeerBrewing_BioProcess_Simulation.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/BeerBrewing_BioProcess_Simulation.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# Beer Brewing Process Simulation with NeqSim Bio-Processing
 
 A rigorous, step-by-step thermodynamic and kinetic simulation of the beer brewing process
 using NeqSim's bio-processing equipment and the **CPA equation of state** for accurate

--- a/docs/examples/ESP_Pump_Tutorial.md
+++ b/docs/examples/ESP_Pump_Tutorial.md
@@ -1,12 +1,11 @@
 ---
 layout: default
 title: "ESP Pump Tutorial"
-description: "Jupyter notebook tutorial for NeqSim"
+description: "Notebook for ESP Pump Tutorial, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# ESP Pump Tutorial
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`ESP_Pump_Tutorial.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/ESP_Pump_Tutorial.ipynb).

--- a/docs/examples/FieldDevelopmentWorkflow.md
+++ b/docs/examples/FieldDevelopmentWorkflow.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: "Transparent field-development screening"
-description: "Executable NeqSim tutorial for unit-safe gas-production profiles, after-tax cash flow, and bounded sensitivities."
+title: "Transparent field-development screening with NeqSim"
+description: "Notebook for Transparent field-development screening with NeqSim, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
@@ -13,7 +13,6 @@ nav_order: 1
 
 ---
 
-# Transparent field-development screening with NeqSim
 
 This tutorial builds an auditable gas-production forecast and after-tax cash flow from current NeqSim APIs. It deliberately uses the lower-level production-profile and economics classes so every unit conversion and assumption is visible.
 

--- a/docs/examples/FieldDevelopmentWorkflow.md
+++ b/docs/examples/FieldDevelopmentWorkflow.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: "Transparent field-development screening with NeqSim"
-description: "Notebook for Transparent field-development screening with NeqSim, including NeqSim Python examples and workflow context."
+title: "Transparent field-development screening"
+description: "Executable NeqSim tutorial for unit-safe gas-production profiles, after-tax cash flow, and bounded sensitivities."
 parent: Examples
 nav_order: 1
 ---

--- a/docs/examples/GERG2008_NH3_Ammonia_Properties.md
+++ b/docs/examples/GERG2008_NH3_Ammonia_Properties.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "GERG2008 NH3 Ammonia Properties"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "GERG-2008-NH3: Ammonia Thermodynamic Properties"
+description: "Notebook for GERG-2008-NH3: Ammonia Thermodynamic Properties, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# GERG2008 NH3 Ammonia Properties
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`GERG2008_NH3_Ammonia_Properties.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/GERG2008_NH3_Ammonia_Properties.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# GERG-2008-NH3: Ammonia Thermodynamic Properties
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/equinor/neqsim/blob/master/docs/examples/GERG2008_NH3_Ammonia_Properties.ipynb)
 

--- a/docs/examples/GraphBasedProcessSimulation.md
+++ b/docs/examples/GraphBasedProcessSimulation.md
@@ -1,12 +1,11 @@
 ---
 layout: default
 title: "GraphBasedProcessSimulation"
-description: "Jupyter notebook tutorial for NeqSim"
+description: "Notebook for GraphBasedProcessSimulation, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# GraphBasedProcessSimulation
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`GraphBasedProcessSimulation.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/GraphBasedProcessSimulation.ipynb).

--- a/docs/examples/H2S_Distribution_Modeling.md
+++ b/docs/examples/H2S_Distribution_Modeling.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "H2S Distribution Modeling"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "H2S Distribution Between Gas, Oil, and Water Phases in NeqSim"
+description: "Notebook for H2S Distribution Between Gas, Oil, and Water Phases in NeqSim, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# H2S Distribution Modeling
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`H2S_Distribution_Modeling.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/H2S_Distribution_Modeling.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# H2S Distribution Between Gas, Oil, and Water Phases in NeqSim
 
 ## Introduction
 

--- a/docs/examples/IntegratedProductionRiskAnalysis.md
+++ b/docs/examples/IntegratedProductionRiskAnalysis.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "IntegratedProductionRiskAnalysis"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "Integrated Production & Risk Analysis"
+description: "Notebook for Integrated Production & Risk Analysis, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# IntegratedProductionRiskAnalysis
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`IntegratedProductionRiskAnalysis.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/IntegratedProductionRiskAnalysis.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# Integrated Production & Risk Analysis
 
 This notebook demonstrates the **complete operational planning workflow** by integrating:
 

--- a/docs/examples/LoopedPipelineNetworkExample.md
+++ b/docs/examples/LoopedPipelineNetworkExample.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "LoopedPipelineNetworkExample"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "Looped Pipeline Network Solver - Hardy Cross Method"
+description: "Notebook for Looped Pipeline Network Solver - Hardy Cross Method, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# LoopedPipelineNetworkExample
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`LoopedPipelineNetworkExample.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/LoopedPipelineNetworkExample.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# Looped Pipeline Network Solver - Hardy Cross Method
 
 This notebook demonstrates NeqSim's Hardy Cross looped network solver for pipeline networks with multiple flow paths and ring mains.
 

--- a/docs/examples/MPC_Integration_Tutorial.md
+++ b/docs/examples/MPC_Integration_Tutorial.md
@@ -1,12 +1,11 @@
 ---
 layout: default
 title: "MPC Integration Tutorial"
-description: "Jupyter notebook tutorial for NeqSim"
+description: "Notebook for MPC Integration Tutorial, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# MPC Integration Tutorial
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`MPC_Integration_Tutorial.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/MPC_Integration_Tutorial.ipynb).

--- a/docs/examples/MultiScenarioVFP_Tutorial.md
+++ b/docs/examples/MultiScenarioVFP_Tutorial.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "MultiScenarioVFP Tutorial"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "Multi-Scenario VFP Generation with NeqSim"
+description: "Notebook for Multi-Scenario VFP Generation with NeqSim, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# MultiScenarioVFP Tutorial
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`MultiScenarioVFP_Tutorial.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/MultiScenarioVFP_Tutorial.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# Multi-Scenario VFP Generation with NeqSim
 
 This notebook demonstrates how to generate VFP (Vertical Flow Performance) tables that account for varying Gas-Oil Ratio (GOR) and Water Cut (WC) conditions. This is essential for reservoir simulation coupling where fluid properties change over the field life.
 

--- a/docs/examples/MultiphaseFlowPipelineRiser_Interactive.md
+++ b/docs/examples/MultiphaseFlowPipelineRiser_Interactive.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "MultiphaseFlowPipelineRiser Interactive"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "🌊 Interactive Multiphase Pipeline & S-Riser Simulation"
+description: "Notebook for 🌊 Interactive Multiphase Pipeline & S-Riser Simulation, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# MultiphaseFlowPipelineRiser Interactive
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`MultiphaseFlowPipelineRiser_Interactive.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/MultiphaseFlowPipelineRiser_Interactive.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# 🌊 Interactive Multiphase Pipeline & S-Riser Simulation
 
 **Understanding Gas-Oil-Water Flow Dynamics using the OLGA Two-Fluid Model**
 

--- a/docs/examples/NeqSim_Python_Optimization.md
+++ b/docs/examples/NeqSim_Python_Optimization.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "NeqSim Python Optimization"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "NeqSim Process Optimization with Python"
+description: "Notebook for NeqSim Process Optimization with Python, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# NeqSim Python Optimization
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`NeqSim_Python_Optimization.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/NeqSim_Python_Optimization.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# NeqSim Process Optimization with Python
 
 This notebook demonstrates how to use **Python optimization libraries** (SciPy, etc.) with **NeqSim process simulations**. This approach gives you the flexibility of Python's optimization ecosystem while leveraging NeqSim's rigorous thermodynamics and equipment models.
 

--- a/docs/examples/NetworkSolverTutorial.md
+++ b/docs/examples/NetworkSolverTutorial.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "NetworkSolverTutorial"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "Multi-Well Network Solver Tutorial"
+description: "Notebook for Multi-Well Network Solver Tutorial, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# NetworkSolverTutorial
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`NetworkSolverTutorial.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/NetworkSolverTutorial.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# Multi-Well Network Solver Tutorial
 
 This notebook demonstrates the NetworkSolver for modeling multi-well gathering systems with flowlines and manifolds.
 

--- a/docs/examples/PVT_Simulation_and_Tuning.md
+++ b/docs/examples/PVT_Simulation_and_Tuning.md
@@ -1,12 +1,11 @@
 ---
 layout: default
 title: "PVT Simulation and Tuning"
-description: "Jupyter notebook tutorial for NeqSim"
+description: "Notebook for PVT Simulation and Tuning, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# PVT Simulation and Tuning
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`PVT_Simulation_and_Tuning.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/PVT_Simulation_and_Tuning.ipynb).

--- a/docs/examples/ProducedWaterEmissions_Tutorial.md
+++ b/docs/examples/ProducedWaterEmissions_Tutorial.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "ProducedWaterEmissions Tutorial"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "🌱 Produced Water Emissions Calculation with NeqSim"
+description: "Notebook for 🌱 Produced Water Emissions Calculation with NeqSim, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# ProducedWaterEmissions Tutorial
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`ProducedWaterEmissions_Tutorial.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/ProducedWaterEmissions_Tutorial.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# 🌱 Produced Water Emissions Calculation with NeqSim
 
 This notebook demonstrates comprehensive greenhouse gas emissions calculation (CO₂, methane, nmVOC) from produced water handling systems using NeqSim.
 

--- a/docs/examples/ProductionOptimizer_Tutorial.md
+++ b/docs/examples/ProductionOptimizer_Tutorial.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "ProductionOptimizer Tutorial"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "ProductionOptimizer - Comprehensive Tutorial"
+description: "Notebook for ProductionOptimizer - Comprehensive Tutorial, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# ProductionOptimizer Tutorial
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`ProductionOptimizer_Tutorial.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/ProductionOptimizer_Tutorial.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# ProductionOptimizer - Comprehensive Tutorial
 
 This notebook provides a complete guide to using the `ProductionOptimizer` class from NeqSim for process optimization.
 

--- a/docs/examples/ProductionSystem_BottleneckAnalysis.md
+++ b/docs/examples/ProductionSystem_BottleneckAnalysis.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "ProductionSystem BottleneckAnalysis"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "Production System Optimization & Bottleneck Analysis"
+description: "Notebook for Production System Optimization & Bottleneck Analysis, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# ProductionSystem BottleneckAnalysis
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`ProductionSystem_BottleneckAnalysis.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/ProductionSystem_BottleneckAnalysis.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# Production System Optimization & Bottleneck Analysis
 
 This notebook demonstrates advanced production system modeling with NeqSim, including:
 

--- a/docs/examples/SeparatorEfficiency_GasScrubber_ThreePhase.md
+++ b/docs/examples/SeparatorEfficiency_GasScrubber_ThreePhase.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "SeparatorEfficiency GasScrubber ThreePhase"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "Separator & Gas Scrubber Separation Efficiency"
+description: "Notebook for Separator & Gas Scrubber Separation Efficiency, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# SeparatorEfficiency GasScrubber ThreePhase
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`SeparatorEfficiency_GasScrubber_ThreePhase.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/SeparatorEfficiency_GasScrubber_ThreePhase.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# Separator & Gas Scrubber Separation Efficiency
 
 This notebook demonstrates the **separation-efficiency report** for a
 **two-phase gas scrubber** and a **three-phase separator** in NeqSim.

--- a/docs/examples/TVP_RVP_Study.md
+++ b/docs/examples/TVP_RVP_Study.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "TVP RVP Study"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "True Vapor Pressure (TVP) vs Reid Vapor Pressure (RVP) Study"
+description: "Notebook for True Vapor Pressure (TVP) vs Reid Vapor Pressure (RVP) Study, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# TVP RVP Study
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`TVP_RVP_Study.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/TVP_RVP_Study.ipynb).
@@ -29,7 +28,6 @@ nav_order: 1
 # 5. Stabilized crude has lower RVP than unstabilized
 ```
 
-# True Vapor Pressure (TVP) vs Reid Vapor Pressure (RVP) Study
 
 ## A Comprehensive Analysis Using NeqSim
 

--- a/docs/examples/TwoFluidPipe_Tutorial.md
+++ b/docs/examples/TwoFluidPipe_Tutorial.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "TwoFluidPipe Tutorial"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "TwoFluidPipe Model Tutorial"
+description: "Notebook for TwoFluidPipe Model Tutorial, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# TwoFluidPipe Tutorial
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`TwoFluidPipe_Tutorial.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/TwoFluidPipe_Tutorial.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# TwoFluidPipe Model Tutorial
 ## Multiphase Pipeline Flow Simulation with NeqSim
 
 This notebook demonstrates the use of NeqSim's `TwoFluidPipe` model for simulating multiphase (gas-liquid) flow in pipelines. The two-fluid model solves separate conservation equations for gas and liquid phases, providing detailed predictions of:

--- a/docs/examples/autosize_and_optimize_workflows.md
+++ b/docs/examples/autosize_and_optimize_workflows.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "autosize and optimize workflows"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "Auto-size & optimize: three production-optimization workflows"
+description: "Notebook for Auto-size & optimize: three production-optimization workflows, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# autosize and optimize workflows
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`autosize_and_optimize_workflows.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/autosize_and_optimize_workflows.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# Auto-size & optimize: three production-optimization workflows
 
 This notebook shows how to drive NeqSim's **production optimizer** with a minimum of Python.
 The heavy lifting (auto-sizing equipment, building capacity constraints, the throughput search)

--- a/docs/examples/oilgas_production_energy_optimization.md
+++ b/docs/examples/oilgas_production_energy_optimization.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "oilgas production energy optimization"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "Oil & Gas Topside: Production & Energy Optimization"
+description: "Notebook for Oil & Gas Topside: Production & Energy Optimization, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# oilgas production energy optimization
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`oilgas_production_energy_optimization.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/oilgas_production_energy_optimization.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# Oil & Gas Topside: Production & Energy Optimization
 
 This notebook demonstrates NeqSim's **production optimization** and **energy optimization** functionality on the same oil/gas separation + recompression process used in the NeqSim-Colab `comparesimulations.ipynb` example.
 

--- a/docs/examples/process equipmentutl.md
+++ b/docs/examples/process equipmentutl.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Reservoir-to-Market Optimisation with NeqSim Process Equipment"
-description: "Executed reservoir-to-market process-equipment workflow with field-life depletion, well and flowline hydraulics, export compression, production optimisation, and value-chain economics."
+description: "Notebook for Reservoir-to-Market Optimisation with NeqSim Process Equipment, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
@@ -13,7 +13,6 @@ nav_order: 1
 
 ---
 
-# Reservoir-to-Market Optimisation with NeqSim Process Equipment
 
 This notebook builds a **complete reservoir-to-market chain entirely from NeqSim
 process equipment** and solves it with `ProcessSystem` and `ProcessModel`. No

--- a/docs/examples/process equipmentutl.md
+++ b/docs/examples/process equipmentutl.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Reservoir-to-Market Optimisation with NeqSim Process Equipment"
-description: "Notebook for Reservoir-to-Market Optimisation with NeqSim Process Equipment, including NeqSim Python examples and workflow context."
+description: "Executed reservoir-to-market process-equipment workflow with field-life depletion, well and flowline hydraulics, export compression, production optimisation, and value-chain economics."
 parent: Examples
 nav_order: 1
 ---

--- a/docs/examples/processmodel_plant_optimization.md
+++ b/docs/examples/processmodel_plant_optimization.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "processmodel plant optimization"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "Plant-wide optimization of a multi-area `ProcessModel`"
+description: "Notebook for Plant-wide optimization of a multi-area `ProcessModel`, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# processmodel plant optimization
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`processmodel_plant_optimization.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/processmodel_plant_optimization.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# Plant-wide optimization of a multi-area `ProcessModel`
 
 This notebook demonstrates the **agentic optimization workflow** on a large multi-area
 NeqSim `ProcessModel` — the same pattern used to optimize real offshore plants such as the

--- a/docs/examples/reservoir_to_market_optimization.md
+++ b/docs/examples/reservoir_to_market_optimization.md
@@ -1,12 +1,11 @@
 ---
 layout: default
-title: "reservoir to market optimization"
-description: "Jupyter notebook tutorial for NeqSim"
+title: "Reservoir-to-Market Optimisation with NeqSim Process Equipment"
+description: "Notebook for Reservoir-to-Market Optimisation with NeqSim Process Equipment, including NeqSim Python examples and workflow context."
 parent: Examples
 nav_order: 1
 ---
 
-# reservoir to market optimization
 
 > **Note:** This is an auto-generated Markdown version of the Jupyter notebook
 > [`reservoir_to_market_optimization.ipynb`](https://github.com/equinor/neqsim/blob/master/docs/examples/reservoir_to_market_optimization.ipynb).
@@ -15,7 +14,6 @@ nav_order: 1
 
 ---
 
-# Reservoir-to-Market Optimisation with NeqSim Process Equipment
 
 This notebook builds a **complete reservoir-to-market chain entirely from NeqSim
 process equipment** and solves it with `ProcessSystem` and `ProcessModel`. No

--- a/docs/test_convert_notebooks.py
+++ b/docs/test_convert_notebooks.py
@@ -1,4 +1,5 @@
 import json
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -59,7 +60,7 @@ class ConvertNotebooksTest(unittest.TestCase):
                 generated_content,
             )
             self.assertNotIn(f"# {curated_title}", generated_content)
-            self.assertEqual(generated_content.count("# Notebook title"), 1)
+            self.assertNotIn("# Notebook title", generated_content)
 
     def test_converter_can_strip_notebook_h1_from_generated_page(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -133,7 +134,7 @@ class ConvertNotebooksTest(unittest.TestCase):
                 "field-life depletion, well and flowline hydraulics",
                 generated_content,
             )
-            self.assertEqual(generated_content.count(f"# {title}"), 1)
+            self.assertNotIn(f"# {title}", generated_content)
             self.assertNotIn("# process equipmentutl", generated_content)
             self.assertIn(
                 "docs/examples/process%20equipmentutl.ipynb",
@@ -144,7 +145,7 @@ class ConvertNotebooksTest(unittest.TestCase):
                 generated_content,
             )
 
-    def test_converter_keeps_default_metadata_behavior(self):
+    def test_converter_uses_notebook_title_as_default_page_metadata(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             examples_dir = Path(temp_dir)
             notebook_path = examples_dir / "Generated.ipynb"
@@ -154,9 +155,17 @@ class ConvertNotebooksTest(unittest.TestCase):
             convert_all_notebooks(examples_dir)
 
             generated_content = markdown_path.read_text(encoding="utf-8")
-            self.assertIn('title: "Generated"', generated_content)
-            self.assertIn("# Generated", generated_content)
-            self.assertIn("# Current notebook title", generated_content)
+            self.assertIn(
+                'title: "Current notebook title"',
+                generated_content,
+            )
+            self.assertIn(
+                "Notebook for Current notebook title, including NeqSim "
+                "Python examples and workflow context.",
+                generated_content,
+            )
+            body = generated_content.split("\n---\n", 1)[1]
+            self.assertNotRegex(body, r"(?m)^# ")
             self.assertIn("open in Google Colab", generated_content)
 
     def test_converter_ignores_non_mapping_documentation_metadata(self):
@@ -173,11 +182,44 @@ class ConvertNotebooksTest(unittest.TestCase):
             convert_all_notebooks(examples_dir)
 
             generated_content = markdown_path.read_text(encoding="utf-8")
-            self.assertIn('title: "InvalidMetadata"', generated_content)
             self.assertIn(
-                'description: "Jupyter notebook tutorial for NeqSim"',
+                'title: "Notebook title"',
                 generated_content,
             )
+            self.assertIn(
+                "Notebook for Notebook title, including NeqSim Python "
+                "examples and workflow context.",
+                generated_content,
+            )
+
+
+    def test_committed_generated_pages_use_front_matter_title_only(self):
+        docs_dir = Path(__file__).resolve().parent
+        examples_dir = docs_dir / "examples"
+
+        generated_pages = []
+        for notebook_path in sorted(examples_dir.glob("*.ipynb")):
+            markdown_path = notebook_path.with_suffix(".md")
+            if markdown_path.exists():
+                generated_pages.append(markdown_path)
+
+        self.assertGreater(len(generated_pages), 20)
+        for markdown_path in generated_pages:
+            with self.subTest(path=markdown_path.name):
+                generated_content = markdown_path.read_text(encoding="utf-8")
+                self.assertTrue(generated_content.startswith("---\n"))
+                self.assertNotIn(
+                    'description: "Jupyter notebook tutorial for NeqSim"',
+                    generated_content,
+                )
+                body = generated_content.split("\n---\n", 1)[1]
+                body_without_fences = re.sub(
+                    r"[\x60]{3}.*?[\x60]{3}",
+                    "",
+                    body,
+                    flags=re.DOTALL,
+                )
+                self.assertNotRegex(body_without_fences, r"(?m)^# ")
 
 
     def test_index_preserves_curated_notebooks(self):

--- a/docs/test_convert_notebooks.py
+++ b/docs/test_convert_notebooks.py
@@ -17,7 +17,7 @@ def write_notebook(path: Path, title: str, documentation_metadata=None) -> None:
             {
                 "cell_type": "markdown",
                 "metadata": {},
-                "source": [f"# {title}\\n"],
+                "source": [f"# {title}\n"],
             }
         ],
         "metadata": {

--- a/docs/test_convert_notebooks.py
+++ b/docs/test_convert_notebooks.py
@@ -192,7 +192,6 @@ class ConvertNotebooksTest(unittest.TestCase):
                 generated_content,
             )
 
-
     def test_committed_generated_pages_use_front_matter_title_only(self):
         docs_dir = Path(__file__).resolve().parent
         examples_dir = docs_dir / "examples"
@@ -220,7 +219,6 @@ class ConvertNotebooksTest(unittest.TestCase):
                     flags=re.DOTALL,
                 )
                 self.assertNotRegex(body_without_fences, r"(?m)^# ")
-
 
     def test_index_preserves_curated_notebooks(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## D096 — generated notebook page rendering and search metadata

Repairs the frozen scope-7 batch for generated notebook companion pages under `docs/examples`.

### What changed

- fixes 52 confirmed page-level defects across 27 generated companion pages:
  - removes 27 body-level H1 headings that duplicated Jekyll's front-matter title
  - replaces 25 non-searchable `Jupyter notebook tutorial for NeqSim` descriptions with page-specific metadata
- preserves the two existing curated descriptions and their metadata-driven titles
- changes `docs/convert_notebooks.py` so future conversions:
  - derive the fallback page title from the notebook's first Markdown H1, with a filename fallback
  - keep that title in front matter instead of emitting a second visible H1
  - remove the notebook-owned H1 across Markdown cells
  - produce a deterministic title-specific fallback description
- adds a repository-wide regression contract covering all committed generated companion pages

### Frozen scope

Exactly 29 files: the converter, its test module, and 27 generated Markdown companions. Notebook JSON, stored outputs, code examples, Java/production sources, images, and unrelated documentation are unchanged.

### Validation — READY TO MERGE

- GitHub-source scan of all 36 `docs/examples/*.md` pages identified the 27 affected notebook companions and 25 generic descriptions
- all 27 modified pages have front matter, no body H1 outside fenced code, and no legacy generic description
- the two pre-existing curated descriptions remain intact
- Python syntax compilation passed for `docs/convert_notebooks.py` and `docs/test_convert_notebooks.py`
- repaired both attributable documentation-contract findings: the extractor's whitespace escape and the test fixture's literal `\\n`
- exact head passes all five workflows:
  - documentation: 216 contracts, Jekyll build, generated-search coverage, and search JavaScript
  - pre-commit
  - Spotless
  - CodeQL
  - build/agent-reference change detection (Java jobs correctly skipped because no Java/XML changed)
- mergeable, zero commits behind `master`, exactly 29 frozen files
- no reviews or unresolved threads
- no notebook was modified, so the executed-notebook/render gate is not applicable

Campaign: #2499
Base: `a6aa6160bceaa3e9b3a233192e060b62f66ebdc3`
Head: `6d4b2ed1cd726f23428221cd8b1897e5edb03790`