### PR TITLE
[AI-Assisted] fix(thermo): correct Henry temperature derivatives

### DIFF
--- a/docs/thermo/fluid_creation_guide.md
+++ b/docs/thermo/fluid_creation_guide.md
@@ -392,6 +392,10 @@ activity-based scale-potential screening after reactive gas-aqueous or gas-oil-a
 saturation ratio; explicit mineral precipitation, solid amounts, solid-phase equilibrium and wax checks are not yet
 supported by the hybrid strategy.
 
+Neutral-gas dissolution also requires a qualified Henry-law reference and, for brines, separately qualified Pitzer
+neutral-ion interactions. See [Henry-law reference states and aqueous gas-solubility evidence](henry_law_reference.md)
+for the implemented temperature law, derivative contract, current coefficient audit, source matrix and adoption gates.
+
 The solver is not restricted to Pitzer. Desmukh-Mather and Kent-Eisenberg use the same reactive coupling when
 `chemicalReactionInit()` and `setMultiPhaseCheck(true)` are enabled. Other `SystemEosGE` systems can opt in explicitly:
 

--- a/docs/thermo/henry_law_reference.md
+++ b/docs/thermo/henry_law_reference.md
@@ -1,0 +1,111 @@
+# Henry-law reference states and aqueous gas-solubility evidence
+
+NeqSim uses Henry-law reference states for neutral solutes in aqueous excess-Gibbs
+models. This page records the implemented convention, the evidence boundary, and
+the validation required before changing gas-solubility parameters.
+
+## Engineering question and stop boundary
+
+The current increment asks whether the temperature derivative supplied to
+equilibrium and property algorithms is consistent with the implemented Henry
+correlation. It does not change a coefficient, EOS binary interaction parameter,
+Pitzer neutral-ion interaction, reaction equilibrium constant, flash topology, or
+model default.
+
+The implementation stores four coefficients and evaluates
+
+$$H(T)=1.802\exp(C_1+C_2/T+C_3\ln T+C_4T)$$
+
+where the public component contract reports \(H\) in bar and \(T\) in kelvin.
+For an active finite correlation, the logarithmic derivative required by a
+fugacity coefficient is
+
+$$\frac{\mathrm{d}\ln H}{\mathrm{d}T}=-\frac{C_2}{T^2}+\frac{C_3}{T}+C_4.$$
+
+The previous GE path added \(\mathrm{d}H/\mathrm{d}T\) directly to
+\(\mathrm{d}\ln\gamma/\mathrm{d}T\). That mixes dimensional and logarithmic
+derivatives. The corrected path divides by \(H\), while a fail-closed constant
+Henry reference contributes zero.
+
+## Model semantics
+
+- EOS models such as SRK, PR, CPA, and electrolyte CPA calculate aqueous
+  solubility from EOS fugacity and mixing/association parameters. This GE
+  derivative change adds no EOS kernel work.
+- Pitzer uses a molality activity scale for neutral dissolved gases and maps it
+  to the common mole-fraction fugacity kernel. Henry reference parameters and
+  Pitzer \(\lambda\), \(\zeta\), \(\mu\), and \(\eta\) interactions are separate
+  parameter families and must not be substituted for one another.
+- Pure-water Henry data do not qualify electrolyte salting-out behavior.
+  Brine validation additionally requires independently sourced neutral-ion
+  interactions or a separately reviewed activity correction.
+- A reaction equilibrium constant does not replace the molecular-gas Henry
+  reference. Reactive CO2 and H2S cases require both molecular dissolution and
+  aqueous speciation closure.
+
+## Current-master coefficient audit
+
+The exact \`COMP.csv\` rows on master
+\`3d539d745168727ccca22fe2f571c4e200669b85\` expose a concrete qualification
+gap:
+
+| Component | Stored Henry row | Current interpretation | Qualification decision |
+| --- | --- | --- | --- |
+| CO2 | four non-zero coefficients | finite temperature correlation | provenance and range not recorded per row; do not refit silently |
+| methane | \(C_1=900\) | overflows and is fail-closed as effectively insoluble in Pitzer | unqualified for aqueous-solubility prediction |
+| nitrogen | all zero | evaluates to 1.802 bar through the conversion factor | unqualified; zero is not accepted as evidence |
+| oxygen | all zero | evaluates to 1.802 bar through the conversion factor | unqualified; zero is not accepted as evidence |
+| hydrogen | all zero and database reference state \`solvent\` | not a qualified aqueous solute reference | unqualified |
+| H2S | only \(C_4\) is non-zero | finite but row provenance/range is absent | unqualified for publication-quality solubility |
+
+No value from this audit is newly adopted. The table is a source-comparison and
+triage record; it prevents placeholder or sentinel values from being mistaken
+for qualified correlations.
+
+## Public evidence matrix
+
+| Source | Species/system | Convention and range | Licensing/reuse | Use in this increment |
+| --- | --- | --- | --- | --- |
+| Sander (2023), [DOI 10.5194/acp-23-10901-2023](https://doi.org/10.5194/acp-23-10901-2023) | water-solvent compilation, 10,173 species | standardized Henry definitions; source-specific ranges and uncertainty | article and supplement are CC BY 4.0 | terminology, conversion cross-check, and future redistributable source index |
+| Fernandez-Prini et al. (2003), [DOI 10.1063/1.1564818](https://doi.org/10.1063/1.1564818) | H2, N2, O2, CO, CO2, H2S, CH4, C2H6 and other gases in water | IAPWS Henry and vapor-liquid distribution correlations from water triple point toward critical conditions; species-specific fitted ranges | authoritative public guideline/article; coefficient redistribution terms not assumed | independent high-temperature validation target; no coefficients copied |
+| IAPWS G7-04, [Henry guideline](https://iapws.org/technical-guidance/release/HenGuide) | common gases in H2O and D2O | authoritative equation and validity definitions | public access; reuse terms must be checked before storing coefficients | independent implementation target only |
+| NIST Chemistry WebBook SRD 69, [CO2 Henry data](https://webbook.nist.gov/cgi/cbook.cgi?ID=C124389&Mask=10) | CO2 in water near ambient temperature | solubility form \(k_H\), mol/(kg bar), with temperature parameter | compilation is copyright protected | read-only cross-check; values are not copied into the repository |
+
+The Sander compilation is not treated as a substitute for its primary
+experimental references. A future coefficient batch must trace each adopted row
+to the original measurements or authoritative correlation, record uncertainty
+and preprocessing, and hold out independent data from fitting.
+
+## Validation gates for a coefficient batch
+
+A publishable gas-solubility dataset must include, for each species and model:
+
+1. explicit Henry convention, standard state, pressure unit, concentration
+   basis, reference temperature, pressure correction, and valid range;
+2. original data/correlation citation, redistributable license, uncertainty,
+   preprocessing, and a versioned dataset identity;
+3. pure-water held-out solubility over temperature and pressure;
+4. brine held-out data over ionic strength and salt composition, with complete
+   Pitzer neutral-ion interactions or an explicit missing-parameter failure;
+5. reactive CO2/H2S molecular-plus-speciation balance, electroneutrality, and
+   reaction \(\max|\ln(Q/K)|\);
+6. VLE/VLLE fugacity closure, non-negative normalized phases, nearby-state
+   trends, deterministic repeated and changed-state execution, clone,
+   serialization, and Java/JPype composability;
+7. complete-calculation and kernel benchmarks, including neutral EOS controls.
+
+## Regression evidence
+
+\`ComponentGEHenryDerivativeTest\` compares the analytical logarithmic derivative
+with a centered finite difference of \(\ln H\), exercises the Pitzer neutral-gas
+path, and verifies zero derivative for overflow and unsupported hydrocarbon
+fail-closed references. These are regression and mathematical-consistency
+checks, not independent solubility validation.
+
+## Next dependency
+
+Adopt one coherent, redistributable common-gas family only after the convention
+mapping and primary-source lineage are complete. The preferred first batch is
+CO2/CH4/N2/H2S in pure water plus NaCl brine, because it binds EOS validation,
+Pitzer neutral-ion terms, reactive CO2/H2S closure, and produced-water use
+without mixing parameter formalisms.

--- a/docs/thermo/henry_law_reference.md
+++ b/docs/thermo/henry_law_reference.md
@@ -1,3 +1,9 @@
+---
+title: "Henry-Law Reference States and Aqueous Gas-Solubility Evidence"
+description: "Henry-law conventions, temperature derivatives, parameter provenance, and validation gates for aqueous GE and Pitzer models."
+keywords: "Henry law, gas solubility, electrolyte, Pitzer, activity coefficient, aqueous phase, provenance"
+---
+
 # Henry-law reference states and aqueous gas-solubility evidence
 
 NeqSim uses Henry-law reference states for neutral solutes in aqueous excess-Gibbs

--- a/src/main/java/neqsim/thermo/component/ComponentGE.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGE.java
@@ -19,6 +19,8 @@ import neqsim.thermo.phase.PhaseInterface;
 public abstract class ComponentGE extends Component implements ComponentGEInterface {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  /** Finite fail-closed Henry coefficient used for unsupported or invalid solutes, in bar. */
+  protected static final double INSOLUBLE_HENRY_COEFFICIENT = 1.0e12;
 
   protected double gamma = 0;
   protected double gammaRefCor = 0;
@@ -57,18 +59,59 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
       } else {
         activinf = gamma / ((PhaseGE) phase).getActivityCoefficientInfDil(componentNumber);
       }
-      double henryCoef = getHenryCoef(phase.getTemperature());
-      // Handle infinite or very large Henry coefficients (database error or insoluble component)
-      // Use a large but finite value to represent essentially insoluble components
-      if (Double.isInfinite(henryCoef) || henryCoef > 1.0e12 || isIsIon()) {
-        henryCoef = 1.0e12; // Cap at 1e12 bar - effectively insoluble
-      }
+      double henryCoef = getEffectiveHenryCoefficient(phase.getTemperature());
       fugacityCoefficient = activinf * henryCoef / phase.getPressure();
       // gamma* benyttes ikke
       gammaRefCor = activinf;
     }
 
     return fugacityCoefficient;
+  }
+
+  /**
+   * Returns the Henry coefficient used by the aqueous GE reference state.
+   *
+   * <p>
+   * Invalid, non-positive, unsupported ionic, and excessively large correlations fail closed to a finite insoluble
+   * limit. Model-specific GE components may extend the unsupported-species decision.
+   * </p>
+   *
+   * @param temperature temperature in K
+   * @return effective Henry coefficient in bar
+   */
+  protected double getEffectiveHenryCoefficient(double temperature) {
+    double henryCoefficient = getHenryCoef(temperature);
+    return isHenryCoefficientCapped(henryCoefficient) ? INSOLUBLE_HENRY_COEFFICIENT : henryCoefficient;
+  }
+
+  /**
+   * Tests whether a raw Henry correlation must fail closed.
+   *
+   * @param henryCoefficient raw Henry coefficient in bar
+   * @return {@code true} when the effective reference is the finite insoluble limit
+   */
+  protected boolean isHenryCoefficientCapped(double henryCoefficient) {
+    return !Double.isFinite(henryCoefficient) || henryCoefficient <= 0.0
+        || henryCoefficient > INSOLUBLE_HENRY_COEFFICIENT || isIsIon();
+  }
+
+  /**
+   * Returns the logarithmic temperature derivative of the effective Henry reference.
+   *
+   * <p>
+   * Fugacity-coefficient derivatives are derivatives of {@code ln(phi)}. The database API returns {@code dH/dT}, so
+   * an active correlation contributes {@code (dH/dT)/H}. A fail-closed constant contributes zero.
+   * </p>
+   *
+   * @param temperature temperature in K
+   * @return {@code d(ln H)/dT} in 1/K
+   */
+  protected double getLnHenryCoefficientTemperatureDerivative(double temperature) {
+    double henryCoefficient = getHenryCoef(temperature);
+    if (isHenryCoefficientCapped(henryCoefficient)) {
+      return 0.0;
+    }
+    return getHenryCoefdT(temperature) / henryCoefficient;
   }
 
   /**
@@ -103,7 +146,7 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
       dfugdt = dlngammadt + 1.0 / getAntoineVaporPressure(temperature) * getAntoineVaporPressuredT(temperature);
       logger.info("check this dfug dt - antoine");
     } else {
-      dfugdt = dlngammadt + getHenryCoefdT(temperature);
+      dfugdt = dlngammadt + getLnHenryCoefficientTemperatureDerivative(temperature);
     }
     return dfugdt;
   }

--- a/src/main/java/neqsim/thermo/component/ComponentGE.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGE.java
@@ -99,8 +99,8 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
    * Returns the logarithmic temperature derivative of the effective Henry reference.
    *
    * <p>
-   * Fugacity-coefficient derivatives are derivatives of {@code ln(phi)}. The database API returns {@code dH/dT}, so
-   * an active correlation contributes {@code (dH/dT)/H}. A fail-closed constant contributes zero.
+   * Fugacity-coefficient derivatives are derivatives of {@code ln(phi)}. The database API returns {@code dH/dT}, so an
+   * active correlation contributes {@code (dH/dT)/H}. A fail-closed constant contributes zero.
    * </p>
    *
    * @param temperature temperature in K

--- a/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
@@ -45,11 +45,7 @@ public class ComponentGePitzer extends ComponentGE {
     // reference; hydrocarbons have no Pitzer neutral-interaction parameters and are represented as effectively
     // insoluble instead of being evaluated with the water osmotic coefficient.
     if (Math.abs(getIonicCharge()) < 0.5 && !"water".equalsIgnoreCase(getComponentName())) {
-      double henryCoefficient = getHenryCoef(phase.getTemperature());
-      if (hasHydrocarbonFormula() || isHydrocarbon() || isIsTBPfraction() || !Double.isFinite(henryCoefficient)
-          || henryCoefficient > 1.0e12) {
-        henryCoefficient = 1.0e12;
-      }
+      double henryCoefficient = getEffectiveHenryCoefficient(phase.getTemperature());
       // Pitzer neutral activities and the database Henry constants are on the molality
       // scale, while the common phase-equilibrium kernel evaluates x_i * phi_i * P.
       // Convert m_i * gamma_i * H_i to that mole-fraction representation explicitly.
@@ -63,6 +59,12 @@ public class ComponentGePitzer extends ComponentGE {
       return fugacityCoefficient;
     }
     return super.fugcoef(phase);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected boolean isHenryCoefficientCapped(double henryCoefficient) {
+    return super.isHenryCoefficientCapped(henryCoefficient) || isHydrocarbon() || isIsTBPfraction();
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/ComponentInterface.java
+++ b/src/main/java/neqsim/thermo/component/ComponentInterface.java
@@ -1647,10 +1647,14 @@ public interface ComponentInterface extends ThermodynamicConstantsInterface, Clo
   public double getHenryCoef(double temperature);
 
   /**
-   * getHenryCoefdT.
+   * Returns the temperature derivative of the Henry coefficient.
    *
-   * @param temperature a double
-   * @return a double
+   * <p>
+   * This is {@code dH/dT}, not {@code d(ln H)/dT}.
+   * </p>
+   *
+   * @param temperature temperature in K
+   * @return Henry-coefficient derivative in bar/K
    */
   public double getHenryCoefdT(double temperature);
 

--- a/src/test/java/neqsim/thermo/component/ComponentGEHenryDerivativeTest.java
+++ b/src/test/java/neqsim/thermo/component/ComponentGEHenryDerivativeTest.java
@@ -18,8 +18,7 @@ class ComponentGEHenryDerivativeTest {
     double expected = finiteDifferenceLogHenry(component, TEMPERATURE);
 
     assertEquals(expected, component.fugcoefDiffTemp(phase), 1.0e-9);
-    assertEquals(
-        1200.0 / (TEMPERATURE * TEMPERATURE) + 1.5 / TEMPERATURE + 0.002,
+    assertEquals(1200.0 / (TEMPERATURE * TEMPERATURE) + 1.5 / TEMPERATURE + 0.002,
         component.fugcoefDiffTemp(phase), 1.0e-12);
   }
 
@@ -29,8 +28,7 @@ class ComponentGEHenryDerivativeTest {
     component.setHenryCoefParameter(new double[] { 8.0, -800.0, 0.5, 0.001 });
     PhasePitzer phase = phaseAt(TEMPERATURE);
 
-    assertEquals(
-        finiteDifferenceLogHenry(component, TEMPERATURE), component.fugcoefDiffTemp(phase), 1.0e-9);
+    assertEquals(finiteDifferenceLogHenry(component, TEMPERATURE), component.fugcoefDiffTemp(phase), 1.0e-9);
   }
 
   @Test
@@ -61,7 +59,7 @@ class ComponentGEHenryDerivativeTest {
 
   private static double finiteDifferenceLogHenry(ComponentGE component, double temperature) {
     double step = 1.0e-3;
-    return (Math.log(component.getHenryCoef(temperature + step))
-        - Math.log(component.getHenryCoef(temperature - step))) / (2.0 * step);
+    return (Math.log(component.getHenryCoef(temperature + step)) - Math.log(component.getHenryCoef(temperature - step)))
+        / (2.0 * step);
   }
 }

--- a/src/test/java/neqsim/thermo/component/ComponentGEHenryDerivativeTest.java
+++ b/src/test/java/neqsim/thermo/component/ComponentGEHenryDerivativeTest.java
@@ -18,8 +18,8 @@ class ComponentGEHenryDerivativeTest {
     double expected = finiteDifferenceLogHenry(component, TEMPERATURE);
 
     assertEquals(expected, component.fugcoefDiffTemp(phase), 1.0e-9);
-    assertEquals(1200.0 / (TEMPERATURE * TEMPERATURE) + 1.5 / TEMPERATURE + 0.002,
-        component.fugcoefDiffTemp(phase), 1.0e-12);
+    assertEquals(1200.0 / (TEMPERATURE * TEMPERATURE) + 1.5 / TEMPERATURE + 0.002, component.fugcoefDiffTemp(phase),
+        1.0e-12);
   }
 
   @Test

--- a/src/test/java/neqsim/thermo/component/ComponentGEHenryDerivativeTest.java
+++ b/src/test/java/neqsim/thermo/component/ComponentGEHenryDerivativeTest.java
@@ -12,29 +12,31 @@ class ComponentGEHenryDerivativeTest {
   @Test
   void activeCorrelationReturnsLogarithmicDerivative() {
     ComponentGeNRTL component = new ComponentGeNRTL("CO2", 1.0, 1.0, 0);
-    component.setHenryCoefParameter(new double[] {10.0, -1200.0, 1.5, 0.002});
+    component.setHenryCoefParameter(new double[] { 10.0, -1200.0, 1.5, 0.002 });
     PhasePitzer phase = phaseAt(TEMPERATURE);
 
     double expected = finiteDifferenceLogHenry(component, TEMPERATURE);
 
     assertEquals(expected, component.fugcoefDiffTemp(phase), 1.0e-9);
-    assertEquals(1200.0 / (TEMPERATURE * TEMPERATURE) + 1.5 / TEMPERATURE + 0.002,
+    assertEquals(
+        1200.0 / (TEMPERATURE * TEMPERATURE) + 1.5 / TEMPERATURE + 0.002,
         component.fugcoefDiffTemp(phase), 1.0e-12);
   }
 
   @Test
   void pitzerNeutralGasUsesSameLogarithmicDerivative() {
     ComponentGePitzer component = new ComponentGePitzer("CO2", 1.0, 1.0, 0);
-    component.setHenryCoefParameter(new double[] {8.0, -800.0, 0.5, 0.001});
+    component.setHenryCoefParameter(new double[] { 8.0, -800.0, 0.5, 0.001 });
     PhasePitzer phase = phaseAt(TEMPERATURE);
 
-    assertEquals(finiteDifferenceLogHenry(component, TEMPERATURE), component.fugcoefDiffTemp(phase), 1.0e-9);
+    assertEquals(
+        finiteDifferenceLogHenry(component, TEMPERATURE), component.fugcoefDiffTemp(phase), 1.0e-9);
   }
 
   @Test
   void failClosedCorrelationHasZeroReferenceDerivative() {
     ComponentGeNRTL component = new ComponentGeNRTL("CO2", 1.0, 1.0, 0);
-    component.setHenryCoefParameter(new double[] {1000.0, 0.0, 0.0, 0.0});
+    component.setHenryCoefParameter(new double[] { 1000.0, 0.0, 0.0, 0.0 });
 
     assertTrue(Double.isInfinite(component.getHenryCoef(TEMPERATURE)));
     assertEquals(0.0, component.fugcoefDiffTemp(phaseAt(TEMPERATURE)), 0.0);
@@ -43,7 +45,7 @@ class ComponentGEHenryDerivativeTest {
   @Test
   void unsupportedPitzerHydrocarbonHasZeroReferenceDerivative() {
     ComponentGePitzer component = new ComponentGePitzer("methane", 1.0, 1.0, 0);
-    component.setHenryCoefParameter(new double[] {0.0, 0.0, 0.0, 0.01});
+    component.setHenryCoefParameter(new double[] { 0.0, 0.0, 0.0, 0.01 });
 
     double rawLogDerivative = component.getHenryCoefdT(TEMPERATURE) / component.getHenryCoef(TEMPERATURE);
 

--- a/src/test/java/neqsim/thermo/component/ComponentGEHenryDerivativeTest.java
+++ b/src/test/java/neqsim/thermo/component/ComponentGEHenryDerivativeTest.java
@@ -1,0 +1,65 @@
+package neqsim.thermo.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhasePitzer;
+
+/** Tests temperature derivatives of aqueous Henry-reference fugacity coefficients. */
+class ComponentGEHenryDerivativeTest {
+  private static final double TEMPERATURE = 298.15;
+
+  @Test
+  void activeCorrelationReturnsLogarithmicDerivative() {
+    ComponentGeNRTL component = new ComponentGeNRTL("CO2", 1.0, 1.0, 0);
+    component.setHenryCoefParameter(new double[] {10.0, -1200.0, 1.5, 0.002});
+    PhasePitzer phase = phaseAt(TEMPERATURE);
+
+    double expected = finiteDifferenceLogHenry(component, TEMPERATURE);
+
+    assertEquals(expected, component.fugcoefDiffTemp(phase), 1.0e-9);
+    assertEquals(1200.0 / (TEMPERATURE * TEMPERATURE) + 1.5 / TEMPERATURE + 0.002,
+        component.fugcoefDiffTemp(phase), 1.0e-12);
+  }
+
+  @Test
+  void pitzerNeutralGasUsesSameLogarithmicDerivative() {
+    ComponentGePitzer component = new ComponentGePitzer("CO2", 1.0, 1.0, 0);
+    component.setHenryCoefParameter(new double[] {8.0, -800.0, 0.5, 0.001});
+    PhasePitzer phase = phaseAt(TEMPERATURE);
+
+    assertEquals(finiteDifferenceLogHenry(component, TEMPERATURE), component.fugcoefDiffTemp(phase), 1.0e-9);
+  }
+
+  @Test
+  void failClosedCorrelationHasZeroReferenceDerivative() {
+    ComponentGeNRTL component = new ComponentGeNRTL("CO2", 1.0, 1.0, 0);
+    component.setHenryCoefParameter(new double[] {1000.0, 0.0, 0.0, 0.0});
+
+    assertTrue(Double.isInfinite(component.getHenryCoef(TEMPERATURE)));
+    assertEquals(0.0, component.fugcoefDiffTemp(phaseAt(TEMPERATURE)), 0.0);
+  }
+
+  @Test
+  void unsupportedPitzerHydrocarbonHasZeroReferenceDerivative() {
+    ComponentGePitzer component = new ComponentGePitzer("methane", 1.0, 1.0, 0);
+    component.setHenryCoefParameter(new double[] {0.0, 0.0, 0.0, 0.01});
+
+    double rawLogDerivative = component.getHenryCoefdT(TEMPERATURE) / component.getHenryCoef(TEMPERATURE);
+
+    assertEquals(0.01, rawLogDerivative, 1.0e-12);
+    assertEquals(0.0, component.fugcoefDiffTemp(phaseAt(TEMPERATURE)), 0.0);
+  }
+
+  private static PhasePitzer phaseAt(double temperature) {
+    PhasePitzer phase = new PhasePitzer();
+    phase.setTemperature(temperature);
+    return phase;
+  }
+
+  private static double finiteDifferenceLogHenry(ComponentGE component, double temperature) {
+    double step = 1.0e-3;
+    return (Math.log(component.getHenryCoef(temperature + step))
+        - Math.log(component.getHenryCoef(temperature - step))) / (2.0 * step);
+  }
+}


### PR DESCRIPTION
## Engineering question

Can aqueous excess-Gibbs and Pitzer calculations provide the logarithmic Henry-law temperature derivative required by fugacity algorithms, while failing closed for invalid or unsupported correlations and preserving EOS performance?

Advances #3144.

## Frozen scope

- **Exact base/master:** `3d539d745168727ccca22fe2f571c4e200669b85`
- **Exact head:** `da94ac5a9aabcb1aadc4bea169dbb485fd48aa61`
- **Models:** aqueous GE solute reference states, including classic Pitzer neutral gases
- **Correlation:** `H(T) = 1.802 exp(C1 + C2/T + C3 ln(T) + C4 T)`; public component contract reports bar, T in K
- **Reproducer:** arbitrary finite four-coefficient solute correlation at 298.15 K; analytic `d ln(H)/dT` versus centered finite difference
- **Acceptance:** active GE and Pitzer correlations agree with finite difference; overflow/invalid and unsupported Pitzer hydrocarbon references return zero derivative for their constant fail-closed `1e12 bar` reference
- **Stop boundary:** no coefficient, EOS binary interaction, Pitzer lambda/zeta/mu/eta term, reaction constant, flash topology, model default, or parameter activation change

## Concrete current-master gap

`ComponentGE.fugcoefDiffTemp()` added `dH/dT` (bar/K) directly to `d ln(gamma)/dT` (1/K). The required solute contribution is `(dH/dT)/H = d ln(H)/dT`. This dimensional inconsistency affects derivative-consuming GE/Pitzer calculations.

The accompanying exact-master `COMP.csv` audit also records that methane overflows to the insoluble sentinel, nitrogen/oxygen zero rows evaluate to 1.802 bar, hydrogen is marked as a solvent, and H2S lacks row-level provenance/range. Those rows are classified unqualified; no value is silently fitted or adopted here.

## Implementation

- centralize the finite fail-closed Henry reference in `ComponentGE`;
- reject non-finite, non-positive, excessively large, and ionic raw references deterministically;
- calculate the active logarithmic derivative as `(dH/dT)/H`;
- preserve the Pitzer hydrocarbon/TBP fail-closed boundary through a model-specific override;
- define the existing public `getHenryCoefdT` contract explicitly as `dH/dT` in bar/K;
- add analytical/finite-difference, Pitzer-neutral, overflow, and unsupported-hydrocarbon regressions;
- add a durable Henry convention, source, licensing, current-row audit, validation-gate, and next-dataset guide.

## Scientific and public-data basis

No external coefficient is copied. Convention and future validation sources are:

- Sander (2023), [DOI 10.5194/acp-23-10901-2023](https://doi.org/10.5194/acp-23-10901-2023), article and supplement CC BY 4.0;
- Fernandez-Prini et al. (2003), [DOI 10.1063/1.1564818](https://doi.org/10.1063/1.1564818), primary IAPWS correlation paper;
- [IAPWS G7-04](https://iapws.org/technical-guidance/release/HenGuide), independent common-gas water validation target;
- NIST Chemistry WebBook SRD 69 CO2 page, read-only convention/value cross-check; NIST compilation values are not redistributed.

Pure-water Henry coefficients and brine Pitzer neutral-ion interactions remain separate parameter families. Reactive CO2/H2S additionally require molecular dissolution plus speciation, charge, element, and reaction closure.

## Validation status

**DRAFT — VALIDATION PENDING CI**

The branch was built and repaired through the connected GitHub interface from exact master. Initial hosted pre-commit identified Spotless and missing documentation-front-matter defects; head `da94ac5a9aabcb1aadc4bea169dbb485fd48aa61` applies only those mechanical repairs. Fresh exact-head pre-commit, Spotless, and PaperLab now pass. Documentation search, CodeQL, Java 8/21 Ubuntu/Windows, slow shards, and Javadocs remain in progress; no pending check is claimed passed.

## Performance and compatibility

Neutral PR/SRK/CPA and electrolyte-EOS property kernels are unchanged. Ordinary GE fugacity evaluation retains the existing validity branch through a small helper expected to inline. Only derivative calls add one division for an active finite Henry correlation; capped references return zero without numerical differencing.

## Documentation impact

User-visible derivative units, Henry standard-state/model boundaries, current parameter qualification, sources, licensing, validation requirements, and Java/Pitzer usage are documented in:

- `docs/thermo/henry_law_reference.md`
- `docs/thermo/fluid_creation_guide.md`
- `ComponentInterface` Javadocs

## Next dependency

After this derivative foundation is green and merged, adopt one coherent redistributable CO2/CH4/N2/H2S family for pure water plus NaCl brine, with primary-source lineage, convention mapping, Pitzer neutral-ion terms, held-out solubility/speciation data, and EOS controls.

AI-assisted contribution.