### PR TITLE
[AI-Assisted] feat(kinetics): propagate aqueous CO2 temperature trajectory

### DIFF
--- a/docs/chemicalreactions/README.md
+++ b/docs/chemicalreactions/README.md
@@ -139,6 +139,8 @@ See the [CO₂ impurity kinetics guide](co2_impurity_kinetics_guide) for reactio
 Java usage, numerical safeguards, and model limitations. Use the
 [CO₂ transport reaction-kinetics guide](co2_transport_reaction_kinetics) to enforce evidence
 ranges and screen a reaction/transport Damköhler number.
+Use the [CO₂ hydration temperature-trajectory guide](co2_hydration_temperature_trajectory) for
+exact, carbon-conserving propagation of the qualified neutral pair through ordered temperature segments.
 
 
 ---

--- a/docs/chemicalreactions/co2_hydration_temperature_trajectory.md
+++ b/docs/chemicalreactions/co2_hydration_temperature_trajectory.md
@@ -1,0 +1,70 @@
+---
+title: Aqueous CO2 hydration temperature trajectory
+description: Exact piecewise-isothermal propagation of the qualified neutral CO2(aq)/H2CO3 kinetic pair.
+---
+
+`AqueousCO2HydrationTrajectory` propagates the reversible neutral molecular pair
+
+$$
+\mathrm{CO_2(aq) + H_2O \rightleftharpoons H_2CO_3}
+$$
+
+through an ordered set of piecewise-isothermal segments. Each segment uses the exact analytical
+`AqueousCO2HydrationKinetics.advance(...)` solution with the Soli and Byrne (2002) correlations,
+[doi:10.1016/S0304-4203(02)00010-5](https://doi.org/10.1016/S0304-4203%2802%2900010-5).
+No kinetic parameter is fitted or tuned by the trajectory helper.
+
+## Ordered analytical propagation
+
+For segment $i$ with duration $\Delta t_i$ and temperature $T_i$, the local rates are $k_H(T_i)$
+and $k_D(T_i)$. The exact affine update is applied to the result of the preceding segment. This
+preserves
+
+$$
+c_{\mathrm{CO_2(aq)}} + c_{\mathrm{H_2CO_3}}
+$$
+
+without a numerical timestep approximation. The result reports final pair concentrations, elapsed
+time, segment count, temperature bounds, and the carbon-balance residual.
+
+It also reports the dimensionless cumulative relaxation exposure
+
+$$
+\Theta = \sum_i \left(k_H(T_i) + k_D(T_i)\right)\Delta t_i.
+$$
+
+For repeated segments at one temperature, splitting a duration leaves the exact final state
+unchanged and $\Theta$ equals the ordinary pair Damköhler number. For changing temperatures, the
+pair equilibrium target also changes. Therefore $\exp(-\Theta)$ is **not** reported as one global
+remaining-deviation fraction, and segment order must be preserved.
+
+## Java and Python use
+
+```java
+double[] durationsSeconds = {0.04, 0.02};
+double[] temperaturesK = {288.15, 305.65};
+
+AqueousCO2HydrationTrajectory.TrajectoryResult result =
+    AqueousCO2HydrationTrajectory.advance(
+        1000.0, 0.0, durationsSeconds, temperaturesK);
+```
+
+The two concentration inputs and outputs use mol/m3. The duration and temperature arrays must be
+non-null, non-empty, equal in length, and ordered consistently. A zero-duration segment is a valid
+qualified no-op. Invalid or non-finite input fails closed. Python users call the same Java API
+through JPype; no separate numerical implementation exists.
+
+## Evidence and applicability boundary
+
+The entire trajectory must remain within the published Soli-Byrne range of 288.15–305.65 K at
+0.65 molal NaCl. A single out-of-range segment rejects the calculation. The primary source did not
+qualify dense-phase CO2 pressure or other salinities.
+
+This helper does not apply the van Eldik-Palmer pressure multipliers, combine datasets, select an
+aqueous phase, calculate gas-to-water transfer or water dropout, run bicarbonate/carbonate
+speciation or pH, reflash a fluid, integrate a transient pipeline, or calculate corrosion and scale.
+It is a bounded neutral-pair trajectory diagnostic, not Northern Lights facility calibration or a
+pipeline reaction source term.
+
+See the [CO2 transport reaction-kinetics guide](co2_transport_reaction_kinetics) for provenance,
+the electrolyte handoff, pressure-response limits, and the wider transport-coupling roadmap.

--- a/docs/test_co2_hydration_temperature_trajectory_documentation.py
+++ b/docs/test_co2_hydration_temperature_trajectory_documentation.py
@@ -1,0 +1,83 @@
+"""Contracts for the qualified aqueous CO2 hydration temperature-trajectory guide."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDE = ROOT / "docs/chemicalreactions/co2_hydration_temperature_trajectory.md"
+PACKAGE_INDEX = ROOT / "docs/chemicalreactions/README.md"
+TRAJECTORY = (
+    ROOT
+    / "src/main/java/neqsim/process/equipment/reactor/"
+    / "AqueousCO2HydrationTrajectory.java"
+)
+JAVA_TEST = (
+    ROOT
+    / "src/test/java/neqsim/process/equipment/reactor/"
+    / "AqueousCO2HydrationTrajectoryTest.java"
+)
+
+
+class AqueousCO2HydrationTrajectoryDocumentationTest(unittest.TestCase):
+    """Protect evidence, equations, boundaries, and executable mirroring."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+        cls.package_index = PACKAGE_INDEX.read_text(encoding="utf-8")
+        cls.trajectory = TRAJECTORY.read_text(encoding="utf-8")
+        cls.java_test = JAVA_TEST.read_text(encoding="utf-8")
+        cls.normalized = " ".join(cls.guide.split())
+
+    def test_guide_records_primary_source_and_numerical_contract(self):
+        for token in (
+            "doi:10.1016/S0304-4203(02)00010-5",
+            "piecewise-isothermal segments",
+            "exact analytical",
+            "without a numerical timestep approximation",
+            "cumulative relaxation exposure",
+            "segment order must be preserved",
+            "288.15–305.65 K",
+            "0.65 molal NaCl",
+        ):
+            self.assertIn(token, self.normalized)
+
+    def test_guide_keeps_scientific_stop_boundary_explicit(self):
+        for token in (
+            "does not apply the van Eldik-Palmer pressure multipliers",
+            "combine datasets",
+            "gas-to-water transfer or water dropout",
+            "bicarbonate/carbonate speciation or pH",
+            "integrate a transient pipeline",
+            "not Northern Lights facility calibration",
+            "or a pipeline reaction source term",
+        ):
+            self.assertIn(token, self.normalized)
+
+    def test_documented_api_and_conservation_are_executable(self):
+        for token in (
+            "public static TrajectoryResult advance(",
+            "cumulativeRelaxationExposure += relaxationRate * duration",
+            "initialTotalConcentration - finalTotalConcentration",
+            "getCumulativeRelaxationExposure()",
+            "getCarbonBalanceResidual()",
+        ):
+            self.assertIn(token, self.trajectory)
+
+        for token in (
+            "testSameTemperatureSegmentsMatchOneAnalyticalStep",
+            "testChangingTemperatureMatchesOrderedExactUpdates",
+            "testInvalidTrajectoryFailsClosed",
+            "assertNotEquals",
+            "getCarbonBalanceResidual()",
+        ):
+            self.assertIn(token, self.java_test)
+
+    def test_guide_is_discoverable(self):
+        self.assertIn("co2_hydration_temperature_trajectory", self.package_index)
+        self.assertIn("CO₂ hydration temperature-trajectory guide", self.package_index)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousCO2HydrationTrajectory.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousCO2HydrationTrajectory.java
@@ -1,0 +1,181 @@
+package neqsim.process.equipment.reactor;
+
+import java.io.Serializable;
+
+/**
+ * Exact piecewise-isothermal propagation of the qualified aqueous CO2/H2CO3 pair.
+ *
+ * <p>
+ * Each segment delegates to {@link AqueousCO2HydrationKinetics#advance(double, double, double, double)} and therefore
+ * uses the Soli-Byrne first-order correlations only inside their published 288.15-305.65 K and 0.65 molal NaCl
+ * boundary. The result does not add pressure correction, phase transfer, electrolyte speciation, or a pipeline source
+ * term.
+ * </p>
+ *
+ * @see <a href="https://doi.org/10.1016/S0304-4203(02)00010-5">Soli and Byrne (2002), Marine Chemistry 78, 65-73</a>
+ * @author NeqSim Team
+ * @version 1.0
+ */
+public final class AqueousCO2HydrationTrajectory implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private AqueousCO2HydrationTrajectory() {
+  }
+
+  /**
+   * Advance a closed aqueous CO2/H2CO3 pair through piecewise-isothermal segments.
+   *
+   * <p>
+   * The cumulative relaxation exposure is
+   * {@code sum((kH(T_i) + kD(T_i)) * duration_i)}. It is useful as a dimensionless diagnostic, but a changing
+   * temperature also changes the pair equilibrium target. Consequently the exposure must not be interpreted as one
+   * global remaining-deviation fraction. Final concentrations are obtained from the ordered sequence of exact
+   * analytical updates.
+   * </p>
+   *
+   * @param co2Concentration initial aqueous CO2 concentration [mol/m3]
+   * @param carbonicAcidConcentration initial H2CO3 concentration [mol/m3]
+   * @param segmentDurationsSeconds ordered segment durations [s]
+   * @param temperaturesK ordered aqueous temperatures corresponding to the durations [K]
+   * @return immutable trajectory result
+   * @throws IllegalArgumentException when concentrations or arrays are invalid, arrays are empty or have different
+   * lengths, any duration is negative or non-finite, any temperature is outside the published range, or an accumulated
+   * quantity is non-finite
+   */
+  public static TrajectoryResult advance(double co2Concentration, double carbonicAcidConcentration,
+      double[] segmentDurationsSeconds, double[] temperaturesK) {
+    requireFiniteNonNegative(co2Concentration, "CO2 concentration");
+    requireFiniteNonNegative(carbonicAcidConcentration, "H2CO3 concentration");
+    if (segmentDurationsSeconds == null || temperaturesK == null) {
+      throw new IllegalArgumentException("trajectory duration and temperature arrays must not be null");
+    }
+    if (segmentDurationsSeconds.length == 0) {
+      throw new IllegalArgumentException("trajectory must contain at least one segment");
+    }
+    if (segmentDurationsSeconds.length != temperaturesK.length) {
+      throw new IllegalArgumentException("trajectory duration and temperature arrays must have the same length");
+    }
+
+    double initialTotalConcentration = co2Concentration + carbonicAcidConcentration;
+    if (!Double.isFinite(initialTotalConcentration)) {
+      throw new IllegalArgumentException("total carbon concentration must be finite");
+    }
+
+    for (int index = 0; index < segmentDurationsSeconds.length; index++) {
+      requireFiniteNonNegative(segmentDurationsSeconds[index], "segment duration");
+      AqueousCO2HydrationKinetics.hydrationRateConstant(temperaturesK[index]);
+    }
+
+    double currentCO2 = co2Concentration;
+    double currentCarbonicAcid = carbonicAcidConcentration;
+    double elapsedTime = 0.0;
+    double cumulativeRelaxationExposure = 0.0;
+    double minimumTemperature = temperaturesK[0];
+    double maximumTemperature = temperaturesK[0];
+
+    for (int index = 0; index < segmentDurationsSeconds.length; index++) {
+      double duration = segmentDurationsSeconds[index];
+      double temperature = temperaturesK[index];
+      double relaxationRate = AqueousCO2HydrationKinetics.hydrationRateConstant(temperature)
+          + AqueousCO2HydrationKinetics.dehydrationRateConstant(temperature);
+
+      elapsedTime += duration;
+      cumulativeRelaxationExposure += relaxationRate * duration;
+      if (!Double.isFinite(elapsedTime) || !Double.isFinite(cumulativeRelaxationExposure)) {
+        throw new IllegalArgumentException("accumulated trajectory time and relaxation exposure must be finite");
+      }
+
+      AqueousCO2HydrationKinetics.Result segmentResult = AqueousCO2HydrationKinetics.advance(currentCO2,
+          currentCarbonicAcid, duration, temperature);
+      currentCO2 = segmentResult.getCO2Concentration();
+      currentCarbonicAcid = segmentResult.getCarbonicAcidConcentration();
+      minimumTemperature = Math.min(minimumTemperature, temperature);
+      maximumTemperature = Math.max(maximumTemperature, temperature);
+    }
+
+    double finalTotalConcentration = currentCO2 + currentCarbonicAcid;
+    return new TrajectoryResult(currentCO2, currentCarbonicAcid, finalTotalConcentration, elapsedTime,
+        cumulativeRelaxationExposure, segmentDurationsSeconds.length, minimumTemperature, maximumTemperature,
+        initialTotalConcentration - finalTotalConcentration);
+  }
+
+  private static void requireFiniteNonNegative(double value, String name) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and non-negative");
+    }
+  }
+
+  /** Result of an exact piecewise-isothermal aqueous CO2/H2CO3 trajectory. */
+  public static final class TrajectoryResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double co2Concentration;
+    private final double carbonicAcidConcentration;
+    private final double totalMolecularCO2Concentration;
+    private final double elapsedTimeSeconds;
+    private final double cumulativeRelaxationExposure;
+    private final int segmentCount;
+    private final double minimumTemperatureK;
+    private final double maximumTemperatureK;
+    private final double carbonBalanceResidual;
+
+    private TrajectoryResult(double co2Concentration, double carbonicAcidConcentration,
+        double totalMolecularCO2Concentration, double elapsedTimeSeconds, double cumulativeRelaxationExposure,
+        int segmentCount, double minimumTemperatureK, double maximumTemperatureK, double carbonBalanceResidual) {
+      this.co2Concentration = co2Concentration;
+      this.carbonicAcidConcentration = carbonicAcidConcentration;
+      this.totalMolecularCO2Concentration = totalMolecularCO2Concentration;
+      this.elapsedTimeSeconds = elapsedTimeSeconds;
+      this.cumulativeRelaxationExposure = cumulativeRelaxationExposure;
+      this.segmentCount = segmentCount;
+      this.minimumTemperatureK = minimumTemperatureK;
+      this.maximumTemperatureK = maximumTemperatureK;
+      this.carbonBalanceResidual = carbonBalanceResidual;
+    }
+
+    /** @return final aqueous CO2 concentration [mol/m3]. */
+    public double getCO2Concentration() {
+      return co2Concentration;
+    }
+
+    /** @return final carbonic-acid concentration [mol/m3]. */
+    public double getCarbonicAcidConcentration() {
+      return carbonicAcidConcentration;
+    }
+
+    /** @return final lumped {@code CO2(aq) + H2CO3} concentration [mol/m3]. */
+    public double getTotalMolecularCO2Concentration() {
+      return totalMolecularCO2Concentration;
+    }
+
+    /** @return total trajectory time [s]. */
+    public double getElapsedTimeSeconds() {
+      return elapsedTimeSeconds;
+    }
+
+    /** @return dimensionless sum of local reversible-pair relaxation rates multiplied by segment durations. */
+    public double getCumulativeRelaxationExposure() {
+      return cumulativeRelaxationExposure;
+    }
+
+    /** @return number of propagated trajectory segments. */
+    public int getSegmentCount() {
+      return segmentCount;
+    }
+
+    /** @return minimum evaluated trajectory temperature [K]. */
+    public double getMinimumTemperatureK() {
+      return minimumTemperatureK;
+    }
+
+    /** @return maximum evaluated trajectory temperature [K]. */
+    public double getMaximumTemperatureK() {
+      return maximumTemperatureK;
+    }
+
+    /** @return initial minus final molecular-carbon concentration [mol/m3]. */
+    public double getCarbonBalanceResidual() {
+      return carbonBalanceResidual;
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousCO2HydrationTrajectory.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousCO2HydrationTrajectory.java
@@ -26,11 +26,10 @@ public final class AqueousCO2HydrationTrajectory implements Serializable {
    * Advance a closed aqueous CO2/H2CO3 pair through piecewise-isothermal segments.
    *
    * <p>
-   * The cumulative relaxation exposure is
-   * {@code sum((kH(T_i) + kD(T_i)) * duration_i)}. It is useful as a dimensionless diagnostic, but a changing
-   * temperature also changes the pair equilibrium target. Consequently the exposure must not be interpreted as one
-   * global remaining-deviation fraction. Final concentrations are obtained from the ordered sequence of exact
-   * analytical updates.
+   * The cumulative relaxation exposure is {@code sum((kH(T_i) + kD(T_i)) * duration_i)}. It is useful as a
+   * dimensionless diagnostic, but a changing temperature also changes the pair equilibrium target. Consequently the
+   * exposure must not be interpreted as one global remaining-deviation fraction. Final concentrations are obtained from
+   * the ordered sequence of exact analytical updates.
    * </p>
    *
    * @param co2Concentration initial aqueous CO2 concentration [mol/m3]

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousCO2HydrationTrajectoryTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousCO2HydrationTrajectoryTest.java
@@ -1,0 +1,106 @@
+package neqsim.process.equipment.reactor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+
+/** Tests exact piecewise-isothermal propagation of the published neutral CO2 hydration pair. */
+public class AqueousCO2HydrationTrajectoryTest extends NeqSimTest {
+
+  @Test
+  void testSameTemperatureSegmentsMatchOneAnalyticalStep() {
+    double initialCO2 = 1000.0;
+    double initialCarbonicAcid = 20.0;
+    double temperatureK = 298.15;
+    AqueousCO2HydrationTrajectory.TrajectoryResult trajectory = AqueousCO2HydrationTrajectory.advance(initialCO2,
+        initialCarbonicAcid, new double[] {0.01, 0.02}, new double[] {temperatureK, temperatureK});
+    AqueousCO2HydrationKinetics.Result direct = AqueousCO2HydrationKinetics.advance(initialCO2,
+        initialCarbonicAcid, 0.03, temperatureK);
+
+    assertEquals(direct.getCO2Concentration(), trajectory.getCO2Concentration(), 1.0e-12);
+    assertEquals(direct.getCarbonicAcidConcentration(), trajectory.getCarbonicAcidConcentration(), 1.0e-12);
+    assertEquals(1020.0, trajectory.getTotalMolecularCO2Concentration(), 1.0e-12);
+    assertEquals(0.0, trajectory.getCarbonBalanceResidual(), 1.0e-12);
+    assertEquals(0.03, trajectory.getElapsedTimeSeconds(), 0.0);
+    assertEquals(2, trajectory.getSegmentCount());
+    assertEquals(temperatureK, trajectory.getMinimumTemperatureK(), 0.0);
+    assertEquals(temperatureK, trajectory.getMaximumTemperatureK(), 0.0);
+    assertEquals((AqueousCO2HydrationKinetics.hydrationRateConstant(temperatureK)
+        + AqueousCO2HydrationKinetics.dehydrationRateConstant(temperatureK)) * 0.03,
+        trajectory.getCumulativeRelaxationExposure(), 1.0e-15);
+  }
+
+  @Test
+  void testChangingTemperatureMatchesOrderedExactUpdates() {
+    double initialCO2 = 1000.0;
+    double initialCarbonicAcid = 0.0;
+    double[] durations = {0.04, 0.02};
+    double[] temperatures = {288.15, 305.65};
+
+    AqueousCO2HydrationKinetics.Result first = AqueousCO2HydrationKinetics.advance(initialCO2,
+        initialCarbonicAcid, durations[0], temperatures[0]);
+    AqueousCO2HydrationKinetics.Result second = AqueousCO2HydrationKinetics.advance(first.getCO2Concentration(),
+        first.getCarbonicAcidConcentration(), durations[1], temperatures[1]);
+    AqueousCO2HydrationTrajectory.TrajectoryResult trajectory = AqueousCO2HydrationTrajectory.advance(initialCO2,
+        initialCarbonicAcid, durations, temperatures);
+
+    assertEquals(second.getCO2Concentration(), trajectory.getCO2Concentration(), 0.0);
+    assertEquals(second.getCarbonicAcidConcentration(), trajectory.getCarbonicAcidConcentration(), 0.0);
+    assertEquals(288.15, trajectory.getMinimumTemperatureK(), 0.0);
+    assertEquals(305.65, trajectory.getMaximumTemperatureK(), 0.0);
+    assertTrue(trajectory.getCO2Concentration() >= 0.0);
+    assertTrue(trajectory.getCarbonicAcidConcentration() >= 0.0);
+
+    AqueousCO2HydrationTrajectory.TrajectoryResult reversed = AqueousCO2HydrationTrajectory.advance(initialCO2,
+        initialCarbonicAcid, new double[] {0.02, 0.04}, new double[] {305.65, 288.15});
+    assertNotEquals(trajectory.getCarbonicAcidConcentration(), reversed.getCarbonicAcidConcentration(), 1.0e-9,
+        "Changing equilibrium targets make the ordered trajectory physically significant");
+
+    AqueousCO2HydrationTrajectory.TrajectoryResult repeated = AqueousCO2HydrationTrajectory.advance(initialCO2,
+        initialCarbonicAcid, durations, temperatures);
+    assertEquals(trajectory.getCO2Concentration(), repeated.getCO2Concentration(), 0.0);
+    assertEquals(trajectory.getCarbonicAcidConcentration(), repeated.getCarbonicAcidConcentration(), 0.0);
+  }
+
+  @Test
+  void testZeroDurationSegmentIsAQualifiedNoOp() {
+    AqueousCO2HydrationTrajectory.TrajectoryResult result = AqueousCO2HydrationTrajectory.advance(3.0, 2.0,
+        new double[] {0.0}, new double[] {298.15});
+
+    assertEquals(3.0, result.getCO2Concentration(), 0.0);
+    assertEquals(2.0, result.getCarbonicAcidConcentration(), 0.0);
+    assertEquals(0.0, result.getElapsedTimeSeconds(), 0.0);
+    assertEquals(0.0, result.getCumulativeRelaxationExposure(), 0.0);
+    assertEquals(0.0, result.getCarbonBalanceResidual(), 0.0);
+  }
+
+  @Test
+  void testInvalidTrajectoryFailsClosed() {
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2HydrationTrajectory.advance(-1.0, 0.0, new double[] {1.0}, new double[] {298.15}));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2HydrationTrajectory.advance(Double.MAX_VALUE, Double.MAX_VALUE, new double[] {1.0},
+            new double[] {298.15}));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, null, new double[] {298.15}));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[] {1.0}, null));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[0], new double[0]));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[] {1.0},
+            new double[] {298.15, 299.15}));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[] {-1.0}, new double[] {298.15}));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[] {Double.NaN}, new double[] {298.15}));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[] {1.0}, new double[] {305.66}));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0,
+            new double[] {Double.MAX_VALUE, Double.MAX_VALUE}, new double[] {298.15, 298.15}));
+  }
+}

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousCO2HydrationTrajectoryTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousCO2HydrationTrajectoryTest.java
@@ -16,9 +16,9 @@ public class AqueousCO2HydrationTrajectoryTest extends NeqSimTest {
     double initialCarbonicAcid = 20.0;
     double temperatureK = 298.15;
     AqueousCO2HydrationTrajectory.TrajectoryResult trajectory = AqueousCO2HydrationTrajectory.advance(initialCO2,
-        initialCarbonicAcid, new double[] {0.01, 0.02}, new double[] {temperatureK, temperatureK});
-    AqueousCO2HydrationKinetics.Result direct = AqueousCO2HydrationKinetics.advance(initialCO2,
-        initialCarbonicAcid, 0.03, temperatureK);
+        initialCarbonicAcid, new double[] { 0.01, 0.02 }, new double[] { temperatureK, temperatureK });
+    AqueousCO2HydrationKinetics.Result direct = AqueousCO2HydrationKinetics.advance(initialCO2, initialCarbonicAcid,
+        0.03, temperatureK);
 
     assertEquals(direct.getCO2Concentration(), trajectory.getCO2Concentration(), 1.0e-12);
     assertEquals(direct.getCarbonicAcidConcentration(), trajectory.getCarbonicAcidConcentration(), 1.0e-12);
@@ -28,8 +28,9 @@ public class AqueousCO2HydrationTrajectoryTest extends NeqSimTest {
     assertEquals(2, trajectory.getSegmentCount());
     assertEquals(temperatureK, trajectory.getMinimumTemperatureK(), 0.0);
     assertEquals(temperatureK, trajectory.getMaximumTemperatureK(), 0.0);
-    assertEquals((AqueousCO2HydrationKinetics.hydrationRateConstant(temperatureK)
-        + AqueousCO2HydrationKinetics.dehydrationRateConstant(temperatureK)) * 0.03,
+    assertEquals(
+        (AqueousCO2HydrationKinetics.hydrationRateConstant(temperatureK)
+            + AqueousCO2HydrationKinetics.dehydrationRateConstant(temperatureK)) * 0.03,
         trajectory.getCumulativeRelaxationExposure(), 1.0e-15);
   }
 
@@ -37,11 +38,11 @@ public class AqueousCO2HydrationTrajectoryTest extends NeqSimTest {
   void testChangingTemperatureMatchesOrderedExactUpdates() {
     double initialCO2 = 1000.0;
     double initialCarbonicAcid = 0.0;
-    double[] durations = {0.04, 0.02};
-    double[] temperatures = {288.15, 305.65};
+    double[] durations = { 0.04, 0.02 };
+    double[] temperatures = { 288.15, 305.65 };
 
-    AqueousCO2HydrationKinetics.Result first = AqueousCO2HydrationKinetics.advance(initialCO2,
-        initialCarbonicAcid, durations[0], temperatures[0]);
+    AqueousCO2HydrationKinetics.Result first = AqueousCO2HydrationKinetics.advance(initialCO2, initialCarbonicAcid,
+        durations[0], temperatures[0]);
     AqueousCO2HydrationKinetics.Result second = AqueousCO2HydrationKinetics.advance(first.getCO2Concentration(),
         first.getCarbonicAcidConcentration(), durations[1], temperatures[1]);
     AqueousCO2HydrationTrajectory.TrajectoryResult trajectory = AqueousCO2HydrationTrajectory.advance(initialCO2,
@@ -55,7 +56,7 @@ public class AqueousCO2HydrationTrajectoryTest extends NeqSimTest {
     assertTrue(trajectory.getCarbonicAcidConcentration() >= 0.0);
 
     AqueousCO2HydrationTrajectory.TrajectoryResult reversed = AqueousCO2HydrationTrajectory.advance(initialCO2,
-        initialCarbonicAcid, new double[] {0.02, 0.04}, new double[] {305.65, 288.15});
+        initialCarbonicAcid, new double[] { 0.02, 0.04 }, new double[] { 305.65, 288.15 });
     assertNotEquals(trajectory.getCarbonicAcidConcentration(), reversed.getCarbonicAcidConcentration(), 1.0e-9,
         "Changing equilibrium targets make the ordered trajectory physically significant");
 
@@ -68,7 +69,7 @@ public class AqueousCO2HydrationTrajectoryTest extends NeqSimTest {
   @Test
   void testZeroDurationSegmentIsAQualifiedNoOp() {
     AqueousCO2HydrationTrajectory.TrajectoryResult result = AqueousCO2HydrationTrajectory.advance(3.0, 2.0,
-        new double[] {0.0}, new double[] {298.15});
+        new double[] { 0.0 }, new double[] { 298.15 });
 
     assertEquals(3.0, result.getCO2Concentration(), 0.0);
     assertEquals(2.0, result.getCarbonicAcidConcentration(), 0.0);
@@ -80,27 +81,24 @@ public class AqueousCO2HydrationTrajectoryTest extends NeqSimTest {
   @Test
   void testInvalidTrajectoryFailsClosed() {
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousCO2HydrationTrajectory.advance(-1.0, 0.0, new double[] {1.0}, new double[] {298.15}));
+        () -> AqueousCO2HydrationTrajectory.advance(-1.0, 0.0, new double[] { 1.0 }, new double[] { 298.15 }));
+    assertThrows(IllegalArgumentException.class, () -> AqueousCO2HydrationTrajectory.advance(Double.MAX_VALUE,
+        Double.MAX_VALUE, new double[] { 1.0 }, new double[] { 298.15 }));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousCO2HydrationTrajectory.advance(Double.MAX_VALUE, Double.MAX_VALUE, new double[] {1.0},
-            new double[] {298.15}));
+        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, null, new double[] { 298.15 }));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, null, new double[] {298.15}));
-    assertThrows(IllegalArgumentException.class,
-        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[] {1.0}, null));
+        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[] { 1.0 }, null));
     assertThrows(IllegalArgumentException.class,
         () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[0], new double[0]));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[] {1.0},
-            new double[] {298.15, 299.15}));
+        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[] { 1.0 }, new double[] { 298.15, 299.15 }));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[] {-1.0}, new double[] {298.15}));
+        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[] { -1.0 }, new double[] { 298.15 }));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[] {Double.NaN}, new double[] {298.15}));
+        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[] { Double.NaN }, new double[] { 298.15 }));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[] {1.0}, new double[] {305.66}));
-    assertThrows(IllegalArgumentException.class,
-        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0,
-            new double[] {Double.MAX_VALUE, Double.MAX_VALUE}, new double[] {298.15, 298.15}));
+        () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0, new double[] { 1.0 }, new double[] { 305.66 }));
+    assertThrows(IllegalArgumentException.class, () -> AqueousCO2HydrationTrajectory.advance(1.0, 0.0,
+        new double[] { Double.MAX_VALUE, Double.MAX_VALUE }, new double[] { 298.15, 298.15 }));
   }
 }


### PR DESCRIPTION
## Engineering question

Can NeqSim propagate the already-qualified neutral CO2(aq)/H2CO3 pair exactly through a piecewise-isothermal temperature history, while preserving carbon and explicitly refusing to imply pressure, phase-transfer, electrolyte-speciation, or pipeline-solver qualification?

Advances #3318. Capability contract: https://github.com/equinor/neqsim/issues/3318#issuecomment-5491487149

## Exact continuity and capacity

- **Exact base:** `a8fad5f988a58650a3b6ae92a53d472178a7b22f`
- **Exact head:** `88341c47849e58155695b06a97338b1e1b547928`
- **Branch:** `ai/co2-hydration-temperature-trajectory-3318`
- Predecessor #3378 is merged; no active #3318 PR existed before publication.
- Seven pull requests were open before publication; six were positively identified autonomous implementation/repair capabilities. This draft makes seven autonomous capabilities and eight total open PRs, below the target and absolute ceiling of ten.
- No existing PR or branch was closed, rebased, replaced, synchronized, or moved.

## Implementation

Adds `AqueousCO2HydrationTrajectory` with a Java/JPype-friendly array API:

- ordered segment durations [s] and temperatures [K]
- exact sequential delegation to the merged analytical `AqueousCO2HydrationKinetics.advance(...)` solution
- final CO2(aq) and H2CO3 concentrations, total molecular carbon, elapsed time, segment count, and temperature bounds
- dimensionless cumulative relaxation exposure `sum((kH+kD) dt)`
- explicit carbon-balance residual
- fail-closed null, empty, mismatched, negative, non-finite, overflow, and out-of-range input handling

The implementation intentionally does not report `exp(-exposure)` as one global remaining-deviation fraction when temperature changes, because each temperature changes the equilibrium target. Ordered exact propagation remains authoritative.

## Scientific evidence

Primary source: Soli & Byrne (2002), *Marine Chemistry* 78, 65-73:
https://doi.org/10.1016/S0304-4203%2802%2900010-5

No new parameter is fitted or tuned. Every segment retains the published 0.65 molal NaCl and 288.15-305.65 K boundary.

## Numerical gates

Focused regressions require:

- same-temperature split segments equal one analytical step
- changing-temperature trajectory equals direct ordered `advance(...)` calls
- changing equilibrium targets retain order sensitivity
- deterministic repeat
- non-negative final state and carbon closure within `1e-12 mol/m3`
- invalid inputs fail closed

Local validation available in this execution environment:

- documentation contract: **4/4 passed**
- Python syntax compilation: passed
- independent numerical calculation confirmed the order-sensitive test has a `0.0108141 mol/m3` H2CO3 separation
- line-length/trailing-whitespace scan: passed

A local JDK/Maven/Spotless/pre-commit runtime was unavailable, so no Java compilation or repository-wide validation is claimed. Hosted exact-head CI is authoritative.

**VALIDATION PENDING CI**

## Coordination and stop boundary

- no van Eldik-Palmer pressure multiplier or automatic cross-dataset combination
- no electrolyte species/activity/pH/charge-balance change (#3144)
- no flash/stability change (#2937)
- no transient solver change (#2911)
- no pipeline/control-volume source term
- no MCP schema change (#3153)
- no gas-to-water transfer, water dropout, corrosion, scale, or Northern Lights facility calibration

Documentation adds a bounded trajectory guide, an executable evidence contract, and package-index discoverability. Java remains authoritative and Python uses the same API through JPype.

Generated with AI assistance.