### PR TITLE
[AI-Assisted] feat(dexpi): classify endpoint incidence roles

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -156,11 +156,19 @@ stream order, or simulation state.
 order. Each immutable `DexpiConnectionEndpointInfo` records the resolved element and explicit owner
 evidence plus the incoming and outgoing connection-evidence IDs in source order. Counts retain every
 occurrence, including parallel connections. Blank endpoint references remain findings and are omitted
-from this keyed inventory; unresolved non-empty IDs remain visible. These source-incidence records do
-not classify branches or junctions and do not create live process connectivity.
+from this keyed inventory; unresolved non-empty IDs remain visible.
+
+`getIncidenceRole()` classifies only this directed source evidence: zero incoming and one outgoing
+is `SOURCE`; one incoming and zero outgoing is `SINK`; one of each is `PASS_THROUGH`; one
+incoming and multiple outgoing is `SPLIT`; multiple incoming and one outgoing is `MERGE`; and
+all remaining non-empty patterns are `COMPLEX`. `isPotentialMultiConnectionNode()` reports
+whether either directed side has multiple occurrences. These values help reviewers locate topology
+that needs engineering interpretation. They do not prove hydraulic continuity, identify a physical
+branch or fitting, create live process connectivity, or establish process intent.
 
 `toJson()` includes `instrumentCount`, `connectionCount`, `connectionEndpointCount`, and the
-ordered connection and endpoint inventories alongside the process-unit count and findings. Python
+ordered connection and endpoint inventories, including `incidenceRole` and
+`potentialMultiConnectionNode`, alongside the process-unit count and findings. Python
 callers through JPype use the same `ImportResult.getInstruments()`, `ImportResult.getConnections()`,
 and `ImportResult.getConnectionEndpoints()` getters; there is no separate Python reconstruction
 model.

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionEndpointInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionEndpointInfo.java
@@ -20,6 +20,29 @@ import java.util.Map;
  */
 public final class DexpiConnectionEndpointInfo implements Serializable {
   private static final long serialVersionUID = 1000L;
+
+  /**
+   * Directed source-incidence classification for a connection endpoint.
+   *
+   * <p>
+   * Roles describe only explicit connection occurrences in the imported document. They do not
+   * establish hydraulic continuity, fitting type, process intent, or live simulation topology.
+   * </p>
+   */
+  public enum IncidenceRole {
+    /** No incoming and exactly one outgoing occurrence. */
+    SOURCE,
+    /** Exactly one incoming and no outgoing occurrence. */
+    SINK,
+    /** Exactly one incoming and one outgoing occurrence. */
+    PASS_THROUGH,
+    /** Exactly one incoming and more than one outgoing occurrence. */
+    SPLIT,
+    /** More than one incoming and exactly one outgoing occurrence. */
+    MERGE,
+    /** Any remaining non-empty incidence pattern. */
+    COMPLEX
+  }
   private final String endpointId;
   private final String elementName;
   private final String ownerId;
@@ -105,6 +128,45 @@ public final class DexpiConnectionEndpointInfo implements Serializable {
     return getConnectionCount() > 1;
   }
 
+  /**
+   * Classifies the endpoint from explicit incoming and outgoing source occurrences.
+   *
+   * @return evidence-only directed incidence role
+   */
+  public IncidenceRole getIncidenceRole() {
+    int incoming = getIncomingConnectionCount();
+    int outgoing = getOutgoingConnectionCount();
+    if (incoming == 0 && outgoing == 1) {
+      return IncidenceRole.SOURCE;
+    }
+    if (incoming == 1 && outgoing == 0) {
+      return IncidenceRole.SINK;
+    }
+    if (incoming == 1 && outgoing == 1) {
+      return IncidenceRole.PASS_THROUGH;
+    }
+    if (incoming == 1 && outgoing > 1) {
+      return IncidenceRole.SPLIT;
+    }
+    if (incoming > 1 && outgoing == 1) {
+      return IncidenceRole.MERGE;
+    }
+    return IncidenceRole.COMPLEX;
+  }
+
+  /**
+   * Indicates source evidence with more than one incoming or outgoing occurrence.
+   *
+   * <p>
+   * This is a review aid, not a claim that the endpoint is a physical branch or junction.
+   * </p>
+   *
+   * @return whether either directed side contains multiple occurrences
+   */
+  public boolean isPotentialMultiConnectionNode() {
+    return getIncomingConnectionCount() > 1 || getOutgoingConnectionCount() > 1;
+  }
+
   Map<String, Object> toMap() {
     Map<String, Object> result = new LinkedHashMap<String, Object>();
     result.put("endpointId", endpointId);
@@ -114,6 +176,8 @@ public final class DexpiConnectionEndpointInfo implements Serializable {
     result.put("resolved", Boolean.valueOf(resolved));
     result.put("incomingConnectionCount", Integer.valueOf(getIncomingConnectionCount()));
     result.put("outgoingConnectionCount", Integer.valueOf(getOutgoingConnectionCount()));
+    result.put("incidenceRole", getIncidenceRole().name());
+    result.put("potentialMultiConnectionNode", Boolean.valueOf(isPotentialMultiConnectionNode()));
     result.put("incomingConnectionIds", incomingConnectionIds);
     result.put("outgoingConnectionIds", outgoingConnectionIds);
     return result;

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionEndpointInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionEndpointInfo.java
@@ -25,8 +25,8 @@ public final class DexpiConnectionEndpointInfo implements Serializable {
    * Directed source-incidence classification for a connection endpoint.
    *
    * <p>
-   * Roles describe only explicit connection occurrences in the imported document. They do not
-   * establish hydraulic continuity, fitting type, process intent, or live simulation topology.
+   * Roles describe only explicit connection occurrences in the imported document. They do not establish hydraulic
+   * continuity, fitting type, process intent, or live simulation topology.
    * </p>
    */
   public enum IncidenceRole {
@@ -43,6 +43,7 @@ public final class DexpiConnectionEndpointInfo implements Serializable {
     /** Any remaining non-empty incidence pattern. */
     COMPLEX
   }
+
   private final String endpointId;
   private final String elementName;
   private final String ownerId;

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -412,6 +412,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(1, junction.getOutgoingConnectionCount());
     assertEquals(3, junction.getConnectionCount());
     assertTrue(junction.isReferencedMultipleTimes());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.MERGE, junction.getIncidenceRole());
+    assertTrue(junction.isPotentialMultiConnectionNode());
     assertEquals(Arrays.asList("C-1", "C-2"), junction.getIncomingConnectionIds());
     assertEquals(Collections.singletonList("C-3"), junction.getOutgoingConnectionIds());
 
@@ -420,10 +422,41 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertFalse(unresolved.isResolved());
     assertEquals(Collections.singletonList("C-4"), unresolved.getOutgoingConnectionIds());
     assertEquals(0, unresolved.getIncomingConnectionCount());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.SOURCE, unresolved.getIncidenceRole());
+    assertFalse(unresolved.isPotentialMultiConnectionNode());
     assertThrows(UnsupportedOperationException.class, () -> unresolved.getOutgoingConnectionIds().clear());
     assertThrows(UnsupportedOperationException.class, () -> first.getConnectionEndpoints().clear());
     assertTrue(first.toJson().contains("\"connectionEndpointCount\": 5"));
+    assertTrue(first.toJson().contains("\"incidenceRole\": \"MERGE\""));
+    assertTrue(first.toJson().contains("\"potentialMultiConnectionNode\": true"));
     assertEquals(first.toJson(), second.toJson());
+  }
+
+  @Test
+  public void testConnectionEndpointIncidenceRoleClassification() {
+    DexpiConnectionEndpointInfo source = new DexpiConnectionEndpointInfo("SOURCE", "Nozzle", "", "",
+        true, Collections.<String>emptyList(), Collections.singletonList("C-1"));
+    DexpiConnectionEndpointInfo sink = new DexpiConnectionEndpointInfo("SINK", "Nozzle", "", "", true,
+        Collections.singletonList("C-1"), Collections.<String>emptyList());
+    DexpiConnectionEndpointInfo passThrough = new DexpiConnectionEndpointInfo("PASS", "Nozzle", "", "",
+        true, Collections.singletonList("C-1"), Collections.singletonList("C-2"));
+    DexpiConnectionEndpointInfo split = new DexpiConnectionEndpointInfo("SPLIT", "Nozzle", "", "", true,
+        Collections.singletonList("C-1"), Arrays.asList("C-2", "C-3"));
+    DexpiConnectionEndpointInfo merge = new DexpiConnectionEndpointInfo("MERGE", "Nozzle", "", "", true,
+        Arrays.asList("C-1", "C-2"), Collections.singletonList("C-3"));
+    DexpiConnectionEndpointInfo complex = new DexpiConnectionEndpointInfo("COMPLEX", "Nozzle", "", "",
+        true, Arrays.asList("C-1", "C-2"), Arrays.asList("C-3", "C-4"));
+
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.SOURCE, source.getIncidenceRole());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.SINK, sink.getIncidenceRole());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.PASS_THROUGH, passThrough.getIncidenceRole());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.SPLIT, split.getIncidenceRole());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.MERGE, merge.getIncidenceRole());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.COMPLEX, complex.getIncidenceRole());
+    assertFalse(passThrough.isPotentialMultiConnectionNode());
+    assertTrue(split.isPotentialMultiConnectionNode());
+    assertTrue(merge.isPotentialMultiConnectionNode());
+    assertTrue(complex.isPotentialMultiConnectionNode());
   }
 
   @Test
@@ -442,6 +475,12 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         result.getConnectionEndpoints().get(0).getOutgoingConnectionIds());
     assertEquals(Arrays.asList("S-1/connection-1", "S-2/connection-1"),
         result.getConnectionEndpoints().get(1).getIncomingConnectionIds());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.COMPLEX,
+        result.getConnectionEndpoints().get(0).getIncidenceRole());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.COMPLEX,
+        result.getConnectionEndpoints().get(1).getIncidenceRole());
+    assertTrue(result.getConnectionEndpoints().get(0).isPotentialMultiConnectionNode());
+    assertTrue(result.getConnectionEndpoints().get(1).isPotentialMultiConnectionNode());
   }
 
   private static int countDiagnostics(DexpiXmlReader.ImportResult result, String expectedCode) {

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -434,18 +434,18 @@ public class DexpiXmlReaderTest extends NeqSimTest {
 
   @Test
   public void testConnectionEndpointIncidenceRoleClassification() {
-    DexpiConnectionEndpointInfo source = new DexpiConnectionEndpointInfo("SOURCE", "Nozzle", "", "",
-        true, Collections.<String>emptyList(), Collections.singletonList("C-1"));
+    DexpiConnectionEndpointInfo source = new DexpiConnectionEndpointInfo("SOURCE", "Nozzle", "", "", true,
+        Collections.<String>emptyList(), Collections.singletonList("C-1"));
     DexpiConnectionEndpointInfo sink = new DexpiConnectionEndpointInfo("SINK", "Nozzle", "", "", true,
         Collections.singletonList("C-1"), Collections.<String>emptyList());
-    DexpiConnectionEndpointInfo passThrough = new DexpiConnectionEndpointInfo("PASS", "Nozzle", "", "",
-        true, Collections.singletonList("C-1"), Collections.singletonList("C-2"));
+    DexpiConnectionEndpointInfo passThrough = new DexpiConnectionEndpointInfo("PASS", "Nozzle", "", "", true,
+        Collections.singletonList("C-1"), Collections.singletonList("C-2"));
     DexpiConnectionEndpointInfo split = new DexpiConnectionEndpointInfo("SPLIT", "Nozzle", "", "", true,
         Collections.singletonList("C-1"), Arrays.asList("C-2", "C-3"));
     DexpiConnectionEndpointInfo merge = new DexpiConnectionEndpointInfo("MERGE", "Nozzle", "", "", true,
         Arrays.asList("C-1", "C-2"), Collections.singletonList("C-3"));
-    DexpiConnectionEndpointInfo complex = new DexpiConnectionEndpointInfo("COMPLEX", "Nozzle", "", "",
-        true, Arrays.asList("C-1", "C-2"), Arrays.asList("C-3", "C-4"));
+    DexpiConnectionEndpointInfo complex = new DexpiConnectionEndpointInfo("COMPLEX", "Nozzle", "", "", true,
+        Arrays.asList("C-1", "C-2"), Arrays.asList("C-3", "C-4"));
 
     assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.SOURCE, source.getIncidenceRole());
     assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.SINK, sink.getIncidenceRole());


### PR DESCRIPTION
## Capability

Adds deterministic, evidence-only directed-incidence roles to the Proteus 4.1.1 connection-endpoint inventory established by #3376.

- `(0,1)` → `SOURCE`
- `(1,0)` → `SINK`
- `(1,1)` → `PASS_THROUGH`
- `(1,n>1)` → `SPLIT`
- `(n>1,1)` → `MERGE`
- all remaining non-empty incidence → `COMPLEX`

`isPotentialMultiConnectionNode()` separately flags endpoints with multiple incoming or outgoing occurrences. Parallel connection evidence remains distinct and source ordered.

Capability contract: #1332 comment 5490833906 and #2899 comment 5490834126.

## Engineering boundary

These roles classify only explicit connection occurrences in the imported document. They do not establish hydraulic continuity, connected-fluid identity, fitting type, valve state, process intent, branch/junction equipment, or live `ProcessSystem` topology.

This PR does not change reader `read`/`load` behavior, simulation construction, topology rewiring, renderer/layout behavior, SVG/PNG output, writers, native DEXPI 2.0, Classic/DOT output, or public calculation models. No drawing was generated or changed, so rendered whole-sheet inspection is not applicable to this evidence-only reader increment.

## Views and compatibility

- Java: additive Java-8-compatible `IncidenceRole` enum, getter, and review-aid predicate.
- Python/JPype: the same public Java surface; no adapter fork.
- JSON: additive deterministic `incidenceRole` and `potentialMultiConnectionNode` fields.
- MCP: not applicable; no DEXPI import operation is exposed.
- Notebook: not applicable; no calculation or graphical behavior changes.

## Tests and documentation

- Extends the Proteus reader regression to verify merged and unresolved-source roles plus deterministic JSON.
- Covers all six role mappings directly.
- Verifies parallel source/sink occurrences remain `COMPLEX` and visibly multi-connected.
- Updates the DEXPI reader guide with mappings and explicit engineering limitations.

## Exact continuity and validation

- Base: `a8fad5f988a58650a3b6ae92a53d472178a7b22f`
- Exact head: `9000c24c569c5be87a3c0a9364e25579a553bb5d`
- Files: three (`DexpiConnectionEndpointInfo`, focused reader test, reader documentation).
- Focused DEXPI reader suite: 18 tests passed.
- Direct Spotless check, documentation-search audit, pre-commit, and pre-push hooks passed after applying the exact hosted formatting repair.
- All eight hosted workflows pass. Java 8/21 Ubuntu/Windows suites, all four slow shards, Javadocs, Spotless, pre-commit, documentation, notebook execution, diagram performance, CodeQL, and PaperLab are successful.
- Draft is mergeable with no reviews or unresolved threads.

**READY TO MERGE**

## Stop boundary

Stops before topology rewiring, inferred branch equipment, renderer/layout changes, native DEXPI 2.0 expansion, licensed standards mapping, certification, accountable engineering approval, Huldra, or external datasets.

Coordinates #1332 and #2899. Generated with AI assistance.