### PR TITLE
[AI-Assisted] feat(electrolyte): bridge explicit and lumped aqueous CO2

### DIFF
--- a/docs/chemicalreactions/co2_transport_reaction_kinetics.md
+++ b/docs/chemicalreactions/co2_transport_reaction_kinetics.md
@@ -123,8 +123,11 @@ $$
 
 The implementation preserves the source's narrow evidence boundary: 0.65 molal NaCl and
 288.15–305.65 K. At 298.15 K it gives `kH = 0.0302586 s-1`, `kD = 25.9844 s-1`, and
-`[H2CO3]/[CO2(aq)] = kH/kD = 0.00116449`. Calls outside the published temperature range fail
-closed instead of extrapolating.
+`[H2CO3]/[CO2(aq)] = kH/kD = 0.00116449`, or `[CO2(aq)]/[H2CO3] = 858.744`. The paper also
+reports a separately observed 25 °C ratio of 848. The 1.27% difference from the two fitted rate
+equations is a within-source consistency check, not an independent validation dataset. The
+implementation does not tune either correlation to remove the difference. Calls outside the
+published temperature range fail closed instead of extrapolating.
 
 The equations are direct implementations of the primary-source fits, not a new NeqSim calibration
 or an independent validation dataset. Public DOI metadata and the institutional abstract are
@@ -138,12 +141,36 @@ it is the solvent in the published pseudo-first-order model. `advance(...)` prov
 closed-batch update for the CO2/H2CO3 pair. The exact solution is non-negative and conserves that
 pair's carbon without numerical timestep error.
 
+### Explicit/lumped electrolyte-speciation handoff
+
+The finite-rate reaction distinguishes `CO2(aq)` and `H2CO3`, but NeqSim's existing electrolyte
+reaction data does not contain a thermodynamic `H2CO3` component. Its model-specific `CO2water`
+reaction uses one molecular `CO2` inventory together with water, bicarbonate, and hydronium. The
+Pitzer row follows the molality-standard-state carbonate expressions in the public-domain USGS
+PHREEQC 3 database; electrolyte CPA retains its distinct `STANDARD` mole-fraction source.
+
+`collapseExplicitPairToLumpedCO2(...)` therefore performs the conservative handoff
+
+$$
+c_{\mathrm{CO_2^*}} = c_{\mathrm{CO_2(aq)}} + c_{\mathrm{H_2CO_3}},
+$$
+
+before a caller initializes or reruns the selected electrolyte equilibrium model.
+`partitionLumpedMolecularCO2(...)` applies the source rate ratio to split that neutral pool again
+for reporting or to initialize the explicit kinetic pair. Both methods use mol/m3, reject negative
+or non-finite input, and expose a carbon-closure residual. They do not mutate a thermodynamic
+system, run a flash, or alter charge balance.
+
+Do not add an explicit `H2CO3` species beside the current `CO2water` reaction and do not substitute
+the kinetic ratio for the model-specific equilibrium constant. Either action would mix standard
+states and can count hydration twice. A future fully coupled solver needs an explicitly qualified
+thermodynamic `H2CO3` species, true-ionization convention, phase properties, and reaction table.
+
 This bridge does **not** qualify pressure dependence, dense-phase CO2, other salinities, acid
 dissociation, pH, charge balance, or phase transfer. Soli and Byrne did not vary pressure. Do not
-apply the correlation directly at pipeline pressure without separate evidence. A process caller
-must also provide a compatible aqueous thermodynamic system with distinct `CO2`, `water`, and
-`H2CO3` components. Electrolyte speciation and the mapping to the existing bicarbonate reaction set
-remain coordinated with issue #3144.
+apply the correlation directly at pipeline pressure without separate evidence. Electrolyte
+speciation remains owned by issue #3144; pipeline source-term coupling remains owned by issue
+#3318.
 
 ## Intended transport integration
 

--- a/docs/test_co2_transport_reaction_kinetics_documentation.py
+++ b/docs/test_co2_transport_reaction_kinetics_documentation.py
@@ -98,7 +98,10 @@ class CO2TransportReactionKineticsDocumentationContractTest(unittest.TestCase):
             "HYDRATION_INVERSE_TEMPERATURE_K = 7799.0",
             "DEHYDRATION_LOG_PRE_EXPONENTIAL = 30.15",
             "DEHYDRATION_INVERSE_TEMPERATURE_K = 8018.0",
+            "REPORTED_CO2_TO_H2CO3_RATIO_AT_25_C = 848.0",
             "public static Result advance(",
+            "public static SpeciationBridgeResult partitionLumpedMolecularCO2(",
+            "public static double collapseExplicitPairToLumpedCO2(",
             "totalConcentration - updatedCO2 - updatedCarbonicAcid",
         ):
             self.assertIn(token, self.hydration_kinetics)
@@ -108,10 +111,17 @@ class CO2TransportReactionKineticsDocumentationContractTest(unittest.TestCase):
             "288.15–305.65 K",
             "0.0302586 s-1",
             "25.9844 s-1",
+            "858.744",
+            "1.27% difference",
+            "within-source consistency check",
+            "not an independent validation dataset",
+            "collapseExplicitPairToLumpedCO2(...)` therefore performs the conservative handoff",
+            "Do not add an explicit `H2CO3` species",
             "does **not** qualify pressure dependence",
             "not a new NeqSim calibration",
             "uncertainty statistics for these two fitted equations",
             "issue #3144",
+            "#3318",
         ):
             self.assertIn(token, self.guide)
 

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousCO2HydrationKinetics.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousCO2HydrationKinetics.java
@@ -42,6 +42,12 @@ public final class AqueousCO2HydrationKinetics implements Serializable {
   /** Maximum published correlation temperature [K]. */
   public static final double MAXIMUM_TEMPERATURE_K = 305.65;
 
+  /** Temperature of the separately reported equilibrium-ratio observation [K]. */
+  public static final double REPORTED_RATIO_TEMPERATURE_K = 298.15;
+
+  /** Separately reported {@code [CO2(aq)] / [H2CO3]} ratio at 25 degrees Celsius. */
+  public static final double REPORTED_CO2_TO_H2CO3_RATIO_AT_25_C = 848.0;
+
   /** Gas constant used by {@link KineticReaction} [J/(mol K)]. */
   private static final double KINETIC_REACTION_GAS_CONSTANT_J_PER_MOL_K = 8.31446;
   private static final double HYDRATION_LOG_PRE_EXPONENTIAL = 22.66;
@@ -84,6 +90,58 @@ public final class AqueousCO2HydrationKinetics implements Serializable {
    */
   public static double carbonicAcidToCO2EquilibriumRatio(double temperatureK) {
     return hydrationRateConstant(temperatureK) / dehydrationRateConstant(temperatureK);
+  }
+
+  /**
+   * Partition a lumped molecular-CO2 concentration into explicit aqueous CO2 and carbonic acid.
+   *
+   * <p>
+   * NeqSim's existing electrolyte reaction sets use a single molecular {@code CO2} inventory for carbonate equilibrium,
+   * while this kinetic model distinguishes {@code CO2(aq)} from {@code H2CO3}. This method provides the
+   * source-consistent equilibrium partition needed for reporting or for initializing the explicit kinetic pair. It does
+   * not add an {@code H2CO3} component to a thermodynamic system or replace the model-specific {@code CO2water}
+   * equilibrium constant.
+   * </p>
+   *
+   * @param totalMolecularCO2Concentration lumped {@code CO2(aq) + H2CO3} concentration [mol/m3]
+   * @param temperatureK aqueous-phase temperature [K]
+   * @return immutable explicit-pair partition
+   * @throws IllegalArgumentException when the concentration is negative or non-finite, or temperature is outside the
+   * published range
+   */
+  public static SpeciationBridgeResult partitionLumpedMolecularCO2(double totalMolecularCO2Concentration,
+      double temperatureK) {
+    requireFiniteNonNegative(totalMolecularCO2Concentration, "total molecular CO2 concentration");
+    double carbonicAcidToCO2Ratio = carbonicAcidToCO2EquilibriumRatio(temperatureK);
+    double carbonicAcidConcentration = totalMolecularCO2Concentration * carbonicAcidToCO2Ratio
+        / (1.0 + carbonicAcidToCO2Ratio);
+    double co2Concentration = totalMolecularCO2Concentration - carbonicAcidConcentration;
+    return new SpeciationBridgeResult(totalMolecularCO2Concentration, co2Concentration, carbonicAcidConcentration,
+        carbonicAcidToCO2Ratio, totalMolecularCO2Concentration - co2Concentration - carbonicAcidConcentration);
+  }
+
+  /**
+   * Collapse an explicit aqueous CO2/carbonic-acid pair to the lumped molecular-CO2 inventory.
+   *
+   * <p>
+   * Use this conservation-only handoff before invoking an electrolyte equilibrium model whose reaction set already
+   * represents carbonate speciation from one molecular {@code CO2} component. The method does not run hydration,
+   * dissociation, charge balance, or phase equilibrium.
+   * </p>
+   *
+   * @param co2Concentration aqueous CO2 concentration [mol/m3]
+   * @param carbonicAcidConcentration carbonic-acid concentration [mol/m3]
+   * @return lumped {@code CO2(aq) + H2CO3} concentration [mol/m3]
+   * @throws IllegalArgumentException when either input or their sum is negative or non-finite
+   */
+  public static double collapseExplicitPairToLumpedCO2(double co2Concentration, double carbonicAcidConcentration) {
+    requireFiniteNonNegative(co2Concentration, "CO2 concentration");
+    requireFiniteNonNegative(carbonicAcidConcentration, "H2CO3 concentration");
+    double totalMolecularCO2Concentration = co2Concentration + carbonicAcidConcentration;
+    if (!Double.isFinite(totalMolecularCO2Concentration)) {
+      throw new IllegalArgumentException("total molecular CO2 concentration must be finite");
+    }
+    return totalMolecularCO2Concentration;
   }
 
   /**
@@ -201,6 +259,56 @@ public final class AqueousCO2HydrationKinetics implements Serializable {
     /** @return dehydration rate constant [1/s]. */
     public double getDehydrationRateConstant() {
       return dehydrationRateConstant;
+    }
+
+    /** @return carbon concentration closure residual [mol/m3]. */
+    public double getCarbonBalanceResidual() {
+      return carbonBalanceResidual;
+    }
+  }
+
+  /** Result of translating a lumped molecular-CO2 inventory to the explicit kinetic pair. */
+  public static final class SpeciationBridgeResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double totalMolecularCO2Concentration;
+    private final double co2Concentration;
+    private final double carbonicAcidConcentration;
+    private final double carbonicAcidToCO2EquilibriumRatio;
+    private final double carbonBalanceResidual;
+
+    private SpeciationBridgeResult(double totalMolecularCO2Concentration, double co2Concentration,
+        double carbonicAcidConcentration, double carbonicAcidToCO2EquilibriumRatio, double carbonBalanceResidual) {
+      this.totalMolecularCO2Concentration = totalMolecularCO2Concentration;
+      this.co2Concentration = co2Concentration;
+      this.carbonicAcidConcentration = carbonicAcidConcentration;
+      this.carbonicAcidToCO2EquilibriumRatio = carbonicAcidToCO2EquilibriumRatio;
+      this.carbonBalanceResidual = carbonBalanceResidual;
+    }
+
+    /** @return lumped {@code CO2(aq) + H2CO3} concentration [mol/m3]. */
+    public double getTotalMolecularCO2Concentration() {
+      return totalMolecularCO2Concentration;
+    }
+
+    /** @return aqueous CO2 concentration [mol/m3]. */
+    public double getCO2Concentration() {
+      return co2Concentration;
+    }
+
+    /** @return carbonic-acid concentration [mol/m3]. */
+    public double getCarbonicAcidConcentration() {
+      return carbonicAcidConcentration;
+    }
+
+    /** @return correlation-derived {@code [H2CO3] / [CO2(aq)]} ratio. */
+    public double getCarbonicAcidToCO2EquilibriumRatio() {
+      return carbonicAcidToCO2EquilibriumRatio;
+    }
+
+    /** @return correlation-derived {@code [CO2(aq)] / [H2CO3]} ratio. */
+    public double getCO2ToCarbonicAcidEquilibriumRatio() {
+      return 1.0 / carbonicAcidToCO2EquilibriumRatio;
     }
 
     /** @return carbon concentration closure residual [mol/m3]. */

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousCO2HydrationKineticsTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousCO2HydrationKineticsTest.java
@@ -1,10 +1,15 @@
 package neqsim.process.equipment.reactor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import neqsim.NeqSimTest;
+import neqsim.chemicalreactions.chemicalreaction.ChemicalReaction;
+import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionDataSource;
+import neqsim.thermo.system.SystemPitzer;
 
 /** Tests the published aqueous CO2 hydration/dehydration bridge. */
 public class AqueousCO2HydrationKineticsTest extends NeqSimTest {
@@ -65,6 +70,55 @@ public class AqueousCO2HydrationKineticsTest extends NeqSimTest {
   }
 
   @Test
+  void testLumpedSpeciationBridgeConservesCarbonAndRetainsSeparate25CCheck() {
+    double totalMolecularCO2 = 1000.0;
+    double temperatureK = 298.15;
+
+    AqueousCO2HydrationKinetics.SpeciationBridgeResult partition = AqueousCO2HydrationKinetics
+        .partitionLumpedMolecularCO2(totalMolecularCO2, temperatureK);
+
+    assertEquals(totalMolecularCO2, partition.getTotalMolecularCO2Concentration(), 0.0);
+    assertEquals(totalMolecularCO2, partition.getCO2Concentration() + partition.getCarbonicAcidConcentration(),
+        1.0e-12);
+    assertEquals(0.0, partition.getCarbonBalanceResidual(), 1.0e-12);
+    assertEquals(AqueousCO2HydrationKinetics.carbonicAcidToCO2EquilibriumRatio(temperatureK),
+        partition.getCarbonicAcidToCO2EquilibriumRatio(), 0.0);
+    assertEquals(partition.getCarbonicAcidToCO2EquilibriumRatio(),
+        partition.getCarbonicAcidConcentration() / partition.getCO2Concentration(), 1.0e-15);
+    assertEquals(totalMolecularCO2, AqueousCO2HydrationKinetics.collapseExplicitPairToLumpedCO2(
+        partition.getCO2Concentration(), partition.getCarbonicAcidConcentration()), 0.0);
+
+    assertEquals(848.0, AqueousCO2HydrationKinetics.REPORTED_CO2_TO_H2CO3_RATIO_AT_25_C, 0.0);
+    assertEquals(298.15, AqueousCO2HydrationKinetics.REPORTED_RATIO_TEMPERATURE_K, 0.0);
+    double relativeDifference = (partition.getCO2ToCarbonicAcidEquilibriumRatio()
+        - AqueousCO2HydrationKinetics.REPORTED_CO2_TO_H2CO3_RATIO_AT_25_C)
+        / AqueousCO2HydrationKinetics.REPORTED_CO2_TO_H2CO3_RATIO_AT_25_C;
+    assertTrue(relativeDifference > 0.01 && relativeDifference < 0.02,
+        "The separately reported 25 C value must remain visible rather than tuning the two rate fits to it");
+
+    AqueousCO2HydrationKinetics.SpeciationBridgeResult repeated = AqueousCO2HydrationKinetics
+        .partitionLumpedMolecularCO2(totalMolecularCO2, temperatureK);
+    assertEquals(partition.getCO2Concentration(), repeated.getCO2Concentration(), 0.0);
+    assertEquals(partition.getCarbonicAcidConcentration(), repeated.getCarbonicAcidConcentration(), 0.0);
+  }
+
+  @Test
+  void testPitzerEquilibriumUsesLumpedMolecularCO2WithoutExplicitH2CO3() {
+    SystemPitzer system = new SystemPitzer(298.15, 1.01325);
+    system.addComponent("CO2", 0.01);
+    system.addComponent("water", 0.99);
+    system.chemicalReactionInit();
+
+    assertEquals(ChemicalReactionDataSource.PITZER, system.getChemicalReactionDataSource());
+    assertFalse(system.hasComponent("H2CO3"));
+    ChemicalReaction reaction = system.getChemicalReactionOperations().getReactionList().getReaction("CO2water");
+    assertNotNull(reaction);
+    assertEquals(-1.0, stoichiometricCoefficient(reaction, "CO2"), 0.0);
+    assertEquals(1.0, stoichiometricCoefficient(reaction, "HCO3-"), 0.0);
+    assertEquals(1.0, stoichiometricCoefficient(reaction, "H3O+"), 0.0);
+  }
+
+  @Test
   void testPublishedDomainAndInvalidStatesFailClosed() {
     assertTrue(
         AqueousCO2HydrationKinetics.hydrationRateConstant(AqueousCO2HydrationKinetics.MINIMUM_TEMPERATURE_K) > 0.0);
@@ -76,5 +130,29 @@ public class AqueousCO2HydrationKineticsTest extends NeqSimTest {
     assertThrows(IllegalArgumentException.class, () -> AqueousCO2HydrationKinetics.advance(-1.0, 0.0, 1.0, 298.15));
     assertThrows(IllegalArgumentException.class,
         () -> AqueousCO2HydrationKinetics.advance(1.0, 0.0, Double.NaN, 298.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2HydrationKinetics.partitionLumpedMolecularCO2(-1.0, 298.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2HydrationKinetics.partitionLumpedMolecularCO2(Double.NaN, 298.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2HydrationKinetics.partitionLumpedMolecularCO2(1.0, 305.66));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2HydrationKinetics.collapseExplicitPairToLumpedCO2(Double.MAX_VALUE, Double.MAX_VALUE));
+
+    AqueousCO2HydrationKinetics.SpeciationBridgeResult zero = AqueousCO2HydrationKinetics
+        .partitionLumpedMolecularCO2(0.0, AqueousCO2HydrationKinetics.MINIMUM_TEMPERATURE_K);
+    assertEquals(0.0, zero.getCO2Concentration(), 0.0);
+    assertEquals(0.0, zero.getCarbonicAcidConcentration(), 0.0);
+  }
+
+  private static double stoichiometricCoefficient(ChemicalReaction reaction, String componentName) {
+    String[] componentNames = reaction.getNames();
+    double[] coefficients = reaction.getStocCoefs();
+    for (int index = 0; index < componentNames.length; index++) {
+      if (componentName.equals(componentNames[index])) {
+        return coefficients[index];
+      }
+    }
+    throw new AssertionError("Missing reaction component " + componentName);
   }
 }


### PR DESCRIPTION
## Engineering question

Can finite-rate `CO2(aq) <=> H2CO3` state from merged PR #3352 be handed safely to NeqSim's existing lumped molecular-`CO2` carbonate-equilibrium basis—and partitioned again for reporting—without adding an unsupported thermodynamic `H2CO3` component or counting hydration twice?

Advances #3144 and coordinates the kinetics/electrolyte boundary with #3318. Capability contract: https://github.com/equinor/neqsim/issues/3144#issuecomment-5473142622

## Exact continuity and frozen scope

- **Base/current master:** `42d374bc58dd02f33ced526ca2be6775f5b1495c`
- **Exact head:** `57690a3c60672140e7ff6ae85489a89f5fc371fe`
- **Branch:** `ai/co2-hydration-speciation-3144`
- Sole active #3144 implementation PR; no positively identified autonomous implementation PR was open before publication. Unrelated Dependabot PR #3357 is excluded from that capability count.
- Additive state-semantics bridge only; no reaction table, equilibrium constant, component database, Pitzer parameter, EOS, flash, mineral, or pipeline source-term change.

## Model semantics

The merged `AqueousCO2HydrationKinetics` capability distinguishes `CO2(aq)` from `H2CO3`. Current NeqSim electrolyte reaction data has no thermodynamic `H2CO3` component: its model-specific `CO2water` row uses one molecular `CO2` inventory with water, bicarbonate and hydronium.

- finite-rate authority remains Soli & Byrne (2002) at 0.65 mol/kg NaCl and 288.15–305.65 K;
- equilibrium authority remains the selected electrolyte model and its reaction source;
- `SystemPitzer` retains its validated molality-standard-state `PITZER` carbonate rows derived from USGS PHREEQC;
- electrolyte CPA retains its distinct `STANDARD` mole-fraction source.

The bridge conserves only the neutral molecular pool `CO2(aq) + H2CO3`. It does not substitute the kinetic ratio for an activity-based equilibrium constant.

## Change

- `partitionLumpedMolecularCO2(...)` partitions a finite non-negative lumped concentration using the published rate ratio and returns explicit concentrations, both ratio directions, and carbon closure.
- `collapseExplicitPairToLumpedCO2(...)` recombines the explicit pair before an electrolyte-equilibrium handoff and rejects negative, non-finite, or overflowing input.
- the separately reported 25 °C `[CO2]/[H2CO3] = 848` value is retained as a within-source check: the two fitted rate equations give 858.744, a 1.27% difference that is reported rather than tuned away;
- focused tests lock carbon closure, deterministic repeat, boundaries, invalid input, Pitzer's lumped `CO2water` topology, and absence of an explicit `H2CO3` component;
- documentation defines the handoff, units, provenance, standard-state boundary, and double-counting guard.

## Scientific provenance and licensing

- Soli, A. L. and Byrne, R. H. (2002), *Marine Chemistry* 78, 65–73, DOI: https://doi.org/10.1016/S0304-4203(02)00010-5.
- Exact public-domain USGS PHREEQC 3.9.0 source commit: https://github.com/phreeqc-dev/phreeqc3/commit/b0b3be767158ccc3322d2c816625cf470045e67e.
- The source equations and public abstract metadata are cited; no article table is redistributed.
- No Kaasa value, new parameter, fit, or independent-validation claim is introduced.

## Validation

Passed locally on the exact four-file content:

- `AqueousCO2HydrationKineticsTest`, `KineticReactionTransportDiagnosticsTest`, and `CO2TransportReactionKineticsDocumentationTest`;
- `docs/test_co2_transport_reaction_kinetics_documentation.py`: 7/7;
- `python3 devtools/run_spotless.py apply` and `check`;
- `python3 devtools/check_documentation_search.py`: 674 Markdown pages + 1 standalone HTML;
- pre-commit and pre-push stages in a task-specific environment;
- `git diff --check`.

Local Javadoc generation could not run because this runtime has no `javadoc` executable. Hosted exact-head CI is authoritative; no unrun check is claimed passed.

## Performance and compatibility

The API is additive, static, Java 8 compatible, and not called from any property, reaction, flash, Pitzer, electrolyte-CPA, or neutral EOS execution path. Ordinary calculation overhead is therefore structurally zero. The explicit bridge performs a bounded number of scalar arithmetic operations only when called.

## Documentation impact

Updated `docs/chemicalreactions/co2_transport_reaction_kinetics.md` and its executable documentation contract with the new API, mol/m3 basis, exact scientific boundary, within-source discrepancy, and safe handoff sequence.

## Stop boundary

Excluded: reaction/constants/table changes, new `H2CO3` thermodynamic properties, Pitzer parameter adoption, H2S family work, generic flash/stability (#2937), pipeline source terms (#3318), absorber equipment (#205), salt input/API (#448), mineral equilibrium, JSON/MCP, and notebooks.

**DRAFT — VALIDATION PENDING CI**

AI-assisted contribution.