### PR TITLE
fix(thermo): expose aqueous GE fugacity derivatives

### DIFF
--- a/docs/thermo/henry_law_reference.md
+++ b/docs/thermo/henry_law_reference.md
@@ -57,6 +57,32 @@ range. `getHenryCoefficientBarAllowExtrapolation` is deliberately named for
 reproducing guideline check values outside that range; GE and Pitzer fugacity
 paths never call it.
 
+### Analytical derivative contract
+
+For the implemented GE reference states,
+
+$\phi_i=\frac{\gamma_i H_i}{P}$
+
+for a Henry solute, or the corresponding solvent vapor-pressure expression.
+NeqSim therefore exposes the constant-composition analytical derivatives
+
+$\left(\frac{\partial\ln\phi_i}{\partial T}\right)_{P,\mathbf{x}}
+=\frac{\partial\ln\gamma_i}{\partial T}
+ +\frac{\partial\ln H_i}{\partial T},$
+
+and
+
+$\left(\frac{\partial\ln\phi_i}{\partial P}\right)_{T,\mathbf{x}}
+=\frac{\partial\ln\gamma_i}{\partial P}-\frac{1}{P}.$
+
+`SystemInterface.init(2)` and `init(3)` publish these values through
+`getdfugdt()`, `getdfugdp()`, and the Java/JPype
+`getProperty("logfugdT"|"logfugdP", component, phase)` adapter. Pressure is in
+bar, so the pressure derivative is in 1/bar. The (-1/P) term is the derivative
+of the explicit fugacity-coefficient denominator; it is not a Poynting
+correction. The IAPWS reference remains defined at water saturation, and no
+pressure-dependent partial-molar-volume model is implied.
+
 ### Versioned coefficient family
 
 The following values are transcribed from IAPWS G7-04 Tables 2 and 5. `A`, `B`,
@@ -147,7 +173,10 @@ mole-fraction-to-molality mapping, and exercises fail-closed behavior.
 regressions, including the dimensional identity, corrects the historic
 H2/He/Ar solvent classification in aqueous GE phases, and verifies that an
 ionic Pitzer topology without a qualified neutral family remains on one
-deterministic compatibility path even at trace ionic strength. The
+deterministic compatibility path even at trace ionic strength. It also checks
+the system-level `init(2)` derivative dispatch against an IAPWS analytical
+temperature derivative and a centered pressure finite difference, including
+changed-state, return-state, clone, and Java/JPype property access. The
 system-level Pitzer regression verifies the explicit molality conversion,
 including the fixed IAPWS water molar mass. The dimensional identity is
 

--- a/docs/thermo/henry_law_reference.md
+++ b/docs/thermo/henry_law_reference.md
@@ -66,19 +66,16 @@ $\phi_i=\frac{\gamma_i H_i}{P}$
 for a Henry solute, or the corresponding solvent vapor-pressure expression.
 NeqSim therefore exposes the constant-composition analytical derivatives
 
-$\left(\frac{\partial\ln\phi_i}{\partial T}\right)_{P,\mathbf{x}}
-=\frac{\partial\ln\gamma_i}{\partial T}
- +\frac{\partial\ln H_i}{\partial T},$
+$\left(\frac{\partial\ln\phi_i}{\partial T}\right)_{P,\mathbf{x}}=\frac{\partial\ln\gamma_i}{\partial T}+\frac{\partial\ln H_i}{\partial T}$
 
 and
 
-$\left(\frac{\partial\ln\phi_i}{\partial P}\right)_{T,\mathbf{x}}
-=\frac{\partial\ln\gamma_i}{\partial P}-\frac{1}{P}.$
+$\left(\frac{\partial\ln\phi_i}{\partial P}\right)_{T,\mathbf{x}}=\frac{\partial\ln\gamma_i}{\partial P}-\frac{1}{P}$
 
 `SystemInterface.init(2)` and `init(3)` publish these values through
 `getdfugdt()`, `getdfugdp()`, and the Java/JPype
 `getProperty("logfugdT"|"logfugdP", component, phase)` adapter. Pressure is in
-bar, so the pressure derivative is in 1/bar. The (-1/P) term is the derivative
+bar, so the pressure derivative is in 1/bar. The `-1/P` term is the derivative
 of the explicit fugacity-coefficient denominator; it is not a Poynting
 correction. The IAPWS reference remains defined at water saturation, and no
 pressure-dependent partial-molar-volume model is implied.

--- a/src/main/java/neqsim/thermo/component/ComponentGE.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGE.java
@@ -167,16 +167,32 @@ public abstract class ComponentGE extends Component implements ComponentGEInterf
         && phase.hasComponent("water");
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public double logfugcoefdP(PhaseInterface phase) {
+    return fugcoefDiffPres(phase);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double logfugcoefdT(PhaseInterface phase) {
+    return fugcoefDiffTemp(phase);
+  }
+
   /**
-   * fugcoefDiffPres.
+   * Calculates the analytical pressure derivative of the logarithmic GE fugacity coefficient.
    *
-   * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
-   * @return a double
+   * <p>
+   * Every GE reference implemented here has {@code phi = gamma * reference / P}. With no Poynting correction in the
+   * model, the pressure derivative is therefore {@code d(ln gamma)/dP - 1/P}. A future pressure-dependent reference
+   * must add its own derivative without removing the explicit denominator term.
+   * </p>
+   *
+   * @param phase phase containing pressure in bar
+   * @return d(ln(phi))/dP in 1/bar
    */
   public double fugcoefDiffPres(PhaseInterface phase) {
-    // double temperature = phase.getTemperature(), pressure = phase.getPressure();
-    // int numberOfComponents = phase.getNumberOfComponents();
-    dfugdp = 0.0; // forelopig uten pointing
+    dfugdp = dlngammadp - 1.0 / phase.getPressure();
     return dfugdp;
   }
 

--- a/src/main/java/neqsim/thermo/component/ComponentInterface.java
+++ b/src/main/java/neqsim/thermo/component/ComponentInterface.java
@@ -412,10 +412,10 @@ public interface ComponentInterface extends ThermodynamicConstantsInterface, Clo
       double pressure);
 
   /**
-   * logfugcoefdT.
+   * Returns the temperature derivative of the logarithmic fugacity coefficient.
    *
-   * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
-   * @return a double
+   * @param phase phase at the evaluation state
+   * @return d(ln(phi))/dT in 1/K
    */
   public double logfugcoefdT(PhaseInterface phase);
 
@@ -429,10 +429,10 @@ public interface ComponentInterface extends ThermodynamicConstantsInterface, Clo
   public double logfugcoefdNi(PhaseInterface phase, int k);
 
   /**
-   * logfugcoefdP.
+   * Returns the pressure derivative of the logarithmic fugacity coefficient.
    *
-   * @param phase a {@link neqsim.thermo.phase.PhaseInterface} object
-   * @return a double
+   * @param phase phase at the evaluation state
+   * @return d(ln(phi))/dP in reciprocal pressure units used by the phase, normally 1/bar
    */
   public double logfugcoefdP(PhaseInterface phase);
 

--- a/src/test/java/neqsim/thermo/component/ComponentGEHenryDerivativeTest.java
+++ b/src/test/java/neqsim/thermo/component/ComponentGEHenryDerivativeTest.java
@@ -7,7 +7,7 @@ import neqsim.thermo.phase.PhaseInterface;
 import neqsim.thermo.phase.PhasePitzer;
 import neqsim.thermo.system.SystemPitzer;
 
-/** Tests temperature derivatives of aqueous Henry-reference fugacity coefficients. */
+/** Tests temperature and pressure derivatives of aqueous Henry-reference fugacity coefficients. */
 class ComponentGEHenryDerivativeTest {
   private static final double TEMPERATURE = 298.15;
 
@@ -20,8 +20,11 @@ class ComponentGEHenryDerivativeTest {
     double expected = finiteDifferenceLogHenry(component, TEMPERATURE);
 
     assertEquals(expected, component.fugcoefDiffTemp(phase), 1.0e-9);
+    assertEquals(expected, component.logfugcoefdT(phase), 1.0e-9);
     assertEquals(1200.0 / (TEMPERATURE * TEMPERATURE) + 1.5 / TEMPERATURE + 0.002, component.fugcoefDiffTemp(phase),
         1.0e-12);
+    phase.setPressure(10.0);
+    assertEquals(-0.1, component.logfugcoefdP(phase), 1.0e-15);
   }
 
   @Test
@@ -95,6 +98,60 @@ class ComponentGEHenryDerivativeTest {
         carbonDioxide.exposesLnHenryDerivative(unqualifiedBrine), 0.0);
     assertEquals(carbonDioxide.exposesLegacyHenry(TEMPERATURE), carbonDioxide.exposesEffectiveHenry(traceIonTopology),
         0.0);
+  }
+
+  @Test
+  void systemInitializationPublishesAndRefreshesAnalyticalDerivatives() {
+    SystemPitzer system = new SystemPitzer(TEMPERATURE, 10.0);
+    system.addComponent("water", 55.508);
+    system.addComponent("nitrogen", 1.0e-4);
+    system.setMixingRule("classic");
+    system.init(2);
+
+    PhaseInterface aqueous = system.getPhase(1);
+    ComponentInterface nitrogen = aqueous.getComponent("nitrogen");
+    ComponentInterface water = aqueous.getComponent("water");
+    double expectedTemperatureDerivative =
+        IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative("N2", TEMPERATURE);
+
+    assertEquals(expectedTemperatureDerivative, nitrogen.getdfugdt(), 1.0e-12);
+    assertEquals(-0.1, nitrogen.getdfugdp(), 1.0e-15);
+    assertEquals(-0.1, water.getdfugdp(), 1.0e-15);
+    assertEquals(nitrogen.getdfugdt(), system.getProperty("logfugdT", "nitrogen", 1), 0.0);
+    assertEquals(nitrogen.getdfugdp(), system.getProperty("logfugdP", "nitrogen", 1), 0.0);
+    assertEquals(nitrogen.getdfugdp(), centeredPressureDerivative((ComponentGE) nitrogen, aqueous), 2.0e-10);
+
+    system.setPressure(25.0);
+    system.setTemperature(318.15);
+    system.init(2);
+    aqueous = system.getPhase(1);
+    nitrogen = aqueous.getComponent("nitrogen");
+    assertEquals(IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative("N2", 318.15), nitrogen.getdfugdt(),
+        1.0e-12);
+    assertEquals(-0.04, nitrogen.getdfugdp(), 1.0e-15);
+
+    SystemPitzer cloned = system.clone();
+    cloned.init(2);
+    assertEquals(nitrogen.getdfugdt(), cloned.getPhase(1).getComponent("nitrogen").getdfugdt(), 0.0);
+    assertEquals(nitrogen.getdfugdp(), cloned.getPhase(1).getComponent("nitrogen").getdfugdp(), 0.0);
+
+    system.setPressure(10.0);
+    system.setTemperature(TEMPERATURE);
+    system.init(2);
+    assertEquals(expectedTemperatureDerivative, system.getPhase(1).getComponent("nitrogen").getdfugdt(), 1.0e-12);
+    assertEquals(-0.1, system.getPhase(1).getComponent("nitrogen").getdfugdp(), 1.0e-15);
+  }
+
+  private static double centeredPressureDerivative(ComponentGE component, PhaseInterface phase) {
+    double pressure = phase.getPressure();
+    double step = pressure * 1.0e-5;
+    phase.setPressure(pressure + step);
+    double plus = Math.log(component.fugcoef(phase));
+    phase.setPressure(pressure - step);
+    double minus = Math.log(component.fugcoef(phase));
+    phase.setPressure(pressure);
+    component.fugcoef(phase);
+    return (plus - minus) / (2.0 * step);
   }
 
   private static PhasePitzer phaseAt(double temperature) {

--- a/src/test/java/neqsim/thermo/component/ComponentGEHenryDerivativeTest.java
+++ b/src/test/java/neqsim/thermo/component/ComponentGEHenryDerivativeTest.java
@@ -111,8 +111,7 @@ class ComponentGEHenryDerivativeTest {
     PhaseInterface aqueous = system.getPhase(1);
     ComponentInterface nitrogen = aqueous.getComponent("nitrogen");
     ComponentInterface water = aqueous.getComponent("water");
-    double expectedTemperatureDerivative =
-        IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative("N2", TEMPERATURE);
+    double expectedTemperatureDerivative = IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative("N2", TEMPERATURE);
 
     assertEquals(expectedTemperatureDerivative, nitrogen.getdfugdt(), 1.0e-12);
     assertEquals(-0.1, nitrogen.getdfugdp(), 1.0e-15);
@@ -126,8 +125,7 @@ class ComponentGEHenryDerivativeTest {
     system.init(2);
     aqueous = system.getPhase(1);
     nitrogen = aqueous.getComponent("nitrogen");
-    assertEquals(IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative("N2", 318.15), nitrogen.getdfugdt(),
-        1.0e-12);
+    assertEquals(IapwsHenryLaw.getLnHenryCoefficientTemperatureDerivative("N2", 318.15), nitrogen.getdfugdt(), 1.0e-12);
     assertEquals(-0.04, nitrogen.getdfugdp(), 1.0e-15);
 
     SystemPitzer cloned = system.clone();


### PR DESCRIPTION
## Engineering question

Can the analytical aqueous GE/Pitzer fugacity derivatives that NeqSim already calculates be exposed through the standard `init(2/3)` and Java/JPype property APIs, with the explicit `1/P` pressure term represented correctly?

Advances #3144.

## Frozen scope

- **Exact master/base:** `83432c868043ae0adfb45bc630f3b22183fe85bd`
- **Exact head:** `4aa77fd6bcb60c05282a303ae87ca765d5759044`
- **Models:** aqueous excess-Gibbs components, including NRTL-style GE and Pitzer; IAPWS pure-water Henry reference where already qualified
- **Reference equations:** `phi = gamma * reference / P`; `d ln(phi)/dT = d ln(gamma)/dT + d ln(reference)/dT`; `d ln(phi)/dP = d ln(gamma)/dP - 1/P`
- **Units:** temperature K, pressure bar, derivatives 1/K and 1/bar
- **Composition basis:** existing GE mole-fraction reference and Pitzer molality adapter; no basis conversion changes
- **Reaction set:** none changed
- **Stop boundary:** no Poynting/partial-molar-volume model, parameter adoption, reaction constant, EOS mixing rule, flash topology, salt-input API, absorber equipment, or non-GE fugacity change

## Current-master reproducer

`SystemThermo.initAnalytic(2/3)` calls `logfugcoefdT` and `logfugcoefdP` for every component. `ComponentGE` did not override those methods, so it inherited the base implementation that stored and returned zero. Its separate `fugcoefDiffTemp` contained the corrected Henry derivative but was reached only by direct calls. `fugcoefDiffPres` also returned zero although every implemented GE fugacity coefficient contains an explicit `1/P` denominator.

## Implementation

- Dispatches the standard logarithmic derivative methods to the existing GE analytical derivative path.
- Includes `dlngammadp - 1/P`; this is the derivative of the explicit denominator and is not a Poynting correction.
- Documents derivative semantics and units on the public component interface.
- Adds system-level GE/Pitzer regression coverage for IAPWS N2, solvent water, centered pressure finite difference, changed and returned T/P state, clone behavior, and Java/JPype `getProperty` access.
- Updates the Henry reference guide with the exact derivative contract and pressure-model limitation.

## Scientific evidence

The Henry reference remains IAPWS G7-04, based on Fernandez-Prini, Alvarez and Harvey, [DOI 10.1063/1.1564818](https://doi.org/10.1063/1.1564818). No coefficient or experimental table is added. The new pressure result follows directly from differentiating the already implemented `gamma * reference / P` expression at constant composition.

Kaasa (1998) remains a Pitzer-parameter provenance index only. No Kaasa value was inferred, OCRed, copied, mapped, or adopted. The existing source-comparison matrices remain [Henry evidence](https://github.com/equinor/neqsim/blob/83432c868043ae0adfb45bc630f3b22183fe85bd/docs/thermo/henry_law_reference.md) and [Pitzer provenance](https://github.com/equinor/neqsim/blob/83432c868043ae0adfb45bc630f3b22183fe85bd/docs/thermo/pitzer_parameter_provenance.md).

## Acceptance and validation

Focused tests require:

- analytical IAPWS `d ln(H)/dT` to be published by `init(2)` within `1e-12 1/K`;
- `d ln(phi)/dP = -1/P` for pressure-independent gamma within `1e-15 1/bar`;
- agreement with a centered pressure finite difference within `2e-10 1/bar`;
- changed-state, return-state, cloned-state, and public-property access consistency.

Production fugacity/activity kernels are unchanged. The only additional work is in already-requested derivative initialization, so ordinary `init(0/1)`, TP flashes, and neutral SRK/PR/CPA paths add no calls or branches.

## Documentation impact

Updated public derivative Javadocs and `docs/thermo/henry_law_reference.md`. No user example is added; no documentation code snippet requires a separate compilation fixture.

## Validation status

**READY TO MERGE — exact head `4aa77fd6bcb60c05282a303ae87ca765d5759044`**

On exact head `4aa77fd6bcb60c05282a303ae87ca765d5759044`, documentation search, PaperLab, Spotless, pre-commit, CodeQL (including Maven compilation), Java 21 Javadocs, agent-skill reference checks, Java 21 Ubuntu/Windows fast suites, all four Java 21 slow-test shards, and Java 8 Ubuntu/Windows suites pass. The PR is mergeable and remains draft. Reviews=0, PR comments=0, unresolved review threads=0.

The repository's `PitzerCatalogPerformanceBenchmark` was compiled from the exact head and executed on OpenJDK 17.0.20 with the exact electrolyte source/data overlay on the published 3.18.0 runtime. It completed the Pitzer kernel, complete aqueous properties, reactive H2S equilibrium, and neutral SRK control. Representative exact-head results were: IAPWS value-plus-derivative kernel 555 ns; Pitzer catalog kernel 36,375 ns; complete aqueous properties 838,392 ns; reactive-H2S equilibrium 215.53 ms; reaction residual `4.26e-14`; elemental residual `1.19e-13`; normalized charge residual `1.59e-10`; and neutral-SRK loaded/control ratio 0.613.

A five-process paired exact-base/exact-head benchmark used 21 within-process median samples after warmup. Median paired ratios were 0.8030 for the unchanged Pitzer kernel (no slowdown), 0.9988 for neutral SRK (−0.12%, within the 1% control target), and 1.1498 for complete Pitzer `init(3)` (+14.98%). The `init(3)` cost is explicitly justified: this level requests fugacity derivatives, and the base returned incorrect zeros while the head performs the newly exposed analytical GE derivative work. Ordinary `init(0/1)`, TP-flash paths using those levels, and neutral PR/SRK/CPA component classes do not enter this dispatch. Production fugacity/activity kernels and all parameter values remain unchanged.

No merge, auto-merge, ready-for-review transition, force-push, master write, generic #2937 flash change, #205 absorber change, or #448 salt-input change is authorized.

AI-Assisted-by: OpenAI Codex