### PR TITLE
[AI-Assisted] feat(dexpi): report connection endpoint ownership

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -146,6 +146,12 @@ resolution status. Missing source IDs receive deterministic evidence-only identi
 duplicate, self-referential, or unresolved source references remain explicit diagnostics. This
 inventory does not infer connectivity or rewire the returned `ProcessSystem`.
 
+For resolved nozzle endpoints, the same record exposes only explicit source ownership: the nearest
+ancestor `Equipment` or `PipingComponent` identity and XML element name. Direct equipment or
+piping-component endpoints own themselves. Orphaned nozzles and owner elements without source IDs
+remain deterministic warnings; the reader does not derive ownership from coordinates, tags,
+stream order, or simulation state.
+
 `toJson()` includes `instrumentCount`, `connectionCount`, and the ordered connection inventory
 alongside the process-unit count and findings. Python callers through JPype use the same
 `ImportResult.getInstruments()` and `ImportResult.getConnections()` getters; there is no separate

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
@@ -24,6 +24,10 @@ public final class DexpiConnectionInfo implements Serializable {
   private final String toId;
   private final String fromElementName;
   private final String toElementName;
+  private final String fromOwnerId;
+  private final String toOwnerId;
+  private final String fromOwnerElementName;
+  private final String toOwnerElementName;
   private final boolean fromResolved;
   private final boolean toResolved;
 
@@ -42,6 +46,31 @@ public final class DexpiConnectionInfo implements Serializable {
    */
   public DexpiConnectionInfo(String id, String sourceId, String segmentId, String fromId, String toId,
       String fromElementName, String toElementName, boolean fromResolved, boolean toResolved) {
+    this(id, sourceId, segmentId, fromId, toId, fromElementName, toElementName, "", "", "", "",
+        fromResolved, toResolved);
+  }
+
+  /**
+   * Creates an immutable connection evidence record with explicit endpoint ownership.
+   *
+   * @param id stable evidence identity
+   * @param sourceId source connection identity, or empty when absent
+   * @param segmentId owning piping-network segment identity, or empty when absent
+   * @param fromId source endpoint identity
+   * @param toId target endpoint identity
+   * @param fromElementName resolved source XML element name
+   * @param toElementName resolved target XML element name
+   * @param fromOwnerId explicit source owner identity, or empty when absent
+   * @param toOwnerId explicit target owner identity, or empty when absent
+   * @param fromOwnerElementName source owner XML element name, or empty when absent
+   * @param toOwnerElementName target owner XML element name, or empty when absent
+   * @param fromResolved whether the source endpoint resolves in the source document
+   * @param toResolved whether the target endpoint resolves in the source document
+   */
+  public DexpiConnectionInfo(String id, String sourceId, String segmentId, String fromId, String toId,
+      String fromElementName, String toElementName, String fromOwnerId, String toOwnerId,
+      String fromOwnerElementName, String toOwnerElementName, boolean fromResolved,
+      boolean toResolved) {
     this.id = normalize(id);
     this.sourceId = normalize(sourceId);
     this.segmentId = normalize(segmentId);
@@ -49,6 +78,10 @@ public final class DexpiConnectionInfo implements Serializable {
     this.toId = normalize(toId);
     this.fromElementName = normalize(fromElementName);
     this.toElementName = normalize(toElementName);
+    this.fromOwnerId = normalize(fromOwnerId);
+    this.toOwnerId = normalize(toOwnerId);
+    this.fromOwnerElementName = normalize(fromOwnerElementName);
+    this.toOwnerElementName = normalize(toOwnerElementName);
     this.fromResolved = fromResolved;
     this.toResolved = toResolved;
   }
@@ -93,6 +126,31 @@ public final class DexpiConnectionInfo implements Serializable {
     return toElementName;
   }
 
+  /** @return explicit source endpoint owner identity, or empty when absent */
+  public String getFromOwnerId() {
+    return fromOwnerId;
+  }
+
+  /** @return explicit target endpoint owner identity, or empty when absent */
+  public String getToOwnerId() {
+    return toOwnerId;
+  }
+
+  /** @return source owner XML element name, or empty when absent */
+  public String getFromOwnerElementName() {
+    return fromOwnerElementName;
+  }
+
+  /** @return target owner XML element name, or empty when absent */
+  public String getToOwnerElementName() {
+    return toOwnerElementName;
+  }
+
+  /** @return whether both endpoint owners have explicit identities */
+  public boolean isOwnershipResolved() {
+    return !fromOwnerId.isEmpty() && !toOwnerId.isEmpty();
+  }
+
   /** @return whether the source endpoint resolves in the source document */
   public boolean isFromResolved() {
     return fromResolved;
@@ -122,6 +180,10 @@ public final class DexpiConnectionInfo implements Serializable {
     result.put("toId", toId);
     result.put("fromElementName", fromElementName);
     result.put("toElementName", toElementName);
+    result.put("fromOwnerId", fromOwnerId);
+    result.put("toOwnerId", toOwnerId);
+    result.put("fromOwnerElementName", fromOwnerElementName);
+    result.put("toOwnerElementName", toOwnerElementName);
     result.put("fromResolved", Boolean.valueOf(fromResolved));
     result.put("toResolved", Boolean.valueOf(toResolved));
     return result;

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
@@ -46,8 +46,8 @@ public final class DexpiConnectionInfo implements Serializable {
    */
   public DexpiConnectionInfo(String id, String sourceId, String segmentId, String fromId, String toId,
       String fromElementName, String toElementName, boolean fromResolved, boolean toResolved) {
-    this(id, sourceId, segmentId, fromId, toId, fromElementName, toElementName, "", "", "", "",
-        fromResolved, toResolved);
+    this(id, sourceId, segmentId, fromId, toId, fromElementName, toElementName, "", "", "", "", fromResolved,
+        toResolved);
   }
 
   /**
@@ -68,9 +68,8 @@ public final class DexpiConnectionInfo implements Serializable {
    * @param toResolved whether the target endpoint resolves in the source document
    */
   public DexpiConnectionInfo(String id, String sourceId, String segmentId, String fromId, String toId,
-      String fromElementName, String toElementName, String fromOwnerId, String toOwnerId,
-      String fromOwnerElementName, String toOwnerElementName, boolean fromResolved,
-      boolean toResolved) {
+      String fromElementName, String toElementName, String fromOwnerId, String toOwnerId, String fromOwnerElementName,
+      String toOwnerElementName, boolean fromResolved, boolean toResolved) {
     this.id = normalize(id);
     this.sourceId = normalize(sourceId);
     this.segmentId = normalize(segmentId);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -749,8 +749,7 @@ public final class DexpiXmlReader {
 
       connections.add(new DexpiConnectionInfo(evidenceId, sourceId, segmentId, fromId, toId,
           fromElement == null ? "" : fromElement.getTagName(), toElement == null ? "" : toElement.getTagName(),
-          fromOwner == null ? "" : fromOwner.getAttribute("ID"),
-          toOwner == null ? "" : toOwner.getAttribute("ID"),
+          fromOwner == null ? "" : fromOwner.getAttribute("ID"), toOwner == null ? "" : toOwner.getAttribute("ID"),
           fromOwner == null ? "" : fromOwner.getTagName(), toOwner == null ? "" : toOwner.getTagName(),
           fromElement != null, toElement != null));
     }
@@ -782,8 +781,8 @@ public final class DexpiXmlReader {
     return "Equipment".equals(element.getTagName()) || "PipingComponent".equals(element.getTagName());
   }
 
-  private static void addConnectionOwnerDiagnostic(Element connection, Element endpoint, Element owner,
-      boolean source, List<ImportDiagnostic> diagnostics) {
+  private static void addConnectionOwnerDiagnostic(Element connection, Element endpoint, Element owner, boolean source,
+      List<ImportDiagnostic> diagnostics) {
     if (endpoint == null || !"Nozzle".equals(endpoint.getTagName())) {
       return;
     }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -722,6 +722,8 @@ public final class DexpiXmlReader {
       String toId = connection.getAttribute("ToID");
       Element fromElement = elementsById.get(fromId);
       Element toElement = elementsById.get(toId);
+      Element fromOwner = resolveConnectionOwner(fromElement);
+      Element toOwner = resolveConnectionOwner(toElement);
       if (isBlank(fromId)) {
         addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.WARNING,
             "DEXPI_IMPORT_CONNECTION_SOURCE_MISSING", "Connection FromID is missing");
@@ -742,13 +744,60 @@ public final class DexpiXmlReader {
         addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.WARNING,
             "DEXPI_IMPORT_CONNECTION_SELF_REFERENCE", "Connection source and target both reference '" + fromId + "'");
       }
+      addConnectionOwnerDiagnostic(connection, fromElement, fromOwner, true, diagnostics);
+      addConnectionOwnerDiagnostic(connection, toElement, toOwner, false, diagnostics);
 
       connections.add(new DexpiConnectionInfo(evidenceId, sourceId, segmentId, fromId, toId,
           fromElement == null ? "" : fromElement.getTagName(), toElement == null ? "" : toElement.getTagName(),
+          fromOwner == null ? "" : fromOwner.getAttribute("ID"),
+          toOwner == null ? "" : toOwner.getAttribute("ID"),
+          fromOwner == null ? "" : fromOwner.getTagName(), toOwner == null ? "" : toOwner.getTagName(),
           fromElement != null, toElement != null));
     }
     logger.info("Parsed {} material connections from DEXPI XML", connections.size());
     return connections;
+  }
+
+
+  private static Element resolveConnectionOwner(Element endpoint) {
+    if (endpoint == null) {
+      return null;
+    }
+    if (isConnectionOwnerElement(endpoint)) {
+      return endpoint;
+    }
+    Node parent = endpoint.getParentNode();
+    while (parent != null) {
+      if (parent.getNodeType() == Node.ELEMENT_NODE) {
+        Element candidate = (Element) parent;
+        if (isConnectionOwnerElement(candidate)) {
+          return candidate;
+        }
+      }
+      parent = parent.getParentNode();
+    }
+    return null;
+  }
+
+  private static boolean isConnectionOwnerElement(Element element) {
+    return "Equipment".equals(element.getTagName()) || "PipingComponent".equals(element.getTagName());
+  }
+
+  private static void addConnectionOwnerDiagnostic(Element connection, Element endpoint, Element owner,
+      boolean source, List<ImportDiagnostic> diagnostics) {
+    if (endpoint == null || !"Nozzle".equals(endpoint.getTagName())) {
+      return;
+    }
+    String direction = source ? "SOURCE" : "TARGET";
+    if (owner == null) {
+      addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.WARNING,
+          "DEXPI_IMPORT_CONNECTION_" + direction + "_OWNER_MISSING",
+          (source ? "Source" : "Target") + " nozzle has no explicit Equipment or PipingComponent owner");
+    } else if (isBlank(owner.getAttribute("ID"))) {
+      addConnectionDiagnostic(connection, diagnostics, ImportDiagnosticSeverity.WARNING,
+          "DEXPI_IMPORT_CONNECTION_" + direction + "_OWNER_ID_MISSING",
+          (source ? "Source" : "Target") + " nozzle owner has no source identity");
+    }
   }
 
   private static Element findAncestorElement(Node node, String tagName) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -758,7 +758,6 @@ public final class DexpiXmlReader {
     return connections;
   }
 
-
   private static Element resolveConnectionOwner(Element endpoint) {
     if (endpoint == null) {
       return null;

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -297,7 +297,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
   @Test
   public void testReadWithDiagnosticsPreservesParallelMaterialConnections() throws Exception {
     String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
-        + "<Nozzle ID=\"N-OUT\"/><Nozzle ID=\"N-IN\"/>"
+        + "<Equipment ID=\"E-OUT\"><Nozzle ID=\"N-OUT\"/></Equipment>"
+        + "<Equipment ID=\"E-IN\"><Nozzle ID=\"N-IN\"/></Equipment>"
         + "<PipingNetworkSegment ID=\"S-1\" ComponentClass=\"PipingNetworkSegment\">"
         + "<Connection FromID=\"N-OUT\" ToID=\"N-IN\"/></PipingNetworkSegment>"
         + "<PipingNetworkSegment ID=\"S-2\" ComponentClass=\"PipingNetworkSegment\">"
@@ -317,7 +318,12 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("N-IN", firstConnection.getToId());
     assertEquals("Nozzle", firstConnection.getFromElementName());
     assertEquals("Nozzle", firstConnection.getToElementName());
+    assertEquals("E-OUT", firstConnection.getFromOwnerId());
+    assertEquals("E-IN", firstConnection.getToOwnerId());
+    assertEquals("Equipment", firstConnection.getFromOwnerElementName());
+    assertEquals("Equipment", firstConnection.getToOwnerElementName());
     assertTrue(firstConnection.isResolved());
+    assertTrue(firstConnection.isOwnershipResolved());
     assertEquals("S-2/connection-1", first.getConnections().get(1).getId());
     assertEquals(2, countDiagnostics(first, "DEXPI_IMPORT_CONNECTION_ID_SYNTHESIZED"));
     assertTrue(first.toJson().contains("\"connectionCount\": 2"));
@@ -345,6 +351,35 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertDiagnostic(result, "DEXPI_IMPORT_CONNECTION_ID_DUPLICATE");
     assertDiagnostic(result, "DEXPI_IMPORT_CONNECTION_SEGMENT_MISSING");
     assertDiagnostic(result, "DEXPI_IMPORT_CONNECTION_SELF_REFERENCE");
+    assertDiagnostic(result, "DEXPI_IMPORT_CONNECTION_SOURCE_OWNER_MISSING");
+    assertDiagnostic(result, "DEXPI_IMPORT_CONNECTION_TARGET_OWNER_MISSING");
+  }
+
+  @Test
+  public void testReadWithDiagnosticsReportsMissingOwnerIdentity() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
+        + "<Equipment><Nozzle ID=\"N-A\"/></Equipment>"
+        + "<PipingComponent ID=\"PC-1\"><Nozzle ID=\"N-B\"/></PipingComponent>"
+        + "<PipingNetworkSegment ID=\"S-OWNER\" ComponentClass=\"PipingNetworkSegment\">"
+        + "<Connection ID=\"C-OWNER\" FromID=\"N-A\" ToID=\"N-B\"/></PipingNetworkSegment>"
+        + "</PlantModel>";
+
+    DexpiXmlReader.ImportResult result = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    DexpiConnectionInfo connection = result.getConnections().get(0);
+
+    assertEquals("", connection.getFromOwnerId());
+    assertEquals("Equipment", connection.getFromOwnerElementName());
+    assertEquals("PC-1", connection.getToOwnerId());
+    assertEquals("PipingComponent", connection.getToOwnerElementName());
+    assertFalse(connection.isOwnershipResolved());
+    assertDiagnostic(result, "DEXPI_IMPORT_CONNECTION_SOURCE_OWNER_ID_MISSING");
+    assertTrue(result.toJson().contains("\"fromOwnerElementName\": \"Equipment\""));
+
+    DexpiConnectionInfo legacy = new DexpiConnectionInfo("C", "C", "S", "A", "B", "Nozzle",
+        "Nozzle", true, true);
+    assertEquals("", legacy.getFromOwnerId());
+    assertEquals("", legacy.getToOwnerId());
   }
 
   private static int countDiagnostics(DexpiXmlReader.ImportResult result, String expectedCode) {

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -361,8 +361,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         + "<Equipment><Nozzle ID=\"N-A\"/></Equipment>"
         + "<PipingComponent ID=\"PC-1\"><Nozzle ID=\"N-B\"/></PipingComponent>"
         + "<PipingNetworkSegment ID=\"S-OWNER\" ComponentClass=\"PipingNetworkSegment\">"
-        + "<Connection ID=\"C-OWNER\" FromID=\"N-A\" ToID=\"N-B\"/></PipingNetworkSegment>"
-        + "</PlantModel>";
+        + "<Connection ID=\"C-OWNER\" FromID=\"N-A\" ToID=\"N-B\"/></PipingNetworkSegment>" + "</PlantModel>";
 
     DexpiXmlReader.ImportResult result = DexpiXmlReader
         .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
@@ -376,8 +375,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertDiagnostic(result, "DEXPI_IMPORT_CONNECTION_SOURCE_OWNER_ID_MISSING");
     assertTrue(result.toJson().contains("\"fromOwnerElementName\": \"Equipment\""));
 
-    DexpiConnectionInfo legacy = new DexpiConnectionInfo("C", "C", "S", "A", "B", "Nozzle",
-        "Nozzle", true, true);
+    DexpiConnectionInfo legacy = new DexpiConnectionInfo("C", "C", "S", "A", "B", "Nozzle", "Nozzle", true, true);
     assertEquals("", legacy.getFromOwnerId());
     assertEquals("", legacy.getToOwnerId());
   }


### PR DESCRIPTION
## Capability

Expose explicit endpoint/nozzle ownership for imported Proteus 4.1.1 material connections without reconstructing or implying live `ProcessSystem` topology.

Capability contracts: [#1332](https://github.com/equinor/neqsim/issues/1332#issuecomment-5475536889), [#2899](https://github.com/equinor/neqsim/issues/2899#issuecomment-5475536606).

## Changes

- Extends immutable `DexpiConnectionInfo` evidence with source/target owner IDs and XML element names.
- Resolves only explicit ownership: a direct Equipment/PipingComponent endpoint owns itself; otherwise the nearest Equipment/PipingComponent ancestor owns a nozzle.
- Emits deterministic warnings for orphaned nozzles and owner elements without source identities.
- Preserves the existing public constructor, connection ordering, parallel connections, direction, segment ownership, JSON evidence, reader APIs, simulation builder, rendering, and export behavior.
- Adds focused valid, orphaned, and missing-owner-identity regressions.
- Documents the supported Proteus-compatible DEXPI Plant/P&ID 4.1.1 subset and its non-inference boundary.

## Validation

- Base: `671c757fcc06698e83ddb57e0be71e3a959f8e73`
- Head: `49a0920428f8f662a7dce7fbff68f696e43bcb75`
- Local Maven, Spotless, pre-commit, and pre-push were not run because this connector-first run has no prepared local checkout.
- Applied the exact hosted Spotless artifact from the previous head; no behavior changed.
- GitHub CI is authoritative.

**DRAFT — READY TO MERGE**

Exact-head GitHub validation: all eight workflows completed successfully; 26 checks passed and the paper-replication matrix was correctly skipped because no paper changed. The draft is mergeable with no reviews or unresolved threads.

## Stop boundary

This PR stops before live topology rewiring, branch collapse, graphical round-trip equivalence, native DEXPI 2.0 claims, licensed standards qualification, accountable engineering approval, Huldra, or external-dataset work.