### PR TITLE
[AI-Assisted] Compare assessed engineering-diagram deliveries

### DIFF
--- a/docs/integration/engineering-diagram-delivery.md
+++ b/docs/integration/engineering-diagram-delivery.md
@@ -92,6 +92,35 @@ integrity within the published contract; it does not reconstruct or execute a `P
 `ProcessModel`, repeat DEXPI semantic assessment, approve a drawing, or establish standards or
 commercial-CAE conformance.
 
+## Compare two verified deliveries
+
+Use `EngineeringDiagramDeliveryComparison` after independent intake assessment to distinguish an
+unchanged transferred copy from a controlled revision:
+
+```java
+EngineeringDiagramDeliveryComparison.Report comparison =
+    EngineeringDiagramDeliveryComparison.compare(
+        Paths.get("build/baseline-delivery"),
+        Paths.get("build/revised-delivery"));
+if (!comparison.isComplete()) {
+  throw new IllegalStateException(comparison.toJson());
+}
+```
+
+Both inputs must pass `EngineeringDiagramDeliveryAssessment`, use the same plant identity, and
+share the same `ProcessSystem` or `ProcessModel` source scope. The deterministic report classifies
+every declared artifact as `ADDED`, `REMOVED`, `MODIFIED`, or `UNCHANGED`; identifies changed
+controlled JSON, native SVG, PDF, DEXPI Process XML, or multi-area DEXPI package projections; and
+returns the corresponding review scopes. Environment-specific directory paths are excluded from
+the comparison fingerprint.
+
+Changed content with an unchanged controlled revision fails closed as
+`REVISION_REUSE` with `DELIVERY_REVISION_REUSED_WITH_CHANGED_CONTENT`. A normal revision change
+remains `REVIEW_REQUIRED`. This comparison is artifact and manifest evidence only: it does not
+repeat DEXPI semantic or external-validator assessment, reconstruct a process model, decide
+management of change, approve a drawing, or establish fitness for construction or standards
+conformance.
+
 ## Engineering and qualification boundary
 
 The generated document status, issue purpose, source revision, calculated values, and diagnostics

--- a/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryComparison.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryComparison.java
@@ -21,17 +21,15 @@ import java.util.TreeSet;
  * Compares two independently assessed engineering-diagram deliveries.
  *
  * <p>
- * The comparison consumes only complete {@link EngineeringDiagramDeliveryAssessment.Report}
- * instances. It classifies every declared artifact as added, removed, modified, or unchanged and
- * maps changes onto deterministic engineering-review scopes. Directory paths are deliberately
- * excluded from the comparison fingerprint so equivalent transferred copies produce identical
- * evidence.
+ * The comparison consumes only complete {@link EngineeringDiagramDeliveryAssessment.Report} instances. It classifies
+ * every declared artifact as added, removed, modified, or unchanged and maps changes onto deterministic
+ * engineering-review scopes. Directory paths are deliberately excluded from the comparison fingerprint so equivalent
+ * transferred copies produce identical evidence.
  * </p>
  *
  * <p>
- * A comparison does not reconstruct or execute a process model, repeat DEXPI semantic assessment,
- * approve a drawing, decide management of change, establish fitness for construction, or claim
- * standards conformance.
+ * A comparison does not reconstruct or execute a process model, repeat DEXPI semantic assessment, approve a drawing,
+ * decide management of change, establish fitness for construction, or claim standards conformance.
  * </p>
  */
 public final class EngineeringDiagramDeliveryComparison {
@@ -42,35 +40,23 @@ public final class EngineeringDiagramDeliveryComparison {
 
   /** Overall comparison status. */
   public enum Status {
-    IDENTICAL,
-    CHANGED,
-    REVISION_REUSE
+    IDENTICAL, CHANGED, REVISION_REUSE
   }
 
   /** Artifact-level change type. */
   public enum ChangeType {
-    ADDED,
-    REMOVED,
-    MODIFIED,
-    UNCHANGED
+    ADDED, REMOVED, MODIFIED, UNCHANGED
   }
 
   /** Controlled review scope implicated by changed delivery evidence. */
   public enum ReviewScope {
-    CONTROLLED_DOCUMENT_SET,
-    DELIVERY_MANIFEST,
-    DEXPI_PROCESS_EXCHANGE,
-    DEXPI_PROCESS_MODEL_PACKAGE,
-    ENGINEERING_REVIEW,
-    NATIVE_PDF,
-    NATIVE_SVG
+    CONTROLLED_DOCUMENT_SET, DELIVERY_MANIFEST, DEXPI_PROCESS_EXCHANGE, DEXPI_PROCESS_MODEL_PACKAGE, ENGINEERING_REVIEW,
+    NATIVE_PDF, NATIVE_SVG
   }
 
   /** Diagnostic severity. */
   public enum Severity {
-    INFO,
-    WARNING,
-    ERROR
+    INFO, WARNING, ERROR
   }
 
   /** Immutable comparison diagnostic. */
@@ -193,15 +179,14 @@ public final class EngineeringDiagramDeliveryComparison {
           && (!changedArtifactPaths.isEmpty() || !baselineManifestSha256.equals(revisedManifestSha256));
       if (revisionReused) {
         status = Status.REVISION_REUSE;
-      } else if (changedArtifactPaths.isEmpty()
-          && baselineManifestSha256.equals(revisedManifestSha256)) {
+      } else if (changedArtifactPaths.isEmpty() && baselineManifestSha256.equals(revisedManifestSha256)) {
         status = Status.IDENTICAL;
       } else {
         status = Status.CHANGED;
       }
       complete = !hasErrors(diagnostics);
-      fingerprint = sha256(new GsonBuilder().create().toJson(toMapWithoutFingerprint())
-          .getBytes(StandardCharsets.UTF_8));
+      fingerprint = sha256(
+          new GsonBuilder().create().toJson(toMapWithoutFingerprint()).getBytes(StandardCharsets.UTF_8));
     }
 
     public String getPlantId() {
@@ -345,9 +330,8 @@ public final class EngineeringDiagramDeliveryComparison {
       builder.reviewScopes.add(ReviewScope.DELIVERY_MANIFEST);
       builder.reviewScopes.add(ReviewScope.ENGINEERING_REVIEW);
     }
-    if (baseline.getRevision().equals(revised.getRevision())
-        && (!builder.changedArtifactPaths.isEmpty()
-            || !baseline.getManifestSha256().equals(revised.getManifestSha256()))) {
+    if (baseline.getRevision().equals(revised.getRevision()) && (!builder.changedArtifactPaths.isEmpty()
+        || !baseline.getManifestSha256().equals(revised.getManifestSha256()))) {
       builder.diagnostics.add(new Diagnostic(Severity.ERROR, "DELIVERY_REVISION_REUSED_WITH_CHANGED_CONTENT",
           "Changed delivery content must not reuse the same controlled revision", baseline.getRevision()));
     } else if (builder.changedArtifactPaths.isEmpty()
@@ -379,10 +363,10 @@ public final class EngineeringDiagramDeliveryComparison {
   }
 
   private static void compareArtifacts(Builder builder) {
-    Map<String, EngineeringDiagramDeliveryAssessment.ArtifactEvidence> before =
-        new TreeMap<String, EngineeringDiagramDeliveryAssessment.ArtifactEvidence>(builder.baseline.getArtifacts());
-    Map<String, EngineeringDiagramDeliveryAssessment.ArtifactEvidence> after =
-        new TreeMap<String, EngineeringDiagramDeliveryAssessment.ArtifactEvidence>(builder.revised.getArtifacts());
+    Map<String, EngineeringDiagramDeliveryAssessment.ArtifactEvidence> before = new TreeMap<String, EngineeringDiagramDeliveryAssessment.ArtifactEvidence>(
+        builder.baseline.getArtifacts());
+    Map<String, EngineeringDiagramDeliveryAssessment.ArtifactEvidence> after = new TreeMap<String, EngineeringDiagramDeliveryAssessment.ArtifactEvidence>(
+        builder.revised.getArtifacts());
     Set<String> paths = new TreeSet<String>();
     paths.addAll(before.keySet());
     paths.addAll(after.keySet());
@@ -406,8 +390,7 @@ public final class EngineeringDiagramDeliveryComparison {
     if (revised == null) {
       return ChangeType.REMOVED;
     }
-    if (baseline.getSizeBytes() == revised.getSizeBytes()
-        && baseline.getMediaType().equals(revised.getMediaType())
+    if (baseline.getSizeBytes() == revised.getSizeBytes() && baseline.getMediaType().equals(revised.getMediaType())
         && baseline.getSha256().equals(revised.getSha256())) {
       return ChangeType.UNCHANGED;
     }
@@ -429,8 +412,7 @@ public final class EngineeringDiagramDeliveryComparison {
     }
   }
 
-  private static Map<String, Object> artifactMap(
-      EngineeringDiagramDeliveryAssessment.ArtifactEvidence artifact) {
+  private static Map<String, Object> artifactMap(EngineeringDiagramDeliveryAssessment.ArtifactEvidence artifact) {
     if (artifact == null) {
       return null;
     }

--- a/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryComparison.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryComparison.java
@@ -1,0 +1,516 @@
+package neqsim.process.processmodel.diagram;
+
+import com.google.gson.GsonBuilder;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * Compares two independently assessed engineering-diagram deliveries.
+ *
+ * <p>
+ * The comparison consumes only complete {@link EngineeringDiagramDeliveryAssessment.Report}
+ * instances. It classifies every declared artifact as added, removed, modified, or unchanged and
+ * maps changes onto deterministic engineering-review scopes. Directory paths are deliberately
+ * excluded from the comparison fingerprint so equivalent transferred copies produce identical
+ * evidence.
+ * </p>
+ *
+ * <p>
+ * A comparison does not reconstruct or execute a process model, repeat DEXPI semantic assessment,
+ * approve a drawing, decide management of change, establish fitness for construction, or claim
+ * standards conformance.
+ * </p>
+ */
+public final class EngineeringDiagramDeliveryComparison {
+  private static final String SCHEMA = "neqsim_engineering_diagram_delivery_comparison.v1";
+
+  private EngineeringDiagramDeliveryComparison() {
+  }
+
+  /** Overall comparison status. */
+  public enum Status {
+    IDENTICAL,
+    CHANGED,
+    REVISION_REUSE
+  }
+
+  /** Artifact-level change type. */
+  public enum ChangeType {
+    ADDED,
+    REMOVED,
+    MODIFIED,
+    UNCHANGED
+  }
+
+  /** Controlled review scope implicated by changed delivery evidence. */
+  public enum ReviewScope {
+    CONTROLLED_DOCUMENT_SET,
+    DELIVERY_MANIFEST,
+    DEXPI_PROCESS_EXCHANGE,
+    DEXPI_PROCESS_MODEL_PACKAGE,
+    ENGINEERING_REVIEW,
+    NATIVE_PDF,
+    NATIVE_SVG
+  }
+
+  /** Diagnostic severity. */
+  public enum Severity {
+    INFO,
+    WARNING,
+    ERROR
+  }
+
+  /** Immutable comparison diagnostic. */
+  public static final class Diagnostic implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final Severity severity;
+    private final String code;
+    private final String message;
+    private final String subject;
+
+    private Diagnostic(Severity severity, String code, String message, String subject) {
+      this.severity = severity;
+      this.code = code;
+      this.message = message;
+      this.subject = subject;
+    }
+
+    public Severity getSeverity() {
+      return severity;
+    }
+
+    public String getCode() {
+      return code;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public String getSubject() {
+      return subject;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("severity", severity.name());
+      result.put("code", code);
+      result.put("message", message);
+      result.put("subject", subject);
+      return result;
+    }
+  }
+
+  /** Immutable artifact comparison evidence. */
+  public static final class ArtifactChange implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String relativePath;
+    private final ChangeType changeType;
+    private final EngineeringDiagramDeliveryAssessment.ArtifactEvidence baseline;
+    private final EngineeringDiagramDeliveryAssessment.ArtifactEvidence revised;
+
+    private ArtifactChange(String relativePath, ChangeType changeType,
+        EngineeringDiagramDeliveryAssessment.ArtifactEvidence baseline,
+        EngineeringDiagramDeliveryAssessment.ArtifactEvidence revised) {
+      this.relativePath = relativePath;
+      this.changeType = changeType;
+      this.baseline = baseline;
+      this.revised = revised;
+    }
+
+    public String getRelativePath() {
+      return relativePath;
+    }
+
+    public ChangeType getChangeType() {
+      return changeType;
+    }
+
+    public EngineeringDiagramDeliveryAssessment.ArtifactEvidence getBaseline() {
+      return baseline;
+    }
+
+    public EngineeringDiagramDeliveryAssessment.ArtifactEvidence getRevised() {
+      return revised;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("relativePath", relativePath);
+      result.put("changeType", changeType.name());
+      result.put("baseline", artifactMap(baseline));
+      result.put("revised", artifactMap(revised));
+      return result;
+    }
+  }
+
+  /** Immutable serializable comparison report. */
+  public static final class Report implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String plantId;
+    private final String sourceScope;
+    private final String baselineRevision;
+    private final String revisedRevision;
+    private final String baselineManifestSha256;
+    private final String revisedManifestSha256;
+    private final String baselineManifestFingerprint;
+    private final String revisedManifestFingerprint;
+    private final Status status;
+    private final List<ArtifactChange> artifactChanges;
+    private final List<String> changedArtifactPaths;
+    private final List<ReviewScope> reviewScopes;
+    private final List<Diagnostic> diagnostics;
+    private final boolean complete;
+    private final String fingerprint;
+
+    private Report(Builder builder) {
+      plantId = builder.baseline.getPlantId();
+      sourceScope = builder.baseline.getSourceScope();
+      baselineRevision = builder.baseline.getRevision();
+      revisedRevision = builder.revised.getRevision();
+      baselineManifestSha256 = builder.baseline.getManifestSha256();
+      revisedManifestSha256 = builder.revised.getManifestSha256();
+      baselineManifestFingerprint = builder.baseline.getManifestFingerprint();
+      revisedManifestFingerprint = builder.revised.getManifestFingerprint();
+      artifactChanges = immutableChanges(builder.artifactChanges);
+      changedArtifactPaths = immutableStrings(builder.changedArtifactPaths);
+      reviewScopes = immutableScopes(builder.reviewScopes);
+      diagnostics = Collections.unmodifiableList(new ArrayList<Diagnostic>(builder.diagnostics));
+      boolean revisionReused = baselineRevision.equals(revisedRevision)
+          && (!changedArtifactPaths.isEmpty() || !baselineManifestSha256.equals(revisedManifestSha256));
+      if (revisionReused) {
+        status = Status.REVISION_REUSE;
+      } else if (changedArtifactPaths.isEmpty()
+          && baselineManifestSha256.equals(revisedManifestSha256)) {
+        status = Status.IDENTICAL;
+      } else {
+        status = Status.CHANGED;
+      }
+      complete = !hasErrors(diagnostics);
+      fingerprint = sha256(new GsonBuilder().create().toJson(toMapWithoutFingerprint())
+          .getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String getPlantId() {
+      return plantId;
+    }
+
+    public String getSourceScope() {
+      return sourceScope;
+    }
+
+    public String getBaselineRevision() {
+      return baselineRevision;
+    }
+
+    public String getRevisedRevision() {
+      return revisedRevision;
+    }
+
+    public String getBaselineManifestSha256() {
+      return baselineManifestSha256;
+    }
+
+    public String getRevisedManifestSha256() {
+      return revisedManifestSha256;
+    }
+
+    public String getBaselineManifestFingerprint() {
+      return baselineManifestFingerprint;
+    }
+
+    public String getRevisedManifestFingerprint() {
+      return revisedManifestFingerprint;
+    }
+
+    public Status getStatus() {
+      return status;
+    }
+
+    public List<ArtifactChange> getArtifactChanges() {
+      return Collections.unmodifiableList(new ArrayList<ArtifactChange>(artifactChanges));
+    }
+
+    public List<String> getChangedArtifactPaths() {
+      return Collections.unmodifiableList(new ArrayList<String>(changedArtifactPaths));
+    }
+
+    public List<ReviewScope> getReviewScopes() {
+      return Collections.unmodifiableList(new ArrayList<ReviewScope>(reviewScopes));
+    }
+
+    public List<Diagnostic> getDiagnostics() {
+      return Collections.unmodifiableList(new ArrayList<Diagnostic>(diagnostics));
+    }
+
+    public boolean isComplete() {
+      return complete;
+    }
+
+    public boolean isEngineeringReviewRequired() {
+      return status != Status.IDENTICAL;
+    }
+
+    public String getFingerprint() {
+      return fingerprint;
+    }
+
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = toMapWithoutFingerprint();
+      result.put("fingerprint", fingerprint);
+      return result;
+    }
+
+    public String toJson() {
+      return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+    }
+
+    private Map<String, Object> toMapWithoutFingerprint() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("schemaVersion", SCHEMA);
+      result.put("plantId", plantId);
+      result.put("sourceScope", sourceScope);
+      result.put("baselineRevision", baselineRevision);
+      result.put("revisedRevision", revisedRevision);
+      result.put("baselineManifestSha256", baselineManifestSha256);
+      result.put("revisedManifestSha256", revisedManifestSha256);
+      result.put("baselineManifestFingerprint", baselineManifestFingerprint);
+      result.put("revisedManifestFingerprint", revisedManifestFingerprint);
+      result.put("status", status.name());
+      List<Map<String, Object>> changes = new ArrayList<Map<String, Object>>();
+      for (ArtifactChange change : artifactChanges) {
+        changes.add(change.toMap());
+      }
+      result.put("artifactChanges", changes);
+      result.put("changedArtifactPaths", changedArtifactPaths);
+      List<String> scopes = new ArrayList<String>();
+      for (ReviewScope scope : reviewScopes) {
+        scopes.add(scope.name());
+      }
+      result.put("reviewScopes", scopes);
+      List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
+      for (Diagnostic diagnostic : diagnostics) {
+        diagnosticMaps.add(diagnostic.toMap());
+      }
+      result.put("diagnostics", diagnosticMaps);
+      result.put("approvalStatus", "REVIEW_REQUIRED");
+      result.put("engineeringReviewRequired", Boolean.valueOf(isEngineeringReviewRequired()));
+      result.put("fitnessForConstruction", Boolean.FALSE);
+      result.put("iso10628ConformanceClaimed", Boolean.FALSE);
+      result.put("completeWithinDeclaredScope", Boolean.valueOf(complete));
+      result.put("limitations", limitations());
+      return result;
+    }
+  }
+
+  /**
+   * Assesses and compares two delivery directories without modifying their contents.
+   *
+   * @param baselineDirectory baseline delivery root
+   * @param revisedDirectory revised delivery root
+   * @return deterministic comparison evidence
+   * @throws IOException when either delivery cannot be assessed within its intake limits
+   */
+  public static Report compare(Path baselineDirectory, Path revisedDirectory) throws IOException {
+    return compare(EngineeringDiagramDeliveryAssessment.assess(baselineDirectory),
+        EngineeringDiagramDeliveryAssessment.assess(revisedDirectory));
+  }
+
+  /**
+   * Compares two complete independent delivery assessments.
+   *
+   * @param baseline complete baseline assessment
+   * @param revised complete revised assessment
+   * @return deterministic comparison evidence
+   */
+  public static Report compare(EngineeringDiagramDeliveryAssessment.Report baseline,
+      EngineeringDiagramDeliveryAssessment.Report revised) {
+    requireCompatible(baseline, revised);
+    Builder builder = new Builder(baseline, revised);
+    compareArtifacts(builder);
+    if (!baseline.getManifestSha256().equals(revised.getManifestSha256())) {
+      builder.reviewScopes.add(ReviewScope.DELIVERY_MANIFEST);
+      builder.reviewScopes.add(ReviewScope.ENGINEERING_REVIEW);
+    }
+    if (baseline.getRevision().equals(revised.getRevision())
+        && (!builder.changedArtifactPaths.isEmpty()
+            || !baseline.getManifestSha256().equals(revised.getManifestSha256()))) {
+      builder.diagnostics.add(new Diagnostic(Severity.ERROR, "DELIVERY_REVISION_REUSED_WITH_CHANGED_CONTENT",
+          "Changed delivery content must not reuse the same controlled revision", baseline.getRevision()));
+    } else if (builder.changedArtifactPaths.isEmpty()
+        && baseline.getManifestSha256().equals(revised.getManifestSha256())) {
+      builder.diagnostics.add(new Diagnostic(Severity.INFO, "DELIVERY_COMPARISON_IDENTICAL",
+          "The independently assessed deliveries are byte-equivalent within the declared contract",
+          baseline.getPlantId()));
+    } else {
+      builder.diagnostics.add(new Diagnostic(Severity.WARNING, "DELIVERY_COMPARISON_REVIEW_REQUIRED",
+          "Changed delivery artifacts require review in every reported scope", revised.getRevision()));
+    }
+    return new Report(builder);
+  }
+
+  private static void requireCompatible(EngineeringDiagramDeliveryAssessment.Report baseline,
+      EngineeringDiagramDeliveryAssessment.Report revised) {
+    if (baseline == null || revised == null) {
+      throw new IllegalArgumentException("baseline and revised assessments must not be null");
+    }
+    if (!baseline.isComplete() || !revised.isComplete()) {
+      throw new IllegalArgumentException("only complete independently assessed deliveries may be compared");
+    }
+    if (!baseline.getPlantId().equals(revised.getPlantId())) {
+      throw new IllegalArgumentException("deliveries must use the same plant identity");
+    }
+    if (!baseline.getSourceScope().equals(revised.getSourceScope())) {
+      throw new IllegalArgumentException("deliveries must use the same ProcessSystem or ProcessModel source scope");
+    }
+  }
+
+  private static void compareArtifacts(Builder builder) {
+    Map<String, EngineeringDiagramDeliveryAssessment.ArtifactEvidence> before =
+        new TreeMap<String, EngineeringDiagramDeliveryAssessment.ArtifactEvidence>(builder.baseline.getArtifacts());
+    Map<String, EngineeringDiagramDeliveryAssessment.ArtifactEvidence> after =
+        new TreeMap<String, EngineeringDiagramDeliveryAssessment.ArtifactEvidence>(builder.revised.getArtifacts());
+    Set<String> paths = new TreeSet<String>();
+    paths.addAll(before.keySet());
+    paths.addAll(after.keySet());
+    for (String path : paths) {
+      EngineeringDiagramDeliveryAssessment.ArtifactEvidence first = before.get(path);
+      EngineeringDiagramDeliveryAssessment.ArtifactEvidence second = after.get(path);
+      ChangeType type = changeType(first, second);
+      builder.artifactChanges.add(new ArtifactChange(path, type, first, second));
+      if (type != ChangeType.UNCHANGED) {
+        builder.changedArtifactPaths.add(path);
+        addScope(path, builder.reviewScopes);
+      }
+    }
+  }
+
+  private static ChangeType changeType(EngineeringDiagramDeliveryAssessment.ArtifactEvidence baseline,
+      EngineeringDiagramDeliveryAssessment.ArtifactEvidence revised) {
+    if (baseline == null) {
+      return ChangeType.ADDED;
+    }
+    if (revised == null) {
+      return ChangeType.REMOVED;
+    }
+    if (baseline.getSizeBytes() == revised.getSizeBytes()
+        && baseline.getMediaType().equals(revised.getMediaType())
+        && baseline.getSha256().equals(revised.getSha256())) {
+      return ChangeType.UNCHANGED;
+    }
+    return ChangeType.MODIFIED;
+  }
+
+  private static void addScope(String path, Set<ReviewScope> scopes) {
+    scopes.add(ReviewScope.ENGINEERING_REVIEW);
+    if ("document-set.json".equals(path)) {
+      scopes.add(ReviewScope.CONTROLLED_DOCUMENT_SET);
+    } else if ("drawing-set.pdf".equals(path)) {
+      scopes.add(ReviewScope.NATIVE_PDF);
+    } else if ("dexpi-process.xml".equals(path)) {
+      scopes.add(ReviewScope.DEXPI_PROCESS_EXCHANGE);
+    } else if ("dexpi-process-model.zip".equals(path)) {
+      scopes.add(ReviewScope.DEXPI_PROCESS_MODEL_PACKAGE);
+    } else if (path.startsWith("svg/") && path.endsWith(".svg")) {
+      scopes.add(ReviewScope.NATIVE_SVG);
+    }
+  }
+
+  private static Map<String, Object> artifactMap(
+      EngineeringDiagramDeliveryAssessment.ArtifactEvidence artifact) {
+    if (artifact == null) {
+      return null;
+    }
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("relativePath", artifact.getRelativePath());
+    result.put("mediaType", artifact.getMediaType());
+    result.put("sizeBytes", Long.valueOf(artifact.getSizeBytes()));
+    result.put("sha256", artifact.getSha256());
+    return result;
+  }
+
+  private static List<String> limitations() {
+    List<String> result = new ArrayList<String>();
+    result.add("Does not reconstruct or execute a ProcessSystem or ProcessModel");
+    result.add("Does not repeat DEXPI semantic or external-validator assessment");
+    result.add("Does not decide management of change or accountable drawing approval");
+    result.add("Does not establish fitness for construction or standards conformance");
+    return Collections.unmodifiableList(result);
+  }
+
+  private static boolean hasErrors(List<Diagnostic> diagnostics) {
+    for (Diagnostic diagnostic : diagnostics) {
+      if (diagnostic.getSeverity() == Severity.ERROR) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static List<ArtifactChange> immutableChanges(List<ArtifactChange> changes) {
+    List<ArtifactChange> result = new ArrayList<ArtifactChange>(changes);
+    Collections.sort(result, new Comparator<ArtifactChange>() {
+      @Override
+      public int compare(ArtifactChange first, ArtifactChange second) {
+        return first.getRelativePath().compareTo(second.getRelativePath());
+      }
+    });
+    return Collections.unmodifiableList(result);
+  }
+
+  private static List<String> immutableStrings(Set<String> values) {
+    return Collections.unmodifiableList(new ArrayList<String>(new TreeSet<String>(values)));
+  }
+
+  private static List<ReviewScope> immutableScopes(Set<ReviewScope> values) {
+    List<ReviewScope> result = new ArrayList<ReviewScope>(values);
+    Collections.sort(result, new Comparator<ReviewScope>() {
+      @Override
+      public int compare(ReviewScope first, ReviewScope second) {
+        return first.name().compareTo(second.name());
+      }
+    });
+    return Collections.unmodifiableList(result);
+  }
+
+  private static String sha256(byte[] content) {
+    try {
+      byte[] hash = MessageDigest.getInstance("SHA-256").digest(content);
+      StringBuilder result = new StringBuilder();
+      for (byte value : hash) {
+        result.append(String.format("%02x", value & 0xff));
+      }
+      return result.toString();
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is not available", exception);
+    }
+  }
+
+  private static final class Builder {
+    private final EngineeringDiagramDeliveryAssessment.Report baseline;
+    private final EngineeringDiagramDeliveryAssessment.Report revised;
+    private final List<ArtifactChange> artifactChanges = new ArrayList<ArtifactChange>();
+    private final Set<String> changedArtifactPaths = new TreeSet<String>();
+    private final Set<ReviewScope> reviewScopes = new TreeSet<ReviewScope>();
+    private final List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
+
+    private Builder(EngineeringDiagramDeliveryAssessment.Report baseline,
+        EngineeringDiagramDeliveryAssessment.Report revised) {
+      this.baseline = baseline;
+      this.revised = revised;
+    }
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/diagram/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/package-info.java
@@ -28,8 +28,8 @@
  * SVG/PDF, hashes, and explicit review-required evidence for ProcessSystem or multi-area ProcessModel inputs</li>
  * <li><b>Independent delivery intake</b> - Bounded fail-closed verification of transferred manifest fingerprints,
  * artifact hashes, paths, media types, exact file sets, and review boundaries</li>
- * <li><b>Delivery comparison</b> - Deterministic artifact-level revision evidence and review scopes from two
- * complete independent intake assessments, with fail-closed changed-content revision reuse</li>
+ * <li><b>Delivery comparison</b> - Deterministic artifact-level revision evidence and review scopes from two complete
+ * independent intake assessments, with fail-closed changed-content revision reuse</li>
  * <li><b>Drawing-quality diagnostics</b> - Deterministic collision, clipping, route/object, connection-label,
  * label-overflow, and broken-reference evidence remains structured and fail-visible without silently moving reviewed
  * geometry</li>
@@ -80,8 +80,8 @@
  * renderer for controlled drawing sets</li>
  * <li>{@link neqsim.process.processmodel.diagram.EngineeringDiagramDeliveryAssessment} - Independent integrity
  * assessment for stored or transferred controlled deliveries</li>
- * <li>{@link neqsim.process.processmodel.diagram.EngineeringDiagramDeliveryComparison} - Deterministic
- * artifact-level comparison of complete independently assessed deliveries</li>
+ * <li>{@link neqsim.process.processmodel.diagram.EngineeringDiagramDeliveryComparison} - Deterministic artifact-level
+ * comparison of complete independently assessed deliveries</li>
  * <li>{@link neqsim.process.engineering.model.EngineeringDiagramLayoutRegister} - Persistent reviewed manual sheet,
  * position, and route intent</li>
  * <li>{@link neqsim.process.processmodel.diagram.ProcessDiagramExporter} - Main exporter class</li>

--- a/src/main/java/neqsim/process/processmodel/diagram/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/diagram/package-info.java
@@ -28,6 +28,8 @@
  * SVG/PDF, hashes, and explicit review-required evidence for ProcessSystem or multi-area ProcessModel inputs</li>
  * <li><b>Independent delivery intake</b> - Bounded fail-closed verification of transferred manifest fingerprints,
  * artifact hashes, paths, media types, exact file sets, and review boundaries</li>
+ * <li><b>Delivery comparison</b> - Deterministic artifact-level revision evidence and review scopes from two
+ * complete independent intake assessments, with fail-closed changed-content revision reuse</li>
  * <li><b>Drawing-quality diagnostics</b> - Deterministic collision, clipping, route/object, connection-label,
  * label-overflow, and broken-reference evidence remains structured and fail-visible without silently moving reviewed
  * geometry</li>
@@ -78,6 +80,8 @@
  * renderer for controlled drawing sets</li>
  * <li>{@link neqsim.process.processmodel.diagram.EngineeringDiagramDeliveryAssessment} - Independent integrity
  * assessment for stored or transferred controlled deliveries</li>
+ * <li>{@link neqsim.process.processmodel.diagram.EngineeringDiagramDeliveryComparison} - Deterministic
+ * artifact-level comparison of complete independently assessed deliveries</li>
  * <li>{@link neqsim.process.engineering.model.EngineeringDiagramLayoutRegister} - Persistent reviewed manual sheet,
  * position, and route intent</li>
  * <li>{@link neqsim.process.processmodel.diagram.ProcessDiagramExporter} - Main exporter class</li>

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryComparisonTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryComparisonTest.java
@@ -22,15 +22,14 @@ class EngineeringDiagramDeliveryComparisonTest {
   Path temporaryDirectory;
 
   @Test
-  void identicalTransferredCopiesProduceStableRestartableEvidence()
-      throws IOException, ClassNotFoundException {
+  void identicalTransferredCopiesProduceStableRestartableEvidence() throws IOException, ClassNotFoundException {
     Path firstDirectory = deliver("copy-a", "PLANT-CMP", "A", "Comparison case");
     Path secondDirectory = deliver("copy-b", "PLANT-CMP", "A", "Comparison case");
 
-    EngineeringDiagramDeliveryComparison.Report first =
-        EngineeringDiagramDeliveryComparison.compare(firstDirectory, secondDirectory);
-    EngineeringDiagramDeliveryComparison.Report second =
-        EngineeringDiagramDeliveryComparison.compare(secondDirectory, firstDirectory);
+    EngineeringDiagramDeliveryComparison.Report first = EngineeringDiagramDeliveryComparison.compare(firstDirectory,
+        secondDirectory);
+    EngineeringDiagramDeliveryComparison.Report second = EngineeringDiagramDeliveryComparison.compare(secondDirectory,
+        firstDirectory);
 
     assertTrue(first.isComplete(), first.toJson());
     assertEquals(EngineeringDiagramDeliveryComparison.Status.IDENTICAL, first.getStatus());
@@ -66,8 +65,8 @@ class EngineeringDiagramDeliveryComparisonTest {
     Path baseline = deliver("revision-a", "PLANT-CMP", "A", "Comparison case");
     Path revised = deliver("revision-b", "PLANT-CMP", "B", "Comparison case");
 
-    EngineeringDiagramDeliveryComparison.Report report =
-        EngineeringDiagramDeliveryComparison.compare(baseline, revised);
+    EngineeringDiagramDeliveryComparison.Report report = EngineeringDiagramDeliveryComparison.compare(baseline,
+        revised);
 
     assertTrue(report.isComplete(), report.toJson());
     assertEquals(EngineeringDiagramDeliveryComparison.Status.CHANGED, report.getStatus());
@@ -75,16 +74,13 @@ class EngineeringDiagramDeliveryComparisonTest {
     assertTrue(report.getChangedArtifactPaths().contains("document-set.json"));
     assertTrue(report.getChangedArtifactPaths().contains("drawing-set.pdf"));
     assertTrue(report.getChangedArtifactPaths().contains("dexpi-process.xml"));
-    assertTrue(report.getReviewScopes()
-        .contains(EngineeringDiagramDeliveryComparison.ReviewScope.CONTROLLED_DOCUMENT_SET));
-    assertTrue(report.getReviewScopes()
-        .contains(EngineeringDiagramDeliveryComparison.ReviewScope.DELIVERY_MANIFEST));
-    assertTrue(report.getReviewScopes()
-        .contains(EngineeringDiagramDeliveryComparison.ReviewScope.DEXPI_PROCESS_EXCHANGE));
-    assertTrue(report.getReviewScopes()
-        .contains(EngineeringDiagramDeliveryComparison.ReviewScope.NATIVE_PDF));
-    assertTrue(report.getReviewScopes()
-        .contains(EngineeringDiagramDeliveryComparison.ReviewScope.NATIVE_SVG));
+    assertTrue(
+        report.getReviewScopes().contains(EngineeringDiagramDeliveryComparison.ReviewScope.CONTROLLED_DOCUMENT_SET));
+    assertTrue(report.getReviewScopes().contains(EngineeringDiagramDeliveryComparison.ReviewScope.DELIVERY_MANIFEST));
+    assertTrue(
+        report.getReviewScopes().contains(EngineeringDiagramDeliveryComparison.ReviewScope.DEXPI_PROCESS_EXCHANGE));
+    assertTrue(report.getReviewScopes().contains(EngineeringDiagramDeliveryComparison.ReviewScope.NATIVE_PDF));
+    assertTrue(report.getReviewScopes().contains(EngineeringDiagramDeliveryComparison.ReviewScope.NATIVE_SVG));
     assertTrue(report.toJson().contains("DELIVERY_COMPARISON_REVIEW_REQUIRED"));
     assertTrue(report.toJson().contains("\"fitnessForConstruction\": false"));
     assertTrue(report.toJson().contains("\"iso10628ConformanceClaimed\": false"));
@@ -95,14 +91,13 @@ class EngineeringDiagramDeliveryComparisonTest {
     Path baseline = deliver("title-a", "PLANT-CMP", "A", "First title");
     Path revised = deliver("title-b", "PLANT-CMP", "A", "Changed title");
 
-    EngineeringDiagramDeliveryComparison.Report report =
-        EngineeringDiagramDeliveryComparison.compare(baseline, revised);
+    EngineeringDiagramDeliveryComparison.Report report = EngineeringDiagramDeliveryComparison.compare(baseline,
+        revised);
 
     assertFalse(report.isComplete());
     assertEquals(EngineeringDiagramDeliveryComparison.Status.REVISION_REUSE, report.getStatus());
     assertTrue(report.toJson().contains("DELIVERY_REVISION_REUSED_WITH_CHANGED_CONTENT"));
-    assertTrue(report.getReviewScopes()
-        .contains(EngineeringDiagramDeliveryComparison.ReviewScope.ENGINEERING_REVIEW));
+    assertTrue(report.getReviewScopes().contains(EngineeringDiagramDeliveryComparison.ReviewScope.ENGINEERING_REVIEW));
   }
 
   @Test
@@ -110,8 +105,8 @@ class EngineeringDiagramDeliveryComparisonTest {
     Path baseline = deliverModel("model-a", "A");
     Path revised = deliverModel("model-b", "B");
 
-    EngineeringDiagramDeliveryComparison.Report report =
-        EngineeringDiagramDeliveryComparison.compare(baseline, revised);
+    EngineeringDiagramDeliveryComparison.Report report = EngineeringDiagramDeliveryComparison.compare(baseline,
+        revised);
 
     assertTrue(report.isComplete(), report.toJson());
     assertEquals("PROCESS_MODEL", report.getSourceScope());
@@ -127,10 +122,8 @@ class EngineeringDiagramDeliveryComparisonTest {
   void rejectsDifferentPlantAndIncompleteAssessment() throws IOException {
     Path first = deliver("plant-a", "PLANT-A", "A", "Plant A");
     Path second = deliver("plant-b", "PLANT-B", "B", "Plant B");
-    EngineeringDiagramDeliveryAssessment.Report firstAssessment =
-        EngineeringDiagramDeliveryAssessment.assess(first);
-    EngineeringDiagramDeliveryAssessment.Report secondAssessment =
-        EngineeringDiagramDeliveryAssessment.assess(second);
+    EngineeringDiagramDeliveryAssessment.Report firstAssessment = EngineeringDiagramDeliveryAssessment.assess(first);
+    EngineeringDiagramDeliveryAssessment.Report secondAssessment = EngineeringDiagramDeliveryAssessment.assess(second);
 
     assertThrows(IllegalArgumentException.class,
         () -> EngineeringDiagramDeliveryComparison.compare(firstAssessment, secondAssessment));
@@ -138,32 +131,28 @@ class EngineeringDiagramDeliveryComparisonTest {
         () -> EngineeringDiagramDeliveryComparison.compare(null, secondAssessment));
 
     Path damaged = deliver("damaged", "PLANT-A", "B", "Plant A");
-    Files.write(damaged.resolve("drawing-set.pdf"), new byte[] {1}, StandardOpenOption.APPEND);
-    EngineeringDiagramDeliveryAssessment.Report incomplete =
-        EngineeringDiagramDeliveryAssessment.assess(damaged);
+    Files.write(damaged.resolve("drawing-set.pdf"), new byte[] { 1 }, StandardOpenOption.APPEND);
+    EngineeringDiagramDeliveryAssessment.Report incomplete = EngineeringDiagramDeliveryAssessment.assess(damaged);
     assertFalse(incomplete.isComplete());
     assertThrows(IllegalArgumentException.class,
         () -> EngineeringDiagramDeliveryComparison.compare(firstAssessment, incomplete));
   }
 
-  private Path deliver(String name, String plantId, String revision, String title)
-      throws IOException {
+  private Path deliver(String name, String plantId, String revision, String title) throws IOException {
     Path target = temporaryDirectory.resolve(name);
     EngineeringDiagramDelivery.Request request = EngineeringDiagramDelivery.Request
         .builder(plantId, revision, "PFD-CMP-001", title, ContentProfile.PFD).build();
-    EngineeringDiagramDelivery.deliver(
-        EngineeringDiagramReferenceFixtures.simpleTrain().getProcessSystem(), target, request);
+    EngineeringDiagramDelivery.deliver(EngineeringDiagramReferenceFixtures.simpleTrain().getProcessSystem(), target,
+        request);
     return target;
   }
 
   private Path deliverModel(String name, String revision) throws IOException {
     Path target = temporaryDirectory.resolve(name);
     EngineeringDiagramDelivery.Request request = EngineeringDiagramDelivery.Request
-        .builder("PLANT-MODEL", revision, "PFD-MODEL-001", "Multi-area comparison",
-            ContentProfile.PFD)
-        .build();
-    EngineeringDiagramDelivery.deliver(
-        EngineeringDiagramReferenceFixtures.multiAreaFacility().getProcessModel(), target, request);
+        .builder("PLANT-MODEL", revision, "PFD-MODEL-001", "Multi-area comparison", ContentProfile.PFD).build();
+    EngineeringDiagramDelivery.deliver(EngineeringDiagramReferenceFixtures.multiAreaFacility().getProcessModel(),
+        target, request);
     return target;
   }
 }

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryComparisonTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryComparisonTest.java
@@ -1,0 +1,169 @@
+package neqsim.process.processmodel.diagram;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class EngineeringDiagramDeliveryComparisonTest {
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void identicalTransferredCopiesProduceStableRestartableEvidence()
+      throws IOException, ClassNotFoundException {
+    Path firstDirectory = deliver("copy-a", "PLANT-CMP", "A", "Comparison case");
+    Path secondDirectory = deliver("copy-b", "PLANT-CMP", "A", "Comparison case");
+
+    EngineeringDiagramDeliveryComparison.Report first =
+        EngineeringDiagramDeliveryComparison.compare(firstDirectory, secondDirectory);
+    EngineeringDiagramDeliveryComparison.Report second =
+        EngineeringDiagramDeliveryComparison.compare(secondDirectory, firstDirectory);
+
+    assertTrue(first.isComplete(), first.toJson());
+    assertEquals(EngineeringDiagramDeliveryComparison.Status.IDENTICAL, first.getStatus());
+    assertTrue(first.getChangedArtifactPaths().isEmpty());
+    assertTrue(first.getReviewScopes().isEmpty());
+    assertEquals(first.getFingerprint(), second.getFingerprint());
+    assertTrue(first.toJson().contains("DELIVERY_COMPARISON_IDENTICAL"));
+    assertTrue(first.toJson().contains("\"engineeringReviewRequired\": false"));
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    ObjectOutputStream output = new ObjectOutputStream(bytes);
+    try {
+      output.writeObject(first);
+    } finally {
+      output.close();
+    }
+    ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    EngineeringDiagramDeliveryComparison.Report restored;
+    try {
+      restored = (EngineeringDiagramDeliveryComparison.Report) input.readObject();
+    } finally {
+      input.close();
+    }
+    assertEquals(first.toJson(), restored.toJson());
+    assertThrows(UnsupportedOperationException.class, () -> restored.getArtifactChanges().clear());
+    assertThrows(UnsupportedOperationException.class, () -> restored.getChangedArtifactPaths().clear());
+    assertThrows(UnsupportedOperationException.class, () -> restored.getReviewScopes().clear());
+    assertThrows(UnsupportedOperationException.class, () -> restored.getDiagnostics().clear());
+  }
+
+  @Test
+  void changedRevisionClassifiesArtifactsAndReviewScopes() throws IOException {
+    Path baseline = deliver("revision-a", "PLANT-CMP", "A", "Comparison case");
+    Path revised = deliver("revision-b", "PLANT-CMP", "B", "Comparison case");
+
+    EngineeringDiagramDeliveryComparison.Report report =
+        EngineeringDiagramDeliveryComparison.compare(baseline, revised);
+
+    assertTrue(report.isComplete(), report.toJson());
+    assertEquals(EngineeringDiagramDeliveryComparison.Status.CHANGED, report.getStatus());
+    assertFalse(report.getChangedArtifactPaths().isEmpty());
+    assertTrue(report.getChangedArtifactPaths().contains("document-set.json"));
+    assertTrue(report.getChangedArtifactPaths().contains("drawing-set.pdf"));
+    assertTrue(report.getChangedArtifactPaths().contains("dexpi-process.xml"));
+    assertTrue(report.getReviewScopes()
+        .contains(EngineeringDiagramDeliveryComparison.ReviewScope.CONTROLLED_DOCUMENT_SET));
+    assertTrue(report.getReviewScopes()
+        .contains(EngineeringDiagramDeliveryComparison.ReviewScope.DELIVERY_MANIFEST));
+    assertTrue(report.getReviewScopes()
+        .contains(EngineeringDiagramDeliveryComparison.ReviewScope.DEXPI_PROCESS_EXCHANGE));
+    assertTrue(report.getReviewScopes()
+        .contains(EngineeringDiagramDeliveryComparison.ReviewScope.NATIVE_PDF));
+    assertTrue(report.getReviewScopes()
+        .contains(EngineeringDiagramDeliveryComparison.ReviewScope.NATIVE_SVG));
+    assertTrue(report.toJson().contains("DELIVERY_COMPARISON_REVIEW_REQUIRED"));
+    assertTrue(report.toJson().contains("\"fitnessForConstruction\": false"));
+    assertTrue(report.toJson().contains("\"iso10628ConformanceClaimed\": false"));
+  }
+
+  @Test
+  void changedContentCannotReuseControlledRevision() throws IOException {
+    Path baseline = deliver("title-a", "PLANT-CMP", "A", "First title");
+    Path revised = deliver("title-b", "PLANT-CMP", "A", "Changed title");
+
+    EngineeringDiagramDeliveryComparison.Report report =
+        EngineeringDiagramDeliveryComparison.compare(baseline, revised);
+
+    assertFalse(report.isComplete());
+    assertEquals(EngineeringDiagramDeliveryComparison.Status.REVISION_REUSE, report.getStatus());
+    assertTrue(report.toJson().contains("DELIVERY_REVISION_REUSED_WITH_CHANGED_CONTENT"));
+    assertTrue(report.getReviewScopes()
+        .contains(EngineeringDiagramDeliveryComparison.ReviewScope.ENGINEERING_REVIEW));
+  }
+
+  @Test
+  void multiAreaRevisionRetainsPackageScopeAndQualificationBoundary() throws IOException {
+    Path baseline = deliverModel("model-a", "A");
+    Path revised = deliverModel("model-b", "B");
+
+    EngineeringDiagramDeliveryComparison.Report report =
+        EngineeringDiagramDeliveryComparison.compare(baseline, revised);
+
+    assertTrue(report.isComplete(), report.toJson());
+    assertEquals("PROCESS_MODEL", report.getSourceScope());
+    assertEquals(EngineeringDiagramDeliveryComparison.Status.CHANGED, report.getStatus());
+    assertTrue(report.getChangedArtifactPaths().contains("dexpi-process-model.zip"));
+    assertTrue(report.getReviewScopes()
+        .contains(EngineeringDiagramDeliveryComparison.ReviewScope.DEXPI_PROCESS_MODEL_PACKAGE));
+    assertTrue(report.isEngineeringReviewRequired());
+    assertTrue(report.toJson().contains("Does not repeat DEXPI semantic or external-validator assessment"));
+  }
+
+  @Test
+  void rejectsDifferentPlantAndIncompleteAssessment() throws IOException {
+    Path first = deliver("plant-a", "PLANT-A", "A", "Plant A");
+    Path second = deliver("plant-b", "PLANT-B", "B", "Plant B");
+    EngineeringDiagramDeliveryAssessment.Report firstAssessment =
+        EngineeringDiagramDeliveryAssessment.assess(first);
+    EngineeringDiagramDeliveryAssessment.Report secondAssessment =
+        EngineeringDiagramDeliveryAssessment.assess(second);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> EngineeringDiagramDeliveryComparison.compare(firstAssessment, secondAssessment));
+    assertThrows(IllegalArgumentException.class,
+        () -> EngineeringDiagramDeliveryComparison.compare(null, secondAssessment));
+
+    Path damaged = deliver("damaged", "PLANT-A", "B", "Plant A");
+    Files.write(damaged.resolve("drawing-set.pdf"), new byte[] {1}, StandardOpenOption.APPEND);
+    EngineeringDiagramDeliveryAssessment.Report incomplete =
+        EngineeringDiagramDeliveryAssessment.assess(damaged);
+    assertFalse(incomplete.isComplete());
+    assertThrows(IllegalArgumentException.class,
+        () -> EngineeringDiagramDeliveryComparison.compare(firstAssessment, incomplete));
+  }
+
+  private Path deliver(String name, String plantId, String revision, String title)
+      throws IOException {
+    Path target = temporaryDirectory.resolve(name);
+    EngineeringDiagramDelivery.Request request = EngineeringDiagramDelivery.Request
+        .builder(plantId, revision, "PFD-CMP-001", title, ContentProfile.PFD).build();
+    EngineeringDiagramDelivery.deliver(
+        EngineeringDiagramReferenceFixtures.simpleTrain().getProcessSystem(), target, request);
+    return target;
+  }
+
+  private Path deliverModel(String name, String revision) throws IOException {
+    Path target = temporaryDirectory.resolve(name);
+    EngineeringDiagramDelivery.Request request = EngineeringDiagramDelivery.Request
+        .builder("PLANT-MODEL", revision, "PFD-MODEL-001", "Multi-area comparison",
+            ContentProfile.PFD)
+        .build();
+    EngineeringDiagramDelivery.deliver(
+        EngineeringDiagramReferenceFixtures.multiAreaFacility().getProcessModel(), target, request);
+    return target;
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryComparisonTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryComparisonTest.java
@@ -73,11 +73,11 @@ class EngineeringDiagramDeliveryComparisonTest {
     assertFalse(report.getChangedArtifactPaths().isEmpty());
     assertTrue(report.getChangedArtifactPaths().contains("document-set.json"));
     assertTrue(report.getChangedArtifactPaths().contains("drawing-set.pdf"));
-    assertTrue(report.getChangedArtifactPaths().contains("dexpi-process.xml"));
+    assertFalse(report.getChangedArtifactPaths().contains("dexpi-process.xml"));
     assertTrue(
         report.getReviewScopes().contains(EngineeringDiagramDeliveryComparison.ReviewScope.CONTROLLED_DOCUMENT_SET));
     assertTrue(report.getReviewScopes().contains(EngineeringDiagramDeliveryComparison.ReviewScope.DELIVERY_MANIFEST));
-    assertTrue(
+    assertFalse(
         report.getReviewScopes().contains(EngineeringDiagramDeliveryComparison.ReviewScope.DEXPI_PROCESS_EXCHANGE));
     assertTrue(report.getReviewScopes().contains(EngineeringDiagramDeliveryComparison.ReviewScope.NATIVE_PDF));
     assertTrue(report.getReviewScopes().contains(EngineeringDiagramDeliveryComparison.ReviewScope.NATIVE_SVG));


### PR DESCRIPTION
## Engineering question

Can NeqSim compare two independently assessed engineering-diagram delivery directories deterministically, identify the exact controlled artifacts that changed, and fail closed when changed content reuses a revision identifier?

## Frozen scope

This increment adds post-intake comparison only. It consumes complete `EngineeringDiagramDeliveryAssessment.Report` values (or delivery roots that can be assessed) and does not reconstruct process topology, reassess DEXPI semantics, approve drawings, perform MOC, or claim standards conformance.

Exact base: `9e4e36d4b6a59404ac9aa629740fbc312610d3c8`  
Exact head: `41f2b14b04c7ce07a2abbc2bcd7e3ae744c0e9a8`

## Changes

- Add `EngineeringDiagramDeliveryComparison` with a deterministic, serializable report and restartable fingerprint.
- Classify every assessed artifact as `ADDED`, `REMOVED`, `MODIFIED`, or `UNCHANGED`.
- Project changes into controlled review scopes for document sets, manifests, DEXPI Process exchange/model packages, native SVG/PDF, and engineering review.
- Reject incomplete assessments, cross-plant comparisons, and cross-source-scope comparisons.
- Fail closed with `DELIVERY_REVISION_REUSED_WITH_CHANGED_CONTENT` when equal revision identifiers contain changed controlled content.
- Preserve input reports and returned collections through defensive copies.
- Document the public workflow, requirements, review semantics, and limitations in the delivery guide and package Javadocs.

## Focused regression coverage

Five tests cover:

1. deterministic identical comparison, Java serialization restart, and defensive collections;
2. changed-revision artifact and review-scope classification;
3. same-revision changed-content rejection;
4. multi-area `ProcessModel` package comparison and area-boundary preservation;
5. null, incomplete, cross-plant, and cross-source-scope rejection.

## Compatibility and engineering boundary

- Additive public API; existing delivery publication/intake and Classic/DOT outputs are unchanged.
- No P&ID engineering approval, MOC completion, ISO 10628 conformance, whole-plant DEXPI conformance, or external-validator claim.
- No Huldra or public-dataset material was fetched, modeled, or published.
- Comparison evidence supports controlled review; it does not replace accountable engineering judgment.

## Documentation impact

User-visible comparison behavior is new. `docs/integration/engineering-diagram-delivery.md` and diagram package documentation are updated in this PR.

## Validation

**READY TO MERGE** on exact head `41f2b14b04c7ce07a2abbc2bcd7e3ae744c0e9a8`.

The first Java 21 Windows suite exposed one branch-attributable assertion defect in the new comparison regression: changing only the controlled delivery revision leaves the byte-identical `dexpi-process.xml` artifact unchanged. Head `41f2b14b04c7ce07a2abbc2bcd7e3ae744c0e9a8` corrects the regression contract to require that unchanged DEXPI content is neither listed as changed nor escalated to `DEXPI_PROCESS_EXCHANGE`. Production comparison behavior is unchanged.

All 26 exact-head checks completed: 25 passed and the paper-replication matrix entry skipped as expected because no paper or book changed. Passing evidence includes:

- Java 21 fast suites on Ubuntu and Windows;
- all four Java 21 slow-test shards;
- Java 8 suites on Ubuntu and Windows;
- Java 21 Javadocs and agent/skill cross-references;
- hosted Spotless, pre-commit, documentation search, engineering-diagram performance, PaperLab, and CodeQL;
- ancillary Java/Kotlin, Python, Actions, and Maven submission analyzers.

The final four-file diff is mergeable, with no reviews or unresolved inline threads. This is a readiness classification only: the PR remains draft and unmerged for maintainer review.

Advances #1332 and #2899. Neither roadmap is closed by this increment.
