### PR TITLE
[AI-Assisted] docs: harden flow assurance overview contract

### DIFF
--- a/docs/pvtsimulation/flow_assurance_overview.md
+++ b/docs/pvtsimulation/flow_assurance_overview.md
@@ -30,14 +30,17 @@ salinity, and phase range of interest.
 
 ## Executable first screen
 
-The following complete Java 8 program runs three independent screens. It uses:
+The following complete Java 8 program runs three independent screens and reports results through
+the repository's Log4j2 logging contract. It uses:
 
 - a hydrate equilibrium calculation for a specified gas, water, MEG, and salt mixture;
 - the repository's De Boer implementation, using absolute pressure in bar and in-situ
-  oil density in kg/m3;
+  oil density in kg/m³;
 - mineral saturation indices from explicit produced-water chemistry in mg/L.
 
 ```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.pvtsimulation.flowassurance.DeBoerAsphalteneScreening;
 import neqsim.pvtsimulation.flowassurance.DeBoerAsphalteneScreening.DeBoerRisk;
 import neqsim.pvtsimulation.flowassurance.ScalePredictionCalculator;
@@ -46,6 +49,9 @@ import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 public class FlowAssuranceScreen {
+    private static final Logger logger =
+        LogManager.getLogger(FlowAssuranceScreen.class);
+
     public static void main(String[] args) throws Exception {
         SystemInterface hydrateFluid =
             new SystemElectrolyteCPAstatoil(273.15 + 10.0, 50.0);
@@ -89,15 +95,15 @@ public class FlowAssuranceScreen {
         scaleScreen.enableAutoPH();
         scaleScreen.calculate();
 
-        System.out.printf(
-            "Hydrate equilibrium temperature: %.2f °C%n",
+        logger.info(
+            "Hydrate equilibrium temperature: {} °C",
             hydrateTemperatureC);
-        System.out.printf(
-            "De Boer screen: %s; risk index %.3f%n",
+        logger.info(
+            "De Boer screen: {}; risk index {}",
             asphalteneRisk,
             asphalteneRiskIndex);
-        System.out.printf(
-            "Calcite SI: %.3f; barite SI: %.3f; any scale flag: %s%n",
+        logger.info(
+            "Calcite SI: {}; barite SI: {}; any scale flag: {}",
             scaleScreen.getCaCO3SaturationIndex(),
             scaleScreen.getBaSO4SaturationIndex(),
             scaleScreen.hasScalingRisk());
@@ -119,9 +125,11 @@ calculation is not evidence that no hydrate or scale risk exists.
 For a pipeline point at operating temperature $T_{op}$, define thermodynamic
 subcooling as:
 
-$$
-\Delta T_{sub} = T_{eq} - T_{op}
-$$
+$\Delta T_{\mathrm{sub}}=T_{\mathrm{eq}}-T_{\mathrm{op}}$
+
+Here, $T_{\mathrm{eq}}$ is the calculated hydrate-equilibrium temperature and
+$T_{\mathrm{op}}$ is the operating temperature, both expressed on the same K or °C scale.
+The temperature difference has the same numerical increment in K and °C.
 
 A positive value means the operating point is below the calculated hydrate
 equilibrium temperature. It identifies thermodynamic stability, not nucleation time,
@@ -150,9 +158,10 @@ type and the configured model.
 
 The screening calculator reports:
 
-$$
-SI = \log_{10}\left(\frac{IAP}{K_{sp}}\right)
-$$
+$SI=\log_{10}\left(\frac{IAP}{K_{sp}}\right)$
+
+Here, $IAP$ is the dimensionless ion-activity product and $K_{sp}$ is the
+dimensionless thermodynamic solubility product on the same standard-state basis.
 
 Positive SI indicates supersaturation in the calculator. It does not predict how
 quickly a mineral precipitates, how much adheres to equipment, or the required

--- a/docs/pvtsimulation/flow_assurance_overview.md
+++ b/docs/pvtsimulation/flow_assurance_overview.md
@@ -125,7 +125,7 @@ calculation is not evidence that no hydrate or scale risk exists.
 For a pipeline point at operating temperature $T_{op}$, define thermodynamic
 subcooling as:
 
-$\Delta T_{\mathrm{sub}}=T_{\mathrm{eq}}-T_{\mathrm{op}}$
+$$\Delta T_{\mathrm{sub}}=T_{\mathrm{eq}}-T_{\mathrm{op}}$$
 
 Here, $T_{\mathrm{eq}}$ is the calculated hydrate-equilibrium temperature and
 $T_{\mathrm{op}}$ is the operating temperature, both expressed on the same K or °C scale.
@@ -158,7 +158,7 @@ type and the configured model.
 
 The screening calculator reports:
 
-$SI=\log_{10}\left(\frac{IAP}{K_{sp}}\right)$
+$$SI=\log_{10}\left(\frac{IAP}{K_{sp}}\right)$$
 
 Here, $IAP$ is the dimensionless ion-activity product and $K_{sp}$ is the
 dimensionless thermodynamic solubility product on the same standard-state basis.

--- a/docs/test_flow_assurance_overview_documentation.py
+++ b/docs/test_flow_assurance_overview_documentation.py
@@ -1,0 +1,166 @@
+"""Contracts for the integrated flow-assurance overview."""
+
+from pathlib import Path
+import re
+import unittest
+from urllib.parse import unquote
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDE = ROOT / "docs/pvtsimulation/flow_assurance_overview.md"
+JAVA_TEST = (
+    ROOT
+    / "src/test/java/neqsim/pvtsimulation/flowassurance/"
+    / "FlowAssuranceDocumentationTest.java"
+)
+DE_BOER_SOURCE = (
+    ROOT
+    / "src/main/java/neqsim/pvtsimulation/flowassurance/"
+    / "DeBoerAsphalteneScreening.java"
+)
+SCALE_SOURCE = (
+    ROOT
+    / "src/main/java/neqsim/pvtsimulation/flowassurance/"
+    / "ScalePredictionCalculator.java"
+)
+
+
+def resolve_internal_target(source, destination):
+    target, _, fragment = unquote(destination).partition("#")
+    raw_target = source.parent / target
+    candidates = [raw_target]
+    if not Path(target).suffix:
+        candidates.extend(
+            (
+                Path("{}.md".format(raw_target)),
+                raw_target / "README.md",
+                raw_target / "index.md",
+            )
+        )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve(), fragment
+    raise AssertionError("Unresolved guide link: {}".format(destination))
+
+
+class FlowAssuranceOverviewDocumentationContractTest(unittest.TestCase):
+    """Protect rendering, executable API, units, and engineering boundaries."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+        cls.java_test = JAVA_TEST.read_text(encoding="utf-8")
+        cls.de_boer_source = DE_BOER_SOURCE.read_text(encoding="utf-8")
+        cls.scale_source = SCALE_SOURCE.read_text(encoding="utf-8")
+
+    def test_structure_math_and_internal_links_are_renderable(self):
+        self.assertTrue(self.guide.startswith("---\n"))
+        self.assertEqual(self.guide.count("# Flow Assurance Overview"), 1)
+        self.assertEqual(self.guide.count("```") % 2, 0)
+        without_fences = re.sub(
+            r"```.*?```",
+            "",
+            self.guide,
+            flags=re.DOTALL,
+        )
+        self.assertNotIn(r"\[", without_fences)
+        self.assertNotIn(r"\]", without_fences)
+
+        math_parts = without_fences.split("$$")
+        self.assertEqual(1, len(math_parts) % 2)
+        for equation in math_parts[1::2]:
+            self.assertEqual(equation, equation.strip())
+            self.assertNotIn("\n", equation)
+
+        links = re.findall(r"(?<!!)\[[^\]]+\]\(([^)]+)\)", self.guide)
+        for destination in links:
+            if destination.startswith(("http://", "https://", "mailto:", "#")):
+                continue
+            target, _fragment = resolve_internal_target(GUIDE, destination)
+            self.assertTrue(target.is_file())
+
+    def test_java_example_uses_repository_logging_contract(self):
+        for token in (
+            "import org.apache.logging.log4j.LogManager;",
+            "import org.apache.logging.log4j.Logger;",
+            "private static final Logger logger =",
+            "LogManager.getLogger(FlowAssuranceScreen.class)",
+            'logger.info(',
+        ):
+            self.assertIn(token, self.guide)
+
+        self.assertNotIn("System.out", self.guide)
+        self.assertNotIn("System.err", self.guide)
+        self.assertNotIn('"%n"', self.guide)
+
+    def test_documented_calls_have_executable_regression_coverage(self):
+        for guide_token in (
+            "new SystemElectrolyteCPAstatoil(273.15 + 10.0, 50.0)",
+            "hydrateOps.hydrateFormationTemperature()",
+            "new DeBoerAsphalteneScreening(350.0, 150.0, 750.0)",
+            "new ScalePredictionCalculator()",
+            "scaleScreen.enableAutoPH()",
+            "scaleScreen.calculate()",
+        ):
+            self.assertIn(guide_token, self.guide)
+
+        for test_token in (
+            "testDeBoerQuickStart",
+            "testIntegratedOverviewHydrateAndScaleScreen",
+            "hydrateOps.hydrateFormationTemperature()",
+            "Double.isFinite(hydrateTemperatureC)",
+            "scaleScreen.calculate()",
+            "getCaCO3SaturationIndex()",
+            "getBaSO4SaturationIndex()",
+            "scaleScreen.toJson()",
+        ):
+            self.assertIn(test_token, self.java_test)
+
+        for source_token in (
+            "evaluateRisk()",
+            "calculateRiskIndex()",
+        ):
+            self.assertIn(source_token, self.de_boer_source)
+
+        for source_token in (
+            "setPressureBara(double pressBar)",
+            "enableAutoPH()",
+            "getCaCO3SaturationIndex()",
+            "getBaSO4SaturationIndex()",
+            "hasScalingRisk()",
+        ):
+            self.assertIn(source_token, self.scale_source)
+
+    def test_equations_define_symbols_units_and_standard_state(self):
+        normalized = " ".join(self.guide.split())
+        for token in (
+            r"$$\Delta T_{\mathrm{sub}}=T_{\mathrm{eq}}-T_{\mathrm{op}}$$",
+            r"$$SI=\log_{10}\left(\frac{IAP}{K_{sp}}\right)$$",
+            "both expressed on the same K or °C scale",
+            "same numerical increment in K and °C",
+            "dimensionless ion-activity product",
+            "dimensionless thermodynamic solubility product",
+            "same standard-state basis",
+            "oil density in kg/m³",
+            "produced-water chemistry in mg/L",
+        ):
+            self.assertIn(token, normalized)
+
+    def test_screening_and_failure_boundaries_are_explicit(self):
+        normalized = " ".join(self.guide.split())
+        for token in (
+            "no single result establishes that a line is safe",
+            "not an engineering approval",
+            "does not establish",
+            "Do not transfer them to another fluid or water analysis",
+            "lets calculation errors propagate",
+            "not evidence that no hydrate or scale risk exists",
+            "not nucleation time",
+            "not predict how quickly a mineral precipitates",
+            "required expert review",
+        ):
+            self.assertIn(token, normalized)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

**READY TO MERGE** on exact head `4d88f45cfce08eef70edeebec6fb58563517be83`.

Advances documentation-quality campaign #2499 as **D101** (rotation scope 5: PVT and flow assurance) with a frozen integrated flow-assurance overview batch.

The overview's canonical three-screen Java program now follows the repository logging contract, its equations render with the required compact delimiters, every symbol and unit is defined, and a new source-linked documentation contract prevents the page from drifting away from executable repository evidence.

### Confirmed defects repaired

1. The complete Java program used prohibited `System.out.printf` calls.
2. The example omitted the required Log4j2 imports.
3. The example omitted a class logger.
4. The output example used printf formatting instead of parameterized repository logging.
5. Both display equations contained delimiter-adjacent line breaks.
6. Hydrate-equilibrium and operating-temperature symbols were not explicitly defined.
7. The temperature-difference unit relationship between K and °C was unstated.
8. `IAP` and `K_sp` were not defined.
9. The ion-activity and solubility-product standard-state basis was unstated.
10. In-situ density used ambiguous plain-text `kg/m3` notation.
11. The integrated guide lacked a durable rendering and internal-link contract.
12. The guide's API calls and engineering boundaries were not tied to the existing executable Java regression.

## Frozen scope

Base: `567ab66837ca07e2c87e0967af2cfda5b1136280`  
Head: `4d88f45cfce08eef70edeebec6fb58563517be83`

- `docs/pvtsimulation/flow_assurance_overview.md`
- `docs/test_flow_assurance_overview_documentation.py`

The existing `FlowAssuranceDocumentationTest` already executes the documented hydrate, De Boer, and mineral-scale calls, so no Java change is required.

## Validation

- PASS — all five exact-head GitHub workflows.
- PASS — exact-head comparison contains exactly 2 files (189 additions / 14 deletions) and is zero commits behind `master`.
- PASS — documentation contracts, Jekyll build, search coverage, and all 15 internal links.
- PASS — pre-commit, Spotless, CodeQL, and agent-skill cross-references.
- PASS — connector-side semantic audit of front matter, H1, fences, balanced compact KaTeX, and rejection of bracket delimiters.
- PASS — Log4j2 imports, class logger, parameterized logging, and absence of `System.out`/`System.err`.
- PASS — source anchors for De Boer and scale APIs.
- PASS — existing executable Java coverage for hydrate, De Boer, scale, finite-result checks, risk indices, and JSON output.
- PASS — explicit K/°C, kg/m³, mg/L, dimensionless activity, and common-standard-state definitions.
- PASS — five documentation-contract groups cover rendering, links, logging, APIs, units, equations, and engineering boundaries.
- NOT APPLICABLE — Java/Javadocs matrices were correctly skipped because the exact diff contains no Java or XML changes.
- PASS — mergeable, draft, no comments, reviews, requested changes, or unresolved threads.

## Documentation impact

Updated the nearest user-facing overview because its canonical executable example violated repository policy and its equations and units were ambiguous. Added durable source-linked regression coverage. No public API or production behavior changes.

## Boundaries

- No production source or Java-test changes.
- No claim that equilibrium, saturation index, or empirical screening constitutes design approval.
- Model-specific erosion, emulsion, asphaltene fitting, corrosion, hydrate kinetics, deposition, and pipeline integrity guides remain separate validation concepts.
- No DEXPI/PFD, Pitzer, TP-flash, refinery, notebook-output, merge, review-state, or Huldra work.

Campaign: #2499
