### PR TITLE
[AI-Assisted] docs: qualify process rendering contracts

### DIFF
--- a/docs/process/equipment/adsorbers.md
+++ b/docs/process/equipment/adsorbers.md
@@ -3,8 +3,6 @@ title: Adsorbers
 description: Documentation for adsorption equipment in NeqSim.
 ---
 
-# Adsorbers
-
 Documentation for adsorption equipment in NeqSim.
 
 ## Table of Contents

--- a/docs/process/equipment/battery_storage.md
+++ b/docs/process/equipment/battery_storage.md
@@ -3,8 +3,6 @@ title: Battery Storage
 description: Documentation for battery storage equipment in NeqSim for energy storage and power management applications.
 ---
 
-# Battery Storage
-
 Documentation for battery storage equipment in NeqSim for energy storage and power management applications.
 
 ## Table of Contents

--- a/docs/process/equipment/compressor_antisurge_control.md
+++ b/docs/process/equipment/compressor_antisurge_control.md
@@ -3,8 +3,6 @@ title: Compressor Anti-Surge and Coordinated Control
 description: Guide to compressor anti-surge protection, speed/load control, recycle override, coordinated pressure-speed-recycle control, and anti-surge application design examples in NeqSim.
 ---
 
-# Compressor Anti-Surge and Coordinated Control
-
 This guide explains how NeqSim represents compressor operating-envelope protection and coordinated compressor control in the dynamic compressor map example.
 
 The focus is educational and simulation-oriented. The models illustrate common control philosophy patterns used for centrifugal compressors; they are not a replacement for vendor-certified compressor controls, machinery protection systems, or site-specific control narratives.

--- a/docs/process/equipment/compressor_curves.md
+++ b/docs/process/equipment/compressor_curves.md
@@ -3,8 +3,6 @@ title: Compressor Curves and Performance Maps
 description: Detailed documentation for compressor performance curves in NeqSim, including multi-speed and single-speed compressor handling, automatic curve generation, and predefined templates.
 ---
 
-# Compressor Curves and Performance Maps
-
 Detailed documentation for compressor performance curves in NeqSim, including multi-speed and single-speed compressor handling, automatic curve generation, and predefined templates.
 
 ## Table of Contents

--- a/docs/process/equipment/compressor_shaft.md
+++ b/docs/process/equipment/compressor_shaft.md
@@ -3,8 +3,6 @@ title: "CompressorShaft: Multiple Compressor Bodies on One Shaft"
 description: "Model a multi-body compressor string driven by a single gas turbine or motor at one common speed with CompressorShaft. Covers the degrees-of-freedom rule, iterating the common speed to the final discharge (intermediate pressures float), the process-integrated CompressorShaftCalculator that converges the shaft speed inside process.run(), shared pressure nodes, fixed-speed drivers, single-body use, and coexistence with anti-surge control."
 ---
 
-# CompressorShaft: Multiple Compressor Bodies on One Shaft
-
 `neqsim.process.equipment.compressor.CompressorShaft` groups several
 `Compressor` bodies that sit on **one driver shaft** (a single gas turbine or
 motor, often through a gearbox) so they all turn at the **same speed**. A

--- a/docs/process/equipment/control_valves.md
+++ b/docs/process/equipment/control_valves.md
@@ -3,8 +3,6 @@ title: Control Valves
 description: Comprehensive documentation for control valves in NeqSim including CheckValve, LevelControlValve, PressureControlValve, and safety valves (ESD, PSD).
 ---
 
-# Control Valves
-
 Comprehensive documentation for control valves in NeqSim process simulation.
 
 ## Table of Contents

--- a/docs/process/equipment/differential_pressure.md
+++ b/docs/process/equipment/differential_pressure.md
@@ -3,8 +3,6 @@ title: Differential Pressure Devices
 description: Documentation for differential pressure measurement and flow restriction equipment in NeqSim.
 ---
 
-# Differential Pressure Devices
-
 Documentation for differential pressure measurement and flow restriction equipment in NeqSim.
 
 ## Table of Contents

--- a/docs/process/equipment/ejectors.md
+++ b/docs/process/equipment/ejectors.md
@@ -3,8 +3,6 @@ title: Ejector Equipment
 description: "Documentation for ejector equipment in NeqSim process simulation, including Transvac-style vendor parameters (entrainment ratio, compression ratio, critical back pressure, area ratio, Mach numbers)."
 ---
 
-# Ejector Equipment
-
 Documentation for ejector equipment in NeqSim process simulation.
 
 ## Table of Contents

--- a/docs/process/equipment/electrolyzers.md
+++ b/docs/process/equipment/electrolyzers.md
@@ -3,8 +3,6 @@ title: Electrolyzer Equipment
 description: "Documentation for electrolyzer equipment in NeqSim — water electrolysis (green hydrogen), PEM/Alkaline/SOEC/AEM technologies, I-V polarisation models, power-driven operation, stack sizing, turndown/standby, ramp limits, balance-of-plant losses, thermal and water consumption, delivery pressure, and CO2 electrolysis."
 ---
 
-# Electrolyzer Equipment
-
 Documentation for electrolyzer equipment in NeqSim process simulation.
 
 ## Table of Contents

--- a/docs/process/equipment/expanders.md
+++ b/docs/process/equipment/expanders.md
@@ -3,8 +3,6 @@ title: Expanders and Turbines
 description: Documentation for expansion equipment in NeqSim.
 ---
 
-# Expanders and Turbines
-
 Documentation for expansion equipment in NeqSim.
 
 ## Table of Contents

--- a/docs/process/equipment/failure_modes.md
+++ b/docs/process/equipment/failure_modes.md
@@ -3,8 +3,6 @@ title: Equipment Failure Modes
 description: Documentation for equipment failure mode modeling in NeqSim for reliability and risk analysis.
 ---
 
-# Equipment Failure Modes
-
 Documentation for equipment failure mode modeling in NeqSim for reliability and risk analysis.
 
 ## Table of Contents

--- a/docs/process/equipment/flares.md
+++ b/docs/process/equipment/flares.md
@@ -3,8 +3,6 @@ title: Flare Systems
 description: Documentation for flare equipment in NeqSim process simulation.
 ---
 
-# Flare Systems
-
 Documentation for flare equipment in NeqSim process simulation.
 
 ## Table of Contents

--- a/docs/process/equipment/heat_exchangers.md
+++ b/docs/process/equipment/heat_exchangers.md
@@ -4,8 +4,6 @@ description: Source-anchored guide to heater, cooler, two-stream heat-exchanger,
 keywords: "heat exchanger, heater, cooler, UA, duty, effectiveness, LMTD, dynamic heat exchanger, auto sizing"
 ---
 
-# Heat Exchanger Equipment
-
 NeqSim provides single-stream temperature or duty equipment and a two-stream heat exchanger.
 This guide separates their specifications and result APIs so that a model does not accidentally
 mix heater, exchanger, column-condenser, or mechanical-design semantics.

--- a/docs/process/equipment/heat_integration.md
+++ b/docs/process/equipment/heat_integration.md
@@ -3,8 +3,6 @@ title: "Heat Integration and Pinch Analysis"
 description: "Guide to using PinchAnalysis and HeatStream classes for process heat integration, minimum utility targeting, composite curves, and grand composite curves using the Linnhoff method."
 ---
 
-# Heat Integration and Pinch Analysis
-
 NeqSim provides a classical pinch analysis engine (Linnhoff method) for determining minimum heating and cooling utility requirements for a set of process streams.
 
 ## Classes

--- a/docs/process/equipment/iron_sulfide_wall_source.md
+++ b/docs/process/equipment/iron_sulfide_wall_source.md
@@ -3,8 +3,6 @@ title: Iron-sulfide wall inventory and elemental-sulfur source
 description: "Stateful screening model for FeS formation on carbon-steel walls, oxidation during oxygen ingress, and coupling of generated S8 to condensate transport and compressor deposition."
 ---
 
-# Iron-sulfide wall inventory and elemental-sulfur source
-
 `IronSulfideWallInventory` and `IronSulfideOxidationSource` represent a source that a fluid-only
 equilibrium calculation cannot retain: corrosion product accumulated during an earlier wet or sour
 period. The source can be connected directly to NeqSim's existing S8 solid flash, sulfur filter, and
@@ -28,14 +26,12 @@ all kinetic defaults are zero and an uncalibrated calculation reports low/base/h
 
 The implemented bookkeeping reactions are:
 
-\[
-\begin{aligned}
+$$\begin{aligned}
 \mathrm{Fe + H_2S} &\rightarrow \mathrm{FeS + H_2} \\
 \mathrm{FeCO_3 + H_2S} &\rightarrow \mathrm{FeS + CO_2 + H_2O} \\
 \mathrm{Fe_2O_3 + 3H_2S} &\rightarrow \mathrm{2FeS + S^0 + 3H_2O} \\
 \mathrm{4FeS + 3O_2} &\rightarrow \mathrm{2Fe_2O_3 + 4S^0}
-\end{aligned}
-\]
+\end{aligned}$$
 
 The last equation is the default Fe2O3-equivalent screening branch. The oxygen stoichiometry and
 fraction ending as S0 are configurable because partially oxidised sulfur and iron products are

--- a/docs/process/equipment/looped_networks.md
+++ b/docs/process/equipment/looped_networks.md
@@ -3,8 +3,6 @@ title: Looped Pipeline Networks
 description: Documentation for looped pipeline network modeling with Hardy Cross solver in NeqSim.
 ---
 
-# Looped Pipeline Networks
-
 Documentation for looped pipeline network modeling with Hardy Cross solver in NeqSim.
 
 ## Table of Contents

--- a/docs/process/equipment/manifold_design.md
+++ b/docs/process/equipment/manifold_design.md
@@ -3,8 +3,6 @@ title: Manifold Mechanical Design Guide
 description: This guide documents the manifold mechanical design capabilities in NeqSim, covering topside, onshore, and subsea applications.
 ---
 
-# Manifold Mechanical Design Guide
-
 This guide documents the manifold mechanical design capabilities in NeqSim, covering topside, onshore, and subsea applications.
 
 ## Overview

--- a/docs/process/equipment/manifolds.md
+++ b/docs/process/equipment/manifolds.md
@@ -3,8 +3,6 @@ title: Manifolds
 description: Documentation for manifold equipment that combines stream mixing and splitting in NeqSim.
 ---
 
-# Manifolds
-
 Documentation for manifold equipment that combines stream mixing and splitting in NeqSim.
 
 ## Table of Contents

--- a/docs/process/equipment/measurement_devices.md
+++ b/docs/process/equipment/measurement_devices.md
@@ -3,8 +3,6 @@ title: Measurement Devices and Analysers
 description: NeqSim provides a comprehensive set of measurement devices and process analysers for monitoring fluid properties, compositions, and process conditions.
 ---
 
-# Measurement Devices and Analysers
-
 NeqSim provides a comprehensive set of measurement devices and process analysers for monitoring fluid properties, compositions, and process conditions.
 
 ## Overview

--- a/docs/process/equipment/membranes.md
+++ b/docs/process/equipment/membranes.md
@@ -3,8 +3,6 @@ title: Membrane Separation Equipment
 description: Documentation for membrane separation equipment in NeqSim process simulation.
 ---
 
-# Membrane Separation Equipment
-
 Documentation for membrane separation equipment in NeqSim process simulation.
 
 ## Table of Contents

--- a/docs/process/equipment/multiphase_flow_correlations.md
+++ b/docs/process/equipment/multiphase_flow_correlations.md
@@ -3,8 +3,6 @@ title: Multiphase Flow Correlations
 description: "Multiphase pipe flow correlations in NeqSim: Beggs and Brill, Hagedorn-Brown, and Mukherjee-Brill models for pressure drop, liquid holdup, and flow pattern prediction in vertical, horizontal, and inclined pipelines."
 ---
 
-# Multiphase Flow Correlations
-
 NeqSim provides several empirical and mechanistic correlations for multiphase pipe
 flow. This page covers the three main correlations, when to use each, and code examples.
 

--- a/docs/process/equipment/multistream_heat_exchanger.md
+++ b/docs/process/equipment/multistream_heat_exchanger.md
@@ -3,8 +3,6 @@ title: Multi-Stream Heat Exchanger
 description: Comprehensive guide to multi-stream heat exchanger modeling in NeqSim, including mathematical foundations, composite curves, and practical examples for LNG, cryogenic, and refinery applications.
 ---
 
-# Multi-Stream Heat Exchanger
-
 The `MultiStreamHeatExchanger2` class models heat exchangers with multiple hot and cold streams exchanging heat simultaneously. This is essential for:
 
 - **LNG/Cryogenic Plants**: Main cryogenic heat exchangers (MCHE)

--- a/docs/process/equipment/networks.md
+++ b/docs/process/equipment/networks.md
@@ -3,8 +3,6 @@ title: Pipeline Networks
 description: Documentation for pipeline network modeling in NeqSim.
 ---
 
-# Pipeline Networks
-
 Documentation for pipeline network modeling in NeqSim.
 
 ## Table of Contents

--- a/docs/process/equipment/pipeline_simulation.md
+++ b/docs/process/equipment/pipeline_simulation.md
@@ -4,8 +4,6 @@ description: Comprehensive documentation for pipeline simulation in NeqSim, cove
 keywords: "pipeline simulation, multiphase flow, Beggs and Brill, pressure drop, pipe flow, gas pipeline, oil pipeline, subsea, heat transfer, elevation, slug, holdup"
 ---
 
-# Pipeline Simulation Guide
-
 Comprehensive documentation for pipeline simulation in NeqSim, covering all pipeline types, common interface, flow modeling, and integration with mechanical design.
 
 ## Table of Contents

--- a/docs/process/equipment/pipelines.md
+++ b/docs/process/equipment/pipelines.md
@@ -4,8 +4,6 @@ description: Documentation for pipeline equipment in NeqSim.
 keywords: "pipeline, pipe, pipe flow, pressure drop, Beggs and Brill, multiphase flow, elevation, heat transfer, pipe sizing, subsea pipeline, export pipeline, gas pipeline"
 ---
 
-# Pipelines and Pipes
-
 Documentation for pipeline equipment in NeqSim.
 
 > **📘 Comprehensive Documentation Available**

--- a/docs/process/equipment/plug_flow_reactor.md
+++ b/docs/process/equipment/plug_flow_reactor.md
@@ -3,8 +3,6 @@ title: "Plug Flow Reactor (PFR) Guide"
 description: "Comprehensive guide to the NeqSim Plug Flow Reactor for rigorous kinetic modeling. Covers governing equations, kinetic rate expressions (power-law, LHHW, reversible), catalyst bed modeling, Ergun pressure drop, energy modes, integration methods, axial profiles, and worked examples for ammonia synthesis and steam reforming."
 ---
 
-# Plug Flow Reactor (PFR) Guide
-
 The NeqSim Plug Flow Reactor models chemical transformation along a tubular reactor by solving
 coupled ordinary differential equations for species molar flows, temperature, and pressure as a
 function of axial position. It supports homogeneous gas-phase and heterogeneous catalytic reactions

--- a/docs/process/equipment/power_generation.md
+++ b/docs/process/equipment/power_generation.md
@@ -3,8 +3,6 @@ title: Power Generation Equipment
 description: "Documentation for power generation equipment in NeqSim: gas turbines, steam turbines, HRSG, combined-cycle systems, fuel cells, wind turbines, and solar panels."
 ---
 
-# Power Generation Equipment
-
 Documentation for power generation equipment in NeqSim, including gas turbines, steam turbines, HRSG, combined-cycle systems, fuel cells, wind turbines, and solar panels.
 
 ## Table of Contents

--- a/docs/process/equipment/production_well_networks.md
+++ b/docs/process/equipment/production_well_networks.md
@@ -3,8 +3,6 @@ title: "Production Well Networks"
 description: "Modeling production well networks with IPR, chokes, tubing VLP, and multiphase pipe flow using LoopedPipeNetwork. Covers Newton-Raphson Global Gradient Algorithm with generalized resistance elements for oil and gas gathering systems."
 ---
 
-# Production Well Networks
-
 Model complete production well networks — from reservoir sandface through tubing,
 chokes, flowlines, and manifolds to delivery — using the `LoopedPipeNetwork`
 Newton-Raphson Global Gradient Algorithm (NR-GGA) solver.

--- a/docs/process/equipment/reactors.md
+++ b/docs/process/equipment/reactors.md
@@ -3,8 +3,6 @@ title: Reactors
 description: "Documentation for chemical reactor equipment in NeqSim: plug flow reactor (PFR), stirred tank reactor (CSTR), Gibbs equilibrium reactor, stoichiometric reactor, sulfur oxidation reactor, sulfur deposition analyser, hydrogen production reformers, ammonia synthesis reactor, and bio-processing reactors."
 ---
 
-# Reactors
-
 NeqSim provides a family of reactor models for gas-phase kinetics, chemical equilibrium,
 stoichiometric conversion, catalytic reactions, and bio-processing. All reactors live in the
 `neqsim.process.equipment.reactor` package and integrate with `ProcessSystem` flowsheets.

--- a/docs/process/equipment/reservoirs.md
+++ b/docs/process/equipment/reservoirs.md
@@ -3,8 +3,6 @@ title: Reservoir Modeling
 description: Documentation for reservoir modeling equipment in NeqSim, enabling coupled reservoir-process simulations.
 ---
 
-# Reservoir Modeling
-
 Documentation for reservoir modeling equipment in NeqSim, enabling coupled reservoir-process simulations.
 
 ## Table of Contents

--- a/docs/process/equipment/separator-entrainment-modeling.md
+++ b/docs/process/equipment/separator-entrainment-modeling.md
@@ -3,8 +3,6 @@ title: "Enhanced Separator Entrainment Modeling"
 description: "Physics-based separator performance modeling with droplet size distributions, flow regime prediction, inlet device modeling, grade efficiency curves, vessel geometry, and internals databases. Comparable to commercial tools like MySep and ProSep."
 ---
 
-# Enhanced Separator Entrainment Modeling
-
 Physics-based, inlet-to-outlet separator performance calculation using open-literature
 correlations. This is an optional enhancement to the standard NeqSim separator that
 computes entrainment from first principles rather than user-specified fractions.

--- a/docs/process/equipment/streams.md
+++ b/docs/process/equipment/streams.md
@@ -3,8 +3,6 @@ title: Streams
 description: Comprehensive documentation for process streams in NeqSim.
 ---
 
-# Streams
-
 Comprehensive documentation for process streams in NeqSim.
 
 ## Table of Contents

--- a/docs/process/equipment/subsea_boosters.md
+++ b/docs/process/equipment/subsea_boosters.md
@@ -3,8 +3,6 @@ title: Subsea Boosters
 description: Documentation for subsea booster pump and compressor equipment in NeqSim.
 ---
 
-# Subsea Boosters
-
 Documentation for subsea booster pump and compressor equipment in NeqSim.
 
 ## Table of Contents

--- a/docs/process/equipment/subsea_equipment.md
+++ b/docs/process/equipment/subsea_equipment.md
@@ -3,8 +3,6 @@ title: Subsea Equipment
 description: Documentation for subsea production equipment in NeqSim.
 ---
 
-# Subsea Equipment
-
 Documentation for subsea production equipment in NeqSim.
 
 ## Table of Contents

--- a/docs/process/equipment/subsea_manifolds.md
+++ b/docs/process/equipment/subsea_manifolds.md
@@ -3,8 +3,6 @@ title: Subsea Manifolds
 description: Documentation for subsea production manifold equipment in NeqSim.
 ---
 
-# Subsea Manifolds
-
 Documentation for subsea production manifold equipment in NeqSim.
 
 ## Table of Contents

--- a/docs/process/equipment/subsea_systems.md
+++ b/docs/process/equipment/subsea_systems.md
@@ -3,8 +3,6 @@ title: Subsea Production Systems
 description: Documentation for subsea production equipment in NeqSim.
 ---
 
-# Subsea Production Systems
-
 Documentation for subsea production equipment in NeqSim.
 
 ## Table of Contents

--- a/docs/process/equipment/subsea_trees.md
+++ b/docs/process/equipment/subsea_trees.md
@@ -3,8 +3,6 @@ title: Subsea Trees
 description: Documentation for subsea Christmas tree equipment in NeqSim for subsea production modeling.
 ---
 
-# Subsea Trees
-
 Documentation for subsea Christmas tree equipment in NeqSim for subsea production modeling.
 
 ## Table of Contents

--- a/docs/process/equipment/tanks.md
+++ b/docs/process/equipment/tanks.md
@@ -3,8 +3,6 @@ title: Storage Tanks
 description: Documentation for liquid storage tanks in NeqSim.
 ---
 
-# Storage Tanks
-
 Documentation for liquid storage tanks in NeqSim.
 
 ## Table of Contents

--- a/docs/process/equipment/umbilicals.md
+++ b/docs/process/equipment/umbilicals.md
@@ -3,8 +3,6 @@ title: Umbilicals
 description: Documentation for subsea umbilical equipment in NeqSim.
 ---
 
-# Umbilicals
-
 Documentation for subsea umbilical equipment in NeqSim.
 
 ## Table of Contents

--- a/docs/process/equipment/util/README.md
+++ b/docs/process/equipment/util/README.md
@@ -3,8 +3,6 @@ title: Utility Equipment
 description: This folder contains documentation for utility and control equipment in NeqSim.
 ---
 
-# Utility Equipment
-
 This folder contains documentation for utility and control equipment in NeqSim.
 
 ## Equipment Categories

--- a/docs/process/equipment/util/adjusters.md
+++ b/docs/process/equipment/util/adjusters.md
@@ -3,8 +3,6 @@ title: Adjusters
 description: "Documentation for adjuster equipment in NeqSim process simulation. Covers single-variable Adjuster with standard and functional interface modes, and MultiVariableAdjuster for simultaneous multi-variable specification using damped successive substitution."
 ---
 
-# Adjusters
-
 Documentation for adjuster equipment in NeqSim process simulation.
 
 ## Table of Contents

--- a/docs/process/equipment/util/fuel_gas_system.md
+++ b/docs/process/equipment/util/fuel_gas_system.md
@@ -3,8 +3,6 @@ title: Fuel Gas System
 description: Documentation for fuel gas conditioning systems in NeqSim for gas turbines, fired heaters, and flare pilots.
 ---
 
-# Fuel Gas System
-
 Models fuel gas conditioning for process facilities including gas turbines, fired heaters, and flare pilots.
 
 ## Table of Contents

--- a/docs/process/equipment/util/produced_water_degassing.md
+++ b/docs/process/equipment/util/produced_water_degassing.md
@@ -3,8 +3,6 @@ title: Produced Water Degassing System
 description: Documentation for multi-stage produced water degassing with emission calculations per Norwegian regulations.
 ---
 
-# Produced Water Degassing System
-
 High-level model for produced water degassing with greenhouse gas emission calculations.
 
 ## Table of Contents

--- a/docs/process/equipment/util/recycles.md
+++ b/docs/process/equipment/util/recycles.md
@@ -3,8 +3,6 @@ title: Recycles
 description: Documentation for recycle handling in NeqSim process simulation.
 ---
 
-# Recycles
-
 Documentation for recycle handling in NeqSim process simulation.
 
 ## Table of Contents

--- a/docs/process/equipment/util/saturators.md
+++ b/docs/process/equipment/util/saturators.md
@@ -3,8 +3,6 @@ title: Stream Saturator Utility
 description: Water saturation utility for simulating reservoir conditions, wet gas systems, and water content analysis in natural gas streams.
 ---
 
-# Stream Saturator Utility
-
 The `StreamSaturatorUtil` is a utility unit operation that saturates a gas or hydrocarbon stream with water at the stream's current temperature and pressure conditions. This is essential for simulating:
 
 - **Reservoir conditions** where gas is in equilibrium with formation water

--- a/docs/process/equipment/util/stream_fitters.md
+++ b/docs/process/equipment/util/stream_fitters.md
@@ -3,8 +3,6 @@ title: "Stream Fitters: GOR and MPFM Data Fitting"
 description: Utilities for adjusting stream compositions based on measured Gas-Oil Ratio (GOR) or Multiphase Flow Meter (MPFM) data.
 ---
 
-# Stream Fitters: GOR and MPFM Data Fitting
-
 Utilities for adjusting stream compositions based on measured Gas-Oil Ratio (GOR) or Multiphase Flow Meter (MPFM) data.
 
 ## Table of Contents

--- a/docs/process/equipment/util/utility_air_system.md
+++ b/docs/process/equipment/util/utility_air_system.md
@@ -3,8 +3,6 @@ title: Utility Air System
 description: Documentation for utility air systems in NeqSim including instrument air, plant air, and breathing air per ISO 8573-1.
 ---
 
-# Utility Air System
-
 Models utility air systems for offshore and onshore facilities per ISO 8573-1.
 
 ## Table of Contents

--- a/docs/process/equipment/water_cooler_reboiler.md
+++ b/docs/process/equipment/water_cooler_reboiler.md
@@ -3,8 +3,6 @@ title: Water Cooler and Reboiler
 description: Documentation for WaterCooler and ReBoiler heat exchanger equipment in NeqSim.
 ---
 
-# Water Cooler and Reboiler
-
 Documentation for specialized heat exchangers: WaterCooler for seawater/cooling water systems and ReBoiler for distillation column reboilers.
 
 ## Table of Contents

--- a/docs/process/equipment/water_treatment.md
+++ b/docs/process/equipment/water_treatment.md
@@ -3,8 +3,6 @@ title: Water Treatment Equipment
 description: "Documentation for produced water treatment equipment in NeqSim: hydrocyclones with physics-based d50, DSD integration, PDR model, liner sizing, demulsifier dose optimization, OIW analyzer drift, monthly OIW warnings, OSPAR compliance, ASME VIII mechanical design, gas flotation units (IGF/DGF), treatment trains, and regulatory compliance."
 ---
 
-# Water Treatment Equipment
-
 Documentation for produced water treatment equipment in NeqSim.
 
 ## Table of Contents

--- a/docs/process/equipment/well_allocation.md
+++ b/docs/process/equipment/well_allocation.md
@@ -3,8 +3,6 @@ title: Well Production Allocation
 description: Documentation for production allocation in commingled well systems.
 ---
 
-# Well Production Allocation
-
 Documentation for production allocation in commingled well systems.
 
 ## Table of Contents

--- a/docs/process/equipment/wells.md
+++ b/docs/process/equipment/wells.md
@@ -3,8 +3,6 @@ title: Well and Reservoir Equipment
 description: Documentation for well and reservoir equipment in NeqSim process simulation.
 ---
 
-# Well and Reservoir Equipment
-
 Documentation for well and reservoir equipment in NeqSim process simulation.
 
 ## Table of Contents

--- a/docs/process/processmodel/DIAGRAM_ARCHITECTURE_DEXPI_SYNERGY.md
+++ b/docs/process/processmodel/DIAGRAM_ARCHITECTURE_DEXPI_SYNERGY.md
@@ -3,8 +3,6 @@ title: "PFD Diagram System: Architecture Alignment and DEXPI Synergy"
 description: "How process topology, the canonical engineering graph, PFD rendering, and DEXPI exchange align."
 ---
 
-# PFD Diagram System: Architecture Alignment and DEXPI Synergy
-
 ## 1. Architectural Fit Assessment
 
 ### 1.1 Current NeqSim Process Model Architecture

--- a/docs/process/processmodel/README.md
+++ b/docs/process/processmodel/README.md
@@ -3,8 +3,6 @@ title: Process System and Flowsheet Management
 description: This folder contains documentation for process system and flowsheet management in NeqSim.
 ---
 
-# Process System and Flowsheet Management
-
 This folder contains documentation for process system and flowsheet management in NeqSim.
 
 ## Contents

--- a/docs/process/processmodel/diagram_export.md
+++ b/docs/process/processmodel/diagram_export.md
@@ -3,8 +3,6 @@ title: Process Flow Diagram (PFD) Export
 description: Export deterministic simulator-style PFD topology and Graphviz diagrams from NeqSim process models.
 ---
 
-# Process Flow Diagram (PFD) Export
-
 NeqSim can export deterministic simulator-style process flow diagrams (PFDs) as Graphviz DOT and,
 when Graphviz is installed, SVG or PDF. These exports help inspect simulation topology; they are not
 qualified engineering drawings and do not claim ISO 10628 conformance.

--- a/docs/process/processmodel/graph_simulation.md
+++ b/docs/process/processmodel/graph_simulation.md
@@ -3,8 +3,6 @@ title: Graph-Based Process Simulation
 description: Documentation for graph-based execution in NeqSim.
 ---
 
-# Graph-Based Process Simulation
-
 Documentation for graph-based execution in NeqSim.
 
 ## Table of Contents

--- a/docs/process/processmodel/low_flow_bypass.md
+++ b/docs/process/processmodel/low_flow_bypass.md
@@ -3,8 +3,6 @@ title: Low-Flow Section Bypass
 description: Auto-bypass and manual deactivation of low-flow process sections in ProcessSystem and ProcessModel. Covers minimum-flow thresholds, section deactivation, ProcessModel convergence handling, and feed-flow configuration patterns for parallel compressor trains on platform-scale models.
 ---
 
-# Low-Flow Section Bypass
-
 NeqSim can automatically (or manually) bypass parts of a flowsheet that are
 receiving negligible flow, so that turning off a parallel train, a recycle,
 or a seasonal export route does not destabilise the rest of a

--- a/docs/process/processmodel/parallel_scenario_sweeps.md
+++ b/docs/process/processmodel/parallel_scenario_sweeps.md
@@ -4,8 +4,6 @@ description: How to run process scenario sweeps and Design-of-Experiments (DoE) 
 keywords: "parallel, scenario sweep, DoE, copy, clone, thread safety, ProcessSystem, parameter study, multithread"
 ---
 
-# Parallel Scenario Sweeps with Clone-and-Run
-
 When running a parameter sweep or Design-of-Experiments (DoE) study, you often want to
 evaluate many variations of the same flowsheet — for example, the compressor power at a
 range of discharge pressures. Because each scenario is independent, these runs can be

--- a/docs/process/processmodel/process_model.md
+++ b/docs/process/processmodel/process_model.md
@@ -3,8 +3,6 @@ title: ProcessModel Class
 description: Documentation for the ProcessModel class in NeqSim.
 ---
 
-# ProcessModel Class
-
 Documentation for the ProcessModel class in NeqSim.
 
 ## Table of Contents

--- a/docs/process/processmodel/process_module.md
+++ b/docs/process/processmodel/process_module.md
@@ -3,8 +3,6 @@ title: ProcessModule Class
 description: Documentation for modular process units in NeqSim.
 ---
 
-# ProcessModule Class
-
 Documentation for modular process units in NeqSim.
 
 ## Table of Contents

--- a/docs/process/processmodel/run_status.md
+++ b/docs/process/processmodel/run_status.md
@@ -4,8 +4,6 @@ description: How to detect whether a ProcessSystem or ProcessModel run succeeded
 keywords: "RunStatus, UnitRunStatus, getRunStatus, run failure, failed unit, ProcessSystem, ProcessModel, diagnostics, agent"
 ---
 
-# Run Status — Detecting and Diagnosing Failed Runs
-
 When a process run fails, the failure surfaces as a `RuntimeException`. For interactive use
 that is fine, but agents, optimizers, and batch drivers usually want a structured answer to
 the question *"did the last run succeed, and if not, which unit failed and why?"* without

--- a/docs/test_heat_exchanger_equipment_documentation.py
+++ b/docs/test_heat_exchanger_equipment_documentation.py
@@ -36,7 +36,7 @@ class HeatExchangerEquipmentDocumentationContractTest(unittest.TestCase):
     def test_front_matter_heading_and_fences_are_complete(self):
         self.assertTrue(self.guide.startswith("---\n"))
         self.assertIn("Source-anchored guide", self.guide.split("---", 2)[1])
-        self.assertEqual(1, len(re.findall(r"^# ", self.guide, re.MULTILINE)))
+        self.assertEqual(0, len(re.findall(r"^# ", self.guide, re.MULTILINE)))
         self.assertEqual(0, self.guide.count("```") % 2)
 
     def test_complete_quick_start_uses_current_two_stream_api(self):

--- a/docs/test_process_documentation_rendering.py
+++ b/docs/test_process_documentation_rendering.py
@@ -1,0 +1,179 @@
+"""Contracts for curated process-equipment documentation rendering."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+DOCS = Path(__file__).resolve().parent
+SCOPE_PAGES = (
+    DOCS / "process/README.md",
+    DOCS / "process/equipment/LNGHeatExchanger.md",
+    DOCS / "process/equipment/README.md",
+    DOCS / "process/equipment/absorbers.md",
+    DOCS / "process/equipment/adsorbers.md",
+    DOCS / "process/equipment/adsorption_bed.md",
+    DOCS / "process/equipment/battery_storage.md",
+    DOCS / "process/equipment/black_oil_separator.md",
+    DOCS / "process/equipment/compressor_antisurge_control.md",
+    DOCS / "process/equipment/compressor_curves.md",
+    DOCS / "process/equipment/compressor_shaft.md",
+    DOCS / "process/equipment/compressors.md",
+    DOCS / "process/equipment/control_valves.md",
+    DOCS / "process/equipment/differential_pressure.md",
+    DOCS / "process/equipment/distillation.md",
+    DOCS / "process/equipment/ejectors.md",
+    DOCS / "process/equipment/electrolyzers.md",
+    DOCS / "process/equipment/energy_conversion.md",
+    DOCS / "process/equipment/equipment_catalog.md",
+    DOCS / "process/equipment/expanders.md",
+    DOCS / "process/equipment/failure_modes.md",
+    DOCS / "process/equipment/filters.md",
+    DOCS / "process/equipment/flares.md",
+    DOCS / "process/equipment/heat_exchangers.md",
+    DOCS / "process/equipment/heat_integration.md",
+    DOCS / "process/equipment/iron_sulfide_wall_source.md",
+    DOCS / "process/equipment/looped_networks.md",
+    DOCS / "process/equipment/manifold_design.md",
+    DOCS / "process/equipment/manifolds.md",
+    DOCS / "process/equipment/measurement_devices.md",
+    DOCS / "process/equipment/membranes.md",
+    DOCS / "process/equipment/mixers_splitters.md",
+    DOCS / "process/equipment/multiphase_flow_correlations.md",
+    DOCS / "process/equipment/multistream_heat_exchanger.md",
+    DOCS / "process/equipment/networks.md",
+    DOCS / "process/equipment/pipeline_simulation.md",
+    DOCS / "process/equipment/pipelines.md",
+    DOCS / "process/equipment/plug_flow_reactor.md",
+    DOCS / "process/equipment/power_generation.md",
+    DOCS / "process/equipment/production_well_networks.md",
+    DOCS / "process/equipment/pumps.md",
+    DOCS / "process/equipment/reactors.md",
+    DOCS / "process/equipment/reservoirs.md",
+    DOCS / "process/equipment/separator-entrainment-modeling.md",
+    DOCS / "process/equipment/separators.md",
+    DOCS / "process/equipment/solid_handling.md",
+    DOCS / "process/equipment/streams.md",
+    DOCS / "process/equipment/subsea_boosters.md",
+    DOCS / "process/equipment/subsea_equipment.md",
+    DOCS / "process/equipment/subsea_manifolds.md",
+    DOCS / "process/equipment/subsea_systems.md",
+    DOCS / "process/equipment/subsea_trees.md",
+    DOCS / "process/equipment/tanks.md",
+    DOCS / "process/equipment/umbilicals.md",
+    DOCS / "process/equipment/util/README.md",
+    DOCS / "process/equipment/util/adjusters.md",
+    DOCS / "process/equipment/util/calculators.md",
+    DOCS / "process/equipment/util/fuel_gas_system.md",
+    DOCS / "process/equipment/util/produced_water_degassing.md",
+    DOCS / "process/equipment/util/recycles.md",
+    DOCS / "process/equipment/util/saturators.md",
+    DOCS / "process/equipment/util/stream_fitters.md",
+    DOCS / "process/equipment/util/utility_air_system.md",
+    DOCS / "process/equipment/valves.md",
+    DOCS / "process/equipment/vessel_depressurization.md",
+    DOCS / "process/equipment/water_cooler_reboiler.md",
+    DOCS / "process/equipment/water_treatment.md",
+    DOCS / "process/equipment/well_allocation.md",
+    DOCS / "process/equipment/wells.md",
+    DOCS / "process/index.md",
+    DOCS / "process/processmodel/DIAGRAM_ARCHITECTURE_DEXPI_SYNERGY.md",
+    DOCS / "process/processmodel/README.md",
+    DOCS / "process/processmodel/diagram_export.md",
+    DOCS / "process/processmodel/graph_simulation.md",
+    DOCS / "process/processmodel/low_flow_bypass.md",
+    DOCS / "process/processmodel/parallel_scenario_sweeps.md",
+    DOCS / "process/processmodel/process_model.md",
+    DOCS / "process/processmodel/process_module.md",
+    DOCS / "process/processmodel/process_system.md",
+    DOCS / "process/processmodel/run_status.md",
+)
+
+
+def metadata_value(metadata, name):
+    """Return a plain scalar, including folded YAML front-matter values."""
+    prefix = name + ":"
+    lines = metadata.splitlines()
+    for index, line in enumerate(lines):
+        if not line.startswith(prefix):
+            continue
+        value = line[len(prefix) :].strip()
+        if value in {">", ">-", "|", "|-"}:
+            parts = []
+            for continuation in lines[index + 1 :]:
+                if continuation and not continuation[0].isspace():
+                    break
+                if continuation.strip():
+                    parts.append(continuation.strip())
+            return " ".join(parts)
+        return value.strip().strip("'\"")
+    return ""
+
+
+def parse_front_matter(source):
+    """Return title, description, and body from one Markdown page."""
+    match = re.match(r"\A---\n(?P<metadata>.*?)\n---\n(?P<body>.*)\Z", source, re.DOTALL)
+    if match is None:
+        raise AssertionError("Missing Jekyll front matter")
+    metadata = match.group("metadata")
+    return (
+        metadata_value(metadata, "title"),
+        metadata_value(metadata, "description"),
+        match.group("body"),
+    )
+
+
+def remove_fenced_code(source):
+    """Remove backtick and tilde code fences before inspecting rendered Markdown."""
+    rendered = []
+    marker = None
+    for line in source.splitlines():
+        stripped = line.lstrip()
+        if marker is None and (stripped.startswith("~~~") or stripped.startswith("```")):
+            marker = stripped[:3]
+            continue
+        if marker is not None:
+            if stripped.startswith(marker):
+                marker = None
+            continue
+        rendered.append(line)
+    return "\n".join(rendered)
+
+
+class ProcessDocumentationRenderingContractTest(unittest.TestCase):
+    """Protect the curated process-equipment and flowsheet documentation surface."""
+
+    def test_frozen_scope_exists(self):
+        self.assertEqual(len(SCOPE_PAGES), 80)
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                self.assertTrue(page.is_file())
+
+    def test_pages_have_searchable_front_matter(self):
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                title, description, _body = parse_front_matter(page.read_text(encoding="utf-8"))
+                self.assertTrue(title)
+                self.assertGreaterEqual(len(description.split()), 5)
+
+    def test_front_matter_title_is_not_repeated_as_h1(self):
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                title, _description, body = parse_front_matter(page.read_text(encoding="utf-8"))
+                rendered_markdown = remove_fenced_code(body)
+                headings = re.findall(r"^#\s+(.+?)\s*$", rendered_markdown, re.MULTILINE)
+                self.assertNotIn(title, headings)
+
+    def test_pages_use_supported_math_delimiters(self):
+        unsupported = re.compile(r"\\\[|\\\]|\\\(|\\\)")
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                _title, _description, body = parse_front_matter(
+                    page.read_text(encoding="utf-8")
+                )
+                rendered_markdown = remove_fenced_code(body)
+                self.assertIsNone(unsupported.search(rendered_markdown))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Campaign / capability

Advances #2499 as D107, rotation scope 3 (process equipment and process simulation).

Capability contract: [campaign ledger](https://github.com/equinor/neqsim/issues/2499#issuecomment-5432666687)

Exact base: `1dec02d734eb5daef4df0ca567724635721e93f1`  
Exact head: `6b1eaf16f7c07a3591ecbb3b5d44af43309f1a70`

## Engineering question

Can the curated process-equipment and flowsheet-management documentation render unambiguously under the repository's Jekyll/KaTeX contract without changing authoritative NeqSim process calculations, APIs, or examples?

Current maturity: **experimental**  
Target maturity: **qualified**

## Frozen scan and confirmed defects

The exact-`master` scan covers 80 curated Markdown pages:

- `docs/process/equipment/**`;
- `docs/process/processmodel/**`;
- `docs/process/README.md`;
- `docs/process/index.md`.

The branch contains exactly 62 changed files:

- 60 repaired documentation pages;
- `docs/test_process_documentation_rendering.py`;
- `docs/test_heat_exchanger_equipment_documentation.py`, aligned with the no-duplicate-title contract after exact-head CI exposed its stale one-H1 expectation.

Confirmed defects: **61 found / 61 repaired**.

- 60 pages repeated their exact Jekyll front-matter `title` as a Markdown H1.
- `docs/process/equipment/iron_sulfide_wall_source.md` used one unsupported `\[...\]` display-equation block.

## Change and regression coverage

- removes only exact title/H1 duplication;
- converts the affected aligned reaction block to compact `$$\begin{aligned}...\end{aligned}$$` syntax;
- preserves equation content, technical claims, examples, links, units, model selection, and validity boundaries;
- adds a dependency-free 80-page contract for:
  - frozen-path existence;
  - searchable plain and folded YAML front matter;
  - no exact title/H1 duplication outside backtick or tilde code fences;
  - no unsupported math delimiters outside code fences.

## Applicable capability views

- **Java:** unchanged; current Java equipment, `ProcessSystem`, and `ProcessModel` source remain authoritative. No example changed.
- **Python:** the new documentation contract is the executable regression view.
- **JSON/MCP/notebook:** not applicable; no schema, runner, tool, or notebook surface changed.
- **Engineering validation:** Jekyll/KaTeX rendering and metadata consistency only; no process-design approval, conservation, convergence, performance, or scientific-benchmark claim.

## Validation

Connector-side exact-source transformation and proposed-corpus inspection pass:

- zero targeted defects remain across all 80 frozen pages;
- all 80 pages have nonempty searchable title/description metadata, including folded YAML values;
- the new Python contract parses successfully with `ast.parse`;
- exact remote compare reports two linear commits and exactly 62 changed files;
- no frozen file overlaps active #3352, #3353, #3354, or #3355.

On the original exact head, build/test/Javadocs, pre-commit, Spotless, and CodeQL passed; documentation-search failed only because the changed `heat_exchangers.md` intentionally removed its duplicated title/H1 while its older documentation contract still required one H1. That attributable assertion is now aligned to require zero H1 headings.

On repaired exact head `6b1eaf16f7c07a3591ecbb3b5d44af43309f1a70`, documentation contracts/Jekyll/search/link coverage, pre-commit, Spotless, CodeQL, agent-skill cross-references, and the documentation-only build gate pass. Java/Javadoc/slow-matrix jobs are correctly skipped because no Java or XML file changed. No local Maven, Jekyll, Spotless, pre-commit, or Python test run is claimed.

**READY TO MERGE** as a classification only; the PR remains a draft and no merge or readiness-state change was performed.

## Dependencies, risk, and stop boundary

D105 and D106 provide the merged rendering convention and contract pattern. Compatibility risk is documentation-only.

Stop before production code, process algorithms/APIs, example behavior, mechanical/design claims, safety/standards interpretation, DEXPI/PFD semantics, JSON/MCP, notebooks, or Huldra.