### PR TITLE
[AI-Assisted] fix(mcp): format electrolyte scale view

### DIFF
--- a/src/main/java/neqsim/mcp/runners/ChemistryRunner.java
+++ b/src/main/java/neqsim/mcp/runners/ChemistryRunner.java
@@ -54,9 +54,9 @@ public class ChemistryRunner {
   private static final Gson GSON = new GsonBuilder().setPrettyPrinting().serializeNulls()
       .serializeSpecialFloatingPointValues().create();
 
-  private static final List<String> SUPPORTED_ANALYSES = Collections.unmodifiableList(Arrays.asList("electrolyteScale",
-      "multiMineralScale", "mechanisticCorrosion", "langmuirInhibitor", "packedBedScavenger",
-      "electrolyteScaleEquilibrium", "pitzerQualification"));
+  private static final List<String> SUPPORTED_ANALYSES = Collections
+      .unmodifiableList(Arrays.asList("electrolyteScale", "multiMineralScale", "mechanisticCorrosion",
+          "langmuirInhibitor", "packedBedScavenger", "electrolyteScaleEquilibrium", "pitzerQualification"));
 
   /**
    * Private constructor — static utility class.
@@ -262,7 +262,6 @@ public class ChemistryRunner {
     return JsonParser.parseString(bed.toJson()).getAsJsonObject();
   }
 
-
   /**
    * Runs the authoritative single-pure-mineral electrolyte equilibrium operation and reports its scientific gates.
    *
@@ -316,19 +315,16 @@ public class ChemistryRunner {
       electrolyteCpa.setMultiPhaseCheck(true);
       system = electrolyteCpa;
     } else {
-      throw new IllegalArgumentException("Unknown electrolyte model '" + model
-          + "'; use pitzer or electrolyte-cpa");
+      throw new IllegalArgumentException("Unknown electrolyte model '" + model + "'; use pitzer or electrolyte-cpa");
     }
 
     SaltPrecipitationResult solid = new ThermodynamicOperations(system).precipitateScale(mineral);
     JsonObject phaseState = validateAqueousPhaseState(system);
     boolean numericalGatesPass = Double.isFinite(solid.getInitialSaturationRatio())
-        && Double.isFinite(solid.getFinalSaturationRatio())
-        && solid.getFinalSaturationRatio() > 0.0
+        && Double.isFinite(solid.getFinalSaturationRatio()) && solid.getFinalSaturationRatio() > 0.0
         && Double.isFinite(solid.getPrecipitatedMoles()) && solid.getPrecipitatedMoles() >= 0.0
         && Double.isFinite(solid.getPrecipitatedMassGrams()) && solid.getPrecipitatedMassGrams() >= 0.0
-        && solid.getComplementarityViolation() <= 1.0e-6
-        && solid.getMaximumIonBalanceResidualMoles() <= 1.0e-10
+        && solid.getComplementarityViolation() <= 1.0e-6 && solid.getMaximumIonBalanceResidualMoles() <= 1.0e-10
         && phaseState.get("normalizedNonNegative").getAsBoolean()
         && Math.abs(phaseState.get("chargeResidual_molPerKgWater").getAsDouble()) <= 1.0e-10;
     if (!numericalGatesPass) {
@@ -400,9 +396,9 @@ public class ChemistryRunner {
   private static void requireElectroneutralInput(PhaseInterface phase, Map<String, Double> components) {
     JsonObject validation = validateElectroneutrality(phase, components);
     if (!validation.get("valid").getAsBoolean()) {
-      throw new IllegalArgumentException("Electrolyte input is not electroneutral: residual "
-          + validation.get("chargeResidual_mol").getAsDouble() + " mol exceeds tolerance "
-          + validation.get("chargeTolerance_mol").getAsDouble() + " mol");
+      throw new IllegalArgumentException(
+          "Electrolyte input is not electroneutral: residual " + validation.get("chargeResidual_mol").getAsDouble()
+              + " mol exceeds tolerance " + validation.get("chargeTolerance_mol").getAsDouble() + " mol");
     }
   }
 
@@ -412,8 +408,8 @@ public class ChemistryRunner {
     } else if ("phreeqc-catalog".equals(selector)) {
       system.applyCompletePhreeqcPitzerCatalogParameters();
     } else {
-      throw new IllegalArgumentException("Unknown scale Pitzer dataset selector '" + selector
-          + "'; use phreeqc-ca-mg-cl-so4 or phreeqc-catalog");
+      throw new IllegalArgumentException(
+          "Unknown scale Pitzer dataset selector '" + selector + "'; use phreeqc-ca-mg-cl-so4 or phreeqc-catalog");
     }
   }
 
@@ -431,8 +427,7 @@ public class ChemistryRunner {
       chargeResidual += component.getMolality(aqueous) * component.getIonicCharge();
     }
     JsonObject state = new JsonObject();
-    state.addProperty("normalizedNonNegative",
-        finiteNonNegative && Math.abs(moleFractionSum - 1.0) <= 1.0e-12);
+    state.addProperty("normalizedNonNegative", finiteNonNegative && Math.abs(moleFractionSum - 1.0) <= 1.0e-12);
     state.addProperty("moleFractionSum", moleFractionSum);
     state.addProperty("normalizationTolerance", 1.0e-12);
     state.addProperty("chargeResidual_molPerKgWater", chargeResidual);

--- a/src/test/java/neqsim/mcp/runners/ChemistryRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/ChemistryRunnerTest.java
@@ -63,28 +63,25 @@ class ChemistryRunnerTest {
     assertEquals("error", obj.get("status").getAsString());
   }
 
-
   @Test
   void electrolyteScaleEquilibriumPitzerUsesAuthoritativePrecipitationOperation() {
     String input = "{\"analysis\":\"electrolyteScaleEquilibrium\",\"model\":\"pitzer\","
         + "\"dataset\":\"phreeqc-ca-mg-cl-so4\",\"temperature_K\":298.15,"
         + "\"pressure_bara\":1.01325,\"mineral\":\"CaSO4_A\","
-        + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,"
-        + "\"Mg++\":0.0,\"Cl-\":1.0,\"SO4--\":0.2}}";
+        + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2," + "\"Mg++\":0.0,\"Cl-\":1.0,\"SO4--\":0.2}}";
 
     JsonObject result = JsonParser.parseString(ChemistryRunner.run(input)).getAsJsonObject();
     JsonObject data = result.getAsJsonObject("data");
 
     assertEquals("success", result.get("status").getAsString());
-    assertEquals("ThermodynamicOperations.precipitateScale",
-        data.get("authoritativeJavaOperation").getAsString());
+    assertEquals("ThermodynamicOperations.precipitateScale", data.get("authoritativeJavaOperation").getAsString());
     assertTrue(data.get("precipitatedSolid").getAsBoolean());
     assertEquals(1.0, data.get("finalSaturationRatio").getAsDouble(), 1.0e-6);
     assertTrue(data.get("complementarityViolation_log10SR").getAsDouble() <= 1.0e-6);
     assertTrue(data.get("maximumIonBalanceResidual_mol").getAsDouble() <= 1.0e-10);
     assertTrue(data.getAsJsonObject("aqueousPhaseState").get("normalizedNonNegative").getAsBoolean());
-    assertEquals(0.0,
-        data.getAsJsonObject("aqueousPhaseState").get("chargeResidual_molPerKgWater").getAsDouble(), 1.0e-10);
+    assertEquals(0.0, data.getAsJsonObject("aqueousPhaseState").get("chargeResidual_molPerKgWater").getAsDouble(),
+        1.0e-10);
     assertTrue(data.get("engineeringGatesPass").getAsBoolean());
     assertFalse(data.get("mineralTargetQualified").getAsBoolean());
     assertFalse(data.get("publicationReady").getAsBoolean());
@@ -94,11 +91,9 @@ class ChemistryRunnerTest {
   void electrolyteScaleEquilibriumElectrolyteCpaUsesItsOwnAqueousModel() {
     String input = "{\"analysis\":\"electrolyteScaleEquilibrium\",\"model\":\"electrolyte-cpa\","
         + "\"temperature_K\":298.15,\"pressure_bara\":1.01325,\"mineral\":\"CaSO4_A\","
-        + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,"
-        + "\"Cl-\":1.0,\"SO4--\":0.2}}";
+        + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2," + "\"Cl-\":1.0,\"SO4--\":0.2}}";
 
-    JsonObject data = JsonParser.parseString(ChemistryRunner.run(input)).getAsJsonObject()
-        .getAsJsonObject("data");
+    JsonObject data = JsonParser.parseString(ChemistryRunner.run(input)).getAsJsonObject().getAsJsonObject("data");
 
     assertEquals("electrolyte-cpa", data.get("model").getAsString());
     assertTrue(data.get("precipitatedSolid").getAsBoolean());
@@ -114,8 +109,7 @@ class ChemistryRunnerTest {
     String template = "{\"analysis\":\"electrolyteScaleEquilibrium\",\"model\":\"pitzer\","
         + "\"dataset\":\"phreeqc-ca-mg-cl-so4\",\"temperature_K\":298.15,"
         + "\"pressure_bara\":1.01325,\"mineral\":\"CaSO4_A\","
-        + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":%s,"
-        + "\"Mg++\":0.0,\"Cl-\":1.0,\"SO4--\":%s}}";
+        + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":%s," + "\"Mg++\":0.0,\"Cl-\":1.0,\"SO4--\":%s}}";
     String supersaturated = String.format(template, "0.2", "0.2");
     String undersaturated = String.format(template, "0.0001", "0.0001");
 

--- a/src/test/java/neqsim/thermo/phase/PitzerCatalogPerformanceBenchmark.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerCatalogPerformanceBenchmark.java
@@ -18,8 +18,7 @@ public final class PitzerCatalogPerformanceBenchmark {
   private static final String SCALE_EQUILIBRIUM_REQUEST = "{\"analysis\":\"electrolyteScaleEquilibrium\","
       + "\"model\":\"pitzer\",\"dataset\":\"phreeqc-ca-mg-cl-so4\","
       + "\"temperature_K\":298.15,\"pressure_bara\":1.01325,\"mineral\":\"CaSO4_A\","
-      + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,\"Mg++\":0.0,"
-      + "\"Cl-\":1.0,\"SO4--\":0.2}}";
+      + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,\"Mg++\":0.0," + "\"Cl-\":1.0,\"SO4--\":0.2}}";
 
   private PitzerCatalogPerformanceBenchmark() {
   }


### PR DESCRIPTION
## Summary

Repairs the branch-attributable Spotless failure left by merged electrolyte capability PR #3345. This is a formatting-only continuation of the already-frozen `electrolyteScaleEquilibrium` Java/JPype, JSON, and MCP view; it is not a new capability or model change.

## Frozen scope

- Apply the exact `spotless-format-patch` artifact produced for #3345 head `c49eafa55b8accea09b36fede28804866cccd4b6`.
- Touch only the three Java files named by the failed pre-commit job.
- Preserve all calculations, parameter datasets, public APIs, tests, tolerances, documentation, model selection, and runtime behavior byte-for-byte apart from formatting.
- Stop after exact-head formatting and regression CI qualification.

## Changed files

- `src/main/java/neqsim/mcp/runners/ChemistryRunner.java`
- `src/test/java/neqsim/mcp/runners/ChemistryRunnerTest.java`
- `src/test/java/neqsim/thermo/phase/PitzerCatalogPerformanceBenchmark.java`

The resulting blob SHAs exactly match the formatter artifact targets: `fd0d1fe`, `b477a1c`, and `0cdf363`.

## Validation

Reused scientific and software evidence from #3345 exact head:
- Java 8/21 Ubuntu and Windows suites passed.
- All four Java 21 slow shards passed.
- Javadocs, MCP protocol qualification, documentation search, CodeQL, and PaperLab passed.
- No reviews or unresolved threads.
- Scientific gates and benchmark behavior are unchanged because this PR changes formatting only.

The #3345 pre-commit job failed solely because these three files did not match Spotless. This draft applies GitHub Actions' own exact formatter artifact. New exact-head validation is **VALIDATION PENDING CI**.

## Scientific/provenance impact

No thermodynamic, Pitzer, electrolyte-EOS, reaction, mineral, Henry-law, or other parameter is changed. No public validation datum is added or reinterpreted. The existing source-comparison matrix and model-convention boundary remain authoritative in #3144.

Refs #3144.