### PR TITLE
[AI-Assisted] feat(dexpi): report piping import provenance

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -118,6 +118,20 @@ or unclassified equipment or piping-component object. Warnings describe honest s
 loss; malformed XML and parser failures still raise `DexpiXmlReaderException`. Existing `read(...)`
 and `load(...)` calls keep their previous behavior and logging.
 
+Piping-network diagnostics also distinguish source-backed values from reconstruction aids. Calling
+`readWithDiagnostics(...)` without a template records `DEXPI_IMPORT_DEFAULT_TEMPLATE_USED`, because
+the compatibility reader supplies a synthetic methane/ethane fluid and operating state. For every
+segment, the report identifies operating values retained from the template, invalid source numbers,
+and source numbers whose units had to use the documented default. Missing identity, component class,
+line number, service/fluid code, nominal-size representation, piping class, and insulation are
+reported separately. In particular, the reader never converts hydraulic bore into DN, NPS, or
+schedule; absent nominal size remains an explicit source-data gap.
+
+`INFO` entries carry provenance and do not make `hasLosses()` true by themselves. `WARNING` and
+`ERROR` entries do. The diagnostic sequence and JSON are deterministic for the same XML and template.
+The report schema is experimental: consumers should key on stable diagnostic codes rather than list
+positions as additional supported-subset checks are added.
+
 This evidence applies to NeqSim's Proteus-compatible DEXPI Plant/P&ID 4.1.1 supported subset. It is
 not proof of full semantic or graphical round-trip equivalence, native DEXPI 2.0 support, DEXPI
 certification, standards conformance, or engineering approval.

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -148,7 +148,12 @@ public final class DexpiXmlReader {
 
     /** @return whether unsupported or deliberately skipped source content was observed */
     public boolean hasLosses() {
-      return !diagnostics.isEmpty();
+      for (ImportDiagnostic diagnostic : diagnostics) {
+        if (diagnostic.getSeverity() != ImportDiagnosticSeverity.INFO) {
+          return true;
+        }
+      }
+      return false;
     }
 
     /** @return whether any import diagnostic has error severity */
@@ -448,11 +453,17 @@ public final class DexpiXmlReader {
     }
 
     Stream streamTemplate = templateOrDefault(templateStream);
+    if (diagnostics != null && templateStream == null
+        && document.getElementsByTagName("PipingNetworkSegment").getLength() > 0) {
+      diagnostics.add(new ImportDiagnostic(ImportDiagnosticSeverity.WARNING, "DEXPI_IMPORT_DEFAULT_TEMPLATE_USED", "",
+          "", "PlantModel",
+          "No template stream was supplied; imported piping segments use the reader's synthetic default fluid and state"));
+    }
 
     addUnits(document, processSystem, "Equipment", EQUIPMENT_CLASS_MAP, DexpiMetadata.TAG_NAME, diagnostics);
     addUnits(document, processSystem, "PipingComponent", PIPING_COMPONENT_MAP, "PipingComponentNumberAssignmentClass",
         diagnostics);
-    addPipingSegments(document, processSystem, streamTemplate);
+    addPipingSegments(document, processSystem, streamTemplate, diagnostics);
   }
 
   /**
@@ -679,7 +690,8 @@ public final class DexpiXmlReader {
     logger.info("Added {} units from {} elements", totalUnits, tagName);
   }
 
-  private static void addPipingSegments(Document document, ProcessSystem processSystem, Stream templateStream) {
+  private static void addPipingSegments(Document document, ProcessSystem processSystem, Stream templateStream,
+      List<ImportDiagnostic> diagnostics) {
     NodeList segmentNodes = document.getElementsByTagName("PipingNetworkSegment");
     logger.info("Found {} PipingNetworkSegments", segmentNodes.getLength());
     for (int i = 0; i < segmentNodes.getLength(); i++) {
@@ -690,8 +702,89 @@ public final class DexpiXmlReader {
       Element element = (Element) node;
       String baseName = firstNonEmpty(attributeValue(element, DexpiMetadata.SEGMENT_NUMBER),
           element.getAttribute("ID"));
+      addPipingSegmentDiagnostics(element, diagnostics);
       addDexpiStream(processSystem, element, templateStream, baseName);
     }
+  }
+
+  private static void addPipingSegmentDiagnostics(Element element, List<ImportDiagnostic> diagnostics) {
+    if (diagnostics == null) {
+      return;
+    }
+
+    String segmentNumber = attributeValue(element, DexpiMetadata.SEGMENT_NUMBER);
+    if (isBlank(segmentNumber) && isBlank(element.getAttribute("ID"))) {
+      addPipingDiagnostic(element, diagnostics, ImportDiagnosticSeverity.WARNING,
+          "DEXPI_IMPORT_SEGMENT_IDENTITY_MISSING", "Piping segment has neither an ID nor a segment-number assignment");
+    }
+    if (isBlank(element.getAttribute("ComponentClass"))) {
+      addPipingDiagnostic(element, diagnostics, ImportDiagnosticSeverity.WARNING, "DEXPI_IMPORT_SEGMENT_CLASS_MISSING",
+          "Piping segment ComponentClass is missing");
+    }
+    addMissingPipingMetadataDiagnostic(element, diagnostics, DexpiMetadata.LINE_NUMBER,
+        "DEXPI_IMPORT_LINE_NUMBER_MISSING", "Source line number is missing");
+    addMissingPipingMetadataDiagnostic(element, diagnostics, DexpiMetadata.FLUID_CODE,
+        "DEXPI_IMPORT_SERVICE_CODE_MISSING", "Source service or fluid code is missing");
+    if (isBlank(firstNonEmpty(attributeValue(element, DexpiMetadata.NOMINAL_DIAMETER_REPRESENTATION),
+        attributeValue(element, DexpiMetadata.LINE_SIZE)))) {
+      addPipingDiagnostic(element, diagnostics, ImportDiagnosticSeverity.WARNING, "DEXPI_IMPORT_NOMINAL_SIZE_MISSING",
+          "Source nominal-size representation is missing; no DN, NPS, or schedule is inferred");
+    }
+    if (isBlank(firstNonEmpty(attributeValue(element, DexpiMetadata.PIPING_CLASS_CODE_ASSIGNMENT),
+        attributeValue(element, DexpiMetadata.PIPING_CLASS_CODE)))) {
+      addPipingDiagnostic(element, diagnostics, ImportDiagnosticSeverity.WARNING, "DEXPI_IMPORT_PIPING_CLASS_MISSING",
+          "Source piping-class code is missing");
+    }
+    if (isBlank(firstNonEmpty(attributeValue(element, DexpiMetadata.INSULATION_TYPE_ASSIGNMENT),
+        attributeValue(element, DexpiMetadata.INSULATION_CODE)))) {
+      addPipingDiagnostic(element, diagnostics, ImportDiagnosticSeverity.WARNING, "DEXPI_IMPORT_INSULATION_UNSPECIFIED",
+          "Source insulation is unspecified; absence is not interpreted as uninsulated service");
+    }
+
+    addOperatingValueDiagnostic(element, diagnostics, DexpiMetadata.OPERATING_PRESSURE_VALUE,
+        DexpiMetadata.OPERATING_PRESSURE_UNIT, DexpiMetadata.DEFAULT_PRESSURE_UNIT, "PRESSURE");
+    addOperatingValueDiagnostic(element, diagnostics, DexpiMetadata.OPERATING_TEMPERATURE_VALUE,
+        DexpiMetadata.OPERATING_TEMPERATURE_UNIT, DexpiMetadata.DEFAULT_TEMPERATURE_UNIT, "TEMPERATURE");
+    addOperatingValueDiagnostic(element, diagnostics, DexpiMetadata.OPERATING_FLOW_VALUE,
+        DexpiMetadata.OPERATING_FLOW_UNIT, DexpiMetadata.DEFAULT_FLOW_UNIT, "FLOW");
+  }
+
+  private static void addMissingPipingMetadataDiagnostic(Element element, List<ImportDiagnostic> diagnostics,
+      String attributeName, String code, String message) {
+    if (isBlank(attributeValue(element, attributeName))) {
+      addPipingDiagnostic(element, diagnostics, ImportDiagnosticSeverity.WARNING, code, message);
+    }
+  }
+
+  private static void addOperatingValueDiagnostic(Element element, List<ImportDiagnostic> diagnostics,
+      String valueAttribute, String unitAttribute, String defaultUnit, String quantity) {
+    String valueText = firstNonEmpty(getGenericAttribute(element, valueAttribute),
+        findAttributeInAncestors(element, valueAttribute));
+    if (isBlank(valueText)) {
+      addPipingDiagnostic(element, diagnostics, ImportDiagnosticSeverity.INFO,
+          "DEXPI_IMPORT_" + quantity + "_FROM_TEMPLATE",
+          "Source operating " + quantity.toLowerCase() + " is missing; the template-stream value is retained");
+      return;
+    }
+    if (parseNumeric(valueText) == null) {
+      addPipingDiagnostic(element, diagnostics, ImportDiagnosticSeverity.WARNING,
+          "DEXPI_IMPORT_" + quantity + "_INVALID",
+          "Source operating " + quantity.toLowerCase() + " value is invalid; the template-stream value is retained");
+      return;
+    }
+    String unit = firstNonEmpty(getGenericAttribute(element, unitAttribute),
+        findAttributeInAncestors(element, unitAttribute));
+    if (isBlank(unit)) {
+      addPipingDiagnostic(element, diagnostics, ImportDiagnosticSeverity.WARNING,
+          "DEXPI_IMPORT_" + quantity + "_UNIT_DEFAULTED",
+          "Source operating " + quantity.toLowerCase() + " unit is missing; " + defaultUnit + " is used");
+    }
+  }
+
+  private static void addPipingDiagnostic(Element element, List<ImportDiagnostic> diagnostics,
+      ImportDiagnosticSeverity severity, String code, String message) {
+    diagnostics.add(new ImportDiagnostic(severity, code, element.getAttribute("ID"),
+        element.getAttribute("ComponentClass"), element.getTagName(), message));
   }
 
   private static void addDexpiStream(ProcessSystem processSystem, Element element, Stream templateStream,

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -159,4 +159,52 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     ProcessSystem legacy = DexpiXmlReader.read(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
     assertEquals(first.getProcessSystem().getAllUnitNames(), legacy.getAllUnitNames());
   }
+
+  @Test
+  public void testReadWithDiagnosticsReportsPipingProvenanceAndMetadataGaps() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel><PipingNetworkSystem>"
+        + "<PipingNetworkSegment ComponentClass=\"PipingNetworkSegment\" ID=\"S-1\">" + "<GenericAttributes>"
+        + "<GenericAttribute Name=\"SegmentNumberAssignmentClass\" Value=\"S-1\"/>"
+        + "<GenericAttribute Name=\"LineNumberAssignmentClass\" Value=\"100-FG-001\"/>"
+        + "<GenericAttribute Name=\"FluidCodeAssignmentClass\" Value=\"FG\"/>"
+        + "<GenericAttribute Name=\"NominalDiameterRepresentationAssignmentClass\" Value=\"DN 100\"/>"
+        + "<GenericAttribute Name=\"PipingClassCodeAssignmentClass\" Value=\"A1\"/>"
+        + "<GenericAttribute Name=\"InsulationTypeAssignmentClass\" Value=\"H\"/>"
+        + "<GenericAttribute Name=\"OperatingPressureValue\" Value=\"not-a-number\"/>"
+        + "<GenericAttribute Name=\"OperatingPressureUnit\" Value=\"bara\"/>"
+        + "<GenericAttribute Name=\"OperatingTemperatureValue\" Value=\"25.0\"/>"
+        + "</GenericAttributes></PipingNetworkSegment>" + "<PipingNetworkSegment/>"
+        + "</PipingNetworkSystem></PlantModel>";
+
+    DexpiXmlReader.ImportResult result = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+    assertEquals(2, result.getProcessSystem().getAllUnitNames().size());
+    DexpiStream sourceBacked = (DexpiStream) result.getProcessSystem().getUnit("100-FG-001-S-1");
+    assertNotNull(sourceBacked);
+    assertEquals("DN 100", sourceBacked.getNominalDiameterRepresentation());
+    assertEquals("A1", sourceBacked.getPipingClassCode());
+    assertEquals("H", sourceBacked.getInsulationType());
+    assertEquals(50.0, sourceBacked.getPressure("bara"), 1.0e-12);
+    assertEquals(25.0, sourceBacked.getTemperature("C"), 1.0e-12);
+
+    assertEquals(14, result.getDiagnostics().size());
+    assertEquals("DEXPI_IMPORT_DEFAULT_TEMPLATE_USED", result.getDiagnostics().get(0).getCode());
+    assertEquals("DEXPI_IMPORT_PRESSURE_INVALID", result.getDiagnostics().get(1).getCode());
+    assertEquals("DEXPI_IMPORT_TEMPERATURE_UNIT_DEFAULTED", result.getDiagnostics().get(2).getCode());
+    assertEquals("DEXPI_IMPORT_FLOW_FROM_TEMPLATE", result.getDiagnostics().get(3).getCode());
+    assertEquals(DexpiXmlReader.ImportDiagnosticSeverity.INFO, result.getDiagnostics().get(3).getSeverity());
+    assertEquals("DEXPI_IMPORT_SEGMENT_IDENTITY_MISSING", result.getDiagnostics().get(4).getCode());
+    assertEquals("DEXPI_IMPORT_SEGMENT_CLASS_MISSING", result.getDiagnostics().get(5).getCode());
+    assertEquals("DEXPI_IMPORT_LINE_NUMBER_MISSING", result.getDiagnostics().get(6).getCode());
+    assertEquals("DEXPI_IMPORT_SERVICE_CODE_MISSING", result.getDiagnostics().get(7).getCode());
+    assertEquals("DEXPI_IMPORT_NOMINAL_SIZE_MISSING", result.getDiagnostics().get(8).getCode());
+    assertEquals("DEXPI_IMPORT_PIPING_CLASS_MISSING", result.getDiagnostics().get(9).getCode());
+    assertEquals("DEXPI_IMPORT_INSULATION_UNSPECIFIED", result.getDiagnostics().get(10).getCode());
+    assertEquals("DEXPI_IMPORT_PRESSURE_FROM_TEMPLATE", result.getDiagnostics().get(11).getCode());
+    assertEquals("DEXPI_IMPORT_TEMPERATURE_FROM_TEMPLATE", result.getDiagnostics().get(12).getCode());
+    assertEquals("DEXPI_IMPORT_FLOW_FROM_TEMPLATE", result.getDiagnostics().get(13).getCode());
+    assertTrue(result.hasLosses());
+    assertFalse(result.hasErrors());
+  }
 }


### PR DESCRIPTION
## Engineering question

Can the Proteus-compatible reader distinguish source-backed piping-network data from template/defaulted values and expose missing or invalid line-design metadata deterministically, without changing legacy reconstruction behavior?

Advances #1332 and #2899. Capability contracts: [#1332](https://github.com/equinor/neqsim/issues/1332#issuecomment-5470943096), [#2899](https://github.com/equinor/neqsim/issues/2899#issuecomment-5470943013).

## Implementation

- reports synthetic default-template use only when piping segments actually require it
- records template-backed pressure, temperature, and flow as informational provenance
- reports invalid source operating values and defaulted units
- reports missing segment identity/class, line number, service code, nominal-size representation, piping class, and insulation
- never infers DN, NPS, or schedule from hydraulic bore
- makes `hasLosses()` ignore informational provenance while retaining warnings/errors as loss evidence
- preserves existing `read(...)` and `load(...)` reconstruction, names, state, and logging
- keeps deterministic source order and the existing experimental JSON report schema

## Compatibility and stop boundary

Base: `d65dceb54535a9af811c755fb43447ae5675a246`
Head: `b0fada825d30c49126a314eb354ac39592320c10`

The Java reader remains authoritative. Python/JPype callers use the same getters and JSON. No MCP import tool is applicable. Writer, layout, XML export, SVG/PNG, ProcessModel, legacy DOT/Graphviz, simulation calculations, and Classic output paths are unchanged.

Stop before topology or instrumentation reconstruction, semantic/graphical diff, native DEXPI 2.0, external CAE qualification, licensed-standards mapping, engineering approval, or external datasets.

## Validation

Local final-diff evidence:

- `DexpiXmlReaderTest`: 7/7 passed
- directly affected `DexpiXmlWriterTest`: 31/31 passed
- documentation-search audit: passed (674 Markdown pages, 1 standalone HTML page)
- `git diff --check`: passed
- Spotless apply formatted the three changed files; the final full-tree Spotless check is blocked only by four pre-existing master files outside this PR: `ChemistryRunner.java`, `ChemistryRunnerTest.java`, `PitzerCatalogPerformanceBenchmark.java`, and `OilAssayCharacterisationOediCoaTest.java`
- pre-commit and pre-push were not run because the executable is unavailable

Rendering impact: none. No export or graphical primitive changed, so no new whole-sheet visual defect is introduced by this read-only capability. Hosted diagram/notebook gates remain authoritative.

**VALIDATION PENDING CI**

This is experimental supported-subset provenance evidence, not DEXPI certification, ISO/ISA conformance, an approved P&ID, or accountable engineering approval.

Generated with AI assistance.