### PR TITLE
[AI-Assisted] fix(dexpi): support empty streams and render Plant P&ID SVG

### DIFF
--- a/.github/skills/neqsim-process-modeling/SKILL.md
+++ b/.github/skills/neqsim-process-modeling/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-process-modeling
 description: "Process modeling and flowsheet construction patterns for NeqSim. USE WHEN: building executable NeqSim process simulations, ProcessSystem flowsheets, or runnable process models with streams, separators, compressors, heat exchangers, valves, pumps, distillation columns, recycles, adjusters, topology checks, result extraction, and engineering validation."
-last_verified: "2026-08-22"
+last_verified: "2026-08-29"
 ---
 
 # NeqSim Process Modeling Skill
@@ -210,6 +210,10 @@ Both switches are re-applied by `run(UUID)`, `run_step(UUID)`,
 - Use `Dexpi20XmlWriter` for native Plant/P&ID exchange and `Dexpi20ProcessModelWriter` for native Process/PFD/BFD
   exchange. A Proteus document with a changed header is not native DEXPI 2.0. Preserve the conformance report and still
   require a named-CAE round-trip before project qualification.
+- Keep an explicitly registered terminal product as `new Stream(productName, upstreamOutlet)` when the product must
+  remain a named topology node. NeqSim reports the wrapped outlet as that stream's inlet and the DEXPI Process exporter
+  maps the node to a sink. Zero-flow and isolated empty streams must not be deleted merely to avoid invalid empty port
+  collections.
 - Use `Cfihos20HandoverExporter` only with an exact project-controlled CFIHOS 2.0 Core or Extended RDL delivery.
   Verify its digest from controlled bytes, map canonical nodes/properties/documents to exact RDL identifiers, record
   mapping approval, and close the generated gap register. Its CSVs are staging data; Principal transformation,

--- a/.github/skills/neqsim-process-modeling/SKILL.md
+++ b/.github/skills/neqsim-process-modeling/SKILL.md
@@ -214,6 +214,8 @@ Both switches are re-applied by `run(UUID)`, `run_step(UUID)`,
   remain a named topology node. NeqSim reports the wrapped outlet as that stream's inlet and the DEXPI Process exporter
   maps the node to a sink. Zero-flow and isolated empty streams must not be deleted merely to avoid invalid empty port
   collections.
+- An isolated `new Stream(name)` with no fluid runs as an inactive topology placeholder. Do not connect downstream
+  thermodynamic equipment to that placeholder until a real fluid state is assigned.
 - Use `Cfihos20HandoverExporter` only with an exact project-controlled CFIHOS 2.0 Core or Extended RDL delivery.
   Verify its digest from controlled bytes, map canonical nodes/properties/documents to exact RDL identifiers, record
   mapping approval, and close the generated gap register. Its CSVs are staging data; Principal transformation,

--- a/docs/integration/dexpi-20-conformance.md
+++ b/docs/integration/dexpi-20-conformance.md
@@ -58,6 +58,12 @@ is multiplicity-sensitive, so two parallel streams between the same steps must r
 Synthetic product sinks are retained in the exported-connection inventory but excluded from the
 in-model topology comparison.
 
+Registered terminal streams created with `new Stream(productName, upstreamOutlet)` remain explicit
+topology nodes and are exported as DEXPI Process sinks. Zero mass flow does not remove that
+connection. Standalone empty streams may coexist with a connected process; because they have no
+material ports, the exporter omits their `Ports` collection instead of writing schema-invalid empty
+components. A Process exchange still requires at least one actual material connection.
+
 `writeAndAssessTopology(...)` builds one canonical snapshot, uses its supported material-connection
 projection to drive the native Process exchange, and assesses the same snapshot. Regression coverage
 requires the assessed simple and parallel-branch output to preserve the existing sequential DEXPI
@@ -215,8 +221,9 @@ Reviewed NeqSim-to-DEXPI Process mappings are:
 
 | NeqSim equipment | DEXPI 2.0 Process type |
 |---|---|
-| feed or boundary `Stream` | `Source` |
-| unconsumed product outlet | `Sink` |
+| standalone feed or empty `Stream` | `Source` |
+| registered terminal `Stream` wrapping an upstream outlet | `Sink` |
+| unconsumed equipment product outlet | `Sink` |
 | compressor | `Compressing` |
 | pump | `Pumping` |
 | separator | `SeparatingByGravity` |

--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -146,6 +146,12 @@ DexpiXmlSvgRenderer.render(dexpi, svg);
 The renderer is self-contained Java and does not require Graphviz or pyDEXPI. Use an independent
 DEXPI consumer as an interoperability check when qualifying an exchange for a project handoff.
 
+An intentionally unconfigured `new Stream("spare")` may remain registered in the `ProcessSystem`.
+Its `run(UUID)` call completes as an inactive topology placeholder without inventing a fluid state,
+and the DEXPI writers and renderer ignore unsupported empty geometry while preserving the connected
+process. Equipment that consumes the placeholder still requires a real thermodynamic inlet before it
+can run.
+
 ### Layout and visualization features
 
 The export path applies NeqSim's built-in auto-layout and visualization defaults: equipment tag

--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -127,6 +127,25 @@ process.run();
 DexpiXmlWriter.write(process, new File("output.xml"));
 ```
 
+### NeqSim-native SVG rendering
+
+`DexpiXmlSvgRenderer` renders the geometry in a Proteus-compatible DEXPI Plant/P&ID exchange
+directly to SVG. It resolves each equipment, valve, nozzle, off-page connector, and instrument
+instance against the document's `ShapeCatalogue`, and preserves process, signal, utility, label,
+stream-table, drawing-border, and title-block primitives. The SVG is therefore a view of the DEXPI
+document rather than a separately reconstructed process diagram.
+
+```java
+File dexpi = new File("plant.xml");
+File svg = new File("plant.svg");
+
+DexpiXmlWriter.write(process, dexpi);
+DexpiXmlSvgRenderer.render(dexpi, svg);
+```
+
+The renderer is self-contained Java and does not require Graphviz or pyDEXPI. Use an independent
+DEXPI consumer as an interoperability check when qualifying an exchange for a project handoff.
+
 ### Layout and visualization features
 
 The export path applies NeqSim's built-in auto-layout and visualization defaults: equipment tag

--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -143,8 +143,11 @@ DexpiXmlWriter.write(process, dexpi);
 DexpiXmlSvgRenderer.render(dexpi, svg);
 ```
 
-The renderer is self-contained Java and does not require Graphviz or pyDEXPI. Use an independent
-DEXPI consumer as an interoperability check when qualifying an exchange for a project handoff.
+The renderer is self-contained Java and does not require Graphviz or pyDEXPI. Generated title
+blocks are marked `PROPOSAL`, and their initial revision is `Engineering Proposal`; a controlled
+owner status and accountable review are required before a drawing can be issued for design or
+construction. Use an independent DEXPI consumer as an interoperability check when qualifying an
+exchange for a project handoff.
 
 An intentionally unconfigured `new Stream("spare")` may remain registered in the `ProcessSystem`.
 Its `run(UUID)` call completes as an inactive topology placeholder without inventing a fluid state,

--- a/src/main/java/neqsim/process/diagnostics/FailurePropagationTracer.java
+++ b/src/main/java/neqsim/process/diagnostics/FailurePropagationTracer.java
@@ -161,17 +161,19 @@ public class FailurePropagationTracer implements Serializable {
       result.addStep(new PropagationStep(directName, delay, 1, effect, impact));
     }
 
-    // Trace indirect downstream effects
-    double cumulativeDelay = DEFAULT_DIRECT_DELAY;
-    for (String indirectName : depResult.getIndirectlyAffected()) {
-      if (visited.contains(indirectName)) {
-        continue;
+    // Trace indirect downstream effects only when the configured depth includes them
+    if (maxCascadeDepth >= 2) {
+      double cumulativeDelay = DEFAULT_DIRECT_DELAY;
+      for (String indirectName : depResult.getIndirectlyAffected()) {
+        if (visited.contains(indirectName)) {
+          continue;
+        }
+        visited.add(indirectName);
+        cumulativeDelay += DEFAULT_INDIRECT_DELAY;
+        String effect = classifyEffect(failedEquipmentName, indirectName);
+        PropagationStep.ImpactLevel impact = assessImpact(indirectName);
+        result.addStep(new PropagationStep(indirectName, cumulativeDelay, 2, effect, impact));
       }
-      visited.add(indirectName);
-      cumulativeDelay += DEFAULT_INDIRECT_DELAY;
-      String effect = classifyEffect(failedEquipmentName, indirectName);
-      PropagationStep.ImpactLevel impact = assessImpact(indirectName);
-      result.addStep(new PropagationStep(indirectName, cumulativeDelay, 2, effect, impact));
     }
 
     // Add production impact

--- a/src/main/java/neqsim/process/engineering/dexpi/DexpiEngineeringMaterializer.java
+++ b/src/main/java/neqsim/process/engineering/dexpi/DexpiEngineeringMaterializer.java
@@ -22,9 +22,8 @@ import neqsim.process.engineering.SafetyFunctionDesign;
 
 /** Materializes governed engineering requirements as DEXPI P&amp;ID objects. */
 public final class DexpiEngineeringMaterializer {
-  private static final int INSTRUMENT_ROWS_PER_COLUMN = 3;
-  private static final double INSTRUMENT_COLUMN_SPACING = 50.0;
-  private static final double INSTRUMENT_X_SPACING = 22.0;
+  private static final int INSTRUMENT_COLUMNS = 5;
+  private static final double INSTRUMENT_X_SPACING = 26.0;
   private static final double INSTRUMENT_ROW_SPACING = 14.0;
   private static final double INSTRUMENT_VERTICAL_CLEARANCE = 10.0;
   private static final int DEVICE_COLUMNS = 2;
@@ -282,14 +281,19 @@ public final class DexpiEngineeringMaterializer {
     int functionCount = 0;
     int deviceCount = 0;
     List<CauseAndEffectEntry> matrix = new ArrayList<CauseAndEffectEntry>();
-    Map<String, Integer> loopCounts = new LinkedHashMap<String, Integer>();
-    Map<String, Integer> nextLoopIndexes = new LinkedHashMap<String, Integer>();
+    Map<String, Integer> instrumentCounts = new LinkedHashMap<String, Integer>();
+    Map<String, Integer> nextInstrumentIndexes = new LinkedHashMap<String, Integer>();
     Map<String, Integer> nextDeviceIndexes = new LinkedHashMap<String, Integer>();
     for (EngineeringRequirement requirement : project.getRequirements()) {
       String equipmentTag = requirement.getEquipmentTag();
-      if (equipment.containsKey(equipmentTag) && definitionFor(requirement) != null) {
-        Integer count = loopCounts.get(equipmentTag);
-        loopCounts.put(equipmentTag, Integer.valueOf(count == null ? 1 : count.intValue() + 1));
+      FunctionDefinition definition = definitionFor(requirement);
+      if (equipment.containsKey(equipmentTag) && definition != null) {
+        int instrumentCount = definition.sensors.size() + (definition.controller == null ? 0 : 1);
+        if (instrumentCount > 0) {
+          Integer count = instrumentCounts.get(equipmentTag);
+          instrumentCounts.put(equipmentTag,
+              Integer.valueOf((count == null ? 0 : count.intValue()) + instrumentCount));
+        }
       }
     }
 
@@ -306,25 +310,20 @@ public final class DexpiEngineeringMaterializer {
       String number = tagNumber(equipmentTag);
       List<String> loopMembers = new ArrayList<String>();
       String initiatingTag = "";
-      int loopIndex = nextIndex(nextLoopIndexes, equipmentTag);
-      int loopCount = loopCounts.get(equipmentTag).intValue();
-      int columnCount = (loopCount + INSTRUMENT_ROWS_PER_COLUMN - 1) / INSTRUMENT_ROWS_PER_COLUMN;
-      int columnIndex = loopIndex / INSTRUMENT_ROWS_PER_COLUMN;
-      int rowIndex = loopIndex % INSTRUMENT_ROWS_PER_COLUMN;
-      double columnCenter = protectedEquipment.x
-          + (columnIndex - (columnCount - 1) / 2.0) * INSTRUMENT_COLUMN_SPACING;
+      int instrumentStartIndex = currentIndex(nextInstrumentIndexes, equipmentTag);
+      Integer totalInstrumentCountValue = instrumentCounts.get(equipmentTag);
+      int totalInstrumentCount = totalInstrumentCountValue == null ? 0 : totalInstrumentCountValue.intValue();
       int instrumentCount = definition.sensors.size() + (definition.controller == null ? 0 : 1);
-      double baseX = columnCenter - Math.max(0, instrumentCount - 1) * INSTRUMENT_X_SPACING / 2.0;
-      double baseY = protectedEquipment.annotationTopY + INSTRUMENT_VERTICAL_CLEARANCE
-          + rowIndex * INSTRUMENT_ROW_SPACING;
 
       for (int i = 0; i < definition.sensors.size(); i++) {
         String tag = definition.sensors.get(i) + "-" + number;
         if (i > 0) {
           tag += "-" + (i + 1);
         }
+        double[] instrumentPosition =
+            instrumentPosition(protectedEquipment, instrumentStartIndex + i, totalInstrumentCount);
         String id = appendInstrumentFunction(document, root, usedIds, project, requirement, protectedEquipment, tag,
-            definition.controlSystem, "SENSOR_OR_SWITCH", baseX + i * INSTRUMENT_X_SPACING, baseY);
+            definition.controlSystem, "SENSOR_OR_SWITCH", instrumentPosition[0], instrumentPosition[1]);
         loopMembers.add(id);
         functionCount++;
         if (initiatingTag.isEmpty()) {
@@ -334,9 +333,10 @@ public final class DexpiEngineeringMaterializer {
 
       if (definition.controller != null) {
         String tag = definition.controller + "-" + number;
+        double[] controllerPosition = instrumentPosition(protectedEquipment,
+            instrumentStartIndex + definition.sensors.size(), totalInstrumentCount);
         String id = appendInstrumentFunction(document, root, usedIds, project, requirement, protectedEquipment, tag,
-            definition.controlSystem, "CONTROLLER_OR_LOGIC_SOLVER",
-            baseX + definition.sensors.size() * INSTRUMENT_X_SPACING, baseY);
+            definition.controlSystem, "CONTROLLER_OR_LOGIC_SOLVER", controllerPosition[0], controllerPosition[1]);
         for (String sensorId : loopMembers) {
           appendInformationFlow(document, root, usedIds, project, requirement, sensorId, id, definition.controlSystem,
               "SignalConveyingFunction");
@@ -344,6 +344,8 @@ public final class DexpiEngineeringMaterializer {
         loopMembers.add(id);
         functionCount++;
       }
+
+      nextInstrumentIndexes.put(equipmentTag, Integer.valueOf(instrumentStartIndex + instrumentCount));
 
       String actuatingSourceId = last(loopMembers);
       int equipmentDeviceIndex = currentIndex(nextDeviceIndexes, equipmentTag);
@@ -720,6 +722,15 @@ public final class DexpiEngineeringMaterializer {
       }
     }
     return top;
+  }
+
+  private static double[] instrumentPosition(EquipmentReference equipment, int index, int total) {
+    int columns = Math.min(INSTRUMENT_COLUMNS, Math.max(1, total));
+    int column = index % columns;
+    int row = index / columns;
+    double startX = equipment.x - (columns - 1) * INSTRUMENT_X_SPACING / 2.0;
+    return new double[] { startX + column * INSTRUMENT_X_SPACING,
+        equipment.annotationTopY + INSTRUMENT_VERTICAL_CLEARANCE + row * INSTRUMENT_ROW_SPACING };
   }
 
   private static int currentIndex(Map<String, Integer> indexes, String equipmentTag) {

--- a/src/main/java/neqsim/process/engineering/dexpi/DexpiEngineeringMaterializer.java
+++ b/src/main/java/neqsim/process/engineering/dexpi/DexpiEngineeringMaterializer.java
@@ -22,6 +22,16 @@ import neqsim.process.engineering.SafetyFunctionDesign;
 
 /** Materializes governed engineering requirements as DEXPI P&amp;ID objects. */
 public final class DexpiEngineeringMaterializer {
+  private static final int INSTRUMENT_ROWS_PER_COLUMN = 3;
+  private static final double INSTRUMENT_COLUMN_SPACING = 50.0;
+  private static final double INSTRUMENT_X_SPACING = 22.0;
+  private static final double INSTRUMENT_ROW_SPACING = 14.0;
+  private static final double INSTRUMENT_VERTICAL_CLEARANCE = 10.0;
+  private static final int DEVICE_COLUMNS = 2;
+  private static final double DEVICE_X_SPACING = 50.0;
+  private static final double DEVICE_ROW_SPACING = 16.0;
+  private static final double DEVICE_VERTICAL_OFFSET = 24.0;
+
   private DexpiEngineeringMaterializer() {
   }
 
@@ -186,14 +196,17 @@ public final class DexpiEngineeringMaterializer {
     private final String outletNozzleId;
     private final double x;
     private final double y;
+    private final double annotationTopY;
 
-    EquipmentReference(Element element, String id, String inletNozzleId, String outletNozzleId, double x, double y) {
+    EquipmentReference(Element element, String id, String inletNozzleId, String outletNozzleId, double x, double y,
+        double annotationTopY) {
       this.element = element;
       this.id = id;
       this.inletNozzleId = inletNozzleId;
       this.outletNozzleId = outletNozzleId;
       this.x = x;
       this.y = y;
+      this.annotationTopY = annotationTopY;
     }
   }
 
@@ -268,8 +281,17 @@ public final class DexpiEngineeringMaterializer {
     Element reliefSystem = createNetworkSystem(document, usedIds, "ReliefAndBlowdown", "FLARE_RELIEF_AND_BLOWDOWN");
     int functionCount = 0;
     int deviceCount = 0;
-    int offset = 0;
     List<CauseAndEffectEntry> matrix = new ArrayList<CauseAndEffectEntry>();
+    Map<String, Integer> loopCounts = new LinkedHashMap<String, Integer>();
+    Map<String, Integer> nextLoopIndexes = new LinkedHashMap<String, Integer>();
+    Map<String, Integer> nextDeviceIndexes = new LinkedHashMap<String, Integer>();
+    for (EngineeringRequirement requirement : project.getRequirements()) {
+      String equipmentTag = requirement.getEquipmentTag();
+      if (equipment.containsKey(equipmentTag) && definitionFor(requirement) != null) {
+        Integer count = loopCounts.get(equipmentTag);
+        loopCounts.put(equipmentTag, Integer.valueOf(count == null ? 1 : count.intValue() + 1));
+      }
+    }
 
     for (EngineeringRequirement requirement : project.getRequirements()) {
       EquipmentReference protectedEquipment = equipment.get(requirement.getEquipmentTag());
@@ -280,11 +302,21 @@ public final class DexpiEngineeringMaterializer {
       if (definition == null) {
         continue;
       }
-      String number = tagNumber(requirement.getEquipmentTag());
+      String equipmentTag = requirement.getEquipmentTag();
+      String number = tagNumber(equipmentTag);
       List<String> loopMembers = new ArrayList<String>();
       String initiatingTag = "";
-      double baseX = protectedEquipment.x - 6.0 + (offset % 4) * 4.0;
-      double baseY = protectedEquipment.y + 16.0 + (offset / 4) * 8.0;
+      int loopIndex = nextIndex(nextLoopIndexes, equipmentTag);
+      int loopCount = loopCounts.get(equipmentTag).intValue();
+      int columnCount = (loopCount + INSTRUMENT_ROWS_PER_COLUMN - 1) / INSTRUMENT_ROWS_PER_COLUMN;
+      int columnIndex = loopIndex / INSTRUMENT_ROWS_PER_COLUMN;
+      int rowIndex = loopIndex % INSTRUMENT_ROWS_PER_COLUMN;
+      double columnCenter = protectedEquipment.x
+          + (columnIndex - (columnCount - 1) / 2.0) * INSTRUMENT_COLUMN_SPACING;
+      int instrumentCount = definition.sensors.size() + (definition.controller == null ? 0 : 1);
+      double baseX = columnCenter - Math.max(0, instrumentCount - 1) * INSTRUMENT_X_SPACING / 2.0;
+      double baseY = protectedEquipment.annotationTopY + INSTRUMENT_VERTICAL_CLEARANCE
+          + rowIndex * INSTRUMENT_ROW_SPACING;
 
       for (int i = 0; i < definition.sensors.size(); i++) {
         String tag = definition.sensors.get(i) + "-" + number;
@@ -292,7 +324,7 @@ public final class DexpiEngineeringMaterializer {
           tag += "-" + (i + 1);
         }
         String id = appendInstrumentFunction(document, root, usedIds, project, requirement, protectedEquipment, tag,
-            definition.controlSystem, "SENSOR_OR_SWITCH", baseX + i * 4.0, baseY);
+            definition.controlSystem, "SENSOR_OR_SWITCH", baseX + i * INSTRUMENT_X_SPACING, baseY);
         loopMembers.add(id);
         functionCount++;
         if (initiatingTag.isEmpty()) {
@@ -303,7 +335,8 @@ public final class DexpiEngineeringMaterializer {
       if (definition.controller != null) {
         String tag = definition.controller + "-" + number;
         String id = appendInstrumentFunction(document, root, usedIds, project, requirement, protectedEquipment, tag,
-            definition.controlSystem, "CONTROLLER_OR_LOGIC_SOLVER", baseX + 8.0, baseY);
+            definition.controlSystem, "CONTROLLER_OR_LOGIC_SOLVER",
+            baseX + definition.sensors.size() * INSTRUMENT_X_SPACING, baseY);
         for (String sensorId : loopMembers) {
           appendInformationFlow(document, root, usedIds, project, requirement, sensorId, id, definition.controlSystem,
               "SignalConveyingFunction");
@@ -313,12 +346,17 @@ public final class DexpiEngineeringMaterializer {
       }
 
       String actuatingSourceId = last(loopMembers);
+      int equipmentDeviceIndex = currentIndex(nextDeviceIndexes, equipmentTag);
       for (DeviceDefinition device : definition.finalElements) {
         String tag = device.tagPrefix + "-" + number;
         Element targetSystem = isReliefOrBlowdownTag(tag) ? reliefSystem : protectionSystem;
+        int deviceColumn = equipmentDeviceIndex % DEVICE_COLUMNS;
+        int deviceRow = equipmentDeviceIndex / DEVICE_COLUMNS;
+        double deviceX = protectedEquipment.x
+            + (deviceColumn - (DEVICE_COLUMNS - 1) / 2.0) * DEVICE_X_SPACING;
+        double deviceY = protectedEquipment.y - DEVICE_VERTICAL_OFFSET - deviceRow * DEVICE_ROW_SPACING;
         String id = appendPipingComponent(document, targetSystem, usedIds, project, requirement, protectedEquipment,
-            tag, device.componentClass, definition.controlSystem, baseX + 12.0 + deviceCount % 4 * 3.0,
-            protectedEquipment.y);
+            tag, device.componentClass, definition.controlSystem, deviceX, deviceY);
         if (actuatingSourceId != null && !"SwingCheckValve".equals(device.componentClass)
             && !"SpringLoadedGlobeSafetyValve".equals(device.componentClass)) {
           appendInformationFlow(document, root, usedIds, project, requirement, actuatingSourceId, id,
@@ -326,7 +364,9 @@ public final class DexpiEngineeringMaterializer {
         }
         loopMembers.add(id);
         deviceCount++;
+        equipmentDeviceIndex++;
       }
+      nextDeviceIndexes.put(equipmentTag, Integer.valueOf(equipmentDeviceIndex));
 
       appendInstrumentationLoop(document, root, usedIds, project, requirement, loopMembers);
       if (definition.cause != null) {
@@ -335,7 +375,6 @@ public final class DexpiEngineeringMaterializer {
         }
         matrix.add(new CauseAndEffectEntry(requirement, initiatingTag, definition.cause, definition.effects));
       }
-      offset++;
     }
 
     if (hasPipingSegments(protectionSystem)) {
@@ -657,9 +696,41 @@ public final class DexpiEngineeringMaterializer {
       String outletNozzle = nozzles.getLength() == 0 ? null
           : ((Element) nozzles.item(nozzles.getLength() - 1)).getAttribute("ID");
       result.put(tag, new EquipmentReference(equipment, equipment.getAttribute("ID"), inletNozzle, outletNozzle,
-          position[0], position[1]));
+          position[0], position[1], findAnnotationTop(equipment, position[1])));
     }
     return result;
+  }
+
+  private static double findAnnotationTop(Element equipment, double equipmentY) {
+    double top = equipmentY + 22.0;
+    NodeList labels = equipment.getElementsByTagName("Label");
+    for (int i = 0; i < labels.getLength(); i++) {
+      Element label = (Element) labels.item(i);
+      if (!"EquipmentBarLabel".equals(label.getAttribute("ComponentClass"))) {
+        continue;
+      }
+      NodeList coordinates = label.getElementsByTagName("Coordinate");
+      for (int j = 0; j < coordinates.getLength(); j++) {
+        Element coordinate = (Element) coordinates.item(j);
+        try {
+          top = Math.max(top, Double.parseDouble(coordinate.getAttribute("Y")));
+        } catch (NumberFormatException ignored) {
+          // Keep the deterministic equipment-relative fallback for malformed graphical metadata.
+        }
+      }
+    }
+    return top;
+  }
+
+  private static int currentIndex(Map<String, Integer> indexes, String equipmentTag) {
+    Integer index = indexes.get(equipmentTag);
+    return index == null ? 0 : index.intValue();
+  }
+
+  private static int nextIndex(Map<String, Integer> indexes, String equipmentTag) {
+    int index = currentIndex(indexes, equipmentTag);
+    indexes.put(equipmentTag, Integer.valueOf(index + 1));
+    return index;
   }
 
   private static double[] findPosition(Element element) {

--- a/src/main/java/neqsim/process/engineering/dexpi/DexpiEngineeringMaterializer.java
+++ b/src/main/java/neqsim/process/engineering/dexpi/DexpiEngineeringMaterializer.java
@@ -478,7 +478,7 @@ public final class DexpiEngineeringMaterializer {
     function.setAttribute("ComponentClassURI", "http://sandbox.dexpi.org/rdl/ProcessInstrumentationFunction");
     function.setAttribute("ComponentName", "INSTRUMENTATION_BUBBLE_SHAPE_FIELD");
     appendPosition(document, function, x, y);
-    appendLabel(document, function, id, tag, x, y);
+    appendInstrumentLabel(document, function, id, tag, x, y);
 
     String[] parts = tag.split("-", 2);
     Element dexpi = document.createElement("GenericAttributes");
@@ -817,6 +817,19 @@ public final class DexpiEngineeringMaterializer {
     parent.appendChild(scale);
   }
 
+  private static void appendInstrumentLabel(Document document, Element parent, String parentId, String tag, double x,
+      double y) {
+    String[] parts = tag.split("-", 2);
+    String functionText = parts[0];
+    String numberText = parts.length > 1 ? parts[1] : tag;
+    Element label = document.createElement("Label");
+    label.setAttribute("ID", parentId + "-Label");
+    label.setAttribute("ComponentClass", "ProcessInstrumentationFunctionLabel");
+    appendLabelText(document, label, functionText, x, y + 1.2, 1.8);
+    appendLabelText(document, label, numberText, x, y - 1.2, numberText.length() > 10 ? 1.1 : 1.4);
+    parent.appendChild(label);
+  }
+
   private static void appendLabel(Document document, Element parent, String parentId, String tag, double x, double y) {
     Element label = document.createElement("Label");
     label.setAttribute("ID", parentId + "-Label");
@@ -829,6 +842,17 @@ public final class DexpiEngineeringMaterializer {
     appendTextPosition(document, text, x, y + 3.5);
     label.appendChild(text);
     parent.appendChild(label);
+  }
+
+  private static void appendLabelText(Document document, Element label, String value, double x, double y,
+      double height) {
+    Element text = document.createElement("Text");
+    text.setAttribute("String", value);
+    text.setAttribute("Font", "Arial");
+    text.setAttribute("Height", String.valueOf(height));
+    text.setAttribute("Justification", "CenterCenter");
+    appendTextPosition(document, text, x, y);
+    label.appendChild(text);
   }
 
   private static void appendTextPosition(Document document, Element parent, double x, double y) {

--- a/src/main/java/neqsim/process/engineering/dexpi/DexpiEngineeringMaterializer.java
+++ b/src/main/java/neqsim/process/engineering/dexpi/DexpiEngineeringMaterializer.java
@@ -24,8 +24,9 @@ import neqsim.process.engineering.SafetyFunctionDesign;
 public final class DexpiEngineeringMaterializer {
   private static final int INSTRUMENT_COLUMNS = 5;
   private static final double INSTRUMENT_X_SPACING = 26.0;
-  private static final double INSTRUMENT_ROW_SPACING = 14.0;
-  private static final double INSTRUMENT_VERTICAL_CLEARANCE = 10.0;
+  private static final double INSTRUMENT_ROW_SPACING = 12.0;
+  private static final double INSTRUMENT_VERTICAL_CLEARANCE = 6.0;
+  private static final double ENGINEERING_BOUNDARY_CLEARANCE = 10.0;
   private static final int DEVICE_COLUMNS = 2;
   private static final double DEVICE_X_SPACING = 50.0;
   private static final double DEVICE_ROW_SPACING = 16.0;
@@ -383,6 +384,7 @@ public final class DexpiEngineeringMaterializer {
     if (hasPipingSegments(reliefSystem)) {
       insertBeforeCatalogue(root, reliefSystem);
     }
+    expandBatteryLimitBoundary(document);
     return new MaterializationResult(matrix, functionCount, deviceCount);
   }
 
@@ -720,6 +722,83 @@ public final class DexpiEngineeringMaterializer {
       }
     }
     return top;
+  }
+
+  private static void expandBatteryLimitBoundary(Document document) {
+    Element boundary = null;
+    NodeList labels = document.getElementsByTagName("Label");
+    for (int i = 0; i < labels.getLength(); i++) {
+      Element candidate = (Element) labels.item(i);
+      if ("BatteryLimit-1".equals(candidate.getAttribute("ID"))) {
+        boundary = candidate;
+        break;
+      }
+    }
+    if (boundary == null) {
+      return;
+    }
+
+    NodeList coordinates = boundary.getElementsByTagName("Coordinate");
+    if (coordinates.getLength() < 5) {
+      return;
+    }
+    double left = Double.MAX_VALUE;
+    double right = -Double.MAX_VALUE;
+    double bottom = Double.MAX_VALUE;
+    double top = -Double.MAX_VALUE;
+    for (int i = 0; i < coordinates.getLength(); i++) {
+      Element coordinate = (Element) coordinates.item(i);
+      try {
+        double x = Double.parseDouble(coordinate.getAttribute("X"));
+        double y = Double.parseDouble(coordinate.getAttribute("Y"));
+        left = Math.min(left, x);
+        right = Math.max(right, x);
+        bottom = Math.min(bottom, y);
+        top = Math.max(top, y);
+      } catch (NumberFormatException ignored) {
+        return;
+      }
+    }
+
+    NodeList all = document.getElementsByTagName("*");
+    for (int i = 0; i < all.getLength(); i++) {
+      Element element = (Element) all.item(i);
+      String elementName = element.getTagName();
+      if (!"ProcessInstrumentationFunction".equals(elementName) && !"PipingComponent".equals(elementName)) {
+        continue;
+      }
+      if (findGenericAttribute(element, "ProtectedEquipmentTag") == null) {
+        continue;
+      }
+      double[] position = findPosition(element);
+      left = Math.min(left, position[0] - ENGINEERING_BOUNDARY_CLEARANCE);
+      right = Math.max(right, position[0] + ENGINEERING_BOUNDARY_CLEARANCE);
+      bottom = Math.min(bottom, position[1] - ENGINEERING_BOUNDARY_CLEARANCE);
+      top = Math.max(top, position[1] + ENGINEERING_BOUNDARY_CLEARANCE);
+    }
+
+    setCoordinate((Element) coordinates.item(0), left, bottom);
+    setCoordinate((Element) coordinates.item(1), right, bottom);
+    setCoordinate((Element) coordinates.item(2), right, top);
+    setCoordinate((Element) coordinates.item(3), left, top);
+    setCoordinate((Element) coordinates.item(4), left, bottom);
+
+    NodeList texts = boundary.getElementsByTagName("Text");
+    if (texts.getLength() > 0) {
+      Element text = (Element) texts.item(0);
+      text.setAttribute("Justification", "LeftTop");
+      NodeList locations = text.getElementsByTagName("Location");
+      if (locations.getLength() > 0) {
+        Element location = (Element) locations.item(0);
+        location.setAttribute("X", String.valueOf(left + 2.0));
+        location.setAttribute("Y", String.valueOf(top - 2.0));
+      }
+    }
+  }
+
+  private static void setCoordinate(Element coordinate, double x, double y) {
+    coordinate.setAttribute("X", String.valueOf(x));
+    coordinate.setAttribute("Y", String.valueOf(y));
   }
 
   private static double[] instrumentPosition(EquipmentReference equipment, int index, int total) {

--- a/src/main/java/neqsim/process/engineering/dexpi/DexpiEngineeringMaterializer.java
+++ b/src/main/java/neqsim/process/engineering/dexpi/DexpiEngineeringMaterializer.java
@@ -291,8 +291,7 @@ public final class DexpiEngineeringMaterializer {
         int instrumentCount = definition.sensors.size() + (definition.controller == null ? 0 : 1);
         if (instrumentCount > 0) {
           Integer count = instrumentCounts.get(equipmentTag);
-          instrumentCounts.put(equipmentTag,
-              Integer.valueOf((count == null ? 0 : count.intValue()) + instrumentCount));
+          instrumentCounts.put(equipmentTag, Integer.valueOf((count == null ? 0 : count.intValue()) + instrumentCount));
         }
       }
     }
@@ -320,8 +319,8 @@ public final class DexpiEngineeringMaterializer {
         if (i > 0) {
           tag += "-" + (i + 1);
         }
-        double[] instrumentPosition =
-            instrumentPosition(protectedEquipment, instrumentStartIndex + i, totalInstrumentCount);
+        double[] instrumentPosition = instrumentPosition(protectedEquipment, instrumentStartIndex + i,
+            totalInstrumentCount);
         String id = appendInstrumentFunction(document, root, usedIds, project, requirement, protectedEquipment, tag,
             definition.controlSystem, "SENSOR_OR_SWITCH", instrumentPosition[0], instrumentPosition[1]);
         loopMembers.add(id);
@@ -354,8 +353,7 @@ public final class DexpiEngineeringMaterializer {
         Element targetSystem = isReliefOrBlowdownTag(tag) ? reliefSystem : protectionSystem;
         int deviceColumn = equipmentDeviceIndex % DEVICE_COLUMNS;
         int deviceRow = equipmentDeviceIndex / DEVICE_COLUMNS;
-        double deviceX = protectedEquipment.x
-            + (deviceColumn - (DEVICE_COLUMNS - 1) / 2.0) * DEVICE_X_SPACING;
+        double deviceX = protectedEquipment.x + (deviceColumn - (DEVICE_COLUMNS - 1) / 2.0) * DEVICE_X_SPACING;
         double deviceY = protectedEquipment.y - DEVICE_VERTICAL_OFFSET - deviceRow * DEVICE_ROW_SPACING;
         String id = appendPipingComponent(document, targetSystem, usedIds, project, requirement, protectedEquipment,
             tag, device.componentClass, definition.controlSystem, deviceX, deviceY);

--- a/src/main/java/neqsim/process/equipment/stream/Stream.java
+++ b/src/main/java/neqsim/process/equipment/stream/Stream.java
@@ -570,10 +570,24 @@ public class Stream extends ProcessEquipmentBaseClass
   /** {@inheritDoc} */
   @Override
   public void run(UUID id) {
-    if (!getFluid().isInitialized()) {
-      getFluid().init(0);
+    SystemInterface fluid = getFluid();
+    if (fluid == null) {
+      // A named but unconfigured stream is a valid inactive topology placeholder. Treat it as
+      // solved for this pass so ProcessSystem execution, diagram generation, and exchange export
+      // can retain the placeholder without inventing a thermodynamic state.
+      isActive(false);
+      lastFlowRate = 0.0;
+      lastTemperature = Double.NaN;
+      lastPressure = Double.NaN;
+      lastComposition = null;
+      lastSpecification = getSpecification();
+      setCalculationIdentifier(id);
+      return;
     }
-    thermoSystem = getFluid().clone();
+    if (!fluid.isInitialized()) {
+      fluid.init(0);
+    }
+    thermoSystem = fluid.clone();
 
     if (getFlowRate("kg/hr") < getMinimumFlow()) {
       isActive(false);

--- a/src/main/java/neqsim/process/equipment/stream/Stream.java
+++ b/src/main/java/neqsim/process/equipment/stream/Stream.java
@@ -8,7 +8,9 @@ package neqsim.process.equipment.stream;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
@@ -1132,6 +1134,23 @@ public class Stream extends ProcessEquipmentBaseClass
    */
   public void setInletStream(StreamInterface stream) {
     this.setStream(stream);
+  }
+
+  /**
+   * Returns the stream wrapped by this stream unit, when present.
+   *
+   * <p>
+   * A stream constructed from another stream is a topology node as well as a fluid-state view. Reporting that wrapped
+   * stream as its inlet lets graph, exchange, and diagram APIs retain explicit terminal product streams. A standalone
+   * feed or empty stream has no inlet.
+   * </p>
+   *
+   * @return an immutable singleton containing the wrapped stream, or an empty list
+   */
+  @Override
+  public List<StreamInterface> getInletStreams() {
+    return stream == null || stream == this ? Collections.<StreamInterface>emptyList()
+        : Collections.singletonList(stream);
   }
 
   /**

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriter.java
@@ -244,9 +244,6 @@ public final class Dexpi20ProcessModelWriter {
     Map<StreamInterface, Boolean> consumed = new IdentityHashMap<StreamInterface, Boolean>();
     int number = 1;
     for (ProcessEquipmentInterface target : units) {
-      if (target instanceof StreamInterface) {
-        continue;
-      }
       for (StreamInterface inlet : target.getInletStreams()) {
         ProcessEquipmentInterface source = sourceByStream.get(inlet);
         if (source != null) {
@@ -330,9 +327,8 @@ public final class Dexpi20ProcessModelWriter {
     Element step = object(document, id, type);
     data(document, step, "Identifier", name);
     data(document, step, "Label", name);
-    Element ports = components(document, step, "Ports");
     processSteps.appendChild(step);
-    return new Step(ports);
+    return new Step(step);
   }
 
   private static String appendPort(Document document, Step step, String id, String connectionId, String direction) {
@@ -340,13 +336,13 @@ public final class Dexpi20ProcessModelWriter {
     data(document, port, "Identifier", id);
     dataReference(document, port, "NominalDirection", "Process/Enumerations.PortDirection." + direction);
     references(document, port, "ConnectorReference", connectionId);
-    step.ports.appendChild(port);
+    step.ports(document).appendChild(port);
     return id;
   }
 
   private static String type(ProcessEquipmentInterface unit) {
     if (unit instanceof StreamInterface) {
-      return "Process/Process.Source";
+      return hasMaterialInlet(unit) ? "Process/Process.Sink" : "Process/Process.Source";
     }
     if (unit instanceof Expander) {
       return "Process/Process.TransportingFluids";
@@ -389,6 +385,23 @@ public final class Dexpi20ProcessModelWriter {
     }
     throw new IllegalArgumentException(
         "No reviewed DEXPI 2.0 Process type mapping for " + unit.getClass().getName() + " (" + unit.getName() + ")");
+  }
+
+  private static boolean hasMaterialInlet(ProcessEquipmentInterface unit) {
+    try {
+      List<StreamInterface> inlets = unit.getInletStreams();
+      if (inlets == null) {
+        return false;
+      }
+      for (StreamInterface inlet : inlets) {
+        if (inlet != null && inlet != unit) {
+          return true;
+        }
+      }
+    } catch (RuntimeException ex) {
+      // An unconfigured stream remains a source and is serialized without ports.
+    }
+    return false;
   }
 
   private static void physicalQuantity(Document document, Element stream, String property, Double value,
@@ -612,10 +625,18 @@ public final class Dexpi20ProcessModelWriter {
   }
 
   private static final class Step {
-    private final Element ports;
+    private final Element processStep;
+    private Element ports;
 
-    Step(Element ports) {
-      this.ports = ports;
+    Step(Element processStep) {
+      this.processStep = processStep;
+    }
+
+    Element ports(Document document) {
+      if (ports == null) {
+        ports = components(document, processStep, "Ports");
+      }
+      return ports;
     }
   }
 

--- a/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessTopologyAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessTopologyAssessment.java
@@ -276,7 +276,7 @@ public final class Dexpi20ProcessTopologyAssessment {
     EngineeringGraph graph = canonical.getGraph();
     List<String> connectionIds = canonicalConnectionIds(graph);
     List<String> expected = canonicalMaterialConnections(graph, diagnostics);
-    List<ExportedConnection> exported = exportedConnections(file, diagnostics);
+    List<ExportedConnection> exported = exportedConnections(file, expected, diagnostics);
     List<String> actual = materialConnections(exported);
     compareMaterialConnections(expected, actual, diagnostics);
     diagnostics.add(new Diagnostic(Severity.WARNING, "DEXPI_PROCESS_MULTI_AREA_UNSUPPORTED",
@@ -336,8 +336,8 @@ public final class Dexpi20ProcessTopologyAssessment {
         + String.valueOf(node.getProperties().get("targetEquipment"));
   }
 
-  private static List<ExportedConnection> exportedConnections(Path file, List<Diagnostic> diagnostics)
-      throws IOException {
+  private static List<ExportedConnection> exportedConnections(Path file, List<String> canonicalMaterialConnections,
+      List<Diagnostic> diagnostics) throws IOException {
     Document document = parse(file);
     Map<String, StepReference> stepByPort = new LinkedHashMap<String, StepReference>();
     NodeList objects = document.getElementsByTagName("Object");
@@ -372,7 +372,9 @@ public final class Dexpi20ProcessTopologyAssessment {
         diagnostics.add(new Diagnostic(Severity.ERROR, "DEXPI_PROCESS_EXPORTED_PORT_REUSED",
             "Each exported material connection must own distinct source and target ports", stream.getAttribute("id")));
       }
-      boolean boundary = "Process/Process.Sink".equals(target.type);
+      String materialConnection = source.name + "->" + target.name;
+      boolean boundary = "Process/Process.Sink".equals(target.type)
+          && !canonicalMaterialConnections.contains(materialConnection);
       if (boundary) {
         diagnostics.add(new Diagnostic(Severity.INFO, "DEXPI_PROCESS_BOUNDARY_SINK_SYNTHESIZED",
             "An unconsumed material outlet was projected to a DEXPI Process sink", stream.getAttribute("id")));

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiLayoutEngine.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiLayoutEngine.java
@@ -1581,13 +1581,13 @@ final class DexpiLayoutEngine {
     appendTitleCell(document, label, col3, row2Bottom, col4, row2Top, "REV");
     appendTitleCell(document, label, col4, row2Bottom, blockRight, row2Top, revision != null ? revision : "0");
 
-    // Row 3: APPROVED BY | - | STATUS | IFC
+    // Row 3: APPROVED BY | - | STATUS | PROPOSAL
     double row3Bottom = row2Top;
     double row3Top = row3Bottom + TITLE_ROW_HEIGHT;
     appendTitleCell(document, label, blockLeft, row3Bottom, col2, row3Top, "APPROVED BY");
     appendTitleCell(document, label, col2, row3Bottom, col3, row3Top, "-");
     appendTitleCell(document, label, col3, row3Bottom, col4, row3Top, "STATUS");
-    appendTitleCell(document, label, col4, row3Bottom, blockRight, row3Top, "IFC");
+    appendTitleCell(document, label, col4, row3Bottom, blockRight, row3Top, "PROPOSAL");
 
     // Row 4-6: Main title area (Name of drawing, large font)
     double titleBottom = row3Top;

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRenderer.java
@@ -1,0 +1,439 @@
+package neqsim.process.processmodel.dexpi;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * Renders the graphical content of a Proteus-compatible DEXPI Plant/P&amp;ID document as SVG.
+ *
+ * <p>
+ * The renderer consumes the geometry already present in the DEXPI exchange. Component instances are resolved against
+ * the document's {@code ShapeCatalogue}; process, signal and utility lines, labels, drawing furniture and ISO 10628
+ * symbol geometry are therefore rendered from one source document rather than reconstructed from the simulation
+ * topology.
+ * </p>
+ */
+public final class DexpiXmlSvgRenderer {
+  private DexpiXmlSvgRenderer() {
+  }
+
+  /**
+   * Renders a DEXPI Plant/P&amp;ID XML file to an SVG string.
+   *
+   * @param dexpiFile Proteus-compatible DEXPI XML document
+   * @return complete UTF-8 SVG document
+   * @throws IOException if the document cannot be parsed or rendered
+   */
+  public static String render(File dexpiFile) throws IOException {
+    if (dexpiFile == null) {
+      throw new IllegalArgumentException("dexpiFile must not be null");
+    }
+    Document document = parse(dexpiFile);
+    double[] extent = drawingExtent(document);
+    double width = extent[0];
+    double height = extent[1];
+    Map<String, Element> shapes = shapeCatalogue(document);
+
+    StringBuilder svg = new StringBuilder(256 * 1024);
+    svg.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    svg.append("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"").append(number(width)).append("mm\" height=\"")
+        .append(number(height)).append("mm\" viewBox=\"0 0 ").append(number(width)).append(' ').append(number(height))
+        .append("\">\n");
+    svg.append("  <title>").append(xml(drawingName(document))).append("</title>\n");
+    svg.append("  <desc>Rendered by NeqSim from DEXPI Plant/P&amp;ID graphical content.</desc>\n");
+    svg.append("  <rect width=\"100%\" height=\"100%\" fill=\"#ffffff\"/>\n");
+    svg.append("  <g id=\"dexpi-lines\" fill=\"none\" stroke-linejoin=\"round\" ")
+        .append("stroke-linecap=\"round\">\n");
+    renderGlobalCurves(document, height, svg);
+    svg.append("  </g>\n");
+    svg.append("  <g id=\"dexpi-symbols\" fill=\"none\" stroke-linejoin=\"round\" ")
+        .append("stroke-linecap=\"round\">\n");
+    renderComponentInstances(document, shapes, height, svg);
+    svg.append("  </g>\n");
+    svg.append("  <g id=\"dexpi-text\" font-family=\"Arial,Helvetica,sans-serif\" ").append("font-weight=\"400\">\n");
+    renderText(document, height, svg);
+    svg.append("  </g>\n");
+    svg.append("</svg>\n");
+    return svg.toString();
+  }
+
+  /**
+   * Renders a DEXPI Plant/P&amp;ID XML file to an SVG file.
+   *
+   * @param dexpiFile Proteus-compatible DEXPI XML document
+   * @param svgFile destination SVG file
+   * @throws IOException if the document cannot be parsed or the SVG cannot be written
+   */
+  public static void render(File dexpiFile, File svgFile) throws IOException {
+    if (svgFile == null) {
+      throw new IllegalArgumentException("svgFile must not be null");
+    }
+    File parent = svgFile.getAbsoluteFile().getParentFile();
+    if (parent != null) {
+      Files.createDirectories(parent.toPath());
+    }
+    Files.write(svgFile.toPath(), render(dexpiFile).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static Document parse(File file) throws IOException {
+    try {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setNamespaceAware(false);
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+      factory.setXIncludeAware(false);
+      factory.setExpandEntityReferences(false);
+      return factory.newDocumentBuilder().parse(file);
+    } catch (ParserConfigurationException | SAXException ex) {
+      throw new IOException("Could not parse DEXPI XML", ex);
+    }
+  }
+
+  private static double[] drawingExtent(Document document) {
+    NodeList drawings = document.getElementsByTagName("Drawing");
+    if (drawings.getLength() > 0) {
+      Element extent = firstDescendant((Element) drawings.item(0), "Extent");
+      Element max = extent == null ? null : firstDirectChild(extent, "Max");
+      if (max != null) {
+        double width = attribute(max, "X", 0.0);
+        double height = attribute(max, "Y", 0.0);
+        if (width > 0.0 && height > 0.0) {
+          return new double[] { width, height };
+        }
+      }
+    }
+    double maxX = 0.0;
+    double maxY = 0.0;
+    NodeList coordinates = document.getElementsByTagName("Coordinate");
+    for (int index = 0; index < coordinates.getLength(); index++) {
+      Element coordinate = (Element) coordinates.item(index);
+      if (!inside(coordinate, "ShapeCatalogue")) {
+        maxX = Math.max(maxX, attribute(coordinate, "X", 0.0));
+        maxY = Math.max(maxY, attribute(coordinate, "Y", 0.0));
+      }
+    }
+    return new double[] { Math.max(297.0, maxX + 10.0), Math.max(210.0, maxY + 10.0) };
+  }
+
+  private static String drawingName(Document document) {
+    NodeList drawings = document.getElementsByTagName("Drawing");
+    if (drawings.getLength() == 0) {
+      return "NeqSim DEXPI Plant P&ID";
+    }
+    String name = ((Element) drawings.item(0)).getAttribute("Name");
+    return name == null || name.trim().isEmpty() ? "NeqSim DEXPI Plant P&ID" : name;
+  }
+
+  private static Map<String, Element> shapeCatalogue(Document document) {
+    Map<String, Element> result = new LinkedHashMap<String, Element>();
+    NodeList catalogues = document.getElementsByTagName("ShapeCatalogue");
+    if (catalogues.getLength() == 0) {
+      return result;
+    }
+    Element catalogue = (Element) catalogues.item(0);
+    NodeList children = catalogue.getChildNodes();
+    for (int index = 0; index < children.getLength(); index++) {
+      Node child = children.item(index);
+      if (child instanceof Element) {
+        Element shape = (Element) child;
+        String name = shape.getAttribute("ComponentName");
+        if (name != null && !name.trim().isEmpty()) {
+          result.put(name, shape);
+        }
+      }
+    }
+    return result;
+  }
+
+  private static void renderGlobalCurves(Document document, double sheetHeight, StringBuilder svg) {
+    renderGlobalTag(document, "CenterLine", sheetHeight, svg);
+    renderGlobalTag(document, "PolyLine", sheetHeight, svg);
+    NodeList circles = document.getElementsByTagName("Circle");
+    for (int index = 0; index < circles.getLength(); index++) {
+      Element circle = (Element) circles.item(index);
+      if (inside(circle, "ShapeCatalogue") || circle.getParentNode() instanceof Element
+          && "TrimmedCurve".equals(((Element) circle.getParentNode()).getTagName())) {
+        continue;
+      }
+      double[] location = location(circle);
+      if (location == null) {
+        continue;
+      }
+      svg.append("    <circle cx=\"").append(number(location[0])).append("\" cy=\"")
+          .append(number(sheetHeight - location[1])).append("\" r=\"").append(number(attribute(circle, "Radius", 0.0)))
+          .append("\" ").append(style(circle)).append("/>").append('\n');
+    }
+  }
+
+  private static void renderGlobalTag(Document document, String tagName, double sheetHeight, StringBuilder svg) {
+    NodeList curves = document.getElementsByTagName(tagName);
+    for (int index = 0; index < curves.getLength(); index++) {
+      Element curve = (Element) curves.item(index);
+      if (inside(curve, "ShapeCatalogue")) {
+        continue;
+      }
+      NodeList coordinates = curve.getElementsByTagName("Coordinate");
+      if (coordinates.getLength() < 2) {
+        continue;
+      }
+      svg.append("    <polyline points=\"");
+      for (int point = 0; point < coordinates.getLength(); point++) {
+        Element coordinate = (Element) coordinates.item(point);
+        if (point > 0) {
+          svg.append(' ');
+        }
+        svg.append(number(attribute(coordinate, "X", 0.0))).append(',')
+            .append(number(sheetHeight - attribute(coordinate, "Y", 0.0)));
+      }
+      svg.append("\" ").append(style(curve)).append("/>").append('\n');
+    }
+  }
+
+  private static void renderComponentInstances(Document document, Map<String, Element> shapes, double sheetHeight,
+      StringBuilder svg) {
+    NodeList all = document.getElementsByTagName("*");
+    for (int index = 0; index < all.getLength(); index++) {
+      Element instance = (Element) all.item(index);
+      if (inside(instance, "ShapeCatalogue")) {
+        continue;
+      }
+      String shapeName = instance.getAttribute("ComponentName");
+      Element shape = shapes.get(shapeName);
+      double[] position = directLocation(instance);
+      if (shape == null || position == null) {
+        continue;
+      }
+      double[] scale = directScale(instance);
+      String identity = instance.getAttribute("ID");
+      svg.append("    <g transform=\"translate(").append(number(position[0])).append(' ')
+          .append(number(sheetHeight - position[1])).append(") scale(").append(number(scale[0])).append(' ')
+          .append(number(-scale[1])).append(")\"");
+      if (identity != null && !identity.isEmpty()) {
+        svg.append(" data-dexpi-id=\"").append(xml(identity)).append("\"");
+      }
+      svg.append(">\n");
+      renderShape(shape, svg);
+      svg.append("    </g>\n");
+    }
+  }
+
+  private static void renderShape(Element shape, StringBuilder svg) {
+    NodeList children = shape.getChildNodes();
+    for (int index = 0; index < children.getLength(); index++) {
+      Node child = children.item(index);
+      if (!(child instanceof Element)) {
+        continue;
+      }
+      Element primitive = (Element) child;
+      if ("PolyLine".equals(primitive.getTagName())) {
+        NodeList coordinates = primitive.getElementsByTagName("Coordinate");
+        if (coordinates.getLength() < 2) {
+          continue;
+        }
+        svg.append("      <polyline points=\"");
+        for (int point = 0; point < coordinates.getLength(); point++) {
+          Element coordinate = (Element) coordinates.item(point);
+          if (point > 0) {
+            svg.append(' ');
+          }
+          svg.append(number(attribute(coordinate, "X", 0.0))).append(',')
+              .append(number(attribute(coordinate, "Y", 0.0)));
+        }
+        svg.append("\" ").append(style(primitive)).append("/>").append('\n');
+      } else if ("Circle".equals(primitive.getTagName())) {
+        appendLocalCircle(primitive, primitive, svg);
+      } else if ("TrimmedCurve".equals(primitive.getTagName())) {
+        Element circle = firstDirectChild(primitive, "Circle");
+        if (circle != null) {
+          appendLocalArc(primitive, circle, svg);
+        }
+      }
+    }
+  }
+
+  private static void appendLocalCircle(Element circle, Element styleSource, StringBuilder svg) {
+    double[] location = location(circle);
+    if (location == null) {
+      location = new double[] { 0.0, 0.0 };
+    }
+    boolean filled = "Solid".equalsIgnoreCase(circle.getAttribute("Filled"));
+    String circleStyle = style(styleSource);
+    if (filled) {
+      circleStyle = circleStyle.replace(" fill=\"none\"", "");
+    }
+    svg.append("      <circle cx=\"").append(number(location[0])).append("\" cy=\"").append(number(location[1]))
+        .append("\" r=\"").append(number(attribute(circle, "Radius", 0.0))).append("\" ").append(circleStyle);
+    if (filled) {
+      svg.append(" fill=\"").append(color(circle)).append("\"");
+    }
+    svg.append("/>\n");
+  }
+
+  private static void appendLocalArc(Element curve, Element circle, StringBuilder svg) {
+    double[] center = location(circle);
+    if (center == null) {
+      center = new double[] { 0.0, 0.0 };
+    }
+    double radius = attribute(circle, "Radius", 0.0);
+    double start = Math.toRadians(attribute(curve, "StartAngle", 0.0));
+    double end = Math.toRadians(attribute(curve, "EndAngle", 0.0));
+    double startX = center[0] + radius * Math.cos(start);
+    double startY = center[1] + radius * Math.sin(start);
+    double endX = center[0] + radius * Math.cos(end);
+    double endY = center[1] + radius * Math.sin(end);
+    double delta = (Math.toDegrees(end - start) + 360.0) % 360.0;
+    int largeArc = delta > 180.0 ? 1 : 0;
+    svg.append("      <path d=\"M ").append(number(startX)).append(' ').append(number(startY)).append(" A ")
+        .append(number(radius)).append(' ').append(number(radius)).append(" 0 ").append(largeArc).append(" 1 ")
+        .append(number(endX)).append(' ').append(number(endY)).append("\" ").append(style(circle)).append("/>\n");
+  }
+
+  private static void renderText(Document document, double sheetHeight, StringBuilder svg) {
+    NodeList texts = document.getElementsByTagName("Text");
+    for (int index = 0; index < texts.getLength(); index++) {
+      Element text = (Element) texts.item(index);
+      if (inside(text, "ShapeCatalogue")) {
+        continue;
+      }
+      double[] position = location(text);
+      if (position == null) {
+        continue;
+      }
+      String value = text.getAttribute("String");
+      double size = Math.max(1.8, attribute(text, "Height", 2.5));
+      String justification = text.getAttribute("Justification");
+      String anchor = justification.startsWith("Left") ? "start" : justification.startsWith("Right") ? "end" : "middle";
+      String baseline = justification.endsWith("Bottom") ? "auto"
+          : justification.endsWith("Top") ? "hanging" : "middle";
+      svg.append("    <text x=\"").append(number(position[0])).append("\" y=\"")
+          .append(number(sheetHeight - position[1])).append("\" font-size=\"").append(number(size))
+          .append("\" text-anchor=\"").append(anchor).append("\" dominant-baseline=\"").append(baseline)
+          .append("\" fill=\"").append(color(text)).append("\">").append(xml(value)).append("</text>\n");
+    }
+  }
+
+  private static String style(Element element) {
+    Element presentation = firstDirectChild(element, "Presentation");
+    String stroke = color(presentation == null ? element : presentation);
+    double weight = presentation == null ? 0.3 : attribute(presentation, "LineWeight", 0.3);
+    StringBuilder result = new StringBuilder();
+    result.append("stroke=\"").append(stroke).append("\" stroke-width=\"").append(number(Math.max(0.18, weight)))
+        .append("\" fill=\"none\"");
+    int lineType = presentation == null ? 0 : (int) attribute(presentation, "LineType", 0.0);
+    if (lineType == 1) {
+      result.append(" stroke-dasharray=\"4 2\"");
+    } else if (lineType == 2) {
+      result.append(" stroke-dasharray=\"1 1.8\"");
+    } else if (lineType == 3) {
+      result.append(" stroke-dasharray=\"6 2 1 2\"");
+    }
+    return result.toString();
+  }
+
+  private static String color(Element element) {
+    Element presentation = element == null ? null : firstDirectChild(element, "Presentation");
+    Element source = presentation == null ? element : presentation;
+    if (source == null) {
+      return "#000000";
+    }
+    int red = channel(attribute(source, "R", 0.0));
+    int green = channel(attribute(source, "G", 0.0));
+    int blue = channel(attribute(source, "B", 0.0));
+    return String.format(Locale.ROOT, "#%02x%02x%02x", red, green, blue);
+  }
+
+  private static int channel(double value) {
+    return (int) Math.round(255.0 * Math.max(0.0, Math.min(1.0, value)));
+  }
+
+  private static double[] directLocation(Element parent) {
+    Element position = firstDirectChild(parent, "Position");
+    Element location = position == null ? null : firstDirectChild(position, "Location");
+    return location == null ? null : new double[] { attribute(location, "X", 0.0), attribute(location, "Y", 0.0) };
+  }
+
+  private static double[] location(Element parent) {
+    Element position = firstDescendant(parent, "Position");
+    Element location = position == null ? null : firstDescendant(position, "Location");
+    return location == null ? null : new double[] { attribute(location, "X", 0.0), attribute(location, "Y", 0.0) };
+  }
+
+  private static double[] directScale(Element parent) {
+    Element scale = firstDirectChild(parent, "Scale");
+    return scale == null ? new double[] { 1.0, 1.0 }
+        : new double[] { attribute(scale, "X", 1.0), attribute(scale, "Y", 1.0) };
+  }
+
+  private static Element firstDirectChild(Element parent, String name) {
+    NodeList children = parent.getChildNodes();
+    for (int index = 0; index < children.getLength(); index++) {
+      Node child = children.item(index);
+      if (child instanceof Element && name.equals(((Element) child).getTagName())) {
+        return (Element) child;
+      }
+    }
+    return null;
+  }
+
+  private static Element firstDescendant(Element parent, String name) {
+    NodeList items = parent.getElementsByTagName(name);
+    return items.getLength() == 0 ? null : (Element) items.item(0);
+  }
+
+  private static boolean inside(Node node, String ancestorName) {
+    Node parent = node.getParentNode();
+    while (parent != null) {
+      if (parent instanceof Element && ancestorName.equals(((Element) parent).getTagName())) {
+        return true;
+      }
+      parent = parent.getParentNode();
+    }
+    return false;
+  }
+
+  private static double attribute(Element element, String name, double fallback) {
+    if (element == null) {
+      return fallback;
+    }
+    try {
+      String value = element.getAttribute(name);
+      return value == null || value.trim().isEmpty() ? fallback : Double.parseDouble(value);
+    } catch (NumberFormatException ex) {
+      return fallback;
+    }
+  }
+
+  private static String number(double value) {
+    if (Math.abs(value - Math.rint(value)) < 1.0e-9) {
+      return Long.toString(Math.round(value));
+    }
+    String formatted = String.format(Locale.ROOT, "%.6f", value);
+    int end = formatted.length();
+    while (end > 0 && formatted.charAt(end - 1) == '0') {
+      end--;
+    }
+    return formatted.substring(0, end);
+  }
+
+  private static String xml(String value) {
+    return value == null ? ""
+        : value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;").replace("'",
+            "&apos;");
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRenderer.java
@@ -179,6 +179,17 @@ public final class DexpiXmlSvgRenderer {
           .append(number(sheetHeight - location[1])).append("\" r=\"").append(number(attribute(circle, "Radius", 0.0)))
           .append("\" ").append(style(circle)).append("/>").append('\n');
     }
+    NodeList arcs = document.getElementsByTagName("TrimmedCurve");
+    for (int index = 0; index < arcs.getLength(); index++) {
+      Element curve = (Element) arcs.item(index);
+      if (inside(curve, "ShapeCatalogue")) {
+        continue;
+      }
+      Element circle = firstDirectChild(curve, "Circle");
+      if (circle != null) {
+        appendGlobalArc(curve, circle, sheetHeight, svg);
+      }
+    }
   }
 
   private static void renderGlobalTag(Document document, String tagName, double sheetHeight, StringBuilder svg) {
@@ -301,7 +312,26 @@ public final class DexpiXmlSvgRenderer {
     int largeArc = delta > 180.0 ? 1 : 0;
     svg.append("      <path d=\"M ").append(number(startX)).append(' ').append(number(startY)).append(" A ")
         .append(number(radius)).append(' ').append(number(radius)).append(" 0 ").append(largeArc).append(" 1 ")
-        .append(number(endX)).append(' ').append(number(endY)).append("\" ").append(style(circle)).append("/>\n");
+        .append(number(endX)).append(' ').append(number(endY)).append("\" ").append(style(curve)).append("/>\n");
+  }
+
+  private static void appendGlobalArc(Element curve, Element circle, double sheetHeight, StringBuilder svg) {
+    double[] center = location(circle);
+    if (center == null) {
+      center = new double[] { 0.0, 0.0 };
+    }
+    double radius = attribute(circle, "Radius", 0.0);
+    double start = Math.toRadians(attribute(curve, "StartAngle", 0.0));
+    double end = Math.toRadians(attribute(curve, "EndAngle", 0.0));
+    double startX = center[0] + radius * Math.cos(start);
+    double startY = sheetHeight - center[1] - radius * Math.sin(start);
+    double endX = center[0] + radius * Math.cos(end);
+    double endY = sheetHeight - center[1] - radius * Math.sin(end);
+    double delta = (Math.toDegrees(end - start) + 360.0) % 360.0;
+    int largeArc = delta > 180.0 ? 1 : 0;
+    svg.append("    <path d=\"M ").append(number(startX)).append(' ').append(number(startY)).append(" A ")
+        .append(number(radius)).append(' ').append(number(radius)).append(" 0 ").append(largeArc).append(" 0 ")
+        .append(number(endX)).append(' ').append(number(endY)).append("\" ").append(style(curve)).append("/>\n");
   }
 
   private static void renderText(Document document, double sheetHeight, StringBuilder svg) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
@@ -721,7 +721,7 @@ public final class DexpiXmlWriter {
 
     // Revision history (NORSOK Z-003)
     List<String[]> revisions = new ArrayList<>();
-    revisions.add(new String[] { "0", today, "Issued for Design", "NeqSim", "" });
+    revisions.add(new String[] { "0", today, "Engineering Proposal", "NeqSim", "" });
     DexpiLayoutEngine.appendRevisionHistory(document, root, revisions, sheetSize[0]);
 
     writeDocument(document, outputStream);

--- a/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/package-info.java
@@ -10,6 +10,8 @@
  * <ul>
  * <li>{@link neqsim.process.processmodel.dexpi.DexpiXmlReader} - Import DEXPI P&amp;ID XML to ProcessSystem</li>
  * <li>{@link neqsim.process.processmodel.dexpi.DexpiXmlWriter} - Export ProcessSystem to DEXPI XML</li>
+ * <li>{@link neqsim.process.processmodel.dexpi.DexpiXmlSvgRenderer} - Render the graphical content and shape catalogue
+ * of a Proteus-compatible DEXPI Plant/P&amp;ID document to SVG</li>
  * <li>{@link neqsim.process.processmodel.dexpi.DexpiProcessUnit} - Lightweight placeholder for imported equipment</li>
  * <li>{@link neqsim.process.processmodel.dexpi.DexpiStream} - Runnable stream with DEXPI metadata</li>
  * <li>{@link neqsim.process.processmodel.dexpi.DexpiMetadata} - Shared constants for DEXPI exchanges</li>
@@ -47,6 +49,9 @@
  *
  * // Export back to DEXPI XML
  * DexpiXmlWriter.write(process, new File("export.xml"));
+ *
+ * // Render that DEXPI graphical content without an external drawing tool
+ * DexpiXmlSvgRenderer.render(new File("export.xml"), new File("export.svg"));
  * </pre>
  *
  * @author NeqSim

--- a/src/test/java/neqsim/process/engineering/NorsokOffshoreEngineeringBuilderTest.java
+++ b/src/test/java/neqsim/process/engineering/NorsokOffshoreEngineeringBuilderTest.java
@@ -6,12 +6,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import javax.xml.parsers.DocumentBuilderFactory;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 import neqsim.NeqSimTest;
 import neqsim.process.engineering.dexpi.DexpiEngineeringExporter;
 import neqsim.process.engineering.dexpi.DexpiEngineeringExporter.ExportResult;
@@ -209,6 +216,8 @@ class NorsokOffshoreEngineeringBuilderTest extends NeqSimTest {
     assertTrue(xml.contains("UnresolvedBoundary"));
     assertTrue(xml.contains("FLARE_RELIEF_AND_BLOWDOWN"));
     assertTrue(xml.contains("PROCESS_CONTROL_ISOLATION_AND_RECYCLE"));
+    assertMinimumMaterializedSpacing(result.getDexpiFile(), "ProcessInstrumentationFunction", 12.0);
+    assertMinimumMaterializedSpacing(result.getDexpiFile(), "PipingComponent", 14.0);
 
     String dexpi20 = new String(Files.readAllBytes(result.getDexpi20File()), StandardCharsets.UTF_8);
     assertTrue(dexpi20.contains("<Model"));
@@ -315,4 +324,51 @@ class NorsokOffshoreEngineeringBuilderTest extends NeqSimTest {
     }
     throw new AssertionError("Relief coverage not found for: " + equipmentTag);
   }
+
+  private static void assertMinimumMaterializedSpacing(Path dexpiFile, String elementName, double minimumSpacing)
+      throws Exception {
+    Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(dexpiFile.toFile());
+    Map<String, List<double[]>> positionsByEquipment = new LinkedHashMap<String, List<double[]>>();
+    NodeList elements = document.getElementsByTagName(elementName);
+    for (int i = 0; i < elements.getLength(); i++) {
+      Element element = (Element) elements.item(i);
+      String equipmentTag = genericAttribute(element, "ProtectedEquipmentTag");
+      NodeList locations = element.getElementsByTagName("Location");
+      if (equipmentTag == null || locations.getLength() == 0) {
+        continue;
+      }
+      Element location = (Element) locations.item(0);
+      List<double[]> positions = positionsByEquipment.get(equipmentTag);
+      if (positions == null) {
+        positions = new ArrayList<double[]>();
+        positionsByEquipment.put(equipmentTag, positions);
+      }
+      positions.add(new double[] { Double.parseDouble(location.getAttribute("X")),
+          Double.parseDouble(location.getAttribute("Y")) });
+    }
+    for (Map.Entry<String, List<double[]>> entry : positionsByEquipment.entrySet()) {
+      List<double[]> positions = entry.getValue();
+      for (int i = 0; i < positions.size(); i++) {
+        for (int j = i + 1; j < positions.size(); j++) {
+          double dx = positions.get(i)[0] - positions.get(j)[0];
+          double dy = positions.get(i)[1] - positions.get(j)[1];
+          double distance = Math.sqrt(dx * dx + dy * dy);
+          assertTrue(distance >= minimumSpacing,
+              elementName + " annotations overlap on " + entry.getKey() + ": " + distance + " mm");
+        }
+      }
+    }
+  }
+
+  private static String genericAttribute(Element parent, String name) {
+    NodeList attributes = parent.getElementsByTagName("GenericAttribute");
+    for (int i = 0; i < attributes.getLength(); i++) {
+      Element attribute = (Element) attributes.item(i);
+      if (name.equals(attribute.getAttribute("Name"))) {
+        return attribute.getAttribute("Value");
+      }
+    }
+    return null;
+  }
+
 }

--- a/src/test/java/neqsim/process/engineering/NorsokOffshoreEngineeringBuilderTest.java
+++ b/src/test/java/neqsim/process/engineering/NorsokOffshoreEngineeringBuilderTest.java
@@ -219,6 +219,7 @@ class NorsokOffshoreEngineeringBuilderTest extends NeqSimTest {
     assertMinimumMaterializedSpacing(result.getDexpiFile(), "ProcessInstrumentationFunction", 12.0);
     assertMinimumMaterializedSpacing(result.getDexpiFile(), "PipingComponent", 14.0);
     assertMaterializedInstrumentLabelsAreCompact(result.getDexpiFile());
+    assertEngineeringFunctionsWithinBatteryLimit(result.getDexpiFile());
 
     String dexpi20 = new String(Files.readAllBytes(result.getDexpi20File()), StandardCharsets.UTF_8);
     assertTrue(dexpi20.contains("<Model"));
@@ -324,6 +325,64 @@ class NorsokOffshoreEngineeringBuilderTest extends NeqSimTest {
       }
     }
     throw new AssertionError("Relief coverage not found for: " + equipmentTag);
+  }
+
+  private static void assertEngineeringFunctionsWithinBatteryLimit(Path dexpiFile) throws Exception {
+    Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(dexpiFile.toFile());
+    Element boundary = null;
+    NodeList labels = document.getElementsByTagName("Label");
+    for (int i = 0; i < labels.getLength(); i++) {
+      Element candidate = (Element) labels.item(i);
+      if ("BatteryLimit-1".equals(candidate.getAttribute("ID"))) {
+        boundary = candidate;
+        break;
+      }
+    }
+    assertTrue(boundary != null, "Generated engineering drawing must retain its battery-limit boundary");
+
+    NodeList coordinates = boundary.getElementsByTagName("Coordinate");
+    assertTrue(coordinates.getLength() >= 5, "Battery-limit boundary must remain a closed rectangle");
+    double left = Double.MAX_VALUE;
+    double right = -Double.MAX_VALUE;
+    double bottom = Double.MAX_VALUE;
+    double top = -Double.MAX_VALUE;
+    for (int i = 0; i < coordinates.getLength(); i++) {
+      Element coordinate = (Element) coordinates.item(i);
+      double x = Double.parseDouble(coordinate.getAttribute("X"));
+      double y = Double.parseDouble(coordinate.getAttribute("Y"));
+      left = Math.min(left, x);
+      right = Math.max(right, x);
+      bottom = Math.min(bottom, y);
+      top = Math.max(top, y);
+    }
+
+    String[] elementNames = new String[] { "ProcessInstrumentationFunction", "PipingComponent" };
+    for (String elementName : elementNames) {
+      NodeList elements = document.getElementsByTagName(elementName);
+      for (int i = 0; i < elements.getLength(); i++) {
+        Element element = (Element) elements.item(i);
+        if (genericAttribute(element, "ProtectedEquipmentTag") == null) {
+          continue;
+        }
+        NodeList locations = element.getElementsByTagName("Location");
+        assertTrue(locations.getLength() > 0, "Governed engineering function must have a drawing position");
+        Element location = (Element) locations.item(0);
+        double x = Double.parseDouble(location.getAttribute("X"));
+        double y = Double.parseDouble(location.getAttribute("Y"));
+        assertTrue(x >= left + 9.0 && x <= right - 9.0 && y >= bottom + 9.0 && y <= top - 9.0,
+            elementName + " must remain clear of the battery-limit line: " + element.getAttribute("ID"));
+      }
+    }
+
+    NodeList areaTexts = boundary.getElementsByTagName("Text");
+    assertTrue(areaTexts.getLength() > 0, "Battery-limit boundary must retain its area label");
+    NodeList areaLocations = ((Element) areaTexts.item(0)).getElementsByTagName("Location");
+    assertTrue(areaLocations.getLength() > 0, "Battery-limit area label must have a drawing position");
+    Element areaLocation = (Element) areaLocations.item(0);
+    double labelX = Double.parseDouble(areaLocation.getAttribute("X"));
+    double labelY = Double.parseDouble(areaLocation.getAttribute("Y"));
+    assertTrue(labelX > left && labelX < right && labelY > bottom && labelY < top,
+        "Battery-limit area label must be placed inside the boundary");
   }
 
   private static void assertMaterializedInstrumentLabelsAreCompact(Path dexpiFile) throws Exception {

--- a/src/test/java/neqsim/process/engineering/NorsokOffshoreEngineeringBuilderTest.java
+++ b/src/test/java/neqsim/process/engineering/NorsokOffshoreEngineeringBuilderTest.java
@@ -218,6 +218,7 @@ class NorsokOffshoreEngineeringBuilderTest extends NeqSimTest {
     assertTrue(xml.contains("PROCESS_CONTROL_ISOLATION_AND_RECYCLE"));
     assertMinimumMaterializedSpacing(result.getDexpiFile(), "ProcessInstrumentationFunction", 12.0);
     assertMinimumMaterializedSpacing(result.getDexpiFile(), "PipingComponent", 14.0);
+    assertMaterializedInstrumentLabelsAreCompact(result.getDexpiFile());
 
     String dexpi20 = new String(Files.readAllBytes(result.getDexpi20File()), StandardCharsets.UTF_8);
     assertTrue(dexpi20.contains("<Model"));
@@ -323,6 +324,27 @@ class NorsokOffshoreEngineeringBuilderTest extends NeqSimTest {
       }
     }
     throw new AssertionError("Relief coverage not found for: " + equipmentTag);
+  }
+
+  private static void assertMaterializedInstrumentLabelsAreCompact(Path dexpiFile) throws Exception {
+    Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(dexpiFile.toFile());
+    NodeList instruments = document.getElementsByTagName("ProcessInstrumentationFunction");
+    for (int i = 0; i < instruments.getLength(); i++) {
+      Element instrument = (Element) instruments.item(i);
+      String equipmentTag = genericAttribute(instrument, "ProtectedEquipmentTag");
+      if (equipmentTag == null) {
+        continue;
+      }
+      String fullTag = genericAttribute(instrument, "TagNameAssignmentClass");
+      NodeList labels = instrument.getElementsByTagName("Label");
+      assertTrue(labels.getLength() > 0, "Governed instrument must have a visible compact label");
+      NodeList texts = ((Element) labels.item(0)).getElementsByTagName("Text");
+      assertEquals(2, texts.getLength(), "Governed instrument label must use function and number rows");
+      for (int j = 0; j < texts.getLength(); j++) {
+        assertFalse(fullTag.equals(((Element) texts.item(j)).getAttribute("String")),
+            "Full stable tag must stay in metadata instead of becoming a collision-prone external label");
+      }
+    }
   }
 
   private static void assertMinimumMaterializedSpacing(Path dexpiFile, String elementName, double minimumSpacing)

--- a/src/test/java/neqsim/process/equipment/stream/StreamTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/StreamTest.java
@@ -62,6 +62,19 @@ class StreamTest extends neqsim.NeqSimTest {
   }
 
   @Test
+  public void testUnconfiguredStreamRunsAsInactiveTopologyPlaceholder() {
+    Stream emptyStream = new Stream("empty-placeholder");
+    ProcessSystem process = new ProcessSystem();
+    process.add(emptyStream);
+
+    process.run();
+    process.run();
+
+    assertFalse(emptyStream.isActive(), "Unconfigured stream should remain an inactive placeholder");
+    assertTrue(emptyStream.getFluid() == null, "Running an empty stream must not invent a fluid state");
+  }
+
+  @Test
   public void testEquilibriumStreamCloneDoesNotReplaceOriginalFluid() {
     SystemInterface fluid = new SystemSrkEos(298.15, 10.0);
     fluid.addComponent("methane", 1.0);

--- a/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/Dexpi20ProcessModelWriterTest.java
@@ -152,6 +152,35 @@ class Dexpi20ProcessModelWriterTest {
   }
 
   @Test
+  void exportsZeroFlowTerminalAndIsolatedEmptyStreamsWithoutInvalidPorts() throws Exception {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 40.0);
+    fluid.addComponent("methane", 1.0);
+    Stream feed = new Stream("10-FEED-EMPTY", fluid);
+    feed.setFlowRate(0.0, "kg/hr");
+    Heater heater = new Heater("10-HA-EMPTY", feed);
+    Stream product = new Stream("10-PRODUCT-EMPTY", heater.getOutletStream());
+    Stream isolated = new Stream("10-ISOLATED-EMPTY");
+    ProcessSystem process = new ProcessSystem("DEXPI empty-stream regression");
+    process.add(feed);
+    process.add(heater);
+    process.add(product);
+    process.add(isolated);
+    Path output = temporaryDirectory.resolve("empty-streams.dexpi.xml");
+
+    Dexpi20ProcessTopologyAssessment.Report report = Dexpi20ProcessModelWriter.writeAndAssessTopology(process,
+        output.toFile(), "DEXPI-EMPTY-STREAMS", "A");
+
+    assertTrue(report.isSchemaProfileAndSupportedTopologyValid(), report.getDiagnostics().toString());
+    assertEquals(report.getCanonicalMaterialConnections(), report.getExportedMaterialConnections());
+    assertTrue(report.getCanonicalMaterialConnections().contains("10-HA-EMPTY->10-PRODUCT-EMPTY"));
+    assertTrue(hasAssessedConnection(report, "10-HA-EMPTY", "10-PRODUCT-EMPTY", false));
+    assertEquals("Process/Process.Sink", processStepType(output, "10-PRODUCT-EMPTY"));
+    assertEquals("Process/Process.Source", processStepType(output, "10-ISOLATED-EMPTY"));
+    assertFalse(hasDirectPorts(output, "10-ISOLATED-EMPTY"));
+    assertEquals(heater.getOutletStream(), product.getInletStreams().get(0));
+  }
+
+  @Test
   void documentationExampleWritesAssessedPlantAndProcessExchanges() throws Exception {
     ProcessSystem process = documentationProcess();
     process.run();
@@ -275,6 +304,17 @@ class Dexpi20ProcessModelWriterTest {
     return false;
   }
 
+  private static boolean hasAssessedConnection(Dexpi20ProcessTopologyAssessment.Report report, String source,
+      String target, boolean boundaryTarget) {
+    for (Dexpi20ProcessTopologyAssessment.ExportedConnection connection : report.getExportedConnections()) {
+      if (source.equals(connection.getSourceStep()) && target.equals(connection.getTargetStep())
+          && boundaryTarget == connection.isBoundaryTarget()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private static double physicalQuantity(Path file, String streamLabel, String property) throws Exception {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
@@ -299,6 +339,39 @@ class Dexpi20ProcessModelWriterTest {
       }
     }
     throw new AssertionError("Missing " + property + " for stream " + streamLabel);
+  }
+
+  private static String processStepType(Path file, String stepLabel) throws Exception {
+    Element step = processStep(file, stepLabel);
+    return step.getAttribute("type");
+  }
+
+  private static boolean hasDirectPorts(Path file, String stepLabel) throws Exception {
+    Element step = processStep(file, stepLabel);
+    for (Node child = step.getFirstChild(); child != null; child = child.getNextSibling()) {
+      if (child instanceof Element && "Components".equals(((Element) child).getTagName())
+          && "Ports".equals(((Element) child).getAttribute("property"))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static Element processStep(Path file, String stepLabel) throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setXIncludeAware(false);
+    factory.setExpandEntityReferences(false);
+    NodeList objects = factory.newDocumentBuilder().parse(file.toFile()).getElementsByTagName("Object");
+    for (int index = 0; index < objects.getLength(); index++) {
+      Element object = (Element) objects.item(index);
+      if (object.getAttribute("type").startsWith("Process/Process.") && stepLabel.equals(label(object))) {
+        return object;
+      }
+    }
+    throw new AssertionError("Missing process step " + stepLabel);
   }
 
   private static String label(Element object) {

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiRenderingImprovementsTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiRenderingImprovementsTest.java
@@ -1,6 +1,7 @@
 package neqsim.process.processmodel.dexpi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayOutputStream;
@@ -472,6 +473,12 @@ public class DexpiRenderingImprovementsTest extends NeqSimTest {
     assertTrue(xml.contains("Owner:"), "Title block must include the ISO 7200 owner field");
     assertTrue(xml.contains("Scale:"), "Title block must include the ISO 7200 scale field");
     assertTrue(xml.contains("Sheet:"), "Title block must include the ISO 7200 sheet field");
+    assertTrue(xml.contains("String=\"PROPOSAL\""),
+        "Unapproved generated drawings must be marked as engineering proposals");
+    assertTrue(xml.contains("Engineering Proposal"),
+        "Initial revision history must preserve the proposal-only engineering boundary");
+    assertFalse(xml.contains("String=\"IFC\""), "Generated drawings must not default to issued-for-construction");
+    assertFalse(xml.contains("Issued for Design"), "Generated drawings must not imply accountable design issue");
   }
 
   /**

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRendererTest.java
@@ -2,6 +2,7 @@ package neqsim.process.processmodel.dexpi;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -48,5 +49,22 @@ class DexpiXmlSvgRendererTest extends NeqSimTest {
     assertTrue(content.contains("data-dexpi-id=\"PT-101\""));
     assertTrue(content.contains("<polyline"));
     assertTrue(content.contains("DEXPI SVG renderer regression"));
+  }
+
+  @Test
+  void rendersGlobalTrimmedCurveWithCurvePresentation() throws Exception {
+    String dexpiContent = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        + "<PlantModel><Drawing Name=\"Crossing hop\"><Extent><Min X=\"0\" Y=\"0\"/>"
+        + "<Max X=\"297\" Y=\"210\"/></Extent><TrimmedCurve StartAngle=\"0\" EndAngle=\"180\">"
+        + "<Presentation LineType=\"0\" LineWeight=\"0.5\" R=\"0\" G=\"0\" B=\"0\"/>"
+        + "<Circle Radius=\"1.6\"><Position><Location X=\"50\" Y=\"100\"/>"
+        + "</Position></Circle></TrimmedCurve></Drawing></PlantModel>";
+    Path dexpi = temporaryDirectory.resolve("crossing-hop.xml");
+    java.nio.file.Files.write(dexpi, dexpiContent.getBytes(StandardCharsets.UTF_8));
+
+    String content = DexpiXmlSvgRenderer.render(dexpi.toFile());
+
+    assertTrue(content.contains("<path d=\"M 51.6 110 A 1.6 1.6 0 0 0 48.4 110\""));
+    assertTrue(content.contains("stroke-width=\"0.5\""));
   }
 }

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRendererTest.java
@@ -1,0 +1,52 @@
+package neqsim.process.processmodel.dexpi;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import neqsim.NeqSimTest;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.measurementdevice.PressureTransmitter;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Regression tests for the NeqSim-native DEXPI Plant/P&amp;ID SVG renderer. */
+class DexpiXmlSvgRendererTest extends NeqSimTest {
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void rendersWriterGeometryShapeCatalogueAndInstrumentationWithEmptyStream() throws Exception {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.95);
+    fluid.addComponent("water", 0.05);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    Stream feed = new Stream("10-FEED-001", fluid);
+    feed.setFlowRate(10_000.0, "kg/hr");
+    Separator separator = new Separator("20-V-101", feed);
+    PressureTransmitter transmitter = new PressureTransmitter("PT-101", separator.getGasOutStream());
+
+    ProcessSystem process = new ProcessSystem("DEXPI SVG renderer regression");
+    process.add(feed);
+    process.add(separator);
+    process.add(transmitter);
+    process.run();
+    process.add(new Stream("90-EMPTY-SPARE"));
+
+    Path dexpi = temporaryDirectory.resolve("plant.xml");
+    Path svg = temporaryDirectory.resolve("plant.svg");
+    DexpiXmlWriter.writeForPyDexpi(process, dexpi.toFile());
+    DexpiXmlSvgRenderer.render(dexpi.toFile(), svg.toFile());
+
+    String content = new String(java.nio.file.Files.readAllBytes(svg), java.nio.charset.StandardCharsets.UTF_8);
+    assertTrue(content.contains("<svg"));
+    assertTrue(content.contains("data-dexpi-id=\"ID-20-V-101\""));
+    assertTrue(content.contains("data-dexpi-id=\"PT-101\""));
+    assertTrue(content.contains("<polyline"));
+    assertTrue(content.contains("DEXPI SVG renderer regression"));
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
 import neqsim.process.equipment.heatexchanger.Heater;
@@ -81,7 +82,11 @@ class EngineeringDiagramDeliveryTest {
 
     assertTrue(report.isComplete(), report.toJson());
     assertTrue(Files.isRegularFile(report.getDirectory().resolve("dexpi-process.xml")));
-    assertTrue(report.toJson().contains("10-HA-EMPTY->10-PRODUCT-EMPTY"));
+    Map<?, ?> assessment = (Map<?, ?>) report.toMap().get("dexpiAssessment");
+    assertTrue(((List<?>) assessment.get("canonicalMaterialConnections"))
+        .contains("10-HA-EMPTY->10-PRODUCT-EMPTY"), report.toJson());
+    assertTrue(((List<?>) assessment.get("exportedMaterialConnections"))
+        .contains("10-HA-EMPTY->10-PRODUCT-EMPTY"), report.toJson());
   }
 
   @Test

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryTest.java
@@ -83,10 +83,10 @@ class EngineeringDiagramDeliveryTest {
     assertTrue(report.isComplete(), report.toJson());
     assertTrue(Files.isRegularFile(report.getDirectory().resolve("dexpi-process.xml")));
     Map<?, ?> assessment = (Map<?, ?>) report.toMap().get("dexpiAssessment");
-    assertTrue(((List<?>) assessment.get("canonicalMaterialConnections"))
-        .contains("10-HA-EMPTY->10-PRODUCT-EMPTY"), report.toJson());
-    assertTrue(((List<?>) assessment.get("exportedMaterialConnections"))
-        .contains("10-HA-EMPTY->10-PRODUCT-EMPTY"), report.toJson());
+    assertTrue(((List<?>) assessment.get("canonicalMaterialConnections")).contains("10-HA-EMPTY->10-PRODUCT-EMPTY"),
+        report.toJson());
+    assertTrue(((List<?>) assessment.get("exportedMaterialConnections")).contains("10-HA-EMPTY->10-PRODUCT-EMPTY"),
+        report.toJson());
   }
 
   @Test

--- a/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryTest.java
+++ b/src/test/java/neqsim/process/processmodel/diagram/EngineeringDiagramDeliveryTest.java
@@ -12,9 +12,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import neqsim.process.engineering.model.EngineeringDiagramDocumentSet.ContentProfile;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.stream.Stream;
 import neqsim.process.processmodel.ProcessConnection;
 import neqsim.process.processmodel.ProcessModel;
 import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -55,6 +58,30 @@ class EngineeringDiagramDeliveryTest {
       assertEquals(64, artifact.getValue().getSha256().length());
       assertTrue(artifact.getValue().getSizeBytes() > 0L);
     }
+  }
+
+  @Test
+  void publishesDeliveryWithZeroFlowTerminalAndIsolatedEmptyStreams() throws IOException {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 40.0);
+    fluid.addComponent("methane", 1.0);
+    Stream feed = new Stream("10-FEED-EMPTY", fluid);
+    feed.setFlowRate(0.0, "kg/hr");
+    Heater heater = new Heater("10-HA-EMPTY", feed);
+    Stream product = new Stream("10-PRODUCT-EMPTY", heater.getOutletStream());
+    ProcessSystem process = new ProcessSystem("Empty-stream delivery");
+    process.add(feed);
+    process.add(heater);
+    process.add(product);
+    process.add(new Stream("10-ISOLATED-EMPTY"));
+    EngineeringDiagramDelivery.Request request = EngineeringDiagramDelivery.Request
+        .builder("PLANT-EMPTY", "A", "PFD-EMPTY-001", "Empty-stream delivery", ContentProfile.PFD).build();
+
+    EngineeringDiagramDelivery.Report report = EngineeringDiagramDelivery.deliver(process,
+        temporaryDirectory.resolve("empty-streams"), request);
+
+    assertTrue(report.isComplete(), report.toJson());
+    assertTrue(Files.isRegularFile(report.getDirectory().resolve("dexpi-process.xml")));
+    assertTrue(report.toJson().contains("10-HA-EMPTY->10-PRODUCT-EMPTY"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Make NeqSim process execution, engineering-diagram delivery, and DEXPI delivery tolerate terminal and isolated empty streams, and add a NeqSim-native renderer for graphical DEXPI Plant/P&ID exchanges.

- run a fluid-less `Stream` as an inactive topology placeholder without inventing thermodynamic state
- expose a wrapped upstream stream through `Stream.getInletStreams()`
- map registered terminal stream nodes to DEXPI Process sinks
- create Process `Ports` collections lazily so disconnected empty streams do not serialize invalid empty components
- distinguish explicit canonical sink connections from synthesized boundary sinks during topology assessment
- add `DexpiXmlSvgRenderer`, which reads the Proteus-compatible DEXPI Plant/P&ID geometry and resolves component instances against the document `ShapeCatalogue`
- render equipment, valves, nozzles, instruments, process/signal/utility lines, labels, stream tables, borders, and title blocks without Graphviz or pyDEXPI
- add focused stream, writer, renderer, and end-to-end regressions
- document the supported empty-stream and native SVG-rendering behavior

## Campaign context

This is the next bounded engineering-diagram slice for #1332 and #2899. It also corrects the demonstration boundary: the visible ISO-style P&ID is rendered from the graphical DEXPI Plant/P&ID exchange, not from the DEXPI Process PFD/BFD projection.

## Acceptance criteria

- an isolated `new Stream(name)` completes `run(UUID)` as inactive and retains a null fluid state
- a zero-flow terminal `new Stream(productName, upstreamOutlet)` remains a canonical and exported material connection
- the terminal step is a native DEXPI Process `Sink`, not a synthesized boundary
- an isolated stream can coexist with a connected process without an empty `Ports` collection
- generated native DEXPI Process XML remains official-schema/profile conformant
- a graphical Proteus-compatible DEXPI Plant/P&ID XML document can be rendered directly to SVG by NeqSim
- SVG component shapes come from the exchange document's `ShapeCatalogue`
- existing parallel-branch compatibility remains byte-identical

## Exact-head visual-quality follow-up

Exact current head: `9a2b52a44672279234ff7fad3cbd90d98556e168`.

Full-sheet and readable-detail rendering of the exact hosted `plant-proteus.xml` artifacts exposed and closed three branch-attributable presentation failures:

- governed instrument/controller bubbles and safeguard tags reused or nearly reused coordinates around `INLET-SEP` and `EXPORT-COMP`;
- the process-area dash-dot battery-limit boundary crossed two instrument bubbles and both equipment data bars after engineering functions were materialized;
- the generated title block defaulted to `STATUS IFC` and revision text `Issued for Design`, contradicting the proposal-only engineering boundary.

The current head now:

- allocates all governed instruments on a deterministic five-column grid above the measured equipment data-bar ceiling;
- uses compact two-row visible labels while retaining each full stable tag in DEXPI metadata;
- allocates control and protective valves on a separate two-column grid below their protected equipment;
- expands the battery-limit rectangle from the materialized engineering-function extents, moves its area label inside, and enforces 9 mm minimum line clearance;
- marks generated title blocks `PROPOSAL` and the initial revision `Engineering Proposal`;
- adds structural regressions for 12 mm instrument spacing, 14 mm protective-device spacing, compact labels, boundary enclosure, and fail-closed status defaults.

Exact hosted artifact evidence: workflow artifact `9714991341`, digest `sha256:09a00fd7c915446d4cd169c36f5fc93baf51c9a1fb12d932349be0d1705d9980`, head `3050f7f74002c46568decdb4752b9065972c421c`. NeqSim's renderer produced a 4200 × 3028 PNG from the actual Proteus 4.1.1-compatible graphical primitives. Full-sheet and detail inspection confirm separated bubbles/labels, unobstructed equipment tables, safeguarded symbols clear of process lines, and battery-limit geometry `(18,100)–(310,289.5)`. The title block remains `PROPOSAL`.

Hosted validation for the prior DEXPI state passed Spotless, pre-commit, documentation search, performance, both engineering notebooks, PaperLab, CodeQL, Javadocs, agent/skill checks, and all four Java 21 slow shards. The fast workflow then exposed the pre-existing deterministic `PostTripAnalysisTest.testPropagationMaxDepth` failure: `setMaxCascadeDepth(1)` still emitted depth-2 indirect effects. The current head guards indirect propagation with `maxCascadeDepth >= 2`, preserving the default trace while enforcing the public limit. The failing test now passes locally, and a fresh hosted run is in progress. **VALIDATION PENDING CI**.

## Validation

PASS:

```
./mvnw -Dtest=PostTripAnalysisTest,StreamTest,DexpiXmlSvgRendererTest,DexpiRenderingImprovementsTest,Dexpi20ProcessModelWriterTest test
```

- 66 tests run
- 0 failures
- 0 errors
- 0 skipped

PASS:

```
python devtools/run_spotless.py check
python devtools/check_documentation_search.py
```

Documentation search audited 670 Markdown pages and one standalone HTML page.

PASS:

```
./mvnw --file pomJava8.xml -DskipTests compile
```

Java 8 compatibility compilation completed successfully.

The `pre-commit` executable was unavailable; the mandatory direct Spotless and documentation-search gates passed.

Executable demonstration evidence:

- NeqSim simulated a three-phase separation, gas-compression, and oil-treatment process with an unconfigured `90-EMPTY-SPARE` stream registered throughout the run
- `DexpiXmlWriter.write(...)` generated the graphical DEXPI Plant/P&ID XML
- `DexpiXmlSvgRenderer.render(...)` rendered the SVG from that XML
- `DexpiXmlReader.read(...)` imported 8 units from the generated file
- feed = products = 60,000.0 kg/h
- mass-balance error = 0.000000%

## Documentation impact

Updated:

- `docs/integration/dexpi-20-conformance.md` for empty and terminal Process streams
- `docs/integration/dexpi-reader.md` for runnable empty placeholders and NeqSim-native DEXPI Plant/P&ID SVG rendering
- Stream and DEXPI package Javadocs and usage example
- process-modeling skill guidance

The cascade-depth repair needs no additional documentation: it restores the behavior already promised by the public `setMaxCascadeDepth(int)` Javadoc, regression test, and root-cause-analysis skill without changing the API, defaults, units, or usage.

## Scope and evidence boundary

An empty stream is an inactive topology placeholder; equipment connected downstream still requires a real thermodynamic inlet before it can run. The graphical P&ID path is the established DEXPI 1.x / Proteus 4.1.1 Plant/P&ID serialization with ISO 10628-registered shapes and ISA-style instrumentation. It is distinct from native DEXPI XML 2.0 object/property/reference serialization. This PR does not claim a DEXPI EV certificate, named-CAE round trip, ISO certification, drawing approval, or fitness for design/construction.

Refs #1332
Refs #2899

AI-Assisted-by: OpenAI Codex