### PR TITLE
[AI-Assisted] feat(kinetics): add aqueous CO2 hydration bridge

### DIFF
--- a/docs/chemicalreactions/co2_transport_reaction_kinetics.md
+++ b/docs/chemicalreactions/co2_transport_reaction_kinetics.md
@@ -100,6 +100,51 @@ Non-finite rates, invalid phase indexes, and unsupported rate bases fail explici
 These labels do not establish that equilibrium chemistry is valid. They also do not update
 composition, conserve elements over a timestep, reflash the fluid, or solve charge balance.
 
+## Published aqueous CO2 hydration bridge
+
+`AqueousCO2HydrationKinetics` implements the reversible aqueous reaction
+
+$$
+\mathrm{CO_2(aq) + H_2O \rightleftharpoons H_2CO_3}
+$$
+
+using the primary measurements and correlations of Soli and Byrne (2002),
+[doi:10.1016/S0304-4203(02)00010-5](https://doi.org/10.1016/S0304-4203%2802%2900010-5):
+
+$$
+\ln(k_H / \mathrm{s^{-1}}) = 22.66 - \frac{7799}{T}
+$$
+
+and
+
+$$
+\ln(k_D / \mathrm{s^{-1}}) = 30.15 - \frac{8018}{T}.
+$$
+
+The implementation preserves the source's narrow evidence boundary: 0.65 molal NaCl and
+288.15–305.65 K. At 298.15 K it gives `kH = 0.0302586 s-1`, `kD = 25.9844 s-1`, and
+`[H2CO3]/[CO2(aq)] = kH/kD = 0.00116449`. Calls outside the published temperature range fail
+closed instead of extrapolating.
+
+The equations are direct implementations of the primary-source fits, not a new NeqSim calibration
+or an independent validation dataset. Public DOI metadata and the institutional abstract are
+available without redistributing the paper's tabulated data. The public abstract does not report
+uncertainty statistics for these two fitted equations, so exact equation-reproduction tests must not
+be interpreted as experimental prediction uncertainty.
+
+`createReaction()` maps the two correlations exactly onto the generic reversible
+`KineticReaction` contract. Water has stoichiometric coefficient -1 but kinetic order zero because
+it is the solvent in the published pseudo-first-order model. `advance(...)` provides the analytical
+closed-batch update for the CO2/H2CO3 pair. The exact solution is non-negative and conserves that
+pair's carbon without numerical timestep error.
+
+This bridge does **not** qualify pressure dependence, dense-phase CO2, other salinities, acid
+dissociation, pH, charge balance, or phase transfer. Soli and Byrne did not vary pressure. Do not
+apply the correlation directly at pipeline pressure without separate evidence. A process caller
+must also provide a compatible aqueous thermodynamic system with distinct `CO2`, `water`, and
+`H2CO3` components. Electrolyte speciation and the mapping to the existing bicarbonate reaction set
+remain coordinated with issue #3144.
+
 ## Intended transport integration
 
 A future control-volume integration should:

--- a/docs/test_co2_transport_reaction_kinetics_documentation.py
+++ b/docs/test_co2_transport_reaction_kinetics_documentation.py
@@ -20,6 +20,11 @@ QUALIFICATION = (
     / "src/main/java/neqsim/process/equipment/reactor/"
     / "KineticReactionQualification.java"
 )
+HYDRATION_KINETICS = (
+    ROOT
+    / "src/main/java/neqsim/process/equipment/reactor/"
+    / "AqueousCO2HydrationKinetics.java"
+)
 SYSTEM_INTERFACE = ROOT / "src/main/java/neqsim/thermo/system/SystemInterface.java"
 JAVA_TEST = (
     ROOT
@@ -57,6 +62,7 @@ class CO2TransportReactionKineticsDocumentationContractTest(unittest.TestCase):
         cls.reference_index = REFERENCE_INDEX.read_text(encoding="utf-8")
         cls.diagnostics = DIAGNOSTICS.read_text(encoding="utf-8")
         cls.qualification = QUALIFICATION.read_text(encoding="utf-8")
+        cls.hydration_kinetics = HYDRATION_KINETICS.read_text(encoding="utf-8")
         cls.system_interface = SYSTEM_INTERFACE.read_text(encoding="utf-8")
         cls.java_test = JAVA_TEST.read_text(encoding="utf-8")
         cls.normalized = " ".join(cls.guide.split())
@@ -71,9 +77,43 @@ class CO2TransportReactionKineticsDocumentationContractTest(unittest.TestCase):
         self.assertIn(r"\mathrm{Da}", self.guide)
 
         links = re.findall(r"(?<!!)\[[^\]]+\]\(([^)]+)\)", self.guide)
-        self.assertEqual(3, len(links))
+        self.assertEqual(4, len(links))
         for destination in links:
-            self.assertTrue(resolve_internal_target(GUIDE, destination).is_file())
+            if destination.startswith("https://"):
+                self.assertEqual(
+                    "https://doi.org/10.1016/S0304-4203%2802%2900010-5",
+                    destination,
+                )
+            else:
+                self.assertTrue(resolve_internal_target(GUIDE, destination).is_file())
+
+    def test_published_hydration_bridge_matches_source_contract(self):
+        for token in (
+            'SOURCE_IDENTIFIER = "doi:10.1016/S0304-4203(02)00010-5"',
+            "SOURCE_ACCESS_STATUS =",
+            "PUBLISHED_NACL_MOLALITY = 0.65",
+            "MINIMUM_TEMPERATURE_K = 288.15",
+            "MAXIMUM_TEMPERATURE_K = 305.65",
+            "HYDRATION_LOG_PRE_EXPONENTIAL = 22.66",
+            "HYDRATION_INVERSE_TEMPERATURE_K = 7799.0",
+            "DEHYDRATION_LOG_PRE_EXPONENTIAL = 30.15",
+            "DEHYDRATION_INVERSE_TEMPERATURE_K = 8018.0",
+            "public static Result advance(",
+            "totalConcentration - updatedCO2 - updatedCarbonicAcid",
+        ):
+            self.assertIn(token, self.hydration_kinetics)
+
+        for token in (
+            "0.65 molal NaCl",
+            "288.15–305.65 K",
+            "0.0302586 s-1",
+            "25.9844 s-1",
+            "does **not** qualify pressure dependence",
+            "not a new NeqSim calibration",
+            "uncertainty statistics for these two fitted equations",
+            "issue #3144",
+        ):
+            self.assertIn(token, self.guide)
 
     def test_complete_java_helper_uses_logging_and_fail_closed_order(self):
         for token in (

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousCO2HydrationKinetics.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousCO2HydrationKinetics.java
@@ -1,0 +1,211 @@
+package neqsim.process.equipment.reactor;
+
+import java.io.Serializable;
+
+/**
+ * Published reversible hydration kinetics for aqueous carbon dioxide in 0.65 molal NaCl.
+ *
+ * <p>
+ * Soli and Byrne measured the reversible reaction {@code CO2(aq) + H2O <=> H2CO3} from 15 to 32.5 degrees Celsius in
+ * 0.65 molal NaCl. Their fitted first-order rate constants are {@code ln(kH / s-1) = 22.66 - 7799 / T} and
+ * {@code ln(kD / s-1) = 30.15 - 8018 / T}, with temperature in Kelvin.
+ * </p>
+ *
+ * <p>
+ * The source did not qualify pressure effects or dense-phase CO2. This class therefore provides the aqueous kinetic
+ * bridge and its published temperature/composition boundary, but it does not claim that the correlation is valid at CO2
+ * pipeline pressure. Pressure qualification and phase selection remain caller responsibilities.
+ * </p>
+ *
+ * @see <a href="https://doi.org/10.1016/S0304-4203(02)00010-5">Soli and Byrne (2002), Marine Chemistry 78, 65-73</a>
+ * @author NeqSim Team
+ * @version 1.0
+ */
+public final class AqueousCO2HydrationKinetics implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Primary-source DOI. */
+  public static final String SOURCE_IDENTIFIER = "doi:10.1016/S0304-4203(02)00010-5";
+
+  /** Human-readable primary-source citation. */
+  public static final String SOURCE_CITATION = "A. L. Soli and R. H. Byrne, Marine Chemistry 78 (2002) 65-73";
+
+  /** Public-access and redistribution note for the implemented source material. */
+  public static final String SOURCE_ACCESS_STATUS = "Public DOI and institutional abstract; equations implemented without redistributing tabulated data";
+
+  /** NaCl molality used in the published measurements [mol/kg solvent]. */
+  public static final double PUBLISHED_NACL_MOLALITY = 0.65;
+
+  /** Minimum published correlation temperature [K]. */
+  public static final double MINIMUM_TEMPERATURE_K = 288.15;
+
+  /** Maximum published correlation temperature [K]. */
+  public static final double MAXIMUM_TEMPERATURE_K = 305.65;
+
+  /** Gas constant used by {@link KineticReaction} [J/(mol K)]. */
+  private static final double KINETIC_REACTION_GAS_CONSTANT_J_PER_MOL_K = 8.31446;
+  private static final double HYDRATION_LOG_PRE_EXPONENTIAL = 22.66;
+  private static final double HYDRATION_INVERSE_TEMPERATURE_K = 7799.0;
+  private static final double DEHYDRATION_LOG_PRE_EXPONENTIAL = 30.15;
+  private static final double DEHYDRATION_INVERSE_TEMPERATURE_K = 8018.0;
+
+  private AqueousCO2HydrationKinetics() {
+  }
+
+  /**
+   * Calculate the published first-order CO2 hydration rate constant.
+   *
+   * @param temperatureK aqueous-phase temperature [K]
+   * @return hydration rate constant [1/s]
+   * @throws IllegalArgumentException when temperature is outside the published range
+   */
+  public static double hydrationRateConstant(double temperatureK) {
+    requirePublishedTemperature(temperatureK);
+    return Math.exp(HYDRATION_LOG_PRE_EXPONENTIAL - HYDRATION_INVERSE_TEMPERATURE_K / temperatureK);
+  }
+
+  /**
+   * Calculate the published first-order H2CO3 dehydration rate constant.
+   *
+   * @param temperatureK aqueous-phase temperature [K]
+   * @return dehydration rate constant [1/s]
+   * @throws IllegalArgumentException when temperature is outside the published range
+   */
+  public static double dehydrationRateConstant(double temperatureK) {
+    requirePublishedTemperature(temperatureK);
+    return Math.exp(DEHYDRATION_LOG_PRE_EXPONENTIAL - DEHYDRATION_INVERSE_TEMPERATURE_K / temperatureK);
+  }
+
+  /**
+   * Calculate the kinetic equilibrium ratio {@code [H2CO3] / [CO2(aq)]}.
+   *
+   * @param temperatureK aqueous-phase temperature [K]
+   * @return dimensionless concentration ratio kH/kD
+   */
+  public static double carbonicAcidToCO2EquilibriumRatio(double temperatureK) {
+    return hydrationRateConstant(temperatureK) / dehydrationRateConstant(temperatureK);
+  }
+
+  /**
+   * Create an equivalent generic {@link KineticReaction} definition.
+   *
+   * <p>
+   * Water is retained in the stoichiometry for elemental conservation but has kinetic order zero because it is the
+   * solvent in the published pseudo-first-order model. The returned reaction is not automatically phase- or
+   * pressure-qualified. A compatible thermodynamic system must expose distinct {@code CO2}, {@code water}, and
+   * {@code H2CO3} components before evaluating its rate.
+   * </p>
+   *
+   * @return reversible volume-basis reaction matching the published correlations
+   */
+  public static KineticReaction createReaction() {
+    KineticReaction reaction = new KineticReaction("aqueous CO2 hydration (Soli and Byrne 2002)");
+    reaction.addReactant("CO2", 1.0, 1.0);
+    reaction.addReactant("water", 1.0, 0.0);
+    reaction.addProduct("H2CO3", 1.0, 1.0);
+    reaction.setRateBasis(KineticReaction.RateBasis.VOLUME);
+    reaction.setPreExponentialFactor(Math.exp(HYDRATION_LOG_PRE_EXPONENTIAL));
+    reaction.setActivationEnergy(HYDRATION_INVERSE_TEMPERATURE_K * KINETIC_REACTION_GAS_CONSTANT_J_PER_MOL_K);
+    reaction.setEquilibriumConstantCorrelation(HYDRATION_LOG_PRE_EXPONENTIAL - DEHYDRATION_LOG_PRE_EXPONENTIAL,
+        DEHYDRATION_INVERSE_TEMPERATURE_K - HYDRATION_INVERSE_TEMPERATURE_K, 0.0, 0.0);
+    return reaction;
+  }
+
+  /**
+   * Advance a closed, isothermal aqueous CO2/H2CO3 pair analytically.
+   *
+   * <p>
+   * The exact solution of the two first-order rates is used, so the update is deterministic, non-negative, and
+   * conserves the supplied dissolved inorganic carbon without a timestep-size error. It does not perform acid
+   * dissociation, charge balance, phase equilibrium, or energy coupling.
+   * </p>
+   *
+   * @param co2Concentration initial aqueous CO2 concentration [mol/m3]
+   * @param carbonicAcidConcentration initial H2CO3 concentration [mol/m3]
+   * @param elapsedTimeSeconds elapsed reaction time [s]
+   * @param temperatureK aqueous-phase temperature [K]
+   * @return immutable analytical update result
+   */
+  public static Result advance(double co2Concentration, double carbonicAcidConcentration, double elapsedTimeSeconds,
+      double temperatureK) {
+    requireFiniteNonNegative(co2Concentration, "CO2 concentration");
+    requireFiniteNonNegative(carbonicAcidConcentration, "H2CO3 concentration");
+    requireFiniteNonNegative(elapsedTimeSeconds, "elapsed time");
+
+    double hydrationRate = hydrationRateConstant(temperatureK);
+    double dehydrationRate = dehydrationRateConstant(temperatureK);
+    double totalConcentration = co2Concentration + carbonicAcidConcentration;
+    if (!Double.isFinite(totalConcentration)) {
+      throw new IllegalArgumentException("total carbon concentration must be finite");
+    }
+
+    double equilibriumCarbonicAcid = totalConcentration * hydrationRate / (hydrationRate + dehydrationRate);
+    double relaxation = Math.exp(-(hydrationRate + dehydrationRate) * elapsedTimeSeconds);
+    double updatedCarbonicAcid = equilibriumCarbonicAcid
+        + (carbonicAcidConcentration - equilibriumCarbonicAcid) * relaxation;
+    updatedCarbonicAcid = Math.max(0.0, Math.min(totalConcentration, updatedCarbonicAcid));
+    double updatedCO2 = totalConcentration - updatedCarbonicAcid;
+
+    return new Result(updatedCO2, updatedCarbonicAcid, hydrationRate, dehydrationRate,
+        totalConcentration - updatedCO2 - updatedCarbonicAcid);
+  }
+
+  private static void requirePublishedTemperature(double temperatureK) {
+    if (!Double.isFinite(temperatureK) || temperatureK < MINIMUM_TEMPERATURE_K
+        || temperatureK > MAXIMUM_TEMPERATURE_K) {
+      throw new IllegalArgumentException("temperature must be within the published Soli-Byrne range of "
+          + MINIMUM_TEMPERATURE_K + " to " + MAXIMUM_TEMPERATURE_K + " K");
+    }
+  }
+
+  private static void requireFiniteNonNegative(double value, String name) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and non-negative");
+    }
+  }
+
+  /** Result of an analytical aqueous CO2 hydration/dehydration update. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double co2Concentration;
+    private final double carbonicAcidConcentration;
+    private final double hydrationRateConstant;
+    private final double dehydrationRateConstant;
+    private final double carbonBalanceResidual;
+
+    private Result(double co2Concentration, double carbonicAcidConcentration, double hydrationRateConstant,
+        double dehydrationRateConstant, double carbonBalanceResidual) {
+      this.co2Concentration = co2Concentration;
+      this.carbonicAcidConcentration = carbonicAcidConcentration;
+      this.hydrationRateConstant = hydrationRateConstant;
+      this.dehydrationRateConstant = dehydrationRateConstant;
+      this.carbonBalanceResidual = carbonBalanceResidual;
+    }
+
+    /** @return aqueous CO2 concentration [mol/m3]. */
+    public double getCO2Concentration() {
+      return co2Concentration;
+    }
+
+    /** @return carbonic-acid concentration [mol/m3]. */
+    public double getCarbonicAcidConcentration() {
+      return carbonicAcidConcentration;
+    }
+
+    /** @return hydration rate constant [1/s]. */
+    public double getHydrationRateConstant() {
+      return hydrationRateConstant;
+    }
+
+    /** @return dehydration rate constant [1/s]. */
+    public double getDehydrationRateConstant() {
+      return dehydrationRateConstant;
+    }
+
+    /** @return carbon concentration closure residual [mol/m3]. */
+    public double getCarbonBalanceResidual() {
+      return carbonBalanceResidual;
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousCO2HydrationKineticsTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousCO2HydrationKineticsTest.java
@@ -1,0 +1,80 @@
+package neqsim.process.equipment.reactor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+
+/** Tests the published aqueous CO2 hydration/dehydration bridge. */
+public class AqueousCO2HydrationKineticsTest extends NeqSimTest {
+
+  @Test
+  void testPublishedRateCorrelationsAt25C() {
+    double temperatureK = 298.15;
+
+    assertEquals(0.030258620071021758, AqueousCO2HydrationKinetics.hydrationRateConstant(temperatureK), 1.0e-14);
+    assertEquals(25.98439659038074, AqueousCO2HydrationKinetics.dehydrationRateConstant(temperatureK), 1.0e-11);
+    assertEquals(1.1644919275217386e-3, AqueousCO2HydrationKinetics.carbonicAcidToCO2EquilibriumRatio(temperatureK),
+        1.0e-15);
+    assertEquals("doi:10.1016/S0304-4203(02)00010-5", AqueousCO2HydrationKinetics.SOURCE_IDENTIFIER);
+    assertTrue(AqueousCO2HydrationKinetics.SOURCE_ACCESS_STATUS.contains("without redistributing"));
+  }
+
+  @Test
+  void testGenericReactionMatchesPublishedForwardAndReverseCorrelations() {
+    double temperatureK = 298.15;
+    KineticReaction reaction = AqueousCO2HydrationKinetics.createReaction();
+
+    assertEquals(AqueousCO2HydrationKinetics.hydrationRateConstant(temperatureK),
+        reaction.calculateRateConstant(temperatureK), 1.0e-14);
+    assertEquals(AqueousCO2HydrationKinetics.carbonicAcidToCO2EquilibriumRatio(temperatureK),
+        reaction.calculateEquilibriumConstant(temperatureK), 1.0e-15);
+    assertEquals(-1.0, reaction.getStoichiometricCoefficient("CO2"), 0.0);
+    assertEquals(-1.0, reaction.getStoichiometricCoefficient("water"), 0.0);
+    assertEquals(1.0, reaction.getStoichiometricCoefficient("H2CO3"), 0.0);
+    assertEquals(KineticReaction.RateBasis.VOLUME, reaction.getRateBasis());
+    assertTrue(reaction.isReversible());
+  }
+
+  @Test
+  void testAnalyticalAdvanceConservesCarbonAndRecoversEquilibrium() {
+    double initialCO2 = 1000.0;
+    double initialCarbonicAcid = 0.0;
+    double temperatureK = 298.15;
+
+    AqueousCO2HydrationKinetics.Result unchanged = AqueousCO2HydrationKinetics.advance(initialCO2, initialCarbonicAcid,
+        0.0, temperatureK);
+    assertEquals(initialCO2, unchanged.getCO2Concentration(), 0.0);
+    assertEquals(initialCarbonicAcid, unchanged.getCarbonicAcidConcentration(), 0.0);
+
+    AqueousCO2HydrationKinetics.Result equilibrated = AqueousCO2HydrationKinetics.advance(initialCO2,
+        initialCarbonicAcid, 10.0, temperatureK);
+    assertEquals(initialCO2 + initialCarbonicAcid,
+        equilibrated.getCO2Concentration() + equilibrated.getCarbonicAcidConcentration(), 1.0e-12);
+    assertEquals(0.0, equilibrated.getCarbonBalanceResidual(), 1.0e-12);
+    assertTrue(equilibrated.getCO2Concentration() >= 0.0);
+    assertTrue(equilibrated.getCarbonicAcidConcentration() >= 0.0);
+    assertEquals(AqueousCO2HydrationKinetics.carbonicAcidToCO2EquilibriumRatio(temperatureK),
+        equilibrated.getCarbonicAcidConcentration() / equilibrated.getCO2Concentration(), 1.0e-15);
+
+    AqueousCO2HydrationKinetics.Result repeated = AqueousCO2HydrationKinetics.advance(initialCO2, initialCarbonicAcid,
+        10.0, temperatureK);
+    assertEquals(equilibrated.getCO2Concentration(), repeated.getCO2Concentration(), 0.0);
+    assertEquals(equilibrated.getCarbonicAcidConcentration(), repeated.getCarbonicAcidConcentration(), 0.0);
+  }
+
+  @Test
+  void testPublishedDomainAndInvalidStatesFailClosed() {
+    assertTrue(
+        AqueousCO2HydrationKinetics.hydrationRateConstant(AqueousCO2HydrationKinetics.MINIMUM_TEMPERATURE_K) > 0.0);
+    assertTrue(
+        AqueousCO2HydrationKinetics.dehydrationRateConstant(AqueousCO2HydrationKinetics.MAXIMUM_TEMPERATURE_K) > 0.0);
+
+    assertThrows(IllegalArgumentException.class, () -> AqueousCO2HydrationKinetics.hydrationRateConstant(288.14));
+    assertThrows(IllegalArgumentException.class, () -> AqueousCO2HydrationKinetics.dehydrationRateConstant(305.66));
+    assertThrows(IllegalArgumentException.class, () -> AqueousCO2HydrationKinetics.advance(-1.0, 0.0, 1.0, 298.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2HydrationKinetics.advance(1.0, 0.0, Double.NaN, 298.15));
+  }
+}


### PR DESCRIPTION
## Engineering question

Can NeqSim reproduce one public reversible CO2(aq)/H2CO3 kinetic model, conserve the closed aqueous carbon pair exactly, and expose it through the existing generic kinetic-reaction contract without implying qualification at dense-phase pipeline pressure?

Advances #3318. Capability contract: https://github.com/equinor/neqsim/issues/3318#issuecomment-5471264784

Coordinates with electrolyte/speciation #3144, flash/stability #2937, transient state #2911, pipeline/TwoFluid ownership, and future MCP exposure #3153.

## Exact continuity and frozen scope

- **Exact base/master:** `e380f78e0880b9185a668737fd539d7552d69d47`
- **Exact head:** `730c6201043c3010e3144d528b050654faa807d2`
- **Branch:** `ai/co2-aqueous-hydration-3318`
- Sole active #3318 implementation PR; merged #3319 is the prerequisite.
- Implements only the Soli & Byrne (2002) reversible aqueous CO2 hydration/dehydration bridge for 0.65 molal NaCl and 288.15–305.65 K.
- No proprietary Northern Lights data, pressure extrapolation, pipeline source terms, electrolyte database change, or SOx/H2S/NOx parameters.

## Primary evidence and equations

Soli, A. L. and Byrne, R. H. (2002), *CO2 System Hydration and Dehydration Kinetics and the Equilibrium CO2/H2CO3 Ratio in Aqueous NaCl Solution*, Marine Chemistry 78, 65–73. DOI: https://doi.org/10.1016/S0304-4203(02)00010-5

Direct source fits, with T in K:

- `ln(kH / s^-1) = 22.66 - 7799/T`
- `ln(kD / s^-1) = 30.15 - 8018/T`

At 298.15 K the implementation gives `kH = 0.0302586200710 s^-1`, `kD = 25.9843965904 s^-1`, and `[H2CO3]/[CO2(aq)] = 0.00116449192752`.

The source equations are reproduced directly; this is not a new NeqSim calibration or an independent high-pressure validation. Public DOI/institutional metadata and abstract are available; no tabulated dataset is redistributed. The public abstract does not provide uncertainty statistics for the two fits.

## Implementation

- `AqueousCO2HydrationKinetics`
  - programmatic citation, DOI, access note, NaCl molality and temperature boundary;
  - fail-closed temperature validation;
  - published forward and reverse rate constants;
  - exact mapping to reversible volume-basis `KineticReaction`;
  - analytical closed-batch update for CO2(aq)/H2CO3 with deterministic, non-negative, carbon-conserving behavior.
- `AqueousCO2HydrationKineticsTest`
  - equation reproduction at 25 C;
  - generic-reaction forward/equilibrium consistency;
  - stoichiometry and rate basis;
  - zero-time recovery, carbon closure, non-negativity, deterministic repeat and equilibrium recovery;
  - invalid concentration/time and temperature-bound rejection.
- Updated CCS kinetics guide and executable documentation contract.

## Scientific stop boundary

This PR does **not** qualify pressure effects, dense-phase CO2, other salinities, H2CO3/bicarbonate system mapping, acid dissociation, pH, activity corrections, charge balance, heat effects, phase transfer, corrosion, scale, or pipeline control-volume coupling. Soli & Byrne did not vary pressure. Application at pipeline pressure requires separate public evidence.

## Validation

**DRAFT — VALIDATION PENDING CI**

Passed locally on exact source:

- `./mvnw -q -Dtest=AqueousCO2HydrationKineticsTest,KineticReactionTransportDiagnosticsTest,CO2TransportReactionKineticsDocumentationTest test`
- `python3 docs/test_co2_transport_reaction_kinetics_documentation.py` — 7/7
- `python3 devtools/check_documentation_search.py` — 674 Markdown + 1 standalone HTML audited
- `git diff --check`
- `python3 devtools/run_spotless.py apply` was run; the two changed Java files were stable after formatting.

Repository-wide `spotless:check` and the pre-commit aggregate currently fail on four pre-existing, untouched master files:
`ChemistryRunner.java`, `ChemistryRunnerTest.java`, `OilAssayCharacterisationOediCoaTest.java`, and `PitzerCatalogPerformanceBenchmark.java`. The open formatting-repair PRs #3349 and #3351 address parts of this baseline. This PR does not absorb unrelated formatting.

Fresh exact-head GitHub CI is authoritative; no unrun check is claimed as passing.

## Documentation impact

Updated the existing CO2 transport kinetics guide with equations, units, numerical reference values, evidence/access boundary, calibration-versus-validation distinction, and the high-pressure exclusion.

## Next dependency

After this exact head is green and merged, the next #3318 increment should coordinate with #3144 to map the explicit H2CO3 bridge onto the electrolyte bicarbonate/speciation basis, then qualify pressure effects before any dense-phase pipeline source-term coupling.

AI-assisted contribution.