### PR TITLE
[AI-Assisted] fix(refinery): make API gravity reference explicit

### DIFF
--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -48,6 +48,7 @@ For crude/petroleum assays, use `OilAssayCharacterisation` rather than manually 
 - volume-to-mass conversion using cut density;
 - kg/mol and g/mol explicit molar-mass helpers;
 - specific-gravity, kg/m3, and API-gravity density inputs;
+- exact API-gravity/SG60/60 round-tripping and explicit bulk density at 60 degF;
 - pre-binned cumulative TBP cut-boundary ingestion;
 - preserved lower/upper boiling ranges;
 - closure, duplicate-name, monotonicity, and repeated-application guards.

--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -125,11 +125,11 @@ The API-gravity conversion follows the conventional relation
 
 $$SG_{60/60}=\frac{141.5}{API+131.5}$$
 
-with the existing NeqSim 60 degF water-density reference. Negative API gravities are accepted when physically meaningful; the singular range at and below -131.5 degrees API is rejected.
+and stores the result as dimensionless specific gravity. Negative API gravities are accepted when physically meaningful; the singular range at and below -131.5 degrees API is rejected. This exact dimensionless handling corrects the earlier assay path, which additionally multiplied API-derived specific gravity by the water density and therefore made API- and specific-gravity-origin cuts differ by about 0.0985%.
 
 ### Reconstructed whole-assay density
 
-For a complete cut table, `getBulkSpecificGravity()` reconstructs the ideal additive-volume whole-assay specific gravity without creating pseudo-components or mutating the thermodynamic system. `getBulkApiGravity()` reports the corresponding degrees API. Both mass- and liquid-volume-basis assays use the same resolved relation:
+For a complete cut table, `getBulkSpecificGravity()` reconstructs the ideal additive-volume whole-assay specific gravity without creating pseudo-components or mutating the thermodynamic system. `getBulkApiGravity()` reports the corresponding degrees API. `getBulkDensityKgPerCubicMetreAt60F()` provides physical density at 60 degF by multiplying the dimensionless result by 999.016 kg/m3. Both mass- and liquid-volume-basis assays use the same resolved relation:
 
 $$SG_{bulk}=\left(\sum_i\frac{w_i}{SG_i}\right)^{-1}$$
 

--- a/docs/thermo/characterization/refinery_big_hill_validation.md
+++ b/docs/thermo/characterization/refinery_big_hill_validation.md
@@ -47,6 +47,8 @@ The same source reports whole-crude specific gravity **0.8451** and API gravity 
    must reproduce the normalized DOE weight-yield shape with maximum absolute deviation below **0.007 mass fraction** (0.7 percentage points).
 3. Supplying the same cuts through the public API-gravity input path must reproduce the mass-fraction shape obtained from the four-decimal specific-gravity values within **5e-5 mass fraction**. This tolerance reflects the DOE table's one-decimal API rounding, not a thermodynamic-model uncertainty.
 
+Each published API input must also round-trip exactly through the conventional dimensionless SG60/60 relation to `1e-12`. Physical density is exposed separately as SG60/60 multiplied by 999.016 kg/m3. This prevents the reference water density from being applied twice when API gravity is used as an assay input.
+
 For the frozen values, the largest pre-CI volume-to-mass deviation is approximately **0.00667 mass fraction**. The largest specific-gravity versus rounded-API mass-shape deviation is approximately **4.27e-5 mass fraction**. These tolerances are therefore data-agreement gates rather than machine-precision tolerances.
 
 The test then applies the normalized slice through `OilAssayCharacterisation`, requires finite positive pseudo-component molar masses and mole amounts, and requires reconstructed assay mass closure to `1e-10`.

--- a/docs/thermo/characterization/refinery_oedi_coa_bulk_density_validation.md
+++ b/docs/thermo/characterization/refinery_oedi_coa_bulk_density_validation.md
@@ -72,3 +72,5 @@ The calculation uses the density reference condition represented by the source t
 The matrix intentionally does not create pseudo-components because the summary categories do not provide finite representative boiling points and molar masses for all terminal categories. This increment adds no production formula, coefficient tuning, terminal-cut extrapolation, TBP/ASTM conversion, column change, JSON/MCP schema, notebook, vacuum model, blending optimizer or conversion-unit model.
 
 Python uses the same authoritative Java methods through the normal NeqSim JVM gateway; no separate Python property equation is maintained.
+
+Physical density at 60 degF is available separately through `getBulkDensityKgPerCubicMetreAt60F()`, using 999.016 kg/m3 for water. API-gravity inputs remain dimensionless SG60/60 values and are not pre-multiplied by water density; this preserves exact API-to-SG round-tripping while keeping physical-density units explicit.

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -41,7 +41,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
   private static final double PERCENT_TOLERANCE = 1e-8;
   private static final double KELVIN_OFFSET = 273.15;
   private static final double GRAMS_PER_KILOGRAM = 1000.0;
-  private static final double WATER_DENSITY_60F_G_CC = 0.999016;
+  private static final double WATER_DENSITY_60F_KG_M3 = 999.016;
 
   private transient SystemInterface system;
   private double totalAssayMass = 1.0;
@@ -227,6 +227,22 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
    */
   public double getBulkApiGravity() {
     return 141.5 / getBulkSpecificGravity() - 131.5;
+  }
+
+  /**
+   * Reconstruct the bulk assay density at 60 degF from {@link #getBulkSpecificGravity()}.
+   *
+   * <p>
+   * This method keeps dimensionless specific gravity separate from physical density. It uses a water density of 999.016
+   * kg/m3 at 60 degF and inherits the ideal-additive-volume assumptions and validation boundary of
+   * {@link #getBulkSpecificGravity()}.
+   * </p>
+   *
+   * @return reconstructed bulk density at 60 degF in kg/m3
+   * @throws IllegalStateException if bulk specific gravity cannot be reconstructed
+   */
+  public double getBulkDensityKgPerCubicMetreAt60F() {
+    return getBulkSpecificGravity() * WATER_DENSITY_60F_KG_M3;
   }
 
   /**
@@ -790,8 +806,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
         return density;
       }
       if (apiGravity != null) {
-        double specificGravity = 141.5 / (apiGravity + 131.5);
-        return specificGravity * WATER_DENSITY_60F_G_CC;
+        return 141.5 / (apiGravity + 131.5);
       }
       throw new IllegalStateException("Density or API gravity required for cut " + name);
     }

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTest.java
@@ -42,6 +42,16 @@ public class OilAssayCharacterisationDoeBigHillTest {
       double calculatedApi = 141.5 / SPECIFIC_GRAVITY[i] - 131.5;
       assertEquals(API_GRAVITY[i], calculatedApi, 0.05,
           "Published specific-gravity/API pair should agree within reported rounding");
+
+      SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+      OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+      characterisation.clearCuts();
+      characterisation.addCut(new AssayCut("API_" + i).withMassFraction(1.0).withApiGravity(API_GRAVITY[i]));
+      double apiDerivedSpecificGravity = 141.5 / (API_GRAVITY[i] + 131.5);
+      assertEquals(apiDerivedSpecificGravity, characterisation.getBulkSpecificGravity(), 1e-12);
+      assertEquals(API_GRAVITY[i], characterisation.getBulkApiGravity(), 1e-12);
+      assertEquals(apiDerivedSpecificGravity * 999.016, characterisation.getBulkDensityKgPerCubicMetreAt60F(), 1e-9);
+      assertEquals(0, system.getNumberOfComponents());
     }
 
     double wholeCrudeApi = 141.5 / 0.8451 - 131.5;

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationTest.java
@@ -35,7 +35,7 @@ public class OilAssayCharacterisationTest {
     assertEquals(expectedLightMolarMass, lightComponent.getMolarMass(), 1e-8);
     assertEquals(0.4 / expectedLightMolarMass, lightComponent.getNumberOfmoles(), 1e-8);
 
-    double heavyDensity = 141.5 / (25.0 + 131.5) * 0.999016;
+    double heavyDensity = 141.5 / (25.0 + 131.5);
     double heavyBoilingPoint = 350.0 + 273.15;
     double expectedHeavyMolarMass = 5.805e-5 * Math.pow(heavyBoilingPoint, 2.3776) / Math.pow(heavyDensity, 0.9371)
         / 1000.0;
@@ -56,7 +56,7 @@ public class OilAssayCharacterisationTest {
     characterisation.addCut(
         new AssayCut("Heavy").withVolumePercent(60.0).withApiGravity(25.0).withAverageBoilingPointCelsius(350.0));
 
-    double heavyDensity = 141.5 / (25.0 + 131.5) * 0.999016;
+    double heavyDensity = 141.5 / (25.0 + 131.5);
     double totalRelativeMass = 0.4 * 0.75 + 0.6 * heavyDensity;
     double expectedLightMassFraction = 0.4 * 0.75 / totalRelativeMass;
     double expectedHeavyMassFraction = 0.6 * heavyDensity / totalRelativeMass;
@@ -81,6 +81,7 @@ public class OilAssayCharacterisationTest {
     double expectedMassBasisSpecificGravity = 1.0 / (0.25 / 0.80 + 0.75 / 0.90);
     assertEquals(expectedMassBasisSpecificGravity, massAssay.getBulkSpecificGravity(), 1e-12);
     assertEquals(141.5 / expectedMassBasisSpecificGravity - 131.5, massAssay.getBulkApiGravity(), 1e-12);
+    assertEquals(expectedMassBasisSpecificGravity * 999.016, massAssay.getBulkDensityKgPerCubicMetreAt60F(), 1e-9);
     assertEquals(0, massSystem.getNumberOfComponents());
 
     SystemInterface volumeSystem = new SystemSrkEos(298.15, 10.0);
@@ -284,6 +285,23 @@ public class OilAssayCharacterisationTest {
     AssayCut denseCut = new AssayCut("Residue").withMassFraction(1.0).withApiGravity(-5.0)
         .withAverageBoilingPointCelsius(520.0);
     assertTrue(denseCut.resolveDensity() > 1.0);
+  }
+
+  @Test
+  public void testApiGravityResolvesDimensionlessSpecificGravity() {
+    double apiGravity = 34.97;
+    double expectedSpecificGravity = 141.5 / (apiGravity + 131.5);
+    SystemInterface system = new SystemSrkEos(298.15, 10.0);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+    AssayCut cut = new AssayCut("ApiCut").withMassFraction(1.0).withApiGravity(apiGravity);
+    characterisation.addCut(cut);
+
+    assertEquals(expectedSpecificGravity, cut.resolveDensity(), 1e-12);
+    assertEquals(expectedSpecificGravity, characterisation.getBulkSpecificGravity(), 1e-12);
+    assertEquals(apiGravity, characterisation.getBulkApiGravity(), 1e-12);
+    assertEquals(expectedSpecificGravity * 999.016, characterisation.getBulkDensityKgPerCubicMetreAt60F(), 1e-9);
+    assertEquals(0, system.getNumberOfComponents());
   }
 
   @Test


### PR DESCRIPTION
## Engineering question

Can refinery-assay API-gravity input round-trip exactly through the conventional dimensionless SG60/60 relation, while physical density remains available through an explicitly unit-bearing method?

Advances #3305. Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5471842622

## Exact continuity and frozen scope

- **Exact base:** `1dec02d734eb5daef4df0ca567724635721e93f1`
- **Exact head:** `042f6d03a0a419af6e7c06924887a056970e5217`
- Sole active #3305 implementation PR; three other autonomous capabilities were open before publication, below the target and absolute ceiling of ten.
- Stops before temperature/pressure density correction, excess volume, blend contraction, pseudo-component coefficient qualification, complete-crude terminal treatment, columns, blending, optimization, or conversion models.

## Implementation

- `AssayCut.withApiGravity(...).resolveDensity()` now returns the conventional dimensionless `SG60/60 = 141.5 / (API + 131.5)` without additionally multiplying by water density.
- Adds `getBulkDensityKgPerCubicMetreAt60F()`, which explicitly converts bulk SG to physical density using 999.016 kg/m³ for water at 60 °F.
- Keeps `getBulkSpecificGravity()` dimensionless and `getBulkApiGravity()` in degrees API.
- Adds analytical and public DOE Big Hill regression coverage for API→SG→API round-trip, explicit physical-density output, no system mutation, and existing mass/basis behavior.
- Updates the refinery API, Big Hill, OEDI, and characterization-index documentation.

The corrected API-derived cut value is about 0.0985% higher than the previous density-scaled value. This compatibility change is deliberate and documented; no coefficient or public datum is tuned.

## Public evidence and validity

- DOE SPR Big Hill Sweet bounded cut pairs cover API 17.8–49.6.
- The DOE/OEDI COA whole-crude matrix covers API 35.6–53.5 and retains its existing SG/API error evidence.
- The public pairs qualify source consistency and reporting precision; they are not statistically independent property measurements.
- Target maturity is **qualified for assay screening** inside these public ranges. Negative API remains software-supported but outside public qualification.

## Views

Java is authoritative. Python/JPype automatically exposes the same methods. JSON and MCP are not applicable because no refinery-assay schema owns this object. A notebook is not applicable to this bounded reference-semantics correction.

## Validation

Passed on the final source:

- `python3 devtools/run_spotless.py apply`
- `python3 devtools/run_spotless.py check`
- `python3 devtools/check_documentation_search.py` — 674 Markdown pages and one standalone HTML page
- `./mvnw -q -Dtest=OilAssayCharacterisationTest,OilAssayCharacterisationDoeBigHillTest,OilAssayCharacterisationOediCoaTest test`
- `git diff --check`

The `pre-commit` executable was unavailable locally; direct repository-equivalent gates passed and hosted pre-commit remains authoritative. No broad local suite was run under the fast-validation policy.

**VALIDATION PENDING CI**

Documentation impact: updated all nearest refinery-assay and public-validation pages; no notebook, schema, process, or release documentation is affected.

Generated with AI assistance.