### PR TITLE
[AI-Assisted] Fix aqueous rollback overwriting gas-to-oil transition

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -184,8 +184,8 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │  IF multiPhaseCheck enabled:                                                    │
 │     → Preserve an already balanced neutral two-phase aqueous reference          │
 │     → Delegate to TPmultiflash for stability analysis and phase split           │
-│     → If a rejected third-phase trial leaves an invalid two-phase aqueous       │
-│       endpoint, restore the balanced reference                                  │
+│     → If a rejected third-phase trial leaves the same topology invalid,         │
+│       restore the balanced reference; retain GAS↔OIL root transitions          │
 │     → If cleanup collapses a strong water/non-water K split to one phase, retry │
 │       the ordinary flash and retain it only when balanced and lower in Gibbs    │
 │     → If a neutral three-phase beta solve stalls, test the three two-phase      │
@@ -242,10 +242,10 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 │     → Replace only with a lower-Gibbs root that already satisfies                │
 │       max |Δ ln(fᵢ)| < 1e-8; phase fractions and compositions stay unchanged     │
 │                                                                                 │
-│  IF multiphase, neutral GAS+AQUEOUS has water feed >= 0.01:                      │
+│  IF multiphase, neutral GAS+AQUEOUS has a lower alternate cubic root:            │
 │     → Evaluate one ordinary candidate from the unchanged feed                    │
 │     → Accept exactly one AQUEOUS plus one GAS/OIL/LIQUID phase; the cubic root   │
-│       may change label and composition only when strict thermodynamic gates pass │
+│       may change label only when balance, fugacity, and lower-Gibbs gates pass    │
 │                                                                                 │
 │  IF a final neutral two-phase aqueous endpoint with water feed ≥ 0.01 fails:     │
 │     → Audit max |Δzᵢ| and max |Δ ln(fᵢ)| against 1e-8                            │
@@ -297,15 +297,15 @@ The following flowchart shows the complete two-phase flash algorithm as implemen
 | Gibbs increase tolerance | 1e-8 | Relative increase that triggers K-reset |
 | Supplementary stability TPD limit | -1e-6 | Accept a converged amplified-K or composition-perturbation trial only when its reduced TPD exceeds that SSI solve's residual/step resolution and the trial composition is non-trivial |
 | Ordinary water-rich refinement feed threshold | 0.01 mole fraction water | Avoid phase-search overhead for valid trace-water flashes. An already-active neutral aqueous split bypasses only this feed threshold when `max abs(Delta z_i)` is non-finite or above `1e-8`, allowing the bounded beta correction below without another stability calculation. An incipient trace-water GAS+OIL endpoint with `min(beta) <= 1e-4` also bypasses the threshold when its confirmed log-fugacity residual is non-finite or at least `1e-8`; the guarded candidate must then pass the strict feasibility and lower-Gibbs gates. |
-| Water-rich cross-algorithm fallback | water feed `>= 0.01` and either an explicit-multiphase GAS+AQUEOUS endpoint, current `max abs(Delta ln(f_i)) >= 1e-8`, material-balance failure, or multiphase collapse to one hydrocarbon phase | Evaluate the existing cold candidate through the alternate path first. A feasible GAS+AQUEOUS endpoint still receives this one composition-relaxed candidate because fixed-composition equilibrium and cubic-root checks cannot exclude a lower-Gibbs OIL+AQUEOUS state. If an invalid ordinary two-phase split remains after that candidate is rejected, preserve its compositions as the seed for one fully initialized `TPmultiflash` trial. A multiphase endpoint collapsed to one phase may try the ordinary path, including the same seeded refinement when the cold ordinary result is invalid, but accepts only a result that restores an AQUEOUS phase; ordinary gas appearance remains outside this aqueous-recovery fallback. Genuine OIL+AQUEOUS liquid-liquid endpoints remain on the multiphase path. Prevent reciprocal recursion and replace the endpoint only when the candidate has exactly one AQUEOUS and one cubic fluid phase with distinct bounded phases, normalized beta and compositions, material balance and fugacity residuals below `1e-8`, and a Gibbs reduction larger than `max(1e-6 J, 1e-8 abs(G))`. Other already-feasible two-phase endpoints incur only the residual acceptance scan. |
+| Water-rich cross-algorithm fallback | water feed `>= 0.01` and current `max abs(Delta ln(f_i)) >= 1e-8`, material-balance failure, or multiphase collapse to one hydrocarbon phase | Evaluate the existing cold candidate through the alternate path first. If an invalid ordinary two-phase split remains after that candidate is rejected, preserve its compositions as the seed for one fully initialized `TPmultiflash` trial. A multiphase endpoint collapsed to one phase may try the ordinary path, including the same seeded refinement when the cold ordinary result is invalid, but accepts only a result that restores an AQUEOUS phase; ordinary gas appearance remains outside this aqueous-recovery fallback. Genuine OIL+AQUEOUS liquid-liquid endpoints remain on the multiphase path. Prevent reciprocal recursion and replace the endpoint only when the candidate has exactly two distinct bounded phases, normalized beta and compositions, material balance and fugacity residuals below `1e-8`, and a Gibbs reduction larger than `max(1e-6 J, 1e-8 abs(G))`. Already-feasible two-phase endpoints incur only the residual acceptance scan. |
 | CPA high-water hydrocarbon-liquid stability screen | ordinary one-phase AQUEOUS CPA endpoint, water feed `>= 0.01`, `f_water / p_water_sat >= 0.8`, and at least 0.01 hydrocarbon feed with `T_c > T + 80 K` | Use the water saturation, composition, and critical-temperature checks only as a performance gate for one cloned multiphase stability calculation. Accept only an exactly-two-phase, distinct, bounded, normalized result with material-balance and log-fugacity residuals below `1e-8` and a Gibbs reduction larger than `max(1e-8 J, 1e-12 abs(G))`. Chemical, ionic, solid, wax, non-CPA, explicit-multiphase, gas, and non-aqueous endpoints retain their existing paths. |
 | Trace-water aqueous-stability screen | water feed `< 0.01`, GAS+OIL, `min(beta) <= 0.01`, and `x_water,oil >= 10 z_water` | Use the structural conditions only as a performance gate for an aqueous TPD trial. The TPD result, reduced-active-set convergence below `1e-10`, phase normalization, `1e-8` material/fugacity checks, distinct compositions, and lower Gibbs energy determine acceptance. Full recursive TPmultiflash is not run. |
 | CPA one-phase aqueous-stability screen | water feed `< 0.01`, one ordinary phase, CPA model, and `f_water / p_water_sat >= 0.8` | Use the fugacity ratio only as a conservative performance gate for the existing aqueous TPD trial. When the trial adds one phase, rebuild the two-phase active set and require beta-solver residual `< 1e-10`, phase normalization, `1e-8` material/fugacity checks, distinct compositions, and a Gibbs reduction larger than `max(1e-8 J, 1e-12 abs(G))`. The tighter Gibbs tolerance retains independently converged incipient aqueous fractions without treating the saturation screen itself as a stability criterion. |
 | Water-rich material-balance tolerance | 1e-8 in `max abs(Delta z_i)` | Reject a non-conservative reference before comparing feasible Gibbs minima |
 | Dry cubic-root screen and acceptance | Screen normally ordered GAS+OIL endpoints when `max abs(Delta ln(f_i)) >= 1e-8`; accept below `1e-8` | Evaluate both roots for one phase at a time and retain a lower-Gibbs root seed only when the resulting unchanged composition split restores fugacity equality. Inverted mean-molar-mass order retains the paired-root comparison. |
-| Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Ordinary flashes accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality. A water-rich multiphase GAS+AQUEOUS endpoint independently evaluates a cold, composition-relaxed ordinary candidate containing exactly one AQUEOUS and one cubic GAS/OIL/LIQUID phase, so a lower-Gibbs gas-to-oil transition is not hidden by the reference phase composition or rejected by its new label. The candidate must additionally retain normalized positive phases, distinct compositions, fugacity equality, and component balance below `1e-8`. |
+| Aqueous cubic-root equilibrium tolerance | 1e-8 in `max abs(Delta ln(f_i))` | Ordinary flashes accept an alternate root only when it lowers Gibbs energy and already satisfies component fugacity equality. A multiphase GAS+AQUEOUS endpoint may replay a lower-Gibbs ordinary candidate containing exactly one AQUEOUS and one cubic GAS/OIL/LIQUID phase, so a valid gas-to-oil root transition is not rejected by its new label. The candidate must additionally retain normalized positive phases, distinct compositions, and component balance below `1e-8`. |
 | Stable-single-phase aqueous-seed gate | `1e-8` in phase-composition normalization | Reject only a structurally invalid aqueous trial whose composition is non-finite, out of `[0, 1]`, or unnormalized; leave normalized endpoints to model-specific convergence and refinement paths |
-| Post-removal aqueous recovery | `1e-8` in `max abs(Delta z_i)` and `max abs(Delta ln(f_i))` | Restore a balanced neutral two-phase aqueous reference only when a rejected third-phase trial leaves the final two-phase endpoint infeasible; genuine three-phase and already feasible endpoints are retained |
+| Post-removal aqueous recovery | `1e-8` in `max abs(Delta z_i)` and `max abs(Delta ln(f_i))` | Restore a balanced neutral two-phase aqueous reference only when a rejected third-phase trial leaves the same two-phase topology infeasible; a valid GAS↔OIL root transition, genuine three-phase result, or already feasible endpoint is retained |
 | Final aqueous active-set refinement | water feed `>= 0.01`, or an active aqueous split with `max abs(Delta z_i) > 1e-8`; at most 3 beta refinements; `1e-8` in phase normalization, `max abs(Delta z_i)`, and `max abs(Delta ln(f_i))` | Preserve the selected neutral two-phase active set while correcting stale beta/compositions after phase cleanup or root selection. Trace-water bypass does not run phase search. Roll back unless the result is feasible; also require no Gibbs increase when the reference material balance was valid. |
 | Final neutral gas/oil equilibrium refinement | `1e-8 <= max abs(Delta ln(f_i)) <= 1e-5`; at most 8 SSI updates | Repair only balanced, near-converged vapor-liquid endpoints after post-convergence root handling. Preserve both phase types and roll back unless phase fractions, compositions, material balance, fugacity equality, and Gibbs energy pass the strict acceptance checks. |
 | Stalled three-phase active-set fallback | `1e-8` in phase normalization, material balance, and `max abs(Delta ln(f_i))` | For neutral non-reactive systems only, evaluate each two-phase active set after a non-converged three-phase endpoint and accept the lowest-Gibbs feasible equilibrium only when it also lowers Gibbs energy relative to the stalled state |
@@ -1807,16 +1807,14 @@ Commercial process simulators do not publish all implementation details, but pub
   Gibbs energy by more than `max(1e-8 J, 1e-12 abs(G))`. Stable polar aqueous endpoints without condensable
   hydrocarbons stay on the ordinary fast path. Chemical, ionic, solid, wax, and explicit-multiphase calculations are
   excluded.
-- The same strict gate is reciprocal for a water-rich multiphase GAS+AQUEOUS endpoint. One ordinary candidate is
-  always evaluated from the unchanged feed, including when the reference endpoint is balanced and fugacity-equal.
-  Fixed-composition equilibrium and alternate-root checks cannot exclude a lower-Gibbs state whose cubic and aqueous
-  phase compositions re-equilibrate together. The candidate replaces the multiphase endpoint only when it contains
-  exactly one AQUEOUS and one cubic GAS/OIL/LIQUID phase, is independently feasible, and lowers extensive Gibbs energy
-  beyond `max(1e-6 J, 1e-8 abs(G))`. Allowing both the cubic phase identity and composition to change prevents a stable
-  liquid state from being rejected merely because the reference endpoint called its cubic phase GAS. The accepted
-  ordinary calculation is repeated on the live system to rebuild the cubic/aqueous storage mapping; a recursion guard
-  prevents fallback ping-pong. Genuine three-phase endpoints, chemical/electrolyte systems, solid/wax calculations,
-  and dry systems do not run the additional flash.
+- The same strict gate is reciprocal for a water-rich multiphase GAS+AQUEOUS endpoint. If its gas phase has a
+  lower-Gibbs alternate cubic root, one ordinary candidate is evaluated from the unchanged feed. It replaces the
+  multiphase endpoint only when it contains exactly one AQUEOUS and one cubic GAS/OIL/LIQUID phase, is independently
+  feasible, and lowers extensive Gibbs energy beyond `max(1e-6 J, 1e-8 abs(G))`. Allowing the cubic phase identity to
+  change prevents a stable liquid root from being rejected merely because the reference endpoint called the same
+  phase GAS. The accepted ordinary calculation is repeated on the live system to rebuild the cubic/aqueous storage
+  mapping; a recursion guard prevents fallback ping-pong. Genuine three-phase endpoints, chemical/electrolyte systems,
+  solid/wax calculations, and dry systems do not run the additional flash.
 - For a neutral non-CPA water-rich asymmetric feed, ordinary and explicit-multiphase calculations retain the cold
   pre-iteration state instead of relying on a clone of a final endpoint. A post-flash clone can preserve collapsed
   phase-storage and cubic-root history even after beta and compositions are reset, causing it to revisit a rejected
@@ -1857,9 +1855,11 @@ Commercial process simulators do not publish all implementation details, but pub
   normalized endpoints because specialized fluid and solid-phase models retain their existing convergence and
   refinement paths.
 - A neutral, balanced two-phase aqueous state is preserved before multiphase phase-appearance trials. If a trial third
-  phase is subsequently removed but its phase fractions leave the surviving two-phase state outside `1e-8` component
-  material-balance or fugacity tolerances, the pre-trial state is restored. The recovery does not run another flash and
-  is not considered for chemical, ionic, solid, wax, genuine three-phase, or already feasible endpoints.
+  phase is subsequently removed but its phase fractions leave the same surviving two-phase topology outside `1e-8`
+  component material-balance or fugacity tolerances, the pre-trial state is restored. A GAS↔OIL root transition is
+  retained for the later endpoint refinement instead of being overwritten by the saved topology. The recovery does not
+  run another flash and is not considered for chemical, ionic, solid, wax, genuine three-phase, or already feasible
+  endpoints.
 - Ordinary neutral aqueous splits now compare both cubic roots of the non-aqueous phase at the converged composition. An alternate root is retained only when it lowers Gibbs energy and already satisfies `max abs(Delta ln(f_i)) < 1e-8`; no extra TPflash or multiphase stability calculation is run.
 - Balanced neutral gas/oil endpoints whose terminal fugacity residual is between `1e-8` and `1e-5` receive at most
   eight additional SSI updates. This targets stale, near-converged K-values after root selection without adding work to

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TPflash.java
@@ -896,6 +896,7 @@ public class TPflash extends Flash {
         rescueLiquidLiquidEndpointLegacy();
         rescueLowerGibbsNeutralEndpoint();
         rescueWaterRichEndpoint();
+        rescueLowerGibbsMultiphaseAqueousRoot();
         refineInvalidAqueousTwoPhaseEndpoint();
         refineInvalidNeutralGasLiquidTwoPhaseEndpointLegacy();
         refineInvalidNeutralTwoPhaseEndpoint();
@@ -1121,6 +1122,7 @@ public class TPflash extends Flash {
     rescueLowerGibbsHydrocarbonPhaseRoots();
     rescueLiquidLiquidEndpointLegacy();
     rescueWaterRichEndpoint();
+    rescueLowerGibbsMultiphaseAqueousRoot();
     rescueLowerGibbsPhaseRoot();
     refineInvalidAqueousTwoPhaseEndpoint();
     refineInvalidNeutralGasLiquidTwoPhaseEndpointLegacy();
@@ -1655,20 +1657,18 @@ public class TPflash extends Flash {
    * endpoint whose fugacity residual is already outside the equilibrium tolerance may still use the cloned stability
    * calculation because it is not an acceptable result. A cheap aqueous tangent-plane trial and safeguarded multiphase
    * beta solve are used for trace-water gas/oil endpoints whose small hydrocarbon liquid disproportionately
-   * concentrates water. Full recursive flashing is avoided. A multiphase-enabled water-rich gas/aqueous endpoint always
-   * uses one cold ordinary candidate, even when the reference endpoint is internally feasible, because a
-   * fixed-composition residual or cubic-root comparison cannot exclude a lower-Gibbs state with re-equilibrated phase
-   * compositions. A genuine oil/aqueous liquid-liquid endpoint remains on the multiphase path. A water-rich multiphase
-   * endpoint that collapsed to one hydrocarbon phase also uses a cold ordinary candidate, whose invalid two-phase
-   * cubic-root split may seed the multiphase solver. An ordinary neutral non-CPA water-rich asymmetric feed retains its
-   * pre-iteration state for this reciprocal calculation; cloning the final endpoint can retain the collapsed phase/root
-   * history and miss the cold phase set. For an ordinary endpoint, an existing invalid two-phase split is retained as
-   * the multiphase phase-set seed when the existing cold candidate is rejected. Trying the cold candidate first
-   * preserves its gas/oil cubic-root classification whenever it already reaches the same feasible equilibrium. The
-   * nested candidates cannot start a reciprocal fallback cycle. A candidate replaces the original state only after
-   * strict phase-fraction, composition-normalization, material-balance, fugacity, distinct-composition, and lower-Gibbs
-   * checks pass. A collapsed multiphase endpoint additionally requires the candidate to restore the missing aqueous
-   * phase, keeping ordinary gas appearance outside this fallback's scope.
+   * concentrates water. Full recursive flashing is avoided. A multiphase-enabled water-rich gas/aqueous endpoint uses
+   * one cold ordinary candidate; a genuine oil/aqueous liquid-liquid endpoint remains on the multiphase path. A
+   * water-rich multiphase endpoint that collapsed to one hydrocarbon phase also uses a cold ordinary candidate, whose
+   * invalid two-phase cubic-root split may seed the multiphase solver. An ordinary neutral non-CPA water-rich
+   * asymmetric feed retains its pre-iteration state for this reciprocal calculation; cloning the final endpoint can
+   * retain the collapsed phase/root history and miss the cold phase set. For an ordinary endpoint, an existing invalid
+   * two-phase split is retained as the multiphase phase-set seed when the existing cold candidate is rejected. Trying
+   * the cold candidate first preserves its gas/oil cubic-root classification whenever it already reaches the same
+   * feasible equilibrium. The nested candidates cannot start a reciprocal fallback cycle. A candidate replaces the
+   * original state only after strict phase-fraction, composition-normalization, material-balance, fugacity,
+   * distinct-composition, and lower-Gibbs checks pass. A collapsed multiphase endpoint additionally requires the
+   * candidate to restore the missing aqueous phase, keeping ordinary gas appearance outside this fallback's scope.
    * </p>
    */
   private void rescueWaterRichEndpoint() {
@@ -1705,10 +1705,8 @@ public class TPflash extends Flash {
     double materialBalanceResidual = maximumComponentMaterialBalanceResidual(system);
     boolean materialBalanceInvalid = !Double.isFinite(materialBalanceResidual)
         || materialBalanceResidual > WATER_RICH_MATERIAL_BALANCE_TOLERANCE;
-    double maximumFugacityResidual = hasAqueousPhase ? maximumLogFugacityResidualWithReplacement(0, system.getPhase(0))
-        : Double.NaN;
-    if (shouldSkipCompositionRelaxedWaterRichCandidate(hasAqueousPhase, singlePhaseCpaAqueousEndpoint,
-        gasAqueousMultiphaseEndpoint, materialBalanceInvalid, maximumFugacityResidual)) {
+    if (hasAqueousPhase && !singlePhaseCpaAqueousEndpoint && !materialBalanceInvalid
+        && maximumLogFugacityResidualWithReplacement(0, system.getPhase(0)) < PHASE_ROOT_EQUILIBRIUM_TOLERANCE) {
       return;
     }
 
@@ -1748,9 +1746,9 @@ public class TPflash extends Flash {
       }
       boolean incipientCpaAqueousTrial = system.getNumberOfPhases() == 1 && !system.doMultiPhaseCheck()
           && system.getModelName() != null && system.getModelName().contains("CPA");
-      boolean requiresAqueousCandidate = gasAqueousMultiphaseEndpoint || singlePhaseWaterRichMultiphaseEndpoint;
-      boolean hasRequiredAqueousTopology = !requiresAqueousCandidate || hasExactlyOneAqueousAndOneCubicPhase(candidate);
-      if (candidateConverged && hasRequiredAqueousTopology && candidate.getNumberOfPhases() == 2
+      boolean restoresCollapsedAqueousPhase = !singlePhaseWaterRichMultiphaseEndpoint
+          || candidate.hasPhaseType(PhaseType.AQUEOUS);
+      if (candidateConverged && restoresCollapsedAqueousPhase && candidate.getNumberOfPhases() == 2
           && isBalancedEquilibriumCandidate(candidate) && shouldAcceptWaterRichCandidate(candidate,
               referenceGibbsEnergy, materialBalanceInvalid, incipientCpaAqueousTrial)) {
         if (gasAqueousMultiphaseEndpoint) {
@@ -1766,27 +1764,6 @@ public class TPflash extends Flash {
     if (invalidOrdinaryTwoPhaseSeed) {
       trySeededWaterRichPhaseSet(referenceGibbsEnergy, materialBalanceInvalid);
     }
-  }
-
-  /**
-   * Checks whether a feasible aqueous endpoint needs no composition-relaxed reciprocal candidate.
-   *
-   * <p>
-   * A balanced multiphase GAS+AQUEOUS endpoint remains eligible because its fixed phase compositions can satisfy
-   * fugacity equality while a re-equilibrated OIL+AQUEOUS state has lower total Gibbs energy.
-   * </p>
-   *
-   * @param hasAqueousPhase whether the reference contains an aqueous phase
-   * @param singlePhaseCpaAqueousEndpoint whether the reference needs the CPA aqueous stability screen
-   * @param gasAqueousMultiphaseEndpoint whether the reference is an explicit-multiphase GAS+AQUEOUS endpoint
-   * @param materialBalanceInvalid whether the reference fails component material balance
-   * @param maximumFugacityResidual maximum component log-fugacity residual of the reference
-   * @return true when the feasible endpoint may stay on the existing fast path
-   */
-  boolean shouldSkipCompositionRelaxedWaterRichCandidate(boolean hasAqueousPhase, boolean singlePhaseCpaAqueousEndpoint,
-      boolean gasAqueousMultiphaseEndpoint, boolean materialBalanceInvalid, double maximumFugacityResidual) {
-    return hasAqueousPhase && !singlePhaseCpaAqueousEndpoint && !gasAqueousMultiphaseEndpoint && !materialBalanceInvalid
-        && maximumFugacityResidual < PHASE_ROOT_EQUILIBRIUM_TOLERANCE;
   }
 
   /**
@@ -3346,18 +3323,46 @@ public class TPflash extends Flash {
    * a near-boundary hydrocarbon-liquid trial. If that trial disappears during {@link TPmultiflash} cleanup, the
    * remaining phases can retain phase fractions from the rejected three-phase iterate. Composition normalization alone
    * does not repair the resulting component material-balance or fugacity residuals. The pre-trial state is restored
-   * only when the final endpoint still has exactly two phases including an aqueous phase and fails the same strict
-   * acceptance checks. Genuine three-phase results and feasible multiphase refinements are unchanged.
+   * only when the final endpoint still has the same two phase types and fails the same strict acceptance checks. A
+   * gas-to-oil root transition must remain available to the later endpoint refinement. Genuine three-phase results and
+   * feasible multiphase refinements are unchanged.
    * </p>
    *
    * @param balancedReference feasible pre-trial state, or {@code null} when recovery is not applicable
    */
   private void restoreBalancedAqueousReferenceAfterInvalidPhaseRemoval(BalancedTwoPhaseState balancedReference) {
     if (balancedReference == null || system.getNumberOfPhases() != 2 || !system.hasPhaseType(PhaseType.AQUEOUS)
-        || isBalancedEquilibriumCandidate(system)) {
+        || !hasSameTwoPhaseTopology(balancedReference) || isBalancedEquilibriumCandidate(system)) {
       return;
     }
     restoreBalancedTwoPhaseState(balancedReference);
+  }
+
+  /**
+   * Checks whether the active two-phase topology matches a saved two-phase state, independent of phase order.
+   *
+   * @param reference saved two-phase state
+   * @return {@code true} when both states contain the same phase types
+   */
+  private boolean hasSameTwoPhaseTopology(BalancedTwoPhaseState reference) {
+    PhaseType firstType = system.getPhase(0).getType();
+    PhaseType secondType = system.getPhase(1).getType();
+    return hasSameTwoPhaseTopology(firstType, secondType, reference.phaseTypes[0], reference.phaseTypes[1]);
+  }
+
+  /**
+   * Checks two unordered pairs of phase types for equality.
+   *
+   * @param firstType first active phase type
+   * @param secondType second active phase type
+   * @param referenceFirstType first saved phase type
+   * @param referenceSecondType second saved phase type
+   * @return {@code true} when both pairs describe the same topology
+   */
+  static boolean hasSameTwoPhaseTopology(PhaseType firstType, PhaseType secondType, PhaseType referenceFirstType,
+      PhaseType referenceSecondType) {
+    return firstType == referenceFirstType && secondType == referenceSecondType
+        || firstType == referenceSecondType && secondType == referenceFirstType;
   }
 
   /**
@@ -3592,12 +3597,53 @@ public class TPflash extends Flash {
   }
 
   /**
-   * Checks whether a reciprocal water-rich candidate has one aqueous and one cubic fluid phase.
+   * Refines a feasible multiphase gas/aqueous endpoint when its gas phase has a lower-Gibbs cubic root.
+   *
+   * <p>
+   * {@link TPmultiflash} can converge a balanced gas/aqueous split on a higher-Gibbs cubic root while the ordinary
+   * two-phase path reaches the lower root and a slightly adjusted equilibrium composition. A cheap alternate-root
+   * comparison screens the converged gas phase before any retry. Only a lower root beyond numerical noise starts an
+   * ordinary TP flash on a clone; the candidate is replayed on the live system only when it retains exactly one aqueous
+   * phase and one cubic fluid phase. The cubic phase may change from gas to oil/liquid when the alternate root is
+   * stable. The candidate must still pass the existing strict phase-fraction, normalization, material-balance,
+   * distinct-composition, and fugacity checks, and lower total extensive Gibbs energy beyond the same tolerance.
+   * Three-phase results and chemical, electrolyte, solid, and wax calculations remain on their existing paths.
+   * </p>
+   */
+  private void rescueLowerGibbsMultiphaseAqueousRoot() {
+    if (!system.doMultiPhaseCheck() || system.getNumberOfPhases() != 2 || system.isChemicalSystem() || system.hasIons()
+        || solidCheck || system.doSolidPhaseCheck() || system.isMultiphaseWaxCheck()
+        || !system.hasPhaseType(PhaseType.GAS) || !system.hasPhaseType(PhaseType.AQUEOUS)
+        || !waterRichCrossAlgorithmFallbackAllowed || MULTIPHASE_RESCUE_ACTIVE.get().booleanValue()
+        || !isBalancedEquilibriumCandidate(system) || !hasLowerGibbsAlternateGasRoot()) {
+      return;
+    }
+
+    double referenceGibbsEnergy = system.getGibbsEnergy();
+    SystemInterface candidate = system.clone();
+    MULTIPHASE_RESCUE_ACTIVE.set(Boolean.TRUE);
+    try {
+      candidate.setMultiPhaseCheck(false);
+      new TPflash(candidate, false).run();
+      candidate.init(1);
+      if (isLowerGibbsMultiphaseAqueousRootCandidate(candidate, referenceGibbsEnergy)) {
+        runAcceptedOrdinaryWaterRichFallback(candidate);
+      }
+    } catch (Exception ex) {
+      logger.debug("Multiphase aqueous lower-Gibbs root refinement failed: {}", ex.getMessage());
+    } finally {
+      MULTIPHASE_RESCUE_ACTIVE.set(Boolean.FALSE);
+    }
+  }
+
+  /**
+   * Checks an ordinary candidate for the reciprocal multiphase aqueous-root rescue.
    *
    * @param candidate ordinary TP flash candidate
-   * @return true when the candidate retains the required two-phase topology
+   * @param referenceGibbsEnergy Gibbs energy of the multiphase reference endpoint
+   * @return true when the candidate retains the expected topology, is feasible, and lowers Gibbs energy
    */
-  boolean hasExactlyOneAqueousAndOneCubicPhase(SystemInterface candidate) {
+  boolean isLowerGibbsMultiphaseAqueousRootCandidate(SystemInterface candidate, double referenceGibbsEnergy) {
     if (candidate.getNumberOfPhases() != 2 || !candidate.hasPhaseType(PhaseType.AQUEOUS)) {
       return false;
     }
@@ -3613,7 +3659,35 @@ public class TPflash extends Flash {
         return false;
       }
     }
-    return aqueousPhaseCount == 1 && cubicFluidPhaseCount == 1;
+    double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceGibbsEnergy) * 1.0e-8);
+    return aqueousPhaseCount == 1 && cubicFluidPhaseCount == 1 && isBalancedEquilibriumCandidate(candidate)
+        && candidate.getGibbsEnergy() < referenceGibbsEnergy - gibbsTolerance;
+  }
+
+  /**
+   * Screens the converged gas phase for a lower-Gibbs alternate cubic root.
+   *
+   * @return true when another cubic root lowers the gas-phase Gibbs energy beyond numerical noise
+   */
+  private boolean hasLowerGibbsAlternateGasRoot() {
+    int gasPhaseIndex = system.getPhaseNumberOfPhase(PhaseType.GAS);
+    PhaseInterface gasPhase = system.getPhase(gasPhaseIndex);
+    double referenceGibbsEnergy = gasPhase.getGibbsEnergy();
+    double gibbsTolerance = Math.max(1.0e-6, Math.abs(referenceGibbsEnergy) * 1.0e-8);
+    for (PhaseType trialRoot : CUBIC_ROOT_PHASE_TYPES) {
+      try {
+        PhaseInterface trialPhase = gasPhase.clone();
+        trialPhase.init(system.getTotalNumberOfMoles(), trialPhase.getNumberOfComponents(), 1, trialRoot,
+            system.getBeta(gasPhaseIndex));
+        double gibbsReduction = referenceGibbsEnergy - trialPhase.getGibbsEnergy();
+        if (Double.isFinite(gibbsReduction) && gibbsReduction > gibbsTolerance) {
+          return true;
+        }
+      } catch (Exception ex) {
+        logger.debug("Multiphase gas-root screen failed for {}: {}", trialRoot, ex.getMessage());
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousRootTransitionCandidateTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashAqueousRootTransitionCandidateTest.java
@@ -12,15 +12,18 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 class TPflashAqueousRootTransitionCandidateTest {
   @Test
-  void acceptsOilAqueousCandidateTopologyAcrossSeparatorPressures() {
+  void acceptsLowerGibbsOilAqueousCandidateAcrossSeparatorPressures() {
     for (double pressureBara : new double[] { 2.10, 1.62, 1.20, 0.74 }) {
       SystemInterface candidate = createOilAqueousCandidate(pressureBara);
       TPflash flash = new TPflash(candidate.clone(), false);
+      double referenceGibbsEnergy = candidate.getGibbsEnergy() + 1.0;
 
       assertTrue(candidate.hasPhaseType(PhaseType.OIL));
       assertTrue(candidate.hasPhaseType(PhaseType.AQUEOUS));
-      assertTrue(flash.hasExactlyOneAqueousAndOneCubicPhase(candidate),
-          "OIL+AQUEOUS candidate was rejected at " + pressureBara + " bara");
+      assertTrue(flash.isLowerGibbsMultiphaseAqueousRootCandidate(candidate, referenceGibbsEnergy),
+          "lower-Gibbs OIL+AQUEOUS candidate was rejected at " + pressureBara + " bara");
+      assertFalse(flash.isLowerGibbsMultiphaseAqueousRootCandidate(candidate, candidate.getGibbsEnergy() - 1.0),
+          "higher-Gibbs candidate was accepted at " + pressureBara + " bara");
     }
   }
 
@@ -29,15 +32,15 @@ class TPflashAqueousRootTransitionCandidateTest {
     SystemInterface gasAqueous = createSrkCandidate(260.0, 100.0);
     TPflash flash = new TPflash(gasAqueous.clone(), false);
 
-    assertTrue(flash.hasExactlyOneAqueousAndOneCubicPhase(gasAqueous));
+    assertTrue(flash.isLowerGibbsMultiphaseAqueousRootCandidate(gasAqueous, gasAqueous.getGibbsEnergy() + 1.0));
 
     SystemInterface threePhase = createSrkCandidate(255.0, 90.0);
-    assertFalse(flash.hasExactlyOneAqueousAndOneCubicPhase(threePhase));
+    assertFalse(flash.isLowerGibbsMultiphaseAqueousRootCandidate(threePhase, threePhase.getGibbsEnergy() + 1.0));
 
     SystemInterface dryGasOil = createDryGasOilCandidate();
     assertTrue(dryGasOil.hasPhaseType(PhaseType.GAS));
     assertTrue(dryGasOil.hasPhaseType(PhaseType.OIL));
-    assertFalse(flash.hasExactlyOneAqueousAndOneCubicPhase(dryGasOil));
+    assertFalse(flash.isLowerGibbsMultiphaseAqueousRootCandidate(dryGasOil, dryGasOil.getGibbsEnergy() + 1.0));
   }
 
   private SystemInterface createDryGasOilCandidate() {

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashIssue3274SyntheticSearchTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashIssue3274SyntheticSearchTest.java
@@ -1,35 +1,17 @@
 package neqsim.thermodynamicoperations.flashops;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import neqsim.thermo.phase.PhaseType;
-import neqsim.thermo.system.SystemInterface;
-import neqsim.thermo.system.SystemSrkEos;
-import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 class TPflashIssue3274SyntheticSearchTest {
   @Test
-  void balancedGasAqueousEndpointRemainsEligibleForCompositionRelaxation() {
-    SystemInterface endpoint = new SystemSrkEos(260.0, 100.0);
-    endpoint.addComponent("CO2", 0.543865141103918);
-    endpoint.addComponent("methane", 0.2937712952303271);
-    endpoint.addComponent("ethane", 0.07010605470616459);
-    endpoint.addComponent("water", 0.09225750895959021);
-    endpoint.setMixingRule("classic");
-    endpoint.setMultiPhaseCheck(true);
-    new ThermodynamicOperations(endpoint).TPflash();
-    endpoint.init(3);
-
-    assertEquals(2, endpoint.getNumberOfPhases());
-    assertTrue(endpoint.hasPhaseType(PhaseType.GAS));
-    assertTrue(endpoint.hasPhaseType(PhaseType.AQUEOUS));
-
-    TPflash flash = new TPflash(endpoint, false);
-    assertFalse(flash.shouldSkipCompositionRelaxedWaterRichCandidate(true, false, true, false, 1.0e-12),
-        "a feasible GAS+AQUEOUS endpoint still needs a cold composition-relaxed candidate");
-    assertTrue(flash.shouldSkipCompositionRelaxedWaterRichCandidate(true, false, false, false, 1.0e-12),
-        "other feasible aqueous endpoints should retain the fast path");
+  void aqueousRollbackRequiresUnchangedPhaseTopology() {
+    assertTrue(TPflash.hasSameTwoPhaseTopology(PhaseType.GAS, PhaseType.AQUEOUS, PhaseType.GAS, PhaseType.AQUEOUS));
+    assertTrue(TPflash.hasSameTwoPhaseTopology(PhaseType.AQUEOUS, PhaseType.GAS, PhaseType.GAS, PhaseType.AQUEOUS),
+        "phase ordering must not affect rollback eligibility");
+    assertFalse(TPflash.hasSameTwoPhaseTopology(PhaseType.OIL, PhaseType.AQUEOUS, PhaseType.GAS, PhaseType.AQUEOUS),
+        "a GAS-to-OIL root transition must not be overwritten by the saved GAS+AQUEOUS state");
   }
 }


### PR DESCRIPTION
## Summary

- make the post-phase-removal aqueous rollback topology-aware
- retain a valid `GAS+AQUEOUS` → `OIL+AQUEOUS` transition for the existing final active-set refinement
- remove the always-on composition-relaxed cold flash introduced by #3285, avoiding that extra work for every feasible water-rich `GAS+AQUEOUS` endpoint
- add topology regression coverage and update the TP-flash algorithm documentation

Follow-up to #3285. Refs #3274. This PR is intentionally draft; #3274 should remain open pending agreement on the density interpretation below.

## Root cause

The regression was introduced by `063fd4ae776272f51d145948d0f5edfdac0afb8b` (#2736).

Before `TPmultiflash`, `TPflash` saves a balanced neutral two-phase aqueous reference. After a rejected phase-appearance trial, it restored that reference whenever the final two-phase aqueous endpoint failed the strict feasibility checks. The recovery did not require the current phase types to match the saved phase types.

For the exact private E300 cases, the saved topology is `GAS+AQUEOUS`, while `TPmultiflash` transitions to `OIL+AQUEOUS`. The unconditional recovery overwrites that valid root/topology change before the final active-set refinement can repair beta and compositions.

The fix restores the saved state only when the unordered pair of active phase types is unchanged. A gas-to-oil transition is retained and then converged by the existing refinement path.

## Why #3285 is removed

The exact E300 model remains `GAS+AQUEOUS` on #3285 because its cold ordinary flash does not discover the oil root. Running that candidate for every otherwise-feasible water-rich `GAS+AQUEOUS` endpoint therefore adds cost without fixing these cases. This follow-up returns that code to the pre-#3285 gated behavior and fixes the actual rollback defect.

## Private exact-case validation

The E300 characterization was used only in an untracked local test and is not included in this branch.

| Case | #3285 / current master | This branch |
|---|---:|---:|
| Case 1 | `GAS+AQUEOUS`, 109.4447255 kg/m³ | `OIL+AQUEOUS`, 683.2946076 kg/m³ |
| Case 2 | `GAS+AQUEOUS`, 102.9270700 kg/m³ | `OIL+AQUEOUS`, 680.1155627 kg/m³ |
| Control | `OIL+AQUEOUS`, 707.3396889 kg/m³ | unchanged, 707.3396889 kg/m³ |

For Case 1, the corrected endpoint has max component-balance residual `2.94e-14` and max log-fugacity residual `1.28e-13`.

The same root, balance, and fugacity assertions pass over a 3×3 temperature/pressure neighborhood for all three compositions (27 points), and repeated explicit-multiphase flashes are deterministic.

### Density interpretation

The v3.16.0 Case 1 endpoint uses the same phase roots/compositions as the corrected result, but retains stale phase fractions: oil beta `0.26007248` instead of `0.41278972`. Its reported overall density, `719.8115932 kg/m³`, therefore has a max component material-balance residual of `0.15257799`.

The corrected, balanced beta yields `683.2946076 kg/m³`. This is slightly below the originally reported expected interval, so the phase-root regression is fixed but the issue should stay open until the reporter/maintainer accepts this interpretation.

## Validation

- focused TP-flash family: 98 tests, 0 failures/errors
- Java 8 target: 5 tests, 0 failures/errors
- full Java 17 suite: 12,348 tests, 0 failures/errors, 215 skipped
- Spotless check passed
- documentation search/index validation passed
- `git diff --check` passed
