### PR TITLE
[AI-Assisted] test(mcp): qualify reusable model registry contract

### DIFF
--- a/.github/workflows/mcp_protocol_qualification.yml
+++ b/.github/workflows/mcp_protocol_qualification.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Install exact NeqSim core without tests
         run: mvn -B install -DskipTests -Dmaven.javadoc.skip=true -ntp
 
+      - name: Run focused model-registry Java contract
+        run: mvn -B -Dtest=neqsim.mcp.runners.ModelRegistryTest test -ntp
+
       - name: Build exact MCP server package
         shell: bash
         run: |
@@ -66,6 +69,9 @@ jobs:
 
       - name: Run focused real-MCP automation-read qualification
         run: cd neqsim-mcp-server && python test_automation_read_protocol.py
+
+      - name: Run focused real-MCP model-registry qualification
+        run: cd neqsim-mcp-server && python test_model_registry_protocol.py
 
       - name: Run comprehensive real-MCP protocol regression
         run: cd neqsim-mcp-server && python test_mcp_server.py

--- a/neqsim-mcp-server/docs/evidence/MODEL_REGISTRY_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/MODEL_REGISTRY_CONTRACT.md
@@ -1,0 +1,105 @@
+# Reusable model-registry contract evidence
+
+This note records the bounded Phase 0 evidence for the existing `manageModel`
+software contract used by the NeqSim MCP server. The contract is implemented by
+the core `ModelRegistry`; registered handles resolve back to the same canonical
+NeqSim process definition and are consumed by normal `ProcessSystem` /
+`ProcessModel` runners. There is no MCP-only process simulator or second
+flowsheet representation.
+
+## Foundation and engineering value
+
+Merged PR #2875 introduced reusable model handles after a real converted plant
+model showed that repeatedly resending, parsing, and solving the same flowsheet
+made interactive troubleshooting impractical. Current `ModelRegistry` keeps
+definitions in a bounded in-memory working set, issues stable content-derived
+`model_*` handles, scopes records to the authenticated principal and tenant,
+tracks revisions, reuses solved `ProcessSystem` instances for read-only routes,
+and invalidates cached solves on revision or deletion.
+
+The existing `ModelRegistryTest` is the source-level contract. It covers:
+
+- handle registration and resolution;
+- idempotent content-addressed registration and distinct-content separation;
+- stable-handle revisioning;
+- structure inspection and documented response fields;
+- owner/tenant isolation and unknown-handle failure;
+- nested-object and escaped-string definitions;
+- cached-solve reuse plus revision/delete invalidation;
+- inline-JSON compatibility;
+- handle use through process and automation runner paths; and
+- usage accounting and bounded registry behavior.
+
+This evidence reuses #2875 rather than adding a competing model/session layer.
+
+## Packaged MCP qualification
+
+`test_model_registry_protocol.py` starts the exact packaged server over STDIO
+and obtains the canonical `process/simple-separation` fixture through MCP. It
+then qualifies seven bounded protocol scenarios:
+
+1. registration plus idempotent repeated registration;
+2. `get`, caller-visible `list`, and structure-only `inspect`;
+3. use of the issued handle through canonical `runProcess` and
+   `listSimulationUnits`;
+4. stable model identity with monotonic revision and retained updated
+   definition;
+5. fail-closed invalid definitions, unknown actions, and unknown handles;
+6. deletion plus rejection of the deleted handle through both registry and
+   process-execution paths; and
+7. preservation of current Phase 0 accounting: inventory 1.18 remains
+   **20 `EXPLICIT_TRUST` + 16 `CONTRACT_TESTED` + 35 `CONFIRMED_GAP`**, with
+   `manageModel` still `CONFIRMED_GAP`.
+
+The `MCP protocol qualification` workflow now runs both the existing focused
+`ModelRegistryTest` under Java 21 and this packaged transport harness before the
+authoritative comprehensive MCP protocol regression.
+
+## Qualification boundary
+
+This increment is an evidence prerequisite, not a trust promotion.
+`manageModel` remains `CONFIRMED_GAP` until a later atomic change moves its
+machine-readable coverage record and the authoritative primary packaged
+protocol accounting together on one exact validated head.
+
+The bounded evidence supports registry/lifecycle/transport behavior only. It
+does **not** establish:
+
+- thermodynamic or process-model numerical accuracy;
+- convergence adequacy, mass/energy closure, or facility fidelity;
+- validity of engineering conclusions obtained from a registered model;
+- persistence or durability across MCP server restarts;
+- correctness of an external identity provider or authorization policy;
+- multi-process or distributed cache coherence;
+- protection against every deployment-specific memory-pressure condition;
+- plant authority, control-system write permission, design certification, or
+  accountable engineering approval.
+
+The source-level tests exercise principal/tenant isolation, but the focused
+STDIO harness intentionally runs as one local caller. Production deployment
+identity and tenant enforcement remain governed by the security foundation from
+#2874 and deployment configuration.
+
+`ModelRegistry` stores a working set, not an engineering document archive.
+Revision labels and model handles are traceability aids; they do not replace
+project document control or provenance for source facility data.
+
+## Compatibility and documentation impact
+
+No public MCP tool name, argument schema, response envelope, process JSON
+grammar, model solver, numerical tolerance, security default, or agent/skill
+handoff changes. Existing inline `processJson` callers remain supported.
+No companion agent/skill repository update is required.
+
+Owner boundaries remain unchanged: DEXPI/P&ID semantics belong to #2899,
+dynamics to #2911, TP-flash/stability/performance to #2937, and production
+optimization #2941 is complete. This evidence does not import or duplicate
+those implementations.
+
+## Next dependency
+
+After this evidence is merged and current `master` is re-audited, the next
+dependency-ready Phase 0 step is an atomic `manageModel` trust-classification
+increment, if the exact merged evidence still supports it. That later change
+must update machine-readable coverage and the authoritative primary protocol
+accounting together and retain all boundaries above.

--- a/neqsim-mcp-server/test_model_registry_protocol.py
+++ b/neqsim-mcp-server/test_model_registry_protocol.py
@@ -1,0 +1,407 @@
+"""Focused real-MCP qualification for reusable process model handles.
+
+This dependency-free harness starts the packaged NeqSim MCP server over STDIO and
+qualifies the existing manageModel lifecycle plus handle reuse through canonical
+runProcess and automation-read routes. It is software-contract and transport
+evidence only: it does not validate process numerical accuracy, convergence
+quality, facility completeness, persistence across server restarts, external
+authorization, or plant authority.
+"""
+import copy
+import json
+import subprocess
+import sys
+import time
+
+JAR = "target/neqsim-mcp-server-1.0.0-SNAPSHOT-runner.jar"
+
+
+class McpClient:
+    """Minimal line-delimited JSON-RPC MCP client for packaged-server tests."""
+
+    def __init__(self):
+        self.proc = None
+        self.message_id = 0
+
+    def next_id(self):
+        self.message_id += 1
+        return self.message_id
+
+    def send(self, message):
+        self.proc.stdin.write(json.dumps(message) + "\n")
+        self.proc.stdin.flush()
+
+    def receive(self):
+        line = self.proc.stdout.readline()
+        if not line:
+            stderr = self.proc.stderr.read() if self.proc and self.proc.stderr else ""
+            raise RuntimeError("MCP server closed stdout unexpectedly: " + stderr)
+        return json.loads(line)
+
+    def start(self):
+        self.proc = subprocess.Popen(
+            ["java", "-jar", JAR],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "neqsim-model-registry-test",
+                        "version": "1.0",
+                    },
+                },
+            }
+        )
+        response = self.receive()
+        require("result" in response, "MCP initialize did not return a result", response)
+        self.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        time.sleep(0.2)
+
+    def call_tool(self, name, arguments):
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            }
+        )
+        response = self.receive()
+        content = response.get("result", {}).get("content", [])
+        require(content, "MCP tool call returned no content", response)
+        text = content[0].get("text", "")
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as error:
+            raise AssertionError(
+                f"MCP tool returned non-JSON content: {error}: {text}"
+            )
+
+    def manage_model(self, request):
+        return self.call_tool(
+            "manageModel", {"modelJson": json.dumps(request)}
+        )
+
+    def close(self):
+        if self.proc is None:
+            return
+        if self.proc.stdin:
+            self.proc.stdin.close()
+        try:
+            self.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.proc.terminate()
+            self.proc.wait(timeout=10)
+        self.proc = None
+
+
+def require(condition, message, detail=None):
+    """Raise a compact assertion with JSON detail when a protocol contract fails."""
+    if condition:
+        return
+    suffix = ""
+    if detail is not None:
+        suffix = "\n" + json.dumps(detail, indent=2, sort_keys=True)
+    raise AssertionError(message + suffix)
+
+
+def payload(response):
+    """Return canonical data while retaining standardized envelope state."""
+    data = response.get("data") if isinstance(response, dict) else None
+    if not isinstance(data, dict):
+        return response
+    merged = dict(data)
+    for key in (
+        "status",
+        "message",
+        "tool",
+        "action",
+        "code",
+        "errors",
+        "provenance",
+        "validation",
+        "qualityGate",
+    ):
+        if key in response:
+            merged.setdefault(key, response[key])
+    return merged
+
+
+def simple_process(client):
+    """Retrieve the canonical catalog fixture through MCP instead of duplicating it."""
+    example = client.call_tool(
+        "getExample", {"category": "process", "name": "simple-separation"}
+    )
+    if isinstance(example, dict) and isinstance(example.get("data"), dict):
+        example = example["data"]
+    require(isinstance(example, dict), "simple-separation example is not an object", example)
+    require("process" in example, "simple-separation example omitted process", example)
+    return example
+
+
+def register(client, process_definition):
+    result = client.manage_model(
+        {
+            "action": "register",
+            "name": "phase0-model-registry",
+            "version": "1.0.0",
+            "processJson": process_definition,
+        }
+    )
+    data = payload(result)
+    require(data.get("status") == "success", "manageModel register failed", result)
+    model_id = data.get("modelId")
+    require(
+        isinstance(model_id, str) and model_id.startswith("model_"),
+        "registration did not issue a model handle",
+        result,
+    )
+    require(data.get("revision") == 1, "initial model revision drifted", result)
+    require(data.get("name") == "phase0-model-registry", "model name drifted", result)
+    require(data.get("version") == "1.0.0", "model version drifted", result)
+    require(bool(data.get("usage")), "registration omitted handle-usage guidance", result)
+    return model_id
+
+
+def test_registration_is_idempotent(client, process_definition):
+    model_id = register(client, process_definition)
+    repeated = payload(
+        client.manage_model(
+            {
+                "action": "register",
+                "name": "phase0-model-registry",
+                "version": "1.0.0",
+                "processJson": process_definition,
+            }
+        )
+    )
+    require(repeated.get("status") == "success", "repeat registration failed", repeated)
+    require(
+        repeated.get("modelId") == model_id,
+        "identical content did not retain the same handle",
+        repeated,
+    )
+    require(repeated.get("revision") == 1, "idempotent registration changed revision", repeated)
+    return model_id
+
+
+def test_get_list_and_inspect(client, model_id):
+    fetched = payload(client.manage_model({"action": "get", "modelId": model_id}))
+    require(fetched.get("status") == "success", "manageModel get failed", fetched)
+    require(fetched.get("modelId") == model_id, "get lost model identity", fetched)
+    definition = fetched.get("definition")
+    require(isinstance(definition, dict), "get omitted stored definition", fetched)
+    require("process" in definition, "stored definition lost process content", fetched)
+
+    listed = payload(client.manage_model({"action": "list"}))
+    require(listed.get("status") == "success", "manageModel list failed", listed)
+    models = listed.get("models", [])
+    require(isinstance(models, list), "model list is not an array", listed)
+    require(
+        any(item.get("modelId") == model_id for item in models if isinstance(item, dict)),
+        "registered model is absent from caller-visible list",
+        listed,
+    )
+    require(listed.get("count") == len(models), "model count does not match list", listed)
+
+    inspected = payload(client.manage_model({"action": "inspect", "modelId": model_id}))
+    require(inspected.get("status") == "success", "manageModel inspect failed", inspected)
+    require(inspected.get("modelId") == model_id, "inspect lost model identity", inspected)
+    equipment = inspected.get("equipment", [])
+    require(
+        isinstance(equipment, list) and len(equipment) >= 2,
+        "inspect did not expose expected process structure",
+        inspected,
+    )
+    require(
+        inspected.get("equipmentCount") == len(equipment),
+        "inspect equipment count drifted",
+        inspected,
+    )
+
+
+def test_handle_drives_canonical_process_and_read_routes(client, model_id):
+    process_result = payload(client.call_tool("runProcess", {"processJson": model_id}))
+    require(process_result.get("status") == "success", "runProcess(handle) failed", process_result)
+    require(
+        isinstance(process_result.get("provenance"), dict),
+        "runProcess(handle) omitted provenance",
+        process_result,
+    )
+    require(
+        isinstance(process_result.get("validation"), dict),
+        "runProcess(handle) omitted validation",
+        process_result,
+    )
+
+    units_result = payload(
+        client.call_tool("listSimulationUnits", {"processJson": model_id})
+    )
+    require(
+        units_result.get("status") == "success",
+        "listSimulationUnits(handle) failed",
+        units_result,
+    )
+    units = units_result.get("units", [])
+    require(isinstance(units, list) and units, "handle-backed unit inventory is empty", units_result)
+
+
+def test_revision_is_stable_and_visible(client, model_id, process_definition):
+    revised = copy.deepcopy(process_definition)
+    revised["phase0QualificationRevision"] = 2
+
+    result = payload(
+        client.manage_model(
+            {
+                "action": "revise",
+                "modelId": model_id,
+                "version": "1.0.1",
+                "processJson": revised,
+            }
+        )
+    )
+    require(result.get("status") == "success", "manageModel revise failed", result)
+    require(result.get("modelId") == model_id, "revision changed stable handle", result)
+    require(result.get("revision") == 2, "revision counter did not increment", result)
+    require(result.get("version") == "1.0.1", "revision version was not retained", result)
+
+    fetched = payload(client.manage_model({"action": "get", "modelId": model_id}))
+    require(fetched.get("revision") == 2, "get did not expose revised version", fetched)
+    require(fetched.get("definition") == revised, "revised definition was not retained exactly", fetched)
+
+
+def error_code(response):
+    """Collect the stable root/domain error code without assuming one envelope layout."""
+    data = payload(response)
+    if isinstance(data, dict) and data.get("code"):
+        return data.get("code")
+    for item in data.get("errors", []) if isinstance(data, dict) else []:
+        if isinstance(item, dict) and item.get("code"):
+            return item.get("code")
+    return None
+
+
+def test_invalid_requests_fail_closed(client):
+    invalid_definition = client.manage_model(
+        {"action": "register", "processJson": {"fluid": {"components": {"methane": 1.0}}}}
+    )
+    require(
+        payload(invalid_definition).get("status") == "error",
+        "invalid process definition was accepted",
+        invalid_definition,
+    )
+    require(
+        error_code(invalid_definition) == "INVALID_DEFINITION",
+        "invalid-definition error code drifted",
+        invalid_definition,
+    )
+
+    unknown_action = client.manage_model({"action": "not-a-phase0-action"})
+    require(
+        payload(unknown_action).get("status") == "error",
+        "unknown model action was accepted",
+        unknown_action,
+    )
+    require(
+        error_code(unknown_action) == "UNKNOWN_ACTION",
+        "unknown-action error code drifted",
+        unknown_action,
+    )
+
+    unknown_model = client.manage_model(
+        {"action": "get", "modelId": "model_deadbeefdeadbeef"}
+    )
+    require(
+        payload(unknown_model).get("status") == "error",
+        "unknown model handle was accepted",
+        unknown_model,
+    )
+    require(
+        error_code(unknown_model) == "UNKNOWN_MODEL",
+        "unknown-model error code drifted",
+        unknown_model,
+    )
+
+
+def test_delete_invalidates_handle(client, model_id):
+    deleted = payload(client.manage_model({"action": "delete", "modelId": model_id}))
+    require(deleted.get("status") == "success", "manageModel delete failed", deleted)
+    require(deleted.get("modelId") == model_id, "delete lost model identity", deleted)
+    require(deleted.get("deleted") is True, "delete did not confirm removal", deleted)
+
+    missing = client.manage_model({"action": "get", "modelId": model_id})
+    require(
+        payload(missing).get("status") == "error",
+        "deleted model remained retrievable",
+        missing,
+    )
+    require(error_code(missing) == "UNKNOWN_MODEL", "deleted handle error drifted", missing)
+
+    process_result = payload(client.call_tool("runProcess", {"processJson": model_id}))
+    require(
+        process_result.get("status") == "error",
+        "deleted handle still executed through runProcess",
+        process_result,
+    )
+
+
+def test_phase0_classification_remains_a_gap(client):
+    result = payload(client.call_tool("getCapabilities", {}))
+    inventory = result.get("phase0EvidenceInventory")
+    require(isinstance(inventory, dict), "capabilities omitted Phase 0 evidence inventory", result)
+    require(inventory.get("inventoryVersion") == "1.18", "unexpected evidence inventory version", result)
+    limitations = inventory.get("knownLimitations", {})
+    require(
+        limitations.get("contractTestedToolCount") == 16
+        and limitations.get("confirmedGapToolCount") == 35,
+        "qualification PR must not change trust accounting",
+        limitations,
+    )
+    record = limitations.get("coverageRecords", {}).get("manageModel", {})
+    require(
+        record.get("coverageStatus") == "CONFIRMED_GAP",
+        "manageModel must remain a gap until a later atomic promotion",
+        record,
+    )
+    require(
+        record.get("contractTrustAvailable") is False,
+        "qualification evidence was incorrectly presented as promoted trust",
+        record,
+    )
+
+
+def main():
+    client = McpClient()
+    model_id = None
+    try:
+        client.start()
+        process_definition = simple_process(client)
+        model_id = test_registration_is_idempotent(client, process_definition)
+        test_get_list_and_inspect(client, model_id)
+        test_handle_drives_canonical_process_and_read_routes(client, model_id)
+        test_revision_is_stable_and_visible(client, model_id, process_definition)
+        test_invalid_requests_fail_closed(client)
+        test_phase0_classification_remains_a_gap(client)
+        test_delete_invalidates_handle(client, model_id)
+        model_id = None
+    finally:
+        try:
+            if client.proc is not None and model_id is not None:
+                client.manage_model({"action": "delete", "modelId": model_id})
+        finally:
+            client.close()
+    print("manageModel real-MCP qualification: 7/7 scenarios passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/neqsim-mcp-server/test_model_registry_protocol.py
+++ b/neqsim-mcp-server/test_model_registry_protocol.py
@@ -373,7 +373,7 @@ def test_phase0_classification_remains_a_gap(client):
         record,
     )
     require(
-        record.get("contractTrustAvailable") is False,
+        record.get("toolSpecificTrustAvailable") is False,
         "qualification evidence was incorrectly presented as promoted trust",
         record,
     )


### PR DESCRIPTION
## Summary

Advances #3153 Phase 0 from exact current-master base `4b0b533c5066ece83119bd36728f010ee24b97c4` to exact head `2720e94f4ae63fcd8deebdd2675f02ca3edffdc3` by adding direct Java-21 and real packaged-MCP qualification for the existing reusable process-model registry introduced by merged #2875.

This increment qualifies the existing `manageModel` software contract without changing its trust classification. It reuses the canonical `ModelRegistry` plus normal `ProcessSystem` / `ProcessModel`, `runProcess`, and automation paths; it does not add an MCP-only simulator, alternate flowsheet representation, or specialist engineering implementation.

## Frozen scope

Exactly three files:

- `.github/workflows/mcp_protocol_qualification.yml`
- `neqsim-mcp-server/test_model_registry_protocol.py`
- `neqsim-mcp-server/docs/evidence/MODEL_REGISTRY_CONTRACT.md`

The hosted MCP qualification now runs the existing `ModelRegistryTest` explicitly under Java 21 and then a new focused packaged-STDIO harness before the authoritative comprehensive `test_mcp_server.py` regression.

## Packaged MCP evidence

The new harness obtains the canonical `process/simple-separation` example through MCP and freezes seven bounded scenarios:

1. register plus idempotent repeated registration;
2. `get`, caller-visible `list`, and structure-only `inspect`;
3. handle use through canonical `runProcess` and `listSimulationUnits`;
4. stable handle with monotonic revision and retained revised definition;
5. fail-closed invalid definition, unknown action, and unknown handle;
6. delete followed by rejection through both registry and process execution paths; and
7. preservation of current Phase 0 accounting.

Existing source-level `ModelRegistryTest` already covers registration/resolution, inline compatibility, content-addressed identity, revisioning, structure inspection, owner/tenant isolation, nested definitions, solved-model reuse, stale-solve invalidation, handle equivalence through process/automation runners, usage accounting, and deletion.

## Phase 0 / trust boundary

Merged #3322 is now on current `master` and establishes inventory **1.18 / 20 `EXPLICIT_TRUST` + 16 `CONTRACT_TESTED` + 35 `CONFIRMED_GAP`**. This qualification PR deliberately keeps that accounting unchanged and keeps `manageModel` as `CONFIRMED_GAP`.

A later atomic increment may promote `manageModel` to `CONTRACT_TESTED` only after this evidence merges and current master is re-audited. That later promotion must change the machine-readable coverage record and authoritative primary packaged-protocol accounting together on one exact validated head; no intermediate inconsistent 20/17/34 state is published here.

## Engineering and safety boundary

This is lifecycle, routing, isolation-source-regression, and packaged-transport evidence only. It does **not** establish thermodynamic or process numerical accuracy, convergence adequacy, mass/energy closure, facility fidelity, engineering applicability, persistence across MCP server restarts, distributed cache coherence, correctness of an external identity provider/authorization policy, live-plant authority, control permission, design certification, or accountable engineering approval.

`ModelRegistry` remains a bounded in-memory working set, not an engineering document archive. The source tests qualify owner/tenant isolation; the focused STDIO harness itself intentionally runs as one local caller.

Owner-roadmap boundaries remain unchanged: DEXPI/P&ID #2899, dynamics #2911, TP-flash/stability/performance #2937, and completed production optimization #2941 are not modified or duplicated.

## Validation status

**DRAFT — VALIDATION PENDING CI**

One local supporting check was run: Python syntax compilation of the new protocol harness passed. Local Maven/Java/JDK 21/Spotless/pre-commit/Javadocs and packaged-server execution were not run, so no such pass is claimed. Hosted exact-head GitHub CI is the authoritative validator.

The branch is one commit ahead and zero commits behind its exact base. The final pre-publication GitHub comparison reports exactly three changed files: 6 workflow additions, a 105-line evidence note, and a 407-line focused protocol harness.

## Documentation impact

Adds one bounded evidence note for the reusable model registry and strengthens the existing MCP qualification workflow. No public MCP tool name, argument schema, response envelope, process JSON grammar, numerical model, solver tolerance, security default, README/API invocation contract, or companion agent/skill handoff changes; no companion repository update is required.

## Stop boundary / next dependency

Stop before trust promotion, persistent model storage, distributed/multi-process registry design, facility calibration, numerical conservation qualification, plant-data writes, control commands, or owner-roadmap implementation.

After this evidence merges and current master is re-audited, the next dependency-ready Phase 0 step is an atomic `manageModel` classification promotion from **20/16/35 → 20/17/34**, but only if the exact merged evidence still supports it and all accounting paths move together.

AI-assisted contribution. No unrun check is claimed as passed.