### PR TITLE
[AI-Assisted] test(mcp): qualify adjustable-parameter discovery

### DIFF
--- a/.github/workflows/mcp_protocol_qualification.yml
+++ b/.github/workflows/mcp_protocol_qualification.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Run focused persisted-state Java contract
         run: mvn -B -Dtest=neqsim.mcp.runners.StatePersistenceRunnerTest test -ntp
 
+      - name: Run focused adjustable-parameter Java contract
+        run: mvn -B -Dtest=neqsim.mcp.runners.AutomationLoopRunnerTest test -ntp
+
       - name: Build exact MCP server package
         shell: bash
         run: |
@@ -84,6 +87,9 @@ jobs:
 
       - name: Run focused real-MCP persisted-state qualification
         run: cd neqsim-mcp-server && python test_state_persistence_protocol.py
+
+      - name: Run focused real-MCP adjustable-parameter qualification
+        run: cd neqsim-mcp-server && python test_adjustable_parameters_protocol.py
 
       - name: Run comprehensive real-MCP protocol regression
         run: cd neqsim-mcp-server && python test_mcp_server.py

--- a/neqsim-mcp-server/docs/evidence/ADJUSTABLE_PARAMETERS_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/ADJUSTABLE_PARAMETERS_CONTRACT.md
@@ -1,0 +1,51 @@
+# Adjustable-parameter discovery contract evidence
+
+## Capability and engineering question
+
+`getAdjustableParameters` answers which process inputs the existing NeqSim
+automation model exposes for bounded study setup, using stable addresses and
+explicit units. The authoritative route is
+`NeqSimTools.getAdjustableParameters` →
+`AutomationRunner.getAdjustableParameters` → solved canonical `ProcessSystem`
+→ `ProcessAutomation.getAdjustableParametersJson()`.
+
+The capability accepts either an explicit process JSON definition or a reusable
+`ModelRegistry` handle. It returns `schemaVersion`, `count`, and parameter
+records containing `name`, `address`, `unit`, nullable `lowerBound` and
+`upperBound`, `targetUnitName`, `targetProperty`, and `source`.
+
+## Qualification evidence
+
+`AutomationLoopRunnerTest` verifies the Java contract on a canonical compressor,
+including the stable `Compressor.outletPressure` address, `bara` unit, target
+metadata, provenance, bounds fields, and internally consistent count.
+
+`test_adjustable_parameters_protocol.py` starts the packaged MCP server over
+STDIO and retrieves the canonical `process/compression-with-cooling` catalog
+fixture. It verifies:
+
+- non-empty, unit-bearing parameter records with the documented schema;
+- stable compressor pressure addresses;
+- deterministic equivalence between an explicit definition and a reusable
+  `manageModel` handle;
+- fail-closed behavior for a blank request; and
+- unchanged Phase 0 trust accounting while this evidence is a prerequisite.
+
+The focused Java and packaged-MCP checks run in
+`.github/workflows/mcp_protocol_qualification.yml` before the comprehensive MCP
+regression.
+
+## Scope and limitations
+
+This contract is discovery-only and does not mutate a process, start an
+optimization, or issue a plant command. Bounds and units are those already
+declared by the canonical Java automation registry. Their presence does not
+establish physical feasibility, model fidelity, convergence quality, mass or
+energy conservation, a globally optimal operating point, design certification,
+or accountable engineering approval.
+
+Phase 0 inventory deliberately remains version `1.21` with 20
+`EXPLICIT_TRUST`, 19 `CONTRACT_TESTED`, and 32 `CONFIRMED_GAP` tools.
+`getAdjustableParameters` remains a confirmed gap until this prerequisite is
+merged and a separate atomic promotion updates machine-readable inventory,
+primary protocol accounting, and documentation together.

--- a/neqsim-mcp-server/docs/evidence/ADJUSTABLE_PARAMETERS_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/ADJUSTABLE_PARAMETERS_CONTRACT.md
@@ -11,14 +11,15 @@ explicit units. The authoritative route is
 
 The capability accepts either an explicit process JSON definition or a reusable
 `ModelRegistry` handle. It returns `schemaVersion`, `count`, and parameter
-records containing `name`, `address`, `unit`, nullable `lowerBound` and
-`upperBound`, `targetUnitName`, `targetProperty`, and `source`.
+records containing `name`, `address`, `unit`, `targetUnitName`,
+`targetProperty`, and `source`. Optional `lowerBound` and `upperBound` values are
+numeric when declared and may be omitted when the registry has no bound.
 
 ## Qualification evidence
 
 `AutomationLoopRunnerTest` verifies the Java contract on a canonical compressor,
 including the stable `Compressor.outletPressure` address, `bara` unit, target
-metadata, provenance, bounds fields, and internally consistent count.
+metadata, provenance, declared bounds, and internally consistent count.
 
 `test_adjustable_parameters_protocol.py` starts the packaged MCP server over
 STDIO and retrieves the canonical `process/compression-with-cooling` catalog

--- a/neqsim-mcp-server/docs/evidence/ADJUSTABLE_PARAMETERS_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/ADJUSTABLE_PARAMETERS_CONTRACT.md
@@ -13,7 +13,9 @@ The capability accepts either an explicit process JSON definition or a reusable
 `ModelRegistry` handle. It returns `schemaVersion`, `count`, and parameter
 records containing `name`, `address`, `unit`, `targetUnitName`,
 `targetProperty`, and `source`. Optional `lowerBound` and `upperBound` values are
-numeric when declared and may be omitted when the registry has no bound.
+numeric when declared and may be omitted when the registry has no bound. The `unit`
+field is an engineering-unit string; the existing registry uses an empty string for a
+qualified dimensionless property such as `polytropicEfficiency`.
 
 ## Qualification evidence
 
@@ -25,7 +27,8 @@ metadata, provenance, declared bounds, and internally consistent count.
 STDIO and retrieves the canonical `process/compression-with-cooling` catalog
 fixture. It verifies:
 
-- non-empty, unit-bearing parameter records with the documented schema;
+- non-empty parameter records with explicit unit metadata, including the
+  dimensionless empty-string convention;
 - stable compressor pressure addresses;
 - deterministic equivalence between an explicit definition and a reusable
   `manageModel` handle;

--- a/neqsim-mcp-server/test_adjustable_parameters_protocol.py
+++ b/neqsim-mcp-server/test_adjustable_parameters_protocol.py
@@ -1,0 +1,278 @@
+"""Focused real-MCP qualification for adjustable-parameter discovery.
+
+This dependency-free harness starts the packaged NeqSim MCP server over STDIO
+and qualifies deterministic parameter discovery for the canonical
+``compression-with-cooling`` process. It is bounded software-contract evidence:
+it does not validate optimization, numerical fidelity, conservation, parameter
+feasibility, live-plant authority, or engineering approval.
+"""
+import json
+import subprocess
+import sys
+import time
+
+JAR = "target/neqsim-mcp-server-1.0.0-SNAPSHOT-runner.jar"
+
+
+class McpClient:
+    """Minimal line-delimited JSON-RPC client for packaged-server qualification."""
+
+    def __init__(self):
+        self.proc = None
+        self.message_id = 0
+
+    def next_id(self):
+        self.message_id += 1
+        return self.message_id
+
+    def send(self, message):
+        self.proc.stdin.write(json.dumps(message) + "\n")
+        self.proc.stdin.flush()
+
+    def receive(self):
+        line = self.proc.stdout.readline()
+        if not line:
+            stderr = self.proc.stderr.read() if self.proc and self.proc.stderr else ""
+            raise RuntimeError("MCP server closed stdout unexpectedly: " + stderr)
+        return json.loads(line)
+
+    def start(self):
+        self.proc = subprocess.Popen(
+            ["java", "-jar", JAR],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "neqsim-adjustable-parameters-contract-test",
+                        "version": "1.0",
+                    },
+                },
+            }
+        )
+        response = self.receive()
+        require("result" in response, "MCP initialize did not return a result", response)
+        self.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        time.sleep(0.2)
+
+    def call_tool(self, name, arguments):
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            }
+        )
+        response = self.receive()
+        content = response.get("result", {}).get("content", [])
+        require(content, "MCP tool call returned no content", response)
+        text = content[0].get("text", "")
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as error:
+            raise AssertionError(
+                f"MCP tool returned non-JSON content: {error}: {text}"
+            )
+
+    def manage_model(self, request):
+        return self.call_tool("manageModel", {"modelJson": json.dumps(request)})
+
+    def close(self):
+        if self.proc is None:
+            return
+        if self.proc.stdin:
+            self.proc.stdin.close()
+        try:
+            self.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.proc.terminate()
+            self.proc.wait(timeout=10)
+        self.proc = None
+
+
+def require(condition, message, detail=None):
+    """Raise a compact assertion with JSON detail when a contract fails."""
+    if condition:
+        return
+    suffix = ""
+    if detail is not None:
+        suffix = "\n" + json.dumps(detail, indent=2, sort_keys=True)
+    raise AssertionError(message + suffix)
+
+
+def payload(response):
+    """Return canonical data while retaining standardized envelope fields."""
+    data = response.get("data") if isinstance(response, dict) else None
+    if not isinstance(data, dict):
+        return response
+    merged = dict(data)
+    for key in (
+        "status",
+        "message",
+        "tool",
+        "action",
+        "code",
+        "errors",
+        "provenance",
+        "validation",
+        "qualityGate",
+    ):
+        if key in response:
+            merged.setdefault(key, response[key])
+    return merged
+
+
+def error_code(response):
+    """Return the canonical code from the standard nested error envelope."""
+    if not isinstance(response, dict):
+        return None
+    if isinstance(response.get("code"), str):
+        return response["code"]
+    errors = response.get("errors")
+    if isinstance(errors, list) and errors and isinstance(errors[0], dict):
+        return errors[0].get("code")
+    return None
+
+
+def canonical_process(client):
+    """Retrieve the catalog fixture through MCP instead of duplicating model JSON."""
+    example = client.call_tool(
+        "getExample", {"category": "process", "name": "compression-with-cooling"}
+    )
+    if isinstance(example, dict) and isinstance(example.get("data"), dict):
+        example = example["data"]
+    require(isinstance(example, dict), "compression example is not an object", example)
+    require("process" in example, "compression example omitted process", example)
+    return example
+
+
+def assert_registry(result):
+    """Validate stable parameter-address and unit-bearing metadata."""
+    data = payload(result)
+    require(data.get("status") == "success", "parameter discovery failed", result)
+    parameters = data.get("parameters")
+    require(isinstance(parameters, list) and parameters, "parameter registry is empty", data)
+    require(data.get("count") == len(parameters), "parameter count drifted", data)
+    required_keys = {
+        "name",
+        "address",
+        "unit",
+        "lowerBound",
+        "upperBound",
+        "targetUnitName",
+        "targetProperty",
+        "source",
+    }
+    for parameter in parameters:
+        require(isinstance(parameter, dict), "parameter record is not an object", parameter)
+        require(required_keys.issubset(parameter), "parameter metadata is incomplete", parameter)
+        require(bool(parameter.get("address")), "parameter address is empty", parameter)
+        require(bool(parameter.get("unit")), "parameter unit is empty", parameter)
+        require(
+            parameter.get("source") in {"INPUT_VARIABLE", "ADJUSTER"},
+            "parameter provenance is unsupported",
+            parameter,
+        )
+    addresses = {parameter["address"] for parameter in parameters}
+    require(
+        {"1st Stage.outletPressure", "2nd Stage.outletPressure"}.issubset(addresses),
+        "canonical compressor addresses drifted",
+        parameters,
+    )
+    return data
+
+
+def register_model(client, process):
+    result = payload(
+        client.manage_model(
+            {
+                "action": "register",
+                "name": "phase0-adjustable-parameters",
+                "version": "1.0.0",
+                "processJson": process,
+            }
+        )
+    )
+    require(result.get("status") == "success", "model registration failed", result)
+    model_id = result.get("modelId")
+    require(isinstance(model_id, str) and model_id, "registration omitted modelId", result)
+    return model_id
+
+
+def test_direct_and_handle_equivalence(client):
+    process = canonical_process(client)
+    direct = assert_registry(
+        client.call_tool("getAdjustableParameters", {"processJson": json.dumps(process)})
+    )
+    model_id = register_model(client, process)
+    try:
+        handled = assert_registry(
+            client.call_tool("getAdjustableParameters", {"processJson": model_id})
+        )
+        require(
+            handled.get("schemaVersion") == direct.get("schemaVersion")
+            and handled.get("count") == direct.get("count")
+            and handled.get("parameters") == direct.get("parameters"),
+            "direct and model-handle registries differ",
+            {"direct": direct, "handled": handled},
+        )
+    finally:
+        deleted = payload(client.manage_model({"action": "delete", "modelId": model_id}))
+        require(deleted.get("status") == "success", "model cleanup failed", deleted)
+
+
+def test_invalid_request_fails_closed(client):
+    result = client.call_tool("getAdjustableParameters", {"processJson": ""})
+    require(payload(result).get("status") == "error", "blank request did not fail", result)
+    require(error_code(result) == "INPUT_ERROR", "blank request error code drifted", result)
+
+
+def test_phase0_boundary_remains_unpromoted(client):
+    result = payload(client.call_tool("getCapabilities", {}))
+    inventory = result.get("phase0EvidenceInventory")
+    require(isinstance(inventory, dict), "capabilities omitted Phase 0 inventory", result)
+    require(inventory.get("inventoryVersion") == "1.21", "inventory version drifted", inventory)
+    limitations = inventory.get("knownLimitations", {})
+    record = limitations.get("coverageRecords", {}).get("getAdjustableParameters", {})
+    require(
+        limitations.get("contractTestedToolCount") == 19
+        and limitations.get("confirmedGapToolCount") == 32
+        and record.get("coverageStatus") == "CONFIRMED_GAP",
+        "prerequisite evidence prematurely changed trust accounting",
+        limitations,
+    )
+
+
+def main():
+    client = McpClient()
+    tests = [
+        ("direct and handle equivalence", test_direct_and_handle_equivalence),
+        ("invalid request fails closed", test_invalid_request_fails_closed),
+        ("Phase 0 boundary remains unpromoted", test_phase0_boundary_remains_unpromoted),
+    ]
+    try:
+        client.start()
+        for label, test in tests:
+            test(client)
+            print("PASS:", label)
+    finally:
+        client.close()
+    print(f"\n{len(tests)}/{len(tests)} adjustable-parameter contract scenarios passed.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print("FAIL:", error, file=sys.stderr)
+        sys.exit(1)

--- a/neqsim-mcp-server/test_adjustable_parameters_protocol.py
+++ b/neqsim-mcp-server/test_adjustable_parameters_protocol.py
@@ -167,8 +167,6 @@ def assert_registry(result):
         "name",
         "address",
         "unit",
-        "lowerBound",
-        "upperBound",
         "targetUnitName",
         "targetProperty",
         "source",
@@ -178,6 +176,18 @@ def assert_registry(result):
         require(required_keys.issubset(parameter), "parameter metadata is incomplete", parameter)
         require(bool(parameter.get("address")), "parameter address is empty", parameter)
         require(bool(parameter.get("unit")), "parameter unit is empty", parameter)
+        for bound_key in ("lowerBound", "upperBound"):
+            if bound_key in parameter:
+                bound = parameter[bound_key]
+                require(
+                    bound is None
+                    or (
+                        isinstance(bound, (int, float))
+                        and not isinstance(bound, bool)
+                    ),
+                    "parameter bound is not numeric or null",
+                    parameter,
+                )
         require(
             parameter.get("source") in {"INPUT_VARIABLE", "ADJUSTER"},
             "parameter provenance is unsupported",

--- a/neqsim-mcp-server/test_adjustable_parameters_protocol.py
+++ b/neqsim-mcp-server/test_adjustable_parameters_protocol.py
@@ -175,7 +175,14 @@ def assert_registry(result):
         require(isinstance(parameter, dict), "parameter record is not an object", parameter)
         require(required_keys.issubset(parameter), "parameter metadata is incomplete", parameter)
         require(bool(parameter.get("address")), "parameter address is empty", parameter)
-        require(bool(parameter.get("unit")), "parameter unit is empty", parameter)
+        unit = parameter.get("unit")
+        require(isinstance(unit, str), "parameter unit is not a string", parameter)
+        if not unit:
+            require(
+                parameter.get("targetProperty") == "polytropicEfficiency",
+                "empty unit is reserved for qualified dimensionless properties",
+                parameter,
+            )
         for bound_key in ("lowerBound", "upperBound"):
             if bound_key in parameter:
                 bound = parameter[bound_key]

--- a/src/test/java/neqsim/mcp/runners/AutomationLoopRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/AutomationLoopRunnerTest.java
@@ -87,8 +87,25 @@ class AutomationLoopRunnerTest {
     JsonObject root = JsonParser.parseString(result).getAsJsonObject();
     assertEquals("success", root.get("status").getAsString(), "getAdjustableParameters failed: " + result);
     JsonObject data = root.getAsJsonObject("data");
-    assertTrue(data.has("parameters"), "Should expose a parameters array");
-    assertTrue(data.has("count"));
+    JsonArray parameters = data.getAsJsonArray("parameters");
+    assertEquals(parameters.size(), data.get("count").getAsInt());
+    assertTrue(parameters.size() > 0, "Should expose at least one adjustable parameter");
+
+    JsonObject compressorPressure = null;
+    for (int index = 0; index < parameters.size(); index++) {
+      JsonObject parameter = parameters.get(index).getAsJsonObject();
+      if ("Compressor.outletPressure".equals(parameter.get("address").getAsString())) {
+        compressorPressure = parameter;
+        break;
+      }
+    }
+    assertNotNull(compressorPressure, "Should expose the canonical compressor pressure address");
+    assertEquals("bara", compressorPressure.get("unit").getAsString());
+    assertTrue(compressorPressure.has("lowerBound"));
+    assertTrue(compressorPressure.has("upperBound"));
+    assertEquals("Compressor", compressorPressure.get("targetUnitName").getAsString());
+    assertEquals("outletPressure", compressorPressure.get("targetProperty").getAsString());
+    assertEquals("INPUT_VARIABLE", compressorPressure.get("source").getAsString());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Qualify the existing `getAdjustableParameters` discovery path as a bounded Phase 0 evidence prerequisite.

- strengthen the direct Java regression for stable addresses, units, bounds fields, target metadata, provenance, and count consistency
- add a dependency-free packaged-MCP STDIO harness using the canonical `process/compression-with-cooling` fixture
- prove deterministic equivalence between an explicit process definition and a reusable `manageModel` handle
- prove blank input fails closed
- wire the focused Java and packaged-protocol checks into the authoritative MCP qualification workflow
- document the capability, evidence, units, advisory boundary, and explicit limitations

Capability contract: https://github.com/equinor/neqsim/issues/3153#issuecomment-5474768984

## Exact-head repair

Current head: `5d87ee94491a92fe9c82777fb44575e2c241c495`.

The initial packaged qualification exposed two test-contract mismatches, repaired without changing production behavior:

1. undeclared `lowerBound` and `upperBound` values may be omitted by serialization, while declared values remain numeric;
2. the authoritative registry represents qualified dimensionless `polytropicEfficiency` with an empty unit string.

The harness and evidence note now reflect those existing Java semantics while continuing to reject missing unit metadata for non-dimensionless properties.

## Frozen scope and stop boundary

This PR changes tests, workflow qualification, and evidence documentation only. It does not change production behavior, schemas, optimizers, setters, `runProcessLoop`, numerical models, or Phase 0 trust accounting.

Inventory deliberately remains `1.21 / 20 EXPLICIT_TRUST + 19 CONTRACT_TESTED + 32 CONFIRMED_GAP`; `getAdjustableParameters` remains `CONFIRMED_GAP`. A later atomic promotion is allowed only after this prerequisite merges and current master is re-audited.

The evidence does not establish physical feasibility, numerical/model fidelity, convergence adequacy, mass/component/energy conservation, a global optimum, plant authority, design certification, or accountable engineering approval.

## Validation

Prior local evidence on the original source state:

- `AutomationLoopRunnerTest` — pass
- Spotless apply/check — pass
- Python compilation and `git diff --check` — pass
- documentation search — blocked by the base's stale generated `docs/process/equipment/equipment_catalog.md`
- packaged-MCP execution — blocked during one-time Maven bootstrap by DNS resolution of `maven-enforcer-plugin:3.6.3`
- pre-commit — unavailable in the runner

Hosted validation on exact head `5d87ee94491a92fe9c82777fb44575e2c241c495`:

- MCP protocol qualification — **pass**, including the repaired packaged adjustable-parameter contract
- CodeQL — **pass**
- pre-commit — **pass**
- Spotless — **pass**
- Java 21 Ubuntu and Windows tests — **pass**
- Java 8 Ubuntu and Windows tests — **pass**
- all four Java 21 slow-test shards — **pass**
- Java 21 Javadocs and agent/skill cross-reference validation — **pass**

There are no reviews, PR comments, Copilot findings, or unresolved review threads. GitHub reports the draft mergeable and the final diff remains the four expected files.

**Classification: READY TO MERGE**