### PR TITLE
[AI-Assisted] feat(refinery): expose DOE-qualified Watson factor

### DIFF
--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -49,11 +49,12 @@ For crude/petroleum assays, use `OilAssayCharacterisation` rather than manually 
 - kg/mol and g/mol explicit molar-mass helpers;
 - specific-gravity, kg/m3, and API-gravity density inputs;
 - exact API-gravity/SG60/60 round-tripping and explicit bulk density at 60 degF;
+- per-cut UOP/Watson characterization factors from representative boiling point and specific gravity;
 - pre-binned cumulative TBP cut-boundary ingestion;
 - preserved lower/upper boiling ranges;
 - closure, duplicate-name, monotonicity, and repeated-application guards.
 
-See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data bookkeeping evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation), whole-assay density/API evidence in [DOE/OEDI COA bulk density qualification](refinery_oedi_coa_bulk_density_validation), and the process-integration gate in [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation).
+See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data bookkeeping evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation), whole-assay density/API evidence in [DOE/OEDI COA bulk density qualification](refinery_oedi_coa_bulk_density_validation), per-cut characterization evidence in [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation), and the process-integration gate in [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation).
 
 ## TBP fraction models
 
@@ -137,6 +138,7 @@ A bookkeeping regression does not by itself validate a petroleum-property correl
 
 - [Refinery Assay and TBP Cut Characterization](refinery_assay)
 - [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation)
+- [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation)
 - [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation)
 - [DOE/OEDI COA bulk density and API qualification](refinery_oedi_coa_bulk_density_validation)
 - [Fluid Characterization Guide](../../wiki/fluid_characterization)

--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -137,6 +137,16 @@ where `w_i` is the resolved mass fraction and `SG_i` is the cut specific gravity
 
 These methods are screening calculations at the density reference condition represented by the inputs. They assume ideal additive liquid volumes and do not apply temperature correction, excess-volume, or blend-contraction models. They are not custody-transfer or certified blend-design calculations. The public validation and numerical error boundary are documented in [DOE/OEDI COA bulk density and API qualification](refinery_oedi_coa_bulk_density_validation).
 
+## Per-cut UOP/Watson characterization factor
+
+`AssayCut.getWatsonCharacterizationFactor()` calculates the dimensionless UOP/Watson factor from the same authoritative density and representative-boiling-point inputs used by the assay workflow:
+
+$$K_W=\frac{(1.8T_b)^{1/3}}{SG}$$
+
+Here $T_b$ is in K and $SG$ is dimensionless specific gravity. This is equivalent to using boiling point in degrees Rankine. A finite boiling interval uses its arithmetic midpoint. Kelvin, Celsius and Fahrenheit inputs therefore share one calculation, and exact-equivalent SG/API inputs give the same result. Missing density or boiling-point information fails closed.
+
+The public [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation) covers four bounded 375-1050 degF cuts with SG 0.8297-0.9336. The maximum absolute difference from DOE's one-decimal UOP K values is 0.0122. The method is qualified for assay screening inside that matrix; it is not a whole-crude aggregation, ASTM conversion or design-certification method.
+
 ## Existing petroleum-property correlations
 
 This refinery-assay API deliberately reuses the existing NeqSim TBP/pseudo-component property framework. It does not add or retune critical-property, acentric-factor, or molecular-weight coefficients.
@@ -170,9 +180,10 @@ The regression suite for this API currently verifies:
 - exact reconstructed assay-mass closure;
 - analytical mass- and volume-basis bulk specific-gravity reconstruction;
 - whole-assay SG/API agreement across all five complete four-category rows in the public DOE/OEDI COA summary workbook;
+- per-cut UOP/Watson factors against four bounded cuts in the public DOE SPR Big Hill Sweet 2021 assay;
 - input-order independence and no thermodynamic-system mutation for bulk-property queries.
 
-These tests establish software/bookkeeping correctness and qualify ideal-additive-volume SG/API screening over the frozen COA matrix (published crude SG 0.765–0.847; maximum observed errors 0.006 SG and 1.5 degrees API). They do **not** qualify temperature correction, contraction, pseudo-component properties, or atmospheric/vacuum fractionation; those remain separate campaign gates in issue #3305.
+These tests establish software/bookkeeping correctness, qualify ideal-additive-volume SG/API screening over the frozen COA matrix (published crude SG 0.765-0.847; maximum observed errors 0.006 SG and 1.5 degrees API), and qualify per-cut Watson factors over the frozen DOE matrix (375-1050 degF; maximum observed error 0.0122). They do **not** qualify temperature correction, contraction, molecular-weight or critical-property correlations, or atmospheric/vacuum fractionation; those remain separate campaign gates in issue #3305.
 
 ## Refinery capability inventory after this increment
 
@@ -181,9 +192,10 @@ These tests establish software/bookkeeping correctness and qualify ideal-additiv
 | Pre-binned crude/petroleum assay cuts | `OilAssayCharacterisation` | Foundation hardened in #3305 |
 | Mass- and volume-basis cut yields | Unit/basis-explicit assay API | Foundation hardened in #3305 |
 | Pre-binned cumulative TBP cut boundaries | `addTBPCutBoundariesCelsius/Kelvin` | Initial implementation in #3305 |
+| Per-cut UOP/Watson characterization factor | `AssayCut.getWatsonCharacterizationFactor()` | DOE-qualified for assay screening over 375-1050 degF |
 | TBP pseudo-component properties | Pedersen, Lee-Kesler, Riazi-Daubert, Twu, Cavett, Standing and related models | Existing; needs refinery-range independent validation |
 | Plus-fraction splitting/lumping | `Characterise`, plus-fraction and lumping models | Existing; refinery assay integration still to be qualified |
-| Oil density/API and volatility standards | Oil-quality standards package, RVP/TVP workflows | Experimental whole-assay SG/API reconstruction; broader stream-property API remains open |
+| Oil density/API and volatility standards | Oil-quality standards package, RVP/TVP workflows | Whole-assay SG/API and per-cut Watson screening qualified over frozen public matrices; broader stream properties remain open |
 | Rigorous distillation columns | `DistillationColumn`, `SimpleTray`, Naphtali-Sandholm solver, side-draw support | Existing foundation; broad-boiling atmospheric/vacuum refinery benchmark remains open |
 | Crude preheat/fired heater | General heater/heat-exchanger process equipment | Refinery workflow and fuel/emission integration remain open |
 | Product blending/specification optimization | Generic optimization/process facilities | Refinery property/blending framework remains open |

--- a/docs/thermo/characterization/refinery_big_hill_validation.md
+++ b/docs/thermo/characterization/refinery_big_hill_validation.md
@@ -7,6 +7,8 @@ description: "Public-data qualification of NeqSim refinery assay volume-to-mass 
 
 Issue #3305 requires refinery characterization to be qualified against public refinery data before atmospheric/vacuum fractionation and conversion-unit models are expanded. This page freezes the first external refinery-assay benchmark used by the campaign.
 
+The later public DOE workbook, reported on 24 September 2021, is treated as a separate frozen source rather than silently replacing this 1998 MLI 009 matrix. Its per-cut UOP K values qualify the [DOE Big Hill Watson-factor calculation](refinery_big_hill_watson_validation).
+
 ## Source and provenance
 
 The benchmark uses the U.S. Department of Energy Strategic Petroleum Reserve (SPR) **Big Hill Sweet**, sample **MLI 009**, assay date **1998-05-04**, published in Exhibit D of the SPR Standard Sales Provisions in the Code of Federal Regulations archive:

--- a/docs/thermo/characterization/refinery_big_hill_watson_validation.md
+++ b/docs/thermo/characterization/refinery_big_hill_watson_validation.md
@@ -1,0 +1,54 @@
+---
+title: "DOE Big Hill Watson-factor qualification"
+description: "Public-data qualification of per-cut UOP/Watson characterization factors from a DOE Strategic Petroleum Reserve assay."
+---
+
+# DOE Big Hill Watson-factor qualification
+
+This benchmark qualifies `AssayCut.getWatsonCharacterizationFactor()` against reported refinery-cut properties in the public U.S. Department of Energy Strategic Petroleum Reserve Big Hill Sweet assay.
+
+## Source and provenance
+
+The source is the DOE/SPR **Big Hill Sweet** comprehensive assay workbook:
+
+- workbook: <https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx>
+- DOE assay landing page: <https://www.spr.doe.gov/reports/Crude_Oil_Assays.html>
+- report date recorded in the workbook: **24 September 2021**
+
+The workbook is publicly distributed by DOE/SPR and carries an informational-use disclaimer. No separate license statement was found. The regression therefore freezes only four attributed numerical UOP K-factor facts and the directly associated cut boundaries and relative densities; it does not redistribute the workbook or reproduce a proprietary standard.
+
+## Calculation
+
+For representative normal boiling point $T_b$ in K and specific gravity $SG$, NeqSim uses the established UOP/Watson relation:
+
+$$K_W=\frac{(1.8T_b)^{1/3}}{SG}$$
+
+This is equivalent to using the boiling point in degrees Rankine. A finite cut interval uses its arithmetic midpoint. API-gravity inputs follow the same dimensionless SG60/60 relation as the rest of `OilAssayCharacterisation`.
+
+## Frozen matrix and observed errors
+
+| DOE cut (degF) | SG60/60 | DOE UOP K | NeqSim midpoint K | Absolute error |
+| --- | ---: | ---: | ---: | ---: |
+| 375-530 | 0.8297 | 11.7 | 11.688825 | 0.011175 |
+| 530-650 | 0.8604 | 11.8 | 11.811830 | 0.011830 |
+| 650-850 | 0.9039 | 11.8 | 11.787868 | 0.012132 |
+| 850-1050 | 0.9336 | 12.0 | 12.010054 | 0.010054 |
+
+The maximum/mean/RMSE absolute error is **0.012132 / 0.011298 / 0.011326**. No coefficient or datum is tuned.
+
+## Acceptance and maturity
+
+`OilAssayCharacterisationDoeBigHillWatsonTest` requires:
+
+- all four bounded cuts to agree with DOE within **0.05 K-factor units**, consistent with one-decimal source reporting;
+- the observed maximum error to remain frozen at `0.012132370527373482` within numerical precision;
+- Kelvin, Celsius, Fahrenheit and finite-range midpoint input paths to agree to `1e-12`;
+- exact-SG and equivalent API-gravity inputs to use the same authoritative calculation;
+- missing density or representative boiling point to fail closed;
+- property queries not to add or modify thermodynamic components.
+
+Within the frozen matrix, the method is **qualified for assay screening** over 375-1050 degF cut boundaries and SG 0.8297-0.9336. It is a constant-time scalar calculation with no iterative solver.
+
+## Stop boundary
+
+This evidence does not qualify whole-crude K-factor aggregation, ASTM D86/D1160-to-TBP conversion, density-temperature correction, blend contraction, molecular-weight estimation, pseudo-component critical properties, vapor-liquid equilibrium, columns, blending, optimization or conversion-unit models. Those remain separate #3305 gates.

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -824,6 +824,27 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     }
 
     /**
+     * Calculate the UOP/Watson characterization factor for this assay cut.
+     *
+     * <p>
+     * The calculation uses {@code K_W = (1.8 T_b)^(1/3) / SG}, where {@code T_b} is the representative normal boiling
+     * point in K and {@code SG} is dimensionless specific gravity. This is equivalent to using the boiling point in
+     * degrees Rankine. A configured boiling interval uses its arithmetic midpoint through
+     * {@link #resolveAverageBoilingPoint()}.
+     * </p>
+     *
+     * @return dimensionless UOP/Watson characterization factor
+     * @throws IllegalStateException if density or representative boiling point is unavailable, or the result is invalid
+     */
+    public double getWatsonCharacterizationFactor() {
+      double factor = Math.cbrt(1.8) * Math.cbrt(resolveAverageBoilingPoint()) / resolveDensity();
+      if (!Double.isFinite(factor) || !(factor > 0.0)) {
+        throw new IllegalStateException("Unable to calculate Watson characterization factor for cut " + name);
+      }
+      return factor;
+    }
+
+    /**
      * Resolve the cut molar mass.
      *
      * <p>

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillWatsonTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillWatsonTest.java
@@ -1,0 +1,81 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Public DOE refinery-assay qualification of per-cut UOP/Watson characterization factors. */
+public class OilAssayCharacterisationDoeBigHillWatsonTest {
+  private static final double[] LOWER_BOUNDARY_F = { 375.0, 530.0, 650.0, 850.0 };
+  private static final double[] UPPER_BOUNDARY_F = { 530.0, 650.0, 850.0, 1050.0 };
+  private static final double[] SPECIFIC_GRAVITY = { 0.8297, 0.8604, 0.9039, 0.9336 };
+  private static final double[] DOE_WATSON_FACTOR = { 11.7, 11.8, 11.8, 12.0 };
+
+  @Test
+  public void doeBoundedCutsReproducePublishedWatsonFactors() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation characterisation = system.getOilAssayCharacterisation();
+    characterisation.clearCuts();
+
+    double maximumAbsoluteError = 0.0;
+    for (int i = 0; i < DOE_WATSON_FACTOR.length; i++) {
+      AssayCut cut = new AssayCut("DOE_BH_2021_" + (i + 1)).withMassFraction(0.25)
+          .withSpecificGravity(SPECIFIC_GRAVITY[i])
+          .withBoilingRangeCelsius(fahrenheitToCelsius(LOWER_BOUNDARY_F[i]), fahrenheitToCelsius(UPPER_BOUNDARY_F[i]));
+      characterisation.addCut(cut);
+
+      double absoluteError = Math.abs(cut.getWatsonCharacterizationFactor() - DOE_WATSON_FACTOR[i]);
+      maximumAbsoluteError = Math.max(maximumAbsoluteError, absoluteError);
+      assertEquals(DOE_WATSON_FACTOR[i], cut.getWatsonCharacterizationFactor(), 0.05,
+          "DOE one-decimal UOP K factor should agree with the bounded-cut midpoint calculation");
+    }
+
+    assertEquals(0.012132370527373482, maximumAbsoluteError, 1.0e-12);
+    assertEquals(0, system.getNumberOfComponents(), "Property queries must not mutate the thermodynamic system");
+  }
+
+  @Test
+  public void temperatureAndDensityInputViewsRemainEquivalent() {
+    double midpointFahrenheit = 0.5 * (375.0 + 530.0);
+    double midpointCelsius = fahrenheitToCelsius(midpointFahrenheit);
+    double midpointKelvin = midpointCelsius + 273.15;
+    double specificGravity = 0.8297;
+    double exactApiGravity = 141.5 / specificGravity - 131.5;
+
+    AssayCut kelvinCut = new AssayCut("Kelvin").withMassFraction(1.0).withSpecificGravity(specificGravity)
+        .withAverageBoilingPointKelvin(midpointKelvin);
+    AssayCut celsiusCut = new AssayCut("Celsius").withMassFraction(1.0).withSpecificGravity(specificGravity)
+        .withAverageBoilingPointCelsius(midpointCelsius);
+    AssayCut fahrenheitCut = new AssayCut("Fahrenheit").withMassFraction(1.0).withApiGravity(exactApiGravity)
+        .withAverageBoilingPointFahrenheit(midpointFahrenheit);
+    AssayCut rangeCut = new AssayCut("Range").withMassFraction(1.0).withSpecificGravity(specificGravity)
+        .withBoilingRangeCelsius(fahrenheitToCelsius(375.0), fahrenheitToCelsius(530.0));
+
+    double expected = kelvinCut.getWatsonCharacterizationFactor();
+    assertEquals(expected, celsiusCut.getWatsonCharacterizationFactor(), 1.0e-12);
+    assertEquals(expected, fahrenheitCut.getWatsonCharacterizationFactor(), 1.0e-12);
+    assertEquals(expected, rangeCut.getWatsonCharacterizationFactor(), 1.0e-12);
+    assertTrue(Double.isFinite(expected));
+    assertTrue(expected > 0.0);
+  }
+
+  @Test
+  public void missingInputsFailClosed() {
+    AssayCut missingDensity = new AssayCut("MissingDensity").withMassFraction(1.0)
+        .withAverageBoilingPointFahrenheit(452.5);
+    AssayCut missingBoilingPoint = new AssayCut("MissingBoilingPoint").withMassFraction(1.0)
+        .withSpecificGravity(0.8297);
+
+    assertThrows(IllegalStateException.class, missingDensity::getWatsonCharacterizationFactor);
+    assertThrows(IllegalStateException.class, missingBoilingPoint::getWatsonCharacterizationFactor);
+  }
+
+  private static double fahrenheitToCelsius(double fahrenheit) {
+    return (fahrenheit - 32.0) * 5.0 / 9.0;
+  }
+}


### PR DESCRIPTION
## Engineering question

Can NeqSim expose a unit-consistent per-cut UOP/Watson characterization factor and reproduce the values reported for bounded fractions in the public DOE SPR Big Hill Sweet assay?

Advances #3305. Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5474007388

## Exact continuity and frozen scope

- **Exact base:** `42d374bc58dd02f33ced526ca2be6775f5b1495c`
- **Exact head:** `a038dfc206ec8dbc56ba1f705a1b4cf1577a9d97`
- The preceding refinery capability #3355 is merged; this is the sole active #3305 implementation PR.
- Stops before whole-crude K aggregation, ASTM conversion, density-temperature correction, blend contraction, molecular-weight/critical-property qualification, terminal cuts, columns, blending, optimization, or conversion units.

## Implementation

- Adds `AssayCut.getWatsonCharacterizationFactor()`.
- Uses `K_W = (1.8 T_b[K])^(1/3) / SG`, equivalent to the boiling point in degrees Rankine.
- Reuses the authoritative representative-boiling-point and dimensionless SG/API inputs already owned by `AssayCut`.
- Uses the midpoint of a finite cut interval, fails closed when boiling point or density is missing, and performs no thermodynamic-system mutation.
- Java is authoritative; Python/JPype exposes the same public method. JSON, MCP, and notebook views are not applicable because no refinery-assay schema owns `AssayCut` and this is a bounded scalar API qualification.

## Public evidence

Source: U.S. DOE/SPR Big Hill Sweet comprehensive assay workbook, report date 24 September 2021:
https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx

The regression freezes every bounded cut that reports a UOP K factor:

| Cut (degF) | SG | DOE K | NeqSim K | Absolute error |
| --- | ---: | ---: | ---: | ---: |
| 375-530 | 0.8297 | 11.7 | 11.688825 | 0.011175 |
| 530-650 | 0.8604 | 11.8 | 11.811830 | 0.011830 |
| 650-850 | 0.9039 | 11.8 | 11.787868 | 0.012132 |
| 850-1050 | 0.9336 | 12.0 | 12.010054 | 0.010054 |

Maximum/mean/RMSE absolute error is `0.012132 / 0.011298 / 0.011326`; acceptance is `0.05`, consistent with one-decimal source reporting. No coefficient or datum is tuned. DOE publicly distributes the workbook with an informational-use disclaimer; no separate license statement was found, so only the attributed numerical facts above are frozen.

## Validation

Passed on the final local state:

- `python3 devtools/run_spotless.py apply`
- `python3 devtools/run_spotless.py check`
- `python3 devtools/check_documentation_search.py` — 675 Markdown pages and one standalone HTML page
- `./mvnw -q -DskipTests compile`
- `./mvnw -q -Dtest=OilAssayCharacterisationDoeBigHillWatsonTest,OilAssayCharacterisationTest,OilAssayCharacterisationDoeBigHillTest test`
- `git diff --check`

The `pre-commit` executable was unavailable locally; hosted pre-commit remains authoritative. No broad local suite was run under the fast-validation policy.

**VALIDATION PENDING CI**

## Documentation impact

Updated the characterization index, refinery-assay guide, original Big Hill provenance page, capability inventory, and a dedicated DOE Watson-factor qualification page. No notebook, schema, process, release, or migration documentation is affected.

Generated with AI assistance.