### PR TITLE
[AI-Assisted] feat(dexpi): model vessel taps and piping transitions

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -102,8 +102,10 @@ flow settings from the template stream.
 
 Both the reader and writer share `DexpiMetadata` constants that describe the recommended generic
 attributes for DEXPI exchanges. Equipment exports include tag names, line numbers, and fluid codes.
-Piping segments carry segment numbers and operating pressure/temperature/flow triples with explicit
-unit annotations. Query `DexpiMetadata.recommendedStreamAttributes()` and
+Piping segments carry segment numbers, nominal-diameter representations, piping-class and
+insulation codes, and operating pressure/temperature/flow triples with explicit unit annotations.
+The reader preserves these values on `DexpiStream`; it does not derive them from hydraulic inside
+diameter. Query `DexpiMetadata.recommendedStreamAttributes()` and
 `DexpiMetadata.recommendedEquipmentAttributes()` for the minimal metadata sets guaranteed by NeqSim.
 
 ---
@@ -332,7 +334,31 @@ Each piping connection carries operating line data and a NORSOK Z-003 line-ident
 - A `FluidCode` generic attribute (service code: `PG` process gas, `PL` process liquid, `FL` flare,
   `DR` drain, `FG` fuel gas, `UT` utility) derived by `DexpiServiceClassifier`
 - Operating pressure, temperature and flow generic attributes when available on the stream
-- A line-number text label (e.g. `PG-001`) composed by `NorsokLineNumber`
+- A line designation composed by `NorsokLineNumber`, with nominal size, fluid code, sequence,
+  piping class, and insulation code when those values are available
+- A visible `SIZE?` field and `LineSizeStatus=MISSING_SOURCE_DATA` when neither source nominal size
+  nor a model inside diameter is available
+
+Source-backed line data can be supplied by a `DexpiStream`:
+
+```java
+DexpiStream line = new DexpiStream("process-line", fluid, "PipingNetworkSegment", "1001", "PG");
+line.setNominalDiameterRepresentation("DN 150");
+line.setPipingClassCode("A1B");
+line.setInsulationType("H25");
+
+// Optional endpoint values make a real transition explicit.
+line.setFlowInNominalDiameterRepresentation("DN 150");
+line.setFlowOutNominalDiameterRepresentation("DN 100");
+line.setFlowInPipingClassCode("A1B");
+line.setFlowOutPipingClassCode("B2C");
+```
+
+If a NeqSim pipe model supplies only hydraulic diameter, the drawing identifies it explicitly as
+`ID ... mm`; it is never relabelled as DN or NPS. A source-backed endpoint-size change produces a
+`PipeReducer` with distinct flow-in and flow-out sizes and connection points. Explicit piping-class
+or insulation changes produce a `PropertyBreak` marker. The exporter does not guess nominal size,
+schedule, piping class, or insulation.
 
 The writer serializes numeric generic-attribute values with eight significant digits. This
 scale-aware canonical precision suppresses insignificant solver noise so repeated exports remain
@@ -476,6 +502,8 @@ from crossing gas equipment. The engine produces the following visual elements:
 - Instrument circles with function letter labels (PT, TT, FT, LT, AT)
 - Proper ISA 5.1 function letter decomposition (first letter = measured variable, subsequent = function)
 - Field transmitter bubbles connected by measuring lines to an explicit process-segment or nozzle sensing location
+- Level-transmitter measuring lines terminate at a dedicated tank or separator sensing tap; oil
+  level and water-interface functions use distinct taps and never reuse a process inlet or liquid outlet
 - Central/control-room controller bubbles distinguished from field instruments by their symbol and DEXPI location metadata
 - PID controller parameters displayed (Kp, Ti, Td) when controllers are present
 - Typed signal lines from transmitters to controllers and from controllers to actual final control elements
@@ -499,6 +527,13 @@ functions used by DEXPI and the identification/location conventions used by ISA-
 imply that the transmitter circle must geometrically overlap the process line: the measuring line
 and its `is located in` association identify the physical sensing point.
 
+The implementation is informed by [ISO 10628-1 diagram rules](https://www.iso.org/standard/51840.html),
+[ISO 10628-2 graphical symbols](https://www.iso.org/standard/51841.html),
+[IEC 62424 PCE representation](https://webstore.iec.ch/en/publication/25442), the
+[ISA-5 series](https://www.isa.org/standards-and-publications/isa-standards/isa-5-standard), and the
+[DEXPI 1.4 model](https://dexpi.org/static/pid_specification_1.4/). These references guide the
+projection; generated sheets still require project-specific engineering and drafting review.
+
 **Safety elements:**
 - PST (Partial Stroke Test) annotation boxes near safety valves
 - Relief valve shapes with ISO 10628 spring/bonnet symbol
@@ -507,6 +542,8 @@ and its `is located in` association identify the physical sensing point.
 - Heat trace indication marks (zigzag pattern with ET/ST type labels)
 - Insulation marks on process lines
 - Piping class and line size attribute export
+- Source-backed reducer symbols for line-size transitions
+- Property-break symbols for explicit piping-class or insulation changes
 
 **Annotations:**
 - Equipment weight annotations (dry and operating weight)

--- a/docs/integration/dexpi-reference-cases.md
+++ b/docs/integration/dexpi-reference-cases.md
@@ -56,6 +56,8 @@ writer and rendered from its actual graphical primitives. The suite checks:
   solid fill preserved in the rendered SVG;
 - every measurement function having a resolvable process-segment, nozzle, mount, piping-component,
   or equipment sensing location;
+- separator and tank level functions referencing the vessel equipment boundary rather than an inlet
+  or liquid-product nozzle, with invalid attachments counted separately;
 - central/control-room symbols and matching location metadata for controller functions, plus a
   real tagged final element and directed actuating signal before a loop is classified complete;
 - synthesized measurement proposals being both machine-identifiable and visibly marked `[PROP]`,
@@ -85,6 +87,22 @@ symbols are explicit, and closed-loop actuation is emitted only for an attached 
 element. The assessment records measurement, sensing-location, controller, complete-loop,
 incomplete-loop, and synthesized-proposal counts so these defects fail deterministically in future
 diagram work.
+
+A vessel-level continuation found that separator measurements were associated with the liquid
+product nozzle and tanks could not host a `LevelTransmitter`. Level measurements now use the
+authoritative separator or tank liquid-level state, associate with the equipment identity, and start
+their measuring line at the rendered vessel boundary. The assessment reports vessel-level function,
+valid boundary-attachment, and invalid attachment counts; synthesized tank measurements retain
+`[PROP]` and measurement-only provenance. This is a design-support projection, not a designed
+process tap, transmitter technology selection, or approved loop.
+
+The vessel-level bubble lane also clears the outlet-side continuation symbols instead of running a
+vertical measuring line through a product connector. A coordinate regression reserves at least
+45 mm between the vessel centre and each level bubble.
+
+The same full-sheet review exposed a storage-tank roof arc whose endpoints did not meet the side
+walls and whose radius spread far outside the equipment symbol. The catalogue arc now terminates at
+both wall tops; exact start angle, end angle, and radius assertions protect that rendered geometry.
 
 The compatibility metrics from the first topology review remain available alongside the stricter
 DEXPI-oriented metrics: transmitter/controller counts, resolved and missing measurement attachments,

--- a/docs/integration/dexpi-reference-cases.md
+++ b/docs/integration/dexpi-reference-cases.md
@@ -56,12 +56,16 @@ writer and rendered from its actual graphical primitives. The suite checks:
   solid fill preserved in the rendered SVG;
 - every measurement function having a resolvable process-segment, nozzle, mount, piping-component,
   or equipment sensing location;
-- separator and tank level functions referencing the vessel equipment boundary rather than an inlet
-  or liquid-product nozzle, with invalid attachments counted separately;
 - central/control-room symbols and matching location metadata for controller functions, plus a
   real tagged final element and directed actuating signal before a loop is classified complete;
 - synthesized measurement proposals being both machine-identifiable and visibly marked `[PROP]`,
   without synthesized controllers or command lines;
+- every level measurement resolving to a dedicated tank/separator sensing tap rather than a process
+  inlet or outlet nozzle;
+- every routed line exposing source-backed nominal size, an explicitly labelled model inside
+  diameter, or a visible `SIZE?` missing-data state;
+- every detected endpoint-size change having a `PipeReducer` with distinct flow-in/out sizes and
+  connection points, and every explicit piping-class or insulation change having a `PropertyBreak`;
 - deterministic report JSON and SVG output across repeated exports; and
 - preservation of an intentionally unconfigured stream through `ProcessSystem.run()` without
   inventing a fluid state.
@@ -88,27 +92,19 @@ element. The assessment records measurement, sensing-location, controller, compl
 incomplete-loop, and synthesized-proposal counts so these defects fail deterministically in future
 diagram work.
 
-A vessel-level continuation found that separator measurements were associated with the liquid
-product nozzle and tanks could not host a `LevelTransmitter`. Level measurements now use the
-authoritative separator or tank liquid-level state, associate with the equipment identity, and start
-their measuring line at the rendered vessel boundary. The assessment reports vessel-level function,
-valid boundary-attachment, and invalid attachment counts; synthesized tank measurements retain
-`[PROP]` and measurement-only provenance. This is a design-support projection, not a designed
-process tap, transmitter technology selection, or approved loop.
-
-The vessel-level bubble lane also clears the outlet-side continuation symbols instead of running a
-vertical measuring line through a product connector. A coordinate regression reserves at least
-45 mm between the vessel centre and each level bubble.
-
-The same full-sheet review exposed a storage-tank roof arc whose endpoints did not meet the side
-walls and whose radius spread far outside the equipment symbol. The catalogue arc now terminates at
-both wall tops; exact start angle, end angle, and radius assertions protect that rendered geometry.
-
 The compatibility metrics from the first topology review remain available alongside the stricter
 DEXPI-oriented metrics: transmitter/controller counts, resolved and missing measurement attachments,
 measuring-line validity, closed/incomplete loops, actuating-signal validity, and synthesized proposal
 counts. Missing source data is reported separately from renderer/layout failures; the exporter does
 not invent a nozzle, controller, valve, or operational intent to make a proposal appear complete.
+
+The same fail-closed rule now applies to piping data. Hydraulic inside diameter remains labelled
+`ID ... mm`, never silently converted to DN/NPS. Missing nominal-size source data remains visible as
+`SIZE?`. The assessment records line-size provenance, missing-size states, detected size/property
+changes, reducers, and property breaks. A line-size transition without a fitting, a reducer without
+two distinct endpoint sizes and connection points, or a property change without a break marker is
+an error. Full-sheet inspection additionally checks that stream numbers, line designations, fitting
+labels, and equipment annotations remain legible and non-overlapping.
 
 Recycle connectivity is projected when the recycle block exposes a configured outlet through the
 standard equipment outlet API and a downstream unit consumes that same stream identity. The benchmark

--- a/docs/process/dynamic-simulation.md
+++ b/docs/process/dynamic-simulation.md
@@ -229,7 +229,7 @@ The exported file contains:
 - **ProcessInstrumentationFunction** elements for each transmitter (with ISA category, functions, and number)
 - **ProcessSignalGeneratingFunction** elements for sensor elements
 - **ActuatingFunction** elements for controller outputs
-- **SignalConveyingFunction** elements linking instruments to actuators
+- **InformationFlow** elements classified as **SignalLineFunction** linking transmitters, controllers, and actuators
 - **InstrumentationLoopFunction** elements grouping each control loop
 
 ### Importing Instrument Metadata from DEXPI XML

--- a/docs/process/equipment/measurement_devices.md
+++ b/docs/process/equipment/measurement_devices.md
@@ -231,10 +231,10 @@ double separatorFraction = separatorLevel.getMeasuredValue("");
 double tankFraction = tankLevel.getMeasuredValue("");
 ```
 
-Proteus-compatible P&ID export associates these measurements with the vessel equipment identity and
-draws the measuring line from the rendered vessel boundary. A separator's liquid product nozzle is
-not relabelled as a level tap. Automatically generated tank or separator measurements remain visibly
-and machine-readably marked as unreviewed measurement-only proposals.
+Proteus-compatible P&amp;ID export creates a dedicated sensing tap/nozzle on the owning tank or separator and terminates
+the measuring line there. A vessel's process inlet or phase outlet is never relabelled as the level tap. Automatically
+generated tank or separator measurements remain visibly and machine-readably marked as unreviewed measurement-only
+proposals.
 
 ### VolumeFlowTransmitter
 

--- a/docs/process/equipment/measurement_devices.md
+++ b/docs/process/equipment/measurement_devices.md
@@ -217,15 +217,24 @@ bindings fail the transaction-coverage preflight until they provide a complete s
 
 ### LevelTransmitter
 
-Monitors liquid level in vessels.
+Monitors the unitless liquid-level fraction reported by a `Separator` or `Tank`. The transmitter
+delegates to the vessel's authoritative Java state; it does not infer instrument technology, nozzle
+design, alarm setpoints, or control intent.
 
 ```java
 import neqsim.process.measurementdevice.LevelTransmitter;
 
-LevelTransmitter lt = new LevelTransmitter(separator);
-lt.setUnit("%");
-double level = lt.getMeasuredValue();
+LevelTransmitter separatorLevel = new LevelTransmitter("LT-2001", separator);
+LevelTransmitter tankLevel = new LevelTransmitter("LT-2002", tank);
+
+double separatorFraction = separatorLevel.getMeasuredValue("");
+double tankFraction = tankLevel.getMeasuredValue("");
 ```
+
+Proteus-compatible P&ID export associates these measurements with the vessel equipment identity and
+draws the measuring line from the rendered vessel boundary. A separator's liquid product nozzle is
+not relabelled as a level tap. Automatically generated tank or separator measurements remain visibly
+and machine-readably marked as unreviewed measurement-only proposals.
 
 ### VolumeFlowTransmitter
 

--- a/src/main/java/neqsim/process/equipment/tank/Tank.java
+++ b/src/main/java/neqsim/process/equipment/tank/Tank.java
@@ -1,5 +1,8 @@
 package neqsim.process.equipment.tank;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -166,6 +169,25 @@ public class Tank extends ProcessEquipmentBaseClass implements AutoSizeable, Cap
    */
   public StreamInterface getGasOutStream() {
     return gasOutStream;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public List<StreamInterface> getInletStreams() {
+    return inletStreamMixer.getInletStreams();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public List<StreamInterface> getOutletStreams() {
+    List<StreamInterface> outlets = new ArrayList<StreamInterface>(2);
+    if (gasOutStream != null) {
+      outlets.add(gasOutStream);
+    }
+    if (liquidOutStream != null) {
+      outlets.add(liquidOutStream);
+    }
+    return Collections.unmodifiableList(outlets);
   }
 
   /**

--- a/src/main/java/neqsim/process/measurementdevice/LevelTransmitter.java
+++ b/src/main/java/neqsim/process/measurementdevice/LevelTransmitter.java
@@ -1,5 +1,7 @@
 package neqsim.process.measurementdevice;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.tank.Tank;
@@ -14,9 +16,9 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
 public class LevelTransmitter extends MeasurementDeviceBaseClass {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  private static final Logger logger = LogManager.getLogger(LevelTransmitter.class);
 
   protected Separator separator = null;
-  /** Tank whose liquid level is measured, when this transmitter is tank-backed. */
   protected Tank tank = null;
 
   /**
@@ -35,21 +37,33 @@ public class LevelTransmitter extends MeasurementDeviceBaseClass {
    * @param separator a {@link neqsim.process.equipment.separator.Separator} object
    */
   public LevelTransmitter(String name, Separator separator) {
-    super(name, "");
-    this.setMaximumValue(1);
-    this.setMinimumValue(0);
-    this.separator = separator;
+    this(name, (ProcessEquipmentInterface) separator);
+  }
+
+  /**
+   * Constructor for a tank level transmitter.
+   *
+   * @param tank tank whose liquid level is measured
+   */
+  public LevelTransmitter(Tank tank) {
+    this("LevelTransmitter", tank);
+  }
+
+  /**
+   * Constructor for a named tank level transmitter.
+   *
+   * @param name name of the level transmitter
+   * @param tank tank whose liquid level is measured
+   */
+  public LevelTransmitter(String name, Tank tank) {
+    this(name, (ProcessEquipmentInterface) tank);
   }
 
   /**
    * Constructor for a level transmitter backed by supported vessel equipment.
    *
-   * <p>
-   * This overload accepts {@link Tank} while preserving the more specific separator constructors. Other equipment
-   * classes fail closed because they do not provide the authoritative liquid-level state required by this device.
-   * </p>
-   *
-   * @param vessel a {@link Separator} or {@link Tank}
+   * @param vessel a separator or tank
+   * @throws IllegalArgumentException when the equipment does not expose a supported vessel level
    */
   public LevelTransmitter(ProcessEquipmentInterface vessel) {
     this("LevelTransmitter", vessel);
@@ -59,17 +73,17 @@ public class LevelTransmitter extends MeasurementDeviceBaseClass {
    * Constructor for a named level transmitter backed by supported vessel equipment.
    *
    * @param name name of the level transmitter
-   * @param vessel a {@link Separator} or {@link Tank}
-   * @throws IllegalArgumentException if {@code vessel} is not a supported level-bearing vessel
+   * @param vessel a separator or tank
+   * @throws IllegalArgumentException when the equipment does not expose a supported vessel level
    */
   public LevelTransmitter(String name, ProcessEquipmentInterface vessel) {
     super(name, "");
     this.setMaximumValue(1);
     this.setMinimumValue(0);
     if (vessel instanceof Separator) {
-      this.separator = (Separator) vessel;
+      separator = (Separator) vessel;
     } else if (vessel instanceof Tank) {
-      this.tank = (Tank) vessel;
+      tank = (Tank) vessel;
     } else {
       throw new IllegalArgumentException("LevelTransmitter requires a Separator or Tank");
     }
@@ -85,28 +99,37 @@ public class LevelTransmitter extends MeasurementDeviceBaseClass {
   }
 
   /**
-   * Returns the supported vessel whose liquid level this transmitter measures.
+   * Returns the tank whose liquid level this transmitter measures.
    *
-   * @return the associated {@link Separator} or {@link Tank}, or {@code null} when no vessel was set
+   * @return associated tank, or {@code null} when this transmitter measures a separator
    */
-  public ProcessEquipmentInterface getVessel() {
+  public Tank getTank() {
+    return tank;
+  }
+
+  /**
+   * Returns the vessel carrying the measured liquid inventory.
+   *
+   * @return associated separator or tank, or {@code null} if no source was configured
+   */
+  public ProcessEquipmentInterface getLevelEquipment() {
     return separator != null ? separator : tank;
   }
 
   /**
-   * Returns the tank whose liquid level this transmitter measures.
+   * Returns the vessel carrying the measured liquid inventory.
    *
-   * @return the associated {@link Tank}, or {@code null} for a separator-backed transmitter
+   * @return associated separator or tank
    */
-  public Tank getTank() {
-    return tank;
+  public ProcessEquipmentInterface getVessel() {
+    return getLevelEquipment();
   }
 
   /** {@inheritDoc} */
   @Override
   @ExcludeFromJacocoGeneratedReport
   public void displayResult() {
-    System.out.println("measured level " + getVesselLiquidLevel());
+    logger.info("measured level {}", measuredLevel());
   }
 
   /** {@inheritDoc} */
@@ -116,16 +139,16 @@ public class LevelTransmitter extends MeasurementDeviceBaseClass {
       throw new RuntimeException(new neqsim.util.exception.InvalidInputException(this, "getMeasuredValue", "unit",
           "currently only supports \"\""));
     }
-    return getVesselLiquidLevel();
+    return measuredLevel();
   }
 
-  private double getVesselLiquidLevel() {
+  private double measuredLevel() {
     if (separator != null) {
       return separator.getLiquidLevel();
     }
     if (tank != null) {
       return tank.getLiquidLevel();
     }
-    throw new IllegalStateException("LevelTransmitter has no supported vessel");
+    throw new IllegalStateException("Level transmitter has no separator or tank source");
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/LevelTransmitter.java
+++ b/src/main/java/neqsim/process/measurementdevice/LevelTransmitter.java
@@ -1,6 +1,8 @@
 package neqsim.process.measurementdevice;
 
+import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.tank.Tank;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
 /**
@@ -14,6 +16,8 @@ public class LevelTransmitter extends MeasurementDeviceBaseClass {
   private static final long serialVersionUID = 1000;
 
   protected Separator separator = null;
+  /** Tank whose liquid level is measured, when this transmitter is tank-backed. */
+  protected Tank tank = null;
 
   /**
    * Constructor for LevelTransmitter.
@@ -38,6 +42,40 @@ public class LevelTransmitter extends MeasurementDeviceBaseClass {
   }
 
   /**
+   * Constructor for a level transmitter backed by supported vessel equipment.
+   *
+   * <p>
+   * This overload accepts {@link Tank} while preserving the more specific separator constructors. Other equipment
+   * classes fail closed because they do not provide the authoritative liquid-level state required by this device.
+   * </p>
+   *
+   * @param vessel a {@link Separator} or {@link Tank}
+   */
+  public LevelTransmitter(ProcessEquipmentInterface vessel) {
+    this("LevelTransmitter", vessel);
+  }
+
+  /**
+   * Constructor for a named level transmitter backed by supported vessel equipment.
+   *
+   * @param name name of the level transmitter
+   * @param vessel a {@link Separator} or {@link Tank}
+   * @throws IllegalArgumentException if {@code vessel} is not a supported level-bearing vessel
+   */
+  public LevelTransmitter(String name, ProcessEquipmentInterface vessel) {
+    super(name, "");
+    this.setMaximumValue(1);
+    this.setMinimumValue(0);
+    if (vessel instanceof Separator) {
+      this.separator = (Separator) vessel;
+    } else if (vessel instanceof Tank) {
+      this.tank = (Tank) vessel;
+    } else {
+      throw new IllegalArgumentException("LevelTransmitter requires a Separator or Tank");
+    }
+  }
+
+  /**
    * Returns the separator whose liquid level this transmitter measures.
    *
    * @return the associated {@link neqsim.process.equipment.separator.Separator}, or {@code null} if none was set
@@ -46,11 +84,29 @@ public class LevelTransmitter extends MeasurementDeviceBaseClass {
     return separator;
   }
 
+  /**
+   * Returns the supported vessel whose liquid level this transmitter measures.
+   *
+   * @return the associated {@link Separator} or {@link Tank}, or {@code null} when no vessel was set
+   */
+  public ProcessEquipmentInterface getVessel() {
+    return separator != null ? separator : tank;
+  }
+
+  /**
+   * Returns the tank whose liquid level this transmitter measures.
+   *
+   * @return the associated {@link Tank}, or {@code null} for a separator-backed transmitter
+   */
+  public Tank getTank() {
+    return tank;
+  }
+
   /** {@inheritDoc} */
   @Override
   @ExcludeFromJacocoGeneratedReport
   public void displayResult() {
-    System.out.println("measured level " + separator.getLiquidLevel());
+    System.out.println("measured level " + getVesselLiquidLevel());
   }
 
   /** {@inheritDoc} */
@@ -60,6 +116,16 @@ public class LevelTransmitter extends MeasurementDeviceBaseClass {
       throw new RuntimeException(new neqsim.util.exception.InvalidInputException(this, "getMeasuredValue", "unit",
           "currently only supports \"\""));
     }
-    return separator.getLiquidLevel();
+    return getVesselLiquidLevel();
+  }
+
+  private double getVesselLiquidLevel() {
+    if (separator != null) {
+      return separator.getLiquidLevel();
+    }
+    if (tank != null) {
+      return tank.getLiquidLevel();
+    }
+    throw new IllegalStateException("LevelTransmitter has no supported vessel");
   }
 }

--- a/src/main/java/neqsim/process/measurementdevice/OilLevelTransmitter.java
+++ b/src/main/java/neqsim/process/measurementdevice/OilLevelTransmitter.java
@@ -65,6 +65,15 @@ public class OilLevelTransmitter extends MeasurementDeviceBaseClass {
   }
 
   /**
+   * Returns the three-phase separator whose oil level is measured.
+   *
+   * @return associated separator
+   */
+  public ThreePhaseSeparator getSeparator() {
+    return separator;
+  }
+
+  /**
    * Get the thickness of the oil layer.
    *
    * @return oil layer thickness in meters (oilLevel - waterLevel)

--- a/src/main/java/neqsim/process/measurementdevice/WaterLevelTransmitter.java
+++ b/src/main/java/neqsim/process/measurementdevice/WaterLevelTransmitter.java
@@ -58,4 +58,13 @@ public class WaterLevelTransmitter extends MeasurementDeviceBaseClass {
     }
     return separator.getWaterLevel();
   }
+
+  /**
+   * Returns the three-phase separator whose water-interface level is measured.
+   *
+   * @return associated separator
+   */
+  public ThreePhaseSeparator getSeparator() {
+    return separator;
+  }
 }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiLayoutEngine.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiLayoutEngine.java
@@ -193,7 +193,7 @@ final class DexpiLayoutEngine {
 
     // Also register pass-through streams (Stream wrapping separator outlets)
     for (ProcessEquipmentInterface unit : units) {
-      if (unit instanceof Stream && !(unit instanceof DexpiStream)) {
+      if (unit instanceof Stream) {
         Stream stream = (Stream) unit;
         if (stream.getFluid() != null) {
           int fluidHash = System.identityHashCode(stream.getFluid());
@@ -3154,8 +3154,9 @@ final class DexpiLayoutEngine {
   }
 
   /**
-   * Appends a prebuilt line-identification label (for example one produced by {@code NorsokLineNumber.build()}) above
-   * the pipe midpoint.
+   * Appends a prebuilt line-identification label (for example one produced by {@code NorsokLineNumber.build()}) below
+   * the pipe midpoint. Stream sequence labels use the lane above the pipe, so keeping the complete line designation
+   * below avoids the two texts being rendered on top of one another.
    *
    * @param document the XML document
    * @param parent the PipingNetworkSegment element
@@ -3172,7 +3173,7 @@ final class DexpiLayoutEngine {
     }
     double midX = (fromX + toX) / 2.0;
     double midY = (fromY + toY) / 2.0;
-    double labelY = midY + 6.0;
+    double labelY = midY - 6.0;
 
     Element text = document.createElement("Text");
     text.setAttribute("String", lineId.trim());
@@ -3203,6 +3204,146 @@ final class DexpiLayoutEngine {
     position.appendChild(ref);
     text.appendChild(position);
     parent.appendChild(text);
+  }
+
+  /**
+   * Appends a source-backed pipe reducer symbol and its size transition label at the routed line midpoint.
+   *
+   * @param document XML document
+   * @param parent PipeReducer element
+   * @param fromX source X coordinate
+   * @param fromY source Y coordinate
+   * @param toX target X coordinate
+   * @param toY target Y coordinate
+   * @param flowInSize upstream size representation
+   * @param flowOutSize downstream size representation
+   */
+  static void appendPipeReducerSymbol(Document document, Element parent, double fromX, double fromY, double toX,
+      double toY, String flowInSize, String flowOutSize) {
+    double[] location = routeMidpointAndDirection(fromX, fromY, toX, toY);
+    double x = location[0];
+    double y = location[1];
+    boolean horizontal = Math.abs(location[2]) >= Math.abs(location[3]);
+
+    Element position = document.createElement("Position");
+    Element point = document.createElement("Location");
+    point.setAttribute("X", String.valueOf(x));
+    point.setAttribute("Y", String.valueOf(y));
+    point.setAttribute("Z", "0");
+    position.appendChild(point);
+    parent.appendChild(position);
+
+    Element reducer = document.createElement("PolyLine");
+    reducer.setAttribute("NumPoints", "5");
+    Element presentation = document.createElement("Presentation");
+    presentation.setAttribute("LineType", "0");
+    presentation.setAttribute("LineWeight", String.valueOf(PROCESS_LINE_WEIGHT));
+    presentation.setAttribute("R", "0");
+    presentation.setAttribute("G", "0");
+    presentation.setAttribute("B", "0");
+    reducer.appendChild(presentation);
+    if (horizontal) {
+      appendCoordinate(document, reducer, x - 4.0, y + 3.0);
+      appendCoordinate(document, reducer, x - 4.0, y - 3.0);
+      appendCoordinate(document, reducer, x + 4.0, y - 1.5);
+      appendCoordinate(document, reducer, x + 4.0, y + 1.5);
+      appendCoordinate(document, reducer, x - 4.0, y + 3.0);
+    } else {
+      appendCoordinate(document, reducer, x - 3.0, y - 4.0);
+      appendCoordinate(document, reducer, x + 3.0, y - 4.0);
+      appendCoordinate(document, reducer, x + 1.5, y + 4.0);
+      appendCoordinate(document, reducer, x - 1.5, y + 4.0);
+      appendCoordinate(document, reducer, x - 3.0, y - 4.0);
+    }
+    parent.appendChild(reducer);
+    // Keep the transition text clear of the stream number (+6 mm) and line
+    // designation (-6 mm) that use the same routed-line midpoint.
+    appendFittingLabel(document, parent, flowInSize + " → " + flowOutSize, x, y - 12.0);
+  }
+
+  /**
+   * Appends the conventional double-slash marker for a piping-class or insulation property break.
+   *
+   * @param document XML document
+   * @param parent PropertyBreak element
+   * @param fromX source X coordinate
+   * @param fromY source Y coordinate
+   * @param toX target X coordinate
+   * @param toY target Y coordinate
+   * @param label changed property description
+   */
+  static void appendPropertyBreakSymbol(Document document, Element parent, double fromX, double fromY, double toX,
+      double toY, String label) {
+    double[] location = routeMidpointAndDirection(fromX, fromY, toX, toY);
+    double x = location[0];
+    double y = location[1];
+    boolean horizontal = Math.abs(location[2]) >= Math.abs(location[3]);
+    for (int offset = -2; offset <= 2; offset += 4) {
+      Element slash = document.createElement("PolyLine");
+      slash.setAttribute("NumPoints", "2");
+      Element presentation = document.createElement("Presentation");
+      presentation.setAttribute("LineType", "0");
+      presentation.setAttribute("LineWeight", String.valueOf(PROCESS_LINE_WEIGHT));
+      presentation.setAttribute("R", "0");
+      presentation.setAttribute("G", "0");
+      presentation.setAttribute("B", "0");
+      slash.appendChild(presentation);
+      if (horizontal) {
+        appendCoordinate(document, slash, x + offset - 1.5, y - 3.0);
+        appendCoordinate(document, slash, x + offset + 1.5, y + 3.0);
+      } else {
+        appendCoordinate(document, slash, x - 3.0, y + offset - 1.5);
+        appendCoordinate(document, slash, x + 3.0, y + offset + 1.5);
+      }
+      parent.appendChild(slash);
+    }
+    appendFittingLabel(document, parent, label, x, y - 12.0);
+  }
+
+  private static void appendFittingLabel(Document document, Element parent, String label, double x, double y) {
+    if (label == null || label.trim().isEmpty()) {
+      return;
+    }
+    Element text = document.createElement("Text");
+    text.setAttribute("String", label.trim());
+    text.setAttribute("Font", FONT_NAME);
+    text.setAttribute("Height", "2.0");
+    text.setAttribute("Width", "0");
+    text.setAttribute("Justification", "CenterTop");
+    Element presentation = document.createElement("Presentation");
+    presentation.setAttribute("R", "0");
+    presentation.setAttribute("G", "0");
+    presentation.setAttribute("B", "0");
+    text.appendChild(presentation);
+    Element position = document.createElement("Position");
+    Element location = document.createElement("Location");
+    location.setAttribute("X", String.valueOf(x));
+    location.setAttribute("Y", String.valueOf(y));
+    location.setAttribute("Z", "0");
+    position.appendChild(location);
+    text.appendChild(position);
+    parent.appendChild(text);
+  }
+
+  private static double[] routeMidpointAndDirection(double fromX, double fromY, double toX, double toY) {
+    double[][] route = routeConnection(fromX, fromY, toX, toY);
+    double totalLength = 0.0;
+    for (int index = 0; index + 1 < route.length; index++) {
+      totalLength += Math.abs(route[index + 1][0] - route[index][0]) + Math.abs(route[index + 1][1] - route[index][1]);
+    }
+    double remaining = totalLength / 2.0;
+    for (int index = 0; index + 1 < route.length; index++) {
+      double deltaX = route[index + 1][0] - route[index][0];
+      double deltaY = route[index + 1][1] - route[index][1];
+      double segmentLength = Math.abs(deltaX) + Math.abs(deltaY);
+      if (remaining <= segmentLength || index + 2 == route.length) {
+        double fraction = segmentLength <= 0.0 ? 0.0 : remaining / segmentLength;
+        return new double[] { route[index][0] + fraction * deltaX, route[index][1] + fraction * deltaY, deltaX,
+            deltaY };
+      }
+      remaining -= segmentLength;
+    }
+    return new double[] { fromX, fromY, toX - fromX, toY - fromY };
   }
 
   // ==== Revision history table (NORSOK Z-003) ====

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiMetadata.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiMetadata.java
@@ -125,6 +125,15 @@ public final class DexpiMetadata {
   /** Generic attribute for pipe/line nominal size (e.g. "6\"", "DN 150"). */
   public static final String LINE_SIZE = "LineSize";
 
+  /** DEXPI 1.4 readable nominal-diameter representation for a piping segment. */
+  public static final String NOMINAL_DIAMETER_REPRESENTATION = "NominalDiameterRepresentationAssignmentClass";
+
+  /** DEXPI 1.4 piping-class code for a piping segment. */
+  public static final String PIPING_CLASS_CODE_ASSIGNMENT = "PipingClassCodeAssignmentClass";
+
+  /** DEXPI 1.4 insulation-type code for a piping segment. */
+  public static final String INSULATION_TYPE_ASSIGNMENT = "InsulationTypeAssignmentClass";
+
   /** Generic attribute for the number of trays in a distillation column. */
   public static final String NUMBER_OF_TRAYS = "NumberOfTrays";
 
@@ -145,15 +154,18 @@ public final class DexpiMetadata {
 
   private static final Set<String> RECOMMENDED_STREAM_ATTRIBUTES = Collections.unmodifiableSet(new LinkedHashSet<>(
       Arrays.asList(LINE_NUMBER, FLUID_CODE, SEGMENT_NUMBER, OPERATING_PRESSURE_VALUE, OPERATING_PRESSURE_UNIT,
-          OPERATING_TEMPERATURE_VALUE, OPERATING_TEMPERATURE_UNIT, OPERATING_FLOW_VALUE, OPERATING_FLOW_UNIT)));
+          OPERATING_TEMPERATURE_VALUE, OPERATING_TEMPERATURE_UNIT, OPERATING_FLOW_VALUE, OPERATING_FLOW_UNIT,
+          NOMINAL_DIAMETER_REPRESENTATION, PIPING_CLASS_CODE_ASSIGNMENT, INSULATION_TYPE_ASSIGNMENT)));
 
   private static final Set<String> RECOMMENDED_EQUIPMENT_ATTRIBUTES = Collections.unmodifiableSet(new LinkedHashSet<>(
       Arrays.asList(TAG_NAME, LINE_NUMBER, FLUID_CODE, INSIDE_DIAMETER, NOMINAL_DIAMETER, TANGENT_TO_TANGENT_LENGTH,
           DESIGN_PRESSURE, DESIGN_TEMPERATURE, ORIENTATION, VALVE_CV, WALL_THICKNESS, WEIGHT)));
 
-  private static final Set<String> SIZING_ATTRIBUTES = Collections.unmodifiableSet(new LinkedHashSet<>(
-      Arrays.asList(INSIDE_DIAMETER, NOMINAL_DIAMETER, TANGENT_TO_TANGENT_LENGTH, DESIGN_PRESSURE, DESIGN_TEMPERATURE,
-          ORIENTATION, VALVE_CV, WALL_THICKNESS, WEIGHT, PIPING_CLASS_CODE, NUMBER_OF_TRAYS, FEED_TRAY)));
+  private static final Set<String> SIZING_ATTRIBUTES = Collections
+      .unmodifiableSet(new LinkedHashSet<>(Arrays.asList(INSIDE_DIAMETER, NOMINAL_DIAMETER, TANGENT_TO_TANGENT_LENGTH,
+          DESIGN_PRESSURE, DESIGN_TEMPERATURE, ORIENTATION, VALVE_CV, WALL_THICKNESS, WEIGHT, PIPING_CLASS_CODE,
+          NOMINAL_DIAMETER_REPRESENTATION, PIPING_CLASS_CODE_ASSIGNMENT, INSULATION_TYPE_ASSIGNMENT, LINE_SIZE,
+          INSULATION_CODE, NUMBER_OF_TRAYS, FEED_TRAY)));
 
   /**
    * Returns the recommended generic attributes that should accompany DEXPI piping segments.

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiShapeCatalog.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiShapeCatalog.java
@@ -291,7 +291,7 @@ final class DexpiShapeCatalog {
     // Flat-bottom cylindrical storage tank: straight sides, flat base, shallow dished roof
     appendPolyLine(document, shape, new double[][] { { -12.5, 12 }, { -12.5, -12 }, { 12.5, -12 }, { 12.5, 12 } });
     // Shallow curved roof
-    appendTrimmedCurve(document, shape, 20.0, 160.0, 36.55, 0, -22.34);
+    appendTrimmedCurve(document, shape, 54.51065674988614, 125.48934325011386, 21.53125, 0, -5.53125);
     // Liquid level line
     appendPolyLine(document, shape, new double[][] { { -12.5, -2 }, { 12.5, -2 } });
     catalogue.appendChild(shape);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiStream.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiStream.java
@@ -1,6 +1,7 @@
 package neqsim.process.processmodel.dexpi;
 
 import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 
 /**
@@ -19,6 +20,15 @@ public class DexpiStream extends Stream {
   private final String dexpiClass;
   private final String lineNumber;
   private final String fluidCode;
+  private String nominalDiameterRepresentation;
+  private String pipingClassCode;
+  private String insulationType;
+  private String flowInNominalDiameterRepresentation;
+  private String flowOutNominalDiameterRepresentation;
+  private String flowInPipingClassCode;
+  private String flowOutPipingClassCode;
+  private String flowInInsulationType;
+  private String flowOutInsulationType;
 
   /**
    * Creates a new DEXPI stream.
@@ -31,6 +41,27 @@ public class DexpiStream extends Stream {
    */
   public DexpiStream(String name, SystemInterface fluid, String dexpiClass, String lineNumber, String fluidCode) {
     super(name, fluid);
+    this.dexpiClass = dexpiClass;
+    this.lineNumber = lineNumber;
+    this.fluidCode = fluidCode;
+  }
+
+  /**
+   * Wraps an existing process stream while adding source DEXPI line metadata.
+   *
+   * <p>
+   * The wrapper delegates to the source stream instead of capturing its current thermodynamic-system object. This
+   * preserves process topology when upstream equipment replaces its outlet fluid during a later simulation run.
+   * </p>
+   *
+   * @param name the stream name
+   * @param stream source stream to wrap
+   * @param dexpiClass the original DEXPI component class
+   * @param lineNumber the line number reference (may be null)
+   * @param fluidCode the fluid code reference (may be null)
+   */
+  public DexpiStream(String name, StreamInterface stream, String dexpiClass, String lineNumber, String fluidCode) {
+    super(name, stream);
     this.dexpiClass = dexpiClass;
     this.lineNumber = lineNumber;
     this.fluidCode = fluidCode;
@@ -61,5 +92,127 @@ public class DexpiStream extends Stream {
    */
   public String getFluidCode() {
     return fluidCode;
+  }
+
+  /**
+   * Gets the source nominal-diameter representation, for example {@code DN 150} or {@code NPS 6}.
+   *
+   * @return nominal-diameter representation, or null if absent from the source model
+   */
+  public String getNominalDiameterRepresentation() {
+    return nominalDiameterRepresentation;
+  }
+
+  /**
+   * Sets the source nominal-diameter representation used in P&amp;ID line annotations.
+   *
+   * @param nominalDiameterRepresentation source representation such as {@code DN 150} or {@code NPS 6}
+   */
+  public void setNominalDiameterRepresentation(String nominalDiameterRepresentation) {
+    this.nominalDiameterRepresentation = trimToNull(nominalDiameterRepresentation);
+  }
+
+  /**
+   * Gets the piping-class code.
+   *
+   * @return piping-class code, or null if absent
+   */
+  public String getPipingClassCode() {
+    return pipingClassCode;
+  }
+
+  /**
+   * Sets the piping-class code used in P&amp;ID line annotations.
+   *
+   * @param pipingClassCode project piping-class code
+   */
+  public void setPipingClassCode(String pipingClassCode) {
+    this.pipingClassCode = trimToNull(pipingClassCode);
+  }
+
+  /**
+   * Gets the insulation-type code.
+   *
+   * @return insulation-type code, or null if absent
+   */
+  public String getInsulationType() {
+    return insulationType;
+  }
+
+  /**
+   * Sets the insulation-type code used in P&amp;ID line annotations.
+   *
+   * @param insulationType project insulation-type code
+   */
+  public void setInsulationType(String insulationType) {
+    this.insulationType = trimToNull(insulationType);
+  }
+
+  /** @return nominal diameter at the flow-in end, or null when not explicitly supplied */
+  public String getFlowInNominalDiameterRepresentation() {
+    return flowInNominalDiameterRepresentation;
+  }
+
+  /** @param value nominal diameter at the flow-in end */
+  public void setFlowInNominalDiameterRepresentation(String value) {
+    flowInNominalDiameterRepresentation = trimToNull(value);
+  }
+
+  /** @return nominal diameter at the flow-out end, or null when not explicitly supplied */
+  public String getFlowOutNominalDiameterRepresentation() {
+    return flowOutNominalDiameterRepresentation;
+  }
+
+  /** @param value nominal diameter at the flow-out end */
+  public void setFlowOutNominalDiameterRepresentation(String value) {
+    flowOutNominalDiameterRepresentation = trimToNull(value);
+  }
+
+  /** @return piping class at the flow-in end, or null when not explicitly supplied */
+  public String getFlowInPipingClassCode() {
+    return flowInPipingClassCode;
+  }
+
+  /** @param value piping class at the flow-in end */
+  public void setFlowInPipingClassCode(String value) {
+    flowInPipingClassCode = trimToNull(value);
+  }
+
+  /** @return piping class at the flow-out end, or null when not explicitly supplied */
+  public String getFlowOutPipingClassCode() {
+    return flowOutPipingClassCode;
+  }
+
+  /** @param value piping class at the flow-out end */
+  public void setFlowOutPipingClassCode(String value) {
+    flowOutPipingClassCode = trimToNull(value);
+  }
+
+  /** @return insulation type at the flow-in end, or null when not explicitly supplied */
+  public String getFlowInInsulationType() {
+    return flowInInsulationType;
+  }
+
+  /** @param value insulation type at the flow-in end */
+  public void setFlowInInsulationType(String value) {
+    flowInInsulationType = trimToNull(value);
+  }
+
+  /** @return insulation type at the flow-out end, or null when not explicitly supplied */
+  public String getFlowOutInsulationType() {
+    return flowOutInsulationType;
+  }
+
+  /** @param value insulation type at the flow-out end */
+  public void setFlowOutInsulationType(String value) {
+    flowOutInsulationType = trimToNull(value);
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
   }
 }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiStreamUtils.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiStreamUtils.java
@@ -8,6 +8,7 @@ import neqsim.process.equipment.separator.ThreePhaseSeparator;
 import neqsim.process.equipment.splitter.Splitter;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.equipment.tank.Tank;
 
 /**
  * Shared utilities for resolving outlet streams from NeqSim process equipment.
@@ -71,6 +72,9 @@ public final class DexpiStreamUtils {
     }
     if (equipment instanceof Separator) {
       return ((Separator) equipment).getLiquidOutStream();
+    }
+    if (equipment instanceof Tank) {
+      return ((Tank) equipment).getLiquidOutStream();
     }
     return null;
   }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessment.java
@@ -212,6 +212,7 @@ public final class DexpiVisualQualityAssessment {
     assessCoordinates(document, extent, findings, metrics);
     assessText(document, findings, metrics);
     assessFlowDirectionArrows(document, svg, findings, metrics);
+    assessPipingLineData(document, findings, metrics);
     assessInstrumentationTopology(document, findings, metrics);
 
     metrics.put("sourcePolylines", countOutsideCatalogue(document, "PolyLine"));
@@ -361,45 +362,41 @@ public final class DexpiVisualQualityAssessment {
     NodeList signalGenerators = document.getElementsByTagName("ProcessSignalGeneratingFunction");
     int measurementFunctions = 0;
     int sensingLocations = 0;
-    int vesselLevelMeasurements = 0;
+    int levelMeasurements = 0;
     int vesselLevelAttachments = 0;
-    int invalidVesselLevelAttachments = 0;
     for (int index = 0; index < signalGenerators.getLength(); index++) {
       Element generator = (Element) signalGenerators.item(index);
       if (inside(generator, "ShapeCatalogue")) {
         continue;
       }
       measurementFunctions++;
-      Element function = nearestAncestor(generator, "ProcessInstrumentationFunction");
-      boolean vesselLevel = function != null
-          && "L".equals(genericAttribute(function, "ProcessInstrumentationFunctionCategoryAssignmentClass"));
-      if (vesselLevel) {
-        vesselLevelMeasurements++;
-      }
       Element association = directAssociation(generator, "is located in");
-      Element location = null;
       if (association == null || association.getAttribute("ItemID").trim().isEmpty()) {
         add(findings, Severity.ERROR, "INSTRUMENT_SENSING_LOCATION_MISSING", generator.getAttribute("ID"),
             "Rendered measurement has no nozzle, process-segment, piping-component, or equipment-mount sensing location");
       } else {
         String locationId = association.getAttribute("ItemID").trim();
-        location = elementWithId(document, locationId);
+        Element location = elementWithId(document, locationId);
         if (location == null || !isSensingLocation(location)) {
           add(findings, Severity.ERROR, "INSTRUMENT_SENSING_LOCATION_INVALID", generator.getAttribute("ID"),
               "Measurement sensing location does not resolve to process equipment, a nozzle, mount, piping component, or process segment");
         } else {
           sensingLocations++;
-        }
-      }
-      if (vesselLevel) {
-        boolean vesselBoundary = isVesselLevelLocation(location)
-            && "ATTACHED_TO_VESSEL_BOUNDARY".equals(genericAttribute(function, "MeasurementAttachmentStatus"));
-        if (vesselBoundary) {
-          vesselLevelAttachments++;
-        } else {
-          invalidVesselLevelAttachments++;
-          add(findings, Severity.ERROR, "LEVEL_MEASUREMENT_VESSEL_ATTACHMENT_INVALID", generator.getAttribute("ID"),
-              "Level measurement must reference a separator or tank boundary, not an inlet or product nozzle");
+          String sensorType = genericAttribute(generator, "SensorTypeAssignmentClass");
+          if (sensorType.contains("Level")) {
+            levelMeasurements++;
+            Element equipment = ancestor(location, "Equipment");
+            String equipmentClass = equipment == null ? "" : equipment.getAttribute("ComponentClass");
+            boolean vesselEquipment = equipmentClass.contains("Separator") || equipmentClass.contains("Tank");
+            if (!"Nozzle".equals(location.getTagName())
+                || !"LEVEL_SENSING_TAP".equals(genericAttribute(location, "PhysicalConnectionRole"))
+                || !vesselEquipment) {
+              add(findings, Severity.ERROR, "LEVEL_MEASUREMENT_NOT_VESSEL_MOUNTED", generator.getAttribute("ID"),
+                  "Level measurement must terminate at a dedicated tank or separator sensing tap, not an outlet line");
+            } else {
+              vesselLevelAttachments++;
+            }
+          }
         }
       }
     }
@@ -485,9 +482,10 @@ public final class DexpiVisualQualityAssessment {
     }
     metrics.put("measurementFunctions", measurementFunctions);
     metrics.put("measurementSensingLocations", sensingLocations);
-    metrics.put("vesselLevelMeasurements", vesselLevelMeasurements);
+    metrics.put("levelMeasurements", levelMeasurements);
     metrics.put("vesselLevelAttachments", vesselLevelAttachments);
-    metrics.put("invalidVesselLevelAttachments", invalidVesselLevelAttachments);
+    metrics.put("vesselLevelMeasurements", levelMeasurements);
+    metrics.put("invalidVesselLevelAttachments", levelMeasurements - vesselLevelAttachments);
     metrics.put("controllerFunctions", controllerFunctions);
     metrics.put("completeControlLoops", completeLoops);
     metrics.put("incompleteControlLoops", incompleteLoops);
@@ -503,6 +501,80 @@ public final class DexpiVisualQualityAssessment {
     metrics.put("sourceActuatingSignals", actuatingSignals);
     metrics.put("invalidActuatingSignals", invalidActuatingSignals);
     metrics.put("synthesizedProposalInstruments", synthesizedProposals);
+  }
+
+  private static void assessPipingLineData(Document document, List<Finding> findings, Map<String, Integer> metrics) {
+    NodeList segments = document.getElementsByTagName("PipingNetworkSegment");
+    int routedLines = 0;
+    int linesWithSourceSize = 0;
+    int linesWithModelInsideDiameter = 0;
+    int linesMissingSize = 0;
+    int sizeChanges = 0;
+    int reducers = 0;
+    int propertyChanges = 0;
+    int propertyBreaks = 0;
+    for (int index = 0; index < segments.getLength(); index++) {
+      Element segment = (Element) segments.item(index);
+      if (firstDirectChild(segment, "Connection") == null || firstDirectChild(segment, "CenterLine") == null) {
+        continue;
+      }
+      routedLines++;
+      String identity = segment.getAttribute("ID");
+      String sizeStatus = genericAttribute(segment, "LineSizeStatus");
+      if ("SOURCE_NOMINAL_DIAMETER".equals(sizeStatus)) {
+        linesWithSourceSize++;
+      } else if ("MODEL_INSIDE_DIAMETER".equals(sizeStatus)) {
+        linesWithModelInsideDiameter++;
+      } else {
+        linesMissingSize++;
+        add(findings, Severity.WARNING, "LINE_SIZE_SOURCE_DATA_MISSING", identity,
+            "Routed process line has no source nominal size or model inside diameter");
+        if (!hasTextContaining(segment, "SIZE?")) {
+          add(findings, Severity.ERROR, "LINE_SIZE_GAP_NOT_VISIBLE", identity,
+              "Missing line-size source data is not visible in the line designation");
+        }
+      }
+
+      if ("TRUE".equals(genericAttribute(segment, "SizeChangeDetected"))) {
+        sizeChanges++;
+        Element reducer = descendantWithComponentClass(segment, "PipingComponent", "PipeReducer");
+        if (reducer == null) {
+          add(findings, Severity.ERROR, "PIPE_REDUCER_MISSING", identity,
+              "A source-backed line-size change is present without a PipeReducer fitting");
+        } else {
+          reducers++;
+          String flowIn = genericAttribute(reducer, "FlowInNominalDiameterRepresentationAssignmentClass");
+          String flowOut = genericAttribute(reducer, "FlowOutNominalDiameterRepresentationAssignmentClass");
+          if (flowIn.isEmpty() || flowOut.isEmpty() || flowIn.equalsIgnoreCase(flowOut)) {
+            add(findings, Severity.ERROR, "PIPE_REDUCER_SIZE_DATA_INVALID", reducer.getAttribute("ID"),
+                "PipeReducer must declare distinct flow-in and flow-out sizes");
+          }
+          if (reducer.getElementsByTagName("Nozzle").getLength() < 2) {
+            add(findings, Severity.ERROR, "PIPE_REDUCER_CONNECTION_POINTS_MISSING", reducer.getAttribute("ID"),
+                "PipeReducer must expose distinct flow-in and flow-out connection points");
+          }
+        }
+      }
+
+      if ("TRUE".equals(genericAttribute(segment, "PipingPropertyChangeDetected"))) {
+        propertyChanges++;
+        Element propertyBreak = firstDescendant(segment, "PropertyBreak");
+        if (propertyBreak == null) {
+          add(findings, Severity.ERROR, "PIPING_PROPERTY_BREAK_MISSING", identity,
+              "A piping-class or insulation change is present without a PropertyBreak marker");
+        } else {
+          propertyBreaks++;
+        }
+      }
+    }
+    metrics.put("routedProcessLines", routedLines);
+    metrics.put("linesWithSourceNominalDiameter", linesWithSourceSize);
+    metrics.put("linesWithModelInsideDiameter", linesWithModelInsideDiameter);
+    metrics.put("linesMissingSizeSourceData", linesMissingSize);
+    metrics.put("detectedLineSizeChanges", sizeChanges);
+    metrics.put("pipeReducers", reducers);
+    metrics.put("detectedPipingPropertyChanges", propertyChanges);
+    metrics.put("propertyBreaks", propertyBreaks);
   }
 
   private static boolean hasActuatingSignal(Element controller) {
@@ -536,15 +608,6 @@ public final class DexpiVisualQualityAssessment {
         || "PipingNetworkSegment".equals(type);
   }
 
-  private static boolean isVesselLevelLocation(Element location) {
-    if (location == null || !"Equipment".equals(location.getTagName())) {
-      return false;
-    }
-    String componentClass = location.getAttribute("ComponentClass");
-    return "Separator".equals(componentClass) || "ThreePhaseSeparator".equals(componentClass)
-        || "Tank".equals(componentClass);
-  }
-
   private static Element elementWithId(Document document, String identity) {
     NodeList elements = document.getElementsByTagName("*");
     for (int index = 0; index < elements.getLength(); index++) {
@@ -564,6 +627,38 @@ public final class DexpiVisualQualityAssessment {
       }
     }
     return false;
+  }
+
+  private static boolean hasTextContaining(Element parent, String value) {
+    NodeList texts = parent.getElementsByTagName("Text");
+    for (int index = 0; index < texts.getLength(); index++) {
+      if (((Element) texts.item(index)).getAttribute("String").contains(value)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static Element descendantWithComponentClass(Element parent, String tagName, String componentClass) {
+    NodeList elements = parent.getElementsByTagName(tagName);
+    for (int index = 0; index < elements.getLength(); index++) {
+      Element element = (Element) elements.item(index);
+      if (componentClass.equals(element.getAttribute("ComponentClass"))) {
+        return element;
+      }
+    }
+    return null;
+  }
+
+  private static Element ancestor(Element element, String tagName) {
+    Node current = element.getParentNode();
+    while (current instanceof Element) {
+      if (tagName.equals(((Element) current).getTagName())) {
+        return (Element) current;
+      }
+      current = current.getParentNode();
+    }
+    return null;
   }
 
   private static Element directAssociation(Element parent, String type) {
@@ -734,18 +829,6 @@ public final class DexpiVisualQualityAssessment {
   private static String identifiedAncestor(Element element) {
     Element ancestor = nearestIdentifiedAncestor(element);
     return ancestor == null ? "" : ancestor.getAttribute("ID");
-  }
-
-  private static Element nearestAncestor(Element element, String ancestorName) {
-    Node current = element.getParentNode();
-    while (current instanceof Element) {
-      Element candidate = (Element) current;
-      if (ancestorName.equals(candidate.getTagName())) {
-        return candidate;
-      }
-      current = current.getParentNode();
-    }
-    return null;
   }
 
   private static boolean inside(Element element, String ancestorName) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessment.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessment.java
@@ -361,24 +361,45 @@ public final class DexpiVisualQualityAssessment {
     NodeList signalGenerators = document.getElementsByTagName("ProcessSignalGeneratingFunction");
     int measurementFunctions = 0;
     int sensingLocations = 0;
+    int vesselLevelMeasurements = 0;
+    int vesselLevelAttachments = 0;
+    int invalidVesselLevelAttachments = 0;
     for (int index = 0; index < signalGenerators.getLength(); index++) {
       Element generator = (Element) signalGenerators.item(index);
       if (inside(generator, "ShapeCatalogue")) {
         continue;
       }
       measurementFunctions++;
+      Element function = nearestAncestor(generator, "ProcessInstrumentationFunction");
+      boolean vesselLevel = function != null
+          && "L".equals(genericAttribute(function, "ProcessInstrumentationFunctionCategoryAssignmentClass"));
+      if (vesselLevel) {
+        vesselLevelMeasurements++;
+      }
       Element association = directAssociation(generator, "is located in");
+      Element location = null;
       if (association == null || association.getAttribute("ItemID").trim().isEmpty()) {
         add(findings, Severity.ERROR, "INSTRUMENT_SENSING_LOCATION_MISSING", generator.getAttribute("ID"),
             "Rendered measurement has no nozzle, process-segment, piping-component, or equipment-mount sensing location");
       } else {
         String locationId = association.getAttribute("ItemID").trim();
-        Element location = elementWithId(document, locationId);
+        location = elementWithId(document, locationId);
         if (location == null || !isSensingLocation(location)) {
           add(findings, Severity.ERROR, "INSTRUMENT_SENSING_LOCATION_INVALID", generator.getAttribute("ID"),
               "Measurement sensing location does not resolve to process equipment, a nozzle, mount, piping component, or process segment");
         } else {
           sensingLocations++;
+        }
+      }
+      if (vesselLevel) {
+        boolean vesselBoundary = isVesselLevelLocation(location)
+            && "ATTACHED_TO_VESSEL_BOUNDARY".equals(genericAttribute(function, "MeasurementAttachmentStatus"));
+        if (vesselBoundary) {
+          vesselLevelAttachments++;
+        } else {
+          invalidVesselLevelAttachments++;
+          add(findings, Severity.ERROR, "LEVEL_MEASUREMENT_VESSEL_ATTACHMENT_INVALID", generator.getAttribute("ID"),
+              "Level measurement must reference a separator or tank boundary, not an inlet or product nozzle");
         }
       }
     }
@@ -464,6 +485,9 @@ public final class DexpiVisualQualityAssessment {
     }
     metrics.put("measurementFunctions", measurementFunctions);
     metrics.put("measurementSensingLocations", sensingLocations);
+    metrics.put("vesselLevelMeasurements", vesselLevelMeasurements);
+    metrics.put("vesselLevelAttachments", vesselLevelAttachments);
+    metrics.put("invalidVesselLevelAttachments", invalidVesselLevelAttachments);
     metrics.put("controllerFunctions", controllerFunctions);
     metrics.put("completeControlLoops", completeLoops);
     metrics.put("incompleteControlLoops", incompleteLoops);
@@ -510,6 +534,15 @@ public final class DexpiVisualQualityAssessment {
     String type = location.getTagName();
     return "Equipment".equals(type) || "Nozzle".equals(type) || "Mount".equals(type) || "PipingComponent".equals(type)
         || "PipingNetworkSegment".equals(type);
+  }
+
+  private static boolean isVesselLevelLocation(Element location) {
+    if (location == null || !"Equipment".equals(location.getTagName())) {
+      return false;
+    }
+    String componentClass = location.getAttribute("ComponentClass");
+    return "Separator".equals(componentClass) || "ThreePhaseSeparator".equals(componentClass)
+        || "Tank".equals(componentClass);
   }
 
   private static Element elementWithId(Document document, String identity) {
@@ -701,6 +734,18 @@ public final class DexpiVisualQualityAssessment {
   private static String identifiedAncestor(Element element) {
     Element ancestor = nearestIdentifiedAncestor(element);
     return ancestor == null ? "" : ancestor.getAttribute("ID");
+  }
+
+  private static Element nearestAncestor(Element element, String ancestorName) {
+    Node current = element.getParentNode();
+    while (current instanceof Element) {
+      Element candidate = (Element) current;
+      if (ancestorName.equals(candidate.getTagName())) {
+        return candidate;
+      }
+      current = current.getParentNode();
+    }
+    return null;
   }
 
   private static boolean inside(Element element, String ancestorName) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -499,6 +499,13 @@ public final class DexpiXmlReader {
 
     DexpiStream stream = new DexpiStream(uniqueName, fluid, element.getAttribute("ComponentClass"), lineNumber,
         fluidCode);
+    stream.setNominalDiameterRepresentation(
+        firstNonEmpty(attributeValue(element, DexpiMetadata.NOMINAL_DIAMETER_REPRESENTATION),
+            attributeValue(element, DexpiMetadata.LINE_SIZE)));
+    stream.setPipingClassCode(firstNonEmpty(attributeValue(element, DexpiMetadata.PIPING_CLASS_CODE_ASSIGNMENT),
+        attributeValue(element, DexpiMetadata.PIPING_CLASS_CODE)));
+    stream.setInsulationType(firstNonEmpty(attributeValue(element, DexpiMetadata.INSULATION_TYPE_ASSIGNMENT),
+        attributeValue(element, DexpiMetadata.INSULATION_CODE)));
     stream.setSpecification(templateStream.getSpecification());
     stream.setPressure(templateStream.getPressure(DexpiMetadata.DEFAULT_PRESSURE_UNIT),
         DexpiMetadata.DEFAULT_PRESSURE_UNIT);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
@@ -2202,8 +2202,9 @@ public final class DexpiXmlWriter {
    *
    * <p>
    * Each transmitter becomes a {@code ProcessInstrumentationFunction} with a {@code ProcessSignalGeneratingFunction}
-   * child. Controllers that share a loop tag with a transmitter are linked via {@code SignalConveyingFunction} and
-   * {@code ActuatingFunction}. Finally, an {@code InstrumentationLoopFunction} groups each loop's elements.
+   * child. Controllers that share a loop tag with a transmitter are linked through {@code InformationFlow} elements
+   * classified as {@code SignalLineFunction}, together with an {@code ActuatingFunction}. Finally, an
+   * {@code InstrumentationLoopFunction} groups each loop's elements.
    * </p>
    *
    * @param document the XML document

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
@@ -53,6 +53,7 @@ import neqsim.process.equipment.heatexchanger.Cooler;
 import neqsim.process.equipment.heatexchanger.HeatExchanger;
 import neqsim.process.equipment.heatexchanger.Heater;
 import neqsim.process.equipment.mixer.Mixer;
+import neqsim.process.equipment.pipeline.PipeLineInterface;
 import neqsim.process.equipment.pump.Pump;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.separator.ThreePhaseSeparator;
@@ -64,10 +65,12 @@ import neqsim.process.equipment.valve.HIPPSValve;
 import neqsim.process.equipment.valve.ThrottlingValve;
 import neqsim.process.measurementdevice.LevelTransmitter;
 import neqsim.process.measurementdevice.MeasurementDeviceInterface;
+import neqsim.process.measurementdevice.OilLevelTransmitter;
 import neqsim.process.measurementdevice.PressureTransmitter;
 import neqsim.process.measurementdevice.StreamMeasurementDeviceBaseClass;
 import neqsim.process.measurementdevice.TemperatureTransmitter;
 import neqsim.process.measurementdevice.VolumeFlowTransmitter;
+import neqsim.process.measurementdevice.WaterLevelTransmitter;
 import neqsim.process.processmodel.ProcessModel;
 import neqsim.process.processmodel.ProcessSystem;
 
@@ -582,6 +585,8 @@ public final class DexpiXmlWriter {
     Map<String, Element> valvePipingComponents = new LinkedHashMap<>();
     // Nozzle positions for connection line geometry (nozzle ID -> {x, y})
     Map<String, double[]> nozzlePositions = new HashMap<>();
+    // Equipment owner for every process nozzle, used to resolve source-backed line properties.
+    Map<String, ProcessEquipmentInterface> nozzleOwners = new HashMap<>();
 
     for (ProcessEquipmentInterface unit : processSystem.getUnitOperations()) {
       if (unit instanceof DexpiStream) {
@@ -605,6 +610,7 @@ public final class DexpiXmlWriter {
           }
         }
         registerNozzlePositions(layoutPositions.get(unit.getName()), inNozzle, outNozzles, nozzlePositions);
+        registerNozzleOwners(unit, inNozzle, outNozzles, nozzleOwners);
         appendProcessUnit(document, root, (DexpiProcessUnit) unit, usedIds, inNozzle, outNozzles,
             layoutPositions.get(unit.getName()), labelCounter++, nozzlePositions);
         equipmentInletNozzle.put(unit.getName(), inNozzle);
@@ -621,6 +627,7 @@ public final class DexpiXmlWriter {
           }
         }
         registerNozzlePositions(layoutPositions.get(unit.getName()), inNozzle, outNozzles, nozzlePositions);
+        registerNozzleOwners(unit, inNozzle, outNozzles, nozzleOwners);
         if (isValveType(unit)) {
           // Valves are PipingComponents in DEXPI — embed in PipingNetworkSegment, not
           // top-level
@@ -640,7 +647,7 @@ public final class DexpiXmlWriter {
     registerPassThroughStreams(processSystem, outletStreamToNozzle);
 
     // Build connections from process wiring using stream identity matching
-    buildConnections(processSystem, outletStreamToNozzle, equipmentInletNozzle, connections);
+    buildConnections(processSystem, outletStreamToNozzle, equipmentInletNozzle, nozzleOwners, connections);
 
     for (Map.Entry<String, List<DexpiStream>> entry : segmentsBySystem.entrySet()) {
       appendPipingNetworkSystem(document, root, entry.getKey(), entry.getValue(), usedIds);
@@ -694,9 +701,11 @@ public final class DexpiXmlWriter {
 
     List<double[]> instrumentPositions = new ArrayList<>();
     if (effectiveTransmitters != null && !effectiveTransmitters.isEmpty()) {
+      Map<String, String> levelSensingLocations = appendLevelSensingLocations(document, effectiveTransmitters,
+          synthesizedInstrumentTags, usedIds, layoutPositions, nozzlePositions);
       appendInstruments(document, root, effectiveTransmitters, effectiveControllers, usedIds, layoutPositions,
           nozzlePositions, equipmentInletNozzle, outletStreamToNozzle, connections, synthesizedInstrumentTags,
-          instrumentPositions, processSystem);
+          levelSensingLocations, instrumentPositions, processSystem);
     }
 
     // Collect stream data for stream table
@@ -922,10 +931,10 @@ public final class DexpiXmlWriter {
    * @param usedIds set of used IDs
    * @param nozzlePositions map of nozzle positions (may be null)
    */
-  private static void appendNozzle(Document document, Element parent, String nozzleId, Set<String> usedIds,
+  private static Element appendNozzle(Document document, Element parent, String nozzleId, Set<String> usedIds,
       Map<String, double[]> nozzlePositions) {
     if (isBlank(nozzleId)) {
-      return;
+      return null;
     }
     Element nozzle = document.createElement("Nozzle");
     nozzle.setAttribute("ID", nozzleId);
@@ -943,6 +952,91 @@ public final class DexpiXmlWriter {
 
     usedIds.add(nozzleId);
     parent.appendChild(nozzle);
+    return nozzle;
+  }
+
+  /**
+   * Creates dedicated, vessel-mounted sensing nozzles for level measurements.
+   *
+   * <p>
+   * A level transmitter is associated with the tank or separator inventory, not its liquid outlet line. Each level
+   * measurement therefore receives an explicit sensing nozzle on the vessel shell. Oil and water-interface measurements
+   * on a three-phase separator receive distinct tapping points.
+   * </p>
+   */
+  private static Map<String, String> appendLevelSensingLocations(Document document,
+      Map<String, MeasurementDeviceInterface> transmitters, Set<String> synthesizedInstrumentTags, Set<String> usedIds,
+      Map<String, DexpiLayoutEngine.EquipmentPosition> layoutPositions, Map<String, double[]> nozzlePositions) {
+    Map<String, List<Map.Entry<String, MeasurementDeviceInterface>>> byEquipment = new LinkedHashMap<>();
+    for (Map.Entry<String, MeasurementDeviceInterface> entry : transmitters.entrySet()) {
+      ProcessEquipmentInterface levelEquipment = levelEquipment(entry.getValue());
+      if (levelEquipment == null) {
+        continue;
+      }
+      List<Map.Entry<String, MeasurementDeviceInterface>> devices = byEquipment.get(levelEquipment.getName());
+      if (devices == null) {
+        devices = new ArrayList<>();
+        byEquipment.put(levelEquipment.getName(), devices);
+      }
+      devices.add(entry);
+    }
+
+    Map<String, String> result = new HashMap<>();
+    for (Map.Entry<String, List<Map.Entry<String, MeasurementDeviceInterface>>> equipmentEntry : byEquipment
+        .entrySet()) {
+      String equipmentName = equipmentEntry.getKey();
+      Element equipmentElement = findComponentElementByTag(document, equipmentName);
+      DexpiLayoutEngine.EquipmentPosition position = layoutPositions.get(equipmentName);
+      if (equipmentElement == null || position == null) {
+        continue;
+      }
+      List<Map.Entry<String, MeasurementDeviceInterface>> devices = equipmentEntry.getValue();
+      devices.sort((first, second) -> Integer.compare(levelTapRank(first.getValue()), levelTapRank(second.getValue())));
+      double startY = position.y - 3.0 + (devices.size() - 1) * 4.0;
+      for (int index = 0; index < devices.size(); index++) {
+        Map.Entry<String, MeasurementDeviceInterface> deviceEntry = devices.get(index);
+        String tag = deviceEntry.getKey();
+        String nozzleId = uniqueIdentifier("Nozzle", equipmentName + "-" + tag + "-LevelTap", usedIds);
+        nozzlePositions.put(nozzleId, new double[] { position.x - 18.0, startY - index * 8.0 });
+        Element nozzle = appendNozzle(document, equipmentElement, nozzleId, usedIds, nozzlePositions);
+        if (nozzle == null) {
+          continue;
+        }
+        Element attributes = document.createElement("GenericAttributes");
+        attributes.setAttribute("Set", "InstrumentAttachment");
+        appendGenericAttribute(document, attributes, "PhysicalConnectionRole", "LEVEL_SENSING_TAP");
+        appendGenericAttribute(document, attributes, "SensingPointType", sensorType(deviceEntry.getValue()));
+        appendGenericAttribute(document, attributes, "MeasurementFunctionTag", tag);
+        appendGenericAttribute(document, attributes, "EngineeringStatus",
+            synthesizedInstrumentTags.contains(tag) ? "PROPOSED" : "MODELLED");
+        nozzle.appendChild(attributes);
+        result.put(tag, nozzleId);
+      }
+    }
+    return result;
+  }
+
+  private static int levelTapRank(MeasurementDeviceInterface device) {
+    if (device instanceof OilLevelTransmitter) {
+      return 1;
+    }
+    if (device instanceof WaterLevelTransmitter) {
+      return 2;
+    }
+    return 0;
+  }
+
+  private static ProcessEquipmentInterface levelEquipment(MeasurementDeviceInterface device) {
+    if (device instanceof LevelTransmitter) {
+      return ((LevelTransmitter) device).getLevelEquipment();
+    }
+    if (device instanceof OilLevelTransmitter) {
+      return ((OilLevelTransmitter) device).getSeparator();
+    }
+    if (device instanceof WaterLevelTransmitter) {
+      return ((WaterLevelTransmitter) device).getSeparator();
+    }
+    return null;
   }
 
   /**
@@ -1336,16 +1430,59 @@ public final class DexpiXmlWriter {
     private final String fromNozzle;
     private final String toNozzle;
     private final StreamInterface stream;
+    private final ProcessEquipmentInterface sourceEquipment;
+    private final ProcessEquipmentInterface targetEquipment;
     private String segmentId;
 
     NozzleConnection(String fromNozzle, String toNozzle) {
-      this(fromNozzle, toNozzle, null);
+      this(fromNozzle, toNozzle, null, null, null);
     }
 
     NozzleConnection(String fromNozzle, String toNozzle, StreamInterface stream) {
+      this(fromNozzle, toNozzle, stream, null, null);
+    }
+
+    NozzleConnection(String fromNozzle, String toNozzle, StreamInterface stream,
+        ProcessEquipmentInterface sourceEquipment, ProcessEquipmentInterface targetEquipment) {
       this.fromNozzle = fromNozzle;
       this.toNozzle = toNozzle;
       this.stream = stream;
+      this.sourceEquipment = sourceEquipment;
+      this.targetEquipment = targetEquipment;
+    }
+  }
+
+  /** Source-backed line designation and endpoint property state for one routed connection. */
+  private static final class LineMetadata {
+    private String lineNumber;
+    private String fluidCode;
+    private String nominalDiameter;
+    private String pipingClassCode;
+    private String insulationType;
+    private String sizeDisplay;
+    private String sizeStatus;
+    private String metadataSource;
+    private String sourceSize;
+    private String targetSize;
+    private String sourcePipingClass;
+    private String targetPipingClass;
+    private String sourceInsulation;
+    private String targetInsulation;
+    private boolean sizeChange;
+    private boolean pipingClassChange;
+    private boolean insulationChange;
+
+    String lineLabel() {
+      return new NorsokLineNumber().size(sizeDisplay == null ? "SIZE?" : sizeDisplay).fluidCode(fluidCode)
+          .sequence(lineNumber).pipingClass(pipingClassCode).insulation(insulationType).build();
+    }
+  }
+
+  private static void registerNozzleOwners(ProcessEquipmentInterface unit, String inletNozzle,
+      List<String> outletNozzles, Map<String, ProcessEquipmentInterface> nozzleOwners) {
+    nozzleOwners.put(inletNozzle, unit);
+    for (String outletNozzle : outletNozzles) {
+      nozzleOwners.put(outletNozzle, unit);
     }
   }
 
@@ -1464,7 +1601,7 @@ public final class DexpiXmlWriter {
     // For each plain Stream in the process, check if its fluid delegates to a
     // registered outlet
     for (ProcessEquipmentInterface unit : processSystem.getUnitOperations()) {
-      if (unit instanceof Stream && !(unit instanceof DexpiStream)) {
+      if (unit instanceof Stream) {
         Stream stream = (Stream) unit;
         if (stream.getFluid() != null) {
           String nozzle = fluidToNozzle.get(System.identityHashCode(stream.getFluid()));
@@ -1491,7 +1628,8 @@ public final class DexpiXmlWriter {
    * @param connections list to populate with connections
    */
   private static void buildConnections(ProcessSystem processSystem, Map<Integer, String> outletStreamToNozzle,
-      Map<String, String> inletNozzles, List<NozzleConnection> connections) {
+      Map<String, String> inletNozzles, Map<String, ProcessEquipmentInterface> nozzleOwners,
+      List<NozzleConnection> connections) {
     for (ProcessEquipmentInterface unit : processSystem.getUnitOperations()) {
       if (unit instanceof Stream || unit instanceof DexpiStream) {
         continue;
@@ -1501,7 +1639,7 @@ public final class DexpiXmlWriter {
         String fromNozzle = outletStreamToNozzle.get(System.identityHashCode(inletStream));
         String toNozzle = inletNozzles.get(unit.getName());
         if (fromNozzle != null && toNozzle != null) {
-          connections.add(new NozzleConnection(fromNozzle, toNozzle, inletStream));
+          connections.add(new NozzleConnection(fromNozzle, toNozzle, inletStream, nozzleOwners.get(fromNozzle), unit));
         }
       }
     }
@@ -1540,6 +1678,7 @@ public final class DexpiXmlWriter {
       double[] fromPos = nozzlePositions.get(conn.fromNozzle);
       double[] toPos = nozzlePositions.get(conn.toNozzle);
       DexpiServiceClassifier.ServiceType service = DexpiServiceClassifier.classify(conn.stream, 0.0);
+      LineMetadata lineMetadata = resolveLineMetadata(conn, service, streamCounter);
       if (fromPos != null && toPos != null) {
         DexpiLayoutEngine.appendServiceConnectionLine(document, segmentElement, fromPos[0], fromPos[1], toPos[0],
             toPos[1], service);
@@ -1550,16 +1689,15 @@ public final class DexpiXmlWriter {
             fromPos[1], toPos[0], toPos[1]);
         // Add a NORSOK Z-003 line-identification label (size-fluidcode-sequence) below the
         // line.
-        String lineId = new NorsokLineNumber().fluidCode(service.getFluidCode())
-            .sequence(String.format(Locale.ROOT, "%03d", streamCounter)).build();
-        DexpiLayoutEngine.appendLineIdLabel(document, segmentElement, lineId, fromPos[0], fromPos[1], toPos[0],
-            toPos[1]);
+        DexpiLayoutEngine.appendLineIdLabel(document, segmentElement, lineMetadata.lineLabel(), fromPos[0], fromPos[1],
+            toPos[0], toPos[1]);
+        appendLinePropertyChangeArtifacts(document, segmentElement, lineMetadata, usedIds, fromPos, toPos);
         // Record the routed sub-segments for the crossing-hop post-pass.
         collectRouteSegments(fromPos[0], fromPos[1], toPos[0], toPos[1], horizontalSegments, verticalSegments);
       }
 
       // Attach operating line data (service, P, T, flow) as DEXPI generic attributes.
-      appendConnectionLineAttributes(document, segmentElement, conn.stream, service);
+      appendConnectionLineAttributes(document, segmentElement, conn.stream, service, lineMetadata);
       streamCounter++;
 
       // Check if the target nozzle belongs to a pre-built valve PipingComponent
@@ -1709,6 +1847,181 @@ public final class DexpiXmlWriter {
     }
   }
 
+  private static LineMetadata resolveLineMetadata(NozzleConnection connection,
+      DexpiServiceClassifier.ServiceType service, int streamCounter) {
+    LineMetadata metadata = new LineMetadata();
+    DexpiStream dexpiStream = connection.stream instanceof DexpiStream ? (DexpiStream) connection.stream : null;
+    metadata.lineNumber = dexpiStream == null ? null : trimToNull(dexpiStream.getLineNumber());
+    if (metadata.lineNumber == null) {
+      metadata.lineNumber = String.format(Locale.ROOT, "%03d", streamCounter);
+    }
+    metadata.fluidCode = dexpiStream == null ? null : trimToNull(dexpiStream.getFluidCode());
+    if (metadata.fluidCode == null && service != null) {
+      metadata.fluidCode = service.getFluidCode();
+    }
+    metadata.nominalDiameter = dexpiStream == null ? null : trimToNull(dexpiStream.getNominalDiameterRepresentation());
+    metadata.pipingClassCode = dexpiStream == null ? null : trimToNull(dexpiStream.getPipingClassCode());
+    metadata.insulationType = dexpiStream == null ? null : trimToNull(dexpiStream.getInsulationType());
+
+    String sourceNominal = firstNonBlank(
+        dexpiStream == null ? null : dexpiStream.getFlowInNominalDiameterRepresentation(),
+        endpointNominalDiameter(connection.sourceEquipment));
+    String targetNominal = firstNonBlank(
+        dexpiStream == null ? null : dexpiStream.getFlowOutNominalDiameterRepresentation(),
+        endpointNominalDiameter(connection.targetEquipment));
+    String sourceModelSize = endpointModelInsideDiameter(connection.sourceEquipment);
+    String targetModelSize = endpointModelInsideDiameter(connection.targetEquipment);
+    boolean hasNominalBasis = firstNonBlank(metadata.nominalDiameter, sourceNominal, targetNominal) != null;
+    if (hasNominalBasis) {
+      // A nominal diameter and a hydraulic inside diameter are different engineering
+      // properties. Compare only nominal-to-nominal values; the line-level nominal
+      // diameter applies to an endpoint unless that endpoint provides an override.
+      metadata.sourceSize = firstNonBlank(sourceNominal, metadata.nominalDiameter);
+      metadata.targetSize = firstNonBlank(targetNominal, metadata.nominalDiameter);
+    } else {
+      metadata.sourceSize = sourceModelSize;
+      metadata.targetSize = targetModelSize;
+    }
+    metadata.sizeDisplay = firstNonBlank(metadata.nominalDiameter, sourceNominal, targetNominal, sourceModelSize,
+        targetModelSize);
+    if (firstNonBlank(metadata.nominalDiameter, sourceNominal, targetNominal) != null) {
+      metadata.sizeStatus = "SOURCE_NOMINAL_DIAMETER";
+      metadata.metadataSource = dexpiStream != null && metadata.nominalDiameter != null ? "DEXPI_STREAM"
+          : "DEXPI_EQUIPMENT";
+    } else if (firstNonBlank(sourceModelSize, targetModelSize) != null) {
+      metadata.sizeStatus = "MODEL_INSIDE_DIAMETER";
+      metadata.metadataSource = "NEQSIM_PIPE_MODEL";
+    } else {
+      metadata.sizeStatus = "MISSING_SOURCE_DATA";
+      metadata.metadataSource = "MISSING_SOURCE_DATA";
+    }
+    metadata.sizeChange = differentKnown(metadata.sourceSize, metadata.targetSize);
+
+    metadata.sourcePipingClass = firstNonBlank(dexpiStream == null ? null : dexpiStream.getFlowInPipingClassCode(),
+        endpointPipingClass(connection.sourceEquipment), metadata.pipingClassCode);
+    metadata.targetPipingClass = firstNonBlank(dexpiStream == null ? null : dexpiStream.getFlowOutPipingClassCode(),
+        endpointPipingClass(connection.targetEquipment), metadata.pipingClassCode);
+    metadata.pipingClassCode = firstNonBlank(metadata.pipingClassCode, metadata.sourcePipingClass,
+        metadata.targetPipingClass);
+    metadata.pipingClassChange = differentKnown(metadata.sourcePipingClass, metadata.targetPipingClass);
+
+    metadata.sourceInsulation = firstNonBlank(dexpiStream == null ? null : dexpiStream.getFlowInInsulationType(),
+        endpointInsulation(connection.sourceEquipment), metadata.insulationType);
+    metadata.targetInsulation = firstNonBlank(dexpiStream == null ? null : dexpiStream.getFlowOutInsulationType(),
+        endpointInsulation(connection.targetEquipment), metadata.insulationType);
+    metadata.insulationType = firstNonBlank(metadata.insulationType, metadata.sourceInsulation,
+        metadata.targetInsulation);
+    metadata.insulationChange = differentKnown(metadata.sourceInsulation, metadata.targetInsulation);
+    return metadata;
+  }
+
+  private static String endpointNominalDiameter(ProcessEquipmentInterface equipment) {
+    if (!(equipment instanceof DexpiProcessUnit)) {
+      return null;
+    }
+    DexpiProcessUnit unit = (DexpiProcessUnit) equipment;
+    return firstNonBlank(unit.getSizingAttribute(DexpiMetadata.NOMINAL_DIAMETER_REPRESENTATION),
+        unit.getSizingAttribute(DexpiMetadata.LINE_SIZE), unit.getSizingAttribute(DexpiMetadata.NOMINAL_DIAMETER));
+  }
+
+  private static String endpointModelInsideDiameter(ProcessEquipmentInterface equipment) {
+    if (!(equipment instanceof PipeLineInterface)) {
+      return null;
+    }
+    double diameter = ((PipeLineInterface) equipment).getDiameter();
+    if (!(diameter > 0.0) || Double.isNaN(diameter) || Double.isInfinite(diameter)) {
+      return null;
+    }
+    return "ID " + formatMechValue(diameter * 1000.0) + " mm";
+  }
+
+  private static String endpointPipingClass(ProcessEquipmentInterface equipment) {
+    if (!(equipment instanceof DexpiProcessUnit)) {
+      return null;
+    }
+    DexpiProcessUnit unit = (DexpiProcessUnit) equipment;
+    return firstNonBlank(unit.getSizingAttribute(DexpiMetadata.PIPING_CLASS_CODE_ASSIGNMENT),
+        unit.getSizingAttribute(DexpiMetadata.PIPING_CLASS_CODE));
+  }
+
+  private static String endpointInsulation(ProcessEquipmentInterface equipment) {
+    if (!(equipment instanceof DexpiProcessUnit)) {
+      return null;
+    }
+    DexpiProcessUnit unit = (DexpiProcessUnit) equipment;
+    return firstNonBlank(unit.getSizingAttribute(DexpiMetadata.INSULATION_TYPE_ASSIGNMENT),
+        unit.getSizingAttribute(DexpiMetadata.INSULATION_CODE));
+  }
+
+  private static boolean differentKnown(String first, String second) {
+    return !isBlank(first) && !isBlank(second)
+        && !first.trim().replaceAll("\\s+", " ").equalsIgnoreCase(second.trim().replaceAll("\\s+", " "));
+  }
+
+  private static String trimToNull(String value) {
+    return isBlank(value) ? null : value.trim();
+  }
+
+  private static void appendLinePropertyChangeArtifacts(Document document, Element segmentElement,
+      LineMetadata metadata, Set<String> usedIds, double[] fromPosition, double[] toPosition) {
+    if (metadata.sizeChange) {
+      Element reducer = document.createElement("PipingComponent");
+      reducer.setAttribute("ID", uniqueIdentifier("PipeReducer", metadata.lineNumber, usedIds));
+      reducer.setAttribute("ComponentClass", "PipeReducer");
+      reducer.setAttribute("ComponentClassURI", "http://data.posccaesar.org/rdl/RDS416294");
+      Element attributes = document.createElement("GenericAttributes");
+      attributes.setAttribute("Set", "DexpiAttributes");
+      appendGenericAttribute(document, attributes, "FlowInNominalDiameterRepresentationAssignmentClass",
+          metadata.sourceSize);
+      appendGenericAttribute(document, attributes, "FlowOutNominalDiameterRepresentationAssignmentClass",
+          metadata.targetSize);
+      appendGenericAttribute(document, attributes, "NominalDiameterBreakSpecialization", "NominalDiameterBreak");
+      appendGenericAttribute(document, attributes, "EngineeringStatus", "MODELLED_SIZE_CHANGE");
+      reducer.appendChild(attributes);
+      Element flowInNozzle = document.createElement("Nozzle");
+      flowInNozzle.setAttribute("ID", uniqueIdentifier("Nozzle", metadata.lineNumber + "-Reducer-FlowIn", usedIds));
+      flowInNozzle.setAttribute("ComponentClass", "Nozzle");
+      flowInNozzle.setAttribute("FlowDirection", "In");
+      reducer.appendChild(flowInNozzle);
+      Element flowOutNozzle = document.createElement("Nozzle");
+      flowOutNozzle.setAttribute("ID", uniqueIdentifier("Nozzle", metadata.lineNumber + "-Reducer-FlowOut", usedIds));
+      flowOutNozzle.setAttribute("ComponentClass", "Nozzle");
+      flowOutNozzle.setAttribute("FlowDirection", "Out");
+      reducer.appendChild(flowOutNozzle);
+      DexpiLayoutEngine.appendPipeReducerSymbol(document, reducer, fromPosition[0], fromPosition[1], toPosition[0],
+          toPosition[1], metadata.sourceSize, metadata.targetSize);
+      segmentElement.appendChild(reducer);
+    }
+
+    if (metadata.pipingClassChange || metadata.insulationChange) {
+      Element propertyBreak = document.createElement("PropertyBreak");
+      propertyBreak.setAttribute("ID", uniqueIdentifier("PropertyBreak", metadata.lineNumber, usedIds));
+      propertyBreak.setAttribute("ComponentClass", "PropertyBreak");
+      Element attributes = document.createElement("GenericAttributes");
+      attributes.setAttribute("Set", "DexpiAttributes");
+      StringBuilder label = new StringBuilder();
+      if (metadata.pipingClassChange) {
+        appendGenericAttribute(document, attributes, "PipingClassBreakSpecialization", "PipingClassBreak");
+        label.append("CLASS ").append(metadata.sourcePipingClass).append(" → ").append(metadata.targetPipingClass);
+      }
+      if (metadata.insulationChange) {
+        appendGenericAttribute(document, attributes, "InsulationBreakSpecialization", "InsulationBreak");
+        if (label.length() > 0) {
+          label.append("; ");
+        }
+        label.append("INS ").append(metadata.sourceInsulation).append(" → ").append(metadata.targetInsulation);
+      }
+      propertyBreak.appendChild(attributes);
+      double[] end = toPosition;
+      if (metadata.sizeChange) {
+        end = routeMidpoint(fromPosition[0], fromPosition[1], toPosition[0], toPosition[1]);
+      }
+      DexpiLayoutEngine.appendPropertyBreakSymbol(document, propertyBreak, fromPosition[0], fromPosition[1], end[0],
+          end[1], label.toString());
+      segmentElement.appendChild(propertyBreak);
+    }
+  }
+
   /**
    * Appends the operating line data (service category, fluid code, pressure, temperature and flow) for a connection as
    * DEXPI {@code GenericAttribute} elements so the pipe carries real process data rather than only geometry.
@@ -1719,13 +2032,28 @@ public final class DexpiXmlWriter {
    * @param service the classified service category (may be null)
    */
   private static void appendConnectionLineAttributes(Document document, Element segmentElement, StreamInterface stream,
-      DexpiServiceClassifier.ServiceType service) {
+      DexpiServiceClassifier.ServiceType service, LineMetadata lineMetadata) {
     Element genericAttributes = document.createElement("GenericAttributes");
     genericAttributes.setAttribute("Set", "DexpiAttributes");
     if (service != null) {
       appendGenericAttribute(document, genericAttributes, DexpiMetadata.FLUID_CODE, service.getFluidCode());
       appendGenericAttribute(document, genericAttributes, "ServiceCategory", service.name());
     }
+    appendGenericAttribute(document, genericAttributes, DexpiMetadata.LINE_NUMBER, lineMetadata.lineNumber);
+    appendGenericAttribute(document, genericAttributes, DexpiMetadata.SEGMENT_NUMBER, lineMetadata.lineNumber);
+    appendGenericAttribute(document, genericAttributes, DexpiMetadata.NOMINAL_DIAMETER_REPRESENTATION,
+        lineMetadata.nominalDiameter);
+    appendGenericAttribute(document, genericAttributes, DexpiMetadata.LINE_SIZE, lineMetadata.sizeDisplay);
+    appendGenericAttribute(document, genericAttributes, DexpiMetadata.PIPING_CLASS_CODE_ASSIGNMENT,
+        lineMetadata.pipingClassCode);
+    appendGenericAttribute(document, genericAttributes, DexpiMetadata.INSULATION_TYPE_ASSIGNMENT,
+        lineMetadata.insulationType);
+    appendGenericAttribute(document, genericAttributes, "LineSizeStatus", lineMetadata.sizeStatus);
+    appendGenericAttribute(document, genericAttributes, "LineMetadataSource", lineMetadata.metadataSource);
+    appendGenericAttribute(document, genericAttributes, "SizeChangeDetected",
+        lineMetadata.sizeChange ? "TRUE" : "FALSE");
+    appendGenericAttribute(document, genericAttributes, "PipingPropertyChangeDetected",
+        lineMetadata.pipingClassChange || lineMetadata.insulationChange ? "TRUE" : "FALSE");
     if (stream != null) {
       try {
         appendNumericAttribute(document, genericAttributes, DexpiMetadata.OPERATING_PRESSURE_VALUE,
@@ -1771,6 +2099,15 @@ public final class DexpiXmlWriter {
     String fluidCode = streams.stream().map(DexpiStream::getFluidCode).filter(value -> !isBlank(value)).findFirst()
         .orElse(null);
     appendGenericAttribute(document, systemAttributes, DexpiMetadata.FLUID_CODE, fluidCode);
+    String nominalDiameter = streams.stream().map(DexpiStream::getNominalDiameterRepresentation)
+        .filter(value -> !isBlank(value)).findFirst().orElse(null);
+    appendGenericAttribute(document, systemAttributes, DexpiMetadata.NOMINAL_DIAMETER_REPRESENTATION, nominalDiameter);
+    String pipingClass = streams.stream().map(DexpiStream::getPipingClassCode).filter(value -> !isBlank(value))
+        .findFirst().orElse(null);
+    appendGenericAttribute(document, systemAttributes, DexpiMetadata.PIPING_CLASS_CODE_ASSIGNMENT, pipingClass);
+    String insulation = streams.stream().map(DexpiStream::getInsulationType).filter(value -> !isBlank(value))
+        .findFirst().orElse(null);
+    appendGenericAttribute(document, systemAttributes, DexpiMetadata.INSULATION_TYPE_ASSIGNMENT, insulation);
     appendGenericAttribute(document, systemAttributes, "NeqSimGroupingKey", key);
     if (systemAttributes.hasChildNodes()) {
       systemElement.appendChild(systemAttributes);
@@ -1808,11 +2145,14 @@ public final class DexpiXmlWriter {
     appendGenericAttribute(document, genericAttributes, DexpiMetadata.OPERATING_FLOW_UNIT,
         DexpiMetadata.DEFAULT_FLOW_UNIT);
 
-    // Piping class and line size (exported when DexpiStream carries metadata)
-    // These are currently placeholder attributes — populated when the stream source provides
-    // piping class or line size data via generic attributes on the imported segment.
-    appendGenericAttribute(document, genericAttributes, DexpiMetadata.PIPING_CLASS_CODE, null);
-    appendGenericAttribute(document, genericAttributes, DexpiMetadata.LINE_SIZE, null);
+    appendGenericAttribute(document, genericAttributes, DexpiMetadata.NOMINAL_DIAMETER_REPRESENTATION,
+        stream.getNominalDiameterRepresentation());
+    appendGenericAttribute(document, genericAttributes, DexpiMetadata.LINE_SIZE,
+        stream.getNominalDiameterRepresentation());
+    appendGenericAttribute(document, genericAttributes, DexpiMetadata.PIPING_CLASS_CODE_ASSIGNMENT,
+        stream.getPipingClassCode());
+    appendGenericAttribute(document, genericAttributes, DexpiMetadata.INSULATION_TYPE_ASSIGNMENT,
+        stream.getInsulationType());
 
     if (genericAttributes.hasChildNodes()) {
       segmentElement.appendChild(genericAttributes);
@@ -1885,7 +2225,8 @@ public final class DexpiXmlWriter {
       Set<String> usedIds, Map<String, DexpiLayoutEngine.EquipmentPosition> layoutPositions,
       Map<String, double[]> nozzlePositions, Map<String, String> equipmentInletNozzle,
       Map<Integer, String> outletStreamToNozzle, List<NozzleConnection> connections,
-      Set<String> synthesizedInstrumentTags, List<double[]> instrumentPositions, ProcessSystem processSystem) {
+      Set<String> synthesizedInstrumentTags, Map<String, String> levelSensingLocations,
+      List<double[]> instrumentPositions, ProcessSystem processSystem) {
 
     // Resolve semantic sensing locations first, then group instruments that share a physical tap so
     // their bubbles fan out around that process location instead of an equipment data table.
@@ -1897,11 +2238,13 @@ public final class DexpiXmlWriter {
       if (parentName != null) {
         tagToEquipment.put(entry.getKey(), parentName);
       }
-      InstrumentAttachment attachment = resolveInstrumentAttachment(entry.getValue(), parentName, parent, processSystem,
-          equipmentInletNozzle, outletStreamToNozzle, connections, nozzlePositions, layoutPositions);
+      InstrumentAttachment attachment = resolveInstrumentAttachment(entry.getKey(), entry.getValue(), parentName,
+          processSystem, equipmentInletNozzle, outletStreamToNozzle, connections, nozzlePositions, layoutPositions,
+          levelSensingLocations);
       if (attachment != null) {
         tagToAttachment.put(entry.getKey(), attachment);
-        String attachmentKey = attachment.locationId == null ? "unlocated:" + entry.getKey() : attachment.locationId;
+        String attachmentKey = attachment.attachmentType.startsWith("VESSEL_LEVEL_TAP") ? "level:" + parentName
+            : attachment.locationId == null ? "unlocated:" + entry.getKey() : attachment.locationId;
         List<String> list = attachmentTransmitters.get(attachmentKey);
         if (list == null) {
           list = new ArrayList<>();
@@ -1932,11 +2275,12 @@ public final class DexpiXmlWriter {
       double cy = 0;
       boolean hasPosition = false;
       if (attachment != null) {
-        String attachmentKey = attachment.locationId == null ? "unlocated:" + tag : attachment.locationId;
+        String attachmentKey = attachment.attachmentType.startsWith("VESSEL_LEVEL_TAP") ? "level:" + parentName
+            : attachment.locationId == null ? "unlocated:" + tag : attachment.locationId;
         List<String> siblings = attachmentTransmitters.get(attachmentKey);
         int idx = siblings.indexOf(tag);
-        double[] pos = DexpiLayoutEngine.computeInstrumentPositionAtSensingPoint(eqPos, attachment.instrumentAnchorX,
-            attachment.y, idx, siblings.size());
+        double[] pos = DexpiLayoutEngine.computeInstrumentPositionAtSensingPoint(eqPos, attachment.x, attachment.y, idx,
+            siblings.size());
         cx = pos[0];
         cy = pos[1];
         hasPosition = true;
@@ -2049,7 +2393,7 @@ public final class DexpiXmlWriter {
       }
 
       // InformationFlow with CenterLine from process line to instrument bubble
-      if (hasPosition && attachment != null) {
+      if (hasPosition) {
         Element infoFlow = document.createElement("InformationFlow");
         infoFlow.setAttribute("ID", mlfId);
         infoFlow.setAttribute("ComponentClass", "MeasuringLineFunction");
@@ -2343,11 +2687,7 @@ public final class DexpiXmlWriter {
    * </tr>
    * <tr>
    * <td>Separator</td>
-   * <td>PT and TT on gas outlet, LT on the vessel boundary</td>
-   * </tr>
-   * <tr>
-   * <td>Tank</td>
-   * <td>LT on the vessel boundary</td>
+   * <td>PT on gas outlet, LT on vessel/liquid outlet, TT on gas outlet</td>
    * </tr>
    * <tr>
    * <td>Compressor</td>
@@ -2396,7 +2736,7 @@ public final class DexpiXmlWriter {
         transmitters.put(lt, new LevelTransmitter(lt, sep));
       } else if (unit instanceof Tank) {
         String lt = "LT-" + (base + 2);
-        transmitters.put(lt, new LevelTransmitter(lt, unit));
+        transmitters.put(lt, new LevelTransmitter(lt, (Tank) unit));
       } else if (unit instanceof Compressor) {
         StreamInterface out = firstOutlet(unit);
         if (out != null) {
@@ -2463,8 +2803,16 @@ public final class DexpiXmlWriter {
       return null;
     }
     if (device instanceof LevelTransmitter) {
-      ProcessEquipmentInterface vessel = ((LevelTransmitter) device).getVessel();
-      return vessel != null ? vessel.getName() : null;
+      ProcessEquipmentInterface equipment = ((LevelTransmitter) device).getLevelEquipment();
+      return equipment != null ? equipment.getName() : null;
+    }
+    if (device instanceof OilLevelTransmitter) {
+      ThreePhaseSeparator separator = ((OilLevelTransmitter) device).getSeparator();
+      return separator != null ? separator.getName() : null;
+    }
+    if (device instanceof WaterLevelTransmitter) {
+      ThreePhaseSeparator separator = ((WaterLevelTransmitter) device).getSeparator();
+      return separator != null ? separator.getName() : null;
     }
     if (!(device instanceof StreamMeasurementDeviceBaseClass)) {
       return null;
@@ -2504,20 +2852,13 @@ public final class DexpiXmlWriter {
   private static final class InstrumentAttachment {
     private final double x;
     private final double y;
-    private final double instrumentAnchorX;
     private final String locationId;
     private final String sensorType;
     private final String attachmentType;
 
     InstrumentAttachment(double x, double y, String locationId, String sensorType, String attachmentType) {
-      this(x, y, x, locationId, sensorType, attachmentType);
-    }
-
-    InstrumentAttachment(double x, double y, double instrumentAnchorX, String locationId, String sensorType,
-        String attachmentType) {
       this.x = x;
       this.y = y;
-      this.instrumentAnchorX = instrumentAnchorX;
       this.locationId = locationId;
       this.sensorType = sensorType;
       this.attachmentType = attachmentType;
@@ -2529,32 +2870,21 @@ public final class DexpiXmlWriter {
    *
    * <p>
    * Stream instruments attach to the routed process segment when possible, then fall back to the stream nozzle. Level
-   * instruments attach to the actual separator or tank equipment identity and start their measuring line at the
-   * rendered vessel boundary. A process/product nozzle is not relabelled as a level tap, and no unmodelled nozzle
-   * technology is invented.
+   * instruments attach to the separator liquid nozzle and are drawn from the vessel boundary. This prevents generic
+   * measuring lines from terminating at the equipment centre or crossing its data annotation bar.
    * </p>
    */
-  private static InstrumentAttachment resolveInstrumentAttachment(MeasurementDeviceInterface device, String parentName,
-      Element documentRoot, ProcessSystem processSystem, Map<String, String> equipmentInletNozzle,
+  private static InstrumentAttachment resolveInstrumentAttachment(String tag, MeasurementDeviceInterface device,
+      String parentName, ProcessSystem processSystem, Map<String, String> equipmentInletNozzle,
       Map<Integer, String> outletStreamToNozzle, List<NozzleConnection> connections,
-      Map<String, double[]> nozzlePositions, Map<String, DexpiLayoutEngine.EquipmentPosition> layoutPositions) {
+      Map<String, double[]> nozzlePositions, Map<String, DexpiLayoutEngine.EquipmentPosition> layoutPositions,
+      Map<String, String> levelSensingLocations) {
     String sensorType = sensorType(device);
-    if (device instanceof LevelTransmitter) {
-      LevelTransmitter level = (LevelTransmitter) device;
-      ProcessEquipmentInterface vessel = level.getVessel();
-      DexpiLayoutEngine.EquipmentPosition equipment = layoutPositions.get(parentName);
-      String locationId = findEquipmentElementId(documentRoot, parentName);
-      if (vessel != null && equipment != null && locationId != null) {
-        double halfWidth = vessel instanceof Tank ? 12.5 : 10.0;
-        double localY = vessel instanceof Tank ? -2.0 : 0.0;
-        double radians = Math.toRadians(equipment.rotation);
-        double localX = halfWidth * equipment.scaleX;
-        double scaledY = localY * equipment.scaleY;
-        double boundaryX = equipment.x + localX * Math.cos(radians) - scaledY * Math.sin(radians);
-        double boundaryY = equipment.y + localX * Math.sin(radians) + scaledY * Math.cos(radians);
-        double instrumentAnchorX = boundaryX + 40.0 * equipment.scaleX;
-        return new InstrumentAttachment(boundaryX, boundaryY, instrumentAnchorX, locationId, sensorType,
-            "VESSEL_BOUNDARY");
+    if (levelEquipment(device) != null) {
+      String locationId = levelSensingLocations.get(tag);
+      double[] nozzle = nozzlePositions.get(locationId);
+      if (nozzle != null) {
+        return new InstrumentAttachment(nozzle[0], nozzle[1], locationId, sensorType, "VESSEL_LEVEL_TAP");
       }
       return null;
     }
@@ -2590,26 +2920,6 @@ public final class DexpiXmlWriter {
         : new InstrumentAttachment(nozzle[0], nozzle[1], inletNozzle, sensorType, "EQUIPMENT_NOZZLE");
   }
 
-  private static String findEquipmentElementId(Element documentRoot, String equipmentName) {
-    if (documentRoot == null || equipmentName == null) {
-      return null;
-    }
-    NodeList equipment = documentRoot.getElementsByTagName("Equipment");
-    for (int index = 0; index < equipment.getLength(); index++) {
-      Element candidate = (Element) equipment.item(index);
-      NodeList attributes = candidate.getElementsByTagName("GenericAttribute");
-      for (int attributeIndex = 0; attributeIndex < attributes.getLength(); attributeIndex++) {
-        Element attribute = (Element) attributes.item(attributeIndex);
-        if (DexpiMetadata.TAG_NAME.equals(attribute.getAttribute("Name"))
-            && equipmentName.equals(attribute.getAttribute("Value"))) {
-          String identity = candidate.getAttribute("ID").trim();
-          return identity.isEmpty() ? null : identity;
-        }
-      }
-    }
-    return null;
-  }
-
   private static String sensorType(MeasurementDeviceInterface device) {
     if (device instanceof PressureTransmitter) {
       return "PressureTap";
@@ -2621,7 +2931,13 @@ public final class DexpiXmlWriter {
       return "InlineFlowMeasurement";
     }
     if (device instanceof LevelTransmitter) {
-      return "VesselLevelMeasurement";
+      return "VesselLevelTap";
+    }
+    if (device instanceof OilLevelTransmitter) {
+      return "OilLevelTap";
+    }
+    if (device instanceof WaterLevelTransmitter) {
+      return "WaterInterfaceLevelTap";
     }
     return device.getClass().getSimpleName();
   }
@@ -2749,6 +3065,11 @@ public final class DexpiXmlWriter {
   }
 
   private static String findComponentIdByTag(Document document, String tagName) {
+    Element component = findComponentElementByTag(document, tagName);
+    return component == null ? null : component.getAttribute("ID");
+  }
+
+  private static Element findComponentElementByTag(Document document, String tagName) {
     if (tagName == null) {
       return null;
     }
@@ -2764,7 +3085,7 @@ public final class DexpiXmlWriter {
         Element element = (Element) ancestor;
         if (("Equipment".equals(element.getTagName()) || "PipingComponent".equals(element.getTagName()))
             && !element.getAttribute("ID").isEmpty()) {
-          return element.getAttribute("ID");
+          return element;
         }
         ancestor = ancestor.getParentNode();
       }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlWriter.java
@@ -1897,7 +1897,7 @@ public final class DexpiXmlWriter {
       if (parentName != null) {
         tagToEquipment.put(entry.getKey(), parentName);
       }
-      InstrumentAttachment attachment = resolveInstrumentAttachment(entry.getValue(), parentName, processSystem,
+      InstrumentAttachment attachment = resolveInstrumentAttachment(entry.getValue(), parentName, parent, processSystem,
           equipmentInletNozzle, outletStreamToNozzle, connections, nozzlePositions, layoutPositions);
       if (attachment != null) {
         tagToAttachment.put(entry.getKey(), attachment);
@@ -1935,8 +1935,8 @@ public final class DexpiXmlWriter {
         String attachmentKey = attachment.locationId == null ? "unlocated:" + tag : attachment.locationId;
         List<String> siblings = attachmentTransmitters.get(attachmentKey);
         int idx = siblings.indexOf(tag);
-        double[] pos = DexpiLayoutEngine.computeInstrumentPositionAtSensingPoint(eqPos, attachment.x, attachment.y, idx,
-            siblings.size());
+        double[] pos = DexpiLayoutEngine.computeInstrumentPositionAtSensingPoint(eqPos, attachment.instrumentAnchorX,
+            attachment.y, idx, siblings.size());
         cx = pos[0];
         cy = pos[1];
         hasPosition = true;
@@ -2343,7 +2343,11 @@ public final class DexpiXmlWriter {
    * </tr>
    * <tr>
    * <td>Separator</td>
-   * <td>PT on gas outlet, LT on vessel/liquid outlet, TT on gas outlet</td>
+   * <td>PT and TT on gas outlet, LT on the vessel boundary</td>
+   * </tr>
+   * <tr>
+   * <td>Tank</td>
+   * <td>LT on the vessel boundary</td>
    * </tr>
    * <tr>
    * <td>Compressor</td>
@@ -2390,6 +2394,9 @@ public final class DexpiXmlWriter {
         }
         String lt = "LT-" + (base + 2);
         transmitters.put(lt, new LevelTransmitter(lt, sep));
+      } else if (unit instanceof Tank) {
+        String lt = "LT-" + (base + 2);
+        transmitters.put(lt, new LevelTransmitter(lt, unit));
       } else if (unit instanceof Compressor) {
         StreamInterface out = firstOutlet(unit);
         if (out != null) {
@@ -2456,8 +2463,8 @@ public final class DexpiXmlWriter {
       return null;
     }
     if (device instanceof LevelTransmitter) {
-      Separator sep = ((LevelTransmitter) device).getSeparator();
-      return sep != null ? sep.getName() : null;
+      ProcessEquipmentInterface vessel = ((LevelTransmitter) device).getVessel();
+      return vessel != null ? vessel.getName() : null;
     }
     if (!(device instanceof StreamMeasurementDeviceBaseClass)) {
       return null;
@@ -2497,13 +2504,20 @@ public final class DexpiXmlWriter {
   private static final class InstrumentAttachment {
     private final double x;
     private final double y;
+    private final double instrumentAnchorX;
     private final String locationId;
     private final String sensorType;
     private final String attachmentType;
 
     InstrumentAttachment(double x, double y, String locationId, String sensorType, String attachmentType) {
+      this(x, y, x, locationId, sensorType, attachmentType);
+    }
+
+    InstrumentAttachment(double x, double y, double instrumentAnchorX, String locationId, String sensorType,
+        String attachmentType) {
       this.x = x;
       this.y = y;
+      this.instrumentAnchorX = instrumentAnchorX;
       this.locationId = locationId;
       this.sensorType = sensorType;
       this.attachmentType = attachmentType;
@@ -2515,29 +2529,34 @@ public final class DexpiXmlWriter {
    *
    * <p>
    * Stream instruments attach to the routed process segment when possible, then fall back to the stream nozzle. Level
-   * instruments attach to the separator liquid nozzle and are drawn from the vessel boundary. This prevents generic
-   * measuring lines from terminating at the equipment centre or crossing its data annotation bar.
+   * instruments attach to the actual separator or tank equipment identity and start their measuring line at the
+   * rendered vessel boundary. A process/product nozzle is not relabelled as a level tap, and no unmodelled nozzle
+   * technology is invented.
    * </p>
    */
   private static InstrumentAttachment resolveInstrumentAttachment(MeasurementDeviceInterface device, String parentName,
-      ProcessSystem processSystem, Map<String, String> equipmentInletNozzle, Map<Integer, String> outletStreamToNozzle,
-      List<NozzleConnection> connections, Map<String, double[]> nozzlePositions,
-      Map<String, DexpiLayoutEngine.EquipmentPosition> layoutPositions) {
+      Element documentRoot, ProcessSystem processSystem, Map<String, String> equipmentInletNozzle,
+      Map<Integer, String> outletStreamToNozzle, List<NozzleConnection> connections,
+      Map<String, double[]> nozzlePositions, Map<String, DexpiLayoutEngine.EquipmentPosition> layoutPositions) {
     String sensorType = sensorType(device);
     if (device instanceof LevelTransmitter) {
       LevelTransmitter level = (LevelTransmitter) device;
-      Separator separator = level.getSeparator();
-      String locationId = null;
-      if (separator != null && separator.getLiquidOutStream() != null) {
-        locationId = findNozzleForStream(separator.getLiquidOutStream(), outletStreamToNozzle, processSystem);
+      ProcessEquipmentInterface vessel = level.getVessel();
+      DexpiLayoutEngine.EquipmentPosition equipment = layoutPositions.get(parentName);
+      String locationId = findEquipmentElementId(documentRoot, parentName);
+      if (vessel != null && equipment != null && locationId != null) {
+        double halfWidth = vessel instanceof Tank ? 12.5 : 10.0;
+        double localY = vessel instanceof Tank ? -2.0 : 0.0;
+        double radians = Math.toRadians(equipment.rotation);
+        double localX = halfWidth * equipment.scaleX;
+        double scaledY = localY * equipment.scaleY;
+        double boundaryX = equipment.x + localX * Math.cos(radians) - scaledY * Math.sin(radians);
+        double boundaryY = equipment.y + localX * Math.sin(radians) + scaledY * Math.cos(radians);
+        double instrumentAnchorX = boundaryX + 40.0 * equipment.scaleX;
+        return new InstrumentAttachment(boundaryX, boundaryY, instrumentAnchorX, locationId, sensorType,
+            "VESSEL_BOUNDARY");
       }
-      if (locationId == null) {
-        locationId = equipmentInletNozzle.get(parentName);
-      }
-      double[] nozzle = nozzlePositions.get(locationId);
-      if (nozzle != null) {
-        return new InstrumentAttachment(nozzle[0], nozzle[1], locationId, sensorType, "VESSEL_LEVEL_TAP");
-      }
+      return null;
     }
 
     if (device instanceof StreamMeasurementDeviceBaseClass) {
@@ -2571,6 +2590,26 @@ public final class DexpiXmlWriter {
         : new InstrumentAttachment(nozzle[0], nozzle[1], inletNozzle, sensorType, "EQUIPMENT_NOZZLE");
   }
 
+  private static String findEquipmentElementId(Element documentRoot, String equipmentName) {
+    if (documentRoot == null || equipmentName == null) {
+      return null;
+    }
+    NodeList equipment = documentRoot.getElementsByTagName("Equipment");
+    for (int index = 0; index < equipment.getLength(); index++) {
+      Element candidate = (Element) equipment.item(index);
+      NodeList attributes = candidate.getElementsByTagName("GenericAttribute");
+      for (int attributeIndex = 0; attributeIndex < attributes.getLength(); attributeIndex++) {
+        Element attribute = (Element) attributes.item(attributeIndex);
+        if (DexpiMetadata.TAG_NAME.equals(attribute.getAttribute("Name"))
+            && equipmentName.equals(attribute.getAttribute("Value"))) {
+          String identity = candidate.getAttribute("ID").trim();
+          return identity.isEmpty() ? null : identity;
+        }
+      }
+    }
+    return null;
+  }
+
   private static String sensorType(MeasurementDeviceInterface device) {
     if (device instanceof PressureTransmitter) {
       return "PressureTap";
@@ -2582,7 +2621,7 @@ public final class DexpiXmlWriter {
       return "InlineFlowMeasurement";
     }
     if (device instanceof LevelTransmitter) {
-      return "VesselLevelTap";
+      return "VesselLevelMeasurement";
     }
     return device.getClass().getSimpleName();
   }

--- a/src/main/java/neqsim/process/processmodel/dexpi/NorsokLineNumber.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/NorsokLineNumber.java
@@ -49,7 +49,7 @@ final class NorsokLineNumber {
       this.size = null;
     } else {
       String s = sizeValue.trim();
-      this.size = s.endsWith("\"") ? s : s + "\"";
+      this.size = s.matches("[0-9]+(?:\\.[0-9]+)?") ? s + "\"" : s;
     }
     return this;
   }

--- a/src/test/java/neqsim/process/measurementdevice/LevelTransmitterTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/LevelTransmitterTest.java
@@ -1,0 +1,44 @@
+package neqsim.process.measurementdevice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.tank.Tank;
+
+/** Tests vessel-backed level measurement compatibility. */
+class LevelTransmitterTest {
+
+  @Test
+  void readsSeparatorLevelThroughExistingApi() {
+    Separator separator = new Separator("20-VA-001");
+    LevelTransmitter transmitter = new LevelTransmitter("LT-2001", separator);
+
+    assertSame(separator, transmitter.getSeparator());
+    assertSame(separator, transmitter.getVessel());
+    assertEquals(separator.getLiquidLevel(), transmitter.getMeasuredValue(""), 1.0e-12);
+  }
+
+  @Test
+  void readsTankLevelThroughGenericVesselApi() {
+    Tank tank = new Tank("20-TK-001");
+    LevelTransmitter transmitter = new LevelTransmitter("LT-2002", tank);
+
+    assertSame(tank, transmitter.getTank());
+    assertSame(tank, transmitter.getVessel());
+    assertEquals(tank.getLiquidLevel(), transmitter.getMeasuredValue(""), 1.0e-12);
+  }
+
+  @Test
+  void rejectsUnsupportedEquipmentAndUnits() {
+    Tank tank = new Tank("20-TK-002");
+    LevelTransmitter transmitter = new LevelTransmitter(tank);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> new LevelTransmitter("LT-INVALID", (ProcessEquipmentInterface) null));
+    assertThrows(RuntimeException.class, () -> transmitter.getMeasuredValue("%"));
+  }
+}

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiInstrumentTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiInstrumentTest.java
@@ -60,7 +60,7 @@ public class DexpiInstrumentTest extends NeqSimTest {
   }
 
   /**
-   * Tests that the writer produces ActuatingFunction elements when controllers are present.
+   * Tests that the writer produces actuation and signal-flow elements when controllers are present.
    *
    * @throws IOException if file operations fail
    */
@@ -79,8 +79,13 @@ public class DexpiInstrumentTest extends NeqSimTest {
     DexpiXmlWriter.write(process, tempFile, transmitters, controllers);
 
     String xml = new String(Files.readAllBytes(tempFile.toPath()), StandardCharsets.UTF_8);
-    assertTrue(xml.contains("ActuatingFunction"), "XML should contain ActuatingFunction for controllers");
-    assertTrue(xml.contains("SignalConveyingFunction"), "XML should contain SignalConveyingFunction for signal lines");
+    assertTrue(xml.contains("<ActuatingFunction"), "XML should contain ActuatingFunction for controllers");
+    assertTrue(xml.contains("ComponentClass=\"SignalLineFunction\""),
+        "XML should contain SignalLineFunction information flows");
+    assertTrue(xml.contains("Value=\"ElectricalSignalConveying\""),
+        "XML should identify transmitter-to-controller signal flows");
+    assertTrue(xml.contains("Value=\"PneumaticSignalConveying\""),
+        "XML should identify controller-to-valve signal flows");
   }
 
   /**

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
@@ -22,9 +22,12 @@ import neqsim.NeqSimTest;
 import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
 import neqsim.process.equipment.heatexchanger.Heater;
 import neqsim.process.equipment.mixer.Mixer;
+import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.splitter.Splitter;
 import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.tank.Tank;
 import neqsim.process.equipment.util.Recycle;
+import neqsim.process.measurementdevice.LevelTransmitter;
 import neqsim.process.measurementdevice.PressureTransmitter;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.process.processmodel.diagram.EngineeringDiagramReferenceFixtures;
@@ -146,11 +149,65 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
   }
 
   @Test
+  void assessesSeparatorAndTankLevelBoundariesDeterministically() throws Exception {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.85);
+    fluid.addComponent("n-heptane", 0.15);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("52-FEED-001", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    Separator separator = new Separator("52-VA-001", feed);
+    Tank tank = new Tank("52-TK-001", separator.getLiquidOutStream());
+    LevelTransmitter separatorLevel = new LevelTransmitter("LT-5201", separator);
+    LevelTransmitter tankLevel = new LevelTransmitter("LT-5202", tank);
+
+    ProcessSystem process = new ProcessSystem("Vessel level visual benchmark");
+    process.add(feed);
+    process.add(separator);
+    process.add(tank);
+    process.add(separatorLevel);
+    process.add(tankLevel);
+
+    Path first = temporaryDirectory.resolve("vessel-level-first.xml");
+    Path second = temporaryDirectory.resolve("vessel-level-second.xml");
+    DexpiXmlWriter.writeForPyDexpi(process, first.toFile());
+    DexpiXmlWriter.writeForPyDexpi(process, second.toFile());
+
+    DexpiVisualQualityAssessment.Report firstReport = DexpiVisualQualityAssessment.assess(first.toFile());
+    DexpiVisualQualityAssessment.Report secondReport = DexpiVisualQualityAssessment.assess(second.toFile());
+
+    assertFalse(firstReport.hasErrors(), firstReport.toJson());
+    assertEquals(2, firstReport.getMetrics().get("vesselLevelMeasurements"));
+    assertEquals(2, firstReport.getMetrics().get("vesselLevelAttachments"));
+    assertEquals(0, firstReport.getMetrics().get("invalidVesselLevelAttachments"));
+    assertEquals(firstReport.getSvgSha256(), secondReport.getSvgSha256());
+    assertEquals(firstReport.toJson(), secondReport.toJson());
+
+    Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(first.toFile());
+    assertTrue(
+        positionX(identifiedElement(document, "LT-5201"))
+            - positionX(identifiedElement(document, "ID-52-VA-001")) >= 45.0,
+        "Separator level bubble lane must clear product off-page connectors");
+    assertTrue(
+        positionX(identifiedElement(document, "LT-5202"))
+            - positionX(identifiedElement(document, "ID-52-TK-001")) >= 45.0,
+        "Tank level bubble lane must clear vessel annotations and boundary connectors");
+  }
+
+  @Test
   void reportsInstrumentationTopologyAndProposalVisibilityDefects() throws Exception {
     String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         + "<PlantModel><PlantInformation SchemaVersion=\"4.1.1\"/>"
         + "<Drawing Name=\"Instrumentation defects\"><Extent><Min X=\"0\" Y=\"0\"/>"
         + "<Max X=\"100\" Y=\"70\"/></Extent></Drawing>"
+        + "<Equipment ID=\"E-1\" ComponentClass=\"Separator\"><Nozzle ID=\"N-1\"/></Equipment>"
+        + "<ProcessInstrumentationFunction ID=\"LT-1\" ComponentClass=\"ProcessInstrumentationFunction\" "
+        + "ComponentName=\"INSTRUMENTATION_BUBBLE_SHAPE_FIELD\"><GenericAttributes>"
+        + "<GenericAttribute Name=\"ProcessInstrumentationFunctionCategoryAssignmentClass\" Value=\"L\"/>"
+        + "<GenericAttribute Name=\"MeasurementAttachmentStatus\" Value=\"ATTACHED_TO_PROCESS_NOZZLE\"/>"
+        + "</GenericAttributes><ProcessSignalGeneratingFunction ID=\"PSGF-LT-1\">"
+        + "<Association Type=\"is located in\" ItemID=\"N-1\"/>"
+        + "</ProcessSignalGeneratingFunction></ProcessInstrumentationFunction>"
         + "<ProcessInstrumentationFunction ID=\"PT-1\" ComponentClass=\"ProcessInstrumentationFunction\" "
         + "ComponentName=\"INSTRUMENTATION_BUBBLE_SHAPE_FIELD\"><GenericAttributes>"
         + "<GenericAttribute Name=\"Origin\" Value=\"SYNTHESIZED_PROPOSAL\"/>"
@@ -169,6 +226,9 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
 
     assertTrue(report.hasErrors());
     assertTrue(hasFinding(report, "INSTRUMENT_SENSING_LOCATION_INVALID"), report.toJson());
+    assertTrue(hasFinding(report, "LEVEL_MEASUREMENT_VESSEL_ATTACHMENT_INVALID"), report.toJson());
+    assertEquals(1, report.getMetrics().get("vesselLevelMeasurements"));
+    assertEquals(1, report.getMetrics().get("invalidVesselLevelAttachments"));
     assertTrue(hasFinding(report, "SYNTHESIZED_PROPOSAL_NOT_VISIBLE"), report.toJson());
     assertTrue(hasFinding(report, "CONTROLLER_LOCATION_SYMBOL_MISMATCH"), report.toJson());
     assertTrue(hasFinding(report, "CONTROL_LOOP_FINAL_ELEMENT_MISSING"), report.toJson());
@@ -342,5 +402,18 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
       }
     }
     throw new AssertionError("Missing element " + identity);
+  }
+
+  private static double positionX(Element element) {
+    NodeList positions = element.getElementsByTagName("Position");
+    if (positions.getLength() == 0) {
+      throw new AssertionError("Missing position for " + element.getAttribute("ID"));
+    }
+    Element position = (Element) positions.item(0);
+    NodeList locations = position.getElementsByTagName("Location");
+    if (locations.getLength() == 0) {
+      throw new AssertionError("Missing location for " + element.getAttribute("ID"));
+    }
+    return Double.parseDouble(((Element) locations.item(0)).getAttribute("X"));
   }
 }

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
@@ -22,12 +22,11 @@ import neqsim.NeqSimTest;
 import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
 import neqsim.process.equipment.heatexchanger.Heater;
 import neqsim.process.equipment.mixer.Mixer;
+import neqsim.process.equipment.pipeline.AdiabaticPipe;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.splitter.Splitter;
 import neqsim.process.equipment.stream.Stream;
-import neqsim.process.equipment.tank.Tank;
 import neqsim.process.equipment.util.Recycle;
-import neqsim.process.measurementdevice.LevelTransmitter;
 import neqsim.process.measurementdevice.PressureTransmitter;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.process.processmodel.diagram.EngineeringDiagramReferenceFixtures;
@@ -59,6 +58,54 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
       assertTrue(report.getMetrics().get("svgTexts") > 0, report.toJson());
       assertTrue(report.getSvgSha256().matches("[0-9a-f]{64}"));
     }
+  }
+
+  @Test
+  void capturesVesselLevelTapsAndVisibleLineSizeDataGaps() throws Exception {
+    ProcessSystem process = EngineeringDiagramReferenceFixtures.branchedSeparatorCompressionTrain().getProcessSystem();
+    process.run();
+    Path dexpi = temporaryDirectory.resolve("level-and-line-gaps.xml");
+    DexpiXmlWriter.writeForPyDexpi(process, dexpi.toFile());
+
+    DexpiVisualQualityAssessment.Report report = DexpiVisualQualityAssessment.assess(dexpi.toFile());
+
+    assertFalse(report.hasErrors(), report.toJson());
+    assertTrue(report.getMetrics().get("levelMeasurements") > 0, report.toJson());
+    assertEquals(report.getMetrics().get("levelMeasurements"), report.getMetrics().get("vesselLevelAttachments"),
+        report.toJson());
+    assertTrue(report.getMetrics().get("linesMissingSizeSourceData") > 0, report.toJson());
+    assertTrue(hasFinding(report, "LINE_SIZE_SOURCE_DATA_MISSING"), report.toJson());
+    assertFalse(hasFinding(report, "LINE_SIZE_GAP_NOT_VISIBLE"), report.toJson());
+  }
+
+  @Test
+  void capturesModeledDiameterChangeAndReducer() throws Exception {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 1.0);
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    AdiabaticPipe upstream = new AdiabaticPipe("upstream", feed);
+    upstream.setDiameter(0.2032);
+    upstream.setLength(100.0);
+    AdiabaticPipe downstream = new AdiabaticPipe("downstream", upstream.getOutletStream());
+    downstream.setDiameter(0.1016);
+    downstream.setLength(100.0);
+    Separator separator = new Separator("separator", downstream.getOutletStream());
+    ProcessSystem process = new ProcessSystem("Reducer benchmark");
+    process.add(feed);
+    process.add(upstream);
+    process.add(downstream);
+    process.add(separator);
+
+    Path dexpi = temporaryDirectory.resolve("reducer.xml");
+    DexpiXmlWriter.write(process, dexpi.toFile());
+    DexpiVisualQualityAssessment.Report report = DexpiVisualQualityAssessment.assess(dexpi.toFile());
+
+    assertFalse(report.hasErrors(), report.toJson());
+    assertEquals(1, report.getMetrics().get("detectedLineSizeChanges"), report.toJson());
+    assertEquals(1, report.getMetrics().get("pipeReducers"), report.toJson());
+    assertFalse(hasFinding(report, "PIPE_REDUCER_MISSING"), report.toJson());
+    assertFalse(hasFinding(report, "PIPE_REDUCER_CONNECTION_POINTS_MISSING"), report.toJson());
   }
 
   @Test
@@ -149,65 +196,11 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
   }
 
   @Test
-  void assessesSeparatorAndTankLevelBoundariesDeterministically() throws Exception {
-    SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
-    fluid.addComponent("methane", 0.85);
-    fluid.addComponent("n-heptane", 0.15);
-    fluid.setMixingRule("classic");
-    Stream feed = new Stream("52-FEED-001", fluid);
-    feed.setFlowRate(1000.0, "kg/hr");
-    Separator separator = new Separator("52-VA-001", feed);
-    Tank tank = new Tank("52-TK-001", separator.getLiquidOutStream());
-    LevelTransmitter separatorLevel = new LevelTransmitter("LT-5201", separator);
-    LevelTransmitter tankLevel = new LevelTransmitter("LT-5202", tank);
-
-    ProcessSystem process = new ProcessSystem("Vessel level visual benchmark");
-    process.add(feed);
-    process.add(separator);
-    process.add(tank);
-    process.add(separatorLevel);
-    process.add(tankLevel);
-
-    Path first = temporaryDirectory.resolve("vessel-level-first.xml");
-    Path second = temporaryDirectory.resolve("vessel-level-second.xml");
-    DexpiXmlWriter.writeForPyDexpi(process, first.toFile());
-    DexpiXmlWriter.writeForPyDexpi(process, second.toFile());
-
-    DexpiVisualQualityAssessment.Report firstReport = DexpiVisualQualityAssessment.assess(first.toFile());
-    DexpiVisualQualityAssessment.Report secondReport = DexpiVisualQualityAssessment.assess(second.toFile());
-
-    assertFalse(firstReport.hasErrors(), firstReport.toJson());
-    assertEquals(2, firstReport.getMetrics().get("vesselLevelMeasurements"));
-    assertEquals(2, firstReport.getMetrics().get("vesselLevelAttachments"));
-    assertEquals(0, firstReport.getMetrics().get("invalidVesselLevelAttachments"));
-    assertEquals(firstReport.getSvgSha256(), secondReport.getSvgSha256());
-    assertEquals(firstReport.toJson(), secondReport.toJson());
-
-    Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(first.toFile());
-    assertTrue(
-        positionX(identifiedElement(document, "LT-5201"))
-            - positionX(identifiedElement(document, "ID-52-VA-001")) >= 45.0,
-        "Separator level bubble lane must clear product off-page connectors");
-    assertTrue(
-        positionX(identifiedElement(document, "LT-5202"))
-            - positionX(identifiedElement(document, "ID-52-TK-001")) >= 45.0,
-        "Tank level bubble lane must clear vessel annotations and boundary connectors");
-  }
-
-  @Test
   void reportsInstrumentationTopologyAndProposalVisibilityDefects() throws Exception {
     String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         + "<PlantModel><PlantInformation SchemaVersion=\"4.1.1\"/>"
         + "<Drawing Name=\"Instrumentation defects\"><Extent><Min X=\"0\" Y=\"0\"/>"
         + "<Max X=\"100\" Y=\"70\"/></Extent></Drawing>"
-        + "<Equipment ID=\"E-1\" ComponentClass=\"Separator\"><Nozzle ID=\"N-1\"/></Equipment>"
-        + "<ProcessInstrumentationFunction ID=\"LT-1\" ComponentClass=\"ProcessInstrumentationFunction\" "
-        + "ComponentName=\"INSTRUMENTATION_BUBBLE_SHAPE_FIELD\"><GenericAttributes>"
-        + "<GenericAttribute Name=\"ProcessInstrumentationFunctionCategoryAssignmentClass\" Value=\"L\"/>"
-        + "<GenericAttribute Name=\"MeasurementAttachmentStatus\" Value=\"ATTACHED_TO_PROCESS_NOZZLE\"/>"
-        + "</GenericAttributes><ProcessSignalGeneratingFunction ID=\"PSGF-LT-1\">"
-        + "<Association Type=\"is located in\" ItemID=\"N-1\"/>"
-        + "</ProcessSignalGeneratingFunction></ProcessInstrumentationFunction>"
         + "<ProcessInstrumentationFunction ID=\"PT-1\" ComponentClass=\"ProcessInstrumentationFunction\" "
         + "ComponentName=\"INSTRUMENTATION_BUBBLE_SHAPE_FIELD\"><GenericAttributes>"
         + "<GenericAttribute Name=\"Origin\" Value=\"SYNTHESIZED_PROPOSAL\"/>"
@@ -226,9 +219,6 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
 
     assertTrue(report.hasErrors());
     assertTrue(hasFinding(report, "INSTRUMENT_SENSING_LOCATION_INVALID"), report.toJson());
-    assertTrue(hasFinding(report, "LEVEL_MEASUREMENT_VESSEL_ATTACHMENT_INVALID"), report.toJson());
-    assertEquals(1, report.getMetrics().get("vesselLevelMeasurements"));
-    assertEquals(1, report.getMetrics().get("invalidVesselLevelAttachments"));
     assertTrue(hasFinding(report, "SYNTHESIZED_PROPOSAL_NOT_VISIBLE"), report.toJson());
     assertTrue(hasFinding(report, "CONTROLLER_LOCATION_SYMBOL_MISMATCH"), report.toJson());
     assertTrue(hasFinding(report, "CONTROL_LOOP_FINAL_ELEMENT_MISSING"), report.toJson());
@@ -402,23 +392,5 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
       }
     }
     throw new AssertionError("Missing element " + identity);
-  }
-
-  private static double positionX(Element element) {
-    NodeList positions = element.getElementsByTagName("Position");
-    if (positions.getLength() == 0) {
-      throw new AssertionError("Missing position for " + element.getAttribute("ID"));
-    }
-    Element position = (Element) positions.item(0);
-    NodeList locations = position.getElementsByTagName("Location");
-    if (locations.getLength() == 0) {
-      throw new AssertionError("Missing location for " + element.getAttribute("ID"));
-    }
-    String rawX = ((Element) locations.item(0)).getAttribute("X");
-    try {
-      return Double.parseDouble(rawX);
-    } catch (NumberFormatException exception) {
-      throw new AssertionError("Invalid X position for " + element.getAttribute("ID") + ": " + rawX, exception);
-    }
   }
 }

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiVisualQualityAssessmentTest.java
@@ -414,6 +414,11 @@ class DexpiVisualQualityAssessmentTest extends NeqSimTest {
     if (locations.getLength() == 0) {
       throw new AssertionError("Missing location for " + element.getAttribute("ID"));
     }
-    return Double.parseDouble(((Element) locations.item(0)).getAttribute("X"));
+    String rawX = ((Element) locations.item(0)).getAttribute("X");
+    try {
+      return Double.parseDouble(rawX);
+    } catch (NumberFormatException exception) {
+      throw new AssertionError("Invalid X position for " + element.getAttribute("ID") + ": " + rawX, exception);
+    }
   }
 }

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
@@ -21,6 +21,7 @@ import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.tank.Tank;
 import neqsim.process.equipment.valve.HIPPSValve;
 import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.measurementdevice.LevelTransmitter;
 import neqsim.process.measurementdevice.PressureTransmitter;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.system.SystemInterface;
@@ -193,6 +194,10 @@ public class DexpiXmlWriterTest extends NeqSimTest {
 
     assertTrue(xml.contains("ComponentClass=\"Tank\""), "Should map Tank to Tank");
     assertTrue(xml.contains("STORAGE_TANK_SHAPE"), "Tank symbol should be present in the ShapeCatalogue");
+    assertTrue(xml.contains("StartAngle=\"54.51065674988614\""));
+    assertTrue(xml.contains("EndAngle=\"125.48934325011386\""));
+    assertTrue(xml.contains("Radius=\"21.53125\""));
+    assertFalse(xml.contains("Radius=\"36.55\""), "Tank roof must remain connected to both side walls");
   }
 
   /**
@@ -839,6 +844,65 @@ public class DexpiXmlWriterTest extends NeqSimTest {
     assertEquals(1, countOccurrences(xml, "Name=\"FunctionalRole\" Value=\"FinalElement\""));
     assertEquals(4, countOccurrences(xml, "Name=\"SafetyIntegrityLevel\" Value=\"3\""),
         "SIL 3 should be available on the final element and each of the three trip sensors");
+  }
+
+  /**
+   * Tests that explicit separator and tank level measurements attach to vessel identities, not process nozzles.
+   *
+   * @throws IOException if writing fails
+   */
+  @Test
+  public void testVesselLevelMeasurementsAttachToEquipmentBoundaries() throws IOException {
+    Stream feed = createFeedStream();
+    Separator separator = new Separator("50-VA-001", feed);
+    Tank tank = new Tank("50-TK-001", separator.getLiquidOutStream());
+    LevelTransmitter separatorLevel = new LevelTransmitter("LT-5101", separator);
+    LevelTransmitter tankLevel = new LevelTransmitter("LT-5102", tank);
+
+    ProcessSystem process = new ProcessSystem("Explicit vessel-level measurements");
+    process.add(feed);
+    process.add(separator);
+    process.add(tank);
+    process.add(separatorLevel);
+    process.add(tankLevel);
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DexpiXmlWriter.writeForPyDexpi(process, out);
+    String xml = out.toString(StandardCharsets.UTF_8.name());
+
+    assertEquals(2,
+        countOccurrences(xml, "Name=\"MeasurementAttachmentStatus\" Value=\"ATTACHED_TO_VESSEL_BOUNDARY\""));
+    assertTrue(xml.contains("Name=\"MeasurementAttachmentTargetID\" Value=\"ID-50-VA-001\""));
+    assertTrue(xml.contains("Name=\"MeasurementAttachmentTargetID\" Value=\"ID-50-TK-001\""));
+    assertEquals(2, countOccurrences(xml, "Value=\"VesselLevelMeasurement\""));
+    assertFalse(xml.contains("Value=\"VESSEL_LEVEL_TAP\""),
+        "Liquid product nozzles must not be reclassified as level taps");
+  }
+
+  /**
+   * Tests that automatic tank level instrumentation remains an identifiable measurement-only proposal.
+   *
+   * @throws IOException if writing fails
+   */
+  @Test
+  public void testAutoSynthesizedTankLevelProposal() throws IOException {
+    Stream feed = createFeedStream();
+    Tank tank = new Tank("51-TK-001", feed);
+    ProcessSystem process = new ProcessSystem("Tank level proposal");
+    process.add(feed);
+    process.add(tank);
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DexpiXmlWriter.writeForPyDexpi(process, out);
+    String xml = out.toString(StandardCharsets.UTF_8.name());
+
+    assertTrue(xml.contains("LT-2002"));
+    assertTrue(xml.contains("Name=\"InstrumentationSource\" Value=\"SYNTHESIZED_PROPOSAL\""));
+    assertTrue(xml.contains("Name=\"Scope\" Value=\"MEASUREMENT_ONLY\""));
+    assertTrue(xml.contains("String=\"[PROP]\""));
+    assertTrue(xml.contains("Name=\"MeasurementAttachmentTargetID\" Value=\"ID-51-TK-001\""));
+    assertTrue(xml.contains("Name=\"MeasurementAttachmentStatus\" Value=\"ATTACHED_TO_VESSEL_BOUNDARY\""));
+    assertFalse(xml.contains("ComponentClass=\"ProcessControlFunction\""));
   }
 
   /**

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlWriterTest.java
@@ -3,11 +3,13 @@ package neqsim.process.processmodel.dexpi;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import neqsim.NeqSimTest;
 import neqsim.process.controllerdevice.ControllerDeviceBaseClass;
@@ -15,6 +17,7 @@ import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.filter.Filter;
 import neqsim.process.equipment.heatexchanger.Cooler;
 import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.pipeline.AdiabaticPipe;
 import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.separator.ThreePhaseSeparator;
 import neqsim.process.equipment.stream.Stream;
@@ -22,7 +25,9 @@ import neqsim.process.equipment.tank.Tank;
 import neqsim.process.equipment.valve.HIPPSValve;
 import neqsim.process.equipment.valve.ThrottlingValve;
 import neqsim.process.measurementdevice.LevelTransmitter;
+import neqsim.process.measurementdevice.OilLevelTransmitter;
 import neqsim.process.measurementdevice.PressureTransmitter;
+import neqsim.process.measurementdevice.WaterLevelTransmitter;
 import neqsim.process.processmodel.ProcessSystem;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
@@ -593,6 +598,158 @@ public class DexpiXmlWriterTest extends NeqSimTest {
         "A measurement-only proposal must not synthesize controller functions");
     assertFalse(xml.contains("Value=\"PneumaticSignalConveying\""),
         "A measurement-only proposal must not draw a command signal to empty process space");
+    assertTrue(xml.contains("Name=\"PhysicalConnectionRole\" Value=\"LEVEL_SENSING_TAP\""),
+        "Separator level must terminate at a dedicated vessel tap");
+    assertTrue(xml.contains("Name=\"NeqSimAttachmentType\" Value=\"VESSEL_LEVEL_TAP\""));
+  }
+
+  @Test
+  public void testLevelTransmittersUseDedicatedSeparatorAndTankTaps() throws IOException {
+    Stream feed = createFeedStream();
+    ThreePhaseSeparator separator = new ThreePhaseSeparator("20-VA-001", feed);
+    Tank tank = new Tank("20-TK-001", separator.getOilOutStream());
+    OilLevelTransmitter oilLevel = new OilLevelTransmitter("LT-2101", separator);
+    WaterLevelTransmitter waterLevel = new WaterLevelTransmitter("LT-2102", separator);
+    LevelTransmitter tankLevel = new LevelTransmitter("LT-2201", tank);
+
+    assertSame(tank, tankLevel.getLevelEquipment());
+    assertEquals(tank.getLiquidLevel(), tankLevel.getMeasuredValue(""), 1.0e-12);
+
+    ProcessSystem process = new ProcessSystem("Vessel level sensing");
+    process.add(feed);
+    process.add(separator);
+    process.add(tank);
+    process.add(oilLevel);
+    process.add(waterLevel);
+    process.add(tankLevel);
+
+    Map<String, DexpiLayoutEngine.EquipmentPosition> positions = DexpiLayoutEngine.computeLayout(process);
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DexpiXmlWriter.writeForPyDexpi(process, out);
+    String xml = out.toString(StandardCharsets.UTF_8.name());
+
+    assertEquals(3, countOccurrences(xml, "Name=\"PhysicalConnectionRole\" Value=\"LEVEL_SENSING_TAP\""));
+    assertEquals(3, countOccurrences(xml, "Name=\"NeqSimAttachmentType\" Value=\"VESSEL_LEVEL_TAP\""));
+    assertTrue(xml.contains("Name=\"SensorTypeAssignmentClass\" Value=\"OilLevelTap\""));
+    assertTrue(xml.contains("Name=\"SensorTypeAssignmentClass\" Value=\"WaterInterfaceLevelTap\""));
+    assertTrue(xml.contains("Name=\"SensorTypeAssignmentClass\" Value=\"VesselLevelTap\""));
+    assertTrue(xml.contains("ID-20-VA-001-LT-2101-LevelTap"));
+    assertTrue(xml.contains("ID-20-TK-001-LT-2201-LevelTap"));
+    assertTrue(positions.get(separator.getName()).x < positions.get(tank.getName()).x,
+        "A tank connected to a separator liquid outlet must remain downstream in the drawing");
+    assertFalse(xml.contains("String=\"FEED 20-TK-001\""),
+        "A connected tank inlet must not be rendered as an off-page feed");
+  }
+
+  @Test
+  public void testLineMetadataAndModeledSizeChangeProduceReducer() throws IOException {
+    Stream feed = createFeedStream();
+    AdiabaticPipe upstream = new AdiabaticPipe("20-PL-001", feed);
+    upstream.setLength(100.0);
+    upstream.setDiameter(0.2032);
+    AdiabaticPipe downstream = new AdiabaticPipe("20-PL-002", upstream.getOutletStream());
+    downstream.setLength(100.0);
+    downstream.setDiameter(0.1016);
+    Separator separator = new Separator("20-VA-002", downstream.getOutletStream());
+
+    ProcessSystem process = new ProcessSystem("Line size change");
+    process.add(feed);
+    process.add(upstream);
+    process.add(downstream);
+    process.add(separator);
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DexpiXmlWriter.write(process, out);
+    String xml = out.toString(StandardCharsets.UTF_8.name());
+
+    assertTrue(xml.contains("ComponentClass=\"PipeReducer\""));
+    assertTrue(xml.contains("Name=\"FlowInNominalDiameterRepresentationAssignmentClass\" Value=\"ID 203.2 mm\""));
+    assertTrue(xml.contains("Name=\"FlowOutNominalDiameterRepresentationAssignmentClass\" Value=\"ID 101.6 mm\""));
+    assertTrue(xml.contains("FlowDirection=\"In\""));
+    assertTrue(xml.contains("FlowDirection=\"Out\""));
+    assertTrue(xml.contains("Name=\"LineSizeStatus\" Value=\"MODEL_INSIDE_DIAMETER\""));
+    assertTrue(xml.contains("String=\"ID 203.2 mm → ID 101.6 mm\""));
+  }
+
+  @Test
+  public void testDexpiStreamPreservesLineDesignationMetadata() throws IOException {
+    DexpiStream line = new DexpiStream("segment-1", createFeedStream().getFluid(), "PipingNetworkSegment", "1001",
+        "PG");
+    line.setNominalDiameterRepresentation("DN 150");
+    line.setPipingClassCode("A1B");
+    line.setInsulationType("H25");
+
+    ProcessSystem process = new ProcessSystem("Source line metadata");
+    process.add(line);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DexpiXmlWriter.write(process, out);
+    String xml = out.toString(StandardCharsets.UTF_8.name());
+
+    assertTrue(xml.contains("Name=\"NominalDiameterRepresentationAssignmentClass\" Value=\"DN 150\""));
+    assertTrue(xml.contains("Name=\"PipingClassCodeAssignmentClass\" Value=\"A1B\""));
+    assertTrue(xml.contains("Name=\"InsulationTypeAssignmentClass\" Value=\"H25\""));
+  }
+
+  @Test
+  public void testNominalLineSizeIsNotComparedWithHydraulicInsideDiameter() throws IOException {
+    Stream feed = createFeedStream();
+    AdiabaticPipe pipe = new AdiabaticPipe("upstream-pipe", feed);
+    pipe.setDiameter(0.2032);
+    DexpiStream line = new DexpiStream("line-to-separator", pipe.getOutletStream(), "PipingNetworkSegment", "1002",
+        "PG");
+    line.setNominalDiameterRepresentation("DN 150");
+    Separator separator = new Separator("separator", line);
+
+    ProcessSystem process = new ProcessSystem("Mixed nominal and hydraulic size provenance");
+    process.add(feed);
+    process.add(pipe);
+    process.add(line);
+    process.add(separator);
+    process.run();
+    Map<String, DexpiLayoutEngine.EquipmentPosition> positions = DexpiLayoutEngine.computeLayout(process);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DexpiXmlWriter.write(process, out);
+    String xml = out.toString(StandardCharsets.UTF_8.name());
+
+    assertTrue(xml.contains("Name=\"NominalDiameterRepresentationAssignmentClass\" Value=\"DN 150\""));
+    assertTrue(xml.contains("Name=\"LineMetadataSource\" Value=\"DEXPI_STREAM\""));
+    assertTrue(positions.get(pipe.getName()).x < positions.get(separator.getName()).x,
+        "A metadata wrapper must preserve upstream-to-downstream layout order");
+    assertFalse(xml.contains("ComponentClass=\"PipeReducer\""),
+        "Nominal diameter and hydraulic inside diameter must not be treated as comparable values");
+  }
+
+  @Test
+  public void testExplicitEndpointPropertiesProduceReducerAndPropertyBreak() throws IOException {
+    Stream feed = createFeedStream();
+    AdiabaticPipe pipe = new AdiabaticPipe("upstream-pipe", feed);
+    pipe.setDiameter(0.1524);
+    DexpiStream line = new DexpiStream("property-transition", pipe.getOutletStream(), "PipingNetworkSegment", "1003",
+        "PL");
+    line.setFlowInNominalDiameterRepresentation("DN 150");
+    line.setFlowOutNominalDiameterRepresentation("DN 100");
+    line.setFlowInPipingClassCode("A1B");
+    line.setFlowOutPipingClassCode("B2C");
+    line.setFlowInInsulationType("H25");
+    line.setFlowOutInsulationType("C50");
+    Separator separator = new Separator("separator", line);
+    ProcessSystem process = new ProcessSystem("Explicit piping property transition");
+    process.add(feed);
+    process.add(pipe);
+    process.add(line);
+    process.add(separator);
+    process.run();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DexpiXmlWriter.write(process, out);
+    String xml = out.toString(StandardCharsets.UTF_8.name());
+
+    assertTrue(xml.contains("ComponentClass=\"PipeReducer\""));
+    assertTrue(xml.contains("ComponentClass=\"PropertyBreak\""));
+    assertTrue(xml.contains("Name=\"PipingClassBreakSpecialization\" Value=\"PipingClassBreak\""));
+    assertTrue(xml.contains("Name=\"InsulationBreakSpecialization\" Value=\"InsulationBreak\""));
+    assertTrue(xml.contains("String=\"CLASS A1B → B2C; INS H25 → C50\""));
   }
 
   /**
@@ -844,65 +1001,6 @@ public class DexpiXmlWriterTest extends NeqSimTest {
     assertEquals(1, countOccurrences(xml, "Name=\"FunctionalRole\" Value=\"FinalElement\""));
     assertEquals(4, countOccurrences(xml, "Name=\"SafetyIntegrityLevel\" Value=\"3\""),
         "SIL 3 should be available on the final element and each of the three trip sensors");
-  }
-
-  /**
-   * Tests that explicit separator and tank level measurements attach to vessel identities, not process nozzles.
-   *
-   * @throws IOException if writing fails
-   */
-  @Test
-  public void testVesselLevelMeasurementsAttachToEquipmentBoundaries() throws IOException {
-    Stream feed = createFeedStream();
-    Separator separator = new Separator("50-VA-001", feed);
-    Tank tank = new Tank("50-TK-001", separator.getLiquidOutStream());
-    LevelTransmitter separatorLevel = new LevelTransmitter("LT-5101", separator);
-    LevelTransmitter tankLevel = new LevelTransmitter("LT-5102", tank);
-
-    ProcessSystem process = new ProcessSystem("Explicit vessel-level measurements");
-    process.add(feed);
-    process.add(separator);
-    process.add(tank);
-    process.add(separatorLevel);
-    process.add(tankLevel);
-
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    DexpiXmlWriter.writeForPyDexpi(process, out);
-    String xml = out.toString(StandardCharsets.UTF_8.name());
-
-    assertEquals(2,
-        countOccurrences(xml, "Name=\"MeasurementAttachmentStatus\" Value=\"ATTACHED_TO_VESSEL_BOUNDARY\""));
-    assertTrue(xml.contains("Name=\"MeasurementAttachmentTargetID\" Value=\"ID-50-VA-001\""));
-    assertTrue(xml.contains("Name=\"MeasurementAttachmentTargetID\" Value=\"ID-50-TK-001\""));
-    assertEquals(2, countOccurrences(xml, "Value=\"VesselLevelMeasurement\""));
-    assertFalse(xml.contains("Value=\"VESSEL_LEVEL_TAP\""),
-        "Liquid product nozzles must not be reclassified as level taps");
-  }
-
-  /**
-   * Tests that automatic tank level instrumentation remains an identifiable measurement-only proposal.
-   *
-   * @throws IOException if writing fails
-   */
-  @Test
-  public void testAutoSynthesizedTankLevelProposal() throws IOException {
-    Stream feed = createFeedStream();
-    Tank tank = new Tank("51-TK-001", feed);
-    ProcessSystem process = new ProcessSystem("Tank level proposal");
-    process.add(feed);
-    process.add(tank);
-
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    DexpiXmlWriter.writeForPyDexpi(process, out);
-    String xml = out.toString(StandardCharsets.UTF_8.name());
-
-    assertTrue(xml.contains("LT-2002"));
-    assertTrue(xml.contains("Name=\"InstrumentationSource\" Value=\"SYNTHESIZED_PROPOSAL\""));
-    assertTrue(xml.contains("Name=\"Scope\" Value=\"MEASUREMENT_ONLY\""));
-    assertTrue(xml.contains("String=\"[PROP]\""));
-    assertTrue(xml.contains("Name=\"MeasurementAttachmentTargetID\" Value=\"ID-51-TK-001\""));
-    assertTrue(xml.contains("Name=\"MeasurementAttachmentStatus\" Value=\"ATTACHED_TO_VESSEL_BOUNDARY\""));
-    assertFalse(xml.contains("ComponentClass=\"ProcessControlFunction\""));
   }
 
   /**

--- a/src/test/java/neqsim/process/processmodel/dexpi/GenerateStandardsPidArtifactTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/GenerateStandardsPidArtifactTest.java
@@ -1,0 +1,77 @@
+package neqsim.process.processmodel.dexpi;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import neqsim.process.equipment.pipeline.AdiabaticPipe;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.tank.Tank;
+import neqsim.process.measurementdevice.LevelTransmitter;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+class GenerateStandardsPidArtifactTest {
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void generateReviewedArtifact() throws Exception {
+    String configuredOutput = System.getProperty("pid.output");
+    Path output = configuredOutput == null ? temporaryDirectory : Paths.get(configuredOutput);
+    Files.createDirectories(output);
+    SystemSrkEos fluid = new SystemSrkEos(303.15, 55.0);
+    fluid.addComponent("methane", 0.78);
+    fluid.addComponent("ethane", 0.12);
+    fluid.addComponent("n-heptane", 0.10);
+    fluid.setMixingRule("classic");
+    Stream feed = new Stream("20-FEED-001", fluid);
+    feed.setFlowRate(12000.0, "kg/hr");
+    AdiabaticPipe upstream = new AdiabaticPipe("20-PL-001A", feed);
+    upstream.setDiameter(0.2032);
+    upstream.setLength(20.0);
+    AdiabaticPipe downstream = new AdiabaticPipe("20-PL-001B", upstream.getOutletStream());
+    downstream.setDiameter(0.1016);
+    downstream.setLength(15.0);
+    DexpiStream separatorLine = new DexpiStream("20-PG-1002", downstream.getOutletStream(), "PipingNetworkSegment",
+        "1002", "PG");
+    separatorLine.setNominalDiameterRepresentation("DN 100");
+    separatorLine.setPipingClassCode("A1B");
+    separatorLine.setInsulationType("H25");
+    Separator separator = new Separator("20-VA-001", separatorLine);
+    Tank tank = new Tank("20-TK-001", separator.getLiquidOutStream());
+    LevelTransmitter separatorLevel = new LevelTransmitter("LT-2101", separator);
+    LevelTransmitter tankLevel = new LevelTransmitter("LT-2201", tank);
+    ProcessSystem process = new ProcessSystem("Vessel taps and line-data reference");
+    process.add(feed);
+    process.add(upstream);
+    process.add(downstream);
+    process.add(separatorLine);
+    process.add(separator);
+    process.add(tank);
+    process.add(separatorLevel);
+    process.add(tankLevel);
+    process.run();
+
+    Path dexpi = output.resolve("neqsim-vessel-taps-line-data.dexpi.xml");
+    Path svg = output.resolve("neqsim-vessel-taps-line-data.pid.svg");
+    Path assessment = output.resolve("neqsim-vessel-taps-line-data.assessment.json");
+    DexpiXmlWriter.writeForPyDexpi(process, dexpi.toFile());
+    DexpiXmlSvgRenderer.render(dexpi.toFile(), svg.toFile());
+    DexpiVisualQualityAssessment.Report report = DexpiVisualQualityAssessment.assess(dexpi.toFile());
+    Files.write(assessment, report.toJson().getBytes(StandardCharsets.UTF_8));
+    assertFalse(report.hasErrors(), report.toJson());
+    assertEquals(3, report.getMetrics().get("routedProcessLines"), report.toJson());
+    assertEquals(1, report.getMetrics().get("linesWithSourceNominalDiameter"), report.toJson());
+    assertEquals(1, report.getMetrics().get("linesWithModelInsideDiameter"), report.toJson());
+    assertEquals(1, report.getMetrics().get("linesMissingSizeSourceData"), report.toJson());
+    assertEquals(1, report.getMetrics().get("pipeReducers"), report.toJson());
+    assertEquals(2, report.getMetrics().get("levelMeasurements"), report.toJson());
+    assertEquals(2, report.getMetrics().get("vesselLevelAttachments"), report.toJson());
+  }
+}


### PR DESCRIPTION
## Status

**DRAFT — VALIDATION PENDING CI**

Exact base/master: `7a7c5a4990b57597355d1182784e12d547b9fb3b`  
Exact head: `67a1c6102d8e85ff18df756ae02a67df4a939466`  
Roadmaps: #1332 and #2899  
Expanded capability contracts: [#1332 comment 5468853804](https://github.com/equinor/neqsim/issues/1332#issuecomment-5468853804), [#2899 comment 5468853731](https://github.com/equinor/neqsim/issues/2899#issuecomment-5468853731)

## Engineering question

Can the Proteus-compatible P&ID projection preserve truthful vessel-level sensing and source-backed piping designations, show explicit reducer/property transitions, and expose missing engineering data without inventing nominal size, controller intent, or process topology?

## Change

- Supports `LevelTransmitter` on separators and tanks while retaining the existing separator API and authoritative unitless liquid-level state.
- Creates a dedicated sensing nozzle/tap on the owning tank or separator for each level measurement; oil-level and water-interface functions use distinct taps and never reuse process inlets or phase outlets.
- Exposes tank inlet/outlet topology through the standard equipment API so separator-to-tank piping remains connected and ordered.
- Preserves DEXPI line number, fluid/service code, nominal-diameter representation, piping class, insulation, and explicit flow-in/flow-out properties on `DexpiStream`.
- Labels hydraulic bore honestly as `ID … mm`; missing size remains visible as `SIZE?` with a structured warning. DN/NPS/schedule is never inferred from inside diameter.
- Compares only nominal-to-nominal or model-ID-to-model-ID endpoint values.
- Emits a machine-readable and visible `PipeReducer` with distinct flow-in/out sizes and connection points for explicit comparable size changes.
- Emits a `PropertyBreak` with changed-property metadata and label for explicit piping-class or insulation transitions.
- Keeps metadata-wrapped streams connected through `ProcessSystem.run()` and includes them in source-to-destination layout topology.
- Separates stream numbers, line designations, and fitting labels to avoid midpoint collisions.
- Retains the reviewed storage-tank roof repair from the earlier PR head.
- Adds deterministic assessment metrics/findings and a runnable separator/tank/line-data SVG benchmark.
- Aligns instrumentation regression assertions and documentation with the emitted `InformationFlow` / `SignalLineFunction` contract and actual `ActuatingFunction` output.

## Standards basis and claim boundary

The projection is informed by [ISO 10628-1](https://www.iso.org/standard/51840.html), [ISO 10628-2](https://www.iso.org/standard/51841.html), [IEC 62424](https://webstore.iec.ch/en/publication/25442), the [ISA-5 series](https://www.isa.org/standards-and-publications/isa-standards/isa-5-standard), and the [DEXPI 1.4 piping model](https://dexpi.org/static/pid_specification_1.4/).

This remains a **Proteus-compatible DEXPI Plant/P&ID, SchemaVersion 4.1.1**, design-support proposal. It does not claim ISO conformance, DEXPI certification, approved-for-construction status, transmitter technology selection, designed nozzle size/class, schedule derivation, alarm/trip setpoints, controller/final-element intent, or accountable engineering approval.

## Whole-sheet evidence

The fixed example was simulated, exported only through `DexpiXmlWriter.writeForPyDexpi`, rendered from the actual graphical primitives, converted to PNG, and inspected at full-sheet and readable-detail scale.

- sheet: 449 × 297 mm;
- SVG SHA-256: `3673831d5f5c8a92f9b95a8fe8e1b8c2c8b71052bf59969d0f2d08d577fd1e21`;
- 3 routed lines and 3 rendered flow arrows;
- 1 source-nominal line, 1 model-ID line, 1 visible `SIZE?` line;
- 1 detected size change and 1 reducer;
- 2 level measurements and 2 dedicated vessel-tap attachments;
- 0 invalid vessel attachments, duplicate IDs, out-of-bounds coordinates, unreadable text, or assessment errors;
- 1 expected warning for missing nominal-size source data on the separator-to-tank line.

The rerender shows upstream-to-downstream equipment order, connected separator-to-tank piping, LTs terminating at vessel taps, a connected tank roof, readable DN/class/insulation and ID transition labels, and no observed collisions among fittings, line IDs, bubbles, data bars, arrows, continuation symbols, tables, legend, or title block.

## Local validation

Passed from a clean `target` before the final signal-flow alignment on exact source `0b7d25c881ec2b0a2abc8db1b118d6649a0d5fb1`:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py` — 672 Markdown pages and 1 standalone HTML page
- `git diff --check`
- clean focused/broader Maven suite — **65 tests, 0 failures/errors/skips**:
  - `LevelTransmitterTest`
  - `EngineeringDiagramReferenceCasesTest`
  - `EngineeringDiagramDeliveryTest`
  - `GenerateStandardsPidArtifactTest`
  - `DexpiXmlWriterTest`
  - both `DexpiXmlReaderTest` suites
  - `DexpiXmlSvgRendererTest`
  - `DexpiVisualQualityAssessmentTest`

On repaired exact head `67a1c6102d8e85ff18df756ae02a67df4a939466`, the focused `DexpiInstrumentTest,DexpiXmlWriterTest` selection passed with the main POM and `pomJava8.xml`; Spotless apply/check, documentation search, pre-commit, pre-push and `git diff --check` also passed. The repair changes regression expectations plus JavaDoc/user documentation, not emitted production topology.

Hosted exact-head build, test, Javadoc, formatting, CodeQL, documentation, notebook and diagram workflows remain authoritative and are pending. No running or unrun check is claimed as passed.

## Compatibility and stop boundary

No thermodynamic equation, phase-equilibrium solver, mass/energy balance, controller, final element, Classic/DOT exporter, native SVG/PDF PFD, or DEXPI 2.0 Process semantics are changed. The main public API additions are tank-backed level measurement, live-stream DEXPI metadata wrapping, explicit endpoint line properties, and standard tank topology exposure.

Further work requiring licensed clause-level mappings, project line-number/specification rules, detailed reducer segment splitting for a specific CAE consumer, dual-tap/DP technology, alarm/trip/control design, vents/drains/relief completeness, or accountable drawing approval is outside this PR.