### PR TITLE
[AI-Assisted] feat(refinery): add assay nitrogen bookkeeping

### DIFF
--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -50,12 +50,12 @@ For crude/petroleum assays, use `OilAssayCharacterisation` rather than manually 
 - specific-gravity, kg/m3, and API-gravity density inputs;
 - exact API-gravity/SG60/60 round-tripping and explicit bulk density at 60 degF;
 - per-cut UOP/Watson characterization factors from representative boiling point and specific gravity;
-- per-cut total-sulfur inputs and mass-basis whole-assay sulfur reconstruction;
+- per-cut total-sulfur and total-nitrogen inputs with mass-basis whole-assay reconstruction;
 - pre-binned cumulative TBP cut-boundary ingestion;
 - preserved lower/upper boiling ranges;
 - closure, duplicate-name, monotonicity, and repeated-application guards.
 
-See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data bookkeeping evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation), whole-assay density/API evidence in [DOE/OEDI COA bulk density qualification](refinery_oedi_coa_bulk_density_validation), per-cut characterization evidence in [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation), assay-quality evidence in [DOE Big Hill sulfur qualification](refinery_big_hill_sulfur_validation), and the process-integration gate in [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation).
+See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data bookkeeping evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation), whole-assay density/API evidence in [DOE/OEDI COA bulk density qualification](refinery_oedi_coa_bulk_density_validation), per-cut characterization evidence in [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation), assay-quality evidence in [DOE Big Hill sulfur qualification](refinery_big_hill_sulfur_validation) and [DOE Big Hill nitrogen qualification](refinery_big_hill_nitrogen_validation), and the process-integration gate in [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation).
 
 ## TBP fraction models
 
@@ -141,6 +141,7 @@ A bookkeeping regression does not by itself validate a petroleum-property correl
 - [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation)
 - [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation)
 - [DOE Big Hill assay sulfur qualification](refinery_big_hill_sulfur_validation)
+- [DOE Big Hill assay nitrogen qualification](refinery_big_hill_nitrogen_validation)
 - [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation)
 - [DOE/OEDI COA bulk density and API qualification](refinery_oedi_coa_bulk_density_validation)
 - [Fluid Characterization Guide](../../wiki/fluid_characterization)

--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -153,6 +153,12 @@ The public [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_v
 
 The public [DOE Big Hill assay sulfur qualification](refinery_big_hill_sulfur_validation) covers a complete non-overlapping crude slate. With the documented zero-sulfur screening assumption for the 1.70 mass% gas cut that lacks a reported value, the reconstructed 0.40867518 mass% agrees with DOE's 0.409 mass% whole-crude result within 0.00032482 mass%. This is linear assay bookkeeping, not sulfur-species thermodynamics, emissions prediction or hydrotreating chemistry.
 
+## Assay-carried total nitrogen
+
+`AssayCut.withNitrogenMassFraction(...)` and `withNitrogenMassPercent(...)` carry total nitrogen explicitly on a mass basis. `getBulkNitrogenMassFraction()` and `getBulkNitrogenMassPercent()` apply the linear mass-basis rule to the same resolved assay mass fractions used for pseudo-component bookkeeping. Positive-yield cuts without nitrogen data fail closed; zero-yield cuts do not contribute.
+
+The public [DOE Big Hill assay nitrogen qualification](refinery_big_hill_nitrogen_validation) covers the same complete non-overlapping crude slate. DOE omits nitrogen for the four lightest cuts, so the documented screening case assigns zero to those cuts. The reconstructed 0.1095129 mass% agrees with DOE's 0.11 mass% whole-crude result within 0.0004871 mass%. This is linear assay bookkeeping, not nitrogen-species thermodynamics, emissions prediction or hydrotreating chemistry.
+
 ## Existing petroleum-property correlations
 
 This refinery-assay API deliberately reuses the existing NeqSim TBP/pseudo-component property framework. It does not add or retune critical-property, acentric-factor, or molecular-weight coefficients.
@@ -188,9 +194,10 @@ The regression suite for this API currently verifies:
 - whole-assay SG/API agreement across all five complete four-category rows in the public DOE/OEDI COA summary workbook;
 - per-cut UOP/Watson factors against four bounded cuts in the public DOE SPR Big Hill Sweet 2021 assay;
 - whole-assay total-sulfur reconstruction against the public DOE Big Hill Sweet 2021 assay;
+- whole-assay total-nitrogen reconstruction against the public DOE Big Hill Sweet 2021 assay;
 - input-order independence and no thermodynamic-system mutation for bulk-property queries.
 
-These tests establish software/bookkeeping correctness, qualify ideal-additive-volume SG/API screening over the frozen COA matrix (published crude SG 0.765-0.847; maximum observed errors 0.006 SG and 1.5 degrees API), qualify per-cut Watson factors over the frozen DOE matrix (375-1050 degF; maximum observed error 0.0122), and qualify linear assay sulfur bookkeeping over one complete DOE crude slate. They do **not** qualify temperature correction, contraction, molecular-weight or critical-property correlations, sulfur species or reactions, or atmospheric/vacuum fractionation; those remain separate campaign gates in issue #3305.
+These tests establish software/bookkeeping correctness, qualify ideal-additive-volume SG/API screening over the frozen COA matrix (published crude SG 0.765-0.847; maximum observed errors 0.006 SG and 1.5 degrees API), qualify per-cut Watson factors over the frozen DOE matrix (375-1050 degF; maximum observed error 0.0122), and qualify linear assay sulfur and nitrogen bookkeeping over one complete DOE crude slate. They do **not** qualify temperature correction, contraction, molecular-weight or critical-property correlations, sulfur/nitrogen species or reactions, or atmospheric/vacuum fractionation; those remain separate campaign gates in issue #3305.
 
 ## Refinery capability inventory after this increment
 
@@ -201,9 +208,10 @@ These tests establish software/bookkeeping correctness, qualify ideal-additive-v
 | Pre-binned cumulative TBP cut boundaries | `addTBPCutBoundariesCelsius/Kelvin` | Initial implementation in #3305 |
 | Per-cut UOP/Watson characterization factor | `AssayCut.getWatsonCharacterizationFactor()` | DOE-qualified for assay screening over 375-1050 degF |
 | Assay-carried total sulfur | `getBulkSulfurMassFraction/Percent()` | DOE-qualified for linear bookkeeping over one complete crude slate |
+| Assay-carried total nitrogen | `getBulkNitrogenMassFraction/Percent()` | DOE-qualified for linear bookkeeping over one complete crude slate |
 | TBP pseudo-component properties | Pedersen, Lee-Kesler, Riazi-Daubert, Twu, Cavett, Standing and related models | Existing; needs refinery-range independent validation |
 | Plus-fraction splitting/lumping | `Characterise`, plus-fraction and lumping models | Existing; refinery assay integration still to be qualified |
-| Oil density/API and volatility standards | Oil-quality standards package, RVP/TVP workflows | Whole-assay SG/API, per-cut Watson and linear sulfur bookkeeping qualified over frozen public matrices; broader stream properties remain open |
+| Oil density/API and volatility standards | Oil-quality standards package, RVP/TVP workflows | Whole-assay SG/API, per-cut Watson and linear sulfur/nitrogen bookkeeping qualified over frozen public matrices; broader stream properties remain open |
 | Rigorous distillation columns | `DistillationColumn`, `SimpleTray`, Naphtali-Sandholm solver, side-draw support | Existing foundation; broad-boiling atmospheric/vacuum refinery benchmark remains open |
 | Crude preheat/fired heater | General heater/heat-exchanger process equipment | Refinery workflow and fuel/emission integration remain open |
 | Product blending/specification optimization | Generic optimization/process facilities | Refinery property/blending framework remains open |

--- a/docs/thermo/characterization/refinery_big_hill_nitrogen_validation.md
+++ b/docs/thermo/characterization/refinery_big_hill_nitrogen_validation.md
@@ -1,0 +1,61 @@
+---
+title: "DOE Big Hill assay nitrogen qualification"
+description: "Public-data qualification of linear refinery-assay total-nitrogen bookkeeping."
+---
+
+# DOE Big Hill assay nitrogen qualification
+
+This benchmark qualifies assay-carried total-nitrogen inputs and bulk nitrogen reconstruction against the public U.S. Department of Energy Strategic Petroleum Reserve Big Hill Sweet assay.
+
+## Source and provenance
+
+The source is the DOE/SPR **Big Hill Sweet** comprehensive assay workbook:
+
+- workbook: <https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx>
+- DOE assay landing page: <https://www.spr.doe.gov/reports/Crude_Oil_Assays.html>
+- report date recorded in the workbook: **24 September 2021**
+
+DOE/SPR publicly distributes the workbook with an informational-use disclaimer. No separate license statement was found. The regression freezes only attributed mass yields, total-nitrogen values and the reported whole-crude result; it does not redistribute the workbook or reproduce a proprietary standard.
+
+## Calculation
+
+For resolved assay mass fractions $w_i$ and cut total-nitrogen mass fractions $N_i$, NeqSim uses the explicit linear mass-basis rule:
+
+$$N_{bulk}=\sum_i w_iN_i$$
+
+Mass- and liquid-volume-basis assays share the existing authoritative basis resolution. Volume yields are converted with cut specific gravities before nitrogen is aggregated. Every positive-yield cut must carry nitrogen data; otherwise the calculation fails closed.
+
+## Frozen DOE matrix
+
+| Non-overlapping cut | Mass yield, % | Total nitrogen, mass % |
+| --- | ---: | ---: |
+| C2-C4 gas | 1.70 | 0.0 assumed |
+| C5-175 degF | 5.22 | 0.0 assumed |
+| 175-250 degF | 8.32 | 0.0 assumed |
+| 250-375 degF | 12.55 | 0.0 assumed |
+| 375-530 degF | 16.19 | 0.0018 |
+| 530-650 degF | 13.18 | 0.0186 |
+| 650-850 degF | 18.44 | 0.102 |
+| 850-1050 degF | 12.84 | 0.234 |
+| 1050 degF+ | 11.56 | 0.501 |
+
+The source does not report total nitrogen for the gas through 250-375 degF cuts. The benchmark assigns zero to those four light cuts as an explicit screening assumption; those values are not presented as measured DOE data. With that assumption, the reconstructed result is **0.1095129 mass%**, compared with DOE's whole-crude **0.11 mass%**. The absolute difference is **0.0004871 mass%**, below the predeclared **0.001 mass%** source-precision gate.
+
+## Acceptance and maturity
+
+`OilAssayCharacterisationDoeBigHillNitrogenTest` requires:
+
+- exact mass-yield closure and analytical mass-weighted nitrogen arithmetic;
+- agreement with DOE whole-crude nitrogen within 0.001 mass%;
+- fraction and mass-percent inputs to agree to numerical precision;
+- input-order independence;
+- a volume-basis analytical control using density-resolved mass fractions;
+- missing nitrogen for a positive-yield cut to fail closed;
+- valid nitrogen inputs to remain between zero and one; and
+- property queries not to add or modify thermodynamic components.
+
+The capability is **qualified for linear assay nitrogen bookkeeping** over this frozen public matrix. The calculation is O(cuts), non-iterative and does not alter thermodynamic or process calculations.
+
+## Stop boundary
+
+This evidence does not create elemental thermodynamic components, propagate nitrogen into pseudo-components, predict nitrogen species, perform hydrotreating chemistry, estimate emissions, apply nonlinear blending, certify a product specification or qualify a conversion unit. Those require separate #3305 contracts and validation.

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -29,8 +29,8 @@ import neqsim.thermo.system.SystemInterface;
  * </p>
  *
  * <p>
- * Optional total-sulfur and total-nitrogen qualities are stored as mass fractions. Bulk qualities are reconstructed
- * by linear mass-basis mixing rules after the assay basis has been resolved.
+ * Optional total-sulfur and total-nitrogen qualities are stored as mass fractions. Bulk qualities are reconstructed by
+ * linear mass-basis mixing rules after the assay basis has been resolved.
  * </p>
  *
  * <p>

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -29,8 +29,8 @@ import neqsim.thermo.system.SystemInterface;
  * </p>
  *
  * <p>
- * Optional total-sulfur qualities are stored as mass fractions. Bulk sulfur is reconstructed by a linear mass-basis
- * mixing rule after the assay basis has been resolved.
+ * Optional total-sulfur and total-nitrogen qualities are stored as mass fractions. Bulk qualities are reconstructed
+ * by linear mass-basis mixing rules after the assay basis has been resolved.
  * </p>
  *
  * <p>
@@ -294,6 +294,50 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
   }
 
   /**
+   * Reconstruct the bulk assay total-nitrogen mass fraction from assay-cut nitrogen data.
+   *
+   * <p>
+   * The calculation is the linear mass-basis mixing rule {@code sum(w_i N_i)}, where {@code w_i} are the resolved assay
+   * mass fractions and {@code N_i} are cut nitrogen mass fractions. Volume-basis assays therefore use the same
+   * density-based conversion as {@link #getResolvedMassFractions()}. Every positive-yield cut must define nitrogen;
+   * zero-yield cuts do not contribute.
+   * </p>
+   *
+   * @return bulk total-nitrogen mass fraction on a 0-1 basis
+   * @throws IllegalStateException if the assay is empty, incomplete, mixed-basis, or lacks nitrogen data for a
+   * positive-yield cut
+   */
+  public double getBulkNitrogenMassFraction() {
+    if (cuts.isEmpty()) {
+      throw new IllegalStateException("No assay cuts supplied");
+    }
+
+    double[] massFractions = resolveMassFractions();
+    double bulkNitrogenMassFraction = 0.0;
+    for (int i = 0; i < cuts.size(); i++) {
+      if (massFractions[i] > 0.0) {
+        bulkNitrogenMassFraction += massFractions[i] * cuts.get(i).getNitrogenMassFraction();
+      }
+    }
+
+    if (!Double.isFinite(bulkNitrogenMassFraction) || bulkNitrogenMassFraction < 0.0
+        || bulkNitrogenMassFraction > 1.0) {
+      throw new IllegalStateException("Unable to reconstruct bulk nitrogen mass fraction from assay cuts");
+    }
+    return bulkNitrogenMassFraction;
+  }
+
+  /**
+   * Reconstruct the bulk assay total nitrogen in mass percent.
+   *
+   * @return bulk total nitrogen in mass percent
+   * @throws IllegalStateException if bulk nitrogen cannot be reconstructed
+   */
+  public double getBulkNitrogenMassPercent() {
+    return 100.0 * getBulkNitrogenMassFraction();
+  }
+
+  /**
    * Generate TBP pseudo-components for all configured cuts and add them to the attached system.
    *
    * <p>
@@ -515,6 +559,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     private Double upperBoilingPointKelvin;
     private Double molarMass;
     private Double sulfurMassFraction;
+    private Double nitrogenMassFraction;
 
     /**
      * Create an assay cut.
@@ -817,6 +862,28 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     }
 
     /**
+     * Set total nitrogen as a mass fraction on a 0-1 basis.
+     *
+     * @param nitrogenMassFraction total-nitrogen mass fraction from 0 to 1
+     * @return this cut
+     */
+    public AssayCut withNitrogenMassFraction(double nitrogenMassFraction) {
+      this.nitrogenMassFraction = sanitiseFraction(nitrogenMassFraction);
+      return this;
+    }
+
+    /**
+     * Set total nitrogen in mass percent.
+     *
+     * @param nitrogenMassPercent total nitrogen in mass percent from 0 to 100
+     * @return this cut
+     */
+    public AssayCut withNitrogenMassPercent(double nitrogenMassPercent) {
+      this.nitrogenMassFraction = sanitisePercent(nitrogenMassPercent);
+      return this;
+    }
+
+    /**
      * Return whether this cut uses a mass fraction.
      *
      * @return true when a mass fraction is set
@@ -887,6 +954,28 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
         throw new IllegalStateException("Sulfur mass fraction not set for cut " + name);
       }
       return sulfurMassFraction;
+    }
+
+    /**
+     * Return whether total-nitrogen data are available for this cut.
+     *
+     * @return true when a nitrogen mass fraction is stored
+     */
+    public boolean hasNitrogenMassFraction() {
+      return nitrogenMassFraction != null;
+    }
+
+    /**
+     * Return the cut total-nitrogen mass fraction.
+     *
+     * @return total-nitrogen mass fraction on a 0-1 basis
+     * @throws IllegalStateException if nitrogen data are not available
+     */
+    public double getNitrogenMassFraction() {
+      if (nitrogenMassFraction == null) {
+        throw new IllegalStateException("Nitrogen mass fraction not set for cut " + name);
+      }
+      return nitrogenMassFraction;
     }
 
     /**

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillNitrogenTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillNitrogenTest.java
@@ -14,8 +14,8 @@ import neqsim.thermo.system.SystemSrkEos;
 
 /** Public DOE refinery-assay qualification of linear total-nitrogen bookkeeping. */
 public class OilAssayCharacterisationDoeBigHillNitrogenTest {
-  private static final double[] MASS_YIELD_PERCENT = {1.70, 5.22, 8.32, 12.55, 16.19, 13.18, 18.44, 12.84, 11.56};
-  private static final double[] NITROGEN_MASS_PERCENT = {0.0, 0.0, 0.0, 0.0, 0.0018, 0.0186, 0.102, 0.234, 0.501};
+  private static final double[] MASS_YIELD_PERCENT = { 1.70, 5.22, 8.32, 12.55, 16.19, 13.18, 18.44, 12.84, 11.56 };
+  private static final double[] NITROGEN_MASS_PERCENT = { 0.0, 0.0, 0.0, 0.0, 0.0018, 0.0186, 0.102, 0.234, 0.501 };
   private static final double DOE_WHOLE_CRUDE_NITROGEN_MASS_PERCENT = 0.11;
 
   @Test
@@ -31,8 +31,8 @@ public class OilAssayCharacterisationDoeBigHillNitrogenTest {
     assertEquals(1.0, resolvedMassClosure, 1.0e-15);
     assertEquals(0.1095129, assay.getBulkNitrogenMassPercent(), 1.0e-12);
     assertEquals(DOE_WHOLE_CRUDE_NITROGEN_MASS_PERCENT, assay.getBulkNitrogenMassPercent(), 0.001);
-    assertEquals(0.0004871,
-        Math.abs(assay.getBulkNitrogenMassPercent() - DOE_WHOLE_CRUDE_NITROGEN_MASS_PERCENT), 1.0e-12);
+    assertEquals(0.0004871, Math.abs(assay.getBulkNitrogenMassPercent() - DOE_WHOLE_CRUDE_NITROGEN_MASS_PERCENT),
+        1.0e-12);
     assertEquals(0.001095129, assay.getBulkNitrogenMassFraction(), 1.0e-12);
     assertEquals(0, system.getNumberOfComponents(), "Property queries must not mutate the thermodynamic system");
   }
@@ -58,10 +58,8 @@ public class OilAssayCharacterisationDoeBigHillNitrogenTest {
   @Test
   public void volumeBasisUsesResolvedMassFractions() {
     OilAssayCharacterisation assay = new SystemSrkEos(298.15, 1.01325).getOilAssayCharacterisation();
-    assay.addCut(new AssayCut("Light").withVolumeFraction(0.25).withSpecificGravity(0.80)
-        .withNitrogenMassPercent(0.1));
-    assay.addCut(new AssayCut("Heavy").withVolumeFraction(0.75).withSpecificGravity(0.90)
-        .withNitrogenMassPercent(0.5));
+    assay.addCut(new AssayCut("Light").withVolumeFraction(0.25).withSpecificGravity(0.80).withNitrogenMassPercent(0.1));
+    assay.addCut(new AssayCut("Heavy").withVolumeFraction(0.75).withSpecificGravity(0.90).withNitrogenMassPercent(0.5));
 
     double expected = (0.25 * 0.80 * 0.001 + 0.75 * 0.90 * 0.005) / (0.25 * 0.80 + 0.75 * 0.90);
     assertEquals(expected, assay.getBulkNitrogenMassFraction(), 1.0e-15);
@@ -82,12 +80,10 @@ public class OilAssayCharacterisationDoeBigHillNitrogenTest {
 
   @Test
   public void nitrogenInputsRejectValuesOutsidePhysicalBounds() {
-    assertThrows(IllegalArgumentException.class,
-        () -> new AssayCut("Negative").withNitrogenMassFraction(-1.0e-9));
+    assertThrows(IllegalArgumentException.class, () -> new AssayCut("Negative").withNitrogenMassFraction(-1.0e-9));
     assertThrows(IllegalArgumentException.class,
         () -> new AssayCut("AboveFraction").withNitrogenMassFraction(1.0000001));
-    assertThrows(IllegalArgumentException.class,
-        () -> new AssayCut("AbovePercent").withNitrogenMassPercent(100.00001));
+    assertThrows(IllegalArgumentException.class, () -> new AssayCut("AbovePercent").withNitrogenMassPercent(100.00001));
     assertFalse(new AssayCut("Unset").hasNitrogenMassFraction());
   }
 

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillNitrogenTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillNitrogenTest.java
@@ -1,0 +1,119 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Public DOE refinery-assay qualification of linear total-nitrogen bookkeeping. */
+public class OilAssayCharacterisationDoeBigHillNitrogenTest {
+  private static final double[] MASS_YIELD_PERCENT = {1.70, 5.22, 8.32, 12.55, 16.19, 13.18, 18.44, 12.84, 11.56};
+  private static final double[] NITROGEN_MASS_PERCENT = {0.0, 0.0, 0.0, 0.0, 0.0018, 0.0186, 0.102, 0.234, 0.501};
+  private static final double DOE_WHOLE_CRUDE_NITROGEN_MASS_PERCENT = 0.11;
+
+  @Test
+  public void doeNonOverlappingSlateReproducesWholeCrudeNitrogen() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
+    addDoeCuts(assay, false);
+
+    double resolvedMassClosure = 0.0;
+    for (double massFraction : assay.getResolvedMassFractions()) {
+      resolvedMassClosure += massFraction;
+    }
+    assertEquals(1.0, resolvedMassClosure, 1.0e-15);
+    assertEquals(0.1095129, assay.getBulkNitrogenMassPercent(), 1.0e-12);
+    assertEquals(DOE_WHOLE_CRUDE_NITROGEN_MASS_PERCENT, assay.getBulkNitrogenMassPercent(), 0.001);
+    assertEquals(0.0004871,
+        Math.abs(assay.getBulkNitrogenMassPercent() - DOE_WHOLE_CRUDE_NITROGEN_MASS_PERCENT), 1.0e-12);
+    assertEquals(0.001095129, assay.getBulkNitrogenMassFraction(), 1.0e-12);
+    assertEquals(0, system.getNumberOfComponents(), "Property queries must not mutate the thermodynamic system");
+  }
+
+  @Test
+  public void inputOrderAndFractionPercentViewsRemainEquivalent() {
+    OilAssayCharacterisation forward = new SystemSrkEos(298.15, 1.01325).getOilAssayCharacterisation();
+    addDoeCuts(forward, false);
+
+    OilAssayCharacterisation reverse = new SystemSrkEos(298.15, 1.01325).getOilAssayCharacterisation();
+    addDoeCuts(reverse, true);
+
+    OilAssayCharacterisation fractionView = new SystemSrkEos(298.15, 1.01325).getOilAssayCharacterisation();
+    for (int i = 0; i < MASS_YIELD_PERCENT.length; i++) {
+      fractionView.addCut(new AssayCut("Fraction" + i).withMassFraction(MASS_YIELD_PERCENT[i] / 100.0)
+          .withNitrogenMassFraction(NITROGEN_MASS_PERCENT[i] / 100.0));
+    }
+
+    assertEquals(forward.getBulkNitrogenMassFraction(), reverse.getBulkNitrogenMassFraction(), 1.0e-15);
+    assertEquals(forward.getBulkNitrogenMassFraction(), fractionView.getBulkNitrogenMassFraction(), 1.0e-15);
+  }
+
+  @Test
+  public void volumeBasisUsesResolvedMassFractions() {
+    OilAssayCharacterisation assay = new SystemSrkEos(298.15, 1.01325).getOilAssayCharacterisation();
+    assay.addCut(new AssayCut("Light").withVolumeFraction(0.25).withSpecificGravity(0.80)
+        .withNitrogenMassPercent(0.1));
+    assay.addCut(new AssayCut("Heavy").withVolumeFraction(0.75).withSpecificGravity(0.90)
+        .withNitrogenMassPercent(0.5));
+
+    double expected = (0.25 * 0.80 * 0.001 + 0.75 * 0.90 * 0.005) / (0.25 * 0.80 + 0.75 * 0.90);
+    assertEquals(expected, assay.getBulkNitrogenMassFraction(), 1.0e-15);
+  }
+
+  @Test
+  public void missingPositiveCutNitrogenFailsClosed() {
+    OilAssayCharacterisation incomplete = new SystemSrkEos(298.15, 1.01325).getOilAssayCharacterisation();
+    incomplete.addCut(new AssayCut("Known").withMassFraction(0.75).withNitrogenMassPercent(0.2));
+    incomplete.addCut(new AssayCut("Missing").withMassFraction(0.25));
+    assertThrows(IllegalStateException.class, incomplete::getBulkNitrogenMassFraction);
+
+    OilAssayCharacterisation zeroYield = new SystemSrkEos(298.15, 1.01325).getOilAssayCharacterisation();
+    zeroYield.addCut(new AssayCut("Known").withMassFraction(1.0).withNitrogenMassPercent(0.2));
+    zeroYield.addCut(new AssayCut("ZeroYield").withMassFraction(0.0));
+    assertEquals(0.002, zeroYield.getBulkNitrogenMassFraction(), 1.0e-15);
+  }
+
+  @Test
+  public void nitrogenInputsRejectValuesOutsidePhysicalBounds() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new AssayCut("Negative").withNitrogenMassFraction(-1.0e-9));
+    assertThrows(IllegalArgumentException.class,
+        () -> new AssayCut("AboveFraction").withNitrogenMassFraction(1.0000001));
+    assertThrows(IllegalArgumentException.class,
+        () -> new AssayCut("AbovePercent").withNitrogenMassPercent(100.00001));
+    assertFalse(new AssayCut("Unset").hasNitrogenMassFraction());
+  }
+
+  @Test
+  public void nitrogenMetadataSurvivesSystemClone() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
+    assay.addCut(new AssayCut("NitrogenCut").withMassFraction(1.0).withNitrogenMassPercent(0.11));
+
+    SystemInterface clonedSystem = system.clone();
+    OilAssayCharacterisation clonedAssay = clonedSystem.getOilAssayCharacterisation();
+
+    assertEquals(0.11, clonedAssay.getBulkNitrogenMassPercent(), 1.0e-15);
+    assertEquals(0.0011, clonedAssay.getCuts().get(0).getNitrogenMassFraction(), 1.0e-15);
+  }
+
+  private static void addDoeCuts(OilAssayCharacterisation assay, boolean reverse) {
+    assay.clearCuts();
+    List<AssayCut> cuts = new ArrayList<AssayCut>();
+    for (int i = 0; i < MASS_YIELD_PERCENT.length; i++) {
+      cuts.add(new AssayCut("DOE_BH_2021_" + i).withWeightPercent(MASS_YIELD_PERCENT[i])
+          .withNitrogenMassPercent(NITROGEN_MASS_PERCENT[i]));
+    }
+    if (reverse) {
+      Collections.reverse(cuts);
+    }
+    assay.addCuts(cuts);
+  }
+}


### PR DESCRIPTION
## Engineering question

Can NeqSim carry total nitrogen as an assay-cut quality and reconstruct whole-assay nitrogen on the authoritative resolved mass basis, while reproducing the public DOE SPR Big Hill Sweet whole-crude result?

Advances #3305. Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5477505915

## Exact continuity and frozen scope

- **Exact base:** `c411b2e39bb9ad9c26b67b07b7bd46cfab182ae3`
- **Exact head:** `68272f0d440903f3676933e34dda398196e9d211`
- **Branch:** `ai/refinery-assay-nitrogen-3305`
- The preceding sulfur capability #3368 is merged; no active refinery implementation PR existed immediately before publication.
- Four positively identified autonomous implementation capabilities were open immediately before publication; this draft makes five, below the target and hard ceiling of ten.
- Scope stops at optional assay metadata and read-only linear aggregation. No pseudo-component, thermodynamic, flash, column, reaction or process behavior changes.

## Implementation

- Adds `AssayCut.withNitrogenMassFraction(...)` and `withNitrogenMassPercent(...)`.
- Adds `hasNitrogenMassFraction()` and `getNitrogenMassFraction()`.
- Adds `OilAssayCharacterisation.getBulkNitrogenMassFraction()` and `getBulkNitrogenMassPercent()`.
- Uses `N_bulk = sum(w_i N_i)` with the existing authoritative mass/volume assay-basis resolution.
- Positive-yield cuts without nitrogen fail closed; zero-yield cuts do not contribute.
- Java is authoritative and Python/JPype exposes the same public methods. JSON/MCP/notebook views are not applicable because no refinery-assay schema owns `AssayCut` and this is a bounded scalar-property qualification.
- Clone retention, input bounds, order independence and no system mutation are regression protected.

## Public evidence

Source: U.S. DOE/SPR Big Hill Sweet comprehensive assay workbook, reported 24 September 2021:
https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx

The regression freezes the complete non-overlapping mass-yield slate. DOE reports nitrogen for the 375–530, 530–650, 650–850, 850–1050 and 1050 °F+ cuts but omits values for the four lighter cuts. The benchmark explicitly assigns zero to those light cuts as a screening assumption; those values are not represented as measured DOE data.

- Reconstructed whole-assay nitrogen: `0.1095129 mass%`
- DOE whole-crude nitrogen: `0.11 mass%`
- Absolute difference: `0.0004871 mass%`
- Predeclared acceptance: `<= 0.001 mass%`

No coefficient or source datum is tuned. DOE publicly distributes the workbook with an informational-use disclaimer; no separate license statement was found, so only attributed numerical facts are frozen.

## Validation

The DOE workbook was inspected directly and the frozen arithmetic independently recalculated. The original one-commit/five-file remote diff was checked against the merged sulfur pattern.

On original head `0c8682c5a8c6341d0023b5b5477e435e19c6b569`, the complete build/test/Javadocs matrix, documentation search, CodeQL, PaperLab and hosted Spotless artifact generation passed. Pre-commit failed only because the Java files differed from the hosted Spotless result. The exact hosted formatter patch was applied without changing calculations, data, tolerances, APIs or documentation, producing current head `68272f0d440903f3676933e34dda398196e9d211`.

A local NeqSim checkout is unavailable after workspace maintenance. Fresh exact-head hosted CI is authoritative.

**VALIDATION PENDING CI**

## Documentation impact

Updated the characterization index, refinery-assay guide, capability inventory and a dedicated DOE nitrogen qualification page. No notebook, schema, process, release or migration document is affected.

## Stop boundary

This does not create elemental thermodynamic components, propagate nitrogen into pseudo-components, predict nitrogen species, perform hydrotreating chemistry, estimate emissions, apply nonlinear blending, certify product specifications, alter terminal-cut treatment, change columns or implement a conversion unit.

Generated with AI assistance.