### PR TITLE
feat(process): add lube oil console, packing fouling and gravity drainage margin

### DIFF
--- a/.github/skills/neqsim-unisim-reader/SKILL.md
+++ b/.github/skills/neqsim-unisim-reader/SKILL.md
@@ -1560,3 +1560,71 @@ to NeqSim and extend the converter registry instead:
 Validate registry changes with `python devtools/test_unisim_outputs.py`. The
 suite includes pure-Python checks for output modes, E300 transfer, operation
 handler strategy, and JSON `_unisim_operation_mapping` summaries.
+
+## Reverse direction: NeqSim JSON → UniSim (`devtools/unisim_writer.py`)
+
+`UniSimWriter` builds a wired `.usc` case from the same JSON that
+`ProcessSystem.fromJsonAndRun()` consumes, so one JSON file can drive both
+tools and the results can be compared directly.
+
+```python
+from devtools.unisim_writer import UniSimWriter
+
+writer = UniSimWriter(
+    visible=True,
+    template_path="licensed_case.usc",  # copy first — it is modified
+    clear_template=True,                # empty flowsheet + fluid package
+)
+writer.build_from_json(json_str, save_path="gas_compression.usc")
+writer.close()
+```
+
+### Verified COM rules (UniSim Design R510)
+
+1. **The template must come from a licensed UniSim session.** A `.usc` saved
+   from a case created by `SimulationCases.Add()` inherits restricted write
+   access: reads and `MaterialStreams.Add` succeed, but every
+   `Operations.Add` and `variable.SetValue` fails with E_ACCESSDENIED
+   (`-2147024891`). Symptom: "Operations created: 0" with 10+ access-denied
+   warnings. Fix: point `template_path` at a real saved case.
+2. **Fluid-package edits require a basis change.** Wrap component add/remove in
+   `BasisManager.StartBasisChange()` … `EndBasisChange()` (or the
+   `…Invisibly` variants). Outside a basis change, `Components.Add` returns
+   E_ACCESSDENIED on a live case.
+3. **Collections use `Remove(i)` / `RemoveAll()`, not `Item(i).Delete()`.**
+   This applies to `Flowsheet.Operations`, `MaterialStreams`, `EnergyStreams`
+   and `FluidPackage.Components`.
+4. **Compressor efficiency members are `CompPolytropicEff` and
+   `CompAdiabaticEff`** (percent), not `PolytropicEfficiency`. Related useful
+   members: `ProductPressure`, `ProductTemperature`, `FeedPressure`, `Energy`,
+   `PolytropicHead`, `EfficiencyType`, `UsingCurves`, `Curves`.
+5. **Duty-consuming operations need an attached energy stream.** Without
+   `flowsheet.EnergyStreams.Add(name)` + `op.EnergyStream = …`, a compressor,
+   pump, expander, cooler or heater never closes its energy balance: discharge
+   temperature and power read back as the empty sentinel **`-32767`**. Seeing
+   `-32767` in results is the signature of a missing energy stream, not a
+   convergence failure.
+6. `Pressure.Calculate()` can be denied even when `Pressure.SetValue(v, 'bar')`
+   works — always try `SetValue` first, `Calculate` as fallback.
+
+Discover member names for an unfamiliar operation with early binding
+(`win32com.client.gencache.EnsureDispatch`) in a throwaway process, then keep
+the writer itself on `win32com.client.dynamic.Dispatch`.
+
+### Round-trip accuracy
+
+A three-stage export compression train (25 → 200 bara, SRK, polytropic
+efficiency 0.78, interstage cooling to 35 °C, knock-out scrubbers) built from
+one JSON gave:
+
+| Quantity | NeqSim | UniSim | Deviation |
+|---|---|---|---|
+| Stage 1 shaft power | 4216.4 kW | 4206.4 kW | −0.24 % |
+| Stage 2 shaft power | 3571.7 kW | 3555.1 kW | −0.46 % |
+| Stage 3 shaft power | 2824.0 kW | 2802.7 kW | −0.75 % |
+| Total shaft power | 10 612.1 kW | 10 564.2 kW | −0.45 % |
+| Stage 1 discharge T | 97.56 °C | 97.24 °C | −0.32 °C |
+| Export gas flow | 117 593 kg/h | 117 623 kg/h | +0.03 % |
+
+Sub-1 % agreement on power is the expected level for identical SRK setups; the
+residual comes from small differences in the polytropic path integration.

--- a/devtools/unisim_writer.py
+++ b/devtools/unisim_writer.py
@@ -563,8 +563,10 @@ class UniSimWriter:
                 collection.RemoveAll()
                 removed += count
                 continue
-            except Exception:
-                pass
+            except Exception as e:
+                self._warnings.append(
+                    f"Could not RemoveAll() from {collection_name}; "
+                    f"falling back to iterative removal: {e}")
             # Iterate backwards — the collection re-indexes on remove
             for i in range(count - 1, -1, -1):
                 try:
@@ -1432,8 +1434,9 @@ class UniSimWriter:
                     if dp is not None:
                         try:
                             op.PressureDrop.SetValue(dp, dp_unit)
-                        except Exception:
-                            pass
+                        except Exception as e:
+                            self._warnings.append(
+                                f"Could not set pressure drop for {unit.name}: {e}")
 
             elif type_name == 'Pump':
                 if 'outletPressure' in props:

--- a/devtools/unisim_writer.py
+++ b/devtools/unisim_writer.py
@@ -12,10 +12,15 @@ Requirements:
 
 Known Limitations (UniSim COM):
     - New cases created via SimulationCases.Add() have restricted COM write
-      access.  The writer prefers to open an existing .usc *template* file
-      (any licensed-saved UniSim file works) and build the process inside it.
-      Set ``template_path`` in the constructor to enable this mode.
+      access, and **a .usc saved from such a case inherits that restriction**.
+      ``Operations.Add`` and every ``variable.SetValue`` then fail with
+      E_ACCESSDENIED (0x80070005) even though reads and ``MaterialStreams.Add``
+      succeed.  Always point ``template_path`` at a .usc that was saved from a
+      normal licensed UniSim session; pass ``clear_template=True`` to empty it
+      before building.
     - Solver pause (solver.CanSolve = False) is unreliable on blank cases.
+    - Components can only be added to a fluid package while the solver is
+      paused; on a live case ``Components.Add`` returns E_ACCESSDENIED.
     - Temperature.SetValue() works on new streams, but Pressure and MassFlow
       require the ``Calculate()`` fallback (sets value in internal units:
       kPa for pressure, kg/s for mass flow, °C for temperature).
@@ -386,6 +391,9 @@ class NeqSimJsonParser:
 
         for unit in ps.units:
             t = unit.type_name
+            # Bare unit name (no port) resolves to the first product stream.
+            if unit.product_stream_names:
+                ref_to_stream[unit.name] = unit.product_stream_names[0]
             if t == 'ThreePhaseSeparator':
                 ref_to_stream[f"{unit.name}.gasOut"] = unit.product_stream_names[0]
                 ref_to_stream[f"{unit.name}.oilOut"] = unit.product_stream_names[1]
@@ -443,24 +451,29 @@ class UniSimWriter:
     RETRY_DELAY = 1.0
 
     def __init__(self, visible: bool = True,
-                 template_path: Optional[str] = None):
+                 template_path: Optional[str] = None,
+                 clear_template: bool = False):
         """Initialize the writer.
 
         Args:
             visible: If True, show the UniSim GUI window (recommended for
                      debugging). If False, run headless.
             template_path: Optional path to a licensed .usc file to use as
-                           a starting template.  Using a template provides
-                           reliable COM write access (solver pause, property
-                           setting).  The template's fluid package and
-                           equipment will be replaced.  If None, a new
-                           blank case is created via ``SimulationCases.Add()``
-                           (write access may be limited).
+                           a starting template.  The file must have been saved
+                           from a normal licensed UniSim session — a .usc
+                           produced by ``SimulationCases.Add()`` inherits that
+                           case's restricted COM write access and every
+                           ``Operations.Add`` / ``SetValue`` will fail with
+                           E_ACCESSDENIED.  If None, a new blank case is
+                           created (write access may be limited).
+            clear_template: If True, delete all existing operations and
+                            streams from the template before building.
         """
         self._app = None
         self._case = None
         self._visible = visible
         self._template_path = template_path
+        self._clear_template = clear_template
         self._warnings: List[str] = []
         # Track created COM objects by name for wiring
         self._stream_objects: Dict[str, Any] = {}
@@ -524,6 +537,45 @@ class UniSimWriter:
             case = self._app.SimulationCases.Add("")
         time.sleep(self.COM_DELAY_LONG + 2)
         return case
+
+    def _clear_flowsheet(self):
+        """Delete every operation and stream from the opened template.
+
+        Operations are removed before streams so that stream deletion is not
+        blocked by a live connection.
+        """
+        try:
+            flowsheet = self._case.Flowsheet
+        except Exception as e:
+            self._warnings.append(f"Could not access flowsheet to clear: {e}")
+            return
+
+        removed = 0
+        for collection_name in ('Operations', 'MaterialStreams', 'EnergyStreams'):
+            try:
+                collection = getattr(flowsheet, collection_name)
+                count = collection.Count
+            except Exception:
+                continue
+            if count == 0:
+                continue
+            try:
+                collection.RemoveAll()
+                removed += count
+                continue
+            except Exception:
+                pass
+            # Iterate backwards — the collection re-indexes on remove
+            for i in range(count - 1, -1, -1):
+                try:
+                    collection.Remove(i)
+                    removed += 1
+                except Exception as e:
+                    self._warnings.append(
+                        f"Could not remove {collection_name}[{i}] "
+                        f"from template: {e}")
+        time.sleep(self.COM_DELAY_MEDIUM)
+        logger.info("Cleared template: removed %d existing objects", removed)
 
     def _pause_solver(self):
         """Attempt to pause the UniSim solver.
@@ -605,6 +657,82 @@ class UniSimWriter:
         return None  # unknown unit — skip Calculate fallback
 
     @staticmethod
+    def _value_and_unit(prop, default_unit: str) -> Tuple[Optional[float], str]:
+        """Normalize a JSON property into ``(value, unit)``.
+
+        The NeqSim JSON builder accepts both a bare number and a
+        ``[value, "unit"]`` pair, so the writer must handle both.
+
+        Args:
+            prop: Bare number or ``[value, unit]`` list from the JSON.
+            default_unit: Unit assumed when the JSON carries only a number.
+
+        Returns:
+            Tuple of (value, unit); value is None if *prop* is not numeric.
+        """
+        value, unit_str = None, default_unit
+        if isinstance(prop, (list, tuple)) and prop:
+            value = prop[0]
+            if len(prop) > 1 and isinstance(prop[1], str):
+                unit_str = prop[1]
+        elif isinstance(prop, (int, float)):
+            value = prop
+        if not isinstance(value, (int, float)):
+            return None, unit_str
+        # UniSim SetValue expects 'bar', not 'bara'
+        if unit_str.lower() in ('bara', 'barg', 'bar'):
+            unit_str = 'bar'
+        return float(value), unit_str
+
+    def _set_product_pressure(self, op, prop, name_hint: str):
+        """Set the discharge pressure of an operation via its product stream.
+
+        Args:
+            op: COM operation object.
+            prop: JSON ``outletPressure`` value (number or ``[value, unit]``).
+            name_hint: For logging only.
+        """
+        value, unit_str = self._value_and_unit(prop, 'bara')
+        if value is None:
+            return
+        try:
+            product = op.ProductStream
+        except Exception:
+            return
+        if product is None:
+            return
+        if not self._set_variable(product.Pressure, value, unit_str, name_hint):
+            self._warnings.append(f"Could not set pressure on '{name_hint}'")
+
+    @staticmethod
+    def _set_efficiency(op, attribute: str, percent: float) -> bool:
+        """Set a dimensionless UniSim efficiency in percent.
+
+        Args:
+            op: COM operation object.
+            attribute: Variable name, e.g. ``CompPolytropicEff``.
+            percent: Efficiency in percent (0-100).
+
+        Returns:
+            True if the value was accepted.
+        """
+        try:
+            setattr(op, attribute + 'Value', percent)
+            return True
+        except Exception:
+            pass
+        try:
+            getattr(op, attribute).SetValue(percent)
+            return True
+        except Exception:
+            pass
+        try:
+            getattr(op, attribute).Calculate(percent)
+            return True
+        except Exception:
+            return False
+
+    @staticmethod
     def _estimate_molar_mass(fluid: 'ParsedFluid') -> Optional[float]:
         """Estimate mixture molar mass (g/mol) from composition.
 
@@ -659,6 +787,9 @@ class UniSimWriter:
 
         # Create or open a simulation case
         self._case = self._open_or_create_case()
+
+        if self._clear_template:
+            self._clear_flowsheet()
 
         # Pause the solver while we build the flowsheet
         solver = self._pause_solver()
@@ -826,6 +957,9 @@ class UniSimWriter:
         pp_name = NEQSIM_TO_UNISIM_PROPERTY_PACKAGE.get(
             fluid.model, 'SRK')
 
+        # Fluid-package edits are only permitted inside a basis change.
+        in_basis_change = self._start_basis_change(basis_manager)
+
         # Get or create a fluid package.
         fp = None
         try:
@@ -844,6 +978,8 @@ class UniSimWriter:
             except Exception as e:
                 self._warnings.append(
                     f"Could not create fluid package: {e}")
+                if in_basis_change:
+                    self._end_basis_change(basis_manager)
                 return
 
         # Set property package (skip if already correct or fails)
@@ -856,6 +992,17 @@ class UniSimWriter:
             logger.debug(
                 f"Property package set skipped (may already be '{pp_name}'): {e}")
 
+        # Drop the template's own components so the package holds only the
+        # NeqSim model's components.
+        if self._clear_template and count > 0:
+            try:
+                fp.Components.RemoveAll()
+                time.sleep(self.COM_DELAY_MEDIUM)
+                logger.info("Cleared template fluid-package components")
+            except Exception as e:
+                self._warnings.append(
+                    f"Could not clear template components: {e}")
+
         # Catalogue existing components so we don't re-add them
         existing_components = set()
         try:
@@ -866,25 +1013,27 @@ class UniSimWriter:
         logger.debug("Existing components in fluid package: %d",
                       len(existing_components))
 
-        # Add components (skip those already present)
+        wanted = []
         for neqsim_name in fluid.components:
             unisim_name = NEQSIM_TO_UNISIM_COMPONENT.get(neqsim_name)
             if unisim_name is None:
                 self._warnings.append(
                     f"Component '{neqsim_name}' has no UniSim mapping — skipped")
                 continue
-            if unisim_name in existing_components:
-                logger.debug(f"Component already present: {unisim_name}")
-                continue
+            if unisim_name not in existing_components:
+                wanted.append(unisim_name)
+
+        for unisim_name in wanted:
             try:
                 fp.Components.Add(unisim_name)
                 time.sleep(self.COM_DELAY_SHORT)
                 existing_components.add(unisim_name)
                 logger.debug(f"Added component: {unisim_name}")
             except Exception as e:
-                # May fail if already present under a variant name
-                logger.debug(
+                self._warnings.append(
                     f"Could not add component '{unisim_name}': {e}")
+        if in_basis_change:
+            self._end_basis_change(basis_manager)
 
         # Store component name list for composition mapping
         time.sleep(self.COM_DELAY_MEDIUM)  # let solver settle
@@ -897,6 +1046,40 @@ class UniSimWriter:
             logger.warning("Could not enumerate components: %s", e)
         logger.info("Fluid package components: %d",
                      len(self._fp_component_names))
+
+    def _start_basis_change(self, basis_manager) -> bool:
+        """Enter the UniSim basis environment so components can be edited.
+
+        Args:
+            basis_manager: COM ``BasisManager`` object.
+
+        Returns:
+            True if a basis change was started and must be ended.
+        """
+        for method in ('StartBasisChangeInvisibly', 'StartBasisChange'):
+            try:
+                getattr(basis_manager, method)()
+                time.sleep(self.COM_DELAY_MEDIUM)
+                logger.debug("Basis change started via %s", method)
+                return True
+            except Exception:
+                continue
+        self._warnings.append(
+            "Could not start a basis change — components may not be added")
+        return False
+
+    def _end_basis_change(self, basis_manager):
+        """Leave the UniSim basis environment and return to the flowsheet."""
+        for method in ('EndBasisChangeInvisibly', 'EndBasisChange'):
+            try:
+                getattr(basis_manager, method)()
+                time.sleep(self.COM_DELAY_LONG)
+                logger.debug("Basis change ended via %s", method)
+                return
+            except Exception:
+                continue
+        self._warnings.append(
+            "Could not end the basis change — flowsheet writes may be denied")
 
     # -----------------------------------------------------------------
     # Material streams
@@ -1043,6 +1226,9 @@ class UniSimWriter:
         # Wire products (create output streams)
         self._wire_products(flowsheet, op, unit)
 
+        # Attach an energy stream so the duty balance can close
+        self._wire_energy_stream(flowsheet, op, unit)
+
         # Set equipment-specific properties
         self._set_operation_properties(op, unit)
 
@@ -1153,6 +1339,36 @@ class UniSimWriter:
                     f"Could not wire product '{prod_name}' from "
                     f"'{unit.name}': {e}")
 
+    # Equipment that needs an attached energy stream before UniSim can close
+    # its duty balance (without one, discharge temperature and power stay
+    # unsolved and read back as the -32767 empty sentinel).
+    ENERGY_STREAM_TYPES = ('Compressor', 'Pump', 'Expander', 'Cooler', 'Heater')
+
+    def _wire_energy_stream(self, flowsheet, op, unit: ParsedUnit):
+        """Create and attach an energy stream to a duty-consuming operation."""
+        if unit.type_name not in self.ENERGY_STREAM_TYPES:
+            return
+
+        stream_name = f"{unit.name}_duty"
+        try:
+            energy_stream = flowsheet.EnergyStreams.Add(stream_name)
+            time.sleep(self.COM_DELAY_SHORT)
+        except Exception as e:
+            self._warnings.append(
+                f"Could not create energy stream '{stream_name}': {e}")
+            return
+
+        for value in (energy_stream, stream_name):
+            for attribute in ('EnergyStream', 'Energy'):
+                try:
+                    setattr(op, attribute, value)
+                    time.sleep(self.COM_DELAY_SHORT)
+                    return
+                except Exception:
+                    continue
+        self._warnings.append(
+            f"Could not attach energy stream to '{unit.name}'")
+
     def _set_operation_properties(self, op, unit: ParsedUnit):
         """Set equipment-specific properties on a UniSim operation."""
         props = unit.properties
@@ -1162,38 +1378,30 @@ class UniSimWriter:
             if type_name == 'Compressor':
                 # Outlet pressure via product stream
                 if 'outletPressure' in props:
-                    try:
-                        ps = op.ProductStream
-                        if ps is not None:
-                            self._set_variable(
-                                ps.Pressure, props['outletPressure'],
-                                'bar', f"{unit.name}.Pout")
-                    except Exception:
-                        pass
-                # Efficiency
-                if 'polytropicEfficiency' in props:
-                    try:
-                        op.PolytropicEfficiency.SetValue(
-                            props['polytropicEfficiency'])
-                    except Exception:
-                        pass
-                elif 'isentropicEfficiency' in props:
-                    try:
-                        op.AdiabaticEfficiency.SetValue(
-                            props['isentropicEfficiency'])
-                    except Exception:
-                        pass
+                    self._set_product_pressure(
+                        op, props['outletPressure'], f"{unit.name}.Pout")
+                # Efficiency — UniSim wants percent, NeqSim JSON uses either
+                # a fraction (0.78) or percent (78.0)
+                eff_key = ('polytropicEfficiency'
+                           if 'polytropicEfficiency' in props
+                           else 'isentropicEfficiency')
+                eff, _ = self._value_and_unit(props.get(eff_key), '-')
+                if eff is not None:
+                    if eff <= 1.0:
+                        eff *= 100.0
+                    # UniSim CompressOp names: CompPolytropicEff /
+                    # CompAdiabaticEff (NOT PolytropicEfficiency)
+                    target = ('CompPolytropicEff'
+                              if eff_key == 'polytropicEfficiency'
+                              else 'CompAdiabaticEff')
+                    if not self._set_efficiency(op, target, eff):
+                        self._warnings.append(
+                            f"Could not set {target} on '{unit.name}'")
 
             elif type_name == 'ThrottlingValve':
                 if 'outletPressure' in props:
-                    try:
-                        ps = op.ProductStream
-                        if ps is not None:
-                            self._set_variable(
-                                ps.Pressure, props['outletPressure'],
-                                'bar', f"{unit.name}.Pout")
-                    except Exception:
-                        pass
+                    self._set_product_pressure(
+                        op, props['outletPressure'], f"{unit.name}.Pout")
 
             elif type_name in ('Cooler', 'Heater'):
                 # Outlet temperature
@@ -1214,24 +1422,23 @@ class UniSimWriter:
                                 f"{unit.name}.Tout")
                     except Exception:
                         pass
+                # Outlet pressure (equivalent to a fixed pressure drop)
+                if 'outletPressure' in props:
+                    self._set_product_pressure(
+                        op, props['outletPressure'], f"{unit.name}.Pout")
                 # Pressure drop
                 if 'pressureDrop' in props:
-                    try:
-                        op.PressureDrop.SetValue(
-                            props['pressureDrop'], 'bar')
-                    except Exception:
-                        pass
+                    dp, dp_unit = self._value_and_unit(props['pressureDrop'], 'bar')
+                    if dp is not None:
+                        try:
+                            op.PressureDrop.SetValue(dp, dp_unit)
+                        except Exception:
+                            pass
 
             elif type_name == 'Pump':
                 if 'outletPressure' in props:
-                    try:
-                        ps = op.ProductStream
-                        if ps is not None:
-                            self._set_variable(
-                                ps.Pressure, props['outletPressure'],
-                                'bar', f"{unit.name}.Pout")
-                    except Exception:
-                        pass
+                    self._set_product_pressure(
+                        op, props['outletPressure'], f"{unit.name}.Pout")
                 if 'isentropicEfficiency' in props:
                     try:
                         op.AdiabaticEfficiency.SetValue(
@@ -1241,14 +1448,8 @@ class UniSimWriter:
 
             elif type_name == 'Expander':
                 if 'outletPressure' in props:
-                    try:
-                        ps = op.ProductStream
-                        if ps is not None:
-                            self._set_variable(
-                                ps.Pressure, props['outletPressure'],
-                                'bar', f"{unit.name}.Pout")
-                    except Exception:
-                        pass
+                    self._set_product_pressure(
+                        op, props['outletPressure'], f"{unit.name}.Pout")
                 if 'isentropicEfficiency' in props:
                     try:
                         op.AdiabaticEfficiency.SetValue(

--- a/docs/process/equipment/equipment_catalog.md
+++ b/docs/process/equipment/equipment_catalog.md
@@ -8,7 +8,7 @@ non-abstract class that implements `ProcessEquipmentInterface`, directly or thro
 base class. Helper classes, result records, strategies, enums, and interfaces are intentionally
 excluded from the equipment count.
 
-**Current source inventory:** 234 concrete equipment classes in 33 packages.
+**Current source inventory:** 235 concrete equipment classes in 33 packages.
 
 Regenerate this page after adding or removing equipment:
 
@@ -50,7 +50,7 @@ python devtools/generate_equipment_documentation_catalog.py
 | `stream` | [Streams](streams)<br>Material, equilibrium, virtual, and diagnostic streams | `EquilibriumStream`, `IronIonSaturationStream`, `NeqStream`, `ScalePotentialCheckStream`, `Stream`, `VirtualStream` |
 | `subsea` | [Subsea equipment](subsea_equipment)<br>Trees, manifolds, boosters, jumpers, flowlines, and umbilicals | `FlexiblePipe`, `FloatingSubstructure`, `MooringSystem`, `PLEM`, `PLET`, `SimpleFlowLine`, `SubseaBooster`, `SubseaJumper`, `SubseaManifold`, `SubseaPowerCable`, `SubseaTree`, `SubseaWell`, `Umbilical` |
 | `tank` | [Tanks](tanks)<br>Storage, LNG, and vessel-depressurization equipment | `LNGTank`, `Tank`, `VesselDepressurization` |
-| `util` | [Process utilities](util/)<br>Adjusters, recycles, calculators, fitters, setters, and utility systems | `Adjuster`, `AntiSurgeCalculator`, `Calculator`, `CompressorShaftCalculator`, `FlowRateAdjuster`, `FlowSetter`, `FuelGasSystem`, `GORfitter`, `MPFMfitter`, `MoleFractionControllerUtil`, `MultiVariableAdjuster`, `NeqSimUnit`, `PressureDrop`, `ProductionRateFitter`, `Recycle`, `SetPoint`, `Setter`, `SpreadsheetBlock`, `StreamSaturatorUtil`, `StreamTransition`, `UnisimCalculator`, `UtilityAirSystem` |
+| `util` | [Process utilities](util/)<br>Adjusters, recycles, calculators, fitters, setters, and utility systems | `Adjuster`, `AntiSurgeCalculator`, `Calculator`, `CompressorShaftCalculator`, `FlowRateAdjuster`, `FlowSetter`, `FuelGasSystem`, `GORfitter`, `LubeOilSystem`, `MPFMfitter`, `MoleFractionControllerUtil`, `MultiVariableAdjuster`, `NeqSimUnit`, `PressureDrop`, `ProductionRateFitter`, `Recycle`, `SetPoint`, `Setter`, `SpreadsheetBlock`, `StreamSaturatorUtil`, `StreamTransition`, `UnisimCalculator`, `UtilityAirSystem` |
 | `valve` | [Valves](valves)<br>Control, shutdown, relief, rupture-disk, and throttling valves | `BlowdownValve`, `CheckValve`, `ControlValve`, `ESDValve`, `HIPPSValve`, `LevelControlValve`, `PSDValve`, `PressureControlValve`, `RuptureDisk`, `SafetyReliefValve`, `SafetyValve`, `ThrottlingValve` |
 | `watertreatment` | [Water treatment](water_treatment)<br>Hydrocyclone, flotation, and produced-water treatment trains | `GasFlotationUnit`, `Hydrocyclone`, `ProducedWaterTreatmentTrain` |
 

--- a/neqsim-mcp-server/test_mcp_server.py
+++ b/neqsim-mcp-server/test_mcp_server.py
@@ -1479,8 +1479,8 @@ def test_capabilities():
     check("implementation inventory resolves 60 classes",
           implementation.get("implementationClassCount") == 60,
           str(implementation))
-    check("implementation inventory exposes 205 factory equipment types",
-          implementation.get("equipmentTypeCount") == 205,
+    check("implementation inventory exposes 206 factory equipment types",
+          implementation.get("equipmentTypeCount") == 206,
           str(implementation))
     report_paths = implementation.get("reportPaths", [])
     check("implementation inventory exposes two report paths",

--- a/src/main/java/neqsim/process/equipment/distillation/internals/GravityDrainageMargin.java
+++ b/src/main/java/neqsim/process/equipment/distillation/internals/GravityDrainageMargin.java
@@ -1,0 +1,219 @@
+package neqsim.process.equipment.distillation.internals;
+
+import java.io.Serializable;
+
+/**
+ * Gravity-drainage criterion for a column or vessel that drains liquid downwards against a gas back-pressure.
+ *
+ * <p>
+ * A packed stripper, a seal leg or a boot that drains by gravity into a downstream vessel can only do so while the
+ * available liquid static head exceeds the gas-side pressure difference it has to push against. When a bed fouls, the
+ * gas-side pressure drop rises; once it exceeds &rho;<sub>L</sub>&nbsp;g&nbsp;h the liquid stops draining, backs up and
+ * floods the section above. The gas flow then has to be stopped to let the liquid down, which is the operating symptom
+ * this class quantifies.
+ * </p>
+ *
+ * <p>
+ * The criterion is a static one. It gives the drainage limit and the margin to it; it does not describe the transient
+ * of the back-up, any frictional loss in the drain line itself, or two-phase effects in the drain leg. Those reduce the
+ * usable head further, so the criterion is optimistic with respect to drainage.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class GravityDrainageMargin implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Standard acceleration of gravity [m/s2]. */
+  public static final double STANDARD_GRAVITY = 9.80665;
+
+  /** Liquid density [kg/m3]. */
+  private final double liquidDensity;
+
+  /** Available static liquid head [m]. */
+  private final double availableStaticHead;
+
+  /** Gas-side pressure difference opposing drainage [Pa]. */
+  private final double gasPressureDrop;
+
+  /**
+   * Create a gravity-drainage criterion.
+   *
+   * @param liquidDensity liquid density [kg/m3], must be finite and positive
+   * @param availableStaticHead static liquid head available to drive drainage [m], must be finite and non-negative
+   * @param gasPressureDrop gas-side pressure difference the liquid must drain against [Pa], must be finite and
+   * non-negative
+   * @throws IllegalArgumentException if any argument is not finite or outside its valid range
+   */
+  public GravityDrainageMargin(double liquidDensity, double availableStaticHead, double gasPressureDrop) {
+    if (!isFinite(liquidDensity) || liquidDensity <= 0.0) {
+      throw new IllegalArgumentException("liquidDensity must be finite and positive");
+    }
+    if (!isFinite(availableStaticHead) || availableStaticHead < 0.0) {
+      throw new IllegalArgumentException("availableStaticHead must be finite and non-negative");
+    }
+    if (!isFinite(gasPressureDrop) || gasPressureDrop < 0.0) {
+      throw new IllegalArgumentException("gasPressureDrop must be finite and non-negative");
+    }
+    this.liquidDensity = liquidDensity;
+    this.availableStaticHead = availableStaticHead;
+    this.gasPressureDrop = gasPressureDrop;
+  }
+
+  /**
+   * Get the liquid density.
+   *
+   * @return liquid density [kg/m3]
+   */
+  public double getLiquidDensity() {
+    return liquidDensity;
+  }
+
+  /**
+   * Get the available static liquid head.
+   *
+   * @return available static head [m]
+   */
+  public double getAvailableStaticHead() {
+    return availableStaticHead;
+  }
+
+  /**
+   * Get the gas-side pressure difference opposing drainage.
+   *
+   * @return gas-side pressure drop [Pa]
+   */
+  public double getGasPressureDrop() {
+    return gasPressureDrop;
+  }
+
+  /**
+   * Get the pressure equivalent of the available static head.
+   *
+   * @return available head pressure [Pa]
+   */
+  public double getAvailableHeadPressure() {
+    return criticalPressureDrop(liquidDensity, availableStaticHead);
+  }
+
+  /**
+   * Get the pressure margin to the drainage limit.
+   *
+   * <p>
+   * Positive values mean the liquid still drains.
+   * </p>
+   *
+   * @return available head pressure minus the gas-side pressure drop [Pa]
+   */
+  public double getMarginPressure() {
+    return getAvailableHeadPressure() - gasPressureDrop;
+  }
+
+  /**
+   * Get the ratio of the available head pressure to the gas-side pressure drop.
+   *
+   * @return available head pressure divided by the gas-side pressure drop [-], or {@link Double#POSITIVE_INFINITY} when
+   * there is no gas-side pressure drop
+   */
+  public double getMarginRatio() {
+    if (gasPressureDrop <= 0.0) {
+      return Double.POSITIVE_INFINITY;
+    }
+    return getAvailableHeadPressure() / gasPressureDrop;
+  }
+
+  /**
+   * Get the fraction of the available head that the gas-side pressure drop already consumes.
+   *
+   * @return gas-side pressure drop divided by the available head pressure [-], or {@link Double#POSITIVE_INFINITY} when
+   * no head is available
+   */
+  public double getHeadUtilisation() {
+    double available = getAvailableHeadPressure();
+    if (available <= 0.0) {
+      return Double.POSITIVE_INFINITY;
+    }
+    return gasPressureDrop / available;
+  }
+
+  /**
+   * Report whether the liquid can still drain by gravity.
+   *
+   * @return true when the available head pressure is at least the gas-side pressure drop
+   */
+  public boolean canDrain() {
+    return getAvailableHeadPressure() >= gasPressureDrop;
+  }
+
+  /**
+   * Get the static head that the present gas-side pressure drop would require.
+   *
+   * @return required static head [m]
+   */
+  public double getRequiredStaticHead() {
+    return criticalStaticHead(liquidDensity, gasPressureDrop);
+  }
+
+  /**
+   * Get the largest gas-side pressure drop the present head can drain against.
+   *
+   * @return maximum allowable gas-side pressure drop [Pa]
+   */
+  public double getMaximumAllowableGasPressureDrop() {
+    return getAvailableHeadPressure();
+  }
+
+  /**
+   * Pressure equivalent of a static liquid head.
+   *
+   * @param liquidDensity liquid density [kg/m3], must be finite and positive
+   * @param staticHead static liquid head [m], must be finite and non-negative
+   * @return head pressure [Pa]
+   * @throws IllegalArgumentException if an argument is not finite or outside its valid range
+   */
+  public static double criticalPressureDrop(double liquidDensity, double staticHead) {
+    if (!isFinite(liquidDensity) || liquidDensity <= 0.0) {
+      throw new IllegalArgumentException("liquidDensity must be finite and positive");
+    }
+    if (!isFinite(staticHead) || staticHead < 0.0) {
+      throw new IllegalArgumentException("staticHead must be finite and non-negative");
+    }
+    return liquidDensity * STANDARD_GRAVITY * staticHead;
+  }
+
+  /**
+   * Static liquid head required to drain against a gas-side pressure drop.
+   *
+   * @param liquidDensity liquid density [kg/m3], must be finite and positive
+   * @param gasPressureDrop gas-side pressure drop [Pa], must be finite and non-negative
+   * @return required static head [m]
+   * @throws IllegalArgumentException if an argument is not finite or outside its valid range
+   */
+  public static double criticalStaticHead(double liquidDensity, double gasPressureDrop) {
+    if (!isFinite(liquidDensity) || liquidDensity <= 0.0) {
+      throw new IllegalArgumentException("liquidDensity must be finite and positive");
+    }
+    if (!isFinite(gasPressureDrop) || gasPressureDrop < 0.0) {
+      throw new IllegalArgumentException("gasPressureDrop must be finite and non-negative");
+    }
+    return gasPressureDrop / (liquidDensity * STANDARD_GRAVITY);
+  }
+
+  /**
+   * Java 8 compatible finiteness test.
+   *
+   * @param value value to check
+   * @return true when the value is neither NaN nor infinite
+   */
+  private static boolean isFinite(double value) {
+    return !Double.isNaN(value) && !Double.isInfinite(value);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String toString() {
+    return "GravityDrainageMargin[head=" + availableStaticHead + " m, dP=" + gasPressureDrop + " Pa, canDrain="
+        + canDrain() + "]";
+  }
+}

--- a/src/main/java/neqsim/process/equipment/distillation/internals/PackingFoulingModel.java
+++ b/src/main/java/neqsim/process/equipment/distillation/internals/PackingFoulingModel.java
@@ -1,0 +1,319 @@
+package neqsim.process.equipment.distillation.internals;
+
+import java.io.Serializable;
+
+/**
+ * Geometric derating of a packed bed caused by solid deposition (fouling).
+ *
+ * <p>
+ * A packed bed that accumulates a solid deposit loses void volume. Because the classical packing factor is
+ * geometrically equivalent to <i>a</i>/&epsilon;<sup>3</sup> and the dry-bed pressure drop of a packed bed scales with
+ * <i>F<sub>p</sub></i>&nbsp;&rho;<sub>G</sub>&nbsp;u<sup>2</sup>/ &epsilon;<sup>3</sup> at a fixed superficial gas
+ * velocity, a modest loss of void fraction produces a large pressure-drop increase. This class converts a fouling
+ * measure - either a uniform deposit thickness or a fractional void loss - into the derated void fraction, specific
+ * surface area and packing factor that a hydraulics calculation should use, and into the resulting pressure-drop and
+ * flooding-velocity ratios relative to the clean bed.
+ * </p>
+ *
+ * <p>
+ * The inverse direction is often the useful one in operations: a measured pressure-drop ratio relative to the clean or
+ * commissioned bed is converted back to the implied void loss with
+ * {@link #voidLossFractionForPressureDropRatio(double)}.
+ * </p>
+ *
+ * <p>
+ * <b>Assumptions.</b> The specific surface area is held at its clean value. This is a first-order treatment valid while
+ * the deposit thickness is small compared with the clean hydraulic diameter
+ * 4&epsilon;<sub>0</sub>/<i>a</i><sub>0</sub>; the deposit is assumed uniform over the wetted surface. The derating is
+ * geometric only - it does not describe the deposition kinetics, and it does not capture channelling caused by locally
+ * blocked cross-section.
+ * </p>
+ *
+ * <p>
+ * The derated values are intended to be fed to a packing hydraulics calculation (for example
+ * {@code PackingHydraulicsCalculator}) through its void-fraction, specific-surface-area and packing-factor setters.
+ * This class deliberately holds no reference to a calculator so that it can be used standalone for screening.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class PackingFoulingModel implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Exponent linking the void-fraction ratio to the pressure-drop ratio. */
+  private static final double PRESSURE_DROP_EXPONENT = 6.0;
+
+  /** Clean (unfouled) void fraction [-]. */
+  private final double cleanVoidFraction;
+
+  /** Clean specific surface area [m2/m3]. */
+  private final double cleanSpecificSurfaceArea;
+
+  /** Clean packing factor [1/m]. */
+  private final double cleanPackingFactor;
+
+  /** Fraction of the clean void volume filled by deposit [-]. */
+  private final double voidLossFraction;
+
+  /** Uniform deposit thickness [m], or NaN when the model was built from a void loss. */
+  private final double depositThickness;
+
+  /**
+   * Create a fouling model from already-validated quantities.
+   *
+   * @param cleanVoidFraction clean void fraction [-], in (0, 1)
+   * @param cleanSpecificSurfaceArea clean specific surface area [m2/m3], positive
+   * @param cleanPackingFactor clean packing factor [1/m], positive
+   * @param voidLossFraction fraction of the clean void volume filled by deposit [-], in [0, 1)
+   * @param depositThickness uniform deposit thickness [m], or {@link Double#NaN} when unknown
+   */
+  private PackingFoulingModel(double cleanVoidFraction, double cleanSpecificSurfaceArea, double cleanPackingFactor,
+      double voidLossFraction, double depositThickness) {
+    this.cleanVoidFraction = cleanVoidFraction;
+    this.cleanSpecificSurfaceArea = cleanSpecificSurfaceArea;
+    this.cleanPackingFactor = cleanPackingFactor;
+    this.voidLossFraction = voidLossFraction;
+    this.depositThickness = depositThickness;
+  }
+
+  /**
+   * Build a fouling model from the fraction of the clean void volume that is filled by deposit.
+   *
+   * @param cleanVoidFraction clean void fraction [-], must be in (0, 1)
+   * @param cleanSpecificSurfaceArea clean specific surface area [m2/m3], must be positive
+   * @param cleanPackingFactor clean packing factor [1/m], must be positive
+   * @param voidLossFraction fraction of the clean void volume filled by deposit [-], must be in [0, 1)
+   * @return the fouling model
+   * @throws IllegalArgumentException if any argument is outside its valid range or not finite
+   */
+  public static PackingFoulingModel fromVoidLossFraction(double cleanVoidFraction, double cleanSpecificSurfaceArea,
+      double cleanPackingFactor, double voidLossFraction) {
+    checkFraction("cleanVoidFraction", cleanVoidFraction);
+    checkPositive("cleanSpecificSurfaceArea", cleanSpecificSurfaceArea);
+    checkPositive("cleanPackingFactor", cleanPackingFactor);
+    if (!isFinite(voidLossFraction) || voidLossFraction < 0.0 || voidLossFraction >= 1.0) {
+      throw new IllegalArgumentException("voidLossFraction must be finite and in [0, 1)");
+    }
+    double thickness = cleanVoidFraction * voidLossFraction / cleanSpecificSurfaceArea;
+    return new PackingFoulingModel(cleanVoidFraction, cleanSpecificSurfaceArea, cleanPackingFactor, voidLossFraction,
+        thickness);
+  }
+
+  /**
+   * Build a fouling model from a uniform deposit thickness on the packing surface.
+   *
+   * <p>
+   * To first order the deposit removes {@code cleanSpecificSurfaceArea * thickness} of void volume per cubic metre of
+   * bed.
+   * </p>
+   *
+   * @param cleanVoidFraction clean void fraction [-], must be in (0, 1)
+   * @param cleanSpecificSurfaceArea clean specific surface area [m2/m3], must be positive
+   * @param cleanPackingFactor clean packing factor [1/m], must be positive
+   * @param depositThickness uniform deposit thickness [m], must be non-negative and small enough that the void fraction
+   * stays positive
+   * @return the fouling model
+   * @throws IllegalArgumentException if any argument is outside its valid range or not finite, or if the deposit would
+   * consume the whole void volume
+   */
+  public static PackingFoulingModel fromDepositThickness(double cleanVoidFraction, double cleanSpecificSurfaceArea,
+      double cleanPackingFactor, double depositThickness) {
+    checkFraction("cleanVoidFraction", cleanVoidFraction);
+    checkPositive("cleanSpecificSurfaceArea", cleanSpecificSurfaceArea);
+    checkPositive("cleanPackingFactor", cleanPackingFactor);
+    if (!isFinite(depositThickness) || depositThickness < 0.0) {
+      throw new IllegalArgumentException("depositThickness must be finite and non-negative");
+    }
+    double loss = cleanSpecificSurfaceArea * depositThickness / cleanVoidFraction;
+    if (loss >= 1.0) {
+      throw new IllegalArgumentException("depositThickness consumes the whole void volume; reduce the thickness");
+    }
+    return new PackingFoulingModel(cleanVoidFraction, cleanSpecificSurfaceArea, cleanPackingFactor, loss,
+        depositThickness);
+  }
+
+  /**
+   * Void loss implied by an observed pressure-drop ratio relative to the clean bed.
+   *
+   * <p>
+   * Inverts {@link #getPressureDropRatio()} at a fixed superficial gas and liquid load.
+   * </p>
+   *
+   * @param pressureDropRatio observed pressure drop divided by the clean-bed pressure drop at the same load [-], must
+   * be finite and at least 1
+   * @return the implied fraction of the clean void volume filled by deposit [-]
+   * @throws IllegalArgumentException if the ratio is not finite or is below 1
+   */
+  public static double voidLossFractionForPressureDropRatio(double pressureDropRatio) {
+    if (!isFinite(pressureDropRatio) || pressureDropRatio < 1.0) {
+      throw new IllegalArgumentException("pressureDropRatio must be finite and at least 1");
+    }
+    return 1.0 - Math.pow(pressureDropRatio, -1.0 / PRESSURE_DROP_EXPONENT);
+  }
+
+  /**
+   * Get the clean void fraction.
+   *
+   * @return clean void fraction [-]
+   */
+  public double getCleanVoidFraction() {
+    return cleanVoidFraction;
+  }
+
+  /**
+   * Get the clean specific surface area.
+   *
+   * @return clean specific surface area [m2/m3]
+   */
+  public double getCleanSpecificSurfaceArea() {
+    return cleanSpecificSurfaceArea;
+  }
+
+  /**
+   * Get the clean packing factor.
+   *
+   * @return clean packing factor [1/m]
+   */
+  public double getCleanPackingFactor() {
+    return cleanPackingFactor;
+  }
+
+  /**
+   * Get the fraction of the clean void volume that is filled by deposit.
+   *
+   * @return void loss fraction [-]
+   */
+  public double getVoidLossFraction() {
+    return voidLossFraction;
+  }
+
+  /**
+   * Get the uniform deposit thickness that corresponds to the void loss.
+   *
+   * @return deposit thickness [m]
+   */
+  public double getDepositThickness() {
+    return depositThickness;
+  }
+
+  /**
+   * Get the derated void fraction of the fouled bed.
+   *
+   * @return fouled void fraction [-]
+   */
+  public double getFouledVoidFraction() {
+    return cleanVoidFraction * (1.0 - voidLossFraction);
+  }
+
+  /**
+   * Get the specific surface area used for the fouled bed.
+   *
+   * <p>
+   * Held at the clean value; see the class-level assumptions.
+   * </p>
+   *
+   * @return fouled specific surface area [m2/m3]
+   */
+  public double getFouledSpecificSurfaceArea() {
+    return cleanSpecificSurfaceArea;
+  }
+
+  /**
+   * Get the derated packing factor of the fouled bed.
+   *
+   * <p>
+   * Scaled from the clean value with the geometric identity
+   * <i>F<sub>p</sub></i>&nbsp;&#8733;&nbsp;<i>a</i>/&epsilon;<sup>3</sup>.
+   * </p>
+   *
+   * @return fouled packing factor [1/m]
+   */
+  public double getFouledPackingFactor() {
+    double ratio = cleanVoidFraction / getFouledVoidFraction();
+    return cleanPackingFactor * ratio * ratio * ratio;
+  }
+
+  /**
+   * Get the clean hydraulic diameter of the bed.
+   *
+   * @return clean hydraulic diameter [m]
+   */
+  public double getCleanHydraulicDiameter() {
+    return 4.0 * cleanVoidFraction / cleanSpecificSurfaceArea;
+  }
+
+  /**
+   * Get the hydraulic diameter of the fouled bed.
+   *
+   * @return fouled hydraulic diameter [m]
+   */
+  public double getFouledHydraulicDiameter() {
+    return 4.0 * getFouledVoidFraction() / getFouledSpecificSurfaceArea();
+  }
+
+  /**
+   * Get the pressure-drop multiplier of the fouled bed relative to the clean bed.
+   *
+   * <p>
+   * Evaluated at the same superficial gas and liquid load.
+   * </p>
+   *
+   * @return pressure drop divided by the clean-bed pressure drop [-]
+   */
+  public double getPressureDropRatio() {
+    return Math.pow(cleanVoidFraction / getFouledVoidFraction(), PRESSURE_DROP_EXPONENT);
+  }
+
+  /**
+   * Get the flooding-velocity multiplier of the fouled bed relative to the clean bed.
+   *
+   * @return flooding velocity divided by the clean-bed flooding velocity [-]
+   */
+  public double getFloodingVelocityRatio() {
+    return Math.sqrt(cleanPackingFactor / getFouledPackingFactor());
+  }
+
+  /**
+   * Check that a value is a finite fraction strictly inside (0, 1).
+   *
+   * @param name argument name used in the exception message
+   * @param value value to check [-]
+   * @throws IllegalArgumentException if the value is not finite or not inside (0, 1)
+   */
+  private static void checkFraction(String name, double value) {
+    if (!isFinite(value) || value <= 0.0 || value >= 1.0) {
+      throw new IllegalArgumentException(name + " must be finite and in (0, 1)");
+    }
+  }
+
+  /**
+   * Check that a value is finite and strictly positive.
+   *
+   * @param name argument name used in the exception message
+   * @param value value to check
+   * @throws IllegalArgumentException if the value is not finite or not positive
+   */
+  private static void checkPositive(String name, double value) {
+    if (!isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and positive");
+    }
+  }
+
+  /**
+   * Java 8 compatible finiteness test.
+   *
+   * @param value value to check
+   * @return true when the value is neither NaN nor infinite
+   */
+  private static boolean isFinite(double value) {
+    return !Double.isNaN(value) && !Double.isInfinite(value);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String toString() {
+    return "PackingFoulingModel[voidLoss=" + voidLossFraction + ", fouledVoid=" + getFouledVoidFraction() + ", dPratio="
+        + getPressureDropRatio() + "]";
+  }
+}

--- a/src/main/java/neqsim/process/equipment/util/LubeOilSystem.java
+++ b/src/main/java/neqsim/process/equipment/util/LubeOilSystem.java
@@ -1,0 +1,2059 @@
+package neqsim.process.equipment.util;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import com.google.gson.GsonBuilder;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.util.validation.ValidationResult;
+
+/**
+ * Screening design of a lubrication (lube oil) console for rotating machinery according to API 614 / ISO 10438
+ * (Lubrication, shaft-sealing and control-oil systems).
+ *
+ * <p>
+ * The system sizes the complete oil console from the heat load of the served bearings, gears and seals:
+ * </p>
+ * <ul>
+ * <li>oil flow per consumer from the bearing heat load and the allowable temperature rise</li>
+ * <li>main and standby pump rated capacity, differential pressure, shaft power and motor rating</li>
+ * <li>reservoir working capacity from retention time and turnover rate</li>
+ * <li>cooler duty and cooling water demand (twin 2 x 100 % coolers)</li>
+ * <li>twin 2 x 100 % filters with transfer valve</li>
+ * <li>overhead (rundown) tank volume for the machine coast-down</li>
+ * <li>accumulator volume covering the pump change-over transient</li>
+ * <li>electric immersion heater power and minimum sheath area (watt density limit)</li>
+ * <li>oil supply pipe size and gravity drain pipe size (half full, sloped)</li>
+ * </ul>
+ *
+ * <h2>Design basis</h2>
+ * <table border="1">
+ * <caption>Default acceptance criteria taken from API 614 / ISO 10438 practice</caption>
+ * <tr>
+ * <th>Item</th>
+ * <th>Criterion</th>
+ * </tr>
+ * <tr>
+ * <td>Reservoir working capacity</td>
+ * <td>Minimum 5 min retention (special purpose), 3 min (general purpose)</td>
+ * </tr>
+ * <tr>
+ * <td>Reservoir turnover</td>
+ * <td>Maximum 8 turnovers per hour</td>
+ * </tr>
+ * <tr>
+ * <td>Oil supply temperature</td>
+ * <td>Maximum 49 &deg;C to hydrodynamic bearings</td>
+ * </tr>
+ * <tr>
+ * <td>Pumps</td>
+ * <td>2 x 100 %, rated for at least 110 % of maximum system demand</td>
+ * </tr>
+ * <tr>
+ * <td>Filters</td>
+ * <td>Twin 2 x 100 %, 10 micron nominal, clean pressure drop max 0.35 bar</td>
+ * </tr>
+ * <tr>
+ * <td>Overhead tank</td>
+ * <td>Minimum 3 min bearing flow during coast-down</td>
+ * </tr>
+ * <tr>
+ * <td>Immersion heater</td>
+ * <td>Maximum watt density 2.3 W/cm&sup2; to avoid oil coking</td>
+ * </tr>
+ * <tr>
+ * <td>Drain lines</td>
+ * <td>Half full at a slope of at least 20.8 mm/m</td>
+ * </tr>
+ * </table>
+ *
+ * <p>
+ * The defaults reflect common API 614 / ISO 10438 practice and are all configurable. They must be verified against the
+ * edition of the standard and the project specification that governs the actual purchase.
+ * </p>
+ *
+ * <h2>Example</h2>
+ *
+ * <pre>
+ * LubeOilSystem console = new LubeOilSystem("Lube oil console 20-LO-001");
+ * console.setServiceCategory(LubeOilSystem.ServiceCategory.SPECIAL_PURPOSE);
+ * console.setOilGrade(LubeOilSystem.OilGrade.ISO_VG_46);
+ * console.addConsumerFromShaftPower("Compressor bearings", LubeOilSystem.ConsumerType.JOURNAL_BEARING, 6000.0);
+ * console.addConsumerFromShaftPower("Gearbox", LubeOilSystem.ConsumerType.GEARBOX, 6000.0);
+ * console.addControlOilConsumer("Governor", 60.0, 10.0);
+ * console.run();
+ * String json = console.toJson();
+ * </pre>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public class LubeOilSystem extends ProcessEquipmentBaseClass {
+
+  private static final long serialVersionUID = 1000L;
+  private static final Logger logger = LogManager.getLogger(LubeOilSystem.class);
+
+  /** Maximum oil supply temperature to hydrodynamic bearings [C]. */
+  public static final double MAX_BEARING_SUPPLY_TEMPERATURE = 49.0;
+
+  /** Maximum reservoir turnover rate [1/hr]. */
+  public static final double MAX_RESERVOIR_TURNOVERS_PER_HOUR = 8.0;
+
+  /** Maximum filter rating for lube oil service [micron nominal]. */
+  public static final double MAX_FILTER_RATING_MICRON = 10.0;
+
+  /** Maximum clean filter pressure drop at rated flow and 38 C [bar]. */
+  public static final double MAX_CLEAN_FILTER_PRESSURE_DROP = 0.35;
+
+  /** Minimum pump rated capacity relative to maximum system demand [-]. */
+  public static final double MIN_PUMP_RATED_MARGIN = 1.10;
+
+  /** Minimum overhead (rundown) tank holdup for special purpose machines [min]. */
+  public static final double MIN_RUNDOWN_TIME = 3.0;
+
+  /** Maximum watt density of electric immersion heaters [W/cm2]. */
+  public static final double MAX_HEATER_WATT_DENSITY = 2.3;
+
+  /** Minimum slope of gravity drain lines [m/m], equal to 20.8 mm/m. */
+  public static final double MIN_DRAIN_SLOPE = 0.0208;
+
+  /** Standard IEC motor ratings used when selecting the pump motor [kW]. */
+  private static final double[] STANDARD_MOTOR_RATINGS = { 0.75, 1.1, 1.5, 2.2, 3.0, 4.0, 5.5, 7.5, 11.0, 15.0, 18.5,
+      22.0, 30.0, 37.0, 45.0, 55.0, 75.0, 90.0, 110.0, 132.0, 160.0, 200.0, 250.0, 315.0, 355.0, 400.0 };
+
+  // ============================================================================
+  // Enumerations
+  // ============================================================================
+
+  /**
+   * Machinery service category, which sets the applicable part of the standard and the minimum reservoir retention
+   * time.
+   */
+  public enum ServiceCategory {
+    /** General purpose machinery, API 614 Chapter 2 / ISO 10438-2. */
+    GENERAL_PURPOSE("API 614 Chapter 2 / ISO 10438-2", 3.0, false),
+    /** Special purpose machinery, API 614 Chapter 3 / ISO 10438-3. */
+    SPECIAL_PURPOSE("API 614 Chapter 3 / ISO 10438-3", 5.0, true);
+
+    private final String reference;
+    private final double minRetentionMinutes;
+    private final boolean rundownTankRequired;
+
+    ServiceCategory(String reference, double minRetentionMinutes, boolean rundownTankRequired) {
+      this.reference = reference;
+      this.minRetentionMinutes = minRetentionMinutes;
+      this.rundownTankRequired = rundownTankRequired;
+    }
+
+    /**
+     * Gets the standard reference for the category.
+     *
+     * @return standard reference text
+     */
+    public String getReference() {
+      return reference;
+    }
+
+    /**
+     * Gets the minimum reservoir retention time.
+     *
+     * @return retention time [min]
+     */
+    public double getMinRetentionMinutes() {
+      return minRetentionMinutes;
+    }
+
+    /**
+     * Checks whether an overhead (rundown) tank is required.
+     *
+     * @return true when a rundown tank is required
+     */
+    public boolean isRundownTankRequired() {
+      return rundownTankRequired;
+    }
+  }
+
+  /**
+   * ISO 3448 viscosity grades commonly used for turbomachinery lube oil.
+   */
+  public enum OilGrade {
+    /** ISO VG 32 turbine oil. */
+    ISO_VG_32(32.0, 5.4, 857.0),
+    /** ISO VG 46 turbine oil. */
+    ISO_VG_46(46.0, 6.8, 865.0),
+    /** ISO VG 68 gear and bearing oil. */
+    ISO_VG_68(68.0, 8.7, 872.0),
+    /** ISO VG 100 gear oil. */
+    ISO_VG_100(100.0, 11.4, 878.0);
+
+    private final double viscosity40;
+    private final double viscosity100;
+    private final double density15;
+
+    OilGrade(double viscosity40, double viscosity100, double density15) {
+      this.viscosity40 = viscosity40;
+      this.viscosity100 = viscosity100;
+      this.density15 = density15;
+    }
+
+    /**
+     * Gets the nominal kinematic viscosity at 40 C.
+     *
+     * @return kinematic viscosity [cSt]
+     */
+    public double getViscosity40() {
+      return viscosity40;
+    }
+
+    /**
+     * Gets the nominal kinematic viscosity at 100 C.
+     *
+     * @return kinematic viscosity [cSt]
+     */
+    public double getViscosity100() {
+      return viscosity100;
+    }
+
+    /**
+     * Gets the density at 15 C.
+     *
+     * @return density [kg/m3]
+     */
+    public double getDensity15() {
+      return density15;
+    }
+  }
+
+  /**
+   * Type of oil consumer served by the console.
+   */
+  public enum ConsumerType {
+    /** Hydrodynamic journal bearing. */
+    JOURNAL_BEARING(0.008, 25.0, false),
+    /** Tilting pad thrust bearing. */
+    THRUST_BEARING(0.006, 25.0, false),
+    /** Speed increasing or reducing gear. */
+    GEARBOX(0.015, 20.0, false),
+    /** Oil lubricated mechanical or film riding seal. */
+    MECHANICAL_SEAL(0.003, 20.0, false),
+    /** Control oil consumer such as a governor or trip and throttle valve. */
+    CONTROL_OIL(0.0, 0.0, true),
+    /** Other lube oil consumer. */
+    OTHER(0.005, 20.0, false);
+
+    private final double lossFraction;
+    private final double temperatureRise;
+    private final boolean controlOil;
+
+    ConsumerType(double lossFraction, double temperatureRise, boolean controlOil) {
+      this.lossFraction = lossFraction;
+      this.temperatureRise = temperatureRise;
+      this.controlOil = controlOil;
+    }
+
+    /**
+     * Gets the indicative mechanical loss as a fraction of transmitted shaft power.
+     *
+     * @return loss fraction [-]
+     */
+    public double getLossFraction() {
+      return lossFraction;
+    }
+
+    /**
+     * Gets the default oil temperature rise across the consumer.
+     *
+     * @return temperature rise [K]
+     */
+    public double getTemperatureRise() {
+      return temperatureRise;
+    }
+
+    /**
+     * Checks whether the consumer is a control oil consumer.
+     *
+     * @return true for control oil consumers
+     */
+    public boolean isControlOil() {
+      return controlOil;
+    }
+  }
+
+  // ============================================================================
+  // Design input
+  // ============================================================================
+
+  /** Machinery service category. */
+  private ServiceCategory serviceCategory = ServiceCategory.SPECIAL_PURPOSE;
+
+  /** Selected oil viscosity grade. */
+  private OilGrade oilGrade = OilGrade.ISO_VG_46;
+
+  /** Oil supply temperature to the bearings [C]. */
+  private double supplyTemperature = 45.0;
+
+  /** Reservoir bulk oil temperature during normal operation [C]. */
+  private double reservoirTemperature = 60.0;
+
+  /** Minimum oil temperature before start-up, used for heater sizing [C]. */
+  private double minimumStartTemperature = 5.0;
+
+  /** Oil temperature required before the machine may be started [C]. */
+  private double requiredStartTemperature = 20.0;
+
+  /** Lube oil header pressure at the bearings [barg]. */
+  private double lubeHeaderPressure = 1.5;
+
+  /** Control oil header pressure [barg]. */
+  private double controlOilHeaderPressure = 10.0;
+
+  /** Static elevation from the reservoir to the highest bearing [m]. */
+  private double bearingElevation = 5.0;
+
+  /** Cooler pressure drop at rated flow [bar]. */
+  private double coolerPressureDrop = 0.35;
+
+  /** Clean filter pressure drop at rated flow and 38 C [bar]. */
+  private double filterPressureDropClean = 0.30;
+
+  /** Filter pressure drop used for pump sizing, that is the fouled condition [bar]. */
+  private double filterPressureDropFouled = 1.0;
+
+  /** Piping and fitting pressure losses [bar]. */
+  private double pipingPressureDrop = 0.5;
+
+  /** Pressure drop across the header pressure control valve [bar]. */
+  private double controlValvePressureDrop = 1.0;
+
+  /** Filter rating [micron nominal]. */
+  private double filterRatingMicron = 10.0;
+
+  /** Number of installed main pumps, normally 2 x 100 percent. */
+  private int numberOfPumps = 2;
+
+  /** Number of installed coolers, normally 2 x 100 percent. */
+  private int numberOfCoolers = 2;
+
+  /** Number of installed filters, normally 2 x 100 percent. */
+  private int numberOfFilters = 2;
+
+  /** Pump rated capacity relative to the maximum system demand [-]. */
+  private double pumpDesignMargin = 1.10;
+
+  /** Pump hydraulic efficiency [-]. */
+  private double pumpEfficiency = 0.65;
+
+  /** Cooling water inlet temperature [C]. */
+  private double coolingWaterInletTemperature = 20.0;
+
+  /** Cooling water outlet temperature [C]. */
+  private double coolingWaterOutletTemperature = 32.0;
+
+  /** Reservoir free board and vapour space fraction of the total volume [-]. */
+  private double reservoirFreeboardFraction = 0.20;
+
+  /** Overhead (rundown) tank holdup time [min]. */
+  private double rundownTime = 3.0;
+
+  /** Pump change-over transient covered by the accumulator [s]. */
+  private double accumulatorTransferTime = 10.0;
+
+  /** Allowable header pressure decay during the pump change-over [bar]. */
+  private double accumulatorAllowablePressureDrop = 0.5;
+
+  /** Polytropic exponent used for the accumulator gas expansion [-]. */
+  private double accumulatorGasExponent = 1.4;
+
+  /** True when a change-over accumulator is fitted. */
+  private boolean accumulatorFitted = true;
+
+  /** Heater soak time used to size the immersion heater [hr]. */
+  private double heaterSoakTime = 8.0;
+
+  /** Maximum oil velocity in pressure piping [m/s]. */
+  private double maxSupplyVelocity = 3.0;
+
+  /** Slope of the gravity drain lines [m/m]. */
+  private double drainSlope = 0.0208;
+
+  /** Manning roughness coefficient used for the gravity drain lines [-]. */
+  private double drainRoughness = 0.012;
+
+  /** Consumers served by the console. */
+  private final List<OilConsumer> consumers = new ArrayList<OilConsumer>();
+
+  // ============================================================================
+  // Calculated results
+  // ============================================================================
+
+  private double totalHeatLoad = 0.0;
+  private double lubeOilFlow = 0.0;
+  private double controlOilFlow = 0.0;
+  private double normalOilFlow = 0.0;
+  private double ratedPumpFlow = 0.0;
+  private double pumpDischargePressure = 0.0;
+  private double pumpDifferentialPressure = 0.0;
+  private double pumpHydraulicPower = 0.0;
+  private double pumpShaftPower = 0.0;
+  private double pumpMotorRating = 0.0;
+  private double reservoirWorkingVolume = 0.0;
+  private double reservoirTotalVolume = 0.0;
+  private double reservoirRetentionTime = 0.0;
+  private double reservoirTurnoverRate = 0.0;
+  private double coolerDuty = 0.0;
+  private double coolerDutyPerUnit = 0.0;
+  private double coolingWaterFlow = 0.0;
+  private double rundownTankVolume = 0.0;
+  private double accumulatorVolume = 0.0;
+  private double accumulatorPrechargePressure = 0.0;
+  private double heaterPower = 0.0;
+  private double heaterMinimumArea = 0.0;
+  private double supplyPipeDiameter = 0.0;
+  private double drainPipeDiameter = 0.0;
+  private double oilDensityAtSupply = 0.0;
+  private double oilHeatCapacityAtSupply = 0.0;
+  private double oilViscosityAtSupply = 0.0;
+  private boolean systemRunning = false;
+
+  /** Compliance checks populated by the last run. */
+  private final List<ComplianceCheck> complianceChecks = new ArrayList<ComplianceCheck>();
+
+  // ============================================================================
+  // Constructors
+  // ============================================================================
+
+  /**
+   * Creates a lube oil console with default design data.
+   *
+   * @param name equipment name
+   */
+  public LubeOilSystem(String name) {
+    super(name);
+  }
+
+  /**
+   * Creates a lube oil console for a given machinery service category.
+   *
+   * @param name equipment name
+   * @param serviceCategory machinery service category
+   */
+  public LubeOilSystem(String name, ServiceCategory serviceCategory) {
+    super(name);
+    setServiceCategory(serviceCategory);
+  }
+
+  // ============================================================================
+  // Consumer configuration
+  // ============================================================================
+
+  /**
+   * Adds a consumer to the console.
+   *
+   * @param consumer consumer to add
+   */
+  public void addConsumer(OilConsumer consumer) {
+    consumers.add(consumer);
+  }
+
+  /**
+   * Adds a lube oil consumer defined by its heat load.
+   *
+   * @param name consumer name
+   * @param type consumer type
+   * @param heatLoadKW dissipated heat load [kW]
+   * @return the created consumer
+   */
+  public OilConsumer addConsumer(String name, ConsumerType type, double heatLoadKW) {
+    OilConsumer consumer = new OilConsumer(name, type);
+    consumer.setHeatLoad(heatLoadKW);
+    consumers.add(consumer);
+    return consumer;
+  }
+
+  /**
+   * Adds a lube oil consumer where the heat load is estimated from the transmitted shaft power using the indicative
+   * loss fraction of the consumer type.
+   *
+   * @param name consumer name
+   * @param type consumer type
+   * @param shaftPowerKW transmitted shaft power [kW]
+   * @return the created consumer
+   */
+  public OilConsumer addConsumerFromShaftPower(String name, ConsumerType type, double shaftPowerKW) {
+    OilConsumer consumer = new OilConsumer(name, type);
+    consumer.setHeatLoad(shaftPowerKW * type.getLossFraction());
+    consumer.setShaftPower(shaftPowerKW);
+    consumers.add(consumer);
+    return consumer;
+  }
+
+  /**
+   * Adds a control oil consumer with a specified flow demand.
+   *
+   * @param name consumer name
+   * @param flowLitrePerMin control oil flow [L/min]
+   * @param supplyPressure required supply pressure [barg]
+   * @return the created consumer
+   */
+  public OilConsumer addControlOilConsumer(String name, double flowLitrePerMin, double supplyPressure) {
+    OilConsumer consumer = new OilConsumer(name, ConsumerType.CONTROL_OIL);
+    consumer.setSpecifiedFlow(flowLitrePerMin);
+    consumer.setRequiredSupplyPressure(supplyPressure);
+    consumers.add(consumer);
+    return consumer;
+  }
+
+  /**
+   * Gets the consumers served by the console.
+   *
+   * @return unmodifiable list of consumers
+   */
+  public List<OilConsumer> getConsumers() {
+    return Collections.unmodifiableList(consumers);
+  }
+
+  // ============================================================================
+  // Oil properties
+  // ============================================================================
+
+  /**
+   * Calculates the oil density at a given temperature from the density at 15 C using a thermal expansion coefficient of
+   * 7.0e-4 1/K.
+   *
+   * @param temperatureC temperature [C]
+   * @return density [kg/m3]
+   */
+  public double getOilDensity(double temperatureC) {
+    return oilGrade.getDensity15() / (1.0 + 7.0e-4 * (temperatureC - 15.0));
+  }
+
+  /**
+   * Calculates the oil specific heat capacity from the standard petroleum liquid correlation cp = (1.685 + 0.0039 T) /
+   * sqrt(SG).
+   *
+   * @param temperatureC temperature [C]
+   * @return specific heat capacity [kJ/kg K]
+   */
+  public double getOilHeatCapacity(double temperatureC) {
+    double specificGravity = oilGrade.getDensity15() / 999.0;
+    return (1.685 + 0.0039 * temperatureC) / Math.sqrt(specificGravity);
+  }
+
+  /**
+   * Calculates the kinematic viscosity at a given temperature with the ASTM D341 (Walther) relation fitted to the grade
+   * viscosities at 40 C and 100 C.
+   *
+   * @param temperatureC temperature [C]
+   * @return kinematic viscosity [cSt]
+   */
+  public double getOilKinematicViscosity(double temperatureC) {
+    double z40 = Math.log10(Math.log10(oilGrade.getViscosity40() + 0.7));
+    double z100 = Math.log10(Math.log10(oilGrade.getViscosity100() + 0.7));
+    double logT40 = Math.log10(313.15);
+    double logT100 = Math.log10(373.15);
+    double slope = (z40 - z100) / (logT100 - logT40);
+    double intercept = z40 + slope * logT40;
+    double logT = Math.log10(temperatureC + 273.15);
+    return Math.pow(10.0, Math.pow(10.0, intercept - slope * logT)) - 0.7;
+  }
+
+  /**
+   * Calculates the dynamic viscosity at a given temperature.
+   *
+   * @param temperatureC temperature [C]
+   * @return dynamic viscosity [Pa s]
+   */
+  public double getOilDynamicViscosity(double temperatureC) {
+    return getOilKinematicViscosity(temperatureC) * 1.0e-6 * getOilDensity(temperatureC);
+  }
+
+  // ============================================================================
+  // Run calculation
+  // ============================================================================
+
+  /** {@inheritDoc} */
+  @Override
+  public void run(UUID id) {
+    oilDensityAtSupply = getOilDensity(supplyTemperature);
+    oilHeatCapacityAtSupply = getOilHeatCapacity(supplyTemperature);
+    oilViscosityAtSupply = getOilKinematicViscosity(supplyTemperature);
+
+    calculateFlows();
+    calculatePumps();
+    calculateReservoir();
+    calculateCoolers();
+    calculateRundownTank();
+    calculateAccumulator();
+    calculateHeater();
+    calculatePiping();
+    buildComplianceReport();
+
+    systemRunning = true;
+    setCalculationIdentifier(id);
+
+    logger.info("Lube oil console {} sized: {} m3/hr normal flow, {} m3 reservoir, {} kW cooler duty", getName(),
+        normalOilFlow, reservoirTotalVolume, coolerDuty);
+  }
+
+  /**
+   * Calculates the oil flow for each consumer and the total system flow.
+   */
+  private void calculateFlows() {
+    totalHeatLoad = 0.0;
+    lubeOilFlow = 0.0;
+    controlOilFlow = 0.0;
+
+    for (OilConsumer consumer : consumers) {
+      double flowLitrePerMin;
+      if (!Double.isNaN(consumer.getSpecifiedFlow())) {
+        flowLitrePerMin = consumer.getSpecifiedFlow();
+      } else {
+        double rise = consumer.getTemperatureRise();
+        if (rise <= 0.0) {
+          flowLitrePerMin = 0.0;
+        } else {
+          double flowM3PerSec = consumer.getHeatLoad() / (oilDensityAtSupply * oilHeatCapacityAtSupply * rise);
+          flowLitrePerMin = flowM3PerSec * 60000.0;
+        }
+      }
+      consumer.setCalculatedFlow(flowLitrePerMin);
+      totalHeatLoad += consumer.getHeatLoad();
+      if (consumer.getType().isControlOil()) {
+        controlOilFlow += flowLitrePerMin;
+      } else {
+        lubeOilFlow += flowLitrePerMin;
+      }
+    }
+
+    normalOilFlow = (lubeOilFlow + controlOilFlow) * 0.06;
+    ratedPumpFlow = normalOilFlow * pumpDesignMargin;
+  }
+
+  /**
+   * Calculates the pump duty point, shaft power and motor rating.
+   */
+  private void calculatePumps() {
+    double requiredHeaderPressure = lubeHeaderPressure;
+    for (OilConsumer consumer : consumers) {
+      if (consumer.getType().isControlOil()) {
+        requiredHeaderPressure = Math.max(requiredHeaderPressure, controlOilHeaderPressure);
+      }
+      if (!Double.isNaN(consumer.getRequiredSupplyPressure())) {
+        requiredHeaderPressure = Math.max(requiredHeaderPressure, consumer.getRequiredSupplyPressure());
+      }
+    }
+
+    double staticHead = oilDensityAtSupply * 9.80665 * bearingElevation / 1.0e5;
+    pumpDischargePressure = requiredHeaderPressure + coolerPressureDrop + filterPressureDropFouled + pipingPressureDrop
+        + controlValvePressureDrop + staticHead;
+    pumpDifferentialPressure = pumpDischargePressure;
+
+    double flowM3PerSec = ratedPumpFlow / 3600.0;
+    pumpHydraulicPower = flowM3PerSec * pumpDifferentialPressure * 1.0e5 / 1000.0;
+    pumpShaftPower = pumpEfficiency > 0.0 ? pumpHydraulicPower / pumpEfficiency : Double.NaN;
+    pumpMotorRating = selectStandardMotor(pumpShaftPower * 1.10);
+  }
+
+  /**
+   * Selects the smallest standard motor rating that covers the required power.
+   *
+   * @param requiredPowerKW required motor power [kW]
+   * @return selected standard motor rating [kW]
+   */
+  private double selectStandardMotor(double requiredPowerKW) {
+    for (int i = 0; i < STANDARD_MOTOR_RATINGS.length; i++) {
+      if (STANDARD_MOTOR_RATINGS[i] >= requiredPowerKW) {
+        return STANDARD_MOTOR_RATINGS[i];
+      }
+    }
+    return Math.ceil(requiredPowerKW / 50.0) * 50.0;
+  }
+
+  /**
+   * Sizes the reservoir on the governing criterion of retention time and turnover rate.
+   */
+  private void calculateReservoir() {
+    double retentionVolume = normalOilFlow / 60.0 * serviceCategory.getMinRetentionMinutes();
+    double turnoverVolume = normalOilFlow / MAX_RESERVOIR_TURNOVERS_PER_HOUR;
+    reservoirWorkingVolume = Math.max(retentionVolume, turnoverVolume);
+    reservoirTotalVolume = reservoirWorkingVolume / (1.0 - reservoirFreeboardFraction);
+    reservoirRetentionTime = normalOilFlow > 0.0 ? reservoirWorkingVolume / (normalOilFlow / 60.0) : Double.NaN;
+    reservoirTurnoverRate = reservoirWorkingVolume > 0.0 ? normalOilFlow / reservoirWorkingVolume : Double.NaN;
+  }
+
+  /**
+   * Calculates the cooler duty and the cooling water demand.
+   */
+  private void calculateCoolers() {
+    double pumpHeat = Double.isNaN(pumpShaftPower) ? 0.0 : pumpShaftPower;
+    coolerDuty = totalHeatLoad + pumpHeat;
+    int dutyCoolers = Math.max(1, numberOfCoolers - 1);
+    coolerDutyPerUnit = coolerDuty / dutyCoolers;
+
+    double waterRise = coolingWaterOutletTemperature - coolingWaterInletTemperature;
+    if (waterRise > 0.0) {
+      double waterMassFlow = coolerDuty / (4.18 * waterRise);
+      coolingWaterFlow = waterMassFlow * 3.6;
+    } else {
+      coolingWaterFlow = Double.NaN;
+    }
+  }
+
+  /**
+   * Sizes the overhead (rundown) tank for the machine coast-down.
+   */
+  private void calculateRundownTank() {
+    if (serviceCategory.isRundownTankRequired()) {
+      rundownTankVolume = lubeOilFlow / 1000.0 * rundownTime;
+    } else {
+      rundownTankVolume = 0.0;
+    }
+  }
+
+  /**
+   * Sizes the change-over accumulator using the adiabatic gas law for a bladder accumulator.
+   */
+  private void calculateAccumulator() {
+    if (!accumulatorFitted || lubeOilFlow <= 0.0) {
+      accumulatorVolume = 0.0;
+      accumulatorPrechargePressure = 0.0;
+      return;
+    }
+
+    double deliveredVolume = lubeOilFlow / 1000.0 / 60.0 * accumulatorTransferTime;
+    double maxPressureAbs = lubeHeaderPressure + 1.01325;
+    double minPressureAbs = Math.max(0.2, lubeHeaderPressure - accumulatorAllowablePressureDrop) + 1.01325;
+    accumulatorPrechargePressure = 0.9 * minPressureAbs;
+
+    double exponent = 1.0 / accumulatorGasExponent;
+    double expansionFactor = Math.pow(accumulatorPrechargePressure / minPressureAbs, exponent)
+        - Math.pow(accumulatorPrechargePressure / maxPressureAbs, exponent);
+    accumulatorVolume = expansionFactor > 1.0e-9 ? deliveredVolume / expansionFactor : Double.NaN;
+  }
+
+  /**
+   * Sizes the electric immersion heater and the minimum sheath area from the watt density limit.
+   */
+  private void calculateHeater() {
+    double deltaT = requiredStartTemperature - minimumStartTemperature;
+    if (deltaT <= 0.0 || heaterSoakTime <= 0.0) {
+      heaterPower = 0.0;
+      heaterMinimumArea = 0.0;
+      return;
+    }
+    double meanTemperature = 0.5 * (minimumStartTemperature + requiredStartTemperature);
+    double oilMass = reservoirWorkingVolume * getOilDensity(meanTemperature);
+    heaterPower = oilMass * getOilHeatCapacity(meanTemperature) * deltaT / (heaterSoakTime * 3600.0);
+    heaterMinimumArea = heaterPower * 1000.0 / MAX_HEATER_WATT_DENSITY / 10000.0;
+  }
+
+  /**
+   * Sizes the oil supply pipe from the velocity limit and the gravity drain pipe from half full Manning flow at the
+   * specified slope.
+   */
+  private void calculatePiping() {
+    double flowM3PerSec = ratedPumpFlow / 3600.0;
+    if (flowM3PerSec > 0.0 && maxSupplyVelocity > 0.0) {
+      supplyPipeDiameter = Math.sqrt(4.0 * flowM3PerSec / (Math.PI * maxSupplyVelocity));
+    } else {
+      supplyPipeDiameter = 0.0;
+    }
+
+    double drainFlow = lubeOilFlow / 60000.0;
+    if (drainFlow > 0.0 && drainSlope > 0.0) {
+      double numerator = drainFlow * drainRoughness * 8.0 * Math.pow(4.0, 2.0 / 3.0);
+      double denominator = Math.PI * Math.sqrt(drainSlope);
+      drainPipeDiameter = Math.pow(numerator / denominator, 3.0 / 8.0);
+    } else {
+      drainPipeDiameter = 0.0;
+    }
+  }
+
+  /**
+   * Builds the API 614 / ISO 10438 compliance checklist for the calculated design.
+   */
+  private void buildComplianceReport() {
+    complianceChecks.clear();
+    String reference = serviceCategory.getReference();
+
+    addCheck("Reservoir retention time", reference,
+        String.format("Minimum %.1f min at normal flow", serviceCategory.getMinRetentionMinutes()),
+        String.format("%.1f min", reservoirRetentionTime),
+        reservoirRetentionTime >= serviceCategory.getMinRetentionMinutes() - 1.0e-6);
+
+    addCheck("Reservoir turnover rate", reference,
+        String.format("Maximum %.0f turnovers per hour", MAX_RESERVOIR_TURNOVERS_PER_HOUR),
+        String.format("%.1f 1/hr", reservoirTurnoverRate),
+        reservoirTurnoverRate <= MAX_RESERVOIR_TURNOVERS_PER_HOUR + 1.0e-6);
+
+    addCheck("Bearing oil supply temperature", reference,
+        String.format("Maximum %.0f C", MAX_BEARING_SUPPLY_TEMPERATURE), String.format("%.1f C", supplyTemperature),
+        supplyTemperature <= MAX_BEARING_SUPPLY_TEMPERATURE);
+
+    addCheck("Main oil pumps", reference, "2 x 100 % pumps with independent drivers", numberOfPumps + " x 100 %",
+        numberOfPumps >= 2);
+
+    addCheck("Pump rated capacity", reference,
+        String.format("Minimum %.0f %% of maximum system demand", MIN_PUMP_RATED_MARGIN * 100.0),
+        String.format("%.0f %%", pumpDesignMargin * 100.0), pumpDesignMargin >= MIN_PUMP_RATED_MARGIN - 1.0e-6);
+
+    addCheck("Oil coolers", reference, "Twin 2 x 100 % coolers with transfer valve", numberOfCoolers + " x 100 %",
+        numberOfCoolers >= 2);
+
+    addCheck("Oil filters", reference, "Twin 2 x 100 % filters with transfer valve", numberOfFilters + " x 100 %",
+        numberOfFilters >= 2);
+
+    addCheck("Filter rating", reference, String.format("Maximum %.0f micron nominal", MAX_FILTER_RATING_MICRON),
+        String.format("%.0f micron", filterRatingMicron), filterRatingMicron <= MAX_FILTER_RATING_MICRON + 1.0e-6);
+
+    addCheck("Clean filter pressure drop", reference,
+        String.format("Maximum %.2f bar at rated flow and 38 C", MAX_CLEAN_FILTER_PRESSURE_DROP),
+        String.format("%.2f bar", filterPressureDropClean),
+        filterPressureDropClean <= MAX_CLEAN_FILTER_PRESSURE_DROP + 1.0e-6);
+
+    if (serviceCategory.isRundownTankRequired()) {
+      addCheck("Overhead (rundown) tank", reference,
+          String.format("Minimum %.0f min of bearing flow", MIN_RUNDOWN_TIME),
+          String.format("%.1f min (%.2f m3)", rundownTime, rundownTankVolume),
+          rundownTime >= MIN_RUNDOWN_TIME - 1.0e-6 && rundownTankVolume > 0.0);
+    }
+
+    addCheck("Heater watt density", reference, String.format("Maximum %.1f W/cm2", MAX_HEATER_WATT_DENSITY),
+        String.format("%.2f m2 minimum sheath area at %.1f kW", heaterMinimumArea, heaterPower),
+        heaterMinimumArea >= 0.0);
+
+    addCheck("Oil supply velocity", reference, String.format("Maximum %.1f m/s in pressure piping", maxSupplyVelocity),
+        String.format("%.0f mm supply pipe inside diameter", supplyPipeDiameter * 1000.0), supplyPipeDiameter > 0.0);
+
+    addCheck("Gravity drain lines", reference,
+        String.format("Half full, slope minimum %.1f mm/m", MIN_DRAIN_SLOPE * 1000.0),
+        String.format("%.0f mm drain at %.1f mm/m", drainPipeDiameter * 1000.0, drainSlope * 1000.0),
+        drainSlope >= MIN_DRAIN_SLOPE - 1.0e-9 && drainPipeDiameter > 0.0);
+  }
+
+  /**
+   * Adds a single entry to the compliance checklist.
+   *
+   * @param item item description
+   * @param reference standard reference
+   * @param requirement requirement text
+   * @param actual actual design value
+   * @param compliant true when the requirement is met
+   */
+  private void addCheck(String item, String reference, String requirement, String actual, boolean compliant) {
+    complianceChecks.add(new ComplianceCheck(item, reference, requirement, actual, compliant));
+  }
+
+  // ============================================================================
+  // Results
+  // ============================================================================
+
+  /**
+   * Gets the total dissipated heat load of all consumers.
+   *
+   * @return heat load [kW]
+   */
+  public double getTotalHeatLoad() {
+    return totalHeatLoad;
+  }
+
+  /**
+   * Gets the total lube oil flow to bearings, gears and seals.
+   *
+   * @return lube oil flow [L/min]
+   */
+  public double getLubeOilFlow() {
+    return lubeOilFlow;
+  }
+
+  /**
+   * Gets the total control oil flow.
+   *
+   * @return control oil flow [L/min]
+   */
+  public double getControlOilFlow() {
+    return controlOilFlow;
+  }
+
+  /**
+   * Gets the normal total system flow.
+   *
+   * @return normal flow [m3/hr]
+   */
+  public double getNormalOilFlow() {
+    return normalOilFlow;
+  }
+
+  /**
+   * Gets the rated pump capacity including the design margin.
+   *
+   * @return rated pump flow [m3/hr]
+   */
+  public double getRatedPumpFlow() {
+    return ratedPumpFlow;
+  }
+
+  /**
+   * Gets the required pump discharge pressure.
+   *
+   * @return discharge pressure [barg]
+   */
+  public double getPumpDischargePressure() {
+    return pumpDischargePressure;
+  }
+
+  /**
+   * Gets the pump differential pressure.
+   *
+   * @return differential pressure [bar]
+   */
+  public double getPumpDifferentialPressure() {
+    return pumpDifferentialPressure;
+  }
+
+  /**
+   * Gets the pump hydraulic power.
+   *
+   * @return hydraulic power [kW]
+   */
+  public double getPumpHydraulicPower() {
+    return pumpHydraulicPower;
+  }
+
+  /**
+   * Gets the pump shaft power.
+   *
+   * @return shaft power [kW]
+   */
+  public double getPumpShaftPower() {
+    return pumpShaftPower;
+  }
+
+  /**
+   * Gets the selected standard motor rating for each main pump.
+   *
+   * @return motor rating [kW]
+   */
+  public double getPumpMotorRating() {
+    return pumpMotorRating;
+  }
+
+  /**
+   * Gets the reservoir working capacity.
+   *
+   * @return working volume [m3]
+   */
+  public double getReservoirWorkingVolume() {
+    return reservoirWorkingVolume;
+  }
+
+  /**
+   * Gets the total reservoir volume including free board and vapour space.
+   *
+   * @return total volume [m3]
+   */
+  public double getReservoirTotalVolume() {
+    return reservoirTotalVolume;
+  }
+
+  /**
+   * Gets the reservoir retention time at normal flow.
+   *
+   * @return retention time [min]
+   */
+  public double getReservoirRetentionTime() {
+    return reservoirRetentionTime;
+  }
+
+  /**
+   * Gets the reservoir turnover rate at normal flow.
+   *
+   * @return turnover rate [1/hr]
+   */
+  public double getReservoirTurnoverRate() {
+    return reservoirTurnoverRate;
+  }
+
+  /**
+   * Gets the total cooler duty including the pump work dissipated into the oil.
+   *
+   * @return cooler duty [kW]
+   */
+  public double getCoolerDuty() {
+    return coolerDuty;
+  }
+
+  /**
+   * Gets the duty of each installed duty cooler.
+   *
+   * @return duty per cooler [kW]
+   */
+  public double getCoolerDutyPerUnit() {
+    return coolerDutyPerUnit;
+  }
+
+  /**
+   * Gets the cooling water demand.
+   *
+   * @return cooling water flow [m3/hr]
+   */
+  public double getCoolingWaterFlow() {
+    return coolingWaterFlow;
+  }
+
+  /**
+   * Gets the overhead (rundown) tank volume.
+   *
+   * @return rundown tank volume [m3]
+   */
+  public double getRundownTankVolume() {
+    return rundownTankVolume;
+  }
+
+  /**
+   * Gets the total accumulator volume covering the pump change-over.
+   *
+   * @return accumulator volume [m3]
+   */
+  public double getAccumulatorVolume() {
+    return accumulatorVolume;
+  }
+
+  /**
+   * Gets the accumulator gas precharge pressure.
+   *
+   * @return precharge pressure [bara]
+   */
+  public double getAccumulatorPrechargePressure() {
+    return accumulatorPrechargePressure;
+  }
+
+  /**
+   * Gets the required immersion heater power.
+   *
+   * @return heater power [kW]
+   */
+  public double getHeaterPower() {
+    return heaterPower;
+  }
+
+  /**
+   * Gets the minimum heater sheath area set by the watt density limit.
+   *
+   * @return minimum sheath area [m2]
+   */
+  public double getHeaterMinimumArea() {
+    return heaterMinimumArea;
+  }
+
+  /**
+   * Gets the required oil supply pipe inside diameter.
+   *
+   * @return inside diameter [m]
+   */
+  public double getSupplyPipeDiameter() {
+    return supplyPipeDiameter;
+  }
+
+  /**
+   * Gets the required gravity drain pipe inside diameter for half full flow.
+   *
+   * @return inside diameter [m]
+   */
+  public double getDrainPipeDiameter() {
+    return drainPipeDiameter;
+  }
+
+  /**
+   * Gets the oil kinematic viscosity at the bearing supply temperature.
+   *
+   * @return kinematic viscosity [cSt]
+   */
+  public double getOilViscosityAtSupply() {
+    return oilViscosityAtSupply;
+  }
+
+  /**
+   * Gets the oil density at the bearing supply temperature.
+   *
+   * @return density [kg/m3]
+   */
+  public double getOilDensityAtSupply() {
+    return oilDensityAtSupply;
+  }
+
+  /**
+   * Gets the oil specific heat capacity at the bearing supply temperature.
+   *
+   * @return specific heat capacity [kJ/kg K]
+   */
+  public double getOilHeatCapacityAtSupply() {
+    return oilHeatCapacityAtSupply;
+  }
+
+  /**
+   * Checks whether the console has been sized.
+   *
+   * @return true when the last run completed
+   */
+  public boolean isSystemRunning() {
+    return systemRunning;
+  }
+
+  /**
+   * Gets the compliance checklist from the last run.
+   *
+   * @return unmodifiable list of compliance checks
+   */
+  public List<ComplianceCheck> getComplianceChecks() {
+    return Collections.unmodifiableList(complianceChecks);
+  }
+
+  /**
+   * Checks whether all compliance items are met.
+   *
+   * @return true when every compliance check passes
+   */
+  public boolean isApiCompliant() {
+    if (complianceChecks.isEmpty()) {
+      return false;
+    }
+    for (ComplianceCheck check : complianceChecks) {
+      if (!check.isCompliant()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Gets the compliance items that are not met.
+   *
+   * @return list of failing compliance checks
+   */
+  public List<ComplianceCheck> getDeviations() {
+    List<ComplianceCheck> deviations = new ArrayList<ComplianceCheck>();
+    for (ComplianceCheck check : complianceChecks) {
+      if (!check.isCompliant()) {
+        deviations.add(check);
+      }
+    }
+    return deviations;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String toJson() {
+    Map<String, Object> results = new LinkedHashMap<String, Object>();
+    results.put("name", getName());
+    results.put("standard", "API 614 / ISO 10438");
+    results.put("serviceCategory", serviceCategory.name());
+    results.put("standardReference", serviceCategory.getReference());
+    results.put("oilGrade", oilGrade.name());
+
+    Map<String, Object> oil = new LinkedHashMap<String, Object>();
+    oil.put("supplyTemperatureC", supplyTemperature);
+    oil.put("reservoirTemperatureC", reservoirTemperature);
+    oil.put("densityAtSupplyKgM3", oilDensityAtSupply);
+    oil.put("heatCapacityAtSupplyKJkgK", oilHeatCapacityAtSupply);
+    oil.put("kinematicViscosityAtSupplyCSt", oilViscosityAtSupply);
+    results.put("oilProperties", oil);
+
+    Map<String, Object> load = new LinkedHashMap<String, Object>();
+    load.put("totalHeatLoadKW", totalHeatLoad);
+    load.put("lubeOilFlowLpm", lubeOilFlow);
+    load.put("controlOilFlowLpm", controlOilFlow);
+    load.put("normalFlowM3h", normalOilFlow);
+    load.put("ratedPumpFlowM3h", ratedPumpFlow);
+    results.put("flowSummary", load);
+
+    Map<String, Object> pumps = new LinkedHashMap<String, Object>();
+    pumps.put("numberOfPumps", numberOfPumps);
+    pumps.put("dischargePressureBarg", pumpDischargePressure);
+    pumps.put("differentialPressureBar", pumpDifferentialPressure);
+    pumps.put("hydraulicPowerKW", pumpHydraulicPower);
+    pumps.put("shaftPowerKW", pumpShaftPower);
+    pumps.put("motorRatingKW", pumpMotorRating);
+    results.put("pumps", pumps);
+
+    Map<String, Object> reservoir = new LinkedHashMap<String, Object>();
+    reservoir.put("workingVolumeM3", reservoirWorkingVolume);
+    reservoir.put("totalVolumeM3", reservoirTotalVolume);
+    reservoir.put("retentionTimeMin", reservoirRetentionTime);
+    reservoir.put("turnoverRatePerHour", reservoirTurnoverRate);
+    results.put("reservoir", reservoir);
+
+    Map<String, Object> coolers = new LinkedHashMap<String, Object>();
+    coolers.put("numberOfCoolers", numberOfCoolers);
+    coolers.put("totalDutyKW", coolerDuty);
+    coolers.put("dutyPerCoolerKW", coolerDutyPerUnit);
+    coolers.put("coolingWaterFlowM3h", coolingWaterFlow);
+    results.put("coolers", coolers);
+
+    Map<String, Object> filters = new LinkedHashMap<String, Object>();
+    filters.put("numberOfFilters", numberOfFilters);
+    filters.put("ratingMicron", filterRatingMicron);
+    filters.put("cleanPressureDropBar", filterPressureDropClean);
+    filters.put("fouledPressureDropBar", filterPressureDropFouled);
+    results.put("filters", filters);
+
+    Map<String, Object> transient1 = new LinkedHashMap<String, Object>();
+    transient1.put("rundownTankVolumeM3", rundownTankVolume);
+    transient1.put("rundownTimeMin", rundownTime);
+    transient1.put("accumulatorVolumeM3", accumulatorVolume);
+    transient1.put("accumulatorPrechargeBara", accumulatorPrechargePressure);
+    transient1.put("accumulatorTransferTimeS", accumulatorTransferTime);
+    results.put("transientProtection", transient1);
+
+    Map<String, Object> heater = new LinkedHashMap<String, Object>();
+    heater.put("powerKW", heaterPower);
+    heater.put("minimumSheathAreaM2", heaterMinimumArea);
+    heater.put("maxWattDensityWcm2", MAX_HEATER_WATT_DENSITY);
+    results.put("heater", heater);
+
+    Map<String, Object> piping = new LinkedHashMap<String, Object>();
+    piping.put("supplyPipeIdMm", supplyPipeDiameter * 1000.0);
+    piping.put("maxSupplyVelocityMs", maxSupplyVelocity);
+    piping.put("drainPipeIdMm", drainPipeDiameter * 1000.0);
+    piping.put("drainSlopeMmPerM", drainSlope * 1000.0);
+    results.put("piping", piping);
+
+    List<Map<String, Object>> consumerList = new ArrayList<Map<String, Object>>();
+    for (OilConsumer consumer : consumers) {
+      Map<String, Object> entry = new LinkedHashMap<String, Object>();
+      entry.put("name", consumer.getName());
+      entry.put("type", consumer.getType().name());
+      entry.put("heatLoadKW", consumer.getHeatLoad());
+      entry.put("temperatureRiseK", consumer.getTemperatureRise());
+      entry.put("flowLpm", consumer.getCalculatedFlow());
+      consumerList.add(entry);
+    }
+    results.put("consumers", consumerList);
+
+    List<Map<String, Object>> checkList = new ArrayList<Map<String, Object>>();
+    for (ComplianceCheck check : complianceChecks) {
+      Map<String, Object> entry = new LinkedHashMap<String, Object>();
+      entry.put("item", check.getItem());
+      entry.put("reference", check.getReference());
+      entry.put("requirement", check.getRequirement());
+      entry.put("actual", check.getActual());
+      entry.put("compliant", check.isCompliant());
+      checkList.add(entry);
+    }
+    results.put("complianceChecks", checkList);
+    results.put("apiCompliant", isApiCompliant());
+
+    return new GsonBuilder().setPrettyPrinting().create().toJson(results);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ValidationResult validateSetup() {
+    ValidationResult result = new ValidationResult(getName());
+    if (consumers.isEmpty()) {
+      result.addError("configuration", "No oil consumers defined",
+          "Call addConsumer(name, type, heatLoadKW) or addConsumerFromShaftPower(...)");
+    }
+    if (supplyTemperature > MAX_BEARING_SUPPLY_TEMPERATURE) {
+      result.addWarning("design",
+          "Oil supply temperature exceeds the API 614 limit of " + MAX_BEARING_SUPPLY_TEMPERATURE + " C",
+          "Call setSupplyTemperature(45.0) or increase the cooler duty");
+    }
+    if (numberOfPumps < 2) {
+      result.addWarning("design", "Only one main oil pump is configured",
+          "API 614 requires a full capacity installed spare, call setNumberOfPumps(2)");
+    }
+    if (pumpEfficiency <= 0.0 || pumpEfficiency > 1.0) {
+      result.addError("design", "Pump efficiency must be in the interval (0, 1]", "Call setPumpEfficiency(0.65)");
+    }
+    if (coolingWaterOutletTemperature <= coolingWaterInletTemperature) {
+      result.addError("design", "Cooling water outlet temperature must exceed the inlet",
+          "Call setCoolingWaterOutletTemperature(32.0)");
+    }
+    return result;
+  }
+
+  // ============================================================================
+  // Getters and setters for design input
+  // ============================================================================
+
+  /**
+   * Gets the machinery service category.
+   *
+   * @return service category
+   */
+  public ServiceCategory getServiceCategory() {
+    return serviceCategory;
+  }
+
+  /**
+   * Sets the machinery service category.
+   *
+   * @param serviceCategory service category
+   */
+  public void setServiceCategory(ServiceCategory serviceCategory) {
+    this.serviceCategory = serviceCategory;
+    this.accumulatorFitted = serviceCategory.isRundownTankRequired();
+  }
+
+  /**
+   * Gets the oil viscosity grade.
+   *
+   * @return oil grade
+   */
+  public OilGrade getOilGrade() {
+    return oilGrade;
+  }
+
+  /**
+   * Sets the oil viscosity grade.
+   *
+   * @param oilGrade oil grade
+   */
+  public void setOilGrade(OilGrade oilGrade) {
+    this.oilGrade = oilGrade;
+  }
+
+  /**
+   * Gets the oil supply temperature to the bearings.
+   *
+   * @return supply temperature [C]
+   */
+  public double getSupplyTemperature() {
+    return supplyTemperature;
+  }
+
+  /**
+   * Sets the oil supply temperature to the bearings.
+   *
+   * @param supplyTemperature supply temperature [C]
+   */
+  public void setSupplyTemperature(double supplyTemperature) {
+    this.supplyTemperature = supplyTemperature;
+  }
+
+  /**
+   * Gets the reservoir bulk oil temperature.
+   *
+   * @return reservoir temperature [C]
+   */
+  public double getReservoirTemperature() {
+    return reservoirTemperature;
+  }
+
+  /**
+   * Sets the reservoir bulk oil temperature.
+   *
+   * @param reservoirTemperature reservoir temperature [C]
+   */
+  public void setReservoirTemperature(double reservoirTemperature) {
+    this.reservoirTemperature = reservoirTemperature;
+  }
+
+  /**
+   * Gets the minimum oil temperature used for heater sizing.
+   *
+   * @return minimum start temperature [C]
+   */
+  public double getMinimumStartTemperature() {
+    return minimumStartTemperature;
+  }
+
+  /**
+   * Sets the minimum oil temperature used for heater sizing.
+   *
+   * @param minimumStartTemperature minimum start temperature [C]
+   */
+  public void setMinimumStartTemperature(double minimumStartTemperature) {
+    this.minimumStartTemperature = minimumStartTemperature;
+  }
+
+  /**
+   * Gets the oil temperature required before start-up.
+   *
+   * @return required start temperature [C]
+   */
+  public double getRequiredStartTemperature() {
+    return requiredStartTemperature;
+  }
+
+  /**
+   * Sets the oil temperature required before start-up.
+   *
+   * @param requiredStartTemperature required start temperature [C]
+   */
+  public void setRequiredStartTemperature(double requiredStartTemperature) {
+    this.requiredStartTemperature = requiredStartTemperature;
+  }
+
+  /**
+   * Gets the lube oil header pressure.
+   *
+   * @return header pressure [barg]
+   */
+  public double getLubeHeaderPressure() {
+    return lubeHeaderPressure;
+  }
+
+  /**
+   * Sets the lube oil header pressure.
+   *
+   * @param lubeHeaderPressure header pressure [barg]
+   */
+  public void setLubeHeaderPressure(double lubeHeaderPressure) {
+    this.lubeHeaderPressure = lubeHeaderPressure;
+  }
+
+  /**
+   * Gets the control oil header pressure.
+   *
+   * @return control oil pressure [barg]
+   */
+  public double getControlOilHeaderPressure() {
+    return controlOilHeaderPressure;
+  }
+
+  /**
+   * Sets the control oil header pressure.
+   *
+   * @param controlOilHeaderPressure control oil pressure [barg]
+   */
+  public void setControlOilHeaderPressure(double controlOilHeaderPressure) {
+    this.controlOilHeaderPressure = controlOilHeaderPressure;
+  }
+
+  /**
+   * Gets the static elevation from the reservoir to the highest bearing.
+   *
+   * @return elevation [m]
+   */
+  public double getBearingElevation() {
+    return bearingElevation;
+  }
+
+  /**
+   * Sets the static elevation from the reservoir to the highest bearing.
+   *
+   * @param bearingElevation elevation [m]
+   */
+  public void setBearingElevation(double bearingElevation) {
+    this.bearingElevation = bearingElevation;
+  }
+
+  /**
+   * Gets the cooler pressure drop.
+   *
+   * @return cooler pressure drop [bar]
+   */
+  public double getCoolerPressureDrop() {
+    return coolerPressureDrop;
+  }
+
+  /**
+   * Sets the cooler pressure drop.
+   *
+   * @param coolerPressureDrop cooler pressure drop [bar]
+   */
+  public void setCoolerPressureDrop(double coolerPressureDrop) {
+    this.coolerPressureDrop = coolerPressureDrop;
+  }
+
+  /**
+   * Gets the clean filter pressure drop.
+   *
+   * @return clean pressure drop [bar]
+   */
+  public double getFilterPressureDropClean() {
+    return filterPressureDropClean;
+  }
+
+  /**
+   * Sets the clean filter pressure drop.
+   *
+   * @param filterPressureDropClean clean pressure drop [bar]
+   */
+  public void setFilterPressureDropClean(double filterPressureDropClean) {
+    this.filterPressureDropClean = filterPressureDropClean;
+  }
+
+  /**
+   * Gets the fouled filter pressure drop used for pump sizing.
+   *
+   * @return fouled pressure drop [bar]
+   */
+  public double getFilterPressureDropFouled() {
+    return filterPressureDropFouled;
+  }
+
+  /**
+   * Sets the fouled filter pressure drop used for pump sizing.
+   *
+   * @param filterPressureDropFouled fouled pressure drop [bar]
+   */
+  public void setFilterPressureDropFouled(double filterPressureDropFouled) {
+    this.filterPressureDropFouled = filterPressureDropFouled;
+  }
+
+  /**
+   * Gets the piping pressure loss allowance.
+   *
+   * @return piping pressure drop [bar]
+   */
+  public double getPipingPressureDrop() {
+    return pipingPressureDrop;
+  }
+
+  /**
+   * Sets the piping pressure loss allowance.
+   *
+   * @param pipingPressureDrop piping pressure drop [bar]
+   */
+  public void setPipingPressureDrop(double pipingPressureDrop) {
+    this.pipingPressureDrop = pipingPressureDrop;
+  }
+
+  /**
+   * Gets the header pressure control valve pressure drop.
+   *
+   * @return control valve pressure drop [bar]
+   */
+  public double getControlValvePressureDrop() {
+    return controlValvePressureDrop;
+  }
+
+  /**
+   * Sets the header pressure control valve pressure drop.
+   *
+   * @param controlValvePressureDrop control valve pressure drop [bar]
+   */
+  public void setControlValvePressureDrop(double controlValvePressureDrop) {
+    this.controlValvePressureDrop = controlValvePressureDrop;
+  }
+
+  /**
+   * Gets the filter rating.
+   *
+   * @return filter rating [micron nominal]
+   */
+  public double getFilterRatingMicron() {
+    return filterRatingMicron;
+  }
+
+  /**
+   * Sets the filter rating.
+   *
+   * @param filterRatingMicron filter rating [micron nominal]
+   */
+  public void setFilterRatingMicron(double filterRatingMicron) {
+    this.filterRatingMicron = filterRatingMicron;
+  }
+
+  /**
+   * Gets the number of installed main pumps.
+   *
+   * @return number of pumps
+   */
+  public int getNumberOfPumps() {
+    return numberOfPumps;
+  }
+
+  /**
+   * Sets the number of installed main pumps.
+   *
+   * @param numberOfPumps number of pumps
+   */
+  public void setNumberOfPumps(int numberOfPumps) {
+    this.numberOfPumps = numberOfPumps;
+  }
+
+  /**
+   * Gets the number of installed coolers.
+   *
+   * @return number of coolers
+   */
+  public int getNumberOfCoolers() {
+    return numberOfCoolers;
+  }
+
+  /**
+   * Sets the number of installed coolers.
+   *
+   * @param numberOfCoolers number of coolers
+   */
+  public void setNumberOfCoolers(int numberOfCoolers) {
+    this.numberOfCoolers = numberOfCoolers;
+  }
+
+  /**
+   * Gets the number of installed filters.
+   *
+   * @return number of filters
+   */
+  public int getNumberOfFilters() {
+    return numberOfFilters;
+  }
+
+  /**
+   * Sets the number of installed filters.
+   *
+   * @param numberOfFilters number of filters
+   */
+  public void setNumberOfFilters(int numberOfFilters) {
+    this.numberOfFilters = numberOfFilters;
+  }
+
+  /**
+   * Gets the pump design margin.
+   *
+   * @return design margin [-]
+   */
+  public double getPumpDesignMargin() {
+    return pumpDesignMargin;
+  }
+
+  /**
+   * Sets the pump design margin.
+   *
+   * @param pumpDesignMargin design margin [-]
+   */
+  public void setPumpDesignMargin(double pumpDesignMargin) {
+    this.pumpDesignMargin = pumpDesignMargin;
+  }
+
+  /**
+   * Gets the pump hydraulic efficiency.
+   *
+   * @return efficiency [-]
+   */
+  public double getPumpEfficiency() {
+    return pumpEfficiency;
+  }
+
+  /**
+   * Sets the pump hydraulic efficiency.
+   *
+   * @param pumpEfficiency efficiency [-]
+   */
+  public void setPumpEfficiency(double pumpEfficiency) {
+    this.pumpEfficiency = pumpEfficiency;
+  }
+
+  /**
+   * Gets the cooling water inlet temperature.
+   *
+   * @return inlet temperature [C]
+   */
+  public double getCoolingWaterInletTemperature() {
+    return coolingWaterInletTemperature;
+  }
+
+  /**
+   * Sets the cooling water inlet temperature.
+   *
+   * @param coolingWaterInletTemperature inlet temperature [C]
+   */
+  public void setCoolingWaterInletTemperature(double coolingWaterInletTemperature) {
+    this.coolingWaterInletTemperature = coolingWaterInletTemperature;
+  }
+
+  /**
+   * Gets the cooling water outlet temperature.
+   *
+   * @return outlet temperature [C]
+   */
+  public double getCoolingWaterOutletTemperature() {
+    return coolingWaterOutletTemperature;
+  }
+
+  /**
+   * Sets the cooling water outlet temperature.
+   *
+   * @param coolingWaterOutletTemperature outlet temperature [C]
+   */
+  public void setCoolingWaterOutletTemperature(double coolingWaterOutletTemperature) {
+    this.coolingWaterOutletTemperature = coolingWaterOutletTemperature;
+  }
+
+  /**
+   * Gets the reservoir free board fraction.
+   *
+   * @return free board fraction [-]
+   */
+  public double getReservoirFreeboardFraction() {
+    return reservoirFreeboardFraction;
+  }
+
+  /**
+   * Sets the reservoir free board fraction.
+   *
+   * @param reservoirFreeboardFraction free board fraction [-]
+   */
+  public void setReservoirFreeboardFraction(double reservoirFreeboardFraction) {
+    this.reservoirFreeboardFraction = reservoirFreeboardFraction;
+  }
+
+  /**
+   * Gets the overhead tank holdup time.
+   *
+   * @return rundown time [min]
+   */
+  public double getRundownTime() {
+    return rundownTime;
+  }
+
+  /**
+   * Sets the overhead tank holdup time.
+   *
+   * @param rundownTime rundown time [min]
+   */
+  public void setRundownTime(double rundownTime) {
+    this.rundownTime = rundownTime;
+  }
+
+  /**
+   * Gets the pump change-over transient time covered by the accumulator.
+   *
+   * @return transfer time [s]
+   */
+  public double getAccumulatorTransferTime() {
+    return accumulatorTransferTime;
+  }
+
+  /**
+   * Sets the pump change-over transient time covered by the accumulator.
+   *
+   * @param accumulatorTransferTime transfer time [s]
+   */
+  public void setAccumulatorTransferTime(double accumulatorTransferTime) {
+    this.accumulatorTransferTime = accumulatorTransferTime;
+  }
+
+  /**
+   * Gets the allowable header pressure decay during the pump change-over.
+   *
+   * @return allowable pressure drop [bar]
+   */
+  public double getAccumulatorAllowablePressureDrop() {
+    return accumulatorAllowablePressureDrop;
+  }
+
+  /**
+   * Sets the allowable header pressure decay during the pump change-over.
+   *
+   * @param accumulatorAllowablePressureDrop allowable pressure drop [bar]
+   */
+  public void setAccumulatorAllowablePressureDrop(double accumulatorAllowablePressureDrop) {
+    this.accumulatorAllowablePressureDrop = accumulatorAllowablePressureDrop;
+  }
+
+  /**
+   * Checks whether a change-over accumulator is fitted.
+   *
+   * @return true when an accumulator is fitted
+   */
+  public boolean isAccumulatorFitted() {
+    return accumulatorFitted;
+  }
+
+  /**
+   * Sets whether a change-over accumulator is fitted.
+   *
+   * @param accumulatorFitted true when an accumulator is fitted
+   */
+  public void setAccumulatorFitted(boolean accumulatorFitted) {
+    this.accumulatorFitted = accumulatorFitted;
+  }
+
+  /**
+   * Gets the heater soak time.
+   *
+   * @return soak time [hr]
+   */
+  public double getHeaterSoakTime() {
+    return heaterSoakTime;
+  }
+
+  /**
+   * Sets the heater soak time.
+   *
+   * @param heaterSoakTime soak time [hr]
+   */
+  public void setHeaterSoakTime(double heaterSoakTime) {
+    this.heaterSoakTime = heaterSoakTime;
+  }
+
+  /**
+   * Gets the maximum oil velocity in pressure piping.
+   *
+   * @return maximum velocity [m/s]
+   */
+  public double getMaxSupplyVelocity() {
+    return maxSupplyVelocity;
+  }
+
+  /**
+   * Sets the maximum oil velocity in pressure piping.
+   *
+   * @param maxSupplyVelocity maximum velocity [m/s]
+   */
+  public void setMaxSupplyVelocity(double maxSupplyVelocity) {
+    this.maxSupplyVelocity = maxSupplyVelocity;
+  }
+
+  /**
+   * Gets the gravity drain line slope.
+   *
+   * @return slope [m/m]
+   */
+  public double getDrainSlope() {
+    return drainSlope;
+  }
+
+  /**
+   * Sets the gravity drain line slope.
+   *
+   * @param drainSlope slope [m/m]
+   */
+  public void setDrainSlope(double drainSlope) {
+    this.drainSlope = drainSlope;
+  }
+
+  // ============================================================================
+  // Inner classes
+  // ============================================================================
+
+  /**
+   * A bearing, gear, seal or control oil consumer served by the console.
+   */
+  public static class OilConsumer implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String name;
+    private final ConsumerType type;
+    private double heatLoad = 0.0;
+    private double shaftPower = Double.NaN;
+    private double temperatureRise;
+    private double specifiedFlow = Double.NaN;
+    private double requiredSupplyPressure = Double.NaN;
+    private double calculatedFlow = 0.0;
+
+    /**
+     * Creates an oil consumer.
+     *
+     * @param name consumer name
+     * @param type consumer type
+     */
+    public OilConsumer(String name, ConsumerType type) {
+      this.name = name;
+      this.type = type;
+      this.temperatureRise = type.getTemperatureRise();
+    }
+
+    /**
+     * Gets the consumer name.
+     *
+     * @return consumer name
+     */
+    public String getName() {
+      return name;
+    }
+
+    /**
+     * Gets the consumer type.
+     *
+     * @return consumer type
+     */
+    public ConsumerType getType() {
+      return type;
+    }
+
+    /**
+     * Gets the dissipated heat load.
+     *
+     * @return heat load [kW]
+     */
+    public double getHeatLoad() {
+      return heatLoad;
+    }
+
+    /**
+     * Sets the dissipated heat load.
+     *
+     * @param heatLoad heat load [kW]
+     */
+    public void setHeatLoad(double heatLoad) {
+      this.heatLoad = heatLoad;
+    }
+
+    /**
+     * Gets the transmitted shaft power used to estimate the heat load.
+     *
+     * @return shaft power [kW], or NaN when not set
+     */
+    public double getShaftPower() {
+      return shaftPower;
+    }
+
+    /**
+     * Sets the transmitted shaft power used to estimate the heat load.
+     *
+     * @param shaftPower shaft power [kW]
+     */
+    public void setShaftPower(double shaftPower) {
+      this.shaftPower = shaftPower;
+    }
+
+    /**
+     * Gets the allowable oil temperature rise across the consumer.
+     *
+     * @return temperature rise [K]
+     */
+    public double getTemperatureRise() {
+      return temperatureRise;
+    }
+
+    /**
+     * Sets the allowable oil temperature rise across the consumer.
+     *
+     * @param temperatureRise temperature rise [K]
+     */
+    public void setTemperatureRise(double temperatureRise) {
+      this.temperatureRise = temperatureRise;
+    }
+
+    /**
+     * Gets the specified oil flow that overrides the heat balance flow.
+     *
+     * @return specified flow [L/min], or NaN when not set
+     */
+    public double getSpecifiedFlow() {
+      return specifiedFlow;
+    }
+
+    /**
+     * Sets a specified oil flow that overrides the heat balance flow.
+     *
+     * @param specifiedFlow specified flow [L/min]
+     */
+    public void setSpecifiedFlow(double specifiedFlow) {
+      this.specifiedFlow = specifiedFlow;
+    }
+
+    /**
+     * Gets the required supply pressure.
+     *
+     * @return supply pressure [barg], or NaN when not set
+     */
+    public double getRequiredSupplyPressure() {
+      return requiredSupplyPressure;
+    }
+
+    /**
+     * Sets the required supply pressure.
+     *
+     * @param requiredSupplyPressure supply pressure [barg]
+     */
+    public void setRequiredSupplyPressure(double requiredSupplyPressure) {
+      this.requiredSupplyPressure = requiredSupplyPressure;
+    }
+
+    /**
+     * Gets the oil flow calculated by the console.
+     *
+     * @return calculated flow [L/min]
+     */
+    public double getCalculatedFlow() {
+      return calculatedFlow;
+    }
+
+    /**
+     * Sets the oil flow calculated by the console.
+     *
+     * @param calculatedFlow calculated flow [L/min]
+     */
+    public void setCalculatedFlow(double calculatedFlow) {
+      this.calculatedFlow = calculatedFlow;
+    }
+  }
+
+  /**
+   * A single entry in the API 614 / ISO 10438 compliance checklist.
+   */
+  public static class ComplianceCheck implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String item;
+    private final String reference;
+    private final String requirement;
+    private final String actual;
+    private final boolean compliant;
+
+    /**
+     * Creates a compliance check entry.
+     *
+     * @param item item description
+     * @param reference standard reference
+     * @param requirement requirement text
+     * @param actual actual design value
+     * @param compliant true when the requirement is met
+     */
+    public ComplianceCheck(String item, String reference, String requirement, String actual, boolean compliant) {
+      this.item = item;
+      this.reference = reference;
+      this.requirement = requirement;
+      this.actual = actual;
+      this.compliant = compliant;
+    }
+
+    /**
+     * Gets the item description.
+     *
+     * @return item description
+     */
+    public String getItem() {
+      return item;
+    }
+
+    /**
+     * Gets the standard reference.
+     *
+     * @return standard reference
+     */
+    public String getReference() {
+      return reference;
+    }
+
+    /**
+     * Gets the requirement text.
+     *
+     * @return requirement text
+     */
+    public String getRequirement() {
+      return requirement;
+    }
+
+    /**
+     * Gets the actual design value.
+     *
+     * @return actual design value
+     */
+    public String getActual() {
+      return actual;
+    }
+
+    /**
+     * Checks whether the requirement is met.
+     *
+     * @return true when the requirement is met
+     */
+    public boolean isCompliant() {
+      return compliant;
+    }
+  }
+}

--- a/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
@@ -141,7 +141,7 @@ class CapabilitiesRunnerTest {
 
     JsonArray equipmentTypes = inventory.getAsJsonArray("supportedEquipmentTypes");
     JsonArray contractEquipment = root.getAsJsonObject("processJsonContract").getAsJsonArray("supportedEquipmentTypes");
-    assertEquals(205, inventory.get("equipmentTypeCount").getAsInt());
+    assertEquals(206, inventory.get("equipmentTypeCount").getAsInt());
     assertEquals(contractEquipment, equipmentTypes);
     assertTrue(equipmentTypes.toString().contains("Compressor"));
     assertTrue(equipmentTypes.toString().contains("ThreePhaseSeparator"));

--- a/src/test/java/neqsim/process/equipment/distillation/internals/GravityDrainageMarginTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/internals/GravityDrainageMarginTest.java
@@ -1,0 +1,68 @@
+package neqsim.process.equipment.distillation.internals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link GravityDrainageMargin}. */
+public class GravityDrainageMarginTest {
+  /** Lean TEG density at regeneration temperature [kg/m3]. */
+  private static final double TEG_DENSITY = 962.0;
+
+  /** Head pressure must equal rho g h and drainage must be reported as possible. */
+  @Test
+  void headPressureAndDrainageAtLowPressureDrop() {
+    GravityDrainageMargin margin = new GravityDrainageMargin(TEG_DENSITY, 1.5, 9000.0);
+    double expected = TEG_DENSITY * GravityDrainageMargin.STANDARD_GRAVITY * 1.5;
+    assertEquals(expected, margin.getAvailableHeadPressure(), 1.0e-9);
+    assertEquals(expected - 9000.0, margin.getMarginPressure(), 1.0e-9);
+    assertEquals(expected / 9000.0, margin.getMarginRatio(), 1.0e-9);
+    assertEquals(9000.0 / expected, margin.getHeadUtilisation(), 1.0e-9);
+    assertTrue(margin.canDrain());
+    assertEquals(expected, margin.getMaximumAllowableGasPressureDrop(), 1.0e-9);
+  }
+
+  /** A gas-side pressure drop above the head must block drainage. */
+  @Test
+  void drainageFailsWhenPressureDropExceedsHead() {
+    GravityDrainageMargin margin = new GravityDrainageMargin(TEG_DENSITY, 1.5, 29000.0);
+    assertFalse(margin.canDrain());
+    assertTrue(margin.getMarginPressure() < 0.0);
+    assertTrue(margin.getMarginRatio() < 1.0);
+    assertTrue(margin.getHeadUtilisation() > 1.0);
+    assertTrue(margin.getRequiredStaticHead() > margin.getAvailableStaticHead());
+    assertTrue(margin.toString().contains("canDrain=false"));
+  }
+
+  /** The static helpers must be exact inverses of one another. */
+  @Test
+  void staticHelpersAreInverses() {
+    double head = 1.25;
+    double dp = GravityDrainageMargin.criticalPressureDrop(TEG_DENSITY, head);
+    assertEquals(head, GravityDrainageMargin.criticalStaticHead(TEG_DENSITY, dp), 1.0e-12);
+    assertEquals(0.0, GravityDrainageMargin.criticalPressureDrop(TEG_DENSITY, 0.0), 1.0e-12);
+  }
+
+  /** With no gas-side pressure drop the margin ratio must be infinite, not NaN. */
+  @Test
+  void zeroPressureDropGivesInfiniteMargin() {
+    GravityDrainageMargin margin = new GravityDrainageMargin(TEG_DENSITY, 1.5, 0.0);
+    assertTrue(Double.isInfinite(margin.getMarginRatio()));
+    assertTrue(margin.canDrain());
+    assertEquals(0.0, margin.getRequiredStaticHead(), 1.0e-12);
+  }
+
+  /** Invalid arguments must be rejected. */
+  @Test
+  void invalidArgumentsAreRejected() {
+    assertThrows(IllegalArgumentException.class, () -> new GravityDrainageMargin(0.0, 1.0, 100.0));
+    assertThrows(IllegalArgumentException.class, () -> new GravityDrainageMargin(TEG_DENSITY, -1.0, 100.0));
+    assertThrows(IllegalArgumentException.class, () -> new GravityDrainageMargin(TEG_DENSITY, 1.0, -1.0));
+    assertThrows(IllegalArgumentException.class, () -> GravityDrainageMargin.criticalPressureDrop(-1.0, 1.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> GravityDrainageMargin.criticalStaticHead(TEG_DENSITY, Double.NaN));
+  }
+}

--- a/src/test/java/neqsim/process/equipment/distillation/internals/PackingFoulingModelTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/internals/PackingFoulingModelTest.java
@@ -1,0 +1,87 @@
+package neqsim.process.equipment.distillation.internals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link PackingFoulingModel}. */
+public class PackingFoulingModelTest {
+  /** Clean 2 inch metal Pall ring void fraction [-]. */
+  private static final double CLEAN_VOID = 0.951;
+
+  /** Clean 2 inch metal Pall ring specific surface area [m2/m3]. */
+  private static final double CLEAN_AREA = 102.0;
+
+  /** Clean 2 inch metal Pall ring packing factor [1/m]. */
+  private static final double CLEAN_FP = 88.0;
+
+  /** A clean bed must reproduce its own geometry and a unity pressure-drop ratio. */
+  @Test
+  void cleanBedIsNeutral() {
+    PackingFoulingModel model = PackingFoulingModel.fromVoidLossFraction(CLEAN_VOID, CLEAN_AREA, CLEAN_FP, 0.0);
+    assertEquals(CLEAN_VOID, model.getFouledVoidFraction(), 1.0e-12);
+    assertEquals(CLEAN_FP, model.getFouledPackingFactor(), 1.0e-9);
+    assertEquals(1.0, model.getPressureDropRatio(), 1.0e-12);
+    assertEquals(1.0, model.getFloodingVelocityRatio(), 1.0e-12);
+    assertEquals(0.0, model.getDepositThickness(), 1.0e-15);
+    assertTrue(model.toString().contains("dPratio"));
+  }
+
+  /** Void loss must raise the packing factor and pressure drop and cut the flooding velocity. */
+  @Test
+  void voidLossRaisesPressureDrop() {
+    PackingFoulingModel model = PackingFoulingModel.fromVoidLossFraction(CLEAN_VOID, CLEAN_AREA, CLEAN_FP, 0.20);
+    assertEquals(CLEAN_VOID * 0.80, model.getFouledVoidFraction(), 1.0e-12);
+    assertEquals(CLEAN_FP / Math.pow(0.80, 3.0), model.getFouledPackingFactor(), 1.0e-9);
+    assertEquals(Math.pow(1.0 / 0.80, 6.0), model.getPressureDropRatio(), 1.0e-9);
+    assertTrue(model.getFloodingVelocityRatio() < 1.0);
+    assertTrue(model.getFouledHydraulicDiameter() < model.getCleanHydraulicDiameter());
+    assertEquals(CLEAN_AREA, model.getFouledSpecificSurfaceArea(), 1.0e-12);
+  }
+
+  /** Deposit thickness and void loss must be consistent inverses of one another. */
+  @Test
+  void depositThicknessAndVoidLossAreConsistent() {
+    double thickness = 5.0e-4;
+    PackingFoulingModel byThickness = PackingFoulingModel.fromDepositThickness(CLEAN_VOID, CLEAN_AREA, CLEAN_FP,
+        thickness);
+    double loss = byThickness.getVoidLossFraction();
+    assertEquals(CLEAN_AREA * thickness / CLEAN_VOID, loss, 1.0e-12);
+
+    PackingFoulingModel byLoss = PackingFoulingModel.fromVoidLossFraction(CLEAN_VOID, CLEAN_AREA, CLEAN_FP, loss);
+    assertEquals(thickness, byLoss.getDepositThickness(), 1.0e-15);
+    assertEquals(byThickness.getPressureDropRatio(), byLoss.getPressureDropRatio(), 1.0e-12);
+  }
+
+  /** The pressure-drop inverse must return the void loss that generated the ratio. */
+  @Test
+  void pressureDropRatioInvertsToVoidLoss() {
+    PackingFoulingModel model = PackingFoulingModel.fromVoidLossFraction(CLEAN_VOID, CLEAN_AREA, CLEAN_FP, 0.35);
+    double recovered = PackingFoulingModel.voidLossFractionForPressureDropRatio(model.getPressureDropRatio());
+    assertEquals(0.35, recovered, 1.0e-12);
+    assertEquals(0.0, PackingFoulingModel.voidLossFractionForPressureDropRatio(1.0), 1.0e-12);
+  }
+
+  /** Invalid arguments must be rejected instead of producing silent nonsense. */
+  @Test
+  void invalidArgumentsAreRejected() {
+    assertThrows(IllegalArgumentException.class,
+        () -> PackingFoulingModel.fromVoidLossFraction(0.0, CLEAN_AREA, CLEAN_FP, 0.1));
+    assertThrows(IllegalArgumentException.class,
+        () -> PackingFoulingModel.fromVoidLossFraction(CLEAN_VOID, -1.0, CLEAN_FP, 0.1));
+    assertThrows(IllegalArgumentException.class,
+        () -> PackingFoulingModel.fromVoidLossFraction(CLEAN_VOID, CLEAN_AREA, 0.0, 0.1));
+    assertThrows(IllegalArgumentException.class,
+        () -> PackingFoulingModel.fromVoidLossFraction(CLEAN_VOID, CLEAN_AREA, CLEAN_FP, 1.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> PackingFoulingModel.fromDepositThickness(CLEAN_VOID, CLEAN_AREA, CLEAN_FP, -1.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> PackingFoulingModel.fromDepositThickness(CLEAN_VOID, CLEAN_AREA, CLEAN_FP, 0.05));
+    assertThrows(IllegalArgumentException.class, () -> PackingFoulingModel.voidLossFractionForPressureDropRatio(0.5));
+    assertFalse(Double
+        .isNaN(PackingFoulingModel.fromVoidLossFraction(CLEAN_VOID, CLEAN_AREA, CLEAN_FP, 0.5).getPressureDropRatio()));
+  }
+}

--- a/src/test/java/neqsim/process/equipment/util/LubeOilSystemTest.java
+++ b/src/test/java/neqsim/process/equipment/util/LubeOilSystemTest.java
@@ -1,0 +1,180 @@
+package neqsim.process.equipment.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.util.LubeOilSystem.ConsumerType;
+import neqsim.process.equipment.util.LubeOilSystem.OilGrade;
+import neqsim.process.equipment.util.LubeOilSystem.ServiceCategory;
+
+/**
+ * Unit tests for the API 614 / ISO 10438 lube oil console.
+ */
+public class LubeOilSystemTest {
+
+  private LubeOilSystem console;
+
+  @BeforeEach
+  public void setUp() {
+    console = new LubeOilSystem("20-LO-001", ServiceCategory.SPECIAL_PURPOSE);
+    console.setOilGrade(OilGrade.ISO_VG_46);
+    console.setSupplyTemperature(45.0);
+    console.addConsumerFromShaftPower("Compressor bearings", ConsumerType.JOURNAL_BEARING, 6000.0);
+    console.addConsumerFromShaftPower("Gearbox", ConsumerType.GEARBOX, 6000.0);
+    console.addControlOilConsumer("Governor", 60.0, 10.0);
+  }
+
+  @Test
+  public void testConstruction() {
+    assertEquals("20-LO-001", console.getName());
+    assertEquals(ServiceCategory.SPECIAL_PURPOSE, console.getServiceCategory());
+    assertEquals(3, console.getConsumers().size());
+  }
+
+  @Test
+  public void testOilPropertyCorrelations() {
+    assertEquals(46.0, console.getOilKinematicViscosity(40.0), 0.2);
+    assertEquals(6.8, console.getOilKinematicViscosity(100.0), 0.05);
+    assertTrue(console.getOilKinematicViscosity(45.0) < console.getOilKinematicViscosity(40.0));
+    assertTrue(console.getOilDensity(45.0) < OilGrade.ISO_VG_46.getDensity15());
+    assertEquals(2.0, console.getOilHeatCapacity(45.0), 0.15);
+  }
+
+  @Test
+  public void testFlowFromHeatBalance() {
+    console.run();
+
+    double heatLoad = 6000.0 * ConsumerType.JOURNAL_BEARING.getLossFraction();
+    double flowLpm = console.getConsumers().get(0).getCalculatedFlow();
+    double flowM3PerSec = flowLpm / 60000.0;
+    double recoveredDuty = flowM3PerSec * console.getOilDensityAtSupply() * console.getOilHeatCapacityAtSupply()
+        * ConsumerType.JOURNAL_BEARING.getTemperatureRise();
+
+    assertEquals(heatLoad, recoveredDuty, 1e-6);
+    assertEquals(60.0, console.getControlOilFlow(), 1e-9);
+    assertEquals(console.getLubeOilFlow() + console.getControlOilFlow(), console.getNormalOilFlow() / 0.06, 1e-6);
+  }
+
+  @Test
+  public void testPumpSizing() {
+    console.run();
+
+    assertEquals(console.getNormalOilFlow() * 1.10, console.getRatedPumpFlow(), 1e-9);
+    // Control oil header pressure governs the pump discharge pressure
+    assertTrue(console.getPumpDischargePressure() > console.getControlOilHeaderPressure());
+    assertTrue(console.getPumpShaftPower() > console.getPumpHydraulicPower());
+    assertTrue(console.getPumpMotorRating() >= console.getPumpShaftPower() * 1.10);
+  }
+
+  @Test
+  public void testReservoirSizing() {
+    console.run();
+
+    assertTrue(console.getReservoirRetentionTime() >= 5.0);
+    assertTrue(console.getReservoirTurnoverRate() <= LubeOilSystem.MAX_RESERVOIR_TURNOVERS_PER_HOUR + 1e-9);
+    assertTrue(console.getReservoirTotalVolume() > console.getReservoirWorkingVolume());
+  }
+
+  @Test
+  public void testGeneralPurposeReservoirIsSmaller() {
+    console.run();
+    double specialPurposeVolume = console.getReservoirWorkingVolume();
+
+    console.setServiceCategory(ServiceCategory.GENERAL_PURPOSE);
+    console.run();
+
+    assertTrue(console.getReservoirWorkingVolume() <= specialPurposeVolume);
+    assertEquals(0.0, console.getRundownTankVolume(), 1e-12);
+  }
+
+  @Test
+  public void testCoolerAndCoolingWaterDuty() {
+    console.run();
+
+    assertEquals(console.getTotalHeatLoad() + console.getPumpShaftPower(), console.getCoolerDuty(), 1e-9);
+    double waterRise = console.getCoolingWaterOutletTemperature() - console.getCoolingWaterInletTemperature();
+    assertEquals(console.getCoolerDuty() / (4.18 * waterRise) * 3.6, console.getCoolingWaterFlow(), 1e-6);
+  }
+
+  @Test
+  public void testRundownTankAndAccumulator() {
+    console.setRundownTime(3.0);
+    console.run();
+
+    assertEquals(console.getLubeOilFlow() / 1000.0 * 3.0, console.getRundownTankVolume(), 1e-9);
+    assertTrue(console.getAccumulatorVolume() > 0.0);
+    assertTrue(console.getAccumulatorPrechargePressure() < console.getLubeHeaderPressure() + 1.01325);
+  }
+
+  @Test
+  public void testHeaterWattDensityLimit() {
+    console.run();
+
+    assertTrue(console.getHeaterPower() > 0.0);
+    double wattDensity = console.getHeaterPower() * 1000.0 / (console.getHeaterMinimumArea() * 10000.0);
+    assertEquals(LubeOilSystem.MAX_HEATER_WATT_DENSITY, wattDensity, 1e-6);
+  }
+
+  @Test
+  public void testPipingSizing() {
+    console.run();
+
+    double area = Math.PI * Math.pow(console.getSupplyPipeDiameter(), 2) / 4.0;
+    double velocity = console.getRatedPumpFlow() / 3600.0 / area;
+    assertEquals(console.getMaxSupplyVelocity(), velocity, 1e-9);
+
+    // Gravity drains run half full and are therefore much larger than the supply line
+    assertTrue(console.getDrainPipeDiameter() > console.getSupplyPipeDiameter());
+  }
+
+  @Test
+  public void testApiCompliance() {
+    console.run();
+
+    assertTrue(console.isApiCompliant());
+    assertTrue(console.getDeviations().isEmpty());
+    assertFalse(console.getComplianceChecks().isEmpty());
+  }
+
+  @Test
+  public void testHighSupplyTemperatureIsFlagged() {
+    console.setSupplyTemperature(55.0);
+    console.run();
+
+    assertFalse(console.isApiCompliant());
+    assertEquals(1, console.getDeviations().size());
+    assertEquals("Bearing oil supply temperature", console.getDeviations().get(0).getItem());
+  }
+
+  @Test
+  public void testSingleFilterIsFlagged() {
+    console.setNumberOfFilters(1);
+    console.setFilterRatingMicron(25.0);
+    console.run();
+
+    assertFalse(console.isApiCompliant());
+    assertEquals(2, console.getDeviations().size());
+  }
+
+  @Test
+  public void testValidateSetup() {
+    LubeOilSystem empty = new LubeOilSystem("empty console");
+    assertFalse(empty.validateSetup().isValid());
+
+    assertTrue(console.validateSetup().isValid());
+  }
+
+  @Test
+  public void testToJson() {
+    console.run();
+    String json = console.toJson();
+
+    assertNotNull(json);
+    assertTrue(json.contains("API 614"));
+    assertTrue(json.contains("reservoir"));
+    assertTrue(json.contains("complianceChecks"));
+  }
+}


### PR DESCRIPTION
## Summary

Adds three screening-design models to the process package and completes the reverse
NeqSim → UniSim writer path in devtools.

### `LubeOilSystem` (`process.equipment.util`)

Screening design of a lubrication / seal / control oil console for rotating machinery
per **API 614 / ISO 10438**. Sizes the complete console from the heat load of the served
bearings, gears and seals:

- oil flow per consumer from bearing heat load and allowable temperature rise
- main and standby pump rated capacity, differential pressure, shaft power, motor rating
- reservoir working capacity from retention time and turnover rate
- cooler duty and cooling-water demand (twin 2 × 100 % coolers)
- twin 2 × 100 % filters with transfer valve
- overhead (rundown) tank volume for machine coast-down
- accumulator volume covering the pump change-over transient
- electric immersion heater power and minimum sheath area (watt-density limit)
- oil supply pipe and gravity drain pipe sizing (half full, sloped)

Compliance is reported through `ComplianceCheck` against the API 614 acceptance criteria.

### `PackingFoulingModel` (`process.equipment.distillation.internals`)

Geometric derating of a packed bed for solid deposition. Converts a deposit thickness or
a fractional void loss into the derated void fraction, specific surface area and packing
factor a hydraulics calculation should use, plus the resulting pressure-drop and
flooding-velocity ratios relative to the clean bed. The inverse mapping —
`voidLossFractionForPressureDropRatio(...)` — turns a measured ΔP ratio back into implied
void loss, which is the direction usually available in operations.

First-order treatment: specific surface area held at its clean value, deposit assumed
uniform, valid while deposit thickness is small relative to the clean hydraulic diameter.
Deposition kinetics and channelling are out of scope.

### `GravityDrainageMargin` (`process.equipment.distillation.internals`)

Static drainage criterion for a packed stripper, seal leg or boot that drains by gravity
against a gas back-pressure. Liquid drains only while ρ_L·g·h exceeds the gas-side ΔP; once
a fouling bed pushes ΔP past that, liquid backs up and floods the section above and gas flow
has to be stopped to let it down. The class quantifies that limit and the margin to it.
The criterion is optimistic with respect to drainage — drain-line friction, the back-up
transient and two-phase effects in the leg all reduce usable head further.

### `devtools/unisim_writer.py` + UniSim reader skill

Reverse direction (NeqSim JSON → UniSim): flowsheet clearing, unit-aware property reads,
product-pressure and efficiency setting, basis-manager change transactions, and energy
stream wiring. `.github/skills/neqsim-unisim-reader/SKILL.md` documents the reverse path,
the verified COM rules for UniSim Design R510, and round-trip accuracy.

## Verification

- `mvnw spotless:check` — passes
- `mvnw test -Dtest=LubeOilSystemTest,GravityDrainageMarginTest,PackingFoulingModelTest`
  — **25 tests, 0 failures, 0 errors**
- `docs/process/equipment/equipment_catalog.md` regenerated (234 → 235 classes)
- Java 8 compatible; complete JavaDoc on all new classes and methods

## Notes

`LubeOilSystem` extends `ProcessEquipmentBaseClass` so it participates in a `ProcessSystem`
like any other unit; the two distillation-internals classes are stateless calculators.
