### PR TITLE
[AI-Assisted] docs: qualify blocked-in liquid expansion screening

### DIFF
--- a/docs/safety/blocked_in_liquid_thermal_expansion.md
+++ b/docs/safety/blocked_in_liquid_thermal_expansion.md
@@ -1,79 +1,157 @@
 ---
 title: Blocked-In Liquid Thermal Expansion Screening
-description: Rigorous equation-of-state isochoric pressure-rise screening for blocked-in (liquid-full, no vapor space) piping or vessel segments per API 521 7th Ed. Section 4.4.12, plus a simplified beta/kappa estimate.
+description: Equation-of-state isochoric pressure-rise and local beta/kappa screening for initialized single-liquid blocked-in inventories, with explicit units, numerical boundaries, and relief-design handoff.
 ---
 
-Blocked-in liquid thermal expansion is one of the most severe overpressure scenarios in process
-plants: because liquids are nearly incompressible, even a modest temperature rise can produce
-extreme pressure increases when a segment is isolated with no vapor space and no relief path.
-`BlockedInLiquidExpansionAnalysis` (`neqsim.process.util.fire`) provides two complementary
-screening methods for this scenario, per API 521 7th Ed. Section 4.4.12.
+# Blocked-In Liquid Thermal Expansion Screening
+
+A liquid-full segment with fixed mass, rigid volume, no vapour space, and no open relief path can
+develop a large pressure rise when heated. This guide separates two engineering questions:
+
+1. **What absolute pressure is required to retain the initial liquid density at a new
+   temperature?**
+2. **What thermal-relief flow and certified device area are required for the real heat input,
+   inventory, piping, and back pressure?**
+
+`BlockedInLiquidExpansionAnalysis` in `neqsim.process.util.fire` addresses only the first
+question. It provides an equation-of-state pressure screen and a local constant-property
+cross-check. It does not calculate thermal-relief flow, select a valve, or approve a design.
 
 ## When to Use This vs `TrappedLiquidFireRuptureStudy`
 
 | Tool | Scope | Use when |
-|------|-------|----------|
-| `BlockedInLiquidExpansionAnalysis` | Pure thermal-expansion pressure rise for a blocked-in liquid (no fire, no pipe stress/flange checks) | Quick check of whether a blocked-in liquid segment needs a thermal relief valve (TSV), or to size the magnitude of an expansion-pressure problem |
-| `TrappedLiquidFireRuptureStudy` ([docs](trapped_liquid_fire_rupture.md)) | Full fire-exposure transient: wall heat-up, pipe/flange stress, rupture time, PFP demand | Fire case screening for a blocked-in segment, including material strength derating and rupture-time estimation |
+| --- | --- | --- |
+| `BlockedInLiquidExpansionAnalysis` | Rigid-volume, fixed-mass pressure screening without fire heat-transfer, pipe-stress, or flange checks | Screening an initialized single-liquid inventory for pressure sensitivity to temperature |
+| `TrappedLiquidFireRuptureStudy` ([guide](trapped_liquid_fire_rupture.md)) | Fire-exposure transient with wall heat-up, pipe/flange checks, failure time, and PFP demand | Screening a defined fire case and its thermomechanical response |
 
-Both classes provide complementary screening: use `BlockedInLiquidExpansionAnalysis`
-(`neqsim.process.util.fire`) first as a fast, fire-independent screening check, then move to
-`TrappedLiquidFireRuptureStudy` (`neqsim.process.safety.rupture`) when a fire scenario and
-material/flange checks are required.
+Use the blocked-in analysis for the thermodynamic pressure question. Move to the rupture study only
+when its additional fire, geometry, material, and flange inputs represent the scenario. Neither tool
+replaces project relief-system design or accountable safety review.
 
-## Two Calculation Modes
+## Calculation Modes
 
-1. **Rigorous isochoric pressure march** — `computeIsochoricPressureProfile(fluid, temperaturesK)`
-   re-flashes a clone of the fluid at each requested temperature, searching (bracket + bisection)
-   for the pressure that reproduces the reference density recorded at the initial blocked-in
-   state. This avoids the constant-property assumption of the simplified relation and is accurate
-   over large temperature spans.
-2. **Simplified screening relation** — the classical $dP = (\beta / \kappa)\, dT$ relation from API
-   521 §4.4.12, where $\beta$ is the isobaric thermal expansion coefficient and $\kappa$ is the
-   isothermal compressibility. Use `estimateThermalExpansionCoefficient(fluid, dT)` and
-   `estimateIsothermalCompressibility(fluid, dP)` to estimate $\beta$ and $\kappa$ by central finite
-   differences at the reference state, then `simplifiedPressureRise(beta, kappa, deltaT)` for the
-   pressure rise. This relation is only accurate for small temperature steps around the reference
-   state; for larger temperature changes prefer the isochoric pressure march.
+### Isochoric equation-of-state march
 
-## Java Example
+`computeIsochoricPressureProfile(fluid, temperaturesK)` records the mixture density at the
+supplied fluid's current temperature and pressure. For each requested temperature it performs
+`TPflash()` calculations on internal clones and uses bracket expansion plus bisection to find the
+absolute pressure that reproduces that reference density.
+
+The current implementation:
+
+- interprets input temperatures as absolute K and returns absolute pressures in Pa;
+- converts the supplied system's canonical pressure from bara to Pa;
+- seeds each point with the preceding pressure result, so an increasing temperature sequence is the
+  clearest heating workflow;
+- accepts a relative density error below `1.0e-6`;
+- searches between `1.0e3` Pa and `1.0e9` Pa; and
+- does not modify the supplied `SystemInterface`.
+
+The algorithm does not prove that every trial or result is a single liquid phase. Confirm the
+initial state and the requested range independently. A phase transition, non-monotonic density
+response, unsuitable equation of state, or unreachable density may prevent bracketing and raise
+`IllegalStateException`.
+
+### Local beta/kappa relation
+
+For a small step around the initialized reference state, the constant-property differential relation
+is
+
+$$dP=\frac{\beta}{\kappa}\,dT$$
+
+where `estimateThermalExpansionCoefficient(fluid, dT)` returns the isobaric expansion
+coefficient $\beta$ in 1/K, and
+`estimateIsothermalCompressibility(fluid, dP)` returns the isothermal compressibility
+$\kappa$ in 1/Pa. The finite-difference steps are in K and Pa respectively and must be positive.
+`simplifiedPressureRise(beta, kappa, deltaT)` returns a pressure change in Pa.
+
+This relation is a local diagnostic, not a validation tolerance for a long temperature interval.
+The repository regression demonstrates only a subcooled-propane case over 5 K where the simplified
+and EOS results differ by less than 30%.
+
+## Executable Java Workflow
+
+The following state and step sizes are exercised by
+`BlockedInLiquidExpansionAnalysisTest`:
 
 ```java
 import neqsim.process.util.fire.BlockedInLiquidExpansionAnalysis;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 
-SystemInterface oil = new SystemSrkEos(298.15, 10.0);
-oil.addComponent("n-heptane", 100.0);
-oil.setMixingRule("classic");
+double referenceTemperatureK = 293.15;
+double referencePressureBara = 15.0;
 
-// 1. Rigorous isochoric pressure march from 25 C to 60 C
-double[] temperaturesK = {298.15, 308.15, 318.15, 328.15, 333.15};
-double[] pressuresPa =
-    BlockedInLiquidExpansionAnalysis.computeIsochoricPressureProfile(oil, temperaturesK);
+SystemInterface liquid =
+    new SystemSrkEos(referenceTemperatureK, referencePressureBara);
+liquid.addComponent("propane", 1.0);
+liquid.setMixingRule("classic");
 
-// 2. Simplified beta/kappa screening estimate for a quick cross-check
-double beta = BlockedInLiquidExpansionAnalysis.estimateThermalExpansionCoefficient(oil, 1.0);
-double kappa = BlockedInLiquidExpansionAnalysis.estimateIsothermalCompressibility(oil, 1.0e5);
-double simplifiedDeltaPPa = BlockedInLiquidExpansionAnalysis.simplifiedPressureRise(beta, kappa, 35.0);
+double[] temperaturesK = {
+    referenceTemperatureK,
+    referenceTemperatureK + 2.0,
+    referenceTemperatureK + 4.0,
+    referenceTemperatureK + 6.0,
+    referenceTemperatureK + 8.0,
+    referenceTemperatureK + 10.0
+};
+double[] absolutePressuresPa =
+    BlockedInLiquidExpansionAnalysis.computeIsochoricPressureProfile(
+        liquid, temperaturesK);
+
+double betaPerK =
+    BlockedInLiquidExpansionAnalysis.estimateThermalExpansionCoefficient(
+        liquid, 0.5);
+double kappaPerPa =
+    BlockedInLiquidExpansionAnalysis.estimateIsothermalCompressibility(
+        liquid, 2.0e5);
+
+double comparisonTemperatureRiseK = 5.0;
+double simplifiedPressureRisePa =
+    BlockedInLiquidExpansionAnalysis.simplifiedPressureRise(
+        betaPerK, kappaPerPa, comparisonTemperatureRiseK);
 ```
 
-`computeIsochoricPressureProfile` returns pressures in Pa for each requested temperature (Kelvin);
-`simplifiedPressureRise` returns the estimated pressure rise in Pa. The simplified estimate should
-agree with the isochoric march to within roughly 30% for moderate temperature spans — use the
-isochoric march as the reference and the simplified relation only for a fast order-of-magnitude
-check.
+`absolutePressuresPa` contains absolute pressures, not pressure rises. If the first requested
+temperature equals the initialized temperature, its result should reproduce the initial absolute
+pressure within the numerical density tolerance. Calculate a rise explicitly, for example
+`absolutePressuresPa[i] - absolutePressuresPa[0]`.
 
-## Standards Basis
+Before accepting a result, require finite positive pressures, verify the expected trend, confirm that
+the supplied fluid still represents the intended liquid phase, and compare against nearby step
+sizes or an independent property source. Treat a bracket failure as a failed screen, not as evidence
+of acceptable pressure.
 
-| Topic | Standard / method |
-|-------|--------------------|
-| Liquid thermal expansion overpressure scenario | API 521 7th Ed., Section 4.4.12 |
-| Thermal relief valve sizing once a relief requirement is confirmed | `ReliefValveSizing` ([docs](relief_valve_sizing_api.md)) — API 520 |
-| Full fire-exposure rupture screening for the same blocked-in segment | `TrappedLiquidFireRuptureStudy` ([docs](trapped_liquid_fire_rupture.md)) |
+## Thermal-Relief Design Handoff
+
+This analysis supplies no heat-input model, expansion volume rate, required relieving rate,
+accumulation case, back pressure, discharge coefficient, viscosity correction, inlet/outlet
+hydraulics, or certified orifice selection. Those inputs cannot be inferred from a pressure rise
+alone.
+
+`ReliefValveSizing.calculateLiquidReliefArea(...)` is a separate static screen. It requires an
+independently established liquid volume flow at relieving conditions in m³/s, liquid density in
+kg/m³, absolute set and back pressures in Pa, overpressure fraction, viscosity in Pa·s, and valve
+configuration. Use the project heat-transfer and hydraulic basis to establish those inputs, then
+apply the licensed project standard and vendor data.
+
+## Standards and Evidence Boundary
+
+API 521 identifies blocked-in liquid thermal expansion as an overpressure scenario, while API 520
+provides relief-device sizing methods. Edition and section numbering must be checked against the
+project's licensed copies; NeqSim does not reproduce or certify either standard.
+
+The repository regression is numerical software evidence for one EOS case. It is not experimental
+validation, a universal 30% acceptance criterion, or evidence that SRK is suitable for every liquid.
 
 ## Limitations
 
-This is a screening tool. It does not replace a thermal relief valve sizing study, and it does not
-account for vapor space, trace heating, insulation credit, or non-uniform heating along a pipe run.
-Use `ReliefValveSizing` to size the thermal relief device once a relief requirement is confirmed.
+The current pressure screen assumes fixed mass and rigid volume. It does not model pipe/vessel
+elasticity, vapour space, boiling or flashing acceptance, dissolved-gas release, non-uniform or
+time-dependent heating, trace heating, insulation credit, thermal relief flow, relief-line
+hydraulics, valve dynamics, material limits, or structural failure.
+
+Use a fluid model and characterization suitable for the liquid and pressure range, perform
+sensitivity checks, and retain explicit units, input provenance, software version, and failed-case
+diagnostics. Safety-critical conclusions require project-specific standards, independent
+verification, and accountable engineering review.

--- a/docs/safety/blocked_in_liquid_thermal_expansion.md
+++ b/docs/safety/blocked_in_liquid_thermal_expansion.md
@@ -126,8 +126,7 @@ of acceptable pressure.
 
 This analysis supplies no heat-input model, expansion volume rate, required relieving rate,
 accumulation case, back pressure, discharge coefficient, viscosity correction, inlet/outlet
-hydraulics, or certified orifice selection. Those inputs cannot be inferred from a pressure rise
-alone.
+hydraulics, or certified orifice selection. Those inputs cannot be inferred from a pressure rise alone.
 
 `ReliefValveSizing.calculateLiquidReliefArea(...)` is a separate static screen. It requires an
 independently established liquid volume flow at relieving conditions in m³/s, liquid density in
@@ -142,7 +141,8 @@ provides relief-device sizing methods. Edition and section numbering must be che
 project's licensed copies; NeqSim does not reproduce or certify either standard.
 
 The repository regression is numerical software evidence for one EOS case. It is not experimental
-validation, a universal 30% acceptance criterion, or evidence that SRK is suitable for every liquid.
+validation or a universal 30% acceptance criterion, and it is not evidence that SRK is suitable for
+every liquid.
 
 ## Limitations
 

--- a/docs/safety/blocked_in_liquid_thermal_expansion.md
+++ b/docs/safety/blocked_in_liquid_thermal_expansion.md
@@ -141,8 +141,8 @@ provides relief-device sizing methods. Edition and section numbering must be che
 project's licensed copies; NeqSim does not reproduce or certify either standard.
 
 The repository regression is numerical software evidence for one EOS case. It is not experimental
-validation or a universal 30% acceptance criterion, and it is not evidence that SRK is suitable for
-every liquid.
+validation. It is not a universal 30% acceptance criterion, and it is not evidence that SRK is
+suitable for every liquid.
 
 ## Limitations
 

--- a/docs/test_blocked_in_liquid_expansion_documentation.py
+++ b/docs/test_blocked_in_liquid_expansion_documentation.py
@@ -1,0 +1,174 @@
+"""Regression contracts for blocked-in liquid expansion documentation."""
+
+import re
+import unittest
+from pathlib import Path
+from urllib.parse import unquote
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDE = ROOT / "docs" / "safety" / "blocked_in_liquid_thermal_expansion.md"
+SOURCE = ROOT / (
+    "src/main/java/neqsim/process/util/fire/"
+    "BlockedInLiquidExpansionAnalysis.java"
+)
+JAVA_TEST = ROOT / (
+    "src/test/java/neqsim/process/util/fire/"
+    "BlockedInLiquidExpansionAnalysisTest.java"
+)
+RELIEF_SOURCE = ROOT / (
+    "src/main/java/neqsim/process/util/fire/ReliefValveSizing.java"
+)
+
+
+def resolve_internal_target(destination):
+    target, _, fragment = unquote(destination).partition("#")
+    raw_target = GUIDE.parent / target
+    candidates = [raw_target]
+    if not Path(target).suffix:
+        candidates.extend(
+            (
+                Path("{}.md".format(raw_target)),
+                raw_target / "README.md",
+                raw_target / "index.md",
+            )
+        )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve(), fragment
+    raise AssertionError("Unresolved guide link: {}".format(destination))
+
+
+class BlockedInLiquidExpansionDocumentationContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+        cls.source = SOURCE.read_text(encoding="utf-8")
+        cls.java_test = JAVA_TEST.read_text(encoding="utf-8")
+        cls.relief_source = RELIEF_SOURCE.read_text(encoding="utf-8")
+
+    def test_jekyll_structure_math_and_internal_links(self):
+        self.assertTrue(self.guide.startswith("---\n"))
+        self.assertEqual(
+            self.guide.count("# Blocked-In Liquid Thermal Expansion Screening"),
+            1,
+        )
+        self.assertEqual(self.guide.count("```") % 2, 0)
+        without_fences = re.sub(
+            r"```.*?```",
+            "",
+            self.guide,
+            flags=re.DOTALL,
+        )
+        self.assertNotIn(r"\[", without_fences)
+        self.assertNotIn(r"\]", without_fences)
+        self.assertIn(
+            r"$$dP=\frac{\beta}{\kappa}\,dT$$",
+            without_fences,
+        )
+        for destination in re.findall(
+            r"(?<!!)\[[^\]]+\]\(([^)]+)\)",
+            self.guide,
+        ):
+            if destination.startswith(("http://", "https://", "mailto:")):
+                continue
+            target, _fragment = resolve_internal_target(destination)
+            self.assertTrue(target.is_file())
+
+    def test_public_methods_units_and_search_bounds_match_source(self):
+        for signature in (
+            "public static double[] computeIsochoricPressureProfile(",
+            "public static double estimateThermalExpansionCoefficient(",
+            "public static double estimateIsothermalCompressibility(",
+            "public static double simplifiedPressureRise(",
+        ):
+            self.assertIn(signature, self.source)
+
+        for source_token in (
+            "PA_PER_BARA = 1.0e5",
+            "DENSITY_RELATIVE_TOLERANCE = 1.0e-6",
+            "MIN_SEARCH_PRESSURE_PA = 1.0e3",
+            "MAX_SEARCH_PRESSURE_PA = 1.0e9",
+            'state.setTemperature(temperatureK, "K")',
+            'state.setPressure(pressurePa / PA_PER_BARA, "bara")',
+            "SystemInterface state = template.clone()",
+            "operations.TPflash()",
+        ):
+            self.assertIn(source_token, self.source)
+
+        for guide_token in (
+            "input temperatures as absolute K",
+            "absolute pressures in Pa",
+            "canonical pressure from bara to Pa",
+            "relative density error below `1.0e-6`",
+            "between `1.0e3` Pa and `1.0e9` Pa",
+            "does not modify the supplied `SystemInterface`",
+        ):
+            self.assertIn(guide_token, self.guide)
+
+    def test_executable_workflow_is_exactly_covered(self):
+        for guide_token in (
+            "new SystemSrkEos(referenceTemperatureK, referencePressureBara)",
+            'liquid.addComponent("propane", 1.0)',
+            "referenceTemperatureK + 10.0",
+            "liquid, 0.5",
+            "liquid, 2.0e5",
+            "comparisonTemperatureRiseK = 5.0",
+        ):
+            self.assertIn(guide_token, self.guide)
+
+        for test_token in (
+            "testIsochoricPressureProfileIsMonotonicAndMatchesInitialState",
+            "testIsochoricMarchMatchesSimplifiedBetaOverKappaEstimateNearReferenceState",
+            "Double.isFinite(pressurePa)",
+            "fluid.getTemperature()",
+            "fluid.getPressure()",
+            "relativeDifference < 0.3",
+        ):
+            self.assertIn(test_token, self.java_test)
+
+    def test_phase_failure_and_validation_boundaries_are_explicit(self):
+        for guide_token in (
+            "does not prove that every trial or result is a single liquid phase",
+            "may prevent bracketing and raise",
+            "Treat a bracket failure as a failed screen",
+            "not experimental validation",
+            "not a universal 30% acceptance criterion",
+            "fixed mass and rigid volume",
+            "pipe/vessel elasticity",
+        ):
+            self.assertIn(guide_token, self.guide)
+
+        self.assertNotIn("accurate over large temperature spans", self.guide)
+        self.assertNotIn(
+            "within roughly 30% for moderate temperature spans",
+            self.guide,
+        )
+
+    def test_relief_sizing_handoff_does_not_invent_flow(self):
+        self.assertIn(
+            "public static LiquidPSVSizingResult calculateLiquidReliefArea(",
+            self.relief_source,
+        )
+        for source_token in (
+            "@param volumeFlowRate Volume flow rate at relieving conditions [m3/s]",
+            "@param liquidDensity Liquid density at relieving conditions [kg/m3]",
+            "@param setPressure PSV set pressure [Pa absolute]",
+            "@param backPressure Downstream/back pressure [Pa absolute]",
+            "@param viscosity Dynamic viscosity [Pa*s]",
+        ):
+            self.assertIn(source_token, self.relief_source)
+
+        for guide_token in (
+            "supplies no heat-input model",
+            "cannot be inferred from a pressure rise alone",
+            "independently established liquid volume flow",
+            "m³/s",
+            "absolute set and back pressures in Pa",
+            "viscosity in Pa·s",
+        ):
+            self.assertIn(guide_token, self.guide)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/test_blocked_in_liquid_expansion_documentation.py
+++ b/docs/test_blocked_in_liquid_expansion_documentation.py
@@ -128,6 +128,7 @@ class BlockedInLiquidExpansionDocumentationContractTest(unittest.TestCase):
             self.assertIn(test_token, self.java_test)
 
     def test_phase_failure_and_validation_boundaries_are_explicit(self):
+        normalized_guide = " ".join(self.guide.split())
         for guide_token in (
             "does not prove that every trial or result is a single liquid phase",
             "may prevent bracketing and raise",
@@ -137,12 +138,12 @@ class BlockedInLiquidExpansionDocumentationContractTest(unittest.TestCase):
             "fixed mass and rigid volume",
             "pipe/vessel elasticity",
         ):
-            self.assertIn(guide_token, self.guide)
+            self.assertIn(guide_token, normalized_guide)
 
-        self.assertNotIn("accurate over large temperature spans", self.guide)
+        self.assertNotIn("accurate over large temperature spans", normalized_guide)
         self.assertNotIn(
             "within roughly 30% for moderate temperature spans",
-            self.guide,
+            normalized_guide,
         )
 
     def test_relief_sizing_handoff_does_not_invent_flow(self):

--- a/src/test/java/neqsim/process/util/fire/BlockedInLiquidExpansionAnalysisTest.java
+++ b/src/test/java/neqsim/process/util/fire/BlockedInLiquidExpansionAnalysisTest.java
@@ -26,6 +26,8 @@ public class BlockedInLiquidExpansionAnalysisTest {
     double t0 = 293.15;
     double p0Bara = 15.0;
     SystemInterface fluid = subcooledPropaneLiquid(t0, p0Bara);
+    double originalTemperatureK = fluid.getTemperature();
+    double originalPressureBara = fluid.getPressure();
 
     double[] temperaturesK = { t0, t0 + 2.0, t0 + 4.0, t0 + 6.0, t0 + 8.0, t0 + 10.0 };
     double[] pressuresPa = BlockedInLiquidExpansionAnalysis.computeIsochoricPressureProfile(fluid, temperaturesK);
@@ -33,6 +35,14 @@ public class BlockedInLiquidExpansionAnalysisTest {
     assertEquals(temperaturesK.length, pressuresPa.length);
     assertEquals(p0Bara * 1.0e5, pressuresPa[0], p0Bara * 1.0e5 * 1.0e-3,
         "First profile point should match the initial blocked-in pressure");
+    for (double pressurePa : pressuresPa) {
+      assertTrue(Double.isFinite(pressurePa) && pressurePa > 0.0,
+          "Every documented absolute pressure must be positive and finite");
+    }
+    assertEquals(originalTemperatureK, fluid.getTemperature(), 0.0,
+        "The screening calculation must not mutate the supplied temperature");
+    assertEquals(originalPressureBara, fluid.getPressure(), 0.0,
+        "The screening calculation must not mutate the supplied pressure");
     for (int i = 1; i < pressuresPa.length; i++) {
       assertTrue(pressuresPa[i] > pressuresPa[i - 1], "Isochoric pressure must rise monotonically with temperature");
     }
@@ -78,6 +88,10 @@ public class BlockedInLiquidExpansionAnalysisTest {
         () -> BlockedInLiquidExpansionAnalysis.computeIsochoricPressureProfile(fluid, new double[0]));
     assertThrows(IllegalArgumentException.class,
         () -> BlockedInLiquidExpansionAnalysis.computeIsochoricPressureProfile(null, new double[] { 300.0 }));
+    assertThrows(IllegalArgumentException.class,
+        () -> BlockedInLiquidExpansionAnalysis.estimateThermalExpansionCoefficient(fluid, 0.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> BlockedInLiquidExpansionAnalysis.estimateIsothermalCompressibility(fluid, 0.0));
     assertThrows(IllegalArgumentException.class,
         () -> BlockedInLiquidExpansionAnalysis.simplifiedPressureRise(1.0e-3, 0.0, 10.0));
   }


### PR DESCRIPTION
## Summary

Advances documentation-quality campaign #2499 as **D100** (rotation scope 4: engineering design and safety) with a frozen blocked-in-liquid expansion batch.

The batch makes the current EOS pressure-screening API truthful and fail-visible without changing production behavior or overlapping active diagram, Pitzer, or flash work.

### Confirmed defects repaired

1. The page lacked a visible H1.
2. Pressure-rise screening was blurred with thermal-relief device sizing.
3. Returned absolute pressures could be mistaken for pressure rises.
4. Temperature, pressure, beta, kappa, and finite-difference units were incomplete.
5. The initialized single-liquid prerequisite was missing.
6. The guide implied the algorithm proves liquid-phase validity when it does not.
7. Bracketing failure lacked fail-closed interpretation.
8. Density tolerance and pressure-search bounds were undocumented.
9. Sequential pressure seeding and the preferred increasing-temperature workflow were undocumented.
10. An unsupported “accurate over large temperature spans” claim was removed.
11. One 5 K propane regression was overgeneralized to a 30% criterion for moderate spans.
12. The n-heptane example did not match executable repository evidence.
13. Clone/non-mutation and finite-positive output behavior lacked focused regression assertions.
14. The relief-design handoff omitted the independently required volume flow, density, absolute pressures, viscosity, hydraulics, licensed-standard, vendor-data, and accountable-review inputs.

## Frozen scope

Base: `b358d3c6dfff2d25967c6be48d0feb4887d4b207`  
Head: `abc6eebccbf1bda19bb6bc08bef652cc6181d3d0`

- `docs/safety/blocked_in_liquid_thermal_expansion.md`
- `docs/test_blocked_in_liquid_expansion_documentation.py`
- `src/test/java/neqsim/process/util/fire/BlockedInLiquidExpansionAnalysisTest.java`

The guide was already exposed by the safety hub and search/navigation contracts, so no index change is required.

## Validation

- PASS — exact-head comparison contains exactly 3 files (324 additions / 57 deletions) and is zero commits behind `master`.
- PASS — Python contract syntax and Markdown/front-matter/fence checks.
- PASS — compact KaTeX equation and rejection of bracket delimiters.
- PASS — source-linked audit of public methods, canonical conversions, search bounds, density tolerance, cloning, and TP flash ownership.
- PASS — relief-sizing handoff matches the current `calculateLiquidReliefArea` parameter units.
- PASS — existing Java regression now asserts finite positive absolute pressures, monotonic heating behavior, input non-mutation, the bounded 5 K comparison, and positive finite-difference steps.
- PASS — documentation/Jekyll/search, pre-commit, Spotless, CodeQL, agent-skill references, and Javadocs on the exact head.
- PASS — focused Java execution, Ubuntu/Windows Java 21 fast suites, and all four Java 21 slow-test shards.
- **VALIDATION PENDING CI** — downstream Ubuntu and Windows Java 8 suites.

## Documentation impact

Updated the nearest user guide because the existing scope, units, validation claim, failure semantics, and relief-design handoff were user-visible and materially misleading. Added durable source-linked documentation contracts and focused executable coverage.

## Boundaries

- No production-code behavior changes.
- No claim that API 520/API 521 text is reproduced or certified; project licensed editions remain authoritative.
- No browser-rendered artifact, notebook output, DEXPI/PFD, Pitzer, flash, merge, or Huldra work.
- Further expansion would enter unrelated safety/fire/structural models or active campaign ownership.

Campaign: #2499
