### PR TITLE
[AI-Assisted] fix(refinery): format COA density qualification

### DIFF
--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationOediCoaTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationOediCoaTest.java
@@ -13,16 +13,14 @@ public class OilAssayCharacterisationOediCoaTest {
   private static final double MAX_API_GRAVITY_ERROR = 1.5;
 
   private static final CoaCase[] CASES = {
-      new CoaCase(920, "Turner Valley, Alberta", 0.779, 50.1, 70.5, 0.754, 13.2, 0.813,
-          3.7, 0.831, 12.6, 0.889, 0.781647),
-      new CoaCase(50146, "Ranch W, Texas", 0.847, 35.6, 17.8, 0.794, 0.0, 0.0, 78.7,
-          0.856, 3.5, 0.907, 0.846749),
-      new CoaCase(56337, "Manderson, Wyoming", 0.771, 52.0, 88.7, 0.767, 8.7, 0.794, 0.0,
-          0.0, 2.6, 0.815, 0.770597),
-      new CoaCase(60205, "South McCallum, Colorado", 0.765, 53.5, 75.0, 0.741, 19.8,
-          0.804, 4.2, 0.842, 1.0, 0.873, 0.759036),
-      new CoaCase(68120, "Vermilion Block 14, Louisiana", 0.782, 49.4, 49.7, 0.749, 38.5,
-          0.805, 0.0, 0.0, 11.8, 0.832, 0.780354)};
+      new CoaCase(920, "Turner Valley, Alberta", 0.779, 50.1, 70.5, 0.754, 13.2, 0.813, 3.7, 0.831, 12.6, 0.889,
+          0.781647),
+      new CoaCase(50146, "Ranch W, Texas", 0.847, 35.6, 17.8, 0.794, 0.0, 0.0, 78.7, 0.856, 3.5, 0.907, 0.846749),
+      new CoaCase(56337, "Manderson, Wyoming", 0.771, 52.0, 88.7, 0.767, 8.7, 0.794, 0.0, 0.0, 2.6, 0.815, 0.770597),
+      new CoaCase(60205, "South McCallum, Colorado", 0.765, 53.5, 75.0, 0.741, 19.8, 0.804, 4.2, 0.842, 1.0, 0.873,
+          0.759036),
+      new CoaCase(68120, "Vermilion Block 14, Louisiana", 0.782, 49.4, 49.7, 0.749, 38.5, 0.805, 0.0, 0.0, 11.8, 0.832,
+          0.780354) };
 
   @Test
   public void testCompleteFourCategoryCoaDensityMatrix() {
@@ -42,30 +40,24 @@ public class OilAssayCharacterisationOediCoaTest {
       assay.clearCuts();
       addCategories(assay, coaCase, false);
 
-      assertEquals(coaCase.expectedAdditiveVolumeSpecificGravity,
-          coaCase.calculateAdditiveVolumeSpecificGravity(), 1e-12, message);
-      assertEquals(coaCase.expectedAdditiveVolumeSpecificGravity,
-          assay.getBulkSpecificGravity(), 1e-12, message);
+      assertEquals(coaCase.expectedAdditiveVolumeSpecificGravity, coaCase.calculateAdditiveVolumeSpecificGravity(),
+          1e-12, message);
+      assertEquals(coaCase.expectedAdditiveVolumeSpecificGravity, assay.getBulkSpecificGravity(), 1e-12, message);
       assertTrue(Double.isFinite(assay.getBulkSpecificGravity()), message);
       assertTrue(Double.isFinite(assay.getBulkApiGravity()), message);
       assertEquals(0, system.getNumberOfComponents(), message);
 
-      double specificGravityError =
-          Math.abs(assay.getBulkSpecificGravity() - coaCase.publishedSpecificGravity);
-      double apiGravityError =
-          Math.abs(assay.getBulkApiGravity() - coaCase.publishedApiGravity);
+      double specificGravityError = Math.abs(assay.getBulkSpecificGravity() - coaCase.publishedSpecificGravity);
+      double apiGravityError = Math.abs(assay.getBulkApiGravity() - coaCase.publishedApiGravity);
       assertTrue(specificGravityError <= MAX_SPECIFIC_GRAVITY_ERROR, message);
       assertTrue(apiGravityError <= MAX_API_GRAVITY_ERROR, message);
 
-      OilAssayCharacterisation reversed =
-          new SystemSrkEos(288.706, 1.01325).getOilAssayCharacterisation();
+      OilAssayCharacterisation reversed = new SystemSrkEos(288.706, 1.01325).getOilAssayCharacterisation();
       reversed.clearCuts();
       addCategories(reversed, coaCase, true);
-      assertEquals(assay.getBulkSpecificGravity(), reversed.getBulkSpecificGravity(), 1e-12,
-          message);
+      assertEquals(assay.getBulkSpecificGravity(), reversed.getBulkSpecificGravity(), 1e-12, message);
 
-      maximumSpecificGravityError =
-          Math.max(maximumSpecificGravityError, specificGravityError);
+      maximumSpecificGravityError = Math.max(maximumSpecificGravityError, specificGravityError);
       sumSpecificGravityError += specificGravityError;
       sumSquaredSpecificGravityError += specificGravityError * specificGravityError;
       maximumApiGravityError = Math.max(maximumApiGravityError, apiGravityError);
@@ -75,44 +67,32 @@ public class OilAssayCharacterisationOediCoaTest {
 
     assertEquals(0.005964, maximumSpecificGravityError, 1e-12);
     assertEquals(0.0021822, sumSpecificGravityError / CASES.length, 1e-12);
-    assertEquals(0.003016973019435194,
-        Math.sqrt(sumSquaredSpecificGravityError / CASES.length), 1e-12);
+    assertEquals(0.003016973019435194, Math.sqrt(sumSquaredSpecificGravityError / CASES.length), 1e-12);
     assertEquals(1.4206704293340522, maximumApiGravityError, 1e-12);
     assertEquals(0.5108445008224933, sumApiGravityError / CASES.length, 1e-12);
-    assertEquals(0.7133115463932141, Math.sqrt(sumSquaredApiGravityError / CASES.length),
-        1e-12);
+    assertEquals(0.7133115463932141, Math.sqrt(sumSquaredApiGravityError / CASES.length), 1e-12);
   }
 
-  private static void addCategories(OilAssayCharacterisation assay, CoaCase coaCase,
-      boolean reverse) {
+  private static void addCategories(OilAssayCharacterisation assay, CoaCase coaCase, boolean reverse) {
     if (reverse) {
-      addCategory(assay, "Residuum", coaCase.residuumVolumePercent,
-          coaCase.residuumSpecificGravity);
-      addCategory(assay, "GasOil", coaCase.gasOilVolumePercent,
-          coaCase.gasOilSpecificGravity);
-      addCategory(assay, "Kerosene", coaCase.keroseneVolumePercent,
-          coaCase.keroseneSpecificGravity);
-      addCategory(assay, "GasolineNaphtha", coaCase.gasolineVolumePercent,
-          coaCase.gasolineSpecificGravity);
+      addCategory(assay, "Residuum", coaCase.residuumVolumePercent, coaCase.residuumSpecificGravity);
+      addCategory(assay, "GasOil", coaCase.gasOilVolumePercent, coaCase.gasOilSpecificGravity);
+      addCategory(assay, "Kerosene", coaCase.keroseneVolumePercent, coaCase.keroseneSpecificGravity);
+      addCategory(assay, "GasolineNaphtha", coaCase.gasolineVolumePercent, coaCase.gasolineSpecificGravity);
       return;
     }
-    addCategory(assay, "GasolineNaphtha", coaCase.gasolineVolumePercent,
-        coaCase.gasolineSpecificGravity);
-    addCategory(assay, "Kerosene", coaCase.keroseneVolumePercent,
-        coaCase.keroseneSpecificGravity);
-    addCategory(assay, "GasOil", coaCase.gasOilVolumePercent,
-        coaCase.gasOilSpecificGravity);
-    addCategory(assay, "Residuum", coaCase.residuumVolumePercent,
-        coaCase.residuumSpecificGravity);
+    addCategory(assay, "GasolineNaphtha", coaCase.gasolineVolumePercent, coaCase.gasolineSpecificGravity);
+    addCategory(assay, "Kerosene", coaCase.keroseneVolumePercent, coaCase.keroseneSpecificGravity);
+    addCategory(assay, "GasOil", coaCase.gasOilVolumePercent, coaCase.gasOilSpecificGravity);
+    addCategory(assay, "Residuum", coaCase.residuumVolumePercent, coaCase.residuumSpecificGravity);
   }
 
-  private static void addCategory(OilAssayCharacterisation assay, String name,
-      double volumePercent, double specificGravity) {
+  private static void addCategory(OilAssayCharacterisation assay, String name, double volumePercent,
+      double specificGravity) {
     if (volumePercent == 0.0) {
       return;
     }
-    assay.addCut(
-        new AssayCut(name).withVolumePercent(volumePercent).withSpecificGravity(specificGravity));
+    assay.addCut(new AssayCut(name).withVolumePercent(volumePercent).withSpecificGravity(specificGravity));
   }
 
   private static final class CoaCase {
@@ -130,12 +110,10 @@ public class OilAssayCharacterisationOediCoaTest {
     private final double residuumSpecificGravity;
     private final double expectedAdditiveVolumeSpecificGravity;
 
-    private CoaCase(int sampleId, String location, double publishedSpecificGravity,
-        double publishedApiGravity, double gasolineVolumePercent,
-        double gasolineSpecificGravity, double keroseneVolumePercent,
-        double keroseneSpecificGravity, double gasOilVolumePercent,
-        double gasOilSpecificGravity, double residuumVolumePercent,
-        double residuumSpecificGravity, double expectedAdditiveVolumeSpecificGravity) {
+    private CoaCase(int sampleId, String location, double publishedSpecificGravity, double publishedApiGravity,
+        double gasolineVolumePercent, double gasolineSpecificGravity, double keroseneVolumePercent,
+        double keroseneSpecificGravity, double gasOilVolumePercent, double gasOilSpecificGravity,
+        double residuumVolumePercent, double residuumSpecificGravity, double expectedAdditiveVolumeSpecificGravity) {
       this.sampleId = sampleId;
       this.location = location;
       this.publishedSpecificGravity = publishedSpecificGravity;
@@ -152,15 +130,12 @@ public class OilAssayCharacterisationOediCoaTest {
     }
 
     private double totalVolumePercent() {
-      return gasolineVolumePercent + keroseneVolumePercent + gasOilVolumePercent
-          + residuumVolumePercent;
+      return gasolineVolumePercent + keroseneVolumePercent + gasOilVolumePercent + residuumVolumePercent;
     }
 
     private double calculateAdditiveVolumeSpecificGravity() {
-      return (gasolineVolumePercent * gasolineSpecificGravity
-          + keroseneVolumePercent * keroseneSpecificGravity
-          + gasOilVolumePercent * gasOilSpecificGravity
-          + residuumVolumePercent * residuumSpecificGravity) / 100.0;
+      return (gasolineVolumePercent * gasolineSpecificGravity + keroseneVolumePercent * keroseneSpecificGravity
+          + gasOilVolumePercent * gasOilSpecificGravity + residuumVolumePercent * residuumSpecificGravity) / 100.0;
     }
   }
 }


### PR DESCRIPTION
## Summary

Repairs the branch-attributable Spotless failure left by merged refinery qualification PR #3346. This is a formatting-only continuation of the already-contracted multi-assay COA bulk-density qualification for #3305; it does not introduce or redirect a capability.

## Frozen scope

- Apply the exact `spotless-format-patch` artifact generated for #3346 head `a7e243b6c730bc581b611dc74d4e8ec83a1c0f5c`.
- Touch only `OilAssayCharacterisationOediCoaTest.java`.
- Preserve public data, calculations, thresholds, API behavior, test behavior, provenance, and documentation byte-for-byte apart from formatter whitespace.
- Stop after exact-head formatting and regression-CI qualification.

## Exact continuity

- Base: `d65dceb54535a9af811c755fb43447ae5675a246`
- Head: `2bdd79d8438394a774ac149ecfd3f8254aa24113`
- Resulting file blob: `5a998bce6483b3f29472e75b47543c63f5d5c3c5`, exactly matching the formatter artifact target.
- Capability contract: equinor/neqsim#3305 comment 5470104169.

## Validation

Reused exact-head #3346 evidence:

- complete build/test/Javadocs workflow passed;
- CodeQL passed;
- documentation search passed;
- Spotless patch workflow passed and produced this exact repair;
- the pre-commit workflow failed solely because the merged refinery test did not match Spotless.

Final repair evidence:

- whitespace-stripped pre/post source is identical;
- documentation-search audit passed (674 Markdown pages and 1 standalone HTML page);
- `git diff --check` passed;
- no Maven regression test was rerun because this change is formatter-only and #3346's exact scientific/build matrix already passed;
- full-tree local Spotless remains blocked by three unrelated current-master files owned by #3349; this PR does not overlap or duplicate that repair.

**VALIDATION PENDING CI**

## Scientific and interface impact

None. Java remains authoritative; Python/JPype sees the same behavior. JSON, MCP, notebook, and graphical views are not applicable to this formatting-only repair. The DOE/OEDI evidence, validity range, assumptions, error statistics, and experimental maturity recorded by #3346 are unchanged.

Refs #3305. Generated with AI assistance.