### PR TITLE
[AI-Assisted] docs: repair Java quickstart contract

### DIFF
--- a/docs/quickstart/java-quickstart.md
+++ b/docs/quickstart/java-quickstart.md
@@ -5,151 +5,189 @@ description: Get started with NeqSim in Java. Maven setup, first flash calculati
 
 # Java Quickstart
 
-Get NeqSim running in your Java project in under 10 minutes.
+Get NeqSim running in a Java project with one thermodynamic calculation and one composable
+process simulation. The examples use NeqSim 3.18.0; check
+[Maven Central](https://central.sonatype.com/artifact/com.equinor.neqsim/neqsim) for a newer
+published version before starting a new project.
 
-## Step 1: Add Maven Dependency (2 minutes)
+## Step 1: add NeqSim to a project
 
-Add to your `pom.xml`:
+Add the dependency to your `pom.xml`:
 
 ```xml
 <dependency>
-    <groupId>com.equinor.neqsim</groupId>
-    <artifactId>neqsim</artifactId>
-    <version>3.0.0</version>
+  <groupId>com.equinor.neqsim</groupId>
+  <artifactId>neqsim</artifactId>
+  <version>3.18.0</version>
 </dependency>
 ```
 
-Or with Gradle (`build.gradle`):
+The run command below uses Maven's exec plugin. Add this build entry if the project does not
+already configure it:
 
-```groovy
-implementation 'com.equinor.neqsim:neqsim:3.0.0'
+```xml
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>exec-maven-plugin</artifactId>
+      <version>3.6.3</version>
+    </plugin>
+  </plugins>
+</build>
 ```
 
-## Step 2: First Flash Calculation (3 minutes)
+With Gradle:
+
+```groovy
+implementation 'com.equinor.neqsim:neqsim:3.18.0'
+```
+
+## Step 2: first flash calculation
 
 Create `FirstCalculation.java`:
 
 ```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 public class FirstCalculation {
+    private static final Logger logger = LogManager.getLogger(FirstCalculation.class);
+
     public static void main(String[] args) {
-        // Create a natural gas at 25°C and 50 bar
-        SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);  // Temperature in Kelvin!
-        
-        // Add components (mole fractions)
+        // SystemSrkEos accepts temperature in K and absolute pressure in bara.
+        SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
+
+        // addComponent accepts component amounts in mol. These sum to 1.0 mol,
+        // so the amounts are also the overall mole fractions for this example.
         fluid.addComponent("methane", 0.85);
         fluid.addComponent("ethane", 0.10);
         fluid.addComponent("propane", 0.05);
-        
-        // IMPORTANT: Always set mixing rule
+
+        // Select an appropriate mixing rule before flashing a cubic-EOS mixture.
         fluid.setMixingRule("classic");
-        
-        // Run flash calculation
-        ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
-        ops.TPflash();
-        
-        // Initialize properties (required for most property access)
+
+        ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+        operations.TPflash();
+
+        // Initialize physical properties before reading density or transport properties.
         fluid.initProperties();
-        
-        // Print results
-        System.out.println("Number of phases: " + fluid.getNumberOfPhases());
-        System.out.println("Density: " + fluid.getDensity("kg/m3") + " kg/m³");
-        System.out.println("Z-factor: " + fluid.getZ());
-        
-        // Pretty print full results
-        fluid.prettyPrint();
+
+        logger.info("Number of phases: {}", fluid.getNumberOfPhases());
+        logger.info("Bulk density: {} kg/m³", fluid.getDensity("kg/m3"));
+        logger.info("System Z-factor: {}", fluid.getZ());
     }
 }
 ```
 
-Run it:
+The API unit token is `"kg/m3"`; the displayed SI symbol is kg/m³. `getDensity("kg/m3")`
+converts the returned unit but does not select or validate a density model.
+
+Run it from the project directory:
+
 ```bash
 mvn compile exec:java -Dexec.mainClass="FirstCalculation"
 ```
 
-## Step 3: First Process Simulation (5 minutes)
+## Step 3: first process simulation
 
 Create `FirstProcess.java`:
 
 ```java
-import neqsim.process.processmodel.ProcessSystem;
-import neqsim.process.equipment.stream.Stream;
-import neqsim.process.equipment.separator.Separator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.system.SystemSrkEos;
 
 public class FirstProcess {
+    private static final Logger logger = LogManager.getLogger(FirstProcess.class);
+
     public static void main(String[] args) {
-        // 1. Create feed fluid
-        SystemSrkEos fluid = new SystemSrkEos(273.15 + 30, 50.0);  // 30°C, 50 bara
+        SystemSrkEos fluid = new SystemSrkEos(273.15 + 30.0, 50.0);
         fluid.addComponent("methane", 0.70);
         fluid.addComponent("ethane", 0.10);
         fluid.addComponent("propane", 0.10);
         fluid.addComponent("n-butane", 0.05);
         fluid.addComponent("n-pentane", 0.05);
         fluid.setMixingRule("classic");
-        
-        // 2. Create process system
+
         ProcessSystem process = new ProcessSystem();
-        
-        // 3. Add feed stream
+
         Stream feed = new Stream("Feed", fluid);
-        feed.setFlowRate(10000, "kg/hr");
+        feed.setFlowRate(10000.0, "kg/hr");
         process.add(feed);
-        
-        // 4. Add separator (flash to 20 bar)
+
+        // Separator performs an equilibrium split at the feed state, here 50 bara.
         Separator separator = new Separator("HP Separator", feed);
-        separator.setInternalDiameter(2.0);  // meters
+        separator.setInternalDiameter(2.0);
         process.add(separator);
-        
-        // 5. Add compressor on gas outlet
-        Compressor compressor = new Compressor("Gas Compressor", separator.getGasOutStream());
-        compressor.setOutletPressure(80.0);  // bara
+
+        Compressor compressor =
+            new Compressor("Gas Compressor", separator.getGasOutStream());
+        compressor.setOutletPressure(80.0, "bara");
         compressor.setIsentropicEfficiency(0.75);
         process.add(compressor);
-        
-        // 6. Run the process
+
         process.run();
-        
-        // 7. Print results
-        System.out.println("=== SEPARATOR ===");
-        System.out.println("Gas out: " + separator.getGasOutStream().getFlowRate("kg/hr") + " kg/hr");
-        System.out.println("Liquid out: " + separator.getLiquidOutStream().getFlowRate("kg/hr") + " kg/hr");
-        
-        System.out.println("\n=== COMPRESSOR ===");
-        System.out.println("Power: " + compressor.getPower("kW") + " kW");
-        System.out.println("Outlet T: " + (compressor.getOutletStream().getTemperature() - 273.15) + " °C");
+
+        double gasFlowKgPerHour =
+            separator.getGasOutStream().getFlowRate("kg/hr");
+        double liquidFlowKgPerHour =
+            separator.getLiquidOutStream().getFlowRate("kg/hr");
+
+        logger.info("Gas outlet: {} kg/hr", gasFlowKgPerHour);
+        logger.info("Liquid outlet: {} kg/hr", liquidFlowKgPerHour);
+        logger.info("Separated total: {} kg/hr", gasFlowKgPerHour + liquidFlowKgPerHour);
+        logger.info("Compressor power: {} kW", compressor.getPower("kW"));
+        logger.info(
+            "Compressor outlet temperature: {} °C",
+            compressor.getOutletStream().getTemperature("C"));
     }
 }
 ```
 
-## Common Gotchas
+A `Separator` does not impose a pressure reduction. Add a valve or another pressure-changing
+unit upstream when the engineering case requires letdown before separation. The stream, separator,
+compressor, and `ProcessSystem` remain available for extension into a larger flowsheet.
 
-| Issue | Solution |
-|-------|----------|
-| `NullPointerException` on properties | Call `fluid.initProperties()` after flash |
-| Wrong density values | Use `getDensity("kg/m3")` with unit for Peneloux correction |
-| Temperature seems wrong | NeqSim uses **Kelvin** internally. Convert: `T_K = T_C + 273.15` |
-| Missing mixing rule | Always call `setMixingRule("classic")` after adding components |
-| Flash doesn't converge | Check if T,P are in valid range for your composition |
+## Common gotchas
 
-## Next Steps
+| Issue | Corrective action |
+|-------|-------------------|
+| `NullPointerException` or unavailable physical properties | Call `fluid.initProperties()` after the flash before reading density, viscosity, or conductivity. |
+| Unexpected density | Request an explicit supported unit and verify the selected thermodynamic model, volume-correction setting, composition, temperature, and pressure. The unit string alone does not enable Peneloux correction. |
+| Temperature seems wrong | Constructors use K unless an API explicitly accepts a unit. Convert with `T_K = T_C + 273.15` or use a setter with a unit argument. |
+| Pressure basis is unclear | Constructors and single-argument process pressure setters use bara. Prefer overloads such as `setOutletPressure(80.0, "bara")` in user examples. |
+| Mixing rule is missing | Select the mixing rule appropriate to the chosen model and mixture before the first flash. `"classic"` is the simple cubic-EOS choice used here. |
+| Separator pressure is unexpected | A separator uses its inlet state; it does not perform an implicit letdown. Model pressure-changing equipment explicitly. |
+| Flash does not converge | Verify component names, positive amounts, units, model applicability, and a physically plausible temperature-pressure state. Let the exception propagate while diagnosing it. |
 
-- **[Reading Fluid Properties](../thermo/reading_fluid_properties)** - Understanding init levels and property access
-- **[Thermodynamic Models](../thermo/thermodynamic_models)** - Choosing the right equation of state
-- **[Process Equipment](../process/equipment/)** - All available unit operations
-- **[JavaDoc API](https://equinor.github.io/neqsim/javadoc/index.html)** - Complete API reference
+## Engineering boundary
 
-## API Quick Reference
+These examples demonstrate API composition and deterministic calculations, not fluid-model
+selection, equipment sizing, process design approval, or safety certification. Validate the model,
+composition, operating envelope, convergence, conservation, and results against suitable
+engineering evidence before design use.
 
-Key interfaces to explore in the [JavaDoc](https://equinor.github.io/neqsim/javadoc/index.html):
+## Next steps
+
+- **[Reading Fluid Properties](../thermo/reading_fluid_properties)** - Understand initialization
+  levels and property access.
+- **[Thermodynamic Models](../thermo/thermodynamic_models)** - Choose an equation of state.
+- **[Process Equipment](../process/equipment/)** - Explore available unit operations.
+- **[JavaDoc API](https://equinor.github.io/neqsim/javadoc/index.html)** - Read the API reference.
+
+## API quick reference
 
 | Interface | Purpose |
 |-----------|---------|
-| `SystemInterface` | Fluid/mixture - composition, properties, flash |
+| `SystemInterface` | Fluid composition, properties, and flash state |
 | `PhaseInterface` | Individual phase properties |
-| `ComponentInterface` | Pure component properties |
-| `ProcessEquipmentInterface` | Base for all equipment |
-| `StreamInterface` | Material streams |
+| `ComponentInterface` | Pure-component and in-mixture properties |
+| `ProcessEquipmentInterface` | Common process-equipment contract |
+| `StreamInterface` | Composable material streams |

--- a/docs/quickstart/java-quickstart.md
+++ b/docs/quickstart/java-quickstart.md
@@ -184,6 +184,8 @@ engineering evidence before design use.
 
 ## API quick reference
 
+Key interfaces to explore in the [JavaDoc](https://equinor.github.io/neqsim/javadoc/index.html):
+
 | Interface | Purpose |
 |-----------|---------|
 | `SystemInterface` | Fluid composition, properties, and flash state |

--- a/docs/test_java_quickstart_documentation.py
+++ b/docs/test_java_quickstart_documentation.py
@@ -144,7 +144,7 @@ class JavaQuickstartDocumentationContractTest(unittest.TestCase):
             "temperature in K and absolute pressure in bara",
             "component amounts in mol",
             "sum to 1.0 mol",
-            'API unit token is "kg/m3"',
+            'API unit token is `"kg/m3"`',
             "does not select or validate a density model",
             "equilibrium split at the feed state, here 50 bara",
             "does not impose a pressure reduction",

--- a/docs/test_java_quickstart_documentation.py
+++ b/docs/test_java_quickstart_documentation.py
@@ -1,0 +1,164 @@
+"""Contracts for the Java quickstart guide."""
+
+from pathlib import Path
+import re
+import unittest
+from urllib.parse import unquote
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDE = ROOT / "docs/quickstart/java-quickstart.md"
+POM = ROOT / "pom.xml"
+JAVA_TEST = ROOT / "src/test/java/neqsim/documentation/JavaQuickstartDocumentationTest.java"
+TWO_PORT = ROOT / "src/main/java/neqsim/process/equipment/TwoPortInterface.java"
+STREAM = ROOT / "src/main/java/neqsim/process/equipment/stream/StreamInterface.java"
+SYSTEM = ROOT / "src/main/java/neqsim/thermo/system/SystemInterface.java"
+
+
+def resolve_internal_target(source, destination):
+    target, _, fragment = unquote(destination).partition("#")
+    raw_target = source.parent / target
+    candidates = [raw_target]
+    if not Path(target).suffix:
+        candidates.extend(
+            (
+                Path("{}.md".format(raw_target)),
+                raw_target / "README.md",
+                raw_target / "index.md",
+            )
+        )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve(), fragment
+    raise AssertionError("Unresolved guide link: {}".format(destination))
+
+
+class JavaQuickstartDocumentationContractTest(unittest.TestCase):
+    """Protect setup, executable API, units, and engineering boundaries."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+        cls.pom = POM.read_text(encoding="utf-8")
+        cls.java_test = JAVA_TEST.read_text(encoding="utf-8")
+        cls.two_port = TWO_PORT.read_text(encoding="utf-8")
+        cls.stream = STREAM.read_text(encoding="utf-8")
+        cls.system = SYSTEM.read_text(encoding="utf-8")
+
+    def test_structure_and_internal_links_are_renderable(self):
+        self.assertTrue(self.guide.startswith("---\n"))
+        self.assertEqual(self.guide.count("# Java Quickstart"), 1)
+        self.assertEqual(self.guide.count("\x60\x60\x60") % 2, 0)
+
+        links = re.findall(r"(?<!!)\[[^\]]+\]\(([^)]+)\)", self.guide)
+        for destination in links:
+            if destination.startswith(("http://", "https://", "mailto:", "#")):
+                continue
+            target, _fragment = resolve_internal_target(GUIDE, destination)
+            self.assertTrue(target.is_file())
+
+    def test_dependency_matches_current_repository_revision(self):
+        revision = re.search(r"<revision>([^<]+)</revision>", self.pom)
+        self.assertIsNotNone(revision)
+        version = revision.group(1)
+
+        self.assertIn("<version>{}</version>".format(version), self.guide)
+        self.assertIn(
+            "com.equinor.neqsim:neqsim:{}".format(version),
+            self.guide,
+        )
+        self.assertNotIn("<version>3.0.0</version>", self.guide)
+        self.assertNotIn("neqsim:3.0.0", self.guide)
+        self.assertIn("<artifactId>exec-maven-plugin</artifactId>", self.guide)
+        self.assertIn(
+            'mvn compile exec:java -Dexec.mainClass="FirstCalculation"',
+            self.guide,
+        )
+
+    def test_java_examples_use_repository_logging_contract(self):
+        fence = "\x60\x60\x60"
+        java_blocks = re.findall(fence + r"java\n(.*?)" + fence, self.guide, flags=re.DOTALL)
+        self.assertEqual(2, len(java_blocks))
+        for block in java_blocks:
+            self.assertIn("import org.apache.logging.log4j.LogManager;", block)
+            self.assertIn("import org.apache.logging.log4j.Logger;", block)
+            self.assertIn("private static final Logger logger =", block)
+            self.assertIn("logger.info(", block)
+            self.assertNotIn("System.out", block)
+            self.assertNotIn("System.err", block)
+            self.assertNotIn(".prettyPrint()", block)
+
+    def test_documented_calls_have_executable_regression_coverage(self):
+        for guide_token in (
+            "new SystemSrkEos(298.15, 50.0)",
+            'fluid.addComponent("methane", 0.85)',
+            'fluid.setMixingRule("classic")',
+            "operations.TPflash()",
+            "fluid.initProperties()",
+            'fluid.getDensity("kg/m3")',
+            'new Stream("Feed", fluid)',
+            'feed.setFlowRate(10000.0, "kg/hr")',
+            'new Separator("HP Separator", feed)',
+            "separator.setInternalDiameter(2.0)",
+            'compressor.setOutletPressure(80.0, "bara")',
+            "compressor.setIsentropicEfficiency(0.75)",
+            "process.run()",
+            'compressor.getPower("kW")',
+            'compressor.getOutletStream().getTemperature("C")',
+        ):
+            self.assertIn(guide_token, self.guide)
+            self.assertIn(guide_token, self.java_test)
+
+        for test_token in (
+            "testFirstFlashCalculation",
+            "testFirstProcessSimulation",
+            "assertTrue(Double.isFinite(densityKgPerCubicMetre))",
+            "assertEquals(feedFlowKgPerHour, separatedFlowKgPerHour",
+            'assertTrue(compressor.getPower("kW") > 0.0)',
+        ):
+            self.assertIn(test_token, self.java_test)
+
+    def test_documented_overloads_exist_in_current_source(self):
+        self.assertIn(
+            "void setOutletPressure(double pressure, String unit)",
+            self.two_port,
+        )
+
+        for token in (
+            "void setFlowRate(double flowrate, String unit)",
+            "double getFlowRate(String unit)",
+            "double getTemperature(String unit)",
+        ):
+            self.assertIn(token, self.stream)
+
+        for token in (
+            "double getDensity(String unit)",
+            "double getZ()",
+            "void initProperties()",
+        ):
+            self.assertIn(token, self.system)
+
+    def test_units_semantics_and_engineering_boundaries_are_explicit(self):
+        normalized = " ".join(self.guide.split())
+        for token in (
+            "temperature in K and absolute pressure in bara",
+            "component amounts in mol",
+            "sum to 1.0 mol",
+            'API unit token is "kg/m3"',
+            "does not select or validate a density model",
+            "equilibrium split at the feed state, here 50 bara",
+            "does not impose a pressure reduction",
+            "unit string alone does not enable Peneloux correction",
+            "Constructors and single-argument process pressure setters use bara",
+            "does not perform an implicit letdown",
+            "not fluid-model selection, equipment sizing, process design approval, or safety certification",
+            "convergence, conservation",
+        ):
+            self.assertIn(token, normalized)
+
+        self.assertNotIn("flash to 20 bar", normalized)
+        self.assertNotIn("Always set mixing rule", normalized)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test/java/neqsim/documentation/JavaQuickstartDocumentationTest.java
+++ b/src/test/java/neqsim/documentation/JavaQuickstartDocumentationTest.java
@@ -1,0 +1,79 @@
+package neqsim.documentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Verifies the complete Java quickstart calculations against the current public API. */
+class JavaQuickstartDocumentationTest {
+
+  @Test
+  void testFirstFlashCalculation() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.85);
+    fluid.addComponent("ethane", 0.10);
+    fluid.addComponent("propane", 0.05);
+    fluid.setMixingRule("classic");
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+    operations.TPflash();
+    fluid.initProperties();
+
+    double densityKgPerCubicMetre = fluid.getDensity("kg/m3");
+    double compressibilityFactor = fluid.getZ();
+
+    assertTrue(fluid.getNumberOfPhases() >= 1);
+    assertTrue(Double.isFinite(densityKgPerCubicMetre));
+    assertTrue(densityKgPerCubicMetre > 0.0);
+    assertTrue(Double.isFinite(compressibilityFactor));
+    assertTrue(compressibilityFactor > 0.0);
+  }
+
+  @Test
+  void testFirstProcessSimulation() {
+    SystemSrkEos fluid = new SystemSrkEos(273.15 + 30.0, 50.0);
+    fluid.addComponent("methane", 0.70);
+    fluid.addComponent("ethane", 0.10);
+    fluid.addComponent("propane", 0.10);
+    fluid.addComponent("n-butane", 0.05);
+    fluid.addComponent("n-pentane", 0.05);
+    fluid.setMixingRule("classic");
+
+    ProcessSystem process = new ProcessSystem();
+
+    Stream feed = new Stream("Feed", fluid);
+    feed.setFlowRate(10000.0, "kg/hr");
+    process.add(feed);
+
+    Separator separator = new Separator("HP Separator", feed);
+    separator.setInternalDiameter(2.0);
+    process.add(separator);
+
+    Compressor compressor = new Compressor("Gas Compressor", separator.getGasOutStream());
+    compressor.setOutletPressure(80.0, "bara");
+    compressor.setIsentropicEfficiency(0.75);
+    process.add(compressor);
+
+    process.run();
+
+    double feedFlowKgPerHour = feed.getFlowRate("kg/hr");
+    double gasFlowKgPerHour = separator.getGasOutStream().getFlowRate("kg/hr");
+    double liquidFlowKgPerHour = separator.getLiquidOutStream().getFlowRate("kg/hr");
+    double separatedFlowKgPerHour = gasFlowKgPerHour + liquidFlowKgPerHour;
+    double outletTemperatureC = compressor.getOutletStream().getTemperature("C");
+
+    assertTrue(gasFlowKgPerHour > 0.0);
+    assertTrue(liquidFlowKgPerHour >= 0.0);
+    assertEquals(feedFlowKgPerHour, separatedFlowKgPerHour,
+        Math.max(1.0e-6, feedFlowKgPerHour * 1.0e-10));
+    assertTrue(compressor.getPower("kW") > 0.0);
+    assertTrue(Double.isFinite(outletTemperatureC));
+    assertEquals(80.0, compressor.getOutletPressure(), 1.0e-10);
+  }
+}

--- a/src/test/java/neqsim/documentation/JavaQuickstartDocumentationTest.java
+++ b/src/test/java/neqsim/documentation/JavaQuickstartDocumentationTest.java
@@ -70,8 +70,7 @@ class JavaQuickstartDocumentationTest {
 
     assertTrue(gasFlowKgPerHour > 0.0);
     assertTrue(liquidFlowKgPerHour >= 0.0);
-    assertEquals(feedFlowKgPerHour, separatedFlowKgPerHour,
-        Math.max(1.0e-6, feedFlowKgPerHour * 1.0e-10));
+    assertEquals(feedFlowKgPerHour, separatedFlowKgPerHour, Math.max(1.0e-6, feedFlowKgPerHour * 1.0e-10));
     assertTrue(compressor.getPower("kW") > 0.0);
     assertTrue(Double.isFinite(outletTemperatureC));
     assertEquals(80.0, compressor.getOutletPressure(), 1.0e-10);


### PR DESCRIPTION
## Summary

**READY TO MERGE** on exact head `9ba9429f4cab6f0c10ff7464ec43efc87254a209`.

Advances documentation-quality campaign #2499 as **D102** (tutorials, cookbook, troubleshooting, and examples) with a frozen Java quickstart batch.

The central Java quickstart now uses the current NeqSim dependency, provides a runnable Maven configuration, follows the repository logging contract, describes component amounts and units accurately, keeps the process example composable, and makes separator pressure behavior and engineering boundaries explicit.

## Confirmed defects repaired

1. Maven used obsolete NeqSim 3.0.0.
2. Gradle used obsolete NeqSim 3.0.0.
3. The run command depended on an undeclared exec plugin.
4. `addComponent` inputs were described as mole fractions instead of component amounts in mol.
5. The flash example used prohibited `System.out`.
6. The process example used prohibited `System.out`.
7. The guide recommended console-oriented `prettyPrint()` instead of structured result access.
8. Physical-property initialization was described too broadly.
9. The separator comment falsely claimed a flash to 20 bar without pressure-changing equipment.
10. The compressor pressure example relied on an implicit pressure unit.
11. Outlet temperature was manually converted instead of using the unit-aware API.
12. The density troubleshooting row falsely implied the unit argument activates Peneloux correction.
13. Mixing-rule guidance was incorrectly universal rather than model- and mixture-specific.
14. Separator pressure behavior and explicit letdown equipment were not explained.
15. The process example did not expose its separated-flow conservation check.
16. The examples lacked a design/safety-certification boundary.
17. The complete Java examples lacked focused executable regression coverage.
18. Setup, rendering, links, current source overloads, units, and boundaries lacked a durable documentation contract.

## Frozen scope

Base: `9e4e36d4b6a59404ac9aa629740fbc312610d3c8`  
Head: `9ba9429f4cab6f0c10ff7464ec43efc87254a209`

- `docs/quickstart/java-quickstart.md`
- `docs/test_java_quickstart_documentation.py`
- `src/test/java/neqsim/documentation/JavaQuickstartDocumentationTest.java`

## Validation

- PASS — connector-side exact-source audit of front matter, H1, balanced fences, dependency revision, Log4j2 use, absence of console calls, API anchors, units, semantics, pressure boundary, and engineering boundary.
- PASS — all three relative links resolve on the exact branch.
- PASS — exact branch comparison contains exactly three frozen files and is zero commits behind `master`.
- PASS — six Python contract groups connect the guide to `pom.xml`, current public API source, and the executable Java regression.
- PASS (first-run diagnostics) — the replacement head repairs exact Spotless formatting, the rendered unit-token assertion, and the pre-existing JavaDoc-link-count contract without expanding the frozen scope.
- PASS — all five exact-head workflows: Python documentation contracts, Jekyll/search, pre-commit, Spotless, CodeQL, Javadocs, agent-skill cross-references, Ubuntu/Windows Java 8 and Java 21 fast suites, and all four Java 21 slow-test shards.
- PASS — mergeable, zero commits behind current `master`, exactly three frozen files, and no comments, reviews, or unresolved threads.
- Local Maven/Java execution was unavailable in this connector-first environment; no unrun check is claimed as passing.

## Documentation impact

The user-facing quickstart is the implementation target. No public API, production algorithm, model parameter, default, or runtime behavior changes.

## Boundaries

- No production source change.
- No notebook-output, DEXPI/PFD, Pitzer, TP-flash algorithm, refinery, or Huldra work.
- The examples demonstrate API composition and conservation checks; they do not certify model choice, equipment sizing, process design, or safety.
- Model-specific tutorials and advanced process examples remain separate validation concepts.

Campaign: #2499
