### PR TITLE
[AI-Assisted] feat(pitzer): gate observable-specific qualification

### DIFF
--- a/docs/thermo/fluid_creation_guide.md
+++ b/docs/thermo/fluid_creation_guide.md
@@ -421,24 +421,35 @@ the active binary, same-sign, ternary, and neutral topology is explicit; qualifi
 observables have independent evidence:
 
 ```java
-PitzerParameterQualification evidence = fluid.getPitzerParameterQualification();
+SystemPitzer qualifiedBrine = new SystemPitzer(298.15, 1.01325);
+qualifiedBrine.addComponent("water", 55.508);
+qualifiedBrine.addComponent("Na+", 0.5);
+qualifiedBrine.addComponent("K+", 0.5);
+qualifiedBrine.addComponent("Cl-", 1.0);
+qualifiedBrine.init(0);
+qualifiedBrine.applyPhreeqcSodiumPotassiumChlorideParameters();
 
-// Strict publication gate: complete interaction coverage and complete qualification
-// of the named dataset. This rejects the broad, partially validated catalog.
-fluid.requireCompletePitzerDatasetQualification();
+PitzerParameterQualification evidence = qualifiedBrine.getPitzerParameterQualification();
+
+// Property-specific publication gate: complete interaction coverage plus independent
+// evidence for the requested observable. A VLE request would fail for this subset.
+qualifiedBrine.requirePitzerDatasetValidationFor(
+    PitzerParameterQualification.ValidationTarget.AQUEOUS_ACTIVITY_COEFFICIENTS);
 
 // Dataset qualification does not prove that this exact state is inside its evidence envelope.
 boolean insideRange = PitzerParameterDatasets.isWithinSodiumPotassiumChlorideValidationRange(
-    fluid.getTemperature(),
+    qualifiedBrine.getTemperature(),
     0.5,  // Na+ molality, mol/kg water
     0.5,  // K+ molality, mol/kg water
     1.0); // Cl- molality, mol/kg water
 ```
 
-The accessor completes lazy parameter selection and interaction-coverage auditing but does not run a flash. The strict
+The accessor completes lazy parameter selection and interaction-coverage auditing but does not run a flash. The target
 gate is opt-in and executes only when called, so neutral models and ordinary Pitzer property calculations do no new
-work. It accepts only a completely qualified named dataset; callers must still apply the use-case-specific range helper
-for the current temperature and molality.
+work. It accepts only a completely qualified named dataset with independent evidence for the requested property;
+callers must still apply the use-case-specific range helper for the current temperature and molality. The legacy
+`requireCompletePitzerDatasetQualification()` gate remains available, but its overall level alone must not be treated
+as VLE, reaction, or mineral evidence.
 
 The complete PHREEQC catalog is intentionally reported as partially validated: CaCl2 and MgCl2 binaries have held-out
 activity evidence, while exact mixed Ca-Mg-Cl-SO4 activity and mineral precipitation remain separate gates. Process

--- a/docs/thermo/henry_law_reference.md
+++ b/docs/thermo/henry_law_reference.md
@@ -180,7 +180,14 @@ including the fixed IAPWS water molar mass. The dimensional identity is
 $$\frac{\mathrm{d}\ln H}{\mathrm{d}T}=\frac{1}{H}\frac{\mathrm{d}H}{\mathrm{d}T}.$$
 
 These tests are implementation and source-table regressions. They are separate
-from independent VLE/VLLE or brine validation.
+from independent VLE/VLLE or brine validation. In particular, six held-out
+CO2-Na2SO4 bubble pressures from Bermejo et al. (2005),
+[DOI 10.1016/j.fluid.2005.10.006](https://doi.org/10.1016/j.fluid.2005.10.006),
+are underpredicted by 32.6–43.8% even though the phase-boundary calculations
+close. `SystemPitzer.requirePitzerDatasetValidationFor(GAS_AQUEOUS_VLE)`
+therefore rejects that parameter subset; aqueous-activity and water-property
+qualification are unaffected. The Pitzer provenance page records the NIST
+ThermoML checksum, preprocessing, uncertainty, and composition convention.
 
 ## Scientific and performance controls
 

--- a/docs/thermo/pitzer_parameter_provenance.md
+++ b/docs/thermo/pitzer_parameter_provenance.md
@@ -69,7 +69,10 @@ may still use a dataset whose full species/range matrix lacks held-out evidence.
 `SystemPitzer.getPitzerParameterQualification()` completes lazy dataset selection and returns the
 immutable metadata for the exact selected dataset. The opt-in
 `requireCompletePitzerDatasetQualification()` first requires complete active-ion coverage and then
-rejects any named dataset below `VALIDATED_WITHIN_DECLARED_ENVELOPE`.
+rejects any named dataset below `VALIDATED_WITHIN_DECLARED_ENVELOPE`. Because an overall level
+cannot distinguish activity, water-property, reaction, mineral, and VLE evidence, property
+publication should use `requirePitzerDatasetValidationFor(ValidationTarget)` instead. The target
+gate requires complete topology and fails unless that exact observable is independently qualified.
 
 This gate is intentionally stricter than subsystem validation. The broad PHREEQC catalog remains
 `PARTIALLY_EXPERIMENTALLY_VALIDATED`, even when the current topology is one of its independently
@@ -77,7 +80,9 @@ checked binaries; callers that need a complete named-dataset gate must select a 
 subset such as Na-K-Cl. A successful dataset gate does not prove that the current temperature,
 pressure, molality, or composition lies inside its evidence envelope. The applicable
 `isWithin...ValidationRange` helper remains a separate mandatory state check. Diagnostics include
-dataset identity, level, validated systems, and limitations in deterministic order.
+dataset identity, level, validated systems, machine-readable validation targets, and limitations in
+deterministic order. Existing callers of the complete-dataset gate retain source compatibility, but
+must not infer a property target from the overall level.
 
 The accessor and gate are explicit setup/publication operations. They perform no flash, change no
 parameter, and add no work to Pitzer activity/property kernels or neutral PR/SRK/CPA calculations.
@@ -147,10 +152,28 @@ A second outside-range comparison is Zhao et al. (2015),
 at 15 MPa and 323–423 K; it is evidence for later full-VLE work, not grounds to widen this subset's
 accepted range.
 
-The current hybrid EOS-GE flash still fails for some gas-forming CO2/brine inventories before a
-scientific VLE comparison can be made. That is a separate phase-topology dependency coordinated
-with the generic flash campaign; this subset is therefore qualified for aqueous activity and
-water/osmotic use only. It must not be described as independently validated CO2 VLE.
+The hybrid EOS-GE phase-boundary calculation now converges for the selected gas-forming CO2/brine
+states, so VLE accuracy can be assessed independently of flash closure. Six held-out bubble
+pressures from Bermejo et al. (2005),
+[DOI 10.1016/j.fluid.2005.10.006](https://doi.org/10.1016/j.fluid.2005.10.006), were selected from
+NIST ThermoML dataset 2. They cover 307.78–340.10 K, 0.986703–0.996313 mol/kg Na2SO4, liquid CO2
+mole fractions 0.00773–0.01161, and 43.5–118.2 bara. The archived 95% expanded pressure
+uncertainties are 0.5–2.0 bara. The publisher-permitted ThermoML JSON has SHA-256
+`aeeff43c1aa196a749b01dbb31d22bf502fe140a85e4823ecea8544f06dd3897`.
+
+Pressure was converted from kPa to bara. On a one-kilogram-water basis, molecular salt molality was
+mapped to `2 Na+ + SO4--`, and the reported liquid CO2 mole fraction was converted with
+`nCO2=x/(1-x)*(nH2O+nNa2SO4)`. No parameter was fitted. Exact-master calculations predict
+29.306, 43.165, 53.064, 74.040, 45.715, and 58.930 bara: underprediction of 32.6–43.8%, outside
+each experimental uncertainty. Treating the reported fraction with an explicit-ion denominator
+reduces the central-point residual only to 31.5%, so the composition-basis sensitivity does not
+change the rejection. Material-balance residuals are at most order `1e-16`, logarithmic fugacity
+residuals are below `1e-10`, and aqueous charge is zero. The fixture is therefore held-out
+scientific evidence, not a flash convergence failure or a training-data regression.
+
+The subset remains qualified for aqueous activity and water/osmotic targets only.
+`GAS_AQUEOUS_VLE` fails closed through the observable-specific gate. No Pitzer coefficient, Henry
+correlation, Poynting correction, or reaction row is changed to fit these six points.
 
 ### Qualified public-domain Na-K-Cl subset
 
@@ -457,6 +480,7 @@ topology and validation matrix are documented.
 | Harvie, Møller and Weare (1984), [natural-water model](https://doi.org/10.1016/0016-7037(84)90098-X) | Na/K/Mg/Ca/H with Cl/SO4/OH/HCO3/CO3/CO2/H2O; binary and mixed interactions | 25 °C, high ionic strength; molality-scale Pitzer model | Fitted isopiestic, EMF, and solubility data; multicomponent comparisons outside subsystems are reported | Primary Elsevier article; numerical-table redistribution not established here | High-priority scientific comparison. No coefficient copied; full family and electrostatic convention must be mapped together. |
 | Pitzer (1975), [higher-order electrostatic mixing](https://doi.org/10.1007/BF00646562) | Nonsymmetric same-sign electrostatic terms `Etheta` and its ionic-strength derivative for unequal charge pairs; no fitted short-range coefficient is supplied by this term | Molality-scale Pitzer formulation; the term is zero for equal charges and depends on charge tuple, ionic strength, and `Aphi` | Primary equation source; it establishes model structure rather than a parameter fit | Primary Springer article; no numerical table copied | Equation structure accepted in this increment: the public PHREEQC recurrence and its ion/activity/osmotic placement are mapped directly. No fitted coefficient is copied; short-range tuple coverage remains independently fail-closed. |
 | USGS PHRQPITZ (Plummer et al. 1988), [WRIR 88-4153](https://doi.org/10.3133/wri884153), PHREEQC 3.8.6 tag commit [`74cdaf0`](https://github.com/phreeqc-dev/phreeqc3/commit/74cdaf00f90b15b7a5bbc03f405eb2f8129aacf1), and [PHREEQC 3.9.0-17591](https://github.com/phreeqc-dev/phreeqc3/releases/tag/v3.9.0) commit [`b0b3be7`](https://github.com/phreeqc-dev/phreeqc3/commit/b0b3be767158ccc3322d2c816625cf470045e67e) | Na/K/Mg/Ca/H plus major anions and extended Fe/Mn/Sr/Ba/Li/Br; `B0`, `B1`, `B2`, `C0`, `theta`, `psi`, `lambda`, `zeta`, and six temperature coefficients. Release 3.9.0 revises Mg/Ba/carbonate/bicarbonate/CO2 species and related HCO3 and neutral-H2 Pitzer interactions. Exact catalog inspection on 2026-08-27 found no `H+|HCO3-` `B0`, `B1`, or `C0` row. | Molality scale; PHREEQC enables nonsymmetric electrostatic mixing by default. Default alpha is charge dependent: `2/12` when a pair contains a monovalent ion, `1.4/12` for 2-2, and `2/50` otherwise. Pressure is absent from these interaction functions. PHREEQC names the proton `H+`; NeqSim's reacting species is `H3O+`, and no standard-state alias is assumed. | Appelo (2015), [DOI 10.1016/j.apgeochem.2014.11.007](https://doi.org/10.1016/j.apgeochem.2014.11.007), documents database principles and calculations from 0–200 °C and 1–1000 atm; applicability remains parameter/system specific. Exact fitted observables, residuals, and uncertainty remain row/source specific. | USGS software and data are public domain. Audited release date: 2026-05-13. Audited blobs: [`pitzer.cpp` `1f32a08`](https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/src/pitzer.cpp) and [`pitzer.dat` `324f852`](https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/database/pitzer.dat). | The exact interaction block is stored as a lazy catalog and selected automatically for complete active topologies. Missing mixed families fail closed rather than receiving zero or legacy coefficients. CO2-Na2SO4, Na-K-Cl, Ca-Mg-Cl-SO4, and SrCl2 have dedicated mappings/evidence. `H3O+|HCO3-` remains unqualified; no value is adopted. |
+| Bermejo et al. (2005), [DOI 10.1016/j.fluid.2005.10.006](https://doi.org/10.1016/j.fluid.2005.10.006), [NIST ThermoML dataset 2](https://trc.nist.gov/ThermoML/10.1016/j.fluid.2005.10.006.html) | CO2 + H2O + Na2SO4 bubble pressure; validation observable only, with no `beta`, `Cphi`, `theta`, `psi`, `lambda`, `zeta`, `mu`, `eta`, alpha, reaction `log K`, or temperature coefficient adopted | Reported solvent Na2SO4 molality, liquid CO2 mole fraction, temperature in K, and pressure in kPa; six selected states span 307.78–340.10 K, 0.986703–0.996313 mol/kg, and 43.5–118.2 bara. The molecular-salt mole-fraction mapping and kPa-to-bara conversion are explicit. | Source contains 112 bubble-pressure points and 95% expanded uncertainties. Six held-out states have 0.5–2.0 bara uncertainty; exact-master residuals are −32.6% to −43.8% without refitting. The experiment is independent of the PHREEQC parameter lineage. | Publisher-permitted NIST ThermoML numerical archive; JSON SHA-256 `aeeff43c1aa196a749b01dbb31d22bf502fe140a85e4823ecea8544f06dd3897`. Six observations and metadata are stored, not an article table. | Reject `GAS_AQUEOUS_VLE` qualification for the existing CO2-Na2SO4 family. Activity and water-property targets remain qualified. The data cannot be used to mix model families or infer a missing pressure correction. |
 | Xia, Maurer and coworkers (2000), [DOI 10.1021/ie990416p](https://doi.org/10.1021/ie990416p), as cited on PHREEQC H2S rows | Neutral `H2Sg` with Na+/Cl-: `lambda(Cl-,H2Sg)=-0.005`, `lambda(H2Sg,Na+)=[0.1047,0,-0.0413]`, and `zeta(H2Sg,Cl-,Na+)=-0.0123`; PHREEQC also defines separate `(H2Sg)2` rows and a dimerization reaction | Molality-scale PHREEQC neutral-ion convention; Xia measurements cover H2S solubility in 4-6 mol/kg NaCl from 313-393 K and total pressures to 10 MPa. Pressure dependence is not encoded in the listed Pitzer functions. | Primary H2S solubility observables; public abstract does not provide row-wise parameter uncertainty. The PHREEQC row is redistributable public-domain data, while the ACS article remains copyright. | No primary table is copied. The exact PHREEQC values and source comment are recorded for comparison. | Rejected for activation in NeqSim: the available family lacks an `H2Sg-H2Sg` self interaction and instead relies on an explicit `(H2Sg)2` species that NeqSim does not model. Partial aliasing would violate fail-closed topology and change the source species model. |
 | Hershey, Pleše and Millero (1988), [DOI 10.1016/0016-7037(88)90183-4](https://doi.org/10.1016/0016-7037(88)90183-4) | First H2S dissociation only; pK1 and HS- interactions with Na+, K+, Mg+2, and Ca+2. It supplies no second-dissociation or neutral-H2S self/dimer family. | Molality scale; NaCl from 0.1 mol/kg to saturation at 5, 25, and 45 °C, KCl at 5 and 25 °C, and selected MgCl2/CaCl2 additions to ionic strength 6 mol/kg. Infinite-dilution `pK1=-98.080+5765.4/T+15.0455 ln(T)`. | EMF measurements; replicate uncertainty is reported in the paper and the infinite-dilution correlation provides an independent check of PHREEQC pK1. | Publisher-controlled primary article; only its published equation, DOI, scope, and residual summary are recorded, not its tables. | Accepted solely as independent validation of the Pitzer reaction-table pK1. No interaction coefficient is adopted or transferred. |
 | Partanen (2013), [traceable SrCl2 values](https://doi.org/10.1021/je400472v), NIST ThermoML MD5 `0f26a7668fdc333b8a9d6f35223d3fbd` | Recommended SrCl2 mean ionic activity coefficients; no Pitzer parameter is supplied or adopted | 283.15-333.15 K, 101 kPa, molality scale; 22 points at 298.15 K from 0.01-3.52 mol/kg and 36 temperature states from 0.01-0.30 mol/kg | Rounded values have 95% expanded uncertainty 0.001; all 58 are checked without refitting; maximum relative residual 3.11%, relative RMSE 1.58% | Primary ACS article; numerical record distributed through the publisher-permitted NIST ThermoML archive and stored with exact archive checksum | Accepted as held-out binary validation of the PHREEQC Sr++/Cl- B0/B1/C0 temperature family and NeqSim equation convention. It does not qualify mixed Sr brines, chloride minerals, or sulfate scale. |
@@ -523,6 +547,15 @@ CO2-Na2SO4 and Na-K-Cl subsets are separately versioned: their complete companio
 equation mappings, range evidence, and independent IPhreeqc gates are recorded above. Conflicting
 NeqSim legacy NaCl/KCl rows remain available only under the unchanged legacy identity; no family is
 silently mixed across formulations.
+
+For the CO2-Na2SO4 VLE qualification increment, no new Kaasa coefficient was found or needed: the
+already audited Appendix F CO2 neutral-family inventory supplies provenance leads, not an
+independent bubble-pressure dataset or a redistributable coefficient family. Consequently there is
+no new Kaasa/PHREEQC numerical agreement or disagreement and no convention mapping beyond the
+previously verified six-term coefficient-order permutation. No coefficient was adopted or rejected
+anew. The next missing neutral interaction remains a complete redistributable H2S family, including
+the self/dimer semantics required by the source model plus all active ion companions; partial
+`H2Sg-Na+`, `H2Sg-Cl-`, and ternary rows remain fail-closed.
 
 ## Unequal-charge electrostatic mixing mapping
 

--- a/src/main/java/neqsim/thermo/phase/PitzerParameterDatasets.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerParameterDatasets.java
@@ -557,13 +557,18 @@ public final class PitzerParameterDatasets {
       return new PitzerParameterQualification(datasetId,
           PitzerParameterQualification.Level.VALIDATED_WITHIN_DECLARED_ENVELOPE,
           Arrays.asList("CO2-Na2SO4 activity, mean ionic activity, osmotic coefficient, and salting-out trend"),
-          Arrays.asList("303.15-423.15 K; 1-2 mol/kg Na2SO4; no gas-forming VLE qualification"));
+          Arrays.asList("303.15-423.15 K; 1-2 mol/kg Na2SO4 for activity and water-property evidence",
+              "Gas-aqueous VLE is not qualified: six held-out NIST ThermoML bubble pressures are underpredicted by 32.6-43.8%"),
+          Arrays.asList(PitzerParameterQualification.ValidationTarget.AQUEOUS_ACTIVITY_COEFFICIENTS,
+              PitzerParameterQualification.ValidationTarget.WATER_ACTIVITY_AND_OSMOTIC_COEFFICIENT));
     }
     if (PHREEQC_NA_K_CL_ID.equals(datasetId)) {
       return new PitzerParameterQualification(datasetId,
           PitzerParameterQualification.Level.VALIDATED_WITHIN_DECLARED_ENVELOPE,
           Arrays.asList("NaCl and KCl mean activity", "Na-K-Cl activity and water properties versus IPhreeqc"),
-          Arrays.asList("298.15-423.15 K implementation matrix; mixed-salt experimental evidence remains limited"));
+          Arrays.asList("298.15-423.15 K implementation matrix; mixed-salt experimental evidence remains limited"),
+          Arrays.asList(PitzerParameterQualification.ValidationTarget.AQUEOUS_ACTIVITY_COEFFICIENTS,
+              PitzerParameterQualification.ValidationTarget.WATER_ACTIVITY_AND_OSMOTIC_COEFFICIENT));
     }
     if (PHREEQC_PITZER_CATALOG_ID.equals(datasetId)) {
       return new PitzerParameterQualification(datasetId,

--- a/src/main/java/neqsim/thermo/phase/PitzerParameterQualification.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerParameterQualification.java
@@ -3,7 +3,9 @@ package neqsim.thermo.phase;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Scientific qualification metadata for a versioned Pitzer parameter dataset.
@@ -28,10 +30,25 @@ public final class PitzerParameterQualification implements Serializable {
     VALIDATED_WITHIN_DECLARED_ENVELOPE
   }
 
+  /** Observable-specific scientific targets that require independent evidence. */
+  public enum ValidationTarget {
+    /** Solute and ion activity coefficients on the declared activity scale. */
+    AQUEOUS_ACTIVITY_COEFFICIENTS,
+    /** Water activity and the corresponding osmotic coefficient. */
+    WATER_ACTIVITY_AND_OSMOTIC_COEFFICIENT,
+    /** Gas-aqueous vapor-liquid equilibrium or solubility. */
+    GAS_AQUEOUS_VLE,
+    /** Coupled aqueous reaction equilibrium and ionic speciation. */
+    REACTIVE_SPECIATION,
+    /** Mineral saturation, precipitation, and dissolution equilibrium. */
+    MINERAL_SATURATION_AND_PRECIPITATION
+  }
+
   private final String datasetId;
   private final Level level;
   private final List<String> validatedSystems;
   private final List<String> limitations;
+  private final Set<ValidationTarget> validatedTargets;
 
   /**
    * Creates immutable qualification metadata.
@@ -43,6 +60,20 @@ public final class PitzerParameterQualification implements Serializable {
    */
   public PitzerParameterQualification(String datasetId, Level level, List<String> validatedSystems,
       List<String> limitations) {
+    this(datasetId, level, validatedSystems, limitations, Collections.<ValidationTarget>emptyList());
+  }
+
+  /**
+   * Creates immutable qualification metadata with machine-readable validation targets.
+   *
+   * @param datasetId stable parameter-dataset identity
+   * @param level overall qualification level
+   * @param validatedSystems independently checked systems and observables
+   * @param limitations unresolved validation or applicability boundaries
+   * @param validatedTargets independently validated property targets for the complete named dataset
+   */
+  public PitzerParameterQualification(String datasetId, Level level, List<String> validatedSystems,
+      List<String> limitations, List<ValidationTarget> validatedTargets) {
     if (datasetId == null || datasetId.trim().isEmpty()) {
       throw new IllegalArgumentException("Pitzer parameter dataset identity must not be empty");
     }
@@ -53,6 +84,7 @@ public final class PitzerParameterQualification implements Serializable {
     this.level = level;
     this.validatedSystems = immutableCopy(validatedSystems);
     this.limitations = immutableCopy(limitations);
+    this.validatedTargets = immutableTargetCopy(validatedTargets);
   }
 
   /** @return stable parameter-dataset identity */
@@ -76,6 +108,18 @@ public final class PitzerParameterQualification implements Serializable {
   }
 
   /**
+   * Returns the property targets independently validated for the complete named dataset.
+   *
+   * @return immutable, deterministic set of validated targets
+   */
+  public Set<ValidationTarget> getValidatedTargets() {
+    if (validatedTargets.isEmpty()) {
+      return Collections.emptySet();
+    }
+    return Collections.unmodifiableSet(EnumSet.copyOf(validatedTargets));
+  }
+
+  /**
    * Reports whether the complete named dataset is validated for use inside its declared envelope.
    *
    * @return {@code true} only for complete declared-envelope qualification
@@ -85,13 +129,44 @@ public final class PitzerParameterQualification implements Serializable {
   }
 
   /**
+   * Reports whether one property target has independent evidence for the complete named dataset.
+   *
+   * <p>
+   * This does not check the current state against a temperature, pressure, or composition envelope. The appropriate
+   * dataset-specific range helper remains a separate gate.
+   * </p>
+   *
+   * @param target requested scientific target
+   * @return {@code true} only when the dataset level and requested target are both qualified
+   */
+  public boolean isValidatedFor(ValidationTarget target) {
+    return target != null && isValidatedWithinDeclaredEnvelope() && validatedTargets.contains(target);
+  }
+
+  /**
    * Formats a deterministic diagnostic for publication and engineering gates.
    *
    * @return dataset identity, qualification level, validated systems, and limitations
    */
   public String formatDiagnostic() {
     return "Pitzer parameter dataset '" + datasetId + "' qualification: level=" + level + ", validatedSystems="
-        + validatedSystems + ", limitations=" + limitations;
+        + validatedSystems + ", validatedTargets=" + validatedTargets + ", limitations=" + limitations;
+  }
+
+  /**
+   * Requires independent qualification for one property target.
+   *
+   * @param target requested scientific target
+   * @throws IllegalArgumentException when the requested target is null
+   * @throws IllegalStateException when the dataset is not qualified for the requested target
+   */
+  public void requireValidationFor(ValidationTarget target) {
+    if (target == null) {
+      throw new IllegalArgumentException("Pitzer validation target must not be null");
+    }
+    if (!isValidatedFor(target)) {
+      throw new IllegalStateException(formatDiagnostic() + ", requestedTarget=" + target);
+    }
   }
 
   /**
@@ -116,5 +191,14 @@ public final class PitzerParameterQualification implements Serializable {
       return Collections.emptyList();
     }
     return Collections.unmodifiableList(new ArrayList<String>(values));
+  }
+
+  private static Set<ValidationTarget> immutableTargetCopy(List<ValidationTarget> values) {
+    if (values == null || values.isEmpty()) {
+      return Collections.emptySet();
+    }
+    EnumSet<ValidationTarget> copy = EnumSet.noneOf(ValidationTarget.class);
+    copy.addAll(values);
+    return Collections.unmodifiableSet(copy);
   }
 }

--- a/src/main/java/neqsim/thermo/system/SystemPitzer.java
+++ b/src/main/java/neqsim/thermo/system/SystemPitzer.java
@@ -5,6 +5,7 @@ import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionDataSource;
 import neqsim.thermo.phase.PhasePitzer;
 import neqsim.thermo.phase.PitzerParameterDatasets;
 import neqsim.thermo.phase.PitzerParameterQualification;
+import neqsim.thermo.phase.PitzerParameterQualification.ValidationTarget;
 import neqsim.thermo.phase.PhaseSrkEos;
 
 /**
@@ -106,7 +107,8 @@ public class SystemPitzer extends SystemEosGE {
    * <p>
    * This is an explicit publication gate. A broad dataset with only partially validated subsystems is rejected even
    * when it covers the active topology. A successful result still requires the caller to check the appropriate
-   * subsystem-specific temperature and molality range helper.
+   * subsystem-specific temperature and molality range helper. This legacy gate does not select an observable; use
+   * {@link #requirePitzerDatasetValidationFor(ValidationTarget)} before publishing a property-specific calculation.
    * </p>
    *
    * @return immutable qualification metadata for the accepted dataset
@@ -118,6 +120,32 @@ public class SystemPitzer extends SystemEosGE {
     PitzerParameterQualification qualification = PitzerParameterDatasets
         .getQualification(aqueousPhase.getParameterDatasetId());
     qualification.requireCompleteDatasetQualification();
+    return qualification;
+  }
+
+  /**
+   * Requires complete interaction coverage and independent qualification for one scientific target.
+   *
+   * <p>
+   * This explicit publication gate does not run a flash and does not check whether the current temperature, pressure,
+   * or composition lies inside the evidence envelope. Callers must also use the applicable dataset-specific range
+   * helper in {@link PitzerParameterDatasets}.
+   * </p>
+   *
+   * @param target requested property or equilibrium target
+   * @return immutable qualification metadata for the accepted dataset and target
+   * @throws IllegalArgumentException when {@code target} is null
+   * @throws IllegalStateException when coverage is incomplete or the target lacks independent qualification
+   */
+  public PitzerParameterQualification requirePitzerDatasetValidationFor(ValidationTarget target) {
+    if (target == null) {
+      throw new IllegalArgumentException("Pitzer validation target must not be null");
+    }
+    PhasePitzer aqueousPhase = (PhasePitzer) phaseArray[1];
+    aqueousPhase.requireCompletePitzerParameterCoverage();
+    PitzerParameterQualification qualification = PitzerParameterDatasets
+        .getQualification(aqueousPhase.getParameterDatasetId());
+    qualification.requireValidationFor(target);
     return qualification;
   }
 

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -86,6 +86,8 @@ import neqsim.pvtsimulation.flowassurance.ScaleMassCalculator;
 import neqsim.pvtsimulation.flowassurance.ScalePredictionCalculator;
 import neqsim.pvtsimulation.flowassurance.WaterCompatibilityScreener;
 import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.phase.PitzerParameterDatasets;
+import neqsim.thermo.phase.PitzerParameterQualification;
 import neqsim.thermo.system.FluidBuilder;
 import neqsim.thermo.system.SystemDesmukhMather;
 import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
@@ -122,6 +124,27 @@ public class DocExamplesCompilationTest {
     assertTrue(hasAqueousPhase);
     assertTrue(fluid.hasPhaseType(PhaseType.GAS));
     assertTrue(fluid.hasPhaseType(PhaseType.OIL));
+  }
+
+  /** Pitzer property-specific qualification example from docs/thermo/fluid_creation_guide.md. */
+  @Test
+  public void testPitzerObservableQualificationFluidCreationGuide() {
+    SystemPitzer qualifiedBrine = new SystemPitzer(298.15, 1.01325);
+    qualifiedBrine.addComponent("water", 55.508);
+    qualifiedBrine.addComponent("Na+", 0.5);
+    qualifiedBrine.addComponent("K+", 0.5);
+    qualifiedBrine.addComponent("Cl-", 1.0);
+    qualifiedBrine.init(0);
+    qualifiedBrine.applyPhreeqcSodiumPotassiumChlorideParameters();
+
+    PitzerParameterQualification evidence = qualifiedBrine.getPitzerParameterQualification();
+    qualifiedBrine
+        .requirePitzerDatasetValidationFor(PitzerParameterQualification.ValidationTarget.AQUEOUS_ACTIVITY_COEFFICIENTS);
+    boolean insideRange = PitzerParameterDatasets
+        .isWithinSodiumPotassiumChlorideValidationRange(qualifiedBrine.getTemperature(), 0.5, 0.5, 1.0);
+
+    assertTrue(evidence.isValidatedFor(PitzerParameterQualification.ValidationTarget.AQUEOUS_ACTIVITY_COEFFICIENTS));
+    assertTrue(insideRange);
   }
 
   /** Generic SystemEosGE opt-in example from docs/thermo/fluid_creation_guide.md. */

--- a/src/test/java/neqsim/thermo/system/PitzerCo2SodiumSulfateVleValidationTest.java
+++ b/src/test/java/neqsim/thermo/system/PitzerCo2SodiumSulfateVleValidationTest.java
@@ -1,0 +1,113 @@
+package neqsim.thermo.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+import neqsim.thermodynamicoperations.flashops.saturationops.ElectrolytePhaseBoundaryResult;
+
+/** Held-out CO2-Na2SO4 bubble-pressure evidence for the Pitzer qualification boundary. */
+class PitzerCo2SodiumSulfateVleValidationTest extends neqsim.NeqSimTest {
+  private static final double WATER_MOLES_PER_KILOGRAM = 55.508;
+  private static final String REFERENCE_RESOURCE = "/neqsim/thermo/system/bermejo-co2-na2so4-bubble-pressure-reference.csv";
+
+  /**
+   * The qualified activity subset closes every flash but does not reproduce independent gas-aqueous VLE data.
+   *
+   * @throws IOException if the reviewed validation fixture cannot be read
+   */
+  @Test
+  void heldOutBubblePressuresRejectGasAqueousVleQualification() throws IOException {
+    double minimumAbsoluteRelativeResidual = Double.POSITIVE_INFINITY;
+    double maximumAbsoluteRelativeResidual = 0.0;
+
+    for (ReferenceState state : readReferenceStates()) {
+      ElectrolytePhaseBoundaryResult result = calculateBubblePressure(state);
+      double calculatedPressure = result.getBoundaryValue();
+      double absoluteRelativeResidual = Math.abs(calculatedPressure - state.pressureBara) / state.pressureBara;
+
+      assertEquals(state.masterCalculatedPressureBara, calculatedPressure, 0.03, state.pointId);
+      assertEquals(PhaseType.GAS, result.getTargetPhase(), state.pointId);
+      assertTrue(calculatedPressure < state.pressureBara - state.expandedUncertaintyBara, state.pointId);
+      assertTrue(result.getBracketWidth() <= 0.02, state.pointId);
+      assertTrue(result.getTargetPhaseFraction() > 1.0e-10, state.pointId);
+      assertTrue(result.getMaximumMaterialBalanceResidual() <= 1.0e-7, state.pointId);
+      assertTrue(result.getMaximumPhaseNormalizationResidual() <= 1.0e-10, state.pointId);
+      assertTrue(Math.abs(result.getAqueousChargeMolality()) <= 1.0e-8, state.pointId);
+      assertTrue(result.getMaximumIonMoleFractionOutsideAqueous() <= 1.0e-30, state.pointId);
+      assertTrue(result.getMaximumLogFugacityResidual() <= 1.0e-5, state.pointId);
+      assertTrue(result.getMaximumAbsoluteElementBalanceResidual() <= 1.0e-8, state.pointId);
+      assertTrue(result.getMaximumAbsoluteReactionLogResidual() <= 2.0e-6, state.pointId);
+      minimumAbsoluteRelativeResidual = Math.min(minimumAbsoluteRelativeResidual, absoluteRelativeResidual);
+      maximumAbsoluteRelativeResidual = Math.max(maximumAbsoluteRelativeResidual, absoluteRelativeResidual);
+    }
+
+    assertTrue(minimumAbsoluteRelativeResidual >= 0.325);
+    assertTrue(maximumAbsoluteRelativeResidual <= 0.439);
+  }
+
+  private static ElectrolytePhaseBoundaryResult calculateBubblePressure(ReferenceState state) {
+    double saltFormulaMoles = state.saltMolality;
+    double carbonDioxideMoles = state.carbonDioxideLiquidMoleFraction / (1.0 - state.carbonDioxideLiquidMoleFraction)
+        * (WATER_MOLES_PER_KILOGRAM + saltFormulaMoles);
+    SystemPitzer system = new SystemPitzer(state.temperatureKelvin, state.pressureBara);
+    system.addComponent("CO2", carbonDioxideMoles);
+    system.addComponent("water", WATER_MOLES_PER_KILOGRAM);
+    system.addComponent("Na+", 2.0 * saltFormulaMoles);
+    system.addComponent("SO4--", saltFormulaMoles);
+    system.init(0);
+    system.applyPhreeqcCo2SodiumSulfateParameters();
+    system.setMixingRule("classic");
+    system.setMultiPhaseCheck(true);
+    return new ThermodynamicOperations(system).electrolytePhaseBoundaryPressureFlash(PhaseType.GAS, 1.0, 200.0, 0.02,
+        30);
+  }
+
+  private static List<ReferenceState> readReferenceStates() throws IOException {
+    InputStream input = PitzerCo2SodiumSulfateVleValidationTest.class.getResourceAsStream(REFERENCE_RESOURCE);
+    assertNotNull(input, REFERENCE_RESOURCE);
+    List<ReferenceState> states = new ArrayList<ReferenceState>();
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.isEmpty() || line.startsWith("#") || line.startsWith("point_id")) {
+          continue;
+        }
+        String[] fields = line.split(",");
+        assertEquals(7, fields.length, line);
+        states.add(new ReferenceState(fields));
+      }
+    }
+    assertEquals(6, states.size());
+    return states;
+  }
+
+  private static final class ReferenceState {
+    private final String pointId;
+    private final double saltMolality;
+    private final double carbonDioxideLiquidMoleFraction;
+    private final double temperatureKelvin;
+    private final double pressureBara;
+    private final double expandedUncertaintyBara;
+    private final double masterCalculatedPressureBara;
+
+    private ReferenceState(String[] fields) {
+      pointId = fields[0];
+      saltMolality = Double.parseDouble(fields[1]);
+      carbonDioxideLiquidMoleFraction = Double.parseDouble(fields[2]);
+      temperatureKelvin = Double.parseDouble(fields[3]);
+      pressureBara = Double.parseDouble(fields[4]);
+      expandedUncertaintyBara = Double.parseDouble(fields[5]);
+      masterCalculatedPressureBara = Double.parseDouble(fields[6]);
+    }
+  }
+}

--- a/src/test/java/neqsim/thermo/system/PitzerCo2SodiumSulfateVleValidationTest.java
+++ b/src/test/java/neqsim/thermo/system/PitzerCo2SodiumSulfateVleValidationTest.java
@@ -2,6 +2,7 @@ package neqsim.thermo.system;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -55,6 +56,17 @@ class PitzerCo2SodiumSulfateVleValidationTest extends neqsim.NeqSimTest {
     assertTrue(maximumAbsoluteRelativeResidual <= 0.439);
   }
 
+  @Test
+  void malformedReferenceStateReportsPointContext() {
+    String[] fields = { "invalid-point", "not-a-number", "0.01", "323.15", "75.0", "1.0", "50.0" };
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new ReferenceState(fields));
+
+    assertTrue(exception.getMessage().contains("invalid-point"));
+    assertTrue(exception.getMessage().contains("not-a-number"));
+    assertTrue(exception.getCause() instanceof NumberFormatException);
+  }
+
   private static ElectrolytePhaseBoundaryResult calculateBubblePressure(ReferenceState state) {
     double saltFormulaMoles = state.saltMolality;
     double carbonDioxideMoles = state.carbonDioxideLiquidMoleFraction / (1.0 - state.carbonDioxideLiquidMoleFraction)
@@ -102,12 +114,17 @@ class PitzerCo2SodiumSulfateVleValidationTest extends neqsim.NeqSimTest {
 
     private ReferenceState(String[] fields) {
       pointId = fields[0];
-      saltMolality = Double.parseDouble(fields[1]);
-      carbonDioxideLiquidMoleFraction = Double.parseDouble(fields[2]);
-      temperatureKelvin = Double.parseDouble(fields[3]);
-      pressureBara = Double.parseDouble(fields[4]);
-      expandedUncertaintyBara = Double.parseDouble(fields[5]);
-      masterCalculatedPressureBara = Double.parseDouble(fields[6]);
+      try {
+        saltMolality = Double.parseDouble(fields[1]);
+        carbonDioxideLiquidMoleFraction = Double.parseDouble(fields[2]);
+        temperatureKelvin = Double.parseDouble(fields[3]);
+        pressureBara = Double.parseDouble(fields[4]);
+        expandedUncertaintyBara = Double.parseDouble(fields[5]);
+        masterCalculatedPressureBara = Double.parseDouble(fields[6]);
+      } catch (NumberFormatException invalidNumber) {
+        throw new IllegalArgumentException(
+            "Invalid numeric value for point " + pointId + ": " + String.join(",", fields), invalidNumber);
+      }
     }
   }
 }

--- a/src/test/java/neqsim/thermo/system/SystemPitzerParameterQualificationTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerParameterQualificationTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
 import neqsim.thermo.phase.PitzerParameterDatasets;
 import neqsim.thermo.phase.PitzerParameterQualification;
+import neqsim.thermo.phase.PitzerParameterQualification.ValidationTarget;
 
 /** Tests the explicit SystemPitzer scientific-qualification publication gate. */
 class SystemPitzerParameterQualificationTest {
@@ -30,6 +31,27 @@ class SystemPitzerParameterQualificationTest {
     assertEquals(PitzerParameterDatasets.PHREEQC_NA_K_CL_ID, qualification.getDatasetId());
     assertEquals(PitzerParameterQualification.Level.VALIDATED_WITHIN_DECLARED_ENVELOPE, qualification.getLevel());
     assertTrue(qualification.isValidatedWithinDeclaredEnvelope());
+    assertTrue(qualification.isValidatedFor(ValidationTarget.AQUEOUS_ACTIVITY_COEFFICIENTS));
+    assertTrue(qualification.isValidatedFor(ValidationTarget.WATER_ACTIVITY_AND_OSMOTIC_COEFFICIENT));
+    assertFalse(qualification.isValidatedFor(ValidationTarget.GAS_AQUEOUS_VLE));
+    assertEquals(qualification.formatDiagnostic(),
+        system.requirePitzerDatasetValidationFor(ValidationTarget.AQUEOUS_ACTIVITY_COEFFICIENTS).formatDiagnostic());
+  }
+
+  @Test
+  void carbonDioxideSodiumSulfateFailsClosedForUnqualifiedVleTarget() {
+    SystemPitzer system = createCarbonDioxideSodiumSulfateSystem();
+    system.applyPhreeqcCo2SodiumSulfateParameters();
+
+    assertTrue(system.requirePitzerDatasetValidationFor(ValidationTarget.AQUEOUS_ACTIVITY_COEFFICIENTS)
+        .isValidatedFor(ValidationTarget.AQUEOUS_ACTIVITY_COEFFICIENTS));
+    IllegalStateException failure = assertThrows(IllegalStateException.class,
+        () -> system.requirePitzerDatasetValidationFor(ValidationTarget.GAS_AQUEOUS_VLE));
+
+    assertTrue(failure.getMessage().contains("requestedTarget=GAS_AQUEOUS_VLE"));
+    assertTrue(failure.getMessage().contains("NIST ThermoML"));
+    assertTrue(failure.getMessage().contains("32.6-43.8%"));
+    assertThrows(IllegalArgumentException.class, () -> system.requirePitzerDatasetValidationFor(null));
   }
 
   @Test
@@ -117,6 +139,16 @@ class SystemPitzerParameterQualificationTest {
     system.addComponent("Na+", 1.0);
     system.addComponent("Cl-", 1.0);
     system.useLegacyPitzerParameters();
+    system.init(0);
+    return system;
+  }
+
+  private static SystemPitzer createCarbonDioxideSodiumSulfateSystem() {
+    SystemPitzer system = new SystemPitzer(319.63, 80.9);
+    system.addComponent("CO2", 0.6);
+    system.addComponent("water", 55.508);
+    system.addComponent("Na+", 2.0);
+    system.addComponent("SO4--", 1.0);
     system.init(0);
     return system;
   }

--- a/src/test/resources/neqsim/thermo/system/bermejo-co2-na2so4-bubble-pressure-reference.csv
+++ b/src/test/resources/neqsim/thermo/system/bermejo-co2-na2so4-bubble-pressure-reference.csv
@@ -1,0 +1,16 @@
+# Held-out CO2-Na2SO4 bubble-pressure evidence; no parameter was fitted to these rows.
+# Primary source: Bermejo et al. (2005), Fluid Phase Equilibria, doi:10.1016/j.fluid.2005.10.006.
+# Machine source: NIST ThermoML dataset 2, https://trc.nist.gov/ThermoML/10.1016/j.fluid.2005.10.006.json
+# Retrieved: 2026-08-30; JSON SHA-256: aeeff43c1aa196a749b01dbb31d22bf502fe140a85e4823ecea8544f06dd3897
+# Reuse basis: publisher-permitted NIST ThermoML archive; this fixture stores six selected numerical observations.
+# Source variables: Na2SO4 solvent molality (mol/kg), liquid CO2 mole fraction, temperature (K), pressure (kPa).
+# Preprocessing: pressure_kPa/100=pressure_bara; 95% expanded pressure uncertainty converted identically.
+# Composition mapping: 1 kg water=55.508 mol; nCO2=x/(1-x)*(nH2O+nNa2SO4); salt becomes 2 Na+ + SO4--.
+# Selection: two replicated compositions plus nearby temperature/composition states across 307.78-340.10 K.
+point_id,salt_molality_mol_per_kg,co2_liquid_mole_fraction,temperature_k,pressure_bara,expanded_uncertainty_bara,master_calculated_pressure_bara
+B2005-01,0.986703,0.00773,307.78,43.50,0.50,29.306
+B2005-02,0.986703,0.00773,327.19,64.00,0.80,43.165
+B2005-03,0.986703,0.01026,319.63,80.90,1.30,53.064
+B2005-04,0.986703,0.01026,340.10,118.20,1.70,74.040
+B2005-05,0.995676,0.00986,314.54,68.60,0.80,45.715
+B2005-06,0.996313,0.01161,316.51,104.80,2.00,58.930


### PR DESCRIPTION
## Engineering question

Can the named PHREEQC CO2-Na2SO4 Pitzer subset be prevented from being published for gas-aqueous VLE merely because its aqueous activity evidence and complete interaction topology pass?

## Frozen scope

Base `4e4bdcbc3fe4cd74fb13d24f3e0bfee43148261f`; exact head `d8517fe60884f766ad73bafd74226ce73f07c778`.

This PR adds an observable-specific scientific qualification contract and held-out quantitative VLE evidence. It does not fit or change a Pitzer parameter, Henry correlation, Poynting correction, reaction row, flash algorithm, phase model, salt-input API, absorber, or electrolyte-EOS parameter.

## Current-master reproducer and result

Six independent CO2 + H2O + Na2SO4 bubble-pressure states from Bermejo et al. (2005) were evaluated with `SystemPitzer`, the explicit PHREEQC CO2-Na2SO4 subset, classic mixing, molecular-salt liquid composition mapping, and the electrolyte phase-boundary pressure flash.

- T: 307.78-340.10 K
- Na2SO4: 0.986703-0.996313 mol/kg water
- liquid CO2 mole fraction: 0.00773-0.01161
- measured pressure: 43.5-118.2 bara
- 95% expanded pressure uncertainty: 0.5-2.0 bara
- master predictions: 29.306, 43.165, 53.064, 74.040, 45.715, 58.930 bara
- relative residual: -32.6% to -43.8%, outside every experimental uncertainty
- explicit-ion composition-denominator sensitivity at the central state still leaves -31.5%

Every calculation closes: material balance is order `1e-16`, maximum log-fugacity residual is below `1e-10`, charge is zero, phase normalization and ion confinement pass. This is therefore a scientific qualification failure, not a solver-convergence failure.

## Change

- add machine-readable `ValidationTarget` values for aqueous activity, water/osmotic properties, gas-aqueous VLE, reactive speciation, and mineral equilibrium;
- add `SystemPitzer.requirePitzerDatasetValidationFor(...)`, which first requires complete interaction coverage and then fails closed for an unsupported target;
- qualify the CO2-Na2SO4 and Na-K-Cl subsets only for the activity and water-property targets supported by existing evidence;
- make `GAS_AQUEOUS_VLE` fail closed for CO2-Na2SO4 with the quantitative limitation;
- add the six-state NIST ThermoML fixture, source checksum, uncertainty, unit conversion, composition basis, deterministic master predictions, and full closure assertions;
- update executable API documentation, Henry/Pitzer evidence boundaries, and the durable source-comparison matrix.

The legacy complete-dataset gate remains source compatible, but documentation now forbids inferring an observable from its overall level.

## Public data, provenance, and reuse

- Bermejo et al. (2005), DOI: https://doi.org/10.1016/j.fluid.2005.10.006
- NIST ThermoML record: https://trc.nist.gov/ThermoML/10.1016/j.fluid.2005.10.006.html
- ThermoML JSON SHA-256: `aeeff43c1aa196a749b01dbb31d22bf502fe140a85e4823ecea8544f06dd3897`
- reuse basis: publisher-permitted NIST ThermoML archive; only six numerical observations and their metadata are stored
- preprocessing: kPa / 100 to bara; 1 kg water = 55.508 mol; `nCO2=x/(1-x)*(nH2O+nNa2SO4)`; Na2SO4 becomes `2 Na+ + SO4--`

The experimental data are independent of the PHREEQC parameter lineage and were not used for fitting.

## Kaasa and parameter-adoption decision

Kaasa (1998) remains a high-priority provenance index. No new thesis coefficient was copied, inferred, OCRed, adopted, or rejected in this increment. The previously audited Appendix F CO2 neutral-family inventory supplies provenance leads but no independent bubble-pressure evidence; there is therefore no new Kaasa/PHREEQC coefficient agreement or disagreement and no new convention mapping beyond the verified six-term order permutation.

The next missing neutral interaction remains a complete redistributable H2S family, including source-model self/dimer semantics and all active ion companions. Partial H2Sg-Na+, H2Sg-Cl-, and ternary rows remain fail-closed.

## Validation

Passed locally:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py` (672 Markdown pages)
- `./mvnw -q checkstyle:check`
- `./mvnw -q pmd:check`
- `./mvnw -q -Dtest=PitzerCo2SodiumSulfateVleValidationTest,SystemPitzerParameterQualificationTest,PitzerParameterDatasetsTest,SystemHybridEosGeFlashTest,DocExamplesCompilationTest test` (105 tests)
- final direct rerun of the two modified qualification classes (7 tests)
- review follow-up: focused VLE class (2 tests), including malformed-row diagnostic coverage
- `git diff --check`

Whole-repository SpotBugs is infrastructure-blocked: both attempts exhaust the plugin's 536 MB heap while analyzing unchanged `SolidFlash12`. A branch-scoped run reports only the pre-existing `SystemPitzer.clone()` nullability and inherited-hash-code findings; no new class finding is introduced. Local pre-commit is unavailable because the `pre_commit` module is not installed.

Initial exact-head CI passed on `1c3be3ce8d452f7c5bf3363832ad73132939d596`. Six duplicate code-quality threads requested contextual handling of malformed numeric fixture rows; `d8517fe60884f766ad73bafd74226ce73f07c778` implements the justified test-only repair, adds a focused regression, and resolves all six threads.

Exact-head hosted validation is fully green: Java 8/21 on Ubuntu and Windows, all four slow shards, Javadocs, CodeQL, documentation search, Spotless, pre-commit, PaperLab, and agent-reference checks pass. Merged as `542afb89603fdd25d9e44f0e95baaa34475cca3c`; verified present on current master `21ea4c9fea4235368427f3f65dbd255f82386b50`.

## Performance and compatibility

The production activity, fugacity, flash, reaction, and neutral EOS kernels are byte-for-byte unchanged. New work occurs only when an explicit qualification accessor/gate is called. The six complete boundary calculations take 7.52 s in the final local focused run. Neutral PR/SRK/CPA and non-ionic paths execute no new branch or allocation.

## Stop boundary and coordination

Generic TP-flash changes remain with #2937, reactive-absorber equipment with #205, and salt input/API work with #448. The quantitative pressure gap is recorded rather than tuned. A scientifically reviewed pressure/standard-state model change requires separate primary evidence and validation.

Advances #3144.