### PR TITLE
[AI-Assisted] feat(refinery): preserve terminal assay boiling limits

### DIFF
--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -52,10 +52,10 @@ For crude/petroleum assays, use `OilAssayCharacterisation` rather than manually 
 - per-cut UOP/Watson characterization factors from representative boiling point and specific gravity;
 - per-cut total-sulfur and total-nitrogen inputs with mass-basis whole-assay reconstruction;
 - pre-binned cumulative TBP cut-boundary ingestion;
-- preserved lower/upper boiling ranges;
+- preserved finite and one-sided lower/upper boiling boundaries;
 - closure, duplicate-name, monotonicity, and repeated-application guards.
 
-See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data bookkeeping evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation), whole-assay density/API evidence in [DOE/OEDI COA bulk density qualification](refinery_oedi_coa_bulk_density_validation), per-cut characterization evidence in [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation), assay-quality evidence in [DOE Big Hill sulfur qualification](refinery_big_hill_sulfur_validation) and [DOE Big Hill nitrogen qualification](refinery_big_hill_nitrogen_validation), and the process-integration gate in [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation).
+See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data bookkeeping evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation), whole-assay density/API evidence in [DOE/OEDI COA bulk density qualification](refinery_oedi_coa_bulk_density_validation), per-cut characterization evidence in [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation), assay-quality evidence in [DOE Big Hill sulfur qualification](refinery_big_hill_sulfur_validation) and [DOE Big Hill nitrogen qualification](refinery_big_hill_nitrogen_validation), terminal-boundary evidence in [DOE Big Hill terminal-cut qualification](refinery_big_hill_terminal_boundary_validation), and the process-integration gate in [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation).
 
 ## TBP fraction models
 
@@ -142,6 +142,7 @@ A bookkeeping regression does not by itself validate a petroleum-property correl
 - [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation)
 - [DOE Big Hill assay sulfur qualification](refinery_big_hill_sulfur_validation)
 - [DOE Big Hill assay nitrogen qualification](refinery_big_hill_nitrogen_validation)
+- [DOE Big Hill terminal-cut boundary qualification](refinery_big_hill_terminal_boundary_validation)
 - [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation)
 - [DOE/OEDI COA bulk density and API qualification](refinery_oedi_coa_bulk_density_validation)
 - [Fluid Characterization Guide](../../wiki/fluid_characterization)

--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -147,6 +147,25 @@ Here $T_b$ is in K and $SG$ is dimensionless specific gravity. This is equivalen
 
 The public [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation) covers four bounded 375-1050 degF cuts with SG 0.8297-0.9336. The maximum absolute difference from DOE's one-decimal UOP K values is 0.0122. The method is qualified for assay screening inside that matrix; it is not a whole-crude aggregation, ASTM conversion or design-certification method.
 
+## Open-ended terminal boiling boundaries
+
+Terminal assay cuts often publish only one boiling limit. Use
+`withLowerBoilingPointKelvin/Celsius/Fahrenheit(...)` for a heavy-end “plus” cut and
+`withUpperBoilingPointKelvin/Celsius/Fahrenheit(...)` for a light-end “minus” cut.
+`hasLowerBoilingPoint()` and `hasUpperBoilingPoint()` distinguish one-sided metadata from a
+complete finite interval.
+
+A one-sided limit is provenance, not a representative boiling point. NeqSim never turns it into a
+finite midpoint. Pseudo-component generation therefore still requires either an explicit molar mass
+or an independently supported representative boiling point together with density. Contradictory
+bounds or representative values fail before the cut is changed.
+
+The public [DOE Big Hill terminal-cut qualification](refinery_big_hill_terminal_boundary_validation)
+freezes the workbook's 11.56 mass% 1050 degF+ residue boundary. It verifies exact unit conversion,
+one-sided retention, clone behavior, fail-closed incomplete characterization and exact mass closure
+when an explicit engineering molar mass is supplied. DOE does not publish that molar mass; the test
+does not present its control value as source data.
+
 ## Assay-carried total sulfur
 
 `AssayCut.withSulfurMassFraction(...)` and `withSulfurMassPercent(...)` carry total sulfur explicitly on a mass basis. `getBulkSulfurMassFraction()` and `getBulkSulfurMassPercent()` apply the linear mass-basis rule to the same resolved assay mass fractions used for pseudo-component bookkeeping. Positive-yield cuts without sulfur data fail closed; zero-yield cuts do not contribute.
@@ -187,7 +206,7 @@ The regression suite for this API currently verifies:
 - API-gravity handling, including negative API gravity;
 - rounding-scale closure versus incomplete-assay rejection;
 - rejection of mixed mass/volume bases and duplicate cuts;
-- TBP boundary monotonicity, complete 0-100% coverage, stored boiling ranges, and generated pseudo-components;
+- TBP boundary monotonicity, complete 0-100% coverage, finite and one-sided stored boiling limits, and generated pseudo-components;
 - repeated-application protection;
 - exact reconstructed assay-mass closure;
 - analytical mass- and volume-basis bulk specific-gravity reconstruction;
@@ -206,6 +225,7 @@ These tests establish software/bookkeeping correctness, qualify ideal-additive-v
 | Pre-binned crude/petroleum assay cuts | `OilAssayCharacterisation` | Foundation hardened in #3305 |
 | Mass- and volume-basis cut yields | Unit/basis-explicit assay API | Foundation hardened in #3305 |
 | Pre-binned cumulative TBP cut boundaries | `addTBPCutBoundariesCelsius/Kelvin` | Initial implementation in #3305 |
+| Open-ended terminal boiling limits | Unit-explicit one-sided `AssayCut` boundaries | DOE-qualified for metadata and fail-closed preparation |
 | Per-cut UOP/Watson characterization factor | `AssayCut.getWatsonCharacterizationFactor()` | DOE-qualified for assay screening over 375-1050 degF |
 | Assay-carried total sulfur | `getBulkSulfurMassFraction/Percent()` | DOE-qualified for linear bookkeeping over one complete crude slate |
 | Assay-carried total nitrogen | `getBulkNitrogenMassFraction/Percent()` | DOE-qualified for linear bookkeeping over one complete crude slate |
@@ -222,4 +242,4 @@ These tests establish software/bookkeeping correctness, qualify ideal-additive-v
 
 ## Next campaign step
 
-The next dependency-ready characterization increment should extend the public-data matrix beyond one DOE/OEDI assay and qualify generated pseudo-component properties. The process benchmark should then advance from the bounded DOE atmospheric integration case to a complete crude slate with independent cut-yield and boiling-range evidence before vacuum fractionation.
+The next dependency-ready characterization increment should extend the public-data matrix beyond one DOE/OEDI assay and qualify generated pseudo-component properties. With terminal-bound metadata now explicit, the process benchmark should next supply independently defensible light-end and residue representative properties, then advance from the bounded DOE atmospheric integration case to a complete crude slate with independent cut-yield and boiling-range evidence before vacuum fractionation.

--- a/docs/thermo/characterization/refinery_big_hill_terminal_boundary_validation.md
+++ b/docs/thermo/characterization/refinery_big_hill_terminal_boundary_validation.md
@@ -1,0 +1,61 @@
+---
+title: "DOE Big Hill terminal-cut boundary qualification"
+description: "Public-data qualification of one-sided refinery-assay boiling-boundary metadata."
+---
+
+# DOE Big Hill terminal-cut boundary qualification
+
+This benchmark qualifies one-sided boiling-boundary metadata against the public U.S. Department of
+Energy Strategic Petroleum Reserve Big Hill Sweet assay. It prevents an open terminal cut from
+being silently converted into a fabricated finite interval.
+
+## Source and provenance
+
+The source is the DOE/SPR **Big Hill Sweet** comprehensive assay workbook:
+
+- workbook: <https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx>
+- DOE assay landing page: <https://www.spr.doe.gov/reports/Crude_Oil_Assays.html>
+- report date recorded in the workbook: **24 September 2021**
+
+DOE/SPR publicly distributes the workbook with an informational-use disclaimer and no separate
+license statement. The regression freezes only the attributed 1050 degF+ terminal boundary, its
+11.56 mass% yield and its 1.0089 reported relative density. The workbook is not redistributed.
+
+## Engineering contract
+
+The DOE table reports a residue with a lower boiling limit of **1050 degF** and no finite upper
+limit. NeqSim stores that value as **838.7055555556 K**, reports that a lower limit is present, and
+reports that no upper limit or complete boiling range is present.
+
+A one-sided limit does not determine a representative boiling point. It is therefore insufficient
+by itself for the existing inverse molecular-weight correlation. Pseudo-component generation must
+fail before mutating the thermodynamic system unless the caller also supplies either:
+
+- an independently supported representative boiling point and density; or
+- an explicit molar mass and density.
+
+The focused generation control uses 650 g/mol only as an explicit engineering input to prove this
+API path and exact mass closure. DOE does not report that value, and this qualification does not
+validate it.
+
+## Acceptance and maturity
+
+`OilAssayCharacterisationDoeBigHillTerminalBoundaryTest` requires:
+
+- exact Fahrenheit-to-Kelvin preservation of the DOE 1050 degF+ lower limit;
+- Kelvin, Celsius and Fahrenheit terminal-limit inputs to agree numerically;
+- independent lower/upper presence views and unchanged complete-range semantics;
+- contradictory limits or representative values to fail without partial cut mutation;
+- one-sided metadata to survive thermodynamic-system cloning;
+- missing representative properties to fail before adding any component; and
+- an explicitly characterized terminal cut to generate with the existing exact mass-closure gate.
+
+The capability is **qualified for terminal-bound metadata and fail-closed pseudo-component
+preparation**. It is O(1) per boundary assignment and does not alter thermodynamic calculations.
+
+## Stop boundary
+
+This evidence does not choose a representative boiling point or molecular weight for the DOE
+residue, infer C2-C4 gas composition, split a plus fraction, validate critical properties or VLE,
+match atmospheric product yields, change a column solver, or qualify vacuum fractionation. Those
+remain separate #3305 engineering contracts.

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -698,6 +698,12 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
      */
     public AssayCut withAverageBoilingPointKelvin(double temperatureKelvin) {
       validatePositiveFinite(temperatureKelvin, "Boiling point");
+      if (lowerBoilingPointKelvin != null && temperatureKelvin < lowerBoilingPointKelvin) {
+        throw new IllegalArgumentException("Representative boiling point cannot be below lower boundary");
+      }
+      if (upperBoilingPointKelvin != null && temperatureKelvin > upperBoilingPointKelvin) {
+        throw new IllegalArgumentException("Representative boiling point cannot exceed upper boundary");
+      }
       this.averageBoilingPointKelvin = temperatureKelvin;
       return this;
     }
@@ -727,6 +733,96 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
       }
       double temperatureCelsius = (temperatureFahrenheit - 32.0) * 5.0 / 9.0;
       return withAverageBoilingPointKelvin(temperatureCelsius + KELVIN_OFFSET);
+    }
+
+    /**
+     * Set and preserve a lower boiling limit in K without inventing an upper limit.
+     *
+     * @param temperatureKelvin lower cut boundary in K
+     * @return this cut
+     */
+    public AssayCut withLowerBoilingPointKelvin(double temperatureKelvin) {
+      validatePositiveFinite(temperatureKelvin, "Lower boiling point");
+      if (upperBoilingPointKelvin != null && !(upperBoilingPointKelvin > temperatureKelvin)) {
+        throw new IllegalArgumentException("Upper boiling-point boundary must exceed lower boundary");
+      }
+      if (averageBoilingPointKelvin != null && averageBoilingPointKelvin < temperatureKelvin) {
+        throw new IllegalArgumentException("Representative boiling point cannot be below lower boundary");
+      }
+      this.lowerBoilingPointKelvin = temperatureKelvin;
+      return this;
+    }
+
+    /**
+     * Set and preserve a lower boiling limit in degC without inventing an upper limit.
+     *
+     * @param temperatureCelsius lower cut boundary in degC
+     * @return this cut
+     */
+    public AssayCut withLowerBoilingPointCelsius(double temperatureCelsius) {
+      if (!Double.isFinite(temperatureCelsius)) {
+        throw new IllegalArgumentException("Lower boiling point must be finite");
+      }
+      return withLowerBoilingPointKelvin(temperatureCelsius + KELVIN_OFFSET);
+    }
+
+    /**
+     * Set and preserve a lower boiling limit in degF without inventing an upper limit.
+     *
+     * @param temperatureFahrenheit lower cut boundary in degF
+     * @return this cut
+     */
+    public AssayCut withLowerBoilingPointFahrenheit(double temperatureFahrenheit) {
+      if (!Double.isFinite(temperatureFahrenheit)) {
+        throw new IllegalArgumentException("Lower boiling point must be finite");
+      }
+      double temperatureCelsius = (temperatureFahrenheit - 32.0) * 5.0 / 9.0;
+      return withLowerBoilingPointKelvin(temperatureCelsius + KELVIN_OFFSET);
+    }
+
+    /**
+     * Set and preserve an upper boiling limit in K without inventing a lower limit.
+     *
+     * @param temperatureKelvin upper cut boundary in K
+     * @return this cut
+     */
+    public AssayCut withUpperBoilingPointKelvin(double temperatureKelvin) {
+      validatePositiveFinite(temperatureKelvin, "Upper boiling point");
+      if (lowerBoilingPointKelvin != null && !(temperatureKelvin > lowerBoilingPointKelvin)) {
+        throw new IllegalArgumentException("Upper boiling-point boundary must exceed lower boundary");
+      }
+      if (averageBoilingPointKelvin != null && averageBoilingPointKelvin > temperatureKelvin) {
+        throw new IllegalArgumentException("Representative boiling point cannot exceed upper boundary");
+      }
+      this.upperBoilingPointKelvin = temperatureKelvin;
+      return this;
+    }
+
+    /**
+     * Set and preserve an upper boiling limit in degC without inventing a lower limit.
+     *
+     * @param temperatureCelsius upper cut boundary in degC
+     * @return this cut
+     */
+    public AssayCut withUpperBoilingPointCelsius(double temperatureCelsius) {
+      if (!Double.isFinite(temperatureCelsius)) {
+        throw new IllegalArgumentException("Upper boiling point must be finite");
+      }
+      return withUpperBoilingPointKelvin(temperatureCelsius + KELVIN_OFFSET);
+    }
+
+    /**
+     * Set and preserve an upper boiling limit in degF without inventing a lower limit.
+     *
+     * @param temperatureFahrenheit upper cut boundary in degF
+     * @return this cut
+     */
+    public AssayCut withUpperBoilingPointFahrenheit(double temperatureFahrenheit) {
+      if (!Double.isFinite(temperatureFahrenheit)) {
+        throw new IllegalArgumentException("Upper boiling point must be finite");
+      }
+      double temperatureCelsius = (temperatureFahrenheit - 32.0) * 5.0 / 9.0;
+      return withUpperBoilingPointKelvin(temperatureCelsius + KELVIN_OFFSET);
     }
 
     /**
@@ -774,6 +870,24 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
      */
     public boolean hasBoilingRange() {
       return lowerBoilingPointKelvin != null && upperBoilingPointKelvin != null;
+    }
+
+    /**
+     * Return whether a lower cut boiling boundary is available.
+     *
+     * @return true when a lower boundary is stored
+     */
+    public boolean hasLowerBoilingPoint() {
+      return lowerBoilingPointKelvin != null;
+    }
+
+    /**
+     * Return whether an upper cut boiling boundary is available.
+     *
+     * @return true when an upper boundary is stored
+     */
+    public boolean hasUpperBoilingPoint() {
+      return upperBoilingPointKelvin != null;
     }
 
     /**

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTerminalBoundaryTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTerminalBoundaryTest.java
@@ -17,8 +17,8 @@ public class OilAssayCharacterisationDoeBigHillTerminalBoundaryTest {
 
   @Test
   public void doeResidueRetainsOnlyPublishedLowerBoundary() {
-    AssayCut residue = new AssayCut("DOE_BH_1050F_PLUS").withWeightPercent(11.56)
-        .withSpecificGravity(1.0089).withLowerBoilingPointFahrenheit(DOE_RESIDUE_LOWER_BOUNDARY_F);
+    AssayCut residue = new AssayCut("DOE_BH_1050F_PLUS").withWeightPercent(11.56).withSpecificGravity(1.0089)
+        .withLowerBoilingPointFahrenheit(DOE_RESIDUE_LOWER_BOUNDARY_F);
 
     assertTrue(residue.hasLowerBoilingPoint());
     assertFalse(residue.hasUpperBoilingPoint());
@@ -32,31 +32,24 @@ public class OilAssayCharacterisationDoeBigHillTerminalBoundaryTest {
   public void kelvinCelsiusAndFahrenheitPathsAreEquivalent() {
     AssayCut kelvin = new AssayCut("K").withLowerBoilingPointKelvin(DOE_RESIDUE_LOWER_BOUNDARY_K);
     AssayCut celsius = new AssayCut("C").withLowerBoilingPointCelsius(565.5555555555555);
-    AssayCut fahrenheit =
-        new AssayCut("F").withLowerBoilingPointFahrenheit(DOE_RESIDUE_LOWER_BOUNDARY_F);
+    AssayCut fahrenheit = new AssayCut("F").withLowerBoilingPointFahrenheit(DOE_RESIDUE_LOWER_BOUNDARY_F);
 
     assertEquals(kelvin.getLowerBoilingPointKelvin(), celsius.getLowerBoilingPointKelvin(), 1.0e-12);
-    assertEquals(kelvin.getLowerBoilingPointKelvin(), fahrenheit.getLowerBoilingPointKelvin(),
-        1.0e-12);
+    assertEquals(kelvin.getLowerBoilingPointKelvin(), fahrenheit.getLowerBoilingPointKelvin(), 1.0e-12);
 
     AssayCut upperCelsius = new AssayCut("UpperC").withUpperBoilingPointCelsius(79.44444444444444);
     AssayCut upperFahrenheit = new AssayCut("UpperF").withUpperBoilingPointFahrenheit(175.0);
-    assertEquals(upperCelsius.getUpperBoilingPointKelvin(), upperFahrenheit.getUpperBoilingPointKelvin(),
-        1.0e-12);
+    assertEquals(upperCelsius.getUpperBoilingPointKelvin(), upperFahrenheit.getUpperBoilingPointKelvin(), 1.0e-12);
   }
 
   @Test
   public void contradictoryInputsFailWithoutPartialMutation() {
-    AssayCut lowerFirst =
-        new AssayCut("LowerFirst").withLowerBoilingPointFahrenheit(DOE_RESIDUE_LOWER_BOUNDARY_F);
-    assertThrows(IllegalArgumentException.class,
-        () -> lowerFirst.withAverageBoilingPointFahrenheit(1000.0));
+    AssayCut lowerFirst = new AssayCut("LowerFirst").withLowerBoilingPointFahrenheit(DOE_RESIDUE_LOWER_BOUNDARY_F);
+    assertThrows(IllegalArgumentException.class, () -> lowerFirst.withAverageBoilingPointFahrenheit(1000.0));
     assertThrows(IllegalStateException.class, lowerFirst::resolveAverageBoilingPoint);
 
-    AssayCut representativeFirst =
-        new AssayCut("RepresentativeFirst").withAverageBoilingPointFahrenheit(1100.0);
-    assertThrows(IllegalArgumentException.class,
-        () -> representativeFirst.withLowerBoilingPointFahrenheit(1150.0));
+    AssayCut representativeFirst = new AssayCut("RepresentativeFirst").withAverageBoilingPointFahrenheit(1100.0);
+    assertThrows(IllegalArgumentException.class, () -> representativeFirst.withLowerBoilingPointFahrenheit(1150.0));
     assertFalse(representativeFirst.hasLowerBoilingPoint());
     assertEquals(866.4833333333333, representativeFirst.resolveAverageBoilingPoint(), 1.0e-12);
 
@@ -69,8 +62,8 @@ public class OilAssayCharacterisationDoeBigHillTerminalBoundaryTest {
   public void oneSidedBoundaryDoesNotInventRepresentativeProperties() {
     SystemInterface system = new SystemSrkEos(298.15, 1.01325);
     OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
-    assay.addCut(new AssayCut("UncharacterizedResidue").withMassFraction(1.0)
-        .withSpecificGravity(1.0089).withLowerBoilingPointFahrenheit(DOE_RESIDUE_LOWER_BOUNDARY_F));
+    assay.addCut(new AssayCut("UncharacterizedResidue").withMassFraction(1.0).withSpecificGravity(1.0089)
+        .withLowerBoilingPointFahrenheit(DOE_RESIDUE_LOWER_BOUNDARY_F));
 
     assertThrows(IllegalStateException.class, assay::apply);
     assertEquals(0, system.getNumberOfComponents(), "Failed preparation must not mutate the system");
@@ -81,9 +74,8 @@ public class OilAssayCharacterisationDoeBigHillTerminalBoundaryTest {
     SystemInterface system = new SystemSrkEos(298.15, 1.01325);
     OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
     assay.setTotalAssayMass(1.0);
-    assay.addCut(new AssayCut("CharacterizedResidue").withMassFraction(1.0)
-        .withSpecificGravity(1.0089).withLowerBoilingPointFahrenheit(DOE_RESIDUE_LOWER_BOUNDARY_F)
-        .withMolarMassGramPerMol(650.0));
+    assay.addCut(new AssayCut("CharacterizedResidue").withMassFraction(1.0).withSpecificGravity(1.0089)
+        .withLowerBoilingPointFahrenheit(DOE_RESIDUE_LOWER_BOUNDARY_F).withMolarMassGramPerMol(650.0));
 
     SystemInterface clonedSystem = system.clone();
     AssayCut clonedCut = clonedSystem.getOilAssayCharacterisation().getCuts().get(0);

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTerminalBoundaryTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillTerminalBoundaryTest.java
@@ -1,0 +1,96 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Public DOE qualification of open-ended refinery-assay boiling boundaries. */
+public class OilAssayCharacterisationDoeBigHillTerminalBoundaryTest {
+  private static final double DOE_RESIDUE_LOWER_BOUNDARY_F = 1050.0;
+  private static final double DOE_RESIDUE_LOWER_BOUNDARY_K = 838.7055555555555;
+
+  @Test
+  public void doeResidueRetainsOnlyPublishedLowerBoundary() {
+    AssayCut residue = new AssayCut("DOE_BH_1050F_PLUS").withWeightPercent(11.56)
+        .withSpecificGravity(1.0089).withLowerBoilingPointFahrenheit(DOE_RESIDUE_LOWER_BOUNDARY_F);
+
+    assertTrue(residue.hasLowerBoilingPoint());
+    assertFalse(residue.hasUpperBoilingPoint());
+    assertFalse(residue.hasBoilingRange());
+    assertEquals(DOE_RESIDUE_LOWER_BOUNDARY_K, residue.getLowerBoilingPointKelvin(), 1.0e-12);
+    assertThrows(IllegalStateException.class, residue::getUpperBoilingPointKelvin);
+    assertThrows(IllegalStateException.class, residue::resolveAverageBoilingPoint);
+  }
+
+  @Test
+  public void kelvinCelsiusAndFahrenheitPathsAreEquivalent() {
+    AssayCut kelvin = new AssayCut("K").withLowerBoilingPointKelvin(DOE_RESIDUE_LOWER_BOUNDARY_K);
+    AssayCut celsius = new AssayCut("C").withLowerBoilingPointCelsius(565.5555555555555);
+    AssayCut fahrenheit =
+        new AssayCut("F").withLowerBoilingPointFahrenheit(DOE_RESIDUE_LOWER_BOUNDARY_F);
+
+    assertEquals(kelvin.getLowerBoilingPointKelvin(), celsius.getLowerBoilingPointKelvin(), 1.0e-12);
+    assertEquals(kelvin.getLowerBoilingPointKelvin(), fahrenheit.getLowerBoilingPointKelvin(),
+        1.0e-12);
+
+    AssayCut upperCelsius = new AssayCut("UpperC").withUpperBoilingPointCelsius(79.44444444444444);
+    AssayCut upperFahrenheit = new AssayCut("UpperF").withUpperBoilingPointFahrenheit(175.0);
+    assertEquals(upperCelsius.getUpperBoilingPointKelvin(), upperFahrenheit.getUpperBoilingPointKelvin(),
+        1.0e-12);
+  }
+
+  @Test
+  public void contradictoryInputsFailWithoutPartialMutation() {
+    AssayCut lowerFirst =
+        new AssayCut("LowerFirst").withLowerBoilingPointFahrenheit(DOE_RESIDUE_LOWER_BOUNDARY_F);
+    assertThrows(IllegalArgumentException.class,
+        () -> lowerFirst.withAverageBoilingPointFahrenheit(1000.0));
+    assertThrows(IllegalStateException.class, lowerFirst::resolveAverageBoilingPoint);
+
+    AssayCut representativeFirst =
+        new AssayCut("RepresentativeFirst").withAverageBoilingPointFahrenheit(1100.0);
+    assertThrows(IllegalArgumentException.class,
+        () -> representativeFirst.withLowerBoilingPointFahrenheit(1150.0));
+    assertFalse(representativeFirst.hasLowerBoilingPoint());
+    assertEquals(866.4833333333333, representativeFirst.resolveAverageBoilingPoint(), 1.0e-12);
+
+    AssayCut bounded = new AssayCut("Bounded").withLowerBoilingPointCelsius(100.0);
+    assertThrows(IllegalArgumentException.class, () -> bounded.withUpperBoilingPointCelsius(90.0));
+    assertFalse(bounded.hasUpperBoilingPoint());
+  }
+
+  @Test
+  public void oneSidedBoundaryDoesNotInventRepresentativeProperties() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
+    assay.addCut(new AssayCut("UncharacterizedResidue").withMassFraction(1.0)
+        .withSpecificGravity(1.0089).withLowerBoilingPointFahrenheit(DOE_RESIDUE_LOWER_BOUNDARY_F));
+
+    assertThrows(IllegalStateException.class, assay::apply);
+    assertEquals(0, system.getNumberOfComponents(), "Failed preparation must not mutate the system");
+  }
+
+  @Test
+  public void explicitlyCharacterizedTerminalCutClosesMassAndSurvivesClone() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
+    assay.setTotalAssayMass(1.0);
+    assay.addCut(new AssayCut("CharacterizedResidue").withMassFraction(1.0)
+        .withSpecificGravity(1.0089).withLowerBoilingPointFahrenheit(DOE_RESIDUE_LOWER_BOUNDARY_F)
+        .withMolarMassGramPerMol(650.0));
+
+    SystemInterface clonedSystem = system.clone();
+    AssayCut clonedCut = clonedSystem.getOilAssayCharacterisation().getCuts().get(0);
+    assertEquals(DOE_RESIDUE_LOWER_BOUNDARY_K, clonedCut.getLowerBoilingPointKelvin(), 1.0e-12);
+    assertFalse(clonedCut.hasUpperBoilingPoint());
+
+    assay.apply();
+    assertEquals(1, system.getNumberOfComponents());
+  }
+}


### PR DESCRIPTION
## Summary

Preserves one-sided boiling limits on refinery assay terminal cuts without inventing a finite interval or midpoint.

- adds lower- and upper-bound builders in K, °C and °F
- adds independent lower/upper presence queries
- validates bound/representative consistency without partial mutation
- keeps existing complete-range midpoint behavior
- leaves pseudo-component preparation fail-closed unless a terminal cut also has independently supported representative properties
- documents and regression-protects the public DOE Big Hill Sweet 1050 °F+ residue boundary

Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5483901997

## Public evidence and engineering boundary

The official DOE/SPR Big Hill Sweet workbook (reported 2021-09-24) publishes an 11.56 mass% residue with relative density 1.0089 and a 1050 °F+ lower boiling limit, but no finite upper limit or molecular weight:

https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx

The regression preserves 1050 °F as 838.7055555556 K and never infers an upper bound or midpoint. Its 650 g/mol generation control is explicitly an engineering input used only to prove the existing mass-closure path; DOE does not publish or validate that value.

This qualifies terminal-bound metadata and fail-closed pseudo-component preparation. It does not qualify plus-fraction splitting, residue molecular weight, critical properties, VLE, light-gas composition, atmospheric yields, vacuum fractionation, blending, or conversion models.

## Exact continuity

- exact base: `1f7a01b06307d9d56451e43bb8d6023d28d14007`
- exact head: `a6b488c1d5625bd6b1fd65710ba0418911aaa3c8`
- branch: `ai/refinery-terminal-boiling-boundaries-3305`
- predecessor #3370 is merged
- no competing #3305 PR existed at publication
- autonomous capacity remained below the 10-capability ceiling

## Validation

Evidence actually performed before publication:

- official DOE XLSX inspected directly; the 1050 °F+, 11.56 mass%, and 1.0089 relative-density fields were verified
- Fahrenheit-to-Kelvin conversion independently checked
- exact five-file connector-built diff and source anchors inspected

Local Maven, focused Java tests, Spotless, documentation search, pre-commit and pre-push were unavailable because this run had no prepared repository checkout; they are not claimed. GitHub CI is authoritative.

**VALIDATION PENDING CI**

## Documentation impact

Updates the characterization index, refinery-assay guide/capability matrix, and adds a dedicated DOE terminal-boundary provenance and acceptance page. Java is authoritative; Python/JPype receives the same public methods. JSON, MCP and notebook views are not applicable because no refinery-assay schema owns `AssayCut` and this bounded scalar metadata API adds no distinct notebook workflow.

Advances #3305; does not close it.

Generated with AI assistance.