### PR TITLE
docs: remove duplicate tutorial and example titles

### DIFF
--- a/docs/examples/NorwegianEmissionMethods_Comparison.md
+++ b/docs/examples/NorwegianEmissionMethods_Comparison.md
@@ -3,8 +3,6 @@ title: "NeqSim vs Norwegian Handbook: Emission Calculation Methods Comparison"
 description: "This document compares the conventional Norwegian handbook method for emission reporting with the NeqSim thermodynamic method implemented via NeqSimLive."
 ---
 
-# NeqSim vs Norwegian Handbook: Emission Calculation Methods Comparison
-
 > **📖 Related Documentation:**
 > - [Produced Water Emissions Tutorial](ProducedWaterEmissions_Tutorial) - Complete implementation guide
 > - [Examples Index](index) - All tutorials and examples

--- a/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
+++ b/docs/examples/PRODUCTION_OPTIMIZATION_GUIDE.md
@@ -3,8 +3,6 @@ title: Production Optimization Guide
 description: This guide provides comprehensive examples for setting up and running production optimization simulations in NeqSim, covering both Java and Python implementations.
 ---
 
-# Production Optimization Guide
-
 > **New to process optimization?** Start with the [Optimization Overview](../process/optimization/OPTIMIZATION_OVERVIEW) to understand when to use which optimizer.
 
 This guide provides comprehensive examples for setting up and running production optimization simulations in NeqSim, covering both Java and Python implementations.

--- a/docs/examples/selective-logic-execution.md
+++ b/docs/examples/selective-logic-execution.md
@@ -3,8 +3,6 @@ title: Selective Logic Execution in ProcessScenarioRunner
 description: The `ProcessScenarioRunner` provides multiple ways to control which logic sequences execute during a scenario.
 ---
 
-# Selective Logic Execution in ProcessScenarioRunner
-
 The `ProcessScenarioRunner` provides multiple ways to control which logic sequences execute during a scenario.
 
 ## Method 1: Add Only What You Need (Simplest)

--- a/docs/test_tutorial_cookbook_examples_documentation.py
+++ b/docs/test_tutorial_cookbook_examples_documentation.py
@@ -1,0 +1,219 @@
+"""Contracts for tutorials, cookbook, troubleshooting, and examples."""
+
+from pathlib import Path
+import re
+import unittest
+from urllib.parse import unquote
+
+
+DOCS = Path(__file__).resolve().parent
+SCOPE_PAGES = (
+    DOCS / "cookbook/adsorption-recipes.md",
+    DOCS / "cookbook/index.md",
+    DOCS / "cookbook/pipeline-recipes.md",
+    DOCS / "cookbook/process-recipes.md",
+    DOCS / "cookbook/thermodynamics-recipes.md",
+    DOCS / "cookbook/unit-conversion-recipes.md",
+    DOCS / "examples/AIPlatformIntegration.md",
+    DOCS / "examples/AdvancedRiskFramework_Tutorial.md",
+    DOCS / "examples/BeerBrewing_BioProcess_Simulation.md",
+    DOCS / "examples/ESP_Pump_Tutorial.md",
+    DOCS / "examples/FieldDevelopmentWorkflow.md",
+    DOCS / "examples/GERG2008_NH3_Ammonia_Properties.md",
+    DOCS / "examples/GraphBasedProcessSimulation.md",
+    DOCS / "examples/H2S_Distribution_Modeling.md",
+    DOCS / "examples/IntegratedProductionRiskAnalysis.md",
+    DOCS / "examples/LoopedPipelineNetworkExample.md",
+    DOCS / "examples/MPC_Integration_Tutorial.md",
+    DOCS / "examples/MercuryRemoval_LNG_Pretreatment.md",
+    DOCS / "examples/MultiScenarioVFP_Tutorial.md",
+    DOCS / "examples/MultiphaseFlowPipelineRiser_Interactive.md",
+    DOCS / "examples/NeqSim_Python_Optimization.md",
+    DOCS / "examples/NetworkSolverTutorial.md",
+    DOCS / "examples/NorwegianEmissionMethods_Comparison.md",
+    DOCS / "examples/PRODUCTION_OPTIMIZATION_GUIDE.md",
+    DOCS / "examples/PVT_Simulation_and_Tuning.md",
+    DOCS / "examples/ProducedWaterEmissions_Tutorial.md",
+    DOCS / "examples/ProductionOptimizer_Tutorial.md",
+    DOCS / "examples/ProductionSystem_BottleneckAnalysis.md",
+    DOCS / "examples/ReadingFluidProperties.md",
+    DOCS / "examples/ReservoirToMarket_DebottleneckPortfolio.md",
+    DOCS / "examples/SeparatorEfficiency_GasScrubber_ThreePhase.md",
+    DOCS / "examples/TVP_RVP_Study.md",
+    DOCS / "examples/TwoFluidPipe_Tutorial.md",
+    DOCS / "examples/autosize_and_optimize_workflows.md",
+    DOCS / "examples/comparesimulations_quickstart.md",
+    DOCS / "examples/index.md",
+    DOCS / "examples/oilgas_production_energy_optimization.md",
+    DOCS / "examples/process equipmentutl.md",
+    DOCS / "examples/processmodel_plant_optimization.md",
+    DOCS / "examples/reservoir_to_market_optimization.md",
+    DOCS / "examples/selective-logic-execution.md",
+    DOCS / "examples/transient_slug_separator_control_example.md",
+    DOCS / "troubleshooting/index.md",
+    DOCS / "tutorials/gosp_tutorial.md",
+    DOCS / "tutorials/index.md",
+    DOCS / "tutorials/learning-paths.md",
+    DOCS / "tutorials/solve-engineering-task.md",
+    DOCS / "tutorials/teg_dehydration_tutorial.md",
+)
+
+INDEX_PAGES = (
+    DOCS / "REFERENCE_MANUAL_INDEX.md",
+    DOCS / "cookbook/index.md",
+    DOCS / "examples/index.md",
+    DOCS / "troubleshooting/index.md",
+    DOCS / "tutorials/index.md",
+)
+
+
+def metadata_value(metadata, name):
+    """Return a plain scalar, including folded YAML front-matter values."""
+    prefix = name + ":"
+    lines = metadata.splitlines()
+    for index, line in enumerate(lines):
+        if not line.startswith(prefix):
+            continue
+        value = line[len(prefix) :].strip()
+        if value in {">", ">-", "|", "|-"}:
+            parts = []
+            for continuation in lines[index + 1 :]:
+                if continuation and not continuation[0].isspace():
+                    break
+                if continuation.strip():
+                    parts.append(continuation.strip())
+            return " ".join(parts)
+        return value.strip().strip("'\"")
+    return ""
+
+
+def parse_front_matter(source):
+    """Return title, description, and body from one Markdown page."""
+    match = re.match(r"\A---\n(?P<metadata>.*?)\n---\n(?P<body>.*)\Z", source, re.DOTALL)
+    if match is None:
+        raise AssertionError("Missing Jekyll front matter")
+    metadata = match.group("metadata")
+    return (
+        metadata_value(metadata, "title"),
+        metadata_value(metadata, "description"),
+        match.group("body"),
+    )
+
+
+def remove_fenced_code(source):
+    """Remove backtick and tilde code fences before inspecting rendered Markdown."""
+    rendered = []
+    marker = None
+    for line in source.splitlines():
+        stripped = line.lstrip()
+        if marker is None and (
+            stripped.startswith(("\x60\x60\x60", "~~~"))
+        ):
+            marker = stripped[:3]
+            continue
+        if marker is not None:
+            if stripped.startswith(marker):
+                marker = None
+            continue
+        rendered.append(line)
+    return "\n".join(rendered)
+
+
+def link_candidates(page, raw_target):
+    """Return repository-source candidates for one relative documentation link."""
+    target = unquote(raw_target.split("#", 1)[0].split("?", 1)[0].strip().strip("<>"))
+    if target.startswith("/"):
+        candidate = DOCS / target.lstrip("/")
+    else:
+        candidate = page.parent / target
+    if candidate.suffix:
+        stem = candidate.with_suffix("")
+        return (
+            candidate,
+            stem / "README.md",
+            stem / "index.md",
+        )
+    return (
+        candidate.with_suffix(".md"),
+        candidate / "README.md",
+        candidate / "index.md",
+    )
+
+
+class TutorialCookbookExamplesDocumentationContractTest(unittest.TestCase):
+    """Protect the frozen rotation-scope-6 documentation surface."""
+
+    def test_frozen_scope_exists(self):
+        self.assertEqual(48, len(SCOPE_PAGES))
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                self.assertTrue(page.is_file())
+
+    def test_pages_have_searchable_front_matter(self):
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                title, description, _body = parse_front_matter(
+                    page.read_text(encoding="utf-8")
+                )
+                self.assertTrue(title)
+                self.assertGreaterEqual(len(description.split()), 5)
+
+    def test_front_matter_title_is_not_repeated_as_h1(self):
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                title, _description, body = parse_front_matter(
+                    page.read_text(encoding="utf-8")
+                )
+                rendered = remove_fenced_code(body)
+                headings = re.findall(r"^#\s+(.+?)\s*$", rendered, re.MULTILINE)
+                self.assertNotIn(title, headings)
+
+    def test_pages_are_discoverable_from_repository_indexes(self):
+        link_pattern = re.compile(r"(?<!!)\[[^\]\n]+\]\(([^)\n]+)\)")
+        scheme = re.compile(r"^[a-z][a-z0-9+.-]*:", re.IGNORECASE)
+        discovered = set()
+        for index_page in INDEX_PAGES:
+            rendered = remove_fenced_code(index_page.read_text(encoding="utf-8"))
+            for match in link_pattern.finditer(rendered):
+                raw_target = match.group(1).strip().split()[0]
+                if raw_target.startswith("#") or scheme.match(raw_target):
+                    continue
+                for candidate in link_candidates(index_page, raw_target):
+                    if candidate.is_file():
+                        discovered.add(candidate.resolve())
+
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                self.assertIn(page.resolve(), discovered)
+
+    def test_pages_use_supported_math_delimiters(self):
+        unsupported = re.compile(r"\\\[|\\\]|\\\(|\\\)")
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                _title, _description, body = parse_front_matter(
+                    page.read_text(encoding="utf-8")
+                )
+                self.assertIsNone(unsupported.search(remove_fenced_code(body)))
+
+    def test_relative_source_links_resolve(self):
+        link_pattern = re.compile(r"(?<!!)\[[^\]\n]+\]\(([^)\n]+)\)")
+        scheme = re.compile(r"^[a-z][a-z0-9+.-]*:", re.IGNORECASE)
+        for page in SCOPE_PAGES:
+            rendered = remove_fenced_code(page.read_text(encoding="utf-8"))
+            with self.subTest(page=page, check="single-line destinations"):
+                self.assertNotRegex(rendered, r"\]\([^\n)]*\n")
+            for match in link_pattern.finditer(rendered):
+                raw_target = match.group(1).strip().split()[0]
+                if raw_target.startswith("#") or scheme.match(raw_target):
+                    continue
+                candidates = link_candidates(page, raw_target)
+                with self.subTest(page=page, target=raw_target):
+                    self.assertTrue(
+                        any(candidate.is_file() for candidate in candidates),
+                        msg="Missing target; tried: "
+                        + ", ".join(str(candidate) for candidate in candidates),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/tutorials/solve-engineering-task.md
+++ b/docs/tutorials/solve-engineering-task.md
@@ -3,8 +3,6 @@ title: "How to Solve an Engineering Task with NeqSim"
 description: "Complete hands-on guide to solving engineering tasks using the AI-assisted 3-step workflow. Covers setup, scope definition, simulation, validation, report generation, and contributing results back. Works with VS Code Copilot, OpenAI Codex, Claude Code, or manually."
 ---
 
-# How to Solve an Engineering Task with NeqSim
-
 This guide walks you through solving a real engineering task — from a blank
 screen to a validated Word/HTML report — using NeqSim's AI-assisted workflow.
 


### PR DESCRIPTION
## Summary

Advances documentation-quality campaign #2499 as D110 (rotation scope 6).

- removes four exact front-matter-title/H1 duplicates across tutorial and example pages
- adds a shared 48-page contract for metadata, rendered titles, supported math, relative links, and repository-index discoverability
- preserves every equation, code example, stored notebook result, technical claim, API, and Java behavior

## Frozen scope and boundaries

Base: `cc16fcc8f546f14b0564628944c7735402341684`

The scan covers all 48 Markdown pages under `docs/tutorials/**`, `docs/cookbook/**`, `docs/troubleshooting/**`, and `docs/examples/**`. The changed batch is limited to the four confirmed title defects plus one shared contract.

It excludes production code, calculation/API/example behavior, notebook source/output changes, external-link policy, refinery assay, electrolyte/MCP, DEXPI/PFD, dynamics, and Huldra work.

## Validation

- exact-source baseline: 48 pages inspected; four duplicate rendered titles confirmed
- proposed corpus: zero duplicate title/H1 pairs, missing/weak metadata findings, unsupported math-delimiter findings, unclosed fences, or multiline relative-link findings
- all 224 relative-link occurrences (213 page/target pairs) resolve
- all 48 pages are discoverable from the reference manual or their section index
- all 52 top-level documentation test modules were audited for stale page-specific H1 assertions; none target these four pages
- the new Python contract parses successfully with Python 3
- no file overlap with active PRs #3374, #3376, #3377, #3378, #3379, or #3380

**VALIDATION PENDING CI:** documentation/Jekyll/search, pre-commit, Spotless, CodeQL, build/test, and Javadocs have not yet completed on this exact head.

## Maturity

D110 remains experimental until exact-head CI passes. Target maturity is qualified after independent merge and current-`master` blob verification.