### PR TITLE
[AI-Assisted] feat(dexpi): report structured import losses

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -93,6 +93,35 @@ if (feedPump.getMappedEquipment() == EquipmentEnum.Pump) {
 }
 ```
 
+### Structured supported-subset diagnostics
+
+Use `readWithDiagnostics(...)` when an import must retain machine-readable evidence for source
+objects that the reader cannot reconstruct. The returned process is built by the same Java parser
+as `read(...)`; the additional report lists skipped objects in deterministic source-document order.
+
+```java
+DexpiXmlReader.ImportResult result =
+    DexpiXmlReader.readWithDiagnostics(xmlFile.toFile(), template);
+ProcessSystem process = result.getProcessSystem();
+
+for (DexpiXmlReader.ImportDiagnostic diagnostic : result.getDiagnostics()) {
+  System.out.printf("%s %s %s%n",
+      diagnostic.getSeverity(), diagnostic.getCode(), diagnostic.getElementId());
+}
+
+String evidenceJson = result.toJson();
+```
+
+The JSON uses the stable report schema `neqsim_dexpi_proteus_import.v1` and records the exact
+source ID, component class, XML element name, severity, and diagnostic code for every unsupported
+or unclassified equipment or piping-component object. Warnings describe honest supported-subset
+loss; malformed XML and parser failures still raise `DexpiXmlReaderException`. Existing `read(...)`
+and `load(...)` calls keep their previous behavior and logging.
+
+This evidence applies to NeqSim's Proteus-compatible DEXPI Plant/P&ID 4.1.1 supported subset. It is
+not proof of full semantic or graphical round-trip equivalence, native DEXPI 2.0 support, DEXPI
+certification, standards conformance, or engineering approval.
+
 Each imported equipment item is represented as a lightweight `DexpiProcessUnit` that records the
 original DEXPI class, mapped `EquipmentEnum` category, and contextual information (line numbers,
 fluid codes). Piping segments become `DexpiStream` objects that clone pressure, temperature, and

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1,13 +1,16 @@
 package neqsim.process.processmodel.dexpi;
 
+import com.google.gson.GsonBuilder;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -49,6 +52,136 @@ public final class DexpiXmlReader {
 
   private static final Map<String, EquipmentEnum> EQUIPMENT_CLASS_MAP;
   private static final Map<String, EquipmentEnum> PIPING_COMPONENT_MAP;
+
+  /** Severity of one structured import diagnostic. */
+  public enum ImportDiagnosticSeverity {
+    /** Informational evidence that does not describe a loss. */
+    INFO,
+    /** A source object was unsupported or deliberately skipped. */
+    WARNING,
+    /** A condition prevented a reliable supported-subset import. */
+    ERROR
+  }
+
+  /** Immutable evidence for one unsupported or deliberately skipped source object. */
+  public static final class ImportDiagnostic implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final ImportDiagnosticSeverity severity;
+    private final String code;
+    private final String elementId;
+    private final String componentClass;
+    private final String elementName;
+    private final String message;
+
+    private ImportDiagnostic(ImportDiagnosticSeverity severity, String code, String elementId, String componentClass,
+        String elementName, String message) {
+      this.severity = severity;
+      this.code = code;
+      this.elementId = elementId == null ? "" : elementId;
+      this.componentClass = componentClass == null ? "" : componentClass;
+      this.elementName = elementName == null ? "" : elementName;
+      this.message = message;
+    }
+
+    /** @return diagnostic severity */
+    public ImportDiagnosticSeverity getSeverity() {
+      return severity;
+    }
+
+    /** @return stable machine-readable diagnostic code */
+    public String getCode() {
+      return code;
+    }
+
+    /** @return source XML element ID, or an empty string when absent */
+    public String getElementId() {
+      return elementId;
+    }
+
+    /** @return source component class, or an empty string when absent */
+    public String getComponentClass() {
+      return componentClass;
+    }
+
+    /** @return source XML element name */
+    public String getElementName() {
+      return elementName;
+    }
+
+    /** @return human-readable explanation */
+    public String getMessage() {
+      return message;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("severity", severity.name());
+      result.put("code", code);
+      result.put("elementId", elementId);
+      result.put("componentClass", componentClass);
+      result.put("elementName", elementName);
+      result.put("message", message);
+      return result;
+    }
+  }
+
+  /** Reconstructed process plus deterministic supported-subset import evidence. */
+  public static final class ImportResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final ProcessSystem processSystem;
+    private final List<ImportDiagnostic> diagnostics;
+
+    private ImportResult(ProcessSystem processSystem, List<ImportDiagnostic> diagnostics) {
+      this.processSystem = processSystem;
+      this.diagnostics = Collections.unmodifiableList(new ArrayList<ImportDiagnostic>(diagnostics));
+    }
+
+    /** @return reconstructed process system using the same behavior as {@link #read(File)} */
+    public ProcessSystem getProcessSystem() {
+      return processSystem;
+    }
+
+    /** @return immutable diagnostics in deterministic source-document order */
+    public List<ImportDiagnostic> getDiagnostics() {
+      return diagnostics;
+    }
+
+    /** @return whether unsupported or deliberately skipped source content was observed */
+    public boolean hasLosses() {
+      return !diagnostics.isEmpty();
+    }
+
+    /** @return whether any import diagnostic has error severity */
+    public boolean hasErrors() {
+      for (ImportDiagnostic diagnostic : diagnostics) {
+        if (diagnostic.getSeverity() == ImportDiagnosticSeverity.ERROR) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    /** @return deterministic automation-friendly representation excluding live simulation state */
+    public Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("schemaVersion", "neqsim_dexpi_proteus_import.v1");
+      result.put("profile", "Proteus-compatible DEXPI Plant/P&ID 4.1.1 supported subset");
+      result.put("importedUnitCount", Integer.valueOf(processSystem.getAllUnitNames().size()));
+      result.put("hasLosses", Boolean.valueOf(hasLosses()));
+      result.put("hasErrors", Boolean.valueOf(hasErrors()));
+      List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
+      for (ImportDiagnostic diagnostic : diagnostics) {
+        diagnosticMaps.add(diagnostic.toMap());
+      }
+      result.put("diagnostics", diagnosticMaps);
+      return result;
+    }
+
+    /** @return deterministic pretty-printed JSON evidence */
+    public String toJson() {
+      return new GsonBuilder().setPrettyPrinting().create().toJson(toMap());
+    }
+  }
 
   static {
     // Load from properties files; fall back to built-in defaults if load fails
@@ -170,6 +303,66 @@ public final class DexpiXmlReader {
   }
 
   /**
+   * Reads a DEXPI XML file and returns the reconstructed process together with structured evidence for unsupported or
+   * skipped source objects.
+   *
+   * @param file DEXPI XML file
+   * @return reconstructed process and deterministic import diagnostics
+   * @throws IOException if the file cannot be read
+   * @throws DexpiXmlReaderException if the file cannot be parsed
+   */
+  public static ImportResult readWithDiagnostics(File file) throws IOException, DexpiXmlReaderException {
+    return readWithDiagnostics(file, null);
+  }
+
+  /**
+   * Reads a DEXPI XML file with a template stream and returns structured supported-subset evidence.
+   *
+   * @param file DEXPI XML file
+   * @param templateStream optional template for generated piping segments
+   * @return reconstructed process and deterministic import diagnostics
+   * @throws IOException if the file cannot be read
+   * @throws DexpiXmlReaderException if the file cannot be parsed
+   */
+  public static ImportResult readWithDiagnostics(File file, Stream templateStream)
+      throws IOException, DexpiXmlReaderException {
+    Objects.requireNonNull(file, "file");
+    logger.info("Reading DEXPI XML file with diagnostics: {}", file.getAbsolutePath());
+    try (InputStream inputStream = new FileInputStream(file)) {
+      return readWithDiagnostics(inputStream, templateStream);
+    }
+  }
+
+  /**
+   * Reads a DEXPI XML stream and returns structured supported-subset import evidence.
+   *
+   * @param inputStream stream containing DEXPI XML data
+   * @return reconstructed process and deterministic import diagnostics
+   * @throws IOException if the stream cannot be read
+   * @throws DexpiXmlReaderException if the stream cannot be parsed
+   */
+  public static ImportResult readWithDiagnostics(InputStream inputStream) throws IOException, DexpiXmlReaderException {
+    return readWithDiagnostics(inputStream, null);
+  }
+
+  /**
+   * Reads a DEXPI XML stream with a template stream and returns structured supported-subset evidence.
+   *
+   * @param inputStream stream containing DEXPI XML data
+   * @param templateStream optional template for generated piping segments
+   * @return reconstructed process and deterministic import diagnostics
+   * @throws IOException if the stream cannot be read
+   * @throws DexpiXmlReaderException if the stream cannot be parsed
+   */
+  public static ImportResult readWithDiagnostics(InputStream inputStream, Stream templateStream)
+      throws IOException, DexpiXmlReaderException {
+    ProcessSystem processSystem = new ProcessSystem("DEXPI process");
+    List<ImportDiagnostic> diagnostics = new ArrayList<ImportDiagnostic>();
+    loadInternal(inputStream, processSystem, templateStream, false, diagnostics);
+    return new ImportResult(processSystem, diagnostics);
+  }
+
+  /**
    * Populates an existing {@link ProcessSystem} with units parsed from a DEXPI XML file.
    *
    * @param file XML file to parse
@@ -241,6 +434,11 @@ public final class DexpiXmlReader {
    */
   public static void load(InputStream inputStream, ProcessSystem processSystem, Stream templateStream,
       boolean namespaceAware) throws IOException, DexpiXmlReaderException {
+    loadInternal(inputStream, processSystem, templateStream, namespaceAware, null);
+  }
+
+  private static void loadInternal(InputStream inputStream, ProcessSystem processSystem, Stream templateStream,
+      boolean namespaceAware, List<ImportDiagnostic> diagnostics) throws IOException, DexpiXmlReaderException {
     Objects.requireNonNull(inputStream, "inputStream");
     Objects.requireNonNull(processSystem, "processSystem");
 
@@ -251,8 +449,9 @@ public final class DexpiXmlReader {
 
     Stream streamTemplate = templateOrDefault(templateStream);
 
-    addUnits(document, processSystem, "Equipment", EQUIPMENT_CLASS_MAP, DexpiMetadata.TAG_NAME);
-    addUnits(document, processSystem, "PipingComponent", PIPING_COMPONENT_MAP, "PipingComponentNumberAssignmentClass");
+    addUnits(document, processSystem, "Equipment", EQUIPMENT_CLASS_MAP, DexpiMetadata.TAG_NAME, diagnostics);
+    addUnits(document, processSystem, "PipingComponent", PIPING_COMPONENT_MAP, "PipingComponentNumberAssignmentClass",
+        diagnostics);
     addPipingSegments(document, processSystem, streamTemplate);
   }
 
@@ -436,7 +635,7 @@ public final class DexpiXmlReader {
   }
 
   private static void addUnits(Document document, ProcessSystem processSystem, String tagName,
-      Map<String, EquipmentEnum> equipmentMap, String nameAttribute) {
+      Map<String, EquipmentEnum> equipmentMap, String nameAttribute, List<ImportDiagnostic> diagnostics) {
     NodeList parentNodes = document.getElementsByTagName(tagName);
     logger.info("Found {} {} parent elements", parentNodes.getLength(), tagName);
 
@@ -460,6 +659,14 @@ public final class DexpiXmlReader {
         EquipmentEnum equipmentEnum = equipmentMap.get(componentClass);
         if (equipmentEnum == null) {
           logger.warn("Unsupported component class: {}", componentClass);
+          if (diagnostics != null) {
+            boolean missingClass = isBlank(componentClass);
+            diagnostics.add(new ImportDiagnostic(ImportDiagnosticSeverity.WARNING,
+                missingClass ? "DEXPI_IMPORT_COMPONENT_CLASS_MISSING" : "DEXPI_IMPORT_COMPONENT_UNSUPPORTED",
+                element.getAttribute("ID"), componentClass, element.getTagName(),
+                missingClass ? "Source object was skipped because ComponentClass is missing"
+                    : "Source object was skipped because its ComponentClass is not supported by this reader"));
+          }
           continue;
         }
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -5,11 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import neqsim.NeqSimTest;
 import neqsim.process.equipment.EquipmentEnum;
@@ -123,5 +125,38 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     DexpiRoundTripProfile.ValidationResult result = DexpiRoundTripProfile.minimalRunnableProfile().validate(process);
     assertFalse(result.isSuccessful());
     assertTrue(result.getViolations().size() >= 2, "Expected at least 2 violations (no stream, no equipment)");
+  }
+
+  @Test
+  public void testReadWithDiagnosticsReportsUnsupportedObjectsDeterministically() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel><Equipment>"
+        + "<PlateHeatExchanger ComponentClass=\"PlateHeatExchanger\" ID=\"E-1\">"
+        + "<GenericAttributes><GenericAttribute Name=\"TagNameAssignmentClass\" Value=\"E-1\"/>"
+        + "</GenericAttributes></PlateHeatExchanger>"
+        + "<ProjectSpecificObject ComponentClass=\"OwnerCustomPackage\" ID=\"X-1\"/>"
+        + "<UnclassifiedObject ID=\"X-2\"/>" + "</Equipment></PlantModel>";
+
+    DexpiXmlReader.ImportResult first = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    DexpiXmlReader.ImportResult second = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+    assertEquals(1, first.getProcessSystem().getAllUnitNames().size());
+    assertNotNull(first.getProcessSystem().getUnit("E-1"));
+    assertTrue(first.hasLosses());
+    assertFalse(first.hasErrors());
+    assertEquals(2, first.getDiagnostics().size());
+    assertEquals("DEXPI_IMPORT_COMPONENT_UNSUPPORTED", first.getDiagnostics().get(0).getCode());
+    assertEquals("X-1", first.getDiagnostics().get(0).getElementId());
+    assertEquals("OwnerCustomPackage", first.getDiagnostics().get(0).getComponentClass());
+    assertEquals("ProjectSpecificObject", first.getDiagnostics().get(0).getElementName());
+    assertEquals(DexpiXmlReader.ImportDiagnosticSeverity.WARNING, first.getDiagnostics().get(0).getSeverity());
+    assertEquals("DEXPI_IMPORT_COMPONENT_CLASS_MISSING", first.getDiagnostics().get(1).getCode());
+    assertEquals("X-2", first.getDiagnostics().get(1).getElementId());
+    assertEquals(first.toJson(), second.toJson());
+    assertTrue(first.toJson().contains("neqsim_dexpi_proteus_import.v1"));
+
+    ProcessSystem legacy = DexpiXmlReader.read(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    assertEquals(first.getProcessSystem().getAllUnitNames(), legacy.getAllUnitNames());
   }
 }


### PR DESCRIPTION
## Summary

Adds an additive, structured loss-evidence path to the Proteus-compatible DEXPI Plant/P&ID 4.1.1 reader.

- introduces `DexpiXmlReader.readWithDiagnostics(...)` without changing existing `read(...)` or `load(...)` behavior
- returns the reconstructed `ProcessSystem` plus immutable diagnostics in deterministic source order
- records stable severity/code/source ID/component class/XML element/message fields
- serializes automation-friendly evidence using schema `neqsim_dexpi_proteus_import.v1`
- reports unsupported and missing-class equipment or piping-component objects instead of leaving loss evidence only in logs
- documents the supported-subset and standards/approval boundaries

Capability contracts: [#1332](https://github.com/equinor/neqsim/issues/1332#issuecomment-5469744041), [#2899](https://github.com/equinor/neqsim/issues/2899#issuecomment-5469743936).

## Compatibility and scope

Existing public import entry points and their logging remain unchanged. The new API parses once and does not alter the writer, DEXPI XML, SVG/PNG rendering, layout, simulation calculations, Classic outputs, or legacy DOT/Graphviz behavior.

This is supported-subset loss evidence, not full semantic/graphical round-trip equivalence, native DEXPI 2.0, DEXPI certification, ISO conformance, or engineering approval. The stop boundary excludes ProcessModel reconstruction, semantic diffing, graphical equivalence, external CAE interoperability, and external datasets.

## Validation

Base: `2b330659716d157727fd88ebc5d7c8019d88aa86`
Head: `331e996377cc135f1f86b351c5f4a64acb70d438`

Local:
- `DexpiXmlReaderTest`: 6 passed
- directly affected `DexpiXmlWriterTest`: 31 passed
- Spotless apply/check: passed
- documentation search audit: passed (674 Markdown pages, 1 standalone HTML page)
- `git diff --check`: passed
- pre-commit and pre-push: not run because the `pre-commit` executable is unavailable

Rendering impact: none. This change is confined to read-side diagnostics, tests, and documentation; it does not modify generated XML or graphical primitives.

**VALIDATION PENDING CI**

## Follow-on gaps

- expand the inventory beyond equipment and piping components at the next dependency-ready boundary
- define semantic comparison and independent round-trip evidence separately
- retain licensed-standards mapping and accountable engineering review as external qualification dependencies

Generated with AI assistance.