### PR TITLE
[AI-Assisted] fix(dexpi): preserve recycle return topology

### DIFF
--- a/docs/integration/dexpi-reference-cases.md
+++ b/docs/integration/dexpi-reference-cases.md
@@ -63,10 +63,11 @@ The first full-sheet benchmark inspection found that instrument bubbles intersec
 data bars and sat outside the generated battery limit. The layout now reserves 55 mm above an
 equipment centre for instruments and expands the battery-limit envelope through the highest bubble;
 an exact coordinate regression protects both clearances. Re-rendered simple, branched, and
-recycle/control cases show separated bubbles and data bars inside the boundary. Recycle connectivity
-remains limited by the current Proteus topology projection: the recycle equipment symbol and tag are
-present, but a complete routed return line is not inferred from simulation state. That is a writer
-semantics gap, not an SVG primitive loss, and requires a separate topology change.
+recycle/control cases show separated bubbles and data bars inside the boundary. Recycle connectivity is projected when the recycle block exposes a configured outlet through the
+standard equipment outlet API and a downstream unit consumes that same stream identity. The benchmark
+asserts the directed recycle-to-mixer connection in the Proteus XML before rendering. The writer does
+not infer a return line from convergence state: an unconfigured outlet remains absent, and no fluid
+state or connection is invented.
 
 Run the focused regression with the repository Maven wrapper:
 

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiStreamUtils.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiStreamUtils.java
@@ -31,7 +31,8 @@ public final class DexpiStreamUtils {
    * <p>
    * For separators, this returns the gas outlet stream. For splitters, it returns the first split stream. For streams,
    * it returns the stream itself. For all other TwoPortEquipment (compressor, pump, valve, heater, cooler, expander,
-   * heat exchanger), it returns the outlet stream directly.
+   * heat exchanger), it returns the outlet stream directly. Equipment such as recycle blocks that expose their
+   * primary outlet only through the standard {@code getOutletStreams()} API use the first declared outlet.
    * </p>
    *
    * @param equipment the process equipment
@@ -53,7 +54,8 @@ public final class DexpiStreamUtils {
     if (equipment instanceof TwoPortEquipment) {
       return ((TwoPortEquipment) equipment).getOutletStream();
     }
-    return null;
+    List<StreamInterface> outlets = equipment.getOutletStreams();
+    return outlets != null && !outlets.isEmpty() ? outlets.get(0) : null;
   }
 
   /**

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiStreamUtils.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiStreamUtils.java
@@ -31,8 +31,8 @@ public final class DexpiStreamUtils {
    * <p>
    * For separators, this returns the gas outlet stream. For splitters, it returns the first split stream. For streams,
    * it returns the stream itself. For all other TwoPortEquipment (compressor, pump, valve, heater, cooler, expander,
-   * heat exchanger), it returns the outlet stream directly. Equipment such as recycle blocks that expose their
-   * primary outlet only through the standard {@code getOutletStreams()} API use the first declared outlet.
+   * heat exchanger), it returns the outlet stream directly. Equipment such as recycle blocks that expose their primary
+   * outlet only through the standard {@code getOutletStreams()} API use the first declared outlet.
    * </p>
    *
    * @param equipment the process equipment

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiStreamUtilsTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiStreamUtilsTest.java
@@ -1,0 +1,30 @@
+package neqsim.process.processmodel.dexpi;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.equipment.util.Recycle;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests standard outlet resolution used by DEXPI topology and layout projection. */
+class DexpiStreamUtilsTest extends NeqSimTest {
+  @Test
+  void resolvesConfiguredRecycleOutlet() {
+    StreamInterface outlet = new Stream("recycle outlet", new SystemSrkEos(298.15, 50.0));
+    Recycle recycle = new Recycle("recycle");
+    recycle.setOutletStream(outlet);
+
+    assertSame(outlet, DexpiStreamUtils.getGasOutletStream(recycle));
+  }
+
+  @Test
+  void keepsUnconfiguredRecycleOutletAbsent() {
+    Recycle recycle = new Recycle("unconfigured recycle");
+
+    assertNull(DexpiStreamUtils.getGasOutletStream(recycle));
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
@@ -79,6 +79,10 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
     assertTrue(report.getMetrics().get("componentInstances") >= 4, report.toJson());
     assertTrue(report.getMetrics().get("sourceTexts") >= 4, report.toJson());
     assertTrue(report.getMetrics().get("sourceCenterLines") > 0, report.toJson());
+
+    Document exportedDocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(dexpi.toFile());
+    assertTrue(hasDirectedEquipmentConnection(exportedDocument, "ID-50-RC-001", "ID-50-MX-001"),
+        "The configured recycle outlet must be routed back to the mixer inlet");
   }
 
   @Test
@@ -196,6 +200,26 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
   private static boolean hasFinding(DexpiVisualQualityAssessment.Report report, String code) {
     for (DexpiVisualQualityAssessment.Finding finding : report.getFindings()) {
       if (code.equals(finding.getCode())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasDirectedEquipmentConnection(Document document, String sourceId, String targetId) {
+    Element source = identifiedElement(document, sourceId);
+    Element target = identifiedElement(document, targetId);
+    NodeList sourceNozzles = source.getElementsByTagName("Nozzle");
+    NodeList targetNozzles = target.getElementsByTagName("Nozzle");
+    if (sourceNozzles.getLength() < 2 || targetNozzles.getLength() < 1) {
+      return false;
+    }
+    String fromId = ((Element) sourceNozzles.item(sourceNozzles.getLength() - 1)).getAttribute("ID");
+    String toId = ((Element) targetNozzles.item(0)).getAttribute("ID");
+    NodeList connections = document.getElementsByTagName("Connection");
+    for (int index = 0; index < connections.getLength(); index++) {
+      Element connection = (Element) connections.item(index);
+      if (fromId.equals(connection.getAttribute("FromID")) && toId.equals(connection.getAttribute("ToID"))) {
         return true;
       }
     }


### PR DESCRIPTION
## Engineering question

Close the remaining Proteus P&ID writer-semantics gap from #3330: when a configured `Recycle` outlet is explicitly consumed by a downstream mixer, preserve that directed return connection in the exported DEXPI/Proteus topology and rendered linework.

## Baseline and cause

At master `4e4bdcbc3fe4cd74fb13d24f3e0bfee43148261f`, `Recycle` exposes its configured outlet through the standard `ProcessEquipmentInterface.getOutletStreams()` API, but `DexpiStreamUtils.getGasOutletStream()` only recognized selected concrete classes and `TwoPortEquipment`. The writer and layout engine therefore registered the recycle equipment and inlet while omitting its outlet identity, so the return edge could not be projected.

## Change

- resolve the first declared standard outlet after preserving all existing separator, splitter, stream, and `TwoPortEquipment` mappings;
- keep an unconfigured recycle outlet absent rather than inventing a stream or fluid state;
- add a focused utility regression for configured and unconfigured recycle blocks;
- extend the fixed visual benchmark to assert the directed recycle-to-mixer connection in the actual Proteus XML before SVG assessment;
- update the DEXPI reference-case documentation and qualification boundary.

## Compatibility and stop boundary

This is an additive internal topology-resolution correction. Public APIs, legacy DOT/Graphviz behavior, native DEXPI 2.0 Process export, existing Proteus schema/profile (`SchemaVersion 4.1.1`), Classic outputs, and empty-placeholder behavior remain unchanged. The PR does not infer connections from convergence state and does not broaden into symbol qualification, ISO interpretation, or accountable engineering approval.

## Validation

**READY TO MERGE**

GitHub CI is complete at exact head `f70adb4e68f7f28c652290d301bd18504eaf9862`. Java 8 and Java 21 Ubuntu/Windows fast suites, all four Java 21 slow shards, Java 21 Javadocs, Spotless, pre-commit, documentation search, engineering-diagram performance, the process-to-engineering notebook, CodeQL, PaperLab, and agent-reference checks pass. The draft is open, unmerged, and mergeable, with no reviews or unresolved review threads.

The exact four-file branch diff was re-read through GitHub; it is five commits ahead and zero behind exact base `4e4bdcbc3fe4cd74fb13d24f3e0bfee43148261f`. The first hosted attempt identified one Spotless Javadoc-wrap hunk; exact head `f70adb4e68f7f28c652290d301bd18504eaf9862` contains the hosted formatter output. Local Maven/Spotless/pre-commit execution was unavailable in the connector-only implementation run, so no local check is claimed; completed GitHub CI is the authoritative validator.

Focused regression command:

```bash
./mvnw -Dtest=DexpiStreamUtilsTest,DexpiVisualQualityAssessmentTest test
```

## Documentation impact

Updated `docs/integration/dexpi-reference-cases.md` to describe explicit recycle topology projection and retain the fail-closed boundary for unconfigured outlets.

Tracks #1332 and #2899.
