### PR TITLE
[AI-Assisted] feat(kinetics): add aqueous CO2 pressure response

### DIFF
--- a/docs/chemicalreactions/co2_transport_reaction_kinetics.md
+++ b/docs/chemicalreactions/co2_transport_reaction_kinetics.md
@@ -172,6 +172,34 @@ apply the correlation directly at pipeline pressure without separate evidence. E
 speciation remains owned by issue #3144; pipeline source-term coupling remains owned by issue
 #3318.
 
+## Published pressure response
+
+`AqueousCO2PressureKinetics` implements the pressure derivative measured by van Eldik and Palmer
+(1982), [doi:10.1007/BF00649292](https://doi.org/10.1007/BF00649292), for the hydration of aqueous
+CO2 and dehydration of carbonic acid at 298.15 K and ionic strength 0.5:
+
+$$
+\frac{k(P_2)}{k(P_1)} =
+\exp\!\left[-\frac{\Delta V^{\ddagger}(P_2-P_1)}{RT}\right].
+$$
+
+The reported activation volumes are `-9.9 +/- 1.9 cm3/mol` for hydration and
+`+6.4 +/- 0.4 cm3/mol` for dehydration. From 1 to 100 bara at 298.15 K, the implementation gives
+a nominal hydration multiplier of `1.04032877` and a nominal dehydration multiplier of
+`0.974764734`. The corresponding uncertainty intervals are 1.03246477–1.04825267 and
+0.973208843–0.976323112. Calls outside the deliberately narrow 298.15 K and 1–1000 bara gate fail
+closed.
+
+Conway et al. (2016), [doi:10.1071/CH15271](https://doi.org/10.1071/CH15271), independently report
+stopped-flow high-pressure hydration measurements from 400 to 1000 atm. That public abstract is
+retained as corroborating provenance but is not used as a numerical parameter source.
+
+These are dimensionless pressure multipliers, not absolute rate constants. Do **not** automatically
+multiply the Soli–Byrne absolute rates by these factors: the studies used different solution
+compositions, so doing so is a separate cross-dataset assumption requiring its own validation.
+This class does not mutate a fluid, select a phase, calculate speciation, or apply a pipeline source
+term.
+
 ## Intended transport integration
 
 A future control-volume integration should:

--- a/docs/test_co2_transport_reaction_kinetics_documentation.py
+++ b/docs/test_co2_transport_reaction_kinetics_documentation.py
@@ -25,6 +25,11 @@ HYDRATION_KINETICS = (
     / "src/main/java/neqsim/process/equipment/reactor/"
     / "AqueousCO2HydrationKinetics.java"
 )
+PRESSURE_KINETICS = (
+    ROOT
+    / "src/main/java/neqsim/process/equipment/reactor/"
+    / "AqueousCO2PressureKinetics.java"
+)
 SYSTEM_INTERFACE = ROOT / "src/main/java/neqsim/thermo/system/SystemInterface.java"
 JAVA_TEST = (
     ROOT
@@ -63,6 +68,7 @@ class CO2TransportReactionKineticsDocumentationContractTest(unittest.TestCase):
         cls.diagnostics = DIAGNOSTICS.read_text(encoding="utf-8")
         cls.qualification = QUALIFICATION.read_text(encoding="utf-8")
         cls.hydration_kinetics = HYDRATION_KINETICS.read_text(encoding="utf-8")
+        cls.pressure_kinetics = PRESSURE_KINETICS.read_text(encoding="utf-8")
         cls.system_interface = SYSTEM_INTERFACE.read_text(encoding="utf-8")
         cls.java_test = JAVA_TEST.read_text(encoding="utf-8")
         cls.normalized = " ".join(cls.guide.split())
@@ -77,12 +83,16 @@ class CO2TransportReactionKineticsDocumentationContractTest(unittest.TestCase):
         self.assertIn(r"\mathrm{Da}", self.guide)
 
         links = re.findall(r"(?<!!)\[[^\]]+\]\(([^)]+)\)", self.guide)
-        self.assertEqual(4, len(links))
+        self.assertEqual(6, len(links))
         for destination in links:
             if destination.startswith("https://"):
-                self.assertEqual(
-                    "https://doi.org/10.1016/S0304-4203%2802%2900010-5",
+                self.assertIn(
                     destination,
+                    (
+                        "https://doi.org/10.1016/S0304-4203%2802%2900010-5",
+                        "https://doi.org/10.1007/BF00649292",
+                        "https://doi.org/10.1071/CH15271",
+                    ),
                 )
             else:
                 self.assertTrue(resolve_internal_target(GUIDE, destination).is_file())
@@ -122,6 +132,33 @@ class CO2TransportReactionKineticsDocumentationContractTest(unittest.TestCase):
             "uncertainty statistics for these two fitted equations",
             "issue #3144",
             "#3318",
+        ):
+            self.assertIn(token, self.guide)
+
+    def test_pressure_response_matches_source_contract(self):
+        for token in (
+            'SOURCE_IDENTIFIER = "doi:10.1007/BF00649292"',
+            'CORROBORATING_SOURCE_IDENTIFIER = "doi:10.1071/CH15271"',
+            "PUBLISHED_TEMPERATURE_K = 298.15",
+            "PUBLISHED_IONIC_STRENGTH = 0.5",
+            "MAXIMUM_PRESSURE_BARA = 1000.0",
+            "HYDRATION_ACTIVATION_VOLUME_CM3_PER_MOL = -9.9",
+            "HYDRATION_ACTIVATION_VOLUME_UNCERTAINTY_CM3_PER_MOL = 1.9",
+            "DEHYDRATION_ACTIVATION_VOLUME_CM3_PER_MOL = 6.4",
+            "DEHYDRATION_ACTIVATION_VOLUME_UNCERTAINTY_CM3_PER_MOL = 0.4",
+            "-activationVolumeM3PerMol * pressureDifferencePa",
+            "public static MultiplierRange hydrationMultiplierRange(",
+        ):
+            self.assertIn(token, self.pressure_kinetics)
+
+        for token in (
+            "1.04032877",
+            "0.974764734",
+            "1–1000 bara",
+            "Do **not** automatically",
+            "multiply the Soli–Byrne absolute rates",
+            "separate cross-dataset assumption",
+            "not used as a numerical parameter source",
         ):
             self.assertIn(token, self.guide)
 

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousCO2PressureKinetics.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousCO2PressureKinetics.java
@@ -1,0 +1,196 @@
+package neqsim.process.equipment.reactor;
+
+import java.io.Serializable;
+
+/**
+ * Published pressure multipliers for aqueous carbon-dioxide hydration and carbonic-acid dehydration.
+ *
+ * <p>
+ * van Eldik and Palmer measured activation volumes for {@code CO2(aq) + H2O -> H2CO3} and
+ * {@code H2CO3 -> CO2(aq) + H2O} at 25 degrees Celsius, ionic strength 0.5, and pressures up to 1 kbar. This class
+ * evaluates only the pressure response implied by those activation volumes:
+ * {@code k(P2) / k(P1) = exp(-deltaV * (P2 - P1) / (R * T))}.
+ * </p>
+ *
+ * <p>
+ * The result is a dimensionless multiplier, not an absolute high-pressure rate constant. Combining it with a rate
+ * correlation from a different solution composition is a separate cross-dataset assumption and is intentionally left to
+ * the caller.
+ * </p>
+ *
+ * @see <a href="https://doi.org/10.1007/BF00649292">van Eldik and Palmer (1982), Journal of Solution Chemistry 11,
+ * 339-346</a>
+ * @author NeqSim Team
+ * @version 1.0
+ */
+public final class AqueousCO2PressureKinetics implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Primary-source DOI. */
+  public static final String SOURCE_IDENTIFIER = "doi:10.1007/BF00649292";
+
+  /** Human-readable primary-source citation. */
+  public static final String SOURCE_CITATION = "R. van Eldik and D. A. Palmer, Journal of Solution Chemistry 11 (1982) 339-346";
+
+  /** Public-access and redistribution note for the implemented source material. */
+  public static final String SOURCE_ACCESS_STATUS = "Public publisher abstract and DOI; activation volumes implemented without redistributing tabulated data";
+
+  /** Independent high-pressure study retained as corroborating provenance, not a parameter source. */
+  public static final String CORROBORATING_SOURCE_IDENTIFIER = "doi:10.1071/CH15271";
+
+  /** Published experimental temperature [K]. */
+  public static final double PUBLISHED_TEMPERATURE_K = 298.15;
+
+  /** Published ionic strength. */
+  public static final double PUBLISHED_IONIC_STRENGTH = 0.5;
+
+  /** Minimum qualified pressure [bara]. */
+  public static final double MINIMUM_PRESSURE_BARA = 1.0;
+
+  /** Maximum qualified pressure [bara]. */
+  public static final double MAXIMUM_PRESSURE_BARA = 1000.0;
+
+  /** Hydration activation volume [cm3/mol]. */
+  public static final double HYDRATION_ACTIVATION_VOLUME_CM3_PER_MOL = -9.9;
+
+  /** Reported hydration activation-volume uncertainty [cm3/mol]. */
+  public static final double HYDRATION_ACTIVATION_VOLUME_UNCERTAINTY_CM3_PER_MOL = 1.9;
+
+  /** Dehydration activation volume [cm3/mol]. */
+  public static final double DEHYDRATION_ACTIVATION_VOLUME_CM3_PER_MOL = 6.4;
+
+  /** Reported dehydration activation-volume uncertainty [cm3/mol]. */
+  public static final double DEHYDRATION_ACTIVATION_VOLUME_UNCERTAINTY_CM3_PER_MOL = 0.4;
+
+  private static final double GAS_CONSTANT_J_PER_MOL_K = 8.31446261815324;
+  private static final double BARA_TO_PA = 1.0e5;
+  private static final double CM3_TO_M3 = 1.0e-6;
+  private static final double TEMPERATURE_TOLERANCE_K = 1.0e-9;
+
+  private AqueousCO2PressureKinetics() {
+  }
+
+  /**
+   * Calculate the published pressure multiplier for aqueous CO2 hydration.
+   *
+   * @param targetPressureBara target pressure [bara]
+   * @param referencePressureBara reference pressure of the supplied rate [bara]
+   * @param temperatureK aqueous-phase temperature [K]
+   * @return dimensionless {@code k(target) / k(reference)}
+   */
+  public static double hydrationMultiplier(double targetPressureBara, double referencePressureBara,
+      double temperatureK) {
+    return pressureMultiplier(HYDRATION_ACTIVATION_VOLUME_CM3_PER_MOL, targetPressureBara, referencePressureBara,
+        temperatureK);
+  }
+
+  /**
+   * Calculate the published pressure multiplier for carbonic-acid dehydration.
+   *
+   * @param targetPressureBara target pressure [bara]
+   * @param referencePressureBara reference pressure of the supplied rate [bara]
+   * @param temperatureK aqueous-phase temperature [K]
+   * @return dimensionless {@code k(target) / k(reference)}
+   */
+  public static double dehydrationMultiplier(double targetPressureBara, double referencePressureBara,
+      double temperatureK) {
+    return pressureMultiplier(DEHYDRATION_ACTIVATION_VOLUME_CM3_PER_MOL, targetPressureBara, referencePressureBara,
+        temperatureK);
+  }
+
+  /**
+   * Calculate the hydration multiplier and the interval implied by the reported uncertainty.
+   *
+   * @param targetPressureBara target pressure [bara]
+   * @param referencePressureBara reference pressure of the supplied rate [bara]
+   * @param temperatureK aqueous-phase temperature [K]
+   * @return nominal, minimum, and maximum dimensionless multipliers
+   */
+  public static MultiplierRange hydrationMultiplierRange(double targetPressureBara, double referencePressureBara,
+      double temperatureK) {
+    return multiplierRange(HYDRATION_ACTIVATION_VOLUME_CM3_PER_MOL, HYDRATION_ACTIVATION_VOLUME_UNCERTAINTY_CM3_PER_MOL,
+        targetPressureBara, referencePressureBara, temperatureK);
+  }
+
+  /**
+   * Calculate the dehydration multiplier and the interval implied by the reported uncertainty.
+   *
+   * @param targetPressureBara target pressure [bara]
+   * @param referencePressureBara reference pressure of the supplied rate [bara]
+   * @param temperatureK aqueous-phase temperature [K]
+   * @return nominal, minimum, and maximum dimensionless multipliers
+   */
+  public static MultiplierRange dehydrationMultiplierRange(double targetPressureBara, double referencePressureBara,
+      double temperatureK) {
+    return multiplierRange(DEHYDRATION_ACTIVATION_VOLUME_CM3_PER_MOL,
+        DEHYDRATION_ACTIVATION_VOLUME_UNCERTAINTY_CM3_PER_MOL, targetPressureBara, referencePressureBara, temperatureK);
+  }
+
+  private static MultiplierRange multiplierRange(double activationVolumeCm3PerMol, double uncertaintyCm3PerMol,
+      double targetPressureBara, double referencePressureBara, double temperatureK) {
+    double nominal = pressureMultiplier(activationVolumeCm3PerMol, targetPressureBara, referencePressureBara,
+        temperatureK);
+    double lowerActivationVolume = pressureMultiplier(activationVolumeCm3PerMol - uncertaintyCm3PerMol,
+        targetPressureBara, referencePressureBara, temperatureK);
+    double upperActivationVolume = pressureMultiplier(activationVolumeCm3PerMol + uncertaintyCm3PerMol,
+        targetPressureBara, referencePressureBara, temperatureK);
+    return new MultiplierRange(nominal, Math.min(lowerActivationVolume, upperActivationVolume),
+        Math.max(lowerActivationVolume, upperActivationVolume));
+  }
+
+  private static double pressureMultiplier(double activationVolumeCm3PerMol, double targetPressureBara,
+      double referencePressureBara, double temperatureK) {
+    requirePublishedState(targetPressureBara, temperatureK, "target");
+    requirePublishedState(referencePressureBara, temperatureK, "reference");
+    double pressureDifferencePa = (targetPressureBara - referencePressureBara) * BARA_TO_PA;
+    double activationVolumeM3PerMol = activationVolumeCm3PerMol * CM3_TO_M3;
+    double multiplier = Math
+        .exp(-activationVolumeM3PerMol * pressureDifferencePa / (GAS_CONSTANT_J_PER_MOL_K * temperatureK));
+    if (!Double.isFinite(multiplier) || multiplier <= 0.0) {
+      throw new IllegalArgumentException("pressure multiplier must be finite and positive");
+    }
+    return multiplier;
+  }
+
+  private static void requirePublishedState(double pressureBara, double temperatureK, String pressureRole) {
+    if (!Double.isFinite(temperatureK) || Math.abs(temperatureK - PUBLISHED_TEMPERATURE_K) > TEMPERATURE_TOLERANCE_K) {
+      throw new IllegalArgumentException(
+          "temperature must equal the published value of " + PUBLISHED_TEMPERATURE_K + " K");
+    }
+    if (!Double.isFinite(pressureBara) || pressureBara < MINIMUM_PRESSURE_BARA
+        || pressureBara > MAXIMUM_PRESSURE_BARA) {
+      throw new IllegalArgumentException(pressureRole + " pressure must be within the published range of "
+          + MINIMUM_PRESSURE_BARA + " to " + MAXIMUM_PRESSURE_BARA + " bara");
+    }
+  }
+
+  /** Immutable pressure-multiplier interval. */
+  public static final class MultiplierRange implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double nominal;
+    private final double minimum;
+    private final double maximum;
+
+    private MultiplierRange(double nominal, double minimum, double maximum) {
+      this.nominal = nominal;
+      this.minimum = minimum;
+      this.maximum = maximum;
+    }
+
+    /** @return nominal dimensionless multiplier */
+    public double getNominal() {
+      return nominal;
+    }
+
+    /** @return minimum multiplier implied by the reported activation-volume uncertainty */
+    public double getMinimum() {
+      return minimum;
+    }
+
+    /** @return maximum multiplier implied by the reported activation-volume uncertainty */
+    public double getMaximum() {
+      return maximum;
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousCO2PressureKineticsTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousCO2PressureKineticsTest.java
@@ -1,0 +1,59 @@
+package neqsim.process.equipment.reactor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+
+/** Tests the published pressure response of aqueous CO2 hydration and dehydration. */
+public class AqueousCO2PressureKineticsTest extends NeqSimTest {
+
+  @Test
+  void testEqualPressureHasUnitMultiplier() {
+    assertEquals(1.0, AqueousCO2PressureKinetics.hydrationMultiplier(100.0, 100.0, 298.15), 0.0);
+    assertEquals(1.0, AqueousCO2PressureKinetics.dehydrationMultiplier(100.0, 100.0, 298.15), 0.0);
+  }
+
+  @Test
+  void testPublishedActivationVolumesGiveExpected100BaraResponse() {
+    double hydration = AqueousCO2PressureKinetics.hydrationMultiplier(100.0, 1.0, 298.15);
+    double dehydration = AqueousCO2PressureKinetics.dehydrationMultiplier(100.0, 1.0, 298.15);
+
+    assertEquals(1.0403287704082815, hydration, 1.0e-15);
+    assertEquals(0.9747647335180847, dehydration, 1.0e-15);
+    assertTrue(hydration > 1.0);
+    assertTrue(dehydration < 1.0);
+    assertEquals(hydration, AqueousCO2PressureKinetics.hydrationMultiplier(100.0, 1.0, 298.15), 0.0);
+  }
+
+  @Test
+  void testReportedActivationVolumeUncertaintyIsPropagated() {
+    AqueousCO2PressureKinetics.MultiplierRange hydration = AqueousCO2PressureKinetics.hydrationMultiplierRange(100.0,
+        1.0, 298.15);
+    assertEquals(1.0403287704082815, hydration.getNominal(), 1.0e-15);
+    assertEquals(1.0324647657319799, hydration.getMinimum(), 1.0e-15);
+    assertEquals(1.048252673079751, hydration.getMaximum(), 1.0e-15);
+
+    AqueousCO2PressureKinetics.MultiplierRange dehydration = AqueousCO2PressureKinetics
+        .dehydrationMultiplierRange(100.0, 1.0, 298.15);
+    assertEquals(0.9747647335180847, dehydration.getNominal(), 1.0e-15);
+    assertEquals(0.9732088425468611, dehydration.getMinimum(), 1.0e-15);
+    assertEquals(0.9763231119273673, dehydration.getMaximum(), 1.0e-15);
+  }
+
+  @Test
+  void testPublishedDomainAndInvalidStatesFailClosed() {
+    assertTrue(AqueousCO2PressureKinetics.hydrationMultiplier(1000.0, 1.0, 298.15) > 1.0);
+    assertTrue(AqueousCO2PressureKinetics.dehydrationMultiplier(1000.0, 1.0, 298.15) < 1.0);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2PressureKinetics.hydrationMultiplier(0.99, 1.0, 298.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2PressureKinetics.hydrationMultiplier(1000.01, 1.0, 298.15));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2PressureKinetics.hydrationMultiplier(100.0, 1.0, 298.16));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2PressureKinetics.hydrationMultiplier(100.0, Double.NaN, 298.15));
+  }
+}


### PR DESCRIPTION
## Engineering question

Can NeqSim expose the published pressure response of aqueous CO2 hydration and carbonic-acid dehydration as bounded, uncertainty-aware multipliers without claiming an absolute high-pressure rate correlation?

Advances #3318. Capability contract: https://github.com/equinor/neqsim/issues/3318#issuecomment-5476047907

## Exact continuity and capability capacity

- **Exact base:** `5182515deda6aefbde6e3dd5e01c26c7b6714954`
- **Exact head:** `dacb5c2d81eb9597cf1b2eef05938ba820e12471`
- **Branch:** `ai/co2-hydration-pressure-3318`
- No active #3318 implementation PR existed immediately before publication.
- Four positively identified autonomous implementation capabilities were open immediately before publication; this draft makes five, below the target and absolute ceiling of ten.
- No existing PR was closed, rebased, replaced, or moved.

## Implementation

- Adds standalone `AqueousCO2PressureKinetics`.
- Implements `k(P2)/k(P1) = exp[-DeltaV*(P2-P1)/(R*T)]`.
- Hydration activation volume: `-9.9 +/- 1.9 cm3/mol`.
- Dehydration activation volume: `+6.4 +/- 0.4 cm3/mol`.
- Returns nominal multipliers plus min/max intervals from the reported uncertainty.
- Fails closed outside 298.15 K and 1–1000 bara, or for non-finite input.
- At 1→100 bara: hydration `1.0403287704`; dehydration `0.9747647335`.
- Deterministic, dimensionless and side-effect free.

## Scientific evidence and boundary

Primary numerical source: van Eldik & Palmer (1982), *Journal of Solution Chemistry* 11, 339–346:
https://doi.org/10.1007/BF00649292

Corroborating high-pressure study, retained as provenance but not used for numerical parameters: Conway et al. (2016):
https://doi.org/10.1071/CH15271

The implementation supplies pressure multipliers, not absolute high-pressure rates. It deliberately does **not** multiply the Soli–Byrne 0.65 molal NaCl rates by these factors because the evidence bases have different solution compositions. Such a combination is a separate cross-dataset assumption requiring independent validation.

## Coordination and stop boundary

- #3144 retains electrolyte speciation, activity models and charge balance.
- #2937 retains generic flash behavior.
- #2911 retains dynamic integration.
- Pipeline work retains phase selection, residence-time trajectories and conservative source-term coupling.
- #3153 retains JSON/MCP exposure.

This PR does not mutate a thermodynamic system, select a phase, add H2CO3 thermodynamics, calculate pH/speciation, change flashes or dynamics, apply pipeline source terms, or claim Northern Lights facility calibration.

## Validation

Passed on the final local four-file state:

- `./mvnw -q -Dtest=AqueousCO2PressureKineticsTest,AqueousCO2HydrationKineticsTest,KineticReactionTransportDiagnosticsTest,CO2TransportReactionKineticsDocumentationTest test`
- `python3 docs/test_co2_transport_reaction_kinetics_documentation.py` — 8/8
- `python3 devtools/check_documentation_search.py` — 675 Markdown pages and one standalone HTML page
- `python3 devtools/run_spotless.py check`
- `git diff --check`

The `pre-commit` executable was unavailable locally; hosted exact-head CI is authoritative.

**VALIDATION PENDING CI**

## Documentation impact

Updates the existing CO2 transport reaction-kinetics guide and its executable source/provenance contract. No notebook, JSON schema, MCP surface, process model or migration document is changed.

Generated with AI assistance.