### PR TITLE
[AI-Assisted] feat(kinetics): qualify CO2 transport reaction timescales

### DIFF
--- a/docs/chemicalreactions/co2_transport_reaction_kinetics.md
+++ b/docs/chemicalreactions/co2_transport_reaction_kinetics.md
@@ -1,0 +1,105 @@
+---
+title: CO2 transport reaction kinetics
+description: Qualification and transport-timescale workflow for finite-rate impurity chemistry in CO2 pipelines and injection systems.
+---
+
+# CO2 transport reaction kinetics
+
+NeqSim contains general `KineticReaction` models and an experimental
+`CO2ImpurityKineticReactor`. Finite-rate chemistry in a CCS transport system must not be treated as
+validated simply because a reaction can be evaluated numerically. Kinetic parameters are strongly
+dependent on temperature, pressure, phase state, water availability, concentration basis, and in
+some cases wall or catalyst material.
+
+This workflow adds two reusable building blocks for Northern-Lights-type and other dense-phase CO2
+transport studies without embedding facility-specific data or unqualified kinetic constants in the
+library.
+
+## Scientific qualification
+
+`KineticReactionQualification` records the evidence boundary independently of the numerical
+`KineticReaction` object:
+
+```java
+KineticReactionQualification qualification = new KineticReactionQualification(
+    "reaction name",
+    "primary literature citation",
+    "DOI or stable public identifier",
+    ChemicalReactionValidationStatus.VALIDATED,
+    minimumTemperatureK,
+    maximumTemperatureK,
+    minimumPressureBara,
+    maximumPressureBara,
+    "model, phase, composition, and material limitations");
+
+qualification.requireValidatedAt(localTemperatureK, localPressureBara);
+```
+
+`requireValidatedAt` fails closed when a parameterization is unvalidated or when the local state is
+outside its declared temperature/pressure range. The qualification object does not claim that a
+complete pipeline, electrolyte, corrosion, or precipitation model is validated.
+
+## Reaction time versus transport time
+
+For a volume-basis `KineticReaction`, `KineticReactionDiagnostics` estimates the local time required
+to consume the limiting reactant at the current rate. It compares this reaction time with a caller
+supplied residence time:
+
+$$
+Da = \frac{t_{transport}}{t_{reaction}}
+$$
+
+```java
+KineticReactionDiagnostics diagnostic =
+    KineticReactionDiagnostics.evaluate(reaction, fluid, phaseIndex, residenceTimeSeconds);
+
+logger.info("reaction={} Da={} regime={} limitingReactant={}",
+    diagnostic.getReactionName(),
+    diagnostic.getDamkohlerNumber(),
+    diagnostic.getRegime(),
+    diagnostic.getLimitingReactant());
+```
+
+The regime labels are intentionally coarse screening diagnostics:
+
+| Damkohler number | Regime | Interpretation |
+|---:|---|---|
+| no finite rate | `INACTIVE` | no local finite-rate conversion predicted |
+| `Da < 0.1` | `TRANSPORT_DOMINATED` | chemistry is slow relative to residence time |
+| `0.1 <= Da <= 10` | `COUPLED` | kinetics and transport occur on comparable timescales |
+| `Da > 10` | `REACTION_DOMINATED` | chemistry is fast relative to residence time |
+
+These thresholds do not prove that an equilibrium assumption is valid. A coupled pipeline model
+must still demonstrate timestep refinement, phase consistency, element conservation, and agreement
+with independent kinetic evidence.
+
+## Intended CCS workflow
+
+A representative future pipeline integration should evaluate each control volume in the following
+order:
+
+1. solve the local pressure, temperature, and phase state;
+2. determine whether the phase required by each reaction is present;
+3. require the selected kinetic parameterization to be scientifically qualified at the local state;
+4. evaluate reaction rate and reaction/transport timescale diagnostics;
+5. apply conservative reaction source terms over the local timestep or residence interval;
+6. reflash and, when an aqueous phase exists, update electrolyte speciation and charge balance;
+7. retain reaction extent, source provenance, range status, and conservation diagnostics in the
+   pipeline result.
+
+Operator splitting is acceptable as a first coupling strategy only when timestep refinement shows
+that splitting error is controlled. Reactions with catalyst-mass or catalyst-area rate bases require
+explicit local catalyst loading or area before a transport timescale can be computed; the generic
+transport diagnostic therefore rejects those bases rather than silently converting units.
+
+## CO2 impurity chemistry scope
+
+The campaign in issue #3318 targets, in evidence order, CO2/water chemistry followed by qualified
+SOx, H2S, NOx/O2, and cross-impurity reactions. Aqueous acid/base speciation, mineral saturation,
+and precipitation should use the electrolyte framework coordinated under issue #3144. Generic
+phase-stability defects remain owned by issue #2937, while full transient plant/pipeline state
+management is coordinated with issue #2911 and the pipeline roadmaps.
+
+The current `CO2ImpurityKineticReactor` includes illustrative default kinetic constants. Those
+constants remain experimental and must not be used as design correlations without independent
+qualification.

--- a/src/main/java/neqsim/process/equipment/reactor/KineticReactionDiagnostics.java
+++ b/src/main/java/neqsim/process/equipment/reactor/KineticReactionDiagnostics.java
@@ -7,10 +7,12 @@ import neqsim.thermo.system.SystemInterface;
 /**
  * Reaction-timescale diagnostics for coupling {@link KineticReaction} models to transport.
  *
- * <p>The diagnostic compares the time required to consume the limiting reactant at the current
- * local reaction rate with a caller-provided residence time. The resulting Damkohler number is a
- * screening measure for whether chemistry is effectively frozen, competes with transport, or is
- * fast relative to transport. It does not replace timestep-refinement or kinetic validation.</p>
+ * <p>
+ * The diagnostic compares the time required to consume the limiting reactant at the current local reaction rate with a
+ * caller-provided residence time. The resulting Damkohler number is a screening measure for whether chemistry is
+ * effectively frozen, competes with transport, or is fast relative to transport. It does not replace
+ * timestep-refinement or kinetic validation.
+ * </p>
  *
  * @author NeqSim Team
  * @version 1.0
@@ -40,9 +42,8 @@ public final class KineticReactionDiagnostics implements Serializable {
   private final double damkohlerNumber;
   private final Regime regime;
 
-  private KineticReactionDiagnostics(String reactionName, double reactionRate,
-      KineticReaction.RateBasis rateBasis, String limitingReactant,
-      double limitingReactantConcentrationMolPerM3, double reactionTimeSeconds,
+  private KineticReactionDiagnostics(String reactionName, double reactionRate, KineticReaction.RateBasis rateBasis,
+      String limitingReactant, double limitingReactantConcentrationMolPerM3, double reactionTimeSeconds,
       double residenceTimeSeconds, double damkohlerNumber, Regime regime) {
     this.reactionName = reactionName;
     this.reactionRate = reactionRate;
@@ -58,9 +59,11 @@ public final class KineticReactionDiagnostics implements Serializable {
   /**
    * Evaluate a kinetic reaction against a local transport residence time.
    *
-   * <p>The timescale estimate is directly meaningful for volume-basis rates. Catalyst-mass and
-   * catalyst-area rates are rejected because a reactor-specific catalyst loading or area is needed
-   * before a volumetric reactant-consumption timescale can be defined.</p>
+   * <p>
+   * The timescale estimate is directly meaningful for volume-basis rates. Catalyst-mass and catalyst-area rates are
+   * rejected because a reactor-specific catalyst loading or area is needed before a volumetric reactant-consumption
+   * timescale can be defined.
+   * </p>
    *
    * @param reaction kinetic reaction
    * @param system initialized thermodynamic system
@@ -68,8 +71,8 @@ public final class KineticReactionDiagnostics implements Serializable {
    * @param residenceTimeSeconds local transport residence time [s]
    * @return immutable reaction/transport diagnostic
    */
-  public static KineticReactionDiagnostics evaluate(KineticReaction reaction,
-      SystemInterface system, int phaseIndex, double residenceTimeSeconds) {
+  public static KineticReactionDiagnostics evaluate(KineticReaction reaction, SystemInterface system, int phaseIndex,
+      double residenceTimeSeconds) {
     if (reaction == null) {
       throw new IllegalArgumentException("reaction cannot be null");
     }
@@ -80,8 +83,7 @@ public final class KineticReactionDiagnostics implements Serializable {
       throw new IllegalArgumentException("residence time must be finite and non-negative");
     }
     if (reaction.getRateBasis() != KineticReaction.RateBasis.VOLUME) {
-      throw new IllegalArgumentException(
-          "transport timescale diagnostic currently requires a VOLUME rate basis");
+      throw new IllegalArgumentException("transport timescale diagnostic currently requires a VOLUME rate basis");
     }
     if (phaseIndex < 0 || phaseIndex >= system.getNumberOfPhases()) {
       throw new IllegalArgumentException("phase index is outside the active phase range");
@@ -114,9 +116,9 @@ public final class KineticReactionDiagnostics implements Serializable {
     }
 
     if (!Double.isFinite(reactionTime) || reactionTime <= 0.0) {
-      return new KineticReactionDiagnostics(reaction.getName(), rate, reaction.getRateBasis(),
-          limitingReactant, Double.isFinite(limitingConcentration) ? limitingConcentration : 0.0,
-          Double.POSITIVE_INFINITY, residenceTimeSeconds, 0.0, Regime.INACTIVE);
+      return new KineticReactionDiagnostics(reaction.getName(), rate, reaction.getRateBasis(), limitingReactant,
+          Double.isFinite(limitingConcentration) ? limitingConcentration : 0.0, Double.POSITIVE_INFINITY,
+          residenceTimeSeconds, 0.0, Regime.INACTIVE);
     }
 
     double damkohler = residenceTimeSeconds / reactionTime;
@@ -129,13 +131,11 @@ public final class KineticReactionDiagnostics implements Serializable {
       regime = Regime.COUPLED;
     }
 
-    return new KineticReactionDiagnostics(reaction.getName(), rate, reaction.getRateBasis(),
-        limitingReactant, limitingConcentration, reactionTime, residenceTimeSeconds, damkohler,
-        regime);
+    return new KineticReactionDiagnostics(reaction.getName(), rate, reaction.getRateBasis(), limitingReactant,
+        limitingConcentration, reactionTime, residenceTimeSeconds, damkohler, regime);
   }
 
-  private static double getConcentration(SystemInterface system, int phaseIndex,
-      String componentName) {
+  private static double getConcentration(SystemInterface system, int phaseIndex, String componentName) {
     if (!system.hasComponent(componentName)) {
       return 0.0;
     }

--- a/src/main/java/neqsim/process/equipment/reactor/KineticReactionDiagnostics.java
+++ b/src/main/java/neqsim/process/equipment/reactor/KineticReactionDiagnostics.java
@@ -1,0 +1,191 @@
+package neqsim.process.equipment.reactor;
+
+import java.io.Serializable;
+import java.util.Map;
+import neqsim.thermo.system.SystemInterface;
+
+/**
+ * Reaction-timescale diagnostics for coupling {@link KineticReaction} models to transport.
+ *
+ * <p>The diagnostic compares the time required to consume the limiting reactant at the current
+ * local reaction rate with a caller-provided residence time. The resulting Damkohler number is a
+ * screening measure for whether chemistry is effectively frozen, competes with transport, or is
+ * fast relative to transport. It does not replace timestep-refinement or kinetic validation.</p>
+ *
+ * @author NeqSim Team
+ * @version 1.0
+ */
+public final class KineticReactionDiagnostics implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Qualitative reaction/transport timescale classification. */
+  public enum Regime {
+    /** No finite local reaction rate at the evaluated state. */
+    INACTIVE,
+    /** Reaction time is at least ten times longer than residence time. */
+    TRANSPORT_DOMINATED,
+    /** Reaction and transport times are of comparable order. */
+    COUPLED,
+    /** Reaction time is at least ten times shorter than residence time. */
+    REACTION_DOMINATED
+  }
+
+  private final String reactionName;
+  private final double reactionRate;
+  private final KineticReaction.RateBasis rateBasis;
+  private final String limitingReactant;
+  private final double limitingReactantConcentrationMolPerM3;
+  private final double reactionTimeSeconds;
+  private final double residenceTimeSeconds;
+  private final double damkohlerNumber;
+  private final Regime regime;
+
+  private KineticReactionDiagnostics(String reactionName, double reactionRate,
+      KineticReaction.RateBasis rateBasis, String limitingReactant,
+      double limitingReactantConcentrationMolPerM3, double reactionTimeSeconds,
+      double residenceTimeSeconds, double damkohlerNumber, Regime regime) {
+    this.reactionName = reactionName;
+    this.reactionRate = reactionRate;
+    this.rateBasis = rateBasis;
+    this.limitingReactant = limitingReactant;
+    this.limitingReactantConcentrationMolPerM3 = limitingReactantConcentrationMolPerM3;
+    this.reactionTimeSeconds = reactionTimeSeconds;
+    this.residenceTimeSeconds = residenceTimeSeconds;
+    this.damkohlerNumber = damkohlerNumber;
+    this.regime = regime;
+  }
+
+  /**
+   * Evaluate a kinetic reaction against a local transport residence time.
+   *
+   * <p>The timescale estimate is directly meaningful for volume-basis rates. Catalyst-mass and
+   * catalyst-area rates are rejected because a reactor-specific catalyst loading or area is needed
+   * before a volumetric reactant-consumption timescale can be defined.</p>
+   *
+   * @param reaction kinetic reaction
+   * @param system initialized thermodynamic system
+   * @param phaseIndex phase in which the reaction rate is evaluated
+   * @param residenceTimeSeconds local transport residence time [s]
+   * @return immutable reaction/transport diagnostic
+   */
+  public static KineticReactionDiagnostics evaluate(KineticReaction reaction,
+      SystemInterface system, int phaseIndex, double residenceTimeSeconds) {
+    if (reaction == null) {
+      throw new IllegalArgumentException("reaction cannot be null");
+    }
+    if (system == null) {
+      throw new IllegalArgumentException("system cannot be null");
+    }
+    if (!Double.isFinite(residenceTimeSeconds) || residenceTimeSeconds < 0.0) {
+      throw new IllegalArgumentException("residence time must be finite and non-negative");
+    }
+    if (reaction.getRateBasis() != KineticReaction.RateBasis.VOLUME) {
+      throw new IllegalArgumentException(
+          "transport timescale diagnostic currently requires a VOLUME rate basis");
+    }
+    if (phaseIndex < 0 || phaseIndex >= system.getNumberOfPhases()) {
+      throw new IllegalArgumentException("phase index is outside the active phase range");
+    }
+
+    double rate = reaction.calculateRate(system, phaseIndex);
+    if (!Double.isFinite(rate)) {
+      throw new IllegalStateException("kinetic reaction returned a non-finite rate");
+    }
+    double absoluteRate = Math.abs(rate);
+
+    String limitingReactant = "";
+    double limitingConcentration = Double.POSITIVE_INFINITY;
+    double reactionTime = Double.POSITIVE_INFINITY;
+
+    if (absoluteRate > 0.0) {
+      for (Map.Entry<String, Double> entry : reaction.getStoichiometry().entrySet()) {
+        double stoichiometricCoefficient = entry.getValue().doubleValue();
+        if (stoichiometricCoefficient >= 0.0) {
+          continue;
+        }
+        double concentration = getConcentration(system, phaseIndex, entry.getKey());
+        double speciesTime = concentration / (-stoichiometricCoefficient * absoluteRate);
+        if (speciesTime < reactionTime) {
+          reactionTime = speciesTime;
+          limitingReactant = entry.getKey();
+          limitingConcentration = concentration;
+        }
+      }
+    }
+
+    if (!Double.isFinite(reactionTime) || reactionTime <= 0.0) {
+      return new KineticReactionDiagnostics(reaction.getName(), rate, reaction.getRateBasis(),
+          limitingReactant, Double.isFinite(limitingConcentration) ? limitingConcentration : 0.0,
+          Double.POSITIVE_INFINITY, residenceTimeSeconds, 0.0, Regime.INACTIVE);
+    }
+
+    double damkohler = residenceTimeSeconds / reactionTime;
+    Regime regime;
+    if (damkohler < 0.1) {
+      regime = Regime.TRANSPORT_DOMINATED;
+    } else if (damkohler > 10.0) {
+      regime = Regime.REACTION_DOMINATED;
+    } else {
+      regime = Regime.COUPLED;
+    }
+
+    return new KineticReactionDiagnostics(reaction.getName(), rate, reaction.getRateBasis(),
+        limitingReactant, limitingConcentration, reactionTime, residenceTimeSeconds, damkohler,
+        regime);
+  }
+
+  private static double getConcentration(SystemInterface system, int phaseIndex,
+      String componentName) {
+    if (!system.hasComponent(componentName)) {
+      return 0.0;
+    }
+    double moleFraction = system.getPhase(phaseIndex).getComponent(componentName).getx();
+    double molarDensity = system.getPhase(phaseIndex).getDensity("mol/m3");
+    return Math.max(0.0, moleFraction * molarDensity);
+  }
+
+  /** @return reaction name. */
+  public String getReactionName() {
+    return reactionName;
+  }
+
+  /** @return signed local reaction rate in units implied by {@link #getRateBasis()}. */
+  public double getReactionRate() {
+    return reactionRate;
+  }
+
+  /** @return reaction rate basis. */
+  public KineticReaction.RateBasis getRateBasis() {
+    return rateBasis;
+  }
+
+  /** @return limiting reactant name, or an empty string when inactive. */
+  public String getLimitingReactant() {
+    return limitingReactant;
+  }
+
+  /** @return limiting reactant concentration [mol/m3]. */
+  public double getLimitingReactantConcentrationMolPerM3() {
+    return limitingReactantConcentrationMolPerM3;
+  }
+
+  /** @return local reaction timescale [s], or positive infinity when inactive. */
+  public double getReactionTimeSeconds() {
+    return reactionTimeSeconds;
+  }
+
+  /** @return transport residence time used for the comparison [s]. */
+  public double getResidenceTimeSeconds() {
+    return residenceTimeSeconds;
+  }
+
+  /** @return residence time divided by reaction time. */
+  public double getDamkohlerNumber() {
+    return damkohlerNumber;
+  }
+
+  /** @return qualitative timescale regime. */
+  public Regime getRegime() {
+    return regime;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/reactor/KineticReactionQualification.java
+++ b/src/main/java/neqsim/process/equipment/reactor/KineticReactionQualification.java
@@ -6,10 +6,12 @@ import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionValidationStatu
 /**
  * Scientific qualification metadata for a {@link KineticReaction}.
  *
- * <p>This class keeps kinetic parameters separate from their evidence. It records the public
- * source, validation status, and the temperature/pressure range for which a kinetic reaction has
- * been qualified. A reaction model can therefore be reused in process and pipeline calculations
- * without silently treating an unvalidated parameter set as generally applicable.</p>
+ * <p>
+ * This class keeps kinetic parameters separate from their evidence. It records the public source, validation status,
+ * and the temperature/pressure range for which a kinetic reaction has been qualified. A reaction model can therefore be
+ * reused in process and pipeline calculations without silently treating an unvalidated parameter set as generally
+ * applicable.
+ * </p>
  *
  * @author NeqSim Team
  * @version 1.0
@@ -40,10 +42,9 @@ public class KineticReactionQualification implements Serializable {
    * @param maximumPressureBara maximum qualified pressure [bara]
    * @param limitations concise limitations or evidence boundary
    */
-  public KineticReactionQualification(String reactionName, String sourceCitation,
-      String sourceIdentifier, ChemicalReactionValidationStatus validationStatus,
-      double minimumTemperatureK, double maximumTemperatureK, double minimumPressureBara,
-      double maximumPressureBara, String limitations) {
+  public KineticReactionQualification(String reactionName, String sourceCitation, String sourceIdentifier,
+      ChemicalReactionValidationStatus validationStatus, double minimumTemperatureK, double maximumTemperatureK,
+      double minimumPressureBara, double maximumPressureBara, String limitations) {
     this.reactionName = requireText(reactionName, "reaction name");
     this.sourceCitation = requireText(sourceCitation, "source citation");
     this.sourceIdentifier = requireText(sourceIdentifier, "source identifier");
@@ -83,12 +84,12 @@ public class KineticReactionQualification implements Serializable {
    */
   public void requireValidatedAt(double temperatureK, double pressureBara) {
     if (validationStatus != ChemicalReactionValidationStatus.VALIDATED) {
-      throw new IllegalStateException("Kinetic reaction '" + reactionName
-          + "' is not independently validated: " + validationStatus);
+      throw new IllegalStateException(
+          "Kinetic reaction '" + reactionName + "' is not independently validated: " + validationStatus);
     }
     if (!isWithinRange(temperatureK, pressureBara)) {
-      throw new IllegalStateException("Kinetic reaction '" + reactionName
-          + "' is outside its qualified temperature/pressure range");
+      throw new IllegalStateException(
+          "Kinetic reaction '" + reactionName + "' is outside its qualified temperature/pressure range");
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/reactor/KineticReactionQualification.java
+++ b/src/main/java/neqsim/process/equipment/reactor/KineticReactionQualification.java
@@ -1,0 +1,160 @@
+package neqsim.process.equipment.reactor;
+
+import java.io.Serializable;
+import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionValidationStatus;
+
+/**
+ * Scientific qualification metadata for a {@link KineticReaction}.
+ *
+ * <p>This class keeps kinetic parameters separate from their evidence. It records the public
+ * source, validation status, and the temperature/pressure range for which a kinetic reaction has
+ * been qualified. A reaction model can therefore be reused in process and pipeline calculations
+ * without silently treating an unvalidated parameter set as generally applicable.</p>
+ *
+ * @author NeqSim Team
+ * @version 1.0
+ */
+public class KineticReactionQualification implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final String reactionName;
+  private final String sourceCitation;
+  private final String sourceIdentifier;
+  private final ChemicalReactionValidationStatus validationStatus;
+  private final double minimumTemperatureK;
+  private final double maximumTemperatureK;
+  private final double minimumPressureBara;
+  private final double maximumPressureBara;
+  private final String limitations;
+
+  /**
+   * Create immutable kinetic-reaction qualification metadata.
+   *
+   * @param reactionName reaction identifier or name
+   * @param sourceCitation human-readable primary-source citation
+   * @param sourceIdentifier DOI, report identifier, or stable public URL
+   * @param validationStatus validation status for this kinetic parameterization
+   * @param minimumTemperatureK minimum qualified temperature [K]
+   * @param maximumTemperatureK maximum qualified temperature [K]
+   * @param minimumPressureBara minimum qualified pressure [bara]
+   * @param maximumPressureBara maximum qualified pressure [bara]
+   * @param limitations concise limitations or evidence boundary
+   */
+  public KineticReactionQualification(String reactionName, String sourceCitation,
+      String sourceIdentifier, ChemicalReactionValidationStatus validationStatus,
+      double minimumTemperatureK, double maximumTemperatureK, double minimumPressureBara,
+      double maximumPressureBara, String limitations) {
+    this.reactionName = requireText(reactionName, "reaction name");
+    this.sourceCitation = requireText(sourceCitation, "source citation");
+    this.sourceIdentifier = requireText(sourceIdentifier, "source identifier");
+    if (validationStatus == null) {
+      throw new IllegalArgumentException("validation status cannot be null");
+    }
+    validateRange(minimumTemperatureK, maximumTemperatureK, "temperature");
+    validateRange(minimumPressureBara, maximumPressureBara, "pressure");
+    this.validationStatus = validationStatus;
+    this.minimumTemperatureK = minimumTemperatureK;
+    this.maximumTemperatureK = maximumTemperatureK;
+    this.minimumPressureBara = minimumPressureBara;
+    this.maximumPressureBara = maximumPressureBara;
+    this.limitations = limitations == null ? "" : limitations.trim();
+  }
+
+  /**
+   * Check whether a thermodynamic state lies inside the declared qualification range.
+   *
+   * @param temperatureK temperature [K]
+   * @param pressureBara absolute pressure [bara]
+   * @return true when both temperature and pressure are inside the inclusive ranges
+   */
+  public boolean isWithinRange(double temperatureK, double pressureBara) {
+    validateFinite(temperatureK, "temperature");
+    validateFinite(pressureBara, "pressure");
+    return temperatureK >= minimumTemperatureK && temperatureK <= maximumTemperatureK
+        && pressureBara >= minimumPressureBara && pressureBara <= maximumPressureBara;
+  }
+
+  /**
+   * Fail closed unless the parameterization is validated and the state is within range.
+   *
+   * @param temperatureK temperature [K]
+   * @param pressureBara absolute pressure [bara]
+   * @throws IllegalStateException when validation or range requirements are not met
+   */
+  public void requireValidatedAt(double temperatureK, double pressureBara) {
+    if (validationStatus != ChemicalReactionValidationStatus.VALIDATED) {
+      throw new IllegalStateException("Kinetic reaction '" + reactionName
+          + "' is not independently validated: " + validationStatus);
+    }
+    if (!isWithinRange(temperatureK, pressureBara)) {
+      throw new IllegalStateException("Kinetic reaction '" + reactionName
+          + "' is outside its qualified temperature/pressure range");
+    }
+  }
+
+  /** @return reaction name. */
+  public String getReactionName() {
+    return reactionName;
+  }
+
+  /** @return human-readable source citation. */
+  public String getSourceCitation() {
+    return sourceCitation;
+  }
+
+  /** @return DOI, report identifier, or stable source URL. */
+  public String getSourceIdentifier() {
+    return sourceIdentifier;
+  }
+
+  /** @return validation status. */
+  public ChemicalReactionValidationStatus getValidationStatus() {
+    return validationStatus;
+  }
+
+  /** @return minimum qualified temperature [K]. */
+  public double getMinimumTemperatureK() {
+    return minimumTemperatureK;
+  }
+
+  /** @return maximum qualified temperature [K]. */
+  public double getMaximumTemperatureK() {
+    return maximumTemperatureK;
+  }
+
+  /** @return minimum qualified pressure [bara]. */
+  public double getMinimumPressureBara() {
+    return minimumPressureBara;
+  }
+
+  /** @return maximum qualified pressure [bara]. */
+  public double getMaximumPressureBara() {
+    return maximumPressureBara;
+  }
+
+  /** @return declared model limitations. */
+  public String getLimitations() {
+    return limitations;
+  }
+
+  private static String requireText(String value, String name) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(name + " cannot be empty");
+    }
+    return value.trim();
+  }
+
+  private static void validateRange(double minimum, double maximum, String name) {
+    validateFinite(minimum, name + " minimum");
+    validateFinite(maximum, name + " maximum");
+    if (minimum <= 0.0 || maximum < minimum) {
+      throw new IllegalArgumentException(name + " range must be positive and ordered");
+    }
+  }
+
+  private static void validateFinite(double value, String name) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException(name + " must be finite");
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/reactor/KineticReactionTransportDiagnosticsTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/KineticReactionTransportDiagnosticsTest.java
@@ -1,0 +1,102 @@
+package neqsim.process.equipment.reactor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionValidationStatus;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Tests for kinetic-reaction qualification and transport-timescale diagnostics. */
+public class KineticReactionTransportDiagnosticsTest extends NeqSimTest {
+
+  @Test
+  void testQualificationFailsClosedOutsideEvidenceBoundary() {
+    KineticReactionQualification qualification = new KineticReactionQualification(
+        "SO2 oxidation", "Public laboratory study", "doi:10.example/kinetics",
+        ChemicalReactionValidationStatus.VALIDATED, 273.15, 323.15, 50.0, 150.0,
+        "Synthetic test metadata");
+
+    assertTrue(qualification.isWithinRange(298.15, 100.0));
+    qualification.requireValidatedAt(298.15, 100.0);
+    assertThrows(IllegalStateException.class, () -> qualification.requireValidatedAt(250.0, 100.0));
+
+    KineticReactionQualification unvalidated = new KineticReactionQualification(
+        "SO2 oxidation", "Illustrative source", "internal:illustrative",
+        ChemicalReactionValidationStatus.UNVALIDATED, 273.15, 323.15, 50.0, 150.0,
+        "Not independently validated");
+    assertThrows(IllegalStateException.class, () -> unvalidated.requireValidatedAt(298.15, 100.0));
+  }
+
+  @Test
+  void testDamkohlerDiagnosticSeparatesTransportAndReactionTimescales() {
+    SystemSrkEos system = createReactiveSystem();
+    KineticReaction reaction = createSyntheticOxidationReaction();
+
+    KineticReactionDiagnostics reference =
+        KineticReactionDiagnostics.evaluate(reaction, system, 0, 1.0);
+    assertTrue(reference.getReactionRate() > 0.0);
+    assertTrue(reference.getReactionTimeSeconds() > 0.0);
+    assertTrue(Double.isFinite(reference.getReactionTimeSeconds()));
+    assertTrue(reference.getLimitingReactant().length() > 0);
+
+    double reactionTime = reference.getReactionTimeSeconds();
+    KineticReactionDiagnostics slowTransport =
+        KineticReactionDiagnostics.evaluate(reaction, system, 0, 0.01 * reactionTime);
+    KineticReactionDiagnostics coupled =
+        KineticReactionDiagnostics.evaluate(reaction, system, 0, reactionTime);
+    KineticReactionDiagnostics fastChemistry =
+        KineticReactionDiagnostics.evaluate(reaction, system, 0, 100.0 * reactionTime);
+
+    assertEquals(KineticReactionDiagnostics.Regime.TRANSPORT_DOMINATED,
+        slowTransport.getRegime());
+    assertEquals(KineticReactionDiagnostics.Regime.COUPLED, coupled.getRegime());
+    assertEquals(KineticReactionDiagnostics.Regime.REACTION_DOMINATED,
+        fastChemistry.getRegime());
+    assertEquals(0.01, slowTransport.getDamkohlerNumber(), 1.0e-10);
+    assertEquals(1.0, coupled.getDamkohlerNumber(), 1.0e-10);
+    assertEquals(100.0, fastChemistry.getDamkohlerNumber(), 1.0e-8);
+  }
+
+  @Test
+  void testInactiveReactionAndUnsupportedBasisAreExplicit() {
+    SystemSrkEos system = createReactiveSystem();
+    KineticReaction reaction = createSyntheticOxidationReaction();
+    reaction.setPreExponentialFactor(0.0);
+
+    KineticReactionDiagnostics inactive =
+        KineticReactionDiagnostics.evaluate(reaction, system, 0, 100.0);
+    assertEquals(KineticReactionDiagnostics.Regime.INACTIVE, inactive.getRegime());
+    assertEquals(0.0, inactive.getDamkohlerNumber(), 0.0);
+    assertTrue(Double.isInfinite(inactive.getReactionTimeSeconds()));
+
+    reaction.setRateBasis(KineticReaction.RateBasis.CATALYST_MASS);
+    assertThrows(IllegalArgumentException.class,
+        () -> KineticReactionDiagnostics.evaluate(reaction, system, 0, 100.0));
+  }
+
+  private SystemSrkEos createReactiveSystem() {
+    SystemSrkEos system = new SystemSrkEos(298.15, 100.0);
+    system.addComponent("CO2", 1.0);
+    system.addComponent("SO2", 1.0e-4);
+    system.addComponent("oxygen", 5.0e-4);
+    system.setMixingRule("classic");
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+    operations.TPflash();
+    system.initProperties();
+    return system;
+  }
+
+  private KineticReaction createSyntheticOxidationReaction() {
+    KineticReaction reaction = new KineticReaction("synthetic SO2 oxidation");
+    reaction.addReactant("SO2", 1.0, 1.0);
+    reaction.addReactant("oxygen", 0.5, 1.0);
+    reaction.addProduct("SO3", 1.0);
+    reaction.setPreExponentialFactor(1.0e-3);
+    reaction.setActivationEnergy(0.0);
+    reaction.setRateBasis(KineticReaction.RateBasis.VOLUME);
+    return reaction;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/reactor/KineticReactionTransportDiagnosticsTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/KineticReactionTransportDiagnosticsTest.java
@@ -14,18 +14,16 @@ public class KineticReactionTransportDiagnosticsTest extends NeqSimTest {
 
   @Test
   void testQualificationFailsClosedOutsideEvidenceBoundary() {
-    KineticReactionQualification qualification = new KineticReactionQualification(
-        "SO2 oxidation", "Public laboratory study", "doi:10.example/kinetics",
-        ChemicalReactionValidationStatus.VALIDATED, 273.15, 323.15, 50.0, 150.0,
-        "Synthetic test metadata");
+    KineticReactionQualification qualification = new KineticReactionQualification("SO2 oxidation",
+        "Public laboratory study", "doi:10.example/kinetics", ChemicalReactionValidationStatus.VALIDATED, 273.15,
+        323.15, 50.0, 150.0, "Synthetic test metadata");
 
     assertTrue(qualification.isWithinRange(298.15, 100.0));
     qualification.requireValidatedAt(298.15, 100.0);
     assertThrows(IllegalStateException.class, () -> qualification.requireValidatedAt(250.0, 100.0));
 
-    KineticReactionQualification unvalidated = new KineticReactionQualification(
-        "SO2 oxidation", "Illustrative source", "internal:illustrative",
-        ChemicalReactionValidationStatus.UNVALIDATED, 273.15, 323.15, 50.0, 150.0,
+    KineticReactionQualification unvalidated = new KineticReactionQualification("SO2 oxidation", "Illustrative source",
+        "internal:illustrative", ChemicalReactionValidationStatus.UNVALIDATED, 273.15, 323.15, 50.0, 150.0,
         "Not independently validated");
     assertThrows(IllegalStateException.class, () -> unvalidated.requireValidatedAt(298.15, 100.0));
   }
@@ -35,26 +33,22 @@ public class KineticReactionTransportDiagnosticsTest extends NeqSimTest {
     SystemSrkEos system = createReactiveSystem();
     KineticReaction reaction = createSyntheticOxidationReaction();
 
-    KineticReactionDiagnostics reference =
-        KineticReactionDiagnostics.evaluate(reaction, system, 0, 1.0);
+    KineticReactionDiagnostics reference = KineticReactionDiagnostics.evaluate(reaction, system, 0, 1.0);
     assertTrue(reference.getReactionRate() > 0.0);
     assertTrue(reference.getReactionTimeSeconds() > 0.0);
     assertTrue(Double.isFinite(reference.getReactionTimeSeconds()));
     assertTrue(reference.getLimitingReactant().length() > 0);
 
     double reactionTime = reference.getReactionTimeSeconds();
-    KineticReactionDiagnostics slowTransport =
-        KineticReactionDiagnostics.evaluate(reaction, system, 0, 0.01 * reactionTime);
-    KineticReactionDiagnostics coupled =
-        KineticReactionDiagnostics.evaluate(reaction, system, 0, reactionTime);
-    KineticReactionDiagnostics fastChemistry =
-        KineticReactionDiagnostics.evaluate(reaction, system, 0, 100.0 * reactionTime);
+    KineticReactionDiagnostics slowTransport = KineticReactionDiagnostics.evaluate(reaction, system, 0,
+        0.01 * reactionTime);
+    KineticReactionDiagnostics coupled = KineticReactionDiagnostics.evaluate(reaction, system, 0, reactionTime);
+    KineticReactionDiagnostics fastChemistry = KineticReactionDiagnostics.evaluate(reaction, system, 0,
+        100.0 * reactionTime);
 
-    assertEquals(KineticReactionDiagnostics.Regime.TRANSPORT_DOMINATED,
-        slowTransport.getRegime());
+    assertEquals(KineticReactionDiagnostics.Regime.TRANSPORT_DOMINATED, slowTransport.getRegime());
     assertEquals(KineticReactionDiagnostics.Regime.COUPLED, coupled.getRegime());
-    assertEquals(KineticReactionDiagnostics.Regime.REACTION_DOMINATED,
-        fastChemistry.getRegime());
+    assertEquals(KineticReactionDiagnostics.Regime.REACTION_DOMINATED, fastChemistry.getRegime());
     assertEquals(0.01, slowTransport.getDamkohlerNumber(), 1.0e-10);
     assertEquals(1.0, coupled.getDamkohlerNumber(), 1.0e-10);
     assertEquals(100.0, fastChemistry.getDamkohlerNumber(), 1.0e-8);
@@ -66,15 +60,13 @@ public class KineticReactionTransportDiagnosticsTest extends NeqSimTest {
     KineticReaction reaction = createSyntheticOxidationReaction();
     reaction.setPreExponentialFactor(0.0);
 
-    KineticReactionDiagnostics inactive =
-        KineticReactionDiagnostics.evaluate(reaction, system, 0, 100.0);
+    KineticReactionDiagnostics inactive = KineticReactionDiagnostics.evaluate(reaction, system, 0, 100.0);
     assertEquals(KineticReactionDiagnostics.Regime.INACTIVE, inactive.getRegime());
     assertEquals(0.0, inactive.getDamkohlerNumber(), 0.0);
     assertTrue(Double.isInfinite(inactive.getReactionTimeSeconds()));
 
     reaction.setRateBasis(KineticReaction.RateBasis.CATALYST_MASS);
-    assertThrows(IllegalArgumentException.class,
-        () -> KineticReactionDiagnostics.evaluate(reaction, system, 0, 100.0));
+    assertThrows(IllegalArgumentException.class, () -> KineticReactionDiagnostics.evaluate(reaction, system, 0, 100.0));
   }
 
   private SystemSrkEos createReactiveSystem() {


### PR DESCRIPTION
## Engineering question

Can NeqSim expose a safe, reusable finite-rate-chemistry contract for CO2 transport/injection calculations before coupling reaction source terms directly into pipeline control volumes?

Advances #3318. Coordinates with #3144, #2937 and #2911.

## Frozen scope

- **Exact base/master:** `9e4e36d4b6a59404ac9aa629740fbc312610d3c8`
- **Branch:** `ai/co2-kinetics-diagnostics-3318`
- Reuse existing `KineticReaction` and experimental `CO2ImpurityKineticReactor`; no parallel reaction engine.
- Add scientific qualification metadata and transport/reaction timescale diagnostics.
- No new kinetic constants, fitted parameters, proprietary Northern Lights data, electrolyte parameters, flash changes, or pipeline hydraulic changes.

## Implementation

- `KineticReactionQualification`
  - immutable source citation/identifier and declared T/P range;
  - reuses `ChemicalReactionValidationStatus`;
  - `requireValidatedAt(...)` fails closed for unvalidated parameterizations and out-of-range states.
- `KineticReactionDiagnostics`
  - evaluates existing volume-basis `KineticReaction` rates;
  - identifies the limiting reactant from reaction stoichiometry;
  - estimates reaction time and `Da = t_transport / t_reaction`;
  - classifies `INACTIVE`, `TRANSPORT_DOMINATED`, `COUPLED`, and `REACTION_DOMINATED` regimes;
  - rejects catalyst-mass/area bases until explicit local catalyst loading/area is supplied.
- Focused JUnit coverage for evidence-range enforcement, unvalidated fail-closed behavior, inactive rates, unsupported rate bases, and Damkohler regime transitions.
- New CCS transport kinetics guide documents the intended future control-volume coupling and explicit engineering limitations.

## Scientific boundary

This PR deliberately adds **no kinetic parameter dataset**. The current `CO2ImpurityKineticReactor` default constants remain experimental/illustrative. Future #3318 increments must attach primary literature and qualification metadata before enabling reaction source terms in a representative CCS pipeline trajectory.

## Validation

**DRAFT — VALIDATION PENDING CI**

The initial exact-head pre-commit run exposed Spotless-only violations in the three new Java files. The exact patch produced by the hosted Spotless workflow was applied without behavioral changes, advancing the branch to `858fa9d22e9be3a89ecfdcf8249ef5c56667719f`. Fresh exact-head CI is authoritative and remains in progress.

The implementation and repair were made through the connected GitHub repository interface. No unrun local check is claimed as passing.

## Next dependency-ready increment

After this foundation is green/merged:
1. qualify the first public CO2/H2O finite-rate/equilibrium bridge with primary literature;
2. attach qualification metadata to a reusable reaction set;
3. couple conservative reaction extents and diagnostics into a simple pressure/temperature trajectory before full pipeline control-volume integration.

AI-assisted contribution.