### PR TITLE
Add separator internals elevation API and gas scrubber drainage head check

### DIFF
--- a/src/main/java/neqsim/process/mechanicaldesign/separator/DrainageHeadResult.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/separator/DrainageHeadResult.java
@@ -1,0 +1,141 @@
+package neqsim.process.mechanicaldesign.separator;
+
+import java.io.Serializable;
+
+/**
+ * Breakdown of the demisting-cyclone drainage head check for a gas scrubber.
+ *
+ * <p>
+ * Represents the total pressure drop the liquid film must overcome to drain
+ * from the cyclone bank back into the vessel bulk — mesh pad pressure drop
+ * plus the fraction of cyclone pressure drop acting at the drain chamber —
+ * expressed as an equivalent clear-liquid column height. The available head
+ * is the geometric elevation from the cyclone deck down to the High-High
+ * Liquid Level (LA(HH)). The ratio of required to available head (percent)
+ * is the governing conformity metric.
+ * </p>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public class DrainageHeadResult implements Serializable {
+  /** Serialization version UID. */
+  private static final long serialVersionUID = 1000L;
+
+  private final double meshDpPa;
+  private final double cycloneDpToDrainPa;
+  private final double totalDpPa;
+  private final double requiredHeadMm;
+  private final double availableHeadMm;
+  private final double percentOfAvailable;
+  private final double gasDensityKgM3;
+  private final double liquidDensityKgM3;
+
+  /**
+   * Constructs a DrainageHeadResult.
+   *
+   * @param meshDpPa             mesh pad pressure drop [Pa]
+   * @param cycloneDpToDrainPa   cyclone pressure drop reaching drain chamber [Pa]
+   * @param requiredHeadMm       equivalent clear-liquid head required [mm]
+   * @param availableHeadMm      geometric elevation cyclone deck - LA(HH) [mm]
+   * @param gasDensityKgM3       gas phase density used in the calculation [kg/m3]
+   * @param liquidDensityKgM3    liquid phase density used in the calculation
+   *                             [kg/m3]
+   */
+  public DrainageHeadResult(double meshDpPa, double cycloneDpToDrainPa, double requiredHeadMm,
+      double availableHeadMm, double gasDensityKgM3, double liquidDensityKgM3) {
+    this.meshDpPa = meshDpPa;
+    this.cycloneDpToDrainPa = cycloneDpToDrainPa;
+    this.totalDpPa = meshDpPa + cycloneDpToDrainPa;
+    this.requiredHeadMm = requiredHeadMm;
+    this.availableHeadMm = availableHeadMm;
+    this.percentOfAvailable = availableHeadMm > 0 ? requiredHeadMm / availableHeadMm * 100.0
+        : Double.NaN;
+    this.gasDensityKgM3 = gasDensityKgM3;
+    this.liquidDensityKgM3 = liquidDensityKgM3;
+  }
+
+  /**
+   * Gets the mesh pad pressure drop contribution.
+   *
+   * @return mesh pad dP [Pa]
+   */
+  public double getMeshDpPa() {
+    return meshDpPa;
+  }
+
+  /**
+   * Gets the fraction of cyclone pressure drop reaching the drain chamber.
+   *
+   * @return cyclone drain dP [Pa]
+   */
+  public double getCycloneDpToDrainPa() {
+    return cycloneDpToDrainPa;
+  }
+
+  /**
+   * Gets the total pressure drop the drainage column must balance.
+   *
+   * @return total dP [Pa]
+   */
+  public double getTotalDpPa() {
+    return totalDpPa;
+  }
+
+  /**
+   * Gets the required clear-liquid head (computed from total dP and two-phase
+   * density difference).
+   *
+   * @return required head [mm]
+   */
+  public double getRequiredHeadMm() {
+    return requiredHeadMm;
+  }
+
+  /**
+   * Gets the geometric drainage elevation between cyclone deck and LA(HH).
+   *
+   * @return available head [mm]
+   */
+  public double getAvailableHeadMm() {
+    return availableHeadMm;
+  }
+
+  /**
+   * Gets the required head as a percentage of the available head. A value below
+   * 100 % means
+   * adequate drainage; above 100 % means the drainage column floods the cyclone
+   * bank.
+   *
+   * @return required / available [%]
+   */
+  public double getPercentOfAvailable() {
+    return percentOfAvailable;
+  }
+
+  /**
+   * Gets the gas density used in the head calculation.
+   *
+   * @return gas density [kg/m3]
+   */
+  public double getGasDensityKgM3() {
+    return gasDensityKgM3;
+  }
+
+  /**
+   * Gets the liquid density used in the head calculation.
+   *
+   * @return liquid density [kg/m3]
+   */
+  public double getLiquidDensityKgM3() {
+    return liquidDensityKgM3;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String toString() {
+    return String.format(
+        "DrainageHead[mesh=%.1f Pa, cyc=%.1f Pa, req=%.1f mm, avail=%.1f mm, %.1f %%]",
+        meshDpPa, cycloneDpToDrainPa, requiredHeadMm, availableHeadMm, percentOfAvailable);
+  }
+}

--- a/src/main/java/neqsim/process/mechanicaldesign/separator/DrainageHeadResult.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/separator/DrainageHeadResult.java
@@ -6,13 +6,11 @@ import java.io.Serializable;
  * Breakdown of the demisting-cyclone drainage head check for a gas scrubber.
  *
  * <p>
- * Represents the total pressure drop the liquid film must overcome to drain
- * from the cyclone bank back into the vessel bulk — mesh pad pressure drop
- * plus the fraction of cyclone pressure drop acting at the drain chamber —
- * expressed as an equivalent clear-liquid column height. The available head
- * is the geometric elevation from the cyclone deck down to the High-High
- * Liquid Level (LA(HH)). The ratio of required to available head (percent)
- * is the governing conformity metric.
+ * Represents the total pressure drop the liquid film must overcome to drain from the cyclone bank back into the vessel
+ * bulk — mesh pad pressure drop plus the fraction of cyclone pressure drop acting at the drain chamber — expressed as
+ * an equivalent clear-liquid column height. The available head is the geometric elevation from the cyclone deck down to
+ * the High-High Liquid Level (LA(HH)). The ratio of required to available head (percent) is the governing conformity
+ * metric.
  * </p>
  *
  * @author NeqSim Development Team
@@ -34,23 +32,21 @@ public class DrainageHeadResult implements Serializable {
   /**
    * Constructs a DrainageHeadResult.
    *
-   * @param meshDpPa             mesh pad pressure drop [Pa]
-   * @param cycloneDpToDrainPa   cyclone pressure drop reaching drain chamber [Pa]
-   * @param requiredHeadMm       equivalent clear-liquid head required [mm]
-   * @param availableHeadMm      geometric elevation cyclone deck - LA(HH) [mm]
-   * @param gasDensityKgM3       gas phase density used in the calculation [kg/m3]
-   * @param liquidDensityKgM3    liquid phase density used in the calculation
-   *                             [kg/m3]
+   * @param meshDpPa mesh pad pressure drop [Pa]
+   * @param cycloneDpToDrainPa cyclone pressure drop reaching drain chamber [Pa]
+   * @param requiredHeadMm equivalent clear-liquid head required [mm]
+   * @param availableHeadMm geometric elevation cyclone deck - LA(HH) [mm]
+   * @param gasDensityKgM3 gas phase density used in the calculation [kg/m3]
+   * @param liquidDensityKgM3 liquid phase density used in the calculation [kg/m3]
    */
-  public DrainageHeadResult(double meshDpPa, double cycloneDpToDrainPa, double requiredHeadMm,
-      double availableHeadMm, double gasDensityKgM3, double liquidDensityKgM3) {
+  public DrainageHeadResult(double meshDpPa, double cycloneDpToDrainPa, double requiredHeadMm, double availableHeadMm,
+      double gasDensityKgM3, double liquidDensityKgM3) {
     this.meshDpPa = meshDpPa;
     this.cycloneDpToDrainPa = cycloneDpToDrainPa;
     this.totalDpPa = meshDpPa + cycloneDpToDrainPa;
     this.requiredHeadMm = requiredHeadMm;
     this.availableHeadMm = availableHeadMm;
-    this.percentOfAvailable = availableHeadMm > 0 ? requiredHeadMm / availableHeadMm * 100.0
-        : Double.NaN;
+    this.percentOfAvailable = availableHeadMm > 0 ? requiredHeadMm / availableHeadMm * 100.0 : Double.NaN;
     this.gasDensityKgM3 = gasDensityKgM3;
     this.liquidDensityKgM3 = liquidDensityKgM3;
   }
@@ -83,8 +79,7 @@ public class DrainageHeadResult implements Serializable {
   }
 
   /**
-   * Gets the required clear-liquid head (computed from total dP and two-phase
-   * density difference).
+   * Gets the required clear-liquid head, from the total dP and the two-phase density difference.
    *
    * @return required head [mm]
    */
@@ -102,10 +97,7 @@ public class DrainageHeadResult implements Serializable {
   }
 
   /**
-   * Gets the required head as a percentage of the available head. A value below
-   * 100 % means
-   * adequate drainage; above 100 % means the drainage column floods the cyclone
-   * bank.
+   * Gets required head as a percentage of available head; above 100 % the column floods the cyclone bank.
    *
    * @return required / available [%]
    */
@@ -134,8 +126,7 @@ public class DrainageHeadResult implements Serializable {
   /** {@inheritDoc} */
   @Override
   public String toString() {
-    return String.format(
-        "DrainageHead[mesh=%.1f Pa, cyc=%.1f Pa, req=%.1f mm, avail=%.1f mm, %.1f %%]",
-        meshDpPa, cycloneDpToDrainPa, requiredHeadMm, availableHeadMm, percentOfAvailable);
+    return String.format("DrainageHead[mesh=%.1f Pa, cyc=%.1f Pa, req=%.1f mm, avail=%.1f mm, %.1f %%]", meshDpPa,
+        cycloneDpToDrainPa, requiredHeadMm, availableHeadMm, percentOfAvailable);
   }
 }

--- a/src/main/java/neqsim/process/mechanicaldesign/separator/GasScrubberMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/separator/GasScrubberMechanicalDesign.java
@@ -518,8 +518,7 @@ public class GasScrubberMechanicalDesign extends SeparatorMechanicalDesign {
 
     double cycDp = 0.0;
     if (hasDemistingCyclones && numberOfDemistingCyclones > 0 && demistingCycloneDiameterM > 0) {
-      double cycArea =
-          numberOfDemistingCyclones * Math.PI * Math.pow(demistingCycloneDiameterM / 2.0, 2);
+      double cycArea = numberOfDemistingCyclones * Math.PI * Math.pow(demistingCycloneDiameterM / 2.0, 2);
       double vCyc = cycArea > 0 ? gasFlowM3s / cycArea : 0.0;
       double momentum = rhoGas * vCyc * vCyc;
       double cycDpTotal = cycloneEulerNumber * momentum;

--- a/src/main/java/neqsim/process/mechanicaldesign/separator/GasScrubberMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/separator/GasScrubberMechanicalDesign.java
@@ -455,6 +455,90 @@ public class GasScrubberMechanicalDesign extends SeparatorMechanicalDesign {
   }
 
   /**
+   * Gets the elevation of the TOP of the cyclone tubes (gas-outlet face of the demisting cyclones),
+   * measured from the Bottom Tangent Line. This is the derived value
+   * {@code cycloneDeckElevation + cycloneLength}.
+   *
+   * @return cyclone tube top elevation from BTL [m]; 0.0 if either deck or length is not set
+   */
+  public double getCycloneTopElevation() {
+    if (cycloneDeckElevationM <= 0.0 || cycloneLengthM <= 0.0) {
+      return 0.0;
+    }
+    return cycloneDeckElevationM + cycloneLengthM;
+  }
+
+  /**
+   * Computes the drainage head breakdown at the current operating state.
+   *
+   * <p>
+   * The total pressure drop the liquid film must balance to drain from the cyclone bank back into
+   * the vessel bulk is {@code dP_total = dP_mesh + dP_cyclone_to_drain}, where the mesh pad
+   * pressure drop uses the stored Euler coefficient
+   * ({@code dP_mesh = Eu * 0.5 * rho_g * v_mesh^2}, defaulting to 0.5 for standard knitmesh if
+   * unset) and the cyclone fraction reaching the drain chamber uses {@code cycloneDpToDrainPct}.
+   * The equivalent clear-liquid head accounts for gas column buoyancy:
+   * {@code h_required = dP_total / ((rho_L - rho_G) * g)}.
+   * </p>
+   *
+   * <p>
+   * The available drainage elevation is the geometric distance from the cyclone deck down to
+   * LA(HH).
+   * </p>
+   *
+   * @return a {@link DrainageHeadResult} holding the breakdown, or a result with {@code NaN}
+   *         required head if the fluid state is not available
+   */
+  public DrainageHeadResult computeDrainageHead() {
+    Separator sep = (Separator) getProcessEquipment();
+    neqsim.thermo.system.SystemInterface fluid = sep.getThermoSystem();
+    if (fluid == null) {
+      return new DrainageHeadResult(0, 0, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+    }
+    fluid.initPhysicalProperties();
+
+    double rhoGas = fluid.getPhase(0).getPhysicalProperties().getDensity();
+    double gasFlowM3s = fluid.getPhase(0).getFlowRate("m3/sec");
+
+    double rhoLiq = 1000.0;
+    if (fluid.getNumberOfPhases() >= 2) {
+      if (fluid.hasPhaseType("oil")) {
+        rhoLiq = fluid.getPhase("oil").getPhysicalProperties().getDensity();
+      } else if (fluid.hasPhaseType("aqueous")) {
+        rhoLiq = fluid.getPhase("aqueous").getPhysicalProperties().getDensity();
+      }
+    }
+    double g = 9.81;
+
+    double meshDp = 0.0;
+    if (hasMeshPad && meshPadAreaM2 > 0) {
+      double vMesh = gasFlowM3s / meshPadAreaM2;
+      double euMesh = getMistEliminatorDpCoeff();
+      if (euMesh <= 0) {
+        euMesh = 0.5; // standard knitmesh
+      }
+      meshDp = euMesh * 0.5 * rhoGas * vMesh * vMesh;
+    }
+
+    double cycDp = 0.0;
+    if (hasDemistingCyclones && numberOfDemistingCyclones > 0 && demistingCycloneDiameterM > 0) {
+      double cycArea =
+          numberOfDemistingCyclones * Math.PI * Math.pow(demistingCycloneDiameterM / 2.0, 2);
+      double vCyc = cycArea > 0 ? gasFlowM3s / cycArea : 0.0;
+      double momentum = rhoGas * vCyc * vCyc;
+      double cycDpTotal = cycloneEulerNumber * momentum;
+      cycDp = cycDpTotal * cycloneDpToDrainPct / 100.0;
+    }
+
+    double totalDp = meshDp + cycDp;
+    double rhoDelta = rhoLiq - rhoGas;
+    double requiredMm = rhoDelta > 0 ? totalDp / (rhoDelta * g) * 1000.0 : Double.NaN;
+    double availableMm = (cycloneDeckElevationM - laHHElevationM) * 1000.0;
+
+    return new DrainageHeadResult(meshDp, cycDp, requiredMm, availableMm, rhoGas, rhoLiq);
+  }
+
+  /**
    * Gets the cyclone Euler number for total pressure drop.
    *
    * @return Euler number (dp vs rho*v^2, not 0.5*rho*v^2)

--- a/src/main/java/neqsim/process/mechanicaldesign/separator/GasScrubberMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/separator/GasScrubberMechanicalDesign.java
@@ -455,9 +455,8 @@ public class GasScrubberMechanicalDesign extends SeparatorMechanicalDesign {
   }
 
   /**
-   * Gets the elevation of the TOP of the cyclone tubes (gas-outlet face of the demisting cyclones),
-   * measured from the Bottom Tangent Line. This is the derived value
-   * {@code cycloneDeckElevation + cycloneLength}.
+   * Gets the elevation of the TOP of the cyclone tubes (gas-outlet face of the demisting cyclones), measured from the
+   * Bottom Tangent Line. This is the derived value {@code cycloneDeckElevation + cycloneLength} .
    *
    * @return cyclone tube top elevation from BTL [m]; 0.0 if either deck or length is not set
    */
@@ -472,22 +471,19 @@ public class GasScrubberMechanicalDesign extends SeparatorMechanicalDesign {
    * Computes the drainage head breakdown at the current operating state.
    *
    * <p>
-   * The total pressure drop the liquid film must balance to drain from the cyclone bank back into
-   * the vessel bulk is {@code dP_total = dP_mesh + dP_cyclone_to_drain}, where the mesh pad
-   * pressure drop uses the stored Euler coefficient
-   * ({@code dP_mesh = Eu * 0.5 * rho_g * v_mesh^2}, defaulting to 0.5 for standard knitmesh if
-   * unset) and the cyclone fraction reaching the drain chamber uses {@code cycloneDpToDrainPct}.
-   * The equivalent clear-liquid head accounts for gas column buoyancy:
-   * {@code h_required = dP_total / ((rho_L - rho_G) * g)}.
+   * The total pressure drop the liquid film must balance to drain from the cyclone bank back into the vessel bulk is
+   * {@code dP_total = dP_mesh + dP_cyclone_to_drain} , where the mesh pad pressure drop uses the stored Euler
+   * coefficient ( {@code dP_mesh = Eu * 0.5 * rho_g * v_mesh^2} , defaulting to 0.5 for standard knitmesh if unset) and
+   * the cyclone fraction reaching the drain chamber uses {@code cycloneDpToDrainPct} . The equivalent clear-liquid head
+   * accounts for gas column buoyancy: {@code h_required = dP_total / ((rho_L - rho_G) * g)} .
    * </p>
    *
    * <p>
-   * The available drainage elevation is the geometric distance from the cyclone deck down to
-   * LA(HH).
+   * The available drainage elevation is the geometric distance from the cyclone deck down to LA(HH).
    * </p>
    *
-   * @return a {@link DrainageHeadResult} holding the breakdown, or a result with {@code NaN}
-   *         required head if the fluid state is not available
+   * @return a {@link DrainageHeadResult} holding the breakdown, or a result with {@code NaN} required head if the fluid
+   * state is not available
    */
   public DrainageHeadResult computeDrainageHead() {
     Separator sep = (Separator) getProcessEquipment();

--- a/src/main/java/neqsim/process/mechanicaldesign/separator/SeparatorMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/separator/SeparatorMechanicalDesign.java
@@ -152,6 +152,36 @@ public class SeparatorMechanicalDesign extends MechanicalDesign {
   /** Distance from inlet to gas demister [m]. */
   private double inletToGasDemister = 0.0;
 
+  // ============================================================================
+  // Internals elevations.
+  //
+  // Reference frame: all elevations are in metres from the Bottom Tangent Line
+  // (BTL) of the vessel, positive upward.
+  //
+  // For each internal we store the elevation of the GAS-FACING SURFACE that is
+  // most relevant to free-path / vertical-distance calculations:
+  // - Inlet nozzle: centreline elevation
+  // - Inlet device: TOP face of the device (the surface gas leaves through)
+  // - Mesh pad / vane pack: BOTTOM face (the surface gas enters through);
+  // the corresponding TOP elevation is derived = bottom + thickness.
+  // - Cyclones (in GasScrubberMechanicalDesign):
+  // cycloneDeckElevation = BOTTOM of the cyclone tubes (= top face of the
+  // deck plate, i.e. the gas-inlet face of the cyclones);
+  // cycloneTopElevation = deck + cycloneLength.
+  //
+  // Defaults are 0.0, which means "not set" - callers must check before use.
+  // ============================================================================
+  /** Inlet nozzle centreline elevation from BTL [m]. */
+  private double inletNozzleElevation = 0.0;
+  /**
+   * Inlet device top face elevation from BTL [m]. The free-path height for
+   * carry-over correlations is measured from this surface up to the bottom of the next gas-side
+   * internal (mesh pad / vane pack / cyclone deck).
+   */
+  private double inletDeviceTopElevation = 0.0;
+  /** Mesh pad bottom face elevation from BTL [m]. */
+  private double meshPadBottomElevation = 0.0;
+
   // Nozzle sizes
   /** Inlet nozzle internal diameter [m]. */
   private double inletNozzleID = 0.0;
@@ -1085,6 +1115,116 @@ public class SeparatorMechanicalDesign extends MechanicalDesign {
    */
   public void setInletNozzleID(double id) {
     this.inletNozzleID = id;
+  }
+
+  // ============================================================================
+  // Internals elevation accessors (see field block above for reference frame).
+  // All values are metres from the Bottom Tangent Line (BTL), positive upward.
+  // ============================================================================
+
+  /**
+   * Sets the inlet nozzle centreline elevation.
+   *
+   * @param elevationM centreline elevation from BTL [m]
+   */
+  public void setInletNozzleElevation(double elevationM) {
+    this.inletNozzleElevation = elevationM;
+  }
+
+  /**
+   * Gets the inlet nozzle centreline elevation.
+   *
+   * @return centreline elevation from BTL [m]; 0.0 if not set
+   */
+  public double getInletNozzleElevation() {
+    return inletNozzleElevation;
+  }
+
+  /**
+   * Sets the inlet device top face elevation. This is the surface gas leaves through (e.g. top of
+   * an inlet vane), measured from the Bottom Tangent Line.
+   *
+   * @param elevationM top face elevation from BTL [m]
+   */
+  public void setInletDeviceTopElevation(double elevationM) {
+    this.inletDeviceTopElevation = elevationM;
+  }
+
+  /**
+   * Gets the inlet device top face elevation as explicitly stored. Returns 0.0 when not set; use
+   * {@link #getInletDeviceTopElevationOrDefault()} to get the default-derived value.
+   *
+   * @return top face elevation from BTL [m]; 0.0 if not set
+   */
+  public double getInletDeviceTopElevation() {
+    return inletDeviceTopElevation;
+  }
+
+  /**
+   * Gets the inlet device top face elevation, falling back to a default when not explicitly set.
+   * The default assumes a standard inlet vane that fills the upper half of the nozzle bore: top
+   * elevation = nozzle centreline + nozzle ID / 2.
+   *
+   * @return top face elevation from BTL [m]; explicit value if set, else
+   *         {@code inletNozzleElevation + inletNozzleID / 2.0} when both are positive, else 0.0
+   */
+  public double getInletDeviceTopElevationOrDefault() {
+    if (inletDeviceTopElevation > 0.0) {
+      return inletDeviceTopElevation;
+    }
+    if (inletNozzleElevation > 0.0 && inletNozzleID > 0.0) {
+      return inletNozzleElevation + inletNozzleID / 2.0;
+    }
+    return 0.0;
+  }
+
+  /**
+   * Sets the mesh pad bottom face elevation. This is the surface gas enters through, measured from
+   * the Bottom Tangent Line.
+   *
+   * @param elevationM bottom face elevation from BTL [m]
+   */
+  public void setMeshPadBottomElevation(double elevationM) {
+    this.meshPadBottomElevation = elevationM;
+  }
+
+  /**
+   * Gets the mesh pad bottom face elevation.
+   *
+   * @return bottom face elevation from BTL [m]; 0.0 if not set
+   */
+  public double getMeshPadBottomElevation() {
+    return meshPadBottomElevation;
+  }
+
+  /**
+   * Gets the mesh pad top face elevation, derived as bottom elevation plus mesh pad thickness
+   * ({@link #getDemisterThickness()}, which is stored in mm).
+   *
+   * @return top face elevation from BTL [m]; 0.0 if bottom not set
+   */
+  public double getMeshPadTopElevation() {
+    if (meshPadBottomElevation <= 0.0) {
+      return 0.0;
+    }
+    return meshPadBottomElevation + getDemisterThickness() / 1000.0;
+  }
+
+  /**
+   * Gets the free-path height between the inlet device top face and the mesh pad bottom face. This
+   * is the vertical distance available for primary gravity separation and droplet entrainment /
+   * carry-over correlations.
+   *
+   * @return mesh pad bottom elevation minus inlet device top elevation [m]; 0.0 if either elevation
+   *         is unset or the result is non-positive
+   */
+  public double getFreePathHeightAboveInletDevice() {
+    double topInlet = getInletDeviceTopElevationOrDefault();
+    if (topInlet <= 0.0 || meshPadBottomElevation <= 0.0) {
+      return 0.0;
+    }
+    double h = meshPadBottomElevation - topInlet;
+    return h > 0.0 ? h : 0.0;
   }
 
   /**

--- a/src/main/java/neqsim/process/mechanicaldesign/separator/SeparatorMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/separator/SeparatorMechanicalDesign.java
@@ -174,9 +174,8 @@ public class SeparatorMechanicalDesign extends MechanicalDesign {
   /** Inlet nozzle centreline elevation from BTL [m]. */
   private double inletNozzleElevation = 0.0;
   /**
-   * Inlet device top face elevation from BTL [m]. The free-path height for
-   * carry-over correlations is measured from this surface up to the bottom of the next gas-side
-   * internal (mesh pad / vane pack / cyclone deck).
+   * Inlet device top face elevation from BTL [m]. The free-path height for carry-over correlations is measured from
+   * this surface up to the bottom of the next gas-side internal (mesh pad / vane pack / cyclone deck).
    */
   private double inletDeviceTopElevation = 0.0;
   /** Mesh pad bottom face elevation from BTL [m]. */

--- a/src/main/java/neqsim/process/mechanicaldesign/separator/SeparatorMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/separator/SeparatorMechanicalDesign.java
@@ -1141,8 +1141,8 @@ public class SeparatorMechanicalDesign extends MechanicalDesign {
   }
 
   /**
-   * Sets the inlet device top face elevation. This is the surface gas leaves through (e.g. top of
-   * an inlet vane), measured from the Bottom Tangent Line.
+   * Sets the inlet device top face elevation. This is the surface gas leaves through (e.g. top of an inlet vane),
+   * measured from the Bottom Tangent Line.
    *
    * @param elevationM top face elevation from BTL [m]
    */
@@ -1161,12 +1161,12 @@ public class SeparatorMechanicalDesign extends MechanicalDesign {
   }
 
   /**
-   * Gets the inlet device top face elevation, falling back to a default when not explicitly set.
-   * The default assumes a standard inlet vane that fills the upper half of the nozzle bore: top
-   * elevation = nozzle centreline + nozzle ID / 2.
+   * Gets the inlet device top face elevation, falling back to a default when not explicitly set. The default assumes a
+   * standard inlet vane that fills the upper half of the nozzle bore: top elevation = nozzle centreline + nozzle ID /
+   * 2.
    *
    * @return top face elevation from BTL [m]; explicit value if set, else
-   *         {@code inletNozzleElevation + inletNozzleID / 2.0} when both are positive, else 0.0
+   * {@code inletNozzleElevation + inletNozzleID / 2.0} when both are positive, else 0.0
    */
   public double getInletDeviceTopElevationOrDefault() {
     if (inletDeviceTopElevation > 0.0) {
@@ -1179,8 +1179,8 @@ public class SeparatorMechanicalDesign extends MechanicalDesign {
   }
 
   /**
-   * Sets the mesh pad bottom face elevation. This is the surface gas enters through, measured from
-   * the Bottom Tangent Line.
+   * Sets the mesh pad bottom face elevation. This is the surface gas enters through, measured from the Bottom Tangent
+   * Line.
    *
    * @param elevationM bottom face elevation from BTL [m]
    */
@@ -1198,8 +1198,8 @@ public class SeparatorMechanicalDesign extends MechanicalDesign {
   }
 
   /**
-   * Gets the mesh pad top face elevation, derived as bottom elevation plus mesh pad thickness
-   * ({@link #getDemisterThickness()}, which is stored in mm).
+   * Gets the mesh pad top face elevation, derived as bottom elevation plus mesh pad thickness (
+   * {@link #getDemisterThickness()} , which is stored in mm).
    *
    * @return top face elevation from BTL [m]; 0.0 if bottom not set
    */
@@ -1211,12 +1211,11 @@ public class SeparatorMechanicalDesign extends MechanicalDesign {
   }
 
   /**
-   * Gets the free-path height between the inlet device top face and the mesh pad bottom face. This
-   * is the vertical distance available for primary gravity separation and droplet entrainment /
-   * carry-over correlations.
+   * Gets the free-path height between the inlet device top face and the mesh pad bottom face. This is the vertical
+   * distance available for primary gravity separation and droplet entrainment / carry-over correlations.
    *
-   * @return mesh pad bottom elevation minus inlet device top elevation [m]; 0.0 if either elevation
-   *         is unset or the result is non-positive
+   * @return mesh pad bottom elevation minus inlet device top elevation [m]; 0.0 if either elevation is unset or the
+   * result is non-positive
    */
   public double getFreePathHeightAboveInletDevice() {
     double topInlet = getInletDeviceTopElevationOrDefault();

--- a/src/test/java/neqsim/process/mechanicaldesign/separator/SeparatorInternalsElevationTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/separator/SeparatorInternalsElevationTest.java
@@ -190,14 +190,12 @@ public class SeparatorInternalsElevationTest {
 
     DrainageHeadResult result = design.computeDrainageHead();
 
-    assertEquals(result.getMeshDpPa() + result.getCycloneDpToDrainPa(), result.getTotalDpPa(),
-        1.0e-9);
+    assertEquals(result.getMeshDpPa() + result.getCycloneDpToDrainPa(), result.getTotalDpPa(), 1.0e-9);
     assertEquals(1200.0, result.getAvailableHeadMm(), 1.0e-6);
     assertTrue(result.getRequiredHeadMm() >= 0.0, "required head must not be negative");
-    assertEquals(result.getRequiredHeadMm() / result.getAvailableHeadMm() * 100.0,
-        result.getPercentOfAvailable(), 1.0e-9);
+    assertEquals(result.getRequiredHeadMm() / result.getAvailableHeadMm() * 100.0, result.getPercentOfAvailable(),
+        1.0e-9);
     assertTrue(result.getGasDensityKgM3() > 0.0, "gas density must be positive");
-    assertTrue(result.getLiquidDensityKgM3() > result.getGasDensityKgM3(),
-        "liquid must be denser than gas");
+    assertTrue(result.getLiquidDensityKgM3() > result.getGasDensityKgM3(), "liquid must be denser than gas");
   }
 }

--- a/src/test/java/neqsim/process/mechanicaldesign/separator/SeparatorInternalsElevationTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/separator/SeparatorInternalsElevationTest.java
@@ -149,7 +149,7 @@ public class SeparatorInternalsElevationTest {
     GasScrubber scrubber = new GasScrubber("scrubber", createWetGasStream());
     scrubber.run();
     scrubber.initMechanicalDesign();
-    return (GasScrubberMechanicalDesign) scrubber.getMechanicalDesign();
+    return scrubber.getMechanicalDesign();
   }
 
   /** Cyclone top is the deck elevation plus the tube length. */
@@ -159,9 +159,7 @@ public class SeparatorInternalsElevationTest {
 
     assertEquals(0.0, design.getCycloneTopElevation(), TOL);
 
-    design.setDemistingCyclones(12, 0.06);
-    design.setCycloneDeckElevationM(2.50);
-    design.setCycloneLengthM(0.80);
+    design.setDemistingCyclones(12, 0.06, 2.50, 0.80);
 
     assertEquals(3.30, design.getCycloneTopElevation(), 1.0e-9);
   }
@@ -171,7 +169,8 @@ public class SeparatorInternalsElevationTest {
   public void testCycloneTopElevationRequiresDeckAndLength() {
     GasScrubberMechanicalDesign design = createScrubberDesign();
 
-    design.setCycloneDeckElevationM(2.50);
+    // Three-arg overload sets the deck but leaves the tube length unset.
+    design.setDemistingCyclones(12, 0.06, 2.50);
     assertEquals(0.0, design.getCycloneTopElevation(), TOL);
 
     design.setCycloneDeckElevationM(0.0);
@@ -186,10 +185,8 @@ public class SeparatorInternalsElevationTest {
   @Test
   public void testDrainageHeadIsSelfConsistent() {
     GasScrubberMechanicalDesign design = createScrubberDesign();
-    design.setMeshPad(true);
-    design.setMeshPadAreaM2(1.20);
-    design.setDemistingCyclones(12, 0.06);
-    design.setCycloneDeckElevationM(2.50);
+    design.setMeshPad(1.20, 150.0);
+    design.setDemistingCyclones(12, 0.06, 2.50, 0.80);
     design.setLaHHElevationM(1.30);
 
     DrainageHeadResult result = design.computeDrainageHead();

--- a/src/test/java/neqsim/process/mechanicaldesign/separator/SeparatorInternalsElevationTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/separator/SeparatorInternalsElevationTest.java
@@ -10,8 +10,8 @@ import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 
 /**
- * Tests for the internals elevation API on {@link SeparatorMechanicalDesign} and the derived
- * cyclone-top elevation and drainage-head check on {@link GasScrubberMechanicalDesign}.
+ * Tests for the internals elevation API on {@link SeparatorMechanicalDesign} and the derived cyclone-top elevation and
+ * drainage-head check on {@link GasScrubberMechanicalDesign} .
  *
  * <p>
  * All elevations are metres from the vessel Bottom Tangent Line (BTL), positive upward.
@@ -75,8 +75,7 @@ public class SeparatorInternalsElevationTest {
   }
 
   /**
-   * With no explicit inlet device top, the default places it half a nozzle bore above the nozzle
-   * centreline.
+   * With no explicit inlet device top, the default places it half a nozzle bore above the nozzle centreline.
    */
   @Test
   public void testInletDeviceTopElevationFallsBackToHalfNozzleBore() {
@@ -179,8 +178,8 @@ public class SeparatorInternalsElevationTest {
   }
 
   /**
-   * The drainage head result is self-consistent: total dP is the sum of its parts, the available
-   * head follows the deck-to-LA(HH) elevation, and the percentage is required over available.
+   * The drainage head result is self-consistent: total dP is the sum of its parts, the available head follows the
+   * deck-to-LA(HH) elevation, and the percentage is required over available.
    */
   @Test
   public void testDrainageHeadIsSelfConsistent() {

--- a/src/test/java/neqsim/process/mechanicaldesign/separator/SeparatorInternalsElevationTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/separator/SeparatorInternalsElevationTest.java
@@ -1,0 +1,207 @@
+package neqsim.process.mechanicaldesign.separator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.separator.GasScrubber;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Tests for the internals elevation API on {@link SeparatorMechanicalDesign} and the derived
+ * cyclone-top elevation and drainage-head check on {@link GasScrubberMechanicalDesign}.
+ *
+ * <p>
+ * All elevations are metres from the vessel Bottom Tangent Line (BTL), positive upward.
+ * </p>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public class SeparatorInternalsElevationTest {
+
+  /** Absolute tolerance for elevation comparisons [m]. */
+  private static final double TOL = 1.0e-9;
+
+  /**
+   * Builds a wet gas stream for scrubber tests.
+   *
+   * @return a stream carrying a run two-phase gas/water fluid
+   */
+  private Stream createWetGasStream() {
+    SystemInterface fluid = new SystemSrkEos(273.15 + 30.0, 60.0);
+    fluid.addComponent("methane", 0.95);
+    fluid.addComponent("ethane", 0.04);
+    fluid.addComponent("water", 0.01);
+    fluid.setMixingRule("classic");
+    Stream stream = new Stream("feed", fluid);
+    stream.setFlowRate(50000.0, "kg/hr");
+    stream.setTemperature(30.0, "C");
+    stream.setPressure(60.0, "bara");
+    stream.run();
+    return stream;
+  }
+
+  /**
+   * Builds a separator mechanical design bound to a running separator.
+   *
+   * @return an initialised mechanical design
+   */
+  private SeparatorMechanicalDesign createDesign() {
+    Separator sep = new Separator("sep", createWetGasStream());
+    sep.run();
+    sep.initMechanicalDesign();
+    return (SeparatorMechanicalDesign) sep.getMechanicalDesign();
+  }
+
+  /** Elevations round-trip through their accessors and default to zero when unset. */
+  @Test
+  public void testElevationAccessorsRoundTrip() {
+    SeparatorMechanicalDesign design = createDesign();
+
+    assertEquals(0.0, design.getInletNozzleElevation(), TOL);
+    assertEquals(0.0, design.getInletDeviceTopElevation(), TOL);
+    assertEquals(0.0, design.getMeshPadBottomElevation(), TOL);
+
+    design.setInletNozzleElevation(1.20);
+    design.setInletDeviceTopElevation(1.35);
+    design.setMeshPadBottomElevation(2.25);
+
+    assertEquals(1.20, design.getInletNozzleElevation(), TOL);
+    assertEquals(1.35, design.getInletDeviceTopElevation(), TOL);
+    assertEquals(2.25, design.getMeshPadBottomElevation(), TOL);
+  }
+
+  /**
+   * With no explicit inlet device top, the default places it half a nozzle bore above the nozzle
+   * centreline.
+   */
+  @Test
+  public void testInletDeviceTopElevationFallsBackToHalfNozzleBore() {
+    SeparatorMechanicalDesign design = createDesign();
+    design.setInletNozzleElevation(1.20);
+    design.setInletNozzleID(0.30);
+
+    assertEquals(1.35, design.getInletDeviceTopElevationOrDefault(), TOL);
+
+    design.setInletDeviceTopElevation(1.50);
+    assertEquals(1.50, design.getInletDeviceTopElevationOrDefault(), TOL);
+  }
+
+  /** The default is only usable when both nozzle elevation and bore are set. */
+  @Test
+  public void testInletDeviceTopElevationDefaultRequiresBothInputs() {
+    SeparatorMechanicalDesign design = createDesign();
+
+    design.setInletNozzleID(0.30);
+    assertEquals(0.0, design.getInletDeviceTopElevationOrDefault(), TOL);
+
+    design.setInletNozzleElevation(1.20);
+    design.setInletNozzleID(0.0);
+    assertEquals(0.0, design.getInletDeviceTopElevationOrDefault(), TOL);
+  }
+
+  /** Mesh pad top is the bottom face plus the pad thickness, which is stored in mm. */
+  @Test
+  public void testMeshPadTopElevationAddsThicknessConvertedFromMillimetres() {
+    SeparatorMechanicalDesign design = createDesign();
+
+    assertEquals(0.0, design.getMeshPadTopElevation(), TOL);
+
+    design.setMeshPadBottomElevation(2.25);
+    design.setDemisterThickness(150.0);
+
+    assertEquals(2.40, design.getMeshPadTopElevation(), 1.0e-9);
+  }
+
+  /** Free path is mesh pad bottom minus inlet device top. */
+  @Test
+  public void testFreePathHeightAboveInletDevice() {
+    SeparatorMechanicalDesign design = createDesign();
+    design.setInletDeviceTopElevation(1.35);
+    design.setMeshPadBottomElevation(2.25);
+
+    assertEquals(0.90, design.getFreePathHeightAboveInletDevice(), 1.0e-9);
+  }
+
+  /** An unset or inverted geometry yields zero free path rather than a negative distance. */
+  @Test
+  public void testFreePathHeightGuardsUnsetAndInvertedGeometry() {
+    SeparatorMechanicalDesign design = createDesign();
+    assertEquals(0.0, design.getFreePathHeightAboveInletDevice(), TOL);
+
+    design.setInletDeviceTopElevation(1.35);
+    assertEquals(0.0, design.getFreePathHeightAboveInletDevice(), TOL);
+
+    // Mesh pad below the inlet device is not a negative free path.
+    design.setMeshPadBottomElevation(1.00);
+    assertEquals(0.0, design.getFreePathHeightAboveInletDevice(), TOL);
+  }
+
+  /**
+   * Builds a gas scrubber mechanical design bound to a running scrubber.
+   *
+   * @return an initialised scrubber mechanical design
+   */
+  private GasScrubberMechanicalDesign createScrubberDesign() {
+    GasScrubber scrubber = new GasScrubber("scrubber", createWetGasStream());
+    scrubber.run();
+    scrubber.initMechanicalDesign();
+    return (GasScrubberMechanicalDesign) scrubber.getMechanicalDesign();
+  }
+
+  /** Cyclone top is the deck elevation plus the tube length. */
+  @Test
+  public void testCycloneTopElevation() {
+    GasScrubberMechanicalDesign design = createScrubberDesign();
+
+    assertEquals(0.0, design.getCycloneTopElevation(), TOL);
+
+    design.setDemistingCyclones(12, 0.06);
+    design.setCycloneDeckElevationM(2.50);
+    design.setCycloneLengthM(0.80);
+
+    assertEquals(3.30, design.getCycloneTopElevation(), 1.0e-9);
+  }
+
+  /** Cyclone top needs both deck elevation and tube length. */
+  @Test
+  public void testCycloneTopElevationRequiresDeckAndLength() {
+    GasScrubberMechanicalDesign design = createScrubberDesign();
+
+    design.setCycloneDeckElevationM(2.50);
+    assertEquals(0.0, design.getCycloneTopElevation(), TOL);
+
+    design.setCycloneDeckElevationM(0.0);
+    design.setCycloneLengthM(0.80);
+    assertEquals(0.0, design.getCycloneTopElevation(), TOL);
+  }
+
+  /**
+   * The drainage head result is self-consistent: total dP is the sum of its parts, the available
+   * head follows the deck-to-LA(HH) elevation, and the percentage is required over available.
+   */
+  @Test
+  public void testDrainageHeadIsSelfConsistent() {
+    GasScrubberMechanicalDesign design = createScrubberDesign();
+    design.setMeshPad(true);
+    design.setMeshPadAreaM2(1.20);
+    design.setDemistingCyclones(12, 0.06);
+    design.setCycloneDeckElevationM(2.50);
+    design.setLaHHElevationM(1.30);
+
+    DrainageHeadResult result = design.computeDrainageHead();
+
+    assertEquals(result.getMeshDpPa() + result.getCycloneDpToDrainPa(), result.getTotalDpPa(),
+        1.0e-9);
+    assertEquals(1200.0, result.getAvailableHeadMm(), 1.0e-6);
+    assertTrue(result.getRequiredHeadMm() >= 0.0, "required head must not be negative");
+    assertEquals(result.getRequiredHeadMm() / result.getAvailableHeadMm() * 100.0,
+        result.getPercentOfAvailable(), 1.0e-9);
+    assertTrue(result.getGasDensityKgM3() > 0.0, "gas density must be positive");
+    assertTrue(result.getLiquidDensityKgM3() > result.getGasDensityKgM3(),
+        "liquid must be denser than gas");
+  }
+}


### PR DESCRIPTION
## What

Adds the internals elevation API on `SeparatorMechanicalDesign`, plus the derived
cyclone-top elevation and drainage-head check on `GasScrubberMechanicalDesign`.

This is the public geometry an entrainment / carry-over correlation needs to read
in order to know how far a droplet travels between internals. It is a
prerequisite for pluggable carry-over models; the model itself is not part of
this PR.

## Reference frame

All elevations are **metres from the vessel Bottom Tangent Line (BTL), positive
upward**. This is stated on every accessor, because an elevation without a datum
is the obvious place for a silent error.

For each internal we store the **gas-facing surface** most relevant to free-path
calculations:

| Internal | Stored surface |
|---|---|
| Inlet nozzle | centreline elevation |
| Inlet device | TOP face (the surface gas leaves through) |
| Mesh pad / vane pack | BOTTOM face (the surface gas enters through) |
| Demisting cyclones | deck elevation = BOTTOM of the tubes |

## API added

`SeparatorMechanicalDesign`

- `set/getInletNozzleElevation(double)` — nozzle centreline [m]
- `set/getInletDeviceTopElevation(double)` — device top face [m]
- `getInletDeviceTopElevationOrDefault()` — falls back to
  `inletNozzleElevation + inletNozzleID / 2` when not explicitly set, matching the
  standard inlet-vane assumption that the device fills the upper half of the bore
- `set/getMeshPadBottomElevation(double)` — pad bottom face [m]
- `getMeshPadTopElevation()` — bottom plus `getDemisterThickness()`, which is
  stored in **mm** and converted here
- `getFreePathHeightAboveInletDevice()` — mesh pad bottom minus inlet device top

`GasScrubberMechanicalDesign`

- `getCycloneTopElevation()` — `cycloneDeckElevationM + cycloneLengthM`
- `computeDrainageHead()` — returns a `DrainageHeadResult`

`DrainageHeadResult` (new, immutable, `Serializable`)

## Drainage head

The liquid film draining from the cyclone bank back into the bulk must balance

```
dP_total = dP_mesh + dP_cyclone_to_drain
```

where `dP_mesh = Eu · 0.5 · rho_g · v_mesh²` (Euler coefficient defaults to 0.5
for standard knitmesh when unset) and the cyclone share reaching the drain
chamber is set by `cycloneDpToDrainPct`. The equivalent clear-liquid column
accounts for gas buoyancy:

```
h_required = dP_total / ((rho_L − rho_G) · g)
```

Available head is the geometric distance from the cyclone deck down to LA(HH).
`getPercentOfAvailable()` is the governing metric — above 100 % the drainage
column floods the cyclone bank.

## Behaviour and compatibility

Purely additive — **no existing line is modified** (572 insertions, 0 deletions).
Unset elevations return `0.0`, and every derived getter guards on that, so no
existing model changes behaviour. Inverted geometry (mesh pad below the inlet
device) returns `0.0` rather than a negative free path.

Java 8 compatible. `DrainageHeadResult` is `Serializable` with a
`serialVersionUID`, consistent with the other mechanical-design result classes.

## Tests

`SeparatorInternalsElevationTest` — 9 tests asserting exact values rather than
non-null:

- accessor round-trip and zero defaults
- inlet-device-top fallback = 1.35 m for a 1.20 m nozzle at 0.30 m bore, and that
  the fallback requires *both* inputs
- mesh pad top = 2.40 m for a 2.25 m bottom and 150 mm pad, covering the mm→m
  conversion
- free path = 0.90 m, and the unset / inverted-geometry guards
- cyclone top = 3.30 m for a 2.50 m deck and 0.80 m tube, and that it needs both
- drainage head self-consistency: total dP equals the sum of its parts, available
  head follows deck−LA(HH), the percentage equals required/available, and the
  liquid is denser than the gas

## Verification status

Please rely on CI for the build. The author's workstation currently has no
runnable JDK — AppLocker blocks executables under the user profile, where the
only installed JDK and Maven live — so `spotless:apply`, `compile` and `test`
could not be run locally. Formatting was matched to the surrounding code by hand;
if `spotless:check` objects I will push the fixup.

## Origin

Extracted from the long-lived `scrubbers_kollsnes` branch and re-applied onto
current `master`. That branch was 4 months behind and is superseded.
