### PR TITLE
[AI-Assisted] test(refinery): qualify DOE Big Hill assay bookkeeping

### DIFF
--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -52,7 +52,7 @@ For crude/petroleum assays, use `OilAssayCharacterisation` rather than manually 
 - preserved lower/upper boiling ranges;
 - closure, duplicate-name, monotonicity, and repeated-application guards.
 
-See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix.
+See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation).
 
 ## TBP fraction models
 
@@ -135,6 +135,7 @@ A bookkeeping regression does not by itself validate a petroleum-property correl
 ## Related documentation
 
 - [Refinery Assay and TBP Cut Characterization](refinery_assay)
+- [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation)
 - [Fluid Characterization Guide](../../wiki/fluid_characterization)
 - [TBP Fraction Models](../../wiki/tbp_fraction_models)
 - [PVT Fluid Characterization](../pvt_fluid_characterization)

--- a/docs/thermo/characterization/refinery_big_hill_validation.md
+++ b/docs/thermo/characterization/refinery_big_hill_validation.md
@@ -1,0 +1,73 @@
+---
+title: "DOE Big Hill Sweet refinery assay validation"
+description: "Independent public-data qualification of NeqSim refinery assay volume-to-mass bookkeeping using a Strategic Petroleum Reserve Big Hill Sweet crude assay."
+---
+
+# DOE Big Hill Sweet refinery assay validation
+
+Issue #3305 requires refinery characterization to be qualified against independent public data before atmospheric/vacuum fractionation and conversion-unit models are expanded. This page freezes the first external refinery-assay benchmark used by the campaign.
+
+## Source and provenance
+
+The benchmark uses the U.S. Department of Energy Strategic Petroleum Reserve (SPR) **Big Hill Sweet**, sample **MLI 009**, assay date **1998-05-04**, published in Exhibit D of the SPR Standard Sales Provisions in the Code of Federal Regulations archive:
+
+- GovInfo source: <https://www.govinfo.gov/content/pkg/CFR-2004-title10-vol4/pdf/CFR-2004-title10-vol4-chapII-subchapI.pdf>
+- DOE SPR Crude Oil Assay Manual, 5th edition, 1 August 2024: <https://www.spr.doe.gov/reports/docs/CrudeOilAssayManual.pdf>
+- DOE SPR assay landing page: <https://www.spr.doe.gov/reports/Crude_Oil_Assays.html>
+
+The 2024 DOE manual documents atmospheric/light-vacuum fractionation by ASTM D2892 followed by D5236 for the residuum. It also states that distillation fractions are measured on a **mass-percent basis** and that volume-percent values are calculated using each fraction's specific gravity. This makes the published paired volume/weight yields and specific gravities directly useful for an independent check of NeqSim's volume-to-mass assay bookkeeping.
+
+No ASTM equation or proprietary commercial-simulator implementation is reproduced. The regression freezes only numerical assay facts openly published by the U.S. Government and cites their public source.
+
+## Frozen validation slice
+
+The first regression intentionally uses only the bounded **175-1050 degF** distillate slice. Each included interval has finite lower/upper cut temperatures plus published volume yield, weight yield, specific gravity, and API gravity. The unbounded light and 1050 degF+ tails are excluded rather than assigning invented boiling boundaries.
+
+| Cut range (degF) | Volume % of whole assay | Weight % of whole assay | SG 60/60 F | API gravity |
+| --- | ---: | ---: | ---: | ---: |
+| 175-250 | 9.8 | 8.6 | 0.7815 | 49.6 |
+| 250-375 | 15.4 | 15.2 | 0.8305 | 38.9 |
+| 375-530 | 15.5 | 15.2 | 0.8623 | 32.6 |
+| 530-650 | 10.8 | 11.1 | 0.9226 | 21.9 |
+| 650-1050 | 27.8 | 30.3 | 0.9477 | 17.8 |
+
+The same source reports whole-crude specific gravity **0.8451** and API gravity **35.9 degAPI**. Those values provide an additional independent consistency check on the conventional relation `API = 141.5 / SG - 131.5`.
+
+## Acceptance contract
+
+`OilAssayCharacterisationDoeBigHillTest` qualifies two separate things:
+
+1. Published SG/API pairs agree with the conventional API relation within **0.05 degAPI**, consistent with the source's one-decimal API reporting.
+2. After normalizing the bounded 175-1050 degF slice on its own basis, NeqSim's density-based conversion
+
+   $$w_i = \frac{v_i SG_i}{\sum_j v_j SG_j}$$
+
+   must reproduce the normalized DOE weight-yield shape with maximum absolute deviation below **0.007 mass fraction** (0.7 percentage points).
+
+For the frozen values, the largest pre-CI deviation is approximately **0.00667 mass fraction**. The tolerance is therefore a data-agreement gate, not a machine-precision tolerance; the underlying DOE yields and specific gravities are reported with limited decimal precision.
+
+The test then applies the normalized slice through `OilAssayCharacterisation`, requires finite positive pseudo-component molar masses and mole amounts, and requires reconstructed assay mass closure to `1e-10`.
+
+## What this validates
+
+This benchmark provides independent evidence for:
+
+- refinery cut basis handling;
+- SG/API consistency of the published source data;
+- liquid-volume to mass-fraction conversion;
+- preservation of bounded cut ranges;
+- pseudo-component generation from a real refinery-assay slice;
+- exact reconstructed mass closure after pseudo-component creation.
+
+## What this does not validate
+
+This increment deliberately does **not** claim validation of:
+
+- ASTM D86/D1160-to-TBP conversion;
+- the molecular-weight, critical-property, acentric-factor, or EOS correlations for each pseudo-component;
+- the light-ends or 1050 degF+ residue representation;
+- atmospheric or vacuum column product yields;
+- vapor-liquid equilibrium or flash-root changes;
+- hydrotreating, reforming, FCC, hydrocracking, or other conversion-unit models.
+
+Those remain separate #3305 quality gates. The next dependency-ready increment should extend this public-data foundation into a complete crude/pseudo-component slate and a reproducible atmospheric-fractionation case with mass/energy closure, product yields/boiling ranges, convergence/repeatability, and runtime evidence.

--- a/docs/thermo/characterization/refinery_big_hill_validation.md
+++ b/docs/thermo/characterization/refinery_big_hill_validation.md
@@ -1,11 +1,11 @@
 ---
 title: "DOE Big Hill Sweet refinery assay validation"
-description: "Independent public-data qualification of NeqSim refinery assay volume-to-mass bookkeeping using a Strategic Petroleum Reserve Big Hill Sweet crude assay."
+description: "Public-data qualification of NeqSim refinery assay volume-to-mass bookkeeping using a Strategic Petroleum Reserve Big Hill Sweet crude assay."
 ---
 
 # DOE Big Hill Sweet refinery assay validation
 
-Issue #3305 requires refinery characterization to be qualified against independent public data before atmospheric/vacuum fractionation and conversion-unit models are expanded. This page freezes the first external refinery-assay benchmark used by the campaign.
+Issue #3305 requires refinery characterization to be qualified against public refinery data before atmospheric/vacuum fractionation and conversion-unit models are expanded. This page freezes the first external refinery-assay benchmark used by the campaign.
 
 ## Source and provenance
 
@@ -15,7 +15,9 @@ The benchmark uses the U.S. Department of Energy Strategic Petroleum Reserve (SP
 - DOE SPR Crude Oil Assay Manual, 5th edition, 1 August 2024: <https://www.spr.doe.gov/reports/docs/CrudeOilAssayManual.pdf>
 - DOE SPR assay landing page: <https://www.spr.doe.gov/reports/Crude_Oil_Assays.html>
 
-The 2024 DOE manual documents atmospheric/light-vacuum fractionation by ASTM D2892 followed by D5236 for the residuum. It also states that distillation fractions are measured on a **mass-percent basis** and that volume-percent values are calculated using each fraction's specific gravity. This makes the published paired volume/weight yields and specific gravities directly useful for an independent check of NeqSim's volume-to-mass assay bookkeeping.
+The 2024 DOE manual documents atmospheric/light-vacuum fractionation by ASTM D2892 followed by D5236 for the residuum. It also states that distillation fractions are measured on a **mass-percent basis** and that volume-percent values are calculated using each fraction's specific gravity. The paired volume/weight yields and density information therefore provide a transparent public-source consistency qualification for NeqSim's volume-to-mass assay bookkeeping.
+
+The volume and weight yields are **not statistically independent measurements**: DOE states that volume percentages are derived from measured mass percentages using fraction specific gravity. The regression is intentionally a bookkeeping/provenance qualification, not an independent validation of a petroleum-property correlation.
 
 No ASTM equation or proprietary commercial-simulator implementation is reproduced. The regression freezes only numerical assay facts openly published by the U.S. Government and cites their public source.
 
@@ -31,11 +33,11 @@ The first regression intentionally uses only the bounded **175-1050 degF** disti
 | 530-650 | 10.8 | 11.1 | 0.9226 | 21.9 |
 | 650-1050 | 27.8 | 30.3 | 0.9477 | 17.8 |
 
-The same source reports whole-crude specific gravity **0.8451** and API gravity **35.9 degAPI**. Those values provide an additional independent consistency check on the conventional relation `API = 141.5 / SG - 131.5`.
+The same source reports whole-crude specific gravity **0.8451** and API gravity **35.9 degAPI**. Those values provide an additional consistency check on the conventional relation `API = 141.5 / SG - 131.5`.
 
 ## Acceptance contract
 
-`OilAssayCharacterisationDoeBigHillTest` qualifies two separate things:
+`OilAssayCharacterisationDoeBigHillTest` qualifies three separate things:
 
 1. Published SG/API pairs agree with the conventional API relation within **0.05 degAPI**, consistent with the source's one-decimal API reporting.
 2. After normalizing the bounded 175-1050 degF slice on its own basis, NeqSim's density-based conversion
@@ -43,17 +45,19 @@ The same source reports whole-crude specific gravity **0.8451** and API gravity 
    $$w_i = \frac{v_i SG_i}{\sum_j v_j SG_j}$$
 
    must reproduce the normalized DOE weight-yield shape with maximum absolute deviation below **0.007 mass fraction** (0.7 percentage points).
+3. Supplying the same cuts through the public API-gravity input path must reproduce the mass-fraction shape obtained from the four-decimal specific-gravity values within **5e-5 mass fraction**. This tolerance reflects the DOE table's one-decimal API rounding, not a thermodynamic-model uncertainty.
 
-For the frozen values, the largest pre-CI deviation is approximately **0.00667 mass fraction**. The tolerance is therefore a data-agreement gate, not a machine-precision tolerance; the underlying DOE yields and specific gravities are reported with limited decimal precision.
+For the frozen values, the largest pre-CI volume-to-mass deviation is approximately **0.00667 mass fraction**. The largest specific-gravity versus rounded-API mass-shape deviation is approximately **4.27e-5 mass fraction**. These tolerances are therefore data-agreement gates rather than machine-precision tolerances.
 
 The test then applies the normalized slice through `OilAssayCharacterisation`, requires finite positive pseudo-component molar masses and mole amounts, and requires reconstructed assay mass closure to `1e-10`.
 
 ## What this validates
 
-This benchmark provides independent evidence for:
+This benchmark provides public-source evidence for:
 
 - refinery cut basis handling;
 - SG/API consistency of the published source data;
+- equivalence of the specific-gravity and API-gravity user input paths within source reporting precision;
 - liquid-volume to mass-fraction conversion;
 - preservation of bounded cut ranges;
 - pseudo-component generation from a real refinery-assay slice;

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTest.java
@@ -14,29 +14,27 @@ import neqsim.thermo.system.SystemSrkEos;
  * Independent public-data qualification for refinery assay bookkeeping.
  *
  * <p>
- * The source is the U.S. Department of Energy Strategic Petroleum Reserve Big Hill Sweet assay,
- * sample MLI 009, dated 1998-05-04, published as Exhibit D to 10 CFR Part 625 Appendix A. This
- * test freezes the bounded 175-1050 degF distillate slice because every included interval has a
- * reported volume yield, weight yield, specific gravity, API gravity, and explicit cut boundary.
- * The light C5-/175 degF fraction and 1050 degF+ residuum are deliberately excluded because they
- * do not both have finite lower and upper boiling boundaries in the published table.
+ * The source is the U.S. Department of Energy Strategic Petroleum Reserve Big Hill Sweet assay, sample MLI 009, dated
+ * 1998-05-04, published as Exhibit D to 10 CFR Part 625 Appendix A. This test freezes the bounded 175-1050 degF
+ * distillate slice because every included interval has a reported volume yield, weight yield, specific gravity, API
+ * gravity, and explicit cut boundary. The light C5-/175 degF fraction and 1050 degF+ residuum are deliberately excluded
+ * because they do not both have finite lower and upper boiling boundaries in the published table.
  * </p>
  *
  * <p>
- * Source: https://www.govinfo.gov/content/pkg/CFR-2004-title10-vol4/pdf/
- * CFR-2004-title10-vol4-chapII-subchapI.pdf (SPR Crude Oil Comprehensive Analysis, Big Hill
- * Sweet, MLI 009). DOE's 2024 Crude Oil Assay Manual documents D2892/D5236 fractionation and
- * states that fractions are measured on a mass-percent basis while volume percentages are
- * calculated using fraction specific gravity.
+ * Source: https://www.govinfo.gov/content/pkg/CFR-2004-title10-vol4/pdf/ CFR-2004-title10-vol4-chapII-subchapI.pdf (SPR
+ * Crude Oil Comprehensive Analysis, Big Hill Sweet, MLI 009). DOE's 2024 Crude Oil Assay Manual documents D2892/D5236
+ * fractionation and states that fractions are measured on a mass-percent basis while volume percentages are calculated
+ * using fraction specific gravity.
  * </p>
  */
 public class OilAssayCharacterisationDoeBigHillTest {
-  private static final double[] LOWER_BOUNDARY_F = {175.0, 250.0, 375.0, 530.0, 650.0};
-  private static final double[] UPPER_BOUNDARY_F = {250.0, 375.0, 530.0, 650.0, 1050.0};
-  private static final double[] VOLUME_PERCENT = {9.8, 15.4, 15.5, 10.8, 27.8};
-  private static final double[] WEIGHT_PERCENT = {8.6, 15.2, 15.2, 11.1, 30.3};
-  private static final double[] SPECIFIC_GRAVITY = {0.7815, 0.8305, 0.8623, 0.9226, 0.9477};
-  private static final double[] API_GRAVITY = {49.6, 38.9, 32.6, 21.9, 17.8};
+  private static final double[] LOWER_BOUNDARY_F = { 175.0, 250.0, 375.0, 530.0, 650.0 };
+  private static final double[] UPPER_BOUNDARY_F = { 250.0, 375.0, 530.0, 650.0, 1050.0 };
+  private static final double[] VOLUME_PERCENT = { 9.8, 15.4, 15.5, 10.8, 27.8 };
+  private static final double[] WEIGHT_PERCENT = { 8.6, 15.2, 15.2, 11.1, 30.3 };
+  private static final double[] SPECIFIC_GRAVITY = { 0.7815, 0.8305, 0.8623, 0.9226, 0.9477 };
+  private static final double[] API_GRAVITY = { 49.6, 38.9, 32.6, 21.9, 17.8 };
 
   @Test
   public void doeSpecificGravityAndApiPairsAreConsistent() {
@@ -62,11 +60,9 @@ public class OilAssayCharacterisationDoeBigHillTest {
     double weightSum = sum(WEIGHT_PERCENT);
 
     for (int i = 0; i < VOLUME_PERCENT.length; i++) {
-      characterisation.addCut(new AssayCut("DOE_BH_" + (i + 2))
-          .withVolumeFraction(VOLUME_PERCENT[i] / volumeSum)
+      characterisation.addCut(new AssayCut("DOE_BH_" + (i + 2)).withVolumeFraction(VOLUME_PERCENT[i] / volumeSum)
           .withSpecificGravity(SPECIFIC_GRAVITY[i])
-          .withBoilingRangeCelsius(fahrenheitToCelsius(LOWER_BOUNDARY_F[i]),
-              fahrenheitToCelsius(UPPER_BOUNDARY_F[i])));
+          .withBoilingRangeCelsius(fahrenheitToCelsius(LOWER_BOUNDARY_F[i]), fahrenheitToCelsius(UPPER_BOUNDARY_F[i])));
     }
 
     double[] resolvedMassFractions = characterisation.getResolvedMassFractions();

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTest.java
@@ -29,12 +29,12 @@ import neqsim.thermo.system.SystemSrkEos;
  * </p>
  */
 public class OilAssayCharacterisationDoeBigHillTest {
-  private static final double[] LOWER_BOUNDARY_F = {175.0, 250.0, 375.0, 530.0, 650.0};
-  private static final double[] UPPER_BOUNDARY_F = {250.0, 375.0, 530.0, 650.0, 1050.0};
-  private static final double[] VOLUME_PERCENT = {9.8, 15.4, 15.5, 10.8, 27.8};
-  private static final double[] WEIGHT_PERCENT = {8.6, 15.2, 15.2, 11.1, 30.3};
-  private static final double[] SPECIFIC_GRAVITY = {0.7815, 0.8305, 0.8623, 0.9226, 0.9477};
-  private static final double[] API_GRAVITY = {49.6, 38.9, 32.6, 21.9, 17.8};
+  private static final double[] LOWER_BOUNDARY_F = { 175.0, 250.0, 375.0, 530.0, 650.0 };
+  private static final double[] UPPER_BOUNDARY_F = { 250.0, 375.0, 530.0, 650.0, 1050.0 };
+  private static final double[] VOLUME_PERCENT = { 9.8, 15.4, 15.5, 10.8, 27.8 };
+  private static final double[] WEIGHT_PERCENT = { 8.6, 15.2, 15.2, 11.1, 30.3 };
+  private static final double[] SPECIFIC_GRAVITY = { 0.7815, 0.8305, 0.8623, 0.9226, 0.9477 };
+  private static final double[] API_GRAVITY = { 49.6, 38.9, 32.6, 21.9, 17.8 };
 
   @Test
   public void doeSpecificGravityAndApiPairsAreConsistent() {

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTest.java
@@ -29,12 +29,12 @@ import neqsim.thermo.system.SystemSrkEos;
  * </p>
  */
 public class OilAssayCharacterisationDoeBigHillTest {
-  private static final double[] LOWER_BOUNDARY_F = { 175.0, 250.0, 375.0, 530.0, 650.0 };
-  private static final double[] UPPER_BOUNDARY_F = { 250.0, 375.0, 530.0, 650.0, 1050.0 };
-  private static final double[] VOLUME_PERCENT = { 9.8, 15.4, 15.5, 10.8, 27.8 };
-  private static final double[] WEIGHT_PERCENT = { 8.6, 15.2, 15.2, 11.1, 30.3 };
-  private static final double[] SPECIFIC_GRAVITY = { 0.7815, 0.8305, 0.8623, 0.9226, 0.9477 };
-  private static final double[] API_GRAVITY = { 49.6, 38.9, 32.6, 21.9, 17.8 };
+  private static final double[] LOWER_BOUNDARY_F = {175.0, 250.0, 375.0, 530.0, 650.0};
+  private static final double[] UPPER_BOUNDARY_F = {250.0, 375.0, 530.0, 650.0, 1050.0};
+  private static final double[] VOLUME_PERCENT = {9.8, 15.4, 15.5, 10.8, 27.8};
+  private static final double[] WEIGHT_PERCENT = {8.6, 15.2, 15.2, 11.1, 30.3};
+  private static final double[] SPECIFIC_GRAVITY = {0.7815, 0.8305, 0.8623, 0.9226, 0.9477};
+  private static final double[] API_GRAVITY = {49.6, 38.9, 32.6, 21.9, 17.8};
 
   @Test
   public void doeSpecificGravityAndApiPairsAreConsistent() {
@@ -50,21 +50,32 @@ public class OilAssayCharacterisationDoeBigHillTest {
   }
 
   @Test
+  public void doeApiGravityInputMatchesSpecificGravityMassShapeWithinReportedRounding() {
+    SystemInterface specificGravitySystem = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation specificGravityCharacterisation = specificGravitySystem.getOilAssayCharacterisation();
+    configureVolumeBasisCuts(specificGravityCharacterisation, false);
+
+    SystemInterface apiGravitySystem = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation apiGravityCharacterisation = apiGravitySystem.getOilAssayCharacterisation();
+    configureVolumeBasisCuts(apiGravityCharacterisation, true);
+
+    double[] specificGravityMassFractions = specificGravityCharacterisation.getResolvedMassFractions();
+    double[] apiGravityMassFractions = apiGravityCharacterisation.getResolvedMassFractions();
+
+    for (int i = 0; i < specificGravityMassFractions.length; i++) {
+      assertEquals(specificGravityMassFractions[i], apiGravityMassFractions[i], 5.0e-5,
+          "Published one-decimal API gravity should reproduce the mass shape from four-decimal specific gravity");
+    }
+  }
+
+  @Test
   public void doeDistillateSliceQualifiesVolumeToMassConversionAndPseudoComponentClosure() {
     SystemInterface system = new SystemSrkEos(298.15, 1.01325);
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
-    characterisation.clearCuts();
     characterisation.setTotalAssayMass(1.0);
+    configureVolumeBasisCuts(characterisation, false);
 
-    double volumeSum = sum(VOLUME_PERCENT);
     double weightSum = sum(WEIGHT_PERCENT);
-
-    for (int i = 0; i < VOLUME_PERCENT.length; i++) {
-      characterisation.addCut(new AssayCut("DOE_BH_" + (i + 2)).withVolumeFraction(VOLUME_PERCENT[i] / volumeSum)
-          .withSpecificGravity(SPECIFIC_GRAVITY[i])
-          .withBoilingRangeCelsius(fahrenheitToCelsius(LOWER_BOUNDARY_F[i]), fahrenheitToCelsius(UPPER_BOUNDARY_F[i])));
-    }
-
     double[] resolvedMassFractions = characterisation.getResolvedMassFractions();
     double maxAbsoluteMassFractionDeviation = 0.0;
     for (int i = 0; i < resolvedMassFractions.length; i++) {
@@ -90,6 +101,22 @@ public class OilAssayCharacterisationDoeBigHillTest {
     }
 
     assertEquals(1.0, reconstructedMass, 1.0e-10);
+  }
+
+  private static void configureVolumeBasisCuts(OilAssayCharacterisation characterisation, boolean useApiGravity) {
+    characterisation.clearCuts();
+    double volumeSum = sum(VOLUME_PERCENT);
+
+    for (int i = 0; i < VOLUME_PERCENT.length; i++) {
+      AssayCut cut = new AssayCut("DOE_BH_" + (i + 2)).withVolumeFraction(VOLUME_PERCENT[i] / volumeSum)
+          .withBoilingRangeCelsius(fahrenheitToCelsius(LOWER_BOUNDARY_F[i]), fahrenheitToCelsius(UPPER_BOUNDARY_F[i]));
+      if (useApiGravity) {
+        cut.withApiGravity(API_GRAVITY[i]);
+      } else {
+        cut.withSpecificGravity(SPECIFIC_GRAVITY[i]);
+      }
+      characterisation.addCut(cut);
+    }
   }
 
   private static double sum(double[] values) {

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTest.java
@@ -1,0 +1,110 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Independent public-data qualification for refinery assay bookkeeping.
+ *
+ * <p>
+ * The source is the U.S. Department of Energy Strategic Petroleum Reserve Big Hill Sweet assay,
+ * sample MLI 009, dated 1998-05-04, published as Exhibit D to 10 CFR Part 625 Appendix A. This
+ * test freezes the bounded 175-1050 degF distillate slice because every included interval has a
+ * reported volume yield, weight yield, specific gravity, API gravity, and explicit cut boundary.
+ * The light C5-/175 degF fraction and 1050 degF+ residuum are deliberately excluded because they
+ * do not both have finite lower and upper boiling boundaries in the published table.
+ * </p>
+ *
+ * <p>
+ * Source: https://www.govinfo.gov/content/pkg/CFR-2004-title10-vol4/pdf/
+ * CFR-2004-title10-vol4-chapII-subchapI.pdf (SPR Crude Oil Comprehensive Analysis, Big Hill
+ * Sweet, MLI 009). DOE's 2024 Crude Oil Assay Manual documents D2892/D5236 fractionation and
+ * states that fractions are measured on a mass-percent basis while volume percentages are
+ * calculated using fraction specific gravity.
+ * </p>
+ */
+public class OilAssayCharacterisationDoeBigHillTest {
+  private static final double[] LOWER_BOUNDARY_F = {175.0, 250.0, 375.0, 530.0, 650.0};
+  private static final double[] UPPER_BOUNDARY_F = {250.0, 375.0, 530.0, 650.0, 1050.0};
+  private static final double[] VOLUME_PERCENT = {9.8, 15.4, 15.5, 10.8, 27.8};
+  private static final double[] WEIGHT_PERCENT = {8.6, 15.2, 15.2, 11.1, 30.3};
+  private static final double[] SPECIFIC_GRAVITY = {0.7815, 0.8305, 0.8623, 0.9226, 0.9477};
+  private static final double[] API_GRAVITY = {49.6, 38.9, 32.6, 21.9, 17.8};
+
+  @Test
+  public void doeSpecificGravityAndApiPairsAreConsistent() {
+    for (int i = 0; i < SPECIFIC_GRAVITY.length; i++) {
+      double calculatedApi = 141.5 / SPECIFIC_GRAVITY[i] - 131.5;
+      assertEquals(API_GRAVITY[i], calculatedApi, 0.05,
+          "Published specific-gravity/API pair should agree within reported rounding");
+    }
+
+    double wholeCrudeApi = 141.5 / 0.8451 - 131.5;
+    assertEquals(35.9, wholeCrudeApi, 0.05,
+        "Published whole-crude specific gravity and API gravity should be self-consistent");
+  }
+
+  @Test
+  public void doeDistillateSliceQualifiesVolumeToMassConversionAndPseudoComponentClosure() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+    characterisation.setTotalAssayMass(1.0);
+
+    double volumeSum = sum(VOLUME_PERCENT);
+    double weightSum = sum(WEIGHT_PERCENT);
+
+    for (int i = 0; i < VOLUME_PERCENT.length; i++) {
+      characterisation.addCut(new AssayCut("DOE_BH_" + (i + 2))
+          .withVolumeFraction(VOLUME_PERCENT[i] / volumeSum)
+          .withSpecificGravity(SPECIFIC_GRAVITY[i])
+          .withBoilingRangeCelsius(fahrenheitToCelsius(LOWER_BOUNDARY_F[i]),
+              fahrenheitToCelsius(UPPER_BOUNDARY_F[i])));
+    }
+
+    double[] resolvedMassFractions = characterisation.getResolvedMassFractions();
+    double maxAbsoluteMassFractionDeviation = 0.0;
+    for (int i = 0; i < resolvedMassFractions.length; i++) {
+      double publishedSliceMassFraction = WEIGHT_PERCENT[i] / weightSum;
+      maxAbsoluteMassFractionDeviation = Math.max(maxAbsoluteMassFractionDeviation,
+          Math.abs(resolvedMassFractions[i] - publishedSliceMassFraction));
+    }
+
+    assertTrue(maxAbsoluteMassFractionDeviation < 0.007,
+        "Density-based conversion should reproduce the normalized DOE mass-yield shape within 0.7 percentage points");
+
+    characterisation.apply();
+
+    double reconstructedMass = 0.0;
+    for (int i = 0; i < VOLUME_PERCENT.length; i++) {
+      ComponentInterface component = system.getComponent("DOE_BH_" + (i + 2) + "_PC");
+      assertNotNull(component);
+      assertTrue(Double.isFinite(component.getMolarMass()));
+      assertTrue(component.getMolarMass() > 0.0);
+      assertTrue(Double.isFinite(component.getNumberOfmoles()));
+      assertTrue(component.getNumberOfmoles() > 0.0);
+      reconstructedMass += component.getNumberOfmoles() * component.getMolarMass();
+    }
+
+    assertEquals(1.0, reconstructedMass, 1.0e-10);
+  }
+
+  private static double sum(double[] values) {
+    double sum = 0.0;
+    for (double value : values) {
+      sum += value;
+    }
+    return sum;
+  }
+
+  private static double fahrenheitToCelsius(double fahrenheit) {
+    return (fahrenheit - 32.0) * 5.0 / 9.0;
+  }
+}


### PR DESCRIPTION
## Engineering question

Can NeqSim's refinery-assay foundation reproduce a public crude-assay mass-yield shape from liquid-volume yields and refinery density descriptors before the campaign advances to atmospheric fractionation?

Advances #3305.

## Exact scope

- **Base/master:** `9e4e36d4b6a59404ac9aa629740fbc312610d3c8`
- **Exact current head:** `7e7ad317d2d4aa3342b58592fbcaad8a399f4312`
- **Source case:** U.S. DOE Strategic Petroleum Reserve, Big Hill Sweet, sample MLI 009, assay date 1998-05-04
- **Frozen slice:** bounded 175-1050 degF distillate cuts only
- **Stop boundary:** assay bookkeeping, public-data provenance, refinery density-input paths, pseudo-component creation, and mass closure only; no TP-flash/root change, no ASTM conversion, no column solver change, no fitted petroleum correlation, and no conversion-unit model

## Public evidence and provenance

Primary public values are frozen from the U.S. Government GovInfo publication of the SPR Crude Oil Comprehensive Analysis:

- https://www.govinfo.gov/content/pkg/CFR-2004-title10-vol4/pdf/CFR-2004-title10-vol4-chapII-subchapI.pdf

Method context is taken from the DOE SPR *Crude Oil Assay Manual*, 5th ed., 1 Aug 2024:

- https://www.spr.doe.gov/reports/docs/CrudeOilAssayManual.pdf
- https://www.spr.doe.gov/reports/Crude_Oil_Assays.html

The DOE manual documents D2892 atmospheric/light-vacuum distillation followed by D5236 for residuum and states that fractions are measured on a mass-percent basis, with volume percentages calculated using fraction specific gravity.

This means the DOE volume and weight yields are not statistically independent measurements. The regression is deliberately a public-source bookkeeping/provenance qualification, not an independent validation of a petroleum-property correlation. No ASTM equations, proprietary simulator behavior, or proprietary data are copied.

## Frozen validation data

| Cut degF | vol % | wt % | SG 60/60F | API |
| --- | ---: | ---: | ---: | ---: |
| 175-250 | 9.8 | 8.6 | 0.7815 | 49.6 |
| 250-375 | 15.4 | 15.2 | 0.8305 | 38.9 |
| 375-530 | 15.5 | 15.2 | 0.8623 | 32.6 |
| 530-650 | 10.8 | 11.1 | 0.9226 | 21.9 |
| 650-1050 | 27.8 | 30.3 | 0.9477 | 17.8 |

The same source reports whole-crude SG `0.8451` and API `35.9`. The light/unbounded tails are intentionally excluded instead of assigning invented boiling boundaries. The bounded slice is normalized on its own basis for the comparison.

## Implementation

- Add `OilAssayCharacterisationDoeBigHillTest` as the first public refinery-assay qualification.
- Verify published SG/API pairs against the conventional API relation within source reporting precision.
- Convert normalized DOE volume yields through `OilAssayCharacterisation` using published cut specific gravities.
- Compare resolved mass-yield shape against published DOE weight yields; acceptance is maximum absolute deviation `< 0.007` mass fraction (0.7 percentage points).
- Qualify the public API-gravity input path against the four-decimal specific-gravity path; the maximum expected difference from the DOE table rounding is approximately `4.27e-5` mass fraction, with a `5e-5` acceptance gate.
- Apply the real assay helper to produce five bounded pseudo-components and require finite positive amounts/properties plus reconstructed mass closure at `1e-10`.
- Document source provenance, evidence dependence, acceptance criteria, and limitations.

The frozen source values give a maximum normalized volume-to-mass discrepancy of approximately `0.00667` mass fraction. The regression thresholds are therefore published-data agreement gates, not floating-point tolerances.

## Scientific boundary

This PR validates **bookkeeping, density-input equivalence within reporting precision, and pseudo-component creation**, not petroleum property correlations themselves. It does not claim agreement for molecular weight, critical properties, acentric factor, flash equilibrium, atmospheric/vacuum product yields, or conversion-unit performance.

That separation follows #3305's quality-gate order: public assay evidence first, then a complete assay/pseudo-component slate and rigorous atmospheric fractionation benchmark.

## Validation

**DRAFT — VALIDATION PENDING CI** on exact head `7e7ad317d2d4aa3342b58592fbcaad8a399f4312`.

The previous fully hosted-validated head `576d78c87be3ac0f0923d2c93b59f52c9e3398eb` passed the complete PR workflow set before this run extended the same PR.

Current-head evidence:
- first extended head exposed only a branch-attributable Spotless delta in the new Java test; the exact hosted formatter patch was applied as the current head;
- Spotless: **pass**, with an empty exact-head formatter artifact;
- pre-commit: **pass**;
- documentation search: **pass**;
- CodeQL: **pass**;
- Java 21 Javadocs: **pass**;
- repository agent/skill cross-reference checks: **pass**;
- full Java fast/slow test matrix: **running**.

No running or unrun check is claimed as passed. No submitted reviews or unresolved review threads are present on the current PR.

## Portfolio / campaign boundary

#3308 is merged and is the foundation for this increment. #3316 remains the sole active #3305 implementation PR. Seven open `[AI-Assisted]` NeqSim PRs were found during this run, below the campaign cap of ten.

Related generic TBP work remains owned by #1393 and #3120; generic TP-flash/root-selection work remains owned by its flash roadmap.

## Next dependency

After this public-data bookkeeping gate is green/reviewed/merged, extend the DOE basis to a complete reproducible crude/pseudo-component slate and atmospheric fractionation case. Record source/access provenance, mass and energy closure, product yields and boiling ranges, convergence/repeatability, and runtime before vacuum-fractionation or conversion-unit work.

AI-assisted contribution.