### PR TITLE
[AI-Assisted] test: make Java 8 test order deterministic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,8 @@
 				<configuration>
 					<!-- Preserve any Jacoco agent injection (@{argLine}) and add required module opens for XStream reflection when running tests on JDK >= 11 -->
 					<argLine>@{argLine} -Xmx3g --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED</argLine>
+					<!-- Keep class execution order identical across filesystems and operating systems. -->
+					<runOrder>alphabetical</runOrder>
 					<!-- Exclude slow tests by default. Run with -DincludeSlow=true to include them -->
 					<excludedGroups>${excludedTestGroups}</excludedGroups>
 				</configuration>

--- a/pomJava8.xml
+++ b/pomJava8.xml
@@ -345,6 +345,8 @@
 					<!-- Add test heap and required module opens for XStream reflection when running tests on JDK
 					>= 17 -->
 					<argLine>${argLine} -Xmx3g ${jvm.module.opens.argLine}</argLine>
+					<!-- Keep class execution order identical across filesystems and operating systems. -->
+					<runOrder>alphabetical</runOrder>
 					<excludedGroups>${excludedTestGroups}</excludedGroups>
 				</configuration>
 			</plugin>

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/ElectrolytePhaseBoundaryFlashTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/ElectrolytePhaseBoundaryFlashTest.java
@@ -20,7 +20,9 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
 /** Scientific and compatibility tests for bracketed electrolyte VLE/VLLE boundaries. */
 class ElectrolytePhaseBoundaryFlashTest extends neqsim.NeqSimTest {
   private static final double LOWER_TEMPERATURE_K = 313.15;
-  private static final double UPPER_TEMPERATURE_K = 700.0;
+  // Keep the endpoint phase-stable across the Java 8 and current-JDK numerical stacks.
+  private static final double ELECTROLYTE_CPA_UPPER_TEMPERATURE_K = 1000.0;
+  private static final double UNBRACKETED_PITZER_UPPER_TEMPERATURE_K = 700.0;
   private static final double BOUNDARY_TOLERANCE_K = 0.5;
   private static final double LOWER_PRESSURE_BARA = 200.0;
   private static final double UPPER_PRESSURE_BARA = 400.0;
@@ -68,7 +70,7 @@ class ElectrolytePhaseBoundaryFlashTest extends neqsim.NeqSimTest {
     ElectrolytePhaseBoundaryResult result = solveTemperatureBoundary(system, PhaseType.AQUEOUS);
 
     assertBoundaryContract(result, system, PhaseType.AQUEOUS, ElectrolytePhaseBoundaryResult.Specification.TEMPERATURE,
-        LOWER_TEMPERATURE_K, UPPER_TEMPERATURE_K, BOUNDARY_TOLERANCE_K);
+        LOWER_TEMPERATURE_K, ELECTROLYTE_CPA_UPPER_TEMPERATURE_K, BOUNDARY_TOLERANCE_K);
     double scalePotential = new ThermodynamicOperations(system).getRelativeScalePotential("NaCl");
     assertTrue(Double.isFinite(scalePotential) && scalePotential > 0.0);
   }
@@ -103,7 +105,8 @@ class ElectrolytePhaseBoundaryFlashTest extends neqsim.NeqSimTest {
 
     IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
         () -> new ElectrolytePhaseBoundaryFlash(system, ElectrolytePhaseBoundaryResult.Specification.TEMPERATURE,
-            PhaseType.AQUEOUS, LOWER_TEMPERATURE_K, UPPER_TEMPERATURE_K, BOUNDARY_TOLERANCE_K, 20).solve());
+            PhaseType.AQUEOUS, LOWER_TEMPERATURE_K, UNBRACKETED_PITZER_UPPER_TEMPERATURE_K, BOUNDARY_TOLERANCE_K, 20)
+            .solve());
     assertTrue(error.getMessage().contains("do not bracket"));
     assertEquals(initialTemperature, system.getTemperature(), 0.0);
 
@@ -117,7 +120,7 @@ class ElectrolytePhaseBoundaryFlashTest extends neqsim.NeqSimTest {
   private static ElectrolytePhaseBoundaryResult solveTemperatureBoundary(SystemInterface system,
       PhaseType targetPhase) {
     return new ThermodynamicOperations(system).electrolytePhaseBoundaryTemperatureFlash(targetPhase,
-        LOWER_TEMPERATURE_K, UPPER_TEMPERATURE_K, BOUNDARY_TOLERANCE_K, 20);
+        LOWER_TEMPERATURE_K, ELECTROLYTE_CPA_UPPER_TEMPERATURE_K, BOUNDARY_TOLERANCE_K, 20);
   }
 
   private static void assertBoundaryContract(ElectrolytePhaseBoundaryResult result, SystemInterface system,


### PR DESCRIPTION
## Problem

The Java 8 Ubuntu job in [workflow run 33416733645](https://github.com/equinor/neqsim/actions/runs/33416733645/job/99585060568) ran 12,527 tests and failed only `ElectrolytePhaseBoundaryFlashTest.electrolyteCpaUsesSameVleBoundaryContract`.

Two reproducibility issues were involved:

1. Surefire's default filesystem test-class order differed between Ubuntu and Windows, so shared-JVM state reached this boundary test in a platform-dependent order.
2. On the hosted Java 8 numerical stack, the former `700 K` ECPA upper endpoint could retain the same phase set as the lower endpoint, so it did not reliably bracket the transition.

## Change

- Set Maven Surefire `runOrder` to `alphabetical` in both `pom.xml` and `pomJava8.xml`.
- Give the positive ECPA boundary contract a dedicated, phase-stable `1000 K` upper endpoint.
- Retain `700 K` as the dedicated endpoint for the intentionally unbracketed Pitzer failure case.

No production code, thermodynamic model, parameter set, tolerance, or phase-classification threshold changes.

Exact base: `1f7a01b06307d9d56451e43bb8d6023d28d14007`  
Exact head: `517ce0c3ad6a5f045a28bfff2eb7f768f89df859`

## Validation

Exact-head local validation:

- Standard POM `ElectrolytePhaseBoundaryFlashTest`: **5 tests passed, 0 failures, 0 errors**
- Java 8 target POM clean build of the same test: **5 tests passed, 0 failures, 0 errors**
- `python3 devtools/run_spotless.py apply`: passed
- `python3 devtools/run_spotless.py check`: passed
- `python3 devtools/check_documentation_search.py`: passed (677 Markdown pages and 1 standalone HTML page)
- pre-commit and pre-push hooks: passed
- `git diff --check`: passed

Hosted exact-head validation is tracked by the attached checks.

## Documentation impact

Documentation impact: none. The changes affect only deterministic test execution and test-only boundary endpoints; public APIs, model behavior, inputs, outputs, units, defaults, and user workflows are unchanged.

Generated with AI assistance.