### PR TITLE
[AI-Assisted] fix(dexpi): render filled flow arrows

### DIFF
--- a/docs/integration/dexpi-reference-cases.md
+++ b/docs/integration/dexpi-reference-cases.md
@@ -52,12 +52,18 @@ writer and rendered from its actual graphical primitives. The suite checks:
 - stable catalogue references, component identities, locations, line/curve/text primitives, SVG
   identity projection, and SHA-256 fingerprints;
 - drawing bounds, duplicate IDs, minimum text-height risks, missing symbols, and empty SVG output;
+- exactly one source-to-destination flow-direction arrow for every routed material segment, with
+  solid fill preserved in the rendered SVG;
 - deterministic report JSON and SVG output across repeated exports; and
 - preservation of an intentionally unconfigured stream through `ProcessSystem.run()` without
   inventing a fluid state.
 
 The structural gate complements, but does not replace, full-sheet and readable-detail PNG visual
 inspection. It distinguishes renderer/layout defects from missing source-model engineering data.
+
+The flow-arrow regression records routed-segment, source-arrow, and rendered-filled-arrow counts.
+Missing, duplicate, or renderer-dropped arrows produce stable findings instead of relying on visual
+memory. This is a directional-readability gate, not a standards-conformance determination.
 
 The first full-sheet benchmark inspection found that instrument bubbles intersected full equipment
 data bars and sat outside the generated battery limit. The layout now reserves 55 mm above an

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiLayoutEngine.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiLayoutEngine.java
@@ -1705,6 +1705,7 @@ final class DexpiLayoutEngine {
 
     Element poly = document.createElement("PolyLine");
     poly.setAttribute("NumPoints", "4");
+    poly.setAttribute("Filled", "Solid");
     Element pres = document.createElement("Presentation");
     pres.setAttribute("LineType", "0");
     pres.setAttribute("LineWeight", String.valueOf(PROCESS_LINE_WEIGHT));

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessment.java
@@ -211,6 +211,7 @@ public final class DexpiVisualQualityAssessment {
     assessInstances(document, shapes, svg, findings, metrics);
     assessCoordinates(document, extent, findings, metrics);
     assessText(document, findings, metrics);
+    assessFlowDirectionArrows(document, svg, findings, metrics);
 
     metrics.put("sourcePolylines", countOutsideCatalogue(document, "PolyLine"));
     metrics.put("sourceCenterLines", countOutsideCatalogue(document, "CenterLine"));
@@ -308,6 +309,51 @@ public final class DexpiVisualQualityAssessment {
     metrics.put("renderedInstances", rendered);
     metrics.put("missingShapeReferences", missingReferences);
     metrics.put("missingInstancePositions", missingPositions);
+  }
+
+  private static void assessFlowDirectionArrows(Document document, String svg, List<Finding> findings,
+      Map<String, Integer> metrics) {
+    NodeList segments = document.getElementsByTagName("PipingNetworkSegment");
+    int routedSegments = 0;
+    int sourceArrows = 0;
+    for (int index = 0; index < segments.getLength(); index++) {
+      Element segment = (Element) segments.item(index);
+      if (firstDirectChild(segment, "Connection") == null || firstDirectChild(segment, "CenterLine") == null) {
+        continue;
+      }
+      routedSegments++;
+      int segmentArrows = 0;
+      NodeList children = segment.getChildNodes();
+      for (int childIndex = 0; childIndex < children.getLength(); childIndex++) {
+        Node child = children.item(childIndex);
+        if (!(child instanceof Element)) {
+          continue;
+        }
+        Element primitive = (Element) child;
+        if ("PolyLine".equals(primitive.getTagName())
+            && "Solid".equalsIgnoreCase(primitive.getAttribute("Filled"))
+            && primitive.getElementsByTagName("Coordinate").getLength() >= 4) {
+          segmentArrows++;
+          sourceArrows++;
+        }
+      }
+      String identity = segment.getAttribute("ID").trim();
+      if (segmentArrows == 0) {
+        add(findings, Severity.ERROR, "FLOW_DIRECTION_ARROW_MISSING", identity,
+            "Routed material segment has no solid flow-direction arrow");
+      } else if (segmentArrows > 1) {
+        add(findings, Severity.WARNING, "FLOW_DIRECTION_ARROW_AMBIGUOUS", identity,
+            "Routed material segment has more than one solid flow-direction arrow");
+      }
+    }
+    int renderedArrows = occurrences(svg, "data-dexpi-filled=\"solid\"");
+    metrics.put("routedMaterialSegments", routedSegments);
+    metrics.put("sourceFlowDirectionArrows", sourceArrows);
+    metrics.put("renderedFilledFlowDirectionArrows", renderedArrows);
+    if (sourceArrows > renderedArrows) {
+      add(findings, Severity.ERROR, "FLOW_DIRECTION_ARROW_NOT_RENDERED", "",
+          "One or more solid source flow-direction arrows are absent from generated SVG");
+    }
   }
 
   private static void assessCoordinates(Document document, double[] extent, List<Finding> findings,

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessment.java
@@ -330,8 +330,7 @@ public final class DexpiVisualQualityAssessment {
           continue;
         }
         Element primitive = (Element) child;
-        if ("PolyLine".equals(primitive.getTagName())
-            && "Solid".equalsIgnoreCase(primitive.getAttribute("Filled"))
+        if ("PolyLine".equals(primitive.getTagName()) && "Solid".equalsIgnoreCase(primitive.getAttribute("Filled"))
             && primitive.getElementsByTagName("Coordinate").getLength() >= 4) {
           segmentArrows++;
           sourceArrows++;

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRenderer.java
@@ -363,8 +363,8 @@ public final class DexpiXmlSvgRenderer {
     if (!"Solid".equalsIgnoreCase(element.getAttribute("Filled"))) {
       return renderedStyle;
     }
-    return renderedStyle.replace(" fill=\\\"none\\\"", "") + " fill=\\\"" + color(element)
-        + "\\\" data-dexpi-filled=\\\"solid\\\"";
+    return renderedStyle.replace(" fill=\"none\"", "") + " fill=\"" + color(element)
+        + "\" data-dexpi-filled=\"solid\"";
   }
 
   private static String style(Element element) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRenderer.java
@@ -212,7 +212,7 @@ public final class DexpiXmlSvgRenderer {
         svg.append(number(attribute(coordinate, "X", 0.0))).append(',')
             .append(number(sheetHeight - attribute(coordinate, "Y", 0.0)));
       }
-      svg.append("\" ").append(style(curve)).append("/>").append('\n');
+      svg.append("\" ").append(styleWithFill(curve)).append("/>").append('\n');
     }
   }
 
@@ -266,7 +266,7 @@ public final class DexpiXmlSvgRenderer {
           svg.append(number(attribute(coordinate, "X", 0.0))).append(',')
               .append(number(attribute(coordinate, "Y", 0.0)));
         }
-        svg.append("\" ").append(style(primitive)).append("/>").append('\n');
+        svg.append("\" ").append(styleWithFill(primitive)).append("/>").append('\n');
       } else if ("Circle".equals(primitive.getTagName())) {
         appendLocalCircle(primitive, primitive, svg);
       } else if ("TrimmedCurve".equals(primitive.getTagName())) {
@@ -312,7 +312,7 @@ public final class DexpiXmlSvgRenderer {
     int largeArc = delta > 180.0 ? 1 : 0;
     svg.append("      <path d=\"M ").append(number(startX)).append(' ').append(number(startY)).append(" A ")
         .append(number(radius)).append(' ').append(number(radius)).append(" 0 ").append(largeArc).append(" 1 ")
-        .append(number(endX)).append(' ').append(number(endY)).append("\" ").append(style(curve)).append("/>\n");
+        .append(number(endX)).append(' ').append(number(endY)).append("\" ").append(styleWithFill(curve)).append("/>\n");
   }
 
   private static void appendGlobalArc(Element curve, Element circle, double sheetHeight, StringBuilder svg) {
@@ -331,7 +331,7 @@ public final class DexpiXmlSvgRenderer {
     int largeArc = delta > 180.0 ? 1 : 0;
     svg.append("    <path d=\"M ").append(number(startX)).append(' ').append(number(startY)).append(" A ")
         .append(number(radius)).append(' ').append(number(radius)).append(" 0 ").append(largeArc).append(" 0 ")
-        .append(number(endX)).append(' ').append(number(endY)).append("\" ").append(style(curve)).append("/>\n");
+        .append(number(endX)).append(' ').append(number(endY)).append("\" ").append(styleWithFill(curve)).append("/>\n");
   }
 
   private static void renderText(Document document, double sheetHeight, StringBuilder svg) {
@@ -356,6 +356,15 @@ public final class DexpiXmlSvgRenderer {
           .append("\" text-anchor=\"").append(anchor).append("\" dominant-baseline=\"").append(baseline)
           .append("\" fill=\"").append(color(text)).append("\">").append(xml(value)).append("</text>\n");
     }
+  }
+
+  private static String styleWithFill(Element element) {
+    String renderedStyle = style(element);
+    if (!"Solid".equalsIgnoreCase(element.getAttribute("Filled"))) {
+      return renderedStyle;
+    }
+    return renderedStyle.replace(" fill=\\\"none\\\"", "") + " fill=\\\"" + color(element)
+        + "\\\" data-dexpi-filled=\\\"solid\\\"";
   }
 
   private static String style(Element element) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRenderer.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRenderer.java
@@ -312,7 +312,8 @@ public final class DexpiXmlSvgRenderer {
     int largeArc = delta > 180.0 ? 1 : 0;
     svg.append("      <path d=\"M ").append(number(startX)).append(' ').append(number(startY)).append(" A ")
         .append(number(radius)).append(' ').append(number(radius)).append(" 0 ").append(largeArc).append(" 1 ")
-        .append(number(endX)).append(' ').append(number(endY)).append("\" ").append(styleWithFill(curve)).append("/>\n");
+        .append(number(endX)).append(' ').append(number(endY)).append("\" ").append(styleWithFill(curve))
+        .append("/>\n");
   }
 
   private static void appendGlobalArc(Element curve, Element circle, double sheetHeight, StringBuilder svg) {
@@ -331,7 +332,8 @@ public final class DexpiXmlSvgRenderer {
     int largeArc = delta > 180.0 ? 1 : 0;
     svg.append("    <path d=\"M ").append(number(startX)).append(' ').append(number(startY)).append(" A ")
         .append(number(radius)).append(' ').append(number(radius)).append(" 0 ").append(largeArc).append(" 0 ")
-        .append(number(endX)).append(' ').append(number(endY)).append("\" ").append(styleWithFill(curve)).append("/>\n");
+        .append(number(endX)).append(' ').append(number(endY)).append("\" ").append(styleWithFill(curve))
+        .append("/>\n");
   }
 
   private static void renderText(Document document, double sheetHeight, StringBuilder svg) {
@@ -363,8 +365,7 @@ public final class DexpiXmlSvgRenderer {
     if (!"Solid".equalsIgnoreCase(element.getAttribute("Filled"))) {
       return renderedStyle;
     }
-    return renderedStyle.replace(" fill=\"none\"", "") + " fill=\"" + color(element)
-        + "\" data-dexpi-filled=\"solid\"";
+    return renderedStyle.replace(" fill=\"none\"", "") + " fill=\"" + color(element) + "\" data-dexpi-filled=\"solid\"";
   }
 
   private static String style(Element element) {

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
@@ -79,6 +79,11 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
     assertTrue(report.getMetrics().get("componentInstances") >= 4, report.toJson());
     assertTrue(report.getMetrics().get("sourceTexts") >= 4, report.toJson());
     assertTrue(report.getMetrics().get("sourceCenterLines") > 0, report.toJson());
+    assertTrue(report.getMetrics().get("routedMaterialSegments") > 0, report.toJson());
+    assertEquals(report.getMetrics().get("routedMaterialSegments"),
+        report.getMetrics().get("sourceFlowDirectionArrows"), report.toJson());
+    assertEquals(report.getMetrics().get("sourceFlowDirectionArrows"),
+        report.getMetrics().get("renderedFilledFlowDirectionArrows"), report.toJson());
 
     Document exportedDocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(dexpi.toFile());
     assertTrue(hasDirectedEquipmentConnection(exportedDocument, "ID-50-RC-001", "ID-50-MX-001"),
@@ -112,6 +117,28 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
     assertEquals(1, report.getMetrics().get("duplicateIds"));
     assertEquals(1, report.getMetrics().get("outOfBoundsCoordinates"));
     assertEquals(report.toJson(), DexpiVisualQualityAssessment.assess(dexpi.toFile()).toJson());
+  }
+
+  @Test
+  void reportsMissingFlowDirectionArrow() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<PlantModel><PlantInformation SchemaVersion=\"4.1.1\"/>"
+        + "<Drawing Name=\"Missing arrow benchmark\"><Extent><Min X=\"0\" Y=\"0\"/>"
+        + "<Max X=\"100\" Y=\"70\"/></Extent></Drawing>"
+        + "<PipingNetworkSystem ID=\"PNS-1\"><PipingNetworkSegment ID=\"SEG-1\">"
+        + "<CenterLine><Coordinate X=\"10\" Y=\"20\"/><Coordinate X=\"90\" Y=\"20\"/>"
+        + "</CenterLine><Connection FromID=\"N-1\" ToID=\"N-2\"/>"
+        + "</PipingNetworkSegment></PipingNetworkSystem></PlantModel>";
+    Path dexpi = temporaryDirectory.resolve("missing-arrow.xml");
+    Files.write(dexpi, xml.getBytes(StandardCharsets.UTF_8));
+
+    DexpiVisualQualityAssessment.Report report = DexpiVisualQualityAssessment.assess(dexpi.toFile());
+
+    assertTrue(report.hasErrors());
+    assertTrue(hasFinding(report, "FLOW_DIRECTION_ARROW_MISSING"), report.toJson());
+    assertEquals(1, report.getMetrics().get("routedMaterialSegments"));
+    assertEquals(0, report.getMetrics().get("sourceFlowDirectionArrows"));
+    assertEquals(0, report.getMetrics().get("renderedFilledFlowDirectionArrows"));
   }
 
   @Test

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRendererTest.java
@@ -48,7 +48,7 @@ class DexpiXmlSvgRendererTest extends NeqSimTest {
     assertTrue(content.contains("data-dexpi-id=\"ID-20-V-101\""));
     assertTrue(content.contains("data-dexpi-id=\"PT-101\""));
     assertTrue(content.contains("<polyline"));
-    assertTrue(content.contains("data-dexpi-filled=\\\"solid\\\""));
+    assertTrue(content.contains("data-dexpi-filled=\"solid\""));
     assertTrue(content.contains("DEXPI SVG renderer regression"));
   }
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRendererTest.java
@@ -48,8 +48,24 @@ class DexpiXmlSvgRendererTest extends NeqSimTest {
     assertTrue(content.contains("data-dexpi-id=\"ID-20-V-101\""));
     assertTrue(content.contains("data-dexpi-id=\"PT-101\""));
     assertTrue(content.contains("<polyline"));
-    assertTrue(content.contains("data-dexpi-filled=\"solid\""));
     assertTrue(content.contains("DEXPI SVG renderer regression"));
+  }
+
+  @Test
+  void rendersSolidPolylineAsFilledFlowArrow() throws Exception {
+    String dexpiContent = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        + "<PlantModel><Drawing Name=\"Filled flow arrow\"><Extent><Min X=\"0\" Y=\"0\"/>"
+        + "<Max X=\"100\" Y=\"70\"/></Extent><PolyLine Filled=\"Solid\">"
+        + "<Presentation LineType=\"0\" LineWeight=\"0.3\" R=\"0\" G=\"0\" B=\"0\"/>"
+        + "<Coordinate X=\"10\" Y=\"10\"/><Coordinate X=\"20\" Y=\"15\"/>"
+        + "<Coordinate X=\"10\" Y=\"20\"/></PolyLine></Drawing></PlantModel>";
+    Path dexpi = temporaryDirectory.resolve("filled-flow-arrow.xml");
+    java.nio.file.Files.write(dexpi, dexpiContent.getBytes(StandardCharsets.UTF_8));
+
+    String content = DexpiXmlSvgRenderer.render(dexpi.toFile());
+
+    assertTrue(content.contains("fill=\"#000000\""));
+    assertTrue(content.contains("data-dexpi-filled=\"solid\""));
   }
 
   @Test

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRendererTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlSvgRendererTest.java
@@ -48,6 +48,7 @@ class DexpiXmlSvgRendererTest extends NeqSimTest {
     assertTrue(content.contains("data-dexpi-id=\"ID-20-V-101\""));
     assertTrue(content.contains("data-dexpi-id=\"PT-101\""));
     assertTrue(content.contains("<polyline"));
+    assertTrue(content.contains("data-dexpi-filled=\\\"solid\\\""));
     assertTrue(content.contains("DEXPI SVG renderer regression"));
   }
 


### PR DESCRIPTION
## Engineering question

Can every NeqSim-generated routed material segment show an unambiguous filled source-to-destination flow arrow in the actual Proteus-compatible DEXPI graphical primitives and native SVG, with a deterministic structural gate for missing or renderer-dropped arrows?

Advances #1332 and #2899.

## Baseline and confirmed finding

At exact current-master base `71b94aaabc6aacde7ae0eb99d366e22d23023097`, `DexpiLayoutEngine.appendFlowArrow()` documents a solid triangular direction arrow but emitted an unmarked closed `PolyLine`. `DexpiXmlSvgRenderer` then forced every polyline to `fill="none"`. The direction triangle was therefore only an outline, and the existing visual-quality assessment counted geometry without verifying one visible filled arrow per routed material segment.

## Change

- mark generated flow-arrow polylines as `Filled="Solid"`;
- preserve solid polyline fill and source colour in native SVG while retaining other polyline styles;
- add deterministic routed-segment, source-arrow, and rendered-filled-arrow metrics;
- emit stable errors for missing or renderer-dropped arrows and a warning for duplicate arrows;
- extend the recycle/control benchmark and focused renderer regression;
- add a malformed-source regression and document the directional-readability gate.

## Compatibility and stop boundary

The change is limited to graphical presentation and visual-quality evidence for NeqSim-generated Proteus-compatible Plant/P&ID `SchemaVersion 4.1.1`. Material topology, `Connection FromID/ToID` direction, stable equipment/stream identities, public APIs, Classic DOT/Graphviz, native DEXPI 2.0 Process exchange, controlled native PFD SVG/PDF, and empty-placeholder behavior are unchanged.

This is not an ISO/IEC conformance determination, DEXPI certification, engineering approval, safety completeness, or fitness-for-construction claim. Symbol qualification, licensed clause mapping, nozzle/line design data, and accountable review remain outside this tranche.

## Validation

**VALIDATION PENDING CI**

Exact branch head `e3ad83874ebd762aeabf319c0192757f472baad4` is eleven linear commits from exact base `71b94aaabc6aacde7ae0eb99d366e22d23023097`, with six changed files and no base-branch synchronization.

The first exact-head Windows run showed that the broad empty-stream renderer fixture did not guarantee a routed solid arrow. The repaired head moves that marker assertion into a deterministic minimal `Filled="Solid"` polyline fixture; production behavior and the visual-quality contract are unchanged.

Local validation at the exact head on OpenJDK 17.0.20, Maven 3.9.16, and Python 3.12.13:

- `./mvnw -B -ntp -Dtest=DexpiVisualQualityAssessmentTest,DexpiXmlSvgRendererTest test` — PASS, 9 tests, 0 failures, 0 errors;
- `python3 devtools/run_spotless.py apply` — PASS, no resulting diff;
- `pre-commit run --all-files --hook-stage pre-commit` — PASS;
- `python3 devtools/run_spotless.py check` — PASS;
- `python3 devtools/check_documentation_search.py` — PASS, 672 Markdown pages and one standalone HTML page audited;
- `pre-commit run --all-files --hook-stage pre-push` — PASS.

Hosted engineering-diagram performance, pre-commit, Spotless, PaperLab, notebook execution, and documentation-search workflows pass at this head. The full Java matrix and CodeQL remain active. Full-sheet/detail PNG visual inspection was not rerun in this repair, so none is claimed.

## Documentation impact

Updated `docs/integration/dexpi-reference-cases.md` with the exact flow-arrow structural rule, deterministic metrics, failure modes, and qualification boundary.
