### PR TITLE
[AI-Assisted] Qualify PR sour-gas three-phase flash

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -2008,6 +2008,39 @@ qualification cost without placing a timing threshold on shared runners. Electro
 phase-boundary calculation, ion confinement, and Pitzer parameterization remain
 outside this neutral-fluid matrix.
 
+#### 6.4.3 PR Sour-Gas Three-Phase Qualification
+
+The sour-gas regression uses the classic PR mixing rule with a synthetic overall
+composition of 49.88 mol methane, 9.87 mol CO2, and 40.22 mol H2S, normalized from a
+99.97 mol total. It is a solver qualification of the existing enhanced multiphase
+path, not an experimental validation of the predicted phase boundary or phase
+fractions. Temperature is in kelvin and pressure is absolute bar.
+
+Fresh flashes at 202 K/47 bara, 205 K/50 bara, and 208 K/53 bara must produce one
+GAS phase and two compositionally distinct OIL phases. Each endpoint requires finite,
+bounded phase fractions and compositions, phase and beta normalization within
+`1e-10`, component material balance within `1e-10`, and maximum cross-phase
+log-fugacity residual below `1e-8`. The enhanced three-phase endpoint must also have
+lower Gibbs energy than the ordinary two-phase endpoint at the same state. This last
+comparison documents why `setEnhancedMultiPhaseCheck(true)` is required for this
+qualification instead of silently treating the ordinary converged split as globally
+stable.
+
+At the interior 205 K/50 bara point, the complete three-phase endpoint must be
+recovered from an initial beta of `1e-12`. Moving the same system to 49 bara must
+remove the second liquid while preserving closure; returning to 50 bara must restore
+the cold-flash beta, compressibility factors, compositions, and Gibbs energy. An
+immediate repeated flash must reproduce that result within `1e-10`, guarding both
+phase appearance/disappearance and stale-state behavior.
+
+This deterministic matrix replaces a 25,551-state slow scan that swallowed every
+flash exception and ended with the tautology `threePhaseCount >= 0`. The focused
+six-test sour-gas class completed in 0.694-0.888 s across local runs, including the new
+qualification, while adding enforceable thermodynamic acceptance gates. Production code, public
+APIs, model parameters, and runtime behavior are unchanged, so no production speedup
+is claimed. The scope is limited to PR; SRK and experimental sour-gas tie-line
+validation remain separate model-qualification work.
+
 ### 6.5 Hybrid EOS-GE ionic-capacity safeguard
 
 In a fixed-role EOS-gas/GE-aqueous calculation, ions are excluded from every non-aqueous role.

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashSourGasConsistencyTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPflashSourGasConsistencyTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import java.util.Comparator;
 import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemPrEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -85,7 +86,54 @@ class TPflashSourGasConsistencyTest {
     assertEquivalent(repeatedReference, changedState, 1.0e-10, "repeated changed-state liquid-liquid boundary");
   }
 
+  @Test
+  void enhancedMultiphaseFlashQualifiesStableThreePhaseLine() {
+    double[][] conditions = { { 202.0, 47.0 }, { 205.0, 50.0 }, { 208.0, 53.0 } };
+
+    for (double[] condition : conditions) {
+      String label = "T=" + condition[0] + " K, P=" + condition[1] + " bara";
+      SystemInterface ordinary = flash(condition[0], condition[1], false, false);
+      SystemInterface enhanced = flash(condition[0], condition[1], true, true);
+
+      assertEquals(2, ordinary.getNumberOfPhases(), label + " ordinary topology");
+      assertThreePhaseTopology(enhanced, label);
+      assertClosure(ordinary, label + " ordinary closure");
+      assertClosure(enhanced, label + " enhanced closure");
+      assertTrue(enhanced.getGibbsEnergy() < ordinary.getGibbsEnergy(),
+          label + " enhanced stability check must select the lower-Gibbs liquid-liquid split");
+    }
+  }
+
+  @Test
+  void threePhaseEndpointRecoversFromPoorBetaAndChangedState() {
+    SystemInterface reference = flash(205.0, 50.0, true, true);
+    SystemInterface poorGuess = flash(205.0, 50.0, true, true, true);
+    assertThreePhaseEquivalent(reference, poorGuess, 1.0e-10, "poor beta initialization");
+
+    SystemInterface changedState = reference.clone();
+    changedState.setPressure(49.0, "bara");
+    new ThermodynamicOperations(changedState).TPflash();
+    changedState.init(1);
+    assertEquals(2, changedState.getNumberOfPhases(), "the second liquid disappears below the phase boundary");
+    assertClosure(changedState, "changed state at 49 bara");
+
+    changedState.setPressure(50.0, "bara");
+    new ThermodynamicOperations(changedState).TPflash();
+    changedState.init(1);
+    assertThreePhaseEquivalent(reference, changedState, 1.0e-10, "return to three-phase state");
+
+    SystemInterface repeatedReference = changedState.clone();
+    new ThermodynamicOperations(changedState).TPflash();
+    changedState.init(1);
+    assertThreePhaseEquivalent(repeatedReference, changedState, 1.0e-10, "deterministic repeat");
+  }
+
   private SystemInterface flash(double temperature, double pressure, boolean multiphase, boolean enhanced) {
+    return flash(temperature, pressure, multiphase, enhanced, false);
+  }
+
+  private SystemInterface flash(double temperature, double pressure, boolean multiphase, boolean enhanced,
+      boolean poorGuess) {
     SystemInterface system = new SystemPrEos(temperature, pressure);
     for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
       system.addComponent(COMPONENTS[componentIndex], FEED[componentIndex]);
@@ -93,9 +141,50 @@ class TPflashSourGasConsistencyTest {
     system.setMixingRule("classic");
     system.setMultiPhaseCheck(multiphase);
     system.setEnhancedMultiPhaseCheck(enhanced);
+    if (poorGuess) {
+      system.setBeta(1.0e-12);
+    }
     new ThermodynamicOperations(system).TPflash();
     system.init(1);
     return system;
+  }
+
+  private void assertThreePhaseTopology(SystemInterface system, String condition) {
+    assertEquals(3, system.getNumberOfPhases(), condition);
+    int gasPhases = 0;
+    int oilPhases = 0;
+    for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+      if (system.getPhase(phaseIndex).getType() == PhaseType.GAS) {
+        gasPhases++;
+      } else if (system.getPhase(phaseIndex).getType() == PhaseType.OIL) {
+        oilPhases++;
+      }
+    }
+    assertEquals(1, gasPhases, condition + " gas phase count");
+    assertEquals(2, oilPhases, condition + " liquid phase count");
+  }
+
+  private void assertThreePhaseEquivalent(SystemInterface reference, SystemInterface candidate, double tolerance,
+      String condition) {
+    assertThreePhaseTopology(reference, condition + " reference topology");
+    assertThreePhaseTopology(candidate, condition + " candidate topology");
+    assertClosure(reference, condition + " reference closure");
+    assertClosure(candidate, condition + " candidate closure");
+    assertEquals(reference.getGibbsEnergy(), candidate.getGibbsEnergy(), 1.0e-8, condition);
+
+    Integer[] referenceOrder = phaseOrder(reference);
+    Integer[] candidateOrder = phaseOrder(candidate);
+    for (int orderedPhase = 0; orderedPhase < referenceOrder.length; orderedPhase++) {
+      int referencePhase = referenceOrder[orderedPhase];
+      int candidatePhase = candidateOrder[orderedPhase];
+      assertEquals(reference.getBeta(referencePhase), candidate.getBeta(candidatePhase), tolerance, condition);
+      assertEquals(reference.getPhase(referencePhase).getZ(), candidate.getPhase(candidatePhase).getZ(), tolerance,
+          condition);
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        assertEquals(reference.getPhase(referencePhase).getComponent(componentIndex).getx(),
+            candidate.getPhase(candidatePhase).getComponent(componentIndex).getx(), tolerance, condition);
+      }
+    }
   }
 
   private void assertEquivalent(SystemInterface reference, SystemInterface candidate, double tolerance,
@@ -131,7 +220,17 @@ class TPflashSourGasConsistencyTest {
   private void assertClosure(SystemInterface system, String condition) {
     double betaTotal = 0.0;
     for (int phaseIndex = 0; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
-      betaTotal += system.getBeta(phaseIndex);
+      double beta = system.getBeta(phaseIndex);
+      assertTrue(Double.isFinite(beta) && beta >= 0.0 && beta <= 1.0, condition + " beta " + phaseIndex);
+      betaTotal += beta;
+      double compositionTotal = 0.0;
+      for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
+        double moleFraction = system.getPhase(phaseIndex).getComponent(componentIndex).getx();
+        assertTrue(Double.isFinite(moleFraction) && moleFraction >= 0.0 && moleFraction <= 1.0,
+            condition + " phase " + phaseIndex + " component " + componentIndex);
+        compositionTotal += moleFraction;
+      }
+      assertEquals(1.0, compositionTotal, 1.0e-10, condition + " phase normalization " + phaseIndex);
     }
     assertEquals(1.0, betaTotal, 1.0e-10, condition);
     for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
@@ -141,14 +240,16 @@ class TPflashSourGasConsistencyTest {
       }
       assertEquals(FEED[componentIndex], recoveredFeed, 1.0e-10, condition);
     }
-    if (system.getNumberOfPhases() == 2) {
+    if (system.getNumberOfPhases() >= 2) {
       double maximumFugacityResidual = 0.0;
       for (int componentIndex = 0; componentIndex < COMPONENTS.length; componentIndex++) {
         double firstLogFugacity = Math.log(system.getPhase(0).getComponent(componentIndex).getx())
             + Math.log(system.getPhase(0).getComponent(componentIndex).getFugacityCoefficient());
-        double secondLogFugacity = Math.log(system.getPhase(1).getComponent(componentIndex).getx())
-            + Math.log(system.getPhase(1).getComponent(componentIndex).getFugacityCoefficient());
-        maximumFugacityResidual = Math.max(maximumFugacityResidual, Math.abs(firstLogFugacity - secondLogFugacity));
+        for (int phaseIndex = 1; phaseIndex < system.getNumberOfPhases(); phaseIndex++) {
+          double otherLogFugacity = Math.log(system.getPhase(phaseIndex).getComponent(componentIndex).getx())
+              + Math.log(system.getPhase(phaseIndex).getComponent(componentIndex).getFugacityCoefficient());
+          maximumFugacityResidual = Math.max(maximumFugacityResidual, Math.abs(firstLogFugacity - otherLogFugacity));
+        }
       }
       assertTrue(maximumFugacityResidual < 1.0e-8,
           condition + " maximum log fugacity residual was " + maximumFugacityResidual);

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashTest.java
@@ -7,7 +7,6 @@ import java.lang.reflect.Field;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.ejml.data.DMatrixRMaj;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import neqsim.thermo.mixingrule.EosMixingRulesInterface;
 import neqsim.thermo.system.SystemInterface;
@@ -132,97 +131,6 @@ class TPmultiflashTest {
       methaneHeptaneSystem.setEnhancedMultiPhaseCheck(true);
     }
     return methaneHeptaneSystem;
-  }
-
-  /**
-   * Test three-phase vapor-liquid-liquid equilibrium for sour gas system (methane/CO2/H2S). At low temperatures and
-   * moderate pressures, this mixture can exhibit three-phase behavior with a vapor phase, a CO2-rich liquid, and an
-   * H2S-rich liquid.
-   */
-  @Test
-  void testSourGasThreePhaseEquilibrium() {
-    // Create a sour gas mixture similar to user's case:
-    // methane: 49.88 mol%, CO2: 9.87 mol%, H2S: 40.22 mol%
-    SystemInterface sourGas = new neqsim.thermo.system.SystemPrEos(210.0, 55.0); // ~-63C, ~55 bar
-    sourGas.addComponent("methane", 49.88);
-    sourGas.addComponent("CO2", 9.87);
-    sourGas.addComponent("H2S", 40.22);
-
-    sourGas.setMixingRule("classic");
-    sourGas.setMultiPhaseCheck(true);
-    sourGas.setEnhancedMultiPhaseCheck(true); // Enable Wilson K-value based stability analysis
-
-    ThermodynamicOperations ops = new ThermodynamicOperations(sourGas);
-    ops.TPflash();
-    sourGas.initProperties();
-
-    // At these conditions, we expect at least 2 phases (vapor + liquid)
-    // The new sour gas seeding should help find additional phases if they exist
-    assertTrue(sourGas.getNumberOfPhases() >= 2,
-        "Expected at least 2 phases for sour gas at low T, got " + sourGas.getNumberOfPhases());
-
-    // Print phase information for debugging
-    logger.info("Sour gas flash at T=" + sourGas.getTemperature("C") + " C, P=" + sourGas.getPressure("bara") + " bar");
-    logger.info("Number of phases: " + sourGas.getNumberOfPhases());
-    for (int i = 0; i < sourGas.getNumberOfPhases(); i++) {
-      logger.info("  Phase " + i + ": " + sourGas.getPhase(i).getType() + ", beta=" + sourGas.getBeta(i));
-    }
-  }
-
-  /**
-   * Test that scans temperature/pressure range for three-phase region in sour gas. This helps verify the stability
-   * analysis can find three-phase regions.
-   */
-  @Tag("slow")
-  @Test
-  void testSourGasThreePhaseRegionScan() {
-    SystemInterface sourGas = new neqsim.thermo.system.SystemPrEos();
-    sourGas.addComponent("methane", 49.88);
-    sourGas.addComponent("CO2", 9.87);
-    sourGas.addComponent("H2S", 40.22);
-
-    sourGas.setMixingRule("classic");
-    sourGas.setMultiPhaseCheck(true);
-    sourGas.setEnhancedMultiPhaseCheck(true); // Enable Wilson K-value based stability analysis
-
-    ThermodynamicOperations ops = new ThermodynamicOperations(sourGas);
-
-    int threePhaseCount = 0;
-    double maxPressureThreePhase = 0;
-
-    // Scan a range of conditions where three-phase behavior might occur
-    // Temperature range: -100 to -50 C (173 to 223 K)
-    // Pressure range: 20 to 100 bar
-    for (double tempK = 180.0; tempK <= 230.0; tempK += 0.1) {
-      for (double presBar = 30.0; presBar <= 80.0; presBar += 1.0) {
-        sourGas.setTemperature(tempK);
-        sourGas.setPressure(presBar);
-
-        try {
-          ops.TPflash();
-          sourGas.initProperties();
-
-          if (sourGas.getNumberOfPhases() == 3) {
-            threePhaseCount++;
-            if (presBar > maxPressureThreePhase) {
-              maxPressureThreePhase = presBar;
-            }
-            // logger.info(
-            // "Three phases found at T=" + (tempK - 273.15) + " C, P=" + presBar +
-            // " bar");
-          }
-        } catch (Exception e) {
-          // Some conditions may fail near critical or unstable regions
-        }
-      }
-    }
-
-    logger.info("Total three-phase points found: " + threePhaseCount);
-    logger.info("Maximum pressure with three phases: " + maxPressureThreePhase + " bar");
-
-    // We don't strictly assert three-phase is found since the thermodynamic model
-    // may not predict it for all parameter combinations, but we verify no crashes
-    assertTrue(threePhaseCount >= 0, "Scan completed without errors");
   }
 
   /**


### PR DESCRIPTION
## Summary

Advances #2937 from exact base `408eb35f73b889f0de094f9171bb462c13ce8863` through exact feature head `bdf4abcb0e613112f8e12324b5ca9424a13a53f9`, merged as `d2fc8fda52a5afbdb99edce4f72a20d96835ce47`.

This replaces the existing non-enforcing sour-gas three-phase scan with a deterministic PR GAS+OIL+OIL qualification:

- fresh cold-start points at 202 K/47 bara, 205 K/50 bara, and 208 K/53 bara;
- exactly one gas and two compositionally distinct liquid phases;
- finite, bounded, normalized beta and compositions;
- component material balance within `1e-10`;
- maximum cross-phase log-fugacity residual below `1e-8`;
- lower Gibbs energy than the ordinary two-phase endpoint;
- poor initialization from beta `1e-12`;
- phase disappearance at 49 bara, reappearance at 50 bara, deterministic repeat, and return-to-state equivalence.

The previous slow test performed 25,551 serial flashes, caught every exception, and ended with `threePhaseCount >= 0`, so it could not detect a lost three-phase region or a convergence failure.

## Scientific and compatibility boundary

The mixture is the existing synthetic sour-gas case: 49.88 mol methane, 9.87 mol CO2, and 40.22 mol H2S, normalized from 99.97 mol total. It uses `SystemPrEos`, the classic mixing rule, explicit multiphase checking, and enhanced stability analysis.

This is solver qualification, not experimental validation of the phase boundary, phase fractions, or model parameters. No production source, public API, model parameter, tolerance, or runtime path changes. No Huldra data or implementation work is included.

## Validation

**MERGED — EXACT FEATURE HEAD JAVA-VALIDATED; BASELINE DOCUMENTATION LINKS REPAIRED ON MASTER**

Passed locally on the final tracked source tree:

- focused sour-gas and adjacent multiflash tests: **13/13**;
- broader `TPflash*`, `TPFlash*`, and `TPmultiflash*` family: **111/111**;
- Spotless apply/check;
- `git diff --check`.

Measured focused sour-gas class runtime was 0.694-0.888 s across local runs. This is test-suite performance evidence only; no production speedup is claimed.

Hosted exact-head evidence:

- Java 21 fast tests passed on Ubuntu and Windows;
- Java 8 fast tests passed on Ubuntu and Windows;
- all four Java 21 slow-test shards passed;
- Javadocs, Spotless, CodeQL, and agent-skill cross-reference checks passed;
- the pre-commit job's Java Spotless stage passed;
- the documentation and aggregate pre-commit workflows were red only on four unchanged links already broken on exact base `408eb35f…`.

Current master `83a99c5c9ef7235798d4a1784adcdd00f2bf0e05` is five commits beyond the merge. Commit `f56b33477aae541c43f8a0e97ab462a430a7e810` repaired those four baseline documentation links. The five post-merge commits changed no TP-flash solver, sour-gas qualification test, or TP-flash algorithm-guide file.

The final diff is review-clean; no submitted reviews or unresolved inline threads.

## Documentation impact

`TPflash_algorithm.md` gains a dedicated PR sour-gas three-phase qualification section covering provenance category, units, topology, residual gates, stability comparison, state-transition coverage, performance evidence, and limitations.

## Stop boundary

This tranche qualifies the existing enhanced PR three-phase path. It does not broaden into SRK model validation, new EOS parameters, an automatic default-mode stability policy, rigorous phase-map continuation, Column Solver, Process Performance, or Huldra integration.

AI-assisted contribution.