### PR TITLE
[AI-Assisted] docs: qualify engineering safety rendering

### DIFF
--- a/docs/fielddevelopment/API_GUIDE.md
+++ b/docs/fielddevelopment/API_GUIDE.md
@@ -3,8 +3,6 @@ title: Field Development API Guide
 description: Source-anchored guide to concept inputs, screening KPIs, option ranking, units, and engineering boundaries.
 ---
 
-# Field Development API Guide
-
 Use the field-development API to define early-phase concepts, run consistent screening, and compare options. The API
 does not replace a reservoir model, a verified `ProcessSystem`, detailed equipment design, a safety study, or an
 accountable economic model.

--- a/docs/fielddevelopment/DECISION_ENGINE_WORKFLOWS.md
+++ b/docs/fielddevelopment/DECISION_ENGINE_WORKFLOWS.md
@@ -3,8 +3,6 @@ title: Field Development Decision Engine Workflows
 description: Detailed workflow guide for NeqSim field development decision support, covering tieback screening, greenfield templates, portfolio optimization, Norwegian economics, process coupling, reservoir exports, route networks, and report-ready tables.
 ---
 
-# Field Development Decision Engine Workflows
-
 NeqSim's field-development layer now supports an end-to-end teaching and screening workflow for brownfield tiebacks, greenfield concepts, and multi-field portfolio decisions. The decision engine keeps early screening models tied to the same thermodynamic and process-simulation foundation used later in detailed studies.
 
 This page explains how the new APIs fit together and where to find executable notebook examples that import workspace classes through `devtools/neqsim_dev_setup.py`.

--- a/docs/fielddevelopment/DIGITAL_FIELD_TWIN.md
+++ b/docs/fielddevelopment/DIGITAL_FIELD_TWIN.md
@@ -3,8 +3,6 @@ title: NeqSim Digital Field Twin Framework
 description: NeqSim provides a comprehensive **Digital Field Twin** capability that links field development planning to detailed thermodynamic, process, and mechanical calculations. This creates consistency throug...
 ---
 
-# NeqSim Digital Field Twin Framework
-
 ## Overview
 
 NeqSim provides a comprehensive **Digital Field Twin** capability that links field development planning to detailed thermodynamic, process, and mechanical calculations. This creates consistency throughout the field lifecycle—from **exploration** through **development**, **operation**, and **decommissioning**.

--- a/docs/fielddevelopment/FIELD_DEVELOPMENT_STRATEGY.md
+++ b/docs/fielddevelopment/FIELD_DEVELOPMENT_STRATEGY.md
@@ -3,8 +3,6 @@ title: NeqSim Field Development Strategy
 description: This document outlines a comprehensive plan to transform NeqSim into a premier tool for **field development screening**, **production scheduling**, **tie-back analysis**, and **new development plannin...
 ---
 
-# NeqSim Field Development Strategy
-
 ## Executive Summary
 
 This document outlines a comprehensive plan to transform NeqSim into a premier tool for **field development screening**, **production scheduling**, **tie-back analysis**, and **new development planning**. The strategy builds on existing NeqSim strengths (thermodynamics, process simulation) while adding high-level orchestration capabilities.

--- a/docs/fielddevelopment/HOST_TIE_IN_CAPACITY.md
+++ b/docs/fielddevelopment/HOST_TIE_IN_CAPACITY.md
@@ -3,8 +3,6 @@ title: Host Tie-In Capacity and Holdback Planning
 description: Time-series host tie-in capacity planning for brownfield tiebacks, including base-host production, satellite holdback, process equipment bottlenecks, deferred value, and debottleneck decisions.
 ---
 
-# Host Tie-In Capacity and Holdback Planning
-
 Brownfield tieback decisions often fail because a host has spare capacity on paper but not in the year when the satellite peaks. The host may already use most separator, compression, liquid-handling, produced-water, export, or power capacity. The host tie-in capacity planner turns that question into a repeatable time-series calculation:
 
 1. Compare base-host production and satellite production against host nameplate capacities.

--- a/docs/fielddevelopment/INTEGRATED_FIELD_DEVELOPMENT_FRAMEWORK.md
+++ b/docs/fielddevelopment/INTEGRATED_FIELD_DEVELOPMENT_FRAMEWORK.md
@@ -3,8 +3,6 @@ title: Integrated Field Development Framework
 description: This document describes how NeqSim integrates PVT, reservoir, well, and process simulations
 ---
 
-# Integrated Field Development Framework
-
 ## Overview
 
 This document describes how NeqSim integrates PVT, reservoir, well, and process simulations

--- a/docs/fielddevelopment/INTEGRATED_PRODUCTION_MODELLING.md
+++ b/docs/fielddevelopment/INTEGRATED_PRODUCTION_MODELLING.md
@@ -4,8 +4,6 @@ description: "State-of-the-art integrated production modelling in NeqSim: couple
 keywords: "integrated production modelling, IPM, GAP, PROSPER, MBAL, Pipesim, network solver, deliverability curve, VFP, IPR, VLP, gas lift, well test, jet pump, sucker rod pump, reservoir to market, choke optimization, production network"
 ---
 
-# Integrated Production Modelling (Reservoir to Market)
-
 NeqSim provides an integrated production-modelling (IPM) stack that couples the four classic
 production layers &mdash; **reservoir**, **wells**, **gathering network / flowlines**, and the
 **facilities / market boundary** &mdash; into a single solvable system. It plays the same role as

--- a/docs/fielddevelopment/LATE_LIFE_OPERATIONS.md
+++ b/docs/fielddevelopment/LATE_LIFE_OPERATIONS.md
@@ -3,8 +3,6 @@ title: Late-Life Operations Support in NeqSim
 description: This document describes how NeqSim supports analysis of late-life field operations, a key topic in TPG4230 and critical for maximizing economic recovery from mature fields.
 ---
 
-# Late-Life Operations Support in NeqSim
-
 This document describes how NeqSim supports analysis of late-life field operations, a key topic in TPG4230 and critical for maximizing economic recovery from mature fields.
 
 ---

--- a/docs/fielddevelopment/MATHEMATICAL_REFERENCE.md
+++ b/docs/fielddevelopment/MATHEMATICAL_REFERENCE.md
@@ -3,8 +3,6 @@ title: NeqSim Field Development - Mathematical Reference
 description: This document provides the complete mathematical foundations for the field development framework, linking thermodynamic calculations to economic evaluation and decision support.
 ---
 
-# NeqSim Field Development - Mathematical Reference
-
 This document provides the complete mathematical foundations for the field development framework, linking thermodynamic calculations to economic evaluation and decision support.
 
 ---

--- a/docs/fielddevelopment/MULTI_SCENARIO_PRODUCTION_OPTIMIZATION.md
+++ b/docs/fielddevelopment/MULTI_SCENARIO_PRODUCTION_OPTIMIZATION.md
@@ -3,8 +3,6 @@ title: Multi-Scenario Production Optimization
 description: VFP table generation with varying GOR and water cut scenarios for reservoir simulation coupling. Enables robust production optimization across changing field conditions.
 ---
 
-# Multi-Scenario Production Optimization
-
 ## Overview
 
 The Multi-Scenario Production Optimization framework generates Vertical Flow Performance (VFP) tables that span different Gas-Oil Ratio (GOR) and Water Cut (WC) conditions. This is essential for reservoir simulation coupling where fluid properties change over time as the field matures.

--- a/docs/process/DESIGN_FRAMEWORK.md
+++ b/docs/process/DESIGN_FRAMEWORK.md
@@ -3,8 +3,6 @@ title: NeqSim Design Framework
 description: The Design Framework provides an integrated workflow for automated equipment sizing, process template-based design, and production optimization. This document describes the key components and usage pa...
 ---
 
-# NeqSim Design Framework
-
 The Design Framework provides an integrated workflow for automated equipment sizing, process template-based design, and production optimization. This document describes the key components and usage patterns.
 
 ## Compatibility

--- a/docs/process/design/templates_guide.md
+++ b/docs/process/design/templates_guide.md
@@ -3,8 +3,6 @@ title: Process Design Templates
 description: The `neqsim.process.design.template` package provides pre-built process templates for common industrial applications. These templates simplify the creation of standard process configurations while all...
 ---
 
-# Process Design Templates
-
 The `neqsim.process.design.template` package provides pre-built process templates for common industrial applications. These templates simplify the creation of standard process configurations while allowing customization through a parameter-based API.
 
 ## Table of Contents

--- a/docs/process/mechanical_design.md
+++ b/docs/process/mechanical_design.md
@@ -3,8 +3,6 @@ title: Mechanical Design Framework
 description: NeqSim provides a comprehensive mechanical design framework for sizing and specifying process equipment according to industry standards. This document describes the architecture, usage patterns, and J...
 ---
 
-# Mechanical Design Framework
-
 NeqSim provides a comprehensive mechanical design framework for sizing and specifying process equipment according to industry standards. This document describes the architecture, usage patterns, and JSON export capabilities.
 
 > **📘 Related Documentation**
@@ -1032,6 +1030,6 @@ System.out.println("Driver power: " + compResponse.getDriverPower() + " kW");
 
 ## See Also
 
-- [Process Equipment](./
+- [Process Equipment](README.md)
 - [Pipeline Mechanical Design](pipeline_mechanical_design)
 - [Design Standards](../standards/)

--- a/docs/process/mechanical_design/tema_standard_guide.md
+++ b/docs/process/mechanical_design/tema_standard_guide.md
@@ -3,8 +3,6 @@ title: TEMA Standard Heat Exchanger Design
 description: The `neqsim.process.mechanicaldesign.heatexchanger` package includes comprehensive TEMA (Tubular Exchanger Manufacturers Association) standard support for shell and tube heat exchanger design.
 ---
 
-# TEMA Standard Heat Exchanger Design
-
 The `neqsim.process.mechanicaldesign.heatexchanger` package includes comprehensive TEMA (Tubular Exchanger Manufacturers Association) standard support for shell and tube heat exchanger design.
 
 ## Table of Contents

--- a/docs/process/mechanical_design/thermal_hydraulic_design.md
+++ b/docs/process/mechanical_design/thermal_hydraulic_design.md
@@ -3,8 +3,6 @@ title: "Heat Exchanger Thermal-Hydraulic Design"
 description: "Comprehensive guide to shell-and-tube heat exchanger thermal-hydraulic design in NeqSim. Covers tube-side and shell-side heat transfer coefficients (Gnielinski, Kern, Bell-Delaware), overall U, pressure drops, LMTD correction factors, vibration screening, zone-by-zone analysis, and rating mode."
 ---
 
-# Heat Exchanger Thermal-Hydraulic Design
-
 NeqSim provides a complete thermal-hydraulic design toolkit for shell-and-tube heat
 exchangers. The toolkit connects rigorous thermodynamic property predictions from
 the process simulation to industry-standard heat transfer and pressure drop

--- a/docs/process/mechanical_design/two_phase_heat_transfer.md
+++ b/docs/process/mechanical_design/two_phase_heat_transfer.md
@@ -3,8 +3,6 @@ title: "Two-Phase Heat Transfer and Advanced Correlations"
 description: "Guide to two-phase (condensation, boiling) heat transfer correlations, two-phase pressure drop methods, dynamic fouling models, incremental zone analysis, and tube insert enhancement models in NeqSim. Covers Shah, Chen, Gungor-Winterton, Friedel, Muller-Steinhagen-Heck, Ebert-Panchal, Kern-Seaton, and Manglik-Bergles correlations."
 ---
 
-# Two-Phase Heat Transfer and Advanced Correlations
-
 NeqSim provides a suite of advanced correlations for heat exchanger services that
 go beyond single-phase convection. These cover condensation, boiling, two-phase
 pressure drop, dynamic fouling prediction, HTRI-style incremental zone analysis,

--- a/docs/process/mechanical_design_database.md
+++ b/docs/process/mechanical_design_database.md
@@ -3,8 +3,6 @@ title: Mechanical Design Database and Data Sources
 description: NeqSim supports loading mechanical design parameters from various data sources including databases and CSV files. This allows organizations to maintain centralized repositories of design data, materia...
 ---
 
-# Mechanical Design Database and Data Sources
-
 ## Overview
 
 NeqSim supports loading mechanical design parameters from various data sources including databases and CSV files. This allows organizations to maintain centralized repositories of design data, material properties, and company-specific standards.

--- a/docs/process/safety/scenario-generation.md
+++ b/docs/process/safety/scenario-generation.md
@@ -3,8 +3,6 @@ title: Automatic Scenario Generation
 description: This document describes the automatic safety scenario generation infrastructure added to NeqSim.
 ---
 
-# Automatic Scenario Generation
-
 This document describes the automatic safety scenario generation infrastructure added to NeqSim.
 
 ## Overview

--- a/docs/risk/api-reference.md
+++ b/docs/risk/api-reference.md
@@ -5,8 +5,6 @@ parent: Risk Framework
 description: "Complete API reference for NeqSim risk and reliability classes including RiskMatrix, BowTieModel, EquipmentReliability, MonteCarloReliability, and SIS integration."
 ---
 
-# API Reference
-
 Complete Java API reference for the Risk Simulation Framework.
 
 ---

--- a/docs/risk/dependency-analysis.md
+++ b/docs/risk/dependency-analysis.md
@@ -5,8 +5,6 @@ parent: Risk Framework
 description: "System dependency and common cause failure analysis for process plants. Identify cascading failures, shared vulnerabilities, and critical single points of failure."
 ---
 
-# Dependency Analysis
-
 Dependency analysis answers critical operational questions:
 
 - *"If this pump fails, what else is affected?"*

--- a/docs/risk/equipment-failure.md
+++ b/docs/risk/equipment-failure.md
@@ -5,8 +5,6 @@ parent: Risk Framework
 description: "Equipment failure modeling using MTBF, MTTR, failure rates, and Weibull distributions. Covers compressors, pumps, heat exchangers, separators, and valves."
 ---
 
-# Equipment Failure Modeling
-
 This document describes how to model equipment failures in NeqSim, including failure types, capacity factors, and reliability data.
 
 ---

--- a/docs/risk/mathematical-reference.md
+++ b/docs/risk/mathematical-reference.md
@@ -5,8 +5,6 @@ parent: Risk Framework
 description: "Mathematical foundations for the NeqSim risk framework. Probability distributions, reliability theory, Monte Carlo methods, Markov chains, and fault tree algebra."
 ---
 
-# Mathematical Reference
-
 This document provides the mathematical foundations for the Risk Simulation Framework, including reliability theory, Monte Carlo methods, and risk calculations.
 
 ---

--- a/docs/risk/production-impact.md
+++ b/docs/risk/production-impact.md
@@ -5,8 +5,6 @@ parent: Risk Framework
 description: "Production impact analysis from equipment failures. Calculate deferred production, revenue loss, and optimal spare parts strategies using process simulation."
 ---
 
-# Production Impact Analysis
-
 Production Impact Analysis quantifies how equipment failures affect plant output, enabling prioritization of maintenance and investment decisions.
 
 ---

--- a/docs/risk/risk-matrix.md
+++ b/docs/risk/risk-matrix.md
@@ -5,8 +5,6 @@ parent: Risk Framework
 description: "Risk matrix implementation for classifying and evaluating risks. ISO 31000 based 5x5 matrix with customizable likelihood, consequence categories, and ALARP thresholds."
 ---
 
-# Risk Matrix
-
 The Risk Matrix provides a visual representation of equipment risks by combining probability (failure frequency) with consequence (production impact). It follows ISO 31000 and NORSOK Z-013 guidelines.
 
 ---

--- a/docs/test_engineering_safety_field_documentation.py
+++ b/docs/test_engineering_safety_field_documentation.py
@@ -1,0 +1,181 @@
+"""Contracts for engineering, safety, risk, and field-development documentation."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+DOCS = Path(__file__).resolve().parent
+SCOPE_PAGES = (
+    DOCS / "examples/FieldDevelopmentWorkflow.md",
+    DOCS / "fielddevelopment/API_GUIDE.md",
+    DOCS / "fielddevelopment/DECISION_ENGINE_WORKFLOWS.md",
+    DOCS / "fielddevelopment/DIGITAL_FIELD_TWIN.md",
+    DOCS / "fielddevelopment/FIELD_DEVELOPMENT_STRATEGY.md",
+    DOCS / "fielddevelopment/HOST_TIE_IN_CAPACITY.md",
+    DOCS / "fielddevelopment/INTEGRATED_FIELD_DEVELOPMENT_FRAMEWORK.md",
+    DOCS / "fielddevelopment/INTEGRATED_PRODUCTION_MODELLING.md",
+    DOCS / "fielddevelopment/LATE_LIFE_OPERATIONS.md",
+    DOCS / "fielddevelopment/MATHEMATICAL_REFERENCE.md",
+    DOCS / "fielddevelopment/MULTI_SCENARIO_PRODUCTION_OPTIMIZATION.md",
+    DOCS / "fielddevelopment/README.md",
+    DOCS / "process/DESIGN_FRAMEWORK.md",
+    DOCS / "process/design/templates_guide.md",
+    DOCS / "process/mechanical_design.md",
+    DOCS / "process/mechanical_design/tema_standard_guide.md",
+    DOCS / "process/mechanical_design/thermal_hydraulic_design.md",
+    DOCS / "process/mechanical_design/two_phase_heat_transfer.md",
+    DOCS / "process/mechanical_design_database.md",
+    DOCS / "process/mechanical_design_standards.md",
+    DOCS / "process/safety/README.md",
+    DOCS / "process/safety/release-dispersion-scenarios.md",
+    DOCS / "process/safety/scenario-generation.md",
+    DOCS / "risk/PHYSICS_BASED_RISK_INTEGRATION.md",
+    DOCS / "risk/README.md",
+    DOCS / "risk/RELIABILITY_DATA_GUIDE.md",
+    DOCS / "risk/api-reference.md",
+    DOCS / "risk/bowtie-analysis.md",
+    DOCS / "risk/condition-based.md",
+    DOCS / "risk/degraded-operation.md",
+    DOCS / "risk/dependency-analysis.md",
+    DOCS / "risk/dynamic-simulation.md",
+    DOCS / "risk/equipment-failure.md",
+    DOCS / "risk/index.md",
+    DOCS / "risk/mathematical-reference.md",
+    DOCS / "risk/monte-carlo.md",
+    DOCS / "risk/overview.md",
+    DOCS / "risk/production-impact.md",
+    DOCS / "risk/risk-matrix.md",
+    DOCS / "risk/sis-integration.md",
+    DOCS / "risk/stid-tagging.md",
+    DOCS / "risk/topology.md",
+)
+
+
+def metadata_value(metadata, name):
+    """Return a plain scalar, including folded YAML front-matter values."""
+    prefix = name + ":"
+    lines = metadata.splitlines()
+    for index, line in enumerate(lines):
+        if not line.startswith(prefix):
+            continue
+        value = line[len(prefix) :].strip()
+        if value in {">", ">-", "|", "|-"}:
+            parts = []
+            for continuation in lines[index + 1 :]:
+                if continuation and not continuation[0].isspace():
+                    break
+                if continuation.strip():
+                    parts.append(continuation.strip())
+            return " ".join(parts)
+        return value.strip().strip("'\"")
+    return ""
+
+
+def parse_front_matter(source):
+    """Return title, description, and body from one Markdown page."""
+    match = re.match(r"\A---\n(?P<metadata>.*?)\n---\n(?P<body>.*)\Z", source, re.DOTALL)
+    if match is None:
+        raise AssertionError("Missing Jekyll front matter")
+    metadata = match.group("metadata")
+    return (
+        metadata_value(metadata, "title"),
+        metadata_value(metadata, "description"),
+        match.group("body"),
+    )
+
+
+def remove_fenced_code(source):
+    """Remove backtick and tilde code fences before inspecting rendered Markdown."""
+    rendered = []
+    marker = None
+    for line in source.splitlines():
+        stripped = line.lstrip()
+        if marker is None and (
+            stripped.startswith(("\x60\x60\x60", "~~~"))
+        ):
+            marker = stripped[:3]
+            continue
+        if marker is not None:
+            if stripped.startswith(marker):
+                marker = None
+            continue
+        rendered.append(line)
+    return "\n".join(rendered)
+
+
+def link_candidates(page, raw_target):
+    """Return repository-source candidates for one relative documentation link."""
+    target = raw_target.split("#", 1)[0].split("?", 1)[0].strip().strip("<>")
+    if target.startswith("/"):
+        candidate = DOCS / target.lstrip("/")
+    else:
+        candidate = page.parent / target
+    if candidate.suffix:
+        return (candidate,)
+    return (
+        candidate.with_suffix(".md"),
+        candidate / "README.md",
+        candidate / "index.md",
+    )
+
+
+class EngineeringSafetyFieldDocumentationContractTest(unittest.TestCase):
+    """Protect the frozen rotation-scope-4 documentation surface."""
+
+    def test_frozen_scope_exists(self):
+        self.assertEqual(42, len(SCOPE_PAGES))
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                self.assertTrue(page.is_file())
+
+    def test_pages_have_searchable_front_matter(self):
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                title, description, _body = parse_front_matter(
+                    page.read_text(encoding="utf-8")
+                )
+                self.assertTrue(title)
+                self.assertGreaterEqual(5, len(description.split()))
+
+    def test_front_matter_title_is_not_repeated_as_h1(self):
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                title, _description, body = parse_front_matter(
+                    page.read_text(encoding="utf-8")
+                )
+                rendered = remove_fenced_code(body)
+                headings = re.findall(r"^#\s+(.+?)\s*$", rendered, re.MULTILINE)
+                self.assertNotIn(title, headings)
+
+    def test_pages_use_supported_math_delimiters(self):
+        unsupported = re.compile(r"\\\[|\\\]|\\\(|\\\)")
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                _title, _description, body = parse_front_matter(
+                    page.read_text(encoding="utf-8")
+                )
+                self.assertIsNone(unsupported.search(remove_fenced_code(body)))
+
+    def test_relative_source_links_resolve(self):
+        link_pattern = re.compile(r"(?<!!)\[[^\]\n]+\]\(([^)\n]+)\)")
+        scheme = re.compile(r"^[a-z][a-z0-9+.-]*:", re.IGNORECASE)
+        for page in SCOPE_PAGES:
+            rendered = remove_fenced_code(page.read_text(encoding="utf-8"))
+            with self.subTest(page=page, check="single-line destinations"):
+                self.assertNotRegex(rendered, r"\]\([^\n)]*\n")
+            for match in link_pattern.finditer(rendered):
+                raw_target = match.group(1).strip().split()[0]
+                if raw_target.startswith("#") or scheme.match(raw_target):
+                    continue
+                candidates = link_candidates(page, raw_target)
+                with self.subTest(page=page, target=raw_target):
+                    self.assertTrue(
+                        any(candidate.is_file() for candidate in candidates),
+                        msg="Missing target; tried: "
+                        + ", ".join(str(candidate) for candidate in candidates),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/test_engineering_safety_field_documentation.py
+++ b/docs/test_engineering_safety_field_documentation.py
@@ -112,7 +112,12 @@ def link_candidates(page, raw_target):
     else:
         candidate = page.parent / target
     if candidate.suffix:
-        return (candidate,)
+        stem = candidate.with_suffix("")
+        return (
+            candidate,
+            stem / "README.md",
+            stem / "index.md",
+        )
     return (
         candidate.with_suffix(".md"),
         candidate / "README.md",
@@ -136,7 +141,7 @@ class EngineeringSafetyFieldDocumentationContractTest(unittest.TestCase):
                     page.read_text(encoding="utf-8")
                 )
                 self.assertTrue(title)
-                self.assertGreaterEqual(5, len(description.split()))
+                self.assertGreaterEqual(len(description.split()), 5)
 
     def test_front_matter_title_is_not_repeated_as_h1(self):
         for page in SCOPE_PAGES:

--- a/docs/test_fielddevelopment_api_guide_documentation.py
+++ b/docs/test_fielddevelopment_api_guide_documentation.py
@@ -94,7 +94,7 @@ class FieldDevelopmentApiGuideDocumentationContractTest(unittest.TestCase):
         self.assertEqual(self.guide.count("```") % 2, 0)
         self.assertEqual(
             len(re.findall(r"^# ", self.guide, flags=re.MULTILINE)),
-            1,
+            0,
         )
         self.assertNotIn("\\[", self.guide)
         self.assertNotIn("\\]", self.guide)


### PR DESCRIPTION
## Campaign / capability

Advances #2499 as D108, rotation scope 4 (engineering design, safety/risk, and field development).

Capability contract: [campaign ledger](https://github.com/equinor/neqsim/issues/2499#issuecomment-5432666687)

Exact base: `42d374bc58dd02f33ced526ca2be6775f5b1495c`  
Exact head: `19143f3ff1c6f0afce09676202a7d9bb5c1bee2c`

## Engineering question

Can the curated engineering-design, mechanical-design, process-safety/risk, and field-development documentation render and navigate unambiguously under the repository's Jekyll source contract without changing authoritative calculations, APIs, examples, or design/safety semantics?

Current maturity: **experimental**  
Target maturity: **qualified**

## Frozen scan and confirmed defects

The exact-`master` scan covers 42 curated Markdown pages under:

- `docs/fielddevelopment/**` and the field-development workflow guide;
- `docs/process/design/**` and selected `docs/process/mechanical_design*` pages;
- `docs/process/safety/**`;
- `docs/risk/**`.

The branch contains exactly 26 changed files:

- 24 repaired documentation pages;
- `docs/test_engineering_safety_field_documentation.py`;
- the aligned existing `docs/test_fielddevelopment_api_guide_documentation.py` contract.

Confirmed defects: **25 found / 25 repaired** across 24 pages.

- 24 pages repeated their exact Jekyll front-matter `title` as a Markdown H1.
- `docs/process/mechanical_design.md` had one malformed cross-line Process Equipment link that swallowed the following list item.

DEXPI-owned pages are deliberately excluded.

## Change and regression coverage

- removes only exact title/H1 duplication;
- repairs the malformed link to the explicit `README.md` source;
- preserves equations, technical and standards claims, examples, units, model selection, and engineering-review boundaries;
- adds a dependency-free 42-page contract for:
  - frozen-path existence;
  - searchable plain and folded YAML front matter;
  - no exact title/H1 duplication outside backtick or tilde code fences;
  - no unsupported math delimiters outside code fences;
  - single-line Markdown destinations and repository-source resolution for every scoped relative link.

## Applicable capability views

- **Java:** unchanged; current mechanical-design, safety/risk, and field-development Java source remains authoritative. No example behavior is edited.
- **Python:** the new documentation contract is the executable regression view.
- **JSON/MCP/notebook:** not applicable; no schema, runner, tool, or notebook surface changes.
- **Engineering validation:** rendering, metadata, and source navigation only; no process, mechanical, safety, or standards qualification claim.

Documentation impact: the affected documentation pages and their shared executable contract are the complete change.

## Validation

Connector-side exact-source scan and proposed-corpus inspection pass:

- zero targeted title, math-delimiter, or multiline-link defects remain across all 42 pages;
- all 42 pages have nonempty searchable title/description metadata;
- all **122** unique proposed relative targets resolve to current repository sources;
- the new Python contract parses successfully with `ast.parse`;
- initial CI exposed a reversed minimum-description assertion and the pre-existing API-guide H1 expectation; both executable contracts are repaired at the current head;
- the reviewed link resolver now returns one stable three-candidate tuple shape;
- exact remote compare reports two commits ahead and exactly 26 changed files;
- no frozen file overlaps active #3358, #3360, #3361, or #3362.

Initial exact-head CI passed build/Javadoc, pre-commit, Spotless, and CodeQL. Documentation-search failed only in the two documentation contracts now repaired. Fresh exact-head CI is active. No local Maven, Jekyll, Spotless, pre-commit, documentation-search, or Python contract execution is claimed.

**VALIDATION PENDING CI**

## Dependencies, risk, and stop boundary

D105–D107 provide the merged rendering convention and contract pattern. Compatibility risk is documentation-only.

Stop before production code, calculation/API/example behavior, standards interpretation, design or safety claim changes, DEXPI/PFD semantics, JSON/MCP, notebooks, external-link policy, or Huldra. The broader legacy Java-snippet logging migration is a separate executable-example batch.