### PR TITLE
[AI-Assisted] test(refinery): qualify DOE atmospheric fractionation integration

### DIFF
--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -52,7 +52,7 @@ For crude/petroleum assays, use `OilAssayCharacterisation` rather than manually 
 - preserved lower/upper boiling ranges;
 - closure, duplicate-name, monotonicity, and repeated-application guards.
 
-See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation).
+See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data bookkeeping evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation), while the next process-integration gate is documented in [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation).
 
 ## TBP fraction models
 
@@ -136,6 +136,7 @@ A bookkeeping regression does not by itself validate a petroleum-property correl
 
 - [Refinery Assay and TBP Cut Characterization](refinery_assay)
 - [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation)
+- [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation)
 - [Fluid Characterization Guide](../../wiki/fluid_characterization)
 - [TBP Fraction Models](../../wiki/tbp_fraction_models)
 - [PVT Fluid Characterization](../pvt_fluid_characterization)

--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -93,6 +93,8 @@ assay.apply();
 
 This creates `TBP1_PC` through `TBP4_PC`. Each `AssayCut` retains its lower and upper TBP boundaries. The interval midpoint is used as the representative boiling temperature for the existing NeqSim molecular-weight/petroleum-property correlation.
 
+When molecular weight is not supplied, the inverse petroleum correlation first produces a g/mol-sized value and `OilAssayCharacterisation` converts it to kg/mol before creating the pseudo-component. This unit conversion is part of the assay API contract; generated refinery cuts must not be passed to `addTBPfraction(...)` with g/mol interpreted as kg/mol.
+
 The input is required to span 0 to 100 liquid-volume percent with strictly increasing yield and temperature boundaries. This is deliberate: the method represents a complete, already-TBP cut table and does not invent unmeasured light or residue tails.
 
 ## Volume-basis conversion
@@ -148,6 +150,7 @@ The regression suite for this API currently verifies:
 - mass-basis cut conversion;
 - volume-to-mass conversion and closure;
 - kg/mol and g/mol explicit molar-mass input;
+- kg/mol scaling of molar mass inferred from boiling point and density;
 - kg/m3 density normalization;
 - API-gravity handling, including negative API gravity;
 - rounding-scale closure versus incomplete-assay rejection;

--- a/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
+++ b/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
@@ -38,7 +38,7 @@ Accordingly, this is an **integration and numerical-robustness qualification**, 
 1. Build an SRK system from the normalized measured DOE mass yields, cut specific gravities, and finite boiling ranges using `OilAssayCharacterisation`.
 2. Generate the five real NeqSim TBP pseudo-components.
 3. Feed the resulting broad-boiling slate to an eight-tray `DistillationColumn` with a reboiler, partial condenser, and one liquid side draw.
-4. Solve at near-atmospheric pressure with the `AUTO` column solver.
+4. Solve at near-atmospheric pressure with the simultaneous `NAPHTALI_SANDHOLM` column solver; guarded fallback products are not accepted.
 5. Re-run the same initialized column to qualify repeatability rather than accepting a one-off solution.
 
 The operating point is deliberately a reproducible **screening case**, not a reconstruction of a proprietary or historical refinery design:

--- a/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
+++ b/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
@@ -1,0 +1,100 @@
+---
+title: "DOE Big Hill atmospheric fractionation qualification"
+description: "Rigorous-column integration benchmark for the bounded DOE Big Hill Sweet refinery-assay slice."
+---
+
+# DOE Big Hill atmospheric fractionation qualification
+
+Issue #3305 separates refinery validation into explicit quality gates. The first DOE Big Hill increment qualified refinery-assay bookkeeping. This benchmark advances the next gate by sending the same public assay basis through NeqSim's rigorous `DistillationColumn` and checking process-level conservation, boiling-order separation, and repeatability.
+
+## Public source and evidence boundary
+
+The source is the U.S. Department of Energy Strategic Petroleum Reserve **Big Hill Sweet**, sample **MLI 009**, assay date **1998-05-04**:
+
+- GovInfo SPR Crude Oil Comprehensive Analysis: <https://www.govinfo.gov/content/pkg/CFR-2000-title10-vol4/pdf/CFR-2000-title10-vol4-part625-appA.pdf>
+- DOE SPR *Crude Oil Assay Manual*, 5th edition, 1 August 2024: <https://www.spr.doe.gov/reports/docs/CrudeOilAssayManual.pdf>
+- DOE SPR assay landing page: <https://www.spr.doe.gov/reports/Crude_Oil_Assays.html>
+
+The DOE manual documents ASTM D2892 atmospheric/light-vacuum distillation followed by D5236 for the residuum. It states that the distillation fractions are measured on a mass-percent basis and that volume-percent values are calculated using each fraction's specific gravity.
+
+This benchmark uses the **measured mass-yield basis** for the five intervals that have finite lower and upper boiling boundaries in the public table:
+
+| Cut range (degF) | Weight % of whole assay | SG 60/60 F |
+| --- | ---: | ---: |
+| 175-250 | 8.6 | 0.7815 |
+| 250-375 | 15.2 | 0.8305 |
+| 375-530 | 15.2 | 0.8623 |
+| 530-650 | 11.1 | 0.9226 |
+| 650-1050 | 30.3 | 0.9477 |
+
+The five bounded cuts are normalized on their own basis. The C5-/175 degF light tail and 1050 degF+ vacuum residuum are **not** included because assigning finite boiling limits to those open-ended fractions would invent data that the published table does not provide.
+
+Accordingly, this is an **integration and numerical-robustness qualification**, not an independent validation of full crude-column product yields. It does not claim that the normalized five-cut slate represents the complete Big Hill crude.
+
+## Column benchmark
+
+`DoeBigHillAtmosphericFractionationTest` performs the following workflow using public NeqSim APIs:
+
+1. Build an SRK system from the normalized measured DOE mass yields, cut specific gravities, and finite boiling ranges using `OilAssayCharacterisation`.
+2. Generate the five real NeqSim TBP pseudo-components.
+3. Feed the resulting broad-boiling slate to an eight-tray `DistillationColumn` with a reboiler, partial condenser, and one liquid side draw.
+4. Solve at near-atmospheric pressure with the `AUTO` column solver.
+5. Re-run the same initialized column to qualify repeatability rather than accepting a one-off solution.
+
+The operating point is deliberately a reproducible **screening case**, not a reconstruction of a proprietary or historical refinery design:
+
+| Quantity | Benchmark value |
+| --- | ---: |
+| Feed flow | 5000 kg/h |
+| Feed temperature | 550 K |
+| Feed pressure | 1.5 bara |
+| Internal trays | 8 |
+| Feed tray | 4, bottom-up |
+| Top pressure | 1.2 bara |
+| Bottom pressure | 1.5 bara |
+| Condenser temperature | 360 K |
+| Reboiler temperature | 690 K |
+| Condenser reflux ratio | 1.0 |
+| Liquid side draw | 10% of tray-5 liquid traffic |
+
+No tuning to a commercial process simulator is used.
+
+## Acceptance contract
+
+The regression requires all of the following on each accepted solve:
+
+- the column reports a solved state;
+- overhead, liquid side draw, and bottoms are finite and strictly positive;
+- external mass closure is within **5%**;
+- `DistillationColumn.getMassBalanceError()` is finite and no greater than **5%**;
+- `DistillationColumn.getEnergyBalanceError()` is finite and no greater than **5%**, with the energy-balance convergence gate enabled;
+- every pseudo-component closes across overhead + side draw + bottoms within **5%** on a molar-flow basis;
+- the lightest bounded DOE cut is enriched in overhead relative to bottoms;
+- the heaviest bounded DOE cut is enriched in bottoms relative to overhead;
+- composition-weighted representative boiling points order as **overhead < side draw < bottoms**;
+- repeated-solve product mass flows and representative boiling points agree within **1%**;
+- the JUnit benchmark has a 120 s upper execution bound to fail closed on pathological solver stalls without treating shared-runner wall time as a performance claim.
+
+The 5% process-balance gates are screening tolerances for this first broad-boiling integration case. They are intentionally much looser than the `1e-10` pseudo-component creation mass-closure gate because the column itself is an iterative process solver. Tighter refinery-specific balance gates should be introduced only after this public heavy-slate case establishes a stable baseline.
+
+## What this benchmark advances
+
+This increment exercises, in one regression:
+
+`DOE assay facts -> OilAssayCharacterisation -> TBP pseudo-components -> Stream -> rigorous DistillationColumn -> three refinery-style product draws`
+
+That closes an important integration gap between the characterization foundation and the refinery fractionation workstream. It also protects against future changes that would make heavy pseudo-components impossible to use in a near-atmospheric column even when assay bookkeeping still passes.
+
+## Remaining scientific gaps
+
+This benchmark does **not** validate:
+
+- the omitted light-end and 1050 degF+ tails;
+- generated pseudo-component molecular weights, critical properties, or acentric factors against independent laboratory property data;
+- full-crude atmospheric product yields or cut-point recovery;
+- pump-around heat duties, side strippers, or a refinery preheat/furnace train;
+- vacuum fractionation;
+- ASTM D86/D1160-to-TBP conversions;
+- refinery conversion units.
+
+The next dependency-ready refinery increment should ingest a complete openly reproducible assay representation with defensible light/residue treatment and compare atmospheric product yields/boiling ranges against independent public evidence. Only after that gate should #3305 advance to vacuum fractionation or conversion-unit models.

--- a/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
+++ b/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
@@ -38,7 +38,7 @@ Accordingly, this is an **integration and numerical-robustness qualification**, 
 1. Build an SRK system from the normalized measured DOE mass yields, cut specific gravities, and finite boiling ranges using `OilAssayCharacterisation`.
 2. Generate the five real NeqSim TBP pseudo-components.
 3. Feed the resulting broad-boiling slate to an eight-tray `DistillationColumn` with a reboiler, partial condenser, and one liquid side draw.
-4. Seed the interior stages with a linear 690-to-360 K bottom-up temperature profile, then solve at near-atmospheric pressure with the simultaneous `NAPHTALI_SANDHOLM` column solver; guarded fallback products are not accepted.
+4. Solve at near-atmospheric pressure with the residual-monitored `MESH_RESIDUAL` column solver; the solved state must satisfy the active full-MESH residual gate and guarded fallback products are not accepted.
 5. Re-run the same initialized column to qualify repeatability rather than accepting a one-off solution.
 
 The operating point is deliberately a reproducible **screening case**, not a reconstruction of a proprietary or historical refinery design:
@@ -54,17 +54,17 @@ The operating point is deliberately a reproducible **screening case**, not a rec
 | Bottom pressure | 1.5 bara |
 | Condenser temperature | 360 K |
 | Reboiler temperature | 690 K |
-| Interior temperature seeds | Linear from 690 K at the bottom to 360 K at the top |
 | Condenser reflux ratio | 1.0 |
 | Liquid side draw | 10% of tray-5 liquid traffic |
 
-The seed profile is only a deterministic initial guess for the simultaneous solver; it does not pin interior tray temperatures or replace their energy balances. No tuning to a commercial process simulator is used.
+`MESH_RESIDUAL` uses inside-out initialization followed by rigorous residual monitoring. Interior tray temperatures remain solver variables governed by the stage energy balances. No tuning to a commercial process simulator is used.
 
 ## Acceptance contract
 
 The regression requires all of the following on each accepted solve:
 
-- the column reports a solved state;
+- the column reports a solved state from `MESH_RESIDUAL`, not guarded fallback products;
+- the full MESH infinity norm satisfies the solver's active residual tolerance;
 - overhead, liquid side draw, and bottoms are finite and strictly positive;
 - external mass closure is within **5%**;
 - `DistillationColumn.getMassBalanceError()` is finite and no greater than **5%**;

--- a/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
+++ b/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
@@ -37,7 +37,7 @@ Accordingly, this is an **integration and numerical-robustness qualification**, 
 
 1. Build an SRK system from the normalized measured DOE mass yields, cut specific gravities, and finite boiling ranges using `OilAssayCharacterisation`.
 2. Generate the five real NeqSim TBP pseudo-components.
-3. Feed the resulting broad-boiling slate to an eight-tray `DistillationColumn` with a reboiler, total condenser, and one liquid side draw.
+3. Feed the resulting broad-boiling slate to an eight-tray `DistillationColumn` with a reboiler, partial condenser, and one liquid side draw.
 4. Solve at near-atmospheric pressure with the residual-monitored `MESH_RESIDUAL` column solver; the solved state must satisfy the active full-MESH residual gate and guarded fallback products are not accepted.
 5. Re-run the same initialized column to qualify repeatability rather than accepting a one-off solution.
 
@@ -52,13 +52,13 @@ The operating point is deliberately a reproducible **screening case**, not a rec
 | Feed tray | 4, bottom-up |
 | Top pressure | 1.2 bara |
 | Bottom pressure | 1.5 bara |
-| Condenser mode | Total |
-| Condenser temperature | 420 K |
-| Reboiler temperature | 690 K |
+| Condenser mode | Partial |
+| Condenser temperature | Solved; no fixed set point |
+| Reboiler temperature | 600 K |
 | Condenser reflux ratio | 1.0 |
-| Liquid side draw | 10% of tray-5 liquid traffic |
+| Liquid side draw | 10% of tray-4 liquid traffic |
 
-All five bounded DOE fractions are condensable petroleum cuts, so the benchmark uses a total condenser and returns part of the liquid condensate as reflux rather than requiring a noncondensed vapor overhead. The 420 K set point lies between the representative normal-boiling temperatures of the first two bounded cuts (373.4 K and 429.0 K), preserving a physically ordered screening split.
+The condenser remains partial and no fixed condenser-temperature specification is imposed. Top pressure and reflux ratio define the terminal controls while the top temperature remains a solved equilibrium/energy-balance result. Fixing both condenser temperature and reflux ratio overconstrains this broad-boiling screening case and can leave a thermally converged-looking profile with open tray material balances. The 600 K equilibrium-reboiler set point lies inside the bounded assay range and below the representative normal-boiling temperature of the heaviest cut, preserving both vapor traffic and a positive heavy bottoms product.
 
 `MESH_RESIDUAL` uses inside-out initialization followed by rigorous residual monitoring. Interior tray temperatures remain solver variables governed by the stage energy balances. No tuning to a commercial process simulator is used.
 
@@ -68,6 +68,7 @@ The regression requires all of the following on each accepted solve:
 
 - the column reports a solved state from `MESH_RESIDUAL`, not guarded fallback products;
 - the full MESH infinity norm satisfies the solver's active residual tolerance;
+- the maximum normalized per-tray component material imbalance satisfies the column's dedicated tolerance;
 - overhead, liquid side draw, and bottoms are finite and strictly positive;
 - external mass closure is within **5%**;
 - `DistillationColumn.getMassBalanceError()` is finite and no greater than **5%**;

--- a/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
+++ b/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
@@ -52,10 +52,12 @@ The operating point is deliberately a reproducible **screening case**, not a rec
 | Feed tray | 4, bottom-up |
 | Top pressure | 1.2 bara |
 | Bottom pressure | 1.5 bara |
-| Condenser temperature | 360 K |
+| Condenser temperature | 420 K |
 | Reboiler temperature | 690 K |
 | Condenser reflux ratio | 1.0 |
 | Liquid side draw | 10% of tray-5 liquid traffic |
+
+The 420 K partial-condenser set point lies between the representative normal-boiling temperatures of the first two bounded cuts (373.4 K and 429.0 K). This avoids the sub-light-cut 360 K condition that collapsed the vapor-overhead initialization into guarded fallback products while preserving a physically ordered separation target.
 
 `MESH_RESIDUAL` uses inside-out initialization followed by rigorous residual monitoring. Interior tray temperatures remain solver variables governed by the stage energy balances. No tuning to a commercial process simulator is used.
 

--- a/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
+++ b/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
@@ -37,7 +37,7 @@ Accordingly, this is an **integration and numerical-robustness qualification**, 
 
 1. Build an SRK system from the normalized measured DOE mass yields, cut specific gravities, and finite boiling ranges using `OilAssayCharacterisation`.
 2. Generate the five real NeqSim TBP pseudo-components.
-3. Feed the resulting broad-boiling slate to an eight-tray `DistillationColumn` with a reboiler, partial condenser, and one liquid side draw.
+3. Feed the resulting broad-boiling slate to an eight-tray `DistillationColumn` with a reboiler, total condenser, and one liquid side draw.
 4. Solve at near-atmospheric pressure with the residual-monitored `MESH_RESIDUAL` column solver; the solved state must satisfy the active full-MESH residual gate and guarded fallback products are not accepted.
 5. Re-run the same initialized column to qualify repeatability rather than accepting a one-off solution.
 
@@ -52,12 +52,13 @@ The operating point is deliberately a reproducible **screening case**, not a rec
 | Feed tray | 4, bottom-up |
 | Top pressure | 1.2 bara |
 | Bottom pressure | 1.5 bara |
+| Condenser mode | Total |
 | Condenser temperature | 420 K |
 | Reboiler temperature | 690 K |
 | Condenser reflux ratio | 1.0 |
 | Liquid side draw | 10% of tray-5 liquid traffic |
 
-The 420 K partial-condenser set point lies between the representative normal-boiling temperatures of the first two bounded cuts (373.4 K and 429.0 K). This avoids the sub-light-cut 360 K condition that collapsed the vapor-overhead initialization into guarded fallback products while preserving a physically ordered separation target.
+All five bounded DOE fractions are condensable petroleum cuts, so the benchmark uses a total condenser and returns part of the liquid condensate as reflux rather than requiring a noncondensed vapor overhead. The 420 K set point lies between the representative normal-boiling temperatures of the first two bounded cuts (373.4 K and 429.0 K), preserving a physically ordered screening split.
 
 `MESH_RESIDUAL` uses inside-out initialization followed by rigorous residual monitoring. Interior tray temperatures remain solver variables governed by the stage energy balances. No tuning to a commercial process simulator is used.
 

--- a/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
+++ b/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
@@ -38,7 +38,7 @@ Accordingly, this is an **integration and numerical-robustness qualification**, 
 1. Build an SRK system from the normalized measured DOE mass yields, cut specific gravities, and finite boiling ranges using `OilAssayCharacterisation`.
 2. Generate the five real NeqSim TBP pseudo-components.
 3. Feed the resulting broad-boiling slate to an eight-tray `DistillationColumn` with a reboiler, partial condenser, and one liquid side draw.
-4. Solve at near-atmospheric pressure with the simultaneous `NAPHTALI_SANDHOLM` column solver; guarded fallback products are not accepted.
+4. Seed the interior stages with a linear 690-to-360 K bottom-up temperature profile, then solve at near-atmospheric pressure with the simultaneous `NAPHTALI_SANDHOLM` column solver; guarded fallback products are not accepted.
 5. Re-run the same initialized column to qualify repeatability rather than accepting a one-off solution.
 
 The operating point is deliberately a reproducible **screening case**, not a reconstruction of a proprietary or historical refinery design:
@@ -54,10 +54,11 @@ The operating point is deliberately a reproducible **screening case**, not a rec
 | Bottom pressure | 1.5 bara |
 | Condenser temperature | 360 K |
 | Reboiler temperature | 690 K |
+| Interior temperature seeds | Linear from 690 K at the bottom to 360 K at the top |
 | Condenser reflux ratio | 1.0 |
 | Liquid side draw | 10% of tray-5 liquid traffic |
 
-No tuning to a commercial process simulator is used.
+The seed profile is only a deterministic initial guess for the simultaneous solver; it does not pin interior tray temperatures or replace their energy balances. No tuning to a commercial process simulator is used.
 
 ## Acceptance contract
 

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -40,6 +40,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
   private static final double ASSAY_CLOSURE_TOLERANCE = 1e-3;
   private static final double PERCENT_TOLERANCE = 1e-8;
   private static final double KELVIN_OFFSET = 273.15;
+  private static final double GRAMS_PER_KILOGRAM = 1000.0;
   private static final double WATER_DENSITY_60F_G_CC = 0.999016;
 
   private transient SystemInterface system;
@@ -767,7 +768,8 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
      *
      * <p>
      * If no explicit molar mass is stored, the existing NeqSim inverse petroleum correlation is used with density and
-     * representative boiling point.
+     * representative boiling point. The inverse petroleum correlation returns a g/mol-sized value, which is converted
+     * to the kg/mol unit required by {@link SystemInterface#addTBPfraction(String, double, double, double)}.
      * </p>
      *
      * @param density specific gravity / g/cm3 numeric value
@@ -783,7 +785,9 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
       }
       double exponent = 2.3776;
       double densityExponent = 0.9371;
-      return 5.805e-5 * Math.pow(boilingPointKelvin, exponent) / Math.pow(density, densityExponent);
+      double molarMassGramPerMol = 5.805e-5 * Math.pow(boilingPointKelvin, exponent)
+          / Math.pow(density, densityExponent);
+      return molarMassGramPerMol / GRAMS_PER_KILOGRAM;
     }
 
     @Override

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
@@ -114,8 +114,8 @@ public class DoeBigHillAtmosphericFractionationTest {
     column.getReboiler().setOutTemperature(690.0);
     column.setCondenserRefluxRatio(1.0);
     column.setLiquidSideDrawFraction(SIDE_DRAW_TRAY, 0.10);
-    column.setSolverType(DistillationColumn.SolverType.AUTO);
-    column.setMaxNumberOfIterations(160);
+    column.setSolverType(DistillationColumn.SolverType.NAPHTALI_SANDHOLM);
+    column.setMaxNumberOfIterations(300);
     column.setTemperatureTolerance(0.20);
     column.setMassBalanceTolerance(BALANCE_TOLERANCE);
     column.setEnthalpyBalanceTolerance(BALANCE_TOLERANCE);

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
@@ -38,8 +38,6 @@ public class DoeBigHillAtmosphericFractionationTest {
   private static final double[] WEIGHT_PERCENT = { 8.6, 15.2, 15.2, 11.1, 30.3 };
   private static final double[] SPECIFIC_GRAVITY = { 0.7815, 0.8305, 0.8623, 0.9226, 0.9477 };
   private static final int SIDE_DRAW_TRAY = 5;
-  private static final double CONDENSER_TEMPERATURE_K = 360.0;
-  private static final double REBOILER_TEMPERATURE_K = 690.0;
   private static final double BALANCE_TOLERANCE = 5.0e-2;
   private static final double REPEAT_TOLERANCE = 1.0e-2;
 
@@ -57,7 +55,11 @@ public class DoeBigHillAtmosphericFractionationTest {
     column.run(UUID.randomUUID());
     double firstRunSeconds = (System.nanoTime() - startNanos) / 1.0e9;
 
-    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    String firstRunDiagnostics = column.getConvergenceDiagnostics();
+    assertTrue(column.solved(), firstRunDiagnostics);
+    assertEquals(DistillationColumn.SolverType.MESH_RESIDUAL, column.getLastSolverTypeUsed(), firstRunDiagnostics);
+    assertNotEquals(DistillationColumn.SolveStatus.FALLBACK_PRODUCTS, column.getLastSolveStatus(), firstRunDiagnostics);
+    assertTrue(column.getLastMeshResidualNorm() <= column.getMeshResidualTolerance(), firstRunDiagnostics);
     assertTrue(Double.isFinite(firstRunSeconds) && firstRunSeconds >= 0.0);
     assertPhysicalProductsAndBalances(column, feed);
 
@@ -74,7 +76,12 @@ public class DoeBigHillAtmosphericFractionationTest {
 
     column.run(UUID.randomUUID());
 
-    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    String repeatedRunDiagnostics = column.getConvergenceDiagnostics();
+    assertTrue(column.solved(), repeatedRunDiagnostics);
+    assertEquals(DistillationColumn.SolverType.MESH_RESIDUAL, column.getLastSolverTypeUsed(), repeatedRunDiagnostics);
+    assertNotEquals(DistillationColumn.SolveStatus.FALLBACK_PRODUCTS, column.getLastSolveStatus(),
+        repeatedRunDiagnostics);
+    assertTrue(column.getLastMeshResidualNorm() <= column.getMeshResidualTolerance(), repeatedRunDiagnostics);
     assertPhysicalProductsAndBalances(column, feed);
     assertRelativeRepeat(firstOverheadMassFlow, overhead.getFlowRate("kg/hr"));
     assertRelativeRepeat(firstSideDrawMassFlow, sideDraw.getFlowRate("kg/hr"));
@@ -112,28 +119,17 @@ public class DoeBigHillAtmosphericFractionationTest {
     column.addFeedStream(feed, 4);
     column.setTopPressure(1.2);
     column.setBottomPressure(1.5);
-    column.getCondenser().setOutTemperature(CONDENSER_TEMPERATURE_K);
-    column.getReboiler().setOutTemperature(REBOILER_TEMPERATURE_K);
-    seedInteriorStageTemperatures(column);
+    column.getCondenser().setOutTemperature(360.0);
+    column.getReboiler().setOutTemperature(690.0);
     column.setCondenserRefluxRatio(1.0);
     column.setLiquidSideDrawFraction(SIDE_DRAW_TRAY, 0.10);
-    column.setSolverType(DistillationColumn.SolverType.NAPHTALI_SANDHOLM);
+    column.setSolverType(DistillationColumn.SolverType.MESH_RESIDUAL);
     column.setMaxNumberOfIterations(300);
     column.setTemperatureTolerance(0.20);
     column.setMassBalanceTolerance(BALANCE_TOLERANCE);
     column.setEnthalpyBalanceTolerance(BALANCE_TOLERANCE);
     column.setEnforceEnergyBalanceTolerance(true);
     return column;
-  }
-
-  private static void seedInteriorStageTemperatures(DistillationColumn column) {
-    int topStage = column.getNumberOfTrays() - 1;
-    for (int stage = 1; stage < topStage; stage++) {
-      double heightFraction = stage / (double) topStage;
-      double seedTemperature = REBOILER_TEMPERATURE_K
-          + heightFraction * (CONDENSER_TEMPERATURE_K - REBOILER_TEMPERATURE_K);
-      column.setSeedTemperature(stage, seedTemperature);
-    }
   }
 
   private static void assertPhysicalProductsAndBalances(DistillationColumn column, Stream feed) {

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
@@ -119,7 +119,7 @@ public class DoeBigHillAtmosphericFractionationTest {
     column.addFeedStream(feed, 4);
     column.setTopPressure(1.2);
     column.setBottomPressure(1.5);
-    column.getCondenser().setOutTemperature(360.0);
+    column.getCondenser().setOutTemperature(420.0);
     column.getReboiler().setOutTemperature(690.0);
     column.setCondenserRefluxRatio(1.0);
     column.setLiquidSideDrawFraction(SIDE_DRAW_TRAY, 0.10);

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
@@ -19,31 +19,31 @@ import neqsim.thermo.system.SystemSrkEos;
  * Atmospheric-column integration qualification using the public DOE Big Hill Sweet assay basis.
  *
  * <p>
- * The source values are the bounded 175-1050 degF distillate slice from U.S. Department of Energy
- * Strategic Petroleum Reserve Big Hill Sweet sample MLI 009 (1998-05-04). The same frozen values are
- * independently qualified in {@code OilAssayCharacterisationDoeBigHillTest}. This test deliberately
- * excludes the unbounded light and residue tails rather than inventing boiling limits for them.
+ * The source values are the bounded 175-1050 degF distillate slice from U.S. Department of Energy Strategic Petroleum
+ * Reserve Big Hill Sweet sample MLI 009 (1998-05-04). The same frozen values are independently qualified in
+ * {@code OilAssayCharacterisationDoeBigHillTest}. This test deliberately excludes the unbounded light and residue tails
+ * rather than inventing boiling limits for them.
  * </p>
  *
  * <p>
- * This is an integration and numerical-robustness benchmark. It qualifies that the public assay basis
- * can be turned into pseudo-components and separated through NeqSim's rigorous column while preserving
- * material and energy closure, boiling-order separation, and repeatability. It is not an independent
- * validation of atmospheric crude-column product yields.
+ * This is an integration and numerical-robustness benchmark. It qualifies that the public assay basis can be turned
+ * into pseudo-components and separated through NeqSim's rigorous column while preserving material and energy closure,
+ * boiling-order separation, and repeatability. It is not an independent validation of atmospheric crude-column product
+ * yields.
  * </p>
  */
 public class DoeBigHillAtmosphericFractionationTest {
-  private static final double[] LOWER_BOUNDARY_F = {175.0, 250.0, 375.0, 530.0, 650.0};
-  private static final double[] UPPER_BOUNDARY_F = {250.0, 375.0, 530.0, 650.0, 1050.0};
-  private static final double[] WEIGHT_PERCENT = {8.6, 15.2, 15.2, 11.1, 30.3};
-  private static final double[] SPECIFIC_GRAVITY = {0.7815, 0.8305, 0.8623, 0.9226, 0.9477};
+  private static final double[] LOWER_BOUNDARY_F = { 175.0, 250.0, 375.0, 530.0, 650.0 };
+  private static final double[] UPPER_BOUNDARY_F = { 250.0, 375.0, 530.0, 650.0, 1050.0 };
+  private static final double[] WEIGHT_PERCENT = { 8.6, 15.2, 15.2, 11.1, 30.3 };
+  private static final double[] SPECIFIC_GRAVITY = { 0.7815, 0.8305, 0.8623, 0.9226, 0.9477 };
   private static final int SIDE_DRAW_TRAY = 5;
   private static final double BALANCE_TOLERANCE = 5.0e-2;
   private static final double REPEAT_TOLERANCE = 1.0e-2;
 
   /**
-   * Run a bounded public refinery-assay slate through an atmospheric fractionator and require physical,
-   * conservative, reproducible products.
+   * Run a bounded public refinery-assay slate through an atmospheric fractionator and require physical, conservative,
+   * reproducible products.
    */
   @Test
   @Timeout(value = 120, unit = TimeUnit.SECONDS)
@@ -92,8 +92,7 @@ public class DoeBigHillAtmosphericFractionationTest {
     for (int i = 0; i < WEIGHT_PERCENT.length; i++) {
       assay.addCut(new AssayCut("DOE_BH_" + (i + 2)).withMassFraction(WEIGHT_PERCENT[i] / weightSum)
           .withSpecificGravity(SPECIFIC_GRAVITY[i])
-          .withBoilingRangeCelsius(fahrenheitToCelsius(LOWER_BOUNDARY_F[i]),
-              fahrenheitToCelsius(UPPER_BOUNDARY_F[i])));
+          .withBoilingRangeCelsius(fahrenheitToCelsius(LOWER_BOUNDARY_F[i]), fahrenheitToCelsius(UPPER_BOUNDARY_F[i])));
     }
     assay.apply();
     crude.setMixingRule("classic");
@@ -107,8 +106,7 @@ public class DoeBigHillAtmosphericFractionationTest {
   }
 
   private static DistillationColumn createAtmosphericColumn(Stream feed) {
-    DistillationColumn column =
-        new DistillationColumn("DOE Big Hill atmospheric benchmark", 8, true, true);
+    DistillationColumn column = new DistillationColumn("DOE Big Hill atmospheric benchmark", 8, true, true);
     column.addFeedStream(feed, 4);
     column.setTopPressure(1.2);
     column.setBottomPressure(1.5);
@@ -138,8 +136,7 @@ public class DoeBigHillAtmosphericFractionationTest {
     assertTrue(Double.isFinite(overheadMassFlow) && overheadMassFlow > 0.0);
     assertTrue(Double.isFinite(sideDrawMassFlow) && sideDrawMassFlow > 0.0);
     assertTrue(Double.isFinite(bottomsMassFlow) && bottomsMassFlow > 0.0);
-    assertEquals(feedMassFlow, overheadMassFlow + sideDrawMassFlow + bottomsMassFlow,
-        BALANCE_TOLERANCE * feedMassFlow);
+    assertEquals(feedMassFlow, overheadMassFlow + sideDrawMassFlow + bottomsMassFlow, BALANCE_TOLERANCE * feedMassFlow);
     assertTrue(Double.isFinite(column.getMassBalanceError()));
     assertTrue(column.getMassBalanceError() <= BALANCE_TOLERANCE, column.getConvergenceDiagnostics());
     assertTrue(Double.isFinite(column.getEnergyBalanceError()));
@@ -169,8 +166,8 @@ public class DoeBigHillAtmosphericFractionationTest {
     assertNotEquals(DistillationColumn.SolveStatus.FAILED, column.getLastSolveStatus());
   }
 
-  private static void assertComponentMolarBalance(Stream feed, StreamInterface overhead,
-      StreamInterface sideDraw, StreamInterface bottoms) {
+  private static void assertComponentMolarBalance(Stream feed, StreamInterface overhead, StreamInterface sideDraw,
+      StreamInterface bottoms) {
     double feedFlow = feed.getFlowRate("mol/hr");
     double overheadFlow = overhead.getFlowRate("mol/hr");
     double sideDrawFlow = sideDraw.getFlowRate("mol/hr");
@@ -183,8 +180,7 @@ public class DoeBigHillAtmosphericFractionationTest {
     for (int componentIndex = 0; componentIndex < feedComposition.length; componentIndex++) {
       double feedComponentFlow = feedFlow * feedComposition[componentIndex];
       double productComponentFlow = overheadFlow * overheadComposition[componentIndex]
-          + sideDrawFlow * sideDrawComposition[componentIndex]
-          + bottomsFlow * bottomsComposition[componentIndex];
+          + sideDrawFlow * sideDrawComposition[componentIndex] + bottomsFlow * bottomsComposition[componentIndex];
       assertEquals(feedComponentFlow, productComponentFlow,
           Math.max(1.0e-7, BALANCE_TOLERANCE * Math.abs(feedComponentFlow)));
     }

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
@@ -120,6 +120,7 @@ public class DoeBigHillAtmosphericFractionationTest {
     column.setTopPressure(1.2);
     column.setBottomPressure(1.5);
     column.getCondenser().setOutTemperature(420.0);
+    column.setCondenserMode(DistillationColumn.CondenserMode.TOTAL);
     column.getReboiler().setOutTemperature(690.0);
     column.setCondenserRefluxRatio(1.0);
     column.setLiquidSideDrawFraction(SIDE_DRAW_TRAY, 0.10);

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
@@ -37,7 +37,7 @@ public class DoeBigHillAtmosphericFractionationTest {
   private static final double[] UPPER_BOUNDARY_F = { 250.0, 375.0, 530.0, 650.0, 1050.0 };
   private static final double[] WEIGHT_PERCENT = { 8.6, 15.2, 15.2, 11.1, 30.3 };
   private static final double[] SPECIFIC_GRAVITY = { 0.7815, 0.8305, 0.8623, 0.9226, 0.9477 };
-  private static final int SIDE_DRAW_TRAY = 5;
+  private static final int SIDE_DRAW_TRAY = 4;
   private static final double BALANCE_TOLERANCE = 5.0e-2;
   private static final double REPEAT_TOLERANCE = 1.0e-2;
 
@@ -119,9 +119,8 @@ public class DoeBigHillAtmosphericFractionationTest {
     column.addFeedStream(feed, 4);
     column.setTopPressure(1.2);
     column.setBottomPressure(1.5);
-    column.getCondenser().setOutTemperature(420.0);
-    column.setCondenserMode(DistillationColumn.CondenserMode.TOTAL);
-    column.getReboiler().setOutTemperature(690.0);
+    column.setCondenserMode(DistillationColumn.CondenserMode.PARTIAL);
+    column.getReboiler().setOutTemperature(600.0);
     column.setCondenserRefluxRatio(1.0);
     column.setLiquidSideDrawFraction(SIDE_DRAW_TRAY, 0.10);
     column.setSolverType(DistillationColumn.SolverType.MESH_RESIDUAL);
@@ -151,6 +150,8 @@ public class DoeBigHillAtmosphericFractionationTest {
     assertTrue(column.getMassBalanceError() <= BALANCE_TOLERANCE, column.getConvergenceDiagnostics());
     assertTrue(Double.isFinite(column.getEnergyBalanceError()));
     assertTrue(column.getEnergyBalanceError() <= BALANCE_TOLERANCE, column.getConvergenceDiagnostics());
+    assertTrue(column.getLastTrayMaterialBalanceError() <= column.getTrayMaterialBalanceTolerance(),
+        column.getConvergenceDiagnostics());
 
     assertComponentMolarBalance(feed, overhead, sideDraw, bottoms);
 

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
@@ -1,0 +1,224 @@
+package neqsim.process.equipment.distillation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.characterization.OilAssayCharacterisation;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Atmospheric-column integration qualification using the public DOE Big Hill Sweet assay basis.
+ *
+ * <p>
+ * The source values are the bounded 175-1050 degF distillate slice from U.S. Department of Energy
+ * Strategic Petroleum Reserve Big Hill Sweet sample MLI 009 (1998-05-04). The same frozen values are
+ * independently qualified in {@code OilAssayCharacterisationDoeBigHillTest}. This test deliberately
+ * excludes the unbounded light and residue tails rather than inventing boiling limits for them.
+ * </p>
+ *
+ * <p>
+ * This is an integration and numerical-robustness benchmark. It qualifies that the public assay basis
+ * can be turned into pseudo-components and separated through NeqSim's rigorous column while preserving
+ * material and energy closure, boiling-order separation, and repeatability. It is not an independent
+ * validation of atmospheric crude-column product yields.
+ * </p>
+ */
+public class DoeBigHillAtmosphericFractionationTest {
+  private static final double[] LOWER_BOUNDARY_F = {175.0, 250.0, 375.0, 530.0, 650.0};
+  private static final double[] UPPER_BOUNDARY_F = {250.0, 375.0, 530.0, 650.0, 1050.0};
+  private static final double[] WEIGHT_PERCENT = {8.6, 15.2, 15.2, 11.1, 30.3};
+  private static final double[] SPECIFIC_GRAVITY = {0.7815, 0.8305, 0.8623, 0.9226, 0.9477};
+  private static final int SIDE_DRAW_TRAY = 5;
+  private static final double BALANCE_TOLERANCE = 5.0e-2;
+  private static final double REPEAT_TOLERANCE = 1.0e-2;
+
+  /**
+   * Run a bounded public refinery-assay slate through an atmospheric fractionator and require physical,
+   * conservative, reproducible products.
+   */
+  @Test
+  @Timeout(value = 120, unit = TimeUnit.SECONDS)
+  public void doeBoundedDistillateSliceRunsReproduciblyThroughAtmosphericColumn() {
+    Stream feed = createDoeFeed();
+    DistillationColumn column = createAtmosphericColumn(feed);
+
+    long startNanos = System.nanoTime();
+    column.run(UUID.randomUUID());
+    double firstRunSeconds = (System.nanoTime() - startNanos) / 1.0e9;
+
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertTrue(Double.isFinite(firstRunSeconds) && firstRunSeconds >= 0.0);
+    assertPhysicalProductsAndBalances(column, feed);
+
+    StreamInterface overhead = column.getGasOutStream();
+    StreamInterface sideDraw = column.getSideDrawStream(SIDE_DRAW_TRAY, DistillationColumn.SideDrawPhase.LIQUID);
+    StreamInterface bottoms = column.getLiquidOutStream();
+
+    double firstOverheadMassFlow = overhead.getFlowRate("kg/hr");
+    double firstSideDrawMassFlow = sideDraw.getFlowRate("kg/hr");
+    double firstBottomsMassFlow = bottoms.getFlowRate("kg/hr");
+    double firstOverheadMeanBoilingPoint = meanRepresentativeBoilingPoint(overhead);
+    double firstSideDrawMeanBoilingPoint = meanRepresentativeBoilingPoint(sideDraw);
+    double firstBottomsMeanBoilingPoint = meanRepresentativeBoilingPoint(bottoms);
+
+    column.run(UUID.randomUUID());
+
+    assertTrue(column.solved(), column.getConvergenceDiagnostics());
+    assertPhysicalProductsAndBalances(column, feed);
+    assertRelativeRepeat(firstOverheadMassFlow, overhead.getFlowRate("kg/hr"));
+    assertRelativeRepeat(firstSideDrawMassFlow, sideDraw.getFlowRate("kg/hr"));
+    assertRelativeRepeat(firstBottomsMassFlow, bottoms.getFlowRate("kg/hr"));
+    assertRelativeRepeat(firstOverheadMeanBoilingPoint, meanRepresentativeBoilingPoint(overhead));
+    assertRelativeRepeat(firstSideDrawMeanBoilingPoint, meanRepresentativeBoilingPoint(sideDraw));
+    assertRelativeRepeat(firstBottomsMeanBoilingPoint, meanRepresentativeBoilingPoint(bottoms));
+  }
+
+  private static Stream createDoeFeed() {
+    SystemInterface crude = new SystemSrkEos(550.0, 1.5);
+    OilAssayCharacterisation assay = crude.getOilAssayCharacterisation();
+    assay.clearCuts();
+    assay.setTotalAssayMass(1.0);
+
+    double weightSum = sum(WEIGHT_PERCENT);
+    for (int i = 0; i < WEIGHT_PERCENT.length; i++) {
+      assay.addCut(new AssayCut("DOE_BH_" + (i + 2)).withMassFraction(WEIGHT_PERCENT[i] / weightSum)
+          .withSpecificGravity(SPECIFIC_GRAVITY[i])
+          .withBoilingRangeCelsius(fahrenheitToCelsius(LOWER_BOUNDARY_F[i]),
+              fahrenheitToCelsius(UPPER_BOUNDARY_F[i])));
+    }
+    assay.apply();
+    crude.setMixingRule("classic");
+
+    Stream feed = new Stream("DOE Big Hill bounded assay feed", crude);
+    feed.setFlowRate(5000.0, "kg/hr");
+    feed.setTemperature(550.0, "K");
+    feed.setPressure(1.5, "bara");
+    feed.run();
+    return feed;
+  }
+
+  private static DistillationColumn createAtmosphericColumn(Stream feed) {
+    DistillationColumn column =
+        new DistillationColumn("DOE Big Hill atmospheric benchmark", 8, true, true);
+    column.addFeedStream(feed, 4);
+    column.setTopPressure(1.2);
+    column.setBottomPressure(1.5);
+    column.getCondenser().setOutTemperature(360.0);
+    column.getReboiler().setOutTemperature(690.0);
+    column.setCondenserRefluxRatio(1.0);
+    column.setLiquidSideDrawFraction(SIDE_DRAW_TRAY, 0.10);
+    column.setSolverType(DistillationColumn.SolverType.AUTO);
+    column.setMaxNumberOfIterations(160);
+    column.setTemperatureTolerance(0.20);
+    column.setMassBalanceTolerance(BALANCE_TOLERANCE);
+    column.setEnthalpyBalanceTolerance(BALANCE_TOLERANCE);
+    column.setEnforceEnergyBalanceTolerance(true);
+    return column;
+  }
+
+  private static void assertPhysicalProductsAndBalances(DistillationColumn column, Stream feed) {
+    StreamInterface overhead = column.getGasOutStream();
+    StreamInterface sideDraw = column.getSideDrawStream(SIDE_DRAW_TRAY, DistillationColumn.SideDrawPhase.LIQUID);
+    StreamInterface bottoms = column.getLiquidOutStream();
+
+    double feedMassFlow = feed.getFlowRate("kg/hr");
+    double overheadMassFlow = overhead.getFlowRate("kg/hr");
+    double sideDrawMassFlow = sideDraw.getFlowRate("kg/hr");
+    double bottomsMassFlow = bottoms.getFlowRate("kg/hr");
+
+    assertTrue(Double.isFinite(overheadMassFlow) && overheadMassFlow > 0.0);
+    assertTrue(Double.isFinite(sideDrawMassFlow) && sideDrawMassFlow > 0.0);
+    assertTrue(Double.isFinite(bottomsMassFlow) && bottomsMassFlow > 0.0);
+    assertEquals(feedMassFlow, overheadMassFlow + sideDrawMassFlow + bottomsMassFlow,
+        BALANCE_TOLERANCE * feedMassFlow);
+    assertTrue(Double.isFinite(column.getMassBalanceError()));
+    assertTrue(column.getMassBalanceError() <= BALANCE_TOLERANCE, column.getConvergenceDiagnostics());
+    assertTrue(Double.isFinite(column.getEnergyBalanceError()));
+    assertTrue(column.getEnergyBalanceError() <= BALANCE_TOLERANCE, column.getConvergenceDiagnostics());
+
+    assertComponentMolarBalance(feed, overhead, sideDraw, bottoms);
+
+    double[] overheadComposition = overhead.getThermoSystem().getMolarComposition();
+    double[] sideDrawComposition = sideDraw.getThermoSystem().getMolarComposition();
+    double[] bottomsComposition = bottoms.getThermoSystem().getMolarComposition();
+    assertEquals(WEIGHT_PERCENT.length, overheadComposition.length);
+    assertEquals(WEIGHT_PERCENT.length, sideDrawComposition.length);
+    assertEquals(WEIGHT_PERCENT.length, bottomsComposition.length);
+
+    assertTrue(overheadComposition[0] > bottomsComposition[0],
+        "The lightest bounded DOE cut should be enriched in the overhead relative to bottoms");
+    assertTrue(bottomsComposition[WEIGHT_PERCENT.length - 1] > overheadComposition[WEIGHT_PERCENT.length - 1],
+        "The heaviest bounded DOE cut should be enriched in bottoms relative to overhead");
+
+    double overheadMeanBoilingPoint = meanRepresentativeBoilingPoint(overhead);
+    double sideDrawMeanBoilingPoint = meanRepresentativeBoilingPoint(sideDraw);
+    double bottomsMeanBoilingPoint = meanRepresentativeBoilingPoint(bottoms);
+    assertTrue(overheadMeanBoilingPoint < sideDrawMeanBoilingPoint,
+        "Overhead should have a lower representative boiling point than the liquid side draw");
+    assertTrue(sideDrawMeanBoilingPoint < bottomsMeanBoilingPoint,
+        "The liquid side draw should have a lower representative boiling point than bottoms");
+    assertNotEquals(DistillationColumn.SolveStatus.FAILED, column.getLastSolveStatus());
+  }
+
+  private static void assertComponentMolarBalance(Stream feed, StreamInterface overhead,
+      StreamInterface sideDraw, StreamInterface bottoms) {
+    double feedFlow = feed.getFlowRate("mol/hr");
+    double overheadFlow = overhead.getFlowRate("mol/hr");
+    double sideDrawFlow = sideDraw.getFlowRate("mol/hr");
+    double bottomsFlow = bottoms.getFlowRate("mol/hr");
+    double[] feedComposition = feed.getThermoSystem().getMolarComposition();
+    double[] overheadComposition = overhead.getThermoSystem().getMolarComposition();
+    double[] sideDrawComposition = sideDraw.getThermoSystem().getMolarComposition();
+    double[] bottomsComposition = bottoms.getThermoSystem().getMolarComposition();
+
+    for (int componentIndex = 0; componentIndex < feedComposition.length; componentIndex++) {
+      double feedComponentFlow = feedFlow * feedComposition[componentIndex];
+      double productComponentFlow = overheadFlow * overheadComposition[componentIndex]
+          + sideDrawFlow * sideDrawComposition[componentIndex]
+          + bottomsFlow * bottomsComposition[componentIndex];
+      assertEquals(feedComponentFlow, productComponentFlow,
+          Math.max(1.0e-7, BALANCE_TOLERANCE * Math.abs(feedComponentFlow)));
+    }
+  }
+
+  private static double meanRepresentativeBoilingPoint(StreamInterface stream) {
+    double[] composition = stream.getThermoSystem().getMolarComposition();
+    double weightedBoilingPoint = 0.0;
+    for (int i = 0; i < composition.length; i++) {
+      double midpointFahrenheit = 0.5 * (LOWER_BOUNDARY_F[i] + UPPER_BOUNDARY_F[i]);
+      weightedBoilingPoint += composition[i] * fahrenheitToKelvin(midpointFahrenheit);
+    }
+    return weightedBoilingPoint;
+  }
+
+  private static void assertRelativeRepeat(double expected, double actual) {
+    assertTrue(Double.isFinite(expected));
+    assertTrue(Double.isFinite(actual));
+    assertEquals(expected, actual, Math.max(1.0e-8, REPEAT_TOLERANCE * Math.abs(expected)));
+  }
+
+  private static double sum(double[] values) {
+    double sum = 0.0;
+    for (double value : values) {
+      sum += value;
+    }
+    return sum;
+  }
+
+  private static double fahrenheitToCelsius(double fahrenheit) {
+    return (fahrenheit - 32.0) * 5.0 / 9.0;
+  }
+
+  private static double fahrenheitToKelvin(double fahrenheit) {
+    return fahrenheitToCelsius(fahrenheit) + 273.15;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillAtmosphericFractionationTest.java
@@ -38,6 +38,8 @@ public class DoeBigHillAtmosphericFractionationTest {
   private static final double[] WEIGHT_PERCENT = { 8.6, 15.2, 15.2, 11.1, 30.3 };
   private static final double[] SPECIFIC_GRAVITY = { 0.7815, 0.8305, 0.8623, 0.9226, 0.9477 };
   private static final int SIDE_DRAW_TRAY = 5;
+  private static final double CONDENSER_TEMPERATURE_K = 360.0;
+  private static final double REBOILER_TEMPERATURE_K = 690.0;
   private static final double BALANCE_TOLERANCE = 5.0e-2;
   private static final double REPEAT_TOLERANCE = 1.0e-2;
 
@@ -110,8 +112,9 @@ public class DoeBigHillAtmosphericFractionationTest {
     column.addFeedStream(feed, 4);
     column.setTopPressure(1.2);
     column.setBottomPressure(1.5);
-    column.getCondenser().setOutTemperature(360.0);
-    column.getReboiler().setOutTemperature(690.0);
+    column.getCondenser().setOutTemperature(CONDENSER_TEMPERATURE_K);
+    column.getReboiler().setOutTemperature(REBOILER_TEMPERATURE_K);
+    seedInteriorStageTemperatures(column);
     column.setCondenserRefluxRatio(1.0);
     column.setLiquidSideDrawFraction(SIDE_DRAW_TRAY, 0.10);
     column.setSolverType(DistillationColumn.SolverType.NAPHTALI_SANDHOLM);
@@ -121,6 +124,16 @@ public class DoeBigHillAtmosphericFractionationTest {
     column.setEnthalpyBalanceTolerance(BALANCE_TOLERANCE);
     column.setEnforceEnergyBalanceTolerance(true);
     return column;
+  }
+
+  private static void seedInteriorStageTemperatures(DistillationColumn column) {
+    int topStage = column.getNumberOfTrays() - 1;
+    for (int stage = 1; stage < topStage; stage++) {
+      double heightFraction = stage / (double) topStage;
+      double seedTemperature = REBOILER_TEMPERATURE_K
+          + heightFraction * (CONDENSER_TEMPERATURE_K - REBOILER_TEMPERATURE_K);
+      column.setSeedTemperature(stage, seedTemperature);
+    }
   }
 
   private static void assertPhysicalProductsAndBalances(DistillationColumn column, Stream feed) {

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTest.java
@@ -95,6 +95,9 @@ public class OilAssayCharacterisationDoeBigHillTest {
       assertNotNull(component);
       assertTrue(Double.isFinite(component.getMolarMass()));
       assertTrue(component.getMolarMass() > 0.0);
+      assertTrue(component.getMolarMass() < 1.0, "DOE petroleum-cut molar mass should remain on the kg/mol scale");
+      assertTrue(component.getNormalBoilingPoint() >= fahrenheitToKelvin(LOWER_BOUNDARY_F[i]));
+      assertTrue(component.getNormalBoilingPoint() <= fahrenheitToKelvin(UPPER_BOUNDARY_F[i]));
       assertTrue(Double.isFinite(component.getNumberOfmoles()));
       assertTrue(component.getNumberOfmoles() > 0.0);
       reconstructedMass += component.getNumberOfmoles() * component.getMolarMass();
@@ -129,5 +132,9 @@ public class OilAssayCharacterisationDoeBigHillTest {
 
   private static double fahrenheitToCelsius(double fahrenheit) {
     return (fahrenheit - 32.0) * 5.0 / 9.0;
+  }
+
+  private static double fahrenheitToKelvin(double fahrenheit) {
+    return fahrenheitToCelsius(fahrenheit) + 273.15;
   }
 }

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationTest.java
@@ -29,7 +29,7 @@ public class OilAssayCharacterisationTest {
     characterisation.apply();
 
     double lightBoilingPoint = 200.0 + 273.15;
-    double expectedLightMolarMass = 5.805e-5 * Math.pow(lightBoilingPoint, 2.3776) / Math.pow(0.75, 0.9371);
+    double expectedLightMolarMass = 5.805e-5 * Math.pow(lightBoilingPoint, 2.3776) / Math.pow(0.75, 0.9371) / 1000.0;
     ComponentInterface lightComponent = system.getComponent("Light_PC");
     assertNotNull(lightComponent);
     assertEquals(expectedLightMolarMass, lightComponent.getMolarMass(), 1e-8);
@@ -37,7 +37,8 @@ public class OilAssayCharacterisationTest {
 
     double heavyDensity = 141.5 / (25.0 + 131.5) * 0.999016;
     double heavyBoilingPoint = 350.0 + 273.15;
-    double expectedHeavyMolarMass = 5.805e-5 * Math.pow(heavyBoilingPoint, 2.3776) / Math.pow(heavyDensity, 0.9371);
+    double expectedHeavyMolarMass = 5.805e-5 * Math.pow(heavyBoilingPoint, 2.3776) / Math.pow(heavyDensity, 0.9371)
+        / 1000.0;
     ComponentInterface heavyComponent = system.getComponent("Heavy_PC");
     assertNotNull(heavyComponent);
     assertEquals(expectedHeavyMolarMass, heavyComponent.getMolarMass(), 1e-8);
@@ -82,9 +83,11 @@ public class OilAssayCharacterisationTest {
     characterisation.apply();
 
     double boilingPoint = 300.0 + 273.15;
-    double expectedMolarMass = 5.805e-5 * Math.pow(boilingPoint, 2.3776) / Math.pow(0.82, 0.9371);
+    double expectedMolarMass = 5.805e-5 * Math.pow(boilingPoint, 2.3776) / Math.pow(0.82, 0.9371) / 1000.0;
     ComponentInterface component = system.getComponent("Assay_PC");
     assertNotNull(component);
+    assertTrue(component.getMolarMass() > 0.05 && component.getMolarMass() < 1.0,
+        "Derived petroleum-cut molar mass should remain on the kg/mol scale");
     assertEquals(2.0 / expectedMolarMass, component.getNumberOfmoles(), 1e-8);
     assertEquals(2.0, component.getNumberOfmoles() * component.getMolarMass(), 1e-10);
   }
@@ -235,7 +238,7 @@ public class OilAssayCharacterisationTest {
     characterisation.apply();
 
     double boilingPoint = 300.0 + 273.15;
-    double expectedMolarMass = 5.805e-5 * Math.pow(boilingPoint, 2.3776) / Math.pow(0.85, 0.9371);
+    double expectedMolarMass = 5.805e-5 * Math.pow(boilingPoint, 2.3776) / Math.pow(0.85, 0.9371) / 1000.0;
     assertEquals(expectedMolarMass, system.getComponent("DensityUnits_PC").getMolarMass(), 1e-10);
   }
 


### PR DESCRIPTION
## Summary

Advances #3305 with a rigorous-column integration benchmark built directly on the qualified U.S. DOE Strategic Petroleum Reserve Big Hill Sweet assay basis.

- builds the bounded 175–1050 °F DOE Big Hill MLI 009 slice from **measured weight yields**, specific gravities, and finite boiling ranges;
- generates real NeqSim TBP pseudo-components through `OilAssayCharacterisation`;
- corrects the inverse petroleum-correlation result from its g/mol-sized value to the kg/mol contract required by `addTBPfraction(...)`;
- feeds the physical broad-boiling slate to an 8-tray `DistillationColumn` with a partial condenser, a 600 K reboiler, and a 10% liquid side draw on feed tray 4;
- requires rigorous `MESH_RESIDUAL` convergence without fallback, including full-MESH and per-tray material-balance gates;
- requires process mass/energy closure, component conservation, light/heavy enrichment, boiling-point ordering, and repeated-solve stability.

## CI repair

The failed Java 21 fast-test run was a real model failure, not a Windows-only issue.

The assay's inverse molar-mass correlation produced values on a g/mol scale but returned them as kg/mol. The five DOE cuts therefore entered NeqSim at roughly 95–389 kg/mol instead of 0.095–0.389 kg/mol, yielding nonphysical normal boiling points and a nonvolatile feed. The implementation now converts inferred values to kg/mol, and regression tests enforce both the kg/mol magnitude and each pseudo-component's DOE boiling interval.

The original fixed condenser temperature plus fixed reflux ratio also overconstrained the broad-boiling terminal stage. The qualified screening point keeps top pressure and reflux as controls, uses a partial condenser with solver-determined top temperature, and sets the reboiler to 600 K. The rigorous solver converges with positive overhead, side-draw, and bottoms products while satisfying the column's material- and energy-balance gates.

## Public evidence

- U.S. DOE SPR Big Hill Sweet, sample MLI 009, assay date 1998-05-04: https://www.govinfo.gov/content/pkg/CFR-2000-title10-vol4/pdf/CFR-2000-title10-vol4-part625-appA.pdf
- DOE SPR *Crude Oil Assay Manual*, 5th ed., 1 Aug 2024: https://www.spr.doe.gov/reports/docs/CrudeOilAssayManual.pdf
- DOE assay landing page: https://www.spr.doe.gov/reports/Crude_Oil_Assays.html

The DOE manual states that D2892/D5236 fractions are measured on a mass-percent basis, with volume percentages calculated from fraction specific gravity. This PR therefore uses the published weight yields for the column feed rather than treating DOE volume/weight values as independent measurements.

## Evidence boundary

This is an **integration and numerical-robustness qualification**, not a full-crude product-yield validation. The open-ended C5-/175 °F and 1050 °F+ tails remain excluded rather than assigning invented finite boiling limits. No commercial-simulator tuning, proprietary correlation, or ASTM implementation is copied.

The next #3305 gate should add a complete openly reproducible crude representation with defensible light/residue handling and independent public atmospheric product-yield/boiling-range evidence before vacuum fractionation.

## Validation

`VALIDATION PENDING CI`

Passed locally on repair commit `c17f3ba030d6705d12cee066e23f55ce9b49010f`:

- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- `./mvnw -q -DskipITs -Dtest=OilAssayCharacterisationTest,OilAssayCharacterisationDoeBigHillTest,OilAssayCharacterisationReservedNameTest,DoeBigHillAtmosphericFractionationTest,DistillationColumnHeterogeneousFeedTest,DistillationColumnCoordinatedFlowTest,DistillationColumnConvergenceGateTest test`
- `git diff --check`

Full hosted CI remains authoritative.

## Documentation impact

Updated `refinery_assay.md` for the inferred-molar-mass unit contract and `refinery_big_hill_atmospheric_fractionation.md` for the qualified operating point and balance acceptance gates.

## Campaign continuity

- Previous refinery PR #3316 is merged and remains foundation work.
- This is the sole active implementation PR for #3305.
- The production change fixes the existing refinery-assay API's documented kg/mol contract. Generic TBP-property API work remains coordinated under #1393/#3120.

Advances #3305.