### PR TITLE
docs: repair interfacial properties guidance

### DIFF
--- a/docs/physical_properties/interfacial_properties.md
+++ b/docs/physical_properties/interfacial_properties.md
@@ -63,7 +63,11 @@ fluid.setMixingRule("classic");
 fluid.setMultiPhaseCheck(true);
 
 ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
-operations.bubblePointPressureFlash(false);
+try {
+  operations.bubblePointPressureFlash(false);
+} catch (Exception exception) {
+  throw new IllegalStateException("Bubble-point flash failed", exception);
+}
 fluid.initProperties();
 
 if (!fluid.hasPhaseType("gas") || !fluid.hasPhaseType("oil")) {
@@ -212,4 +216,3 @@ for model equations and parameter APIs.
 The methods and model names above are anchored to
 [`InterfaceProperties.java`](../../src/main/java/neqsim/physicalproperties/interfaceproperties/InterfaceProperties.java)
 and [`SystemThermo.java`](../../src/main/java/neqsim/thermo/system/SystemThermo.java).
-

--- a/docs/physical_properties/interfacial_properties.md
+++ b/docs/physical_properties/interfacial_properties.md
@@ -1,201 +1,122 @@
 ---
 title: Interfacial Properties
-description: This guide documents the interfacial property calculations available in NeqSim, including surface tension and related phenomena.
+description: Calculate and validate gas-oil, gas-aqueous, and oil-aqueous interfacial tension with the current NeqSim API.
+keywords: surface tension, interfacial tension, parachor, gradient theory, cDFT, adsorption
 ---
 
-This guide documents the interfacial property calculations available in NeqSim, including surface tension and related phenomena.
+NeqSim exposes surface- and interfacial-tension calculations through
+`SystemInterface.getInterphaseProperties()`. The calculation belongs to the flashed
+thermodynamic state: establish the expected phases first, initialize properties, select a
+model, and then evaluate the interface.
 
-## Table of Contents
-- [Overview](#overview)
-- [Surface Tension Models](#surface-tension-models)
-  - [Parachor (Macleod-Sugden)](#parachor-macleod-sugden)
-  - [Gradient Theory (GT)](#gradient-theory-gt)
-  - [Linear Gradient Theory (LGT)](#linear-gradient-theory-lgt)
-  - [Firozabadi-Ramley](#firozabadi-ramley)
-- [Model Selection by Interface Type](#model-selection-by-interface-type)
-- [Usage Examples](#usage-examples)
-- [Adsorption Calculations](#adsorption-calculations)
-- [Mathematical Background](#mathematical-background)
+## Units and phase identity
 
----
-
-## Overview
-
-Interfacial tension (IFT) describes the energy required to create a unit area of interface between two phases. It is critical for:
-- Capillary pressure calculations
-- Droplet/bubble formation
-- Mass transfer at interfaces
-- Enhanced oil recovery studies
-- Separator design
-
-**Units:**
-- Default output: **N/m** (Newtons per meter)
-- Alternative: **mN/m** (milliNewtons per meter = dyne/cm)
-
-**Basic usage:**
-```java
-fluid.initPhysicalProperties();
-double sigma = fluid.getInterphaseProperties().getSurfaceTension(0, 1);  // N/m
-```
-
----
-
-## Surface Tension Models
-
-### Parachor (Macleod-Sugden)
-
-The Parachor method is an empirical correlation relating surface tension to density difference and component parachors.
-
-**Class:** `ParachorSurfaceTension`
-
-**Equation:**
-$$\sigma^{1/4} = \sum_i P_i \left( \frac{\rho_L x_i}{M_{mix,L}} - \frac{\rho_V y_i}{M_{mix,V}} \right)$$
-
-where:
-- $P_i$ is the parachor of component $i$ (from COMP database)
-- $\rho$ is molar density (mol/m³)
-- $x_i, y_i$ are liquid and vapor mole fractions
-- $M_{mix}$ is mixture molar mass
-
-**Parachor values:**
-- Stored in COMP database as `PARACHOR` column
-- For CPA models, use `PARACHOR_CPA`
-
-**Applicable interfaces:** Gas-liquid, Gas-aqueous
-
-**Best for:**
-- Hydrocarbon systems
-- Quick estimates
-- When parachor values are available
-
-**Usage:**
-```java
-fluid.getInterphaseProperties().setInterfacialTensionModel("gas", "oil", "Parachor");
-```
-
----
-
-### Gradient Theory (GT)
-
-The Gradient Theory is a rigorous thermodynamic approach based on density functional theory.
-
-**Classes:**
-- `GTSurfaceTension` - Full gradient theory (most rigorous)
-- `GTSurfaceTensionSimple` - Simplified version
-- `GTSurfaceTensionODE` - ODE-based solver
-
-**Physical basis:**
-
-Near an interface, the Helmholtz energy depends on density gradients:
-
-$$A = \int_{-\infty}^{\infty} \left[ a_0(\boldsymbol{n}) + \frac{1}{2}\sum_i\sum_j c_{ij} \frac{dn_i}{dz}\frac{dn_j}{dz} \right] dz$$
-
-where:
-- $a_0$ is the homogeneous fluid Helmholtz energy
-- $c_{ij}$ are the influence parameters
-- $n_i$ is the number density of component $i$
-- $z$ is the spatial coordinate
-
-**Surface tension calculation:**
-$$\sigma = \int_{-\infty}^{\infty} \sum_i\sum_j c_{ij} \frac{dn_i}{dz}\frac{dn_j}{dz} dz$$
-
-**Influence parameter correlation:**
-$$c_i = (A_i t_i + B_i) a_i b_i^{2/3}$$
-
-where:
-- $t_i = 1 - T/T_{c,i}$
-- $a_i, b_i$ are EoS parameters
-- $A_i, B_i$ are component-specific constants
-
-**Applicable interfaces:** All phase pairs
-
-**Best for:**
-- High accuracy requirements
-- Near-critical conditions
-- When EoS is well-calibrated
-
-**Usage:**
-```java
-// Full gradient theory
-fluid.getInterphaseProperties().setInterfacialTensionModel("gas", "oil", "Full Gradient Theory");
-
-// Simplified version (faster)
-fluid.getInterphaseProperties().setInterfacialTensionModel("gas", "oil", "Simple Gradient Theory");
-```
-
----
-
-### Linear Gradient Theory (LGT)
-
-A linearized approximation of gradient theory that is computationally efficient.
-
-**Class:** `LGTSurfaceTension`
-
-**Approximation:**
-Assumes linear density profile between bulk phases:
-
-$$n_i(z) = n_i^L + \frac{n_i^V - n_i^L}{L} z$$
-
-This allows analytical integration:
-
-$$\sigma = \sum_i\sum_j c_{ij} \frac{(n_i^V - n_i^L)(n_j^V - n_j^L)}{L}$$
-
-where $L$ is optimized to minimize Helmholtz energy.
-
-**Applicable interfaces:** Gas-liquid
-
-**Best for:**
-- Balance of accuracy and speed
-- Parametric studies
-- When full GT is too slow
-
-**Usage:**
-```java
-fluid.getInterphaseProperties().setInterfacialTensionModel("gas", "oil", "Linear Gradient Theory");
-```
-
----
-
-### Firozabadi-Ramley
-
-A correlation specifically designed for liquid-liquid interfaces (oil-water).
-
-**Class:** `FirozabadiRamleyInterfaceTension`
-
-**Equation:**
-$$\sigma_{ow} = \sigma_o + \sigma_w - 2\sqrt{\sigma_o \sigma_w} \phi$$
-
-where:
-- $\sigma_o, \sigma_w$ are oil and water surface tensions
-- $\phi$ is an interaction parameter
-
-**Applicable interfaces:** Oil-water (liquid-liquid)
-
-**Best for:**
-- Oil-water systems
-- When aqueous phase is present
-- Three-phase systems
-
-**Usage:**
-```java
-fluid.getInterphaseProperties().setInterfacialTensionModel("oil", "aqueous", "Firozabadi Ramley");
-```
-
----
-
-## Model Selection by Interface Type
-
-NeqSim automatically selects models based on phase types, but you can override:
-
-### Using Model Numbers
+`getSurfaceTension(int, int)` and the `SystemInterface.getInterfacialTension(...)`
+facade return **N/m**. Convert explicitly when reporting mN/m:
 
 ```java
-// Set interfacial tension model set by number
-fluid.getInterphaseProperties().setInterfacialTensionModel(0);  // Default set
+double sigmaNPerM = fluid.getInterfacialTension("gas", "oil");
+double sigmaMilliNPerM = sigmaNPerM * 1000.0;
 ```
 
-| Number | Gas-Oil | Gas-Aqueous | Oil-Aqueous |
-|--------|---------|-------------|-------------|
+The current `getSurfaceTension(int, int, String unit)` implementation does not convert
+the value: it returns the same N/m result for every unit string. Do not use that overload
+for unit conversion.
+
+Phase numbers are flash results, not stable labels. Resolve them from phase names and
+pass the gas phase first for gas-oil and gas-aqueous calculations. The lower-level
+dispatcher recognizes the ordered pairs gas-oil and gas-aqueous; reversing either pair
+routes to the liquid-liquid model.
+
+```java
+if (!fluid.hasPhaseType("gas") || !fluid.hasPhaseType("oil")) {
+  throw new IllegalStateException("The flashed state does not contain gas and oil phases");
+}
+
+int gas = fluid.getPhaseNumberOfPhase("gas");
+int oil = fluid.getPhaseNumberOfPhase("oil");
+double sigmaNPerM =
+    fluid.getInterphaseProperties().getSurfaceTension(gas, oil);
+
+if (!Double.isFinite(sigmaNPerM) || sigmaNPerM < 0.0) {
+  throw new IllegalStateException("Invalid gas-oil interfacial tension");
+}
+```
+
+The named facade fails closed: `getInterfacialTension("gas", "aqueous")` returns
+`Double.NaN` if either requested phase is absent. Check `Double.isFinite(...)` before an
+IFT value enters equipment sizing, optimization, or a control calculation.
+
+## Complete gas-oil workflow
+
+This pure-component bubble-point example has deterministic gas and oil phase identities
+and exercises the same workflow as the executable documentation regression.
+
+```java
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+SystemInterface fluid = new SystemPrEos(120.0, 1.0); // K, bara
+fluid.addComponent("methane", 1.0);
+fluid.setMixingRule("classic");
+fluid.setMultiPhaseCheck(true);
+
+ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+operations.bubblePointPressureFlash(false);
+fluid.initProperties();
+
+if (!fluid.hasPhaseType("gas") || !fluid.hasPhaseType("oil")) {
+  throw new IllegalStateException("Expected gas and oil at the bubble point");
+}
+
+fluid.getInterphaseProperties()
+    .setInterfacialTensionModel("gas", "oil", "Parachor");
+int gas = fluid.getPhaseNumberOfPhase("gas");
+int oil = fluid.getPhaseNumberOfPhase("oil");
+double sigmaNPerM =
+    fluid.getInterphaseProperties().getSurfaceTension(gas, oil);
+double sigmaMilliNPerM = sigmaNPerM * 1000.0;
+```
+
+For a pressure or temperature sweep, flash and confirm the required phase pair at every
+state. A single-phase result is not an IFT value and should be recorded separately.
+
+## Selecting a model
+
+### Named selector
+
+The named selector has the form:
+
+```java
+fluid.getInterphaseProperties()
+    .setInterfacialTensionModel("gas", "oil", "Full Gradient Theory");
+```
+
+Use these exact, case-sensitive model names:
+
+| Accepted name | Implementation |
+|---|---|
+| `Parachor`, `Weinaug-Katz` | `ParachorSurfaceTension` |
+| `Full Gradient Theory` | `GTSurfaceTension` |
+| `Simple Gradient Theory` | `GTSurfaceTensionSimple` |
+| `Linear Gradient Theory` | `LGTSurfaceTension` |
+| `cDFT`, `Classical DFT` | `CDFTSurfaceTension` |
+| `Firozabadi Ramley` | `FirozabadiRamleyInterfaceTension` |
+
+The accepted interface names are also exact and ordered: `("gas", "oil")`,
+`("gas", "aqueous")`, and `("oil", "aqueous")`. An unknown model name currently
+constructs a Parachor model, while an unknown or reversed interface pair leaves the
+selected interface unchanged. Validate configuration strings before calling the API;
+silent fallback is unsuitable for traceable engineering calculations.
+
+### Numbered model sets
+
+`setInterfacialTensionModel(int)` initializes all three interface models as one set. It
+does not select a model from pressure, temperature, or composition.
+
+| Set | Gas-oil | Gas-aqueous | Oil-aqueous |
+|---:|---|---|---|
 | 0 | Parachor | Parachor | Firozabadi-Ramley |
 | 1 | Full GT | Simple GT | Simple GT |
 | 2 | LGT | LGT | LGT |
@@ -203,206 +124,92 @@ fluid.getInterphaseProperties().setInterfacialTensionModel(0);  // Default set
 | 4 | Simple GT | Parachor | LGT |
 | 5 | Parachor | Parachor | Firozabadi-Ramley |
 
-### Using Named Models
+Set 0 is the initialized default. Values outside 0-5 select Parachor for all three
+interfaces. Prefer the named selector when one interface needs an explicit, auditable
+model choice.
+
+## Model boundaries
+
+### Parachor (Macleod-Sugden)
+
+The Parachor model relates surface tension to the phase-density/composition contrast and
+component parachors. It is the default gas-liquid model and is computationally useful
+for screening. The result is only as reliable as the equilibrium state, equation of
+state, mixing rule, and component parachor data.
+
+### Gradient-theory models
+
+Full, simple, and linear gradient-theory implementations use progressively different
+approximations to the interfacial density profile. Full Gradient Theory is the most
+detailed of these selectors and generally the most computationally demanding. Do not
+interpret the selector name as a validated accuracy guarantee: benchmark the chosen
+equation of state and influence parameters against data in the intended range.
+
+### Classical density functional theory
+
+`cDFT` and `Classical DFT` are aliases for `CDFTSurfaceTension`. The model is available
+for pure fluids and mixtures; it is not a documented alias for Parachor. Treat cDFT as
+an explicit model selection and validate its numerical result for the fluid and state.
+
+### Firozabadi-Ramley
+
+The default oil-aqueous selector is `Firozabadi Ramley`. Use the canonical
+`("oil", "aqueous")` interface order. Confirm that the flashed state contains both
+liquid phases before evaluating it.
+
+## Three-phase calculations
+
+Resolve all three phase numbers by name and preserve the dispatcher order:
 
 ```java
-// Set specific models per interface
-fluid.getInterphaseProperties().setInterfacialTensionModel("gas", "oil", "Full Gradient Theory");
-fluid.getInterphaseProperties().setInterfacialTensionModel("gas", "aqueous", "Parachor");
-fluid.getInterphaseProperties().setInterfacialTensionModel("oil", "aqueous", "Firozabadi Ramley");
-```
-
-Available model names:
-- `"Parachor"` or `"Weinaug-Katz"`
-- `"Full Gradient Theory"`
-- `"Simple Gradient Theory"`
-- `"Linear Gradient Theory"`
-- `"Firozabadi Ramley"`
-
----
-
-## Usage Examples
-
-### Basic Surface Tension
-
-```java
-import neqsim.thermo.system.SystemSrkEos;
-import neqsim.thermodynamicoperations.ThermodynamicOperations;
-
-// Create and flash fluid
-SystemInterface fluid = new SystemSrkEos(300.0, 50.0);
-fluid.addComponent("methane", 0.8);
-fluid.addComponent("n-decane", 0.2);
-fluid.setMixingRule("classic");
-fluid.setMultiPhaseCheck(true);
-
-ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-ops.TPflash();
-
-// Initialize physical properties
-fluid.initPhysicalProperties();
-
-// Get surface tension between phase 0 and 1
-double sigma = fluid.getInterphaseProperties().getSurfaceTension(0, 1);
-System.out.println("Surface tension: " + sigma * 1000 + " mN/m");
-```
-
-### Comparing Surface Tension Models
-
-```java
-String[] models = {"Parachor", "Full Gradient Theory", "Linear Gradient Theory"};
-
-SystemInterface baseFluid = createTwoPhaseFluid();
-ThermodynamicOperations ops = new ThermodynamicOperations(baseFluid);
-ops.TPflash();
-baseFluid.initPhysicalProperties();
-
-for (String model : models) {
-    SystemInterface fluid = baseFluid.clone();
-    fluid.getInterphaseProperties().setInterfacialTensionModel("gas", "oil", model);
-    fluid.initPhysicalProperties();
-    
-    double sigma = fluid.getInterphaseProperties().getSurfaceTension(0, 1) * 1000;
-    System.out.println(model + ": " + sigma + " mN/m");
+if (!(fluid.hasPhaseType("gas")
+    && fluid.hasPhaseType("oil")
+    && fluid.hasPhaseType("aqueous"))) {
+  throw new IllegalStateException("Expected gas, oil, and aqueous phases");
 }
+
+int gas = fluid.getPhaseNumberOfPhase("gas");
+int oil = fluid.getPhaseNumberOfPhase("oil");
+int aqueous = fluid.getPhaseNumberOfPhase("aqueous");
+
+double gasOil = fluid.getInterphaseProperties().getSurfaceTension(gas, oil);
+double gasWater = fluid.getInterphaseProperties().getSurfaceTension(gas, aqueous);
+double oilWater = fluid.getInterphaseProperties().getSurfaceTension(oil, aqueous);
 ```
 
-### Surface Tension vs Pressure (Approaching Critical)
+Do not enumerate arbitrary `i, j` combinations and assume dispatch is symmetric.
+
+## Adsorption is a separate subsystem
+
+Solid adsorption models are exposed by the same interphase-properties object, but they
+do not calculate fluid-fluid IFT. Select an isotherm explicitly when the default DRA
+potential-theory model is not intended:
 
 ```java
-SystemInterface fluid = new SystemSrkEos(350.0, 10.0);
-fluid.addComponent("methane", 0.5);
-fluid.addComponent("n-pentane", 0.5);
-fluid.setMixingRule("classic");
-fluid.setMultiPhaseCheck(true);
+import neqsim.physicalproperties.interfaceproperties.solidadsorption.IsothermType;
 
-double[] pressures = {10, 30, 50, 70, 90, 100, 110};
-
-for (double P : pressures) {
-    fluid.setPressure(P, "bar");
-    
-    ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-    ops.TPflash();
-    
-    if (fluid.getNumberOfPhases() >= 2) {
-        fluid.initPhysicalProperties();
-        double sigma = fluid.getInterphaseProperties().getSurfaceTension(0, 1) * 1000;
-        System.out.println("P=" + P + " bar: σ=" + sigma + " mN/m");
-    } else {
-        System.out.println("P=" + P + " bar: Single phase");
-    }
-}
-// Surface tension approaches zero at critical point
-```
-
-### Three-Phase System
-
-```java
-SystemInterface fluid = new SystemSrkCPAstatoil(300.0, 30.0);
-fluid.addComponent("methane", 0.6);
-fluid.addComponent("n-heptane", 0.3);
-fluid.addComponent("water", 0.1);
-fluid.setMixingRule(10);
-fluid.setMultiPhaseCheck(true);
-
-ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-ops.TPflash();
-fluid.initPhysicalProperties();
-
-// Get all interfacial tensions
-int nPhases = fluid.getNumberOfPhases();
-for (int i = 0; i < nPhases; i++) {
-    for (int j = i + 1; j < nPhases; j++) {
-        double sigma = fluid.getInterphaseProperties().getSurfaceTension(i, j);
-        System.out.println("Phase " + i + " - Phase " + j + ": " + 
-            sigma * 1000 + " mN/m");
-    }
-}
-```
-
----
-
-## Adsorption Calculations
-
-NeqSim also supports adsorption calculations at solid surfaces.
-
-### Setup
-
-```java
-// Initialize adsorption
-fluid.getInterphaseProperties().initAdsorption();
-
-// Set adsorbent material
-fluid.getInterphaseProperties().setSolidAdsorbentMaterial("ite");
-
-// Calculate adsorption
+fluid.getInterphaseProperties().initAdsorption(IsothermType.LANGMUIR);
+fluid.getInterphaseProperties().setSolidAdsorbentMaterial("Zeolite 13X");
 fluid.getInterphaseProperties().calcAdsorption();
 ```
 
-### Access Results
+Supported enum values are `DRA`, `LANGMUIR`, `EXTENDED_LANGMUIR`, `FREUNDLICH`, `BET`,
+and `SIPS`. Material identifiers, fitted parameters, units, and data provenance must be
+part of the simulation input and validation record. See [Adsorption isotherms](../thermo/adsorption_isotherms.md)
+for model equations and parameter APIs.
 
-```java
-AdsorptionInterface ads = fluid.getInterphaseProperties().getAdsorptionCalc("gas");
-// Access adsorption quantities per component
-```
+## Engineering validation checklist
 
----
+- Confirm the flash produced the intended phases at every state.
+- Resolve phase numbers from phase names; preserve gas-first and oil-aqueous ordering.
+- Record the exact model name or numbered model set and its parameter provenance.
+- Treat the API result as N/m and convert explicitly for reports.
+- Reject `NaN`, infinite, or negative results before downstream use.
+- Compare against measurements or an accepted correlation over the operating envelope.
+- Check sensitivity to equation of state, mixing rule, composition, and near-critical
+  phase disappearance.
 
-## Mathematical Background
+The methods and model names above are anchored to
+[`InterfaceProperties.java`](../../src/main/java/neqsim/physicalproperties/interfaceproperties/InterfaceProperties.java)
+and [`SystemThermo.java`](../../src/main/java/neqsim/thermo/system/SystemThermo.java).
 
-### Thermodynamic Definition
-
-Surface tension is defined as:
-
-$$\sigma = \left( \frac{\partial G}{\partial A} \right)_{T,P,n}$$
-
-where $G$ is Gibbs energy and $A$ is interfacial area.
-
-### Young-Laplace Equation
-
-The pressure difference across a curved interface:
-
-$$\Delta P = \sigma \left( \frac{1}{R_1} + \frac{1}{R_2} \right)$$
-
-where $R_1, R_2$ are the principal radii of curvature.
-
-### Temperature Dependence
-
-Surface tension typically decreases with temperature:
-
-$$\sigma = \sigma_0 \left( 1 - T/T_c \right)^n$$
-
-where $n \approx 1.26$ (Guggenheim exponent).
-
-At the critical point: $\sigma \rightarrow 0$.
-
-### Pressure Dependence
-
-Surface tension generally decreases with increasing pressure because:
-1. Density difference decreases
-2. Phases become more similar as pressure increases
-
-Near the critical point, $\sigma \propto (\rho_L - \rho_V)^{3.9}$.
-
----
-
-## Typical Values
-
-| Interface | Temperature | Typical IFT |
-|-----------|-------------|-------------|
-| Methane-Water | 25°C, 100 bar | 50-70 mN/m |
-| Crude Oil-Gas | Reservoir | 5-30 mN/m |
-| Crude Oil-Water | 25°C | 20-30 mN/m |
-| n-Hexane-Air | 25°C | 18 mN/m |
-| Water-Air | 25°C | 72 mN/m |
-| Near critical | - | 0-1 mN/m |
-
----
-
-## References
-
-1. Macleod, D.B. (1923). On a Relation between Surface Tension and Density. Trans. Faraday Soc.
-2. Sugden, S. (1924). The Variation of Surface Tension with Temperature and Some Related Functions. J. Chem. Soc.
-3. Cahn, J.W., Hilliard, J.E. (1958). Free Energy of a Nonuniform System. J. Chem. Phys.
-4. Miqueu, C., et al. (2004). Modelling of the Surface Tension of Pure Components with the Gradient Theory. Fluid Phase Equilib.
-5. Firozabadi, A., Ramey, H.J. (1988). Surface Tension of Water-Hydrocarbon Systems at Reservoir Conditions. JCPT.

--- a/docs/test_interfacial_properties_documentation.py
+++ b/docs/test_interfacial_properties_documentation.py
@@ -1,0 +1,144 @@
+"""Regression contracts for the interfacial-properties guide."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDE = ROOT / "docs" / "physical_properties" / "interfacial_properties.md"
+INTERFACE_PROPERTIES = (
+    ROOT
+    / "src/main/java/neqsim/physicalproperties/interfaceproperties"
+    / "InterfaceProperties.java"
+)
+SYSTEM_THERMO = ROOT / "src/main/java/neqsim/thermo/system/SystemThermo.java"
+ISOTHERM_TYPE = (
+    ROOT
+    / "src/main/java/neqsim/physicalproperties/interfaceproperties"
+    / "solidadsorption/IsothermType.java"
+)
+JAVA_REGRESSION = (
+    ROOT
+    / "src/test/java/neqsim/physicalproperties/interfaceproperties"
+    / "InterfacialPropertiesDocumentationTest.java"
+)
+
+
+class InterfacialPropertiesDocumentationContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+        cls.interface_source = INTERFACE_PROPERTIES.read_text(encoding="utf-8")
+        cls.system_source = SYSTEM_THERMO.read_text(encoding="utf-8")
+        cls.isotherm_source = ISOTHERM_TYPE.read_text(encoding="utf-8")
+        cls.java_regression = JAVA_REGRESSION.read_text(encoding="utf-8")
+
+    def test_search_metadata_and_local_links_are_valid(self):
+        self.assertTrue(self.guide.startswith("---\ntitle:"))
+        front_matter = self.guide.split("---", 2)[1]
+        self.assertIn("description:", front_matter)
+        self.assertIn("keywords:", front_matter)
+        body = self.guide.split("---", 2)[2]
+        body_without_fences = re.sub(
+            r"```.*?```", "", body, flags=re.DOTALL
+        )
+        self.assertNotRegex(body_without_fences, r"(?m)^# ")
+
+        for target in re.findall(r"\[[^\]]+\]\(([^)]+)\)", self.guide):
+            target_path = target.split("#", 1)[0]
+            if not target_path or "://" in target_path:
+                continue
+            resolved = (GUIDE.parent / target_path).resolve()
+            with self.subTest(target=target):
+                self.assertTrue(resolved.is_file(), resolved)
+
+    def test_model_names_and_ordered_interface_pairs_match_source(self):
+        model_names = (
+            "Parachor",
+            "Weinaug-Katz",
+            "Full Gradient Theory",
+            "Simple Gradient Theory",
+            "Linear Gradient Theory",
+            "cDFT",
+            "Classical DFT",
+            "Firozabadi Ramley",
+        )
+        for model in model_names:
+            with self.subTest(model=model):
+                self.assertIn(f'"{model}"', self.interface_source)
+                self.assertIn(f'`{model}`', self.guide)
+
+        for pair in (
+            '("gas", "oil")',
+            '("gas", "aqueous")',
+            '("oil", "aqueous")',
+        ):
+            with self.subTest(pair=pair):
+                self.assertIn(pair, self.guide)
+
+        self.assertIn("exact, case-sensitive model names", self.guide)
+        self.assertIn("unknown model name currently", self.guide)
+        self.assertIn("unknown or reversed interface pair", self.guide)
+
+    def test_units_and_dispatch_boundaries_are_explicit(self):
+        self.assertIn("TODO: add unit conversion", self.interface_source)
+        self.assertIn("return val;", self.interface_source)
+        self.assertIn("does not convert", self.guide)
+        self.assertIn("sigmaNPerM * 1000.0", self.guide)
+        self.assertIn("pass the gas phase first", self.guide)
+        self.assertIn("Do not enumerate arbitrary `i, j`", self.guide)
+        self.assertNotIn('getSurfaceTension(0, 1, "mN/m")', self.guide)
+
+    def test_missing_phase_behavior_and_safe_example_match_system_api(self):
+        for token in (
+            "if (hasPhaseType(phase1) && hasPhaseType(phase2))",
+            "return Double.NaN;",
+        ):
+            self.assertIn(token, self.system_source)
+        for token in (
+            'hasPhaseType("gas")',
+            'getPhaseNumberOfPhase("gas")',
+            "Double.isFinite(sigmaNPerM)",
+            "operations.bubblePointPressureFlash(false)",
+        ):
+            self.assertIn(token, self.guide)
+
+    def test_numbered_sets_match_current_implementation(self):
+        for model_set in range(6):
+            self.assertIn(
+                f"interfacialTensionModel == {model_set}",
+                self.interface_source,
+            )
+            self.assertRegex(self.guide, rf"(?m)^\| {model_set} \|")
+        self.assertIn("does not select a model from pressure", self.guide)
+        self.assertIn("Values outside 0-5 select Parachor", self.guide)
+
+    def test_adsorption_is_separated_and_all_enum_choices_are_visible(self):
+        for isotherm in (
+            "DRA",
+            "LANGMUIR",
+            "EXTENDED_LANGMUIR",
+            "FREUNDLICH",
+            "BET",
+            "SIPS",
+        ):
+            with self.subTest(isotherm=isotherm):
+                self.assertIn(isotherm, self.isotherm_source)
+                self.assertIn(f"`{isotherm}`", self.guide)
+        self.assertIn("do not calculate fluid-fluid IFT", self.guide)
+        self.assertIn("parameter provenance", self.guide)
+
+    def test_complete_workflow_has_executable_java_regression(self):
+        for token in (
+            "class InterfacialPropertiesDocumentationTest",
+            "documentedParachorWorkflowUsesNamedPhaseOrder",
+            "documentedCDFTAliasesSelectCDFT",
+            "missingNamedPhaseReturnsNaN",
+        ):
+            self.assertIn(token, self.java_regression)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/src/test/java/neqsim/physicalproperties/interfaceproperties/InterfacialPropertiesDocumentationTest.java
+++ b/src/test/java/neqsim/physicalproperties/interfaceproperties/InterfacialPropertiesDocumentationTest.java
@@ -16,7 +16,11 @@ class InterfacialPropertiesDocumentationTest {
     fluid.setMultiPhaseCheck(true);
 
     ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
-    operations.bubblePointPressureFlash(false);
+    try {
+      operations.bubblePointPressureFlash(false);
+    } catch (Exception exception) {
+      throw new AssertionError("Bubble-point flash failed", exception);
+    }
     fluid.initProperties();
     assertTrue(fluid.hasPhaseType("gas"));
     assertTrue(fluid.hasPhaseType("oil"));

--- a/src/test/java/neqsim/physicalproperties/interfaceproperties/InterfacialPropertiesDocumentationTest.java
+++ b/src/test/java/neqsim/physicalproperties/interfaceproperties/InterfacialPropertiesDocumentationTest.java
@@ -1,0 +1,59 @@
+package neqsim.physicalproperties.interfaceproperties;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.physicalproperties.interfaceproperties.surfacetension.CDFTSurfaceTension;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class InterfacialPropertiesDocumentationTest {
+  private SystemInterface createBubblePointMethane() {
+    SystemInterface fluid = new SystemPrEos(120.0, 1.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+    operations.bubblePointPressureFlash(false);
+    fluid.initProperties();
+    assertTrue(fluid.hasPhaseType("gas"));
+    assertTrue(fluid.hasPhaseType("oil"));
+    return fluid;
+  }
+
+  @Test
+  void documentedParachorWorkflowUsesNamedPhaseOrder() {
+    SystemInterface fluid = createBubblePointMethane();
+    fluid.getInterphaseProperties().setInterfacialTensionModel("gas", "oil", "Parachor");
+
+    int gas = fluid.getPhaseNumberOfPhase("gas");
+    int oil = fluid.getPhaseNumberOfPhase("oil");
+    double sigmaNPerM = fluid.getInterphaseProperties().getSurfaceTension(gas, oil);
+
+    assertTrue(Double.isFinite(sigmaNPerM));
+    assertTrue(sigmaNPerM > 0.0);
+  }
+
+  @Test
+  void documentedCDFTAliasesSelectCDFT() {
+    SystemInterface fluid = createBubblePointMethane();
+    int gas = fluid.getPhaseNumberOfPhase("gas");
+
+    fluid.getInterphaseProperties().setInterfacialTensionModel("gas", "oil", "cDFT");
+    assertInstanceOf(CDFTSurfaceTension.class,
+        fluid.getInterphaseProperties().getSurfaceTensionModel(gas));
+
+    fluid.getInterphaseProperties()
+        .setInterfacialTensionModel("gas", "oil", "Classical DFT");
+    assertInstanceOf(CDFTSurfaceTension.class,
+        fluid.getInterphaseProperties().getSurfaceTensionModel(gas));
+  }
+
+  @Test
+  void missingNamedPhaseReturnsNaN() {
+    SystemInterface fluid = createBubblePointMethane();
+    assertTrue(Double.isNaN(fluid.getInterfacialTension("gas", "aqueous")));
+  }
+}

--- a/src/test/java/neqsim/physicalproperties/interfaceproperties/InterfacialPropertiesDocumentationTest.java
+++ b/src/test/java/neqsim/physicalproperties/interfaceproperties/InterfacialPropertiesDocumentationTest.java
@@ -42,13 +42,10 @@ class InterfacialPropertiesDocumentationTest {
     int gas = fluid.getPhaseNumberOfPhase("gas");
 
     fluid.getInterphaseProperties().setInterfacialTensionModel("gas", "oil", "cDFT");
-    assertInstanceOf(CDFTSurfaceTension.class,
-        fluid.getInterphaseProperties().getSurfaceTensionModel(gas));
+    assertInstanceOf(CDFTSurfaceTension.class, fluid.getInterphaseProperties().getSurfaceTensionModel(gas));
 
-    fluid.getInterphaseProperties()
-        .setInterfacialTensionModel("gas", "oil", "Classical DFT");
-    assertInstanceOf(CDFTSurfaceTension.class,
-        fluid.getInterphaseProperties().getSurfaceTensionModel(gas));
+    fluid.getInterphaseProperties().setInterfacialTensionModel("gas", "oil", "Classical DFT");
+    assertInstanceOf(CDFTSurfaceTension.class, fluid.getInterphaseProperties().getSurfaceTensionModel(gas));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Advance documentation-quality campaign #2499 with D098, a frozen interfacial-properties batch.

This change repairs the current guide against the exact `InterfaceProperties` and `SystemThermo` behavior:

- documents N/m as the base unit and the current non-converting unit overload
- replaces unstable numeric phase assumptions with named phase discovery
- documents the gas-first and oil-aqueous dispatcher order
- documents the named facade's `NaN` result when a phase is absent
- adds the missing `cDFT` and `Classical DFT` selectors
- records exact, case-sensitive model names and silent Parachor fallback
- records exact ordered interface selector names and no-op invalid pairs
- distinguishes fixed numbered model sets from state-dependent selection
- corrects the cDFT pure-fluid/mixture boundary
- separates solid adsorption from fluid-fluid IFT
- exposes every current `IsothermType` and parameter-provenance boundary
- replaces unsupported typical-value and accuracy claims with validation gates

## Regression coverage

- six source-anchored Python documentation contracts
- three executable Java regressions covering:
  - named-phase Parachor evaluation
  - both cDFT aliases
  - missing named-phase fail-closed behavior

## Frozen scope

Exactly three files:

- `docs/physical_properties/interfacial_properties.md`
- `docs/test_interfacial_properties_documentation.py`
- `src/test/java/neqsim/physicalproperties/interfaceproperties/InterfacialPropertiesDocumentationTest.java`

The asymmetric dispatcher and unit-overload implementation are documented current boundaries. Changing either public behavior requires a separate production-API decision and is outside this documentation batch.

## Hosted repair loop

The first exact-head cycle found two attributable defects, both repaired:

- applied the exact Spotless layout for the cDFT assertions
- handled the checked bubble-point flash failure in both the guide and Java regression

## Validation

Exact head: `2807b98bc6acf26efeae213353aba65c8ce345b4`

Passed:

- Python syntax compilation
- exact remote blob verification
- Spotless
- CodeQL
- Javadocs
- agent-skill cross-reference validation

Pending:

- Java 21 Ubuntu/Windows fast suites
- four Java 21 slow-test shards

Known unchanged base failure:

- documentation search/pre-commit report four broken links in three generated example pages:
  - `BeerBrewing_BioProcess_Simulation.md`
  - `PVT_Simulation_and_Tuning.md`
  - `ProducedWaterEmissions_Tutorial.md`

None is a frozen D098 file or is referenced by the changed guide. **VALIDATION PENDING CI** for the running Java suites.

No production source, notebook output, TPflash/Pitzer work, diagram/MCP work, or Huldra work is included.

Refs #2499