### PR TITLE
[AI-Assisted] feat(mcp): expose competing electrolyte scale equilibrium

### DIFF
--- a/docs/chemistry/index.md
+++ b/docs/chemistry/index.md
@@ -79,10 +79,11 @@ Every analysis is exposed over the NeqSim MCP server:
 
 Send this to the `runChemistry` tool. Supported `analysis` values:
 `electrolyteScale`, `multiMineralScale`, `electrolyteScaleEquilibrium`,
-`mechanisticCorrosion`, `langmuirInhibitor`, `packedBedScavenger`, and
-`pitzerQualification`. `electrolyteScaleEquilibrium` is the authoritative
-single-pure-mineral operation for Pitzer GE and electrolyte CPA; the screening
-analyses retain their separate Davies/BDOT semantics. The last is a setup/publication
+`electrolyteMultiScaleEquilibrium`, `mechanisticCorrosion`,
+`langmuirInhibitor`, `packedBedScavenger`, and `pitzerQualification`.
+`electrolyteScaleEquilibrium` and `electrolyteMultiScaleEquilibrium` are the
+authoritative pure-mineral operations for Pitzer GE and electrolyte CPA; the
+screening analyses retain their separate Davies/BDOT semantics. The last is a setup/publication
 gate over the authoritative Java Pitzer dataset coverage, observable
 qualification, and declared state envelope; it does not perform a flash or
 adopt parameters.

--- a/docs/chemistry/mcp.md
+++ b/docs/chemistry/mcp.md
@@ -140,6 +140,56 @@ reaction constants, mineral log K values, SIT/eNRTL terms, or electrolyte-EOS
 parameters. Multi-mineral competition, solid solutions, kinetics, deposition
 and inhibitor physics remain outside this operation.
 
+### `electrolyteMultiScaleEquilibrium`
+
+Thin JSON/MCP adapter over the authoritative Java
+`ThermodynamicOperations.precipitateScales(String...)` operation. Unlike
+`multiMineralScale`, this operation solves shared-ion competition using the
+selected Pitzer GE or electrolyte-CPA aqueous activities. Mineral names are
+sorted internally, so caller order does not change the coupled result.
+
+| Field | Unit | Required / values |
+|-------|------|-------------------|
+| `temperature_K` | K | required, finite and positive |
+| `pressure_bara` | bara | required, finite and positive |
+| `components` | mol | required electroneutral object; positive water, finite non-negative amounts |
+| `model` | – | `pitzer` (default) or `electrolyte-cpa` |
+| `dataset` | – | for Pitzer: `phreeqc-catalog` (default) or `phreeqc-ca-mg-cl-so4`; not applicable to electrolyte CPA |
+| `minerals` | – | required non-empty array of unique pure COMPSALT names |
+
+```json
+{
+  "analysis": "electrolyteMultiScaleEquilibrium",
+  "model": "pitzer",
+  "dataset": "phreeqc-catalog",
+  "temperature_K": 298.15,
+  "pressure_bara": 1.01325,
+  "minerals": ["CaSO4_A", "CaSO4_G"],
+  "components": {
+    "water": 55.508,
+    "Na+": 1.0,
+    "Ca++": 0.2,
+    "Mg++": 0.15,
+    "Cl-": 1.3,
+    "SO4--": 0.2
+  }
+}
+```
+
+The response contains a deterministic per-mineral solid ledger, active-set
+update count, total COMPSALT ion-formula mass, maximum complementarity and
+component-ledger residuals, aqueous electroneutrality and phase-state evidence,
+and the model/dataset qualification boundary. Passing numerical gates require
+maximum complementarity at most `1e-6 log10(SR)`, component-ledger residual at
+most `1e-10 mol`, aqueous charge at most `1e-10 mol/kg water`, and a finite,
+non-negative normalized aqueous phase.
+
+The result is **design-support** and reports `publicationReady: false` until an
+independent competitive mixed-brine/mineral validation envelope is registered.
+COMPSALT masses represent ion formula units; crystallization water, solid
+solutions, precipitation kinetics, deposition and inhibitor physics are not
+included.
+
 ### `electrolyteScale`
 
 Davies activity-coefficient saturation indices for CaCO3, BaSO4, CaSO4, SrSO4.

--- a/neqsim-mcp-server/README.md
+++ b/neqsim-mcp-server/README.md
@@ -218,7 +218,7 @@ code-level `enforceAccess()` — returns structured error JSON, not a silent ski
 | `runPVT`                      | PVT lab experiments (CME, CVD, DL, separator, swelling, GOR)                                                                                         |
 | `runPipeline`                 | Multiphase pipeline flow (Beggs & Brill)                                                                                                             |
 | `runFlowAssurance`            | Hydrate, wax, asphaltene, corrosion, erosion, cooldown, emulsion                                                                                     |
-| `runChemistry`                | Pitzer qualification, activity-consistent electrolyte scale equilibrium, screening scale, corrosion, inhibitors, and scavengers                  |
+| `runChemistry`                | Pitzer qualification, activity-consistent single/competing scale equilibrium, screening scale, corrosion, inhibitors, and scavengers        |
 | `runWaterHammer`              | Water/liquid-hammer screening for valve closure, pump trip, and check-valve scenarios                                                                |
 | `runRootCauseAnalysis`        | Ranked equipment root-cause hypotheses from reliability, historian, STID, and simulation evidence                                                    |
 | `runMaterialsReview`          | Process-wide material selection, degradation, CUI, and remaining-life review from process/STID data                                                  |

--- a/src/main/java/neqsim/mcp/runners/ChemistryRunner.java
+++ b/src/main/java/neqsim/mcp/runners/ChemistryRunner.java
@@ -55,10 +55,9 @@ public class ChemistryRunner {
   private static final Gson GSON = new GsonBuilder().setPrettyPrinting().serializeNulls()
       .serializeSpecialFloatingPointValues().create();
 
-  private static final List<String> SUPPORTED_ANALYSES = Collections
-      .unmodifiableList(Arrays.asList("electrolyteScale", "multiMineralScale", "mechanisticCorrosion",
-          "langmuirInhibitor", "packedBedScavenger", "electrolyteScaleEquilibrium",
-          "electrolyteMultiScaleEquilibrium", "pitzerQualification"));
+  private static final List<String> SUPPORTED_ANALYSES = Collections.unmodifiableList(Arrays.asList("electrolyteScale",
+      "multiMineralScale", "mechanisticCorrosion", "langmuirInhibitor", "packedBedScavenger",
+      "electrolyteScaleEquilibrium", "electrolyteMultiScaleEquilibrium", "pitzerQualification"));
 
   /**
    * Private constructor — static utility class.
@@ -456,8 +455,7 @@ public class ChemistryRunner {
         && Double.isFinite(equilibrium.getMaximumComponentBalanceResidualMoles())
         && equilibrium.getMaximumComponentBalanceResidualMoles() <= 1.0e-10
         && Double.isFinite(equilibrium.getTotalPrecipitatedMassGrams())
-        && equilibrium.getTotalPrecipitatedMassGrams() >= 0.0
-        && phaseState.get("normalizedNonNegative").getAsBoolean()
+        && equilibrium.getTotalPrecipitatedMassGrams() >= 0.0 && phaseState.get("normalizedNonNegative").getAsBoolean()
         && Math.abs(phaseState.get("chargeResidual_molPerKgWater").getAsDouble()) <= 1.0e-10;
     if (!numericalGatesPass) {
       throw new IllegalStateException(
@@ -479,10 +477,8 @@ public class ChemistryRunner {
     data.addProperty("requestedMineralCount", equilibrium.getMineralResults().size());
     data.addProperty("presentSolidCount", presentSolidCount);
     data.addProperty("equilibriumUpdates", equilibrium.getEquilibriumUpdates());
-    data.addProperty("maximumComplementarityViolation_log10SR",
-        equilibrium.getMaximumComplementarityViolation());
-    data.addProperty("maximumComponentBalanceResidual_mol",
-        equilibrium.getMaximumComponentBalanceResidualMoles());
+    data.addProperty("maximumComplementarityViolation_log10SR", equilibrium.getMaximumComplementarityViolation());
+    data.addProperty("maximumComponentBalanceResidual_mol", equilibrium.getMaximumComponentBalanceResidualMoles());
     data.addProperty("totalPrecipitatedMass_g", equilibrium.getTotalPrecipitatedMassGrams());
     data.add("mineralResults", mineralResults);
     data.add("aqueousPhaseState", phaseState);

--- a/src/main/java/neqsim/mcp/runners/ChemistryRunner.java
+++ b/src/main/java/neqsim/mcp/runners/ChemistryRunner.java
@@ -30,6 +30,7 @@ import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemPitzer;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
+import neqsim.thermodynamicoperations.flashops.saturationops.MultiSaltPrecipitationResult;
 import neqsim.thermodynamicoperations.flashops.saturationops.SaltPrecipitationResult;
 
 /**
@@ -56,7 +57,8 @@ public class ChemistryRunner {
 
   private static final List<String> SUPPORTED_ANALYSES = Collections
       .unmodifiableList(Arrays.asList("electrolyteScale", "multiMineralScale", "mechanisticCorrosion",
-          "langmuirInhibitor", "packedBedScavenger", "electrolyteScaleEquilibrium", "pitzerQualification"));
+          "langmuirInhibitor", "packedBedScavenger", "electrolyteScaleEquilibrium",
+          "electrolyteMultiScaleEquilibrium", "pitzerQualification"));
 
   /**
    * Private constructor — static utility class.
@@ -121,6 +123,9 @@ public class ChemistryRunner {
         break;
       case "electrolyteScaleEquilibrium":
         data = runElectrolyteScaleEquilibrium(input);
+        break;
+      case "electrolyteMultiScaleEquilibrium":
+        data = runElectrolyteMultiScaleEquilibrium(input);
         break;
       case "pitzerQualification":
         data = runPitzerQualification(input);
@@ -366,6 +371,155 @@ public class ChemistryRunner {
         "Numerical engineering gates pass, but no exact mixed-brine mineral evidence envelope is registered for this "
             + "state");
     return data;
+  }
+
+  /**
+   * Runs simultaneous competing pure-mineral equilibrium against the selected electrolyte model.
+   *
+   * <p>
+   * This is a thin JSON/MCP view over {@link ThermodynamicOperations#precipitateScales(String...)}. It is distinct from
+   * the concentration-based {@code multiMineralScale} screening analysis and adds no thermodynamic equation, Ksp, or
+   * interaction parameter.
+   * </p>
+   *
+   * @param input chemistry analysis input
+   * @return deterministic solid ledger, complementarity, aqueous-state, and qualification evidence
+   */
+  private static JsonObject runElectrolyteMultiScaleEquilibrium(JsonObject input) {
+    double temperature = requiredFinitePositive(input, "temperature_K");
+    double pressure = requiredFinitePositive(input, "pressure_bara");
+    Map<String, Double> components = requiredComponentAmounts(input);
+    if (!hasPositiveWater(components)) {
+      throw new IllegalArgumentException("Electrolyte multi-scale equilibrium requires a positive water amount in mol");
+    }
+    String[] mineralNames = requiredMineralNames(input);
+
+    String model = input.has("model") ? input.get("model").getAsString().trim().toLowerCase() : "pitzer";
+    String datasetSelector = input.has("dataset") ? input.get("dataset").getAsString().trim().toLowerCase()
+        : "pitzer".equals(model) ? "phreeqc-catalog" : "not-applicable";
+    SystemInterface system;
+    PitzerParameterQualification pitzerQualification = null;
+
+    if ("pitzer".equals(model)) {
+      SystemPitzer pitzer = new SystemPitzer(temperature, pressure);
+      addComponents(pitzer, components);
+      requireElectroneutralInput(pitzer.getPhase(1), components);
+      pitzer.init(0);
+      applyScalePitzerDataset(pitzer, datasetSelector);
+      pitzer.setMixingRule("classic");
+      pitzer.setMultiPhaseCheck(true);
+      pitzerQualification = pitzer.getPitzerParameterQualification();
+      system = pitzer;
+    } else if ("electrolyte-cpa".equals(model)) {
+      if (input.has("dataset") && !"not-applicable".equals(datasetSelector)) {
+        throw new IllegalArgumentException("Pitzer dataset selectors do not apply to electrolyte-CPA parameters");
+      }
+      SystemElectrolyteCPAstatoil electrolyteCpa = new SystemElectrolyteCPAstatoil(temperature, pressure);
+      addComponents(electrolyteCpa, components);
+      requireElectroneutralInput(electrolyteCpa.getPhase(1), components);
+      electrolyteCpa.chemicalReactionInit();
+      electrolyteCpa.createDatabase(true);
+      electrolyteCpa.setMixingRule(10);
+      electrolyteCpa.setMultiPhaseCheck(true);
+      system = electrolyteCpa;
+    } else {
+      throw new IllegalArgumentException("Unknown electrolyte model '" + model + "'; use pitzer or electrolyte-cpa");
+    }
+
+    MultiSaltPrecipitationResult equilibrium = new ThermodynamicOperations(system).precipitateScales(mineralNames);
+    JsonObject phaseState = validateAqueousPhaseState(system);
+    JsonObject mineralResults = new JsonObject();
+    boolean mineralValuesFinite = true;
+    int presentSolidCount = 0;
+    for (Map.Entry<String, SaltPrecipitationResult> entry : equilibrium.getMineralResults().entrySet()) {
+      SaltPrecipitationResult solid = entry.getValue();
+      mineralValuesFinite &= Double.isFinite(solid.getInitialSaturationRatio())
+          && Double.isFinite(solid.getFinalSaturationRatio()) && solid.getFinalSaturationRatio() > 0.0
+          && Double.isFinite(solid.getPrecipitatedMoles()) && solid.getPrecipitatedMoles() >= 0.0
+          && Double.isFinite(solid.getPrecipitatedMassGrams()) && solid.getPrecipitatedMassGrams() >= 0.0;
+      if (solid.hasPrecipitatedSolid()) {
+        presentSolidCount++;
+      }
+      JsonObject mineral = new JsonObject();
+      mineral.addProperty("precipitatedSolid", solid.hasPrecipitatedSolid());
+      mineral.addProperty("precipitatedMoles_mol", solid.getPrecipitatedMoles());
+      mineral.addProperty("precipitatedMass_g", solid.getPrecipitatedMassGrams());
+      mineral.addProperty("initialSaturationRatio", solid.getInitialSaturationRatio());
+      mineral.addProperty("finalSaturationRatio", solid.getFinalSaturationRatio());
+      mineral.addProperty("complementarityViolation_log10SR", solid.getComplementarityViolation());
+      mineralResults.add(entry.getKey(), mineral);
+    }
+
+    boolean numericalGatesPass = mineralValuesFinite
+        && Double.isFinite(equilibrium.getMaximumComplementarityViolation())
+        && equilibrium.getMaximumComplementarityViolation() <= 1.0e-6
+        && Double.isFinite(equilibrium.getMaximumComponentBalanceResidualMoles())
+        && equilibrium.getMaximumComponentBalanceResidualMoles() <= 1.0e-10
+        && Double.isFinite(equilibrium.getTotalPrecipitatedMassGrams())
+        && equilibrium.getTotalPrecipitatedMassGrams() >= 0.0
+        && phaseState.get("normalizedNonNegative").getAsBoolean()
+        && Math.abs(phaseState.get("chargeResidual_molPerKgWater").getAsDouble()) <= 1.0e-10;
+    if (!numericalGatesPass) {
+      throw new IllegalStateException(
+          "Electrolyte multi-scale equilibrium failed complementarity, balance, or phase-state gates");
+    }
+
+    JsonObject data = new JsonObject();
+    data.addProperty("model", model);
+    data.addProperty("authoritativeJavaOperation", "ThermodynamicOperations.precipitateScales");
+    data.addProperty("temperature_K", temperature);
+    data.addProperty("pressure_bara", pressure);
+    data.addProperty("compositionBasis", "component amount in mol; aqueous molality derived from water mass");
+    data.addProperty("solidLedgerBasis",
+        "pure COMPSALT ion-formula amounts; crystallization water and solid solutions are not represented");
+    data.addProperty("datasetSelector", datasetSelector);
+    data.addProperty("datasetId",
+        pitzerQualification == null ? "not-applicable: electrolyte-EOS parameters are not Pitzer parameters"
+            : pitzerQualification.getDatasetId());
+    data.addProperty("requestedMineralCount", equilibrium.getMineralResults().size());
+    data.addProperty("presentSolidCount", presentSolidCount);
+    data.addProperty("equilibriumUpdates", equilibrium.getEquilibriumUpdates());
+    data.addProperty("maximumComplementarityViolation_log10SR",
+        equilibrium.getMaximumComplementarityViolation());
+    data.addProperty("maximumComponentBalanceResidual_mol",
+        equilibrium.getMaximumComponentBalanceResidualMoles());
+    data.addProperty("totalPrecipitatedMass_g", equilibrium.getTotalPrecipitatedMassGrams());
+    data.add("mineralResults", mineralResults);
+    data.add("aqueousPhaseState", phaseState);
+    data.addProperty("engineeringGatesPass", true);
+    if (pitzerQualification == null) {
+      data.add("pitzerQualificationLevel", null);
+      data.add("mineralTargetQualified", null);
+    } else {
+      data.addProperty("pitzerQualificationLevel", pitzerQualification.getLevel().name());
+      data.addProperty("mineralTargetQualified",
+          pitzerQualification.isValidatedFor(ValidationTarget.MINERAL_SATURATION_AND_PRECIPITATION));
+      data.add("qualificationLimitations", GSON.toJsonTree(pitzerQualification.getLimitations()));
+    }
+    data.addProperty("publicationReady", false);
+    data.addProperty("publicationLimitation",
+        "Numerical engineering gates pass, but no exact competitive mixed-brine mineral evidence envelope is "
+            + "registered for this state");
+    return data;
+  }
+
+  private static String[] requiredMineralNames(JsonObject input) {
+    if (!input.has("minerals") || !input.get("minerals").isJsonArray()
+        || input.getAsJsonArray("minerals").size() == 0) {
+      throw new IllegalArgumentException("'minerals' must be a non-empty JSON array of COMPSALT names");
+    }
+    JsonArray requested = input.getAsJsonArray("minerals");
+    String[] mineralNames = new String[requested.size()];
+    for (int index = 0; index < requested.size(); index++) {
+      if (requested.get(index).isJsonNull()) {
+        throw new IllegalArgumentException("COMPSALT mineral names cannot be null");
+      }
+      mineralNames[index] = requested.get(index).getAsString().trim();
+      if (mineralNames[index].isEmpty()) {
+        throw new IllegalArgumentException("COMPSALT mineral names cannot be blank");
+      }
+    }
+    return mineralNames;
   }
 
   private static Map<String, Double> requiredComponentAmounts(JsonObject input) {

--- a/src/test/java/neqsim/mcp/runners/ChemistryRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/ChemistryRunnerTest.java
@@ -145,16 +145,14 @@ class ChemistryRunnerTest {
     String input = "{\"analysis\":\"electrolyteMultiScaleEquilibrium\",\"model\":\"pitzer\","
         + "\"dataset\":\"phreeqc-catalog\",\"temperature_K\":298.15,\"pressure_bara\":1.01325,"
         + "\"minerals\":[\"CaSO4_A\",\"CaSO4_G\"],"
-        + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,\"Mg++\":0.15,"
-        + "\"Cl-\":1.3,\"SO4--\":0.2}}";
+        + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,\"Mg++\":0.15," + "\"Cl-\":1.3,\"SO4--\":0.2}}";
 
     JsonObject result = JsonParser.parseString(ChemistryRunner.run(input)).getAsJsonObject();
     JsonObject data = result.getAsJsonObject("data");
     JsonObject minerals = data.getAsJsonObject("mineralResults");
 
     assertEquals("success", result.get("status").getAsString());
-    assertEquals("ThermodynamicOperations.precipitateScales",
-        data.get("authoritativeJavaOperation").getAsString());
+    assertEquals("ThermodynamicOperations.precipitateScales", data.get("authoritativeJavaOperation").getAsString());
     assertEquals(2, data.get("requestedMineralCount").getAsInt());
     assertEquals(1, data.get("presentSolidCount").getAsInt());
     assertFalse(minerals.getAsJsonObject("CaSO4_A").get("precipitatedSolid").getAsBoolean());
@@ -164,8 +162,8 @@ class ChemistryRunnerTest {
     assertTrue(data.get("maximumComplementarityViolation_log10SR").getAsDouble() <= 1.0e-6);
     assertTrue(data.get("maximumComponentBalanceResidual_mol").getAsDouble() <= 1.0e-10);
     assertTrue(data.getAsJsonObject("aqueousPhaseState").get("normalizedNonNegative").getAsBoolean());
-    assertEquals(0.0,
-        data.getAsJsonObject("aqueousPhaseState").get("chargeResidual_molPerKgWater").getAsDouble(), 1.0e-10);
+    assertEquals(0.0, data.getAsJsonObject("aqueousPhaseState").get("chargeResidual_molPerKgWater").getAsDouble(),
+        1.0e-10);
     assertTrue(data.get("engineeringGatesPass").getAsBoolean());
     assertFalse(data.get("publicationReady").getAsBoolean());
   }
@@ -179,8 +177,7 @@ class ChemistryRunnerTest {
     String forward = prefix + "\"minerals\":[\"CaSO4_A\",\"CaSO4_G\"]" + suffix;
     String reverse = prefix + "\"minerals\":[\"CaSO4_G\",\"CaSO4_A\"]" + suffix;
 
-    JsonObject first = JsonParser.parseString(ChemistryRunner.run(forward)).getAsJsonObject()
-        .getAsJsonObject("data");
+    JsonObject first = JsonParser.parseString(ChemistryRunner.run(forward)).getAsJsonObject().getAsJsonObject("data");
     JsonObject repeated = JsonParser.parseString(ChemistryRunner.run(forward)).getAsJsonObject()
         .getAsJsonObject("data");
     JsonObject reordered = JsonParser.parseString(ChemistryRunner.run(reverse)).getAsJsonObject()
@@ -194,11 +191,9 @@ class ChemistryRunnerTest {
   void electrolyteMultiScaleEquilibriumUsesElectrolyteCpaAndRejectsDuplicateMinerals() {
     String valid = "{\"analysis\":\"electrolyteMultiScaleEquilibrium\","
         + "\"model\":\"electrolyte-cpa\",\"temperature_K\":298.15,\"pressure_bara\":1.01325,"
-        + "\"minerals\":[\"CaSO4_A\",\"CaSO4_G\"],"
-        + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,"
+        + "\"minerals\":[\"CaSO4_A\",\"CaSO4_G\"]," + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,"
         + "\"Cl-\":1.0,\"SO4--\":0.2}}";
-    JsonObject data = JsonParser.parseString(ChemistryRunner.run(valid)).getAsJsonObject()
-        .getAsJsonObject("data");
+    JsonObject data = JsonParser.parseString(ChemistryRunner.run(valid)).getAsJsonObject().getAsJsonObject("data");
 
     assertEquals("electrolyte-cpa", data.get("model").getAsString());
     assertTrue(data.get("engineeringGatesPass").getAsBoolean());

--- a/src/test/java/neqsim/mcp/runners/ChemistryRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/ChemistryRunnerTest.java
@@ -141,6 +141,77 @@ class ChemistryRunnerTest {
   }
 
   @Test
+  void electrolyteMultiScaleEquilibriumPitzerExposesCompetingMineralLedger() {
+    String input = "{\"analysis\":\"electrolyteMultiScaleEquilibrium\",\"model\":\"pitzer\","
+        + "\"dataset\":\"phreeqc-catalog\",\"temperature_K\":298.15,\"pressure_bara\":1.01325,"
+        + "\"minerals\":[\"CaSO4_A\",\"CaSO4_G\"],"
+        + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,\"Mg++\":0.15,"
+        + "\"Cl-\":1.3,\"SO4--\":0.2}}";
+
+    JsonObject result = JsonParser.parseString(ChemistryRunner.run(input)).getAsJsonObject();
+    JsonObject data = result.getAsJsonObject("data");
+    JsonObject minerals = data.getAsJsonObject("mineralResults");
+
+    assertEquals("success", result.get("status").getAsString());
+    assertEquals("ThermodynamicOperations.precipitateScales",
+        data.get("authoritativeJavaOperation").getAsString());
+    assertEquals(2, data.get("requestedMineralCount").getAsInt());
+    assertEquals(1, data.get("presentSolidCount").getAsInt());
+    assertFalse(minerals.getAsJsonObject("CaSO4_A").get("precipitatedSolid").getAsBoolean());
+    assertTrue(minerals.getAsJsonObject("CaSO4_A").get("finalSaturationRatio").getAsDouble() < 1.0);
+    assertTrue(minerals.getAsJsonObject("CaSO4_G").get("precipitatedSolid").getAsBoolean());
+    assertEquals(1.0, minerals.getAsJsonObject("CaSO4_G").get("finalSaturationRatio").getAsDouble(), 1.0e-6);
+    assertTrue(data.get("maximumComplementarityViolation_log10SR").getAsDouble() <= 1.0e-6);
+    assertTrue(data.get("maximumComponentBalanceResidual_mol").getAsDouble() <= 1.0e-10);
+    assertTrue(data.getAsJsonObject("aqueousPhaseState").get("normalizedNonNegative").getAsBoolean());
+    assertEquals(0.0,
+        data.getAsJsonObject("aqueousPhaseState").get("chargeResidual_molPerKgWater").getAsDouble(), 1.0e-10);
+    assertTrue(data.get("engineeringGatesPass").getAsBoolean());
+    assertFalse(data.get("publicationReady").getAsBoolean());
+  }
+
+  @Test
+  void electrolyteMultiScaleEquilibriumIsOrderIndependentAndDeterministic() {
+    String prefix = "{\"analysis\":\"electrolyteMultiScaleEquilibrium\",\"model\":\"pitzer\","
+        + "\"dataset\":\"phreeqc-catalog\",\"temperature_K\":298.15,\"pressure_bara\":1.01325,";
+    String suffix = ",\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,"
+        + "\"Mg++\":0.15,\"Cl-\":1.3,\"SO4--\":0.2}}";
+    String forward = prefix + "\"minerals\":[\"CaSO4_A\",\"CaSO4_G\"]" + suffix;
+    String reverse = prefix + "\"minerals\":[\"CaSO4_G\",\"CaSO4_A\"]" + suffix;
+
+    JsonObject first = JsonParser.parseString(ChemistryRunner.run(forward)).getAsJsonObject()
+        .getAsJsonObject("data");
+    JsonObject repeated = JsonParser.parseString(ChemistryRunner.run(forward)).getAsJsonObject()
+        .getAsJsonObject("data");
+    JsonObject reordered = JsonParser.parseString(ChemistryRunner.run(reverse)).getAsJsonObject()
+        .getAsJsonObject("data");
+
+    assertEquals(first, repeated);
+    assertEquals(first, reordered);
+  }
+
+  @Test
+  void electrolyteMultiScaleEquilibriumUsesElectrolyteCpaAndRejectsDuplicateMinerals() {
+    String valid = "{\"analysis\":\"electrolyteMultiScaleEquilibrium\","
+        + "\"model\":\"electrolyte-cpa\",\"temperature_K\":298.15,\"pressure_bara\":1.01325,"
+        + "\"minerals\":[\"CaSO4_A\",\"CaSO4_G\"],"
+        + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,"
+        + "\"Cl-\":1.0,\"SO4--\":0.2}}";
+    JsonObject data = JsonParser.parseString(ChemistryRunner.run(valid)).getAsJsonObject()
+        .getAsJsonObject("data");
+
+    assertEquals("electrolyte-cpa", data.get("model").getAsString());
+    assertTrue(data.get("engineeringGatesPass").getAsBoolean());
+    assertTrue(data.get("pitzerQualificationLevel").isJsonNull());
+
+    String duplicate = valid.replace("[\"CaSO4_A\",\"CaSO4_G\"]", "[\"CaSO4_A\",\"CaSO4_A\"]");
+    JsonObject rejected = JsonParser.parseString(ChemistryRunner.run(duplicate)).getAsJsonObject();
+    assertEquals("error", rejected.get("status").getAsString());
+    assertTrue(rejected.getAsJsonArray("errors").get(0).getAsJsonObject().get("message").getAsString()
+        .contains("Duplicate COMPSALT mineral"));
+  }
+
+  @Test
   void qualifiedPitzerTopologyIsAcceptedForItsObservableAndEnvelope() {
     String input = "{\"analysis\":\"pitzerQualification\",\"temperature_K\":298.15,"
         + "\"pressure_bara\":1.01325,\"dataset\":\"phreeqc-na-k-cl\","

--- a/src/test/java/neqsim/thermo/phase/PitzerCatalogPerformanceBenchmark.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerCatalogPerformanceBenchmark.java
@@ -19,6 +19,12 @@ public final class PitzerCatalogPerformanceBenchmark {
       + "\"model\":\"pitzer\",\"dataset\":\"phreeqc-ca-mg-cl-so4\","
       + "\"temperature_K\":298.15,\"pressure_bara\":1.01325,\"mineral\":\"CaSO4_A\","
       + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,\"Mg++\":0.0," + "\"Cl-\":1.0,\"SO4--\":0.2}}";
+  private static final String MULTI_SCALE_EQUILIBRIUM_REQUEST = "{\"analysis\":"
+      + "\"electrolyteMultiScaleEquilibrium\",\"model\":\"pitzer\","
+      + "\"dataset\":\"phreeqc-catalog\",\"temperature_K\":298.15,"
+      + "\"pressure_bara\":1.01325,\"minerals\":[\"CaSO4_A\",\"CaSO4_G\"],"
+      + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,"
+      + "\"Mg++\":0.15,\"Cl-\":1.3,\"SO4--\":0.2}}";
 
   private PitzerCatalogPerformanceBenchmark() {
   }
@@ -77,6 +83,11 @@ public final class PitzerCatalogPerformanceBenchmark {
     }
     System.out.println("pitzerScaleEquilibriumViewNs="
         + medianBatches(PitzerCatalogPerformanceBenchmark::scaleEquilibriumViewChecksum, 5));
+    for (int warmup = 0; warmup < 3; warmup++) {
+      sink += multiScaleEquilibriumViewChecksum();
+    }
+    System.out.println("pitzerMultiScaleEquilibriumViewNs="
+        + medianBatches(PitzerCatalogPerformanceBenchmark::multiScaleEquilibriumViewChecksum, 5));
 
     SystemPitzer reactivePitzer = createReactiveH2sSystem(298.15);
     ChemicalReaction h2sReaction = reactivePitzer.getChemicalReactionOperations().getReactionList()
@@ -154,6 +165,10 @@ public final class PitzerCatalogPerformanceBenchmark {
 
   private static double scaleEquilibriumViewChecksum() {
     return ChemistryRunner.run(SCALE_EQUILIBRIUM_REQUEST).hashCode();
+  }
+
+  private static double multiScaleEquilibriumViewChecksum() {
+    return ChemistryRunner.run(MULTI_SCALE_EQUILIBRIUM_REQUEST).hashCode();
   }
 
   private static double neutralPropertyChecksum(SystemSrkEos system) {

--- a/src/test/java/neqsim/thermo/phase/PitzerCatalogPerformanceBenchmark.java
+++ b/src/test/java/neqsim/thermo/phase/PitzerCatalogPerformanceBenchmark.java
@@ -23,8 +23,7 @@ public final class PitzerCatalogPerformanceBenchmark {
       + "\"electrolyteMultiScaleEquilibrium\",\"model\":\"pitzer\","
       + "\"dataset\":\"phreeqc-catalog\",\"temperature_K\":298.15,"
       + "\"pressure_bara\":1.01325,\"minerals\":[\"CaSO4_A\",\"CaSO4_G\"],"
-      + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2,"
-      + "\"Mg++\":0.15,\"Cl-\":1.3,\"SO4--\":0.2}}";
+      + "\"components\":{\"water\":55.508,\"Na+\":1.0,\"Ca++\":0.2," + "\"Mg++\":0.15,\"Cl-\":1.3,\"SO4--\":0.2}}";
 
   private PitzerCatalogPerformanceBenchmark() {
   }


### PR DESCRIPTION
## Engineering question

Can JSON and MCP callers invoke NeqSim's existing authoritative simultaneous pure-mineral equilibrium operation—using the selected Pitzer GE or electrolyte-CPA aqueous activities—and receive one deterministic coupled solid/material ledger without confusing it with the separate Davies/BDOT `multiMineralScale` screening model?

Advances #3144. Capability contract: https://github.com/equinor/neqsim/issues/3144#issuecomment-5475563482

## Exact continuity and frozen scope

- **Exact base:** `671c757fcc06698e83ddb57e0be71e3a959f8e73`
- **Exact head:** `5c1b1629a7ccca7b5ce1289df114b67c958ccd73`
- **Branch:** `ai/electrolyte-multi-scale-view-3144`
- No active #3144 implementation existed before publication. Three positively identified autonomous implementation capabilities were open immediately before publication; this draft is the fourth, below the ten-capability ceiling.
- Additive stateless view only; the existing `ThermodynamicOperations.precipitateScales(String...)` active-set solver remains authoritative.

## Model and result semantics

- `electrolyteMultiScaleEquilibrium` accepts temperature K, pressure bara, electroneutral component amounts in mol, an explicit model/dataset, and unique pure COMPSALT mineral names.
- Pitzer uses its molality-standard-state GE parameters; electrolyte CPA retains its distinct EOS/mixing-rule-10 parameters. Pitzer selectors fail closed on electrolyte CPA.
- The response reports deterministic per-mineral moles and COMPSALT ion-formula mass, initial/final saturation ratios, active-set updates, maximum `log10(SR)` complementarity violation, component-ledger residual, aqueous charge, phase normalization, and qualification boundary.
- Mineral names are sorted by the authoritative solver, so caller order cannot select a different topology.
- This view is explicitly different from the concentration-based Davies/BDOT `multiMineralScale` screening analysis.

## Scientific and provenance boundary

- Reuses the durable Pitzer source matrix: https://github.com/equinor/neqsim/issues/3144#issuecomment-5468165217
- USGS PHREEQC 3.9.0 public-domain catalog commit: https://github.com/phreeqc-dev/phreeqc3/commit/b0b3be767158ccc3322d2c816625cf470045e67e
- Existing sulfate-mineral comparison includes Plummer & Busenberg (1982): https://doi.org/10.1016/0016-7037(82)90056-4
- No Ksp, Pitzer, electrolyte-EOS, reaction, Henry, or other parameter changed. No Kaasa value or restricted table was copied.
- `publicationReady` remains false until an exact independent competitive mixed-brine/mineral validation envelope is registered.

## Acceptance gates and tests added

Focused runner regressions cover:

- Pitzer anhydrite/gypsum competition and stable topology;
- complementarity `<=1e-6 log10(SR)`;
- component ledger `<=1e-10 mol`;
- aqueous charge `<=1e-10 mol/kg water`;
- finite, non-negative, normalized aqueous state;
- deterministic repeat and caller-order independence;
- electrolyte CPA with separate parameter semantics;
- duplicate-mineral rejection.

The complete opt-in JSON calculation is added to `PitzerCatalogPerformanceBenchmark`. Ordinary electrolyte calculations and neutral PR/SRK/CPA paths do not call the new view, so their structural overhead is zero.

## Documentation impact

Updated the chemistry overview, MCP JSON schema/reference, and MCP server tool table. Java/JPype remains the authoritative calculation; Python uses that Java API through JPype. A notebook is not applicable because this is a stateless service/API exposure rather than a new engineering workflow.

## Validation

**VALIDATION PENDING EXACT-HEAD PERFORMANCE BENCHMARK**

On exact head `5c1b1629a7ccca7b5ce1289df114b67c958ccd73`, Java 8/21 tests pass on Ubuntu and Windows; all four slow shards, Javadocs, MCP protocol qualification, CodeQL, documentation search, PaperLab, pre-commit, and Spotless pass. The PR is mergeable with no reviews, PR comments, or unresolved review threads.

The six new simultaneous-equilibrium calls embedded in the three added runner regressions completed on every platform. Non-paired `ChemistryRunnerTest` class-time differences versus merged predecessor #3358 range from 2.50 s to 13.89 s across Java/OS runners; this proves bounded completion but is too runner-dependent to serve as a per-operation acceptance benchmark. The committed `pitzerMultiScaleEquilibriumViewNs` manual harness has not produced exact-head output and is not claimed as run. Existing Pitzer-kernel and neutral-SRK evidence remains unchanged because this PR adds only an opt-in stateless dispatch branch and no calculation kernel.

## Stop boundary

No solver change, parameter adoption, solid solution, hydrated-solid mass, kinetics, deposition, inhibitor physics, continuation-state JSON, generic TP flash (#2937), salt-input API (#448), reactive-absorber equipment (#205), or H2S parameter work.

AI-assisted contribution.