### PR TITLE
[AI-Assisted] feat(dexpi): report material connection evidence

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -34,6 +34,7 @@ NeqSim provides a complete [DEXPI](https://dexpi.org/) integration that supports
 | `DexpiStream` | Lightweight piping segment with DEXPI class, line number, and fluid code |
 | `DexpiProcessUnit` | Imported equipment with original DEXPI class and mapped `EquipmentEnum` |
 | `DexpiInstrumentInfo` | Instrument metadata (tag, type, function letter) |
+| `DexpiConnectionInfo` | Immutable source-order material-connection evidence and endpoint resolution |
 
 ---
 
@@ -104,6 +105,7 @@ DexpiXmlReader.ImportResult result =
     DexpiXmlReader.readWithDiagnostics(xmlFile.toFile(), template);
 ProcessSystem process = result.getProcessSystem();
 List<DexpiInstrumentInfo> instruments = result.getInstruments();
+List<DexpiConnectionInfo> connections = result.getConnections();
 
 for (DexpiXmlReader.ImportDiagnostic diagnostic : result.getDiagnostics()) {
   System.out.printf("%s %s %s%n",
@@ -137,8 +139,16 @@ evidence. Valid source references resolve against the complete non-catalogue doc
 including equipment nozzles and actuating functions. The reader never promotes measurement-only or
 incomplete source content into closed-loop control intent.
 
-`toJson()` includes `instrumentCount` alongside the process-unit count and ordered findings. Python
-callers through JPype use the same `ImportResult.getInstruments()` getter; there is no separate
+The same result also preserves every source `Connection` in document order, including parallel
+connections between the same endpoints. Each immutable `DexpiConnectionInfo` retains the owning
+piping-network segment, `FromID` and `ToID` direction, the resolved endpoint element names, and
+resolution status. Missing source IDs receive deterministic evidence-only identities; missing,
+duplicate, self-referential, or unresolved source references remain explicit diagnostics. This
+inventory does not infer connectivity or rewire the returned `ProcessSystem`.
+
+`toJson()` includes `instrumentCount`, `connectionCount`, and the ordered connection inventory
+alongside the process-unit count and findings. Python callers through JPype use the same
+`ImportResult.getInstruments()` and `ImportResult.getConnections()` getters; there is no separate
 Python reconstruction model.
 
 `INFO` entries carry provenance and do not make `hasLosses()` true by themselves. `WARNING` and
@@ -662,6 +672,10 @@ projection; generated sheets still require project-specific engineering and draf
 ---
 
 ## Building runnable simulations from DEXPI
+
+The raw connection inventory returned by `DexpiXmlReader.readWithDiagnostics(...)` is loss
+evidence. It deliberately preserves parallel edges and malformed references. The builder path below
+has a different purpose: it resolves a supported subset into runnable equipment-level topology.
 
 The `DexpiSimulationBuilder` provides a high-level API that goes beyond basic import: it resolves
 the P&ID topology (nozzle/connection graph), instantiates real NeqSim equipment (separators,

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
@@ -8,8 +8,8 @@ import java.util.Map;
  * Immutable source-evidence record for one Proteus-compatible DEXPI material connection.
  *
  * <p>
- * This record preserves source order, direction, ownership, and endpoint-resolution evidence. It
- * does not reconstruct or imply live {@code ProcessSystem} topology.
+ * This record preserves source order, direction, ownership, and endpoint-resolution evidence. It does not reconstruct
+ * or imply live {@code ProcessSystem} topology.
  * </p>
  *
  * @author NeqSim
@@ -40,9 +40,8 @@ public final class DexpiConnectionInfo implements Serializable {
    * @param fromResolved whether the source endpoint resolves in the source document
    * @param toResolved whether the target endpoint resolves in the source document
    */
-  public DexpiConnectionInfo(String id, String sourceId, String segmentId, String fromId,
-      String toId, String fromElementName, String toElementName, boolean fromResolved,
-      boolean toResolved) {
+  public DexpiConnectionInfo(String id, String sourceId, String segmentId, String fromId, String toId,
+      String fromElementName, String toElementName, boolean fromResolved, boolean toResolved) {
     this.id = normalize(id);
     this.sourceId = normalize(sourceId);
     this.segmentId = normalize(segmentId);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
@@ -1,0 +1,134 @@
+package neqsim.process.processmodel.dexpi;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Immutable source-evidence record for one Proteus-compatible DEXPI material connection.
+ *
+ * <p>
+ * This record preserves source order, direction, ownership, and endpoint-resolution evidence. It
+ * does not reconstruct or imply live {@code ProcessSystem} topology.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class DexpiConnectionInfo implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final String id;
+  private final String sourceId;
+  private final String segmentId;
+  private final String fromId;
+  private final String toId;
+  private final String fromElementName;
+  private final String toElementName;
+  private final boolean fromResolved;
+  private final boolean toResolved;
+
+  /**
+   * Creates an immutable connection evidence record.
+   *
+   * @param id stable evidence identity
+   * @param sourceId source connection identity, or empty when absent
+   * @param segmentId owning piping-network segment identity, or empty when absent
+   * @param fromId source endpoint identity
+   * @param toId target endpoint identity
+   * @param fromElementName resolved source XML element name
+   * @param toElementName resolved target XML element name
+   * @param fromResolved whether the source endpoint resolves in the source document
+   * @param toResolved whether the target endpoint resolves in the source document
+   */
+  public DexpiConnectionInfo(String id, String sourceId, String segmentId, String fromId,
+      String toId, String fromElementName, String toElementName, boolean fromResolved,
+      boolean toResolved) {
+    this.id = normalize(id);
+    this.sourceId = normalize(sourceId);
+    this.segmentId = normalize(segmentId);
+    this.fromId = normalize(fromId);
+    this.toId = normalize(toId);
+    this.fromElementName = normalize(fromElementName);
+    this.toElementName = normalize(toElementName);
+    this.fromResolved = fromResolved;
+    this.toResolved = toResolved;
+  }
+
+  /** @return stable evidence identity */
+  public String getId() {
+    return id;
+  }
+
+  /** @return original source connection identity, or empty when absent */
+  public String getSourceId() {
+    return sourceId;
+  }
+
+  /** @return whether the source supplied a connection identity */
+  public boolean hasSourceId() {
+    return !sourceId.isEmpty();
+  }
+
+  /** @return owning piping-network segment identity, or empty when absent */
+  public String getSegmentId() {
+    return segmentId;
+  }
+
+  /** @return source endpoint identity */
+  public String getFromId() {
+    return fromId;
+  }
+
+  /** @return target endpoint identity */
+  public String getToId() {
+    return toId;
+  }
+
+  /** @return resolved source endpoint XML element name, or empty when unresolved */
+  public String getFromElementName() {
+    return fromElementName;
+  }
+
+  /** @return resolved target endpoint XML element name, or empty when unresolved */
+  public String getToElementName() {
+    return toElementName;
+  }
+
+  /** @return whether the source endpoint resolves in the source document */
+  public boolean isFromResolved() {
+    return fromResolved;
+  }
+
+  /** @return whether the target endpoint resolves in the source document */
+  public boolean isToResolved() {
+    return toResolved;
+  }
+
+  /** @return whether both endpoint references resolve */
+  public boolean isResolved() {
+    return fromResolved && toResolved;
+  }
+
+  /** @return whether both non-empty endpoint identities are equal */
+  public boolean isSelfReference() {
+    return !fromId.isEmpty() && fromId.equals(toId);
+  }
+
+  Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("id", id);
+    result.put("sourceId", sourceId);
+    result.put("segmentId", segmentId);
+    result.put("fromId", fromId);
+    result.put("toId", toId);
+    result.put("fromElementName", fromElementName);
+    result.put("toElementName", toElementName);
+    result.put("fromResolved", Boolean.valueOf(fromResolved));
+    result.put("toResolved", Boolean.valueOf(toResolved));
+    return result;
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -652,9 +652,7 @@ public final class DexpiXmlReader {
     return instruments;
   }
 
-
-  private static List<DexpiConnectionInfo> parseConnections(Document document,
-      List<ImportDiagnostic> diagnostics) {
+  private static List<DexpiConnectionInfo> parseConnections(Document document, List<ImportDiagnostic> diagnostics) {
     List<DexpiConnectionInfo> connections = new ArrayList<DexpiConnectionInfo>();
     NodeList allElements = document.getElementsByTagName("*");
     Map<String, Element> elementsById = new HashMap<String, Element>();
@@ -682,8 +680,7 @@ public final class DexpiXmlReader {
       Element segment = findAncestorElement(connection, "PipingNetworkSegment");
       String segmentId = "";
       if (segment != null) {
-        segmentId = firstNonEmpty(segment.getAttribute("ID"),
-            attributeValue(segment, DexpiMetadata.SEGMENT_NUMBER));
+        segmentId = firstNonEmpty(segment.getAttribute("ID"), attributeValue(segment, DexpiMetadata.SEGMENT_NUMBER));
         if (segmentId == null) {
           segmentId = "";
         }
@@ -715,12 +712,10 @@ public final class DexpiXmlReader {
 
       if (segment == null) {
         addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.WARNING,
-            "DEXPI_IMPORT_CONNECTION_SEGMENT_MISSING",
-            "Connection is not owned by a PipingNetworkSegment");
+            "DEXPI_IMPORT_CONNECTION_SEGMENT_MISSING", "Connection is not owned by a PipingNetworkSegment");
       } else if (isBlank(segmentId)) {
         addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.WARNING,
-            "DEXPI_IMPORT_CONNECTION_SEGMENT_ID_MISSING",
-            "Owning PipingNetworkSegment has no source identity");
+            "DEXPI_IMPORT_CONNECTION_SEGMENT_ID_MISSING", "Owning PipingNetworkSegment has no source identity");
       }
 
       String fromId = connection.getAttribute("FromID");
@@ -745,13 +740,12 @@ public final class DexpiXmlReader {
       }
       if (!isBlank(fromId) && fromId.equals(toId)) {
         addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.WARNING,
-            "DEXPI_IMPORT_CONNECTION_SELF_REFERENCE",
-            "Connection source and target both reference '" + fromId + "'");
+            "DEXPI_IMPORT_CONNECTION_SELF_REFERENCE", "Connection source and target both reference '" + fromId + "'");
       }
 
       connections.add(new DexpiConnectionInfo(evidenceId, sourceId, segmentId, fromId, toId,
-          fromElement == null ? "" : fromElement.getTagName(),
-          toElement == null ? "" : toElement.getTagName(), fromElement != null, toElement != null));
+          fromElement == null ? "" : fromElement.getTagName(), toElement == null ? "" : toElement.getTagName(),
+          fromElement != null, toElement != null));
     }
     logger.info("Parsed {} material connections from DEXPI XML", connections.size());
     return connections;

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -130,12 +130,14 @@ public final class DexpiXmlReader {
     private static final long serialVersionUID = 1000L;
     private final ProcessSystem processSystem;
     private final List<DexpiInstrumentInfo> instruments;
+    private final List<DexpiConnectionInfo> connections;
     private final List<ImportDiagnostic> diagnostics;
 
     private ImportResult(ProcessSystem processSystem, List<DexpiInstrumentInfo> instruments,
-        List<ImportDiagnostic> diagnostics) {
+        List<DexpiConnectionInfo> connections, List<ImportDiagnostic> diagnostics) {
       this.processSystem = processSystem;
       this.instruments = Collections.unmodifiableList(new ArrayList<DexpiInstrumentInfo>(instruments));
+      this.connections = Collections.unmodifiableList(new ArrayList<DexpiConnectionInfo>(connections));
       this.diagnostics = Collections.unmodifiableList(new ArrayList<ImportDiagnostic>(diagnostics));
     }
 
@@ -155,6 +157,15 @@ public final class DexpiXmlReader {
      */
     public List<DexpiInstrumentInfo> getInstruments() {
       return instruments;
+    }
+
+    /**
+     * Returns the source material-connection inventory without reconstructing live process topology.
+     *
+     * @return immutable connection records in source-document order
+     */
+    public List<DexpiConnectionInfo> getConnections() {
+      return connections;
     }
 
     /** @return immutable diagnostics in deterministic source-document order */
@@ -189,6 +200,12 @@ public final class DexpiXmlReader {
       result.put("profile", "Proteus-compatible DEXPI Plant/P&ID 4.1.1 supported subset");
       result.put("importedUnitCount", Integer.valueOf(processSystem.getAllUnitNames().size()));
       result.put("instrumentCount", Integer.valueOf(instruments.size()));
+      result.put("connectionCount", Integer.valueOf(connections.size()));
+      List<Map<String, Object>> connectionMaps = new ArrayList<Map<String, Object>>();
+      for (DexpiConnectionInfo connection : connections) {
+        connectionMaps.add(connection.toMap());
+      }
+      result.put("connections", connectionMaps);
       result.put("hasLosses", Boolean.valueOf(hasLosses()));
       result.put("hasErrors", Boolean.valueOf(hasErrors()));
       List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
@@ -380,9 +397,10 @@ public final class DexpiXmlReader {
       throws IOException, DexpiXmlReaderException {
     ProcessSystem processSystem = new ProcessSystem("DEXPI process");
     List<DexpiInstrumentInfo> instruments = new ArrayList<DexpiInstrumentInfo>();
+    List<DexpiConnectionInfo> connections = new ArrayList<DexpiConnectionInfo>();
     List<ImportDiagnostic> diagnostics = new ArrayList<ImportDiagnostic>();
-    loadInternal(inputStream, processSystem, templateStream, false, diagnostics, instruments);
-    return new ImportResult(processSystem, instruments, diagnostics);
+    loadInternal(inputStream, processSystem, templateStream, false, diagnostics, instruments, connections);
+    return new ImportResult(processSystem, instruments, connections, diagnostics);
   }
 
   /**
@@ -457,12 +475,12 @@ public final class DexpiXmlReader {
    */
   public static void load(InputStream inputStream, ProcessSystem processSystem, Stream templateStream,
       boolean namespaceAware) throws IOException, DexpiXmlReaderException {
-    loadInternal(inputStream, processSystem, templateStream, namespaceAware, null, null);
+    loadInternal(inputStream, processSystem, templateStream, namespaceAware, null, null, null);
   }
 
   private static void loadInternal(InputStream inputStream, ProcessSystem processSystem, Stream templateStream,
-      boolean namespaceAware, List<ImportDiagnostic> diagnostics, List<DexpiInstrumentInfo> instruments)
-      throws IOException, DexpiXmlReaderException {
+      boolean namespaceAware, List<ImportDiagnostic> diagnostics, List<DexpiInstrumentInfo> instruments,
+      List<DexpiConnectionInfo> connections) throws IOException, DexpiXmlReaderException {
     Objects.requireNonNull(inputStream, "inputStream");
     Objects.requireNonNull(processSystem, "processSystem");
 
@@ -485,6 +503,9 @@ public final class DexpiXmlReader {
     addPipingSegments(document, processSystem, streamTemplate, diagnostics);
     if (instruments != null) {
       instruments.addAll(parseInstruments(document));
+    }
+    if (connections != null) {
+      connections.addAll(parseConnections(document, diagnostics));
     }
     addInstrumentationDiagnostics(document, diagnostics);
   }
@@ -629,6 +650,131 @@ public final class DexpiXmlReader {
 
     logger.info("Parsed {} instruments from DEXPI XML", instruments.size());
     return instruments;
+  }
+
+
+  private static List<DexpiConnectionInfo> parseConnections(Document document,
+      List<ImportDiagnostic> diagnostics) {
+    List<DexpiConnectionInfo> connections = new ArrayList<DexpiConnectionInfo>();
+    NodeList allElements = document.getElementsByTagName("*");
+    Map<String, Element> elementsById = new HashMap<String, Element>();
+    for (int i = 0; i < allElements.getLength(); i++) {
+      Node node = allElements.item(i);
+      if (node.getNodeType() != Node.ELEMENT_NODE || isInsideShapeCatalogue(node)) {
+        continue;
+      }
+      Element element = (Element) node;
+      String id = element.getAttribute("ID");
+      if (!isBlank(id) && !elementsById.containsKey(id)) {
+        elementsById.put(id, element);
+      }
+    }
+
+    Map<String, Integer> segmentOrdinals = new LinkedHashMap<String, Integer>();
+    Map<String, Integer> sourceIdCounts = new LinkedHashMap<String, Integer>();
+    NodeList connectionNodes = document.getElementsByTagName("Connection");
+    for (int i = 0; i < connectionNodes.getLength(); i++) {
+      Node node = connectionNodes.item(i);
+      if (node.getNodeType() != Node.ELEMENT_NODE || isInsideShapeCatalogue(node)) {
+        continue;
+      }
+      Element connection = (Element) node;
+      Element segment = findAncestorElement(connection, "PipingNetworkSegment");
+      String segmentId = "";
+      if (segment != null) {
+        segmentId = firstNonEmpty(segment.getAttribute("ID"),
+            attributeValue(segment, DexpiMetadata.SEGMENT_NUMBER));
+        if (segmentId == null) {
+          segmentId = "";
+        }
+      }
+
+      String segmentKey = isBlank(segmentId) ? "unscoped" : segmentId;
+      Integer previousOrdinal = segmentOrdinals.get(segmentKey);
+      int ordinal = previousOrdinal == null ? 1 : previousOrdinal.intValue() + 1;
+      segmentOrdinals.put(segmentKey, Integer.valueOf(ordinal));
+
+      String sourceId = connection.getAttribute("ID");
+      String evidenceId;
+      if (isBlank(sourceId)) {
+        evidenceId = segmentKey + "/connection-" + ordinal;
+        addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.INFO,
+            "DEXPI_IMPORT_CONNECTION_ID_SYNTHESIZED",
+            "Connection has no source ID; deterministic evidence ID '" + evidenceId + "' is used");
+      } else {
+        Integer previousCount = sourceIdCounts.get(sourceId);
+        int count = previousCount == null ? 1 : previousCount.intValue() + 1;
+        sourceIdCounts.put(sourceId, Integer.valueOf(count));
+        evidenceId = count == 1 ? sourceId : sourceId + "#" + count;
+        if (count > 1) {
+          addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.WARNING,
+              "DEXPI_IMPORT_CONNECTION_ID_DUPLICATE",
+              "Connection ID '" + sourceId + "' is duplicated; evidence ID '" + evidenceId + "' is used");
+        }
+      }
+
+      if (segment == null) {
+        addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.WARNING,
+            "DEXPI_IMPORT_CONNECTION_SEGMENT_MISSING",
+            "Connection is not owned by a PipingNetworkSegment");
+      } else if (isBlank(segmentId)) {
+        addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.WARNING,
+            "DEXPI_IMPORT_CONNECTION_SEGMENT_ID_MISSING",
+            "Owning PipingNetworkSegment has no source identity");
+      }
+
+      String fromId = connection.getAttribute("FromID");
+      String toId = connection.getAttribute("ToID");
+      Element fromElement = elementsById.get(fromId);
+      Element toElement = elementsById.get(toId);
+      if (isBlank(fromId)) {
+        addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.WARNING,
+            "DEXPI_IMPORT_CONNECTION_SOURCE_MISSING", "Connection FromID is missing");
+      } else if (fromElement == null) {
+        addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.WARNING,
+            "DEXPI_IMPORT_CONNECTION_SOURCE_UNRESOLVED",
+            "Connection FromID '" + fromId + "' does not resolve to a source object");
+      }
+      if (isBlank(toId)) {
+        addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.WARNING,
+            "DEXPI_IMPORT_CONNECTION_TARGET_MISSING", "Connection ToID is missing");
+      } else if (toElement == null) {
+        addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.WARNING,
+            "DEXPI_IMPORT_CONNECTION_TARGET_UNRESOLVED",
+            "Connection ToID '" + toId + "' does not resolve to a source object");
+      }
+      if (!isBlank(fromId) && fromId.equals(toId)) {
+        addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.WARNING,
+            "DEXPI_IMPORT_CONNECTION_SELF_REFERENCE",
+            "Connection source and target both reference '" + fromId + "'");
+      }
+
+      connections.add(new DexpiConnectionInfo(evidenceId, sourceId, segmentId, fromId, toId,
+          fromElement == null ? "" : fromElement.getTagName(),
+          toElement == null ? "" : toElement.getTagName(), fromElement != null, toElement != null));
+    }
+    logger.info("Parsed {} material connections from DEXPI XML", connections.size());
+    return connections;
+  }
+
+  private static Element findAncestorElement(Node node, String tagName) {
+    Node parent = node.getParentNode();
+    while (parent != null) {
+      if (parent.getNodeType() == Node.ELEMENT_NODE && tagName.equals(((Element) parent).getTagName())) {
+        return (Element) parent;
+      }
+      parent = parent.getParentNode();
+    }
+    return null;
+  }
+
+  private static void addConnectionDiagnostic(Element connection, List<ImportDiagnostic> diagnostics,
+      ImportDiagnosticSeverity severity, String code, String message) {
+    if (diagnostics == null) {
+      return;
+    }
+    diagnostics.add(new ImportDiagnostic(severity, code, connection.getAttribute("ID"),
+        connection.getAttribute("ComponentClass"), connection.getTagName(), message));
   }
 
   private static void addInstrumentationDiagnostics(Document document, List<ImportDiagnostic> diagnostics) {

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -294,7 +294,6 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(first.toJson(), second.toJson());
   }
 
-
   @Test
   public void testReadWithDiagnosticsPreservesParallelMaterialConnections() throws Exception {
     String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
@@ -302,8 +301,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         + "<PipingNetworkSegment ID=\"S-1\" ComponentClass=\"PipingNetworkSegment\">"
         + "<Connection FromID=\"N-OUT\" ToID=\"N-IN\"/></PipingNetworkSegment>"
         + "<PipingNetworkSegment ID=\"S-2\" ComponentClass=\"PipingNetworkSegment\">"
-        + "<Connection FromID=\"N-OUT\" ToID=\"N-IN\"/></PipingNetworkSegment>"
-        + "</PlantModel>";
+        + "<Connection FromID=\"N-OUT\" ToID=\"N-IN\"/></PipingNetworkSegment>" + "</PlantModel>";
 
     DexpiXmlReader.ImportResult first = DexpiXmlReader
         .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
@@ -329,12 +327,10 @@ public class DexpiXmlReaderTest extends NeqSimTest {
 
   @Test
   public void testReadWithDiagnosticsReportsMalformedMaterialConnections() throws Exception {
-    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
-        + "<Nozzle ID=\"N-1\"/>"
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>" + "<Nozzle ID=\"N-1\"/>"
         + "<PipingNetworkSegment ID=\"S-BROKEN\" ComponentClass=\"PipingNetworkSegment\">"
         + "<Connection ID=\"C-1\" ToID=\"UNKNOWN\"/></PipingNetworkSegment>"
-        + "<Connection ID=\"C-1\" FromID=\"N-1\" ToID=\"N-1\"/>"
-        + "</PlantModel>";
+        + "<Connection ID=\"C-1\" FromID=\"N-1\" ToID=\"N-1\"/>" + "</PlantModel>";
 
     DexpiXmlReader.ImportResult result = DexpiXmlReader
         .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -294,6 +294,73 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(first.toJson(), second.toJson());
   }
 
+
+  @Test
+  public void testReadWithDiagnosticsPreservesParallelMaterialConnections() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
+        + "<Nozzle ID=\"N-OUT\"/><Nozzle ID=\"N-IN\"/>"
+        + "<PipingNetworkSegment ID=\"S-1\" ComponentClass=\"PipingNetworkSegment\">"
+        + "<Connection FromID=\"N-OUT\" ToID=\"N-IN\"/></PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-2\" ComponentClass=\"PipingNetworkSegment\">"
+        + "<Connection FromID=\"N-OUT\" ToID=\"N-IN\"/></PipingNetworkSegment>"
+        + "</PlantModel>";
+
+    DexpiXmlReader.ImportResult first = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    DexpiXmlReader.ImportResult second = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+    assertEquals(2, first.getConnections().size());
+    DexpiConnectionInfo firstConnection = first.getConnections().get(0);
+    assertEquals("S-1/connection-1", firstConnection.getId());
+    assertFalse(firstConnection.hasSourceId());
+    assertEquals("S-1", firstConnection.getSegmentId());
+    assertEquals("N-OUT", firstConnection.getFromId());
+    assertEquals("N-IN", firstConnection.getToId());
+    assertEquals("Nozzle", firstConnection.getFromElementName());
+    assertEquals("Nozzle", firstConnection.getToElementName());
+    assertTrue(firstConnection.isResolved());
+    assertEquals("S-2/connection-1", first.getConnections().get(1).getId());
+    assertEquals(2, countDiagnostics(first, "DEXPI_IMPORT_CONNECTION_ID_SYNTHESIZED"));
+    assertTrue(first.toJson().contains("\"connectionCount\": 2"));
+    assertEquals(first.toJson(), second.toJson());
+    assertThrows(UnsupportedOperationException.class, () -> first.getConnections().clear());
+  }
+
+  @Test
+  public void testReadWithDiagnosticsReportsMalformedMaterialConnections() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
+        + "<Nozzle ID=\"N-1\"/>"
+        + "<PipingNetworkSegment ID=\"S-BROKEN\" ComponentClass=\"PipingNetworkSegment\">"
+        + "<Connection ID=\"C-1\" ToID=\"UNKNOWN\"/></PipingNetworkSegment>"
+        + "<Connection ID=\"C-1\" FromID=\"N-1\" ToID=\"N-1\"/>"
+        + "</PlantModel>";
+
+    DexpiXmlReader.ImportResult result = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+    assertEquals(2, result.getConnections().size());
+    assertEquals("C-1", result.getConnections().get(0).getId());
+    assertFalse(result.getConnections().get(0).isResolved());
+    assertEquals("C-1#2", result.getConnections().get(1).getId());
+    assertTrue(result.getConnections().get(1).isSelfReference());
+    assertDiagnostic(result, "DEXPI_IMPORT_CONNECTION_SOURCE_MISSING");
+    assertDiagnostic(result, "DEXPI_IMPORT_CONNECTION_TARGET_UNRESOLVED");
+    assertDiagnostic(result, "DEXPI_IMPORT_CONNECTION_ID_DUPLICATE");
+    assertDiagnostic(result, "DEXPI_IMPORT_CONNECTION_SEGMENT_MISSING");
+    assertDiagnostic(result, "DEXPI_IMPORT_CONNECTION_SELF_REFERENCE");
+  }
+
+  private static int countDiagnostics(DexpiXmlReader.ImportResult result, String expectedCode) {
+    int count = 0;
+    for (DexpiXmlReader.ImportDiagnostic diagnostic : result.getDiagnostics()) {
+      if (expectedCode.equals(diagnostic.getCode())) {
+        count++;
+      }
+    }
+    return count;
+  }
+
   private static String instrumentAttributes(String tag, String category, String functions, String number) {
     return "<GenericAttributes>" + "<GenericAttribute Name=\"TagNameAssignmentClass\" Value=\"" + tag + "\"/>"
         + "<GenericAttribute Name=\"ProcessInstrumentationFunctionCategoryAssignmentClass\" Value=\"" + category


### PR DESCRIPTION
## Engineering question

Can NeqSim expose every Proteus-compatible DEXPI material `Connection` as deterministic source evidence—including direction, owning segment, parallel connections, and endpoint resolution—without silently reconstructing or inventing live process topology?

Advances #1332 and #2899. Capability contract: https://github.com/equinor/neqsim/issues/1332#issuecomment-5473531005

## Exact continuity and frozen scope

- **Base:** `42d374bc58dd02f33ced526ca2be6775f5b1495c`
- **Exact head:** `ca7551ec977c32dd4b5aa8e08e2f6b2bf00e0ea7`
- **Branch:** `ai/dexpi-material-connection-import-evidence`
- Shared #1332/#2899 lane was free after merged PR #3354 was verified on master.
- Autonomous implementation portfolio was 1/10 before publication; unrelated Dependabot PRs are excluded.

## Change

- adds immutable `DexpiConnectionInfo` records in source-document order;
- preserves `FromID`/`ToID` direction, owning segment, endpoint element names, resolution state, and parallel connections;
- synthesizes deterministic evidence-only IDs when source connection IDs are absent;
- reports missing/duplicate IDs, missing ownership, missing/unresolved endpoints, and self-references with stable diagnostic codes;
- adds ordered `connectionCount` and `connections` JSON evidence;
- preserves existing `read`/`load`, rendering/export, and runnable-builder behavior.

The new inventory is raw source evidence. It does not collapse parallel edges, infer connectivity, or rewire the returned `ProcessSystem`; `DexpiTopologyResolver` and `DexpiSimulationBuilder` remain the separate supported-subset runnable-topology path.

## Regression coverage

Focused tests cover:

- source-order preservation and two parallel material connections;
- deterministic synthetic evidence IDs and JSON;
- immutable inventory exposure;
- direction and endpoint-element resolution;
- missing source, unresolved target, duplicate ID, missing owning segment, and self-reference diagnostics.

## Documentation impact

Updated `docs/integration/dexpi-reader.md` with the Java and JPype views, JSON fields, loss-evidence semantics, diagnostics, and the boundary between raw import evidence and runnable topology reconstruction.

## Compatibility, performance, and limits

The API is additive and Java 8 compatible. Parsing is linear in the document element and connection counts. There are no engineering units or calculations in this evidence view, and no source reference is inferred. This remains the Proteus-compatible DEXPI Plant/P&ID 4.1.1 supported subset; it is not native DEXPI 2.0, full graphical/semantic round-trip proof, standards conformance, certification, or engineering approval.

Stop boundary: no live `ProcessSystem`/`ProcessModel` rewiring, branch/junction reconstruction, graphical equivalence, native DEXPI 2.0 mapping, licensed standards mapping, Huldra, or external-dataset work.

## Validation

Connector-first publication from the exact recorded base. The initial exact head passed PaperLab, the Spotless patch workflow, engineering-diagram performance, documentation search, and CodeQL. Pre-commit and the notebook handover gate both exposed the same three-file Spotless-only defect. Commit `ca7551ec977c32dd4b5aa8e08e2f6b2bf00e0ea7` applies the exact CI-generated formatter patch without changing behavior or scope; fresh exact-head CI is active. No local Maven test is claimed. GitHub CI is authoritative.

**DRAFT — VALIDATION PENDING CI**

AI-assisted contribution.