### PR TITLE
[AI-Assisted] fix(twofluid): align single-liquid transient handoff

### DIFF
--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -838,6 +838,23 @@ its inlet flux, but it must not replace the first finite-volume cell's oil or wa
 an unchanged, near-zero-time handoff from producing an inventory or holdup jump that scales with pipe
 volume.
 
+At an exact oil-only or water-only liquid endpoint, the active phase velocity is synchronized with
+the final bulk-liquid velocity before the conservative state is built. Inspect the phase-resolved
+steady fluxes when qualifying a new transient case:
+
+```java
+double[] gasFlow = pipe.getGasMassFlowProfile();
+double[] oilFlow = pipe.getOilMassFlowProfile();
+double[] waterFlow = pipe.getWaterMassFlowProfile();
+int outlet = gasFlow.length - 1;
+double steadyOutletFlow = gasFlow[outlet] + oilFlow[outlet] + waterFlow[outlet];
+```
+
+For a no-transfer steady case, `steadyOutletFlow` should reproduce the inlet mass flow within the
+chosen numerical tolerance. This is a kinematic handoff check only. It does not prove that the
+phase-momentum sources and fixed-pressure outlet form a transient fixed point, and it does not
+qualify the current liquid-rich or severe-slugging trajectories.
+
 For each phase $k$ and for the total domain, validate the discrete balance
 
 $$

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -761,6 +761,13 @@ residuals below $10^{-9}$. A coupled call that cannot complete its requested int
 reports accepted/requested time, residual/tolerance, iterations/cap, and whether pressure correction
 was limited; it never returns partial or zero progress silently.
 
+Before time marching, a no-transfer steady case can be checked phase by phase with
+`getGasMassFlowProfile()`, `getOilMassFlowProfile()`, and `getWaterMassFlowProfile()`. The active oil
+or water velocity is synchronized with the final bulk-liquid velocity at exact single-liquid
+endpoints, so a stale inactive-phase split cannot distort the handoff outlet flux. Matching the inlet
+and outlet steady fluxes is necessary but not sufficient: it does not establish a transient
+phase-momentum fixed point or qualify liquid-rich/severe-slugging behavior.
+
 After every evaluated window, inspect the sticky diagnostics, which reset on the next steady
 `run()`:
 

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -3995,11 +3995,22 @@ public class TwoFluidPipe extends Pipeline {
     }
 
     if (waterCut <= 1.0e-8 || waterCut >= 1.0 - 1.0e-8) {
+      boolean oilContinuousEndpoint = waterCut <= 1.0e-8;
       waterCut = Math.max(0.0, Math.min(1.0, waterCut));
       sec.setWaterCut(waterCut);
       sec.setOilFractionInLiquid(1.0 - waterCut);
       sec.setWaterHoldup(alphaL * waterCut);
       sec.setOilHoldup(alphaL * (1.0 - waterCut));
+      // The steady closure has just updated the bulk-liquid velocity. Keep the
+      // phase-resolved endpoint state on that same transported flux instead of
+      // rebuilding momentum from a stale oil/water velocity.
+      if (oilContinuousEndpoint) {
+        sec.setOilVelocity(sec.getLiquidVelocity());
+        sec.setWaterVelocity(waterCut > 0.0 ? sec.getLiquidVelocity() : 0.0);
+      } else {
+        sec.setOilVelocity(waterCut < 1.0 ? sec.getLiquidVelocity() : 0.0);
+        sec.setWaterVelocity(sec.getLiquidVelocity());
+      }
       sec.updateWaterOilConservativeVariables();
       return;
     }
@@ -6009,6 +6020,29 @@ public class TwoFluidPipe extends Pipeline {
       oilHoldups[i] = sections[i].getOilHoldup();
     }
     return oilHoldups;
+  }
+
+  /**
+   * Get the per-section gas mass flux along the pipeline.
+   *
+   * <p>
+   * Returns {@code rho_g * alpha_g * A * v_g} for each section. In a converged steady state without mass transfer this
+   * profile and the liquid-phase profiles should reproduce the inlet mass flow before transient integration begins.
+   * </p>
+   *
+   * @return gas mass flow at each section (kg/s)
+   */
+  public double[] getGasMassFlowProfile() {
+    if (sections == null) {
+      return new double[0];
+    }
+    double area = Math.PI * diameter * diameter / 4.0;
+    double[] flows = new double[numberOfSections];
+    for (int i = 0; i < numberOfSections; i++) {
+      TwoFluidSection sec = sections[i];
+      flows[i] = sec.getGasDensity() * sec.getGasHoldup() * area * sec.getGasVelocity();
+    }
+    return flows;
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPressureMomentumLongHorizonTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/TwoFluidPressureMomentumLongHorizonTest.java
@@ -1,5 +1,6 @@
 package neqsim.process.equipment.pipeline;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -46,6 +47,15 @@ class TwoFluidPressureMomentumLongHorizonTest {
     pipe.run();
 
     double initialInventory = pipe.getTotalMassInventory();
+    double[] initialGasFlow = pipe.getGasMassFlowProfile();
+    double[] initialOilFlow = pipe.getOilMassFlowProfile();
+    double[] initialWaterFlow = pipe.getWaterMassFlowProfile();
+    double inletMassFlow = feed.getFlowRate("kg/sec");
+    for (int section = 0; section < initialGasFlow.length; section++) {
+      double sectionMassFlow = initialGasFlow[section] + initialOilFlow[section] + initialWaterFlow[section];
+      assertEquals(inletMassFlow, sectionMassFlow, 1.0e-9 * inletMassFlow,
+          "steady-state handoff mass flow at section " + section + " did not match the inlet");
+    }
     double cumulativeAbsoluteLiquidOutletMassKg = 0.0;
     double maximumLiquidHoldup = 0.0;
     for (int interval = 0; interval < 240; interval++) {


### PR DESCRIPTION
## Engineering question

Can the single-liquid steady/transient handoff preserve the mass flux already solved by the bulk-liquid closure, without changing the pressure/momentum model or overstating severe-slugging and liquid-rich qualification?

Advances #3298; does not close it. Capability contract: https://github.com/equinor/neqsim/issues/3298#issuecomment-5474006546

## Exact continuity and frozen scope

- **Base/current master:** `42d374bc58dd02f33ced526ca2be6775f5b1495c`
- **Exact head:** `9f3c9b52a5734c6dab8296db3df1d0203a3449c0`
- **Branch:** `ai/3298-steady-handoff-residual`
- Sole active #3298 implementation PR at publication.
- Autonomous implementation portfolio was 2/10 before publication (#3358 and #3360); this draft makes it 3/10.
- Scope is the dependency-ready WS3-first handoff seam only. No holdup, flow-regime, friction, pressure-solver, or tuning change.

## Problem and change

Before the first transient step, a 50 kg/s inlet could produce a steady section-state outlet of `60.93696206115146 kg/s`. The steady closure had updated the bulk liquid velocity, but the single-liquid endpoint rebuilt phase momentum using a stale oil/water velocity.

This draft:

- synchronizes the active oil or water endpoint velocity to the current bulk-liquid velocity before rebuilding phase conservative variables;
- preserves exact absent/trace-phase semantics;
- adds public `getGasMassFlowProfile()` alongside the existing liquid-profile accessors;
- asserts exact section-by-section gas+oil+water mass-flow continuity at steady/transient handoff;
- documents the diagnostic contract and its qualification boundary in both two-fluid guides.

## Validation

Focused suite on the exact head:

```text
./mvnw -q -DexcludedTestGroups= -DskipITs   -Dtest=CoupledPressureMomentumSolverTest,CoupledPressureMomentumTengesdalProgressTest,TwoFluidPressureMomentumLongHorizonTest,TwoFluidPipeThreePhaseConservationTest,TwoFluidPipePhaseDegeneracyTest test
```

- **24/24 passed**, 0 failures, 0 errors, 0 skipped.
- Includes exact handoff continuity to relative tolerance `1e-9`.
- Tengesdal signed outlet envelope remained `-18.55225607695185 ... 6.882629908846342 kg/s`, so the landed reverse-flow behavior did not regress.
- `python devtools/run_spotless.py check` — passed.
- `python devtools/check_documentation_search.py` — passed (674 Markdown + 1 standalone HTML).
- `git diff --check` — passed.
- Repository pre-commit and pre-push hook stages — passed.

**VALIDATION PENDING CI:** local Javadoc generation could not run because this environment does not expose the JDK `javadoc` executable. The public getter includes Javadoc, and hosted Java/Javadoc checks remain authoritative.

## Qualification boundary

A deliberately stronger 1800 s inventory gate still failed: final/initial inventory was `0.6316254634029446` rather than within 5%. This increment therefore does **not** qualify WS2, severe slugging, liquid-rich operation, or controls. It fixes only kinematic consistency at the steady/transient handoff.

The dependency-ready next step remains the phase-momentum/fixed-pressure outlet residual and generalized Jacobian in the unsplit pressure-momentum solve. Stop if that requires retuning the model, suppressing reverse flow, or weakening the numerical/public-benchmark gates.

## Documentation impact

Updated:

- `docs/process/TWOFLUIDPIPE_MODEL.md`
- `docs/wiki/two_fluid_model.md`

Both show the exact gas/oil/water profile API and state that handoff continuity is not a dynamic fixed-point or severe-slugging/liquid-rich qualification.

Draft only. No merge/readiness claim.