### PR TITLE
[AI-Assisted] fix(mcp): align Java test evidence count

### DIFF
--- a/.github/workflows/mcp_protocol_qualification.yml
+++ b/.github/workflows/mcp_protocol_qualification.yml
@@ -29,9 +29,9 @@ on:
 
 jobs:
   phase0_contracts:
-    name: Qualify focused contracts over packaged MCP
+    name: Qualify MCP contracts over packaged MCP
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -66,3 +66,6 @@ jobs:
 
       - name: Run focused real-MCP automation-read qualification
         run: cd neqsim-mcp-server && python test_automation_read_protocol.py
+
+      - name: Run comprehensive real-MCP protocol regression
+        run: cd neqsim-mcp-server && python test_mcp_server.py

--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -16,7 +16,7 @@ manually maintained Java method list.
 | Tool implementations | 71 bindings / 60 classes | `getCapabilities.implementationInventory` | `McpImplementationInventory` |
 | Factory equipment | 205 types | `getCapabilities.implementationInventory` | `EquipmentFactory` |
 | Engineering report paths | 2 | `getCapabilities.implementationInventory` | `ReportRunner`, `TaskWorkflowBridge` |
-| MCP Java test classes | 67 | `getCapabilities.phase0EvidenceInventory` | `src/test/java/neqsim/mcp/**/*Test.java` |
+| MCP Java test classes | 68 | `getCapabilities.phase0EvidenceInventory` | `src/test/java/neqsim/mcp/**/*Test.java` |
 | MCP protocol scenarios | 94 | `getCapabilities.phase0EvidenceInventory` | `test_mcp_server.py` |
 | Focused API protocol scenarios | 3 | `getCapabilities.phase0EvidenceInventory` | `test_inspect_api_protocol.py` |
 | MCP guides | 8 | `getCapabilities.phase0EvidenceInventory` | Core guides, foundation traceability, fixtures, baseline harness, and campaign matrix |
@@ -87,7 +87,7 @@ does not claim that an external Word/HTML artifact has been generated or enginee
 ## Tests, guides, and known limitations
 
 `getCapabilities.phase0EvidenceInventory` freezes the remaining source-evidence dimensions of the
-Phase 0 inventory. The exact current source contains 67 JUnit test classes under
+Phase 0 inventory. The exact current source contains 68 JUnit test classes under
 `src/test/java/neqsim/mcp`, 94 named scenarios in the primary real-STDIO JSON-RPC harness
 `neqsim-mcp-server/test_mcp_server.py`, and three focused packaged-MCP API-inspection scenarios in
 `neqsim-mcp-server/test_inspect_api_protocol.py`. The primary protocol regression independently

--- a/neqsim-mcp-server/test_mcp_server.py
+++ b/neqsim-mcp-server/test_mcp_server.py
@@ -1499,8 +1499,8 @@ def test_capabilities():
     tests = evidence.get("tests", {})
     guides = evidence.get("guides", {})
     limitations = evidence.get("knownLimitations", {})
-    check("evidence inventory freezes 67 Java test classes",
-          tests.get("javaTestClassCount") == 67,
+    check("evidence inventory freezes 68 Java test classes",
+          tests.get("javaTestClassCount") == 68,
           str(tests))
     check("evidence inventory freezes 94 protocol scenarios",
           tests.get("protocolScenarioCount") == 94,

--- a/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
@@ -14,7 +14,7 @@ import com.google.gson.JsonParser;
  */
 public final class McpEvidenceInventory {
 
-  private static final int JAVA_TEST_CLASS_COUNT = 67;
+  private static final int JAVA_TEST_CLASS_COUNT = 68;
   private static final int PROTOCOL_SCENARIO_COUNT = 94;
   private static final int FOCUSED_API_PROTOCOL_SCENARIO_COUNT = 3;
 

--- a/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
@@ -163,7 +163,7 @@ class CapabilitiesRunnerTest {
     JsonObject inventory = root.getAsJsonObject("phase0EvidenceInventory");
 
     JsonObject tests = inventory.getAsJsonObject("tests");
-    assertEquals(67, tests.get("javaTestClassCount").getAsInt());
+    assertEquals(68, tests.get("javaTestClassCount").getAsInt());
     assertEquals(94, tests.get("protocolScenarioCount").getAsInt());
 
     JsonObject guides = inventory.getAsJsonObject("guides");


### PR DESCRIPTION
## Summary

Repairs the current `master` MCP protocol failure reported as:

```
FAIL: Java test source count matches the evidence inventory -- found 68
```

The Phase 0 evidence inventory still advertised 67 Java MCP test classes after merged PR #3302 added `AutomationReadContractTest.java`. This PR atomically synchronizes the runtime manifest, its Java regression, the packaged protocol expectation, and the surface documentation to the exact current count of 68.

It also closes the validation gap that allowed this drift to reach `master`: the existing Java-21 `MCP protocol qualification` workflow now runs the authoritative comprehensive `test_mcp_server.py` harness after the focused protocol contracts, so future MCP/evidence changes must pass the same full packaged-protocol accounting they publish.

No MCP tool, schema, response envelope, thermodynamic/process calculation, trust classification, or inventory version changes.

## Root cause

The source-tree recount in `test_mcp_server.py` behaved correctly: it discovered 68 `*Test.java` files under `src/test/java/neqsim/mcp`. The separately frozen `JAVA_TEST_CLASS_COUNT` and its mirrored assertions/documentation remained at 67, producing the sole 319/320 failure.

The hosted focused MCP workflow built the exact package and exercised `inspectApi`, validation profiles, and automation reads, but did not execute `test_mcp_server.py`; therefore that authoritative 320-check invariant was not an exact-head PR gate. This PR fixes both the stale count and that validation hole in one coherent Phase 0 baseline repair.

## Changes

- update `McpEvidenceInventory.JAVA_TEST_CLASS_COUNT` from 67 to 68;
- update `CapabilitiesRunnerTest` to freeze the corrected runtime value;
- update the primary packaged MCP protocol expectation to 68;
- update both affected statements in `docs/SURFACE_INVENTORY.md`;
- extend `.github/workflows/mcp_protocol_qualification.yml` to run `python test_mcp_server.py` against the exact packaged Java-21 server, while retaining the focused contract harnesses and a bounded 45-minute job timeout.

Exact base: `567ab66837ca07e2c87e0967af2cfda5b1136280`  
Exact head: `ede271a8dfb39cb75ccab95738e0f1f5ea5d7bcb`

## Validation

**READY TO MERGE ON EXACT HEAD `ede271a8dfb39cb75ccab95738e0f1f5ea5d7bcb`.**

All applicable hosted exact-head gates pass:

- MCP protocol qualification: **pass**;
  - Java 21 exact NeqSim core install: **pass**;
  - exact MCP uber-jar build: **pass**;
  - focused `inspectApi` real-MCP qualification: **3/3 pass**;
  - focused `manageValidationProfile` real-MCP qualification: **5/5 pass**;
  - focused automation-advisory real-MCP qualification: **6/6 pass**;
  - authoritative comprehensive `test_mcp_server.py`: **320/320 pass, 0 failed**, including `javaTestClassCount=68`, exact source recount agreement, 71-tool discovery, 142 schemas, 114 examples, process/flash/validation scenarios, and unchanged 20/11/40 trust-gap accounting;
- Run build, test and javadoc: **pass**;
- CodeQL Security Analysis: **pass**;
- Pre-commit checks/documentation search: **pass**;
- Spotless format patch: **pass**;
- PaperLab Replication Gate: **pass**;
- repository agent/skill cross-reference validation and Java 21 Javadocs are covered by the passing hosted workflows.

GitHub reports the exact head mergeable. Final diff remains exactly five files with 11 additions / 8 deletions. No review submissions, PR comments/Copilot findings, or unresolved review threads are present.

Passed on preceding count-fix head `b45c9cf276d7f27bf73615e97c95e8fffed8c36f` locally: focused `CapabilitiesRunnerTest` (6/6), source invariant recount, Python AST parse, Spotless apply/check, documentation search, pre-commit/pre-push, and core install. The available local MCP package runtime was Java 17 and could not satisfy the module's Java 21 release requirement, so no local complete packaged-protocol pass is claimed; hosted exact-head Java 21 evidence above is authoritative.

This is a readiness classification only; it grants no merge authority. Campaign policy requires the active implementation PR to remain draft, but GitHub currently reports this PR as non-draft. Repeated connected-plugin attempts to convert it back to draft fail with a GitHub GraphQL connector schema error (`Repository.fullDatabaseId` is unavailable). The branch/head/code are unchanged; the PR has not been merged or enabled for auto-merge. This governance-state limitation must not be confused with a branch-attributable validation failure.

## Documentation impact

`neqsim-mcp-server/docs/SURFACE_INVENTORY.md` now reports the exact 68-class inventory. The workflow change strengthens validation only; no user API, behavior, units, assumptions, compatibility guidance, or recommended usage changes. No companion agent/skill contract changes are required.

## Campaign boundary

This is a Phase 0 baseline repair overlapping #3153. Trust accounting remains `1.17` / 20 `EXPLICIT_TRUST` + 11 `CONTRACT_TESTED` + 40 `CONFIRMED_GAP`; it does not perform the deferred five-tool automation advisory promotion. After this baseline repair merges and current master is re-audited, the next coherent #3153 dependency is the atomic 20/11/40 → 20/16/35 promotion, with machine-readable coverage and primary packaged-protocol accounting changed together on one exact validated head.

AI-assisted contribution.