### PR TITLE
[AI-Assisted] feat(pitzer): enforce complete dataset qualification

### DIFF
--- a/docs/thermo/fluid_creation_guide.md
+++ b/docs/thermo/fluid_creation_guide.md
@@ -417,11 +417,24 @@ the active binary, same-sign, ternary, and neutral topology is explicit; qualifi
 observables have independent evidence:
 
 ```java
-PhasePitzer aqueous = (PhasePitzer) fluid.getGeLiquidPhase();
-aqueous.requireCompletePitzerParameterCoverage();
-PitzerParameterQualification evidence =
-    PitzerParameterDatasets.getQualification(aqueous.getParameterDatasetId());
+PitzerParameterQualification evidence = fluid.getPitzerParameterQualification();
+
+// Strict publication gate: complete interaction coverage and complete qualification
+// of the named dataset. This rejects the broad, partially validated catalog.
+fluid.requireCompletePitzerDatasetQualification();
+
+// Dataset qualification does not prove that this exact state is inside its evidence envelope.
+boolean insideRange = PitzerParameterDatasets.isWithinSodiumPotassiumChlorideValidationRange(
+    fluid.getTemperature(),
+    0.5,  // Na+ molality, mol/kg water
+    0.5,  // K+ molality, mol/kg water
+    1.0); // Cl- molality, mol/kg water
 ```
+
+The accessor completes lazy parameter selection and interaction-coverage auditing but does not run a flash. The strict
+gate is opt-in and executes only when called, so neutral models and ordinary Pitzer property calculations do no new
+work. It accepts only a completely qualified named dataset; callers must still apply the use-case-specific range helper
+for the current temperature and molality.
 
 The complete PHREEQC catalog is intentionally reported as partially validated: CaCl2 and MgCl2 binaries have held-out
 activity evidence, while exact mixed Ca-Mg-Cl-SO4 activity and mineral precipitation remain separate gates. Process

--- a/docs/thermo/pitzer_parameter_provenance.md
+++ b/docs/thermo/pitzer_parameter_provenance.md
@@ -62,6 +62,26 @@ level-zero state initialization. Call `init(0)` after changing composition, as r
 general NeqSim state contract. This work is confined to `PhasePitzer` and `ComponentGePitzer`;
 neutral PR, SRK, CPA, Electrolyte-CPA, and Fürst electrolyte-EOS paths do no new work.
 
+## Complete-dataset qualification publication gate
+
+Interaction coverage and scientific qualification remain independent contracts. A complete topology
+may still use a dataset whose full species/range matrix lacks held-out evidence.
+`SystemPitzer.getPitzerParameterQualification()` completes lazy dataset selection and returns the
+immutable metadata for the exact selected dataset. The opt-in
+`requireCompletePitzerDatasetQualification()` first requires complete active-ion coverage and then
+rejects any named dataset below `VALIDATED_WITHIN_DECLARED_ENVELOPE`.
+
+This gate is intentionally stricter than subsystem validation. The broad PHREEQC catalog remains
+`PARTIALLY_EXPERIMENTALLY_VALIDATED`, even when the current topology is one of its independently
+checked binaries; callers that need a complete named-dataset gate must select a separately qualified
+subset such as Na-K-Cl. A successful dataset gate does not prove that the current temperature,
+pressure, molality, or composition lies inside its evidence envelope. The applicable
+`isWithin...ValidationRange` helper remains a separate mandatory state check. Diagnostics include
+dataset identity, level, validated systems, and limitations in deterministic order.
+
+The accessor and gate are explicit setup/publication operations. They perform no flash, change no
+parameter, and add no work to Pitzer activity/property kernels or neutral PR/SRK/CPA calculations.
+
 ## Pitzer reaction-data validation boundary
 
 Reaction-equilibrium constants and Pitzer ion-interaction coefficients remain separate datasets.

--- a/src/main/java/neqsim/thermo/phase/PitzerParameterQualification.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerParameterQualification.java
@@ -84,6 +84,33 @@ public final class PitzerParameterQualification implements Serializable {
     return level == Level.VALIDATED_WITHIN_DECLARED_ENVELOPE;
   }
 
+  /**
+   * Formats a deterministic diagnostic for publication and engineering gates.
+   *
+   * @return dataset identity, qualification level, validated systems, and limitations
+   */
+  public String formatDiagnostic() {
+    return "Pitzer parameter dataset '" + datasetId + "' qualification: level=" + level + ", validatedSystems="
+        + validatedSystems + ", limitations=" + limitations;
+  }
+
+  /**
+   * Requires complete scientific qualification of the named dataset.
+   *
+   * <p>
+   * This dataset-level gate is intentionally stricter than interaction coverage. It does not test whether the current
+   * temperature, pressure, or composition is inside a subsystem-specific validation range; callers must also apply the
+   * appropriate range helper for their exact use case.
+   * </p>
+   *
+   * @throws IllegalStateException when the complete named dataset is not validated within its declared envelope
+   */
+  public void requireCompleteDatasetQualification() {
+    if (!isValidatedWithinDeclaredEnvelope()) {
+      throw new IllegalStateException(formatDiagnostic());
+    }
+  }
+
   private static List<String> immutableCopy(List<String> values) {
     if (values == null || values.isEmpty()) {
       return Collections.emptyList();

--- a/src/main/java/neqsim/thermo/system/SystemPitzer.java
+++ b/src/main/java/neqsim/thermo/system/SystemPitzer.java
@@ -88,8 +88,8 @@ public class SystemPitzer extends SystemEosGE {
    * Returns scientific qualification metadata for the selected Pitzer parameter dataset.
    *
    * <p>
-   * Calling this method completes lazy dataset selection and the active ionic-topology coverage audit. It does not run a
-   * flash or enter ordinary property kernels.
+   * Calling this method completes lazy dataset selection and the active ionic-topology coverage audit. It does not run
+   * a flash or enter ordinary property kernels.
    * </p>
    *
    * @return immutable qualification metadata for the selected dataset identity
@@ -104,8 +104,8 @@ public class SystemPitzer extends SystemEosGE {
    * Requires complete interaction coverage and complete scientific qualification of the named Pitzer dataset.
    *
    * <p>
-   * This is an explicit publication gate. A broad dataset with only partially validated subsystems is rejected even when
-   * it covers the active topology. A successful result still requires the caller to check the appropriate
+   * This is an explicit publication gate. A broad dataset with only partially validated subsystems is rejected even
+   * when it covers the active topology. A successful result still requires the caller to check the appropriate
    * subsystem-specific temperature and molality range helper.
    * </p>
    *
@@ -115,8 +115,8 @@ public class SystemPitzer extends SystemEosGE {
   public PitzerParameterQualification requireCompletePitzerDatasetQualification() {
     PhasePitzer aqueousPhase = (PhasePitzer) phaseArray[1];
     aqueousPhase.requireCompletePitzerParameterCoverage();
-    PitzerParameterQualification qualification =
-        PitzerParameterDatasets.getQualification(aqueousPhase.getParameterDatasetId());
+    PitzerParameterQualification qualification = PitzerParameterDatasets
+        .getQualification(aqueousPhase.getParameterDatasetId());
     qualification.requireCompleteDatasetQualification();
     return qualification;
   }

--- a/src/main/java/neqsim/thermo/system/SystemPitzer.java
+++ b/src/main/java/neqsim/thermo/system/SystemPitzer.java
@@ -4,6 +4,7 @@ import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionConcentrationBa
 import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionDataSource;
 import neqsim.thermo.phase.PhasePitzer;
 import neqsim.thermo.phase.PitzerParameterDatasets;
+import neqsim.thermo.phase.PitzerParameterQualification;
 import neqsim.thermo.phase.PhaseSrkEos;
 
 /**
@@ -81,6 +82,43 @@ public class SystemPitzer extends SystemEosGE {
    */
   public boolean isUsingPhreeqcPitzerParametersByDefault() {
     return ((PhasePitzer) phaseArray[1]).isUsePhreeqcCatalogByDefault();
+  }
+
+  /**
+   * Returns scientific qualification metadata for the selected Pitzer parameter dataset.
+   *
+   * <p>
+   * Calling this method completes lazy dataset selection and the active ionic-topology coverage audit. It does not run a
+   * flash or enter ordinary property kernels.
+   * </p>
+   *
+   * @return immutable qualification metadata for the selected dataset identity
+   */
+  public PitzerParameterQualification getPitzerParameterQualification() {
+    PhasePitzer aqueousPhase = (PhasePitzer) phaseArray[1];
+    aqueousPhase.getPitzerParameterCoverage();
+    return PitzerParameterDatasets.getQualification(aqueousPhase.getParameterDatasetId());
+  }
+
+  /**
+   * Requires complete interaction coverage and complete scientific qualification of the named Pitzer dataset.
+   *
+   * <p>
+   * This is an explicit publication gate. A broad dataset with only partially validated subsystems is rejected even when
+   * it covers the active topology. A successful result still requires the caller to check the appropriate
+   * subsystem-specific temperature and molality range helper.
+   * </p>
+   *
+   * @return immutable qualification metadata for the accepted dataset
+   * @throws IllegalStateException when interaction coverage is incomplete or the complete dataset is not validated
+   */
+  public PitzerParameterQualification requireCompletePitzerDatasetQualification() {
+    PhasePitzer aqueousPhase = (PhasePitzer) phaseArray[1];
+    aqueousPhase.requireCompletePitzerParameterCoverage();
+    PitzerParameterQualification qualification =
+        PitzerParameterDatasets.getQualification(aqueousPhase.getParameterDatasetId());
+    qualification.requireCompleteDatasetQualification();
+    return qualification;
   }
 
   /** {@inheritDoc} */

--- a/src/test/java/neqsim/thermo/system/SystemPitzerParameterQualificationTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerParameterQualificationTest.java
@@ -28,8 +28,7 @@ class SystemPitzerParameterQualificationTest {
     PitzerParameterQualification qualification = system.requireCompletePitzerDatasetQualification();
 
     assertEquals(PitzerParameterDatasets.PHREEQC_NA_K_CL_ID, qualification.getDatasetId());
-    assertEquals(PitzerParameterQualification.Level.VALIDATED_WITHIN_DECLARED_ENVELOPE,
-        qualification.getLevel());
+    assertEquals(PitzerParameterQualification.Level.VALIDATED_WITHIN_DECLARED_ENVELOPE, qualification.getLevel());
     assertTrue(qualification.isValidatedWithinDeclaredEnvelope());
   }
 
@@ -40,10 +39,9 @@ class SystemPitzerParameterQualificationTest {
     PitzerParameterQualification qualification = system.getPitzerParameterQualification();
 
     assertEquals(PitzerParameterDatasets.PHREEQC_PITZER_CATALOG_ID, qualification.getDatasetId());
-    assertEquals(PitzerParameterQualification.Level.PARTIALLY_EXPERIMENTALLY_VALIDATED,
-        qualification.getLevel());
-    IllegalStateException failure =
-        assertThrows(IllegalStateException.class, system::requireCompletePitzerDatasetQualification);
+    assertEquals(PitzerParameterQualification.Level.PARTIALLY_EXPERIMENTALLY_VALIDATED, qualification.getLevel());
+    IllegalStateException failure = assertThrows(IllegalStateException.class,
+        system::requireCompletePitzerDatasetQualification);
     assertTrue(failure.getMessage().contains(PitzerParameterDatasets.PHREEQC_PITZER_CATALOG_ID));
     assertTrue(failure.getMessage().contains("PARTIALLY_EXPERIMENTALLY_VALIDATED"));
     assertTrue(failure.getMessage().contains("Quaternary Ca-Mg-Cl-SO4"));
@@ -56,8 +54,8 @@ class SystemPitzerParameterQualificationTest {
     PitzerParameterQualification qualification = system.getPitzerParameterQualification();
 
     assertEquals(PitzerParameterQualification.Level.UNQUALIFIED, qualification.getLevel());
-    IllegalStateException failure =
-        assertThrows(IllegalStateException.class, system::requireCompletePitzerDatasetQualification);
+    IllegalStateException failure = assertThrows(IllegalStateException.class,
+        system::requireCompletePitzerDatasetQualification);
     assertEquals(qualification.formatDiagnostic(), failure.getMessage());
     assertTrue(failure.getMessage().contains("No reviewed qualification record"));
   }

--- a/src/test/java/neqsim/thermo/system/SystemPitzerParameterQualificationTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerParameterQualificationTest.java
@@ -1,0 +1,136 @@
+package neqsim.thermo.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PitzerParameterDatasets;
+import neqsim.thermo.phase.PitzerParameterQualification;
+
+/** Tests the explicit SystemPitzer scientific-qualification publication gate. */
+class SystemPitzerParameterQualificationTest {
+  @Test
+  void completeNamedSubsetPassesAfterCoverageAudit() {
+    SystemPitzer system = createSodiumPotassiumChlorideSystem(298.15);
+    system.applyPhreeqcSodiumPotassiumChlorideParameters();
+
+    PitzerParameterQualification qualification = system.requireCompletePitzerDatasetQualification();
+
+    assertEquals(PitzerParameterDatasets.PHREEQC_NA_K_CL_ID, qualification.getDatasetId());
+    assertEquals(PitzerParameterQualification.Level.VALIDATED_WITHIN_DECLARED_ENVELOPE,
+        qualification.getLevel());
+    assertTrue(qualification.isValidatedWithinDeclaredEnvelope());
+  }
+
+  @Test
+  void automaticBroadCatalogFailsCompleteQualificationEvenWhenCoverageIsComplete() {
+    SystemPitzer system = createSodiumChlorideSystem(298.15);
+
+    PitzerParameterQualification qualification = system.getPitzerParameterQualification();
+
+    assertEquals(PitzerParameterDatasets.PHREEQC_PITZER_CATALOG_ID, qualification.getDatasetId());
+    assertEquals(PitzerParameterQualification.Level.PARTIALLY_EXPERIMENTALLY_VALIDATED,
+        qualification.getLevel());
+    IllegalStateException failure =
+        assertThrows(IllegalStateException.class, system::requireCompletePitzerDatasetQualification);
+    assertTrue(failure.getMessage().contains(PitzerParameterDatasets.PHREEQC_PITZER_CATALOG_ID));
+    assertTrue(failure.getMessage().contains("PARTIALLY_EXPERIMENTALLY_VALIDATED"));
+    assertTrue(failure.getMessage().contains("Quaternary Ca-Mg-Cl-SO4"));
+  }
+
+  @Test
+  void legacyDatasetFailsClosedWithDeterministicEvidence() {
+    SystemPitzer system = createSodiumChlorideSystem(298.15);
+    system = createLegacySodiumChlorideSystem();
+
+    PitzerParameterQualification qualification = system.getPitzerParameterQualification();
+
+    assertEquals(PitzerParameterQualification.Level.UNQUALIFIED, qualification.getLevel());
+    IllegalStateException failure =
+        assertThrows(IllegalStateException.class, system::requireCompletePitzerDatasetQualification);
+    assertEquals(qualification.formatDiagnostic(), failure.getMessage());
+    assertTrue(failure.getMessage().contains("No reviewed qualification record"));
+  }
+
+  @Test
+  void datasetGateDoesNotSilentlyClaimCurrentStateIsInsideTheEvidenceRange() {
+    SystemPitzer system = createSodiumPotassiumChlorideSystem(450.0);
+    system.applyPhreeqcSodiumPotassiumChlorideParameters();
+
+    assertTrue(system.requireCompletePitzerDatasetQualification().isValidatedWithinDeclaredEnvelope());
+    assertFalse(PitzerParameterDatasets.isWithinSodiumPotassiumChlorideValidationRange(450.0, 0.5, 0.5, 1.0));
+  }
+
+  @Test
+  void qualificationSurvivesCloneSerializationAndConcurrentReads() throws Exception {
+    SystemPitzer system = createSodiumPotassiumChlorideSystem(298.15);
+    system.applyPhreeqcSodiumPotassiumChlorideParameters();
+    String expected = system.requireCompletePitzerDatasetQualification().formatDiagnostic();
+
+    SystemPitzer cloned = system.clone();
+    assertEquals(expected, cloned.requireCompletePitzerDatasetQualification().formatDiagnostic());
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(system);
+    }
+    SystemPitzer restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored = (SystemPitzer) input.readObject();
+    }
+    assertEquals(expected, restored.requireCompletePitzerDatasetQualification().formatDiagnostic());
+
+    ExecutorService executor = Executors.newFixedThreadPool(4);
+    try {
+      List<Callable<String>> tasks = new ArrayList<Callable<String>>();
+      for (int task = 0; task < 16; task++) {
+        tasks.add(() -> system.getPitzerParameterQualification().formatDiagnostic());
+      }
+      for (Future<String> result : executor.invokeAll(tasks)) {
+        assertEquals(expected, result.get());
+      }
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private static SystemPitzer createSodiumChlorideSystem(double temperature) {
+    SystemPitzer system = new SystemPitzer(temperature, 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("Na+", 1.0);
+    system.addComponent("Cl-", 1.0);
+    system.init(0);
+    return system;
+  }
+
+  private static SystemPitzer createLegacySodiumChlorideSystem() {
+    SystemPitzer system = new SystemPitzer(298.15, 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("Na+", 1.0);
+    system.addComponent("Cl-", 1.0);
+    system.useLegacyPitzerParameters();
+    system.init(0);
+    return system;
+  }
+
+  private static SystemPitzer createSodiumPotassiumChlorideSystem(double temperature) {
+    SystemPitzer system = new SystemPitzer(temperature, 1.01325);
+    system.addComponent("water", 55.508);
+    system.addComponent("Na+", 0.5);
+    system.addComponent("K+", 0.5);
+    system.addComponent("Cl-", 1.0);
+    system.init(0);
+    return system;
+  }
+}

--- a/src/test/java/neqsim/thermo/system/SystemPitzerParameterQualificationTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerParameterQualificationTest.java
@@ -51,8 +51,7 @@ class SystemPitzerParameterQualificationTest {
 
   @Test
   void legacyDatasetFailsClosedWithDeterministicEvidence() {
-    SystemPitzer system = createSodiumChlorideSystem(298.15);
-    system = createLegacySodiumChlorideSystem();
+    SystemPitzer system = createLegacySodiumChlorideSystem();
 
     PitzerParameterQualification qualification = system.getPitzerParameterQualification();
 


### PR DESCRIPTION
## Engineering question

Can a Java or Python electrolyte workflow fail closed when the selected Pitzer parameter dataset has complete interaction coverage but lacks complete independent scientific qualification?

Current master exposes immutable qualification metadata and subsystem range helpers, but no system-level enforcement gate. Callers can therefore audit coverage and still omit the separate qualification decision.

Advances #3144.

## Frozen scope

- **Exact base/master:** `9e4e36d4b6a59404ac9aa629740fbc312610d3c8`
- **Exact head:** `6faee84508b21e7a35f3f0fcde5f5f668291db6f`
- **Model:** `SystemPitzer` electrolyte GE aqueous role; classic Pitzer convention
- **Reproducer:** water/Na+/K+/Cl- at 298.15 K and 1.01325 bara, with the explicit qualified Na-K-Cl subset versus the automatic broad PHREEQC catalog and legacy dataset
- **Composition basis:** component moles in the system; Pitzer solute molality after initialization
- **Acceptance:** complete named Na-K-Cl subset passes; broad partially validated catalog and legacy dataset fail with deterministic dataset/level/evidence/limitation diagnostics; current-state range remains a separate explicit gate
- **Stop boundary:** no coefficient, reaction row, mineral log K, dataset activation/default, flash, electrolyte-EOS mapping, absorber, salt-input API, or property-kernel change

## Implementation

- `PitzerParameterQualification.requireCompleteDatasetQualification()` adds deterministic fail-closed enforcement and `formatDiagnostic()`.
- `SystemPitzer.getPitzerParameterQualification()` completes lazy selection and returns exact selected-dataset evidence.
- `SystemPitzer.requireCompletePitzerDatasetQualification()` first requires complete active interaction coverage, then complete named-dataset qualification.
- Focused tests cover accepted/rejected datasets, deterministic diagnostics, explicit separation from temperature/molality range checks, clone, serialization, and 16 concurrent read-only assessments.
- The fluid-creation guide and durable Pitzer provenance/source-comparison guide document Java/JPype use, limitations, and performance isolation.

## Scientific/data boundary

No parameter is fitted, copied, changed, or adopted. The gate consumes the already reviewed metadata for:

- [Pitzer (1973), DOI 10.1021/j100621a026](https://doi.org/10.1021/j100621a026)
- [Pitzer and Mayorga (1973), DOI 10.1021/j100638a009](https://doi.org/10.1021/j100638a009)
- [PHRQPITZ, USGS WRIR 88-4153](https://doi.org/10.3133/wri884153)
- public-domain [USGS PHREEQC 3](https://www.usgs.gov/software/phreeqc-version-3), exact bundled commit `b0b3be767158ccc3322d2c816625cf470045e67e`

Kaasa (1998), Appendix F printed pp. 260-267 remains a provenance index only. The verified six-term order mapping remains `[a,b,c,d,e,f] -> [a,d,e,b,c,f]`; no thesis coefficient is copied because redistribution, row-level lineage/range, and independent agreement remain unresolved.

## Validation status

**DRAFT — READY TO MERGE ON EXACT HEAD `6faee84508b21e7a35f3f0fcde5f5f668291db6f`**

All applicable exact-head gates pass: Java 8 and Java 21 fast suites on Ubuntu and Windows, all four Java 21 slow-test shards, Java 21 Javadocs, CodeQL, PaperLab, Spotless, pre-commit/pre-push, documentation search/site build, and repository agent-reference checks. The initial pre-commit failure exposed only Spotless differences; two mechanical formatter commits repaired them, and the formatted head passed the complete matrix. No review submissions or unresolved threads exist, and GitHub reports the draft mergeable.

This is a readiness classification only. The PR remains draft; it has not been marked ready, merged, or enabled for auto-merge.

## Performance and compatibility

The new work is opt-in. Ordinary Pitzer activity/property calculations and all neutral PR/SRK/CPA and electrolyte-EOS calculations execute no new branch or lookup. Calling the gate performs one existing lazy dataset selection/coverage audit plus immutable metadata construction; no wall-time claim is made until measured.

## Documentation impact

User-visible Java/Python-callable publication-gate behavior is documented in:

- `docs/thermo/fluid_creation_guide.md`
- `docs/thermo/pitzer_parameter_provenance.md`

## Next dependency

After this gate is validated and merged, qualify one complete redistributable oil-brine family. Ba/Sr sulfate remains blocked by a missing coherent binary/mixed-interaction family and held-out solubility evidence; Pitzer MDEA/DEA remains blocked by complete redistributable reaction and interaction evidence.

AI-assisted contribution.