### PR TITLE
docs: remove duplicate PVT and standards titles

### DIFF
--- a/docs/pvtsimulation/CO2ElectrolyzerExample.md
+++ b/docs/pvtsimulation/CO2ElectrolyzerExample.md
@@ -3,8 +3,6 @@ title: CO₂ Electrolyzer usage example
 description: The snippet below illustrates how to couple the new `CO2Electrolyzer` with a CO₂-rich feed, a
 ---
 
-# CO₂ Electrolyzer usage example
-
 The snippet below illustrates how to couple the new `CO2Electrolyzer` with a CO₂-rich feed, a
 power supply, and a downstream separator in a `ProcessSystem`.
 

--- a/docs/pvtsimulation/SolutionGasWaterRatio.md
+++ b/docs/pvtsimulation/SolutionGasWaterRatio.md
@@ -3,8 +3,6 @@ title: Solution Gas-Water Ratio (Rsw) Calculation
 description: The **Solution Gas-Water Ratio (Rsw)** represents the volume of gas dissolved in water at reservoir conditions, expressed as standard cubic meters of gas per standard cubic meter of water (Sm³/Sm³)....
 ---
 
-# Solution Gas-Water Ratio (Rsw) Calculation
-
 ## Overview
 
 The **Solution Gas-Water Ratio (Rsw)** represents the volume of gas dissolved in water at reservoir conditions, expressed as standard cubic meters of gas per standard cubic meter of water (Sm³/Sm³). This property is essential for:

--- a/docs/pvtsimulation/blackoil_pvt_export.md
+++ b/docs/pvtsimulation/blackoil_pvt_export.md
@@ -3,8 +3,6 @@ title: Black Oil PVT and Reservoir Simulator Export
 description: This document describes NeqSim's black oil implementation and the ability to export PVT data to reservoir simulators like Eclipse and CMG.
 ---
 
-# Black Oil PVT and Reservoir Simulator Export
-
 This document describes NeqSim's black oil implementation and the ability to export PVT data to reservoir simulators like Eclipse and CMG.
 
 ## Overview

--- a/docs/pvtsimulation/flow_assurance_overview.md
+++ b/docs/pvtsimulation/flow_assurance_overview.md
@@ -3,8 +3,6 @@ title: Flow Assurance Overview
 description: Evidence-based NeqSim workflow for hydrate, asphaltene, scale, wax, corrosion, and pipeline screening, with explicit engineering boundaries.
 ---
 
-# Flow Assurance Overview
-
 Flow assurance combines fluid characterization, thermodynamics, transport models,
 operating scenarios, and laboratory or field evidence. NeqSim can calculate several
 inputs to that assessment, but no single result establishes that a line is safe,

--- a/docs/pvtsimulation/flowassurance/asphaltene_cpa_calculations.md
+++ b/docs/pvtsimulation/flowassurance/asphaltene_cpa_calculations.md
@@ -3,8 +3,6 @@ title: CPA-Based Asphaltene Calculations
 description: The **Cubic Plus Association (CPA)** equation of state extends classical cubic equations (SRK or PR) with an association term to handle self-associating and cross-associating compounds. This makes CPA...
 ---
 
-# CPA-Based Asphaltene Calculations
-
 ## Overview
 
 The **Cubic Plus Association (CPA)** equation of state extends classical cubic equations (SRK or PR) with an association term to handle self-associating and cross-associating compounds. This makes CPA particularly suitable for asphaltene modeling, where polar interactions and molecular aggregation are important.

--- a/docs/pvtsimulation/flowassurance/asphaltene_deboer_screening.md
+++ b/docs/pvtsimulation/flowassurance/asphaltene_deboer_screening.md
@@ -3,8 +3,6 @@ title: De Boer Asphaltene Screening
 description: The **De Boer correlation** is an empirical screening method developed from field observations of asphaltene problems in producing oil fields. It provides a quick, conservative assessment of asphalten...
 ---
 
-# De Boer Asphaltene Screening
-
 ## Overview
 
 The **De Boer correlation** is an empirical screening method developed from field observations of asphaltene problems in producing oil fields. It provides a quick, conservative assessment of asphaltene precipitation risk without requiring detailed thermodynamic modeling.

--- a/docs/pvtsimulation/flowassurance/asphaltene_method_comparison.md
+++ b/docs/pvtsimulation/flowassurance/asphaltene_method_comparison.md
@@ -3,8 +3,6 @@ title: Asphaltene Method Comparison
 description: "NeqSim provides six complementary approaches for asphaltene stability analysis: De Boer screening, SARA CII, CPA EOS, Flory-Huggins, Pedersen cubic EOS, and Refractive Index."
 ---
 
-# Asphaltene Method Comparison
-
 ## Overview
 
 NeqSim provides six complementary approaches for asphaltene stability analysis:

--- a/docs/pvtsimulation/flowassurance/asphaltene_modeling.md
+++ b/docs/pvtsimulation/flowassurance/asphaltene_modeling.md
@@ -3,8 +3,6 @@ title: Asphaltene Modeling in NeqSim
 description: Asphaltenes are the heaviest and most polar fraction of crude oil, defined operationally as the fraction soluble in aromatic solvents (toluene) but insoluble in paraffinic solvents (n-heptane or n-pen...
 ---
 
-# Asphaltene Modeling in NeqSim
-
 ## Introduction
 
 Asphaltenes are the heaviest and most polar fraction of crude oil, defined operationally as the fraction soluble in aromatic solvents (toluene) but insoluble in paraffinic solvents (n-heptane or n-pentane). Asphaltene precipitation during production can cause:

--- a/docs/pvtsimulation/flowassurance/asphaltene_parameter_fitting.md
+++ b/docs/pvtsimulation/flowassurance/asphaltene_parameter_fitting.md
@@ -3,8 +3,6 @@ title: Asphaltene Parameter Fitting
 description: The `AsphalteneOnsetFitting` class provides automated CPA parameter tuning using the Levenberg-Marquardt optimization algorithm. This enables matching CPA model predictions to experimental asphaltene ...
 ---
 
-# Asphaltene Parameter Fitting
-
 ## Overview
 
 The `AsphalteneOnsetFitting` class provides automated CPA parameter tuning using the Levenberg-Marquardt optimization algorithm. This enables matching CPA model predictions to experimental asphaltene onset pressure (AOP) measurements.

--- a/docs/pvtsimulation/flowassurance/asphaltene_validation.md
+++ b/docs/pvtsimulation/flowassurance/asphaltene_validation.md
@@ -3,8 +3,6 @@ title: Asphaltene Model Validation
 description: This document summarizes the validation of NeqSim's asphaltene models against published literature and field data. The validation demonstrates that the implemented models correctly capture the physics...
 ---
 
-# Asphaltene Model Validation
-
 ## Overview
 
 This document summarizes the validation of NeqSim's asphaltene models against published literature and field data. The validation demonstrates that the implemented models correctly capture the physics of asphaltene precipitation and provide reliable predictions for field screening applications.

--- a/docs/pvtsimulation/flowassurance/emulsion_viscosity_calculator.md
+++ b/docs/pvtsimulation/flowassurance/emulsion_viscosity_calculator.md
@@ -3,8 +3,6 @@ title: "Emulsion Viscosity Calculator"
 description: "Oil-water emulsion viscosity prediction with Einstein, Taylor, Brinkman, Pal-Rhodes, Woelflin, and Richardson models plus phase inversion detection."
 ---
 
-# Emulsion Viscosity Calculator
-
 The `EmulsionViscosityCalculator` predicts the effective viscosity of oil-water emulsions using six established correlations and includes automatic phase inversion detection.
 
 **Class:** `neqsim.pvtsimulation.flowassurance.EmulsionViscosityCalculator`

--- a/docs/pvtsimulation/flowassurance/erosion_prediction.md
+++ b/docs/pvtsimulation/flowassurance/erosion_prediction.md
@@ -3,8 +3,6 @@ title: "Erosion Prediction Calculator"
 description: "Sand erosion prediction using API RP 14E erosional velocity and DNV RP O501 particle erosion models for pipelines, elbows, tees, chokes, and other geometries."
 ---
 
-# Erosion Prediction Calculator
-
 The `ErosionPredictionCalculator` provides sand erosion assessment for production piping and process equipment using two industry-standard methods.
 
 **Class:** `neqsim.pvtsimulation.flowassurance.ErosionPredictionCalculator`

--- a/docs/pvtsimulation/fluid_characterization_mathematics.md
+++ b/docs/pvtsimulation/fluid_characterization_mathematics.md
@@ -3,8 +3,6 @@ title: "Fluid Characterization in NeqSim: Mathematical Foundations"
 description: "This document provides detailed mathematical documentation of the fluid characterization methods implemented in NeqSim, with emphasis on plus fraction (C7+) modeling, TBP fraction property correlations."
 ---
 
-# Fluid Characterization in NeqSim: Mathematical Foundations
-
 This document provides detailed mathematical documentation of the fluid characterization methods implemented in NeqSim, with emphasis on plus fraction (C7+) modeling, TBP fraction property correlations, and pseudo-component generation.
 
 ## Table of Contents

--- a/docs/pvtsimulation/gas_pseudopressure_pseudocritical.md
+++ b/docs/pvtsimulation/gas_pseudopressure_pseudocritical.md
@@ -3,8 +3,6 @@ title: "Gas Pseudopressure and Pseudocritical Properties"
 description: "Guide to calculating gas pseudopressure (real gas potential) and pseudocritical properties for natural gas mixtures in NeqSim."
 ---
 
-# Gas Pseudopressure and Pseudocritical Properties
-
 NeqSim provides utilities for gas reservoir engineering calculations: the real gas pseudopressure integral and pseudocritical property correlations for natural gas mixtures.
 
 ## Gas Pseudopressure

--- a/docs/pvtsimulation/mineral_scale_chemical_treatment_validation.md
+++ b/docs/pvtsimulation/mineral_scale_chemical_treatment_validation.md
@@ -3,8 +3,6 @@ title: "High-Salinity Mineral Scale and Production-Chemical Validation"
 description: "Pitzer activity validation, coupled mineral precipitation, pH-stabiliser and H2S-scavenger scenarios, and root-cause-analysis guidance."
 ---
 
-# High-Salinity Mineral Scale and Production-Chemical Validation
-
 This workflow combines five distinct engineering questions. Keeping the layers separate is essential: a scale inhibitor
 changes nucleation and growth, while pH adjustment changes carbonate thermodynamics, and an H2S scavenger consumes a
 reactive contaminant and may create a non-mineral spent product.

--- a/docs/pvtsimulation/mineral_scale_formation.md
+++ b/docs/pvtsimulation/mineral_scale_formation.md
@@ -3,8 +3,6 @@ title: Mineral Scale Formation in Oil and Gas Production
 description: Comprehensive guide to mineral scale prediction and management in oil and gas production using NeqSim. Covers carbonate and sulfate scales, saturation index calculations, seawater mixing, temperature effects, and scale inhibitor strategies.
 ---
 
-# Mineral Scale Formation in Oil and Gas Production
-
 This guide covers mineral scale prediction and control using NeqSim's **Electrolyte CPA equation of state**. Scale formation is a critical flow assurance challenge that can cause blockages, reduced production, and equipment damage.
 
 ## Overview

--- a/docs/pvtsimulation/ph_stabilization_corrosion.md
+++ b/docs/pvtsimulation/ph_stabilization_corrosion.md
@@ -3,8 +3,6 @@ title: pH Stabilization and Corrosion Control
 description: Guide to pH stabilization for corrosion control in oil and gas pipelines using NeqSim's Electrolyte CPA equation of state. Covers FeCO3 protective layer formation, hydrate inhibition with pH control, and scale/corrosion thermodynamics.
 ---
 
-# pH Stabilization and Corrosion Control
-
 This guide covers the use of NeqSim's **Electrolyte CPA equation of state** (Statoil model) for modeling pH stabilization, CO2 corrosion control, and protective FeCO3 (siderite) layer formation in oil and gas production systems.
 
 ## Overview

--- a/docs/pvtsimulation/phase_envelope_guide.md
+++ b/docs/pvtsimulation/phase_envelope_guide.md
@@ -3,8 +3,6 @@ title: Phase Envelope and Critical Points Guide
 description: Guide to calculating phase envelopes in NeqSim including bubble point, dew point curves, cricondenbar, cricondentherm, and quality lines for natural gas and oil systems.
 ---
 
-# Phase Envelope and Critical Points Guide
-
 The phase envelope defines the boundary between single-phase and two-phase regions. This guide explains how to calculate phase envelopes and extract key points like cricondenbar and cricondentherm using NeqSim.
 
 ## Key Concepts

--- a/docs/pvtsimulation/pvt_workflow.md
+++ b/docs/pvtsimulation/pvt_workflow.md
@@ -3,8 +3,6 @@ title: "PVT Workflow: From Lab Data to Tuned Fluid Model"
 description: This document describes the complete workflow for generating and tuning fluid models from laboratory PVT data in NeqSim.
 ---
 
-# PVT Workflow: From Lab Data to Tuned Fluid Model
-
 This document describes the complete workflow for generating and tuning fluid models from laboratory PVT data in NeqSim.
 
 ## Typical Laboratory PVT Report Data

--- a/docs/pvtsimulation/relative_permeability.md
+++ b/docs/pvtsimulation/relative_permeability.md
@@ -3,8 +3,6 @@ title: "Relative Permeability Table Generation"
 description: "Guide to generating Corey and LET relative permeability curves and Eclipse-format tables using NeqSim's RelativePermeabilityGenerator."
 ---
 
-# Relative Permeability Table Generation
-
 NeqSim provides a dedicated module for generating relative permeability tables using industry-standard Corey and LET models. The generated tables can be exported in Eclipse-compatible keyword format (SWOF, SGOF, SOF3, SLGOF).
 
 ## Overview

--- a/docs/pvtsimulation/reservoir_material_balance.md
+++ b/docs/pvtsimulation/reservoir_material_balance.md
@@ -4,8 +4,6 @@ description: "Inverse reservoir-surveillance tools in NeqSim: gas and oil materi
 keywords: "material balance, P/Z, OGIP, OOIP, Havlena-Odeh, Cole plot, drive indices, aquifer, Van Everdingen-Hurst, Carter-Tracy, AQUTAB, decline curve, Arps, Duong, EUR, reserves, reservoir surveillance"
 ---
 
-# Reservoir Material Balance, Decline Analysis & Aquifer Influx
-
 This package provides **inverse** reservoir-surveillance tools that regress
 reserves and drive mechanism from a measured pressure-versus-production history.
 They complement the **forward** tank model

--- a/docs/pvtsimulation/scale_prediction_api.md
+++ b/docs/pvtsimulation/scale_prediction_api.md
@@ -3,8 +3,6 @@ title: "Scale Prediction API Reference"
 description: "Complete API reference for NeqSim mineral scale prediction classes. Covers ScalePredictionCalculator (empirical), CheckScalePotential (EOS-based), solid solution models, water compatibility, flowline profiles, and mass calculators."
 ---
 
-# Scale Prediction API Reference
-
 NeqSim provides three complementary approaches for mineral scale prediction:
 
 1. **Rigorous EOS-based** (`CheckScalePotential`) — Uses Electrolyte CPA or Pitzer activity coefficients from a full thermodynamic flash. Best accuracy, requires complete fluid definition.

--- a/docs/pvtsimulation/whitson_pvt_reader.md
+++ b/docs/pvtsimulation/whitson_pvt_reader.md
@@ -3,8 +3,6 @@ title: Whitson PVT Parameter File Reader
 description: The `WhitsonPVTReader` class enables NeqSim to read PVT parameter files exported from Whitson+ and similar PVT software, creating fully configured fluid systems with accurate thermodynamic properties....
 ---
 
-# Whitson PVT Parameter File Reader
-
 The `WhitsonPVTReader` class enables NeqSim to read PVT parameter files exported from Whitson+ and similar PVT software, creating fully configured fluid systems with accurate thermodynamic properties.
 
 ## Overview

--- a/docs/standards/iec81346-reference-designations.md
+++ b/docs/standards/iec81346-reference-designations.md
@@ -3,8 +3,6 @@ title: "IEC 81346 Reference Designation Support"
 description: "Guide to using IEC 81346 reference designations in NeqSim for structured equipment identification in process plants. Covers letter codes, automatic generation, DEXPI export, and automation API integration."
 ---
 
-# IEC 81346 Reference Designation Support
-
 NeqSim provides built-in support for **IEC 81346** — the international standard
 for structuring and identifying objects in industrial plants. This integration
 enables consistent, standards-compliant equipment tagging across process

--- a/docs/standards/iso6578_lng_density.md
+++ b/docs/standards/iso6578_lng_density.md
@@ -3,8 +3,6 @@ title: "ISO 6578 - LNG Density Calculation"
 description: "ISO 6578 provides methods for calculating the density of liquefied natural gas (LNG) from composition and temperature."
 ---
 
-# ISO 6578 - LNG Density Calculation
-
 ISO 6578 provides methods for calculating the density of liquefied natural gas (LNG) from composition and temperature.
 
 ## Table of Contents

--- a/docs/test_flow_assurance_overview_documentation.py
+++ b/docs/test_flow_assurance_overview_documentation.py
@@ -55,7 +55,7 @@ class FlowAssuranceOverviewDocumentationContractTest(unittest.TestCase):
 
     def test_structure_math_and_internal_links_are_renderable(self):
         self.assertTrue(self.guide.startswith("---\n"))
-        self.assertEqual(self.guide.count("# Flow Assurance Overview"), 1)
+        self.assertEqual(self.guide.count("# Flow Assurance Overview"), 0)
         self.assertEqual(self.guide.count("```") % 2, 0)
         without_fences = re.sub(
             r"```.*?```",

--- a/docs/test_pvt_flow_assurance_standards_documentation.py
+++ b/docs/test_pvt_flow_assurance_standards_documentation.py
@@ -1,0 +1,182 @@
+"""Contracts for PVT, flow-assurance, and standards documentation."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+DOCS = Path(__file__).resolve().parent
+SCOPE_PAGES = (
+    DOCS / "pvtsimulation/CO2ElectrolyzerExample.md",
+    DOCS / "pvtsimulation/README.md",
+    DOCS / "pvtsimulation/SolutionGasWaterRatio.md",
+    DOCS / "pvtsimulation/blackoil_pvt_export.md",
+    DOCS / "pvtsimulation/eclipse_e300_fluid_import.md",
+    DOCS / "pvtsimulation/flow_assurance_overview.md",
+    DOCS / "pvtsimulation/flowassurance/README.md",
+    DOCS / "pvtsimulation/flowassurance/asphaltene_cpa_calculations.md",
+    DOCS / "pvtsimulation/flowassurance/asphaltene_deboer_screening.md",
+    DOCS / "pvtsimulation/flowassurance/asphaltene_method_comparison.md",
+    DOCS / "pvtsimulation/flowassurance/asphaltene_modeling.md",
+    DOCS / "pvtsimulation/flowassurance/asphaltene_parameter_fitting.md",
+    DOCS / "pvtsimulation/flowassurance/asphaltene_validation.md",
+    DOCS / "pvtsimulation/flowassurance/emulsion_viscosity_calculator.md",
+    DOCS / "pvtsimulation/flowassurance/erosion_prediction.md",
+    DOCS / "pvtsimulation/flowassurance/flow_assurance_screening_tools.md",
+    DOCS / "pvtsimulation/fluid_characterization_mathematics.md",
+    DOCS / "pvtsimulation/gas_pseudopressure_pseudocritical.md",
+    DOCS / "pvtsimulation/json_fluid_format.md",
+    DOCS / "pvtsimulation/mineral_scale_chemical_treatment_validation.md",
+    DOCS / "pvtsimulation/mineral_scale_formation.md",
+    DOCS / "pvtsimulation/ph_stabilization_corrosion.md",
+    DOCS / "pvtsimulation/phase_envelope_guide.md",
+    DOCS / "pvtsimulation/pvt_lab_tests.md",
+    DOCS / "pvtsimulation/pvt_workflow.md",
+    DOCS / "pvtsimulation/relative_permeability.md",
+    DOCS / "pvtsimulation/reservoir_material_balance.md",
+    DOCS / "pvtsimulation/scale_prediction_api.md",
+    DOCS / "pvtsimulation/whitson_pvt_reader.md",
+    DOCS / "standards/README.md",
+    DOCS / "standards/astm_d6377_rvp.md",
+    DOCS / "standards/dew_point_standards.md",
+    DOCS / "standards/iec81346-reference-designations.md",
+    DOCS / "standards/iso15403_cng_quality.md",
+    DOCS / "standards/iso6578_lng_density.md",
+    DOCS / "standards/iso6976_calorific_values.md",
+    DOCS / "standards/oil_quality_standards.md",
+    DOCS / "standards/sales_contracts.md",
+)
+
+
+def metadata_value(metadata, name):
+    """Return a plain scalar, including folded YAML front-matter values."""
+    prefix = name + ":"
+    lines = metadata.splitlines()
+    for index, line in enumerate(lines):
+        if not line.startswith(prefix):
+            continue
+        value = line[len(prefix) :].strip()
+        if value in {">", ">-", "|", "|-"}:
+            parts = []
+            for continuation in lines[index + 1 :]:
+                if continuation and not continuation[0].isspace():
+                    break
+                if continuation.strip():
+                    parts.append(continuation.strip())
+            return " ".join(parts)
+        return value.strip().strip("'\"")
+    return ""
+
+
+def parse_front_matter(source):
+    """Return title, description, and body from one Markdown page."""
+    match = re.match(r"\A---\n(?P<metadata>.*?)\n---\n(?P<body>.*)\Z", source, re.DOTALL)
+    if match is None:
+        raise AssertionError("Missing Jekyll front matter")
+    metadata = match.group("metadata")
+    return (
+        metadata_value(metadata, "title"),
+        metadata_value(metadata, "description"),
+        match.group("body"),
+    )
+
+
+def remove_fenced_code(source):
+    """Remove backtick and tilde code fences before inspecting rendered Markdown."""
+    rendered = []
+    marker = None
+    for line in source.splitlines():
+        stripped = line.lstrip()
+        if marker is None and (
+            stripped.startswith(("\x60\x60\x60", "~~~"))
+        ):
+            marker = stripped[:3]
+            continue
+        if marker is not None:
+            if stripped.startswith(marker):
+                marker = None
+            continue
+        rendered.append(line)
+    return "\n".join(rendered)
+
+
+def link_candidates(page, raw_target):
+    """Return repository-source candidates for one relative documentation link."""
+    target = raw_target.split("#", 1)[0].split("?", 1)[0].strip().strip("<>")
+    if target.startswith("/"):
+        candidate = DOCS / target.lstrip("/")
+    else:
+        candidate = page.parent / target
+    if candidate.suffix:
+        stem = candidate.with_suffix("")
+        return (
+            candidate,
+            stem / "README.md",
+            stem / "index.md",
+        )
+    return (
+        candidate.with_suffix(".md"),
+        candidate / "README.md",
+        candidate / "index.md",
+    )
+
+
+class PvtFlowAssuranceStandardsDocumentationContractTest(unittest.TestCase):
+    """Protect the frozen rotation-scope-5 documentation surface."""
+
+    def test_frozen_scope_exists(self):
+        self.assertEqual(38, len(SCOPE_PAGES))
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                self.assertTrue(page.is_file())
+
+    def test_pages_have_searchable_front_matter(self):
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                title, description, _body = parse_front_matter(
+                    page.read_text(encoding="utf-8")
+                )
+                self.assertTrue(title)
+                self.assertGreaterEqual(len(description.split()), 5)
+
+    def test_front_matter_title_is_not_repeated_as_h1(self):
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                title, _description, body = parse_front_matter(
+                    page.read_text(encoding="utf-8")
+                )
+                rendered = remove_fenced_code(body)
+                headings = re.findall(r"^#\s+(.+?)\s*$", rendered, re.MULTILINE)
+                self.assertNotIn(title, headings)
+
+    def test_pages_use_supported_math_delimiters(self):
+        unsupported = re.compile(r"\\\[|\\\]|\\\(|\\\)")
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                _title, _description, body = parse_front_matter(
+                    page.read_text(encoding="utf-8")
+                )
+                self.assertIsNone(unsupported.search(remove_fenced_code(body)))
+
+    def test_relative_source_links_resolve(self):
+        link_pattern = re.compile(r"(?<!!)\[[^\]\n]+\]\(([^)\n]+)\)")
+        scheme = re.compile(r"^[a-z][a-z0-9+.-]*:", re.IGNORECASE)
+        for page in SCOPE_PAGES:
+            rendered = remove_fenced_code(page.read_text(encoding="utf-8"))
+            with self.subTest(page=page, check="single-line destinations"):
+                self.assertNotRegex(rendered, r"\]\([^\n)]*\n")
+            for match in link_pattern.finditer(rendered):
+                raw_target = match.group(1).strip().split()[0]
+                if raw_target.startswith("#") or scheme.match(raw_target):
+                    continue
+                candidates = link_candidates(page, raw_target)
+                with self.subTest(page=page, target=raw_target):
+                    self.assertTrue(
+                        any(candidate.is_file() for candidate in candidates),
+                        msg="Missing target; tried: "
+                        + ", ".join(str(candidate) for candidate in candidates),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Advances documentation-quality campaign #2499 as D109.

- removes 25 exact front-matter-title/H1 duplicates across the frozen 38-page PVT, flow-assurance, and standards surface
- adds a shared 38-page contract for metadata, rendered titles, supported math delimiters, and relative-link resolution
- aligns the existing flow-assurance overview contract with the single rendered-title policy
- preserves all equations, examples, standards claims, APIs, and Java behavior

## Frozen scope and boundaries

Base: `c411b2e39bb9ad9c26b67b07b7bd46cfab182ae3`

The batch is limited to the 25 affected Markdown pages plus two Python documentation contracts. It excludes production code, API/example behavior, standards content, refinery assay work, electrolyte/MCP work, DEXPI/PFD work, notebooks, external-link policy, and Huldra work.

## Validation

- exact-source baseline: 38 pages inspected; 25 duplicate rendered titles confirmed
- proposed corpus: 0 duplicate title/H1 pairs, 0 missing/weak metadata findings, 0 unsupported math-delimiter findings, and 0 multiline relative-link findings
- all 93 unique relative targets (239 occurrences outside code fences) resolve
- both changed Python contracts parse successfully with Python 3
- proactively audited all 51 top-level documentation test modules for stale page-specific H1 assertions; updated the one affected focused contract

Exact-head build, Java tests, and Javadocs pass.

**VALIDATION PENDING CI:** documentation/Jekyll/search, pre-commit, Spotless, and CodeQL remain in progress on this exact head.

## Maturity

D109 remains experimental until exact-head CI passes. Target maturity is qualified after independent merge and current-`master` blob verification.