### PR TITLE
[AI-Assisted] feat(refinery): reconstruct assay bulk density and API

### DIFF
--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -137,6 +137,7 @@ A bookkeeping regression does not by itself validate a petroleum-property correl
 - [Refinery Assay and TBP Cut Characterization](refinery_assay)
 - [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation)
 - [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation)
+- [DOE/OEDI COA bulk density and API qualification](refinery_oedi_coa_bulk_density_validation)
 - [Fluid Characterization Guide](../../wiki/fluid_characterization)
 - [TBP Fraction Models](../../wiki/tbp_fraction_models)
 - [PVT Fluid Characterization](../pvt_fluid_characterization)

--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -127,6 +127,16 @@ $$SG_{60/60}=\frac{141.5}{API+131.5}$$
 
 with the existing NeqSim 60 degF water-density reference. Negative API gravities are accepted when physically meaningful; the singular range at and below -131.5 degrees API is rejected.
 
+### Reconstructed whole-assay density
+
+For a complete cut table, `getBulkSpecificGravity()` reconstructs the ideal additive-volume whole-assay specific gravity without creating pseudo-components or mutating the thermodynamic system. `getBulkApiGravity()` reports the corresponding degrees API. Both mass- and liquid-volume-basis assays use the same resolved relation:
+
+$$SG_{bulk}=\left(\sum_i\frac{w_i}{SG_i}\right)^{-1}$$
+
+where `w_i` is the resolved mass fraction and `SG_i` is the cut specific gravity. For volume-basis inputs this reduces to the volume-fraction-weighted cut density after normalization.
+
+These methods are screening calculations at the density reference condition represented by the inputs. They assume ideal additive liquid volumes and do not apply temperature correction, excess-volume, or blend-contraction models. They are not custody-transfer or certified blend-design calculations. The public validation and numerical error boundary are documented in [DOE/OEDI COA bulk density and API qualification](refinery_oedi_coa_bulk_density_validation).
+
 ## Existing petroleum-property correlations
 
 This refinery-assay API deliberately reuses the existing NeqSim TBP/pseudo-component property framework. It does not add or retune critical-property, acentric-factor, or molecular-weight coefficients.
@@ -157,7 +167,10 @@ The regression suite for this API currently verifies:
 - rejection of mixed mass/volume bases and duplicate cuts;
 - TBP boundary monotonicity, complete 0-100% coverage, stored boiling ranges, and generated pseudo-components;
 - repeated-application protection;
-- exact reconstructed assay-mass closure.
+- exact reconstructed assay-mass closure;
+- analytical mass- and volume-basis bulk specific-gravity reconstruction;
+- whole-assay SG/API agreement against one independent public DOE/OEDI crude analysis;
+- input-order independence and no thermodynamic-system mutation for bulk-property queries.
 
 These tests establish software and bookkeeping correctness. They are **not yet an independent refinery-property validation dataset**. Experimental/public-data qualification of pseudo-component properties and atmospheric/vacuum fractionation is a separate campaign gate in issue #3305.
 
@@ -170,7 +183,7 @@ These tests establish software and bookkeeping correctness. They are **not yet a
 | Pre-binned cumulative TBP cut boundaries | `addTBPCutBoundariesCelsius/Kelvin` | Initial implementation in #3305 |
 | TBP pseudo-component properties | Pedersen, Lee-Kesler, Riazi-Daubert, Twu, Cavett, Standing and related models | Existing; needs refinery-range independent validation |
 | Plus-fraction splitting/lumping | `Characterise`, plus-fraction and lumping models | Existing; refinery assay integration still to be qualified |
-| Oil density/API and volatility standards | Oil-quality standards package, RVP/TVP workflows | Existing pieces; unified refinery stream-property API remains open |
+| Oil density/API and volatility standards | Oil-quality standards package, RVP/TVP workflows | Experimental whole-assay SG/API reconstruction; broader stream-property API remains open |
 | Rigorous distillation columns | `DistillationColumn`, `SimpleTray`, Naphtali-Sandholm solver, side-draw support | Existing foundation; broad-boiling atmospheric/vacuum refinery benchmark remains open |
 | Crude preheat/fired heater | General heater/heat-exchanger process equipment | Refinery workflow and fuel/emission integration remain open |
 | Product blending/specification optimization | Generic optimization/process facilities | Refinery property/blending framework remains open |
@@ -181,4 +194,4 @@ These tests establish software and bookkeeping correctness. They are **not yet a
 
 ## Next campaign step
 
-The next dependency-ready increment should select an openly reproducible refinery assay/reference case and use it to qualify the pseudo-component property slate and an atmospheric fractionation workflow. That benchmark should establish mass/energy closure, cut yields, product boiling ranges, numerical robustness, and runtime before adding more refinery-specific correlations.
+The next dependency-ready characterization increment should extend the public-data matrix beyond one DOE/OEDI assay and qualify generated pseudo-component properties. The process benchmark should then advance from the bounded DOE atmospheric integration case to a complete crude slate with independent cut-yield and boiling-range evidence before vacuum fractionation.

--- a/docs/thermo/characterization/refinery_oedi_coa_bulk_density_validation.md
+++ b/docs/thermo/characterization/refinery_oedi_coa_bulk_density_validation.md
@@ -1,0 +1,57 @@
+---
+title: "DOE/OEDI COA bulk density and API qualification"
+description: "Public-data qualification of whole-assay specific gravity and API reconstruction for a complete Bureau of Mines crude cut table."
+---
+
+# DOE/OEDI COA bulk density and API qualification
+
+This qualification advances refinery issue #3305 from cut-yield bookkeeping to a first read-only whole-assay property. It tests whether `OilAssayCharacterisation` can reconstruct a crude's bulk specific gravity and API gravity from a complete liquid-volume-basis cut table without first inventing pseudo-component boiling properties.
+
+## Public source, license, and method
+
+The source is the U.S. Department of Energy/National Renewable Energy Laboratory **Crude Oil Analysis (COA) Database**, distributed through the Open Energy Data Initiative (OEDI):
+
+- dataset catalog and provenance: <https://catalog.data.gov/dataset/crude-oil-analysis-coa-database>
+- OEDI record and archive: <https://data.openei.org/submissions/178>
+- license: [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/)
+
+The public database compiles 9,076 crude-oil analyses made by the U.S. Bureau of Mines and later maintained by DOE. The supplied `COAMDATA_DESC.pdf` identifies the standardized refinery categories and reference method. This regression freezes one transparent row from `Summary of Analyses.xls`: sample 920, Turner Valley, Alberta.
+
+| Reported category | Liquid volume % | Specific gravity at 60 degF |
+| --- | ---: | ---: |
+| Total gasoline and naphtha | 70.5 | 0.754 |
+| Kerosene | 13.2 | 0.813 |
+| Gas oil | 3.7 | 0.831 |
+| Residuum | 12.6 | 0.889 |
+| **Total** | **100.0** | — |
+
+The same public row reports whole-crude specific gravity **0.779** and API gravity **50.1 degrees API**.
+
+## Calculation and acceptance
+
+For resolved mass fractions `w_i` and cut specific gravities `SG_i`, NeqSim applies ideal additive liquid volumes:
+
+$$SG_{bulk}=\left(\sum_i\frac{w_i}{SG_i}\right)^{-1}$$
+
+For this liquid-volume-basis table the equation reduces to the normalized volume-weighted value:
+
+$$SG_{bulk}=0.705(0.754)+0.132(0.813)+0.037(0.831)+0.126(0.889)=0.781647$$
+
+The corresponding NeqSim API value is approximately **49.528 degrees API**. The regression accepts:
+
+- source cut-yield closure at 100.0 vol%;
+- exact reproduction of the additive-volume arithmetic to `1e-12`;
+- absolute whole-crude SG difference no greater than **0.004**;
+- whole-crude API difference no greater than **0.7 degrees API**;
+- identical bulk SG after reversing input order;
+- no added or modified thermodynamic components.
+
+The observed public-source differences are about **0.002647 SG** and **0.572 degrees API**. They are recorded rather than tuned away. The category densities and rounded yields do not encode excess-volume effects or the complete laboratory reconstruction procedure.
+
+## Validity and stop boundary
+
+This is an **experimental screening qualification**, not a blend-density standard or custody-transfer method. It assumes additive liquid volumes at the cut density reference condition. It does not model temperature correction, pressure effects, excess volume, blend contraction, sulfur/heteroatom effects, or uncertainty correlations between reported fields.
+
+The regression intentionally does not create pseudo-components because the COA summary categories do not provide one finite representative boiling point and molar mass for every terminal refinery category. It therefore adds no terminal-cut extrapolation, TBP/ASTM conversion, column tuning, JSON/MCP schema, vacuum fractionation, blending optimizer, or conversion-unit model.
+
+Python uses the same authoritative Java methods through the normal NeqSim JVM gateway; no separate Python property equation is maintained. Promotion from experimental to qualified requires additional independent assay families and an explicit reference-condition/contraction treatment.

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -185,6 +185,51 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
   }
 
   /**
+   * Reconstruct the bulk assay specific gravity from the configured cut yields and densities.
+   *
+   * <p>
+   * The calculation uses ideal additive liquid volumes. For resolved cut mass fractions {@code w_i} and cut specific
+   * gravities {@code SG_i}, the bulk value is {@code 1 / sum(w_i / SG_i)}. The same expression is used for mass- and
+   * liquid-volume-basis assays after the existing basis and closure validation has been applied. No thermodynamic
+   * component is created or modified.
+   * </p>
+   *
+   * <p>
+   * This is a screening property at the density reference conditions represented by the cut inputs. It does not apply
+   * temperature correction, excess-volume, or blend-contraction models.
+   * </p>
+   *
+   * @return reconstructed dimensionless bulk specific gravity
+   * @throws IllegalStateException if the assay is empty, incomplete, mixed-basis, or lacks a cut density
+   */
+  public double getBulkSpecificGravity() {
+    if (cuts.isEmpty()) {
+      throw new IllegalStateException("No assay cuts supplied");
+    }
+
+    double[] massFractions = resolveMassFractions();
+    double reciprocalBulkSpecificGravity = 0.0;
+    for (int i = 0; i < cuts.size(); i++) {
+      reciprocalBulkSpecificGravity += massFractions[i] / cuts.get(i).resolveDensity();
+    }
+
+    if (!Double.isFinite(reciprocalBulkSpecificGravity) || !(reciprocalBulkSpecificGravity > 0.0)) {
+      throw new IllegalStateException("Unable to reconstruct bulk specific gravity from assay cuts");
+    }
+    return 1.0 / reciprocalBulkSpecificGravity;
+  }
+
+  /**
+   * Reconstruct the bulk assay API gravity from {@link #getBulkSpecificGravity()}.
+   *
+   * @return reconstructed bulk gravity in degrees API
+   * @throws IllegalStateException if bulk specific gravity cannot be reconstructed
+   */
+  public double getBulkApiGravity() {
+    return 141.5 / getBulkSpecificGravity() - 131.5;
+  }
+
+  /**
    * Generate TBP pseudo-components for all configured cuts and add them to the attached system.
    *
    * <p>

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationOediCoaTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationOediCoaTest.java
@@ -1,0 +1,41 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Public-data qualification of refinery-assay bulk density bookkeeping. */
+public class OilAssayCharacterisationOediCoaTest {
+  private static final double PUBLISHED_WHOLE_CRUDE_SPECIFIC_GRAVITY = 0.779;
+  private static final double PUBLISHED_WHOLE_CRUDE_API_GRAVITY = 50.1;
+
+  @Test
+  public void testTurnerValleySample920BulkDensityAndApiGravity() {
+    SystemInterface system = new SystemSrkEos(288.706, 1.01325);
+    OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
+    assay.clearCuts();
+
+    assay.addCut(new AssayCut("GasolineNaphtha").withVolumePercent(70.5).withSpecificGravity(0.754));
+    assay.addCut(new AssayCut("Kerosene").withVolumePercent(13.2).withSpecificGravity(0.813));
+    assay.addCut(new AssayCut("GasOil").withVolumePercent(3.7).withSpecificGravity(0.831));
+    assay.addCut(new AssayCut("Residuum").withVolumePercent(12.6).withSpecificGravity(0.889));
+
+    double expectedAdditiveVolumeSpecificGravity = 0.705 * 0.754 + 0.132 * 0.813 + 0.037 * 0.831 + 0.126 * 0.889;
+    assertEquals(1.0, 0.705 + 0.132 + 0.037 + 0.126, 1e-12);
+    assertEquals(0.781647, expectedAdditiveVolumeSpecificGravity, 1e-12);
+    assertEquals(expectedAdditiveVolumeSpecificGravity, assay.getBulkSpecificGravity(), 1e-12);
+    assertEquals(PUBLISHED_WHOLE_CRUDE_SPECIFIC_GRAVITY, assay.getBulkSpecificGravity(), 0.004);
+    assertEquals(PUBLISHED_WHOLE_CRUDE_API_GRAVITY, assay.getBulkApiGravity(), 0.7);
+    assertEquals(0, system.getNumberOfComponents());
+
+    OilAssayCharacterisation reversed = new SystemSrkEos(288.706, 1.01325).getOilAssayCharacterisation();
+    reversed.clearCuts();
+    reversed.addCut(new AssayCut("Residuum").withVolumePercent(12.6).withSpecificGravity(0.889));
+    reversed.addCut(new AssayCut("GasOil").withVolumePercent(3.7).withSpecificGravity(0.831));
+    reversed.addCut(new AssayCut("Kerosene").withVolumePercent(13.2).withSpecificGravity(0.813));
+    reversed.addCut(new AssayCut("GasolineNaphtha").withVolumePercent(70.5).withSpecificGravity(0.754));
+    assertEquals(assay.getBulkSpecificGravity(), reversed.getBulkSpecificGravity(), 1e-12);
+  }
+}

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationTest.java
@@ -71,6 +71,43 @@ public class OilAssayCharacterisationTest {
   }
 
   @Test
+  public void testBulkSpecificGravityUsesResolvedMassAndVolumeBases() {
+    SystemInterface massSystem = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation massAssay = massSystem.getOilAssayCharacterisation();
+    massAssay.clearCuts();
+    massAssay.addCut(new AssayCut("MassLight").withMassFraction(0.25).withSpecificGravity(0.80));
+    massAssay.addCut(new AssayCut("MassHeavy").withMassFraction(0.75).withSpecificGravity(0.90));
+
+    double expectedMassBasisSpecificGravity = 1.0 / (0.25 / 0.80 + 0.75 / 0.90);
+    assertEquals(expectedMassBasisSpecificGravity, massAssay.getBulkSpecificGravity(), 1e-12);
+    assertEquals(141.5 / expectedMassBasisSpecificGravity - 131.5, massAssay.getBulkApiGravity(), 1e-12);
+    assertEquals(0, massSystem.getNumberOfComponents());
+
+    SystemInterface volumeSystem = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation volumeAssay = volumeSystem.getOilAssayCharacterisation();
+    volumeAssay.clearCuts();
+    volumeAssay.addCut(new AssayCut("VolumeLight").withVolumeFraction(0.25).withSpecificGravity(0.80));
+    volumeAssay.addCut(new AssayCut("VolumeHeavy").withVolumeFraction(0.75).withSpecificGravity(0.90));
+
+    double expectedVolumeBasisSpecificGravity = 0.25 * 0.80 + 0.75 * 0.90;
+    assertEquals(expectedVolumeBasisSpecificGravity, volumeAssay.getBulkSpecificGravity(), 1e-12);
+    assertEquals(0, volumeSystem.getNumberOfComponents());
+  }
+
+  @Test
+  public void testBulkSpecificGravityRejectsInvalidAssayWithoutMutation() {
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+    assertThrows(IllegalStateException.class, characterisation::getBulkSpecificGravity);
+
+    characterisation.addCut(new AssayCut("MassCut").withMassFraction(0.5).withSpecificGravity(0.80));
+    characterisation.addCut(new AssayCut("VolumeCut").withVolumeFraction(0.5).withSpecificGravity(0.90));
+    assertThrows(IllegalStateException.class, characterisation::getBulkSpecificGravity);
+    assertEquals(0, system.getNumberOfComponents());
+  }
+
+  @Test
   public void testTotalMassScaling() {
     SystemInterface system = new SystemSrkEos(298.15, 10.0);
     OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();


### PR DESCRIPTION
## Capability contract

Advances #3305 under the refinery assay bulk density/API closure contract recorded before branch creation: https://github.com/equinor/neqsim/issues/3305#issuecomment-5468315653

- Exact base: `7a7c5a4990b57597355d1182784e12d547b9fb3b`
- Exact head: `2c4e130ccaf74d4ce6fdd44cbbb6557861de169b`
- Maturity: **proposed → experimental**
- Status: **VALIDATION PENDING CI**

## Engineering question

Can NeqSim reconstruct whole-assay specific gravity and API gravity from complete mass- or liquid-volume-basis refinery cuts without mutating the thermodynamic system, and reproduce an independent public crude-assay value within the source method's practical resolution?

## Change

- adds read-only `OilAssayCharacterisation.getBulkSpecificGravity()`;
- adds `getBulkApiGravity()` from the same authoritative Java result;
- uses the reciprocal-density/additive-liquid-volume relation after existing assay basis, closure and density validation;
- exposes the same methods automatically to JPype/Python callers, with no duplicate Python formula;
- adds analytical mass- and volume-basis tests, invalid/mixed-basis failure tests and no-mutation gates;
- adds a dedicated public-data qualification using DOE/OEDI Bureau of Mines COA sample 920;
- documents units, assumptions, provenance/license, observed error, maturity and stop boundary.

## Public benchmark

Source: U.S. DOE/NREL OEDI **Crude Oil Analysis (COA) Database**, Bureau of Mines sample 920, Turner Valley, Alberta.

- Catalog/provenance: https://catalog.data.gov/dataset/crude-oil-analysis-coa-database
- OEDI archive: https://data.openei.org/submissions/178
- License: CC BY 4.0

Frozen complete category table:

| Category | vol% | SG at 60 °F |
| --- | ---: | ---: |
| Gasoline + naphtha | 70.5 | 0.754 |
| Kerosene | 13.2 | 0.813 |
| Gas oil | 3.7 | 0.831 |
| Residuum | 12.6 | 0.889 |

The additive-volume result is SG `0.781647` and API about `49.528`; the public whole-crude row reports SG `0.779` and API `50.1`. Acceptance is exact analytical reproduction, SG error ≤ `0.004`, API error ≤ `0.7°`, input-order independence, and no system mutation. Observed differences are about `0.002647 SG` and `0.572° API`; no coefficient is tuned.

## Validation

Passed locally on the source published to the exact remote tree:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py`
- `pre-commit run --all-files --hook-stage pre-commit`
- `pre-commit run --all-files --hook-stage pre-push`
- `./mvnw -q -DskipITs -Dtest=OilAssayCharacterisationTest,OilAssayCharacterisationOediCoaTest,OilAssayCharacterisationDoeBigHillTest test`
- `git diff --check`

Local Javadocs could not run because this container has a Java 17 JRE without `javac`/`javadoc`; the failure is not claimed as passed. Hosted Java/Javadocs, static analysis and full test workflows remain authoritative. **VALIDATION PENDING CI.**

The calculation is O(number of assay cuts) and adds no thermodynamic, flash, column or process-solver hot-path work.

## Documentation impact

Updated the refinery assay guide and characterization index, and added a dedicated DOE/OEDI evidence page covering the formula, source/license, acceptance criteria, observed error and limitations.

## Evidence and interface boundary

Java is authoritative; Python uses the same public Java object. JSON and MCP are intentionally not added because this increment does not own a stable assay schema. A notebook is deferred until the complete-crude and independent product-yield gates.

This is an ideal additive-volume screening property at the input density reference condition, not a custody-transfer, temperature-corrected or blend-contraction calculation.

## Stop boundary

No terminal-cut boiling extrapolation, pseudo-component property retuning, complete crude slate, column change, generic TBP/flash work, JSON/MCP schema, notebook, vacuum fractionation, blending optimization or conversion-unit model. Generic TBP API work remains coordinated with #1393/#3120.

AI-assisted contribution.