### PR TITLE
[AI-Assisted] feat(mcp): expose electrolyte scale equilibrium view

### DIFF
--- a/docs/chemistry/index.md
+++ b/docs/chemistry/index.md
@@ -78,8 +78,11 @@ Every analysis is exposed over the NeqSim MCP server:
 ```
 
 Send this to the `runChemistry` tool. Supported `analysis` values:
-`electrolyteScale`, `mechanisticCorrosion`, `langmuirInhibitor`,
-`packedBedScavenger`, and `pitzerQualification`. The last is a setup/publication
+`electrolyteScale`, `multiMineralScale`, `electrolyteScaleEquilibrium`,
+`mechanisticCorrosion`, `langmuirInhibitor`, `packedBedScavenger`, and
+`pitzerQualification`. `electrolyteScaleEquilibrium` is the authoritative
+single-pure-mineral operation for Pitzer GE and electrolyte CPA; the screening
+analyses retain their separate Davies/BDOT semantics. The last is a setup/publication
 gate over the authoritative Java Pitzer dataset coverage, observable
 qualification, and declared state envelope; it does not perform a flash or
 adopt parameters.

--- a/docs/chemistry/mcp.md
+++ b/docs/chemistry/mcp.md
@@ -1,6 +1,6 @@
 ---
 title: "MCP Chemistry Tool Reference"
-description: "JSON schema reference for the runChemistry MCP tool exposed by the NeqSim MCP server. Covers Pitzer qualification, electrolyte scale prediction, mechanistic CO2 corrosion, Langmuir inhibitor dosing, and packed-bed H2S scavenger breakthrough."
+description: "JSON schema reference for the runChemistry MCP tool exposed by the NeqSim MCP server. Covers Pitzer qualification, activity-consistent electrolyte scale equilibrium, screening-scale prediction, corrosion, inhibitor dosing, and H2S scavenger breakthrough."
 ---
 
 # `runChemistry` MCP Tool Reference
@@ -87,6 +87,58 @@ The declared evidence envelopes and source/license matrix are recorded in
 [Pitzer parameter provenance](../thermo/pitzer_parameter_provenance.md). In
 particular, the PHREEQC `H2Sg`/`(H2Sg)2` source topology is not aliased to
 NeqSim `H2S`; it remains visibly incomplete.
+
+
+### `electrolyteScaleEquilibrium`
+
+Thin JSON/MCP adapter over the authoritative Java
+`ThermodynamicOperations.precipitateScale(String)` operation. It uses the
+selected Pitzer GE or electrolyte-CPA aqueous activity model, retains their
+distinct parameter semantics, and returns the pure-solid material ledger rather
+than inserting a NeqSim solid phase.
+
+| Field | Unit | Required / values |
+|-------|------|-------------------|
+| `temperature_K` | K | required, finite and positive |
+| `pressure_bara` | bara | required, finite and positive |
+| `components` | mol | required electroneutral object; positive water, finite non-negative amounts |
+| `model` | – | `pitzer` (default) or `electrolyte-cpa` |
+| `dataset` | – | for Pitzer: `phreeqc-ca-mg-cl-so4` (default) or `phreeqc-catalog`; not applicable to electrolyte CPA |
+| `mineral` | – | required pure COMPSALT name, for example `CaSO4_A` |
+
+The response reports precipitated mol and g, initial/final saturation ratio,
+pure-phase complementarity violation, maximum ion-ledger residual, aqueous
+charge/normalization evidence, dataset identity and qualification boundary.
+A successful response requires complementarity at most `1e-6`, ion-ledger
+residual at most `1e-10 mol`, charge residual at most
+`1e-10 mol/kg water`, and a finite, non-negative normalized aqueous phase.
+Inputs that mix a Pitzer dataset selector into electrolyte CPA fail closed.
+
+```json
+{
+  "analysis": "electrolyteScaleEquilibrium",
+  "model": "pitzer",
+  "dataset": "phreeqc-ca-mg-cl-so4",
+  "temperature_K": 298.15,
+  "pressure_bara": 1.01325,
+  "mineral": "CaSO4_A",
+  "components": {
+    "water": 55.508,
+    "Na+": 1.0,
+    "Ca++": 0.2,
+    "Mg++": 0.0,
+    "Cl-": 1.0,
+    "SO4--": 0.2
+  }
+}
+```
+
+The adapter is **design-support**, not a new parameter qualification. It sets
+`publicationReady: false` until an exact mixed-brine mineral evidence envelope
+is registered for the requested state. Pitzer coefficients are never reused as
+reaction constants, mineral log K values, SIT/eNRTL terms, or electrolyte-EOS
+parameters. Multi-mineral competition, solid solutions, kinetics, deposition
+and inhibitor physics remain outside this operation.
 
 ### `electrolyteScale`
 

--- a/neqsim-mcp-server/README.md
+++ b/neqsim-mcp-server/README.md
@@ -218,7 +218,7 @@ code-level `enforceAccess()` — returns structured error JSON, not a silent ski
 | `runPVT`                      | PVT lab experiments (CME, CVD, DL, separator, swelling, GOR)                                                                                         |
 | `runPipeline`                 | Multiphase pipeline flow (Beggs & Brill)                                                                                                             |
 | `runFlowAssurance`            | Hydrate, wax, asphaltene, corrosion, erosion, cooldown, emulsion                                                                                     |
-| `runChemistry`                | Open chemistry and integrity calculations for Pitzer qualification, scale, corrosion, inhibitors, and scavengers                                    |
+| `runChemistry`                | Pitzer qualification, activity-consistent electrolyte scale equilibrium, screening scale, corrosion, inhibitors, and scavengers                  |
 | `runWaterHammer`              | Water/liquid-hammer screening for valve closure, pump trip, and check-valve scenarios                                                                |
 | `runRootCauseAnalysis`        | Ranked equipment root-cause hypotheses from reliability, historian, STID, and simulation evidence                                                    |
 | `runMaterialsReview`          | Process-wide material selection, degradation, CUI, and remaining-life review from process/STID data                                                  |

--- a/src/main/java/neqsim/mcp/runners/ChemistryRunner.java
+++ b/src/main/java/neqsim/mcp/runners/ChemistryRunner.java
@@ -18,13 +18,19 @@ import neqsim.process.chemistry.scale.ElectrolyteScaleCalculator;
 import neqsim.process.chemistry.scavenger.PackedBedScavengerReactor;
 import neqsim.pvtsimulation.flowassurance.MultiMineralScaleEquilibrium;
 import neqsim.pvtsimulation.flowassurance.ScalePredictionCalculator;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.phase.PhaseInterface;
 import neqsim.thermo.phase.PhasePitzer;
 import neqsim.thermo.phase.PitzerNeutralParameterCoverage;
 import neqsim.thermo.phase.PitzerParameterCoverage;
 import neqsim.thermo.phase.PitzerParameterDatasets;
 import neqsim.thermo.phase.PitzerParameterQualification;
 import neqsim.thermo.phase.PitzerParameterQualification.ValidationTarget;
+import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
+import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemPitzer;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+import neqsim.thermodynamicoperations.flashops.saturationops.SaltPrecipitationResult;
 
 /**
  * Stateless chemistry-and-integrity runner for MCP integration.
@@ -32,8 +38,8 @@ import neqsim.thermo.system.SystemPitzer;
  * <p>
  * Exposes the open standards-traceable chemistry stack — electrolyte scale prediction, mechanistic corrosion (NORSOK
  * M-506 + Nesic mass transfer + Langmuir inhibitor), Langmuir inhibitor isotherm dosing, packed-bed H2S scavenger
- * breakthrough, and fail-closed Pitzer dataset qualification — as JSON-driven analyses usable by AI agents over the
- * Model Context Protocol.
+ * breakthrough, activity-consistent electrolyte scale equilibrium, and fail-closed Pitzer dataset qualification — as
+ * JSON-driven analyses usable by AI agents over the Model Context Protocol.
  *
  * <p>
  * All analyses follow the same pattern: agents pass an {@code analysis} field naming the routine and a flat object with
@@ -49,7 +55,8 @@ public class ChemistryRunner {
       .serializeSpecialFloatingPointValues().create();
 
   private static final List<String> SUPPORTED_ANALYSES = Collections.unmodifiableList(Arrays.asList("electrolyteScale",
-      "multiMineralScale", "mechanisticCorrosion", "langmuirInhibitor", "packedBedScavenger", "pitzerQualification"));
+      "multiMineralScale", "mechanisticCorrosion", "langmuirInhibitor", "packedBedScavenger",
+      "electrolyteScaleEquilibrium", "pitzerQualification"));
 
   /**
    * Private constructor — static utility class.
@@ -111,6 +118,9 @@ public class ChemistryRunner {
         break;
       case "packedBedScavenger":
         data = runPackedBedScavenger(input);
+        break;
+      case "electrolyteScaleEquilibrium":
+        data = runElectrolyteScaleEquilibrium(input);
         break;
       case "pitzerQualification":
         data = runPitzerQualification(input);
@@ -252,6 +262,184 @@ public class ChemistryRunner {
     return JsonParser.parseString(bed.toJson()).getAsJsonObject();
   }
 
+
+  /**
+   * Runs the authoritative single-pure-mineral electrolyte equilibrium operation and reports its scientific gates.
+   *
+   * <p>
+   * The adapter adds no thermodynamic equation or parameter. Pitzer GE and electrolyte CPA retain distinct parameter
+   * semantics while sharing the public {@link ThermodynamicOperations#precipitateScale(String)} operation.
+   * </p>
+   *
+   * @param input chemistry analysis input
+   * @return precipitation ledger, aqueous-state diagnostics, and qualification boundary
+   */
+  private static JsonObject runElectrolyteScaleEquilibrium(JsonObject input) {
+    double temperature = requiredFinitePositive(input, "temperature_K");
+    double pressure = requiredFinitePositive(input, "pressure_bara");
+    Map<String, Double> components = requiredComponentAmounts(input);
+    if (!hasPositiveWater(components)) {
+      throw new IllegalArgumentException("Electrolyte scale equilibrium requires a positive water amount in mol");
+    }
+    if (!input.has("mineral") || input.get("mineral").isJsonNull()
+        || input.get("mineral").getAsString().trim().isEmpty()) {
+      throw new IllegalArgumentException("A non-empty COMPSALT 'mineral' name is required");
+    }
+
+    String mineral = input.get("mineral").getAsString().trim();
+    String model = input.has("model") ? input.get("model").getAsString().trim().toLowerCase() : "pitzer";
+    String datasetSelector = input.has("dataset") ? input.get("dataset").getAsString().trim().toLowerCase()
+        : "pitzer".equals(model) ? "phreeqc-ca-mg-cl-so4" : "not-applicable";
+    SystemInterface system;
+    PitzerParameterQualification pitzerQualification = null;
+
+    if ("pitzer".equals(model)) {
+      SystemPitzer pitzer = new SystemPitzer(temperature, pressure);
+      addComponents(pitzer, components);
+      requireElectroneutralInput(pitzer.getPhase(1), components);
+      pitzer.init(0);
+      applyScalePitzerDataset(pitzer, datasetSelector);
+      pitzer.setMixingRule("classic");
+      pitzer.setMultiPhaseCheck(true);
+      pitzerQualification = pitzer.getPitzerParameterQualification();
+      system = pitzer;
+    } else if ("electrolyte-cpa".equals(model)) {
+      if (input.has("dataset") && !"not-applicable".equals(datasetSelector)) {
+        throw new IllegalArgumentException("Pitzer dataset selectors do not apply to electrolyte-CPA parameters");
+      }
+      SystemElectrolyteCPAstatoil electrolyteCpa = new SystemElectrolyteCPAstatoil(temperature, pressure);
+      addComponents(electrolyteCpa, components);
+      requireElectroneutralInput(electrolyteCpa.getPhase(1), components);
+      electrolyteCpa.chemicalReactionInit();
+      electrolyteCpa.createDatabase(true);
+      electrolyteCpa.setMixingRule(10);
+      electrolyteCpa.setMultiPhaseCheck(true);
+      system = electrolyteCpa;
+    } else {
+      throw new IllegalArgumentException("Unknown electrolyte model '" + model
+          + "'; use pitzer or electrolyte-cpa");
+    }
+
+    SaltPrecipitationResult solid = new ThermodynamicOperations(system).precipitateScale(mineral);
+    JsonObject phaseState = validateAqueousPhaseState(system);
+    boolean numericalGatesPass = Double.isFinite(solid.getInitialSaturationRatio())
+        && Double.isFinite(solid.getFinalSaturationRatio())
+        && solid.getFinalSaturationRatio() > 0.0
+        && Double.isFinite(solid.getPrecipitatedMoles()) && solid.getPrecipitatedMoles() >= 0.0
+        && Double.isFinite(solid.getPrecipitatedMassGrams()) && solid.getPrecipitatedMassGrams() >= 0.0
+        && solid.getComplementarityViolation() <= 1.0e-6
+        && solid.getMaximumIonBalanceResidualMoles() <= 1.0e-10
+        && phaseState.get("normalizedNonNegative").getAsBoolean()
+        && Math.abs(phaseState.get("chargeResidual_molPerKgWater").getAsDouble()) <= 1.0e-10;
+    if (!numericalGatesPass) {
+      throw new IllegalStateException(
+          "Electrolyte scale equilibrium failed complementarity, balance, or phase-state gates");
+    }
+
+    JsonObject data = new JsonObject();
+    data.addProperty("model", model);
+    data.addProperty("authoritativeJavaOperation", "ThermodynamicOperations.precipitateScale");
+    data.addProperty("temperature_K", temperature);
+    data.addProperty("pressure_bara", pressure);
+    data.addProperty("compositionBasis", "component amount in mol; aqueous molality derived from water mass");
+    data.addProperty("mineral", solid.getSaltName());
+    data.addProperty("datasetSelector", datasetSelector);
+    data.addProperty("datasetId",
+        pitzerQualification == null ? "not-applicable: electrolyte-EOS parameters are not Pitzer parameters"
+            : pitzerQualification.getDatasetId());
+    data.addProperty("precipitatedSolid", solid.hasPrecipitatedSolid());
+    data.addProperty("precipitatedMoles_mol", solid.getPrecipitatedMoles());
+    data.addProperty("precipitatedMass_g", solid.getPrecipitatedMassGrams());
+    data.addProperty("initialSaturationRatio", solid.getInitialSaturationRatio());
+    data.addProperty("finalSaturationRatio", solid.getFinalSaturationRatio());
+    data.addProperty("complementarityViolation_log10SR", solid.getComplementarityViolation());
+    data.addProperty("maximumIonBalanceResidual_mol", solid.getMaximumIonBalanceResidualMoles());
+    data.add("aqueousPhaseState", phaseState);
+    data.addProperty("engineeringGatesPass", true);
+    if (pitzerQualification == null) {
+      data.add("pitzerQualificationLevel", null);
+      data.add("mineralTargetQualified", null);
+    } else {
+      data.addProperty("pitzerQualificationLevel", pitzerQualification.getLevel().name());
+      data.addProperty("mineralTargetQualified",
+          pitzerQualification.isValidatedFor(ValidationTarget.MINERAL_SATURATION_AND_PRECIPITATION));
+      data.add("qualificationLimitations", GSON.toJsonTree(pitzerQualification.getLimitations()));
+    }
+    data.addProperty("publicationReady", false);
+    data.addProperty("publicationLimitation",
+        "Numerical engineering gates pass, but no exact mixed-brine mineral evidence envelope is registered for this "
+            + "state");
+    return data;
+  }
+
+  private static Map<String, Double> requiredComponentAmounts(JsonObject input) {
+    if (!input.has("components") || !input.get("components").isJsonObject()) {
+      throw new IllegalArgumentException("'components' must be a JSON object of component moles");
+    }
+    Map<String, Double> components = new TreeMap<String, Double>();
+    for (Map.Entry<String, com.google.gson.JsonElement> entry : input.getAsJsonObject("components").entrySet()) {
+      String name = entry.getKey() == null ? "" : entry.getKey().trim();
+      if (name.isEmpty() || entry.getValue() == null || entry.getValue().isJsonNull()) {
+        throw new IllegalArgumentException("Electrolyte component names and amounts must not be empty");
+      }
+      double amount = entry.getValue().getAsDouble();
+      if (!Double.isFinite(amount) || amount < 0.0) {
+        throw new IllegalArgumentException("Component '" + name + "' amount must be finite and non-negative mol");
+      }
+      components.put(name, amount);
+    }
+    return components;
+  }
+
+  private static void addComponents(SystemInterface system, Map<String, Double> components) {
+    for (Map.Entry<String, Double> component : components.entrySet()) {
+      system.addComponent(component.getKey(), component.getValue());
+    }
+  }
+
+  private static void requireElectroneutralInput(PhaseInterface phase, Map<String, Double> components) {
+    JsonObject validation = validateElectroneutrality(phase, components);
+    if (!validation.get("valid").getAsBoolean()) {
+      throw new IllegalArgumentException("Electrolyte input is not electroneutral: residual "
+          + validation.get("chargeResidual_mol").getAsDouble() + " mol exceeds tolerance "
+          + validation.get("chargeTolerance_mol").getAsDouble() + " mol");
+    }
+  }
+
+  private static void applyScalePitzerDataset(SystemPitzer system, String selector) {
+    if ("phreeqc-ca-mg-cl-so4".equals(selector)) {
+      system.applyPhreeqcCalciumMagnesiumChlorideSulfateParameters();
+    } else if ("phreeqc-catalog".equals(selector)) {
+      system.applyCompletePhreeqcPitzerCatalogParameters();
+    } else {
+      throw new IllegalArgumentException("Unknown scale Pitzer dataset selector '" + selector
+          + "'; use phreeqc-ca-mg-cl-so4 or phreeqc-catalog");
+    }
+  }
+
+  private static JsonObject validateAqueousPhaseState(SystemInterface system) {
+    int aqueousPhaseNumber = system.getPhaseNumberOfPhase("aqueous");
+    PhaseInterface aqueous = system.getPhase(aqueousPhaseNumber >= 0 ? aqueousPhaseNumber : 1);
+    double moleFractionSum = 0.0;
+    double chargeResidual = 0.0;
+    boolean finiteNonNegative = true;
+    for (int componentIndex = 0; componentIndex < aqueous.getNumberOfComponents(); componentIndex++) {
+      ComponentInterface component = aqueous.getComponent(componentIndex);
+      double moleFraction = component.getx();
+      finiteNonNegative &= Double.isFinite(moleFraction) && moleFraction >= 0.0;
+      moleFractionSum += moleFraction;
+      chargeResidual += component.getMolality(aqueous) * component.getIonicCharge();
+    }
+    JsonObject state = new JsonObject();
+    state.addProperty("normalizedNonNegative",
+        finiteNonNegative && Math.abs(moleFractionSum - 1.0) <= 1.0e-12);
+    state.addProperty("moleFractionSum", moleFractionSum);
+    state.addProperty("normalizationTolerance", 1.0e-12);
+    state.addProperty("chargeResidual_molPerKgWater", chargeResidual);
+    state.addProperty("chargeTolerance_molPerKgWater", 1.0e-10);
+    return state;
+  }
+
   /**
    * Reports active-topology coverage and scientific qualification from the authoritative {@link SystemPitzer} APIs.
    *
@@ -381,12 +569,12 @@ public class ChemistryRunner {
     return false;
   }
 
-  private static JsonObject validateElectroneutrality(PhasePitzer phase, Map<String, Double> components) {
+  private static JsonObject validateElectroneutrality(PhaseInterface phase, Map<String, Double> components) {
     double chargeMoles = 0.0;
     double absoluteChargeMoles = 0.0;
     for (Map.Entry<String, Double> component : components.entrySet()) {
       if (!phase.hasComponent(component.getKey())) {
-        throw new IllegalArgumentException("Unknown Pitzer component '" + component.getKey() + "'");
+        throw new IllegalArgumentException("Unknown electrolyte component '" + component.getKey() + "'");
       }
       double chargedMoles = phase.getComponent(component.getKey()).getIonicCharge() * component.getValue();
       chargeMoles += chargedMoles;

--- a/src/test/java/neqsim/mcp/runners/ChemistryRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/ChemistryRunnerTest.java
@@ -63,6 +63,89 @@ class ChemistryRunnerTest {
     assertEquals("error", obj.get("status").getAsString());
   }
 
+
+  @Test
+  void electrolyteScaleEquilibriumPitzerUsesAuthoritativePrecipitationOperation() {
+    String input = "{\"analysis\":\"electrolyteScaleEquilibrium\",\"model\":\"pitzer\","
+        + "\"dataset\":\"phreeqc-ca-mg-cl-so4\",\"temperature_K\":298.15,"
+        + "\"pressure_bara\":1.01325,\"mineral\":\"CaSO4_A\","
+        + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,"
+        + "\"Mg++\":0.0,\"Cl-\":1.0,\"SO4--\":0.2}}";
+
+    JsonObject result = JsonParser.parseString(ChemistryRunner.run(input)).getAsJsonObject();
+    JsonObject data = result.getAsJsonObject("data");
+
+    assertEquals("success", result.get("status").getAsString());
+    assertEquals("ThermodynamicOperations.precipitateScale",
+        data.get("authoritativeJavaOperation").getAsString());
+    assertTrue(data.get("precipitatedSolid").getAsBoolean());
+    assertEquals(1.0, data.get("finalSaturationRatio").getAsDouble(), 1.0e-6);
+    assertTrue(data.get("complementarityViolation_log10SR").getAsDouble() <= 1.0e-6);
+    assertTrue(data.get("maximumIonBalanceResidual_mol").getAsDouble() <= 1.0e-10);
+    assertTrue(data.getAsJsonObject("aqueousPhaseState").get("normalizedNonNegative").getAsBoolean());
+    assertEquals(0.0,
+        data.getAsJsonObject("aqueousPhaseState").get("chargeResidual_molPerKgWater").getAsDouble(), 1.0e-10);
+    assertTrue(data.get("engineeringGatesPass").getAsBoolean());
+    assertFalse(data.get("mineralTargetQualified").getAsBoolean());
+    assertFalse(data.get("publicationReady").getAsBoolean());
+  }
+
+  @Test
+  void electrolyteScaleEquilibriumElectrolyteCpaUsesItsOwnAqueousModel() {
+    String input = "{\"analysis\":\"electrolyteScaleEquilibrium\",\"model\":\"electrolyte-cpa\","
+        + "\"temperature_K\":298.15,\"pressure_bara\":1.01325,\"mineral\":\"CaSO4_A\","
+        + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,"
+        + "\"Cl-\":1.0,\"SO4--\":0.2}}";
+
+    JsonObject data = JsonParser.parseString(ChemistryRunner.run(input)).getAsJsonObject()
+        .getAsJsonObject("data");
+
+    assertEquals("electrolyte-cpa", data.get("model").getAsString());
+    assertTrue(data.get("precipitatedSolid").getAsBoolean());
+    assertEquals(1.0, data.get("finalSaturationRatio").getAsDouble(), 1.0e-6);
+    assertTrue(data.get("maximumIonBalanceResidual_mol").getAsDouble() <= 1.0e-10);
+    assertTrue(data.get("engineeringGatesPass").getAsBoolean());
+    assertTrue(data.get("pitzerQualificationLevel").isJsonNull());
+    assertFalse(data.get("publicationReady").getAsBoolean());
+  }
+
+  @Test
+  void electrolyteScaleEquilibriumIsDeterministicAndChangedStateIsFresh() {
+    String template = "{\"analysis\":\"electrolyteScaleEquilibrium\",\"model\":\"pitzer\","
+        + "\"dataset\":\"phreeqc-ca-mg-cl-so4\",\"temperature_K\":298.15,"
+        + "\"pressure_bara\":1.01325,\"mineral\":\"CaSO4_A\","
+        + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":%s,"
+        + "\"Mg++\":0.0,\"Cl-\":1.0,\"SO4--\":%s}}";
+    String supersaturated = String.format(template, "0.2", "0.2");
+    String undersaturated = String.format(template, "0.0001", "0.0001");
+
+    JsonObject first = JsonParser.parseString(ChemistryRunner.run(supersaturated)).getAsJsonObject()
+        .getAsJsonObject("data");
+    JsonObject repeated = JsonParser.parseString(ChemistryRunner.run(supersaturated)).getAsJsonObject()
+        .getAsJsonObject("data");
+    JsonObject changed = JsonParser.parseString(ChemistryRunner.run(undersaturated)).getAsJsonObject()
+        .getAsJsonObject("data");
+
+    assertEquals(first, repeated);
+    assertTrue(first.get("precipitatedSolid").getAsBoolean());
+    assertFalse(changed.get("precipitatedSolid").getAsBoolean());
+    assertTrue(changed.get("finalSaturationRatio").getAsDouble() < 1.0);
+    assertEquals(0.0, changed.get("complementarityViolation_log10SR").getAsDouble(), 0.0);
+  }
+
+  @Test
+  void electrolyteScaleEquilibriumRejectsNonElectroneutralInputBeforeCalculation() {
+    String input = "{\"analysis\":\"electrolyteScaleEquilibrium\",\"model\":\"pitzer\","
+        + "\"temperature_K\":298.15,\"pressure_bara\":1.01325,\"mineral\":\"CaSO4_A\","
+        + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Cl-\":0.8}}";
+
+    JsonObject result = JsonParser.parseString(ChemistryRunner.run(input)).getAsJsonObject();
+
+    assertEquals("error", result.get("status").getAsString());
+    assertTrue(result.getAsJsonArray("errors").get(0).getAsJsonObject().get("message").getAsString()
+        .contains("not electroneutral"));
+  }
+
   @Test
   void qualifiedPitzerTopologyIsAcceptedForItsObservableAndEnvelope() {
     String input = "{\"analysis\":\"pitzerQualification\",\"temperature_K\":298.15,"

--- a/src/test/java/neqsim/thermo/phase/PitzerCatalogPerformanceBenchmark.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerCatalogPerformanceBenchmark.java
@@ -15,6 +15,11 @@ public final class PitzerCatalogPerformanceBenchmark {
       + "\"temperature_K\":298.15,\"pressure_bara\":1.01325,\"dataset\":\"phreeqc-na-k-cl\","
       + "\"validationTarget\":\"AQUEOUS_ACTIVITY_COEFFICIENTS\","
       + "\"components\":{\"water\":55.508,\"Na+\":0.5,\"K+\":0.5,\"Cl-\":1.0}}";
+  private static final String SCALE_EQUILIBRIUM_REQUEST = "{\"analysis\":\"electrolyteScaleEquilibrium\","
+      + "\"model\":\"pitzer\",\"dataset\":\"phreeqc-ca-mg-cl-so4\","
+      + "\"temperature_K\":298.15,\"pressure_bara\":1.01325,\"mineral\":\"CaSO4_A\","
+      + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,\"Mg++\":0.0,"
+      + "\"Cl-\":1.0,\"SO4--\":0.2}}";
 
   private PitzerCatalogPerformanceBenchmark() {
   }
@@ -68,6 +73,11 @@ public final class PitzerCatalogPerformanceBenchmark {
     }
     System.out.println("pitzerQualificationViewNs="
         + medianBatches(PitzerCatalogPerformanceBenchmark::qualificationViewChecksum, 100));
+    for (int warmup = 0; warmup < 3; warmup++) {
+      sink += scaleEquilibriumViewChecksum();
+    }
+    System.out.println("pitzerScaleEquilibriumViewNs="
+        + medianBatches(PitzerCatalogPerformanceBenchmark::scaleEquilibriumViewChecksum, 5));
 
     SystemPitzer reactivePitzer = createReactiveH2sSystem(298.15);
     ChemicalReaction h2sReaction = reactivePitzer.getChemicalReactionOperations().getReactionList()
@@ -141,6 +151,10 @@ public final class PitzerCatalogPerformanceBenchmark {
 
   private static double qualificationViewChecksum() {
     return ChemistryRunner.run(QUALIFICATION_REQUEST).hashCode();
+  }
+
+  private static double scaleEquilibriumViewChecksum() {
+    return ChemistryRunner.run(SCALE_EQUILIBRIUM_REQUEST).hashCode();
   }
 
   private static double neutralPropertyChecksum(SystemSrkEos system) {


### PR DESCRIPTION
## Engineering question

Can Java/JPype, JSON and MCP callers invoke the same authoritative single-pure-mineral equilibrium operation against the selected electrolyte GE/Pitzer or electrolyte-EOS aqueous model and receive explicit material-ledger, electroneutrality, phase-state and complementarity diagnostics without duplicating thermodynamic logic?

Advances #3144. Capability contract: [#3144 ledger](https://github.com/equinor/neqsim/issues/3144#issuecomment-5470084774).

## Frozen scope

- **Exact base:** `2b330659716d157727fd88ebc5d7c8019d88aa86`
- **Exact head:** `c49eafa55b8accea09b36fede28804866cccd4b6`
- **Authoritative calculation:** `ThermodynamicOperations.precipitateScale(String)` and `SaltPrecipitationResult`
- **Models:** `SystemPitzer` with explicit PHREEQC catalog selector and `SystemElectrolyteCPAstatoil` with mixing rule 10
- **Inputs:** temperature K, pressure bara, component amounts mol, explicit model/dataset and pure COMPSALT mineral
- **Outputs:** solid mol/g ledger, initial/final saturation ratio, log10(SR) complementarity, maximum ion-ledger residual mol, aqueous charge and normalization, model/dataset qualification boundary
- **Stop boundary:** one named pure mineral; no new Ksp, reaction, Pitzer, electrolyte-EOS or Henry parameter; no multi-mineral/solid-solution coupling, kinetics, deposition or inhibitors; no generic TP-flash (#2937), salt-input/API (#448), or reactive-absorber equipment (#205)

## Implementation

- Adds `electrolyteScaleEquilibrium` to the existing chemistry runner.
- Keeps Pitzer GE and electrolyte CPA parameter semantics separate.
- Requires electroneutral input before calculation.
- Fails the calculation unless complementarity is at most `1e-6`, ion-ledger residual at most `1e-10 mol`, aqueous charge at most `1e-10 mol/kg water`, and the aqueous phase is finite, non-negative and normalized.
- Reports `publicationReady: false` because no exact independently validated mixed-brine mineral evidence envelope is registered for the requested state; this is design-support, not a parameter qualification.
- Adds focused supersaturated/undersaturated, both-model, deterministic/changed-state and fail-closed input regressions.
- Adds an explicit complete-operation JSON benchmark path to the existing Pitzer performance harness.

## Public evidence and parameter boundary

The numerical path reuses merged #3238 evidence: PHREEQC 3.9.0 sulfate-mineral equilibrium constants and Plummer & Busenberg (1982), [DOI 10.1016/0016-7037(82)90056-4](https://doi.org/10.1016/0016-7037(82)90056-4). Pitzer source/convention/licensing comparison remains the durable [#3144 matrix](https://github.com/equinor/neqsim/issues/3144#issuecomment-5468165217), including the exact [USGS PHREEQC 3.9.0 catalog](https://github.com/phreeqc-dev/phreeqc3/blob/b0b3be767158ccc3322d2c816625cf470045e67e/database/pitzer.dat) and [USGS public-data licensing](https://www.usgs.gov/data-management/data-licensing).

No Kaasa thesis value or other parameter was copied or adopted. Pitzer coefficients are not treated as reaction constants, mineral log K values, SIT/eNRTL terms or electrolyte-EOS parameters. Unsupported H2S self/dimer/ion/zeta topology remains outside this PR.

## Documentation impact

Updated the chemistry overview, MCP chemistry schema/reference and server tool table. Notebook is not applicable because this is a stateless API view, not a new numerical workflow.

## Validation

**VALIDATION PENDING CI**

No local checkout/toolchain is available in this connector-first run. Maven, Spotless, documentation search, pre-commit and pre-push were not run and are not claimed. The exact six-file remote diff was inspected against current repository patterns. Authoritative exact-head CI must compile the APIs, run focused and broader suites, apply formatting/static/documentation gates and packaged MCP checks before merge qualification.

Generated with AI assistance.