### PR TITLE
[AI-Assisted] docs: document rigorous absorber capacity screening

### DIFF
--- a/docs/process/equipment/absorbers.md
+++ b/docs/process/equipment/absorbers.md
@@ -29,7 +29,7 @@ engineering question first; the classes do not represent interchangeable fidelit
 
 | Class | Use when | Important boundary |
 | --- | --- | --- |
-| `AbsorptionColumn` | Counter-current equilibrium trays with Murphree efficiencies | Native post-run Fs, Souders-Brown, wetting, and capacity-constraint screens do not feed hydraulics, reactions, entrainment, or flooding back into the MESH solver |
+| `AbsorptionColumn` | Counter-current equilibrium trays with Murphree efficiencies | No tray hydraulics, reactions, entrainment, or flooding feed back into the MESH solver; native post-run Fs, Souders-Brown, wetting, and capacity-constraint results are screening-only |
 | `StrippingColumn` | Counter-current equilibrium trays for stripping service | Fixed tray temperatures imply unreported heating or cooling; the column shares the mechanical-design rating |
 | `PackedColumn` | Equilibrium-stage contactor with packing HETP and hydraulic rating | Use `RateBasedPackedColumn` when axial film-rate profiles or local transfer reversal matter |
 | `RateBasedPackedColumn` | Packed-column films, hydraulics, profiles, or local transfer reversal | Requires packing and transport-property inputs |

--- a/docs/process/equipment/absorbers.md
+++ b/docs/process/equipment/absorbers.md
@@ -260,9 +260,9 @@ or pressure drop in the MESH solve.
 
 The inherited Fs factor and the Souders-Brown gas load factor use different density corrections:
 
-$F_s=v_s\sqrt{\rho_g}$
+$$F_s=v_s\sqrt{\rho_g}$$
 
-$K_s=v_s\sqrt{\frac{\rho_g}{\rho_\ell-\rho_g}}$
+$$K_s=v_s\sqrt{\frac{\rho_g}{\rho_\ell-\rho_g}}$$
 
 where $v_s=Q_g/A$ is superficial gas velocity in m/s, $A=\pi D^2/4$, and gas and liquid
 densities are in kg/m³. `getFsFactor()` therefore returns m/s·sqrt(kg/m³), while

--- a/docs/process/equipment/absorbers.md
+++ b/docs/process/equipment/absorbers.md
@@ -264,7 +264,7 @@ $F_s=v_s\sqrt{\rho_g}$
 
 $K_s=v_s\sqrt{\frac{\rho_g}{\rho_\ell-\rho_g}}$
 
-where `v_s = Q_g/A` is superficial gas velocity in m/s, `A = pi D^2/4`, and gas and liquid
+where $v_s=Q_g/A$ is superficial gas velocity in m/s, $A=\pi D^2/4$, and gas and liquid
 densities are in kg/m³. `getFsFactor()` therefore returns m/s·sqrt(kg/m³), while
 `getGasLoadFactor()` returns m/s. `getWettingRate()` returns liquid m³/h per m² of column
 cross-section.

--- a/docs/process/equipment/absorbers.md
+++ b/docs/process/equipment/absorbers.md
@@ -1,6 +1,6 @@
 ---
 title: Absorbers and Strippers
-description: "Model selection and executable workflows for rigorous tray, shortcut, and rate-based absorber and stripper models."
+description: "Model selection, executable workflows, and hydraulic-capacity screening for rigorous tray, shortcut, and rate-based absorber and stripper models."
 ---
 
 Documentation for gas-liquid mass-transfer equipment in NeqSim. Select the model from the
@@ -12,6 +12,7 @@ engineering question first; the classes do not represent interchangeable fidelit
 - [Absorber](#absorber)
 - [Stripper](#stripper)
 - [Rigorous Tray Absorber](#rigorous-tray-absorber)
+- [Rigorous Absorber Capacity Screening](#rigorous-absorber-capacity-screening)
 - [Mechanical Design and Debottlenecking](#mechanical-design-and-debottlenecking)
 - [Simple Absorber](#simple-absorber)
 - [Simple TEG Absorber](#simple-teg-absorber)
@@ -28,7 +29,7 @@ engineering question first; the classes do not represent interchangeable fidelit
 
 | Class | Use when | Important boundary |
 | --- | --- | --- |
-| `AbsorptionColumn` | Counter-current equilibrium trays with Murphree efficiencies | No tray hydraulics, reactions, entrainment, or flooding in the MESH solver; use the post-process mechanical-design rating |
+| `AbsorptionColumn` | Counter-current equilibrium trays with Murphree efficiencies | Native post-run Fs, Souders-Brown, wetting, and capacity-constraint screens do not feed hydraulics, reactions, entrainment, or flooding back into the MESH solver |
 | `StrippingColumn` | Counter-current equilibrium trays for stripping service | Fixed tray temperatures imply unreported heating or cooling; the column shares the mechanical-design rating |
 | `PackedColumn` | Equilibrium-stage contactor with packing HETP and hydraulic rating | Use `RateBasedPackedColumn` when axial film-rate profiles or local transfer reversal matter |
 | `RateBasedPackedColumn` | Packed-column films, hydraulics, profiles, or local transfer reversal | Requires packing and transport-property inputs |
@@ -196,6 +197,7 @@ leanTeg.setTemperature(35.0, "C");
 leanTeg.setPressure(70.0, "bara");
 
 AbsorptionColumn absorber = new AbsorptionColumn("TEG contactor", 4);
+absorber.setInternalDiameter(1.2); // m; actual or candidate shell internal diameter
 absorber.addGasInStream(wetGas);
 absorber.addSolventInStream(leanTeg);
 absorber.setTopPressure(70.0);
@@ -246,6 +248,89 @@ entrainment, or flooding back into the MESH equations, but the shared column mec
 rate those limits after convergence. It does not model rate-based packing or reactions. The repository regression covers TEG
 dehydration, lean-oil hydrocarbon recovery, methanol water wash, convergence, total balance,
 named-component balance, and efficiency sensitivity.
+
+---
+
+## Rigorous Absorber Capacity Screening
+
+After the rigorous column has converged, `AbsorptionColumn` exposes two live gas-capacity
+indicators plus a liquid wetting rate. These are post-process screens: they read the solved outlet
+states and current internal diameter, but they do not change tray flows, efficiencies, convergence,
+or pressure drop in the MESH solve.
+
+The inherited Fs factor and the Souders-Brown gas load factor use different density corrections:
+
+$F_s=v_s\sqrt{\rho_g}$
+
+$K_s=v_s\sqrt{\frac{\rho_g}{\rho_\ell-\rho_g}}$
+
+where `v_s = Q_g/A` is superficial gas velocity in m/s, `A = pi D^2/4`, and gas and liquid
+densities are in kg/m³. `getFsFactor()` therefore returns m/s·sqrt(kg/m³), while
+`getGasLoadFactor()` returns m/s. `getWettingRate()` returns liquid m³/h per m² of column
+cross-section.
+
+Continue from the complete TEG example above:
+
+```java
+import neqsim.process.equipment.capacity.CapacityConstraint;
+
+absorber.setMaxAllowableFsFactor(3.0);
+absorber.setMaxAllowableGasLoadFactor(0.15);
+
+double superficialVelocity = absorber.getGasSuperficialVelocity();
+double fsFactor = absorber.getFsFactor();
+double gasLoadFactor = absorber.getGasLoadFactor();
+double wettingRate = absorber.getWettingRate();
+
+double minimumDiameterByFs = absorber.getMinimumDiameterForFsLimit();
+double minimumDiameterByGasLoad = absorber.getMinimumDiameterForGasLoadLimit();
+
+if (!Double.isFinite(superficialVelocity) || superficialVelocity <= 0.0
+    || !Double.isFinite(fsFactor) || fsFactor <= 0.0
+    || !Double.isFinite(gasLoadFactor) || gasLoadFactor <= 0.0
+    || !Double.isFinite(wettingRate) || wettingRate <= 0.0
+    || minimumDiameterByFs <= 0.0 || minimumDiameterByGasLoad <= 0.0) {
+  throw new IllegalStateException("Absorber capacity inputs are unavailable");
+}
+
+double fsUtilization = absorber.getFsFactorUtilization();
+double gasLoadUtilization = absorber.getGasLoadFactorUtilization();
+boolean fsWithinLimit = absorber.isFsFactorWithinDesignLimit();
+boolean gasLoadWithinLimit = absorber.isGasLoadFactorWithinDesignLimit();
+
+CapacityConstraint fsConstraint =
+    absorber.getCapacityConstraints().get("fsFactor");
+CapacityConstraint gasLoadConstraint =
+    absorber.getCapacityConstraints().get("gasLoadFactor");
+if (fsConstraint == null || gasLoadConstraint == null) {
+  throw new IllegalStateException("Absorber capacity constraints were not initialized");
+}
+```
+
+The constructor defaults are 3.0 m/s·sqrt(kg/m³) for Fs and 0.15 m/s for
+`K_s`. They are software screening defaults, not vendor guarantees or universal packing/tray
+limits. Set project- and internals-specific values before using utilization in a bottleneck study.
+Both setters update the corresponding live SOFT constraint immediately. The constraints are named
+`fsFactor` and `gasLoadFactor`, have `dataSource = "equipment"`, and appear in ordinary
+process utilization snapshots.
+
+A utilization above 1.0 means the configured limit is exceeded. The two
+`getMinimumDiameter...` methods calculate screening diameters at the current solved gas rate and
+outlet densities; they do not resize the column or rerun the process.
+
+### Fail-closed interpretation
+
+A returned zero is an unavailable-result sentinel, not proof of spare capacity. It is returned
+before outlet states exist, when the diameter is not positive, or when required density data are
+invalid. Consequently, `isFsFactorWithinDesignLimit()` or
+`isGasLoadFactorWithinDesignLimit()` can be `true` for an unavailable zero result; require
+positive finite factors and diameters before accepting either boolean.
+
+For near-dry liquid outlets, the current gas-load implementation substitutes 1000 kg/m³ when the
+raw liquid-gas density difference is below 10 kg/m³. Record that fallback when it is triggered and
+replace the screen with representative liquid-property and vendor hydraulic data for design work.
+Use `DistillationColumnMechanicalDesign.calcDesign()` for the more detailed packing/tray flood,
+demister, wetting, and pressure-drop rating described next.
 
 ---
 

--- a/docs/test_absorber_documentation.py
+++ b/docs/test_absorber_documentation.py
@@ -19,6 +19,17 @@ SIMPLE_SOURCE = (
     / "SimpleAbsorber.java"
 )
 ABSORPTION_SOURCE = SIMPLE_SOURCE.with_name("AbsorptionColumn.java")
+DISTILLATION_SOURCE = (
+    ROOT
+    / "src"
+    / "main"
+    / "java"
+    / "neqsim"
+    / "process"
+    / "equipment"
+    / "distillation"
+    / "DistillationColumn.java"
+)
 STRIPPING_SOURCE = SIMPLE_SOURCE.with_name("StrippingColumn.java")
 ABSORPTION_TEST = (
     ROOT
@@ -42,6 +53,7 @@ class AbsorberDocumentationTest(unittest.TestCase):
         cls.guide = GUIDE.read_text(encoding="utf-8")
         cls.simple_source = SIMPLE_SOURCE.read_text(encoding="utf-8")
         cls.absorption_source = ABSORPTION_SOURCE.read_text(encoding="utf-8")
+        cls.distillation_source = DISTILLATION_SOURCE.read_text(encoding="utf-8")
         cls.stripping_source = STRIPPING_SOURCE.read_text(encoding="utf-8")
         cls.absorption_test = ABSORPTION_TEST.read_text(encoding="utf-8")
         cls.stripping_test = STRIPPING_TEST.read_text(encoding="utf-8")
@@ -164,6 +176,95 @@ class AbsorberDocumentationTest(unittest.TestCase):
             "equipment-duty result",
         ):
             self.assertIn(statement, self.scoped_guide)
+
+
+    def test_rigorous_capacity_methods_and_units_match_source(self):
+        for token in (
+            "public double getGasSuperficialVelocity()",
+            "public double getGasLoadFactor()",
+            "public double getMaxAllowableGasLoadFactor()",
+            "public void setMaxAllowableGasLoadFactor(double",
+            "public double getGasLoadFactorUtilization()",
+            "public boolean isGasLoadFactorWithinDesignLimit()",
+            "public double getMinimumDiameterForGasLoadLimit()",
+            "public double getWettingRate()",
+        ):
+            self.assertIn(token, self.absorption_source)
+
+        for token in (
+            "public double getFsFactor()",
+            "public double getMaxAllowableFsFactor()",
+            "public void setMaxAllowableFsFactor(double",
+            "public double getFsFactorUtilization()",
+            "public boolean isFsFactorWithinDesignLimit()",
+            "public double getMinimumDiameterForFsLimit()",
+        ):
+            self.assertIn(token, self.distillation_source)
+
+        for token in (
+            "getGasSuperficialVelocity()",
+            "getMinimumDiameterForFsLimit()",
+            "getMinimumDiameterForGasLoadLimit()",
+            "liquid m³/h per m²",
+            "m/s·sqrt(kg/m³)",
+            "returns m/s",
+        ):
+            self.assertIn(token, self.scoped_guide)
+
+    def test_capacity_equations_defaults_and_fallback_are_explicit(self):
+        self.assertIn("DEFAULT_MAX_ALLOWABLE_FS_FACTOR = 3.0", self.absorption_source)
+        self.assertIn(
+            "DEFAULT_MAX_ALLOWABLE_GAS_LOAD_FACTOR = 0.15",
+            self.absorption_source,
+        )
+        self.assertIn("DEFAULT_LIQUID_DENSITY = 1000.0", self.absorption_source)
+        self.assertIn(
+            "MIN_LIQUID_GAS_DENSITY_DIFFERENCE = 10.0",
+            self.absorption_source,
+        )
+
+        for token in (
+            "$F_s=v_s\\sqrt{\\rho_g}$",
+            "$K_s=v_s\\sqrt{\\frac{\\rho_g}{\\rho_\\ell-\\rho_g}}$",
+            "software screening defaults, not vendor guarantees",
+            "substitutes 1000 kg/m³",
+            "below 10 kg/m³",
+        ):
+            self.assertIn(token, self.scoped_guide)
+
+    def test_capacity_sentinels_and_constraint_semantics_are_documented(self):
+        for token in (
+            'return 0.0;',
+            '"gasLoadFactor", "m/s"',
+            'setDataSource("equipment")',
+        ):
+            self.assertIn(token, self.absorption_source)
+        for token in (
+            '"fsFactor", "m/s*sqrt(kg/m3)"',
+            'setDataSource("equipment")',
+        ):
+            self.assertIn(token, self.distillation_source)
+
+        for token in (
+            "unavailable-result sentinel, not proof of spare capacity",
+            "can be `true` for an unavailable zero result",
+            "update the corresponding live SOFT constraint immediately",
+            '`fsFactor` and `gasLoadFactor`',
+            'dataSource = "equipment"',
+            "do not resize the column or rerun the process",
+        ):
+            self.assertIn(token, self.scoped_guide)
+
+    def test_capacity_example_is_covered_by_executable_regression(self):
+        for token in (
+            "gasLoadFactorAndFsFactorAreNativelyAvailable",
+            "getGasSuperficialVelocity()",
+            "getMinimumDiameterForFsLimit()",
+            "getMinimumDiameterForGasLoadLimit()",
+            'getCapacityConstraints().containsKey("fsFactor")',
+            'getCapacityConstraints().containsKey("gasLoadFactor")',
+        ):
+            self.assertIn(token, self.absorption_test)
 
 
 if __name__ == "__main__":

--- a/src/test/java/neqsim/process/equipment/absorber/AbsorptionColumnTest.java
+++ b/src/test/java/neqsim/process/equipment/absorber/AbsorptionColumnTest.java
@@ -65,6 +65,14 @@ class AbsorptionColumnTest extends NeqSimTest {
 
     double fs = absorber.getFsFactor();
     double ks = absorber.getGasLoadFactor();
+    double minimumDiameterByFs = absorber.getMinimumDiameterForFsLimit();
+    double minimumDiameterByGasLoad = absorber.getMinimumDiameterForGasLoadLimit();
+    assertTrue(absorber.getGasSuperficialVelocity() > 0.0,
+        "Superficial velocity must be positive once the column has run and has a diameter");
+    assertTrue(Double.isFinite(minimumDiameterByFs) && minimumDiameterByFs > 0.0,
+        "The Fs-factor diameter screen must be positive and finite");
+    assertTrue(Double.isFinite(minimumDiameterByGasLoad) && minimumDiameterByGasLoad > 0.0,
+        "The gas-load-factor diameter screen must be positive and finite");
     assertTrue(fs > 0.0, "Fs factor must be positive once the column has run");
     assertTrue(ks > 0.0, "Gas load factor must be positive once the column has run");
 
@@ -88,7 +96,9 @@ class AbsorptionColumnTest extends NeqSimTest {
     assertTrue(absorber.getCapacityConstraints().containsKey("fsFactor"));
     assertTrue(absorber.getCapacityConstraints().containsKey("gasLoadFactor"));
 
+    absorber.setMaxAllowableFsFactor(3.2);
     absorber.setMaxAllowableGasLoadFactor(0.20);
+    assertEquals(3.2, absorber.getCapacityConstraints().get("fsFactor").getMaxValue(), 1.0e-12);
     assertEquals(0.20, absorber.getCapacityConstraints().get("gasLoadFactor").getMaxValue(), 1.0e-12);
   }
 


### PR DESCRIPTION
## Summary

Advances documentation-quality campaign #2499 as **D099** (rotation scope 3: process equipment) with a frozen absorber-capacity batch.

This change connects the rigorous absorber guide to the native capacity APIs added in #3292 / `56c5f2f`, while preserving the documented boundary between post-run screening and the MESH solve.

### Confirmed defects repaired

1. Capacity screening was not discoverable from the rigorous absorber guide or its contents.
2. The complete TEG example did not establish a positive internal diameter required by the native screens.
3. Fs and Souders–Brown gas-load equations were absent.
4. Return units for velocity, Fs, gas-load factor, and wetting rate were absent.
5. Software defaults (Fs 3.0; gas-load factor 0.15 m/s) were not identified as screening defaults.
6. The guide did not show both minimum-diameter calculations.
7. Utilization and within-limit APIs were not demonstrated.
8. Live SOFT constraint names and equipment provenance were undocumented.
9. Setter-to-constraint synchronization was undocumented and untested.
10. Zero results were liable to be mistaken for spare capacity instead of unavailable-result sentinels.
11. Boolean within-limit results were not qualified for unavailable zero values.
12. The 1000 kg/m³ liquid-density fallback and 10 kg/m³ trigger were undocumented.
13. Native screens were not distinguished clearly from detailed mechanical-design rating.
14. Documentation statements lacked focused source contracts and executable Java regression coverage.

## Frozen scope

Base: `83a99c5c9ef7235798d4a1784adcdd00f2bf0e05`  
Head: `035e450cf67b03da788ecd530915d7860d8894de`

- `docs/process/equipment/absorbers.md`
- `docs/test_absorber_documentation.py`
- `src/test/java/neqsim/process/equipment/absorber/AbsorptionColumnTest.java`

The guide was already indexed in the equipment catalog and reference navigation, so no index change is needed.

## Validation

- PASS — exact-head frozen-scope comparison: exactly 3 files, 198 additions / 2 deletions, zero commits behind `master`.
- PASS — raw base64 source contains literal compact KaTeX display equations and no `\\[` / `\\]` delimiters.
- PASS — source-anchored documentation contracts cover public APIs, units, defaults, fallback behavior, sentinels, constraints, and executable-regression linkage.
- PASS — `python -m py_compile docs/test_absorber_documentation.py` using the exact contract blob.
- PASS — repository documentation/Jekyll/search checks, pre-commit, Spotless, CodeQL, agent-skill references, and Javadocs.
- **VALIDATION PENDING CI** — Ubuntu and Windows Java fast suites plus all four Java 21 slow-test shards.

## Boundaries

- Documentation and focused regression coverage only; no production-code behavior changes.
- No notebook output or generated-site artifacts.
- No Huldra data or integration work.
- Further expansion stops here because the next rotation scope is unrelated and active diagram/DEXPI work is already owned by another campaign PR.

Campaign: #2499
