### PR TITLE
[AI-Assisted] docs: repair package landing-page titles

### DIFF
--- a/docs/chemicalreactions/README.md
+++ b/docs/chemicalreactions/README.md
@@ -3,8 +3,6 @@ title: Chemical Reactions Package
 description: The `chemicalreactions` package provides tools for chemical equilibrium calculations and reaction kinetics.
 ---
 
-# Chemical Reactions Package
-
 The `chemicalreactions` package provides tools for chemical equilibrium calculations and reaction kinetics.
 
 ## Table of Contents

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -3,8 +3,6 @@ title: Development Documentation
 description: Guides for developers contributing to NeqSim, extending models, and creating custom components.
 ---
 
-# Development Documentation
-
 Guides for developers contributing to NeqSim, extending the library with new models, and integrating with Python.
 
 ---

--- a/docs/fluidmechanics/README.md
+++ b/docs/fluidmechanics/README.md
@@ -3,8 +3,6 @@ title: Fluid Mechanics Package
 description: The `fluidmechanics` package provides models for pipeline flow, pressure drop calculations, and transient flow simulation with rigorous non-equilibrium thermodynamic calculations for mass and heat tra...
 ---
 
-# Fluid Mechanics Package
-
 The `fluidmechanics` package provides models for pipeline flow, pressure drop calculations, and transient flow simulation with rigorous non-equilibrium thermodynamic calculations for mass and heat transfer.
 
 ## Table of Contents

--- a/docs/mathlib/README.md
+++ b/docs/mathlib/README.md
@@ -3,8 +3,6 @@ title: Mathematical Library Package
 description: The `mathlib` package provides mathematical utilities, nonlinear solvers, and numerical methods.
 ---
 
-# Mathematical Library Package
-
 The `mathlib` package provides mathematical utilities, nonlinear solvers, and numerical methods.
 
 ## Table of Contents

--- a/docs/statistics/README.md
+++ b/docs/statistics/README.md
@@ -3,8 +3,6 @@ title: "Statistics Package"
 description: "The NeqSim statistics package provides tools for parameter fitting, uncertainty quantification, and data analysis for thermodynamic model development and validation."
 ---
 
-# Statistics Package
-
 The NeqSim statistics package provides tools for parameter fitting, uncertainty quantification, and data analysis for thermodynamic model development and validation.
 
 ## Table of Contents

--- a/docs/test_package_landing_pages_documentation.py
+++ b/docs/test_package_landing_pages_documentation.py
@@ -1,0 +1,82 @@
+"""Contracts for package landing-page metadata and discoverability."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+DOCS = Path(__file__).resolve().parent
+PRIMARY_HUB = DOCS / "README.md"
+SITE_HOME = DOCS / "index.md"
+REFERENCE_INDEX = DOCS / "REFERENCE_MANUAL_INDEX.md"
+PACKAGE_LANDING_PAGES = (
+    DOCS / "fluidmechanics/README.md",
+    DOCS / "chemicalreactions/README.md",
+    DOCS / "statistics/README.md",
+    DOCS / "util/README.md",
+    DOCS / "mathlib/README.md",
+    DOCS / "development/README.md",
+)
+
+
+def parse_front_matter(source):
+    """Return normalized title, description, and body from one Markdown page."""
+    match = re.match(r"\A---\n(?P<metadata>.*?)\n---\n(?P<body>.*)\Z", source, re.DOTALL)
+    if match is None:
+        raise AssertionError("Missing Jekyll front matter")
+
+    metadata = match.group("metadata")
+    title_match = re.search(r"^title:\s*(.+?)\s*$", metadata, re.MULTILINE)
+    description_match = re.search(r"^description:\s*(.+?)\s*$", metadata, re.MULTILINE)
+    if title_match is None or description_match is None:
+        raise AssertionError("Front matter must define title and description")
+
+    title = title_match.group(1).strip().strip("'\"")
+    description = description_match.group(1).strip().strip("'\"")
+    return title, description, match.group("body")
+
+
+def remove_fenced_code(source):
+    """Remove fenced examples before inspecting rendered Markdown headings."""
+    fence_pattern = chr(96) * 3 + r"[^\n]*\n.*?" + chr(96) * 3
+    return re.sub(fence_pattern, "", source, flags=re.DOTALL)
+
+
+class PackageLandingPageDocumentationContractTest(unittest.TestCase):
+    """Protect package hubs from duplicate rendered titles and navigation drift."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.primary_hub = PRIMARY_HUB.read_text(encoding="utf-8")
+        cls.site_home = SITE_HOME.read_text(encoding="utf-8")
+        cls.reference_index = REFERENCE_INDEX.read_text(encoding="utf-8")
+
+    def test_package_hubs_have_searchable_front_matter(self):
+        for page in PACKAGE_LANDING_PAGES:
+            with self.subTest(page=page):
+                title, description, _body = parse_front_matter(page.read_text(encoding="utf-8"))
+                self.assertTrue(title)
+                self.assertGreaterEqual(len(description.split()), 5)
+
+    def test_front_matter_title_is_not_repeated_as_h1(self):
+        for page in PACKAGE_LANDING_PAGES:
+            with self.subTest(page=page):
+                title, _description, body = parse_front_matter(page.read_text(encoding="utf-8"))
+                rendered_markdown = remove_fenced_code(body)
+                headings = re.findall(r"^#\s+(.+?)\s*$", rendered_markdown, re.MULTILINE)
+                self.assertNotIn(title, headings)
+
+    def test_package_hubs_remain_discoverable(self):
+        for page in PACKAGE_LANDING_PAGES:
+            with self.subTest(page=page):
+                package_directory = page.parent.name
+                source_link = "({}/)".format(package_directory)
+                published_link = '"{}/README.html"'.format(package_directory)
+                self.assertTrue(
+                    source_link in self.primary_hub or published_link in self.site_home
+                )
+                self.assertIn("{}/README.md".format(package_directory), self.reference_index)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/util/README.md
+++ b/docs/util/README.md
@@ -3,8 +3,6 @@ title: "Utilities Package"
 description: "The `util` package provides common utilities for database access, unit conversion, serialization, exceptions, and threading."
 ---
 
-# Utilities Package
-
 The `util` package provides common utilities for database access, unit conversion, serialization, exceptions, and threading.
 
 ## Table of Contents


### PR DESCRIPTION
## Campaign / roadmap

Advances #2499 as D105, rotation scope 1 (landing pages, navigation, indexes). D104/#3328 was independently merged before this batch was selected.

Exact base: `5492505ddca7df23a19a22454cd277716befda16`  
Exact head: `1a38b511d4582adf6da75362f8f4fd1fd47f6d6d`

## Confirmed defects and frozen scope

Six package landing pages define a Jekyll `title` in front matter and repeat the same text as a Markdown H1, so the rendered page displays the title twice:

- `docs/fluidmechanics/README.md`
- `docs/chemicalreactions/README.md`
- `docs/statistics/README.md`
- `docs/util/README.md`
- `docs/mathlib/README.md`
- `docs/development/README.md`

This PR removes only those redundant H1s and adds `docs/test_package_landing_pages_documentation.py`. Exactly seven files are frozen.

## Navigation and regression evidence

The new dependency-free documentation contract verifies:

- non-empty, searchable `title` and `description` front matter for all six hubs;
- no front-matter title is repeated as an H1 outside fenced examples;
- each hub remains discoverable from the primary docs hub or site home;
- each exact source path remains present in the reference-manual index.

The scan checked 101 authored links across `docs/README.md` and `docs/index.md` against current GitHub source. All source-backed routes resolve; `search/` is the generated Jekyll search route and is not a missing source page.

## Validation

All five exact-head workflows pass:

- documentation source/search checks, all documentation contracts, Jekyll build, generated-search coverage, and search JavaScript syntax;
- pre-commit checks;
- Spotless format patch check;
- build, tests, Javadocs, and agent-skill checks;
- CodeQL.

The PR is mergeable, zero commits behind, and has no comments, reviews, requested changes, or unresolved threads. Local Maven, Spotless, Jekyll, and pre-commit were not run; hosted CI is the authoritative validation.

## Documentation impact

The user-visible impact is limited to removing duplicate rendered titles from six package landing pages. No example, Java API, production behavior, notebook, equation, parameter, or scientific model changes.

## Stop boundary

Stop at the six confirmed duplicate-title defects and their shared regression. Other landing-page content improvements, generated search behavior, production code, notebooks, and Huldra work are outside D105.