### PR TITLE
[AI-Assisted] fix(pitzer): reject unvalidated active reactions

### DIFF
--- a/docs/thermo/pitzer_parameter_provenance.md
+++ b/docs/thermo/pitzer_parameter_provenance.md
@@ -62,6 +62,25 @@ level-zero state initialization. Call `init(0)` after changing composition, as r
 general NeqSim state contract. This work is confined to `PhasePitzer` and `ComponentGePitzer`;
 neutral PR, SRK, CPA, Electrolyte-CPA, and Fürst electrolyte-EOS paths do no new work.
 
+## Pitzer reaction-data validation boundary
+
+Reaction-equilibrium constants and Pitzer ion-interaction coefficients remain separate datasets.
+The `PITZER` reaction source now treats `VALIDATED` as an initialization requirement for every
+active row that is relevant to the selected feed. The retained `MDEAprot` (`Huttenhuis2005`) and
+`DEAprot` (`Austgen1989`) rows are both active compatibility rows but are explicitly
+`UNVALIDATED`; their activation flags therefore do not authorize use by `SystemPitzer`.
+Initialization rejects either row before it can add `MDEA+` or `DEA+`. Validated carbonate,
+water-dissociation, and first H2S-dissociation rows are unchanged, as are the `STANDARD` and
+`KENT_EISENBERG` sources.
+
+No equilibrium coefficient, Pitzer interaction coefficient, table row, or thesis value is copied,
+changed, or adopted by this gate. Kaasa (1998), Appendix F, printed pp. 260–267 remains a provenance
+index only; its table-redistribution terms and row-level independent qualification remain
+unresolved. Enabling Pitzer amine chemistry requires an independently sourced and redistributable
+molality-standard-state amine equilibrium correlation, the complete applicable binary, same-sign,
+ternary, and neutral-ion interaction family, an explicit species/standard-state mapping, and
+held-out speciation plus gas-liquid-equilibrium validation.
+
 ### Qualified public-domain CO2-Na2SO4 subset
 
 `PitzerParameterDatasets.applyPhreeqcCo2SodiumSulfate` installs one coherent subset identified as

--- a/docs/thermo/reaction_model_audit.md
+++ b/docs/thermo/reaction_model_audit.md
@@ -30,6 +30,16 @@ Use `audit.getReactionsWithoutValidatedEvidence()` to list active rows that are 
 
 The API is deliberately read-only. It requires `chemicalReactionInit()` to have been called and never initializes reactions implicitly, runs a flash, or changes model state. It therefore adds no work to ordinary neutral PR/SRK/CPA calculations and no work to electrolyte calculations unless the audit is explicitly requested.
 
+For the typed `PITZER` source, validation is also an initialization contract. After irrelevant and
+dependent reactions have been removed, `chemicalReactionInit()` rejects every remaining active
+reaction row whose status is not `VALIDATED`, before that row can add its model-specific product
+species. The current `MDEAprot` (`Huttenhuis2005`) and `DEAprot` (`Austgen1989`) compatibility
+rows remain marked `USEREACTION=1` and `UNVALIDATED`; a `SystemPitzer` feed containing the
+corresponding neutral amine therefore fails closed instead of silently using an unqualified
+molality-standard-state correlation. No reaction coefficient or activation flag is changed.
+`STANDARD` and `KENT_EISENBERG` retain their legacy initialization behavior because their
+distinct standard states require separate qualification.
+
 ## Pitzer reaction concentration basis
 
 `SystemPitzer` evaluates solute activities from molality, defined as moles of solute per kilogram of water solvent, while solvent activity retains its mole-fraction convention. This matches the concentration basis of the Pitzer ion-interaction equations. The `PITZER` source supplies molality-standard-state correlations for CO2/HCO3-, HCO3-/CO3--, and water dissociation; Electrolyte-CPA retains the legacy `STANDARD` source and its mole-fraction reaction convention. Pitzer's thermodynamic framework is documented in DOI `10.1021/j100621a026` and the binary-electrolyte formulation in DOI `10.1021/j100638a009`.

--- a/src/main/java/neqsim/chemicalreactions/ChemicalReactionOperations.java
+++ b/src/main/java/neqsim/chemicalreactions/ChemicalReactionOperations.java
@@ -176,6 +176,7 @@ public class ChemicalReactionOperations implements neqsim.thermo.ThermodynamicCo
       reactionList.readReactions(system);
       reactionList.removeJunkReactions(componentNames);
       reactionList.removeDependentReactions();
+      reactionList.requireValidatedEvidenceForActiveReactions();
       allComponentNames = reactionList.getAllComponents();
       this.addNewComponents();
       if (system.getPhase(0).getNumberOfComponents() == old) {

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionDataSource.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionDataSource.java
@@ -13,26 +13,29 @@ package neqsim.chemicalreactions.chemicalreaction;
  */
 public enum ChemicalReactionDataSource {
   /** General NeqSim reaction data used by electrolyte EOS systems. */
-  STANDARD("standard", "reactiondata"),
+  STANDARD("standard", "reactiondata", false),
 
   /** Molality-standard-state reaction data used by the Pitzer electrolyte GE model. */
-  PITZER("pitzer", "reactiondatapitzer"),
+  PITZER("pitzer", "reactiondatapitzer", true),
 
   /** Apparent-equilibrium-constant data used by the Kent-Eisenberg model. */
-  KENT_EISENBERG("kent-eisenberg", "reactiondatakenteisenberg");
+  KENT_EISENBERG("kent-eisenberg", "reactiondatakenteisenberg", false);
 
   private final String identifier;
   private final String databaseTableName;
+  private final boolean requireValidatedActiveReactions;
 
   /**
    * Create a reaction-data source descriptor.
    *
    * @param identifier stable diagnostic identifier
    * @param databaseTableName internal NeqSim database table name
+   * @param requireValidatedActiveReactions whether initialization must reject relevant unvalidated rows
    */
-  ChemicalReactionDataSource(String identifier, String databaseTableName) {
+  ChemicalReactionDataSource(String identifier, String databaseTableName, boolean requireValidatedActiveReactions) {
     this.identifier = identifier;
     this.databaseTableName = databaseTableName;
+    this.requireValidatedActiveReactions = requireValidatedActiveReactions;
   }
 
   /**
@@ -51,5 +54,14 @@ public enum ChemicalReactionDataSource {
    */
   public String getDatabaseTableName() {
     return databaseTableName;
+  }
+
+  /**
+   * Check whether this source must fail closed when a relevant active row lacks validated evidence.
+   *
+   * @return true when reaction initialization requires every relevant active row to be validated
+   */
+  public boolean requiresValidatedActiveReactions() {
+    return requireValidatedActiveReactions;
   }
 }

--- a/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionList.java
+++ b/src/main/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionList.java
@@ -139,6 +139,35 @@ public class ChemicalReactionList implements ThermodynamicConstantsInterface {
   }
 
   /**
+   * Enforce the selected source's validation policy on the relevant independent reaction set.
+   *
+   * <p>
+   * The check runs after irrelevant and dependent reactions have been removed and before reaction products are added to
+   * the thermodynamic system. Sources without a strict policy retain their legacy behavior.
+   * </p>
+   *
+   * @throws IllegalStateException when a strict source contains a relevant active row without validated evidence
+   */
+  public void requireValidatedEvidenceForActiveReactions() {
+    ChemicalReactionDataSource source = getReactionDataSource();
+    if (!source.requiresValidatedActiveReactions()) {
+      return;
+    }
+
+    ArrayList<String> unvalidatedReactionNames = new ArrayList<String>();
+    for (ChemicalReaction reaction : chemicalReactionList) {
+      if (reaction.getValidationStatus() != ChemicalReactionValidationStatus.VALIDATED) {
+        unvalidatedReactionNames.add(reaction.getName());
+      }
+    }
+    if (!unvalidatedReactionNames.isEmpty()) {
+      java.util.Collections.sort(unvalidatedReactionNames);
+      throw new IllegalStateException("Chemical-reaction initialization rejected unvalidated active rows for source '"
+          + source.getIdentifier() + "': reactionsWithoutValidatedEvidence=" + unvalidatedReactionNames);
+    }
+  }
+
+  /**
    * getReaction.
    *
    * @param i a int

--- a/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionProvenanceTest.java
+++ b/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionProvenanceTest.java
@@ -75,6 +75,23 @@ class ChemicalReactionProvenanceTest {
     assertPitzerRejectsUnvalidatedAmine("DEA", "DEA+", "DEAprot");
   }
 
+  /** Pitzer reports every relevant unvalidated row in deterministic reaction-name order. */
+  @Test
+  void pitzerReportsUnvalidatedRowsDeterministically() {
+    SystemInterface system = new SystemPitzer(298.15, 1.01325);
+    system.addComponent("MDEA", 1.0);
+    system.addComponent("DEA", 1.0);
+    system.addComponent("water", 18.0);
+
+    IllegalStateException failure = assertThrows(IllegalStateException.class, system::chemicalReactionInit);
+    assertEquals(
+        "Chemical-reaction initialization rejected unvalidated active rows for source 'pitzer': "
+            + "reactionsWithoutValidatedEvidence=[DEAprot, MDEAprot]",
+        failure.getMessage());
+    assertFalse(system.hasComponent("MDEA+"));
+    assertFalse(system.hasComponent("DEA+"));
+  }
+
   /** Legacy electrolyte-EOS reaction initialization keeps its non-strict compatibility behavior. */
   @Test
   void standardSourceKeepsLegacyUnspecifiedAmineRows() {

--- a/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionProvenanceTest.java
+++ b/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionProvenanceTest.java
@@ -84,10 +84,8 @@ class ChemicalReactionProvenanceTest {
     system.addComponent("water", 18.0);
 
     IllegalStateException failure = assertThrows(IllegalStateException.class, system::chemicalReactionInit);
-    assertEquals(
-        "Chemical-reaction initialization rejected unvalidated active rows for source 'pitzer': "
-            + "reactionsWithoutValidatedEvidence=[DEAprot, MDEAprot]",
-        failure.getMessage());
+    assertEquals("Chemical-reaction initialization rejected unvalidated active rows for source 'pitzer': "
+        + "reactionsWithoutValidatedEvidence=[DEAprot, MDEAprot]", failure.getMessage());
     assertFalse(system.hasComponent("MDEA+"));
     assertFalse(system.hasComponent("DEA+"));
   }

--- a/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionProvenanceTest.java
+++ b/src/test/java/neqsim/chemicalreactions/chemicalreaction/ChemicalReactionProvenanceTest.java
@@ -2,9 +2,12 @@ package neqsim.chemicalreactions.chemicalreaction;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -63,6 +66,27 @@ class ChemicalReactionProvenanceTest {
     assertEquals("USGS-PHREEQC3-PlummerBusenberg1982-fit-0-90C", reaction.getReference());
     assertEquals(ChemicalReactionValidationStatus.VALIDATED, reaction.getValidationStatus());
     assertArrayEquals(PITZER_CO2_WATER, reaction.getEquilibriumConstantCoefficients(), 1.0e-12);
+  }
+
+  /** Pitzer reaction initialization rejects active MDEA and DEA rows that remain explicitly unvalidated. */
+  @Test
+  void pitzerRejectsUnvalidatedActiveAmineRows() {
+    assertPitzerRejectsUnvalidatedAmine("MDEA", "MDEA+", "MDEAprot");
+    assertPitzerRejectsUnvalidatedAmine("DEA", "DEA+", "DEAprot");
+  }
+
+  /** Legacy electrolyte-EOS reaction initialization keeps its non-strict compatibility behavior. */
+  @Test
+  void standardSourceKeepsLegacyUnspecifiedAmineRows() {
+    SystemInterface system = new SystemElectrolyteCPAstatoil(298.15, 1.01325);
+    system.addComponent("MDEA", 1.0);
+    system.addComponent("water", 9.0);
+    system.chemicalReactionInit();
+
+    assertFalse(ChemicalReactionDataSource.STANDARD.requiresValidatedActiveReactions());
+    ChemicalReaction reaction = system.getChemicalReactionOperations().getReactionList().getReaction("MDEAprot");
+    assertNotNull(reaction);
+    assertEquals(ChemicalReactionValidationStatus.UNSPECIFIED, reaction.getValidationStatus());
   }
 
   /**
@@ -139,6 +163,20 @@ class ChemicalReactionProvenanceTest {
     assertEquals(ChemicalReactionDataSource.KENT_EISENBERG,
         restored.getChemicalReactionOperations().getReactionDataSource());
     assertEquals("KentEisenberg1976", getCo2WaterReaction(restored).getReference());
+  }
+
+  private static void assertPitzerRejectsUnvalidatedAmine(String amineName, String protonatedAmineName,
+      String reactionName) {
+    SystemInterface system = new SystemPitzer(298.15, 1.01325);
+    system.addComponent(amineName, 1.0);
+    system.addComponent("water", 9.0);
+
+    assertTrue(ChemicalReactionDataSource.PITZER.requiresValidatedActiveReactions());
+    IllegalStateException failure = assertThrows(IllegalStateException.class, system::chemicalReactionInit);
+    assertTrue(failure.getMessage().contains("source 'pitzer'"));
+    assertTrue(failure.getMessage().contains(reactionName));
+    assertFalse(system.hasComponent(protonatedAmineName),
+        "An unvalidated reaction must be rejected before its model-specific product is added");
   }
 
   /**


### PR DESCRIPTION
## Scientific question

Should `SystemPitzer` initialize an active reaction row that is explicitly marked
`UNVALIDATED` for its molality-standard-state reaction source?

This draft makes the typed Pitzer source fail closed for relevant unvalidated rows. It does not
qualify, fit, copy, or change any reaction or Pitzer interaction coefficient.

## Frozen scope

- **Base:** exact master `016aed9a0a9cc8d7a970d9d9adcff26149934322`
- **Head:** `0e68b0ddfc94a01c9a36d15acda1c3d1a07f8caa`
- **Model:** `SystemPitzer`; classic Pitzer mixing rule and existing reaction source
- **Reproducer:** 298.15 K, 1.01325 bara, 1 mol MDEA or DEA plus 9 mol water
- **Rows:** `MDEAprot` / `DEAprot`, currently `USEREACTION=1` and `UNVALIDATED`
- **Acceptance:** reject deterministically before the unvalidated row adds `MDEA+` or `DEA+`;
  keep validated Pitzer carbonate/water/H2S rows working; preserve `STANDARD` and
  `KENT_EISENBERG` initialization
- **Stop boundary:** no coefficient, activation flag, reaction table, flash, absorber, salt-input,
  or parameter-dataset change

## Current-master gap

On exact base, `ChemicalReactionModelAudit` can report unvalidated active rows after
initialization, but `chemicalReactionInit()` does not enforce that evidence status. The dedicated
Pitzer table therefore retains relevant active `MDEAprot` and `DEAprot` rows even though both are
explicitly `UNVALIDATED`.

## Change

- adds a source-owned initialization policy to `ChemicalReactionDataSource`;
- enforces it after irrelevant/dependent reaction removal and before product insertion;
- reports sorted reaction names in the exception;
- adds MDEA/DEA fail-closed regressions and a legacy Electrolyte-CPA control;
- documents the reaction/interaction-parameter boundary and exact adoption dependencies.

The check is one short reaction-list scan only during explicit chemical-reaction initialization.
Neutral PR/SRK/CPA property kernels, electrolyte activity kernels, and non-Pitzer reaction sources
take no new thermodynamic work.

## Evidence and provenance

No numerical parameter is adopted. Existing validated carbonate and first-H2S rows retain their
documented sources:

- Pitzer (1973), DOI [10.1021/j100621a026](https://doi.org/10.1021/j100621a026)
- Pitzer and Mayorga (1973), DOI [10.1021/j100638a009](https://doi.org/10.1021/j100638a009)
- Plummer and Busenberg (1982), DOI [10.1016/0016-7037(82)90056-4](https://doi.org/10.1016/0016-7037(82)90056-4)
- USGS PHREEQC 3, public domain: [software and licensing page](https://www.usgs.gov/software/phreeqc-version-3)

Kaasa (1998), Appendix F, printed pp. 260–267 was inspected as a provenance index. No thesis
number is copied or inferred; its redistribution and row-level qualification blockers remain. The
durable source-comparison matrix is in
[`docs/thermo/pitzer_parameter_provenance.md`](https://github.com/equinor/neqsim/blob/ai/pitzer-strict-reaction-validation-3144/docs/thermo/pitzer_parameter_provenance.md).

## Validation

**DRAFT — VALIDATION PENDING FRESH JAVA MATRIX AND CODEQL**

Exact head `0e68b0ddfc94a01c9a36d15acda1c3d1a07f8caa`:

- Commit `0e68b0d` is tree-identical to prior validated head
  `c5ffc5f8131641a04ffd0053ef6ff264435a9628`: one commit ahead, zero changed files.
  It exists only to create a genuine pull-request synchronize event against current master without
  merging/rebasing master or changing the feature diff.
- Fresh current-base documentation search/site build, pre-commit, Spotless, and PaperLab checks pass.
- Fresh Java 21 Javadocs and agent-skill reference checks pass.
- Java fast/slow suites and CodeQL are running; no pending check is claimed as passing.
- The prior exact-tree Java 8/21 Ubuntu/Windows suites, all four slow shards, Javadocs, Spotless,
  PaperLab, and CodeQL passed.
- The PR is mergeable. No review comments, requested changes, or unresolved threads exist.

The previous stale merge-ref documentation blocker is superseded by this fresh validation run.

Campaign: #3144. Coordinates generic TP flash with #2937, reactive absorber equipment with #205,
and salt input/API with #448 without overlapping their scope.