### PR TITLE
[AI-Assisted] fix(dexpi): preserve truthful instrument topology

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -475,12 +475,29 @@ from crossing gas equipment. The engine produces the following visual elements:
 **Instrumentation (per ISA 5.1):**
 - Instrument circles with function letter labels (PT, TT, FT, LT, AT)
 - Proper ISA 5.1 function letter decomposition (first letter = measured variable, subsequent = function)
-- Signal lines from instruments to equipment (dashed lines with signal nodes)
+- Field transmitter bubbles connected by measuring lines to an explicit process-segment or nozzle sensing location
+- Central/control-room controller bubbles distinguished from field instruments by their symbol and DEXPI location metadata
 - PID controller parameters displayed (Kp, Ti, Td) when controllers are present
-- Controller signal lines connecting instruments to final control elements
+- Typed signal lines from transmitters to controllers and from controllers to actual final control elements
 - SIL-rated instrument visualization with concentric double-border circles for SIL 2 and above
 - Fail-position markers on control valves: **FC** (red), **FO** (green), **FL** (amber)
 - Solenoid valve symbols with diamond shape and wiring to controllers
+
+When a process contains no explicit measurement devices, the writer may add measurement-only
+engineering proposals. These are marked `[PROP]` on the sheet and carry
+`Origin=SYNTHESIZED_PROPOSAL`, `ApprovalStatus=UNREVIEWED`, and `Scope=MEASUREMENT_ONLY` metadata.
+Compatibility metadata also records `InstrumentationSource=SYNTHESIZED_PROPOSAL` and
+`EngineeringStatus=PROPOSED`. Explicit transmitters expose `MeasurementAttachmentTargetID`; closed
+loops expose both `FinalControlElementID` and `FinalControlElementTag`.
+The writer does not synthesize controllers, manipulated variables, or final control elements. A
+closed loop is drawn only when the model contains an explicit controller attached to a connected
+valve or manipulated equipment item; otherwise the controller is retained as an incomplete-loop
+warning without a command line to empty drawing space.
+
+This representation follows the separation of sensing, signal-conveying, control, and actuation
+functions used by DEXPI and the identification/location conventions used by ISA-5.1. It does not
+imply that the transmitter circle must geometrically overlap the process line: the measuring line
+and its `is located in` association identify the physical sensing point.
 
 **Safety elements:**
 - PST (Partial Stroke Test) annotation boxes near safety valves

--- a/docs/integration/dexpi-reference-cases.md
+++ b/docs/integration/dexpi-reference-cases.md
@@ -54,6 +54,12 @@ writer and rendered from its actual graphical primitives. The suite checks:
 - drawing bounds, duplicate IDs, minimum text-height risks, missing symbols, and empty SVG output;
 - exactly one source-to-destination flow-direction arrow for every routed material segment, with
   solid fill preserved in the rendered SVG;
+- every measurement function having a resolvable process-segment, nozzle, mount, piping-component,
+  or equipment sensing location;
+- central/control-room symbols and matching location metadata for controller functions, plus a
+  real tagged final element and directed actuating signal before a loop is classified complete;
+- synthesized measurement proposals being both machine-identifiable and visibly marked `[PROP]`,
+  without synthesized controllers or command lines;
 - deterministic report JSON and SVG output across repeated exports; and
 - preservation of an intentionally unconfigured stream through `ProcessSystem.run()` without
   inventing a fluid state.
@@ -65,34 +71,28 @@ The flow-arrow regression records routed-segment, source-arrow, and rendered-fil
 Missing, duplicate, or renderer-dropped arrows produce stable findings instead of relying on visual
 memory. This is a directional-readability gate, not a standards-conformance determination.
 
-Instrumentation topology is assessed independently from bubble placement. Stream-based pressure,
-temperature, and flow measurements attach their measuring line to the registered process nozzle for
-the measured stream; a generic line to the equipment centre or data annotation is rejected.
-Controllers use the shared-control-system/panel bubble convention. A command signal and closed-loop
-status are emitted only when the same controller is attached to an actual NeqSim equipment function,
-such as a throttling valve. A standalone controller remains a measurement-only loop and produces the
-structured `CONTROL_FINAL_ELEMENT_SOURCE_DATA_MISSING` proposal diagnostic instead of an actuating
-line to empty space.
-
-The pyDEXPI compatibility exporter retains its existing optional automatic instrumentation synthesis.
-Synthesized bubbles now carry `InstrumentationSource=SYNTHESIZED_PROPOSAL`,
-`EngineeringStatus=PROPOSED`, and a visible `PROP` marker. They do not claim a closed loop when the
-source `ProcessSystem` has no manipulated element. Level taps and other accountable design details
-that cannot be derived from current source identities remain explicit missing-source-data diagnostics;
-the writer does not invent nozzles, valve functions, or operational intent.
-
-The machine-readable assessment records transmitter, controller, process-attachment, missing-source,
-closed/incomplete-loop, actuating-signal, invalid-signal, and synthesized-proposal counts. The fixed
-benchmark covers a nozzle-attached transmitter, an explicit measurement-only controller, a controller
-attached to a real throttling valve, malformed unresolved topology, and automatic proposal provenance.
-These rules are semantic and visual-quality gates for an engineering proposal, not ISA-5.1
-certification or ISO/IEC conformance.
-
 The first full-sheet benchmark inspection found that instrument bubbles intersected full equipment
 data bars and sat outside the generated battery limit. The layout now reserves 55 mm above an
 equipment centre for instruments and expands the battery-limit envelope through the highest bubble;
 an exact coordinate regression protects both clearances. Re-rendered simple, branched, and
-recycle/control cases show separated bubbles and data bars inside the boundary. Recycle connectivity is projected when the recycle block exposes a configured outlet through the
+recycle/control cases show separated bubbles and data bars inside the boundary.
+
+A subsequent whole-sheet instrumentation review found generic measuring lines terminating at
+equipment centres, controller bubbles using field-location symbols, and synthesized controller
+signals ending in empty process space. Measurements now resolve to process segments or nozzles,
+their bubble groups follow the sensing-point lane outside equipment data bars, controller location
+symbols are explicit, and closed-loop actuation is emitted only for an attached final control
+element. The assessment records measurement, sensing-location, controller, complete-loop,
+incomplete-loop, and synthesized-proposal counts so these defects fail deterministically in future
+diagram work.
+
+The compatibility metrics from the first topology review remain available alongside the stricter
+DEXPI-oriented metrics: transmitter/controller counts, resolved and missing measurement attachments,
+measuring-line validity, closed/incomplete loops, actuating-signal validity, and synthesized proposal
+counts. Missing source data is reported separately from renderer/layout failures; the exporter does
+not invent a nozzle, controller, valve, or operational intent to make a proposal appear complete.
+
+Recycle connectivity is projected when the recycle block exposes a configured outlet through the
 standard equipment outlet API and a downstream unit consumes that same stream identity. The benchmark
 asserts the directed recycle-to-mixer connection in the Proteus XML before rendering. The writer does
 not infer a return line from convergence state: an unconfigured outlet remains absent, and no fluid

--- a/docs/integration/dexpi-reference-cases.md
+++ b/docs/integration/dexpi-reference-cases.md
@@ -65,6 +65,29 @@ The flow-arrow regression records routed-segment, source-arrow, and rendered-fil
 Missing, duplicate, or renderer-dropped arrows produce stable findings instead of relying on visual
 memory. This is a directional-readability gate, not a standards-conformance determination.
 
+Instrumentation topology is assessed independently from bubble placement. Stream-based pressure,
+temperature, and flow measurements attach their measuring line to the registered process nozzle for
+the measured stream; a generic line to the equipment centre or data annotation is rejected.
+Controllers use the shared-control-system/panel bubble convention. A command signal and closed-loop
+status are emitted only when the same controller is attached to an actual NeqSim equipment function,
+such as a throttling valve. A standalone controller remains a measurement-only loop and produces the
+structured `CONTROL_FINAL_ELEMENT_SOURCE_DATA_MISSING` proposal diagnostic instead of an actuating
+line to empty space.
+
+The pyDEXPI compatibility exporter retains its existing optional automatic instrumentation synthesis.
+Synthesized bubbles now carry `InstrumentationSource=SYNTHESIZED_PROPOSAL`,
+`EngineeringStatus=PROPOSED`, and a visible `PROP` marker. They do not claim a closed loop when the
+source `ProcessSystem` has no manipulated element. Level taps and other accountable design details
+that cannot be derived from current source identities remain explicit missing-source-data diagnostics;
+the writer does not invent nozzles, valve functions, or operational intent.
+
+The machine-readable assessment records transmitter, controller, process-attachment, missing-source,
+closed/incomplete-loop, actuating-signal, invalid-signal, and synthesized-proposal counts. The fixed
+benchmark covers a nozzle-attached transmitter, an explicit measurement-only controller, a controller
+attached to a real throttling valve, malformed unresolved topology, and automatic proposal provenance.
+These rules are semantic and visual-quality gates for an engineering proposal, not ISA-5.1
+certification or ISO/IEC conformance.
+
 The first full-sheet benchmark inspection found that instrument bubbles intersected full equipment
 data bars and sat outside the generated battery limit. The layout now reserves 55 mm above an
 equipment centre for instruments and expands the battery-limit envelope through the highest bubble;

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiLayoutEngine.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiLayoutEngine.java
@@ -1,6 +1,7 @@
 package neqsim.process.processmodel.dexpi;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -893,6 +894,38 @@ final class DexpiLayoutEngine {
   }
 
   /**
+   * Computes an instrument position above its resolved process sensing point.
+   *
+   * <p>
+   * The bubble group follows the tap rather than the equipment centre. If the tap lies inside the horizontal envelope
+   * of the equipment data bar, the group is shifted beyond the nearest bar edge. Measuring lines can therefore leave a
+   * nozzle along the process lane and rise outside the data table instead of crossing its rows.
+   * </p>
+   *
+   * @param equipmentPos parent equipment position, or null when unavailable
+   * @param tapX process sensing-point X coordinate
+   * @param tapY process sensing-point Y coordinate
+   * @param instrumentIndex zero-based position within instruments sharing the sensing location
+   * @param totalInstruments number of instruments sharing the sensing location
+   * @return the instrument position {x, y}
+   */
+  static double[] computeInstrumentPositionAtSensingPoint(EquipmentPosition equipmentPos, double tapX, double tapY,
+      int instrumentIndex, int totalInstruments) {
+    double totalWidth = Math.max(0, totalInstruments - 1) * INSTRUMENT_X_SPACING;
+    double groupCenterX = tapX;
+    if (equipmentPos != null) {
+      double barHalfWidth = BAR_WIDTH / 2.0;
+      double requiredHalfWidth = totalWidth / 2.0 + INSTRUMENT_BUBBLE_RADIUS + 4.0;
+      if (Math.abs(tapX - equipmentPos.x) < barHalfWidth + requiredHalfWidth) {
+        double direction = tapX < equipmentPos.x ? -1.0 : 1.0;
+        groupCenterX = equipmentPos.x + direction * (barHalfWidth + requiredHalfWidth);
+      }
+    }
+    double startX = groupCenterX - totalWidth / 2.0;
+    return new double[] { startX + instrumentIndex * INSTRUMENT_X_SPACING, tapY + 30.0 };
+  }
+
+  /**
    * Appends a measuring line (CenterLine) connecting an equipment nozzle to an instrument bubble.
    *
    * <p>
@@ -1012,9 +1045,6 @@ final class DexpiLayoutEngine {
       SignalLineKind kind) {
     Element centerLine = document.createElement("CenterLine");
 
-    double departY = fromY - INSTRUMENT_BUBBLE_RADIUS;
-    double arriveY = toY + INSTRUMENT_BUBBLE_RADIUS;
-
     Element presentation = document.createElement("Presentation");
     presentation.setAttribute("LineType", String.valueOf(kind.getLineType()));
     presentation.setAttribute("LineWeight", String.valueOf(SIGNAL_LINE_WEIGHT));
@@ -1022,21 +1052,74 @@ final class DexpiLayoutEngine {
     presentation.setAttribute("G", "0");
     presentation.setAttribute("B", "1");
 
-    if (Math.abs(fromX - toX) < 0.5) {
+    if (Math.abs(fromY - toY) < 0.5) {
+      double direction = toX >= fromX ? 1.0 : -1.0;
       centerLine.setAttribute("NumPoints", "2");
       centerLine.appendChild(presentation);
-      appendCoordinate(document, centerLine, fromX, departY);
-      appendCoordinate(document, centerLine, toX, arriveY);
+      appendCoordinate(document, centerLine, fromX + direction * INSTRUMENT_BUBBLE_RADIUS, fromY);
+      appendCoordinate(document, centerLine, toX - direction * INSTRUMENT_BUBBLE_RADIUS, toY);
+    } else if (Math.abs(fromX - toX) < 0.5) {
+      double direction = toY >= fromY ? 1.0 : -1.0;
+      centerLine.setAttribute("NumPoints", "2");
+      centerLine.appendChild(presentation);
+      appendCoordinate(document, centerLine, fromX, fromY + direction * INSTRUMENT_BUBBLE_RADIUS);
+      appendCoordinate(document, centerLine, toX, toY - direction * INSTRUMENT_BUBBLE_RADIUS);
     } else {
-      double midY = (departY + arriveY) / 2.0;
+      double directionX = toX >= fromX ? 1.0 : -1.0;
+      double directionY = toY >= fromY ? 1.0 : -1.0;
+      double departX = fromX + directionX * INSTRUMENT_BUBBLE_RADIUS;
+      double arriveY = toY - directionY * INSTRUMENT_BUBBLE_RADIUS;
+      double midX = (departX + toX) / 2.0;
       centerLine.setAttribute("NumPoints", "4");
       centerLine.appendChild(presentation);
-      appendCoordinate(document, centerLine, fromX, departY);
-      appendCoordinate(document, centerLine, fromX, midY);
-      appendCoordinate(document, centerLine, toX, midY);
+      appendCoordinate(document, centerLine, departX, fromY);
+      appendCoordinate(document, centerLine, midX, fromY);
+      appendCoordinate(document, centerLine, midX, arriveY);
       appendCoordinate(document, centerLine, toX, arriveY);
     }
 
+    parent.appendChild(centerLine);
+  }
+
+  /**
+   * Appends a signal line from an instrument bubble to an actual equipment or valve point.
+   *
+   * <p>
+   * Only the source is shortened to the bubble edge; the target terminates at the final control element. This overload
+   * prevents command signals from stopping one bubble radius short of a valve or manipulated equipment function.
+   * </p>
+   *
+   * @param document the XML document
+   * @param parent the InformationFlow element
+   * @param fromX source bubble centre X
+   * @param fromY source bubble centre Y
+   * @param targetX final control element X
+   * @param targetY final control element Y
+   * @param kind the ISA-5.1 signal line kind
+   */
+  static void appendSignalLineToPoint(Document document, Element parent, double fromX, double fromY, double targetX,
+      double targetY, SignalLineKind kind) {
+    Element centerLine = document.createElement("CenterLine");
+    Element presentation = document.createElement("Presentation");
+    presentation.setAttribute("LineType", String.valueOf(kind.getLineType()));
+    presentation.setAttribute("LineWeight", String.valueOf(SIGNAL_LINE_WEIGHT));
+    presentation.setAttribute("R", "0");
+    presentation.setAttribute("G", "0");
+    presentation.setAttribute("B", "1");
+    centerLine.appendChild(presentation);
+
+    double directionY = targetY >= fromY ? 1.0 : -1.0;
+    double startY = fromY + directionY * INSTRUMENT_BUBBLE_RADIUS;
+    if (Math.abs(fromX - targetX) < 0.5) {
+      centerLine.setAttribute("NumPoints", "2");
+      appendCoordinate(document, centerLine, fromX, startY);
+      appendCoordinate(document, centerLine, targetX, targetY);
+    } else {
+      centerLine.setAttribute("NumPoints", "3");
+      appendCoordinate(document, centerLine, fromX, startY);
+      appendCoordinate(document, centerLine, fromX, targetY);
+      appendCoordinate(document, centerLine, targetX, targetY);
+    }
     parent.appendChild(centerLine);
   }
 
@@ -1176,6 +1259,17 @@ final class DexpiLayoutEngine {
    * @return a two-element array {width, height} in mm
    */
   static double[] computeSheetSize(Map<String, EquipmentPosition> positions) {
+    return computeSheetSize(positions, Collections.<double[]>emptyList());
+  }
+
+  /**
+   * Computes drawing dimensions from both equipment and actual instrument/controller positions.
+   *
+   * @param positions the computed equipment layout positions
+   * @param instrumentPositions rendered instrument and controller bubble centres
+   * @return a two-element array {width, height} in mm
+   */
+  static double[] computeSheetSize(Map<String, EquipmentPosition> positions, List<double[]> instrumentPositions) {
     double maxX = 0;
     double maxY = 0;
     for (EquipmentPosition pos : positions.values()) {
@@ -1193,6 +1287,10 @@ final class DexpiLayoutEngine {
       if (topEdge > maxY) {
         maxY = topEdge;
       }
+    }
+    for (double[] instrument : instrumentPositions) {
+      maxX = Math.max(maxX, instrument[0] + INSTRUMENT_BUBBLE_RADIUS + 12.0);
+      maxY = Math.max(maxY, instrument[1] + INSTRUMENT_BUBBLE_RADIUS + 5.0);
     }
     // Add right-side padding for nozzles, arrows, and border margin
     double width = Math.max(MIN_SHEET_WIDTH, maxX + BORDER_MARGIN + 40.0);
@@ -1930,6 +2028,20 @@ final class DexpiLayoutEngine {
    */
   static void appendBatteryLimitBoundary(Document document, Element parent, Map<String, EquipmentPosition> positions,
       String areaLabel) {
+    appendBatteryLimitBoundary(document, parent, positions, Collections.<double[]>emptyList(), areaLabel);
+  }
+
+  /**
+   * Appends a battery-limit boundary enclosing equipment and actual instrument/controller positions.
+   *
+   * @param document the XML document
+   * @param parent the Drawing or PlantModel element
+   * @param positions all equipment positions
+   * @param instrumentPositions rendered instrument and controller bubble centres
+   * @param areaLabel the battery limit label
+   */
+  static void appendBatteryLimitBoundary(Document document, Element parent, Map<String, EquipmentPosition> positions,
+      List<double[]> instrumentPositions, String areaLabel) {
     if (positions == null || positions.isEmpty()) {
       return;
     }
@@ -1952,13 +2064,21 @@ final class DexpiLayoutEngine {
       }
     }
 
+    for (double[] instrument : instrumentPositions) {
+      minX = Math.min(minX, instrument[0] - INSTRUMENT_BUBBLE_RADIUS - 2.0);
+      maxX = Math.max(maxX, instrument[0] + INSTRUMENT_BUBBLE_RADIUS + 12.0);
+      minY = Math.min(minY, instrument[1] - INSTRUMENT_BUBBLE_RADIUS - 2.0);
+      maxY = Math.max(maxY, instrument[1] + INSTRUMENT_BUBBLE_RADIUS + 5.0);
+    }
+
     double bLeft = minX - BATTERY_LIMIT_PADDING;
     double bRight = maxX + BATTERY_LIMIT_PADDING;
     double bBottom = minY - BATTERY_LIMIT_PADDING;
     // Enclose instrument bubbles and their signal-line endpoints as well as equipment symbols.
     // The previous equipment-only padding crossed both bubbles and full equipment data bars.
     double instrumentEnvelope = INSTRUMENT_OFFSET_Y + INSTRUMENT_BUBBLE_RADIUS + 5.0;
-    double bTop = maxY + Math.max(BATTERY_LIMIT_PADDING, instrumentEnvelope);
+    double bTop = maxY
+        + (instrumentPositions.isEmpty() ? Math.max(BATTERY_LIMIT_PADDING, instrumentEnvelope) : BATTERY_LIMIT_PADDING);
 
     Element label = document.createElement("Label");
     label.setAttribute("ID", "BatteryLimit-1");

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessment.java
@@ -212,6 +212,7 @@ public final class DexpiVisualQualityAssessment {
     assessCoordinates(document, extent, findings, metrics);
     assessText(document, findings, metrics);
     assessFlowDirectionArrows(document, svg, findings, metrics);
+    assessInstrumentationTopology(document, findings, metrics);
 
     metrics.put("sourcePolylines", countOutsideCatalogue(document, "PolyLine"));
     metrics.put("sourceCenterLines", countOutsideCatalogue(document, "CenterLine"));
@@ -309,6 +310,113 @@ public final class DexpiVisualQualityAssessment {
     metrics.put("renderedInstances", rendered);
     metrics.put("missingShapeReferences", missingReferences);
     metrics.put("missingInstancePositions", missingPositions);
+  }
+
+  private static void assessInstrumentationTopology(Document document, List<Finding> findings,
+      Map<String, Integer> metrics) {
+    NodeList functions = document.getElementsByTagName("ProcessInstrumentationFunction");
+    int transmitters = 0;
+    int controllers = 0;
+    int attachedMeasurements = 0;
+    int measurementDataGaps = 0;
+    int closedLoops = 0;
+    int incompleteLoops = 0;
+    int synthesizedProposals = 0;
+    for (int index = 0; index < functions.getLength(); index++) {
+      Element function = (Element) functions.item(index);
+      if (inside(function, "ShapeCatalogue")) {
+        continue;
+      }
+      String identity = function.getAttribute("ID").trim();
+      String role = genericAttribute(function, "InstrumentationRole");
+      String source = genericAttribute(function, "InstrumentationSource");
+      String engineeringStatus = genericAttribute(function, "EngineeringStatus");
+      if ("SYNTHESIZED_PROPOSAL".equals(source)) {
+        synthesizedProposals++;
+        if (!"PROPOSED".equals(engineeringStatus)) {
+          add(findings, Severity.ERROR, "SYNTHESIZED_INSTRUMENT_NOT_MARKED_PROPOSED", identity,
+              "Automatically synthesized instrumentation must be identified as a proposal");
+        }
+      }
+      if ("TRANSMITTER".equals(role)) {
+        transmitters++;
+        String status = genericAttribute(function, "MeasurementAttachmentStatus");
+        String target = genericAttribute(function, "MeasurementAttachmentTargetID");
+        if ("ATTACHED_TO_PROCESS_NOZZLE".equals(status)) {
+          attachedMeasurements++;
+          if (target.trim().isEmpty()) {
+            add(findings, Severity.ERROR, "MEASUREMENT_ATTACHMENT_TARGET_MISSING", identity,
+                "Attached measurement does not identify its process nozzle");
+          }
+        } else {
+          measurementDataGaps++;
+          add(findings, Severity.WARNING, "MEASUREMENT_ATTACHMENT_SOURCE_DATA_MISSING", identity,
+              "Source model does not identify an accountable process tap/nozzle for this measurement");
+        }
+      } else if ("CONTROLLER".equals(role)) {
+        controllers++;
+        String status = genericAttribute(function, "ControlLoopStatus");
+        String finalElement = genericAttribute(function, "FinalControlElementID");
+        if ("CLOSED_MODELLED".equals(status)) {
+          closedLoops++;
+          if (finalElement.trim().isEmpty()) {
+            add(findings, Severity.ERROR, "CONTROL_FINAL_ELEMENT_TARGET_MISSING", identity,
+                "Closed loop does not identify its manipulated equipment function");
+          }
+        } else {
+          incompleteLoops++;
+          add(findings, Severity.WARNING, "CONTROL_FINAL_ELEMENT_SOURCE_DATA_MISSING", identity,
+              "Controller is rendered measurement-only because no manipulated equipment function is attached");
+        }
+      }
+    }
+
+    NodeList flows = document.getElementsByTagName("InformationFlow");
+    int measuringLines = 0;
+    int invalidMeasuringLines = 0;
+    int actuatingSignals = 0;
+    int invalidActuatingSignals = 0;
+    for (int index = 0; index < flows.getLength(); index++) {
+      Element flow = (Element) flows.item(index);
+      String componentClass = flow.getAttribute("ComponentClass");
+      if ("MeasuringLineFunction".equals(componentClass)) {
+        measuringLines++;
+        if (genericAttribute(flow, "MeasurementAttachmentTargetID").trim().isEmpty()) {
+          invalidMeasuringLines++;
+          add(findings, Severity.ERROR, "MEASUREMENT_LINE_PROCESS_TARGET_MISSING",
+              flow.getAttribute("ID").trim(), "Measuring line is not attached to an identified process nozzle");
+        }
+      } else if ("ActuatingSystemFunction".equals(componentClass)) {
+        actuatingSignals++;
+        if (genericAttribute(flow, "FinalControlElementID").trim().isEmpty()) {
+          invalidActuatingSignals++;
+          add(findings, Severity.ERROR, "ACTUATING_SIGNAL_FINAL_ELEMENT_MISSING",
+              flow.getAttribute("ID").trim(), "Actuating signal has no identified final control element");
+        }
+      }
+    }
+    metrics.put("sourceTransmitters", transmitters);
+    metrics.put("sourceControllers", controllers);
+    metrics.put("processMeasurementAttachments", attachedMeasurements);
+    metrics.put("measurementAttachmentDataGaps", measurementDataGaps);
+    metrics.put("sourceMeasuringLines", measuringLines);
+    metrics.put("invalidMeasuringLines", invalidMeasuringLines);
+    metrics.put("closedControlLoops", closedLoops);
+    metrics.put("incompleteControlLoops", incompleteLoops);
+    metrics.put("sourceActuatingSignals", actuatingSignals);
+    metrics.put("invalidActuatingSignals", invalidActuatingSignals);
+    metrics.put("synthesizedProposalInstruments", synthesizedProposals);
+  }
+
+  private static String genericAttribute(Element parent, String name) {
+    NodeList attributes = parent.getElementsByTagName("GenericAttribute");
+    for (int index = 0; index < attributes.getLength(); index++) {
+      Element attribute = (Element) attributes.item(index);
+      if (name.equals(attribute.getAttribute("Name"))) {
+        return attribute.getAttribute("Value");
+      }
+    }
+    return "";
   }
 
   private static void assessFlowDirectionArrows(Document document, String svg, List<Finding> findings,

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessment.java
@@ -383,15 +383,15 @@ public final class DexpiVisualQualityAssessment {
         measuringLines++;
         if (genericAttribute(flow, "MeasurementAttachmentTargetID").trim().isEmpty()) {
           invalidMeasuringLines++;
-          add(findings, Severity.ERROR, "MEASUREMENT_LINE_PROCESS_TARGET_MISSING",
-              flow.getAttribute("ID").trim(), "Measuring line is not attached to an identified process nozzle");
+          add(findings, Severity.ERROR, "MEASUREMENT_LINE_PROCESS_TARGET_MISSING", flow.getAttribute("ID").trim(),
+              "Measuring line is not attached to an identified process nozzle");
         }
       } else if ("ActuatingSystemFunction".equals(componentClass)) {
         actuatingSignals++;
         if (genericAttribute(flow, "FinalControlElementID").trim().isEmpty()) {
           invalidActuatingSignals++;
-          add(findings, Severity.ERROR, "ACTUATING_SIGNAL_FINAL_ELEMENT_MISSING",
-              flow.getAttribute("ID").trim(), "Actuating signal has no identified final control element");
+          add(findings, Severity.ERROR, "ACTUATING_SIGNAL_FINAL_ELEMENT_MISSING", flow.getAttribute("ID").trim(),
+              "Actuating signal has no identified final control element");
         }
       }
     }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessment.java
@@ -312,113 +312,6 @@ public final class DexpiVisualQualityAssessment {
     metrics.put("missingInstancePositions", missingPositions);
   }
 
-  private static void assessInstrumentationTopology(Document document, List<Finding> findings,
-      Map<String, Integer> metrics) {
-    NodeList functions = document.getElementsByTagName("ProcessInstrumentationFunction");
-    int transmitters = 0;
-    int controllers = 0;
-    int attachedMeasurements = 0;
-    int measurementDataGaps = 0;
-    int closedLoops = 0;
-    int incompleteLoops = 0;
-    int synthesizedProposals = 0;
-    for (int index = 0; index < functions.getLength(); index++) {
-      Element function = (Element) functions.item(index);
-      if (inside(function, "ShapeCatalogue")) {
-        continue;
-      }
-      String identity = function.getAttribute("ID").trim();
-      String role = genericAttribute(function, "InstrumentationRole");
-      String source = genericAttribute(function, "InstrumentationSource");
-      String engineeringStatus = genericAttribute(function, "EngineeringStatus");
-      if ("SYNTHESIZED_PROPOSAL".equals(source)) {
-        synthesizedProposals++;
-        if (!"PROPOSED".equals(engineeringStatus)) {
-          add(findings, Severity.ERROR, "SYNTHESIZED_INSTRUMENT_NOT_MARKED_PROPOSED", identity,
-              "Automatically synthesized instrumentation must be identified as a proposal");
-        }
-      }
-      if ("TRANSMITTER".equals(role)) {
-        transmitters++;
-        String status = genericAttribute(function, "MeasurementAttachmentStatus");
-        String target = genericAttribute(function, "MeasurementAttachmentTargetID");
-        if ("ATTACHED_TO_PROCESS_NOZZLE".equals(status)) {
-          attachedMeasurements++;
-          if (target.trim().isEmpty()) {
-            add(findings, Severity.ERROR, "MEASUREMENT_ATTACHMENT_TARGET_MISSING", identity,
-                "Attached measurement does not identify its process nozzle");
-          }
-        } else {
-          measurementDataGaps++;
-          add(findings, Severity.WARNING, "MEASUREMENT_ATTACHMENT_SOURCE_DATA_MISSING", identity,
-              "Source model does not identify an accountable process tap/nozzle for this measurement");
-        }
-      } else if ("CONTROLLER".equals(role)) {
-        controllers++;
-        String status = genericAttribute(function, "ControlLoopStatus");
-        String finalElement = genericAttribute(function, "FinalControlElementID");
-        if ("CLOSED_MODELLED".equals(status)) {
-          closedLoops++;
-          if (finalElement.trim().isEmpty()) {
-            add(findings, Severity.ERROR, "CONTROL_FINAL_ELEMENT_TARGET_MISSING", identity,
-                "Closed loop does not identify its manipulated equipment function");
-          }
-        } else {
-          incompleteLoops++;
-          add(findings, Severity.WARNING, "CONTROL_FINAL_ELEMENT_SOURCE_DATA_MISSING", identity,
-              "Controller is rendered measurement-only because no manipulated equipment function is attached");
-        }
-      }
-    }
-
-    NodeList flows = document.getElementsByTagName("InformationFlow");
-    int measuringLines = 0;
-    int invalidMeasuringLines = 0;
-    int actuatingSignals = 0;
-    int invalidActuatingSignals = 0;
-    for (int index = 0; index < flows.getLength(); index++) {
-      Element flow = (Element) flows.item(index);
-      String componentClass = flow.getAttribute("ComponentClass");
-      if ("MeasuringLineFunction".equals(componentClass)) {
-        measuringLines++;
-        if (genericAttribute(flow, "MeasurementAttachmentTargetID").trim().isEmpty()) {
-          invalidMeasuringLines++;
-          add(findings, Severity.ERROR, "MEASUREMENT_LINE_PROCESS_TARGET_MISSING", flow.getAttribute("ID").trim(),
-              "Measuring line is not attached to an identified process nozzle");
-        }
-      } else if ("ActuatingSystemFunction".equals(componentClass)) {
-        actuatingSignals++;
-        if (genericAttribute(flow, "FinalControlElementID").trim().isEmpty()) {
-          invalidActuatingSignals++;
-          add(findings, Severity.ERROR, "ACTUATING_SIGNAL_FINAL_ELEMENT_MISSING", flow.getAttribute("ID").trim(),
-              "Actuating signal has no identified final control element");
-        }
-      }
-    }
-    metrics.put("sourceTransmitters", transmitters);
-    metrics.put("sourceControllers", controllers);
-    metrics.put("processMeasurementAttachments", attachedMeasurements);
-    metrics.put("measurementAttachmentDataGaps", measurementDataGaps);
-    metrics.put("sourceMeasuringLines", measuringLines);
-    metrics.put("invalidMeasuringLines", invalidMeasuringLines);
-    metrics.put("closedControlLoops", closedLoops);
-    metrics.put("incompleteControlLoops", incompleteLoops);
-    metrics.put("sourceActuatingSignals", actuatingSignals);
-    metrics.put("invalidActuatingSignals", invalidActuatingSignals);
-    metrics.put("synthesizedProposalInstruments", synthesizedProposals);
-  }
-
-  private static String genericAttribute(Element parent, String name) {
-    NodeList attributes = parent.getElementsByTagName("GenericAttribute");
-    for (int index = 0; index < attributes.getLength(); index++) {
-      Element attribute = (Element) attributes.item(index);
-      if (name.equals(attribute.getAttribute("Name"))) {
-        return attribute.getAttribute("Value");
-      }
-    }
-    return "";
-  }
-
   private static void assessFlowDirectionArrows(Document document, String svg, List<Finding> findings,
       Map<String, Integer> metrics) {
     NodeList segments = document.getElementsByTagName("PipingNetworkSegment");
@@ -461,6 +354,206 @@ public final class DexpiVisualQualityAssessment {
       add(findings, Severity.ERROR, "FLOW_DIRECTION_ARROW_NOT_RENDERED", "",
           "One or more solid source flow-direction arrows are absent from generated SVG");
     }
+  }
+
+  private static void assessInstrumentationTopology(Document document, List<Finding> findings,
+      Map<String, Integer> metrics) {
+    NodeList signalGenerators = document.getElementsByTagName("ProcessSignalGeneratingFunction");
+    int measurementFunctions = 0;
+    int sensingLocations = 0;
+    for (int index = 0; index < signalGenerators.getLength(); index++) {
+      Element generator = (Element) signalGenerators.item(index);
+      if (inside(generator, "ShapeCatalogue")) {
+        continue;
+      }
+      measurementFunctions++;
+      Element association = directAssociation(generator, "is located in");
+      if (association == null || association.getAttribute("ItemID").trim().isEmpty()) {
+        add(findings, Severity.ERROR, "INSTRUMENT_SENSING_LOCATION_MISSING", generator.getAttribute("ID"),
+            "Rendered measurement has no nozzle, process-segment, piping-component, or equipment-mount sensing location");
+      } else {
+        String locationId = association.getAttribute("ItemID").trim();
+        Element location = elementWithId(document, locationId);
+        if (location == null || !isSensingLocation(location)) {
+          add(findings, Severity.ERROR, "INSTRUMENT_SENSING_LOCATION_INVALID", generator.getAttribute("ID"),
+              "Measurement sensing location does not resolve to process equipment, a nozzle, mount, piping component, or process segment");
+        } else {
+          sensingLocations++;
+        }
+      }
+    }
+
+    NodeList instrumentation = document.getElementsByTagName("ProcessInstrumentationFunction");
+    int controllerFunctions = 0;
+    int completeLoops = 0;
+    int incompleteLoops = 0;
+    int synthesizedProposals = 0;
+    for (int index = 0; index < instrumentation.getLength(); index++) {
+      Element function = (Element) instrumentation.item(index);
+      if (inside(function, "ShapeCatalogue")) {
+        continue;
+      }
+      String source = genericAttribute(function, "InstrumentationSource");
+      if ("SYNTHESIZED_PROPOSAL".equals(genericAttribute(function, "Origin"))
+          || "SYNTHESIZED_PROPOSAL".equals(source)) {
+        synthesizedProposals++;
+        if (!hasText(function, "[PROP]")) {
+          add(findings, Severity.ERROR, "SYNTHESIZED_PROPOSAL_NOT_VISIBLE", function.getAttribute("ID"),
+              "Synthesized measurement provenance is present in metadata but not visible on the drawing");
+        }
+      }
+      if (!"ProcessControlFunction".equals(function.getAttribute("ComponentClass"))) {
+        continue;
+      }
+      controllerFunctions++;
+      String identity = function.getAttribute("ID");
+      if (!"INSTRUMENTATION_BUBBLE_SHAPE_CENTRAL".equals(function.getAttribute("ComponentName"))
+          || !"CentralLocation".equals(genericAttribute(function, "LocationSpecialization"))) {
+        add(findings, Severity.ERROR, "CONTROLLER_LOCATION_SYMBOL_MISMATCH", identity,
+            "Controller must use the central/control-room symbol and matching location metadata");
+      }
+      String completeness = genericAttribute(function, "ControlLoopCompleteness");
+      if ("COMPLETE".equals(completeness)) {
+        completeLoops++;
+        String finalElement = genericAttribute(function, "FinalControlElementTag");
+        String finalElementId = genericAttribute(function, "FinalControlElementID");
+        boolean hasActuatingFunction = function.getElementsByTagName("ActuatingFunction").getLength() > 0
+            || function.getElementsByTagName("ActuatingElectricalFunction").getLength() > 0;
+        if (finalElement.isEmpty() || finalElementId.isEmpty() || elementWithId(document, finalElementId) == null
+            || !hasActuatingFunction || !hasActuatingSignal(function)) {
+          add(findings, Severity.ERROR, "CONTROL_LOOP_FINAL_ELEMENT_MISSING", identity,
+              "Complete control loop lacks a tagged final element, actuating function, or directed command signal");
+        }
+      } else {
+        incompleteLoops++;
+        add(findings, Severity.WARNING, "CONTROL_FINAL_ELEMENT_SOURCE_DATA_MISSING", identity,
+            "Controller is rendered measurement-only because no connected final control element is modelled");
+      }
+    }
+
+    NodeList flows = document.getElementsByTagName("InformationFlow");
+    int measuringLines = 0;
+    int invalidMeasuringLines = 0;
+    int actuatingSignals = 0;
+    int invalidActuatingSignals = 0;
+    for (int index = 0; index < flows.getLength(); index++) {
+      Element flow = (Element) flows.item(index);
+      if ("MeasuringLineFunction".equals(flow.getAttribute("ComponentClass"))) {
+        measuringLines++;
+        String target = genericAttribute(flow, "MeasurementAttachmentTargetID");
+        if (target.isEmpty() || elementWithId(document, target) == null) {
+          invalidMeasuringLines++;
+          add(findings, Severity.ERROR, "MEASUREMENT_LINE_PROCESS_TARGET_MISSING", flow.getAttribute("ID"),
+              "Measuring line is not attached to an identified process location");
+        }
+        continue;
+      }
+      Element logicalEnd = directAssociation(flow, "has logical end");
+      Element signalTarget = logicalEnd == null ? null : elementWithId(document, logicalEnd.getAttribute("ItemID"));
+      if (signalTarget == null || !("ActuatingFunction".equals(signalTarget.getTagName())
+          || "ActuatingElectricalFunction".equals(signalTarget.getTagName()))) {
+        continue;
+      }
+      actuatingSignals++;
+      String finalElementId = genericAttribute(flow, "FinalControlElementID");
+      if (finalElementId.isEmpty() || elementWithId(document, finalElementId) == null) {
+        invalidActuatingSignals++;
+        add(findings, Severity.ERROR, "ACTUATING_SIGNAL_FINAL_ELEMENT_MISSING", flow.getAttribute("ID"),
+            "Actuating signal has no identified final control element");
+      }
+    }
+    metrics.put("measurementFunctions", measurementFunctions);
+    metrics.put("measurementSensingLocations", sensingLocations);
+    metrics.put("controllerFunctions", controllerFunctions);
+    metrics.put("completeControlLoops", completeLoops);
+    metrics.put("incompleteControlLoops", incompleteLoops);
+    metrics.put("synthesizedMeasurementProposals", synthesizedProposals);
+    // Compatibility metrics retained from the first instrument-topology review branch.
+    metrics.put("sourceTransmitters", measurementFunctions);
+    metrics.put("sourceControllers", controllerFunctions);
+    metrics.put("processMeasurementAttachments", sensingLocations);
+    metrics.put("measurementAttachmentDataGaps", measurementFunctions - sensingLocations);
+    metrics.put("sourceMeasuringLines", measuringLines);
+    metrics.put("invalidMeasuringLines", invalidMeasuringLines);
+    metrics.put("closedControlLoops", completeLoops);
+    metrics.put("sourceActuatingSignals", actuatingSignals);
+    metrics.put("invalidActuatingSignals", invalidActuatingSignals);
+    metrics.put("synthesizedProposalInstruments", synthesizedProposals);
+  }
+
+  private static boolean hasActuatingSignal(Element controller) {
+    List<String> actuatingIds = new ArrayList<String>();
+    NodeList hydraulic = controller.getElementsByTagName("ActuatingFunction");
+    for (int index = 0; index < hydraulic.getLength(); index++) {
+      actuatingIds.add(((Element) hydraulic.item(index)).getAttribute("ID"));
+    }
+    NodeList electrical = controller.getElementsByTagName("ActuatingElectricalFunction");
+    for (int index = 0; index < electrical.getLength(); index++) {
+      actuatingIds.add(((Element) electrical.item(index)).getAttribute("ID"));
+    }
+    NodeList flows = controller.getElementsByTagName("InformationFlow");
+    for (int index = 0; index < flows.getLength(); index++) {
+      Element flow = (Element) flows.item(index);
+      if (directAssociation(flow, "has logical start") != null && directAssociation(flow, "has logical end") != null
+          && ("PneumaticSignalConveying".equals(genericAttribute(flow, "SignalConveyingTypeSpecialization"))
+              || "ElectricalSignalConveying".equals(genericAttribute(flow, "SignalConveyingTypeSpecialization")))) {
+        String target = directAssociation(flow, "has logical end").getAttribute("ItemID");
+        if (actuatingIds.contains(target)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean isSensingLocation(Element location) {
+    String type = location.getTagName();
+    return "Equipment".equals(type) || "Nozzle".equals(type) || "Mount".equals(type) || "PipingComponent".equals(type)
+        || "PipingNetworkSegment".equals(type);
+  }
+
+  private static Element elementWithId(Document document, String identity) {
+    NodeList elements = document.getElementsByTagName("*");
+    for (int index = 0; index < elements.getLength(); index++) {
+      Element element = (Element) elements.item(index);
+      if (identity.equals(element.getAttribute("ID"))) {
+        return element;
+      }
+    }
+    return null;
+  }
+
+  private static boolean hasText(Element parent, String value) {
+    NodeList texts = parent.getElementsByTagName("Text");
+    for (int index = 0; index < texts.getLength(); index++) {
+      if (value.equals(((Element) texts.item(index)).getAttribute("String"))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static Element directAssociation(Element parent, String type) {
+    NodeList children = parent.getChildNodes();
+    for (int index = 0; index < children.getLength(); index++) {
+      Node child = children.item(index);
+      if (child instanceof Element && "Association".equals(((Element) child).getTagName())
+          && type.equals(((Element) child).getAttribute("Type"))) {
+        return (Element) child;
+      }
+    }
+    return null;
+  }
+
+  private static String genericAttribute(Element parent, String name) {
+    NodeList attributes = parent.getElementsByTagName("GenericAttribute");
+    for (int index = 0; index < attributes.getLength(); index++) {
+      Element attribute = (Element) attributes.item(index);
+      if (name.equals(attribute.getAttribute("Name"))) {
+        return attribute.getAttribute("Value").trim();
+      }
+    }
+    return "";
   }
 
   private static void assessCoordinates(Document document, double[] extent, List<Finding> findings,

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
@@ -38,6 +38,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
 import neqsim.process.controllerdevice.ControllerDeviceInterface;
 import neqsim.process.equipment.EquipmentEnum;
@@ -656,6 +657,7 @@ public final class DexpiXmlWriter {
     // Auto-collect instruments from ProcessSystem if not explicitly provided
     Map<String, MeasurementDeviceInterface> effectiveTransmitters = transmitters;
     Map<String, ControllerDeviceInterface> effectiveControllers = controllers;
+    boolean synthesizedInstrumentation = false;
     if ((effectiveTransmitters == null || effectiveTransmitters.isEmpty())
         && !processSystem.getMeasurementDevices().isEmpty()) {
       effectiveTransmitters = new LinkedHashMap<>();
@@ -687,11 +689,12 @@ public final class DexpiXmlWriter {
         effectiveControllers = new LinkedHashMap<>();
       }
       synthesizeStandardInstrumentation(processSystem, effectiveTransmitters, effectiveControllers);
+      synthesizedInstrumentation = true;
     }
 
     if (effectiveTransmitters != null && !effectiveTransmitters.isEmpty()) {
       appendInstruments(document, root, effectiveTransmitters, effectiveControllers, usedIds, layoutPositions,
-          nozzlePositions, processSystem);
+          nozzlePositions, equipmentInletNozzle, outletStreamToNozzle, processSystem, synthesizedInstrumentation);
     }
 
     // Collect stream data for stream table
@@ -1865,12 +1868,16 @@ public final class DexpiXmlWriter {
    * @param usedIds set of already used XML IDs
    * @param layoutPositions equipment layout positions keyed by equipment name
    * @param nozzlePositions nozzle positions keyed by nozzle ID
+   * @param equipmentInletNozzle inlet nozzle IDs keyed by equipment name
+   * @param outletStreamToNozzle outlet nozzle IDs keyed by stream identity
    * @param processSystem the process system for stream-to-equipment matching
+   * @param synthesizedInstrumentation whether the complete instrument set was synthesized as a proposal
    */
   private static void appendInstruments(Document document, Element parent,
       Map<String, MeasurementDeviceInterface> transmitters, Map<String, ControllerDeviceInterface> controllers,
       Set<String> usedIds, Map<String, DexpiLayoutEngine.EquipmentPosition> layoutPositions,
-      Map<String, double[]> nozzlePositions, ProcessSystem processSystem) {
+      Map<String, double[]> nozzlePositions, Map<String, String> equipmentInletNozzle,
+      Map<Integer, String> outletStreamToNozzle, ProcessSystem processSystem, boolean synthesizedInstrumentation) {
 
     // Group transmitters by parent equipment for correct positioning
     Map<String, List<String>> equipmentTransmitters = new LinkedHashMap<>();
@@ -1914,6 +1921,9 @@ public final class DexpiXmlWriter {
         cy = pos[1];
         hasPosition = true;
       }
+      String measurementTargetId =
+          findMeasurementTargetNozzle(device, processSystem, equipmentInletNozzle, outletStreamToNozzle);
+      double[] measurementTap = measurementTargetId == null ? null : nozzlePositions.get(measurementTargetId);
 
       // ProcessInstrumentationFunction (the instrument bubble)
       String pifId = uniqueIdentifier("ProcessInstrumentationFunction", tag, usedIds);
@@ -1941,6 +1951,10 @@ public final class DexpiXmlWriter {
             new String[] { "ProcessInstrumentationFunctionCategory", "ProcessInstrumentationFunctions" });
         appendInstrumentLabelText(document, label, loopNumber, cx, cy - 1.2, pifId,
             new String[] { "ProcessInstrumentationFunctionNumber" });
+        if (synthesizedInstrumentation) {
+          appendInstrumentLabelText(document, label, "PROP", cx, cy + 6.0, pifId,
+              new String[] { "EngineeringStatus" });
+        }
 
         pif.appendChild(label);
       }
@@ -1953,6 +1967,16 @@ public final class DexpiXmlWriter {
       appendGenericAttribute(document, pifAttrs, "ProcessInstrumentationFunctionsAssignmentClass", functions);
       appendGenericAttribute(document, pifAttrs, DexpiMetadata.TAG_NAME, tag);
       appendGenericAttribute(document, pifAttrs, "MeasurementUnit", device.getUnit());
+      appendGenericAttribute(document, pifAttrs, "InstrumentationRole", "TRANSMITTER");
+      appendGenericAttribute(document, pifAttrs, "InstrumentationSource",
+          synthesizedInstrumentation ? "SYNTHESIZED_PROPOSAL" : "EXPLICIT_MODEL");
+      appendGenericAttribute(document, pifAttrs, "EngineeringStatus",
+          synthesizedInstrumentation ? "PROPOSED" : "MODELLED");
+      appendGenericAttribute(document, pifAttrs, "MeasurementAttachmentStatus",
+          measurementTap == null ? "MISSING_SOURCE_DATA" : "ATTACHED_TO_PROCESS_NOZZLE");
+      if (measurementTargetId != null) {
+        appendGenericAttribute(document, pifAttrs, "MeasurementAttachmentTargetID", measurementTargetId);
+      }
       // ISA-5.1 tag conformance check: flag non-conforming instrument tags so the diagram and the
       // exported data record the deviation rather than silently emitting an invalid tag.
       IsaTagValidator.ValidationResult tagCheck = IsaTagValidator.validate(tag);
@@ -1999,8 +2023,8 @@ public final class DexpiXmlWriter {
         pif.appendChild(assocEnd);
       }
 
-      // InformationFlow with CenterLine from process line to instrument bubble
-      if (hasPosition && eqPos != null) {
+      // InformationFlow with CenterLine from the authoritative process nozzle to the instrument bubble.
+      if (hasPosition && measurementTap != null) {
         Element infoFlow = document.createElement("InformationFlow");
         infoFlow.setAttribute("ID", mlfId);
         infoFlow.setAttribute("ComponentClass", "MeasuringLineFunction");
@@ -2011,12 +2035,22 @@ public final class DexpiXmlWriter {
         assocStart.setAttribute("ItemID", psgfId);
         infoFlow.appendChild(assocStart);
 
+        Element processAttachment = document.createElement("Association");
+        processAttachment.setAttribute("Type", "is attached to");
+        processAttachment.setAttribute("ItemID", measurementTargetId);
+        infoFlow.appendChild(processAttachment);
+
         Element assocEndInner = document.createElement("Association");
         assocEndInner.setAttribute("Type", "has logical end");
         assocEndInner.setAttribute("ItemID", pifId);
         infoFlow.appendChild(assocEndInner);
 
-        DexpiLayoutEngine.appendMeasuringLine(document, infoFlow, cx, eqPos.y, cx, cy);
+        Element attachmentAttrs = document.createElement("GenericAttributes");
+        attachmentAttrs.setAttribute("Set", "InstrumentAttachment");
+        appendGenericAttribute(document, attachmentAttrs, "MeasurementAttachmentTargetID", measurementTargetId);
+        infoFlow.appendChild(attachmentAttrs);
+
+        DexpiLayoutEngine.appendMeasuringLine(document, infoFlow, measurementTap[0], measurementTap[1], cx, cy);
 
         pif.appendChild(infoFlow);
       }
@@ -2062,6 +2096,14 @@ public final class DexpiXmlWriter {
       }
 
       String controllerPifId = null;
+      ProcessEquipmentInterface finalControlElement =
+          matchedController == null ? null : findManipulatedEquipment(matchedController, processSystem);
+      String finalControlElementId =
+          finalControlElement == null ? null : findEquipmentElementId(parent, finalControlElement.getName());
+      DexpiLayoutEngine.EquipmentPosition finalControlPosition =
+          finalControlElement == null ? null : layoutPositions.get(finalControlElement.getName());
+      boolean hasFinalControlElement =
+          finalControlElementId != null && finalControlPosition != null;
       if (matchedController != null) {
         // SignalConveyingFunction on the transmitter PIF
         String scfId = uniqueIdentifier("SignalConveyingFunction", tag, usedIds);
@@ -2070,17 +2112,20 @@ public final class DexpiXmlWriter {
         scf.setAttribute("ComponentClass", "SignalConveyingFunction");
         pif.appendChild(scf);
 
-        // ActuatingFunction on the transmitter PIF
-        String afId = uniqueIdentifier("ActuatingFunction", controllerTag, usedIds);
-        Element af = document.createElement("ActuatingFunction");
-        af.setAttribute("ID", afId);
-        af.setAttribute("ComponentClass", "ActuatingFunction");
+        if (hasFinalControlElement) {
+          // ActuatingFunction is emitted only when the model identifies a real manipulated element.
+          String afId = uniqueIdentifier("ActuatingFunction", controllerTag, usedIds);
+          Element af = document.createElement("ActuatingFunction");
+          af.setAttribute("ID", afId);
+          af.setAttribute("ComponentClass", "ActuatingFunction");
 
-        Element afAttrs = document.createElement("GenericAttributes");
-        afAttrs.setAttribute("Set", "DexpiAttributes");
-        appendGenericAttribute(document, afAttrs, "ActuatingFunctionNumberAssignmentClass", controllerTag);
-        af.appendChild(afAttrs);
-        pif.appendChild(af);
+          Element afAttrs = document.createElement("GenericAttributes");
+          afAttrs.setAttribute("Set", "DexpiAttributes");
+          appendGenericAttribute(document, afAttrs, "ActuatingFunctionNumberAssignmentClass", controllerTag);
+          appendGenericAttribute(document, afAttrs, "FinalControlElementID", finalControlElementId);
+          af.appendChild(afAttrs);
+          pif.appendChild(af);
+        }
 
         // Controller bubble (separate ProcessInstrumentationFunction)
         String[] ctrlParsed = parseIsaTag(controllerTag);
@@ -2092,7 +2137,7 @@ public final class DexpiXmlWriter {
         ctrlPif.setAttribute("ID", controllerPifId);
         ctrlPif.setAttribute("ComponentClass", "ProcessInstrumentationFunction");
         ctrlPif.setAttribute("ComponentClassURI", "http://sandbox.dexpi.org/rdl/ProcessInstrumentationFunction");
-        ctrlPif.setAttribute("ComponentName", DexpiShapeCatalog.INSTRUMENT_BUBBLE_FIELD_SHAPE);
+        ctrlPif.setAttribute("ComponentName", DexpiShapeCatalog.INSTRUMENT_BUBBLE_CENTRAL_SHAPE);
 
         // Position controller bubble to the right of the transmitter bubble
         double ctrlCx = cx + DexpiLayoutEngine.INSTRUMENT_X_SPACING;
@@ -2125,6 +2170,18 @@ public final class DexpiXmlWriter {
             loopNumber);
         appendGenericAttribute(document, ctrlAttrSet, "ProcessInstrumentationFunctionsAssignmentClass", ctrlFunctions);
         appendGenericAttribute(document, ctrlAttrSet, DexpiMetadata.TAG_NAME, controllerTag);
+        appendGenericAttribute(document, ctrlAttrSet, "InstrumentationRole", "CONTROLLER");
+        appendGenericAttribute(document, ctrlAttrSet, "ControllerLocation", "SHARED_CONTROL_SYSTEM");
+        appendGenericAttribute(document, ctrlAttrSet, "InstrumentationSource",
+            synthesizedInstrumentation ? "SYNTHESIZED_PROPOSAL" : "EXPLICIT_MODEL");
+        appendGenericAttribute(document, ctrlAttrSet, "EngineeringStatus",
+            synthesizedInstrumentation ? "PROPOSED" : "MODELLED");
+        appendGenericAttribute(document, ctrlAttrSet, "ControlLoopStatus",
+            hasFinalControlElement ? "CLOSED_MODELLED" : "MEASUREMENT_ONLY_MISSING_FINAL_ELEMENT");
+        if (hasFinalControlElement) {
+          appendGenericAttribute(document, ctrlAttrSet, "FinalControlElementID", finalControlElementId);
+          appendGenericAttribute(document, ctrlAttrSet, "FinalControlElementTag", finalControlElement.getName());
+        }
         ctrlPif.appendChild(ctrlAttrSet);
 
         // PID tuning parameters
@@ -2164,18 +2221,28 @@ public final class DexpiXmlWriter {
               DexpiLayoutEngine.SignalLineKind.ELECTRIC);
           ctrlPif.appendChild(sigFlow);
 
-          // Signal line from controller bubble down to the process line (to the valve)
-          String actuateFlowId = uniqueIdentifier("ActuatingInformationFlow", controllerTag, usedIds);
-          Element actuateFlow = document.createElement("InformationFlow");
-          actuateFlow.setAttribute("ID", actuateFlowId);
-          actuateFlow.setAttribute("ComponentClass", "ActuatingSystemFunction");
-          actuateFlow.setAttribute("ComponentClassURI", "http://sandbox.dexpi.org/rdl/ActuatingSystemFunction");
+          if (hasFinalControlElement) {
+            String actuateFlowId = uniqueIdentifier("ActuatingInformationFlow", controllerTag, usedIds);
+            Element actuateFlow = document.createElement("InformationFlow");
+            actuateFlow.setAttribute("ID", actuateFlowId);
+            actuateFlow.setAttribute("ComponentClass", "ActuatingSystemFunction");
+            actuateFlow.setAttribute("ComponentClassURI", "http://sandbox.dexpi.org/rdl/ActuatingSystemFunction");
 
-          // Command side (controller -> final control element): ISA-5.1 pneumatic signal.
-          DexpiLayoutEngine.appendSignalLine(document, actuateFlow, ctrlCx, ctrlCy, ctrlCx,
-              eqPos != null ? eqPos.y : cy - DexpiLayoutEngine.INSTRUMENT_OFFSET_Y,
-              DexpiLayoutEngine.SignalLineKind.PNEUMATIC);
-          ctrlPif.appendChild(actuateFlow);
+            Element finalElementAssociation = document.createElement("Association");
+            finalElementAssociation.setAttribute("Type", "has logical end");
+            finalElementAssociation.setAttribute("ItemID", finalControlElementId);
+            actuateFlow.appendChild(finalElementAssociation);
+
+            Element finalElementAttrs = document.createElement("GenericAttributes");
+            finalElementAttrs.setAttribute("Set", "InstrumentAttachment");
+            appendGenericAttribute(document, finalElementAttrs, "FinalControlElementID", finalControlElementId);
+            actuateFlow.appendChild(finalElementAttrs);
+
+            // Command side (controller -> final control element): ISA-5.1 pneumatic signal.
+            DexpiLayoutEngine.appendSignalLine(document, actuateFlow, ctrlCx, ctrlCy, finalControlPosition.x,
+                finalControlPosition.y, DexpiLayoutEngine.SignalLineKind.PNEUMATIC);
+            ctrlPif.appendChild(actuateFlow);
+          }
         }
 
         parent.appendChild(ctrlPif);
@@ -2192,6 +2259,14 @@ public final class DexpiXmlWriter {
       Element loopAttrs = document.createElement("GenericAttributes");
       loopAttrs.setAttribute("Set", "DexpiAttributes");
       appendGenericAttribute(document, loopAttrs, DexpiMetadata.LOOP_NUMBER, loopNumber);
+      appendGenericAttribute(document, loopAttrs, "InstrumentationSource",
+          synthesizedInstrumentation ? "SYNTHESIZED_PROPOSAL" : "EXPLICIT_MODEL");
+      appendGenericAttribute(document, loopAttrs, "ControlLoopStatus",
+          matchedController == null ? "MEASUREMENT_ONLY"
+              : hasFinalControlElement ? "CLOSED_MODELLED" : "MEASUREMENT_ONLY_MISSING_FINAL_ELEMENT");
+      if (hasFinalControlElement) {
+        appendGenericAttribute(document, loopAttrs, "FinalControlElementID", finalControlElementId);
+      }
       loop.appendChild(loopAttrs);
 
       Element loopAssoc = document.createElement("Association");
@@ -2415,6 +2490,82 @@ public final class DexpiXmlWriter {
         }
         if (fluidHash > 0 && s.getFluid() != null && System.identityHashCode(s.getFluid()) == fluidHash) {
           return eq.getName();
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Resolves the registered process nozzle measured by a stream-based transmitter.
+   *
+   * @return stable nozzle ID, or {@code null} when the source model does not identify an attachment
+   */
+  private static String findMeasurementTargetNozzle(MeasurementDeviceInterface device, ProcessSystem processSystem,
+      Map<String, String> equipmentInletNozzle, Map<Integer, String> outletStreamToNozzle) {
+    if (!(device instanceof StreamMeasurementDeviceBaseClass) || processSystem == null) {
+      return null;
+    }
+    StreamInterface measuredStream = ((StreamMeasurementDeviceBaseClass) device).getStream();
+    if (measuredStream == null) {
+      return null;
+    }
+    String outletNozzle = outletStreamToNozzle.get(Integer.valueOf(System.identityHashCode(measuredStream)));
+    if (outletNozzle != null) {
+      return outletNozzle;
+    }
+    for (ProcessEquipmentInterface unit : processSystem.getUnitOperations()) {
+      for (StreamInterface inlet : unit.getInletStreams()) {
+        if (inlet == measuredStream) {
+          return equipmentInletNozzle.get(unit.getName());
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Finds the equipment function that owns the supplied controller.
+   *
+   * @return manipulated equipment, or {@code null} when the controller is standalone
+   */
+  private static ProcessEquipmentInterface findManipulatedEquipment(ControllerDeviceInterface controller,
+      ProcessSystem processSystem) {
+    if (controller == null || processSystem == null) {
+      return null;
+    }
+    for (ProcessEquipmentInterface unit : processSystem.getUnitOperations()) {
+      for (ControllerDeviceInterface configured : unit.getControllers()) {
+        if (configured == controller || configured != null && controller.getName().equals(configured.getName())) {
+          return unit;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Finds an already-emitted equipment or piping-component identity by its tag name.
+   *
+   * @return stable element ID, or {@code null} when the element is not present
+   */
+  private static String findEquipmentElementId(Element parent, String tagName) {
+    if (tagName == null) {
+      return null;
+    }
+    NodeList elements = parent.getElementsByTagName("*");
+    for (int index = 0; index < elements.getLength(); index++) {
+      Element candidate = (Element) elements.item(index);
+      String identity = candidate.getAttribute("ID");
+      if (identity == null || identity.trim().isEmpty()) {
+        continue;
+      }
+      NodeList attributes = candidate.getElementsByTagName("GenericAttribute");
+      for (int attributeIndex = 0; attributeIndex < attributes.getLength(); attributeIndex++) {
+        Element attribute = (Element) attributes.item(attributeIndex);
+        if (DexpiMetadata.TAG_NAME.equals(attribute.getAttribute("Name"))
+            && tagName.equals(attribute.getAttribute("Value"))) {
+          return identity;
         }
       }
     }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
@@ -38,6 +38,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
 import neqsim.process.controllerdevice.ControllerDeviceInterface;
@@ -2016,7 +2017,7 @@ public final class DexpiXmlWriter {
       String mlfId = uniqueIdentifier("MeasuringLineFunction", tag, usedIds);
       String psgfId = uniqueIdentifier("ProcessSignalGeneratingFunction", tag, usedIds);
 
-      if (hasPosition) {
+      if (hasPosition && measurementTap != null) {
         Element assocEnd = document.createElement("Association");
         assocEnd.setAttribute("Type", "is logical end of");
         assocEnd.setAttribute("ItemID", mlfId);
@@ -2066,7 +2067,7 @@ public final class DexpiXmlWriter {
       appendGenericAttribute(document, psgfAttrs, "ProcessSignalGeneratingFunctionNumberAssignmentClass", tag);
       psgf.appendChild(psgfAttrs);
 
-      if (hasPosition) {
+      if (hasPosition && measurementTap != null) {
         Element startAssoc = document.createElement("Association");
         startAssoc.setAttribute("Type", "is logical start of");
         startAssoc.setAttribute("ItemID", mlfId);
@@ -2560,12 +2561,24 @@ public final class DexpiXmlWriter {
       if (identity == null || identity.trim().isEmpty()) {
         continue;
       }
-      NodeList attributes = candidate.getElementsByTagName("GenericAttribute");
-      for (int attributeIndex = 0; attributeIndex < attributes.getLength(); attributeIndex++) {
-        Element attribute = (Element) attributes.item(attributeIndex);
-        if (DexpiMetadata.TAG_NAME.equals(attribute.getAttribute("Name"))
-            && tagName.equals(attribute.getAttribute("Value"))) {
-          return identity;
+      NodeList children = candidate.getChildNodes();
+      for (int childIndex = 0; childIndex < children.getLength(); childIndex++) {
+        Node child = children.item(childIndex);
+        if (!(child instanceof Element) || !"GenericAttributes".equals(((Element) child).getTagName())) {
+          continue;
+        }
+        NodeList attributes = ((Element) child).getChildNodes();
+        for (int attributeIndex = 0; attributeIndex < attributes.getLength(); attributeIndex++) {
+          Node attributeNode = attributes.item(attributeIndex);
+          if (!(attributeNode instanceof Element)) {
+            continue;
+          }
+          Element attribute = (Element) attributeNode;
+          if ("GenericAttribute".equals(attribute.getTagName())
+              && DexpiMetadata.TAG_NAME.equals(attribute.getAttribute("Name"))
+              && tagName.equals(attribute.getAttribute("Value"))) {
+            return identity;
+          }
         }
       }
     }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
@@ -108,12 +108,12 @@ public final class DexpiXmlWriter {
       .withInitial(() -> Boolean.FALSE);
 
   /**
-   * Thread-local flag controlling whether standard ISA-5.1 instrumentation (pressure, temperature, level and flow loops
-   * with matched controllers) is automatically synthesized for a {@link ProcessSystem} that defines no measurement
-   * devices or controllers of its own. When {@code true} (the default) every separator, compressor, cooler/heater and
-   * pump receives a realistic set of indicating/controlling loops so the exported P&amp;ID resembles a real engineering
-   * diagram instead of a bare block flow sketch. Set to {@code false} to export only the instrumentation that is
-   * explicitly present in the model.
+   * Thread-local flag controlling whether standard ISA-5.1 measurement proposals (pressure, temperature, level and flow
+   * transmitters) are automatically synthesized for a {@link ProcessSystem} that defines no measurement devices of its
+   * own. When {@code true} (the default) common equipment receives unreviewed measurement proposals so the exported
+   * P&amp;ID communicates likely sensing requirements. Closed control loops are never invented: controllers and final
+   * control elements are exported only when they are explicitly present and connected in the process model. Set to
+   * {@code false} to export only explicitly modelled instrumentation.
    */
   private static final transient ThreadLocal<Boolean> AUTO_SYNTHESIZE_INSTRUMENTS = ThreadLocal
       .withInitial(() -> Boolean.TRUE);
@@ -122,8 +122,8 @@ public final class DexpiXmlWriter {
    * Enables or disables automatic synthesis of standard ISA-5.1 instrumentation for process systems that contain no
    * explicit measurement devices or controllers.
    *
-   * @param enabled {@code true} to synthesize standard control loops (default), {@code false} to export only explicitly
-   * modelled instrumentation
+   * @param enabled {@code true} to synthesize standard measurement proposals (default), {@code false} to export only
+   * explicitly modelled instrumentation
    */
   public static void setAutoSynthesizeInstrumentation(boolean enabled) {
     AUTO_SYNTHESIZE_INSTRUMENTS.set(Boolean.valueOf(enabled));
@@ -658,7 +658,6 @@ public final class DexpiXmlWriter {
     // Auto-collect instruments from ProcessSystem if not explicitly provided
     Map<String, MeasurementDeviceInterface> effectiveTransmitters = transmitters;
     Map<String, ControllerDeviceInterface> effectiveControllers = controllers;
-    boolean synthesizedInstrumentation = false;
     if ((effectiveTransmitters == null || effectiveTransmitters.isEmpty())
         && !processSystem.getMeasurementDevices().isEmpty()) {
       effectiveTransmitters = new LinkedHashMap<>();
@@ -678,24 +677,26 @@ public final class DexpiXmlWriter {
       }
     }
 
-    // When the model carries no instrumentation of its own, synthesize a standard set of ISA-5.1
-    // control loops so the exported P&ID looks like a real engineering diagram (control valves,
-    // transmitters and PID controllers) rather than a bare block flow sketch. Synthesis is limited
-    // to the rich pyDEXPI/P&ID export path; the plain write(...) overloads stay backwards
-    // compatible and emit only the instrumentation explicitly present in the model.
+    // When the model carries no instrumentation of its own, synthesize an explicitly identified set
+    // of ISA-5.1 measurement proposals. Do not invent PID controllers or final control elements: a
+    // closed loop is rendered only when the ProcessSystem contains both the controller and the
+    // manipulated equipment. Synthesis is limited to the rich pyDEXPI/P&ID export path; the plain
+    // write(...) overloads stay backwards compatible and emit only explicitly present instruments.
+    Set<String> synthesizedInstrumentTags = new LinkedHashSet<>();
     if ((effectiveTransmitters == null || effectiveTransmitters.isEmpty())
         && AUTO_SYNTHESIZE_INSTRUMENTS.get().booleanValue() && Boolean.TRUE.equals(OMIT_DEFAULT_NAMESPACE.get())) {
       effectiveTransmitters = new LinkedHashMap<>();
       if (effectiveControllers == null) {
         effectiveControllers = new LinkedHashMap<>();
       }
-      synthesizeStandardInstrumentation(processSystem, effectiveTransmitters, effectiveControllers);
-      synthesizedInstrumentation = true;
+      synthesizeStandardInstrumentation(processSystem, effectiveTransmitters, synthesizedInstrumentTags);
     }
 
+    List<double[]> instrumentPositions = new ArrayList<>();
     if (effectiveTransmitters != null && !effectiveTransmitters.isEmpty()) {
       appendInstruments(document, root, effectiveTransmitters, effectiveControllers, usedIds, layoutPositions,
-          nozzlePositions, equipmentInletNozzle, outletStreamToNozzle, processSystem, synthesizedInstrumentation);
+          nozzlePositions, equipmentInletNozzle, outletStreamToNozzle, connections, synthesizedInstrumentTags,
+          instrumentPositions, processSystem);
     }
 
     // Collect stream data for stream table
@@ -708,24 +709,25 @@ public final class DexpiXmlWriter {
     DexpiShapeCatalog.appendShapeCatalogue(document, root);
 
     // Append Drawing with professional border, zone markers, and title block
-    double[] sheetSize = DexpiLayoutEngine.computeSheetSize(layoutPositions);
+    double[] sheetSize = DexpiLayoutEngine.computeSheetSize(layoutPositions, instrumentPositions);
     String drawingName = processSystem.getName();
     String today = LocalDate.now().toString();
     DexpiLayoutEngine.appendDrawing(document, root, drawingName, "PID-001", "0", today, sheetSize[0], sheetSize[1]);
 
     // Battery limit boundary (NORSOK Z-003)
-    DexpiLayoutEngine.appendBatteryLimitBoundary(document, root, layoutPositions, drawingName);
+    DexpiLayoutEngine.appendBatteryLimitBoundary(document, root, layoutPositions, instrumentPositions, drawingName);
 
     // Symbol legend (ISO 10628)
     List<String[]> legendEntries = new ArrayList<>();
     legendEntries.add(new String[] { "Process", "Process Line", "0" });
-    legendEntries.add(new String[] { "Signal", "Signal Line (dashed)", "1" });
-    legendEntries.add(new String[] { "Utility", "Utility Line (dash-dot)", "3" });
+    legendEntries.add(new String[] { "Measure", "Measuring Connection", "0" });
+    legendEntries.add(new String[] { "Electric", "Electrical Signal", "2" });
+    legendEntries.add(new String[] { "Pneumatic", "Pneumatic Command", "3" });
     DexpiLayoutEngine.appendSymbolLegend(document, root, legendEntries);
 
     // Revision history (NORSOK Z-003)
     List<String[]> revisions = new ArrayList<>();
-    revisions.add(new String[] { "0", today, "Engineering Proposal", "NeqSim", "" });
+    revisions.add(new String[] { "0", today, "Engineering Proposal", "NeqSim", "-" });
     DexpiLayoutEngine.appendRevisionHistory(document, root, revisions, sheetSize[0]);
 
     writeDocument(document, outputStream);
@@ -1334,6 +1336,7 @@ public final class DexpiXmlWriter {
     private final String fromNozzle;
     private final String toNozzle;
     private final StreamInterface stream;
+    private String segmentId;
 
     NozzleConnection(String fromNozzle, String toNozzle) {
       this(fromNozzle, toNozzle, null);
@@ -1530,7 +1533,8 @@ public final class DexpiXmlWriter {
     for (NozzleConnection conn : connections) {
       Element segmentElement = document.createElement("PipingNetworkSegment");
       segmentElement.setAttribute("ComponentClass", "PipingNetworkSegment");
-      segmentElement.setAttribute("ID", uniqueIdentifier("PipingNetworkSegment", "Conn", usedIds));
+      conn.segmentId = uniqueIdentifier("PipingNetworkSegment", "Conn", usedIds);
+      segmentElement.setAttribute("ID", conn.segmentId);
 
       // Add connection line geometry if nozzle positions are available
       double[] fromPos = nozzlePositions.get(conn.fromNozzle);
@@ -1869,28 +1873,39 @@ public final class DexpiXmlWriter {
    * @param usedIds set of already used XML IDs
    * @param layoutPositions equipment layout positions keyed by equipment name
    * @param nozzlePositions nozzle positions keyed by nozzle ID
-   * @param equipmentInletNozzle inlet nozzle IDs keyed by equipment name
-   * @param outletStreamToNozzle outlet nozzle IDs keyed by stream identity
+   * @param equipmentInletNozzle inlet nozzle ID keyed by equipment name
+   * @param outletStreamToNozzle outlet nozzle ID keyed by stream identity hash
+   * @param connections routed process connections with their generated segment identities
+   * @param synthesizedInstrumentTags tags generated as unreviewed measurement proposals
+   * @param instrumentPositions collector for rendered transmitter and controller bubble centres
    * @param processSystem the process system for stream-to-equipment matching
-   * @param synthesizedInstrumentation whether the complete instrument set was synthesized as a proposal
    */
   private static void appendInstruments(Document document, Element parent,
       Map<String, MeasurementDeviceInterface> transmitters, Map<String, ControllerDeviceInterface> controllers,
       Set<String> usedIds, Map<String, DexpiLayoutEngine.EquipmentPosition> layoutPositions,
       Map<String, double[]> nozzlePositions, Map<String, String> equipmentInletNozzle,
-      Map<Integer, String> outletStreamToNozzle, ProcessSystem processSystem, boolean synthesizedInstrumentation) {
+      Map<Integer, String> outletStreamToNozzle, List<NozzleConnection> connections,
+      Set<String> synthesizedInstrumentTags, List<double[]> instrumentPositions, ProcessSystem processSystem) {
 
-    // Group transmitters by parent equipment for correct positioning
-    Map<String, List<String>> equipmentTransmitters = new LinkedHashMap<>();
+    // Resolve semantic sensing locations first, then group instruments that share a physical tap so
+    // their bubbles fan out around that process location instead of an equipment data table.
     Map<String, String> tagToEquipment = new HashMap<>();
+    Map<String, InstrumentAttachment> tagToAttachment = new HashMap<>();
+    Map<String, List<String>> attachmentTransmitters = new LinkedHashMap<>();
     for (Map.Entry<String, MeasurementDeviceInterface> entry : transmitters.entrySet()) {
       String parentName = findParentEquipment(entry.getValue(), processSystem);
       if (parentName != null) {
         tagToEquipment.put(entry.getKey(), parentName);
-        List<String> list = equipmentTransmitters.get(parentName);
+      }
+      InstrumentAttachment attachment = resolveInstrumentAttachment(entry.getValue(), parentName, processSystem,
+          equipmentInletNozzle, outletStreamToNozzle, connections, nozzlePositions, layoutPositions);
+      if (attachment != null) {
+        tagToAttachment.put(entry.getKey(), attachment);
+        String attachmentKey = attachment.locationId == null ? "unlocated:" + entry.getKey() : attachment.locationId;
+        List<String> list = attachmentTransmitters.get(attachmentKey);
         if (list == null) {
           list = new ArrayList<>();
-          equipmentTransmitters.put(parentName, list);
+          attachmentTransmitters.put(attachmentKey, list);
         }
         list.add(entry.getKey());
       }
@@ -1901,6 +1916,7 @@ public final class DexpiXmlWriter {
     for (Map.Entry<String, MeasurementDeviceInterface> entry : transmitters.entrySet()) {
       String tag = entry.getKey();
       MeasurementDeviceInterface device = entry.getValue();
+      boolean synthesizedProposal = synthesizedInstrumentTags.contains(tag);
       HIPPSValve hippsFunction = findHippsForTransmitter(device, processSystem);
 
       String[] parsed = parseIsaTag(tag);
@@ -1910,21 +1926,22 @@ public final class DexpiXmlWriter {
 
       // Compute instrument position above parent equipment
       String parentName = tagToEquipment.get(tag);
+      InstrumentAttachment attachment = tagToAttachment.get(tag);
       DexpiLayoutEngine.EquipmentPosition eqPos = parentName != null ? layoutPositions.get(parentName) : null;
       double cx = 0;
       double cy = 0;
       boolean hasPosition = false;
-      if (eqPos != null && equipmentTransmitters.containsKey(parentName)) {
-        List<String> siblings = equipmentTransmitters.get(parentName);
+      if (attachment != null) {
+        String attachmentKey = attachment.locationId == null ? "unlocated:" + tag : attachment.locationId;
+        List<String> siblings = attachmentTransmitters.get(attachmentKey);
         int idx = siblings.indexOf(tag);
-        double[] pos = DexpiLayoutEngine.computeInstrumentPosition(eqPos, idx, siblings.size());
+        double[] pos = DexpiLayoutEngine.computeInstrumentPositionAtSensingPoint(eqPos, attachment.x, attachment.y, idx,
+            siblings.size());
         cx = pos[0];
         cy = pos[1];
         hasPosition = true;
+        instrumentPositions.add(new double[] { cx, cy });
       }
-      String measurementTargetId = findMeasurementTargetNozzle(device, processSystem, equipmentInletNozzle,
-          outletStreamToNozzle);
-      double[] measurementTap = measurementTargetId == null ? null : nozzlePositions.get(measurementTargetId);
 
       // ProcessInstrumentationFunction (the instrument bubble)
       String pifId = uniqueIdentifier("ProcessInstrumentationFunction", tag, usedIds);
@@ -1952,9 +1969,6 @@ public final class DexpiXmlWriter {
             new String[] { "ProcessInstrumentationFunctionCategory", "ProcessInstrumentationFunctions" });
         appendInstrumentLabelText(document, label, loopNumber, cx, cy - 1.2, pifId,
             new String[] { "ProcessInstrumentationFunctionNumber" });
-        if (synthesizedInstrumentation) {
-          appendInstrumentLabelText(document, label, "PROP", cx, cy + 6.0, pifId, new String[] { "EngineeringStatus" });
-        }
 
         pif.appendChild(label);
       }
@@ -1965,17 +1979,17 @@ public final class DexpiXmlWriter {
       appendGenericAttribute(document, pifAttrs, "ProcessInstrumentationFunctionCategoryAssignmentClass", category);
       appendGenericAttribute(document, pifAttrs, "ProcessInstrumentationFunctionNumberAssignmentClass", loopNumber);
       appendGenericAttribute(document, pifAttrs, "ProcessInstrumentationFunctionsAssignmentClass", functions);
+      appendGenericAttribute(document, pifAttrs, "LocationSpecialization", "Field");
       appendGenericAttribute(document, pifAttrs, DexpiMetadata.TAG_NAME, tag);
       appendGenericAttribute(document, pifAttrs, "MeasurementUnit", device.getUnit());
       appendGenericAttribute(document, pifAttrs, "InstrumentationRole", "TRANSMITTER");
       appendGenericAttribute(document, pifAttrs, "InstrumentationSource",
-          synthesizedInstrumentation ? "SYNTHESIZED_PROPOSAL" : "EXPLICIT_MODEL");
-      appendGenericAttribute(document, pifAttrs, "EngineeringStatus",
-          synthesizedInstrumentation ? "PROPOSED" : "MODELLED");
+          synthesizedProposal ? "SYNTHESIZED_PROPOSAL" : "EXPLICIT_MODEL");
+      appendGenericAttribute(document, pifAttrs, "EngineeringStatus", synthesizedProposal ? "PROPOSED" : "MODELLED");
       appendGenericAttribute(document, pifAttrs, "MeasurementAttachmentStatus",
-          measurementTap == null ? "MISSING_SOURCE_DATA" : "ATTACHED_TO_PROCESS_NOZZLE");
-      if (measurementTargetId != null) {
-        appendGenericAttribute(document, pifAttrs, "MeasurementAttachmentTargetID", measurementTargetId);
+          attachment == null ? "MISSING_SOURCE_DATA" : "ATTACHED_TO_" + attachment.attachmentType);
+      if (attachment != null && attachment.locationId != null) {
+        appendGenericAttribute(document, pifAttrs, "MeasurementAttachmentTargetID", attachment.locationId);
       }
       // ISA-5.1 tag conformance check: flag non-conforming instrument tags so the diagram and the
       // exported data record the deviation rather than silently emitting an invalid tag.
@@ -1985,6 +1999,17 @@ public final class DexpiXmlWriter {
         appendGenericAttribute(document, pifAttrs, "TagConformanceWarning", tagCheck.getMessage());
       }
       pif.appendChild(pifAttrs);
+      if (synthesizedProposal) {
+        Element proposalAttrs = document.createElement("GenericAttributes");
+        proposalAttrs.setAttribute("Set", "NeqSimEngineeringStatus");
+        appendGenericAttribute(document, proposalAttrs, "Origin", "SYNTHESIZED_PROPOSAL");
+        appendGenericAttribute(document, proposalAttrs, "ApprovalStatus", "UNREVIEWED");
+        appendGenericAttribute(document, proposalAttrs, "Scope", "MEASUREMENT_ONLY");
+        pif.appendChild(proposalAttrs);
+        if (hasPosition) {
+          appendProposalMarker(document, pif, cx, cy);
+        }
+      }
       if (hippsFunction != null) {
         appendHippsSafetyMetadata(document, pif, hippsFunction, tag);
       }
@@ -2016,15 +2041,15 @@ public final class DexpiXmlWriter {
       String mlfId = uniqueIdentifier("MeasuringLineFunction", tag, usedIds);
       String psgfId = uniqueIdentifier("ProcessSignalGeneratingFunction", tag, usedIds);
 
-      if (hasPosition && measurementTap != null) {
+      if (hasPosition) {
         Element assocEnd = document.createElement("Association");
         assocEnd.setAttribute("Type", "is logical end of");
         assocEnd.setAttribute("ItemID", mlfId);
         pif.appendChild(assocEnd);
       }
 
-      // InformationFlow with CenterLine from the authoritative process nozzle to the instrument bubble.
-      if (hasPosition && measurementTap != null) {
+      // InformationFlow with CenterLine from process line to instrument bubble
+      if (hasPosition && attachment != null) {
         Element infoFlow = document.createElement("InformationFlow");
         infoFlow.setAttribute("ID", mlfId);
         infoFlow.setAttribute("ComponentClass", "MeasuringLineFunction");
@@ -2035,22 +2060,22 @@ public final class DexpiXmlWriter {
         assocStart.setAttribute("ItemID", psgfId);
         infoFlow.appendChild(assocStart);
 
-        Element processAttachment = document.createElement("Association");
-        processAttachment.setAttribute("Type", "is attached to");
-        processAttachment.setAttribute("ItemID", measurementTargetId);
-        infoFlow.appendChild(processAttachment);
-
         Element assocEndInner = document.createElement("Association");
         assocEndInner.setAttribute("Type", "has logical end");
         assocEndInner.setAttribute("ItemID", pifId);
         infoFlow.appendChild(assocEndInner);
 
+        Element processAttachment = document.createElement("Association");
+        processAttachment.setAttribute("Type", "is attached to");
+        processAttachment.setAttribute("ItemID", attachment.locationId);
+        infoFlow.appendChild(processAttachment);
+
         Element attachmentAttrs = document.createElement("GenericAttributes");
         attachmentAttrs.setAttribute("Set", "InstrumentAttachment");
-        appendGenericAttribute(document, attachmentAttrs, "MeasurementAttachmentTargetID", measurementTargetId);
+        appendGenericAttribute(document, attachmentAttrs, "MeasurementAttachmentTargetID", attachment.locationId);
         infoFlow.appendChild(attachmentAttrs);
 
-        DexpiLayoutEngine.appendMeasuringLine(document, infoFlow, measurementTap[0], measurementTap[1], cx, cy);
+        DexpiLayoutEngine.appendMeasuringLine(document, infoFlow, attachment.x, attachment.y, cx, cy);
 
         pif.appendChild(infoFlow);
       }
@@ -2064,9 +2089,21 @@ public final class DexpiXmlWriter {
       Element psgfAttrs = document.createElement("GenericAttributes");
       psgfAttrs.setAttribute("Set", "DexpiAttributes");
       appendGenericAttribute(document, psgfAttrs, "ProcessSignalGeneratingFunctionNumberAssignmentClass", tag);
+      if (attachment != null) {
+        appendGenericAttribute(document, psgfAttrs, "SensorTypeAssignmentClass", attachment.sensorType);
+        appendGenericAttribute(document, psgfAttrs, "NeqSimAttachmentType", attachment.attachmentType);
+      }
       psgf.appendChild(psgfAttrs);
 
-      if (hasPosition && measurementTap != null) {
+      if (attachment != null && attachment.locationId != null) {
+        Element sensingLocation = document.createElement("Association");
+        sensingLocation.setAttribute("Type", "is located in");
+        sensingLocation.setAttribute("ItemID", attachment.locationId);
+        psgf.appendChild(sensingLocation);
+        appendOppositeLocationAssociation(document, attachment.locationId, psgfId);
+      }
+
+      if (hasPosition) {
         Element startAssoc = document.createElement("Association");
         startAssoc.setAttribute("Type", "is logical start of");
         startAssoc.setAttribute("ItemID", mlfId);
@@ -2088,45 +2125,28 @@ public final class DexpiXmlWriter {
         DexpiLayoutEngine.appendSilMarker(document, pif, silRating, cx, cy);
       }
 
-      // Look for matching controller (e.g. PT-xxx -> PC-xxx)
-      String controllerTag = deriveControllerTag(tag);
-      ControllerDeviceInterface matchedController = null;
-      if (controllers != null && controllerTag != null) {
-        matchedController = controllers.get(controllerTag);
-      }
+      // Match a controller by measured category and loop number. This accepts both compact
+      // controller tags (PC-100) and indicating-controller tags (PIC-100).
+      Map.Entry<String, ControllerDeviceInterface> controllerMatch = findMatchingController(tag, controllers);
+      String controllerTag = controllerMatch == null ? null : controllerMatch.getKey();
+      ControllerDeviceInterface matchedController = controllerMatch == null ? null : controllerMatch.getValue();
 
       String controllerPifId = null;
-      ProcessEquipmentInterface finalControlElement = matchedController == null ? null
-          : findManipulatedEquipment(matchedController, processSystem);
-      String finalControlElementId = finalControlElement == null ? null
-          : findEquipmentElementId(parent, finalControlElement.getName());
-      DexpiLayoutEngine.EquipmentPosition finalControlPosition = finalControlElement == null ? null
-          : layoutPositions.get(finalControlElement.getName());
-      boolean hasFinalControlElement = finalControlElementId != null && finalControlPosition != null;
+      boolean completeControllerLoop = false;
+      String finalControlElementId = null;
       if (matchedController != null) {
-        // SignalConveyingFunction on the transmitter PIF
-        String scfId = uniqueIdentifier("SignalConveyingFunction", tag, usedIds);
-        Element scf = document.createElement("SignalConveyingFunction");
-        scf.setAttribute("ID", scfId);
-        scf.setAttribute("ComponentClass", "SignalConveyingFunction");
-        pif.appendChild(scf);
+        ProcessEquipmentInterface finalControlElement = findFinalControlElement(matchedController, processSystem);
+        DexpiLayoutEngine.EquipmentPosition finalPosition = finalControlElement == null ? null
+            : layoutPositions.get(finalControlElement.getName());
+        String finalControlLocation = findFinalControlLocation(finalControlElement, equipmentInletNozzle, connections);
+        finalControlElementId = finalControlElement == null ? null
+            : findComponentIdByTag(document, finalControlElement.getName());
+        boolean completeLoop = finalControlElement != null && finalPosition != null && finalControlLocation != null
+            && finalControlElementId != null;
+        completeControllerLoop = completeLoop;
+        boolean valveActuation = finalControlElement instanceof ThrottlingValve;
 
-        if (hasFinalControlElement) {
-          // ActuatingFunction is emitted only when the model identifies a real manipulated element.
-          String afId = uniqueIdentifier("ActuatingFunction", controllerTag, usedIds);
-          Element af = document.createElement("ActuatingFunction");
-          af.setAttribute("ID", afId);
-          af.setAttribute("ComponentClass", "ActuatingFunction");
-
-          Element afAttrs = document.createElement("GenericAttributes");
-          afAttrs.setAttribute("Set", "DexpiAttributes");
-          appendGenericAttribute(document, afAttrs, "ActuatingFunctionNumberAssignmentClass", controllerTag);
-          appendGenericAttribute(document, afAttrs, "FinalControlElementID", finalControlElementId);
-          af.appendChild(afAttrs);
-          pif.appendChild(af);
-        }
-
-        // Controller bubble (separate ProcessInstrumentationFunction)
+        // Controller bubble (separate central/control-room ProcessControlFunction)
         String[] ctrlParsed = parseIsaTag(controllerTag);
         String ctrlCategory = ctrlParsed[0];
         String ctrlFunctions = ctrlParsed[1];
@@ -2134,15 +2154,20 @@ public final class DexpiXmlWriter {
         controllerPifId = uniqueIdentifier("ProcessInstrumentationFunction", controllerTag, usedIds);
         Element ctrlPif = document.createElement("ProcessInstrumentationFunction");
         ctrlPif.setAttribute("ID", controllerPifId);
-        ctrlPif.setAttribute("ComponentClass", "ProcessInstrumentationFunction");
-        ctrlPif.setAttribute("ComponentClassURI", "http://sandbox.dexpi.org/rdl/ProcessInstrumentationFunction");
+        ctrlPif.setAttribute("ComponentClass", "ProcessControlFunction");
+        ctrlPif.setAttribute("ComponentClassURI", "http://sandbox.dexpi.org/rdl/ProcessControlFunction");
         ctrlPif.setAttribute("ComponentName", DexpiShapeCatalog.INSTRUMENT_BUBBLE_CENTRAL_SHAPE);
 
-        // Position controller bubble to the right of the transmitter bubble
-        double ctrlCx = cx + DexpiLayoutEngine.INSTRUMENT_X_SPACING;
-        double ctrlCy = cy;
+        // Place a complete controller above its actual final element. An incomplete controller is
+        // kept beside its transmitter and explicitly marked rather than connected to empty space.
+        double ctrlCx = completeLoop ? finalPosition.x : cx + DexpiLayoutEngine.INSTRUMENT_X_SPACING;
+        double ctrlCy = completeLoop ? Math.max(cy, finalPosition.y + DexpiLayoutEngine.INSTRUMENT_OFFSET_Y) : cy;
+        if (Math.abs(ctrlCx - cx) < 0.5) {
+          ctrlCx += DexpiLayoutEngine.INSTRUMENT_X_SPACING;
+        }
         if (hasPosition) {
           appendInstrumentPosition(document, ctrlPif, ctrlCx, ctrlCy);
+          instrumentPositions.add(new double[] { ctrlCx, ctrlCy });
 
           // Controller label
           String ctrlLabelId = uniqueIdentifier("ProcessInstrumentationFunctionLabel", controllerTag, usedIds);
@@ -2168,18 +2193,21 @@ public final class DexpiXmlWriter {
         appendGenericAttribute(document, ctrlAttrSet, "ProcessInstrumentationFunctionNumberAssignmentClass",
             loopNumber);
         appendGenericAttribute(document, ctrlAttrSet, "ProcessInstrumentationFunctionsAssignmentClass", ctrlFunctions);
+        appendGenericAttribute(document, ctrlAttrSet, "LocationSpecialization", "CentralLocation");
         appendGenericAttribute(document, ctrlAttrSet, DexpiMetadata.TAG_NAME, controllerTag);
         appendGenericAttribute(document, ctrlAttrSet, "InstrumentationRole", "CONTROLLER");
         appendGenericAttribute(document, ctrlAttrSet, "ControllerLocation", "SHARED_CONTROL_SYSTEM");
-        appendGenericAttribute(document, ctrlAttrSet, "InstrumentationSource",
-            synthesizedInstrumentation ? "SYNTHESIZED_PROPOSAL" : "EXPLICIT_MODEL");
-        appendGenericAttribute(document, ctrlAttrSet, "EngineeringStatus",
-            synthesizedInstrumentation ? "PROPOSED" : "MODELLED");
+        appendGenericAttribute(document, ctrlAttrSet, "InstrumentationSource", "EXPLICIT_MODEL");
+        appendGenericAttribute(document, ctrlAttrSet, "EngineeringStatus", "MODELLED");
+        appendGenericAttribute(document, ctrlAttrSet, "ControlLoopCompleteness",
+            completeLoop ? "COMPLETE" : "NO_FINAL_CONTROL_ELEMENT");
         appendGenericAttribute(document, ctrlAttrSet, "ControlLoopStatus",
-            hasFinalControlElement ? "CLOSED_MODELLED" : "MEASUREMENT_ONLY_MISSING_FINAL_ELEMENT");
-        if (hasFinalControlElement) {
-          appendGenericAttribute(document, ctrlAttrSet, "FinalControlElementID", finalControlElementId);
+            completeLoop ? "CLOSED_MODELLED" : "MEASUREMENT_ONLY_MISSING_FINAL_ELEMENT");
+        if (finalControlElement != null) {
           appendGenericAttribute(document, ctrlAttrSet, "FinalControlElementTag", finalControlElement.getName());
+        }
+        if (finalControlElementId != null) {
+          appendGenericAttribute(document, ctrlAttrSet, "FinalControlElementID", finalControlElementId);
         }
         ctrlPif.appendChild(ctrlAttrSet);
 
@@ -2207,39 +2235,56 @@ public final class DexpiXmlWriter {
         appendGenericAttribute(document, ctrlSysAttrs, "ControlSystem", systemAssignment);
         ctrlPif.appendChild(ctrlSysAttrs);
 
-        // Signal line between transmitter bubble and controller bubble (dashed blue)
+        // Signal line between transmitter and controller. Logical source/target associations and
+        // conveying type make the topology independent of the rendered line geometry.
         if (hasPosition) {
           String sigFlowId = uniqueIdentifier("SignalInformationFlow", controllerTag, usedIds);
           Element sigFlow = document.createElement("InformationFlow");
           sigFlow.setAttribute("ID", sigFlowId);
-          sigFlow.setAttribute("ComponentClass", "SignalConveyingFunction");
-          sigFlow.setAttribute("ComponentClassURI", "http://sandbox.dexpi.org/rdl/SignalConveyingFunction");
+          sigFlow.setAttribute("ComponentClass", "SignalLineFunction");
+          sigFlow.setAttribute("ComponentClassURI", "http://sandbox.dexpi.org/rdl/SignalLineFunction");
+          appendSignalAssociations(document, sigFlow, pifId, controllerPifId);
+          appendSignalType(document, sigFlow, "ElectricalSignalConveying");
 
-          // Measurement side (sensor -> controller): ISA-5.1 electric signal.
           DexpiLayoutEngine.appendSignalLine(document, sigFlow, cx, cy, ctrlCx, ctrlCy,
               DexpiLayoutEngine.SignalLineKind.ELECTRIC);
           ctrlPif.appendChild(sigFlow);
 
-          if (hasFinalControlElement) {
+          if (completeLoop) {
+            String afId = uniqueIdentifier("ActuatingFunction", controllerTag, usedIds);
+            Element af = document.createElement(valveActuation ? "ActuatingFunction" : "ActuatingElectricalFunction");
+            af.setAttribute("ID", afId);
+            af.setAttribute("ComponentClass", valveActuation ? "ActuatingFunction" : "ActuatingElectricalFunction");
+            af.setAttribute("ComponentClassURI", valveActuation ? "http://sandbox.dexpi.org/rdl/ActuatingFunction"
+                : "http://sandbox.dexpi.org/rdl/ActuatingElectricalFunction");
+            Element afAttrs = document.createElement("GenericAttributes");
+            afAttrs.setAttribute("Set", "DexpiAttributes");
+            appendGenericAttribute(document, afAttrs, valveActuation ? "ActuatingFunctionNumberAssignmentClass"
+                : "ActuatingElectricalFunctionNumberAssignmentClass", controllerTag);
+            appendGenericAttribute(document, afAttrs, "FinalControlElementID", finalControlElementId);
+            af.appendChild(afAttrs);
+            Element locationAssociation = document.createElement("Association");
+            locationAssociation.setAttribute("Type", "is located in");
+            locationAssociation.setAttribute("ItemID", finalControlLocation);
+            af.appendChild(locationAssociation);
+            ctrlPif.appendChild(af);
+            appendOppositeLocationAssociation(document, finalControlLocation, afId);
+
             String actuateFlowId = uniqueIdentifier("ActuatingInformationFlow", controllerTag, usedIds);
             Element actuateFlow = document.createElement("InformationFlow");
             actuateFlow.setAttribute("ID", actuateFlowId);
-            actuateFlow.setAttribute("ComponentClass", "ActuatingSystemFunction");
-            actuateFlow.setAttribute("ComponentClassURI", "http://sandbox.dexpi.org/rdl/ActuatingSystemFunction");
-
-            Element finalElementAssociation = document.createElement("Association");
-            finalElementAssociation.setAttribute("Type", "has logical end");
-            finalElementAssociation.setAttribute("ItemID", finalControlElementId);
-            actuateFlow.appendChild(finalElementAssociation);
-
+            actuateFlow.setAttribute("ComponentClass", "SignalLineFunction");
+            actuateFlow.setAttribute("ComponentClassURI", "http://sandbox.dexpi.org/rdl/SignalLineFunction");
+            appendSignalAssociations(document, actuateFlow, controllerPifId, afId);
+            appendSignalType(document, actuateFlow,
+                valveActuation ? "PneumaticSignalConveying" : "ElectricalSignalConveying");
             Element finalElementAttrs = document.createElement("GenericAttributes");
             finalElementAttrs.setAttribute("Set", "InstrumentAttachment");
             appendGenericAttribute(document, finalElementAttrs, "FinalControlElementID", finalControlElementId);
             actuateFlow.appendChild(finalElementAttrs);
-
-            // Command side (controller -> final control element): ISA-5.1 pneumatic signal.
-            DexpiLayoutEngine.appendSignalLine(document, actuateFlow, ctrlCx, ctrlCy, finalControlPosition.x,
-                finalControlPosition.y, DexpiLayoutEngine.SignalLineKind.PNEUMATIC);
+            DexpiLayoutEngine.appendSignalLineToPoint(document, actuateFlow, ctrlCx, ctrlCy, finalPosition.x,
+                finalPosition.y, valveActuation ? DexpiLayoutEngine.SignalLineKind.PNEUMATIC
+                    : DexpiLayoutEngine.SignalLineKind.ELECTRIC);
             ctrlPif.appendChild(actuateFlow);
           }
         }
@@ -2259,10 +2304,10 @@ public final class DexpiXmlWriter {
       loopAttrs.setAttribute("Set", "DexpiAttributes");
       appendGenericAttribute(document, loopAttrs, DexpiMetadata.LOOP_NUMBER, loopNumber);
       appendGenericAttribute(document, loopAttrs, "InstrumentationSource",
-          synthesizedInstrumentation ? "SYNTHESIZED_PROPOSAL" : "EXPLICIT_MODEL");
+          synthesizedProposal ? "SYNTHESIZED_PROPOSAL" : "EXPLICIT_MODEL");
       appendGenericAttribute(document, loopAttrs, "ControlLoopStatus", matchedController == null ? "MEASUREMENT_ONLY"
-          : hasFinalControlElement ? "CLOSED_MODELLED" : "MEASUREMENT_ONLY_MISSING_FINAL_ELEMENT");
-      if (hasFinalControlElement) {
+          : completeControllerLoop ? "CLOSED_MODELLED" : "MEASUREMENT_ONLY_MISSING_FINAL_ELEMENT");
+      if (finalControlElementId != null) {
         appendGenericAttribute(document, loopAttrs, "FinalControlElementID", finalControlElementId);
       }
       loop.appendChild(loopAttrs);
@@ -2286,46 +2331,46 @@ public final class DexpiXmlWriter {
   }
 
   /**
-   * Synthesizes a standard set of ISA-5.1 instrumentation loops for a process system that defines no measurement
-   * devices or controllers of its own. The generated loops give every common piece of equipment a realistic
-   * indicating/controlling scheme so the exported P&amp;ID resembles a real engineering diagram:
+   * Synthesizes a standard set of ISA-5.1 measurement proposals for a process system that defines no measurement
+   * devices of its own. The generated transmitters identify common sensing requirements without inventing closed-loop
+   * control intent, manipulated variables, or final control elements:
    *
    * <table>
-   * <caption>Synthesized control loops by equipment type</caption>
+   * <caption>Synthesized measurement proposals by equipment type</caption>
    * <tr>
    * <th>Equipment</th>
    * <th>Loops</th>
    * </tr>
    * <tr>
    * <td>Separator</td>
-   * <td>PT/PIC on gas outlet, LT/LIC on liquid outlet, TT on gas outlet</td>
+   * <td>PT on gas outlet, LT on vessel/liquid outlet, TT on gas outlet</td>
    * </tr>
    * <tr>
    * <td>Compressor</td>
-   * <td>PT/PIC and TT on discharge, FT on suction</td>
+   * <td>PT and TT on discharge, FT on suction</td>
    * </tr>
    * <tr>
    * <td>Cooler / Heater / HeatExchanger</td>
-   * <td>TT/TIC on the process outlet</td>
+   * <td>TT on the process outlet</td>
    * </tr>
    * <tr>
    * <td>Pump</td>
-   * <td>PT/PIC on discharge</td>
+   * <td>PT on discharge</td>
    * </tr>
    * </table>
    *
    * <p>
    * The transmitters are bound to live process streams (or, for level, to the separator) so the downstream positioning
-   * logic can place each bubble above its parent equipment. Controller set-points are seeded from the current simulated
-   * stream conditions.
+   * logic can place each bubble above its parent equipment and connect it to an explicit sensing location. Each tag is
+   * marked as an unreviewed synthesized proposal in the exchange metadata.
    * </p>
    *
    * @param processSystem the process system to instrument
    * @param transmitters the (initially empty) transmitter map to populate, keyed by ISA tag
-   * @param controllers the controller map to populate, keyed by derived ISA controller tag
+   * @param synthesizedInstrumentTags collector for tags that must be marked as synthesized proposals
    */
   private static void synthesizeStandardInstrumentation(ProcessSystem processSystem,
-      Map<String, MeasurementDeviceInterface> transmitters, Map<String, ControllerDeviceInterface> controllers) {
+      Map<String, MeasurementDeviceInterface> transmitters, Set<String> synthesizedInstrumentTags) {
     int eqIndex = 0;
     for (ProcessEquipmentInterface unit : processSystem.getUnitOperations()) {
       if (unit instanceof Stream || unit instanceof Mixer || unit instanceof Splitter) {
@@ -2340,19 +2385,16 @@ public final class DexpiXmlWriter {
         if (gas != null) {
           String pt = "PT-" + (base + 1);
           transmitters.put(pt, new PressureTransmitter(pt, gas));
-          controllers.put("PC-" + (base + 1), makeSynthController("PC-" + (base + 1), safePressure(gas)));
           String tt = "TT-" + (base + 3);
           transmitters.put(tt, new TemperatureTransmitter(tt, gas));
         }
         String lt = "LT-" + (base + 2);
         transmitters.put(lt, new LevelTransmitter(lt, sep));
-        controllers.put("LC-" + (base + 2), makeSynthController("LC-" + (base + 2), 0.5));
       } else if (unit instanceof Compressor) {
         StreamInterface out = firstOutlet(unit);
         if (out != null) {
           String pt = "PT-" + (base + 1);
           transmitters.put(pt, new PressureTransmitter(pt, out));
-          controllers.put("PC-" + (base + 1), makeSynthController("PC-" + (base + 1), safePressure(out)));
           String tt = "TT-" + (base + 3);
           transmitters.put(tt, new TemperatureTransmitter(tt, out));
         }
@@ -2368,31 +2410,16 @@ public final class DexpiXmlWriter {
         if (out != null) {
           String tt = "TT-" + (base + 3);
           transmitters.put(tt, new TemperatureTransmitter(tt, out));
-          controllers.put("TC-" + (base + 3), makeSynthController("TC-" + (base + 3), safeTemperature(out)));
         }
       } else if (unit instanceof Pump) {
         StreamInterface out = firstOutlet(unit);
         if (out != null) {
           String pt = "PT-" + (base + 1);
           transmitters.put(pt, new PressureTransmitter(pt, out));
-          controllers.put("PC-" + (base + 1), makeSynthController("PC-" + (base + 1), safePressure(out)));
         }
       }
     }
-  }
-
-  /**
-   * Builds a PID controller seeded with a realistic set-point for synthesized instrumentation.
-   *
-   * @param name the ISA controller tag
-   * @param setPoint the controller set-point value
-   * @return a configured controller device
-   */
-  private static ControllerDeviceInterface makeSynthController(String name, double setPoint) {
-    ControllerDeviceBaseClass controller = new ControllerDeviceBaseClass(name);
-    controller.setControllerSetPoint(setPoint);
-    controller.setControllerParameters(0.5, 200.0, 0.0);
-    return controller;
+    synthesizedInstrumentTags.addAll(transmitters.keySet());
   }
 
   /**
@@ -2415,34 +2442,6 @@ public final class DexpiXmlWriter {
   private static StreamInterface firstInlet(ProcessEquipmentInterface unit) {
     List<StreamInterface> inlets = unit.getInletStreams();
     return inlets != null && !inlets.isEmpty() ? inlets.get(0) : null;
-  }
-
-  /**
-   * Reads the pressure of a stream in bara, returning {@code 0.0} if the value cannot be obtained.
-   *
-   * @param stream the stream to read
-   * @return the pressure in bara, or {@code 0.0} on error
-   */
-  private static double safePressure(StreamInterface stream) {
-    try {
-      return stream.getPressure("bara");
-    } catch (RuntimeException e) {
-      return 0.0;
-    }
-  }
-
-  /**
-   * Reads the temperature of a stream in degrees Celsius, returning {@code 0.0} if the value cannot be obtained.
-   *
-   * @param stream the stream to read
-   * @return the temperature in degrees Celsius, or {@code 0.0} on error
-   */
-  private static double safeTemperature(StreamInterface stream) {
-    try {
-      return stream.getTemperature("C");
-    } catch (RuntimeException e) {
-      return 0.0;
-    }
   }
 
   /**
@@ -2494,47 +2493,173 @@ public final class DexpiXmlWriter {
     return null;
   }
 
+  /** Resolved semantic and graphical sensing attachment for one measurement device. */
+  private static final class InstrumentAttachment {
+    private final double x;
+    private final double y;
+    private final String locationId;
+    private final String sensorType;
+    private final String attachmentType;
+
+    InstrumentAttachment(double x, double y, String locationId, String sensorType, String attachmentType) {
+      this.x = x;
+      this.y = y;
+      this.locationId = locationId;
+      this.sensorType = sensorType;
+      this.attachmentType = attachmentType;
+    }
+  }
+
   /**
-   * Resolves the registered process nozzle measured by a stream-based transmitter.
+   * Resolves a measurement to a DEXPI sensing location and to the corresponding rendered tap point.
    *
-   * @return stable nozzle ID, or {@code null} when the source model does not identify an attachment
+   * <p>
+   * Stream instruments attach to the routed process segment when possible, then fall back to the stream nozzle. Level
+   * instruments attach to the separator liquid nozzle and are drawn from the vessel boundary. This prevents generic
+   * measuring lines from terminating at the equipment centre or crossing its data annotation bar.
+   * </p>
    */
-  private static String findMeasurementTargetNozzle(MeasurementDeviceInterface device, ProcessSystem processSystem,
-      Map<String, String> equipmentInletNozzle, Map<Integer, String> outletStreamToNozzle) {
-    if (!(device instanceof StreamMeasurementDeviceBaseClass) || processSystem == null) {
+  private static InstrumentAttachment resolveInstrumentAttachment(MeasurementDeviceInterface device, String parentName,
+      ProcessSystem processSystem, Map<String, String> equipmentInletNozzle, Map<Integer, String> outletStreamToNozzle,
+      List<NozzleConnection> connections, Map<String, double[]> nozzlePositions,
+      Map<String, DexpiLayoutEngine.EquipmentPosition> layoutPositions) {
+    String sensorType = sensorType(device);
+    if (device instanceof LevelTransmitter) {
+      LevelTransmitter level = (LevelTransmitter) device;
+      Separator separator = level.getSeparator();
+      String locationId = null;
+      if (separator != null && separator.getLiquidOutStream() != null) {
+        locationId = findNozzleForStream(separator.getLiquidOutStream(), outletStreamToNozzle, processSystem);
+      }
+      if (locationId == null) {
+        locationId = equipmentInletNozzle.get(parentName);
+      }
+      double[] nozzle = nozzlePositions.get(locationId);
+      if (nozzle != null) {
+        return new InstrumentAttachment(nozzle[0], nozzle[1], locationId, sensorType, "VESSEL_LEVEL_TAP");
+      }
+    }
+
+    if (device instanceof StreamMeasurementDeviceBaseClass) {
+      StreamInterface measuredStream = ((StreamMeasurementDeviceBaseClass) device).getStream();
+      NozzleConnection connection = findConnectionForStream(measuredStream, connections);
+      if (connection != null && connection.segmentId != null) {
+        double[] from = nozzlePositions.get(connection.fromNozzle);
+        double[] to = nozzlePositions.get(connection.toNozzle);
+        if (from != null && to != null) {
+          double[] midpoint = routeMidpoint(from[0], from[1], to[0], to[1]);
+          return new InstrumentAttachment(midpoint[0], midpoint[1], connection.segmentId, sensorType, "PROCESS_LINE");
+        }
+      }
+      String nozzleId = findNozzleForStream(measuredStream, outletStreamToNozzle, processSystem);
+      if (nozzleId == null) {
+        nozzleId = equipmentInletNozzle.get(parentName);
+      }
+      double[] nozzle = nozzlePositions.get(nozzleId);
+      if (nozzle != null) {
+        return new InstrumentAttachment(nozzle[0], nozzle[1], nozzleId, sensorType, "PROCESS_NOZZLE");
+      }
+    }
+
+    DexpiLayoutEngine.EquipmentPosition equipment = layoutPositions.get(parentName);
+    if (equipment == null) {
       return null;
     }
-    StreamInterface measuredStream = ((StreamMeasurementDeviceBaseClass) device).getStream();
-    if (measuredStream == null) {
+    String inletNozzle = equipmentInletNozzle.get(parentName);
+    double[] nozzle = nozzlePositions.get(inletNozzle);
+    return nozzle == null ? null
+        : new InstrumentAttachment(nozzle[0], nozzle[1], inletNozzle, sensorType, "EQUIPMENT_NOZZLE");
+  }
+
+  private static String sensorType(MeasurementDeviceInterface device) {
+    if (device instanceof PressureTransmitter) {
+      return "PressureTap";
+    }
+    if (device instanceof TemperatureTransmitter) {
+      return "Thermowell";
+    }
+    if (device instanceof VolumeFlowTransmitter) {
+      return "InlineFlowMeasurement";
+    }
+    if (device instanceof LevelTransmitter) {
+      return "VesselLevelTap";
+    }
+    return device.getClass().getSimpleName();
+  }
+
+  private static NozzleConnection findConnectionForStream(StreamInterface stream, List<NozzleConnection> connections) {
+    if (stream == null) {
       return null;
     }
-    String outletNozzle = outletStreamToNozzle.get(Integer.valueOf(System.identityHashCode(measuredStream)));
-    if (outletNozzle != null) {
-      return outletNozzle;
+    for (NozzleConnection connection : connections) {
+      if (connection.stream == stream) {
+        return connection;
+      }
     }
-    for (ProcessEquipmentInterface unit : processSystem.getUnitOperations()) {
-      for (StreamInterface inlet : unit.getInletStreams()) {
-        if (inlet == measuredStream) {
-          return equipmentInletNozzle.get(unit.getName());
+    if (stream.getFluid() != null) {
+      int fluidIdentity = System.identityHashCode(stream.getFluid());
+      for (NozzleConnection connection : connections) {
+        if (connection.stream != null && connection.stream.getFluid() != null
+            && System.identityHashCode(connection.stream.getFluid()) == fluidIdentity) {
+          return connection;
         }
       }
     }
     return null;
   }
 
-  /**
-   * Finds the equipment function that owns the supplied controller.
-   *
-   * @return manipulated equipment, or {@code null} when the controller is standalone
-   */
-  private static ProcessEquipmentInterface findManipulatedEquipment(ControllerDeviceInterface controller,
+  private static String findNozzleForStream(StreamInterface stream, Map<Integer, String> outletStreamToNozzle,
+      ProcessSystem processSystem) {
+    if (stream == null) {
+      return null;
+    }
+    String nozzle = outletStreamToNozzle.get(System.identityHashCode(stream));
+    if (nozzle != null || stream.getFluid() == null) {
+      return nozzle;
+    }
+    int fluidIdentity = System.identityHashCode(stream.getFluid());
+    for (ProcessEquipmentInterface unit : processSystem.getUnitOperations()) {
+      for (StreamInterface outlet : unit.getOutletStreams()) {
+        if (outlet != null && outlet.getFluid() != null
+            && System.identityHashCode(outlet.getFluid()) == fluidIdentity) {
+          nozzle = outletStreamToNozzle.get(System.identityHashCode(outlet));
+          if (nozzle != null) {
+            return nozzle;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  private static double[] routeMidpoint(double fromX, double fromY, double toX, double toY) {
+    double[][] route = DexpiLayoutEngine.routeConnection(fromX, fromY, toX, toY);
+    double totalLength = 0.0;
+    for (int index = 0; index + 1 < route.length; index++) {
+      totalLength += Math.abs(route[index + 1][0] - route[index][0]) + Math.abs(route[index + 1][1] - route[index][1]);
+    }
+    double remaining = totalLength / 2.0;
+    for (int index = 0; index + 1 < route.length; index++) {
+      double segmentLength = Math.abs(route[index + 1][0] - route[index][0])
+          + Math.abs(route[index + 1][1] - route[index][1]);
+      if (remaining <= segmentLength || index + 2 == route.length) {
+        double fraction = segmentLength <= 0.0 ? 0.0 : remaining / segmentLength;
+        return new double[] { route[index][0] + fraction * (route[index + 1][0] - route[index][0]),
+            route[index][1] + fraction * (route[index + 1][1] - route[index][1]) };
+      }
+      remaining -= segmentLength;
+    }
+    return new double[] { fromX, fromY };
+  }
+
+  private static ProcessEquipmentInterface findFinalControlElement(ControllerDeviceInterface controller,
       ProcessSystem processSystem) {
     if (controller == null || processSystem == null) {
       return null;
     }
     for (ProcessEquipmentInterface unit : processSystem.getUnitOperations()) {
-      for (ControllerDeviceInterface configured : unit.getControllers()) {
-        if (configured == controller || configured != null && controller.getName().equals(configured.getName())) {
+      for (ControllerDeviceInterface attached : unit.getControllers()) {
+        if (attached == controller) {
           return unit;
         }
       }
@@ -2542,44 +2667,88 @@ public final class DexpiXmlWriter {
     return null;
   }
 
-  /**
-   * Finds an already-emitted equipment or piping-component identity by its tag name.
-   *
-   * @return stable element ID, or {@code null} when the element is not present
-   */
-  private static String findEquipmentElementId(Element parent, String tagName) {
-    if (tagName == null) {
+  private static String findFinalControlLocation(ProcessEquipmentInterface finalControlElement,
+      Map<String, String> equipmentInletNozzle, List<NozzleConnection> connections) {
+    if (finalControlElement == null) {
       return null;
     }
-    NodeList elements = parent.getElementsByTagName("*");
-    for (int index = 0; index < elements.getLength(); index++) {
-      Element candidate = (Element) elements.item(index);
-      String identity = candidate.getAttribute("ID");
-      if (identity == null || identity.trim().isEmpty()) {
-        continue;
-      }
-      NodeList children = candidate.getChildNodes();
-      for (int childIndex = 0; childIndex < children.getLength(); childIndex++) {
-        Node child = children.item(childIndex);
-        if (!(child instanceof Element) || !"GenericAttributes".equals(((Element) child).getTagName())) {
-          continue;
-        }
-        NodeList attributes = ((Element) child).getChildNodes();
-        for (int attributeIndex = 0; attributeIndex < attributes.getLength(); attributeIndex++) {
-          Node attributeNode = attributes.item(attributeIndex);
-          if (!(attributeNode instanceof Element)) {
-            continue;
-          }
-          Element attribute = (Element) attributeNode;
-          if ("GenericAttribute".equals(attribute.getTagName())
-              && DexpiMetadata.TAG_NAME.equals(attribute.getAttribute("Name"))
-              && tagName.equals(attribute.getAttribute("Value"))) {
-            return identity;
-          }
-        }
+    String inletNozzle = equipmentInletNozzle.get(finalControlElement.getName());
+    if (inletNozzle == null) {
+      return null;
+    }
+    if (!(finalControlElement instanceof ThrottlingValve)) {
+      return inletNozzle;
+    }
+    for (NozzleConnection connection : connections) {
+      if (inletNozzle.equals(connection.toNozzle)) {
+        return connection.segmentId;
       }
     }
     return null;
+  }
+
+  private static void appendOppositeLocationAssociation(Document document, String locationId, String functionId) {
+    Element location = findElementById(document, locationId);
+    if (location == null) {
+      return;
+    }
+    Element association = document.createElement("Association");
+    association.setAttribute("Type", "is the location of");
+    association.setAttribute("ItemID", functionId);
+    location.appendChild(association);
+  }
+
+  private static Element findElementById(Document document, String identity) {
+    NodeList all = document.getElementsByTagName("*");
+    for (int index = 0; index < all.getLength(); index++) {
+      Element element = (Element) all.item(index);
+      if (identity.equals(element.getAttribute("ID"))) {
+        return element;
+      }
+    }
+    return null;
+  }
+
+  private static String findComponentIdByTag(Document document, String tagName) {
+    if (tagName == null) {
+      return null;
+    }
+    NodeList attributes = document.getElementsByTagName("GenericAttribute");
+    for (int index = 0; index < attributes.getLength(); index++) {
+      Element attribute = (Element) attributes.item(index);
+      if (!DexpiMetadata.TAG_NAME.equals(attribute.getAttribute("Name"))
+          || !tagName.equals(attribute.getAttribute("Value"))) {
+        continue;
+      }
+      Node ancestor = attribute.getParentNode();
+      while (ancestor instanceof Element) {
+        Element element = (Element) ancestor;
+        if (("Equipment".equals(element.getTagName()) || "PipingComponent".equals(element.getTagName()))
+            && !element.getAttribute("ID").isEmpty()) {
+          return element.getAttribute("ID");
+        }
+        ancestor = ancestor.getParentNode();
+      }
+    }
+    return null;
+  }
+
+  private static void appendSignalAssociations(Document document, Element signal, String sourceId, String targetId) {
+    Element start = document.createElement("Association");
+    start.setAttribute("Type", "has logical start");
+    start.setAttribute("ItemID", sourceId);
+    signal.appendChild(start);
+    Element end = document.createElement("Association");
+    end.setAttribute("Type", "has logical end");
+    end.setAttribute("ItemID", targetId);
+    signal.appendChild(end);
+  }
+
+  private static void appendSignalType(Document document, Element signal, String type) {
+    Element attributes = document.createElement("GenericAttributes");
+    attributes.setAttribute("Set", "DexpiAttributes");
+    appendGenericAttribute(document, attributes, "SignalConveyingTypeSpecialization", type);
+    signal.appendChild(attributes);
   }
 
   /**
@@ -2655,6 +2824,36 @@ public final class DexpiXmlWriter {
   }
 
   /**
+   * Adds a visible status marker beside an automatically synthesized measurement proposal.
+   *
+   * <p>
+   * Proposal provenance is also exported as machine-readable metadata, but a reviewer must not need to inspect XML to
+   * distinguish an inferred measurement from approved control intent.
+   * </p>
+   *
+   * @param document the XML document
+   * @param parent the measurement function
+   * @param x measurement bubble centre X
+   * @param y measurement bubble centre Y
+   */
+  private static void appendProposalMarker(Document document, Element parent, double x, double y) {
+    Element text = document.createElement("Text");
+    text.setAttribute("String", "[PROP]");
+    text.setAttribute("Font", "Calibri");
+    text.setAttribute("Height", "2.0");
+    text.setAttribute("Width", "0");
+    text.setAttribute("Justification", "LeftCenter");
+    Element presentation = document.createElement("Presentation");
+    presentation.setAttribute("R", "0");
+    presentation.setAttribute("G", "0");
+    presentation.setAttribute("B", "0");
+    text.appendChild(presentation);
+    appendInstrumentPosition(document, text, x + DexpiLayoutEngine.INSTRUMENT_BUBBLE_RADIUS + 1.5,
+        y - DexpiLayoutEngine.INSTRUMENT_BUBBLE_RADIUS - 1.0);
+    parent.appendChild(text);
+  }
+
+  /**
    * Appends a signal Node with position inside a ConnectionPoints element.
    *
    * @param document the XML document
@@ -2697,32 +2896,28 @@ public final class DexpiXmlWriter {
   }
 
   /**
-   * Derives the controller tag from a transmitter tag. For example, "PT-HP sep" becomes "PC-HP sep", "LT-HP sep"
-   * becomes "LC-HP sep".
+   * Finds a controller with the same measured-variable category and loop number as a transmitter.
+   *
+   * <p>
+   * Both compact controller functions such as {@code PC} and indicating-controller functions such as {@code PIC} are
+   * accepted. The first matching entry is returned, preserving the deterministic insertion order of the controller map.
+   * </p>
    *
    * @param transmitterTag the transmitter tag
-   * @return the expected controller tag, or null if not derivable
+   * @param controllers available controller devices keyed by tag
+   * @return matching controller entry, or {@code null}
    */
-  private static String deriveControllerTag(String transmitterTag) {
-    if (transmitterTag == null || transmitterTag.isEmpty()) {
+  private static Map.Entry<String, ControllerDeviceInterface> findMatchingController(String transmitterTag,
+      Map<String, ControllerDeviceInterface> controllers) {
+    if (transmitterTag == null || transmitterTag.isEmpty() || controllers == null) {
       return null;
     }
-    int dashIndex = transmitterTag.indexOf('-');
-    if (dashIndex <= 0) {
-      return null;
-    }
-    String prefix = transmitterTag.substring(0, dashIndex);
-    String suffix = transmitterTag.substring(dashIndex);
-
-    // Map transmitter prefix to controller prefix
-    if ("PT".equals(prefix)) {
-      return "PC" + suffix;
-    } else if ("LT".equals(prefix)) {
-      return "LC" + suffix;
-    } else if ("FT".equals(prefix)) {
-      return "FC" + suffix;
-    } else if ("TT".equals(prefix)) {
-      return "TC" + suffix;
+    String[] transmitter = parseIsaTag(transmitterTag);
+    for (Map.Entry<String, ControllerDeviceInterface> entry : controllers.entrySet()) {
+      String[] controller = parseIsaTag(entry.getKey());
+      if (transmitter[0].equals(controller[0]) && transmitter[2].equals(controller[2]) && controller[1].contains("C")) {
+        return entry;
+      }
     }
     return null;
   }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
@@ -1922,8 +1922,8 @@ public final class DexpiXmlWriter {
         cy = pos[1];
         hasPosition = true;
       }
-      String measurementTargetId =
-          findMeasurementTargetNozzle(device, processSystem, equipmentInletNozzle, outletStreamToNozzle);
+      String measurementTargetId = findMeasurementTargetNozzle(device, processSystem, equipmentInletNozzle,
+          outletStreamToNozzle);
       double[] measurementTap = measurementTargetId == null ? null : nozzlePositions.get(measurementTargetId);
 
       // ProcessInstrumentationFunction (the instrument bubble)
@@ -1953,8 +1953,7 @@ public final class DexpiXmlWriter {
         appendInstrumentLabelText(document, label, loopNumber, cx, cy - 1.2, pifId,
             new String[] { "ProcessInstrumentationFunctionNumber" });
         if (synthesizedInstrumentation) {
-          appendInstrumentLabelText(document, label, "PROP", cx, cy + 6.0, pifId,
-              new String[] { "EngineeringStatus" });
+          appendInstrumentLabelText(document, label, "PROP", cx, cy + 6.0, pifId, new String[] { "EngineeringStatus" });
         }
 
         pif.appendChild(label);
@@ -2097,14 +2096,13 @@ public final class DexpiXmlWriter {
       }
 
       String controllerPifId = null;
-      ProcessEquipmentInterface finalControlElement =
-          matchedController == null ? null : findManipulatedEquipment(matchedController, processSystem);
-      String finalControlElementId =
-          finalControlElement == null ? null : findEquipmentElementId(parent, finalControlElement.getName());
-      DexpiLayoutEngine.EquipmentPosition finalControlPosition =
-          finalControlElement == null ? null : layoutPositions.get(finalControlElement.getName());
-      boolean hasFinalControlElement =
-          finalControlElementId != null && finalControlPosition != null;
+      ProcessEquipmentInterface finalControlElement = matchedController == null ? null
+          : findManipulatedEquipment(matchedController, processSystem);
+      String finalControlElementId = finalControlElement == null ? null
+          : findEquipmentElementId(parent, finalControlElement.getName());
+      DexpiLayoutEngine.EquipmentPosition finalControlPosition = finalControlElement == null ? null
+          : layoutPositions.get(finalControlElement.getName());
+      boolean hasFinalControlElement = finalControlElementId != null && finalControlPosition != null;
       if (matchedController != null) {
         // SignalConveyingFunction on the transmitter PIF
         String scfId = uniqueIdentifier("SignalConveyingFunction", tag, usedIds);
@@ -2262,9 +2260,8 @@ public final class DexpiXmlWriter {
       appendGenericAttribute(document, loopAttrs, DexpiMetadata.LOOP_NUMBER, loopNumber);
       appendGenericAttribute(document, loopAttrs, "InstrumentationSource",
           synthesizedInstrumentation ? "SYNTHESIZED_PROPOSAL" : "EXPLICIT_MODEL");
-      appendGenericAttribute(document, loopAttrs, "ControlLoopStatus",
-          matchedController == null ? "MEASUREMENT_ONLY"
-              : hasFinalControlElement ? "CLOSED_MODELLED" : "MEASUREMENT_ONLY_MISSING_FINAL_ELEMENT");
+      appendGenericAttribute(document, loopAttrs, "ControlLoopStatus", matchedController == null ? "MEASUREMENT_ONLY"
+          : hasFinalControlElement ? "CLOSED_MODELLED" : "MEASUREMENT_ONLY_MISSING_FINAL_ELEMENT");
       if (hasFinalControlElement) {
         appendGenericAttribute(document, loopAttrs, "FinalControlElementID", finalControlElementId);
       }

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
@@ -25,7 +25,6 @@ import neqsim.process.equipment.mixer.Mixer;
 import neqsim.process.equipment.splitter.Splitter;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.util.Recycle;
-import neqsim.process.equipment.valve.ThrottlingValve;
 import neqsim.process.measurementdevice.PressureTransmitter;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.process.processmodel.diagram.EngineeringDiagramReferenceFixtures;
@@ -76,19 +75,14 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
     assertFalse(xml.contains("90-EMPTY-SPARE"));
     assertTrue(xml.contains("PT-5001"));
     assertTrue(xml.contains("PC-5001"));
-    assertTrue(xml.contains("INSTRUMENTATION_BUBBLE_SHAPE_CENTRAL"),
-        "Controller must use the shared-system/panel location convention");
-    assertTrue(xml.contains("MeasurementAttachmentTargetID"), "Transmitter must identify the measured process nozzle");
-    assertFalse(xml.contains("ComponentClass=\"ActuatingSystemFunction\""),
-        "A standalone controller must not emit an actuating signal to empty space");
     assertFalse(report.hasErrors(), report.toJson());
+    assertTrue(report.getMetrics().get("componentInstances") >= 4, report.toJson());
+    assertTrue(report.getMetrics().get("sourceTexts") >= 4, report.toJson());
+    assertTrue(report.getMetrics().get("sourceCenterLines") > 0, report.toJson());
     assertEquals(1, report.getMetrics().get("processMeasurementAttachments"), report.toJson());
     assertEquals(1, report.getMetrics().get("incompleteControlLoops"), report.toJson());
     assertEquals(0, report.getMetrics().get("sourceActuatingSignals"), report.toJson());
     assertTrue(hasFinding(report, "CONTROL_FINAL_ELEMENT_SOURCE_DATA_MISSING"), report.toJson());
-    assertTrue(report.getMetrics().get("componentInstances") >= 4, report.toJson());
-    assertTrue(report.getMetrics().get("sourceTexts") >= 4, report.toJson());
-    assertTrue(report.getMetrics().get("sourceCenterLines") > 0, report.toJson());
     assertTrue(report.getMetrics().get("routedMaterialSegments") > 0, report.toJson());
     assertEquals(report.getMetrics().get("routedMaterialSegments"),
         report.getMetrics().get("sourceFlowDirectionArrows"), report.toJson());
@@ -98,68 +92,6 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
     Document exportedDocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(dexpi.toFile());
     assertTrue(hasDirectedEquipmentConnection(exportedDocument, "ID-50-RC-001", "ID-50-MX-001"),
         "The configured recycle outlet must be routed back to the mixer inlet");
-  }
-
-  @Test
-  void connectsControllerOnlyToModelledFinalControlElement() throws Exception {
-    SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
-    fluid.addComponent("methane", 1.0);
-    fluid.setMixingRule("classic");
-
-    Stream feed = new Stream("51-FEED-001", fluid);
-    feed.setFlowRate(1000.0, "kg/hr");
-    PressureTransmitter pressure = new PressureTransmitter("PT-5101", feed);
-    ControllerDeviceBaseClass controller = new ControllerDeviceBaseClass("PC-5101");
-    controller.setControllerSetPoint(45.0);
-    controller.setControllerParameters(1.0, 30.0, 0.0);
-    controller.setTransmitter(pressure);
-    ThrottlingValve valve = new ThrottlingValve("51-PV-001", feed);
-    valve.setOutletPressure(45.0);
-    valve.setController(controller);
-
-    ProcessSystem process = new ProcessSystem("Modelled final-control-element benchmark");
-    process.add(feed);
-    process.add(valve);
-    process.add(pressure);
-    process.add(controller);
-    process.run();
-
-    Path dexpi = temporaryDirectory.resolve("modelled-final-element.xml");
-    DexpiXmlWriter.writeForPyDexpi(process, dexpi.toFile());
-    String xml = new String(Files.readAllBytes(dexpi), StandardCharsets.UTF_8);
-    DexpiVisualQualityAssessment.Report report = DexpiVisualQualityAssessment.assess(dexpi.toFile());
-
-    assertFalse(report.hasErrors(), report.toJson());
-    assertTrue(xml.contains("ComponentClass=\"ActuatingSystemFunction\""));
-    assertTrue(xml.contains("Name=\"FinalControlElementTag\" Value=\"51-PV-001\""));
-    assertTrue(xml.contains("Name=\"ControlLoopStatus\" Value=\"CLOSED_MODELLED\""));
-    assertEquals(1, report.getMetrics().get("closedControlLoops"), report.toJson());
-    assertEquals(1, report.getMetrics().get("sourceActuatingSignals"), report.toJson());
-    assertEquals(0, report.getMetrics().get("invalidActuatingSignals"), report.toJson());
-  }
-
-  @Test
-  void reportsUnresolvedInstrumentTopologyDeterministically() throws Exception {
-    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-        + "<PlantModel><PlantInformation SchemaVersion=\"4.1.1\"/>"
-        + "<Drawing Name=\"Instrument topology defect\"><Extent><Min X=\"0\" Y=\"0\"/>"
-        + "<Max X=\"100\" Y=\"70\"/></Extent></Drawing>"
-        + "<ProcessInstrumentationFunction ID=\"PT-1\"><GenericAttributes>"
-        + "<GenericAttribute Name=\"InstrumentationRole\" Value=\"TRANSMITTER\"/>"
-        + "<GenericAttribute Name=\"MeasurementAttachmentStatus\" Value=\"MISSING_SOURCE_DATA\"/>"
-        + "</GenericAttributes></ProcessInstrumentationFunction>"
-        + "<InformationFlow ID=\"ACT-1\" ComponentClass=\"ActuatingSystemFunction\"/>" + "</PlantModel>";
-    Path dexpi = temporaryDirectory.resolve("instrument-topology-defect.xml");
-    Files.write(dexpi, xml.getBytes(StandardCharsets.UTF_8));
-
-    DexpiVisualQualityAssessment.Report report = DexpiVisualQualityAssessment.assess(dexpi.toFile());
-
-    assertTrue(report.hasErrors(), report.toJson());
-    assertTrue(hasFinding(report, "MEASUREMENT_ATTACHMENT_SOURCE_DATA_MISSING"), report.toJson());
-    assertTrue(hasFinding(report, "ACTUATING_SIGNAL_FINAL_ELEMENT_MISSING"), report.toJson());
-    assertEquals(1, report.getMetrics().get("measurementAttachmentDataGaps"));
-    assertEquals(1, report.getMetrics().get("invalidActuatingSignals"));
-    assertEquals(report.toJson(), DexpiVisualQualityAssessment.assess(dexpi.toFile()).toJson());
   }
 
   @Test
@@ -214,6 +146,35 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
   }
 
   @Test
+  void reportsInstrumentationTopologyAndProposalVisibilityDefects() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<PlantModel><PlantInformation SchemaVersion=\"4.1.1\"/>"
+        + "<Drawing Name=\"Instrumentation defects\"><Extent><Min X=\"0\" Y=\"0\"/>"
+        + "<Max X=\"100\" Y=\"70\"/></Extent></Drawing>"
+        + "<ProcessInstrumentationFunction ID=\"PT-1\" ComponentClass=\"ProcessInstrumentationFunction\" "
+        + "ComponentName=\"INSTRUMENTATION_BUBBLE_SHAPE_FIELD\"><GenericAttributes>"
+        + "<GenericAttribute Name=\"Origin\" Value=\"SYNTHESIZED_PROPOSAL\"/>"
+        + "</GenericAttributes><ProcessSignalGeneratingFunction ID=\"PSGF-1\">"
+        + "<Association Type=\"is located in\" ItemID=\"DOES-NOT-EXIST\"/>"
+        + "</ProcessSignalGeneratingFunction></ProcessInstrumentationFunction>"
+        + "<ProcessInstrumentationFunction ID=\"PC-1\" ComponentClass=\"ProcessControlFunction\" "
+        + "ComponentName=\"INSTRUMENTATION_BUBBLE_SHAPE_FIELD\"><GenericAttributes>"
+        + "<GenericAttribute Name=\"LocationSpecialization\" Value=\"Field\"/>"
+        + "<GenericAttribute Name=\"ControlLoopCompleteness\" Value=\"COMPLETE\"/>"
+        + "</GenericAttributes></ProcessInstrumentationFunction></PlantModel>";
+    Path dexpi = temporaryDirectory.resolve("instrumentation-defects.xml");
+    Files.write(dexpi, xml.getBytes(StandardCharsets.UTF_8));
+
+    DexpiVisualQualityAssessment.Report report = DexpiVisualQualityAssessment.assess(dexpi.toFile());
+
+    assertTrue(report.hasErrors());
+    assertTrue(hasFinding(report, "INSTRUMENT_SENSING_LOCATION_INVALID"), report.toJson());
+    assertTrue(hasFinding(report, "SYNTHESIZED_PROPOSAL_NOT_VISIBLE"), report.toJson());
+    assertTrue(hasFinding(report, "CONTROLLER_LOCATION_SYMBOL_MISMATCH"), report.toJson());
+    assertTrue(hasFinding(report, "CONTROL_LOOP_FINAL_ELEMENT_MISSING"), report.toJson());
+  }
+
+  @Test
   void keepsInstrumentBubblesClearOfDataBarsAndInsideBatteryLimit() throws Exception {
     Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
     Element root = document.createElement("PlantModel");
@@ -235,10 +196,29 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
 
     Map<String, DexpiLayoutEngine.EquipmentPosition> positions = new LinkedHashMap<String, DexpiLayoutEngine.EquipmentPosition>();
     positions.put("20-VA-001", equipment);
-    DexpiLayoutEngine.appendBatteryLimitBoundary(document, root, positions, "Area 20");
+    List<double[]> instrumentPositions = new ArrayList<double[]>();
+    instrumentPositions.add(instrument);
+    double[] rightmostInstrument = new double[] { 160.0, 170.0 };
+    instrumentPositions.add(rightmostInstrument);
+    DexpiLayoutEngine.appendBatteryLimitBoundary(document, root, positions, instrumentPositions, "Area 20");
     Element boundary = identifiedElement(document, "BatteryLimit-1");
     assertTrue(maximumCoordinateY(boundary) > instrument[1] + DexpiLayoutEngine.INSTRUMENT_BUBBLE_RADIUS,
         "Battery limit must enclose the highest instrument bubble");
+    assertTrue(maximumCoordinateX(boundary) > rightmostInstrument[0] + DexpiLayoutEngine.INSTRUMENT_BUBBLE_RADIUS,
+        "Battery limit must enclose the rightmost instrument bubble and proposal marker");
+  }
+
+  @Test
+  void positionsTapMountedInstrumentLanesOutsideEquipmentDataBars() {
+    DexpiLayoutEngine.EquipmentPosition equipment = new DexpiLayoutEngine.EquipmentPosition(100.0, 150.0, 1.0, 1.0);
+
+    for (int index = 0; index < 4; index++) {
+      double[] instrument = DexpiLayoutEngine.computeInstrumentPositionAtSensingPoint(equipment, 118.0, 150.0, index,
+          4);
+      assertTrue(instrument[0] - DexpiLayoutEngine.INSTRUMENT_BUBBLE_RADIUS > 125.0,
+          "Every bubble sharing a right-side nozzle tap must clear the 50 mm equipment data bar");
+      assertEquals(180.0, instrument[1], 1.0e-12);
+    }
   }
 
   private void assertCleanAndDeterministic(String name, ProcessSystem process) throws Exception {
@@ -334,6 +314,20 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
         maximum = Math.max(maximum, Double.parseDouble(rawY));
       } catch (NumberFormatException exception) {
         throw new AssertionError("Invalid Y coordinate at index " + index + ": " + rawY, exception);
+      }
+    }
+    return maximum;
+  }
+
+  private static double maximumCoordinateX(Element parent) {
+    NodeList coordinates = parent.getElementsByTagName("Coordinate");
+    double maximum = -Double.MAX_VALUE;
+    for (int index = 0; index < coordinates.getLength(); index++) {
+      String rawX = ((Element) coordinates.item(index)).getAttribute("X");
+      try {
+        maximum = Math.max(maximum, Double.parseDouble(rawX));
+      } catch (NumberFormatException exception) {
+        throw new AssertionError("Invalid X coordinate at index " + index + ": " + rawX, exception);
       }
     }
     return maximum;

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
@@ -25,6 +25,7 @@ import neqsim.process.equipment.mixer.Mixer;
 import neqsim.process.equipment.splitter.Splitter;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.util.Recycle;
+import neqsim.process.equipment.valve.ThrottlingValve;
 import neqsim.process.measurementdevice.PressureTransmitter;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.process.processmodel.diagram.EngineeringDiagramReferenceFixtures;
@@ -75,7 +76,17 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
     assertFalse(xml.contains("90-EMPTY-SPARE"));
     assertTrue(xml.contains("PT-5001"));
     assertTrue(xml.contains("PC-5001"));
+    assertTrue(xml.contains("INSTRUMENTATION_BUBBLE_SHAPE_CENTRAL"),
+        "Controller must use the shared-system/panel location convention");
+    assertTrue(xml.contains("MeasurementAttachmentTargetID"),
+        "Transmitter must identify the measured process nozzle");
+    assertFalse(xml.contains("ComponentClass=\"ActuatingSystemFunction\""),
+        "A standalone controller must not emit an actuating signal to empty space");
     assertFalse(report.hasErrors(), report.toJson());
+    assertEquals(1, report.getMetrics().get("processMeasurementAttachments"), report.toJson());
+    assertEquals(1, report.getMetrics().get("incompleteControlLoops"), report.toJson());
+    assertEquals(0, report.getMetrics().get("sourceActuatingSignals"), report.toJson());
+    assertTrue(hasFinding(report, "CONTROL_FINAL_ELEMENT_SOURCE_DATA_MISSING"), report.toJson());
     assertTrue(report.getMetrics().get("componentInstances") >= 4, report.toJson());
     assertTrue(report.getMetrics().get("sourceTexts") >= 4, report.toJson());
     assertTrue(report.getMetrics().get("sourceCenterLines") > 0, report.toJson());
@@ -88,6 +99,69 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
     Document exportedDocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(dexpi.toFile());
     assertTrue(hasDirectedEquipmentConnection(exportedDocument, "ID-50-RC-001", "ID-50-MX-001"),
         "The configured recycle outlet must be routed back to the mixer inlet");
+  }
+
+  @Test
+  void connectsControllerOnlyToModelledFinalControlElement() throws Exception {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("51-FEED-001", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    PressureTransmitter pressure = new PressureTransmitter("PT-5101", feed);
+    ControllerDeviceBaseClass controller = new ControllerDeviceBaseClass("PC-5101");
+    controller.setControllerSetPoint(45.0);
+    controller.setControllerParameters(1.0, 30.0, 0.0);
+    controller.setTransmitter(pressure);
+    ThrottlingValve valve = new ThrottlingValve("51-PV-001", feed);
+    valve.setOutletPressure(45.0);
+    valve.setController(controller);
+
+    ProcessSystem process = new ProcessSystem("Modelled final-control-element benchmark");
+    process.add(feed);
+    process.add(valve);
+    process.add(pressure);
+    process.add(controller);
+    process.run();
+
+    Path dexpi = temporaryDirectory.resolve("modelled-final-element.xml");
+    DexpiXmlWriter.writeForPyDexpi(process, dexpi.toFile());
+    String xml = new String(Files.readAllBytes(dexpi), StandardCharsets.UTF_8);
+    DexpiVisualQualityAssessment.Report report = DexpiVisualQualityAssessment.assess(dexpi.toFile());
+
+    assertFalse(report.hasErrors(), report.toJson());
+    assertTrue(xml.contains("ComponentClass=\"ActuatingSystemFunction\""));
+    assertTrue(xml.contains("Name=\"FinalControlElementTag\" Value=\"51-PV-001\""));
+    assertTrue(xml.contains("Name=\"ControlLoopStatus\" Value=\"CLOSED_MODELLED\""));
+    assertEquals(1, report.getMetrics().get("closedControlLoops"), report.toJson());
+    assertEquals(1, report.getMetrics().get("sourceActuatingSignals"), report.toJson());
+    assertEquals(0, report.getMetrics().get("invalidActuatingSignals"), report.toJson());
+  }
+
+  @Test
+  void reportsUnresolvedInstrumentTopologyDeterministically() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<PlantModel><PlantInformation SchemaVersion=\"4.1.1\"/>"
+        + "<Drawing Name=\"Instrument topology defect\"><Extent><Min X=\"0\" Y=\"0\"/>"
+        + "<Max X=\"100\" Y=\"70\"/></Extent></Drawing>"
+        + "<ProcessInstrumentationFunction ID=\"PT-1\"><GenericAttributes>"
+        + "<GenericAttribute Name=\"InstrumentationRole\" Value=\"TRANSMITTER\"/>"
+        + "<GenericAttribute Name=\"MeasurementAttachmentStatus\" Value=\"MISSING_SOURCE_DATA\"/>"
+        + "</GenericAttributes></ProcessInstrumentationFunction>"
+        + "<InformationFlow ID=\"ACT-1\" ComponentClass=\"ActuatingSystemFunction\"/>"
+        + "</PlantModel>";
+    Path dexpi = temporaryDirectory.resolve("instrument-topology-defect.xml");
+    Files.write(dexpi, xml.getBytes(StandardCharsets.UTF_8));
+
+    DexpiVisualQualityAssessment.Report report = DexpiVisualQualityAssessment.assess(dexpi.toFile());
+
+    assertTrue(report.hasErrors(), report.toJson());
+    assertTrue(hasFinding(report, "MEASUREMENT_ATTACHMENT_SOURCE_DATA_MISSING"), report.toJson());
+    assertTrue(hasFinding(report, "ACTUATING_SIGNAL_FINAL_ELEMENT_MISSING"), report.toJson());
+    assertEquals(1, report.getMetrics().get("measurementAttachmentDataGaps"));
+    assertEquals(1, report.getMetrics().get("invalidActuatingSignals"));
+    assertEquals(report.toJson(), DexpiVisualQualityAssessment.assess(dexpi.toFile()).toJson());
   }
 
   @Test

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
@@ -78,8 +78,7 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
     assertTrue(xml.contains("PC-5001"));
     assertTrue(xml.contains("INSTRUMENTATION_BUBBLE_SHAPE_CENTRAL"),
         "Controller must use the shared-system/panel location convention");
-    assertTrue(xml.contains("MeasurementAttachmentTargetID"),
-        "Transmitter must identify the measured process nozzle");
+    assertTrue(xml.contains("MeasurementAttachmentTargetID"), "Transmitter must identify the measured process nozzle");
     assertFalse(xml.contains("ComponentClass=\"ActuatingSystemFunction\""),
         "A standalone controller must not emit an actuating signal to empty space");
     assertFalse(report.hasErrors(), report.toJson());
@@ -149,8 +148,7 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
         + "<GenericAttribute Name=\"InstrumentationRole\" Value=\"TRANSMITTER\"/>"
         + "<GenericAttribute Name=\"MeasurementAttachmentStatus\" Value=\"MISSING_SOURCE_DATA\"/>"
         + "</GenericAttributes></ProcessInstrumentationFunction>"
-        + "<InformationFlow ID=\"ACT-1\" ComponentClass=\"ActuatingSystemFunction\"/>"
-        + "</PlantModel>";
+        + "<InformationFlow ID=\"ACT-1\" ComponentClass=\"ActuatingSystemFunction\"/>" + "</PlantModel>";
     Path dexpi = temporaryDirectory.resolve("instrument-topology-defect.xml");
     Files.write(dexpi, xml.getBytes(StandardCharsets.UTF_8));
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
@@ -574,6 +574,14 @@ public class DexpiXmlWriterTest extends NeqSimTest {
     // Cooler should get a temperature loop.
     assertTrue(xml.contains("TT-2023"), "Cooler should get a temperature transmitter");
     assertTrue(xml.contains("TC-2023"), "Cooler should get a temperature controller");
+    assertTrue(xml.contains("Name=\"InstrumentationSource\" Value=\"SYNTHESIZED_PROPOSAL\""),
+        "Automatically synthesized content must carry explicit proposal provenance");
+    assertTrue(xml.contains("String=\"PROP\""),
+        "Automatically synthesized content must be visibly marked on the drawing");
+    assertTrue(xml.contains(DexpiShapeCatalog.INSTRUMENT_BUBBLE_CENTRAL_SHAPE),
+        "Synthesized controllers must use the shared-system location convention");
+    assertFalse(xml.contains("ComponentClass=\"ActuatingSystemFunction\""),
+        "Synthesized controllers without manipulated equipment must not draw false command signals");
   }
 
   /**

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import neqsim.NeqSimTest;
+import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.filter.Filter;
 import neqsim.process.equipment.heatexchanger.Cooler;
@@ -532,9 +533,8 @@ public class DexpiXmlWriterTest extends NeqSimTest {
   }
 
   /**
-   * Tests that a process system without any explicitly modelled measurement devices or controllers still exports a
-   * realistic set of synthesized ISA-5.1 instrumentation (transmitters and matched PID controllers) so the resulting
-   * P&amp;ID resembles a real engineering diagram.
+   * Tests that a process system without explicitly modelled measurement devices still exports clearly identified
+   * ISA-5.1 measurement proposals, without inventing controllers or final control elements.
    *
    * @throws IOException if writing fails
    */
@@ -565,23 +565,102 @@ public class DexpiXmlWriterTest extends NeqSimTest {
     assertTrue(xml.contains("PT-2001"), "Separator should get a pressure transmitter");
     assertTrue(xml.contains("LT-2002"), "Separator should get a level transmitter");
     assertTrue(xml.contains("TT-2003"), "Separator should get a temperature transmitter");
-    // Matched controllers should be present.
-    assertTrue(xml.contains("PC-2001"), "Separator pressure loop should get a controller");
-    assertTrue(xml.contains("LC-2002"), "Separator level loop should get a controller");
+    // Synthesized proposals must not imply closed control loops that do not exist in the model.
+    assertFalse(xml.contains("Value=\"PC-2001\""), "Synthesis must not invent a pressure controller");
+    assertFalse(xml.contains("Value=\"LC-2002\""), "Synthesis must not invent a level controller");
     // Compressor should get a discharge pressure transmitter and a suction flow transmitter.
     assertTrue(xml.contains("PT-2011"), "Compressor should get a discharge pressure transmitter");
     assertTrue(xml.contains("FT-2014"), "Compressor should get a suction flow transmitter");
-    // Cooler should get a temperature loop.
+    // Cooler should get a temperature measurement proposal, not an invented controller.
     assertTrue(xml.contains("TT-2023"), "Cooler should get a temperature transmitter");
-    assertTrue(xml.contains("TC-2023"), "Cooler should get a temperature controller");
-    assertTrue(xml.contains("Name=\"InstrumentationSource\" Value=\"SYNTHESIZED_PROPOSAL\""),
-        "Automatically synthesized content must carry explicit proposal provenance");
-    assertTrue(xml.contains("String=\"PROP\""),
-        "Automatically synthesized content must be visibly marked on the drawing");
-    assertTrue(xml.contains(DexpiShapeCatalog.INSTRUMENT_BUBBLE_CENTRAL_SHAPE),
-        "Synthesized controllers must use the shared-system location convention");
-    assertFalse(xml.contains("ComponentClass=\"ActuatingSystemFunction\""),
-        "Synthesized controllers without manipulated equipment must not draw false command signals");
+    assertFalse(xml.contains("Value=\"TC-2023\""), "Synthesis must not invent a temperature controller");
+    assertTrue(xml.contains("Name=\"Origin\" Value=\"SYNTHESIZED_PROPOSAL\""),
+        "Synthesized transmitters must be identifiable as engineering proposals");
+    assertTrue(xml.contains("Name=\"InstrumentationSource\" Value=\"SYNTHESIZED_PROPOSAL\""));
+    assertTrue(xml.contains("Name=\"EngineeringStatus\" Value=\"PROPOSED\""));
+    assertTrue(xml.contains("Name=\"Scope\" Value=\"MEASUREMENT_ONLY\""),
+        "Synthesized transmitters must declare their measurement-only scope");
+    assertTrue(xml.contains("String=\"[PROP]\""),
+        "Synthesized transmitters must be visibly identifiable without inspecting XML metadata");
+    assertTrue(xml.contains("Type=\"is located in\""),
+        "Every synthesized measurement must reference a DEXPI sensing location");
+    assertFalse(xml.contains("ComponentClass=\"ProcessControlFunction\""),
+        "A measurement-only proposal must not synthesize controller functions");
+    assertFalse(xml.contains("Value=\"PneumaticSignalConveying\""),
+        "A measurement-only proposal must not draw a command signal to empty process space");
+  }
+
+  /**
+   * Tests a complete explicit loop from line-mounted transmitter through a central controller to a connected valve.
+   *
+   * @throws IOException if writing fails
+   */
+  @Test
+  public void testExplicitControllerTerminatesAtFinalControlElement() throws IOException {
+    Stream feed = createFeedStream();
+    Separator separator = new Separator("40-VA-001", feed);
+    ThrottlingValve valve = new ThrottlingValve("40-PV-4101", separator.getGasOutStream());
+    valve.setOutletPressure(45.0, "bara");
+    PressureTransmitter transmitter = new PressureTransmitter("PT-4101", separator.getGasOutStream());
+    ControllerDeviceBaseClass controller = new ControllerDeviceBaseClass("PIC-4101");
+    controller.setControllerSetPoint(50.0);
+    controller.setTransmitter(transmitter);
+    valve.setController(controller);
+
+    ProcessSystem process = new ProcessSystem("Explicit pressure-control loop");
+    process.add(feed);
+    process.add(separator);
+    process.add(valve);
+    process.add(transmitter);
+    process.add(controller);
+    process.run();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DexpiXmlWriter.writeForPyDexpi(process, out);
+    String xml = out.toString(StandardCharsets.UTF_8.name());
+
+    assertTrue(xml.contains("ComponentClass=\"ProcessControlFunction\""));
+    assertTrue(xml.contains("ComponentName=\"INSTRUMENTATION_BUBBLE_SHAPE_CENTRAL\""));
+    assertTrue(xml.contains("Name=\"LocationSpecialization\" Value=\"CentralLocation\""));
+    assertTrue(xml.contains("Name=\"ControlLoopCompleteness\" Value=\"COMPLETE\""));
+    assertTrue(xml.contains("Name=\"ControlLoopStatus\" Value=\"CLOSED_MODELLED\""));
+    assertTrue(xml.contains("Name=\"FinalControlElementTag\" Value=\"40-PV-4101\""));
+    assertTrue(xml.contains("Name=\"FinalControlElementID\""));
+    assertTrue(xml.contains("Name=\"MeasurementAttachmentTargetID\""));
+    assertTrue(xml.contains("ComponentClass=\"ActuatingFunction\""));
+    assertTrue(xml.contains("Name=\"SignalConveyingTypeSpecialization\" Value=\"PneumaticSignalConveying\""));
+    assertTrue(xml.contains("Name=\"NeqSimAttachmentType\" Value=\"PROCESS_LINE\""));
+  }
+
+  /**
+   * Tests that a modelled controller without a manipulated element is reported but has no fabricated command line.
+   *
+   * @throws IOException if writing fails
+   */
+  @Test
+  public void testControllerWithoutFinalElementIsNotDrawnAsClosedLoop() throws IOException {
+    Stream feed = createFeedStream();
+    Separator separator = new Separator("40-VA-002", feed);
+    PressureTransmitter transmitter = new PressureTransmitter("PT-4201", separator.getGasOutStream());
+    ControllerDeviceBaseClass controller = new ControllerDeviceBaseClass("PC-4201");
+    controller.setControllerSetPoint(50.0);
+    controller.setTransmitter(transmitter);
+
+    ProcessSystem process = new ProcessSystem("Incomplete pressure-control loop");
+    process.add(feed);
+    process.add(separator);
+    process.add(transmitter);
+    process.add(controller);
+    process.run();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DexpiXmlWriter.writeForPyDexpi(process, out);
+    String xml = out.toString(StandardCharsets.UTF_8.name());
+
+    assertTrue(xml.contains("Name=\"ControlLoopCompleteness\" Value=\"NO_FINAL_CONTROL_ELEMENT\""));
+    assertTrue(xml.contains("Name=\"ControlLoopStatus\" Value=\"MEASUREMENT_ONLY_MISSING_FINAL_ELEMENT\""));
+    assertFalse(xml.contains("Value=\"PneumaticSignalConveying\""));
+    assertFalse(xml.contains("ComponentClass=\"ActuatingFunction\""));
   }
 
   /**


### PR DESCRIPTION
## Capability contract

**Capability:** P&ID instrument attachment and control-loop truthfulness  
**Engineering question:** Can NeqSim emit and assess Proteus 4.1.1 P&ID instrumentation without attaching measurements to generic equipment centres or implying closed control loops absent from the source model?  
**Maturity:** experimental → qualified design-support.

Follow-up to merged #3337. The authoritative model remains the Java `ProcessSystem`: explicit instrument identity and measured stream, registered stream/nozzle topology, controller identity, and controller-to-equipment attachment. XML/SVG and the assessment report are proposal views.

## What changed

- attach each process-signal-generating function to a real routed process segment or nozzle
- place transmitter groups around their resolved sensing point and outside equipment data bars
- distinguish field transmitters from central/shared-control-system controllers
- emit directed, typed transmitter-to-controller and controller-to-final-element signals
- classify a loop complete only when an explicit controller is attached to a rendered final control element
- limit automatic synthesis to visible, unreviewed measurement proposals; do not invent controllers or command signals
- preserve the shared branch's provenance fields and compatibility metrics (`InstrumentationRole/Source`, engineering status, attachment/final-element IDs, missing-source diagnostics)
- size the battery limit and sheet from actual transmitter/controller coordinates
- add deterministic whole-sheet topology metrics and failure codes
- document behavior, compatibility, and the engineering-review boundary

## Standards and exchange-model review

Compared against:

- ISO 10628-1:2014 — diagram classification, content, representation, and drafting rules: https://www.iso.org/standard/51840.html
- ISO 10628-2:2012 — graphical symbols (confirmed current in 2024): https://www.iso.org/standard/51841.html
- ANSI/ISA-5.1-2024 — instrumentation symbols and identification: https://www.isa.org/products/ansi-isa-5-1-2024-instrumentation-symbols-and
- IEC 62424:2016 — process-control engineering requests in P&IDs and data exchange: https://webstore.iec.ch/en/publication/25462
- DEXPI P&ID specification 1.4 — sensing locations, signal lines, control and actuating functions: https://docs.dexpi.org/2025-07-04/specifications/pid_specification_1.4/plant_structure/instrumentation/

A transmitter bubble does not have to overlap the process pipe geometrically. The rendered measuring connection and DEXPI `is located in` / `is the location of` associations must identify an unambiguous sensing point.

## Whole-sheet defect disposition

| Area | Previous result | Updated result |
| --- | --- | --- |
| Measurement | Generic line ended at equipment centre/data annotation | Measuring line starts at a resolvable segment/nozzle tap |
| Bubble placement | Measuring lines crossed equipment data tables | Bubbles follow sensing-point lanes and clear table envelopes |
| Controller location | Controller used a field-instrument symbol | Controller uses central/shared-system symbol and metadata |
| Final element | Synthesized/standalone controller signalled empty space | Command signal exists only for an attached rendered valve/equipment function |
| Automatic content | Export invented controllers/apparent closed loops | Measurement-only proposals, visibly marked `[PROP]` and machine-identifiable |
| Signal semantics | Generic signal/actuation classes | Directed `SignalLineFunction` with electrical/pneumatic specialization |
| Boundary | Moved outlet instruments could cross battery limit | Sheet and boundary consume actual bubble coordinates |
| Future QA | Basic geometry metrics and visual memory | Sensing location, symbol/location consistency, loop completeness, final element, signal target, proposal visibility, bounds, arrows, text, and rendering gates |

## Validation

Exact remote state:

- base: `7d66ae23f3b2024522378e860823b12ec2d35332` (merged #3337)
- head: `24f09ecae829be93334e137d13504afff6122c78`
- branch is 16 commits ahead, 0 behind; final seven Git blobs match the locally validated files exactly

Commands and results:

- `python devtools/run_spotless.py apply` — stable on the second run
- `python devtools/run_spotless.py check` — passed
- `python devtools/check_documentation_search.py` — passed (672 Markdown pages, 1 standalone HTML page)
- `./mvnw -B -ntp -Dtest=EngineeringDiagramReferenceCasesTest,EngineeringDiagramDeliveryTest,DexpiVisualQualityAssessmentTest,DexpiXmlWriterTest,DexpiXmlSvgRendererTest test` — 46 tests passed
- optional `pre-commit` executable was unavailable in this environment

Rendered engineering evidence:

- branched reference: 20,000 kg/h feed; mass-balance error 0.000000000 kg/h; 9 measurements; 9 resolved sensing locations; 0 controllers; 9 visible synthesized proposals; 0 findings
- explicit pressure loop: 1 measurement; 1 central controller; 1 complete loop; 1 pneumatic actuating signal to `40-PV-4101`; 0 invalid signals; 0 findings
- both SVG/PNG sheets inspected at full-sheet and readable-detail scale; measuring lines clear data bars and all bubbles/markers lie inside the battery limit

## Compatibility and engineering boundary

Public APIs, legacy DOT/Graphviz, native PFD rendering, DEXPI 2.0 Process exchange, and the Proteus 4.1.1 compatibility profile remain in place. This PR does not invent line classes, relief/vent/drain systems, safeguards, valves, setpoints, or operational intent absent from the source model.

Generated P&IDs remain engineering proposals, not issued-for-construction drawings or claims of ISO/ISA/IEC/DEXPI certification. Missing source-model data is reported separately from renderer/layout defects and requires accountable discipline review.

## AI-assisted development

Implementation, standards comparison, tests, rendering review, and PR preparation used OpenAI Codex/ChatGPT. The final commits preserve and reconcile the prior shared automation work.

Roadmaps: #1332 and #2899.