### PR TITLE
[AI-Assisted] feat(refinery): harden assay and TBP cut foundation

### DIFF
--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -1,307 +1,143 @@
 ---
 title: "Characterization Package"
-description: "Documentation for plus fraction and asphaltene characterization in NeqSim."
+description: "Petroleum TBP, plus-fraction, assay, lumping, asphaltene, and pseudo-component characterization in NeqSim."
 ---
 
 # Characterization Package
 
-Documentation for plus fraction and asphaltene characterization in NeqSim.
+The `neqsim.thermo.characterization` package converts petroleum assay, TBP, and plus-fraction information into pseudo-components suitable for NeqSim equations of state and process calculations.
 
-## Table of Contents
-- [Overview](#overview)
-- [Plus Fraction Methods](#plus-fraction-methods)
-- [Characterization Approaches](#characterization-approaches)
-- [Lumping Configuration](#lumping-configuration)
-- [Asphaltene Characterization](#asphaltene-characterization)
-- [TBP Methods](#tbp-methods)
-- [Examples](#examples)
+## Main workflows
 
----
+| Workflow | Primary API | Use |
+| --- | --- | --- |
+| Pre-binned TBP fractions | `SystemInterface.addTBPfraction(...)` | Add a petroleum cut from moles, molar mass, and specific gravity |
+| Plus fraction | `SystemInterface.addPlusFraction(...)` + `Characterise` | Represent and split a C7+/C20+ heavy end |
+| Refinery assay | `OilAssayCharacterisation` | Convert mass- or volume-basis refinery cuts/TBP boundaries to pseudo-components |
+| TBP property model selection | `Characterise.setTBPModel(...)` | Select Pedersen, Lee-Kesler, Riazi-Daubert, Twu, Cavett, Standing, and related models |
+| Lumping | `Characterise.configureLumping()` | Reduce a detailed heavy-end slate while preserving configured grouping rules |
+| Common-slate characterization | `PseudoComponentCombiner` | Align multiple characterized fluids to a shared pseudo-component definition |
+| Wax/asphaltene characterization | wax/asphaltene classes | Specialized heavy-phase workflows |
 
-## Overview
+## Critical unit contract
 
-**Location:** `neqsim.thermo.characterization`
+`addTBPfraction` and `addPlusFraction` use **kg/mol** for molar mass. Petroleum examples therefore use values such as `0.096 kg/mol` for a roughly C7 cut, not `96.0`.
 
-The characterization package handles petroleum plus fraction and asphaltene characterization:
-- Converting C7+ (or other plus fractions) into pseudo-components
-- Estimating critical properties from correlations
-- Splitting heavy ends into discrete pseudo-components
-- Characterizing asphaltene components for precipitation modeling
-
----
-
-## Plus Fraction Methods
-
-### Adding Plus Fractions
+The density argument is the petroleum specific gravity/relative-density numeric value. Current system APIs also accept density values above 1.5 as kg/m3 and normalize them internally, but unit-explicit refinery-assay helpers are preferred when importing assay tables.
 
 ```java
+import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 
-SystemSrkEos fluid = new SystemSrkEos(373.15, 100.0);
-
-// Light components
+SystemInterface fluid = new SystemSrkEos(373.15, 100.0);
 fluid.addComponent("methane", 0.70);
 fluid.addComponent("ethane", 0.10);
 fluid.addComponent("propane", 0.08);
 fluid.addComponent("n-butane", 0.05);
 
-// C7+ as single pseudo-component
-fluid.addTBPfraction("C7+", 0.07, 150.0, 0.78);  // name, moles, MW, SG
+// name, moles, molar mass [kg/mol], specific gravity [-]
+fluid.addTBPfraction("C7", 0.04, 0.096, 0.727);
+fluid.addPlusFraction("C20+", 0.03, 0.400, 0.90);
 ```
 
-### Multiple Plus Fractions
+## Refinery assay characterization
+
+For crude/petroleum assays, use `OilAssayCharacterisation` rather than manually converting every volume cut to moles. The assay API provides:
+
+- one explicit composition basis per assay: mass or liquid volume;
+- volume-to-mass conversion using cut density;
+- kg/mol and g/mol explicit molar-mass helpers;
+- specific-gravity, kg/m3, and API-gravity density inputs;
+- pre-binned cumulative TBP cut-boundary ingestion;
+- preserved lower/upper boiling ranges;
+- closure, duplicate-name, monotonicity, and repeated-application guards.
+
+See [Refinery Assay and TBP Cut Characterization](refinery_assay.md) for the complete contract and the refinery campaign gap matrix.
+
+## TBP fraction models
+
+TBP models estimate the properties needed to represent petroleum pseudo-components in an EOS. Available implementations include Pedersen SRK/PR variants, Lee-Kesler, Riazi-Daubert, Twu, Cavett, and Standing.
 
 ```java
-// Split C7+ into multiple fractions
-fluid.addTBPfraction("C7", 0.02, 96.0, 0.727);
-fluid.addTBPfraction("C8", 0.015, 107.0, 0.749);
-fluid.addTBPfraction("C9", 0.01, 121.0, 0.768);
-fluid.addTBPfraction("C10+", 0.025, 180.0, 0.82);
+SystemInterface fluid = new SystemSrkEos(350.0, 50.0);
+fluid.getCharacterization().setTBPModel("PedersenSRK");
+fluid.addTBPfraction("C7", 0.05, 0.096, 0.727);
+fluid.addTBPfraction("C10", 0.04, 0.134, 0.782);
+fluid.addTBPfraction("C12+", 0.15, 0.250, 0.85);
 ```
 
----
+For equations, model selection boundaries, and references, see:
 
-## Characterization Approaches
+- [TBP Fraction Models](../../wiki/tbp_fraction_models.md)
+- [Fluid Characterization Mathematical Foundations](../../pvtsimulation/fluid_characterization_mathematics.md)
+- [PVT Fluid Characterization](../pvt_fluid_characterization.md)
 
-### Pedersen Method
+## Lumping configuration
 
-```java
-import neqsim.thermo.characterization.PedersenCharacterization;
-
-// Characterize using Pedersen correlations
-PedersenCharacterization charPedersen = new PedersenCharacterization(fluid);
-charPedersen.characterize();
-```
-
-### Whitson Gamma Distribution
+After plus-fraction splitting, lumping can reduce the number of pseudo-components for faster process calculations.
 
 ```java
-import neqsim.thermo.characterization.WhitsonCharacterization;
-
-// Characterize using Whitson gamma distribution
-WhitsonCharacterization charWhitson = new WhitsonCharacterization(fluid);
-charWhitson.setAlpha(1.0);  // Shape parameter
-charWhitson.characterize();
-```
-
----
-
-## TBP Methods
-
-### Adding TBP Fractions
-
-```java
-// addTBPfraction(name, moles, MW, specificGravity)
-fluid.addTBPfraction("C7", moles, 96.0, 0.727);
-
-// addPlusFraction with characterization
-fluid.addPlusFraction("C20+", moles, 400.0, 0.90);
-```
-
-### Property Estimation
-
-For pseudo-components, critical properties are estimated using correlations:
-
-| Correlation | Properties Estimated |
-|-------------|---------------------|
-| Twu | Tc, Pc, omega from MW, SG |
-| Lee-Kesler | Tc, Pc, omega from Tb, SG |
-| Riazi-Daubert | Tb from MW, SG |
-| Pedersen | Tc, Pc, omega for petroleum |
-
----
-
-## Lumping Configuration
-
-After plus fraction splitting, lumping reduces the number of pseudo-components for computational efficiency. NeqSim provides a fluent API for clear, explicit configuration.
-
-### Fluent API (Recommended)
-
-```java
-// PVTlumpingModel: Preserve C6-C9, lump C10+ into 5 groups
+// Preserve lighter TBP fractions and lump the heavier range.
 fluid.getCharacterization().configureLumping()
     .model("PVTlumpingModel")
     .plusFractionGroups(5)
     .build();
 
-// Standard model: Lump all from C6 into 6 pseudo-components
+// Target a total number of pseudo-components.
 fluid.getCharacterization().configureLumping()
     .model("standard")
     .totalPseudoComponents(6)
     .build();
 
-// Custom boundaries to match PVT lab report
+// Match user-defined grouping boundaries.
 fluid.getCharacterization().configureLumping()
-    .customBoundaries(6, 7, 10, 15, 20)  // C6, C7-C9, C10-C14, C15-C19, C20+
+    .customBoundaries(6, 7, 10, 15, 20)
     .build();
 
-// No lumping: keep all SCN components
+// Keep the detailed SCN representation.
 fluid.getCharacterization().configureLumping()
     .noLumping()
     .build();
 ```
 
-### Lumping Models Comparison
+| Model | Behaviour | Typical use |
+| --- | --- | --- |
+| `PVTlumpingModel` | Preserves configured lighter TBP fractions and lumps the plus fraction | PVT/process workflows that retain light-cut detail |
+| `standard` | Lumps the characterized heavy range to a requested total | Smaller simulation slates |
+| custom boundaries | Uses explicit carbon-number/group boundaries | Matching an external/reference characterization |
+| no lumping | Retains the generated detailed representation | Detailed characterization studies |
 
-| Model | Behavior | Use Case |
-|-------|----------|----------|
-| `PVTlumpingModel` | Preserves TBP fractions (C6-C9), lumps only C10+ | Standard PVT matching |
-| `standard` | Lumps all heavy fractions from C6 | Minimal components for fast simulation |
-| `no lumping` | Keeps all individual SCN components | Detailed compositional studies |
+## Common pseudo-component slates
 
-### Quick Reference
+When several reservoir or process fluids need to be mixed consistently, use `PseudoComponentCombiner` rather than assuming independently generated pseudo-components have identical meaning.
 
-| I want to... | Fluent API |
-|--------------|------------|
-| Keep C6-C9 separate, lump C10+ into N groups | `.model("PVTlumpingModel").plusFractionGroups(N)` |
-| Get exactly N total pseudo-components | `.model("standard").totalPseudoComponents(N)` |
-| Match specific PVT lab groupings | `.customBoundaries(6, 10, 20)` |
-| Keep all SCN components | `.noLumping()` |
+See [Fluid Characterization Combining](fluid_characterization_combining.md) for common-slate and reference-slate workflows.
 
-For complete mathematical details, see [Fluid Characterization Mathematics](../../pvtsimulation/fluid_characterization_mathematics#lumping-methods).
+## Asphaltene and wax workflows
 
----
+NeqSim also contains specialized heavy-phase characterization used by wax and asphaltene calculations. These are separate from the refinery-assay bookkeeping API because they introduce additional phase-model assumptions and validation requirements.
 
-## Asphaltene Characterization
+See:
 
-### Pedersen's Asphaltene Method
+- [Wax Characterization](wax_characterization.md)
+- [Asphaltene Modeling](../../pvtsimulation/flowassurance/asphaltene_modeling.md)
 
-The `PedersenAsphalteneCharacterization` class implements Pedersen's approach for treating asphaltene as a heavy liquid pseudo-component. This enables liquid-liquid equilibrium (LLE) calculations for asphaltene precipitation.
+## Validation guidance
 
-```java
-import neqsim.thermo.characterization.PedersenAsphalteneCharacterization;
-import neqsim.thermo.system.SystemSrkEos;
+Characterization validation should distinguish three layers:
 
-// Create fluid system
-SystemInterface fluid = new SystemSrkEos(373.15, 50.0);
-fluid.addComponent("methane", 0.40);
-fluid.addComponent("n-pentane", 0.25);
-fluid.addComponent("n-heptane", 0.20);
-fluid.addComponent("nC10", 0.10);
+1. **Bookkeeping:** units, cut yields, composition/mass closure, component identity, splitting/lumping conservation.
+2. **Property correlations:** boiling point, molecular weight, density, critical properties, acentric factor, and applicability ranges.
+3. **Process behaviour:** flash, phase envelope, distillation/fractionation, and product-yield agreement for representative fluids.
 
-// Create and configure asphaltene characterization
-PedersenAsphalteneCharacterization asphChar = new PedersenAsphalteneCharacterization();
-asphChar.setAsphalteneMW(750.0);     // Molecular weight g/mol
-asphChar.setAsphalteneDensity(1.10); // Density g/cm³
+A bookkeeping regression does not by itself validate a petroleum-property correlation, and a property match does not by itself establish refinery column performance. The refinery campaign in issue #3305 uses these layers as separate quality gates.
 
-// Add asphaltene pseudo-component (BEFORE setting mixing rule)
-asphChar.addAsphalteneToSystem(fluid, 0.05);  // 5 mol% asphaltene
+## Related documentation
 
-// Set mixing rule (AFTER adding all components)
-fluid.setMixingRule("classic");
-
-// Print estimated critical properties
-System.out.println(asphChar.toString());
-```
-
-### Critical Property Correlations
-
-Pedersen's method estimates critical properties from molecular weight (MW) and liquid density (ρ):
-
-| Property | Correlation |
-|----------|-------------|
-| Critical Temperature (Tc) | f(MW, ρ) |
-| Critical Pressure (Pc) | f(MW, ρ) |
-| Acentric Factor (ω) | f(MW, ρ) |
-| Normal Boiling Point (Tb) | f(MW, ρ) |
-
-Typical values for asphaltene (MW=750 g/mol, ρ=1.10 g/cm³):
-
-| Property | Value | Unit |
-|----------|-------|------|
-| Tc | 996 | K |
-| Pc | 16.3 | bar |
-| ω | 0.925 | - |
-| Tb | 838 | K |
-
-### TPflash with Automatic Asphaltene Detection
-
-The class provides static methods for TPflash with automatic detection of asphaltene-rich phases:
-
-```java
-// Static TPflash - marks asphaltene-rich liquid phases as LIQUID_ASPHALTENE
-boolean hasAsphaltene = PedersenAsphalteneCharacterization.TPflash(fluid);
-
-// With explicit T,P specification
-boolean hasAsphaltene = PedersenAsphalteneCharacterization.TPflash(fluid, 373.15, 50.0);
-
-// Check result
-if (hasAsphaltene) {
-    System.out.println("Asphaltene-rich liquid phase detected");
-    fluid.prettyPrint();  // Shows "ASPHALTENE LIQUID" column
-}
-```
-
-### Asphaltene Detection Criteria
-
-A liquid phase is marked as `PhaseType.LIQUID_ASPHALTENE` when:
-- The phase contains an "Asphaltene" component, AND
-- The asphaltene mole fraction in that phase exceeds 0.5 (50%)
-
----
-
-## Examples
-
-### Example 1: Natural Gas with C7+
-
-```java
-import neqsim.thermo.system.SystemSrkEos;
-import neqsim.thermodynamicoperations.ThermodynamicOperations;
-
-SystemSrkEos gas = new SystemSrkEos(373.15, 100.0);
-
-// Wellstream composition
-gas.addComponent("nitrogen", 0.015);
-gas.addComponent("CO2", 0.020);
-gas.addComponent("methane", 0.750);
-gas.addComponent("ethane", 0.080);
-gas.addComponent("propane", 0.045);
-gas.addComponent("i-butane", 0.012);
-gas.addComponent("n-butane", 0.020);
-gas.addComponent("i-pentane", 0.008);
-gas.addComponent("n-pentane", 0.010);
-gas.addComponent("n-hexane", 0.015);
-
-// C7+ fraction
-gas.addTBPfraction("C7+", 0.025, 145.0, 0.78);
-
-gas.setMixingRule("classic");
-
-ThermodynamicOperations ops = new ThermodynamicOperations(gas);
-ops.TPflash();
-
-System.out.println("Gas fraction: " + gas.getGasPhase().getBeta());
-System.out.println("C7+ in gas: " + gas.getGasPhase().getComponent("C7+_PC").getx());
-```
-
-### Example 2: Oil Characterization
-
-```java
-// Black oil with detailed C7+ split
-SystemSrkEos oil = new SystemSrkEos(350.0, 50.0);
-
-oil.addComponent("methane", 0.40);
-oil.addComponent("ethane", 0.08);
-oil.addComponent("propane", 0.06);
-oil.addComponent("n-butane", 0.04);
-oil.addComponent("n-pentane", 0.03);
-oil.addComponent("n-hexane", 0.03);
-
-// Detailed C7+ split
-oil.addTBPfraction("C7", 0.05, 96.0, 0.727);
-oil.addTBPfraction("C8", 0.05, 107.0, 0.749);
-oil.addTBPfraction("C9", 0.04, 121.0, 0.768);
-oil.addTBPfraction("C10", 0.04, 134.0, 0.782);
-oil.addTBPfraction("C11", 0.03, 147.0, 0.793);
-oil.addTBPfraction("C12+", 0.15, 250.0, 0.85);
-
-oil.setMixingRule("classic");
-```
-
----
-
-## Related Documentation
-
-- [PVT Fluid Characterization](../pvt_fluid_characterization) - Detailed characterization guide
-- [Fluid Creation Guide](../fluid_creation_guide) - Creating fluids
-- [Thermo Package](../) - Package overview
+- [Refinery Assay and TBP Cut Characterization](refinery_assay.md)
+- [Fluid Characterization Guide](../../wiki/fluid_characterization.md)
+- [TBP Fraction Models](../../wiki/tbp_fraction_models.md)
+- [PVT Fluid Characterization](../pvt_fluid_characterization.md)
+- [Fluid Characterization Mathematical Foundations](../../pvtsimulation/fluid_characterization_mathematics.md)
+- [Fluid Characterization Combining](fluid_characterization_combining.md)
+- [Fluid Creation Guide](../fluid_creation_guide.md)

--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -52,7 +52,7 @@ For crude/petroleum assays, use `OilAssayCharacterisation` rather than manually 
 - preserved lower/upper boiling ranges;
 - closure, duplicate-name, monotonicity, and repeated-application guards.
 
-See [Refinery Assay and TBP Cut Characterization](refinery_assay.md) for the complete contract and the refinery campaign gap matrix.
+See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix.
 
 ## TBP fraction models
 
@@ -68,9 +68,9 @@ fluid.addTBPfraction("C12+", 0.15, 0.250, 0.85);
 
 For equations, model selection boundaries, and references, see:
 
-- [TBP Fraction Models](../../wiki/tbp_fraction_models.md)
-- [Fluid Characterization Mathematical Foundations](../../pvtsimulation/fluid_characterization_mathematics.md)
-- [PVT Fluid Characterization](../pvt_fluid_characterization.md)
+- [TBP Fraction Models](../../wiki/tbp_fraction_models)
+- [Fluid Characterization Mathematical Foundations](../../pvtsimulation/fluid_characterization_mathematics)
+- [PVT Fluid Characterization](../pvt_fluid_characterization)
 
 ## Lumping configuration
 
@@ -111,7 +111,7 @@ fluid.getCharacterization().configureLumping()
 
 When several reservoir or process fluids need to be mixed consistently, use `PseudoComponentCombiner` rather than assuming independently generated pseudo-components have identical meaning.
 
-See [Fluid Characterization Combining](fluid_characterization_combining.md) for common-slate and reference-slate workflows.
+See [Fluid Characterization Combining](fluid_characterization_combining) for common-slate and reference-slate workflows.
 
 ## Asphaltene and wax workflows
 
@@ -119,8 +119,8 @@ NeqSim also contains specialized heavy-phase characterization used by wax and as
 
 See:
 
-- [Wax Characterization](wax_characterization.md)
-- [Asphaltene Modeling](../../pvtsimulation/flowassurance/asphaltene_modeling.md)
+- [Wax Characterization](wax_characterization)
+- [Asphaltene Modeling](../../pvtsimulation/flowassurance/asphaltene_modeling)
 
 ## Validation guidance
 
@@ -134,10 +134,10 @@ A bookkeeping regression does not by itself validate a petroleum-property correl
 
 ## Related documentation
 
-- [Refinery Assay and TBP Cut Characterization](refinery_assay.md)
-- [Fluid Characterization Guide](../../wiki/fluid_characterization.md)
-- [TBP Fraction Models](../../wiki/tbp_fraction_models.md)
-- [PVT Fluid Characterization](../pvt_fluid_characterization.md)
-- [Fluid Characterization Mathematical Foundations](../../pvtsimulation/fluid_characterization_mathematics.md)
-- [Fluid Characterization Combining](fluid_characterization_combining.md)
-- [Fluid Creation Guide](../fluid_creation_guide.md)
+- [Refinery Assay and TBP Cut Characterization](refinery_assay)
+- [Fluid Characterization Guide](../../wiki/fluid_characterization)
+- [TBP Fraction Models](../../wiki/tbp_fraction_models)
+- [PVT Fluid Characterization](../pvt_fluid_characterization)
+- [Fluid Characterization Mathematical Foundations](../../pvtsimulation/fluid_characterization_mathematics)
+- [Fluid Characterization Combining](fluid_characterization_combining)
+- [Fluid Creation Guide](../fluid_creation_guide)

--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -68,7 +68,7 @@ assay.addCut(new AssayCut("Residue")
 assay.apply();
 ```
 
-`apply()` resolves every cut before adding the first component, checks assay closure, calculates cut moles from the configured mass basis, and rejects duplicate/repeated application if the generated pseudo-component already exists.
+`apply()` resolves every cut before adding the first component, checks assay closure, calculates cut moles from the configured mass basis, and rejects duplicate/repeated application if the generated pseudo-component already exists. Every strictly positive normalized mass fraction is retained, including trace cuts below ordinary comparison tolerances; only exact-zero cuts are omitted so trace handling remains consistent with the reconstructed-mass closure gate.
 
 ## Java: cumulative TBP cut boundaries
 

--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -1,0 +1,181 @@
+---
+title: "Refinery Assay and TBP Cut Characterization"
+description: "Create mass- or volume-basis refinery assay cuts, ingest pre-binned TBP boundaries, and generate NeqSim pseudo-components with explicit units and mass closure."
+---
+
+# Refinery Assay and TBP Cut Characterization
+
+`OilAssayCharacterisation` is the first refinery-specific assay entry point in NeqSim. It converts a pre-binned crude or petroleum-fraction assay into TBP pseudo-components that can be used by the existing thermodynamic and `ProcessSystem` APIs.
+
+This API is intentionally conservative. It handles **assay representation and pseudo-component generation**; it does not claim to replace a laboratory assay package or to convert ASTM D86/D1160 data to true boiling point (TBP).
+
+## Scope and unit contract
+
+| Quantity | API basis | Notes |
+| --- | --- | --- |
+| Assay mass | kg | `setTotalAssayMass(...)` |
+| Molar mass | kg/mol | Use `withMolarMassKgPerMol(...)`; `withMolarMassGramPerMol(...)` is provided for assay tables reported in g/mol |
+| Specific gravity | dimensionless | Numerically equivalent to density in g/cm3 for the petroleum correlations used here |
+| Density | kg/m3 | Use `withDensityKgPerCubicMetre(...)` for explicit SI density input |
+| API gravity | degrees API | Negative API gravity is supported for liquids denser than water |
+| Boiling temperature | K, degC, or degF | Unit-explicit builder methods are provided |
+| Cut yield | mass fraction or liquid-volume fraction | One assay must use exactly one basis; mass and volume bases cannot be mixed |
+
+The historical `withMolarMass(double)` method remains available and means **kg/mol**. Values such as `150.0` therefore mean 150 kg/mol, not 150 g/mol. For a 150 g/mol petroleum cut, use `withMolarMassKgPerMol(0.150)` or `withMolarMassGramPerMol(150.0)`.
+
+## Why the fraction basis is explicit
+
+A refinery assay is commonly reported on either a weight basis or a liquid-volume basis. Combining a 40 wt% cut with a 60 vol% cut does not define one physical composition unless an additional conversion basis is supplied.
+
+NeqSim therefore requires all cuts in one `OilAssayCharacterisation` to use the same basis:
+
+- **mass basis:** mass fractions are used directly;
+- **volume basis:** each cut yield is multiplied by its liquid density and the resulting masses are normalized;
+- **mixed basis:** rejected before the thermodynamic system is mutated.
+
+The declared fractions must close to unity within 0.001. This tolerance permits ordinary assay-table rounding but rejects incomplete assays rather than silently scaling a materially incomplete slate to 100%.
+
+## Java: pre-binned mass-basis assay
+
+```java
+import neqsim.thermo.characterization.OilAssayCharacterisation;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+SystemInterface crude = new SystemSrkEos(298.15, 1.01325);
+OilAssayCharacterisation assay = crude.getOilAssayCharacterisation();
+assay.clearCuts();
+assay.setTotalAssayMass(1.0); // kg basis
+
+assay.addCut(new AssayCut("Naphtha")
+    .withWeightPercent(18.0)
+    .withSpecificGravity(0.72)
+    .withBoilingRangeCelsius(90.0, 180.0));
+assay.addCut(new AssayCut("Kerosene")
+    .withWeightPercent(22.0)
+    .withSpecificGravity(0.79)
+    .withBoilingRangeCelsius(180.0, 250.0));
+assay.addCut(new AssayCut("GasOil")
+    .withWeightPercent(35.0)
+    .withSpecificGravity(0.86)
+    .withBoilingRangeCelsius(250.0, 380.0));
+assay.addCut(new AssayCut("Residue")
+    .withWeightPercent(25.0)
+    .withApiGravity(12.0)
+    .withBoilingRangeCelsius(380.0, 560.0));
+
+assay.apply();
+```
+
+`apply()` resolves every cut before adding the first component, checks assay closure, calculates cut moles from the configured mass basis, and rejects duplicate/repeated application if the generated pseudo-component already exists.
+
+## Java: cumulative TBP cut boundaries
+
+For a pre-binned true-boiling-point curve, the cumulative liquid-volume yields can be converted directly into assay cuts:
+
+```java
+SystemInterface crude = new SystemSrkEos(298.15, 1.01325);
+OilAssayCharacterisation assay = crude.getOilAssayCharacterisation();
+assay.clearCuts();
+
+// Boundary points: cumulative liquid-volume percent and TBP temperature.
+double[] cumulativeVolumePercent = {0.0, 20.0, 55.0, 80.0, 100.0};
+double[] tbpCelsius = {90.0, 180.0, 270.0, 380.0, 520.0};
+
+// One specific gravity for each interval.
+double[] specificGravity = {0.70, 0.76, 0.84, 0.93};
+
+assay.addTBPCutBoundariesCelsius(
+    "TBP", cumulativeVolumePercent, tbpCelsius, specificGravity);
+assay.apply();
+```
+
+This creates `TBP1_PC` through `TBP4_PC`. Each `AssayCut` retains its lower and upper TBP boundaries. The interval midpoint is used as the representative boiling temperature for the existing NeqSim molecular-weight/petroleum-property correlation.
+
+The input is required to span 0 to 100 liquid-volume percent with strictly increasing yield and temperature boundaries. This is deliberate: the method represents a complete, already-TBP cut table and does not invent unmeasured light or residue tails.
+
+## Volume-basis conversion
+
+For cut volume fractions `v_i` and cut densities `rho_i`, NeqSim first calculates the normalized mass fraction
+
+$$w_i=\frac{v_i\rho_i}{\sum_j v_j\rho_j}$$
+
+and then calculates the pseudo-component amount on the configured assay mass basis `m_assay`:
+
+$$n_i=\frac{m_{assay}w_i}{M_i}$$
+
+where `M_i` is in kg/mol. Before any component is added, the implementation verifies that the reconstructed mass from all generated amounts closes to the configured assay mass.
+
+## Density and API gravity
+
+Use an explicit density method when possible:
+
+```java
+AssayCut cutA = new AssayCut("CutA").withSpecificGravity(0.85);
+AssayCut cutB = new AssayCut("CutB").withDensityKgPerCubicMetre(850.0);
+AssayCut cutC = new AssayCut("CutC").withApiGravity(34.97);
+```
+
+`withDensity(double)` is retained for compatibility. Values up to 1.5 are interpreted as specific gravity/g/cm3; larger values are treated as kg/m3 and divided by 1000. New refinery code should prefer the unit-explicit methods above.
+
+The API-gravity conversion follows the conventional relation
+
+$$SG_{60/60}=\frac{141.5}{API+131.5}$$
+
+with the existing NeqSim 60 degF water-density reference. Negative API gravities are accepted when physically meaningful; the singular range at and below -131.5 degrees API is rejected.
+
+## Existing petroleum-property correlations
+
+This refinery-assay API deliberately reuses the existing NeqSim TBP/pseudo-component property framework. It does not add or retune critical-property, acentric-factor, or molecular-weight coefficients.
+
+The current implementation and its literature lineage are documented in:
+
+- [Fluid Characterization Mathematical Foundations](../../pvtsimulation/fluid_characterization_mathematics.md)
+- [TBP Fraction Models](../../wiki/tbp_fraction_models.md)
+- [PVT Fluid Characterization](../pvt_fluid_characterization.md)
+
+Relevant published foundations already used by NeqSim include petroleum-fraction characterization work by Watson, Nelson and Murphy (1935), Winn (1957), Riazi and Daubert (1980/1987), Pedersen, Thomassen and Fredenslund (1984), and Whitson (1983). This increment changes the **assay input contract and validation**, not those scientific coefficients.
+
+## Python accessibility
+
+`OilAssayCharacterisation` and `AssayCut` are public Java classes and are therefore reachable through the normal NeqSim Python/JVM gateway. The unit and basis contracts are identical from Python. A dedicated refinery notebook is planned after the characterization API has passed the full Java CI matrix and a public refinery benchmark dataset has been selected.
+
+## Validation boundary
+
+The regression suite for this API currently verifies:
+
+- mass-basis cut conversion;
+- volume-to-mass conversion and closure;
+- kg/mol and g/mol explicit molar-mass input;
+- kg/m3 density normalization;
+- API-gravity handling, including negative API gravity;
+- rounding-scale closure versus incomplete-assay rejection;
+- rejection of mixed mass/volume bases and duplicate cuts;
+- TBP boundary monotonicity, complete 0-100% coverage, stored boiling ranges, and generated pseudo-components;
+- repeated-application protection;
+- exact reconstructed assay-mass closure.
+
+These tests establish software and bookkeeping correctness. They are **not yet an independent refinery-property validation dataset**. Experimental/public-data qualification of pseudo-component properties and atmospheric/vacuum fractionation is a separate campaign gate in issue #3305.
+
+## Refinery capability inventory after this increment
+
+| Capability | Current NeqSim foundation | Campaign status |
+| --- | --- | --- |
+| Pre-binned crude/petroleum assay cuts | `OilAssayCharacterisation` | Foundation hardened in #3305 |
+| Mass- and volume-basis cut yields | Unit/basis-explicit assay API | Foundation hardened in #3305 |
+| Pre-binned cumulative TBP cut boundaries | `addTBPCutBoundariesCelsius/Kelvin` | Initial implementation in #3305 |
+| TBP pseudo-component properties | Pedersen, Lee-Kesler, Riazi-Daubert, Twu, Cavett, Standing and related models | Existing; needs refinery-range independent validation |
+| Plus-fraction splitting/lumping | `Characterise`, plus-fraction and lumping models | Existing; refinery assay integration still to be qualified |
+| Oil density/API and volatility standards | Oil-quality standards package, RVP/TVP workflows | Existing pieces; unified refinery stream-property API remains open |
+| Rigorous distillation columns | `DistillationColumn`, `SimpleTray`, Naphtali-Sandholm solver, side-draw support | Existing foundation; broad-boiling atmospheric/vacuum refinery benchmark remains open |
+| Crude preheat/fired heater | General heater/heat-exchanger process equipment | Refinery workflow and fuel/emission integration remain open |
+| Product blending/specification optimization | Generic optimization/process facilities | Refinery property/blending framework remains open |
+| ASTM D86/D1160 to TBP conversion | No qualified refinery conversion API in this increment | Open; requires public correlation provenance and validation |
+| Atmospheric crude-unit benchmark | No campaign benchmark yet | Next high-value validation milestone |
+| Vacuum tower benchmark | No campaign benchmark yet | Open after atmospheric case |
+| Hydrotreating/reforming/FCC/hydrocracking | No campaign-qualified refinery conversion models | Deliberately later phase |
+
+## Next campaign step
+
+The next dependency-ready increment should select an openly reproducible refinery assay/reference case and use it to qualify the pseudo-component property slate and an atmospheric fractionation workflow. That benchmark should establish mass/energy closure, cut yields, product boiling ranges, numerical robustness, and runtime before adding more refinery-specific correlations.

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -37,7 +37,6 @@ import neqsim.thermo.system.SystemInterface;
 public class OilAssayCharacterisation implements Cloneable, Serializable {
   private static final long serialVersionUID = 1000L;
   private static final Logger logger = LogManager.getLogger(OilAssayCharacterisation.class);
-  private static final double FRACTION_TOLERANCE = 1e-10;
   private static final double ASSAY_CLOSURE_TOLERANCE = 1e-3;
   private static final double PERCENT_TOLERANCE = 1e-8;
   private static final double KELVIN_OFFSET = 273.15;
@@ -209,7 +208,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     for (int i = 0; i < cuts.size(); i++) {
       AssayCut cut = cuts.get(i);
       double massFraction = massFractions[i];
-      if (!(massFraction > FRACTION_TOLERANCE)) {
+      if (!(massFraction > 0.0)) {
         continue;
       }
 

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -4,54 +4,109 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.thermo.system.SystemInterface;
 
 /**
- * Utility for characterising an oil system from assay information.
+ * Utility for characterising an oil system from refinery-assay cut information.
+ *
+ * <p>
+ * An assay is represented as a set of pre-binned cuts on one declared composition basis: all
+ * cuts must use either mass fractions or volume fractions. Volume-basis cuts are converted to a
+ * mass basis with the cut densities before moles are calculated. Mixing mass- and volume-basis
+ * cuts in one assay is rejected because the missing conversion basis would otherwise be
+ * ambiguous.
+ * </p>
+ *
+ * <p>
+ * Molar masses are in kg/mol throughout this class. Density inputs used for petroleum
+ * characterisation are specific gravity (numerically equivalent to g/cm3 for the supported
+ * correlations); explicit kg/m3 input helpers are also provided.
+ * </p>
+ *
+ * <p>
+ * The TBP cut-boundary helpers preserve cut yields and boiling ranges, then use the midpoint of
+ * each boiling interval as the representative boiling point for the existing NeqSim petroleum
+ * correlation. They do not convert ASTM D86/D1160 or other laboratory distillation methods to
+ * TBP.
+ * </p>
  */
 public class OilAssayCharacterisation implements Cloneable, Serializable {
   private static final long serialVersionUID = 1000L;
   private static final Logger logger = LogManager.getLogger(OilAssayCharacterisation.class);
   private static final double FRACTION_TOLERANCE = 1e-10;
+  private static final double ASSAY_CLOSURE_TOLERANCE = 1e-3;
+  private static final double PERCENT_TOLERANCE = 1e-8;
   private static final double KELVIN_OFFSET = 273.15;
-  private static final double WATER_DENSITY_60F_G_CC = 0.999016; // API definition reference
-  // density.
+  private static final double WATER_DENSITY_60F_G_CC = 0.999016;
 
   private transient SystemInterface system;
-  private double totalAssayMass = 1.0; // kg basis when converting mass fraction to moles.
-  private List<AssayCut> cuts = new ArrayList<>();
+  private double totalAssayMass = 1.0;
+  private List<AssayCut> cuts = new ArrayList<AssayCut>();
 
+  /**
+   * Create an assay characterisation attached to a thermodynamic system.
+   *
+   * @param system thermodynamic system that will receive generated TBP pseudo-components
+   */
   public OilAssayCharacterisation(SystemInterface system) {
     setThermoSystem(system);
   }
 
+  /**
+   * Attach the assay characterisation to a thermodynamic system.
+   *
+   * @param system thermodynamic system
+   */
   public void setThermoSystem(SystemInterface system) {
     this.system = Objects.requireNonNull(system, "system");
   }
 
+  /**
+   * Return the total assay mass basis.
+   *
+   * @return total assay mass in kg
+   */
   public double getTotalAssayMass() {
     return totalAssayMass;
   }
 
+  /**
+   * Set the total assay mass basis used when converting cut mass fractions to moles.
+   *
+   * @param totalAssayMass total assay mass in kg
+   */
   public void setTotalAssayMass(double totalAssayMass) {
-    if (!(totalAssayMass > 0.0)) {
-      throw new IllegalArgumentException("Total assay mass must be positive");
+    if (!Double.isFinite(totalAssayMass) || !(totalAssayMass > 0.0)) {
+      throw new IllegalArgumentException("Total assay mass must be finite and positive");
     }
     this.totalAssayMass = totalAssayMass;
   }
 
+  /** Remove all assay cuts. */
   public void clearCuts() {
     cuts.clear();
   }
 
+  /**
+   * Add one pre-binned assay cut.
+   *
+   * @param cut assay cut
+   */
   public void addCut(AssayCut cut) {
     cuts.add(Objects.requireNonNull(cut, "cut"));
   }
 
+  /**
+   * Add a collection of pre-binned assay cuts.
+   *
+   * @param cuts assay cuts; {@code null} is ignored
+   */
   public void addCuts(Collection<AssayCut> cuts) {
     if (cuts == null) {
       return;
@@ -61,20 +116,102 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     }
   }
 
+  /**
+   * Return the configured assay cuts in insertion order.
+   *
+   * @return unmodifiable cut list
+   */
   public List<AssayCut> getCuts() {
     return Collections.unmodifiableList(cuts);
   }
 
+  /**
+   * Add pre-binned true-boiling-point cuts from cumulative volume-percent boundaries.
+   *
+   * <p>
+   * The first cumulative point must be 0 vol% and the last must be 100 vol%. The arrays of
+   * cumulative yield and boiling-point boundaries must have the same length. One specific
+   * gravity is required for each resulting interval. The interval midpoint is retained as the
+   * representative boiling point and the complete lower/upper boiling range is stored on the
+   * generated {@link AssayCut}.
+   * </p>
+   *
+   * @param namePrefix component-name prefix; generated names are prefix + 1, prefix + 2, ...
+   * @param cumulativeVolumePercent cumulative liquid-volume yield in percent, from 0 to 100
+   * @param boilingPointCelsius TBP cut boundaries in degC
+   * @param specificGravity specific gravity for each interval
+   */
+  public void addTBPCutBoundariesCelsius(String namePrefix, double[] cumulativeVolumePercent,
+      double[] boilingPointCelsius, double[] specificGravity) {
+    if (boilingPointCelsius == null) {
+      throw new IllegalArgumentException("TBP boiling-point boundaries cannot be null");
+    }
+    double[] boilingPointKelvin = new double[boilingPointCelsius.length];
+    for (int i = 0; i < boilingPointCelsius.length; i++) {
+      if (!Double.isFinite(boilingPointCelsius[i])) {
+        throw new IllegalArgumentException("TBP boiling-point boundaries must be finite");
+      }
+      boilingPointKelvin[i] = boilingPointCelsius[i] + KELVIN_OFFSET;
+    }
+    addTBPCutBoundariesKelvin(namePrefix, cumulativeVolumePercent, boilingPointKelvin,
+        specificGravity);
+  }
+
+  /**
+   * Add pre-binned true-boiling-point cuts from cumulative volume-percent boundaries.
+   *
+   * @param namePrefix component-name prefix; generated names are prefix + 1, prefix + 2, ...
+   * @param cumulativeVolumePercent cumulative liquid-volume yield in percent, from 0 to 100
+   * @param boilingPointKelvin TBP cut boundaries in K
+   * @param specificGravity specific gravity for each interval
+   */
+  public void addTBPCutBoundariesKelvin(String namePrefix, double[] cumulativeVolumePercent,
+      double[] boilingPointKelvin, double[] specificGravity) {
+    validateTBPCutBoundaries(namePrefix, cumulativeVolumePercent, boilingPointKelvin,
+        specificGravity);
+
+    for (int i = 0; i < specificGravity.length; i++) {
+      double volumeFraction =
+          (cumulativeVolumePercent[i + 1] - cumulativeVolumePercent[i]) / 100.0;
+      AssayCut cut = new AssayCut(namePrefix + (i + 1)).withVolumeFraction(volumeFraction)
+          .withSpecificGravity(specificGravity[i])
+          .withBoilingRangeKelvin(boilingPointKelvin[i], boilingPointKelvin[i + 1]);
+      addCut(cut);
+    }
+  }
+
+  /**
+   * Resolve the configured assay to mass fractions without mutating the thermodynamic system.
+   *
+   * @return mass fractions in the same order as {@link #getCuts()}
+   */
+  public double[] getResolvedMassFractions() {
+    double[] fractions = resolveMassFractions();
+    return fractions.clone();
+  }
+
+  /**
+   * Generate TBP pseudo-components for all configured cuts and add them to the attached system.
+   *
+   * <p>
+   * All inputs are resolved and validated before the first pseudo-component is added. Existing
+   * component names are rejected so that repeated calls cannot silently double the assay.
+   * </p>
+   */
   public void apply() {
     if (system == null) {
       throw new IllegalStateException("Thermodynamic system not attached to assay data");
     }
     if (cuts.isEmpty()) {
-      logger.warn("No assay cuts supplied – nothing to characterise");
+      logger.warn("No assay cuts supplied - nothing to characterise");
       return;
     }
 
+    validateUniqueCutNames();
     double[] massFractions = resolveMassFractions();
+    List<ResolvedCut> resolvedCuts = new ArrayList<ResolvedCut>();
+    double reconstructedMass = 0.0;
+
     for (int i = 0; i < cuts.size(); i++) {
       AssayCut cut = cuts.get(i);
       double massFraction = massFractions[i];
@@ -82,80 +219,158 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
         continue;
       }
 
+      String pseudoComponentName = cut.getName() + "_PC";
+      if (system.hasComponent(pseudoComponentName, false)) {
+        throw new IllegalStateException(
+            "Assay pseudo-component already exists in system: " + pseudoComponentName);
+      }
+
       double density = cut.resolveDensity();
       double molarMass;
       if (cut.hasMolarMass()) {
-        // Use explicit molar mass - no boiling point needed
         molarMass = cut.resolveMolarMass(0.0, 0.0);
       } else {
-        // Calculate molar mass from density and boiling point
         double boilingPoint = cut.resolveAverageBoilingPoint();
         molarMass = cut.resolveMolarMass(density, boilingPoint);
       }
       double moles = totalAssayMass * massFraction / molarMass;
 
-      if (moles <= 0.0 || Double.isNaN(moles) || Double.isInfinite(moles)) {
-        throw new IllegalStateException("Calculated mole amount for assay cut " + cut.getName() + " is not finite");
+      if (!Double.isFinite(moles) || !(moles > 0.0)) {
+        throw new IllegalStateException(
+            "Calculated mole amount for assay cut " + cut.getName() + " is not finite and positive");
       }
 
-      system.addTBPfraction(cut.getName(), moles, molarMass, density);
+      resolvedCuts.add(new ResolvedCut(cut, density, molarMass, moles));
+      reconstructedMass += moles * molarMass;
+    }
+
+    double relativeMassError =
+        Math.abs(reconstructedMass - totalAssayMass) / Math.max(totalAssayMass, 1.0e-30);
+    if (!Double.isFinite(relativeMassError) || relativeMassError > 1.0e-10) {
+      throw new IllegalStateException(
+          "Resolved assay does not conserve the configured total mass; relative error="
+              + relativeMassError);
+    }
+
+    for (ResolvedCut resolvedCut : resolvedCuts) {
+      system.addTBPfraction(resolvedCut.cut.getName(), resolvedCut.moles,
+          resolvedCut.molarMass, resolvedCut.density);
+    }
+  }
+
+  private void validateTBPCutBoundaries(String namePrefix, double[] cumulativeVolumePercent,
+      double[] boilingPointKelvin, double[] specificGravity) {
+    if (namePrefix == null || namePrefix.trim().isEmpty()) {
+      throw new IllegalArgumentException("TBP cut name prefix cannot be empty");
+    }
+    if (cumulativeVolumePercent == null || boilingPointKelvin == null
+        || specificGravity == null) {
+      throw new IllegalArgumentException("TBP cut-boundary arrays cannot be null");
+    }
+    if (cumulativeVolumePercent.length < 2
+        || cumulativeVolumePercent.length != boilingPointKelvin.length
+        || specificGravity.length != cumulativeVolumePercent.length - 1) {
+      throw new IllegalArgumentException(
+          "TBP boundaries require N cumulative yields, N temperatures, and N-1 densities");
+    }
+    if (Math.abs(cumulativeVolumePercent[0]) > PERCENT_TOLERANCE
+        || Math.abs(cumulativeVolumePercent[cumulativeVolumePercent.length - 1] - 100.0)
+            > PERCENT_TOLERANCE) {
+      throw new IllegalArgumentException("TBP cumulative volume yield must span 0 to 100 percent");
+    }
+
+    for (int i = 0; i < cumulativeVolumePercent.length; i++) {
+      double cumulativeYield = cumulativeVolumePercent[i];
+      double boilingPoint = boilingPointKelvin[i];
+      if (!Double.isFinite(cumulativeYield) || cumulativeYield < -PERCENT_TOLERANCE
+          || cumulativeYield > 100.0 + PERCENT_TOLERANCE) {
+        throw new IllegalArgumentException("TBP cumulative volume yields must be finite and between 0 and 100");
+      }
+      if (!Double.isFinite(boilingPoint) || !(boilingPoint > 0.0)) {
+        throw new IllegalArgumentException("TBP boiling-point boundaries must be finite and positive");
+      }
+      if (i > 0 && !(cumulativeVolumePercent[i] > cumulativeVolumePercent[i - 1])) {
+        throw new IllegalArgumentException("TBP cumulative volume yields must be strictly increasing");
+      }
+      if (i > 0 && !(boilingPointKelvin[i] > boilingPointKelvin[i - 1])) {
+        throw new IllegalArgumentException("TBP boiling-point boundaries must be strictly increasing");
+      }
+    }
+
+    for (double density : specificGravity) {
+      validateSpecificGravity(density);
+    }
+  }
+
+  private void validateUniqueCutNames() {
+    Set<String> names = new HashSet<String>();
+    for (AssayCut cut : cuts) {
+      if (!names.add(cut.getName())) {
+        throw new IllegalStateException("Duplicate assay cut name: " + cut.getName());
+      }
     }
   }
 
   private double[] resolveMassFractions() {
-    double[] massFractions = new double[cuts.size()];
-    double specifiedMass = 0.0;
-    double volumeMass = 0.0;
-    boolean hasVolumeFractions = false;
+    if (cuts.isEmpty()) {
+      return new double[0];
+    }
+
+    double[] declaredFractions = new double[cuts.size()];
+    FractionBasis basis = null;
+    double totalDeclaredFraction = 0.0;
 
     for (int i = 0; i < cuts.size(); i++) {
       AssayCut cut = cuts.get(i);
-      if (cut.hasMassFraction()) {
-        double massFraction = cut.getMassFraction();
-        specifiedMass += massFraction;
-        massFractions[i] = massFraction;
-      } else if (cut.hasVolumeFraction()) {
-        hasVolumeFractions = true;
-        double density = cut.resolveDensity();
-        volumeMass += cut.getVolumeFraction() * density;
-      } else {
-        throw new IllegalStateException("Assay cut " + cut.getName() + " must define a mass or volume fraction");
+      boolean hasMass = cut.hasMassFraction();
+      boolean hasVolume = cut.hasVolumeFraction();
+      if (hasMass == hasVolume) {
+        throw new IllegalStateException(
+            "Assay cut " + cut.getName() + " must define exactly one mass or volume fraction");
       }
-    }
 
-    if (specifiedMass > 1.0 + 1e-6) {
-      throw new IllegalStateException("Specified mass fractions exceed unity: " + specifiedMass);
-    }
-
-    double remainingMass = Math.max(0.0, 1.0 - specifiedMass);
-
-    if (hasVolumeFractions) {
-      if (!(volumeMass > 0.0)) {
-        throw new IllegalStateException("Unable to derive mass fractions from volume data");
+      FractionBasis cutBasis = hasMass ? FractionBasis.MASS : FractionBasis.VOLUME;
+      if (basis == null) {
+        basis = cutBasis;
+      } else if (basis != cutBasis) {
+        throw new IllegalStateException(
+            "Assay cuts cannot mix mass-fraction and volume-fraction bases");
       }
-      for (int i = 0; i < cuts.size(); i++) {
-        AssayCut cut = cuts.get(i);
-        if (!cut.hasMassFraction() && cut.hasVolumeFraction()) {
-          double density = cut.resolveDensity();
-          double cutMass = cut.getVolumeFraction() * density;
-          massFractions[i] = cutMass / volumeMass * remainingMass;
-        }
-      }
+
+      double fraction = hasMass ? cut.getMassFraction() : cut.getVolumeFraction();
+      declaredFractions[i] = fraction;
+      totalDeclaredFraction += fraction;
     }
 
-    double totalMassFraction = 0.0;
-    for (double fraction : massFractions) {
-      totalMassFraction += fraction;
+    if (!Double.isFinite(totalDeclaredFraction) || !(totalDeclaredFraction > 0.0)) {
+      throw new IllegalStateException("No valid assay fractions supplied");
+    }
+    if (Math.abs(totalDeclaredFraction - 1.0) > ASSAY_CLOSURE_TOLERANCE) {
+      throw new IllegalStateException(
+          "Assay fractions must sum to 1.0 within " + ASSAY_CLOSURE_TOLERANCE
+              + "; supplied sum=" + totalDeclaredFraction);
     }
 
-    if (!(totalMassFraction > 0.0)) {
-      throw new IllegalStateException("No valid mass fractions derived from assay data");
+    for (int i = 0; i < declaredFractions.length; i++) {
+      declaredFractions[i] /= totalDeclaredFraction;
     }
 
-    if (Math.abs(totalMassFraction - 1.0) > 1.0e-8) {
-      for (int i = 0; i < massFractions.length; i++) {
-        massFractions[i] /= totalMassFraction;
-      }
+    if (basis == FractionBasis.MASS) {
+      return declaredFractions;
+    }
+
+    double[] massFractions = new double[cuts.size()];
+    double totalRelativeMass = 0.0;
+    for (int i = 0; i < cuts.size(); i++) {
+      double relativeMass = declaredFractions[i] * cuts.get(i).resolveDensity();
+      massFractions[i] = relativeMass;
+      totalRelativeMass += relativeMass;
+    }
+    if (!Double.isFinite(totalRelativeMass) || !(totalRelativeMass > 0.0)) {
+      throw new IllegalStateException("Unable to derive mass fractions from volume-basis assay data");
+    }
+    for (int i = 0; i < massFractions.length; i++) {
+      massFractions[i] /= totalRelativeMass;
     }
     return massFractions;
   }
@@ -164,7 +379,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
   public OilAssayCharacterisation clone() {
     try {
       OilAssayCharacterisation clone = (OilAssayCharacterisation) super.clone();
-      clone.cuts = new ArrayList<>();
+      clone.cuts = new ArrayList<AssayCut>();
       for (AssayCut cut : cuts) {
         clone.cuts.add(cut.clone());
       }
@@ -175,6 +390,26 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     }
   }
 
+  private enum FractionBasis {
+    MASS,
+    VOLUME
+  }
+
+  private static final class ResolvedCut {
+    private final AssayCut cut;
+    private final double density;
+    private final double molarMass;
+    private final double moles;
+
+    private ResolvedCut(AssayCut cut, double density, double molarMass, double moles) {
+      this.cut = cut;
+      this.density = density;
+      this.molarMass = molarMass;
+      this.moles = moles;
+    }
+  }
+
+  /** Representation of one pre-binned petroleum assay cut. */
   public static final class AssayCut implements Cloneable, Serializable {
     private static final long serialVersionUID = 1000L;
     private final String name;
@@ -183,81 +418,304 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     private Double density;
     private Double apiGravity;
     private Double averageBoilingPointKelvin;
+    private Double lowerBoilingPointKelvin;
+    private Double upperBoilingPointKelvin;
     private Double molarMass;
 
+    /**
+     * Create an assay cut.
+     *
+     * @param name pseudo-component base name; {@code _PC} is added by NeqSim
+     */
     public AssayCut(String name) {
-      this.name = Objects.requireNonNull(name, "name");
+      if (name == null || name.trim().isEmpty()) {
+        throw new IllegalArgumentException("Assay cut name cannot be empty");
+      }
+      this.name = name;
     }
 
+    /**
+     * Return the cut name.
+     *
+     * @return cut name
+     */
     public String getName() {
       return name;
     }
 
+    /**
+     * Set a mass fraction on a 0-1 basis.
+     *
+     * @param massFraction mass fraction from 0 to 1
+     * @return this cut
+     */
     public AssayCut withMassFraction(double massFraction) {
       this.massFraction = sanitiseFraction(massFraction);
       return this;
     }
 
+    /**
+     * Set a mass fraction in weight percent.
+     *
+     * @param weightPercent mass percentage from 0 to 100
+     * @return this cut
+     */
     public AssayCut withWeightPercent(double weightPercent) {
-      this.massFraction = sanitiseFraction(weightPercent / 100.0);
+      this.massFraction = sanitisePercent(weightPercent);
       return this;
     }
 
+    /**
+     * Set a liquid-volume fraction on a 0-1 basis.
+     *
+     * @param volumeFraction volume fraction from 0 to 1
+     * @return this cut
+     */
     public AssayCut withVolumeFraction(double volumeFraction) {
       this.volumeFraction = sanitiseFraction(volumeFraction);
       return this;
     }
 
+    /**
+     * Set a liquid-volume fraction in volume percent.
+     *
+     * @param volumePercent volume percentage from 0 to 100
+     * @return this cut
+     */
     public AssayCut withVolumePercent(double volumePercent) {
-      this.volumeFraction = sanitiseFraction(volumePercent / 100.0);
+      this.volumeFraction = sanitisePercent(volumePercent);
       return this;
     }
 
+    /**
+     * Set petroleum density using the legacy flexible input convention.
+     *
+     * <p>
+     * Values up to 1.5 are interpreted as specific gravity (numerically g/cm3). Values above
+     * 1.5 are interpreted as kg/m3 and divided by 1000. New code should prefer
+     * {@link #withSpecificGravity(double)} or {@link #withDensityKgPerCubicMetre(double)}.
+     * </p>
+     *
+     * @param density specific gravity/g/cm3 or density in kg/m3
+     * @return this cut
+     */
     public AssayCut withDensity(double density) {
-      if (!(density > 0.0)) {
-        throw new IllegalArgumentException("Density must be positive");
-      }
-      this.density = density;
+      validatePositiveFinite(density, "Density");
+      this.density = density > 1.5 ? density / 1000.0 : density;
       return this;
     }
 
+    /**
+     * Set petroleum specific gravity.
+     *
+     * @param specificGravity dimensionless specific gravity, numerically equivalent to g/cm3
+     * @return this cut
+     */
+    public AssayCut withSpecificGravity(double specificGravity) {
+      validateSpecificGravity(specificGravity);
+      this.density = specificGravity;
+      return this;
+    }
+
+    /**
+     * Set liquid density in kg/m3.
+     *
+     * @param densityKgPerCubicMetre liquid density in kg/m3
+     * @return this cut
+     */
+    public AssayCut withDensityKgPerCubicMetre(double densityKgPerCubicMetre) {
+      validatePositiveFinite(densityKgPerCubicMetre, "Density");
+      this.density = densityKgPerCubicMetre / 1000.0;
+      return this;
+    }
+
+    /**
+     * Set API gravity at the conventional 60 degF reference.
+     *
+     * <p>
+     * Negative API gravities are valid for liquids denser than water; only values at or below
+     * -131.5 are rejected because the API conversion becomes undefined.
+     * </p>
+     *
+     * @param apiGravity API gravity in degrees API
+     * @return this cut
+     */
     public AssayCut withApiGravity(double apiGravity) {
-      if (!(apiGravity > 0.0)) {
-        throw new IllegalArgumentException("API gravity must be positive");
+      if (!Double.isFinite(apiGravity) || !(apiGravity > -131.5)) {
+        throw new IllegalArgumentException("API gravity must be finite and greater than -131.5");
       }
       this.apiGravity = apiGravity;
       return this;
     }
 
+    /**
+     * Set the representative cut boiling point in K.
+     *
+     * @param temperatureKelvin representative boiling point in K
+     * @return this cut
+     */
     public AssayCut withAverageBoilingPointKelvin(double temperatureKelvin) {
-      if (!(temperatureKelvin > 0.0)) {
-        throw new IllegalArgumentException("Boiling point must be positive");
-      }
+      validatePositiveFinite(temperatureKelvin, "Boiling point");
       this.averageBoilingPointKelvin = temperatureKelvin;
       return this;
     }
 
+    /**
+     * Set the representative cut boiling point in degC.
+     *
+     * @param temperatureCelsius representative boiling point in degC
+     * @return this cut
+     */
     public AssayCut withAverageBoilingPointCelsius(double temperatureCelsius) {
+      if (!Double.isFinite(temperatureCelsius)) {
+        throw new IllegalArgumentException("Boiling point must be finite");
+      }
       return withAverageBoilingPointKelvin(temperatureCelsius + KELVIN_OFFSET);
     }
 
+    /**
+     * Set the representative cut boiling point in degF.
+     *
+     * @param temperatureFahrenheit representative boiling point in degF
+     * @return this cut
+     */
     public AssayCut withAverageBoilingPointFahrenheit(double temperatureFahrenheit) {
+      if (!Double.isFinite(temperatureFahrenheit)) {
+        throw new IllegalArgumentException("Boiling point must be finite");
+      }
       double temperatureCelsius = (temperatureFahrenheit - 32.0) * 5.0 / 9.0;
       return withAverageBoilingPointKelvin(temperatureCelsius + KELVIN_OFFSET);
     }
 
-    public AssayCut withMolarMass(double molarMass) {
-      if (!(molarMass > 0.0)) {
-        throw new IllegalArgumentException("Molar mass must be positive");
+    /**
+     * Set and preserve a boiling interval in K.
+     *
+     * <p>
+     * The arithmetic midpoint is used as the representative boiling point for the existing
+     * petroleum-characterisation correlation.
+     * </p>
+     *
+     * @param lowerTemperatureKelvin lower cut boundary in K
+     * @param upperTemperatureKelvin upper cut boundary in K
+     * @return this cut
+     */
+    public AssayCut withBoilingRangeKelvin(double lowerTemperatureKelvin,
+        double upperTemperatureKelvin) {
+      validatePositiveFinite(lowerTemperatureKelvin, "Lower boiling point");
+      validatePositiveFinite(upperTemperatureKelvin, "Upper boiling point");
+      if (!(upperTemperatureKelvin > lowerTemperatureKelvin)) {
+        throw new IllegalArgumentException("Upper boiling-point boundary must exceed lower boundary");
       }
-      this.molarMass = molarMass;
+      this.lowerBoilingPointKelvin = lowerTemperatureKelvin;
+      this.upperBoilingPointKelvin = upperTemperatureKelvin;
+      this.averageBoilingPointKelvin =
+          0.5 * (lowerTemperatureKelvin + upperTemperatureKelvin);
       return this;
     }
 
+    /**
+     * Set and preserve a boiling interval in degC.
+     *
+     * @param lowerTemperatureCelsius lower cut boundary in degC
+     * @param upperTemperatureCelsius upper cut boundary in degC
+     * @return this cut
+     */
+    public AssayCut withBoilingRangeCelsius(double lowerTemperatureCelsius,
+        double upperTemperatureCelsius) {
+      if (!Double.isFinite(lowerTemperatureCelsius)
+          || !Double.isFinite(upperTemperatureCelsius)) {
+        throw new IllegalArgumentException("Boiling-point boundaries must be finite");
+      }
+      return withBoilingRangeKelvin(lowerTemperatureCelsius + KELVIN_OFFSET,
+          upperTemperatureCelsius + KELVIN_OFFSET);
+    }
+
+    /**
+     * Return whether the original cut boiling interval is available.
+     *
+     * @return true when both lower and upper boundaries are stored
+     */
+    public boolean hasBoilingRange() {
+      return lowerBoilingPointKelvin != null && upperBoilingPointKelvin != null;
+    }
+
+    /**
+     * Return the lower cut boiling boundary.
+     *
+     * @return lower boundary in K
+     */
+    public double getLowerBoilingPointKelvin() {
+      if (lowerBoilingPointKelvin == null) {
+        throw new IllegalStateException("Lower boiling-point boundary not set for cut " + name);
+      }
+      return lowerBoilingPointKelvin;
+    }
+
+    /**
+     * Return the upper cut boiling boundary.
+     *
+     * @return upper boundary in K
+     */
+    public double getUpperBoilingPointKelvin() {
+      if (upperBoilingPointKelvin == null) {
+        throw new IllegalStateException("Upper boiling-point boundary not set for cut " + name);
+      }
+      return upperBoilingPointKelvin;
+    }
+
+    /**
+     * Set an explicit molar mass in kg/mol.
+     *
+     * <p>
+     * This historical method is retained for compatibility. New code can use the unit-explicit
+     * {@link #withMolarMassKgPerMol(double)} method.
+     * </p>
+     *
+     * @param molarMass molar mass in kg/mol
+     * @return this cut
+     */
+    public AssayCut withMolarMass(double molarMass) {
+      return withMolarMassKgPerMol(molarMass);
+    }
+
+    /**
+     * Set an explicit molar mass in kg/mol.
+     *
+     * @param molarMassKgPerMol molar mass in kg/mol
+     * @return this cut
+     */
+    public AssayCut withMolarMassKgPerMol(double molarMassKgPerMol) {
+      validatePositiveFinite(molarMassKgPerMol, "Molar mass");
+      this.molarMass = molarMassKgPerMol;
+      return this;
+    }
+
+    /**
+     * Set an explicit molar mass in g/mol.
+     *
+     * @param molarMassGramPerMol molar mass in g/mol
+     * @return this cut
+     */
+    public AssayCut withMolarMassGramPerMol(double molarMassGramPerMol) {
+      validatePositiveFinite(molarMassGramPerMol, "Molar mass");
+      this.molarMass = molarMassGramPerMol / 1000.0;
+      return this;
+    }
+
+    /**
+     * Return whether this cut uses a mass fraction.
+     *
+     * @return true when a mass fraction is set
+     */
     public boolean hasMassFraction() {
       return massFraction != null;
     }
 
+    /**
+     * Return the mass fraction.
+     *
+     * @return mass fraction on a 0-1 basis
+     */
     public double getMassFraction() {
       if (massFraction == null) {
         throw new IllegalStateException("Mass fraction not set");
@@ -265,10 +723,20 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
       return massFraction;
     }
 
+    /**
+     * Return whether this cut uses a volume fraction.
+     *
+     * @return true when a volume fraction is set
+     */
     public boolean hasVolumeFraction() {
       return volumeFraction != null;
     }
 
+    /**
+     * Return the volume fraction.
+     *
+     * @return volume fraction on a 0-1 basis
+     */
     public double getVolumeFraction() {
       if (volumeFraction == null) {
         throw new IllegalStateException("Volume fraction not set");
@@ -276,10 +744,20 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
       return volumeFraction;
     }
 
+    /**
+     * Return whether an explicit molar mass was supplied.
+     *
+     * @return true when an explicit molar mass is stored
+     */
     public boolean hasMolarMass() {
       return molarMass != null;
     }
 
+    /**
+     * Resolve the cut density used by petroleum correlations.
+     *
+     * @return density in g/cm3 / equivalent specific-gravity numeric value
+     */
     public double resolveDensity() {
       if (density != null) {
         return density;
@@ -291,6 +769,11 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
       throw new IllegalStateException("Density or API gravity required for cut " + name);
     }
 
+    /**
+     * Resolve the representative boiling point.
+     *
+     * @return boiling point in K
+     */
     public double resolveAverageBoilingPoint() {
       if (averageBoilingPointKelvin == null) {
         throw new IllegalStateException("Average boiling point missing for cut " + name);
@@ -298,6 +781,18 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
       return averageBoilingPointKelvin;
     }
 
+    /**
+     * Resolve the cut molar mass.
+     *
+     * <p>
+     * If no explicit molar mass is stored, the existing NeqSim inverse petroleum correlation is
+     * used with density and representative boiling point.
+     * </p>
+     *
+     * @param density specific gravity / g/cm3 numeric value
+     * @param boilingPointKelvin representative boiling point in K
+     * @return molar mass in kg/mol
+     */
     public double resolveMolarMass(double density, double boilingPointKelvin) {
       if (molarMass != null) {
         return molarMass;
@@ -307,8 +802,8 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
       }
       double exponent = 2.3776;
       double densityExponent = 0.9371;
-      double molarMassKgPerMol = 5.805e-5 * Math.pow(boilingPointKelvin, exponent) / Math.pow(density, densityExponent);
-      return molarMassKgPerMol;
+      return 5.805e-5 * Math.pow(boilingPointKelvin, exponent)
+          / Math.pow(density, densityExponent);
     }
 
     @Override
@@ -317,17 +812,27 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     }
 
     private static double sanitiseFraction(double fraction) {
-      if (fraction < 0.0) {
-        throw new IllegalArgumentException("Fraction cannot be negative");
+      if (!Double.isFinite(fraction) || fraction < 0.0 || fraction > 1.0) {
+        throw new IllegalArgumentException("Fraction must be finite and between 0 and 1");
       }
-      double candidate = fraction;
-      if (candidate > 1.0 + 1e-9) {
-        candidate = candidate / 100.0;
+      return fraction;
+    }
+
+    private static double sanitisePercent(double percent) {
+      if (!Double.isFinite(percent) || percent < 0.0 || percent > 100.0) {
+        throw new IllegalArgumentException("Percent must be finite and between 0 and 100");
       }
-      if (candidate < 0.0 || candidate > 1.0 + 1e-9) {
-        throw new IllegalArgumentException("Fraction must be between 0 and 1");
-      }
-      return candidate;
+      return percent / 100.0;
+    }
+  }
+
+  private static void validateSpecificGravity(double specificGravity) {
+    validatePositiveFinite(specificGravity, "Specific gravity");
+  }
+
+  private static void validatePositiveFinite(double value, String name) {
+    if (!Double.isFinite(value) || !(value > 0.0)) {
+      throw new IllegalArgumentException(name + " must be finite and positive");
     }
   }
 }

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -416,8 +416,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
         throw new IllegalArgumentException("Assay cut name cannot be empty");
       }
       if (name.contains("_PC")) {
-        throw new IllegalArgumentException(
-            "Assay cut name cannot contain reserved _PC pseudo-component marker");
+        throw new IllegalArgumentException("Assay cut name cannot contain reserved _PC pseudo-component marker");
       }
       this.name = name;
     }

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -415,6 +415,10 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
       if (name == null || name.trim().isEmpty()) {
         throw new IllegalArgumentException("Assay cut name cannot be empty");
       }
+      if (name.contains("_PC")) {
+        throw new IllegalArgumentException(
+            "Assay cut name cannot contain reserved _PC pseudo-component marker");
+      }
       this.name = name;
     }
 

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -16,24 +16,22 @@ import neqsim.thermo.system.SystemInterface;
  * Utility for characterising an oil system from refinery-assay cut information.
  *
  * <p>
- * An assay is represented as a set of pre-binned cuts on one declared composition basis: all
- * cuts must use either mass fractions or volume fractions. Volume-basis cuts are converted to a
- * mass basis with the cut densities before moles are calculated. Mixing mass- and volume-basis
- * cuts in one assay is rejected because the missing conversion basis would otherwise be
- * ambiguous.
+ * An assay is represented as a set of pre-binned cuts on one declared composition basis: all cuts must use either mass
+ * fractions or volume fractions. Volume-basis cuts are converted to a mass basis with the cut densities before moles
+ * are calculated. Mixing mass- and volume-basis cuts in one assay is rejected because the missing conversion basis
+ * would otherwise be ambiguous.
  * </p>
  *
  * <p>
- * Molar masses are in kg/mol throughout this class. Density inputs used for petroleum
- * characterisation are specific gravity (numerically equivalent to g/cm3 for the supported
- * correlations); explicit kg/m3 input helpers are also provided.
+ * Molar masses are in kg/mol throughout this class. Density inputs used for petroleum characterisation are specific
+ * gravity (numerically equivalent to g/cm3 for the supported correlations); explicit kg/m3 input helpers are also
+ * provided.
  * </p>
  *
  * <p>
- * The TBP cut-boundary helpers preserve cut yields and boiling ranges, then use the midpoint of
- * each boiling interval as the representative boiling point for the existing NeqSim petroleum
- * correlation. They do not convert ASTM D86/D1160 or other laboratory distillation methods to
- * TBP.
+ * The TBP cut-boundary helpers preserve cut yields and boiling ranges, then use the midpoint of each boiling interval
+ * as the representative boiling point for the existing NeqSim petroleum correlation. They do not convert ASTM D86/D1160
+ * or other laboratory distillation methods to TBP.
  * </p>
  */
 public class OilAssayCharacterisation implements Cloneable, Serializable {
@@ -129,11 +127,10 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
    * Add pre-binned true-boiling-point cuts from cumulative volume-percent boundaries.
    *
    * <p>
-   * The first cumulative point must be 0 vol% and the last must be 100 vol%. The arrays of
-   * cumulative yield and boiling-point boundaries must have the same length. One specific
-   * gravity is required for each resulting interval. The interval midpoint is retained as the
-   * representative boiling point and the complete lower/upper boiling range is stored on the
-   * generated {@link AssayCut}.
+   * The first cumulative point must be 0 vol% and the last must be 100 vol%. The arrays of cumulative yield and
+   * boiling-point boundaries must have the same length. One specific gravity is required for each resulting interval.
+   * The interval midpoint is retained as the representative boiling point and the complete lower/upper boiling range is
+   * stored on the generated {@link AssayCut}.
    * </p>
    *
    * @param namePrefix component-name prefix; generated names are prefix + 1, prefix + 2, ...
@@ -153,8 +150,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
       }
       boilingPointKelvin[i] = boilingPointCelsius[i] + KELVIN_OFFSET;
     }
-    addTBPCutBoundariesKelvin(namePrefix, cumulativeVolumePercent, boilingPointKelvin,
-        specificGravity);
+    addTBPCutBoundariesKelvin(namePrefix, cumulativeVolumePercent, boilingPointKelvin, specificGravity);
   }
 
   /**
@@ -167,12 +163,10 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
    */
   public void addTBPCutBoundariesKelvin(String namePrefix, double[] cumulativeVolumePercent,
       double[] boilingPointKelvin, double[] specificGravity) {
-    validateTBPCutBoundaries(namePrefix, cumulativeVolumePercent, boilingPointKelvin,
-        specificGravity);
+    validateTBPCutBoundaries(namePrefix, cumulativeVolumePercent, boilingPointKelvin, specificGravity);
 
     for (int i = 0; i < specificGravity.length; i++) {
-      double volumeFraction =
-          (cumulativeVolumePercent[i + 1] - cumulativeVolumePercent[i]) / 100.0;
+      double volumeFraction = (cumulativeVolumePercent[i + 1] - cumulativeVolumePercent[i]) / 100.0;
       AssayCut cut = new AssayCut(namePrefix + (i + 1)).withVolumeFraction(volumeFraction)
           .withSpecificGravity(specificGravity[i])
           .withBoilingRangeKelvin(boilingPointKelvin[i], boilingPointKelvin[i + 1]);
@@ -194,8 +188,8 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
    * Generate TBP pseudo-components for all configured cuts and add them to the attached system.
    *
    * <p>
-   * All inputs are resolved and validated before the first pseudo-component is added. Existing
-   * component names are rejected so that repeated calls cannot silently double the assay.
+   * All inputs are resolved and validated before the first pseudo-component is added. Existing component names are
+   * rejected so that repeated calls cannot silently double the assay.
    * </p>
    */
   public void apply() {
@@ -221,8 +215,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
 
       String pseudoComponentName = cut.getName() + "_PC";
       if (system.hasComponent(pseudoComponentName, false)) {
-        throw new IllegalStateException(
-            "Assay pseudo-component already exists in system: " + pseudoComponentName);
+        throw new IllegalStateException("Assay pseudo-component already exists in system: " + pseudoComponentName);
       }
 
       double density = cut.resolveDensity();
@@ -244,17 +237,14 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
       reconstructedMass += moles * molarMass;
     }
 
-    double relativeMassError =
-        Math.abs(reconstructedMass - totalAssayMass) / Math.max(totalAssayMass, 1.0e-30);
+    double relativeMassError = Math.abs(reconstructedMass - totalAssayMass) / Math.max(totalAssayMass, 1.0e-30);
     if (!Double.isFinite(relativeMassError) || relativeMassError > 1.0e-10) {
       throw new IllegalStateException(
-          "Resolved assay does not conserve the configured total mass; relative error="
-              + relativeMassError);
+          "Resolved assay does not conserve the configured total mass; relative error=" + relativeMassError);
     }
 
     for (ResolvedCut resolvedCut : resolvedCuts) {
-      system.addTBPfraction(resolvedCut.cut.getName(), resolvedCut.moles,
-          resolvedCut.molarMass, resolvedCut.density);
+      system.addTBPfraction(resolvedCut.cut.getName(), resolvedCut.moles, resolvedCut.molarMass, resolvedCut.density);
     }
   }
 
@@ -263,19 +253,16 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     if (namePrefix == null || namePrefix.trim().isEmpty()) {
       throw new IllegalArgumentException("TBP cut name prefix cannot be empty");
     }
-    if (cumulativeVolumePercent == null || boilingPointKelvin == null
-        || specificGravity == null) {
+    if (cumulativeVolumePercent == null || boilingPointKelvin == null || specificGravity == null) {
       throw new IllegalArgumentException("TBP cut-boundary arrays cannot be null");
     }
-    if (cumulativeVolumePercent.length < 2
-        || cumulativeVolumePercent.length != boilingPointKelvin.length
+    if (cumulativeVolumePercent.length < 2 || cumulativeVolumePercent.length != boilingPointKelvin.length
         || specificGravity.length != cumulativeVolumePercent.length - 1) {
       throw new IllegalArgumentException(
           "TBP boundaries require N cumulative yields, N temperatures, and N-1 densities");
     }
     if (Math.abs(cumulativeVolumePercent[0]) > PERCENT_TOLERANCE
-        || Math.abs(cumulativeVolumePercent[cumulativeVolumePercent.length - 1] - 100.0)
-            > PERCENT_TOLERANCE) {
+        || Math.abs(cumulativeVolumePercent[cumulativeVolumePercent.length - 1] - 100.0) > PERCENT_TOLERANCE) {
       throw new IllegalArgumentException("TBP cumulative volume yield must span 0 to 100 percent");
     }
 
@@ -333,8 +320,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
       if (basis == null) {
         basis = cutBasis;
       } else if (basis != cutBasis) {
-        throw new IllegalStateException(
-            "Assay cuts cannot mix mass-fraction and volume-fraction bases");
+        throw new IllegalStateException("Assay cuts cannot mix mass-fraction and volume-fraction bases");
       }
 
       double fraction = hasMass ? cut.getMassFraction() : cut.getVolumeFraction();
@@ -346,9 +332,8 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
       throw new IllegalStateException("No valid assay fractions supplied");
     }
     if (Math.abs(totalDeclaredFraction - 1.0) > ASSAY_CLOSURE_TOLERANCE) {
-      throw new IllegalStateException(
-          "Assay fractions must sum to 1.0 within " + ASSAY_CLOSURE_TOLERANCE
-              + "; supplied sum=" + totalDeclaredFraction);
+      throw new IllegalStateException("Assay fractions must sum to 1.0 within " + ASSAY_CLOSURE_TOLERANCE
+          + "; supplied sum=" + totalDeclaredFraction);
     }
 
     for (int i = 0; i < declaredFractions.length; i++) {
@@ -391,8 +376,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
   }
 
   private enum FractionBasis {
-    MASS,
-    VOLUME
+    MASS, VOLUME
   }
 
   private static final class ResolvedCut {
@@ -491,9 +475,9 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
      * Set petroleum density using the legacy flexible input convention.
      *
      * <p>
-     * Values up to 1.5 are interpreted as specific gravity (numerically g/cm3). Values above
-     * 1.5 are interpreted as kg/m3 and divided by 1000. New code should prefer
-     * {@link #withSpecificGravity(double)} or {@link #withDensityKgPerCubicMetre(double)}.
+     * Values up to 1.5 are interpreted as specific gravity (numerically g/cm3). Values above 1.5 are interpreted as
+     * kg/m3 and divided by 1000. New code should prefer {@link #withSpecificGravity(double)} or
+     * {@link #withDensityKgPerCubicMetre(double)}.
      * </p>
      *
      * @param density specific gravity/g/cm3 or density in kg/m3
@@ -533,8 +517,8 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
      * Set API gravity at the conventional 60 degF reference.
      *
      * <p>
-     * Negative API gravities are valid for liquids denser than water; only values at or below
-     * -131.5 are rejected because the API conversion becomes undefined.
+     * Negative API gravities are valid for liquids denser than water; only values at or below -131.5 are rejected
+     * because the API conversion becomes undefined.
      * </p>
      *
      * @param apiGravity API gravity in degrees API
@@ -591,16 +575,15 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
      * Set and preserve a boiling interval in K.
      *
      * <p>
-     * The arithmetic midpoint is used as the representative boiling point for the existing
-     * petroleum-characterisation correlation.
+     * The arithmetic midpoint is used as the representative boiling point for the existing petroleum-characterisation
+     * correlation.
      * </p>
      *
      * @param lowerTemperatureKelvin lower cut boundary in K
      * @param upperTemperatureKelvin upper cut boundary in K
      * @return this cut
      */
-    public AssayCut withBoilingRangeKelvin(double lowerTemperatureKelvin,
-        double upperTemperatureKelvin) {
+    public AssayCut withBoilingRangeKelvin(double lowerTemperatureKelvin, double upperTemperatureKelvin) {
       validatePositiveFinite(lowerTemperatureKelvin, "Lower boiling point");
       validatePositiveFinite(upperTemperatureKelvin, "Upper boiling point");
       if (!(upperTemperatureKelvin > lowerTemperatureKelvin)) {
@@ -608,8 +591,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
       }
       this.lowerBoilingPointKelvin = lowerTemperatureKelvin;
       this.upperBoilingPointKelvin = upperTemperatureKelvin;
-      this.averageBoilingPointKelvin =
-          0.5 * (lowerTemperatureKelvin + upperTemperatureKelvin);
+      this.averageBoilingPointKelvin = 0.5 * (lowerTemperatureKelvin + upperTemperatureKelvin);
       return this;
     }
 
@@ -620,14 +602,11 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
      * @param upperTemperatureCelsius upper cut boundary in degC
      * @return this cut
      */
-    public AssayCut withBoilingRangeCelsius(double lowerTemperatureCelsius,
-        double upperTemperatureCelsius) {
-      if (!Double.isFinite(lowerTemperatureCelsius)
-          || !Double.isFinite(upperTemperatureCelsius)) {
+    public AssayCut withBoilingRangeCelsius(double lowerTemperatureCelsius, double upperTemperatureCelsius) {
+      if (!Double.isFinite(lowerTemperatureCelsius) || !Double.isFinite(upperTemperatureCelsius)) {
         throw new IllegalArgumentException("Boiling-point boundaries must be finite");
       }
-      return withBoilingRangeKelvin(lowerTemperatureCelsius + KELVIN_OFFSET,
-          upperTemperatureCelsius + KELVIN_OFFSET);
+      return withBoilingRangeKelvin(lowerTemperatureCelsius + KELVIN_OFFSET, upperTemperatureCelsius + KELVIN_OFFSET);
     }
 
     /**
@@ -785,8 +764,8 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
      * Resolve the cut molar mass.
      *
      * <p>
-     * If no explicit molar mass is stored, the existing NeqSim inverse petroleum correlation is
-     * used with density and representative boiling point.
+     * If no explicit molar mass is stored, the existing NeqSim inverse petroleum correlation is used with density and
+     * representative boiling point.
      * </p>
      *
      * @param density specific gravity / g/cm3 numeric value
@@ -802,8 +781,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
       }
       double exponent = 2.3776;
       double densityExponent = 0.9371;
-      return 5.805e-5 * Math.pow(boilingPointKelvin, exponent)
-          / Math.pow(density, densityExponent);
+      return 5.805e-5 * Math.pow(boilingPointKelvin, exponent) / Math.pow(density, densityExponent);
     }
 
     @Override

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationReservedNameTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationReservedNameTest.java
@@ -19,9 +19,8 @@ public class OilAssayCharacterisationReservedNameTest {
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
 
-    assertThrows(IllegalArgumentException.class,
-        () -> characterisation.addTBPCutBoundariesCelsius("TBP_PC", new double[] { 0.0, 100.0 },
-            new double[] { 90.0, 520.0 }, new double[] { 0.85 }));
+    assertThrows(IllegalArgumentException.class, () -> characterisation.addTBPCutBoundariesCelsius("TBP_PC",
+        new double[] { 0.0, 100.0 }, new double[] { 90.0, 520.0 }, new double[] { 0.85 }));
     assertTrue(characterisation.getCuts().isEmpty());
   }
 }

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationReservedNameTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationReservedNameTest.java
@@ -20,8 +20,8 @@ public class OilAssayCharacterisationReservedNameTest {
     characterisation.clearCuts();
 
     assertThrows(IllegalArgumentException.class,
-        () -> characterisation.addTBPCutBoundariesCelsius("TBP_PC", new double[] {0.0, 100.0},
-            new double[] {90.0, 520.0}, new double[] {0.85}));
+        () -> characterisation.addTBPCutBoundariesCelsius("TBP_PC", new double[] { 0.0, 100.0 },
+            new double[] { 90.0, 520.0 }, new double[] { 0.85 }));
     assertTrue(characterisation.getCuts().isEmpty());
   }
 }

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationReservedNameTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationReservedNameTest.java
@@ -1,0 +1,27 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+public class OilAssayCharacterisationReservedNameTest {
+  @Test
+  public void testReservedPseudoComponentMarkerInCutNameIsRejected() {
+    assertThrows(IllegalArgumentException.class, () -> new AssayCut("Naphtha_PC_alias"));
+  }
+
+  @Test
+  public void testReservedPseudoComponentMarkerInTbpPrefixIsRejectedBeforeMutation() {
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> characterisation.addTBPCutBoundariesCelsius("TBP_PC", new double[] {0.0, 100.0},
+            new double[] {90.0, 520.0}, new double[] {0.85}));
+    assertTrue(characterisation.getCuts().isEmpty());
+  }
+}

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationTest.java
@@ -314,6 +314,45 @@ public class OilAssayCharacterisationTest {
   }
 
   @Test
+  public void testMultipleTraceMassFractionsAreRetainedAndConserveMass() {
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+
+    double firstTraceFraction = 4.0e-11;
+    double secondTraceFraction = 7.0e-11;
+    characterisation.addCut(new AssayCut("Main").withMassFraction(1.0 - firstTraceFraction - secondTraceFraction)
+        .withSpecificGravity(0.82).withMolarMassKgPerMol(0.200));
+    characterisation.addCut(new AssayCut("Trace1").withMassFraction(firstTraceFraction).withSpecificGravity(0.75)
+        .withMolarMassKgPerMol(0.100));
+    characterisation.addCut(new AssayCut("Trace2").withMassFraction(secondTraceFraction).withSpecificGravity(0.90)
+        .withMolarMassKgPerMol(0.300));
+
+    characterisation.apply();
+
+    assertTrue(system.hasComponent("Main_PC", false));
+    assertTrue(system.hasComponent("Trace1_PC", false));
+    assertTrue(system.hasComponent("Trace2_PC", false));
+    assertEquals(1.0, reconstructedAssayMass(system, "Main_PC", "Trace1_PC", "Trace2_PC"), 1e-12);
+  }
+
+  @Test
+  public void testInvalidTraceCutIsRejectedBeforeAnyAssayMutation() {
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+
+    double traceFraction = 5.0e-11;
+    characterisation.addCut(new AssayCut("Main").withMassFraction(1.0 - traceFraction).withSpecificGravity(0.82)
+        .withMolarMassKgPerMol(0.200));
+    characterisation.addCut(new AssayCut("InvalidTrace").withMassFraction(traceFraction).withSpecificGravity(0.75));
+
+    assertThrows(IllegalStateException.class, characterisation::apply);
+    assertFalse(system.hasComponent("Main_PC", false));
+    assertFalse(system.hasComponent("InvalidTrace_PC", false));
+  }
+
+  @Test
   public void testFractionAndPercentInputsAreUnambiguous() {
     assertThrows(IllegalArgumentException.class, () -> new AssayCut("BadFraction").withMassFraction(40.0));
     assertThrows(IllegalArgumentException.class, () -> new AssayCut("BadPercent").withWeightPercent(120.0));

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationTest.java
@@ -3,6 +3,7 @@ package neqsim.thermo.characterization;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
@@ -13,14 +14,14 @@ import neqsim.thermo.system.SystemSrkEos;
 
 public class OilAssayCharacterisationTest {
   @Test
-  public void testAssayApplicationAddsPseudoComponents() {
+  public void testMassBasisAssayApplicationAddsPseudoComponents() {
     SystemInterface system = new SystemSrkEos(298.15, 10.0);
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
 
-    AssayCut light = new AssayCut("Light").withWeightPercent(40.0).withDensity(0.75)
+    AssayCut light = new AssayCut("Light").withWeightPercent(40.0).withSpecificGravity(0.75)
         .withAverageBoilingPointCelsius(200.0);
-    AssayCut heavy = new AssayCut("Heavy").withVolumePercent(60.0).withApiGravity(25.0)
+    AssayCut heavy = new AssayCut("Heavy").withWeightPercent(60.0).withApiGravity(25.0)
         .withAverageBoilingPointCelsius(350.0);
 
     characterisation.addCut(light);
@@ -28,7 +29,8 @@ public class OilAssayCharacterisationTest {
     characterisation.apply();
 
     double lightBoilingPoint = 200.0 + 273.15;
-    double expectedLightMolarMass = 5.805e-5 * Math.pow(lightBoilingPoint, 2.3776) / Math.pow(0.75, 0.9371);
+    double expectedLightMolarMass =
+        5.805e-5 * Math.pow(lightBoilingPoint, 2.3776) / Math.pow(0.75, 0.9371);
     ComponentInterface lightComponent = system.getComponent("Light_PC");
     assertNotNull(lightComponent);
     assertEquals(expectedLightMolarMass, lightComponent.getMolarMass(), 1e-8);
@@ -36,11 +38,37 @@ public class OilAssayCharacterisationTest {
 
     double heavyDensity = 141.5 / (25.0 + 131.5) * 0.999016;
     double heavyBoilingPoint = 350.0 + 273.15;
-    double expectedHeavyMolarMass = 5.805e-5 * Math.pow(heavyBoilingPoint, 2.3776) / Math.pow(heavyDensity, 0.9371);
+    double expectedHeavyMolarMass =
+        5.805e-5 * Math.pow(heavyBoilingPoint, 2.3776) / Math.pow(heavyDensity, 0.9371);
     ComponentInterface heavyComponent = system.getComponent("Heavy_PC");
     assertNotNull(heavyComponent);
     assertEquals(expectedHeavyMolarMass, heavyComponent.getMolarMass(), 1e-8);
     assertEquals(0.6 / expectedHeavyMolarMass, heavyComponent.getNumberOfmoles(), 1e-8);
+  }
+
+  @Test
+  public void testVolumeBasisAssayConvertsToMassFractions() {
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+
+    characterisation.addCut(new AssayCut("Light").withVolumePercent(40.0)
+        .withSpecificGravity(0.75).withAverageBoilingPointCelsius(200.0));
+    characterisation.addCut(new AssayCut("Heavy").withVolumePercent(60.0)
+        .withApiGravity(25.0).withAverageBoilingPointCelsius(350.0));
+
+    double heavyDensity = 141.5 / (25.0 + 131.5) * 0.999016;
+    double totalRelativeMass = 0.4 * 0.75 + 0.6 * heavyDensity;
+    double expectedLightMassFraction = 0.4 * 0.75 / totalRelativeMass;
+    double expectedHeavyMassFraction = 0.6 * heavyDensity / totalRelativeMass;
+
+    double[] massFractions = characterisation.getResolvedMassFractions();
+    assertEquals(expectedLightMassFraction, massFractions[0], 1e-12);
+    assertEquals(expectedHeavyMassFraction, massFractions[1], 1e-12);
+    assertEquals(1.0, massFractions[0] + massFractions[1], 1e-12);
+
+    characterisation.apply();
+    assertEquals(1.0, reconstructedAssayMass(system, "Light_PC", "Heavy_PC"), 1e-10);
   }
 
   @Test
@@ -49,16 +77,19 @@ public class OilAssayCharacterisationTest {
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
 
-    AssayCut cut = new AssayCut("Assay").withMassFraction(1.0).withDensity(0.82).withAverageBoilingPointCelsius(300.0);
+    AssayCut cut = new AssayCut("Assay").withMassFraction(1.0).withSpecificGravity(0.82)
+        .withAverageBoilingPointCelsius(300.0);
     characterisation.addCut(cut);
     characterisation.setTotalAssayMass(2.0);
     characterisation.apply();
 
     double boilingPoint = 300.0 + 273.15;
-    double expectedMolarMass = 5.805e-5 * Math.pow(boilingPoint, 2.3776) / Math.pow(0.82, 0.9371);
+    double expectedMolarMass =
+        5.805e-5 * Math.pow(boilingPoint, 2.3776) / Math.pow(0.82, 0.9371);
     ComponentInterface component = system.getComponent("Assay_PC");
     assertNotNull(component);
     assertEquals(2.0 / expectedMolarMass, component.getNumberOfmoles(), 1e-8);
+    assertEquals(2.0, component.getNumberOfmoles() * component.getMolarMass(), 1e-10);
   }
 
   @Test
@@ -66,12 +97,12 @@ public class OilAssayCharacterisationTest {
     SystemInterface system = new SystemSrkEos(298.15, 10.0);
     OilAssayCharacterisation original = system.getOilAssayCharacterisation();
     original.clearCuts();
-    original.addCut(
-        new AssayCut("CloneTest").withMassFraction(1.0).withDensity(0.85).withAverageBoilingPointCelsius(310.0));
+    original.addCut(new AssayCut("CloneTest").withMassFraction(1.0)
+        .withSpecificGravity(0.85).withAverageBoilingPointCelsius(310.0));
 
     SystemInterface cloned = system.clone();
     OilAssayCharacterisation cloneCharacterisation = cloned.getOilAssayCharacterisation();
-    assertTrue(cloneCharacterisation.getCuts().size() == 1);
+    assertEquals(1, cloneCharacterisation.getCuts().size());
     cloneCharacterisation.apply();
 
     assertTrue(Arrays.asList(cloned.getComponentNames()).contains("CloneTest_PC"));
@@ -79,26 +110,33 @@ public class OilAssayCharacterisationTest {
   }
 
   @Test
-  public void testExplicitMolarMassSkipsBoilingPointRequirement() {
+  public void testExplicitMolarMassUsesKgPerMol() {
     SystemInterface system = new SystemSrkEos(298.15, 10.0);
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
 
-    // Create a cut with explicit molar mass but no boiling point
-    AssayCut cut = new AssayCut("ExplicitMW").withMassFraction(1.0).withDensity(0.8).withMolarMass(150.0); // Explicit
-    // molar
-    // mass,
-    // no
-    // boiling
-    // point
-
+    AssayCut cut = new AssayCut("ExplicitMW").withMassFraction(1.0)
+        .withSpecificGravity(0.8).withMolarMassKgPerMol(0.150);
     characterisation.addCut(cut);
-    characterisation.apply(); // Should not throw exception
+    characterisation.apply();
 
     ComponentInterface component = system.getComponent("ExplicitMW_PC");
     assertNotNull(component);
-    assertEquals(150.0, component.getMolarMass(), 1e-8);
-    assertEquals(1.0 / 150.0, component.getNumberOfmoles(), 1e-8);
+    assertEquals(0.150, component.getMolarMass(), 1e-12);
+    assertEquals(1.0 / 0.150, component.getNumberOfmoles(), 1e-10);
+  }
+
+  @Test
+  public void testGramPerMolHelperConvertsExplicitMolarMass() {
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+
+    characterisation.addCut(new AssayCut("ExplicitMW").withMassFraction(1.0)
+        .withSpecificGravity(0.8).withMolarMassGramPerMol(150.0));
+    characterisation.apply();
+
+    assertEquals(0.150, system.getComponent("ExplicitMW_PC").getMolarMass(), 1e-12);
   }
 
   @Test
@@ -106,20 +144,12 @@ public class OilAssayCharacterisationTest {
     SystemInterface system = new SystemSrkEos(298.15, 10.0);
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
+    characterisation.addCut(
+        new AssayCut("NoBoilingPoint").withMassFraction(1.0).withSpecificGravity(0.8));
 
-    // Create a cut without explicit molar mass or boiling point - should fail
-    AssayCut cut = new AssayCut("NoBoilingPoint").withMassFraction(1.0).withDensity(0.8);
-    // No molar mass, no boiling point
-
-    characterisation.addCut(cut);
-
-    // This should throw an exception because boiling point is required for molar mass calculation
-    try {
-      characterisation.apply();
-      assertTrue(false, "Expected IllegalStateException for missing boiling point");
-    } catch (IllegalStateException e) {
-      assertTrue(e.getMessage().contains("Average boiling point missing"));
-    }
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, characterisation::apply);
+    assertTrue(exception.getMessage().contains("Average boiling point missing"));
   }
 
   @Test
@@ -128,26 +158,191 @@ public class OilAssayCharacterisationTest {
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
 
-    // Cut with explicit molar mass (no boiling point needed)
-    AssayCut explicitCut = new AssayCut("Explicit").withMassFraction(0.5).withDensity(0.8).withMolarMass(120.0);
-
-    // Cut with calculated molar mass (requires boiling point)
-    AssayCut calculatedCut = new AssayCut("Calculated").withMassFraction(0.5).withDensity(0.85)
-        .withAverageBoilingPointCelsius(250.0);
+    AssayCut explicitCut = new AssayCut("Explicit").withMassFraction(0.5)
+        .withSpecificGravity(0.8).withMolarMassKgPerMol(0.120);
+    AssayCut calculatedCut = new AssayCut("Calculated").withMassFraction(0.5)
+        .withSpecificGravity(0.85).withAverageBoilingPointCelsius(250.0);
 
     characterisation.addCut(explicitCut);
     characterisation.addCut(calculatedCut);
     characterisation.apply();
 
-    // Verify explicit molar mass component
-    ComponentInterface explicitComponent = system.getComponent("Explicit_PC");
-    assertNotNull(explicitComponent);
-    assertEquals(120.0, explicitComponent.getMolarMass(), 1e-8);
+    assertEquals(0.120, system.getComponent("Explicit_PC").getMolarMass(), 1e-12);
+    assertTrue(Math.abs(system.getComponent("Calculated_PC").getMolarMass() - 0.120) > 1e-3);
+    assertEquals(1.0, reconstructedAssayMass(system, "Explicit_PC", "Calculated_PC"), 1e-10);
+  }
 
-    // Verify calculated molar mass component
-    ComponentInterface calculatedComponent = system.getComponent("Calculated_PC");
-    assertNotNull(calculatedComponent);
-    // The calculated molar mass should be different from 120.0
-    assertTrue(Math.abs(calculatedComponent.getMolarMass() - 120.0) > 1.0);
+  @Test
+  public void testMixedMassAndVolumeBasisIsRejected() {
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+    characterisation.addCut(new AssayCut("MassCut").withMassFraction(0.4)
+        .withSpecificGravity(0.75).withAverageBoilingPointCelsius(180.0));
+    characterisation.addCut(new AssayCut("VolumeCut").withVolumeFraction(0.6)
+        .withSpecificGravity(0.85).withAverageBoilingPointCelsius(320.0));
+
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, characterisation::apply);
+    assertTrue(exception.getMessage().contains("cannot mix"));
+    assertFalse(system.hasComponent("MassCut_PC", false));
+    assertFalse(system.hasComponent("VolumeCut_PC", false));
+  }
+
+  @Test
+  public void testCutWithTwoFractionBasesIsRejected() {
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+    characterisation.addCut(new AssayCut("Ambiguous").withMassFraction(1.0)
+        .withVolumeFraction(1.0).withSpecificGravity(0.8)
+        .withAverageBoilingPointCelsius(250.0));
+
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, characterisation::apply);
+    assertTrue(exception.getMessage().contains("exactly one"));
+  }
+
+  @Test
+  public void testIncompleteAssayIsRejectedInsteadOfSilentlyRenormalized() {
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+    characterisation.addCut(new AssayCut("Cut1").withMassFraction(0.4)
+        .withSpecificGravity(0.75).withAverageBoilingPointCelsius(180.0));
+    characterisation.addCut(new AssayCut("Cut2").withMassFraction(0.4)
+        .withSpecificGravity(0.85).withAverageBoilingPointCelsius(320.0));
+
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, characterisation::apply);
+    assertTrue(exception.getMessage().contains("sum to 1.0"));
+  }
+
+  @Test
+  public void testRoundingScaleClosureIsNormalized() {
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+    characterisation.addCut(new AssayCut("Cut1").withMassFraction(0.3333)
+        .withSpecificGravity(0.75).withAverageBoilingPointCelsius(180.0));
+    characterisation.addCut(new AssayCut("Cut2").withMassFraction(0.3333)
+        .withSpecificGravity(0.82).withAverageBoilingPointCelsius(280.0));
+    characterisation.addCut(new AssayCut("Cut3").withMassFraction(0.3333)
+        .withSpecificGravity(0.90).withAverageBoilingPointCelsius(420.0));
+
+    double[] massFractions = characterisation.getResolvedMassFractions();
+    assertEquals(1.0, massFractions[0] + massFractions[1] + massFractions[2], 1e-12);
+  }
+
+  @Test
+  public void testDensityKgPerCubicMetreIsNormalizedBeforeCorrelation() {
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+    characterisation.addCut(new AssayCut("DensityUnits").withMassFraction(1.0)
+        .withDensityKgPerCubicMetre(850.0).withAverageBoilingPointCelsius(300.0));
+    characterisation.apply();
+
+    double boilingPoint = 300.0 + 273.15;
+    double expectedMolarMass =
+        5.805e-5 * Math.pow(boilingPoint, 2.3776) / Math.pow(0.85, 0.9371);
+    assertEquals(expectedMolarMass, system.getComponent("DensityUnits_PC").getMolarMass(), 1e-10);
+  }
+
+  @Test
+  public void testNegativeApiGravityIsSupportedForDenseCuts() {
+    AssayCut denseCut = new AssayCut("Residue").withMassFraction(1.0).withApiGravity(-5.0)
+        .withAverageBoilingPointCelsius(520.0);
+    assertTrue(denseCut.resolveDensity() > 1.0);
+  }
+
+  @Test
+  public void testTBPCutBoundariesCreateVolumeBasisAssayAndPreserveRanges() {
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+
+    double[] cumulativeVolumePercent = {0.0, 20.0, 55.0, 80.0, 100.0};
+    double[] boilingPointCelsius = {90.0, 180.0, 270.0, 380.0, 520.0};
+    double[] specificGravity = {0.70, 0.76, 0.84, 0.93};
+    characterisation.addTBPCutBoundariesCelsius("TBP", cumulativeVolumePercent,
+        boilingPointCelsius, specificGravity);
+
+    assertEquals(4, characterisation.getCuts().size());
+    AssayCut firstCut = characterisation.getCuts().get(0);
+    assertTrue(firstCut.hasBoilingRange());
+    assertEquals(90.0 + 273.15, firstCut.getLowerBoilingPointKelvin(), 1e-12);
+    assertEquals(180.0 + 273.15, firstCut.getUpperBoilingPointKelvin(), 1e-12);
+    assertEquals(135.0 + 273.15, firstCut.resolveAverageBoilingPoint(), 1e-12);
+
+    double[] massFractions = characterisation.getResolvedMassFractions();
+    assertEquals(1.0,
+        massFractions[0] + massFractions[1] + massFractions[2] + massFractions[3],
+        1e-12);
+
+    characterisation.apply();
+    assertTrue(system.hasComponent("TBP1_PC", false));
+    assertTrue(system.hasComponent("TBP4_PC", false));
+    assertEquals(1.0,
+        reconstructedAssayMass(system, "TBP1_PC", "TBP2_PC", "TBP3_PC", "TBP4_PC"),
+        1e-10);
+  }
+
+  @Test
+  public void testInvalidTBPCurveIsRejectedBeforeCutsAreAdded() {
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+
+    assertThrows(IllegalArgumentException.class,
+        () -> characterisation.addTBPCutBoundariesCelsius("TBP",
+            new double[] {0.0, 60.0, 50.0, 100.0},
+            new double[] {90.0, 200.0, 300.0, 500.0}, new double[] {0.7, 0.8, 0.9}));
+    assertTrue(characterisation.getCuts().isEmpty());
+  }
+
+  @Test
+  public void testRepeatedApplyIsRejectedWithoutDoublingAssay() {
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+    characterisation.addCut(new AssayCut("Once").withMassFraction(1.0)
+        .withSpecificGravity(0.82).withAverageBoilingPointCelsius(300.0));
+
+    characterisation.apply();
+    double firstMass = reconstructedAssayMass(system, "Once_PC");
+    assertThrows(IllegalStateException.class, characterisation::apply);
+    assertEquals(firstMass, reconstructedAssayMass(system, "Once_PC"), 1e-12);
+  }
+
+  @Test
+  public void testDuplicateCutNamesAreRejectedBeforeMutation() {
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+    characterisation.addCut(new AssayCut("Duplicate").withMassFraction(0.5)
+        .withSpecificGravity(0.75).withAverageBoilingPointCelsius(180.0));
+    characterisation.addCut(new AssayCut("Duplicate").withMassFraction(0.5)
+        .withSpecificGravity(0.85).withAverageBoilingPointCelsius(320.0));
+
+    assertThrows(IllegalStateException.class, characterisation::apply);
+    assertFalse(system.hasComponent("Duplicate_PC", false));
+  }
+
+  @Test
+  public void testFractionAndPercentInputsAreUnambiguous() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new AssayCut("BadFraction").withMassFraction(40.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> new AssayCut("BadPercent").withWeightPercent(120.0));
+  }
+
+  private static double reconstructedAssayMass(SystemInterface system, String... componentNames) {
+    double mass = 0.0;
+    for (String componentName : componentNames) {
+      ComponentInterface component = system.getComponent(componentName);
+      mass += component.getNumberOfmoles() * component.getMolarMass();
+    }
+    return mass;
   }
 }

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationTest.java
@@ -29,8 +29,7 @@ public class OilAssayCharacterisationTest {
     characterisation.apply();
 
     double lightBoilingPoint = 200.0 + 273.15;
-    double expectedLightMolarMass =
-        5.805e-5 * Math.pow(lightBoilingPoint, 2.3776) / Math.pow(0.75, 0.9371);
+    double expectedLightMolarMass = 5.805e-5 * Math.pow(lightBoilingPoint, 2.3776) / Math.pow(0.75, 0.9371);
     ComponentInterface lightComponent = system.getComponent("Light_PC");
     assertNotNull(lightComponent);
     assertEquals(expectedLightMolarMass, lightComponent.getMolarMass(), 1e-8);
@@ -38,8 +37,7 @@ public class OilAssayCharacterisationTest {
 
     double heavyDensity = 141.5 / (25.0 + 131.5) * 0.999016;
     double heavyBoilingPoint = 350.0 + 273.15;
-    double expectedHeavyMolarMass =
-        5.805e-5 * Math.pow(heavyBoilingPoint, 2.3776) / Math.pow(heavyDensity, 0.9371);
+    double expectedHeavyMolarMass = 5.805e-5 * Math.pow(heavyBoilingPoint, 2.3776) / Math.pow(heavyDensity, 0.9371);
     ComponentInterface heavyComponent = system.getComponent("Heavy_PC");
     assertNotNull(heavyComponent);
     assertEquals(expectedHeavyMolarMass, heavyComponent.getMolarMass(), 1e-8);
@@ -52,10 +50,10 @@ public class OilAssayCharacterisationTest {
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
 
-    characterisation.addCut(new AssayCut("Light").withVolumePercent(40.0)
-        .withSpecificGravity(0.75).withAverageBoilingPointCelsius(200.0));
-    characterisation.addCut(new AssayCut("Heavy").withVolumePercent(60.0)
-        .withApiGravity(25.0).withAverageBoilingPointCelsius(350.0));
+    characterisation.addCut(
+        new AssayCut("Light").withVolumePercent(40.0).withSpecificGravity(0.75).withAverageBoilingPointCelsius(200.0));
+    characterisation.addCut(
+        new AssayCut("Heavy").withVolumePercent(60.0).withApiGravity(25.0).withAverageBoilingPointCelsius(350.0));
 
     double heavyDensity = 141.5 / (25.0 + 131.5) * 0.999016;
     double totalRelativeMass = 0.4 * 0.75 + 0.6 * heavyDensity;
@@ -84,8 +82,7 @@ public class OilAssayCharacterisationTest {
     characterisation.apply();
 
     double boilingPoint = 300.0 + 273.15;
-    double expectedMolarMass =
-        5.805e-5 * Math.pow(boilingPoint, 2.3776) / Math.pow(0.82, 0.9371);
+    double expectedMolarMass = 5.805e-5 * Math.pow(boilingPoint, 2.3776) / Math.pow(0.82, 0.9371);
     ComponentInterface component = system.getComponent("Assay_PC");
     assertNotNull(component);
     assertEquals(2.0 / expectedMolarMass, component.getNumberOfmoles(), 1e-8);
@@ -97,8 +94,8 @@ public class OilAssayCharacterisationTest {
     SystemInterface system = new SystemSrkEos(298.15, 10.0);
     OilAssayCharacterisation original = system.getOilAssayCharacterisation();
     original.clearCuts();
-    original.addCut(new AssayCut("CloneTest").withMassFraction(1.0)
-        .withSpecificGravity(0.85).withAverageBoilingPointCelsius(310.0));
+    original.addCut(new AssayCut("CloneTest").withMassFraction(1.0).withSpecificGravity(0.85)
+        .withAverageBoilingPointCelsius(310.0));
 
     SystemInterface cloned = system.clone();
     OilAssayCharacterisation cloneCharacterisation = cloned.getOilAssayCharacterisation();
@@ -115,8 +112,8 @@ public class OilAssayCharacterisationTest {
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
 
-    AssayCut cut = new AssayCut("ExplicitMW").withMassFraction(1.0)
-        .withSpecificGravity(0.8).withMolarMassKgPerMol(0.150);
+    AssayCut cut = new AssayCut("ExplicitMW").withMassFraction(1.0).withSpecificGravity(0.8)
+        .withMolarMassKgPerMol(0.150);
     characterisation.addCut(cut);
     characterisation.apply();
 
@@ -132,8 +129,8 @@ public class OilAssayCharacterisationTest {
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
 
-    characterisation.addCut(new AssayCut("ExplicitMW").withMassFraction(1.0)
-        .withSpecificGravity(0.8).withMolarMassGramPerMol(150.0));
+    characterisation.addCut(
+        new AssayCut("ExplicitMW").withMassFraction(1.0).withSpecificGravity(0.8).withMolarMassGramPerMol(150.0));
     characterisation.apply();
 
     assertEquals(0.150, system.getComponent("ExplicitMW_PC").getMolarMass(), 1e-12);
@@ -144,11 +141,9 @@ public class OilAssayCharacterisationTest {
     SystemInterface system = new SystemSrkEos(298.15, 10.0);
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
-    characterisation.addCut(
-        new AssayCut("NoBoilingPoint").withMassFraction(1.0).withSpecificGravity(0.8));
+    characterisation.addCut(new AssayCut("NoBoilingPoint").withMassFraction(1.0).withSpecificGravity(0.8));
 
-    IllegalStateException exception =
-        assertThrows(IllegalStateException.class, characterisation::apply);
+    IllegalStateException exception = assertThrows(IllegalStateException.class, characterisation::apply);
     assertTrue(exception.getMessage().contains("Average boiling point missing"));
   }
 
@@ -158,10 +153,10 @@ public class OilAssayCharacterisationTest {
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
 
-    AssayCut explicitCut = new AssayCut("Explicit").withMassFraction(0.5)
-        .withSpecificGravity(0.8).withMolarMassKgPerMol(0.120);
-    AssayCut calculatedCut = new AssayCut("Calculated").withMassFraction(0.5)
-        .withSpecificGravity(0.85).withAverageBoilingPointCelsius(250.0);
+    AssayCut explicitCut = new AssayCut("Explicit").withMassFraction(0.5).withSpecificGravity(0.8)
+        .withMolarMassKgPerMol(0.120);
+    AssayCut calculatedCut = new AssayCut("Calculated").withMassFraction(0.5).withSpecificGravity(0.85)
+        .withAverageBoilingPointCelsius(250.0);
 
     characterisation.addCut(explicitCut);
     characterisation.addCut(calculatedCut);
@@ -177,13 +172,12 @@ public class OilAssayCharacterisationTest {
     SystemInterface system = new SystemSrkEos(298.15, 10.0);
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
-    characterisation.addCut(new AssayCut("MassCut").withMassFraction(0.4)
-        .withSpecificGravity(0.75).withAverageBoilingPointCelsius(180.0));
-    characterisation.addCut(new AssayCut("VolumeCut").withVolumeFraction(0.6)
-        .withSpecificGravity(0.85).withAverageBoilingPointCelsius(320.0));
+    characterisation.addCut(
+        new AssayCut("MassCut").withMassFraction(0.4).withSpecificGravity(0.75).withAverageBoilingPointCelsius(180.0));
+    characterisation.addCut(new AssayCut("VolumeCut").withVolumeFraction(0.6).withSpecificGravity(0.85)
+        .withAverageBoilingPointCelsius(320.0));
 
-    IllegalStateException exception =
-        assertThrows(IllegalStateException.class, characterisation::apply);
+    IllegalStateException exception = assertThrows(IllegalStateException.class, characterisation::apply);
     assertTrue(exception.getMessage().contains("cannot mix"));
     assertFalse(system.hasComponent("MassCut_PC", false));
     assertFalse(system.hasComponent("VolumeCut_PC", false));
@@ -194,12 +188,10 @@ public class OilAssayCharacterisationTest {
     SystemInterface system = new SystemSrkEos(298.15, 10.0);
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
-    characterisation.addCut(new AssayCut("Ambiguous").withMassFraction(1.0)
-        .withVolumeFraction(1.0).withSpecificGravity(0.8)
-        .withAverageBoilingPointCelsius(250.0));
+    characterisation.addCut(new AssayCut("Ambiguous").withMassFraction(1.0).withVolumeFraction(1.0)
+        .withSpecificGravity(0.8).withAverageBoilingPointCelsius(250.0));
 
-    IllegalStateException exception =
-        assertThrows(IllegalStateException.class, characterisation::apply);
+    IllegalStateException exception = assertThrows(IllegalStateException.class, characterisation::apply);
     assertTrue(exception.getMessage().contains("exactly one"));
   }
 
@@ -208,13 +200,12 @@ public class OilAssayCharacterisationTest {
     SystemInterface system = new SystemSrkEos(298.15, 10.0);
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
-    characterisation.addCut(new AssayCut("Cut1").withMassFraction(0.4)
-        .withSpecificGravity(0.75).withAverageBoilingPointCelsius(180.0));
-    characterisation.addCut(new AssayCut("Cut2").withMassFraction(0.4)
-        .withSpecificGravity(0.85).withAverageBoilingPointCelsius(320.0));
+    characterisation.addCut(
+        new AssayCut("Cut1").withMassFraction(0.4).withSpecificGravity(0.75).withAverageBoilingPointCelsius(180.0));
+    characterisation.addCut(
+        new AssayCut("Cut2").withMassFraction(0.4).withSpecificGravity(0.85).withAverageBoilingPointCelsius(320.0));
 
-    IllegalStateException exception =
-        assertThrows(IllegalStateException.class, characterisation::apply);
+    IllegalStateException exception = assertThrows(IllegalStateException.class, characterisation::apply);
     assertTrue(exception.getMessage().contains("sum to 1.0"));
   }
 
@@ -223,12 +214,12 @@ public class OilAssayCharacterisationTest {
     SystemInterface system = new SystemSrkEos(298.15, 10.0);
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
-    characterisation.addCut(new AssayCut("Cut1").withMassFraction(0.3333)
-        .withSpecificGravity(0.75).withAverageBoilingPointCelsius(180.0));
-    characterisation.addCut(new AssayCut("Cut2").withMassFraction(0.3333)
-        .withSpecificGravity(0.82).withAverageBoilingPointCelsius(280.0));
-    characterisation.addCut(new AssayCut("Cut3").withMassFraction(0.3333)
-        .withSpecificGravity(0.90).withAverageBoilingPointCelsius(420.0));
+    characterisation.addCut(
+        new AssayCut("Cut1").withMassFraction(0.3333).withSpecificGravity(0.75).withAverageBoilingPointCelsius(180.0));
+    characterisation.addCut(
+        new AssayCut("Cut2").withMassFraction(0.3333).withSpecificGravity(0.82).withAverageBoilingPointCelsius(280.0));
+    characterisation.addCut(
+        new AssayCut("Cut3").withMassFraction(0.3333).withSpecificGravity(0.90).withAverageBoilingPointCelsius(420.0));
 
     double[] massFractions = characterisation.getResolvedMassFractions();
     assertEquals(1.0, massFractions[0] + massFractions[1] + massFractions[2], 1e-12);
@@ -239,13 +230,12 @@ public class OilAssayCharacterisationTest {
     SystemInterface system = new SystemSrkEos(298.15, 10.0);
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
-    characterisation.addCut(new AssayCut("DensityUnits").withMassFraction(1.0)
-        .withDensityKgPerCubicMetre(850.0).withAverageBoilingPointCelsius(300.0));
+    characterisation.addCut(new AssayCut("DensityUnits").withMassFraction(1.0).withDensityKgPerCubicMetre(850.0)
+        .withAverageBoilingPointCelsius(300.0));
     characterisation.apply();
 
     double boilingPoint = 300.0 + 273.15;
-    double expectedMolarMass =
-        5.805e-5 * Math.pow(boilingPoint, 2.3776) / Math.pow(0.85, 0.9371);
+    double expectedMolarMass = 5.805e-5 * Math.pow(boilingPoint, 2.3776) / Math.pow(0.85, 0.9371);
     assertEquals(expectedMolarMass, system.getComponent("DensityUnits_PC").getMolarMass(), 1e-10);
   }
 
@@ -262,11 +252,10 @@ public class OilAssayCharacterisationTest {
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
 
-    double[] cumulativeVolumePercent = {0.0, 20.0, 55.0, 80.0, 100.0};
-    double[] boilingPointCelsius = {90.0, 180.0, 270.0, 380.0, 520.0};
-    double[] specificGravity = {0.70, 0.76, 0.84, 0.93};
-    characterisation.addTBPCutBoundariesCelsius("TBP", cumulativeVolumePercent,
-        boilingPointCelsius, specificGravity);
+    double[] cumulativeVolumePercent = { 0.0, 20.0, 55.0, 80.0, 100.0 };
+    double[] boilingPointCelsius = { 90.0, 180.0, 270.0, 380.0, 520.0 };
+    double[] specificGravity = { 0.70, 0.76, 0.84, 0.93 };
+    characterisation.addTBPCutBoundariesCelsius("TBP", cumulativeVolumePercent, boilingPointCelsius, specificGravity);
 
     assertEquals(4, characterisation.getCuts().size());
     AssayCut firstCut = characterisation.getCuts().get(0);
@@ -276,16 +265,12 @@ public class OilAssayCharacterisationTest {
     assertEquals(135.0 + 273.15, firstCut.resolveAverageBoilingPoint(), 1e-12);
 
     double[] massFractions = characterisation.getResolvedMassFractions();
-    assertEquals(1.0,
-        massFractions[0] + massFractions[1] + massFractions[2] + massFractions[3],
-        1e-12);
+    assertEquals(1.0, massFractions[0] + massFractions[1] + massFractions[2] + massFractions[3], 1e-12);
 
     characterisation.apply();
     assertTrue(system.hasComponent("TBP1_PC", false));
     assertTrue(system.hasComponent("TBP4_PC", false));
-    assertEquals(1.0,
-        reconstructedAssayMass(system, "TBP1_PC", "TBP2_PC", "TBP3_PC", "TBP4_PC"),
-        1e-10);
+    assertEquals(1.0, reconstructedAssayMass(system, "TBP1_PC", "TBP2_PC", "TBP3_PC", "TBP4_PC"), 1e-10);
   }
 
   @Test
@@ -295,9 +280,8 @@ public class OilAssayCharacterisationTest {
     characterisation.clearCuts();
 
     assertThrows(IllegalArgumentException.class,
-        () -> characterisation.addTBPCutBoundariesCelsius("TBP",
-            new double[] {0.0, 60.0, 50.0, 100.0},
-            new double[] {90.0, 200.0, 300.0, 500.0}, new double[] {0.7, 0.8, 0.9}));
+        () -> characterisation.addTBPCutBoundariesCelsius("TBP", new double[] { 0.0, 60.0, 50.0, 100.0 },
+            new double[] { 90.0, 200.0, 300.0, 500.0 }, new double[] { 0.7, 0.8, 0.9 }));
     assertTrue(characterisation.getCuts().isEmpty());
   }
 
@@ -306,8 +290,8 @@ public class OilAssayCharacterisationTest {
     SystemInterface system = new SystemSrkEos(298.15, 10.0);
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
-    characterisation.addCut(new AssayCut("Once").withMassFraction(1.0)
-        .withSpecificGravity(0.82).withAverageBoilingPointCelsius(300.0));
+    characterisation.addCut(
+        new AssayCut("Once").withMassFraction(1.0).withSpecificGravity(0.82).withAverageBoilingPointCelsius(300.0));
 
     characterisation.apply();
     double firstMass = reconstructedAssayMass(system, "Once_PC");
@@ -320,10 +304,10 @@ public class OilAssayCharacterisationTest {
     SystemInterface system = new SystemSrkEos(298.15, 10.0);
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
     characterisation.clearCuts();
-    characterisation.addCut(new AssayCut("Duplicate").withMassFraction(0.5)
-        .withSpecificGravity(0.75).withAverageBoilingPointCelsius(180.0));
-    characterisation.addCut(new AssayCut("Duplicate").withMassFraction(0.5)
-        .withSpecificGravity(0.85).withAverageBoilingPointCelsius(320.0));
+    characterisation.addCut(new AssayCut("Duplicate").withMassFraction(0.5).withSpecificGravity(0.75)
+        .withAverageBoilingPointCelsius(180.0));
+    characterisation.addCut(new AssayCut("Duplicate").withMassFraction(0.5).withSpecificGravity(0.85)
+        .withAverageBoilingPointCelsius(320.0));
 
     assertThrows(IllegalStateException.class, characterisation::apply);
     assertFalse(system.hasComponent("Duplicate_PC", false));
@@ -331,10 +315,8 @@ public class OilAssayCharacterisationTest {
 
   @Test
   public void testFractionAndPercentInputsAreUnambiguous() {
-    assertThrows(IllegalArgumentException.class,
-        () -> new AssayCut("BadFraction").withMassFraction(40.0));
-    assertThrows(IllegalArgumentException.class,
-        () -> new AssayCut("BadPercent").withWeightPercent(120.0));
+    assertThrows(IllegalArgumentException.class, () -> new AssayCut("BadFraction").withMassFraction(40.0));
+    assertThrows(IllegalArgumentException.class, () -> new AssayCut("BadPercent").withWeightPercent(120.0));
   }
 
   private static double reconstructedAssayMass(SystemInterface system, String... componentNames) {


### PR DESCRIPTION
## Summary

Advances #3305 with the first refinery-characterization implementation increment.

This PR hardens the existing `OilAssayCharacterisation` API and adds a conservative pre-binned TBP cut workflow before attempting atmospheric/vacuum fractionation or conversion-unit models.

### What changes

- require one unambiguous assay composition basis per case: all mass or all liquid volume;
- convert volume-basis cuts to mass fractions using cut density and verify exact reconstructed assay-mass closure;
- reject materially incomplete assays instead of silently renormalizing them, while retaining a 0.1% rounding tolerance;
- add unit-explicit molar-mass helpers for kg/mol and g/mol;
- normalize explicit kg/m3 density input before petroleum correlations;
- support physically valid negative API gravity for dense cuts;
- add cumulative 0-100 vol% pre-binned TBP cut-boundary ingestion in degC/K;
- preserve lower/upper boiling ranges and use the interval midpoint as the representative boiling point for the existing NeqSim petroleum correlation;
- reject non-monotonic/incomplete TBP boundaries, duplicate cut names and repeated `apply()` calls before silent assay doubling;
- reject assay cut names containing the reserved `_PC` pseudo-component marker so preflight checks cannot diverge from `SystemThermo.addTBPfraction(...)` name canonicalization;
- retain every strictly positive normalized assay cut, including multiple trace cuts below `1e-10`, so omission tolerance cannot contradict the exact reconstructed-mass closure gate;
- add focused regression coverage for mass/volume basis, units, closure, TBP ranges, invalid inputs, cloning, mutation guards, and reserved-name aliasing;
- replace the stale characterization package page with source-aligned kg/mol examples and add a refinery assay guide/capability gap matrix.

## Scientific boundary

No critical-property, acentric-factor, density, boiling-point or interaction-parameter coefficients are added or retuned here. The implementation deliberately reuses the existing NeqSim TBP/pseudo-component property models and documents their current literature lineage.

`addTBPCutBoundariesCelsius/Kelvin` accepts an already-TBP, pre-binned full cut table. It **does not** convert ASTM D86/D1160 or other laboratory distillation methods to TBP. Such conversions remain a later #3305 increment requiring public provenance and independent validation.

The interval midpoint is an explicit representation assumption, not a claim of a new assay correlation.

## Validation scope

`OilAssayCharacterisationTest` plus `OilAssayCharacterisationReservedNameTest` cover:

- mass-basis conversion;
- volume-to-mass conversion;
- total-mass scaling and reconstructed mass closure;
- explicit kg/mol and g/mol molar-mass inputs;
- kg/m3 density normalization;
- negative API gravity;
- mixed-basis and dual-basis rejection;
- incomplete-assay rejection and rounding-scale normalization;
- cumulative TBP cut generation, stored boiling ranges and mass closure;
- invalid TBP monotonicity rejection;
- duplicate cut and repeated-application guards;
- cloned-system independence;
- direct cut-name and TBP-prefix rejection for the reserved `_PC` marker before assay mutation;
- multiple positive trace-cut retention, exact reconstructed mass closure, and invalid-trace preflight without partial system mutation.

## Exact branch state

- Base/master: `b358d3c6dfff2d25967c6be48d0feb4887d4b207`
- Current head: `5da9bebd9bfc738cef0a9869a741eca554432b37`
- Ahead/behind base: 15 / 0
- Changed files: 5

## Validation status

`VALIDATION PENDING CI`

An exact-head review found that two or more individually tolerated trace cuts could be skipped and collectively violate the same reconstructed-mass tolerance. Exact head `5da9bebd9bfc738cef0a9869a741eca554432b37` repairs that inconsistency without weakening conservation: every strictly positive cut is retained, exact-zero cuts remain omitted, all cuts are resolved before mutation, and focused regressions cover multiple trace cuts plus invalid-trace preflight.

Fresh PaperLab, CodeQL, Spotless, build/test/Javadocs, documentation search and pre-commit workflows have restarted on this exact head. No running or unrun check is claimed as passed.

A local checkout attempt was made earlier, but this runtime cannot resolve `github.com`, so local Maven/Spotless execution remains unavailable. GitHub CI is authoritative for compile, Java 8/21, Spotless, pre-commit, documentation and cross-platform regression validation.

If CI exposes formatting, compile or focused-regression defects attributable to this branch, repair this exact PR head rather than creating a competing #3305 PR.

## Public benchmark selected for the next campaign increment

The U.S. Department of Energy Strategic Petroleum Reserve publishes a public crude-oil assay collection for Bayou Choctaw, West Hackberry, Big Hill and Bryan Mound sweet/sour streams:

- https://www.spr.doe.gov/reports/Crude_Oil_Assays.html
- SPR Crude Oil Assay Manual, 5th ed. (2024): https://www.spr.doe.gov/reports/docs/CrudeOilAssayManual.pdf

The manual documents crude fractionation by ASTM D2892 followed by D5236 and states that the distillation fractions are measured on a mass-percent basis with volume-percent values calculated from fraction specific gravity. This is a strong independent/public-data basis for the next refinery validation increment. The individual assay workbook has **not yet been ingested or frozen as repository data**, so no numerical agreement claim is made in this PR.

## Related issue boundaries

- #1393 asks for generic TBP input from boiling point plus one known property. This PR provides refinery-assay helpers but does not close the generic API request.
- #3120 owns the generic `addTBPfraction2` boiling-point unit-safety problem. This PR's unit-explicit assay API does not replace that work.
- Generic TP-flash/root-selection changes remain outside this refinery-specific increment and should be coordinated with the owning flash roadmap.

## Next dependency-ready refinery step

After this foundation passes review/CI and merges, freeze one DOE SPR assay workbook/reference stream and qualify the generated pseudo-component slate plus an atmospheric fractionation workflow. Record source/license/access provenance, mass/energy closure, product cut yields and boiling ranges, thermodynamic/numerical robustness, repeatability and runtime before adding additional refinery correlations or conversion-unit models.

Refs #3305