### PR TITLE
fix(ci): authenticate community agent smoke test

### DIFF
--- a/.github/workflows/install_smoke_test.yml
+++ b/.github/workflows/install_smoke_test.yml
@@ -9,7 +9,9 @@ name: Install smoke test
 # skill Python-package install, VS Code export, --force reinstall) fails here
 # instead of on a new user's first day.
 #
-# Community source only: no auth, no private catalogs, no secrets required.
+# Community source only. The workflow token is read-only and is exposed to the
+# installer only to authenticate public GitHub API requests and avoid anonymous
+# API rate limits while preserving the real end-to-end download path.
 
 permissions:
   contents: read
@@ -38,6 +40,8 @@ jobs:
   install-smoke-test:
     name: neqsim agent install --all (community) on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Fixes the failing install smoke test on `master` caused by anonymous GitHub API rate limiting while discovering `community-router-agent` from `equinor/neqsim-community-agents`.

The workflow already grants only `contents: read`. This change exposes the ephemeral read-only Actions token as `GITHUB_TOKEN` to the NeqSim installer, which already knows how to use that variable for authenticated GitHub requests. The real community catalog/download path remains exercised on both Ubuntu and Windows; no agent is skipped and no assertion is relaxed.

## Failure observed on master

- `neqsim agent install --all (community) on ubuntu-latest` failed after 48/49 agents.
- `community-router-agent` discovery failed with GitHub HTTP 403 / anonymous API rate limit while listing the repository tree.
- The corresponding Windows matrix job is also failing in the same smoke-test workflow.

## Validation

- Source inspection confirms `devtools/install_skill.py` adds the `Authorization` header whenever `GITHUB_TOKEN` is present.
- Workflow permissions remain `contents: read`.
- End-to-end GitHub Actions validation: **VALIDATION PENDING CI**.