### PR TITLE
[AI-Assisted] test(mcp): qualify automation diagnostic advisory contracts

### DIFF
--- a/neqsim-mcp-server/docs/evidence/AUTOMATION_READ_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/AUTOMATION_READ_CONTRACT.md
@@ -1,30 +1,36 @@
-# Phase 0 automation read-contract evidence
+# Phase 0 automation advisory-contract evidence
 
-This note records bounded Phase 0 software-contract evidence for the existing read-only automation introspection tools `listSimulationUnits`, `listUnitVariables`, and `getSimulationVariable`.
+This note records bounded Phase 0 software-contract evidence for the existing automation advisory tools `listSimulationUnits`, `listUnitVariables`, `getSimulationVariable`, `diagnoseAutomation`, and `getAutomationLearningReport`.
 
 ## Existing implementation boundary
 
-All three tools use the canonical NeqSim process model. `AutomationRunner` resolves the supplied process definition or model handle to a normal solved `ProcessSystem` and then delegates unit/variable discovery and reads to `ProcessAutomation`. No MCP-only process representation or calculation path is introduced.
+All five tools use the canonical NeqSim process model. `AutomationRunner` resolves the supplied process definition or model handle to a normal solved `ProcessSystem` and then delegates discovery, variable reads, diagnostics, and learning-report retrieval to `ProcessAutomation` and `AutomationDiagnostics`. No MCP-only process representation or calculation path is introduced.
 
 `listSimulationUnits` returns addressable unit names and equipment types. `listUnitVariables` returns the selected unit's variable registry, including addresses, variable type, default unit, source/category metadata, writeability, invalidation behavior, and applicability. `getSimulationVariable` reads one addressed value through the existing safe accessor and preserves the standard MCP envelope, provenance, validation, and quality-gate fields.
 
+`diagnoseAutomation` interprets a failed automation address against the solved model and returns structured advisory evidence such as the error category, candidate names, remediation text, and the current process-local learning report. `getAutomationLearningReport` returns the process-local diagnostic history summary, including operation count, success rate, error-category counts, learned corrections, recent failures, and recommendations. Neither tool writes to a live plant or external operational system.
+
 ## Focused contract evidence
 
-- `src/test/java/neqsim/mcp/runners/AutomationReadContractTest.java` checks canonical unit discovery, variable-addressability metadata, standard-envelope variable reads, and structured fail-closed `INPUT_ERROR` responses.
-- Existing `src/test/java/neqsim/mcp/runners/McpRunnerContractTest.java` already includes the same three tools in the high-use standard-response contract against `ExampleCatalog.processSimpleSeparation()`.
-- `neqsim-mcp-server/test_automation_read_protocol.py` obtains the canonical simple-separation example through real MCP and exercises all three read tools over packaged STDIO transport, including invalid-input rejection.
-- `.github/workflows/mcp_protocol_qualification.yml` builds the exact NeqSim core and packaged MCP server with Java 21 and runs the focused harness with read-only repository permissions.
+- `src/test/java/neqsim/mcp/runners/AutomationReadContractTest.java` checks canonical unit discovery, variable-addressability metadata, standard-envelope variable reads, structured `UNIT_NOT_FOUND` diagnostic evidence, the deterministic zero-history learning baseline of a fresh process, and structured fail-closed `INPUT_ERROR` responses for all five tools.
+- Existing `src/test/java/neqsim/mcp/runners/McpRunnerContractTest.java` already includes the automation surface in the high-use standard-response contract against `ExampleCatalog.processSimpleSeparation()`.
+- `neqsim-mcp-server/test_automation_read_protocol.py` obtains the canonical simple-separation example through real MCP and exercises all five advisory tools over packaged STDIO transport, including invalid-input rejection.
+- `.github/workflows/mcp_protocol_qualification.yml` builds the exact NeqSim core and packaged MCP server with Java 21 and runs this focused harness with read-only repository permissions.
+
+The diagnostic fixture deliberately uses an impossible unit name and verifies structured advice rather than asserting that any recommendation is an engineering diagnosis. The learning-report fixture uses a fresh process and freezes only the empty-history software contract; it does not claim persistent learning across processes, restarts, clients, or tenants.
 
 ## Evidence that is not established
 
-This evidence qualifies lookup, addressability, response-envelope, and packaged-transport behavior only. It does **not** validate thermodynamic or process numerical accuracy, the engineering correctness of any returned variable value, facility topology completeness, equipment performance, control behavior, persistent model state, multi-client isolation, or external authorization.
+This evidence qualifies discovery, lookup, addressability, diagnostic-response shape, process-local learning-report retrieval, standard-envelope behavior, and packaged transport only. It does **not** validate thermodynamic or process numerical accuracy, the engineering correctness of any returned variable value or diagnostic recommendation, causal diagnosis, facility topology completeness, equipment performance, control behavior, persistent model state, learning quality, multi-client or tenant isolation, or external authorization.
 
-A successful read is not an engineering approval or plant measurement. Returned values remain simulation outputs with the case-specific model, assumptions, units, convergence state, provenance, warnings, validation maturity, and limitations as the authoritative engineering context.
+A successful read or diagnostic is not an engineering approval, plant measurement, or control recommendation. Returned values and suggestions remain simulation/advisory outputs with the case-specific model, assumptions, units, convergence state, provenance, warnings, validation maturity, and limitations as the authoritative engineering context.
 
 ## Promotion boundary
 
-The Phase 0 inventory remains version `1.17` with `20 EXPLICIT_TRUST + 11 CONTRACT_TESTED + 40 CONFIRMED_GAP` in this qualification increment. These three tools remain `CONFIRMED_GAP` until machine-readable coverage and the authoritative primary packaged-protocol accounting are promoted atomically on one later exact validated head. This PR supplies the focused source and real-protocol prerequisite for that future classification step.
+The Phase 0 inventory remains version `1.17` with `20 EXPLICIT_TRUST + 11 CONTRACT_TESTED + 40 CONFIRMED_GAP` in this qualification increment. All five tools covered by this note remain `CONFIRMED_GAP` until machine-readable coverage and the authoritative primary packaged-protocol accounting can be changed together on one exact validated head.
+
+Merged #3302 supplied the focused prerequisite for the three discovery/read contracts. This increment extends the same source and real-protocol evidence boundary to `diagnoseAutomation` and `getAutomationLearningReport`. After merge and current-master re-audit, the coherent atomic promotion target is therefore the five-tool automation advisory set, moving Phase 0 accounting from 20/11/40 to 20/16/35 only if the machine-readable coverage records and primary protocol expectations move together and exact-head validation passes.
 
 ## Owner-roadmap boundary
 
-No thermodynamic, process, pipeline, dynamics, DEXPI/P&ID, production-optimization, schema, stable response-envelope, write, live-plant, or control-command behavior changes. Specialist implementation remains owned by the existing NeqSim and coordinated roadmap lanes.
+No thermodynamic, process, pipeline, dynamics, DEXPI/P&ID, production-optimization, schema, stable response-envelope, write, live-plant, or control-command behavior changes. This qualification does not alter #2899 diagram semantics, #2911 dynamics, #2937 flash/stability behavior, or #2941 production-optimization implementation. Specialist implementation remains owned by the existing NeqSim and coordinated roadmap lanes.

--- a/neqsim-mcp-server/test_automation_read_protocol.py
+++ b/neqsim-mcp-server/test_automation_read_protocol.py
@@ -1,10 +1,11 @@
-"""Focused real-MCP qualification for read-only automation introspection contracts.
+"""Focused real-MCP qualification for read-only automation advisory contracts.
 
 This dependency-free harness starts the packaged NeqSim MCP server over STDIO and
-checks listSimulationUnits, listUnitVariables, and getSimulationVariable against
-the canonical simple-separation example. It qualifies software-contract and
-transport behavior only; it does not validate the numerical accuracy of the
-solved process or returned variable values.
+checks listSimulationUnits, listUnitVariables, getSimulationVariable,
+diagnoseAutomation, and getAutomationLearningReport against the canonical
+simple-separation example. It qualifies software-contract and transport behavior
+only; it does not validate numerical process accuracy or the engineering
+correctness of a diagnostic recommendation.
 """
 import json
 import subprocess
@@ -172,6 +173,43 @@ def test_variable_read(client, process_json):
     require(isinstance(data.get("qualityGate"), dict), "variable read omitted quality gate", result)
 
 
+def test_diagnostic_advice(client, process_json):
+    failed_address = "Missing Unit.temperature"
+    result = client.call_tool(
+        "diagnoseAutomation",
+        {
+            "processJson": process_json,
+            "failedAddress": failed_address,
+            "operation": "get",
+        },
+    )
+    data = payload(result)
+    require(data.get("status") == "diagnostic", "diagnoseAutomation did not return diagnostic state", result)
+    require(data.get("tool") == "diagnoseAutomation", "diagnostic tool identity drifted", result)
+    require(data.get("failedAddress") == failed_address, "diagnostic lost failed address", result)
+    require(data.get("operation") == "get", "diagnostic lost operation", result)
+    diagnosis = data.get("diagnosis", {})
+    require(diagnosis.get("category") == "UNIT_NOT_FOUND", "diagnostic category drifted", result)
+    require(isinstance(diagnosis.get("suggestions"), list), "diagnostic suggestions missing", result)
+    require(bool(diagnosis.get("remediation")), "diagnostic remediation missing", result)
+    require("learningReport" in data, "diagnostic omitted learning report", result)
+    require(isinstance(data.get("provenance"), dict), "diagnostic omitted provenance", result)
+    require(isinstance(data.get("qualityGate"), dict), "diagnostic omitted quality gate", result)
+
+
+def test_learning_report_baseline(client, process_json):
+    result = client.call_tool("getAutomationLearningReport", {"processJson": process_json})
+    data = payload(result)
+    require(data.get("status") == "success", "getAutomationLearningReport failed", result)
+    require(data.get("tool") == "getAutomationLearningReport", "learning-report tool identity drifted", result)
+    require(data.get("totalOperations") == 0, "fresh-process learning history is not empty", result)
+    require(data.get("successRate") == 1.0, "fresh-process learning success rate drifted", result)
+    require(isinstance(data.get("errorCategories"), dict), "learning report omitted error categories", result)
+    require(isinstance(data.get("learnedCorrections"), dict), "learning report omitted learned corrections", result)
+    require(isinstance(data.get("recentFailures"), list), "learning report omitted recent failures", result)
+    require(isinstance(data.get("recommendations"), list), "learning report omitted recommendations", result)
+
+
 def test_invalid_requests_fail_closed(client, process_json):
     cases = [
         ("listSimulationUnits", {"processJson": ""}),
@@ -180,6 +218,11 @@ def test_invalid_requests_fail_closed(client, process_json):
             "getSimulationVariable",
             {"processJson": process_json, "address": "", "unit": "C"},
         ),
+        (
+            "diagnoseAutomation",
+            {"processJson": process_json, "failedAddress": "", "operation": "get"},
+        ),
+        ("getAutomationLearningReport", {"processJson": ""}),
     ]
     for tool_name, arguments in cases:
         result = client.call_tool(tool_name, arguments)
@@ -201,10 +244,12 @@ def main():
         test_unit_inventory(client, process_json)
         test_variable_inventory(client, process_json)
         test_variable_read(client, process_json)
+        test_diagnostic_advice(client, process_json)
+        test_learning_report_baseline(client, process_json)
         test_invalid_requests_fail_closed(client, process_json)
     finally:
         client.close()
-    print("automation read real-MCP qualification: 4/4 scenarios passed")
+    print("automation advisory real-MCP qualification: 6/6 scenarios passed")
     return 0
 
 

--- a/src/test/java/neqsim/mcp/runners/AutomationReadContractTest.java
+++ b/src/test/java/neqsim/mcp/runners/AutomationReadContractTest.java
@@ -10,11 +10,11 @@ import com.google.gson.JsonParser;
 import neqsim.mcp.catalog.ExampleCatalog;
 
 /**
- * Focused contract tests for the read-only automation introspection surface.
+ * Focused contract tests for the read-only automation introspection and diagnostic surface.
  *
  * <p>
  * These tests qualify software-contract behavior only. They do not validate the numerical accuracy of the solved
- * process or any returned variable value.
+ * process, any returned variable value, or the engineering correctness of a diagnostic recommendation.
  * </p>
  */
 class AutomationReadContractTest {
@@ -65,10 +65,45 @@ class AutomationReadContractTest {
   }
 
   @Test
+  void diagnoseAutomationReturnsStructuredAdvisoryEvidence() {
+    String failedAddress = "Missing Unit.temperature";
+    JsonObject response = JsonParser.parseString(AutomationRunner.diagnose(PROCESS_JSON, failedAddress, "get"))
+        .getAsJsonObject();
+    assertEquals("diagnostic", response.get("status").getAsString(), response.toString());
+    assertEquals("diagnoseAutomation", response.get("tool").getAsString(), response.toString());
+    assertTrue(response.has("provenance"), response.toString());
+    assertTrue(response.has("validation"), response.toString());
+    assertTrue(response.has("qualityGate"), response.toString());
+
+    JsonObject data = response.getAsJsonObject("data");
+    assertEquals(failedAddress, data.get("failedAddress").getAsString(), response.toString());
+    assertEquals("get", data.get("operation").getAsString(), response.toString());
+    JsonObject diagnosis = data.getAsJsonObject("diagnosis");
+    assertEquals("UNIT_NOT_FOUND", diagnosis.get("category").getAsString(), response.toString());
+    assertTrue(diagnosis.has("suggestions"), response.toString());
+    assertFalse(diagnosis.get("remediation").getAsString().trim().isEmpty(), response.toString());
+    assertTrue(data.has("learningReport"), response.toString());
+  }
+
+  @Test
+  void getAutomationLearningReportReturnsDeterministicFreshProcessBaseline() {
+    JsonObject response = parseSuccess(AutomationRunner.getLearningReport(PROCESS_JSON), "getAutomationLearningReport");
+    JsonObject data = response.getAsJsonObject("data");
+    assertEquals(0, data.get("totalOperations").getAsInt(), response.toString());
+    assertEquals(1.0, data.get("successRate").getAsDouble(), 1.0e-12, response.toString());
+    assertTrue(data.get("errorCategories").isJsonObject(), response.toString());
+    assertTrue(data.get("learnedCorrections").isJsonObject(), response.toString());
+    assertTrue(data.get("recentFailures").isJsonArray(), response.toString());
+    assertTrue(data.get("recommendations").isJsonArray(), response.toString());
+  }
+
+  @Test
   void invalidReadRequestsFailClosedBeforeSimulationUse() {
     assertInputError(AutomationRunner.listUnits(""), "listSimulationUnits");
     assertInputError(AutomationRunner.listVariables(PROCESS_JSON, ""), "listUnitVariables");
     assertInputError(AutomationRunner.getVariable(PROCESS_JSON, "", "C"), "getSimulationVariable");
+    assertInputError(AutomationRunner.diagnose(PROCESS_JSON, "", "get"), "diagnoseAutomation");
+    assertInputError(AutomationRunner.getLearningReport(""), "getAutomationLearningReport");
   }
 
   private static JsonObject parseSuccess(String json, String toolName) {


### PR DESCRIPTION
## Summary

Advances #3153 Phase 0 from exact current-master base `b358d3c6dfff2d25967c6be48d0feb4887d4b207` to exact head `31e55d1af6a2f0d7ef7686ec411cf6c04e89b015` by extending the existing automation advisory qualification to `diagnoseAutomation` and `getAutomationLearningReport`.

- extends `AutomationReadContractTest` with structured diagnostic/advisory evidence, deterministic fresh-process learning-report retrieval, and fail-closed invalid-input coverage;
- extends the existing packaged STDIO harness to exercise all five automation advisory tools: `listSimulationUnits`, `listUnitVariables`, `getSimulationVariable`, `diagnoseAutomation`, and `getAutomationLearningReport`;
- expands `docs/evidence/AUTOMATION_READ_CONTRACT.md` with the diagnostic, process-local learning, causality, persistence, authorization, and plant-authority boundaries.

No production runner, process simulator, schema, public tool signature, stable response envelope, thermodynamic/process/pipeline/dynamic/DEXPI/optimization behavior, live-plant write, or control behavior changes.

## Phase 0 / trust boundary

This PR deliberately does **not** change machine-readable trust classification. Inventory remains `1.17` with **20 `EXPLICIT_TRUST` + 11 `CONTRACT_TESTED` + 40 `CONFIRMED_GAP`**. All five tools covered by this evidence note remain `CONFIRMED_GAP` until the machine-readable coverage records and authoritative primary packaged-protocol accounting can move atomically on one exact validated head.

Merged #3302 supplied the focused source and real-MCP prerequisite for the three discovery/read tools. This PR adds the same bounded evidence for `diagnoseAutomation` and `getAutomationLearningReport`. After merge and current-master re-audit, the coherent future promotion target is therefore the five-tool automation advisory set, **20/11/40 → 20/16/35**, but only if both accounting paths can be updated safely and exact-head validation passes.

The previously planned three-tool 20/14/37 promotion is deferred rather than published inconsistently: the connected remote write surface replaces whole files, while the authoritative `neqsim-mcp-server/test_mcp_server.py` is large enough that reconstructing it from truncated remote reads would be an unsafe write. This PR does not evade that blocker or claim an intermediate promotion.

## Engineering and safety boundary

The tests use the canonical `getExample(process, simple-separation)` process definition and normal NeqSim `ProcessSystem` / `ProcessAutomation` / `AutomationDiagnostics` behavior. The diagnostic case deliberately uses an impossible unit address and asserts structured `UNIT_NOT_FOUND` advisory evidence, not causal diagnosis. The learning-report case freezes only the deterministic zero-history baseline of a fresh process; it does not claim persistent learning across processes, restarts, clients, or tenants.

Diagnostic suggestions are advisory simulation-support output. They are not plant measurements, engineering approval, control instructions, proof of equipment degradation, or accountable root-cause conclusions.

Owner-roadmap boundaries are unchanged: DEXPI/P&ID #2899, dynamics #2911, flash/stability #2937, and merged production optimization #2941 remain authoritative for their specialist implementation.

## Validation

`VALIDATION PENDING CI`

No local Maven/JDK/Spotless/Python/pre-commit/Javadocs pass is claimed. Exact remote source and hosted exact-head CI are the validation authority.

On exact head `31e55d1af6a2f0d7ef7686ec411cf6c04e89b015`:

- hosted **MCP protocol qualification passed**: exact Java 21 core install, exact packaged MCP server build, existing `inspectApi` and validation-profile qualifications, and the extended automation-advisory harness all completed successfully; the latter now exercises **6/6 scenarios** across the five advisory tools and invalid-input rejection;
- hosted **pre-commit/documentation search passed**;
- hosted Spotless format-patch workflow completed successfully and its exact artifact contains an empty `spotless.patch`, so there is no formatter delta to apply;
- CodeQL and the full build/test/Javadocs workflow remain in progress. No running or unrun gate is claimed as passed.

The PR is therefore not READY TO MERGE yet.

## Documentation impact

Updated the existing bounded automation evidence note. README, `MCP_CONTRACT.md`, `API_REFERENCE.md`, schemas/examples, and companion agent/skill contracts do not require synchronized changes because public invocation semantics are unchanged.

## Stop boundary / next dependency

Stop before automation writes (`setSimulationVariable`, state mutation), numerical/causal qualification, persistent learning, control actions, or specialist owner-roadmap implementation. After this PR merges and current master is re-audited, atomically promote the five evidence-qualified automation advisory contracts to 20/16/35 only when the machine-readable inventory and primary packaged-protocol accounting can be changed together safely. Component, energy, and facility-wide conservation gaps remain separate Phase 0 work.

AI-assisted contribution; no unrun check is claimed as passed.