### PR TITLE
[AI-Assisted] feat(refinery): add assay sulfur bookkeeping

### DIFF
--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -50,11 +50,12 @@ For crude/petroleum assays, use `OilAssayCharacterisation` rather than manually 
 - specific-gravity, kg/m3, and API-gravity density inputs;
 - exact API-gravity/SG60/60 round-tripping and explicit bulk density at 60 degF;
 - per-cut UOP/Watson characterization factors from representative boiling point and specific gravity;
+- per-cut total-sulfur inputs and mass-basis whole-assay sulfur reconstruction;
 - pre-binned cumulative TBP cut-boundary ingestion;
 - preserved lower/upper boiling ranges;
 - closure, duplicate-name, monotonicity, and repeated-application guards.
 
-See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data bookkeeping evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation), whole-assay density/API evidence in [DOE/OEDI COA bulk density qualification](refinery_oedi_coa_bulk_density_validation), per-cut characterization evidence in [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation), and the process-integration gate in [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation).
+See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data bookkeeping evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation), whole-assay density/API evidence in [DOE/OEDI COA bulk density qualification](refinery_oedi_coa_bulk_density_validation), per-cut characterization evidence in [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation), assay-quality evidence in [DOE Big Hill sulfur qualification](refinery_big_hill_sulfur_validation), and the process-integration gate in [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation).
 
 ## TBP fraction models
 
@@ -139,6 +140,7 @@ A bookkeeping regression does not by itself validate a petroleum-property correl
 - [Refinery Assay and TBP Cut Characterization](refinery_assay)
 - [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation)
 - [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation)
+- [DOE Big Hill assay sulfur qualification](refinery_big_hill_sulfur_validation)
 - [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation)
 - [DOE/OEDI COA bulk density and API qualification](refinery_oedi_coa_bulk_density_validation)
 - [Fluid Characterization Guide](../../wiki/fluid_characterization)

--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -147,6 +147,12 @@ Here $T_b$ is in K and $SG$ is dimensionless specific gravity. This is equivalen
 
 The public [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation) covers four bounded 375-1050 degF cuts with SG 0.8297-0.9336. The maximum absolute difference from DOE's one-decimal UOP K values is 0.0122. The method is qualified for assay screening inside that matrix; it is not a whole-crude aggregation, ASTM conversion or design-certification method.
 
+## Assay-carried total sulfur
+
+`AssayCut.withSulfurMassFraction(...)` and `withSulfurMassPercent(...)` carry total sulfur explicitly on a mass basis. `getBulkSulfurMassFraction()` and `getBulkSulfurMassPercent()` apply the linear mass-basis rule to the same resolved assay mass fractions used for pseudo-component bookkeeping. Positive-yield cuts without sulfur data fail closed; zero-yield cuts do not contribute.
+
+The public [DOE Big Hill assay sulfur qualification](refinery_big_hill_sulfur_validation) covers a complete non-overlapping crude slate. With the documented zero-sulfur screening assumption for the 1.70 mass% gas cut that lacks a reported value, the reconstructed 0.40867518 mass% agrees with DOE's 0.409 mass% whole-crude result within 0.00032482 mass%. This is linear assay bookkeeping, not sulfur-species thermodynamics, emissions prediction or hydrotreating chemistry.
+
 ## Existing petroleum-property correlations
 
 This refinery-assay API deliberately reuses the existing NeqSim TBP/pseudo-component property framework. It does not add or retune critical-property, acentric-factor, or molecular-weight coefficients.
@@ -181,9 +187,10 @@ The regression suite for this API currently verifies:
 - analytical mass- and volume-basis bulk specific-gravity reconstruction;
 - whole-assay SG/API agreement across all five complete four-category rows in the public DOE/OEDI COA summary workbook;
 - per-cut UOP/Watson factors against four bounded cuts in the public DOE SPR Big Hill Sweet 2021 assay;
+- whole-assay total-sulfur reconstruction against the public DOE Big Hill Sweet 2021 assay;
 - input-order independence and no thermodynamic-system mutation for bulk-property queries.
 
-These tests establish software/bookkeeping correctness, qualify ideal-additive-volume SG/API screening over the frozen COA matrix (published crude SG 0.765-0.847; maximum observed errors 0.006 SG and 1.5 degrees API), and qualify per-cut Watson factors over the frozen DOE matrix (375-1050 degF; maximum observed error 0.0122). They do **not** qualify temperature correction, contraction, molecular-weight or critical-property correlations, or atmospheric/vacuum fractionation; those remain separate campaign gates in issue #3305.
+These tests establish software/bookkeeping correctness, qualify ideal-additive-volume SG/API screening over the frozen COA matrix (published crude SG 0.765-0.847; maximum observed errors 0.006 SG and 1.5 degrees API), qualify per-cut Watson factors over the frozen DOE matrix (375-1050 degF; maximum observed error 0.0122), and qualify linear assay sulfur bookkeeping over one complete DOE crude slate. They do **not** qualify temperature correction, contraction, molecular-weight or critical-property correlations, sulfur species or reactions, or atmospheric/vacuum fractionation; those remain separate campaign gates in issue #3305.
 
 ## Refinery capability inventory after this increment
 
@@ -193,9 +200,10 @@ These tests establish software/bookkeeping correctness, qualify ideal-additive-v
 | Mass- and volume-basis cut yields | Unit/basis-explicit assay API | Foundation hardened in #3305 |
 | Pre-binned cumulative TBP cut boundaries | `addTBPCutBoundariesCelsius/Kelvin` | Initial implementation in #3305 |
 | Per-cut UOP/Watson characterization factor | `AssayCut.getWatsonCharacterizationFactor()` | DOE-qualified for assay screening over 375-1050 degF |
+| Assay-carried total sulfur | `getBulkSulfurMassFraction/Percent()` | DOE-qualified for linear bookkeeping over one complete crude slate |
 | TBP pseudo-component properties | Pedersen, Lee-Kesler, Riazi-Daubert, Twu, Cavett, Standing and related models | Existing; needs refinery-range independent validation |
 | Plus-fraction splitting/lumping | `Characterise`, plus-fraction and lumping models | Existing; refinery assay integration still to be qualified |
-| Oil density/API and volatility standards | Oil-quality standards package, RVP/TVP workflows | Whole-assay SG/API and per-cut Watson screening qualified over frozen public matrices; broader stream properties remain open |
+| Oil density/API and volatility standards | Oil-quality standards package, RVP/TVP workflows | Whole-assay SG/API, per-cut Watson and linear sulfur bookkeeping qualified over frozen public matrices; broader stream properties remain open |
 | Rigorous distillation columns | `DistillationColumn`, `SimpleTray`, Naphtali-Sandholm solver, side-draw support | Existing foundation; broad-boiling atmospheric/vacuum refinery benchmark remains open |
 | Crude preheat/fired heater | General heater/heat-exchanger process equipment | Refinery workflow and fuel/emission integration remain open |
 | Product blending/specification optimization | Generic optimization/process facilities | Refinery property/blending framework remains open |

--- a/docs/thermo/characterization/refinery_big_hill_sulfur_validation.md
+++ b/docs/thermo/characterization/refinery_big_hill_sulfur_validation.md
@@ -1,0 +1,61 @@
+---
+title: "DOE Big Hill assay sulfur qualification"
+description: "Public-data qualification of linear refinery-assay total-sulfur bookkeeping."
+---
+
+# DOE Big Hill assay sulfur qualification
+
+This benchmark qualifies assay-carried total-sulfur inputs and bulk sulfur reconstruction against the public U.S. Department of Energy Strategic Petroleum Reserve Big Hill Sweet assay.
+
+## Source and provenance
+
+The source is the DOE/SPR **Big Hill Sweet** comprehensive assay workbook:
+
+- workbook: <https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx>
+- DOE assay landing page: <https://www.spr.doe.gov/reports/Crude_Oil_Assays.html>
+- report date recorded in the workbook: **24 September 2021**
+
+DOE/SPR publicly distributes the workbook with an informational-use disclaimer. No separate license statement was found. The regression freezes only attributed mass yields, total-sulfur values and the reported whole-crude result; it does not redistribute the workbook or reproduce a proprietary standard.
+
+## Calculation
+
+For resolved assay mass fractions $w_i$ and cut total-sulfur mass fractions $S_i$, NeqSim uses the explicit linear mass-basis rule:
+
+$$S_{bulk}=\sum_i w_iS_i$$
+
+Mass- and liquid-volume-basis assays share the existing authoritative basis resolution. Volume yields are converted with cut specific gravities before sulfur is aggregated. Every positive-yield cut must carry sulfur data; otherwise the calculation fails closed.
+
+## Frozen DOE matrix
+
+| Non-overlapping cut | Mass yield, % | Total sulfur, mass % |
+| --- | ---: | ---: |
+| C2-C4 gas | 1.70 | 0.0 assumed |
+| C5-175 degF | 5.22 | 0.0008 |
+| 175-250 degF | 8.32 | 0.0026 |
+| 250-375 degF | 12.55 | 0.019 |
+| 375-530 degF | 16.19 | 0.096 |
+| 530-650 degF | 13.18 | 0.313 |
+| 650-850 degF | 18.44 | 0.534 |
+| 850-1050 degF | 12.84 | 0.752 |
+| 1050 degF+ | 11.56 | 1.334 |
+
+The source does not report total sulfur for the C2-C4 gas cut. The benchmark assigns zero to that 1.70 mass% cut as an explicit screening assumption; it is not presented as a measured DOE value. With that assumption, the reconstructed result is **0.40867518 mass%**, compared with DOE's whole-crude **0.409 mass%**. The absolute difference is **0.00032482 mass%**, below the predeclared **0.001 mass%** source-precision gate.
+
+## Acceptance and maturity
+
+`OilAssayCharacterisationDoeBigHillSulfurTest` requires:
+
+- exact mass-yield closure and analytical mass-weighted sulfur arithmetic;
+- agreement with DOE whole-crude sulfur within 0.001 mass%;
+- fraction and mass-percent inputs to agree to numerical precision;
+- input-order independence;
+- a volume-basis analytical control using density-resolved mass fractions;
+- missing sulfur for a positive-yield cut to fail closed;
+- valid sulfur inputs to remain between zero and one; and
+- property queries not to add or modify thermodynamic components.
+
+The capability is **qualified for linear assay sulfur bookkeeping** over this frozen public matrix. The calculation is O(cuts), non-iterative and does not alter thermodynamic or process calculations.
+
+## Stop boundary
+
+This evidence does not create elemental thermodynamic components, propagate sulfur into pseudo-components, predict sulfur species, perform hydrotreating chemistry, estimate emissions, apply nonlinear blending, certify a product specification or qualify a conversion unit. Those require separate #3305 contracts and validation.

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -29,6 +29,11 @@ import neqsim.thermo.system.SystemInterface;
  * </p>
  *
  * <p>
+ * Optional total-sulfur qualities are stored as mass fractions. Bulk sulfur is reconstructed by a linear mass-basis
+ * mixing rule after the assay basis has been resolved.
+ * </p>
+ *
+ * <p>
  * The TBP cut-boundary helpers preserve cut yields and boiling ranges, then use the midpoint of each boiling interval
  * as the representative boiling point for the existing NeqSim petroleum correlation. They do not convert ASTM D86/D1160
  * or other laboratory distillation methods to TBP.
@@ -243,6 +248,49 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
    */
   public double getBulkDensityKgPerCubicMetreAt60F() {
     return getBulkSpecificGravity() * WATER_DENSITY_60F_KG_M3;
+  }
+
+  /**
+   * Reconstruct the bulk assay total-sulfur mass fraction from assay-cut sulfur data.
+   *
+   * <p>
+   * The calculation is the linear mass-basis mixing rule {@code sum(w_i S_i)}, where {@code w_i} are the resolved assay
+   * mass fractions and {@code S_i} are cut sulfur mass fractions. Volume-basis assays therefore use the same
+   * density-based conversion as {@link #getResolvedMassFractions()}. Every positive-yield cut must define sulfur;
+   * zero-yield cuts do not contribute.
+   * </p>
+   *
+   * @return bulk total-sulfur mass fraction on a 0-1 basis
+   * @throws IllegalStateException if the assay is empty, incomplete, mixed-basis, or lacks sulfur data for a
+   * positive-yield cut
+   */
+  public double getBulkSulfurMassFraction() {
+    if (cuts.isEmpty()) {
+      throw new IllegalStateException("No assay cuts supplied");
+    }
+
+    double[] massFractions = resolveMassFractions();
+    double bulkSulfurMassFraction = 0.0;
+    for (int i = 0; i < cuts.size(); i++) {
+      if (massFractions[i] > 0.0) {
+        bulkSulfurMassFraction += massFractions[i] * cuts.get(i).getSulfurMassFraction();
+      }
+    }
+
+    if (!Double.isFinite(bulkSulfurMassFraction) || bulkSulfurMassFraction < 0.0 || bulkSulfurMassFraction > 1.0) {
+      throw new IllegalStateException("Unable to reconstruct bulk sulfur mass fraction from assay cuts");
+    }
+    return bulkSulfurMassFraction;
+  }
+
+  /**
+   * Reconstruct the bulk assay total sulfur in mass percent.
+   *
+   * @return bulk total sulfur in mass percent
+   * @throws IllegalStateException if bulk sulfur cannot be reconstructed
+   */
+  public double getBulkSulfurMassPercent() {
+    return 100.0 * getBulkSulfurMassFraction();
   }
 
   /**
@@ -466,6 +514,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     private Double lowerBoilingPointKelvin;
     private Double upperBoilingPointKelvin;
     private Double molarMass;
+    private Double sulfurMassFraction;
 
     /**
      * Create an assay cut.
@@ -746,6 +795,28 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     }
 
     /**
+     * Set total sulfur as a mass fraction on a 0-1 basis.
+     *
+     * @param sulfurMassFraction total-sulfur mass fraction from 0 to 1
+     * @return this cut
+     */
+    public AssayCut withSulfurMassFraction(double sulfurMassFraction) {
+      this.sulfurMassFraction = sanitiseFraction(sulfurMassFraction);
+      return this;
+    }
+
+    /**
+     * Set total sulfur in mass percent.
+     *
+     * @param sulfurMassPercent total sulfur in mass percent from 0 to 100
+     * @return this cut
+     */
+    public AssayCut withSulfurMassPercent(double sulfurMassPercent) {
+      this.sulfurMassFraction = sanitisePercent(sulfurMassPercent);
+      return this;
+    }
+
+    /**
      * Return whether this cut uses a mass fraction.
      *
      * @return true when a mass fraction is set
@@ -794,6 +865,28 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
      */
     public boolean hasMolarMass() {
       return molarMass != null;
+    }
+
+    /**
+     * Return whether total-sulfur data are available for this cut.
+     *
+     * @return true when a sulfur mass fraction is stored
+     */
+    public boolean hasSulfurMassFraction() {
+      return sulfurMassFraction != null;
+    }
+
+    /**
+     * Return the cut total-sulfur mass fraction.
+     *
+     * @return total-sulfur mass fraction on a 0-1 basis
+     * @throws IllegalStateException if sulfur data are not available
+     */
+    public double getSulfurMassFraction() {
+      if (sulfurMassFraction == null) {
+        throw new IllegalStateException("Sulfur mass fraction not set for cut " + name);
+      }
+      return sulfurMassFraction;
     }
 
     /**

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillSulfurTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillSulfurTest.java
@@ -1,0 +1,113 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Public DOE refinery-assay qualification of linear total-sulfur bookkeeping. */
+public class OilAssayCharacterisationDoeBigHillSulfurTest {
+  private static final double[] MASS_YIELD_PERCENT = { 1.70, 5.22, 8.32, 12.55, 16.19, 13.18, 18.44, 12.84, 11.56 };
+  private static final double[] SULFUR_MASS_PERCENT = { 0.0, 0.0008, 0.0026, 0.019, 0.096, 0.313, 0.534, 0.752, 1.334 };
+  private static final double DOE_WHOLE_CRUDE_SULFUR_MASS_PERCENT = 0.409;
+
+  @Test
+  public void doeNonOverlappingSlateReproducesWholeCrudeSulfur() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
+    addDoeCuts(assay, false);
+
+    double resolvedMassClosure = 0.0;
+    for (double massFraction : assay.getResolvedMassFractions()) {
+      resolvedMassClosure += massFraction;
+    }
+    assertEquals(1.0, resolvedMassClosure, 1.0e-15);
+    assertEquals(0.40867518, assay.getBulkSulfurMassPercent(), 1.0e-12);
+    assertEquals(DOE_WHOLE_CRUDE_SULFUR_MASS_PERCENT, assay.getBulkSulfurMassPercent(), 0.001);
+    assertEquals(0.00032482, Math.abs(assay.getBulkSulfurMassPercent() - DOE_WHOLE_CRUDE_SULFUR_MASS_PERCENT), 1.0e-12);
+    assertEquals(0.0040867518, assay.getBulkSulfurMassFraction(), 1.0e-12);
+    assertEquals(0, system.getNumberOfComponents(), "Property queries must not mutate the thermodynamic system");
+  }
+
+  @Test
+  public void inputOrderAndFractionPercentViewsRemainEquivalent() {
+    OilAssayCharacterisation forward = new SystemSrkEos(298.15, 1.01325).getOilAssayCharacterisation();
+    addDoeCuts(forward, false);
+
+    OilAssayCharacterisation reverse = new SystemSrkEos(298.15, 1.01325).getOilAssayCharacterisation();
+    addDoeCuts(reverse, true);
+
+    OilAssayCharacterisation fractionView = new SystemSrkEos(298.15, 1.01325).getOilAssayCharacterisation();
+    for (int i = 0; i < MASS_YIELD_PERCENT.length; i++) {
+      fractionView.addCut(new AssayCut("Fraction" + i).withMassFraction(MASS_YIELD_PERCENT[i] / 100.0)
+          .withSulfurMassFraction(SULFUR_MASS_PERCENT[i] / 100.0));
+    }
+
+    assertEquals(forward.getBulkSulfurMassFraction(), reverse.getBulkSulfurMassFraction(), 1.0e-15);
+    assertEquals(forward.getBulkSulfurMassFraction(), fractionView.getBulkSulfurMassFraction(), 1.0e-15);
+  }
+
+  @Test
+  public void volumeBasisUsesResolvedMassFractions() {
+    OilAssayCharacterisation assay = new SystemSrkEos(298.15, 1.01325).getOilAssayCharacterisation();
+    assay.addCut(new AssayCut("Light").withVolumeFraction(0.25).withSpecificGravity(0.80).withSulfurMassPercent(1.0));
+    assay.addCut(new AssayCut("Heavy").withVolumeFraction(0.75).withSpecificGravity(0.90).withSulfurMassPercent(3.0));
+
+    double expected = (0.25 * 0.80 * 0.01 + 0.75 * 0.90 * 0.03) / (0.25 * 0.80 + 0.75 * 0.90);
+    assertEquals(expected, assay.getBulkSulfurMassFraction(), 1.0e-15);
+  }
+
+  @Test
+  public void missingPositiveCutSulfurFailsClosed() {
+    OilAssayCharacterisation incomplete = new SystemSrkEos(298.15, 1.01325).getOilAssayCharacterisation();
+    incomplete.addCut(new AssayCut("Known").withMassFraction(0.75).withSulfurMassPercent(0.2));
+    incomplete.addCut(new AssayCut("Missing").withMassFraction(0.25));
+    assertThrows(IllegalStateException.class, incomplete::getBulkSulfurMassFraction);
+
+    OilAssayCharacterisation zeroYield = new SystemSrkEos(298.15, 1.01325).getOilAssayCharacterisation();
+    zeroYield.addCut(new AssayCut("Known").withMassFraction(1.0).withSulfurMassPercent(0.2));
+    zeroYield.addCut(new AssayCut("ZeroYield").withMassFraction(0.0));
+    assertEquals(0.002, zeroYield.getBulkSulfurMassFraction(), 1.0e-15);
+  }
+
+  @Test
+  public void sulfurInputsRejectValuesOutsidePhysicalBounds() {
+    assertThrows(IllegalArgumentException.class, () -> new AssayCut("Negative").withSulfurMassFraction(-1.0e-9));
+    assertThrows(IllegalArgumentException.class, () -> new AssayCut("AboveFraction").withSulfurMassFraction(1.0000001));
+    assertThrows(IllegalArgumentException.class, () -> new AssayCut("AbovePercent").withSulfurMassPercent(100.00001));
+    assertFalse(new AssayCut("Unset").hasSulfurMassFraction());
+  }
+
+  @Test
+  public void sulfurMetadataSurvivesSystemClone() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
+    assay.addCut(new AssayCut("SulfurCut").withMassFraction(1.0).withSulfurMassPercent(0.409));
+
+    SystemInterface clonedSystem = system.clone();
+    OilAssayCharacterisation clonedAssay = clonedSystem.getOilAssayCharacterisation();
+
+    assertEquals(0.409, clonedAssay.getBulkSulfurMassPercent(), 1.0e-15);
+    assertEquals(0.00409, clonedAssay.getCuts().get(0).getSulfurMassFraction(), 1.0e-15);
+  }
+
+  private static void addDoeCuts(OilAssayCharacterisation assay, boolean reverse) {
+    assay.clearCuts();
+    List<AssayCut> cuts = new ArrayList<AssayCut>();
+    for (int i = 0; i < MASS_YIELD_PERCENT.length; i++) {
+      cuts.add(new AssayCut("DOE_BH_2021_" + i).withWeightPercent(MASS_YIELD_PERCENT[i])
+          .withSulfurMassPercent(SULFUR_MASS_PERCENT[i]));
+    }
+    if (reverse) {
+      Collections.reverse(cuts);
+    }
+    assay.addCuts(cuts);
+  }
+}


### PR DESCRIPTION
## Engineering question

Can NeqSim carry total sulfur as an assay-cut quality and reconstruct whole-assay sulfur on the authoritative resolved mass basis, while reproducing the public DOE SPR Big Hill Sweet whole-crude result?

Advances #3305. Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5475595796

## Exact continuity and frozen scope

- **Exact base:** `671c757fcc06698e83ddb57e0be71e3a959f8e73`
- **Exact head:** `d2d9122da9d5d6d2689a994ad57d06b27fd1edfa`
- **Branch:** `ai/refinery-assay-sulfur-3305`
- The preceding Watson-factor capability #3362 is merged; no active refinery implementation PR existed immediately before publication.
- Four positively identified autonomous implementation capabilities were open immediately before publication; this draft makes five, below the target and hard ceiling of ten.
- Scope stops at optional assay metadata and read-only linear aggregation. No pseudo-component, thermodynamic, flash, column, reaction or process behavior changes.

## Implementation

- Adds `AssayCut.withSulfurMassFraction(...)` and `withSulfurMassPercent(...)`.
- Adds `hasSulfurMassFraction()` and `getSulfurMassFraction()`.
- Adds `OilAssayCharacterisation.getBulkSulfurMassFraction()` and `getBulkSulfurMassPercent()`.
- Uses `S_bulk = sum(w_i S_i)` with the existing authoritative mass/volume assay-basis resolution.
- Positive-yield cuts without sulfur fail closed; zero-yield cuts do not contribute.
- Java is authoritative and Python/JPype exposes the same public methods. JSON/MCP/notebook views are not applicable because no refinery-assay schema owns `AssayCut` and this is a bounded scalar-property qualification.
- Clone retention, input bounds, order independence and no system mutation are regression protected.

## Public evidence

Source: U.S. DOE/SPR Big Hill Sweet comprehensive assay workbook, reported 24 September 2021:
https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx

The regression freezes the complete non-overlapping mass-yield slate and its reported cut sulfur values. DOE does not report sulfur for the 1.70 mass% C2-C4 gas cut, so the benchmark explicitly assigns zero as a screening assumption; it is not represented as a measured DOE datum.

- Reconstructed whole-assay sulfur: `0.40867518 mass%`
- DOE whole-crude sulfur: `0.409 mass%`
- Absolute difference: `0.00032482 mass%`
- Predeclared acceptance: `<= 0.001 mass%`

No coefficient or source datum is tuned. DOE publicly distributes the workbook with an informational-use disclaimer; no separate license statement was found, so only attributed numerical facts are frozen.

## Validation

Passed on the final local state:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `python devtools/check_documentation_search.py` — 676 Markdown pages and one standalone HTML page
- `./mvnw -q -DskipTests compile`
- `./mvnw -q -Dtest=OilAssayCharacterisationDoeBigHillSulfurTest,OilAssayCharacterisationTest,OilAssayCharacterisationDoeBigHillWatsonTest test`
- `git diff --check`

The `pre-commit` executable was unavailable locally; hosted pre-commit remains authoritative. No broad local suite was run under the fast-validation policy.

**VALIDATION PENDING CI**

## Documentation impact

Updated the characterization index, refinery-assay guide, capability inventory and a dedicated DOE sulfur qualification page. No notebook, schema, process, release or migration document is affected.

## Stop boundary

This does not create elemental thermodynamic components, propagate sulfur into pseudo-components, predict sulfur species, perform hydrotreating chemistry, estimate emissions, apply nonlinear blending, certify product specifications, alter terminal-cut treatment, change columns or implement a conversion unit.

Generated with AI assistance.