### PR TITLE
[AI-Assisted] test(mcp): qualify automation read contracts

### DIFF
--- a/.github/workflows/mcp_protocol_qualification.yml
+++ b/.github/workflows/mcp_protocol_qualification.yml
@@ -63,3 +63,6 @@ jobs:
 
       - name: Run focused real-MCP validation-profile qualification
         run: cd neqsim-mcp-server && python test_validation_profile_protocol.py
+
+      - name: Run focused real-MCP automation-read qualification
+        run: cd neqsim-mcp-server && python test_automation_read_protocol.py

--- a/neqsim-mcp-server/docs/evidence/AUTOMATION_READ_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/AUTOMATION_READ_CONTRACT.md
@@ -1,0 +1,30 @@
+# Phase 0 automation read-contract evidence
+
+This note records bounded Phase 0 software-contract evidence for the existing read-only automation introspection tools `listSimulationUnits`, `listUnitVariables`, and `getSimulationVariable`.
+
+## Existing implementation boundary
+
+All three tools use the canonical NeqSim process model. `AutomationRunner` resolves the supplied process definition or model handle to a normal solved `ProcessSystem` and then delegates unit/variable discovery and reads to `ProcessAutomation`. No MCP-only process representation or calculation path is introduced.
+
+`listSimulationUnits` returns addressable unit names and equipment types. `listUnitVariables` returns the selected unit's variable registry, including addresses, variable type, default unit, source/category metadata, writeability, invalidation behavior, and applicability. `getSimulationVariable` reads one addressed value through the existing safe accessor and preserves the standard MCP envelope, provenance, validation, and quality-gate fields.
+
+## Focused contract evidence
+
+- `src/test/java/neqsim/mcp/runners/AutomationReadContractTest.java` checks canonical unit discovery, variable-addressability metadata, standard-envelope variable reads, and structured fail-closed `INPUT_ERROR` responses.
+- Existing `src/test/java/neqsim/mcp/runners/McpRunnerContractTest.java` already includes the same three tools in the high-use standard-response contract against `ExampleCatalog.processSimpleSeparation()`.
+- `neqsim-mcp-server/test_automation_read_protocol.py` obtains the canonical simple-separation example through real MCP and exercises all three read tools over packaged STDIO transport, including invalid-input rejection.
+- `.github/workflows/mcp_protocol_qualification.yml` builds the exact NeqSim core and packaged MCP server with Java 21 and runs the focused harness with read-only repository permissions.
+
+## Evidence that is not established
+
+This evidence qualifies lookup, addressability, response-envelope, and packaged-transport behavior only. It does **not** validate thermodynamic or process numerical accuracy, the engineering correctness of any returned variable value, facility topology completeness, equipment performance, control behavior, persistent model state, multi-client isolation, or external authorization.
+
+A successful read is not an engineering approval or plant measurement. Returned values remain simulation outputs with the case-specific model, assumptions, units, convergence state, provenance, warnings, validation maturity, and limitations as the authoritative engineering context.
+
+## Promotion boundary
+
+The Phase 0 inventory remains version `1.17` with `20 EXPLICIT_TRUST + 11 CONTRACT_TESTED + 40 CONFIRMED_GAP` in this qualification increment. These three tools remain `CONFIRMED_GAP` until machine-readable coverage and the authoritative primary packaged-protocol accounting are promoted atomically on one later exact validated head. This PR supplies the focused source and real-protocol prerequisite for that future classification step.
+
+## Owner-roadmap boundary
+
+No thermodynamic, process, pipeline, dynamics, DEXPI/P&ID, production-optimization, schema, stable response-envelope, write, live-plant, or control-command behavior changes. Specialist implementation remains owned by the existing NeqSim and coordinated roadmap lanes.

--- a/neqsim-mcp-server/test_automation_read_protocol.py
+++ b/neqsim-mcp-server/test_automation_read_protocol.py
@@ -185,8 +185,11 @@ def test_invalid_requests_fail_closed(client, process_json):
         result = client.call_tool(tool_name, arguments)
         data = payload(result)
         require(data.get("status") == "error", f"{tool_name} invalid request did not fail closed", result)
+        codes = []
+        if data.get("code"):
+            codes.append(data.get("code"))
         errors = data.get("errors", [])
-        codes = [item.get("code") for item in errors if isinstance(item, dict)]
+        codes.extend(item.get("code") for item in errors if isinstance(item, dict))
         require("INPUT_ERROR" in codes, f"{tool_name} missing INPUT_ERROR diagnostic", result)
 
 

--- a/neqsim-mcp-server/test_automation_read_protocol.py
+++ b/neqsim-mcp-server/test_automation_read_protocol.py
@@ -1,0 +1,209 @@
+"""Focused real-MCP qualification for read-only automation introspection contracts.
+
+This dependency-free harness starts the packaged NeqSim MCP server over STDIO and
+checks listSimulationUnits, listUnitVariables, and getSimulationVariable against
+the canonical simple-separation example. It qualifies software-contract and
+transport behavior only; it does not validate the numerical accuracy of the
+solved process or returned variable values.
+"""
+import json
+import subprocess
+import sys
+import time
+
+JAR = "target/neqsim-mcp-server-1.0.0-SNAPSHOT-runner.jar"
+
+
+class McpClient:
+    """Minimal line-delimited JSON-RPC MCP client for packaged-server tests."""
+
+    def __init__(self):
+        self.proc = None
+        self.message_id = 0
+
+    def next_id(self):
+        self.message_id += 1
+        return self.message_id
+
+    def send(self, message):
+        self.proc.stdin.write(json.dumps(message) + "\n")
+        self.proc.stdin.flush()
+
+    def receive(self):
+        line = self.proc.stdout.readline()
+        if not line:
+            stderr = self.proc.stderr.read() if self.proc and self.proc.stderr else ""
+            raise RuntimeError("MCP server closed stdout unexpectedly: " + stderr)
+        return json.loads(line)
+
+    def start(self):
+        self.proc = subprocess.Popen(
+            ["java", "-jar", JAR],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "neqsim-automation-read-test", "version": "1.0"},
+                },
+            }
+        )
+        response = self.receive()
+        require("result" in response, "MCP initialize did not return a result", response)
+        self.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        time.sleep(0.2)
+
+    def call_tool(self, name, arguments):
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            }
+        )
+        response = self.receive()
+        content = response.get("result", {}).get("content", [])
+        require(content, "MCP tool call returned no content", response)
+        text = content[0].get("text", "")
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as error:
+            raise AssertionError(f"MCP tool returned non-JSON content: {error}: {text}")
+
+    def close(self):
+        if self.proc is None:
+            return
+        if self.proc.stdin:
+            self.proc.stdin.close()
+        try:
+            self.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.proc.terminate()
+            self.proc.wait(timeout=10)
+        self.proc = None
+
+
+def require(condition, message, detail=None):
+    """Raise a compact assertion with JSON detail when a protocol contract fails."""
+    if condition:
+        return
+    suffix = ""
+    if detail is not None:
+        suffix = "\n" + json.dumps(detail, indent=2, sort_keys=True)
+    raise AssertionError(message + suffix)
+
+
+def payload(response):
+    """Return canonical data while retaining standardized envelope state."""
+    data = response.get("data") if isinstance(response, dict) else None
+    if not isinstance(data, dict):
+        return response
+    merged = dict(data)
+    for key in ("status", "message", "tool", "errors", "provenance", "validation", "qualityGate"):
+        if key in response:
+            merged.setdefault(key, response[key])
+    return merged
+
+
+def simple_process_json(client):
+    """Retrieve the canonical catalog fixture through MCP instead of duplicating it here."""
+    example = client.call_tool("getExample", {"category": "process", "name": "simple-separation"})
+    if isinstance(example, dict) and isinstance(example.get("data"), dict):
+        example = example["data"]
+    require(isinstance(example, dict), "simple-separation example is not a JSON object", example)
+    require("process" in example, "simple-separation example omitted process definition", example)
+    return json.dumps(example)
+
+
+def test_unit_inventory(client, process_json):
+    result = client.call_tool("listSimulationUnits", {"processJson": process_json})
+    data = payload(result)
+    require(data.get("status") == "success", "listSimulationUnits failed", result)
+    require(data.get("tool") == "listSimulationUnits", "unit inventory tool identity drifted", result)
+    units = data.get("units", [])
+    require(isinstance(units, list) and units, "unit inventory is empty", result)
+    require(data.get("count") == len(units), "unit count does not match payload", result)
+    for unit in units:
+        require(unit.get("name"), "unit inventory contains blank name", result)
+        require(unit.get("type"), "unit inventory contains blank type", result)
+
+
+def test_variable_inventory(client, process_json):
+    result = client.call_tool(
+        "listUnitVariables", {"processJson": process_json, "unitName": "HP Sep"}
+    )
+    data = payload(result)
+    require(data.get("status") == "success", "listUnitVariables failed", result)
+    require(data.get("tool") == "listUnitVariables", "variable inventory tool identity drifted", result)
+    require(data.get("unitName") == "HP Sep", "variable inventory lost requested unit", result)
+    variables = data.get("variables", [])
+    require(isinstance(variables, list) and variables, "variable inventory is empty", result)
+    require(data.get("count") == len(variables), "variable count does not match payload", result)
+    for variable in variables:
+        require(variable.get("address"), "variable inventory contains blank address", result)
+        require(variable.get("type"), "variable inventory contains blank type", result)
+        require("writable" in variable, "variable metadata omitted writable flag", result)
+        require("applicability" in variable, "variable metadata omitted applicability", result)
+
+
+def test_variable_read(client, process_json):
+    result = client.call_tool(
+        "getSimulationVariable",
+        {
+            "processJson": process_json,
+            "address": "HP Sep.gasOutStream.temperature",
+            "unit": "C",
+        },
+    )
+    data = payload(result)
+    require(data.get("status") == "success", "getSimulationVariable failed", result)
+    require(data.get("tool") == "getSimulationVariable", "variable read tool identity drifted", result)
+    require(isinstance(data.get("provenance"), dict), "variable read omitted provenance", result)
+    require(isinstance(data.get("validation"), dict), "variable read omitted validation state", result)
+    require(isinstance(data.get("qualityGate"), dict), "variable read omitted quality gate", result)
+
+
+def test_invalid_requests_fail_closed(client, process_json):
+    cases = [
+        ("listSimulationUnits", {"processJson": ""}),
+        ("listUnitVariables", {"processJson": process_json, "unitName": ""}),
+        (
+            "getSimulationVariable",
+            {"processJson": process_json, "address": "", "unit": "C"},
+        ),
+    ]
+    for tool_name, arguments in cases:
+        result = client.call_tool(tool_name, arguments)
+        data = payload(result)
+        require(data.get("status") == "error", f"{tool_name} invalid request did not fail closed", result)
+        errors = data.get("errors", [])
+        codes = [item.get("code") for item in errors if isinstance(item, dict)]
+        require("INPUT_ERROR" in codes, f"{tool_name} missing INPUT_ERROR diagnostic", result)
+
+
+def main():
+    client = McpClient()
+    try:
+        client.start()
+        process_json = simple_process_json(client)
+        test_unit_inventory(client, process_json)
+        test_variable_inventory(client, process_json)
+        test_variable_read(client, process_json)
+        test_invalid_requests_fail_closed(client, process_json)
+    finally:
+        client.close()
+    print("automation read real-MCP qualification: 4/4 scenarios passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/test/java/neqsim/mcp/runners/AutomationReadContractTest.java
+++ b/src/test/java/neqsim/mcp/runners/AutomationReadContractTest.java
@@ -84,8 +84,9 @@ class AutomationReadContractTest {
     JsonObject response = JsonParser.parseString(json).getAsJsonObject();
     assertEquals("error", response.get("status").getAsString(), json);
     assertEquals(toolName, response.get("tool").getAsString(), json);
-    assertTrue(response.has("errors"), json);
-    JsonObject error = response.getAsJsonArray("errors").get(0).getAsJsonObject();
-    assertEquals("INPUT_ERROR", error.get("code").getAsString(), json);
+    assertTrue(response.has("data"), json);
+    JsonObject data = response.getAsJsonObject("data");
+    assertEquals("INPUT_ERROR", data.get("code").getAsString(), json);
+    assertFalse(data.get("message").getAsString().trim().isEmpty(), json);
   }
 }

--- a/src/test/java/neqsim/mcp/runners/AutomationReadContractTest.java
+++ b/src/test/java/neqsim/mcp/runners/AutomationReadContractTest.java
@@ -56,8 +56,7 @@ class AutomationReadContractTest {
   @Test
   void getSimulationVariableReturnsStandardEnvelopeWithoutClaimingNumericalQualification() {
     JsonObject response = parseSuccess(
-        AutomationRunner.getVariable(PROCESS_JSON, "HP Sep.gasOutStream.temperature", "C"),
-        "getSimulationVariable");
+        AutomationRunner.getVariable(PROCESS_JSON, "HP Sep.gasOutStream.temperature", "C"), "getSimulationVariable");
     JsonObject data = response.getAsJsonObject("data");
     assertTrue(data.size() > 0);
     assertTrue(response.has("provenance"));

--- a/src/test/java/neqsim/mcp/runners/AutomationReadContractTest.java
+++ b/src/test/java/neqsim/mcp/runners/AutomationReadContractTest.java
@@ -1,0 +1,91 @@
+package neqsim.mcp.runners;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import neqsim.mcp.catalog.ExampleCatalog;
+
+/**
+ * Focused contract tests for the read-only automation introspection surface.
+ *
+ * <p>
+ * These tests qualify software-contract behavior only. They do not validate the numerical accuracy of the solved
+ * process or any returned variable value.
+ * </p>
+ */
+class AutomationReadContractTest {
+
+  private static final String PROCESS_JSON = ExampleCatalog.processSimpleSeparation();
+
+  @Test
+  void listSimulationUnitsReturnsCanonicalSolvedProcessInventory() {
+    JsonObject response = parseSuccess(AutomationRunner.listUnits(PROCESS_JSON), "listSimulationUnits");
+    JsonObject data = response.getAsJsonObject("data");
+    assertTrue(data.get("count").getAsInt() > 0);
+    JsonArray units = data.getAsJsonArray("units");
+    assertEquals(data.get("count").getAsInt(), units.size());
+    for (int i = 0; i < units.size(); i++) {
+      JsonObject unit = units.get(i).getAsJsonObject();
+      assertFalse(unit.get("name").getAsString().trim().isEmpty());
+      assertFalse(unit.get("type").getAsString().trim().isEmpty());
+    }
+  }
+
+  @Test
+  void listUnitVariablesPreservesAddressabilityMetadata() {
+    JsonObject response = parseSuccess(AutomationRunner.listVariables(PROCESS_JSON, "HP Sep"), "listUnitVariables");
+    JsonObject data = response.getAsJsonObject("data");
+    assertEquals("HP Sep", data.get("unitName").getAsString());
+    assertTrue(data.get("count").getAsInt() > 0);
+    JsonArray variables = data.getAsJsonArray("variables");
+    assertEquals(data.get("count").getAsInt(), variables.size());
+    for (int i = 0; i < variables.size(); i++) {
+      JsonObject variable = variables.get(i).getAsJsonObject();
+      assertFalse(variable.get("address").getAsString().trim().isEmpty());
+      assertFalse(variable.get("type").getAsString().trim().isEmpty());
+      assertTrue(variable.has("writable"));
+      assertTrue(variable.has("invalidatesProcess"));
+      assertTrue(variable.has("applicability"));
+    }
+  }
+
+  @Test
+  void getSimulationVariableReturnsStandardEnvelopeWithoutClaimingNumericalQualification() {
+    JsonObject response = parseSuccess(
+        AutomationRunner.getVariable(PROCESS_JSON, "HP Sep.gasOutStream.temperature", "C"),
+        "getSimulationVariable");
+    JsonObject data = response.getAsJsonObject("data");
+    assertTrue(data.size() > 0);
+    assertTrue(response.has("provenance"));
+    assertTrue(response.has("validation"));
+    assertTrue(response.has("qualityGate"));
+  }
+
+  @Test
+  void invalidReadRequestsFailClosedBeforeSimulationUse() {
+    assertInputError(AutomationRunner.listUnits(""), "listSimulationUnits");
+    assertInputError(AutomationRunner.listVariables(PROCESS_JSON, ""), "listUnitVariables");
+    assertInputError(AutomationRunner.getVariable(PROCESS_JSON, "", "C"), "getSimulationVariable");
+  }
+
+  private static JsonObject parseSuccess(String json, String toolName) {
+    JsonObject response = JsonParser.parseString(json).getAsJsonObject();
+    assertEquals("success", response.get("status").getAsString(), json);
+    assertEquals(toolName, response.get("tool").getAsString(), json);
+    assertTrue(response.has("data"), json);
+    return response;
+  }
+
+  private static void assertInputError(String json, String toolName) {
+    JsonObject response = JsonParser.parseString(json).getAsJsonObject();
+    assertEquals("error", response.get("status").getAsString(), json);
+    assertEquals(toolName, response.get("tool").getAsString(), json);
+    assertTrue(response.has("errors"), json);
+    JsonObject error = response.getAsJsonArray("errors").get(0).getAsJsonObject();
+    assertEquals("INPUT_ERROR", error.get("code").getAsString(), json);
+  }
+}


### PR DESCRIPTION
## Summary

Advances #3153 Phase 0 from exact current-master base `83a99c5c9ef7235798d4a1784adcdd00f2bf0e05` to exact head `13c7e974d7c51b09808cae857793c34e27baf24c` by closing the focused source + packaged-protocol evidence prerequisite for three existing read-only automation introspection tools:

- `listSimulationUnits`
- `listUnitVariables`
- `getSimulationVariable`

The implementation remains the existing canonical NeqSim path: `AutomationRunner` resolves a normal solved `ProcessSystem` and delegates unit/variable discovery and reads to `ProcessAutomation`. No MCP-only simulator or alternate process representation is introduced.

## Change

- adds `AutomationReadContractTest` for unit inventory, variable-addressability metadata, standard-envelope variable reads, and fail-closed invalid inputs;
- adds `neqsim-mcp-server/test_automation_read_protocol.py`, a dependency-free real-MCP STDIO harness that obtains the canonical simple-separation fixture through `getExample` and exercises all three tools plus invalid-input rejection;
- extends the existing read-only Java 21 `MCP protocol qualification` workflow to execute the new packaged harness;
- adds `docs/evidence/AUTOMATION_READ_CONTRACT.md` with explicit numerical, engineering, deployment, and plant-authority boundaries.

A source-level recheck before publication caught and repaired one harness assumption: `AutomationRunner.errorJson` preserves `INPUT_ERROR` as the legacy/root payload copied into canonical `data.code`, so the new Java and packaged-protocol tests assert that actual stable error contract rather than incorrectly requiring an `errors[]` entry.

## Frozen scope and trust accounting

This PR qualifies evidence only. It deliberately does **not** promote these three tools in `McpEvidenceInventory` or change the authoritative primary packaged-protocol accounting. Current merged-master state therefore remains inventory `1.17` with **20 `EXPLICIT_TRUST` + 11 `CONTRACT_TESTED` + 40 `CONFIRMED_GAP`**; the three tools remain `CONFIRMED_GAP` in this increment.

No thermodynamic/process/pipeline/dynamics/DEXPI/optimization algorithm, public tool name, tool input/output schema, stable response envelope, security policy, deployment profile, plant-data write, or control behavior changes. Owner boundaries #2899, #2911, #2937, #2939, #2941, and #3154 remain unchanged.

## Engineering / safety boundary

This is software-contract and transport evidence only. It does not validate numerical accuracy of the simple-separation solve or any returned variable value; prove facility topology completeness, equipment performance, control behavior, persistent state, multi-client isolation, or external authorization; or imply plant authority/accountable engineering approval.

Returned simulation values remain governed by their case-specific model, units, assumptions, convergence, provenance, validation maturity, warnings, and limitations.

## Validation

**READY TO MERGE on exact head `13c7e974d7c51b09808cae857793c34e27baf24c`.** This is a validation classification only; the PR remains draft and no merge authority is implied.

No local Maven/JDK/Spotless/Python/pre-commit/Javadocs pass is claimed in this run. Hosted exact-head CI is the validation authority.

The first hosted pre-commit run on prior head `b51e6a6b9282bdb10bf140bdc0334a631a411b1e` found one branch-attributable Spotless-only line wrap in `AutomationReadContractTest.java`; documentation search passed in that same run. The exact formatter change reported by hosted Spotless was applied with no semantic or scope change, producing current head `13c7e974d7c51b09808cae857793c34e27baf24c`.

On this exact head every applicable hosted gate has completed successfully:

- `MCP protocol qualification`: exact Java 21 core install and MCP package build; existing `inspectApi` qualification passed; existing validation-profile qualification passed; new automation-read qualification passed, including all three read tools and fail-closed invalid-input cases;
- `Pre-commit checks`: success, including documentation search;
- `Spotless format patch`: success with no remaining formatter defect;
- `CodeQL Security Analysis`: success;
- `Run build, test and javadoc`: success, including agent-skill cross-reference validation, Java 21 Javadocs, Ubuntu/Windows fast tests, and all four Java 21 slow-test shards.

GitHub reports the PR mergeable. No reviews, PR comments, requested changes, or unresolved review threads are present at the readiness inspection.

Repository instructions were re-read; the new Java test uses Java-8-compatible constructs and no production logging/output behavior changes.

## Documentation impact

Adds one bounded evidence note under `neqsim-mcp-server/docs/evidence/`. README, MCP_CONTRACT, API_REFERENCE, schemas/examples, and companion agent/skill invocation contracts do not require synchronized changes because public invocation semantics are unchanged.

## Stop boundary / next dependency

After this PR merges and current master is re-audited, the next dependency is an atomic promotion increment that changes machine-readable coverage and the authoritative primary packaged-protocol accounting together for exactly these three already-qualified tools, moving **20/11/40 → 20/14/37** on one exact validated head if the qualification evidence remains valid.

Component, energy, and complete facility-wide conservation remain separate numerical Phase 0 evidence gaps; do not reconstruct conservation physics inside MCP.

AI-assisted contribution. No unrun check is claimed as passed.