### PR TITLE
[AI-Assisted] fix(twofluid): harden coupled solver progress

### DIFF
--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-dynamic-simulation
 description: "Dynamic simulation guidance for NeqSim. USE WHEN: running transient simulations, modeling startup/shutdown, tuning PID controllers, analyzing pressure/level dynamics, performing blowdown/depressurization, or setting up measurement devices and control loops. Covers runTransient, DynamicProcessHelper, controller tuning, and dynamic equipment configuration."
-last_verified: "2026-08-11"
+last_verified: "2026-08-27"
 ---
 
 # Dynamic Simulation Guidance
@@ -421,6 +421,50 @@ split. Record EOS, mixing rule, composition, absolute pressure, temperature, mas
 relaxation time, and units. The current hydrodynamic state transports bulk phase inventories, not a
 full component-composition vector per cell, and does not establish equivalence with any commercial
 transient multiphase simulator.
+
+## TwoFluidPipe Coupled Pressure-Momentum Gate
+
+For a liquid-rich pressure outlet that physically permits phase fallback, the coupled path requires
+all four options. Keep the nonlinear controls explicit in reproducible studies:
+
+```java
+pipe.setEnableInterfacialPressure(true);
+pipe.setImplicitInterfacialPressureCoupling(true);
+pipe.setEnableCoupledPressureMomentum(true);
+pipe.setAllowOutletPhaseBackflow(true);
+pipe.setCoupledPressureMomentumMaximumIterations(24); // default
+pipe.setCoupledPressureMomentumRelativeVolumeTolerance(1.0e-7); // default
+```
+
+The previous budget of 12 stopped the public Tengesdal progress case near a `6e-7` relative
+cell-volume residual, above the `1e-7` gate. The current 16-section Test 3 probe completes 50/50
+calls of 0.1 s and a 24-section refinement completes 100/100 calls of 0.05 s. Neither rejects a
+nonlinear substep, and phase and total discrete mass residuals remain below `1e-9`.
+
+A coupled call that exhausts its adaptive retries throws with accepted/requested elapsed time,
+residual/tolerance, iterations/cap, and limiter state. Do not catch that exception and advance the
+flowsheet clock. Successful completion still requires the sticky diagnostics to be inspected after
+the full window:
+
+```java
+if (pipe.isTransientOutletBackflowClamped()
+    || pipe.isTransientCoupledPressureMomentumFailureDetected()
+    || pipe.isTransientCoupledPressureMomentumCorrectionLimited()
+    || pipe.getTransientCoupledPressureMomentumRejectedSubsteps() > 0) {
+  throw new IllegalStateException("TwoFluidPipe transient is not qualified");
+}
+```
+
+These flags reset on the next steady `run()`. A pressure-limiter event is not itself a rejected
+substep because the volume residual can converge while the bounded correction is active, but it is
+mandatory qualification evidence. Use
+`isCoupledPressureMomentumPressureCorrectionLimited()` only for the latest correction; use the
+`isTransient...` form for the complete window. The current Tengesdal progress run still activates that flag and
+spans -18.55 to 6.88 kg/s liquid outlet versus the stored 0.375 to 4.03 kg/s comparison. It is
+therefore numerical-progress evidence only, not sustained-severe-slugging or commercial-parity
+evidence. Never tune a public closure to the commercial trace; validate the next boundary-coupling
+increment against the public Tengesdal experiment, conservation, nearby points, and mesh/time-step
+refinement.
 
 ## Running Dynamic Simulation
 

--- a/.github/skills/neqsim-flow-assurance/SKILL.md
+++ b/.github/skills/neqsim-flow-assurance/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-flow-assurance
 description: "Flow assurance analysis patterns for NeqSim. USE WHEN: predicting hydrate formation, wax appearance, asphaltene stability, CO2/H2S corrosion (NORSOK M-506, de Waard-Milliams, FeCO3 film), mineral scale (saturation index, scale kinetics, brine mixing / seawater incompatibility), scale/solids valve plugging & Cv/opening drift (ValveScaleDrift), scale/deposit remediation & dissolver/solvent/wash selection for cleaning fouled equipment (ScaleRemediationAdvisor), elemental sulfur (S8) deposition from oxygen ingress / H2S oxidation at pressure or temperature letdown (compressor inlets, valves, dry-gas seals, letdown stations), per-segment pipeline corrosion+scale profiles, inspected metal-loss screening, pipeline hydraulics, DNV-RP-F109 on-bottom stability screening, DNV-RP-F105 free-span screening, DNV-RP-F104 CO2-envelope screening, DNV-RP-F110 global-buckling response screening, DNV-RP-F114 pipe-soil screening, water/liquid hammer screening, slug flow, thermal analysis, or chemical inhibitor dosing. Covers all flow assurance threats with NeqSim code patterns and industry standards."
-last_verified: "2026-08-02"
+last_verified: "2026-08-27"
 ---
 
 # Flow Assurance Analysis with NeqSim
@@ -553,38 +553,34 @@ for (double qgMSm3d : gasRates) {
 > `−UπD(T−T_surf) + q ≡ −UπD(T − [T_surf + q/(UπD)])`, i.e. by raising the ambient
 > temperature by `q/(UπD)`.
 
-> **`TwoFluidPipe` transient is NOT usable for liquid-rich lines — including
-> severe slugging.** With every boundary condition held constant it leaves its
-> own steady state: on a 5 km liquid-rich line the inventory grows 114.7 → 192.7 t
-> in 30 min and the liquid holdup goes 0.45 → 0.77 while still climbing. The
-> liquid outlet flux collapses to exactly zero because the phase momentum
-> equations develop sustained backflow (oil velocity −2.5 m/s in 9 of 40 cells)
-> and `calcOutletFlux` clamps a negative phase velocity to zero outflow, trapping
-> liquid permanently. The finite-volume balance still closes to 1e-16, so this is
-> a well-posedness defect — there is no interfacial pressure term to keep the
-> two-fluid system hyperbolic at high liquid fraction. Gas-dominated lines are
-> unaffected (0.00 bar null-test drift). For severe slugging use the analytical
-> screen (`SevereSluggingBenchmarkHarnessTest`, Taitel criterion vs the Tengesdal
-> 2002 map, 70.7% accuracy) and treat any transient slug-cycle result as invalid.
+> **`TwoFluidPipe` liquid-rich and severe-slugging transients remain
+> unqualified.** The legacy route can still develop phase backflow and clamp the
+> outlet flux at zero while its finite-volume balance closes exactly. Gas-dominated
+> null cases remain usable, but do not promote a liquid-rich or severe-slugging
+> trajectory from either a small residual or a completed time loop alone. Use the
+> analytical `SevereSluggingBenchmarkHarnessTest` screen and the public Tengesdal
+> evidence until the dynamic qualification gates below pass.
 >
-> A partial remedy exists but is **off by default**:
-> `setEnableInterfacialPressure(true)` adds the missing holdup-gradient momentum
-> term with a Bestion interfacial pressure correction. It removes the backflow
-> entirely (0 of 40 cells versus 9 of 40) and stops the unbounded packing, but it
-> is acoustic in scale and evaluated explicitly, so it needs `setCflNumber(0.05)`
-> — at the default 0.5 it diverges. At that CFL the holdup it settles on is not
-> yet validated, so it is not a drop-in replacement. Finishing it means folding
-> the term into the IMEX implicit pressure solve.
+> **The coupled route is an opt-in four-part configuration.** For a pressure
+> outlet that physically permits phase fallback, use
+> `setEnableInterfacialPressure(true)`,
+> `setImplicitInterfacialPressureCoupling(true)`,
+> `setEnableCoupledPressureMomentum(true)`, and
+> `setAllowOutletPhaseBackflow(true)` together. The nonlinear controls are public:
+> `setCoupledPressureMomentumMaximumIterations(int)` and
+> `setCoupledPressureMomentumRelativeVolumeTolerance(double)`, with defaults 24
+> and `1e-7`.
 >
-> **Re-measured (PR #3086): the interfacial-pressure term does NOT rescue this
-> case.** Sweeping CFL 0.05/0.1/0.2/0.35/0.5/0.8 with and without the term, using
-> `isTransientOutletBackflowClamped()` as the objective detector, every one of the
-> twelve combinations is unstable — with the term ON, backflow trips at *every*
-> CFL including 0.05. So do not reach for `setEnableInterfacialPressure(true)`
-> expecting a stable liquid-rich transient, and note that folding the term into
-> the IMEX solve would only buy step-size relief for a term that does not deliver
-> stability here. `calcVoidWaveSpeed` already feeds the CFL limit, so the small
-> step it needs is a genuine stability limit, not a controller oversight.
+> **WS3 restores progress, not physical parity.** The 16-section Tengesdal Test 3
+> probe now completes 50/50 calls of 0.1 s; a 24-section refinement completes
+> 100/100 calls of 0.05 s. Neither rejects a nonlinear substep, and gas, oil,
+> water, liquid, and total mass residuals are below `1e-9`. The former
+> 12-iteration cap stopped around `6e-7`, above the `1e-7` gate. The sticky pressure
+> limiter still fires, however, and the liquid outlet spans -18.55 to 6.88 kg/s
+> versus the stored 0.375 to 4.03 kg/s comparison. This is a disclosed boundary/
+> pressure-coupling gap, not a reason to tune a public closure to a commercial
+> trace. Subsequent validation must use the public Tengesdal experiment, nearby
+> operating points, conservation, and mesh/time-step refinement.
 >
 > **What did help: fixing the regime.** The same case classified SLUG rather than
 > ANNULAR (PR #3086, Barnea bridging limit) cuts the 30-minute inventory runaway
@@ -592,14 +588,19 @@ for (double qgMSm3d : gasRates) {
 > the flag, but the regime branch is a bigger lever on the runaway than the
 > interfacial-pressure term is.
 >
-> **The transient now tells you when it has failed — always check it.** As of
-> PR #3080, `pipe.isTransientOutletBackflowClamped()` returns true once any phase
-> has reversed at the outlet, which is the first event in the runaway above. This
-> is the transient counterpart of `isSteadyStatePressureFloorLimited()`: ALWAYS
-> read it after `runTransient` and discard the profile when it is true, exactly
-> as with the steady-state flags. The mass-balance report will NOT warn you — it
-> closes to 1e-16 throughout, because it is computed from the same clamped flux.
-> The flag is sticky for the run and is cleared by the next `run()`.
+> **The transient tells you when it has failed — always check every diagnostic.**
+> Read `isTransientOutletBackflowClamped()`,
+> `isTransientCoupledPressureMomentumFailureDetected()`,
+> `isTransientCoupledPressureMomentumCorrectionLimited()`, and
+> `getTransientCoupledPressureMomentumRejectedSubsteps()` after the full window.
+> `isCoupledPressureMomentumPressureCorrectionLimited()` is the non-sticky view
+> of only the latest correction.
+> The flags/counter are sticky and reset on the next steady `run()`. A coupled
+> call that cannot complete its requested interval now throws with accepted time,
+> requested time, residual/tolerance, iterations/cap, and limiter state; never
+> catch it and advance the engineering timeline. The mass-balance report alone
+> cannot qualify the result because a clamped or limited route can still conserve
+> its own discrete fluxes exactly.
 >
 > **Three-phase (gas/oil/water) steady state is fixed.** The oil/water slip
 > ratio uses `S = 1 + 1.75·max(0, 1 − (Fr/3)²)`, a stratified plateau that rolls

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -532,11 +532,16 @@ quantitative dynamic validation.
 
 The slow dynamic benchmark exercises large-facility Test 3 ($v_{SL}=0.50$ m/s and standard
 $v_{SG}=1.00$ m/s). It is currently a **disabled qualification fixture**, not a validated model.
-The coupled transient route does not progress beyond its initial transient state, while the legacy
-route activates `isTransientOutletBackflowClamped()`. Both outcomes are rejected before amplitude,
-period, or slug-length agreement is considered. The class remains in source so issues #2909 and
-#2911 can re-enable the unchanged public benchmark after the numerical gap is resolved; unrelated CI
-must not treat the known-invalid trajectory as a passing or intentionally failing prediction.
+The coupled route now completes the 16-section 50 × 0.1 s progress probe and a 24-section
+100 × 0.05 s refinement with phase and aggregate mass-balance residuals below $10^{-9}$ and
+without a rejected nonlinear substep. That is a numerical-progress result, not severe-slugging
+validation: the sticky pressure-correction limiter fires and the
+interval-average liquid outlet spans -18.55 to 6.88 kg/s, outside the stored 0.375 to 4.03 kg/s
+comparison range. The legacy route still activates `isTransientOutletBackflowClamped()`. Both
+trajectories remain disqualified before amplitude, period, or slug-length agreement is considered.
+The class remains in source so issues #2909, #2911, and #3298 can re-enable the unchanged public
+benchmark after the outlet/pressure coupling is resolved; unrelated CI must not treat a
+known-invalid trajectory as a passing or intentionally failing prediction.
 
 This benchmark previously reported a riser-head-scaled swing of 0.40–0.54 heads and a tracked slug
 of about 2 m. Those results did not come from the momentum balance. The minimum-slip hold-up bound
@@ -1079,6 +1084,8 @@ pipe.setEnableInterfacialPressure(true);
 pipe.setImplicitInterfacialPressureCoupling(true);
 pipe.setEnableCoupledPressureMomentum(true);
 pipe.setAllowOutletPhaseBackflow(true);
+pipe.setCoupledPressureMomentumMaximumIterations(24); // default
+pipe.setCoupledPressureMomentumRelativeVolumeTolerance(1.0e-7); // default
 ```
 
 Use the four settings together for liquid-rich transients whose pressure outlet permits phase
@@ -1089,8 +1096,23 @@ zero. Signed fallback extrapolates the interior phase state and remains opt-in b
 export boundary may instead require a check valve or a supplied external inflow composition. The mode reports
 `isCoupledPressureMomentumConverged()`,
 `getCoupledPressureMomentumVolumeResidual()`, and
-`getCoupledPressureMomentumIterations()`. A non-converged non-adaptive step throws instead of
-returning a bounded-looking but invalid result.
+`getCoupledPressureMomentumIterations()`. The nonlinear gate is available through
+`get/setCoupledPressureMomentumMaximumIterations()` and
+`get/setCoupledPressureMomentumRelativeVolumeTolerance()`. The default iteration budget is 24;
+the former budget of 12 stopped the Tengesdal progress case at about $6\times10^{-7}$ relative
+cell-volume residual, above the $10^{-7}$ default gate.
+
+After a transient window, also read the sticky diagnostics
+`isTransientCoupledPressureMomentumFailureDetected()`,
+`isTransientCoupledPressureMomentumCorrectionLimited()`, and
+`getTransientCoupledPressureMomentumRejectedSubsteps()`. They are cleared by the next steady
+`run()`. `isCoupledPressureMomentumPressureCorrectionLimited()` reports only the latest correction.
+Adaptive execution retries a non-converged correction at a smaller internal step. If the requested
+interval is still incomplete at the minimum factor, `runTransient` throws with accepted and
+requested elapsed time, residual, tolerance, iteration count/cap, and limiter state. It never
+returns a zero- or partial-progress coupled interval silently. A limiter event is diagnostic rather
+than an automatic rejection because the nonlinear residual can converge while a bounded correction
+is active; it must still be reported in qualification evidence.
 
 The option remains off by default while long-horizon severe-slugging, mesh, timestep, and
 independent OLGA/public benchmark qualification is completed. Do not use short startup peaks as
@@ -1191,33 +1213,43 @@ both codes agree that such a case has no solution.
 
 ### Always check the transient outcome too
 
-`runTransient(dt, id)` has the same property: it does not throw when the answer stops being a
-solution, so the outcome has to be read back.
+`runTransient(dt, id)` exposes invalid outcomes that can still satisfy a discrete balance. Coupled
+non-convergence now throws if the requested interval cannot be completed; sticky diagnostics must
+still be read after successful calls.
 
 | Query | Meaning when true |
 |-------|-------------------|
 | `isTransientOutletBackflowClamped()` | A phase reversed at the outlet and its outflow is pinned at zero |
+| `isTransientCoupledPressureMomentumFailureDetected()` | At least one coupled nonlinear correction was rejected |
+| `isTransientCoupledPressureMomentumCorrectionLimited()` | At least one nonlinear pressure correction reached its limiter |
+| `getTransientCoupledPressureMomentumRejectedSubsteps() > 0` | Coupled substeps were retried at a smaller adaptive factor |
 
 ```java
 pipe.runTransient(dt, null);
 if (pipe.isTransientOutletBackflowClamped()) {
   throw new IllegalStateException("Transient liquid inventory is running away");
 }
+if (pipe.isTransientCoupledPressureMomentumFailureDetected()
+    || pipe.isTransientCoupledPressureMomentumCorrectionLimited()) {
+  throw new IllegalStateException("Coupled transient requires diagnostic review");
+}
 ```
 
-Any trajectory for which this flag becomes true is invalid for engineering comparison or model
-qualification, even if its mass-balance residual, pressure amplitude, period, or other headline
-metric appears acceptable. The flag is sticky for the transient run and must be checked after the
-full evaluated window.
+Any trajectory with one of these diagnostic flags is invalid for engineering comparison or model
+qualification until the event has been explained and accepted, even if its mass-balance residual,
+pressure amplitude, period, or other headline metric appears acceptable. The diagnostics are sticky
+for the transient run and must be checked after the full evaluated window.
 
 **Why outlet backflow matters.** The outlet is transmissive: it can carry mass out but not in, so a
 reversed phase velocity is clamped to zero. That is correct as a boundary condition and is also a
 one-way trap. The phase momentum equations of the classical two-fluid system are ill-posed at high
 liquid fraction and can develop sustained backflow, after which the outflow of that phase pins at
 exactly 0 kg/s while the inlet keeps feeding the line and the inventory grows without bound. The
-finite-volume balance still closes to machine precision throughout, so nothing else reports a
-problem — this flag is the only warning. Gas-dominated lines do not show it.
-`setEnableInterfacialPressure(true)` removes it, at the cost of a much smaller stable time step.
+finite-volume balance still closes to machine precision throughout, so the balance alone cannot
+detect the defect. Gas-dominated lines do not show it. Interfacial pressure alone is not a qualified
+remedy. The combined implicit-interfacial, coupled-pressure/momentum, and signed-outlet route now
+advances the short Tengesdal progress probe, but its sticky limiter and outlet-rate mismatch still
+disqualify the trajectory.
 
 ### Direct electrical heating (DEH)
 

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -736,6 +736,45 @@ The `AUSMPlusFluxCalculator` implements AUSM+ flux splitting for:
 - RK2 (Heun's method)
 - RK4 (Classical 4th order)
 - SSPRK3 (Strong stability preserving)
+- IMEX pressure correction
+
+### Coupled Pressure-Momentum Correction
+
+The opt-in coupled route corrects phase masses, phase momenta, compressible densities, and pressure
+inside the same accepted substep. For a liquid-rich pressure outlet that physically permits phase
+fallback, configure all four coupled options and make the nonlinear gate explicit:
+
+```java
+pipe.setEnableInterfacialPressure(true);
+pipe.setImplicitInterfacialPressureCoupling(true);
+pipe.setEnableCoupledPressureMomentum(true);
+pipe.setAllowOutletPhaseBackflow(true);
+pipe.setCoupledPressureMomentumMaximumIterations(24); // default
+pipe.setCoupledPressureMomentumRelativeVolumeTolerance(1.0e-7); // default
+```
+
+The former 12-iteration default stopped the public Tengesdal progress probe near a
+$6\times10^{-7}$ relative cell-volume residual. With 24 iterations, the 16-section Test 3 setup
+completes 50/50 calls of 0.1 s; a 24-section refinement completes 100/100 calls of 0.05 s. Neither
+rejects a nonlinear substep, and both keep gas, oil, water, liquid, and total discrete mass
+residuals below $10^{-9}$. A coupled call that cannot complete its requested interval now throws and
+reports accepted/requested time, residual/tolerance, iterations/cap, and whether pressure correction
+was limited; it never returns partial or zero progress silently.
+
+After every evaluated window, inspect the sticky diagnostics, which reset on the next steady
+`run()`:
+
+```java
+boolean failed = pipe.isTransientCoupledPressureMomentumFailureDetected();
+boolean limited = pipe.isTransientCoupledPressureMomentumCorrectionLimited();
+int rejected = pipe.getTransientCoupledPressureMomentumRejectedSubsteps();
+boolean latestLimited = pipe.isCoupledPressureMomentumPressureCorrectionLimited();
+```
+
+This progress result is not a severe-slugging qualification. The pressure limiter still fires and
+the 50-step liquid-outlet range is -18.55 to 6.88 kg/s versus the stored 0.375 to 4.03 kg/s
+comparison. Do not tune public closures to that commercial trace; use the public Tengesdal
+experiment for subsequent amplitude, period, mesh, and long-horizon validation.
 
 ### Higher-Order Reconstruction
 
@@ -962,7 +1001,6 @@ The `runTransient()` method advances the simulation by a specified time step. It
 pipe.run();
 
 // Transient simulation loop
-UUID simId = UUID.randomUUID();
 for (int step = 0; step < 1000; step++) {
     // Change boundary conditions if needed
     if (step == 100) {
@@ -970,7 +1008,7 @@ for (int step = 0; step < 1000; step++) {
         inletStream.run();
     }
 
-    pipe.runTransient(0.1, simId);  // Advance 0.1 seconds
+    pipe.runTransient(0.1, UUID.randomUUID()); // one UUID per physical step
 
     // Monitor results
     double outletFlow = pipe.getOutletStream().getFlowRate("kg/sec");

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -178,6 +178,15 @@ public class TwoFluidPipe extends Pipeline {
    */
   private boolean coupledPressureMomentumEnabled = false;
 
+  /** Whether any coupled nonlinear correction failed since the latest steady initialization. */
+  private boolean transientCoupledPressureMomentumFailureDetected = false;
+
+  /** Whether any coupled nonlinear pressure correction was limited since steady initialization. */
+  private boolean transientCoupledPressureMomentumCorrectionLimited = false;
+
+  /** Coupled nonlinear substeps rejected since the latest steady initialization. */
+  private int transientCoupledPressureMomentumRejectedSubsteps = 0;
+
   /** Optional phase-resolved compressible volume supplying the inlet pressure boundary. */
   private UpstreamCompressibleVolume upstreamCompressibleVolume = null;
 
@@ -4134,6 +4143,10 @@ public class TwoFluidPipe extends Pipeline {
     lastComponentConservationReport = null;
     componentConservationReports.clear();
     componentConservationTimes.clear();
+    transientOutletBackflowClamped = false;
+    transientCoupledPressureMomentumFailureDetected = false;
+    transientCoupledPressureMomentumCorrectionLimited = false;
+    transientCoupledPressureMomentumRejectedSubsteps = 0;
 
     // Initialize sections
     initializeSections();
@@ -4224,6 +4237,7 @@ public class TwoFluidPipe extends Pipeline {
     double timeRemaining = dt;
     int maxSubSteps = enableAdaptiveTimestepping ? 50000 : 10000;
     int stepCount = 0;
+    int consecutiveCoupledPressureMomentumFailures = 0;
 
     while (timeRemaining > 1e-12 && stepCount < maxSubSteps) {
       stepCount++;
@@ -4349,11 +4363,21 @@ public class TwoFluidPipe extends Pipeline {
       double[][] U_new = timeIntegrator.step(splitState, rhs, dtFinal);
       U_new = applyStiffBubbleDragSourceStep(U_new, 0.5 * dtFinal);
 
+      if (coupledPressureMomentumEnabled && timeIntegrator.isCoupledPressureMomentumPressureCorrectionLimited()) {
+        transientCoupledPressureMomentumCorrectionLimited = true;
+      }
+
       if (coupledPressureMomentumEnabled && !timeIntegrator.isCoupledPressureMomentumConverged()) {
+        transientCoupledPressureMomentumFailureDetected = true;
+        transientCoupledPressureMomentumRejectedSubsteps++;
+        consecutiveCoupledPressureMomentumFailures++;
         equations.applyState(sections, U_prev);
         if (enableAdaptiveTimestepping) {
           adaptiveDtFactor = Math.max(adaptiveDtFactor * 0.5, MIN_ADAPTIVE_DT_FACTOR);
           currentStep--;
+          if (adaptiveDtFactor <= MIN_ADAPTIVE_DT_FACTOR && consecutiveCoupledPressureMomentumFailures >= 2) {
+            break;
+          }
           continue;
         }
         throw new IllegalStateException(
@@ -4361,6 +4385,7 @@ public class TwoFluidPipe extends Pipeline {
                 + "cell-volume residual=" + timeIntegrator.getCoupledPressureMomentumVolumeResidual() + " after "
                 + timeIntegrator.getCoupledPressureMomentumIterations() + " iterations");
       }
+      consecutiveCoupledPressureMomentumFailures = 0;
 
       // 4. ADAPTIVE: check RAW state for NaN/Inf/negative mass BEFORE clamping
       // Only hard-reject on unphysical values. Normal transient changes (even large)
@@ -4564,6 +4589,17 @@ public class TwoFluidPipe extends Pipeline {
           + "outflow is clamped at zero while the inlet keeps feeding it. Liquid inventory will grow without "
           + "bound and the transient result must not be used. This is the ill-posedness of the classical "
           + "two-fluid system in liquid-rich flow; see setEnableInterfacialPressure(boolean).", getName());
+    }
+
+    if (coupledPressureMomentumEnabled && timeRemaining > 1.0e-12) {
+      throw new IllegalStateException(
+          getName() + ": coupled pressure-momentum transient advanced " + acceptedElapsedTime + " of requested " + dt
+              + " s after " + stepCount + " substep attempts; latest maximum relative cell-volume residual="
+              + timeIntegrator.getCoupledPressureMomentumVolumeResidual() + ", tolerance="
+              + timeIntegrator.getCoupledPressureMomentumRelativeVolumeTolerance() + ", iterations="
+              + timeIntegrator.getCoupledPressureMomentumIterations() + "/"
+              + timeIntegrator.getCoupledPressureMomentumMaximumIterations() + ", pressureCorrectionLimited="
+              + timeIntegrator.isCoupledPressureMomentumPressureCorrectionLimited());
     }
 
     setCalculationIdentifier(id);
@@ -7618,6 +7654,70 @@ public class TwoFluidPipe extends Pipeline {
   /** @return convergence status of the most recent coupled correction */
   public boolean isCoupledPressureMomentumConverged() {
     return !coupledPressureMomentumEnabled || timeIntegrator.isCoupledPressureMomentumConverged();
+  }
+
+  /**
+   * Set the nonlinear iteration budget for each coupled pressure-momentum correction.
+   *
+   * @param maximumIterations positive maximum iteration count
+   */
+  public void setCoupledPressureMomentumMaximumIterations(int maximumIterations) {
+    timeIntegrator.setCoupledPressureMomentumMaximumIterations(maximumIterations);
+  }
+
+  /** @return nonlinear iteration budget for each coupled pressure-momentum correction */
+  public int getCoupledPressureMomentumMaximumIterations() {
+    return timeIntegrator.getCoupledPressureMomentumMaximumIterations();
+  }
+
+  /**
+   * Set the convergence tolerance for the relative cell-volume residual.
+   *
+   * @param tolerance positive finite relative tolerance
+   */
+  public void setCoupledPressureMomentumRelativeVolumeTolerance(double tolerance) {
+    timeIntegrator.setCoupledPressureMomentumRelativeVolumeTolerance(tolerance);
+  }
+
+  /** @return convergence tolerance for the relative cell-volume residual */
+  public double getCoupledPressureMomentumRelativeVolumeTolerance() {
+    return timeIntegrator.getCoupledPressureMomentumRelativeVolumeTolerance();
+  }
+
+  /**
+   * Check whether any coupled correction failed since the latest steady initialization.
+   *
+   * @return true after at least one rejected, non-converged coupled correction
+   */
+  public boolean isTransientCoupledPressureMomentumFailureDetected() {
+    return transientCoupledPressureMomentumFailureDetected;
+  }
+
+  /**
+   * Check whether any coupled correction reached its pressure-correction limiter.
+   *
+   * @return true when pressure correction was limited since the latest steady initialization
+   */
+  public boolean isTransientCoupledPressureMomentumCorrectionLimited() {
+    return transientCoupledPressureMomentumCorrectionLimited;
+  }
+
+  /**
+   * Get the number of rejected coupled nonlinear substeps since steady initialization.
+   *
+   * @return rejected coupled substep count
+   */
+  public int getTransientCoupledPressureMomentumRejectedSubsteps() {
+    return transientCoupledPressureMomentumRejectedSubsteps;
+  }
+
+  /**
+   * Check whether the latest coupled correction reached its pressure-correction limiter.
+   *
+   * @return true when the latest coupled correction was limited
+   */
+  public boolean isCoupledPressureMomentumPressureCorrectionLimited() {
+    return coupledPressureMomentumEnabled && timeIntegrator.isCoupledPressureMomentumPressureCorrectionLimited();
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
@@ -30,7 +30,11 @@ public final class CoupledPressureMomentumSolver implements Serializable {
   private static final double MIN_SOUND_SPEED = 1.0;
   private static final double MIN_DIAGONAL = 1.0e-24;
 
-  private int maximumIterations = 12;
+  /**
+   * Default nonlinear budget. The former value of 12 stopped before the public Tengesdal coupled case reached the
+   * default volume tolerance.
+   */
+  private int maximumIterations = 24;
   private double relativeVolumeTolerance = 1.0e-7;
   private double pressureRelaxation = 0.7;
   private double maximumRelativePressureCorrection = 0.25;
@@ -403,12 +407,22 @@ public final class CoupledPressureMomentumSolver implements Serializable {
     return result;
   }
 
+  /** @return maximum nonlinear correction iterations */
+  public int getMaximumIterations() {
+    return maximumIterations;
+  }
+
   /** @param maximumIterations maximum nonlinear correction iterations */
   public void setMaximumIterations(int maximumIterations) {
     if (maximumIterations < 1) {
       throw new IllegalArgumentException("maximumIterations must be at least one");
     }
     this.maximumIterations = maximumIterations;
+  }
+
+  /** @return maximum accepted relative cell-volume residual */
+  public double getRelativeVolumeTolerance() {
+    return relativeVolumeTolerance;
   }
 
   /** @param tolerance maximum accepted relative cell-volume residual */

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
@@ -629,6 +629,34 @@ public class TimeIntegrator implements Serializable {
     return coupledPressureMomentumEnabled;
   }
 
+  /**
+   * Set the nonlinear iteration budget for the coupled pressure-momentum correction.
+   *
+   * @param maximumIterations positive maximum iteration count
+   */
+  public void setCoupledPressureMomentumMaximumIterations(int maximumIterations) {
+    coupledPressureMomentumSolver.setMaximumIterations(maximumIterations);
+  }
+
+  /** @return nonlinear iteration budget for the coupled pressure-momentum correction */
+  public int getCoupledPressureMomentumMaximumIterations() {
+    return coupledPressureMomentumSolver.getMaximumIterations();
+  }
+
+  /**
+   * Set the convergence tolerance for the relative cell-volume residual.
+   *
+   * @param tolerance positive finite relative tolerance
+   */
+  public void setCoupledPressureMomentumRelativeVolumeTolerance(double tolerance) {
+    coupledPressureMomentumSolver.setRelativeVolumeTolerance(tolerance);
+  }
+
+  /** @return convergence tolerance for the relative cell-volume residual */
+  public double getCoupledPressureMomentumRelativeVolumeTolerance() {
+    return coupledPressureMomentumSolver.getRelativeVolumeTolerance();
+  }
+
   private double[][] applyCoupledPressureMomentumCorrection(double[][] state, double dt) {
     if (!coupledPressureMomentumEnabled) {
       return state;
@@ -653,6 +681,11 @@ public class TimeIntegrator implements Serializable {
   /** @return nonlinear iterations used by the latest coupled correction */
   public int getCoupledPressureMomentumIterations() {
     return lastCoupledPressureMomentumResult == null ? 0 : lastCoupledPressureMomentumResult.getIterations();
+  }
+
+  /** @return true when the latest nonlinear solve limited at least one pressure correction */
+  public boolean isCoupledPressureMomentumPressureCorrectionLimited() {
+    return lastCoupledPressureMomentumResult != null && lastCoupledPressureMomentumResult.isPressureCorrectionLimited();
   }
 
   /** @return signed gas, oil, and water outlet mass corrections in kg */

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/CoupledPressureMomentumTengesdalProgressTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/CoupledPressureMomentumTengesdalProgressTest.java
@@ -1,0 +1,199 @@
+package neqsim.process.equipment.pipeline.twophasepipe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport;
+import neqsim.process.equipment.pipeline.TwoFluidMassBalanceReport.Phase;
+import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import neqsim.process.equipment.pipeline.TwoFluidPipe.BoundaryCondition;
+import neqsim.process.equipment.pipeline.twophasepipe.numerics.TimeIntegrator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Progress regression for the coupled solver on Tengesdal's public 2002 large-facility test 3.
+ *
+ * <p>
+ * This fixture verifies numerical progress, conservation, and diagnostics. It records but does not qualify the outlet
+ * range; the public experimental benchmark remains disabled until the full physical acceptance gates pass.
+ */
+@Tag("slow")
+class CoupledPressureMomentumTengesdalProgressTest {
+  private static final org.apache.logging.log4j.Logger logger = org.apache.logging.log4j.LogManager
+      .getLogger(CoupledPressureMomentumTengesdalProgressTest.class);
+  private static final double FLOWLINE_LENGTH_M = 19.81;
+  private static final double RISER_HEIGHT_M = 14.94;
+  private static final double DIAMETER_M = 0.0762;
+  private static final double PIPE_AREA_M2 = Math.PI * DIAMETER_M * DIAMETER_M / 4.0;
+  private static final double LIQUID_DENSITY_KG_PER_M3 = 856.0;
+  private static final double LIQUID_FEED_KG_PER_S = 0.50 * PIPE_AREA_M2 * LIQUID_DENSITY_KG_PER_M3;
+  private static final double GAS_FEED_KG_PER_S = 1.00 * PIPE_AREA_M2 * 1.204;
+  private static final double STORED_COMPARISON_MINIMUM_LIQUID_OUTLET_KG_PER_S = 0.375;
+  private static final double STORED_COMPARISON_MAXIMUM_LIQUID_OUTLET_KG_PER_S = 4.03;
+
+  @Test
+  void coupledConfigurationCompletesFiftyStepsWithConservationAndDiagnostics() {
+    TwoFluidPipe pipe = createTestThreePipe();
+    assertEquals(24, pipe.getCoupledPressureMomentumMaximumIterations());
+    assertEquals(1.0e-7, pipe.getCoupledPressureMomentumRelativeVolumeTolerance(), 0.0);
+    double minimumLiquidOutletRate = Double.POSITIVE_INFINITY;
+    double maximumLiquidOutletRate = Double.NEGATIVE_INFINITY;
+    int minimumLiquidOutletRateStep = -1;
+    int maximumLiquidOutletRateStep = -1;
+    double outletStateRateAtMinimum = Double.NaN;
+    double outletStateRateAtMaximum = Double.NaN;
+
+    for (int step = 0; step < 50; step++) {
+      double startTime = pipe.getSimulationTime();
+      UUID physicalStepId = UUID
+          .nameUUIDFromBytes(("Tengesdal-coupled-progress-" + step).getBytes(StandardCharsets.UTF_8));
+      pipe.runTransient(0.1, physicalStepId);
+      TwoFluidMassBalanceReport balance = pipe.getLastMassBalanceReport();
+
+      assertEquals(0.1, balance.getElapsedTimeSeconds(), 1.0e-10,
+          "coupled solver did not complete interval " + (step + 1));
+      assertEquals(startTime + 0.1, pipe.getSimulationTime(), 1.0e-10,
+          "simulation clock did not complete interval " + (step + 1));
+      assertTrue(pipe.isCoupledPressureMomentumConverged(), "coupled correction failed at interval " + (step + 1));
+      for (Phase phase : Phase.values()) {
+        assertTrue(balance.getRelativeResidual(phase) < 1.0e-9, phase + " mass residual exceeded tolerance at interval "
+            + (step + 1) + ": " + balance.getRelativeResidual(phase));
+      }
+
+      double liquidOutletRate = balance.getOutletMassKg(Phase.LIQUID) / balance.getElapsedTimeSeconds();
+      if (liquidOutletRate < minimumLiquidOutletRate) {
+        minimumLiquidOutletRate = liquidOutletRate;
+        minimumLiquidOutletRateStep = step + 1;
+        double[] oilMassFlowProfile = pipe.getOilMassFlowProfile();
+        outletStateRateAtMinimum = oilMassFlowProfile[oilMassFlowProfile.length - 1];
+      }
+      if (liquidOutletRate > maximumLiquidOutletRate) {
+        maximumLiquidOutletRate = liquidOutletRate;
+        maximumLiquidOutletRateStep = step + 1;
+        double[] oilMassFlowProfile = pipe.getOilMassFlowProfile();
+        outletStateRateAtMaximum = oilMassFlowProfile[oilMassFlowProfile.length - 1];
+      }
+    }
+
+    assertTrue(Double.isFinite(minimumLiquidOutletRate));
+    assertTrue(Double.isFinite(maximumLiquidOutletRate));
+    logger.info(
+        "Tengesdal coupled 50-step outlet comparison: observed={} to {} kg/s at steps {}/{}, final-state rates={}/{} "
+            + "kg/s; stored comparison={} to {} kg/s; latest correction limited={}",
+        minimumLiquidOutletRate, maximumLiquidOutletRate, minimumLiquidOutletRateStep, maximumLiquidOutletRateStep,
+        outletStateRateAtMinimum, outletStateRateAtMaximum, STORED_COMPARISON_MINIMUM_LIQUID_OUTLET_KG_PER_S,
+        STORED_COMPARISON_MAXIMUM_LIQUID_OUTLET_KG_PER_S, pipe.isCoupledPressureMomentumPressureCorrectionLimited());
+    assertFalse(pipe.isTransientOutletBackflowClamped(),
+        "the signed outlet must not fall back to the one-way phase clamp");
+    assertFalse(pipe.isTransientCoupledPressureMomentumFailureDetected(),
+        "the default nonlinear budget must not reject a coupled correction");
+    assertEquals(0, pipe.getTransientCoupledPressureMomentumRejectedSubsteps());
+    assertTrue(pipe.isTransientCoupledPressureMomentumCorrectionLimited(),
+        "the known Tengesdal limiter event must remain visible through the sticky diagnostic");
+  }
+
+  @Test
+  void impossibleConfiguredGateFailsLoudlyAndKeepsDiagnostics() {
+    TwoFluidPipe pipe = createTestThreePipe();
+    pipe.setCoupledPressureMomentumMaximumIterations(1);
+    pipe.setCoupledPressureMomentumRelativeVolumeTolerance(1.0e-14);
+
+    IllegalStateException failure = assertThrows(IllegalStateException.class,
+        () -> pipe.runTransient(0.1, UUID.nameUUIDFromBytes("Tengesdal-fail-loud".getBytes(StandardCharsets.UTF_8))));
+
+    assertTrue(failure.getMessage().contains("advanced"));
+    assertTrue(failure.getMessage().contains("tolerance=1.0E-14"));
+    assertTrue(pipe.isTransientCoupledPressureMomentumFailureDetected());
+    assertTrue(pipe.getTransientCoupledPressureMomentumRejectedSubsteps() > 0);
+    assertNotNull(pipe.getLastMassBalanceReport());
+    assertTrue(pipe.getLastMassBalanceReport().getElapsedTimeSeconds() < 0.1);
+    assertEquals(1, pipe.getCoupledPressureMomentumMaximumIterations());
+    assertEquals(1.0e-14, pipe.getCoupledPressureMomentumRelativeVolumeTolerance(), 0.0);
+  }
+
+  @Test
+  void refinedMeshAndHalfOuterStepAlsoCompleteFiveSeconds() {
+    TwoFluidPipe pipe = createTestThreePipe(24);
+    for (int step = 0; step < 100; step++) {
+      UUID physicalStepId = UUID
+          .nameUUIDFromBytes(("Tengesdal-coupled-refined-" + step).getBytes(StandardCharsets.UTF_8));
+      pipe.runTransient(0.05, physicalStepId);
+      TwoFluidMassBalanceReport balance = pipe.getLastMassBalanceReport();
+
+      assertEquals(0.05, balance.getElapsedTimeSeconds(), 1.0e-10,
+          "refined coupled solver did not complete interval " + (step + 1));
+      assertTrue(pipe.isCoupledPressureMomentumConverged(),
+          "refined coupled correction failed at interval " + (step + 1));
+      for (Phase phase : Phase.values()) {
+        assertTrue(balance.getRelativeResidual(phase) < 1.0e-9,
+            phase + " refined-mesh mass residual exceeded tolerance at interval " + (step + 1));
+      }
+    }
+
+    assertEquals(5.0, pipe.getSimulationTime(), 1.0e-9);
+    assertFalse(pipe.isTransientOutletBackflowClamped());
+    assertFalse(pipe.isTransientCoupledPressureMomentumFailureDetected());
+    assertEquals(0, pipe.getTransientCoupledPressureMomentumRejectedSubsteps());
+  }
+
+  private static TwoFluidPipe createTestThreePipe() {
+    return createTestThreePipe(16);
+  }
+
+  private static TwoFluidPipe createTestThreePipe(int numberOfSections) {
+    double liquidMolarMassKgPerMol = 0.220;
+    double nitrogenMolarMassKgPerMol = 0.0280134;
+    SystemInterface fluid = new SystemSrkEos(298.15, 2.3);
+    fluid.addComponent("nitrogen", GAS_FEED_KG_PER_S / nitrogenMolarMassKgPerMol);
+    fluid.addTBPfraction("Crystex", LIQUID_FEED_KG_PER_S / liquidMolarMassKgPerMol, liquidMolarMassKgPerMol,
+        LIQUID_DENSITY_KG_PER_M3 / 1000.0);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    Stream inlet = new Stream("Tengesdal 2002 large facility test 3", fluid);
+    inlet.setFlowRate(LIQUID_FEED_KG_PER_S + GAS_FEED_KG_PER_S, "kg/sec");
+    inlet.setTemperature(25.0, "C");
+    inlet.setPressure(2.3, "bara");
+    inlet.run();
+
+    double totalLengthM = FLOWLINE_LENGTH_M + RISER_HEIGHT_M;
+    double inclinationRad = Math.toRadians(-3.0);
+    double flowlineDropM = FLOWLINE_LENGTH_M * Math.sin(inclinationRad);
+    double[] elevationM = new double[numberOfSections];
+    for (int section = 0; section < numberOfSections; section++) {
+      double positionM = totalLengthM * section / (numberOfSections - 1.0);
+      elevationM[section] = positionM <= FLOWLINE_LENGTH_M ? positionM * Math.sin(inclinationRad)
+          : flowlineDropM + positionM - FLOWLINE_LENGTH_M;
+    }
+
+    TwoFluidPipe pipe = new TwoFluidPipe("Tengesdal coupled progress", inlet);
+    pipe.setLength(totalLengthM);
+    pipe.setDiameter(DIAMETER_M);
+    pipe.setRoughness(1.5e-6);
+    pipe.setNumberOfSections(numberOfSections);
+    pipe.setElevationProfile(elevationM);
+    pipe.setOutletPressure(1.01325, "bara");
+    pipe.setInletBoundaryCondition(BoundaryCondition.STREAM_CONNECTED);
+    pipe.setOutletBoundaryCondition(BoundaryCondition.CONSTANT_PRESSURE);
+    pipe.setTimeIntegrationMethod(TimeIntegrator.Method.RK4);
+    pipe.setEnableAdaptiveTimestepping(true);
+    pipe.setThermodynamicUpdateInterval(1000);
+    pipe.setIncludeMassTransfer(false);
+    pipe.setEnableInterfacialPressure(true);
+    pipe.setImplicitInterfacialPressureCoupling(true);
+    pipe.setEnableCoupledPressureMomentum(true);
+    pipe.setAllowOutletPhaseBackflow(true);
+    pipe.setSteadyStateMaxWallClockTime(Double.POSITIVE_INFINITY);
+    pipe.run();
+    return pipe;
+  }
+}


### PR DESCRIPTION
## Issue and frozen scope

Advances #3298, WS3 (coupled-solver robustness). This does **not** close #3298.

- **Base:** exact master `83a99c5c9ef7235798d4a1784adcdd00f2bf0e05`
- **Head:** `21a1c928a941e1aba430580b0261f6d06f91641c`
- **Technical concept:** make the existing coupled pressure-momentum path complete a requested interval or fail loudly, and expose the nonlinear gate/limiter needed to qualify it
- **Stop boundary:** no outlet closure, regime-map, friction, IMEX-physics, controls-benchmark, or capability-audit change; no tuning to a proprietary commercial trace

## Reproduction

On initial exact master `016aed9a0a9cc8d7a970d9d9adcff26149934322`, the new Tengesdal progress fixture with the implementation removed entered repeated rejected adaptive substeps and made no physical-time progress; it was interrupted after more than two minutes. Master then advanced by three commits to the base above. Connector comparison showed that none touched the coupled solver, TwoFluidPipe, or the affected model documentation.

## Change

- raises the default coupled nonlinear budget from 12 to 24, enough to reach the existing `1e-7` relative cell-volume tolerance in the public progress case;
- exposes maximum iterations and tolerance through `TimeIntegrator` and `TwoFluidPipe`;
- exposes latest and sticky pressure-limiter state, sticky nonlinear failure state, and rejected-substep count;
- bounds unrecoverable adaptive retries and throws with accepted/requested time, residual/tolerance, iterations/cap, and limiter state instead of returning zero or partial progress silently;
- adds 16-section progress, 24-section/half-step refinement, conservation, configuration, diagnostics, and fail-loud regressions;
- updates both TwoFluidPipe guides and the dynamic-simulation/flow-assurance skills on the same runtime path.

## Validation evidence

| Evidence | Outcome |
|---|---|
| 16 sections, 50 × 0.1 s | 50/50 intervals complete; exact 5.0 s clock |
| 24 sections, 100 × 0.05 s | 100/100 intervals complete; exact 5.0 s clock |
| Discrete conservation | every reported gas/oil/water/liquid/total relative residual < `1e-9` |
| Coupled diagnostics | no nonlinear failure, no rejected substep, no one-way outlet clamp; sticky pressure limiter remains true |
| Liquid outlet comparison | observed -18.552 to 6.883 kg/s versus stored 0.375 to 4.03 kg/s |
| Long-horizon coupled regression | 1200 s liquid-rich test passes |
| Existing null/outlet coverage | passes; two pre-existing liquid-rich null cases remain disabled |

Exact commands run on the final base/worktree:

```text
./mvnw -B -ntp -DexcludedTestGroups= -Dtest=neqsim.process.equipment.pipeline.twophasepipe.CoupledPressureMomentumTengesdalProgressTest,neqsim.process.equipment.pipeline.twophasepipe.numerics.CoupledPressureMomentumSolverTest,neqsim.process.equipment.pipeline.twophasepipe.TwoFluidOutletBoundaryTest test
# Tests run: 7, failures/errors/skips: 0/0/0

./mvnw -B -ntp -DexcludedTestGroups= -Dtest=neqsim.process.equipment.pipeline.TwoFluidPipeTransientNullTest,neqsim.process.equipment.pipeline.TwoFluidPressureMomentumLongHorizonTest test
# Tests run: 7, failures/errors/skips: 0/0/2

python devtools/run_spotless.py check
# passed

python devtools/check_documentation_search.py
# passed: 667 Markdown pages and 1 standalone HTML page

git diff --check
# passed
```

The repository `pre-commit` executable is not installed in the runner; its current pre-commit/pre-push Spotless and documentation hooks were run directly above. `./mvnw -B -ntp -DskipTests javadoc:javadoc` was attempted but could not start because this runner contains a JRE without a `javadoc` executable. No local Javadoc pass is claimed; hosted CI remains required.

## Qualification status and next dependency

This clears the silent-stall prerequisite but does **not** qualify severe slugging. The signed outlet trajectory still overshoots/reverses relative to the stored comparison and activates the pressure-correction limiter. The next dependency is a dimensionally checked outlet/implicit-pressure coupling investigation against the public Tengesdal experiment, conservation, nearby operating points, and mesh/time-step refinement—without changing hold-up closures or tuning to the commercial trace.

**Documentation impact:** updated `TWOFLUIDPIPE_MODEL.md`, `two_fluid_model.md`, `neqsim-dynamic-simulation`, and `neqsim-flow-assurance`. Controls benchmark documentation is unaffected by this WS3-only runtime batch. No `olga-simulation-agent` routing file exists in this repository, and NeqSim ownership is not promoted while the physical gate remains open.

**Split reason:** none. This PR contains the complete dependency-ready WS3 numerical-progress batch; WS1/WS2 physics are outside its recorded stop boundary.
