### PR TITLE
[AI-Assisted] feat(thermo): add IAPWS water Henry references

### DIFF
--- a/docs/thermo/henry_law_reference.md
+++ b/docs/thermo/henry_law_reference.md
@@ -1,117 +1,130 @@
 ---
 title: "Henry-Law Reference States and Aqueous Gas-Solubility Evidence"
-description: "Henry-law conventions, temperature derivatives, parameter provenance, and validation gates for aqueous GE and Pitzer models."
+description: "IAPWS pure-water Henry correlations, GE/Pitzer standard-state mapping, provenance, and validation boundaries."
 keywords: "Henry law, gas solubility, electrolyte, Pitzer, activity coefficient, aqueous phase, provenance"
 ---
 
 # Henry-law reference states and aqueous gas-solubility evidence
 
-NeqSim uses Henry-law reference states for neutral solutes in aqueous excess-Gibbs
-models. This page records the implemented convention, the evidence boundary, and
-the validation required before changing gas-solubility parameters.
+NeqSim uses Henry-law reference states for neutral solutes in aqueous
+excess-Gibbs models. This page records the implemented convention, source
+provenance, qualification status, and the evidence boundary for brines and
+multiphase calculations.
 
 ## Engineering question and stop boundary
 
-The current increment asks whether the temperature derivative supplied to
-equilibrium and property algorithms is consistent with the implemented Henry
-correlation. It does not change a coefficient, EOS binary interaction parameter,
-Pitzer neutral-ion interaction, reaction equilibrium constant, flash topology, or
-model default.
+This increment asks whether common gases can use a reproducible, attributed
+pure-water Henry reference instead of invalid or undocumented database
+placeholders, without changing electrolyte interactions, reaction constants,
+EOS mixing rules, flash topology, or non-aqueous model paths.
 
-The implementation stores four coefficients and evaluates
+It implements the IAPWS G7-04 H2O correlation for He, Ne, Ar, Kr, Xe, H2, N2,
+O2, CO, CO2, H2S, CH4, C2H6, and SF6. It does not add a pressure/Poynting
+correction, a vapor-liquid distribution-constant correlation, brine salting-out
+parameters, reactive speciation, or new electrolyte-EOS parameters.
 
-$$H(T)=1.802\exp(C_1+C_2/T+C_3\ln T+C_4T)$$
+## Convention and equations
 
-where the public component contract reports \(H\) in bar and \(T\) in kelvin.
-For an active finite correlation, the logarithmic derivative required by a
-fugacity coefficient is
+IAPWS defines the mole-fraction Henry constant on the liquid-water saturation
+boundary as
 
-$$\frac{\mathrm{d}\ln H}{\mathrm{d}T}=-\frac{C_2}{T^2}+\frac{C_3}{T}+C_4.$$
+$$k_H(T)=\lim_{x_i\rightarrow0}\frac{f_i}{x_i}.$$
 
-The previous GE path added \(\mathrm{d}H/\mathrm{d}T\) directly to
-\(\mathrm{d}\ln\gamma/\mathrm{d}T\). That mixes dimensional and logarithmic
-derivatives. The corrected path divides by \(H\), while a fail-closed constant
-Henry reference contributes zero.
+With \(T_r=T/T_c\), \(\tau=1-T_r\), and water saturation pressure \(p^*\),
+
+$$\ln\left(\frac{k_H}{p^*}\right)
+ =\frac{A}{T_r}+\frac{B\tau^{0.355}}{T_r}
+  +C T_r^{-0.41}\exp(\tau).$$
+
+The implementation returns \(k_H\) in bar and provides the analytical
+\(\mathrm{d}\ln k_H/\mathrm{d}T\) required by fugacity derivatives. It reports
+whether a requested state is inside the species-specific fitted range, a
+guideline extrapolation, unsupported, or outside the liquid-water correlation
+domain. A supported species outside the domain fails closed.
+
+Pitzer neutral activities use a molality standard state. At infinite dilution,
+
+$$H_m=k_H M_{\mathrm{water}},$$
+
+where \(M_{\mathrm{water}}=0.01801528\) kg/mol. The existing \(m_i/x_i\)
+conversion then maps the Pitzer expression back to the common
+mole-fraction/fugacity kernel. The constant conversion leaves
+\(\mathrm{d}\ln H/\mathrm{d}T\) unchanged.
 
 ## Model semantics
 
-- EOS models such as SRK, PR, CPA, and electrolyte CPA calculate aqueous
-  solubility from EOS fugacity and mixing/association parameters. This GE
-  derivative change adds no EOS kernel work.
-- Pitzer uses a molality activity scale for neutral dissolved gases and maps it
-  to the common mole-fraction fugacity kernel. Henry reference parameters and
-  Pitzer \(\lambda\), \(\zeta\), \(\mu\), and \(\eta\) interactions are separate
-  parameter families and must not be substituted for one another.
+- Generic aqueous GE models use the IAPWS mole-fraction reference only when
+  water is present and the neutral species is supported.
+- Pitzer uses the explicit molality conversion above. Pitzer \(\lambda\),
+  \(\zeta\), \(\mu\), and \(\eta\) interactions remain distinct parameter
+  families.
 - Pure-water Henry data do not qualify electrolyte salting-out behavior.
-  Brine validation additionally requires independently sourced neutral-ion
-  interactions or a separately reviewed activity correction.
-- A reaction equilibrium constant does not replace the molecular-gas Henry
-  reference. Reactive CO2 and H2S cases require both molecular dissolution and
-  aqueous speciation closure.
+  Brine prediction still requires independently sourced neutral-ion
+  interactions and dataset qualification.
+- EOS models such as SRK, PR, CPA, and electrolyte CPA retain their EOS
+  fugacity, association, and mixing-rule paths.
+- Molecular CO2 and H2S dissolution does not replace reaction equilibrium
+  constants or the electroneutral species balance.
 
-## Current-master coefficient audit
+## Current-master gap reproduced before adoption
 
-The exact \`COMP.csv\` rows on master
-\`3d539d745168727ccca22fe2f571c4e200669b85\` expose a concrete qualification
-gap:
+The audited component table contained a methane overflow sentinel, zero
+coefficient rows for nitrogen and oxygen, and incomplete or undocumented rows
+for several other gases. Those rows could not serve as qualified common-gas
+water correlations. The IAPWS dataset is selected by explicit species and water
+topology; unrelated database correlations remain available for unsupported
+species.
 
-| Component | Stored Henry row | Current interpretation | Qualification decision |
-| --- | --- | --- | --- |
-| CO2 | four non-zero coefficients | finite temperature correlation | provenance and range not recorded per row; do not refit silently |
-| methane | \(C_1=900\) | overflows and is fail-closed as effectively insoluble in Pitzer | unqualified for aqueous-solubility prediction |
-| nitrogen | all zero | evaluates to 1.802 bar through the conversion factor | unqualified; zero is not accepted as evidence |
-| oxygen | all zero | evaluates to 1.802 bar through the conversion factor | unqualified; zero is not accepted as evidence |
-| hydrogen | all zero and database reference state \`solvent\` | not a qualified aqueous solute reference | unqualified |
-| H2S | only \(C_4\) is non-zero | finite but row provenance/range is absent | unqualified for publication-quality solubility |
+## Public evidence and source comparison
 
-No value from this audit is newly adopted. The table is a source-comparison and
-triage record; it prevents placeholder or sentinel values from being mistaken
-for qualified correlations.
-
-## Public evidence matrix
-
-| Source | Species/system | Convention and range | Licensing/reuse | Use in this increment |
+| Source | Species/system | Convention and range | Licensing/reuse | Decision |
 | --- | --- | --- | --- | --- |
-| Sander (2023), [DOI 10.5194/acp-23-10901-2023](https://doi.org/10.5194/acp-23-10901-2023) | water-solvent compilation, 10,173 species | standardized Henry definitions; source-specific ranges and uncertainty | article and supplement are CC BY 4.0 | terminology, conversion cross-check, and future redistributable source index |
-| Fernandez-Prini et al. (2003), [DOI 10.1063/1.1564818](https://doi.org/10.1063/1.1564818) | H2, N2, O2, CO, CO2, H2S, CH4, C2H6 and other gases in water | IAPWS Henry and vapor-liquid distribution correlations from water triple point toward critical conditions; species-specific fitted ranges | authoritative public guideline/article; coefficient redistribution terms not assumed | independent high-temperature validation target; no coefficients copied |
-| IAPWS G7-04, [Henry guideline](https://iapws.org/technical-guidance/release/HenGuide) | common gases in H2O and D2O | authoritative equation and validity definitions | public access; reuse terms must be checked before storing coefficients | independent implementation target only |
-| NIST Chemistry WebBook SRD 69, [CO2 Henry data](https://webbook.nist.gov/cgi/cbook.cgi?ID=C124389&Mask=10) | CO2 in water near ambient temperature | solubility form \(k_H\), mol/(kg bar), with temperature parameter | compilation is copyright protected | read-only cross-check; values are not copied into the repository |
+| Fernandez-Prini et al. (2003), [DOI 10.1063/1.1564818](https://doi.org/10.1063/1.1564818) | 14 gases in H2O and 7 gases in D2O | (k_H=f/x) at water saturation; triple-point region toward critical conditions; species-specific fitted ranges and RMS residuals | primary JPCRD article available through NIST | adopted lineage and independent equation cross-check for the 14 H2O gases |
+| IAPWS G7-04, [Henry guideline](https://iapws.org/technical-guidance/release/HenGuide) | He, Ne, Ar, Kr, Xe, H2, N2, O2, CO, CO2, H2S, CH4, C2H6, SF6 in H2O | same equation and standard state; Table 2 fitted ranges; Table 6 check values at 300/400/500/600 K | guideline states that publication in whole or in part is permitted with attribution | adopted coefficients, ranges, equations, and 56 published check values |
+| Sander (2023), [DOI 10.5194/acp-23-10901-2023](https://doi.org/10.5194/acp-23-10901-2023) | water-solvent compilation | standardized alternative Henry definitions and conversions | article and supplement are CC BY 4.0 | terminology and conversion cross-check; no values adopted |
+| NIST Chemistry WebBook SRD 69, [CO2 Henry data](https://webbook.nist.gov/cgi/cbook.cgi?ID=C124389&Mask=10) | CO2 in water near ambient temperature | solubility-form values and temperature parameter | compilation is copyright protected | read-only validation index; no values copied |
 
-The Sander compilation is not treated as a substitute for its primary
-experimental references. A future coefficient batch must trace each adopted row
-to the original measurements or authoritative correlation, record uncertainty
-and preprocessing, and hold out independent data from fitting.
+The IAPWS high-temperature root-mean-square deviations in \(\ln k_H\) range
+from 0.0039 for CO to 0.0577 for Ne. These source residuals describe the
+correlation fit; they are not NeqSim regression tolerances or independent
+held-out validation.
 
-## Validation gates for a coefficient batch
-
-A publishable gas-solubility dataset must include, for each species and model:
-
-1. explicit Henry convention, standard state, pressure unit, concentration
-   basis, reference temperature, pressure correction, and valid range;
-2. original data/correlation citation, redistributable license, uncertainty,
-   preprocessing, and a versioned dataset identity;
-3. pure-water held-out solubility over temperature and pressure;
-4. brine held-out data over ionic strength and salt composition, with complete
-   Pitzer neutral-ion interactions or an explicit missing-parameter failure;
-5. reactive CO2/H2S molecular-plus-speciation balance, electroneutrality, and
-   reaction \(\max|\ln(Q/K)|\);
-6. VLE/VLLE fugacity closure, non-negative normalized phases, nearby-state
-   trends, deterministic repeated and changed-state execution, clone,
-   serialization, and Java/JPype composability;
-7. complete-calculation and kernel benchmarks, including neutral EOS controls.
+Baard Kaasa's 1998 thesis remains a provenance index for Pitzer
+specific-ion-interaction parameters. No Kaasa table was copied and no Pitzer
+coefficient was adopted here: Henry constants and Pitzer interaction
+coefficients are different model families.
 
 ## Regression evidence
 
-\`ComponentGEHenryDerivativeTest\` compares the analytical logarithmic derivative
-with a centered finite difference of \(\ln H\), exercises the Pitzer neutral-gas
-path, and verifies zero derivative for overflow and unsupported hydrocarbon
-fail-closed references. These are regression and mathematical-consistency
-checks, not independent solubility validation.
+`IapwsHenryLawTest` reproduces all 56 rounded IAPWS Table 6 values, compares
+the analytical derivative with centered finite differences for all 14 gases,
+checks fitted/extrapolated/unsupported/out-of-domain diagnostics, verifies
+mole-fraction-to-molality mapping, and exercises fail-closed behavior.
 
-## Next dependency
+`ComponentGEHenryDerivativeTest` retains the legacy database-correlation
+regressions, including the dimensional identity
 
-Adopt one coherent, redistributable common-gas family only after the convention
-mapping and primary-source lineage are complete. The preferred first batch is
-CO2/CH4/N2/H2S in pure water plus NaCl brine, because it binds EOS validation,
-Pitzer neutral-ion terms, reactive CO2/H2S closure, and produced-water use
-without mixing parameter formalisms.
+$$\frac{\mathrm{d}\ln H}{\mathrm{d}T}=\frac{1}{H}\frac{\mathrm{d}H}{\mathrm{d}T}.$$
+
+These tests are implementation and source-table regressions. They are separate
+from independent VLE/VLLE or brine validation.
+
+## Remaining validation boundary
+
+Publication-quality aqueous/electrolyte predictions still require:
+
+1. independently sourced neutral-ion interactions for the selected Pitzer
+   dataset, including complete binary and ternary coverage;
+2. held-out pure-water and brine solubility over temperature, pressure, ionic
+   strength, and salt composition;
+3. reactive CO2/H2S material balance, electroneutrality, and
+   \(\max|\ln(Q/K)|\);
+4. VLE/VLLE fugacity closure, stable topology, normalized non-negative phases,
+   and nearby-state trends;
+5. deterministic repeated and changed-state execution, stale-state protection,
+   clone/serialization/thread checks, and Java/JPype composability;
+6. complete-calculation and kernel benchmarks, including neutral EOS controls.
+
+The next parameter increment is therefore a complete, redistributable
+neutral-gas/ion interaction family with held-out brine validation. Missing
+interactions must remain explicit rather than silently defaulting to zero.

--- a/docs/thermo/henry_law_reference.md
+++ b/docs/thermo/henry_law_reference.md
@@ -51,13 +51,53 @@ conversion then maps the Pitzer expression back to the common
 mole-fraction/fugacity kernel. The constant conversion leaves
 \(\mathrm{d}\ln H/\mathrm{d}T\) unchanged.
 
+The coherent family is identified as `iapws-g7-04-water-gases-v1`.
+Ordinary runtime evaluation accepts only the published species-specific fitted
+range. `getHenryCoefficientBarAllowExtrapolation` is deliberately named for
+reproducing guideline check values outside that range; GE and Pitzer fugacity
+paths never call it.
+
+### Versioned coefficient family
+
+The following values are transcribed from IAPWS G7-04 Tables 2 and 5. `A`, `B`,
+and `C` are dimensionless; temperature limits are in kelvin; RMS is the
+published root-mean-square deviation in `ln(kH)`.
+
+| Species | A | B | C | Tmin | Tmax | RMS |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| He | -3.52839 | 7.12983 | 4.47770 | 273.21 | 553.18 | 0.0341 |
+| Ne | -3.18301 | 5.31448 | 5.43774 | 273.20 | 543.36 | 0.0577 |
+| Ar | -8.40954 | 4.29587 | 10.52779 | 273.19 | 568.36 | 0.0443 |
+| Kr | -8.97358 | 3.61508 | 11.29963 | 273.19 | 525.56 | 0.0434 |
+| Xe | -14.21635 | 4.00041 | 15.60999 | 273.22 | 574.85 | 0.0363 |
+| H2 | -4.73284 | 6.08954 | 6.06066 | 273.15 | 636.09 | 0.0517 |
+| N2 | -9.67578 | 4.72162 | 11.70585 | 278.12 | 636.46 | 0.0372 |
+| O2 | -9.44833 | 4.43822 | 11.42005 | 274.15 | 616.52 | 0.0377 |
+| CO | -10.52862 | 5.13259 | 12.01421 | 278.15 | 588.67 | 0.0039 |
+| CO2 | -8.55445 | 4.01195 | 9.52345 | 274.19 | 642.66 | 0.0528 |
+| H2S | -4.51499 | 5.23538 | 4.42126 | 273.15 | 533.09 | 0.0408 |
+| CH4 | -10.44708 | 4.66491 | 12.12986 | 275.46 | 633.11 | 0.0386 |
+| C2H6 | -19.67563 | 4.51222 | 20.62567 | 275.44 | 473.46 | 0.0259 |
+| SF6 | -16.56118 | 2.15289 | 20.35440 | 283.14 | 505.55 | 0.0505 |
+
 ## Model semantics
 
-- Generic aqueous GE models use the IAPWS mole-fraction reference only when
-  water is present and the neutral species is supported.
-- Pitzer uses the explicit molality conversion above. Pitzer \(\lambda\),
-  \(\zeta\), \(\mu\), and \(\eta\) interactions remain distinct parameter
-  families.
+| Runtime path | IAPWS reference decision | Electrolyte-interaction decision |
+| --- | --- | --- |
+| Generic aqueous GE | use the mole-fraction reference for a supported neutral gas in water, including H2/He/Ar rows historically marked as solvents | retain the GE model's own activity coefficient |
+| Pitzer, no ionic component topology | use the explicit molality conversion above | no salting-out claim; this is the pure-water limit |
+| Pitzer, ions and a coverage-checked neutral family | use the molality reference | apply the explicitly selected `lambda`, `zeta`, `mu`, and `eta` family |
+| Pitzer, ions without a qualified neutral family | preserve the established database/capping reference for the complete calculation | do not silently combine IAPWS with a unit neutral activity coefficient |
+| SRK, PR, CPA, and electrolyte EOS | do not dispatch through this GE reference | retain EOS fugacity, association, and mixing-rule semantics |
+
+The Pitzer decision depends on component topology, not the instantaneous ionic
+strength. Consequently a reaction solve cannot change reference models merely
+because trace ions appear or disappear. Pitzer \(\lambda\), \(\zeta\), \(\mu\),
+and \(\eta\) interactions remain distinct parameter families. CO2 and H2S also
+require a qualified neutral family before Pitzer changes their reference, even
+before reaction species have been added. This prevents initialization order
+from seeding a reactive calculation with a temporarily different standard
+state.
 - Pure-water Henry data do not qualify electrolyte salting-out behavior.
   Brine prediction still requires independently sourced neutral-ion
   interactions and dataset qualification.
@@ -82,7 +122,9 @@ species.
 | Fernandez-Prini et al. (2003), [DOI 10.1063/1.1564818](https://doi.org/10.1063/1.1564818) | 14 gases in H2O and 7 gases in D2O | (k_H=f/x) at water saturation; triple-point region toward critical conditions; species-specific fitted ranges and RMS residuals | primary JPCRD article available through NIST | adopted lineage and independent equation cross-check for the 14 H2O gases |
 | IAPWS G7-04, [Henry guideline](https://iapws.org/technical-guidance/release/HenGuide) | He, Ne, Ar, Kr, Xe, H2, N2, O2, CO, CO2, H2S, CH4, C2H6, SF6 in H2O | same equation and standard state; Table 2 fitted ranges; Table 6 check values at 300/400/500/600 K | guideline states that publication in whole or in part is permitted with attribution | adopted coefficients, ranges, equations, and 56 published check values |
 | Sander (2023), [DOI 10.5194/acp-23-10901-2023](https://doi.org/10.5194/acp-23-10901-2023) | water-solvent compilation | standardized alternative Henry definitions and conversions | article and supplement are CC BY 4.0 | terminology and conversion cross-check; no values adopted |
-| NIST Chemistry WebBook SRD 69, [CO2 Henry data](https://webbook.nist.gov/cgi/cbook.cgi?ID=C124389&Mask=10) | CO2 in water near ambient temperature | solubility-form values and temperature parameter | compilation is copyright protected | read-only validation index; no values copied |
+| NIST Chemistry WebBook SRD 69, [CO2](https://webbook.nist.gov/cgi/cbook.cgi?ID=C124389&Mask=10), [CH4](https://webbook.nist.gov/cgi/cbook.cgi?ID=C74828&Mask=10), and [N2](https://webbook.nist.gov/cgi/cbook.cgi?ID=C7727379&Mask=10) Henry data | three gases in water near ambient temperature | solubility-form values and temperature parameters; conventions require conversion before comparison | compilation is copyright protected | read-only independent screening index; no values copied |
+| USGS PHREEQC 3.9.0, [`pitzer.dat` provenance and license](pitzer_parameter_provenance.md) | ionic and neutral Pitzer interaction families | molality scale, PHREEQC six-term temperature functions, explicit tuple topology | USGS release is public domain; exact release/commit/blob are recorded in the linked matrix | confirms that a pure-water Henry constant is not a substitute for missing neutral-ion terms; no Pitzer value adopted here |
+| Kaasa (1998), [stable National Library item](https://www.nb.no/items/d1d68b489b8ee6704786a011fd2e7283) | oil-recovery-brine Pitzer binary, same-sign, ternary, and neutral families | Appendix F is a provenance index with its own coefficient order and row-level source lineage | scan-table redistribution terms are unresolved; original pages were not retrievable from the public item in this run | metadata/provenance index only; no value inferred, OCRed, copied, or adopted |
 
 The IAPWS high-temperature root-mean-square deviations in \(\ln k_H\) range
 from 0.0039 for CO to 0.0577 for Ne. These source residuals describe the
@@ -102,12 +144,39 @@ checks fitted/extrapolated/unsupported/out-of-domain diagnostics, verifies
 mole-fraction-to-molality mapping, and exercises fail-closed behavior.
 
 `ComponentGEHenryDerivativeTest` retains the legacy database-correlation
-regressions, including the dimensional identity
+regressions, including the dimensional identity, corrects the historic
+H2/He/Ar solvent classification in aqueous GE phases, and verifies that an
+ionic Pitzer topology without a qualified neutral family remains on one
+deterministic compatibility path even at trace ionic strength. The
+system-level Pitzer regression verifies the explicit molality conversion,
+including the fixed IAPWS water molar mass. The dimensional identity is
 
 $$\frac{\mathrm{d}\ln H}{\mathrm{d}T}=\frac{1}{H}\frac{\mathrm{d}H}{\mathrm{d}T}.$$
 
 These tests are implementation and source-table regressions. They are separate
 from independent VLE/VLLE or brine validation.
+
+## Scientific and performance controls
+
+The repository's complete reactive-H2S benchmark remains on the established
+legacy Pitzer reference because its diagnostic reports missing `H2S|H2S`,
+`H2S|H3O+`, `H2S|HS-`, and `H2S|H3O+|HS-` neutral interactions. At 298.15 K,
+the repaired branch gives maximum absolute reaction `ln(Q/K)` residual
+`4.2633e-14`, maximum elemental residual `1.1927e-13`, charge
+`-1.0825e-14` mol, and normalized charge residual `1.5922e-10`. HS- molality
+increases from `3.3995324e-5` mol/kg at 298.15 K to `4.3530791e-5` mol/kg at
+318.15 K. These are compatibility, closure, and nearby-state controls; they
+are not treated as new independent H2S-solubility validation.
+
+`PitzerCatalogPerformanceBenchmark` uses nine fixed-work batches after warmup.
+On OpenJDK 17 in the same runner, the affected combined IAPWS value/derivative
+kernel decreased from 1140 ns on exact pre-repair PR head `a3acb09cf` to 573 ns
+on the repaired tree. The complete reactive-H2S median was 40.76 ms versus
+50.25 ms on that head, with the compatible chemical state above. Absolute
+wall-clock timings remain environment-sensitive; the comparison is a
+regression screen, not a portable throughput guarantee. Neutral SRK/PR/CPA
+paths do not dispatch through this helper and remain covered by their existing
+tests.
 
 ## Remaining validation boundary
 

--- a/docs/thermo/pitzer_parameter_provenance.md
+++ b/docs/thermo/pitzer_parameter_provenance.md
@@ -581,6 +581,13 @@ the returned parameter retains the source parameter's units and standard-state c
 
 ## Neutral-solute interaction mapping
 
+The [aqueous Henry-reference record](henry_law_reference.md) is the durable
+source-comparison and runtime-boundary matrix for the IAPWS gas-reference
+increment. It does not adopt a Kaasa or PHREEQC Pitzer coefficient: reactive
+CO2/H2S Pitzer calculations retain their established reference until this
+matrix contains a complete, independently qualified neutral-interaction
+family for their exact species topology.
+
 The neutral layer follows the public [PHREEQC PITZER contract](https://water.usgs.gov/water-resources/software/PHREEQC/documentation/phreeqc3-html/phreeqc3-37.htm)
 and exact source commit [`b0b3be7`](https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/src/pitzer.cpp).
 The parameter families remain distinct:

--- a/src/main/java/neqsim/thermo/component/ComponentGE.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGE.java
@@ -234,4 +234,3 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
     return gammaRefCor;
   }
 }
-

--- a/src/main/java/neqsim/thermo/component/ComponentGE.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGE.java
@@ -87,9 +87,10 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
   /**
    * Returns the phase-aware Henry coefficient, preferring the qualified IAPWS pure-water reference.
    *
-   * <p>The IAPWS value is selected only for a supported neutral solute in a water-containing phase.
-   * Temperatures outside the liquid-water domain fail closed. Species outside the IAPWS table retain
-   * the legacy database behavior.</p>
+   * <p>
+   * The IAPWS value is selected only for a supported neutral solute in a water-containing phase. Temperatures outside
+   * the liquid-water domain fail closed. Species outside the IAPWS table retain the legacy database behavior.
+   * </p>
    *
    * @param phase phase containing temperature and solvent topology
    * @return effective mole-fraction Henry coefficient in bar
@@ -145,8 +146,7 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
   protected double getLnHenryCoefficientTemperatureDerivative(PhaseInterface phase) {
     if (phase.hasComponent("water") && !isIsIon()) {
       if (IapwsHenryLaw.isUsable(getComponentName(), phase.getTemperature())) {
-        return IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative(
-            getComponentName(), phase.getTemperature());
+        return IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative(getComponentName(), phase.getTemperature());
       }
       if (IapwsHenryLaw.isSupportedSpecies(getComponentName())) {
         return 0.0;
@@ -234,3 +234,4 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
     return gammaRefCor;
   }
 }
+

--- a/src/main/java/neqsim/thermo/component/ComponentGE.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGE.java
@@ -59,7 +59,7 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
       } else {
         activinf = gamma / ((PhaseGE) phase).getActivityCoefficientInfDil(componentNumber);
       }
-      double henryCoef = getEffectiveHenryCoefficient(phase.getTemperature());
+      double henryCoef = getEffectiveHenryCoefficient(phase);
       fugacityCoefficient = activinf * henryCoef / phase.getPressure();
       // gamma* benyttes ikke
       gammaRefCor = activinf;
@@ -82,6 +82,30 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
   protected double getEffectiveHenryCoefficient(double temperature) {
     double henryCoefficient = getHenryCoef(temperature);
     return isHenryCoefficientCapped(henryCoefficient) ? INSOLUBLE_HENRY_COEFFICIENT : henryCoefficient;
+  }
+
+  /**
+   * Returns the phase-aware Henry coefficient, preferring the qualified IAPWS pure-water reference.
+   *
+   * <p>The IAPWS value is selected only for a supported neutral solute in a water-containing phase.
+   * Temperatures outside the liquid-water domain fail closed. Species outside the IAPWS table retain
+   * the legacy database behavior.</p>
+   *
+   * @param phase phase containing temperature and solvent topology
+   * @return effective mole-fraction Henry coefficient in bar
+   */
+  protected double getEffectiveHenryCoefficient(PhaseInterface phase) {
+    if (phase.hasComponent("water") && !isIsIon()) {
+      IapwsHenryLaw.Assessment assessment =
+          IapwsHenryLaw.assess(getComponentName(), phase.getTemperature());
+      if (assessment.isUsable()) {
+        return IapwsHenryLaw.getHenryCoefficientBar(getComponentName(), phase.getTemperature());
+      }
+      if (assessment.isSupportedSpecies()) {
+        return INSOLUBLE_HENRY_COEFFICIENT;
+      }
+    }
+    return getEffectiveHenryCoefficient(phase.getTemperature());
   }
 
   /**
@@ -112,6 +136,27 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
       return 0.0;
     }
     return getHenryCoefdT(temperature) / henryCoefficient;
+  }
+
+  /**
+   * Returns the phase-aware logarithmic derivative for the selected Henry reference.
+   *
+   * @param phase phase containing temperature and solvent topology
+   * @return d(ln H)/dT in 1/K
+   */
+  protected double getLnHenryCoefficientTemperatureDerivative(PhaseInterface phase) {
+    if (phase.hasComponent("water") && !isIsIon()) {
+      IapwsHenryLaw.Assessment assessment =
+          IapwsHenryLaw.assess(getComponentName(), phase.getTemperature());
+      if (assessment.isUsable()) {
+        return IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative(
+            getComponentName(), phase.getTemperature());
+      }
+      if (assessment.isSupportedSpecies()) {
+        return 0.0;
+      }
+    }
+    return getLnHenryCoefficientTemperatureDerivative(phase.getTemperature());
   }
 
   /**
@@ -146,7 +191,7 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
       dfugdt = dlngammadt + 1.0 / getAntoineVaporPressure(temperature) * getAntoineVaporPressuredT(temperature);
       logger.info("check this dfug dt - antoine");
     } else {
-      dfugdt = dlngammadt + getLnHenryCoefficientTemperatureDerivative(temperature);
+      dfugdt = dlngammadt + getLnHenryCoefficientTemperatureDerivative(phase);
     }
     return dfugdt;
   }

--- a/src/main/java/neqsim/thermo/component/ComponentGE.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGE.java
@@ -48,7 +48,7 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
   @Override
   public double fugcoef(PhaseInterface phase) {
     logger.info("fug coef " + gamma * getAntoineVaporPressure(phase.getTemperature()) / phase.getPressure());
-    if (referenceStateType.equals("solvent")) {
+    if (referenceStateType.equals("solvent") && !usesIapwsAqueousReference(phase)) {
       fugacityCoefficient = gamma * getAntoineVaporPressure(phase.getTemperature()) / phase.getPressure();
       gammaRefCor = gamma;
     } else {
@@ -96,13 +96,11 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
    * @return effective mole-fraction Henry coefficient in bar
    */
   protected double getEffectiveHenryCoefficient(PhaseInterface phase) {
-    if (phase.hasComponent("water") && !isIsIon()) {
+    if (!isIsIon() && IapwsHenryLaw.isSupportedSpecies(getComponentName()) && phase.hasComponent("water")) {
       if (IapwsHenryLaw.isUsable(getComponentName(), phase.getTemperature())) {
         return IapwsHenryLaw.getHenryCoefficientBar(getComponentName(), phase.getTemperature());
       }
-      if (IapwsHenryLaw.isSupportedSpecies(getComponentName())) {
-        return INSOLUBLE_HENRY_COEFFICIENT;
-      }
+      return INSOLUBLE_HENRY_COEFFICIENT;
     }
     return getEffectiveHenryCoefficient(phase.getTemperature());
   }
@@ -144,15 +142,29 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
    * @return d(ln H)/dT in 1/K
    */
   protected double getLnHenryCoefficientTemperatureDerivative(PhaseInterface phase) {
-    if (phase.hasComponent("water") && !isIsIon()) {
+    if (!isIsIon() && IapwsHenryLaw.isSupportedSpecies(getComponentName()) && phase.hasComponent("water")) {
       if (IapwsHenryLaw.isUsable(getComponentName(), phase.getTemperature())) {
         return IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative(getComponentName(), phase.getTemperature());
       }
-      if (IapwsHenryLaw.isSupportedSpecies(getComponentName())) {
-        return 0.0;
-      }
+      return 0.0;
     }
     return getLnHenryCoefficientTemperatureDerivative(phase.getTemperature());
+  }
+
+  /**
+   * Tests whether this component uses a Henry rather than a solvent vapor-pressure reference in a phase.
+   *
+   * @param phase owning GE phase
+   * @return true for a solute Henry reference
+   */
+  protected boolean usesHenryReference(PhaseInterface phase) {
+    return !referenceStateType.equals("solvent") || usesIapwsAqueousReference(phase);
+  }
+
+  /** Tests whether IAPWS overrides a legacy solvent classification in an aqueous phase. */
+  private boolean usesIapwsAqueousReference(PhaseInterface phase) {
+    return !"water".equalsIgnoreCase(getComponentName()) && IapwsHenryLaw.isSupportedSpecies(getComponentName())
+        && phase.hasComponent("water");
   }
 
   /**
@@ -164,11 +176,7 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
   public double fugcoefDiffPres(PhaseInterface phase) {
     // double temperature = phase.getTemperature(), pressure = phase.getPressure();
     // int numberOfComponents = phase.getNumberOfComponents();
-    if (referenceStateType.equals("solvent")) {
-      dfugdp = 0.0; // forelopig uten pointing
-    } else {
-      dfugdp = 0.0; // forelopig uten pointing
-    }
+    dfugdp = 0.0; // forelopig uten pointing
     return dfugdp;
   }
 
@@ -183,7 +191,7 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
     // double pressure = phase.getPressure();
     // int numberOfComponents = phase.getNumberOfComponents();
 
-    if (referenceStateType.equals("solvent")) {
+    if (referenceStateType.equals("solvent") && !usesIapwsAqueousReference(phase)) {
       dfugdt = dlngammadt + 1.0 / getAntoineVaporPressure(temperature) * getAntoineVaporPressuredT(temperature);
       logger.info("check this dfug dt - antoine");
     } else {

--- a/src/main/java/neqsim/thermo/component/ComponentGE.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGE.java
@@ -96,12 +96,10 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
    */
   protected double getEffectiveHenryCoefficient(PhaseInterface phase) {
     if (phase.hasComponent("water") && !isIsIon()) {
-      IapwsHenryLaw.Assessment assessment =
-          IapwsHenryLaw.assess(getComponentName(), phase.getTemperature());
-      if (assessment.isUsable()) {
+      if (IapwsHenryLaw.isUsable(getComponentName(), phase.getTemperature())) {
         return IapwsHenryLaw.getHenryCoefficientBar(getComponentName(), phase.getTemperature());
       }
-      if (assessment.isSupportedSpecies()) {
+      if (IapwsHenryLaw.isSupportedSpecies(getComponentName())) {
         return INSOLUBLE_HENRY_COEFFICIENT;
       }
     }
@@ -146,13 +144,11 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
    */
   protected double getLnHenryCoefficientTemperatureDerivative(PhaseInterface phase) {
     if (phase.hasComponent("water") && !isIsIon()) {
-      IapwsHenryLaw.Assessment assessment =
-          IapwsHenryLaw.assess(getComponentName(), phase.getTemperature());
-      if (assessment.isUsable()) {
+      if (IapwsHenryLaw.isUsable(getComponentName(), phase.getTemperature())) {
         return IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative(
             getComponentName(), phase.getTemperature());
       }
-      if (assessment.isSupportedSpecies()) {
+      if (IapwsHenryLaw.isSupportedSpecies(getComponentName())) {
         return 0.0;
       }
     }

--- a/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
@@ -76,7 +76,7 @@ public class ComponentGePitzer extends ComponentGE {
   protected double getEffectiveHenryCoefficient(PhaseInterface phase) {
     double coefficient = super.getEffectiveHenryCoefficient(phase);
     if (phase.hasComponent("water")
-        && IapwsHenryLaw.assess(getComponentName(), phase.getTemperature()).isSupportedSpecies()) {
+        && IapwsHenryLaw.isSupportedSpecies(getComponentName())) {
       return coefficient * IapwsHenryLaw.WATER_MOLAR_MASS_KG_PER_MOL;
     }
     return coefficient;

--- a/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
@@ -67,7 +67,9 @@ public class ComponentGePitzer extends ComponentGE {
    * <p>
    * IAPWS publishes {@code kH = f/x}. Pitzer neutral activities use molality, so {@code Hm = kH * Mwater}; the existing
    * {@code m/x} factor in {@link #fugcoef(PhaseInterface)} maps this back to the common mole-fraction fugacity kernel.
-   * The constant conversion does not change the logarithmic temperature derivative.
+   * The constant conversion does not change the logarithmic temperature derivative. An ionic phase adopts the new
+   * reference only with an explicitly active, coverage-checked neutral interaction family; otherwise this pure-water
+   * batch preserves the pre-existing database/capping result.
    * </p>
    *
    * @param phase aqueous Pitzer phase
@@ -75,11 +77,45 @@ public class ComponentGePitzer extends ComponentGE {
    */
   @Override
   protected double getEffectiveHenryCoefficient(PhaseInterface phase) {
-    double coefficient = super.getEffectiveHenryCoefficient(phase);
-    if (phase.hasComponent("water") && IapwsHenryLaw.isSupportedSpecies(getComponentName())) {
-      return coefficient * IapwsHenryLaw.WATER_MOLAR_MASS_KG_PER_MOL;
+    if (!IapwsHenryLaw.isSupportedSpecies(getComponentName()) || !phase.hasComponent("water")) {
+      return super.getEffectiveHenryCoefficient(phase);
     }
-    return coefficient;
+    if (!neutralPitzerInteractionsActive && (phase.hasIons() || requiresReactivePitzerQualification())) {
+      return getEffectiveHenryCoefficient(phase.getTemperature());
+    }
+    if (!IapwsHenryLaw.isUsable(getComponentName(), phase.getTemperature())) {
+      return INSOLUBLE_HENRY_COEFFICIENT;
+    }
+    double coefficient = IapwsHenryLaw.getHenryCoefficientBar(getComponentName(), phase.getTemperature())
+        * IapwsHenryLaw.WATER_MOLAR_MASS_KG_PER_MOL;
+    return super.isHenryCoefficientCapped(coefficient) ? INSOLUBLE_HENRY_COEFFICIENT : coefficient;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected double getLnHenryCoefficientTemperatureDerivative(PhaseInterface phase) {
+    if (!IapwsHenryLaw.isSupportedSpecies(getComponentName()) || !phase.hasComponent("water")) {
+      return super.getLnHenryCoefficientTemperatureDerivative(phase);
+    }
+    if (!neutralPitzerInteractionsActive && (phase.hasIons() || requiresReactivePitzerQualification())) {
+      return getLnHenryCoefficientTemperatureDerivative(phase.getTemperature());
+    }
+    if (!IapwsHenryLaw.isUsable(getComponentName(), phase.getTemperature())) {
+      return 0.0;
+    }
+    return IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative(getComponentName(), phase.getTemperature());
+  }
+
+  /**
+   * Tests whether a molecular acid gas needs reaction-compatible neutral Pitzer parameters before changing its
+   * reference state.
+   *
+   * @return {@code true} for CO2 and H2S component aliases
+   */
+  private boolean requiresReactivePitzerQualification() {
+    String name = getComponentName();
+    return "CO2".equalsIgnoreCase(name) || "carbon dioxide".equalsIgnoreCase(name) || "H2S".equalsIgnoreCase(name)
+        || "hydrogen sulfide".equalsIgnoreCase(name);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
@@ -621,4 +621,3 @@ public class ComponentGePitzer extends ComponentGE {
     return 3.0 * Aphi;
   }
 }
-

--- a/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
@@ -64,10 +64,11 @@ public class ComponentGePitzer extends ComponentGE {
   /**
    * Returns the Pitzer molality-scale Henry reference.
    *
-   * <p>IAPWS publishes {@code kH = f/x}. Pitzer neutral activities use molality, so
-   * {@code Hm = kH * Mwater}; the existing {@code m/x} factor in {@link #fugcoef(PhaseInterface)}
-   * maps this back to the common mole-fraction fugacity kernel. The constant conversion
-   * does not change the logarithmic temperature derivative.</p>
+   * <p>
+   * IAPWS publishes {@code kH = f/x}. Pitzer neutral activities use molality, so {@code Hm = kH * Mwater}; the existing
+   * {@code m/x} factor in {@link #fugcoef(PhaseInterface)} maps this back to the common mole-fraction fugacity kernel.
+   * The constant conversion does not change the logarithmic temperature derivative.
+   * </p>
    *
    * @param phase aqueous Pitzer phase
    * @return effective molality-scale Henry coefficient in bar kg/mol
@@ -75,8 +76,7 @@ public class ComponentGePitzer extends ComponentGE {
   @Override
   protected double getEffectiveHenryCoefficient(PhaseInterface phase) {
     double coefficient = super.getEffectiveHenryCoefficient(phase);
-    if (phase.hasComponent("water")
-        && IapwsHenryLaw.isSupportedSpecies(getComponentName())) {
+    if (phase.hasComponent("water") && IapwsHenryLaw.isSupportedSpecies(getComponentName())) {
       return coefficient * IapwsHenryLaw.WATER_MOLAR_MASS_KG_PER_MOL;
     }
     return coefficient;
@@ -621,3 +621,4 @@ public class ComponentGePitzer extends ComponentGE {
     return 3.0 * Aphi;
   }
 }
+

--- a/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGePitzer.java
@@ -45,7 +45,7 @@ public class ComponentGePitzer extends ComponentGE {
     // reference; hydrocarbons have no Pitzer neutral-interaction parameters and are represented as effectively
     // insoluble instead of being evaluated with the water osmotic coefficient.
     if (Math.abs(getIonicCharge()) < 0.5 && !"water".equalsIgnoreCase(getComponentName())) {
-      double henryCoefficient = getEffectiveHenryCoefficient(phase.getTemperature());
+      double henryCoefficient = getEffectiveHenryCoefficient(phase);
       // Pitzer neutral activities and the database Henry constants are on the molality
       // scale, while the common phase-equilibrium kernel evaluates x_i * phi_i * P.
       // Convert m_i * gamma_i * H_i to that mole-fraction representation explicitly.
@@ -59,6 +59,27 @@ public class ComponentGePitzer extends ComponentGE {
       return fugacityCoefficient;
     }
     return super.fugcoef(phase);
+  }
+
+  /**
+   * Returns the Pitzer molality-scale Henry reference.
+   *
+   * <p>IAPWS publishes {@code kH = f/x}. Pitzer neutral activities use molality, so
+   * {@code Hm = kH * Mwater}; the existing {@code m/x} factor in {@link #fugcoef(PhaseInterface)}
+   * maps this back to the common mole-fraction fugacity kernel. The constant conversion
+   * does not change the logarithmic temperature derivative.</p>
+   *
+   * @param phase aqueous Pitzer phase
+   * @return effective molality-scale Henry coefficient in bar kg/mol
+   */
+  @Override
+  protected double getEffectiveHenryCoefficient(PhaseInterface phase) {
+    double coefficient = super.getEffectiveHenryCoefficient(phase);
+    if (phase.hasComponent("water")
+        && IapwsHenryLaw.assess(getComponentName(), phase.getTemperature()).isSupportedSpecies()) {
+      return coefficient * IapwsHenryLaw.WATER_MOLAR_MASS_KG_PER_MOL;
+    }
+    return coefficient;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/IapwsHenryLaw.java
+++ b/src/main/java/neqsim/thermo/component/IapwsHenryLaw.java
@@ -1,0 +1,274 @@
+package neqsim.thermo.component;
+
+import java.util.Locale;
+
+/**
+ * IAPWS G7-04 Henry-law correlation for common gases at infinite dilution in liquid H2O.
+ *
+ * <p>The correlation returns the mole-fraction Henry constant
+ * {@code kH = lim(x -> 0) f / x} on the water saturation boundary. It does not
+ * include a Poynting correction or electrolyte salting-out interaction.</p>
+ *
+ * <p>Coefficients and species-specific fitted ranges are from IAPWS G7-04,
+ * based on Fernandez-Prini et al., J. Phys. Chem. Ref. Data 32 (2003),
+ * doi:10.1063/1.1564818. The IAPWS guideline permits reproduction with
+ * attribution.</p>
+ */
+public final class IapwsHenryLaw {
+  /** Water molar mass in kg/mol for converting mole-fraction to molality standard state. */
+  public static final double WATER_MOLAR_MASS_KG_PER_MOL = 0.01801528;
+
+  private static final double WATER_CRITICAL_TEMPERATURE = 647.096;
+  private static final double WATER_CRITICAL_PRESSURE_MPA = 22.064;
+  private static final double CORRELATION_MINIMUM_TEMPERATURE = 273.15;
+  private static final double[] VAPOR_PRESSURE_A = {
+      -7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
+  private static final double[] VAPOR_PRESSURE_B = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
+
+  private static final GasData HE = new GasData("He", -3.52839, 7.12983, 4.47770, 273.21, 553.18);
+  private static final GasData NE = new GasData("Ne", -3.18301, 5.31448, 5.43774, 273.20, 543.36);
+  private static final GasData AR = new GasData("Ar", -8.40954, 4.29587, 10.52779, 273.19, 568.36);
+  private static final GasData KR = new GasData("Kr", -8.97358, 3.61508, 11.29963, 273.19, 525.56);
+  private static final GasData XE = new GasData("Xe", -14.21635, 4.00041, 15.60999, 273.22, 574.85);
+  private static final GasData H2 = new GasData("H2", -4.73284, 6.08954, 6.06066, 273.15, 636.09);
+  private static final GasData N2 = new GasData("N2", -9.67578, 4.72162, 11.70585, 278.12, 636.46);
+  private static final GasData O2 = new GasData("O2", -9.44833, 4.43822, 11.42005, 274.15, 616.52);
+  private static final GasData CO = new GasData("CO", -10.52862, 5.13259, 12.01421, 278.15, 588.67);
+  private static final GasData CO2 = new GasData("CO2", -8.55445, 4.01195, 9.52345, 274.19, 642.66);
+  private static final GasData H2S = new GasData("H2S", -4.51499, 5.23538, 4.42126, 273.15, 533.09);
+  private static final GasData CH4 = new GasData("CH4", -10.44708, 4.66491, 12.12986, 275.46, 633.11);
+  private static final GasData C2H6 = new GasData("C2H6", -19.67563, 4.51222, 20.62567, 275.44, 473.46);
+  private static final GasData SF6 = new GasData("SF6", -16.56118, 2.15289, 20.35440, 283.14, 505.55);
+
+  /** Correlation qualification status for a species and temperature. */
+  public enum Status {
+    /** Temperature is inside the species-specific fitted data range. */
+    WITHIN_FITTED_RANGE,
+    /** Formula is defined, but temperature is outside the species-specific fitted data range. */
+    GUIDELINE_EXTRAPOLATION,
+    /** Species is not included in the IAPWS H2O correlation. */
+    UNSUPPORTED_SPECIES,
+    /** Temperature is outside the liquid-water correlation domain. */
+    OUTSIDE_CORRELATION_DOMAIN
+  }
+
+  /** Immutable qualification result suitable for Java and JPype diagnostics. */
+  public static final class Assessment {
+    private final String canonicalGasName;
+    private final double minimumFittedTemperature;
+    private final double maximumFittedTemperature;
+    private final Status status;
+
+    private Assessment(GasData gas, Status status) {
+      this.canonicalGasName = gas == null ? "" : gas.name;
+      this.minimumFittedTemperature = gas == null ? Double.NaN : gas.minimumTemperature;
+      this.maximumFittedTemperature = gas == null ? Double.NaN : gas.maximumTemperature;
+      this.status = status;
+    }
+
+    /**
+     * @return canonical IAPWS gas symbol, or an empty string for an unsupported species
+     */
+    public String getCanonicalGasName() {
+      return canonicalGasName;
+    }
+
+    /**
+     * @return lower fitted-data temperature in K, or NaN for an unsupported species
+     */
+    public double getMinimumFittedTemperature() {
+      return minimumFittedTemperature;
+    }
+
+    /**
+     * @return upper fitted-data temperature in K, or NaN for an unsupported species
+     */
+    public double getMaximumFittedTemperature() {
+      return maximumFittedTemperature;
+    }
+
+    /**
+     * @return correlation qualification status
+     */
+    public Status getStatus() {
+      return status;
+    }
+
+    /**
+     * @return true when the species exists in the IAPWS H2O table
+     */
+    public boolean isSupportedSpecies() {
+      return status != Status.UNSUPPORTED_SPECIES;
+    }
+
+    /**
+     * @return true when the formula is numerically defined at the requested temperature
+     */
+    public boolean isUsable() {
+      return status == Status.WITHIN_FITTED_RANGE || status == Status.GUIDELINE_EXTRAPOLATION;
+    }
+  }
+
+  private static final class GasData {
+    private final String name;
+    private final double a;
+    private final double b;
+    private final double c;
+    private final double minimumTemperature;
+    private final double maximumTemperature;
+
+    private GasData(String name, double a, double b, double c, double minimumTemperature,
+        double maximumTemperature) {
+      this.name = name;
+      this.a = a;
+      this.b = b;
+      this.c = c;
+      this.minimumTemperature = minimumTemperature;
+      this.maximumTemperature = maximumTemperature;
+    }
+  }
+
+  private IapwsHenryLaw() {}
+
+  /**
+   * Assess whether the IAPWS H2O correlation supports a component at a temperature.
+   *
+   * @param componentName NeqSim component name or IAPWS formula
+   * @param temperature temperature in K
+   * @return immutable assessment with fitted range and status
+   */
+  public static Assessment assess(String componentName, double temperature) {
+    GasData gas = findGas(componentName);
+    if (gas == null) {
+      return new Assessment(null, Status.UNSUPPORTED_SPECIES);
+    }
+    if (!Double.isFinite(temperature) || temperature < CORRELATION_MINIMUM_TEMPERATURE
+        || temperature >= WATER_CRITICAL_TEMPERATURE) {
+      return new Assessment(gas, Status.OUTSIDE_CORRELATION_DOMAIN);
+    }
+    if (temperature < gas.minimumTemperature || temperature > gas.maximumTemperature) {
+      return new Assessment(gas, Status.GUIDELINE_EXTRAPOLATION);
+    }
+    return new Assessment(gas, Status.WITHIN_FITTED_RANGE);
+  }
+
+  /**
+   * Evaluate the IAPWS mole-fraction Henry constant.
+   *
+   * @param componentName NeqSim component name or IAPWS formula
+   * @param temperature temperature in K
+   * @return kH in bar
+   * @throws IllegalArgumentException for an unsupported species or temperature outside the domain
+   */
+  public static double getHenryCoefficientBar(String componentName, double temperature) {
+    GasData gas = requireUsable(componentName, temperature);
+    double reducedTemperature = temperature / WATER_CRITICAL_TEMPERATURE;
+    double tau = 1.0 - reducedTemperature;
+    double logPressureMpa = Math.log(WATER_CRITICAL_PRESSURE_MPA)
+        + vaporPressureSeries(tau) / reducedTemperature;
+    double logHenryMpa = logPressureMpa + gas.a / reducedTemperature
+        + gas.b * Math.pow(tau, 0.355) / reducedTemperature
+        + gas.c * Math.pow(reducedTemperature, -0.41) * Math.exp(tau);
+    return Math.exp(logHenryMpa) * 10.0;
+  }
+
+  /**
+   * Evaluate the logarithmic temperature derivative of the IAPWS Henry constant.
+   *
+   * @param componentName NeqSim component name or IAPWS formula
+   * @param temperature temperature in K
+   * @return d(ln(kH))/dT in 1/K
+   * @throws IllegalArgumentException for an unsupported species or temperature outside the domain
+   */
+  public static double getLnHenryCoefficientTemperatureDerivative(String componentName,
+      double temperature) {
+    GasData gas = requireUsable(componentName, temperature);
+    double tr = temperature / WATER_CRITICAL_TEMPERATURE;
+    double tau = 1.0 - tr;
+    double series = vaporPressureSeries(tau);
+    double seriesDerivative = 0.0;
+    for (int i = 0; i < VAPOR_PRESSURE_A.length; i++) {
+      seriesDerivative -= VAPOR_PRESSURE_A[i] * VAPOR_PRESSURE_B[i]
+          * Math.pow(tau, VAPOR_PRESSURE_B[i] - 1.0);
+    }
+    double derivativeByTr = seriesDerivative / tr - series / (tr * tr)
+        - gas.a / (tr * tr)
+        + gas.b * (-0.355 * Math.pow(tau, -0.645) / tr
+            - Math.pow(tau, 0.355) / (tr * tr));
+    double finalTerm = gas.c * Math.pow(tr, -0.41) * Math.exp(tau);
+    derivativeByTr += finalTerm * (-0.41 / tr - 1.0);
+    return derivativeByTr / WATER_CRITICAL_TEMPERATURE;
+  }
+
+  private static double vaporPressureSeries(double tau) {
+    double sum = 0.0;
+    for (int i = 0; i < VAPOR_PRESSURE_A.length; i++) {
+      sum += VAPOR_PRESSURE_A[i] * Math.pow(tau, VAPOR_PRESSURE_B[i]);
+    }
+    return sum;
+  }
+
+  private static GasData requireUsable(String componentName, double temperature) {
+    Assessment assessment = assess(componentName, temperature);
+    if (!assessment.isUsable()) {
+      throw new IllegalArgumentException("IAPWS Henry correlation is not usable for component '"
+          + componentName + "' at " + temperature + " K: " + assessment.getStatus());
+    }
+    return findGas(componentName);
+  }
+
+  private static GasData findGas(String componentName) {
+    if (componentName == null) {
+      return null;
+    }
+    String name = componentName.trim().toLowerCase(Locale.ROOT);
+    switch (name) {
+      case "he":
+      case "helium":
+        return HE;
+      case "ne":
+      case "neon":
+        return NE;
+      case "ar":
+      case "argon":
+        return AR;
+      case "kr":
+      case "krypton":
+        return KR;
+      case "xe":
+      case "xenon":
+        return XE;
+      case "h2":
+      case "hydrogen":
+        return H2;
+      case "n2":
+      case "nitrogen":
+        return N2;
+      case "o2":
+      case "oxygen":
+        return O2;
+      case "co":
+      case "carbon monoxide":
+        return CO;
+      case "co2":
+      case "carbon dioxide":
+        return CO2;
+      case "h2s":
+      case "hydrogen sulfide":
+      case "hydrogen sulphide":
+        return H2S;
+      case "ch4":
+      case "methane":
+        return CH4;
+      case "c2h6":
+      case "ethane":
+        return C2H6;
+      case "sf6":
+      case "sulfur hexafluoride":
+      case "sulphur hexafluoride":
+        return SF6;
+      default:
+        return null;
+    }
+  }
+}

--- a/src/main/java/neqsim/thermo/component/IapwsHenryLaw.java
+++ b/src/main/java/neqsim/thermo/component/IapwsHenryLaw.java
@@ -298,4 +298,3 @@ public final class IapwsHenryLaw {
     }
   }
 }
-

--- a/src/main/java/neqsim/thermo/component/IapwsHenryLaw.java
+++ b/src/main/java/neqsim/thermo/component/IapwsHenryLaw.java
@@ -5,14 +5,15 @@ import java.util.Locale;
 /**
  * IAPWS G7-04 Henry-law correlation for common gases at infinite dilution in liquid H2O.
  *
- * <p>The correlation returns the mole-fraction Henry constant
- * {@code kH = lim(x -> 0) f / x} on the water saturation boundary. It does not
- * include a Poynting correction or electrolyte salting-out interaction.</p>
+ * <p>
+ * The correlation returns the mole-fraction Henry constant {@code kH = lim(x -> 0) f / x} on the water saturation
+ * boundary. It does not include a Poynting correction or electrolyte salting-out interaction.
+ * </p>
  *
- * <p>Coefficients and species-specific fitted ranges are from IAPWS G7-04,
- * based on Fernandez-Prini et al., J. Phys. Chem. Ref. Data 32 (2003),
- * doi:10.1063/1.1564818. The IAPWS guideline permits reproduction with
- * attribution.</p>
+ * <p>
+ * Coefficients and species-specific fitted ranges are from IAPWS G7-04, based on Fernandez-Prini et al., J. Phys. Chem.
+ * Ref. Data 32 (2003), doi:10.1063/1.1564818. The IAPWS guideline permits reproduction with attribution.
+ * </p>
  */
 public final class IapwsHenryLaw {
   /** Water molar mass in kg/mol for converting mole-fraction to molality standard state. */
@@ -21,9 +22,9 @@ public final class IapwsHenryLaw {
   private static final double WATER_CRITICAL_TEMPERATURE = 647.096;
   private static final double WATER_CRITICAL_PRESSURE_MPA = 22.064;
   private static final double CORRELATION_MINIMUM_TEMPERATURE = 273.15;
-  private static final double[] VAPOR_PRESSURE_A = {
-      -7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-  private static final double[] VAPOR_PRESSURE_B = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
+  private static final double[] VAPOR_PRESSURE_A = { -7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719,
+      1.80122502 };
+  private static final double[] VAPOR_PRESSURE_B = { 1.0, 1.5, 3.0, 3.5, 4.0, 7.5 };
 
   private static final GasData HE = new GasData("He", -3.52839, 7.12983, 4.47770, 273.21, 553.18);
   private static final GasData NE = new GasData("Ne", -3.18301, 5.31448, 5.43774, 273.20, 543.36);
@@ -117,8 +118,7 @@ public final class IapwsHenryLaw {
     private final double minimumTemperature;
     private final double maximumTemperature;
 
-    private GasData(String name, double a, double b, double c, double minimumTemperature,
-        double maximumTemperature) {
+    private GasData(String name, double a, double b, double c, double minimumTemperature, double maximumTemperature) {
       this.name = name;
       this.a = a;
       this.b = b;
@@ -128,7 +128,8 @@ public final class IapwsHenryLaw {
     }
   }
 
-  private IapwsHenryLaw() {}
+  private IapwsHenryLaw() {
+  }
 
   /**
    * Tests whether a component is present in the IAPWS H2O table.
@@ -143,8 +144,10 @@ public final class IapwsHenryLaw {
   /**
    * Tests whether the IAPWS formula is numerically usable at a state.
    *
-   * <p>This allocation-free predicate is intended for the fugacity hot path.
-   * Use {@link #assess(String, double)} when fitted-range diagnostics are needed.</p>
+   * <p>
+   * This allocation-free predicate is intended for the fugacity hot path. Use {@link #assess(String, double)} when
+   * fitted-range diagnostics are needed.
+   * </p>
    *
    * @param componentName NeqSim component name or IAPWS formula
    * @param temperature temperature in K
@@ -152,8 +155,7 @@ public final class IapwsHenryLaw {
    */
   public static boolean isUsable(String componentName, double temperature) {
     return findGas(componentName) != null && Double.isFinite(temperature)
-        && temperature >= CORRELATION_MINIMUM_TEMPERATURE
-        && temperature < WATER_CRITICAL_TEMPERATURE;
+        && temperature >= CORRELATION_MINIMUM_TEMPERATURE && temperature < WATER_CRITICAL_TEMPERATURE;
   }
 
   /**
@@ -190,10 +192,8 @@ public final class IapwsHenryLaw {
     GasData gas = requireUsable(componentName, temperature);
     double reducedTemperature = temperature / WATER_CRITICAL_TEMPERATURE;
     double tau = 1.0 - reducedTemperature;
-    double logPressureMpa = Math.log(WATER_CRITICAL_PRESSURE_MPA)
-        + vaporPressureSeries(tau) / reducedTemperature;
-    double logHenryMpa = logPressureMpa + gas.a / reducedTemperature
-        + gas.b * Math.pow(tau, 0.355) / reducedTemperature
+    double logPressureMpa = Math.log(WATER_CRITICAL_PRESSURE_MPA) + vaporPressureSeries(tau) / reducedTemperature;
+    double logHenryMpa = logPressureMpa + gas.a / reducedTemperature + gas.b * Math.pow(tau, 0.355) / reducedTemperature
         + gas.c * Math.pow(reducedTemperature, -0.41) * Math.exp(tau);
     return Math.exp(logHenryMpa) * 10.0;
   }
@@ -206,21 +206,17 @@ public final class IapwsHenryLaw {
    * @return d(ln(kH))/dT in 1/K
    * @throws IllegalArgumentException for an unsupported species or temperature outside the domain
    */
-  public static double getLnHenryCoefficientTemperatureDerivative(String componentName,
-      double temperature) {
+  public static double getLnHenryCoefficientTemperatureDerivative(String componentName, double temperature) {
     GasData gas = requireUsable(componentName, temperature);
     double tr = temperature / WATER_CRITICAL_TEMPERATURE;
     double tau = 1.0 - tr;
     double series = vaporPressureSeries(tau);
     double seriesDerivative = 0.0;
     for (int i = 0; i < VAPOR_PRESSURE_A.length; i++) {
-      seriesDerivative -= VAPOR_PRESSURE_A[i] * VAPOR_PRESSURE_B[i]
-          * Math.pow(tau, VAPOR_PRESSURE_B[i] - 1.0);
+      seriesDerivative -= VAPOR_PRESSURE_A[i] * VAPOR_PRESSURE_B[i] * Math.pow(tau, VAPOR_PRESSURE_B[i] - 1.0);
     }
-    double derivativeByTr = seriesDerivative / tr - series / (tr * tr)
-        - gas.a / (tr * tr)
-        + gas.b * (-0.355 * Math.pow(tau, -0.645) / tr
-            - Math.pow(tau, 0.355) / (tr * tr));
+    double derivativeByTr = seriesDerivative / tr - series / (tr * tr) - gas.a / (tr * tr)
+        + gas.b * (-0.355 * Math.pow(tau, -0.645) / tr - Math.pow(tau, 0.355) / (tr * tr));
     double finalTerm = gas.c * Math.pow(tr, -0.41) * Math.exp(tau);
     derivativeByTr += finalTerm * (-0.41 / tr - 1.0);
     return derivativeByTr / WATER_CRITICAL_TEMPERATURE;
@@ -237,8 +233,7 @@ public final class IapwsHenryLaw {
   private static GasData requireUsable(String componentName, double temperature) {
     GasData gas = findGas(componentName);
     if (gas == null) {
-      throw new IllegalArgumentException(
-          "IAPWS Henry correlation does not support component '" + componentName + "'");
+      throw new IllegalArgumentException("IAPWS Henry correlation does not support component '" + componentName + "'");
     }
     if (!Double.isFinite(temperature) || temperature < CORRELATION_MINIMUM_TEMPERATURE
         || temperature >= WATER_CRITICAL_TEMPERATURE) {
@@ -254,52 +249,53 @@ public final class IapwsHenryLaw {
     }
     String name = componentName.trim().toLowerCase(Locale.ROOT);
     switch (name) {
-      case "he":
-      case "helium":
-        return HE;
-      case "ne":
-      case "neon":
-        return NE;
-      case "ar":
-      case "argon":
-        return AR;
-      case "kr":
-      case "krypton":
-        return KR;
-      case "xe":
-      case "xenon":
-        return XE;
-      case "h2":
-      case "hydrogen":
-        return H2;
-      case "n2":
-      case "nitrogen":
-        return N2;
-      case "o2":
-      case "oxygen":
-        return O2;
-      case "co":
-      case "carbon monoxide":
-        return CO;
-      case "co2":
-      case "carbon dioxide":
-        return CO2;
-      case "h2s":
-      case "hydrogen sulfide":
-      case "hydrogen sulphide":
-        return H2S;
-      case "ch4":
-      case "methane":
-        return CH4;
-      case "c2h6":
-      case "ethane":
-        return C2H6;
-      case "sf6":
-      case "sulfur hexafluoride":
-      case "sulphur hexafluoride":
-        return SF6;
-      default:
-        return null;
+    case "he":
+    case "helium":
+      return HE;
+    case "ne":
+    case "neon":
+      return NE;
+    case "ar":
+    case "argon":
+      return AR;
+    case "kr":
+    case "krypton":
+      return KR;
+    case "xe":
+    case "xenon":
+      return XE;
+    case "h2":
+    case "hydrogen":
+      return H2;
+    case "n2":
+    case "nitrogen":
+      return N2;
+    case "o2":
+    case "oxygen":
+      return O2;
+    case "co":
+    case "carbon monoxide":
+      return CO;
+    case "co2":
+    case "carbon dioxide":
+      return CO2;
+    case "h2s":
+    case "hydrogen sulfide":
+    case "hydrogen sulphide":
+      return H2S;
+    case "ch4":
+    case "methane":
+      return CH4;
+    case "c2h6":
+    case "ethane":
+      return C2H6;
+    case "sf6":
+    case "sulfur hexafluoride":
+    case "sulphur hexafluoride":
+      return SF6;
+    default:
+      return null;
     }
   }
 }
+

--- a/src/main/java/neqsim/thermo/component/IapwsHenryLaw.java
+++ b/src/main/java/neqsim/thermo/component/IapwsHenryLaw.java
@@ -131,6 +131,32 @@ public final class IapwsHenryLaw {
   private IapwsHenryLaw() {}
 
   /**
+   * Tests whether a component is present in the IAPWS H2O table.
+   *
+   * @param componentName NeqSim component name or IAPWS formula
+   * @return true for a supported H2O correlation species
+   */
+  public static boolean isSupportedSpecies(String componentName) {
+    return findGas(componentName) != null;
+  }
+
+  /**
+   * Tests whether the IAPWS formula is numerically usable at a state.
+   *
+   * <p>This allocation-free predicate is intended for the fugacity hot path.
+   * Use {@link #assess(String, double)} when fitted-range diagnostics are needed.</p>
+   *
+   * @param componentName NeqSim component name or IAPWS formula
+   * @param temperature temperature in K
+   * @return true for a supported species inside the liquid-water domain
+   */
+  public static boolean isUsable(String componentName, double temperature) {
+    return findGas(componentName) != null && Double.isFinite(temperature)
+        && temperature >= CORRELATION_MINIMUM_TEMPERATURE
+        && temperature < WATER_CRITICAL_TEMPERATURE;
+  }
+
+  /**
    * Assess whether the IAPWS H2O correlation supports a component at a temperature.
    *
    * @param componentName NeqSim component name or IAPWS formula
@@ -209,12 +235,17 @@ public final class IapwsHenryLaw {
   }
 
   private static GasData requireUsable(String componentName, double temperature) {
-    Assessment assessment = assess(componentName, temperature);
-    if (!assessment.isUsable()) {
-      throw new IllegalArgumentException("IAPWS Henry correlation is not usable for component '"
-          + componentName + "' at " + temperature + " K: " + assessment.getStatus());
+    GasData gas = findGas(componentName);
+    if (gas == null) {
+      throw new IllegalArgumentException(
+          "IAPWS Henry correlation does not support component '" + componentName + "'");
     }
-    return findGas(componentName);
+    if (!Double.isFinite(temperature) || temperature < CORRELATION_MINIMUM_TEMPERATURE
+        || temperature >= WATER_CRITICAL_TEMPERATURE) {
+      throw new IllegalArgumentException("IAPWS Henry correlation is outside its liquid-water domain for component '"
+          + componentName + "' at " + temperature + " K");
+    }
+    return gas;
   }
 
   private static GasData findGas(String componentName) {

--- a/src/main/java/neqsim/thermo/component/IapwsHenryLaw.java
+++ b/src/main/java/neqsim/thermo/component/IapwsHenryLaw.java
@@ -16,6 +16,8 @@ import java.util.Locale;
  * </p>
  */
 public final class IapwsHenryLaw {
+  /** Stable identity for the transcribed H2O coefficient family. */
+  public static final String DATASET_ID = "iapws-g7-04-water-gases-v1";
   /** Water molar mass in kg/mol for converting mole-fraction to molality standard state. */
   public static final double WATER_MOLAR_MASS_KG_PER_MOL = 0.01801528;
 
@@ -26,20 +28,20 @@ public final class IapwsHenryLaw {
       1.80122502 };
   private static final double[] VAPOR_PRESSURE_B = { 1.0, 1.5, 3.0, 3.5, 4.0, 7.5 };
 
-  private static final GasData HE = new GasData("He", -3.52839, 7.12983, 4.47770, 273.21, 553.18);
-  private static final GasData NE = new GasData("Ne", -3.18301, 5.31448, 5.43774, 273.20, 543.36);
-  private static final GasData AR = new GasData("Ar", -8.40954, 4.29587, 10.52779, 273.19, 568.36);
-  private static final GasData KR = new GasData("Kr", -8.97358, 3.61508, 11.29963, 273.19, 525.56);
-  private static final GasData XE = new GasData("Xe", -14.21635, 4.00041, 15.60999, 273.22, 574.85);
-  private static final GasData H2 = new GasData("H2", -4.73284, 6.08954, 6.06066, 273.15, 636.09);
-  private static final GasData N2 = new GasData("N2", -9.67578, 4.72162, 11.70585, 278.12, 636.46);
-  private static final GasData O2 = new GasData("O2", -9.44833, 4.43822, 11.42005, 274.15, 616.52);
-  private static final GasData CO = new GasData("CO", -10.52862, 5.13259, 12.01421, 278.15, 588.67);
-  private static final GasData CO2 = new GasData("CO2", -8.55445, 4.01195, 9.52345, 274.19, 642.66);
-  private static final GasData H2S = new GasData("H2S", -4.51499, 5.23538, 4.42126, 273.15, 533.09);
-  private static final GasData CH4 = new GasData("CH4", -10.44708, 4.66491, 12.12986, 275.46, 633.11);
-  private static final GasData C2H6 = new GasData("C2H6", -19.67563, 4.51222, 20.62567, 275.44, 473.46);
-  private static final GasData SF6 = new GasData("SF6", -16.56118, 2.15289, 20.35440, 283.14, 505.55);
+  private static final GasData HE = new GasData("He", -3.52839, 7.12983, 4.47770, 273.21, 553.18, 0.0341);
+  private static final GasData NE = new GasData("Ne", -3.18301, 5.31448, 5.43774, 273.20, 543.36, 0.0577);
+  private static final GasData AR = new GasData("Ar", -8.40954, 4.29587, 10.52779, 273.19, 568.36, 0.0443);
+  private static final GasData KR = new GasData("Kr", -8.97358, 3.61508, 11.29963, 273.19, 525.56, 0.0434);
+  private static final GasData XE = new GasData("Xe", -14.21635, 4.00041, 15.60999, 273.22, 574.85, 0.0363);
+  private static final GasData H2 = new GasData("H2", -4.73284, 6.08954, 6.06066, 273.15, 636.09, 0.0517);
+  private static final GasData N2 = new GasData("N2", -9.67578, 4.72162, 11.70585, 278.12, 636.46, 0.0372);
+  private static final GasData O2 = new GasData("O2", -9.44833, 4.43822, 11.42005, 274.15, 616.52, 0.0377);
+  private static final GasData CO = new GasData("CO", -10.52862, 5.13259, 12.01421, 278.15, 588.67, 0.0039);
+  private static final GasData CO2 = new GasData("CO2", -8.55445, 4.01195, 9.52345, 274.19, 642.66, 0.0528);
+  private static final GasData H2S = new GasData("H2S", -4.51499, 5.23538, 4.42126, 273.15, 533.09, 0.0408);
+  private static final GasData CH4 = new GasData("CH4", -10.44708, 4.66491, 12.12986, 275.46, 633.11, 0.0386);
+  private static final GasData C2H6 = new GasData("C2H6", -19.67563, 4.51222, 20.62567, 275.44, 473.46, 0.0259);
+  private static final GasData SF6 = new GasData("SF6", -16.56118, 2.15289, 20.35440, 283.14, 505.55, 0.0505);
 
   /** Correlation qualification status for a species and temperature. */
   public enum Status {
@@ -56,14 +58,24 @@ public final class IapwsHenryLaw {
   /** Immutable qualification result suitable for Java and JPype diagnostics. */
   public static final class Assessment {
     private final String canonicalGasName;
+    private final double temperature;
     private final double minimumFittedTemperature;
     private final double maximumFittedTemperature;
+    private final double coefficientA;
+    private final double coefficientB;
+    private final double coefficientC;
+    private final double rmsLogHenryResidual;
     private final Status status;
 
-    private Assessment(GasData gas, Status status) {
+    private Assessment(GasData gas, double temperature, Status status) {
       this.canonicalGasName = gas == null ? "" : gas.name;
+      this.temperature = temperature;
       this.minimumFittedTemperature = gas == null ? Double.NaN : gas.minimumTemperature;
       this.maximumFittedTemperature = gas == null ? Double.NaN : gas.maximumTemperature;
+      this.coefficientA = gas == null ? Double.NaN : gas.a;
+      this.coefficientB = gas == null ? Double.NaN : gas.b;
+      this.coefficientC = gas == null ? Double.NaN : gas.c;
+      this.rmsLogHenryResidual = gas == null ? Double.NaN : gas.rmsLogHenryResidual;
       this.status = status;
     }
 
@@ -72,6 +84,13 @@ public final class IapwsHenryLaw {
      */
     public String getCanonicalGasName() {
       return canonicalGasName;
+    }
+
+    /**
+     * @return requested temperature in K
+     */
+    public double getTemperature() {
+      return temperature;
     }
 
     /**
@@ -89,6 +108,41 @@ public final class IapwsHenryLaw {
     }
 
     /**
+     * @return IAPWS coefficient A, or NaN for an unsupported species
+     */
+    public double getCoefficientA() {
+      return coefficientA;
+    }
+
+    /**
+     * @return IAPWS coefficient B, or NaN for an unsupported species
+     */
+    public double getCoefficientB() {
+      return coefficientB;
+    }
+
+    /**
+     * @return IAPWS coefficient C, or NaN for an unsupported species
+     */
+    public double getCoefficientC() {
+      return coefficientC;
+    }
+
+    /**
+     * @return published RMS deviation in ln(kH), or NaN for an unsupported species
+     */
+    public double getRmsLogHenryResidual() {
+      return rmsLogHenryResidual;
+    }
+
+    /**
+     * @return stable coefficient-family identity
+     */
+    public String getDatasetId() {
+      return DATASET_ID;
+    }
+
+    /**
      * @return correlation qualification status
      */
     public Status getStatus() {
@@ -103,10 +157,22 @@ public final class IapwsHenryLaw {
     }
 
     /**
-     * @return true when the formula is numerically defined at the requested temperature
+     * @return true only inside the species-specific fitted range
      */
     public boolean isUsable() {
-      return status == Status.WITHIN_FITTED_RANGE || status == Status.GUIDELINE_EXTRAPOLATION;
+      return status == Status.WITHIN_FITTED_RANGE;
+    }
+
+    /**
+     * @return deterministic diagnostic with range, convention, and dataset identity
+     */
+    public String formatDiagnostic() {
+      if (status == Status.UNSUPPORTED_SPECIES) {
+        return "IAPWS Henry request unsupported for dataset '" + DATASET_ID + "'";
+      }
+      return "IAPWS Henry assessment: species='" + canonicalGasName + "', T=" + temperature + " K, status=" + status
+          + ", fittedRange=[" + minimumFittedTemperature + ", " + maximumFittedTemperature
+          + "] K, standardState='limiting f/x at pure-water saturation', dataset='" + DATASET_ID + "'";
     }
   }
 
@@ -117,14 +183,17 @@ public final class IapwsHenryLaw {
     private final double c;
     private final double minimumTemperature;
     private final double maximumTemperature;
+    private final double rmsLogHenryResidual;
 
-    private GasData(String name, double a, double b, double c, double minimumTemperature, double maximumTemperature) {
+    private GasData(String name, double a, double b, double c, double minimumTemperature, double maximumTemperature,
+        double rmsLogHenryResidual) {
       this.name = name;
       this.a = a;
       this.b = b;
       this.c = c;
       this.minimumTemperature = minimumTemperature;
       this.maximumTemperature = maximumTemperature;
+      this.rmsLogHenryResidual = rmsLogHenryResidual;
     }
   }
 
@@ -142,7 +211,7 @@ public final class IapwsHenryLaw {
   }
 
   /**
-   * Tests whether the IAPWS formula is numerically usable at a state.
+   * Tests whether a request lies inside the published species-specific fitted range.
    *
    * <p>
    * This allocation-free predicate is intended for the fugacity hot path. Use {@link #assess(String, double)} when
@@ -151,9 +220,22 @@ public final class IapwsHenryLaw {
    *
    * @param componentName NeqSim component name or IAPWS formula
    * @param temperature temperature in K
-   * @return true for a supported species inside the liquid-water domain
+   * @return true for a supported species inside its fitted range
    */
   public static boolean isUsable(String componentName, double temperature) {
+    GasData gas = findGas(componentName);
+    return gas != null && Double.isFinite(temperature) && temperature >= gas.minimumTemperature
+        && temperature <= gas.maximumTemperature;
+  }
+
+  /**
+   * Tests whether the guideline equation is numerically defined, including explicit extrapolation.
+   *
+   * @param componentName NeqSim component name or IAPWS formula
+   * @param temperature temperature in K
+   * @return true for a supported species inside the liquid-water equation domain
+   */
+  public static boolean isEquationDefined(String componentName, double temperature) {
     return findGas(componentName) != null && Double.isFinite(temperature)
         && temperature >= CORRELATION_MINIMUM_TEMPERATURE && temperature < WATER_CRITICAL_TEMPERATURE;
   }
@@ -168,16 +250,16 @@ public final class IapwsHenryLaw {
   public static Assessment assess(String componentName, double temperature) {
     GasData gas = findGas(componentName);
     if (gas == null) {
-      return new Assessment(null, Status.UNSUPPORTED_SPECIES);
+      return new Assessment(null, temperature, Status.UNSUPPORTED_SPECIES);
     }
     if (!Double.isFinite(temperature) || temperature < CORRELATION_MINIMUM_TEMPERATURE
         || temperature >= WATER_CRITICAL_TEMPERATURE) {
-      return new Assessment(gas, Status.OUTSIDE_CORRELATION_DOMAIN);
+      return new Assessment(gas, temperature, Status.OUTSIDE_CORRELATION_DOMAIN);
     }
     if (temperature < gas.minimumTemperature || temperature > gas.maximumTemperature) {
-      return new Assessment(gas, Status.GUIDELINE_EXTRAPOLATION);
+      return new Assessment(gas, temperature, Status.GUIDELINE_EXTRAPOLATION);
     }
-    return new Assessment(gas, Status.WITHIN_FITTED_RANGE);
+    return new Assessment(gas, temperature, Status.WITHIN_FITTED_RANGE);
   }
 
   /**
@@ -186,10 +268,27 @@ public final class IapwsHenryLaw {
    * @param componentName NeqSim component name or IAPWS formula
    * @param temperature temperature in K
    * @return kH in bar
-   * @throws IllegalArgumentException for an unsupported species or temperature outside the domain
+   * @throws IllegalArgumentException for an unsupported species or temperature outside its fitted range
    */
   public static double getHenryCoefficientBar(String componentName, double temperature) {
     GasData gas = requireUsable(componentName, temperature);
+    return evaluateHenryCoefficientBar(gas, temperature);
+  }
+
+  /**
+   * Evaluate the guideline equation while making extrapolation explicit in the method name.
+   *
+   * @param componentName NeqSim component name or IAPWS formula
+   * @param temperature temperature in K
+   * @return kH in bar
+   * @throws IllegalArgumentException for an unsupported species or temperature outside the equation domain
+   */
+  public static double getHenryCoefficientBarAllowExtrapolation(String componentName, double temperature) {
+    GasData gas = requireEquationDefined(componentName, temperature);
+    return evaluateHenryCoefficientBar(gas, temperature);
+  }
+
+  private static double evaluateHenryCoefficientBar(GasData gas, double temperature) {
     double reducedTemperature = temperature / WATER_CRITICAL_TEMPERATURE;
     double tau = 1.0 - reducedTemperature;
     double logPressureMpa = Math.log(WATER_CRITICAL_PRESSURE_MPA) + vaporPressureSeries(tau) / reducedTemperature;
@@ -204,7 +303,7 @@ public final class IapwsHenryLaw {
    * @param componentName NeqSim component name or IAPWS formula
    * @param temperature temperature in K
    * @return d(ln(kH))/dT in 1/K
-   * @throws IllegalArgumentException for an unsupported species or temperature outside the domain
+   * @throws IllegalArgumentException for an unsupported species or temperature outside its fitted range
    */
   public static double getLnHenryCoefficientTemperatureDerivative(String componentName, double temperature) {
     GasData gas = requireUsable(componentName, temperature);
@@ -235,10 +334,20 @@ public final class IapwsHenryLaw {
     if (gas == null) {
       throw new IllegalArgumentException("IAPWS Henry correlation does not support component '" + componentName + "'");
     }
+    if (!Double.isFinite(temperature) || temperature < gas.minimumTemperature || temperature > gas.maximumTemperature) {
+      throw new IllegalArgumentException(assess(componentName, temperature).formatDiagnostic());
+    }
+    return gas;
+  }
+
+  private static GasData requireEquationDefined(String componentName, double temperature) {
+    GasData gas = findGas(componentName);
+    if (gas == null) {
+      throw new IllegalArgumentException("IAPWS Henry correlation does not support component '" + componentName + "'");
+    }
     if (!Double.isFinite(temperature) || temperature < CORRELATION_MINIMUM_TEMPERATURE
         || temperature >= WATER_CRITICAL_TEMPERATURE) {
-      throw new IllegalArgumentException("IAPWS Henry correlation is outside its liquid-water domain for component '"
-          + componentName + "' at " + temperature + " K");
+      throw new IllegalArgumentException(assess(componentName, temperature).formatDiagnostic());
     }
     return gas;
   }
@@ -246,6 +355,10 @@ public final class IapwsHenryLaw {
   private static GasData findGas(String componentName) {
     if (componentName == null) {
       return null;
+    }
+    GasData exactGas = findExactGas(componentName);
+    if (exactGas != null) {
+      return exactGas;
     }
     String name = componentName.trim().toLowerCase(Locale.ROOT);
     switch (name) {
@@ -290,6 +403,58 @@ public final class IapwsHenryLaw {
     case "ethane":
       return C2H6;
     case "sf6":
+    case "sulfur hexafluoride":
+    case "sulphur hexafluoride":
+      return SF6;
+    default:
+      return null;
+    }
+  }
+
+  /** Exact common NeqSim names avoid normalization allocation in the fugacity hot path. */
+  private static GasData findExactGas(String componentName) {
+    switch (componentName) {
+    case "He":
+    case "helium":
+      return HE;
+    case "Ne":
+    case "neon":
+      return NE;
+    case "Ar":
+    case "argon":
+      return AR;
+    case "Kr":
+    case "krypton":
+      return KR;
+    case "Xe":
+    case "xenon":
+      return XE;
+    case "H2":
+    case "hydrogen":
+      return H2;
+    case "N2":
+    case "nitrogen":
+      return N2;
+    case "O2":
+    case "oxygen":
+      return O2;
+    case "CO":
+    case "carbon monoxide":
+      return CO;
+    case "CO2":
+    case "carbon dioxide":
+      return CO2;
+    case "H2S":
+    case "hydrogen sulfide":
+    case "hydrogen sulphide":
+      return H2S;
+    case "CH4":
+    case "methane":
+      return CH4;
+    case "C2H6":
+    case "ethane":
+      return C2H6;
+    case "SF6":
     case "sulfur hexafluoride":
     case "sulphur hexafluoride":
       return SF6;

--- a/src/test/java/neqsim/thermo/component/ComponentGEHenryDerivativeTest.java
+++ b/src/test/java/neqsim/thermo/component/ComponentGEHenryDerivativeTest.java
@@ -3,7 +3,9 @@ package neqsim.thermo.component;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseInterface;
 import neqsim.thermo.phase.PhasePitzer;
+import neqsim.thermo.system.SystemPitzer;
 
 /** Tests temperature derivatives of aqueous Henry-reference fugacity coefficients. */
 class ComponentGEHenryDerivativeTest {
@@ -51,15 +53,122 @@ class ComponentGEHenryDerivativeTest {
     assertEquals(0.0, component.fugcoefDiffTemp(phaseAt(TEMPERATURE)), 0.0);
   }
 
+  @Test
+  void waterContainingGePhaseUsesQualifiedIapwsReferenceForLegacySolventRow() {
+    PhasePitzer waterPhase = aqueousPhase(false);
+    String[][] gases = { { "hydrogen", "H2" }, { "helium", "He" }, { "argon", "Ar" } };
+    for (String[] gas : gases) {
+      ExposedNrtlComponent component = new ExposedNrtlComponent(gas[0]);
+      component.forceReferenceStateType("solvent");
+      component.setHenryCoefParameter(new double[] { 1000.0, 0.0, 0.0, 0.0 });
+
+      assertTrue(component.exposesUsesHenryReference(waterPhase), gas[0]);
+      assertEquals(IapwsHenryLaw.getHenryCoefficientBar(gas[1], TEMPERATURE),
+          component.exposesEffectiveHenry(waterPhase), 1.0e-10, gas[0]);
+      assertEquals(IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative(gas[1], TEMPERATURE),
+          component.exposesLnHenryDerivative(waterPhase), 1.0e-12, gas[0]);
+      assertEquals(IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative(gas[1], TEMPERATURE),
+          component.fugcoefDiffTemp(waterPhase), 1.0e-12, gas[0]);
+    }
+  }
+
+  @Test
+  void pitzerMapsPureWaterReferenceAndPreservesUnqualifiedBrineCompatibility() {
+    ExposedPitzerComponent methane = new ExposedPitzerComponent("methane");
+    ExposedPitzerComponent carbonDioxide = new ExposedPitzerComponent("CO2");
+    carbonDioxide.setHenryCoefParameter(new double[] { 8.0, -800.0, 0.5, 0.001 });
+    PhasePitzer waterPhase = aqueousPhase(false);
+    PhasePitzer unqualifiedBrine = aqueousPhase(true);
+    PhasePitzer traceIonTopology = aqueousPhaseWithSalt(1.0e-30);
+    double expectedMolalityReference = IapwsHenryLaw.getHenryCoefficientBar("CH4", TEMPERATURE)
+        * IapwsHenryLaw.WATER_MOLAR_MASS_KG_PER_MOL;
+
+    assertEquals(expectedMolalityReference, methane.exposesEffectiveHenry(waterPhase), 1.0e-10);
+    assertEquals(IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative("CH4", TEMPERATURE),
+        methane.exposesLnHenryDerivative(waterPhase), 1.0e-12);
+    assertEquals(carbonDioxide.exposesLegacyHenry(TEMPERATURE), carbonDioxide.exposesEffectiveHenry(waterPhase), 0.0);
+    assertEquals(ComponentGE.INSOLUBLE_HENRY_COEFFICIENT, methane.exposesEffectiveHenry(unqualifiedBrine), 0.0);
+    assertEquals(0.0, methane.exposesLnHenryDerivative(unqualifiedBrine), 0.0);
+    assertEquals(carbonDioxide.exposesLegacyHenry(TEMPERATURE), carbonDioxide.exposesEffectiveHenry(unqualifiedBrine),
+        0.0);
+    assertEquals(carbonDioxide.exposesLegacyLnHenryDerivative(TEMPERATURE),
+        carbonDioxide.exposesLnHenryDerivative(unqualifiedBrine), 0.0);
+    assertEquals(carbonDioxide.exposesLegacyHenry(TEMPERATURE), carbonDioxide.exposesEffectiveHenry(traceIonTopology),
+        0.0);
+  }
+
   private static PhasePitzer phaseAt(double temperature) {
     PhasePitzer phase = new PhasePitzer();
     phase.setTemperature(temperature);
     return phase;
   }
 
+  private static PhasePitzer aqueousPhase(boolean includeSalt) {
+    return aqueousPhaseWithSalt(includeSalt ? 1.0 : 0.0);
+  }
+
+  private static PhasePitzer aqueousPhaseWithSalt(double saltMoles) {
+    SystemPitzer system = new SystemPitzer(TEMPERATURE, 1.01325);
+    system.addComponent("water", 55.508);
+    if (saltMoles > 0.0) {
+      system.addComponent("Na+", saltMoles);
+      system.addComponent("Cl-", saltMoles);
+    }
+    system.init(0);
+    return (PhasePitzer) system.getPhase(1);
+  }
+
   private static double finiteDifferenceLogHenry(ComponentGE component, double temperature) {
     double step = 1.0e-3;
     return (Math.log(component.getHenryCoef(temperature + step)) - Math.log(component.getHenryCoef(temperature - step)))
         / (2.0 * step);
+  }
+
+  private static final class ExposedNrtlComponent extends ComponentGeNRTL {
+    private static final long serialVersionUID = 1000;
+
+    private ExposedNrtlComponent(String name) {
+      super(name, 1.0, 1.0, 0);
+    }
+
+    private void forceReferenceStateType(String referenceState) {
+      referenceStateType = referenceState;
+    }
+
+    private boolean exposesUsesHenryReference(PhaseInterface phase) {
+      return usesHenryReference(phase);
+    }
+
+    private double exposesEffectiveHenry(PhaseInterface phase) {
+      return getEffectiveHenryCoefficient(phase);
+    }
+
+    private double exposesLnHenryDerivative(PhaseInterface phase) {
+      return getLnHenryCoefficientTemperatureDerivative(phase);
+    }
+  }
+
+  private static final class ExposedPitzerComponent extends ComponentGePitzer {
+    private static final long serialVersionUID = 1000;
+
+    private ExposedPitzerComponent(String name) {
+      super(name, 1.0, 1.0, 0);
+    }
+
+    private double exposesEffectiveHenry(PhaseInterface phase) {
+      return getEffectiveHenryCoefficient(phase);
+    }
+
+    private double exposesLnHenryDerivative(PhaseInterface phase) {
+      return getLnHenryCoefficientTemperatureDerivative(phase);
+    }
+
+    private double exposesLegacyHenry(double temperature) {
+      return getEffectiveHenryCoefficient(temperature);
+    }
+
+    private double exposesLegacyLnHenryDerivative(double temperature) {
+      return getLnHenryCoefficientTemperatureDerivative(temperature);
+    }
   }
 }

--- a/src/test/java/neqsim/thermo/component/IapwsHenryLawTest.java
+++ b/src/test/java/neqsim/thermo/component/IapwsHenryLawTest.java
@@ -91,4 +91,3 @@ class IapwsHenryLawTest {
     assertEquals(0.0, methane.getLnHenryCoefficientTemperatureDerivative(aqueousPhase), 0.0);
   }
 }
-

--- a/src/test/java/neqsim/thermo/component/IapwsHenryLawTest.java
+++ b/src/test/java/neqsim/thermo/component/IapwsHenryLawTest.java
@@ -9,32 +9,22 @@ import neqsim.thermo.phase.PhasePitzer;
 
 /** Tests the attributed IAPWS G7-04 common-gas Henry correlation and GE integration. */
 class IapwsHenryLawTest {
-  private static final String[] GASES = {
-      "He", "Ne", "Ar", "Kr", "Xe", "H2", "N2", "O2", "CO", "CO2", "H2S", "CH4", "C2H6", "SF6"};
+  private static final String[] GASES = { "He", "Ne", "Ar", "Kr", "Xe", "H2", "N2", "O2", "CO", "CO2", "H2S", "CH4",
+      "C2H6", "SF6" };
 
-  private static final double[][] EXPECTED_LOG_KH_GPA = {
-      {2.6576, 2.1660, 1.1973, -0.1993},
-      {2.5134, 2.3512, 1.5952, 0.4659},
-      {1.4061, 1.8079, 1.1536, 0.0423},
-      {0.8210, 1.4902, 0.9798, 0.0006},
-      {0.2792, 1.1430, 0.5033, -0.7081},
-      {1.9702, 1.8464, 1.0513, -0.1848},
-      {2.1716, 2.3509, 1.4842, 0.1647},
-      {1.5024, 1.8832, 1.1630, -0.0276},
-      {1.7652, 1.9939, 1.1250, -0.2382},
-      {-1.7508, -0.5450, -0.6524, -1.3489},
-      {-2.8784, -1.7083, -1.6074, -2.1319},
-      {1.4034, 1.7946, 1.0342, -0.2209},
-      {1.1418, 1.8495, 0.8274, -0.8141},
-      {3.1445, 3.6919, 2.6749, 1.2402}};
+  private static final double[][] EXPECTED_LOG_KH_GPA = { { 2.6576, 2.1660, 1.1973, -0.1993 },
+      { 2.5134, 2.3512, 1.5952, 0.4659 }, { 1.4061, 1.8079, 1.1536, 0.0423 }, { 0.8210, 1.4902, 0.9798, 0.0006 },
+      { 0.2792, 1.1430, 0.5033, -0.7081 }, { 1.9702, 1.8464, 1.0513, -0.1848 }, { 2.1716, 2.3509, 1.4842, 0.1647 },
+      { 1.5024, 1.8832, 1.1630, -0.0276 }, { 1.7652, 1.9939, 1.1250, -0.2382 }, { -1.7508, -0.5450, -0.6524, -1.3489 },
+      { -2.8784, -1.7083, -1.6074, -2.1319 }, { 1.4034, 1.7946, 1.0342, -0.2209 }, { 1.1418, 1.8495, 0.8274, -0.8141 },
+      { 3.1445, 3.6919, 2.6749, 1.2402 } };
 
   @Test
   void reproducesAllPublishedGuidelineCheckValues() {
-    double[] temperatures = {300.0, 400.0, 500.0, 600.0};
+    double[] temperatures = { 300.0, 400.0, 500.0, 600.0 };
     for (int gas = 0; gas < GASES.length; gas++) {
       for (int point = 0; point < temperatures.length; point++) {
-        double logKhGpa =
-            Math.log(IapwsHenryLaw.getHenryCoefficientBar(GASES[gas], temperatures[point]) / 10000.0);
+        double logKhGpa = Math.log(IapwsHenryLaw.getHenryCoefficientBar(GASES[gas], temperatures[point]) / 10000.0);
         assertEquals(EXPECTED_LOG_KH_GPA[gas][point], logKhGpa, 5.1e-5,
             GASES[gas] + " at " + temperatures[point] + " K");
       }
@@ -46,12 +36,9 @@ class IapwsHenryLawTest {
     for (String gas : GASES) {
       double temperature = 400.0;
       double step = 1.0e-3;
-      double expected =
-          (Math.log(IapwsHenryLaw.getHenryCoefficientBar(gas, temperature + step))
-              - Math.log(IapwsHenryLaw.getHenryCoefficientBar(gas, temperature - step)))
-              / (2.0 * step);
-      assertEquals(expected,
-          IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative(gas, temperature), 1.0e-9, gas);
+      double expected = (Math.log(IapwsHenryLaw.getHenryCoefficientBar(gas, temperature + step))
+          - Math.log(IapwsHenryLaw.getHenryCoefficientBar(gas, temperature - step))) / (2.0 * step);
+      assertEquals(expected, IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative(gas, temperature), 1.0e-9, gas);
     }
   }
 
@@ -69,8 +56,7 @@ class IapwsHenryLawTest {
     IapwsHenryLaw.Assessment outside = IapwsHenryLaw.assess("CH4", 700.0);
     assertEquals(IapwsHenryLaw.Status.OUTSIDE_CORRELATION_DOMAIN, outside.getStatus());
     assertFalse(outside.isUsable());
-    assertThrows(IllegalArgumentException.class,
-        () -> IapwsHenryLaw.getHenryCoefficientBar("CH4", 700.0));
+    assertThrows(IllegalArgumentException.class, () -> IapwsHenryLaw.getHenryCoefficientBar("CH4", 700.0));
 
     IapwsHenryLaw.Assessment unsupported = IapwsHenryLaw.assess("propane", 300.0);
     assertEquals(IapwsHenryLaw.Status.UNSUPPORTED_SPECIES, unsupported.getStatus());
@@ -101,8 +87,8 @@ class IapwsHenryLawTest {
     aqueousPhase.addComponent("water", 55.508, 55.508, 0);
     ComponentGeNRTL methane = new ComponentGeNRTL("methane", 1.0e-6, 1.0e-6, 1);
 
-    assertEquals(ComponentGE.INSOLUBLE_HENRY_COEFFICIENT,
-        methane.getEffectiveHenryCoefficient(aqueousPhase), 0.0);
+    assertEquals(ComponentGE.INSOLUBLE_HENRY_COEFFICIENT, methane.getEffectiveHenryCoefficient(aqueousPhase), 0.0);
     assertEquals(0.0, methane.getLnHenryCoefficientTemperatureDerivative(aqueousPhase), 0.0);
   }
 }
+

--- a/src/test/java/neqsim/thermo/component/IapwsHenryLawTest.java
+++ b/src/test/java/neqsim/thermo/component/IapwsHenryLawTest.java
@@ -24,7 +24,8 @@ class IapwsHenryLawTest {
     double[] temperatures = { 300.0, 400.0, 500.0, 600.0 };
     for (int gas = 0; gas < GASES.length; gas++) {
       for (int point = 0; point < temperatures.length; point++) {
-        double logKhGpa = Math.log(IapwsHenryLaw.getHenryCoefficientBar(GASES[gas], temperatures[point]) / 10000.0);
+        double logKhGpa = Math
+            .log(IapwsHenryLaw.getHenryCoefficientBarAllowExtrapolation(GASES[gas], temperatures[point]) / 10000.0);
         assertEquals(EXPECTED_LOG_KH_GPA[gas][point], logKhGpa, 5.1e-5,
             GASES[gas] + " at " + temperatures[point] + " K");
       }
@@ -48,10 +49,17 @@ class IapwsHenryLawTest {
     assertEquals(IapwsHenryLaw.Status.WITHIN_FITTED_RANGE, fitted.getStatus());
     assertEquals("CH4", fitted.getCanonicalGasName());
     assertTrue(fitted.isUsable());
+    assertEquals(IapwsHenryLaw.DATASET_ID, fitted.getDatasetId());
+    assertEquals(-10.44708, fitted.getCoefficientA(), 0.0);
+    assertEquals(4.66491, fitted.getCoefficientB(), 0.0);
+    assertEquals(12.12986, fitted.getCoefficientC(), 0.0);
+    assertEquals(0.0386, fitted.getRmsLogHenryResidual(), 0.0);
 
     IapwsHenryLaw.Assessment extrapolated = IapwsHenryLaw.assess("ethane", 600.0);
     assertEquals(IapwsHenryLaw.Status.GUIDELINE_EXTRAPOLATION, extrapolated.getStatus());
-    assertTrue(extrapolated.isUsable());
+    assertFalse(extrapolated.isUsable());
+    assertThrows(IllegalArgumentException.class, () -> IapwsHenryLaw.getHenryCoefficientBar("ethane", 600.0));
+    assertTrue(IapwsHenryLaw.getHenryCoefficientBarAllowExtrapolation("ethane", 600.0) > 0.0);
 
     IapwsHenryLaw.Assessment outside = IapwsHenryLaw.assess("CH4", 700.0);
     assertEquals(IapwsHenryLaw.Status.OUTSIDE_CORRELATION_DOMAIN, outside.getStatus());
@@ -89,5 +97,18 @@ class IapwsHenryLawTest {
 
     assertEquals(ComponentGE.INSOLUBLE_HENRY_COEFFICIENT, methane.getEffectiveHenryCoefficient(aqueousPhase), 0.0);
     assertEquals(0.0, methane.getLnHenryCoefficientTemperatureDerivative(aqueousPhase), 0.0);
+  }
+
+  @Test
+  void supportedSpeciesOutsideFittedRangeFailsClosedInRuntimePath() {
+    PhasePitzer aqueousPhase = new PhasePitzer();
+    aqueousPhase.setTemperature(500.0);
+    aqueousPhase.addComponent("water", 55.508, 55.508, 0);
+    ComponentGeNRTL ethane = new ComponentGeNRTL("ethane", 1.0e-6, 1.0e-6, 1);
+
+    assertEquals(IapwsHenryLaw.Status.GUIDELINE_EXTRAPOLATION,
+        IapwsHenryLaw.assess("ethane", aqueousPhase.getTemperature()).getStatus());
+    assertEquals(ComponentGE.INSOLUBLE_HENRY_COEFFICIENT, ethane.getEffectiveHenryCoefficient(aqueousPhase), 0.0);
+    assertEquals(0.0, ethane.getLnHenryCoefficientTemperatureDerivative(aqueousPhase), 0.0);
   }
 }

--- a/src/test/java/neqsim/thermo/component/IapwsHenryLawTest.java
+++ b/src/test/java/neqsim/thermo/component/IapwsHenryLawTest.java
@@ -1,0 +1,108 @@
+package neqsim.thermo.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhasePitzer;
+
+/** Tests the attributed IAPWS G7-04 common-gas Henry correlation and GE integration. */
+class IapwsHenryLawTest {
+  private static final String[] GASES = {
+      "He", "Ne", "Ar", "Kr", "Xe", "H2", "N2", "O2", "CO", "CO2", "H2S", "CH4", "C2H6", "SF6"};
+
+  private static final double[][] EXPECTED_LOG_KH_GPA = {
+      {2.6576, 2.1660, 1.1973, -0.1993},
+      {2.5134, 2.3512, 1.5952, 0.4659},
+      {1.4061, 1.8079, 1.1536, 0.0423},
+      {0.8210, 1.4902, 0.9798, 0.0006},
+      {0.2792, 1.1430, 0.5033, -0.7081},
+      {1.9702, 1.8464, 1.0513, -0.1848},
+      {2.1716, 2.3509, 1.4842, 0.1647},
+      {1.5024, 1.8832, 1.1630, -0.0276},
+      {1.7652, 1.9939, 1.1250, -0.2382},
+      {-1.7508, -0.5450, -0.6524, -1.3489},
+      {-2.8784, -1.7083, -1.6074, -2.1319},
+      {1.4034, 1.7946, 1.0342, -0.2209},
+      {1.1418, 1.8495, 0.8274, -0.8141},
+      {3.1445, 3.6919, 2.6749, 1.2402}};
+
+  @Test
+  void reproducesAllPublishedGuidelineCheckValues() {
+    double[] temperatures = {300.0, 400.0, 500.0, 600.0};
+    for (int gas = 0; gas < GASES.length; gas++) {
+      for (int point = 0; point < temperatures.length; point++) {
+        double logKhGpa =
+            Math.log(IapwsHenryLaw.getHenryCoefficientBar(GASES[gas], temperatures[point]) / 10000.0);
+        assertEquals(EXPECTED_LOG_KH_GPA[gas][point], logKhGpa, 5.1e-5,
+            GASES[gas] + " at " + temperatures[point] + " K");
+      }
+    }
+  }
+
+  @Test
+  void analyticalDerivativeMatchesCenteredFiniteDifference() {
+    for (String gas : GASES) {
+      double temperature = 400.0;
+      double step = 1.0e-3;
+      double expected =
+          (Math.log(IapwsHenryLaw.getHenryCoefficientBar(gas, temperature + step))
+              - Math.log(IapwsHenryLaw.getHenryCoefficientBar(gas, temperature - step)))
+              / (2.0 * step);
+      assertEquals(expected,
+          IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative(gas, temperature), 1.0e-9, gas);
+    }
+  }
+
+  @Test
+  void assessmentSeparatesFitExtrapolationAndUnsupportedStates() {
+    IapwsHenryLaw.Assessment fitted = IapwsHenryLaw.assess("methane", 300.0);
+    assertEquals(IapwsHenryLaw.Status.WITHIN_FITTED_RANGE, fitted.getStatus());
+    assertEquals("CH4", fitted.getCanonicalGasName());
+    assertTrue(fitted.isUsable());
+
+    IapwsHenryLaw.Assessment extrapolated = IapwsHenryLaw.assess("ethane", 600.0);
+    assertEquals(IapwsHenryLaw.Status.GUIDELINE_EXTRAPOLATION, extrapolated.getStatus());
+    assertTrue(extrapolated.isUsable());
+
+    IapwsHenryLaw.Assessment outside = IapwsHenryLaw.assess("CH4", 700.0);
+    assertEquals(IapwsHenryLaw.Status.OUTSIDE_CORRELATION_DOMAIN, outside.getStatus());
+    assertFalse(outside.isUsable());
+    assertThrows(IllegalArgumentException.class,
+        () -> IapwsHenryLaw.getHenryCoefficientBar("CH4", 700.0));
+
+    IapwsHenryLaw.Assessment unsupported = IapwsHenryLaw.assess("propane", 300.0);
+    assertEquals(IapwsHenryLaw.Status.UNSUPPORTED_SPECIES, unsupported.getStatus());
+    assertFalse(unsupported.isSupportedSpecies());
+  }
+
+  @Test
+  void genericAndPitzerPathsUseExplicitStandardStateMapping() {
+    PhasePitzer aqueousPhase = new PhasePitzer();
+    aqueousPhase.setTemperature(300.0);
+    aqueousPhase.addComponent("water", 55.508, 55.508, 0);
+
+    ComponentGeNRTL generic = new ComponentGeNRTL("methane", 1.0e-6, 1.0e-6, 1);
+    ComponentGePitzer pitzer = new ComponentGePitzer("methane", 1.0e-6, 1.0e-6, 1);
+    double moleFractionHenry = IapwsHenryLaw.getHenryCoefficientBar("CH4", 300.0);
+
+    assertEquals(moleFractionHenry, generic.getEffectiveHenryCoefficient(aqueousPhase), 1.0e-10);
+    assertEquals(moleFractionHenry * IapwsHenryLaw.WATER_MOLAR_MASS_KG_PER_MOL,
+        pitzer.getEffectiveHenryCoefficient(aqueousPhase), 1.0e-10);
+    assertEquals(IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative("CH4", 300.0),
+        generic.getLnHenryCoefficientTemperatureDerivative(aqueousPhase), 1.0e-12);
+  }
+
+  @Test
+  void supportedSpeciesOutsideWaterDomainFailsClosedInIntegratedPath() {
+    PhasePitzer aqueousPhase = new PhasePitzer();
+    aqueousPhase.setTemperature(700.0);
+    aqueousPhase.addComponent("water", 55.508, 55.508, 0);
+    ComponentGeNRTL methane = new ComponentGeNRTL("methane", 1.0e-6, 1.0e-6, 1);
+
+    assertEquals(ComponentGE.INSOLUBLE_HENRY_COEFFICIENT,
+        methane.getEffectiveHenryCoefficient(aqueousPhase), 0.0);
+    assertEquals(0.0, methane.getLnHenryCoefficientTemperatureDerivative(aqueousPhase), 0.0);
+  }
+}

--- a/src/test/java/neqsim/thermo/phase/PitzerCatalogPerformanceBenchmark.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerCatalogPerformanceBenchmark.java
@@ -3,6 +3,7 @@ package neqsim.thermo.phase;
 import java.util.Arrays;
 import neqsim.chemicalreactions.chemicalreaction.ChemicalReaction;
 import neqsim.thermo.component.ComponentGePitzer;
+import neqsim.thermo.component.IapwsHenryLaw;
 import neqsim.thermo.system.SystemPitzer;
 import neqsim.thermo.system.SystemSrkEos;
 
@@ -19,6 +20,12 @@ public final class PitzerCatalogPerformanceBenchmark {
    * @param args ignored
    */
   public static void main(String[] args) {
+    for (int warmup = 0; warmup < 10000; warmup++) {
+      sink += iapwsHenryKernelChecksum();
+    }
+    System.out.println(
+        "iapwsHenryKernelNs=" + medianBatches(PitzerCatalogPerformanceBenchmark::iapwsHenryKernelChecksum, 10000));
+
     SystemSrkEos neutral = createNeutralSystem();
     for (int warmup = 0; warmup < 500; warmup++) {
       neutral.init(3);
@@ -66,6 +73,14 @@ public final class PitzerCatalogPerformanceBenchmark {
         + medianBatches(PitzerCatalogPerformanceBenchmark::solveReactiveH2sState, 10));
     SystemPitzer h2sEvidence = solveReactiveH2sSystem(298.15);
     SystemPitzer warmerH2sEvidence = solveReactiveH2sSystem(318.15);
+    PhasePitzer h2sPhase = (PhasePitzer) h2sEvidence.getPhase(1);
+    System.out.println("pitzerH2sDataset=" + h2sPhase.getParameterDatasetId());
+    System.out.println("pitzerH2sNeutralCoverage=" + h2sPhase.auditNeutralPitzerParameterCoverage().formatDiagnostic());
+    System.out.println("pitzerH2sHasIons=" + h2sPhase.hasIons());
+    System.out.println("pitzerH2sHasNeutralInteractions=" + h2sPhase.hasNeutralPitzerInteractions());
+    System.out.println("pitzerH2sRawHenryBar=" + h2sPhase.getComponent("H2S").getHenryCoef(298.15));
+    System.out.println("pitzerH2sFugacityCoefficient=" + h2sPhase.getComponent("H2S").getFugacityCoefficient());
+    System.out.println("pitzerH2sActivityCoefficient=" + ((ComponentGePitzer) h2sPhase.getComponent("H2S")).getGamma());
     System.out.println("pitzerH2sMaximumReactionResidual="
         + h2sEvidence.getChemicalReactionOperations().getMaximumAbsoluteReactionLogResidual());
     System.out.println("pitzerH2sMaximumElementResidual="
@@ -106,6 +121,11 @@ public final class PitzerCatalogPerformanceBenchmark {
       }
     }
     return value;
+  }
+
+  private static double iapwsHenryKernelChecksum() {
+    return IapwsHenryLaw.getHenryCoefficientBar("CH4", 298.15)
+        + IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative("CH4", 298.15);
   }
 
   private static double neutralPropertyChecksum(SystemSrkEos system) {

--- a/src/test/java/neqsim/thermo/system/SystemElectrolyteCPAMMTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemElectrolyteCPAMMTest.java
@@ -1500,8 +1500,8 @@ public class SystemElectrolyteCPAMMTest {
   }
 
   @Test
-  @DisplayName("Pure liquid: MM e-CPA and Pitzer with no gas phase")
-  void testPureLiquidBothModels() {
+  @DisplayName("Liquid properties: MM e-CPA and Pitzer aqueous phases")
+  void testLiquidPropertiesBothModels() {
     // Pure aqueous NaCl 1 molal at 1 bar, 298.15 K — should stay single liquid phase
     double molesWater = 55.508;
     double m = 1.0;
@@ -1527,12 +1527,12 @@ public class SystemElectrolyteCPAMMTest {
     assertTrue(Double.isFinite(gammaMM) && gammaMM > 0,
         "MM gamma± must be finite and positive in pure liquid (got " + gammaMM + ")");
 
-    // ----- Pitzer: pure liquid -----
-    // Architectural note: SystemPitzer uses phase[0]=SRK(gas) and phase[1]=Pitzer(aqueous).
-    // Without a gas component, TPflash stays in the SRK phase, giving gamma±=1.0.
-    // The standard pattern is to add trace methane + moderate pressure to force 2 phases.
+    // ----- Pitzer: explicit aqueous phase -----
+    // SystemPitzer uses phase[0]=SRK(gas) and phase[1]=Pitzer(aqueous). Use a methane inventory
+    // that exceeds the qualified IAPWS pure-water solubility at this state, so the flash retains
+    // an explicit gas plus aqueous topology while the aqueous properties are checked.
     SystemPitzer pitzerSys = new SystemPitzer(298.15, 10.0);
-    pitzerSys.addComponent("methane", 0.01); // trace gas for 2-phase split
+    pitzerSys.addComponent("methane", 5.0);
     pitzerSys.addComponent("water", molesWater);
     pitzerSys.addComponent("Na+", m);
     pitzerSys.addComponent("Cl-", m);
@@ -1557,7 +1557,7 @@ public class SystemElectrolyteCPAMMTest {
     assertTrue(Double.isFinite(gammaPitzer) && gammaPitzer > 0,
         "Pitzer gamma± must be finite and positive in pure liquid (got " + gammaPitzer + ")");
 
-    logger.info("=== Pure Liquid (no gas) ===");
+    logger.info("=== Liquid properties ===");
     logger.info(String.format("  MM e-CPA:  γ± = %.4f, Vm = %.6e m3/mol, phases = %d", gammaMM, mmVm,
         mmSys.getNumberOfPhases()));
     logger.info(String.format("  Pitzer:    γ± = %.4f, Vm = %.6e m3/mol, phases = %d", gammaPitzer, pitzerVm,

--- a/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
@@ -356,12 +356,9 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
     double moleFraction = aqueous.getComponent("CO2").getx();
     double molality = aqueous.getComponent("CO2").getMolality(aqueous);
     double gamma = aqueous.getActivityCoefficient(aqueous.getComponent("CO2").getComponentNumber());
-    double moleFractionHenry =
-        IapwsHenryLaw.getHenryCoefficientBar("CO2", aqueous.getTemperature());
-    double molalityHenry =
-        moleFractionHenry * IapwsHenryLaw.WATER_MOLAR_MASS_KG_PER_MOL;
-    double expectedFugacityCoefficient =
-        gamma * molalityHenry * molality / (moleFraction * aqueous.getPressure());
+    double moleFractionHenry = IapwsHenryLaw.getHenryCoefficientBar("CO2", aqueous.getTemperature());
+    double molalityHenry = moleFractionHenry * IapwsHenryLaw.WATER_MOLAR_MASS_KG_PER_MOL;
+    double expectedFugacityCoefficient = gamma * molalityHenry * molality / (moleFraction * aqueous.getPressure());
 
     assertTrue(molality / moleFraction > 50.0);
     assertEquals(expectedFugacityCoefficient, aqueous.getComponent("CO2").getFugacityCoefficient(),

--- a/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
@@ -342,26 +342,26 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
     assertEquals(0.0318, vap, 1e-3);
   }
 
-  /** Qualified IAPWS Henry fugacity maps from mole fraction to the Pitzer molality standard state. */
+  /** Neutral-solute Henry fugacity uses the same molality standard state as Pitzer activity. */
   @Test
   public void testNeutralHenryFugacityUsesMolalityBasis() {
     SystemPitzer system = new SystemPitzer(298.15, 1.01325);
     system.addComponent("water", 55.508);
-    system.addComponent("CO2", 1.0e-4);
+    system.addComponent("nitrogen", 1.0e-4);
     system.setMixingRule("classic");
     system.init(0);
     system.init(1);
 
     PhaseInterface aqueous = system.getPhase(1);
-    double moleFraction = aqueous.getComponent("CO2").getx();
-    double molality = aqueous.getComponent("CO2").getMolality(aqueous);
-    double gamma = aqueous.getActivityCoefficient(aqueous.getComponent("CO2").getComponentNumber());
-    double moleFractionHenry = IapwsHenryLaw.getHenryCoefficientBar("CO2", aqueous.getTemperature());
-    double molalityHenry = moleFractionHenry * IapwsHenryLaw.WATER_MOLAR_MASS_KG_PER_MOL;
-    double expectedFugacityCoefficient = gamma * molalityHenry * molality / (moleFraction * aqueous.getPressure());
+    double moleFraction = aqueous.getComponent("nitrogen").getx();
+    double molality = aqueous.getComponent("nitrogen").getMolality(aqueous);
+    double gamma = aqueous.getActivityCoefficient(aqueous.getComponent("nitrogen").getComponentNumber());
+    double henryCoefficient = IapwsHenryLaw.getHenryCoefficientBar("N2", aqueous.getTemperature())
+        * IapwsHenryLaw.WATER_MOLAR_MASS_KG_PER_MOL;
+    double expectedFugacityCoefficient = gamma * henryCoefficient * molality / (moleFraction * aqueous.getPressure());
 
     assertTrue(molality / moleFraction > 50.0);
-    assertEquals(expectedFugacityCoefficient, aqueous.getComponent("CO2").getFugacityCoefficient(),
+    assertEquals(expectedFugacityCoefficient, aqueous.getComponent("nitrogen").getFugacityCoefficient(),
         expectedFugacityCoefficient * 1.0e-12);
   }
 

--- a/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import neqsim.chemicalreactions.chemicalreaction.ChemicalReaction;
 import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionConcentrationBasis;
+import neqsim.thermo.component.IapwsHenryLaw;
 import neqsim.thermo.phase.PhaseInterface;
 import neqsim.thermo.phase.PhasePitzer;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -341,7 +342,7 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
     assertEquals(0.0318, vap, 1e-3);
   }
 
-  /** Neutral-solute Henry fugacity uses the same molality standard state as Pitzer activity. */
+  /** Qualified IAPWS Henry fugacity maps from mole fraction to the Pitzer molality standard state. */
   @Test
   public void testNeutralHenryFugacityUsesMolalityBasis() {
     SystemPitzer system = new SystemPitzer(298.15, 1.01325);
@@ -355,8 +356,12 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
     double moleFraction = aqueous.getComponent("CO2").getx();
     double molality = aqueous.getComponent("CO2").getMolality(aqueous);
     double gamma = aqueous.getActivityCoefficient(aqueous.getComponent("CO2").getComponentNumber());
-    double henryCoefficient = aqueous.getComponent("CO2").getHenryCoef(aqueous.getTemperature());
-    double expectedFugacityCoefficient = gamma * henryCoefficient * molality / (moleFraction * aqueous.getPressure());
+    double moleFractionHenry =
+        IapwsHenryLaw.getHenryCoefficientBar("CO2", aqueous.getTemperature());
+    double molalityHenry =
+        moleFractionHenry * IapwsHenryLaw.WATER_MOLAR_MASS_KG_PER_MOL;
+    double expectedFugacityCoefficient =
+        gamma * molalityHenry * molality / (moleFraction * aqueous.getPressure());
 
     assertTrue(molality / moleFraction > 50.0);
     assertEquals(expectedFugacityCoefficient, aqueous.getComponent("CO2").getFugacityCoefficient(),


### PR DESCRIPTION
## Scientific question

Can NeqSim replace invalid or undocumented aqueous Henry placeholders for common gases with one attributed, reproducible pure-water reference while keeping GE/Pitzer standard states explicit and leaving EOS, reaction constants, flash topology, and electrolyte interaction families unchanged?

Advances #3144.

## Frozen scope

- Base: `4b0b533c5066ece83119bd36728f010ee24b97c4`; current master inspected after validation: `bb497b5189d5b1b177ef0dc8b3edd180b8463ad4`.
- Model/runtime: water-containing excess-Gibbs phases and the Pitzer neutral-solute adapter.
- Correlation: IAPWS G7-04 for He, Ne, Ar, Kr, Xe, H2, N2, O2, CO, CO2, H2S, CH4, C2H6, and SF6.
- Convention: `kH = lim(f/x)` on the liquid-water saturation boundary, returned in bar; Pitzer maps with `Hm = kH * Mwater`.
- Reaction set and electrolyte parameter sets: unchanged.
- Stop boundary: no pressure/Poynting correction, salting-out parameter adoption, electrolyte-EOS mapping, generic TP-flash change, or reactive absorber/equipment change.

## Implementation

- Adds versioned dataset `iapws-g7-04-water-gases-v1`, all 14 coefficient triples, species-specific fitted ranges, published RMS residuals, analytical `d ln(kH)/dT`, and deterministic Java/JPype diagnostics.
- Runtime evaluation is strict to each fitted range. Reproducing guideline check values outside a fitted range requires the explicitly named `getHenryCoefficientBarAllowExtrapolation` API.
- Uses allocation-free exact-name dispatch on common hot-path names.
- Corrects historical aqueous GE solvent classification for H2/He/Ar so those gases use their qualified Henry reference rather than vapor pressure.
- Maps nonreactive ion-free Pitzer gas references to the molality standard state with the fixed IAPWS water molar mass.
- Prevents an unqualified ionic or reactive CO2/H2S Pitzer topology from combining IAPWS with a unit neutral activity coefficient. Reactive acid gases require a complete neutral-interaction family before changing reference, including during pre-reaction initialization.
- Preserves the established reaction root, missing-parameter diagnostics, EOS paths, and unsupported-species/database behavior.

## Public evidence and licensing

- IAPWS G7-04: https://iapws.org/technical-guidance/release/HenGuide — Tables 2/5 coefficients, fitted ranges and RMS; Table 6 check values; publication with attribution permitted by the guideline.
- Fernandez-Prini, Alvarez and Harvey (2003): https://doi.org/10.1063/1.1564818 — primary equation/correlation lineage.
- Sander (2023): https://doi.org/10.5194/acp-23-10901-2023 — CC BY 4.0 convention cross-check; no values adopted.
- NIST SRD 69 CO2/CH4/N2 pages — read-only independent screening index; no protected compilation values copied.
- USGS PHREEQC 3.9.0 public-domain catalog and exact provenance remain documented separately. No Pitzer value is adopted here.
- Kaasa (1998), stable item https://www.nb.no/items/d1d68b489b8ee6704786a011fd2e7283 — provenance index only. Original pages were not retrievable from the public item in this run; no value was inferred, OCRed, copied, or adopted.

## Validation evidence

Exact head: `8c06746ccb97087aa2812f6b8ddd33dfb70f4b3b`.

Regression/source checks:

- all 56 rounded IAPWS Table 6 values;
- analytical derivative versus centered finite differences for all 14 gases;
- fitted/extrapolated/unsupported/out-of-domain states and strict runtime failure;
- coefficient/range/RMS/dataset diagnostics;
- H2/He/Ar legacy-solvent GE dispatch;
- fixed mole-fraction-to-molality mapping;
- deterministic trace-ion and unqualified reactive-Pitzer compatibility;
- qualified Pitzer, hybrid EOS-GE, MM electrolyte-CPA, slow electrolyte-CPA, and neutral PR/SRK-CPA controls.

Local exact-tree commands and results:

- PASS — Spotless check and `python3 devtools/check_documentation_search.py` (672 Markdown pages, one standalone HTML page).
- PASS — 130 tests in two post-reconciliation Maven batches; no failures or skips.
- PASS — `./mvnw -q -DskipTests -Dmaven.javadoc.skip=true package`.
- LOCAL INFRASTRUCTURE BLOCKED — local Javadoc attachment only: runtime has no `javadoc` executable/valid `JAVA_HOME`; the hosted Java 21 Javadoc gate passes on this exact head.

Scientific compatibility benchmark at 298.15 K:

- max absolute reaction `ln(Q/K)`: `4.2633e-14`;
- max elemental residual: `1.1927e-13`;
- aqueous charge: `-1.0825e-14` mol; normalized charge residual `1.5922e-10`;
- HS- molality: `3.3995324e-5` mol/kg at 298.15 K and `4.3530791e-5` mol/kg at 318.15 K;
- diagnostic remains explicit: missing `H2S|H2S`, `H2S|H3O+`, `H2S|HS-`, and `H2S|H3O+|HS-`; therefore the new reference is not activated for this reactive state.

Performance screen (OpenJDK 17, nine fixed-work batches after warmup):

- affected IAPWS value-plus-derivative kernel: 573 ns versus 1140 ns on exact pre-repair head `a3acb09cf`;
- complete reactive-H2S median: 40.76 ms versus 50.25 ms on that head, with the compatible chemical state above;
- neutral EOS paths do not dispatch through this helper and remain covered by PR/SRK/CPA tests.

## Validation status

**READY TO MERGE — exact head `8c06746ccb97087aa2812f6b8ddd33dfb70f4b3b`**

All exact-head hosted gates pass: Java 8/21 fast tests on Ubuntu and Windows, all four Java 21 slow shards, Java 21 Javadocs, CodeQL, documentation search, Spotless, pre-commit/pre-push, PaperLab, and agent-reference checks. Independent re-reading of IAPWS G7-04 confirms the implemented Eq. (3), all 14 Table 2 coefficient/range rows, all 14 Table 5 RMS values, all 56 Table 6 check values, the saturation-boundary standard state, and the attribution-permitted reuse statement. The PR is mergeable and has no reviews, PR comments, or unresolved review threads. It intentionally remains draft; it was not marked ready, merged, or configured for auto-merge.

## Remaining boundary

Pure-water Henry data do not qualify electrolyte salting-out. The next parameter increment requires one complete redistributable neutral-gas/ion family, exact convention mapping, explicit missing-parameter behavior, and independent brine/VLE evidence. Generic TP-flash stays coordinated under #2937, salt input/API under #448, and reactive absorber equipment under #205.