### PR TITLE
[AI-Assisted] feat(dexpi): report connection endpoint incidence

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -159,10 +159,11 @@ occurrence, including parallel connections. Blank endpoint references remain fin
 from this keyed inventory; unresolved non-empty IDs remain visible. These source-incidence records do
 not classify branches or junctions and do not create live process connectivity.
 
-`toJson()` includes `instrumentCount`, `connectionCount`, `connectionEndpointCount`, and the ordered connection inventory
-alongside the process-unit count and findings. Python callers through JPype use the same
-`ImportResult.getInstruments()` and `ImportResult.getConnections()` getters; there is no separate
-Python reconstruction model.
+`toJson()` includes `instrumentCount`, `connectionCount`, `connectionEndpointCount`, and the
+ordered connection and endpoint inventories alongside the process-unit count and findings. Python
+callers through JPype use the same `ImportResult.getInstruments()`, `ImportResult.getConnections()`,
+and `ImportResult.getConnectionEndpoints()` getters; there is no separate Python reconstruction
+model.
 
 `INFO` entries carry provenance and do not make `hasLosses()` true by themselves. `WARNING` and
 `ERROR` entries do. The diagnostic sequence and JSON are deterministic for the same XML and template.

--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -152,7 +152,14 @@ piping-component endpoints own themselves. Orphaned nozzles and owner elements w
 remain deterministic warnings; the reader does not derive ownership from coordinates, tags,
 stream order, or simulation state.
 
-`toJson()` includes `instrumentCount`, `connectionCount`, and the ordered connection inventory
+`ImportResult.getConnectionEndpoints()` provides a distinct endpoint inventory in first-reference
+order. Each immutable `DexpiConnectionEndpointInfo` records the resolved element and explicit owner
+evidence plus the incoming and outgoing connection-evidence IDs in source order. Counts retain every
+occurrence, including parallel connections. Blank endpoint references remain findings and are omitted
+from this keyed inventory; unresolved non-empty IDs remain visible. These source-incidence records do
+not classify branches or junctions and do not create live process connectivity.
+
+`toJson()` includes `instrumentCount`, `connectionCount`, `connectionEndpointCount`, and the ordered connection inventory
 alongside the process-unit count and findings. Python callers through JPype use the same
 `ImportResult.getInstruments()` and `ImportResult.getConnections()` getters; there is no separate
 Python reconstruction model.

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionEndpointInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionEndpointInfo.java
@@ -46,10 +46,8 @@ public final class DexpiConnectionEndpointInfo implements Serializable {
     this.ownerId = normalize(ownerId);
     this.ownerElementName = normalize(ownerElementName);
     this.resolved = resolved;
-    this.incomingConnectionIds =
-        Collections.unmodifiableList(new ArrayList<String>(incomingConnectionIds));
-    this.outgoingConnectionIds =
-        Collections.unmodifiableList(new ArrayList<String>(outgoingConnectionIds));
+    this.incomingConnectionIds = Collections.unmodifiableList(new ArrayList<String>(incomingConnectionIds));
+    this.outgoingConnectionIds = Collections.unmodifiableList(new ArrayList<String>(outgoingConnectionIds));
   }
 
   /** @return explicit source endpoint identity */

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionEndpointInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionEndpointInfo.java
@@ -1,0 +1,127 @@
+package neqsim.process.processmodel.dexpi;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Immutable source-evidence summary for one endpoint referenced by Proteus-compatible DEXPI material connections.
+ *
+ * <p>
+ * Incoming and outgoing occurrences retain connection-evidence IDs in source order. This record does not classify
+ * branches or reconstruct live {@code ProcessSystem} topology.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class DexpiConnectionEndpointInfo implements Serializable {
+  private static final long serialVersionUID = 1000L;
+  private final String endpointId;
+  private final String elementName;
+  private final String ownerId;
+  private final String ownerElementName;
+  private final boolean resolved;
+  private final List<String> incomingConnectionIds;
+  private final List<String> outgoingConnectionIds;
+
+  /**
+   * Creates immutable endpoint-incidence evidence.
+   *
+   * @param endpointId explicit source endpoint identity
+   * @param elementName resolved endpoint XML element name, or empty when unresolved
+   * @param ownerId explicit endpoint owner identity, or empty when absent
+   * @param ownerElementName endpoint owner XML element name, or empty when absent
+   * @param resolved whether the endpoint resolves in the source document
+   * @param incomingConnectionIds incoming connection-evidence IDs in source order
+   * @param outgoingConnectionIds outgoing connection-evidence IDs in source order
+   */
+  public DexpiConnectionEndpointInfo(String endpointId, String elementName, String ownerId, String ownerElementName,
+      boolean resolved, List<String> incomingConnectionIds, List<String> outgoingConnectionIds) {
+    this.endpointId = normalize(endpointId);
+    this.elementName = normalize(elementName);
+    this.ownerId = normalize(ownerId);
+    this.ownerElementName = normalize(ownerElementName);
+    this.resolved = resolved;
+    this.incomingConnectionIds =
+        Collections.unmodifiableList(new ArrayList<String>(incomingConnectionIds));
+    this.outgoingConnectionIds =
+        Collections.unmodifiableList(new ArrayList<String>(outgoingConnectionIds));
+  }
+
+  /** @return explicit source endpoint identity */
+  public String getEndpointId() {
+    return endpointId;
+  }
+
+  /** @return resolved endpoint XML element name, or empty when unresolved */
+  public String getElementName() {
+    return elementName;
+  }
+
+  /** @return explicit endpoint owner identity, or empty when absent */
+  public String getOwnerId() {
+    return ownerId;
+  }
+
+  /** @return endpoint owner XML element name, or empty when absent */
+  public String getOwnerElementName() {
+    return ownerElementName;
+  }
+
+  /** @return whether the endpoint resolves in the source document */
+  public boolean isResolved() {
+    return resolved;
+  }
+
+  /** @return immutable incoming connection-evidence IDs in source order */
+  public List<String> getIncomingConnectionIds() {
+    return incomingConnectionIds;
+  }
+
+  /** @return immutable outgoing connection-evidence IDs in source order */
+  public List<String> getOutgoingConnectionIds() {
+    return outgoingConnectionIds;
+  }
+
+  /** @return number of incoming source connection occurrences */
+  public int getIncomingConnectionCount() {
+    return incomingConnectionIds.size();
+  }
+
+  /** @return number of outgoing source connection occurrences */
+  public int getOutgoingConnectionCount() {
+    return outgoingConnectionIds.size();
+  }
+
+  /** @return total number of source connection occurrences */
+  public int getConnectionCount() {
+    return incomingConnectionIds.size() + outgoingConnectionIds.size();
+  }
+
+  /** @return whether the endpoint occurs in more than one source connection role */
+  public boolean isReferencedMultipleTimes() {
+    return getConnectionCount() > 1;
+  }
+
+  Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("endpointId", endpointId);
+    result.put("elementName", elementName);
+    result.put("ownerId", ownerId);
+    result.put("ownerElementName", ownerElementName);
+    result.put("resolved", Boolean.valueOf(resolved));
+    result.put("incomingConnectionCount", Integer.valueOf(getIncomingConnectionCount()));
+    result.put("outgoingConnectionCount", Integer.valueOf(getOutgoingConnectionCount()));
+    result.put("incomingConnectionIds", incomingConnectionIds);
+    result.put("outgoingConnectionIds", outgoingConnectionIds);
+    return result;
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -131,13 +131,17 @@ public final class DexpiXmlReader {
     private final ProcessSystem processSystem;
     private final List<DexpiInstrumentInfo> instruments;
     private final List<DexpiConnectionInfo> connections;
+    private final List<DexpiConnectionEndpointInfo> connectionEndpoints;
     private final List<ImportDiagnostic> diagnostics;
 
     private ImportResult(ProcessSystem processSystem, List<DexpiInstrumentInfo> instruments,
-        List<DexpiConnectionInfo> connections, List<ImportDiagnostic> diagnostics) {
+        List<DexpiConnectionInfo> connections, List<DexpiConnectionEndpointInfo> connectionEndpoints,
+        List<ImportDiagnostic> diagnostics) {
       this.processSystem = processSystem;
       this.instruments = Collections.unmodifiableList(new ArrayList<DexpiInstrumentInfo>(instruments));
       this.connections = Collections.unmodifiableList(new ArrayList<DexpiConnectionInfo>(connections));
+      this.connectionEndpoints =
+          Collections.unmodifiableList(new ArrayList<DexpiConnectionEndpointInfo>(connectionEndpoints));
       this.diagnostics = Collections.unmodifiableList(new ArrayList<ImportDiagnostic>(diagnostics));
     }
 
@@ -166,6 +170,20 @@ public final class DexpiXmlReader {
      */
     public List<DexpiConnectionInfo> getConnections() {
       return connections;
+    }
+
+    /**
+     * Returns distinct non-empty connection endpoints in first-reference order.
+     *
+     * <p>
+     * Counts and connection IDs preserve every source occurrence, including parallel connections. They are evidence
+     * only and do not classify branches or reconstruct live process topology.
+     * </p>
+     *
+     * @return immutable endpoint-incidence records
+     */
+    public List<DexpiConnectionEndpointInfo> getConnectionEndpoints() {
+      return connectionEndpoints;
     }
 
     /** @return immutable diagnostics in deterministic source-document order */
@@ -206,6 +224,12 @@ public final class DexpiXmlReader {
         connectionMaps.add(connection.toMap());
       }
       result.put("connections", connectionMaps);
+      result.put("connectionEndpointCount", Integer.valueOf(connectionEndpoints.size()));
+      List<Map<String, Object>> endpointMaps = new ArrayList<Map<String, Object>>();
+      for (DexpiConnectionEndpointInfo endpoint : connectionEndpoints) {
+        endpointMaps.add(endpoint.toMap());
+      }
+      result.put("connectionEndpoints", endpointMaps);
       result.put("hasLosses", Boolean.valueOf(hasLosses()));
       result.put("hasErrors", Boolean.valueOf(hasErrors()));
       List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
@@ -400,7 +424,8 @@ public final class DexpiXmlReader {
     List<DexpiConnectionInfo> connections = new ArrayList<DexpiConnectionInfo>();
     List<ImportDiagnostic> diagnostics = new ArrayList<ImportDiagnostic>();
     loadInternal(inputStream, processSystem, templateStream, false, diagnostics, instruments, connections);
-    return new ImportResult(processSystem, instruments, connections, diagnostics);
+    return new ImportResult(processSystem, instruments, connections, summarizeConnectionEndpoints(connections),
+        diagnostics);
   }
 
   /**
@@ -755,6 +780,72 @@ public final class DexpiXmlReader {
     }
     logger.info("Parsed {} material connections from DEXPI XML", connections.size());
     return connections;
+  }
+
+  private static List<DexpiConnectionEndpointInfo> summarizeConnectionEndpoints(
+      List<DexpiConnectionInfo> connections) {
+    Map<String, ConnectionEndpointAccumulator> endpoints =
+        new LinkedHashMap<String, ConnectionEndpointAccumulator>();
+    for (DexpiConnectionInfo connection : connections) {
+      addConnectionEndpointOccurrence(endpoints, connection, true);
+      addConnectionEndpointOccurrence(endpoints, connection, false);
+    }
+
+    List<DexpiConnectionEndpointInfo> result = new ArrayList<DexpiConnectionEndpointInfo>();
+    for (ConnectionEndpointAccumulator endpoint : endpoints.values()) {
+      result.add(endpoint.toInfo());
+    }
+    return result;
+  }
+
+  private static void addConnectionEndpointOccurrence(Map<String, ConnectionEndpointAccumulator> endpoints,
+      DexpiConnectionInfo connection, boolean source) {
+    String endpointId = source ? connection.getFromId() : connection.getToId();
+    if (isBlank(endpointId)) {
+      return;
+    }
+    ConnectionEndpointAccumulator endpoint = endpoints.get(endpointId);
+    if (endpoint == null) {
+      endpoint = new ConnectionEndpointAccumulator(endpointId,
+          source ? connection.getFromElementName() : connection.getToElementName(),
+          source ? connection.getFromOwnerId() : connection.getToOwnerId(),
+          source ? connection.getFromOwnerElementName() : connection.getToOwnerElementName(),
+          source ? connection.isFromResolved() : connection.isToResolved());
+      endpoints.put(endpointId, endpoint);
+    }
+    endpoint.add(connection.getId(), source);
+  }
+
+  private static final class ConnectionEndpointAccumulator {
+    private final String endpointId;
+    private final String elementName;
+    private final String ownerId;
+    private final String ownerElementName;
+    private final boolean resolved;
+    private final List<String> incomingConnectionIds = new ArrayList<String>();
+    private final List<String> outgoingConnectionIds = new ArrayList<String>();
+
+    private ConnectionEndpointAccumulator(String endpointId, String elementName, String ownerId,
+        String ownerElementName, boolean resolved) {
+      this.endpointId = endpointId;
+      this.elementName = elementName;
+      this.ownerId = ownerId;
+      this.ownerElementName = ownerElementName;
+      this.resolved = resolved;
+    }
+
+    private void add(String connectionId, boolean source) {
+      if (source) {
+        outgoingConnectionIds.add(connectionId);
+      } else {
+        incomingConnectionIds.add(connectionId);
+      }
+    }
+
+    private DexpiConnectionEndpointInfo toInfo() {
+      return new DexpiConnectionEndpointInfo(endpointId, elementName, ownerId, ownerElementName, resolved,
+          incomingConnectionIds, outgoingConnectionIds);
+    }
   }
 
   private static Element resolveConnectionOwner(Element endpoint) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -140,8 +140,8 @@ public final class DexpiXmlReader {
       this.processSystem = processSystem;
       this.instruments = Collections.unmodifiableList(new ArrayList<DexpiInstrumentInfo>(instruments));
       this.connections = Collections.unmodifiableList(new ArrayList<DexpiConnectionInfo>(connections));
-      this.connectionEndpoints =
-          Collections.unmodifiableList(new ArrayList<DexpiConnectionEndpointInfo>(connectionEndpoints));
+      this.connectionEndpoints = Collections
+          .unmodifiableList(new ArrayList<DexpiConnectionEndpointInfo>(connectionEndpoints));
       this.diagnostics = Collections.unmodifiableList(new ArrayList<ImportDiagnostic>(diagnostics));
     }
 
@@ -782,10 +782,8 @@ public final class DexpiXmlReader {
     return connections;
   }
 
-  private static List<DexpiConnectionEndpointInfo> summarizeConnectionEndpoints(
-      List<DexpiConnectionInfo> connections) {
-    Map<String, ConnectionEndpointAccumulator> endpoints =
-        new LinkedHashMap<String, ConnectionEndpointAccumulator>();
+  private static List<DexpiConnectionEndpointInfo> summarizeConnectionEndpoints(List<DexpiConnectionInfo> connections) {
+    Map<String, ConnectionEndpointAccumulator> endpoints = new LinkedHashMap<String, ConnectionEndpointAccumulator>();
     for (DexpiConnectionInfo connection : connections) {
       addConnectionEndpointOccurrence(endpoints, connection, true);
       addConnectionEndpointOccurrence(endpoints, connection, false);

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -12,6 +12,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import neqsim.NeqSimTest;
 import neqsim.process.equipment.EquipmentEnum;
@@ -378,6 +380,70 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     DexpiConnectionInfo legacy = new DexpiConnectionInfo("C", "C", "S", "A", "B", "Nozzle", "Nozzle", true, true);
     assertEquals("", legacy.getFromOwnerId());
     assertEquals("", legacy.getToOwnerId());
+  }
+
+  @Test
+  public void testReadWithDiagnosticsSummarizesConnectionEndpointIncidence() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
+        + "<Equipment ID=\"E-A\"><Nozzle ID=\"N-A\"/></Equipment>"
+        + "<Equipment ID=\"E-B\"><Nozzle ID=\"N-B\"/></Equipment>"
+        + "<PipingComponent ID=\"PC-J\"><Nozzle ID=\"N-J\"/></PipingComponent>"
+        + "<Equipment ID=\"E-C\"><Nozzle ID=\"N-C\"/></Equipment>"
+        + "<PipingNetworkSegment ID=\"S-1\"><Connection ID=\"C-1\" FromID=\"N-A\" ToID=\"N-J\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-2\"><Connection ID=\"C-2\" FromID=\"N-B\" ToID=\"N-J\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-3\"><Connection ID=\"C-3\" FromID=\"N-J\" ToID=\"N-C\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-4\"><Connection ID=\"C-4\" FromID=\"UNKNOWN\"/>"
+        + "</PipingNetworkSegment>" + "</PlantModel>";
+
+    DexpiXmlReader.ImportResult first = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    DexpiXmlReader.ImportResult second = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+    assertEquals(5, first.getConnectionEndpoints().size());
+    DexpiConnectionEndpointInfo junction = first.getConnectionEndpoints().get(1);
+    assertEquals("N-J", junction.getEndpointId());
+    assertEquals("Nozzle", junction.getElementName());
+    assertEquals("PC-J", junction.getOwnerId());
+    assertTrue(junction.isResolved());
+    assertEquals(2, junction.getIncomingConnectionCount());
+    assertEquals(1, junction.getOutgoingConnectionCount());
+    assertEquals(3, junction.getConnectionCount());
+    assertTrue(junction.isReferencedMultipleTimes());
+    assertEquals(Arrays.asList("C-1", "C-2"), junction.getIncomingConnectionIds());
+    assertEquals(Collections.singletonList("C-3"), junction.getOutgoingConnectionIds());
+
+    DexpiConnectionEndpointInfo unresolved = first.getConnectionEndpoints().get(4);
+    assertEquals("UNKNOWN", unresolved.getEndpointId());
+    assertFalse(unresolved.isResolved());
+    assertEquals(Collections.singletonList("C-4"), unresolved.getOutgoingConnectionIds());
+    assertEquals(0, unresolved.getIncomingConnectionCount());
+    assertThrows(UnsupportedOperationException.class, () -> unresolved.getOutgoingConnectionIds().clear());
+    assertThrows(UnsupportedOperationException.class, () -> first.getConnectionEndpoints().clear());
+    assertTrue(first.toJson().contains("\"connectionEndpointCount\": 5"));
+    assertEquals(first.toJson(), second.toJson());
+  }
+
+  @Test
+  public void testConnectionEndpointSummaryPreservesParallelOccurrences() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
+        + "<Nozzle ID=\"N-OUT\"/><Nozzle ID=\"N-IN\"/>"
+        + "<PipingNetworkSegment ID=\"S-1\"><Connection FromID=\"N-OUT\" ToID=\"N-IN\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-2\"><Connection FromID=\"N-OUT\" ToID=\"N-IN\"/>"
+        + "</PipingNetworkSegment>" + "</PlantModel>";
+
+    DexpiXmlReader.ImportResult result = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+    assertEquals(2, result.getConnectionEndpoints().size());
+    assertEquals(Arrays.asList("S-1/connection-1", "S-2/connection-1"),
+        result.getConnectionEndpoints().get(0).getOutgoingConnectionIds());
+    assertEquals(Arrays.asList("S-1/connection-1", "S-2/connection-1"),
+        result.getConnectionEndpoints().get(1).getIncomingConnectionIds());
   }
 
   private static int countDiagnostics(DexpiXmlReader.ImportResult result, String expectedCode) {

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -394,8 +394,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         + "<PipingNetworkSegment ID=\"S-2\"><Connection ID=\"C-2\" FromID=\"N-B\" ToID=\"N-J\"/>"
         + "</PipingNetworkSegment>"
         + "<PipingNetworkSegment ID=\"S-3\"><Connection ID=\"C-3\" FromID=\"N-J\" ToID=\"N-C\"/>"
-        + "</PipingNetworkSegment>"
-        + "<PipingNetworkSegment ID=\"S-4\"><Connection ID=\"C-4\" FromID=\"UNKNOWN\"/>"
+        + "</PipingNetworkSegment>" + "<PipingNetworkSegment ID=\"S-4\"><Connection ID=\"C-4\" FromID=\"UNKNOWN\"/>"
         + "</PipingNetworkSegment>" + "</PlantModel>";
 
     DexpiXmlReader.ImportResult first = DexpiXmlReader
@@ -431,10 +430,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
   public void testConnectionEndpointSummaryPreservesParallelOccurrences() throws Exception {
     String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
         + "<Nozzle ID=\"N-OUT\"/><Nozzle ID=\"N-IN\"/>"
-        + "<PipingNetworkSegment ID=\"S-1\"><Connection FromID=\"N-OUT\" ToID=\"N-IN\"/>"
-        + "</PipingNetworkSegment>"
-        + "<PipingNetworkSegment ID=\"S-2\"><Connection FromID=\"N-OUT\" ToID=\"N-IN\"/>"
-        + "</PipingNetworkSegment>" + "</PlantModel>";
+        + "<PipingNetworkSegment ID=\"S-1\"><Connection FromID=\"N-OUT\" ToID=\"N-IN\"/>" + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-2\"><Connection FromID=\"N-OUT\" ToID=\"N-IN\"/>" + "</PipingNetworkSegment>"
+        + "</PlantModel>";
 
     DexpiXmlReader.ImportResult result = DexpiXmlReader
         .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));


### PR DESCRIPTION
## Summary

Adds deterministic endpoint-incidence evidence to the existing Proteus-compatible DEXPI 4.1.1 import report.

- introduces immutable `DexpiConnectionEndpointInfo` records
- preserves distinct non-empty endpoints in first-reference order
- retains incoming and outgoing connection-evidence IDs without collapsing parallel occurrences
- carries the resolved endpoint element and explicit owner evidence from the existing connection inventory
- keeps unresolved non-empty endpoint IDs visible and omits blank IDs already covered by structured diagnostics
- adds deterministic JSON endpoint counts/inventory, focused regressions, and reader documentation

## Capability boundary

This is source evidence only. It does not classify branches or junctions, infer hydraulic continuity, reconstruct live `ProcessSystem`/`ProcessModel` topology, or change simulation, rendering, export, Classic/DOT, native DEXPI 2.0, or Proteus writer behavior.

Profile: **Proteus-compatible DEXPI Plant/P&ID 4.1.1 supported subset**. This is not DEXPI certification, ISO/ISA conformance, safety completeness, or accountable engineering approval.

## Compatibility

- existing `read`/`load` behavior is unchanged
- existing `ImportResult`, connection, instrumentation, diagnostics, and JSON fields remain
- Java and Python/JPype consumers receive the same additive getter
- processing remains linear in connection and endpoint occurrences
- no engineering units or calculated state are introduced

## Tests

Added focused regressions for:

- source-ordered fan-in/fan-out-shaped endpoint evidence
- resolved owner and unresolved endpoint preservation
- immutable endpoint/list exposure
- deterministic JSON
- exact parallel-connection occurrence retention

Local Maven, Spotless, documentation hooks, pre-commit, and pre-push were not run because this connector-first run had no prepared local checkout. GitHub CI is authoritative.

**READY TO MERGE (exact-head qualification)**

At exact head `98bceeb95b04f5826eb8d3f015f91e9cc6a3aef6`, all eight hosted workflows completed successfully: 19 jobs passed, one paper-replication job was expectedly skipped, and zero jobs failed or remained pending. Java 8 and Java 21 passed on Ubuntu and Windows; all four Java 21 slow shards, Javadocs, Spotless, pre-commit, documentation search, notebook execution, engineering-diagram performance, CodeQL, and PaperLab passed. Both code-quality threads are resolved.

The first CI run identified a branch-attributable Spotless-only failure in pre-commit and the notebook handover gate. Commit `98bceeb95b04f5826eb8d3f015f91e9cc6a3aef6` applies the exact hosted formatter artifact; capability behavior and scope are unchanged.

## Documentation and visual impact

Updated `docs/integration/dexpi-reader.md` with Java/JPype/JSON views and the explicit no-topology-inference boundary. No graphical primitive, layout, renderer, writer, benchmark notebook, SVG, or PNG path changed; the whole-sheet visual baseline is not reclassified.

Exact base: `1f7a01b06307d9d56451e43bb8d6023d28d14007`  
Exact head: `98bceeb95b04f5826eb8d3f015f91e9cc6a3aef6`

Coordinates #1332 and #2899.

Generated with AI assistance.