### PR TITLE
[AI-Assisted] feat(dexpi): expose material connection components

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -166,11 +166,22 @@ whether either directed side has multiple occurrences. These values help reviewe
 that needs engineering interpretation. They do not prove hydraulic continuity, identify a physical
 branch or fitting, create live process connectivity, or establish process intent.
 
-`toJson()` includes `instrumentCount`, `connectionCount`, `connectionEndpointCount`, and the
-ordered connection and endpoint inventories, including `incidenceRole` and
-`potentialMultiConnectionNode`, alongside the process-unit count and findings. Python
-callers through JPype use the same `ImportResult.getInstruments()`, `ImportResult.getConnections()`,
-and `ImportResult.getConnectionEndpoints()` getters; there is no separate Python reconstruction
+`ImportResult.getConnectionComponents()` groups non-empty endpoint identities by weak connectivity
+through explicit material-connection references. Components are ordered by their first endpoint;
+their endpoint IDs retain first-reference order and their connection-evidence IDs retain source
+order, including parallel occurrences. Each immutable `DexpiConnectionComponentInfo` also lists
+source, sink, potential multi-connection, and unresolved endpoints from the endpoint evidence.
+A connection with one non-empty endpoint remains visible as a singleton component. A connection
+with two blank endpoint references remains diagnostic evidence and is not assigned invented nodes.
+This grouping is a document-review aid, not proof that the grouped references form a hydraulically
+continuous line or executable process network.
+
+`toJson()` includes `instrumentCount`, `connectionCount`, `connectionEndpointCount`,
+`connectionComponentCount`, and the ordered connection, endpoint, and component inventories,
+including incidence roles and component review subsets, alongside the process-unit count and
+findings. Python callers through JPype use the same `ImportResult.getInstruments()`,
+`ImportResult.getConnections()`, `ImportResult.getConnectionEndpoints()`, and
+`ImportResult.getConnectionComponents()` getters; there is no separate Python reconstruction
 model.
 
 `INFO` entries carry provenance and do not make `hasLosses()` true by themselves. `WARNING` and

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionComponentInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionComponentInfo.java
@@ -8,12 +8,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Immutable evidence for one weakly connected group of explicit DEXPI material-connection endpoint
- * references.
+ * Immutable evidence for one weakly connected group of explicit DEXPI material-connection endpoint references.
  *
  * <p>
- * A component groups source reference identities only. It does not establish hydraulic continuity,
- * physical branch or fitting identity, process intent, or live {@code ProcessSystem} topology.
+ * A component groups source reference identities only. It does not establish hydraulic continuity, physical branch or
+ * fitting identity, process intent, or live {@code ProcessSystem} topology.
  * </p>
  *
  * @author NeqSim
@@ -38,20 +37,18 @@ public final class DexpiConnectionComponentInfo implements Serializable {
    * @param connectionIds connection-evidence identities in source order
    * @param sourceEndpointIds endpoints classified as source evidence
    * @param sinkEndpointIds endpoints classified as sink evidence
-   * @param potentialMultiConnectionEndpointIds endpoints with multiple incoming or outgoing
-   *        occurrences
+   * @param potentialMultiConnectionEndpointIds endpoints with multiple incoming or outgoing occurrences
    * @param unresolvedEndpointIds endpoint identities that do not resolve in the source document
    */
-  public DexpiConnectionComponentInfo(String id, List<String> endpointIds,
-      List<String> connectionIds, List<String> sourceEndpointIds, List<String> sinkEndpointIds,
-      List<String> potentialMultiConnectionEndpointIds, List<String> unresolvedEndpointIds) {
+  public DexpiConnectionComponentInfo(String id, List<String> endpointIds, List<String> connectionIds,
+      List<String> sourceEndpointIds, List<String> sinkEndpointIds, List<String> potentialMultiConnectionEndpointIds,
+      List<String> unresolvedEndpointIds) {
     this.id = normalize(id);
     this.endpointIds = immutableCopy(endpointIds);
     this.connectionIds = immutableCopy(connectionIds);
     this.sourceEndpointIds = immutableCopy(sourceEndpointIds);
     this.sinkEndpointIds = immutableCopy(sinkEndpointIds);
-    this.potentialMultiConnectionEndpointIds =
-        immutableCopy(potentialMultiConnectionEndpointIds);
+    this.potentialMultiConnectionEndpointIds = immutableCopy(potentialMultiConnectionEndpointIds);
     this.unresolvedEndpointIds = immutableCopy(unresolvedEndpointIds);
   }
 
@@ -120,15 +117,12 @@ public final class DexpiConnectionComponentInfo implements Serializable {
     result.put("endpointCount", Integer.valueOf(getEndpointCount()));
     result.put("connectionCount", Integer.valueOf(getConnectionCount()));
     result.put("hasUnresolvedEndpoints", Boolean.valueOf(hasUnresolvedEndpoints()));
-    result.put(
-        "hasPotentialMultiConnectionNodes",
-        Boolean.valueOf(hasPotentialMultiConnectionNodes()));
+    result.put("hasPotentialMultiConnectionNodes", Boolean.valueOf(hasPotentialMultiConnectionNodes()));
     result.put("endpointIds", endpointIds);
     result.put("connectionIds", connectionIds);
     result.put("sourceEndpointIds", sourceEndpointIds);
     result.put("sinkEndpointIds", sinkEndpointIds);
-    result.put(
-        "potentialMultiConnectionEndpointIds", potentialMultiConnectionEndpointIds);
+    result.put("potentialMultiConnectionEndpointIds", potentialMultiConnectionEndpointIds);
     result.put("unresolvedEndpointIds", unresolvedEndpointIds);
     return result;
   }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionComponentInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionComponentInfo.java
@@ -1,0 +1,143 @@
+package neqsim.process.processmodel.dexpi;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Immutable evidence for one weakly connected group of explicit DEXPI material-connection endpoint
+ * references.
+ *
+ * <p>
+ * A component groups source reference identities only. It does not establish hydraulic continuity,
+ * physical branch or fitting identity, process intent, or live {@code ProcessSystem} topology.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class DexpiConnectionComponentInfo implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final String id;
+  private final List<String> endpointIds;
+  private final List<String> connectionIds;
+  private final List<String> sourceEndpointIds;
+  private final List<String> sinkEndpointIds;
+  private final List<String> potentialMultiConnectionEndpointIds;
+  private final List<String> unresolvedEndpointIds;
+
+  /**
+   * Creates immutable source-reference component evidence.
+   *
+   * @param id deterministic component evidence identity
+   * @param endpointIds explicit endpoint identities in first-reference order
+   * @param connectionIds connection-evidence identities in source order
+   * @param sourceEndpointIds endpoints classified as source evidence
+   * @param sinkEndpointIds endpoints classified as sink evidence
+   * @param potentialMultiConnectionEndpointIds endpoints with multiple incoming or outgoing
+   *        occurrences
+   * @param unresolvedEndpointIds endpoint identities that do not resolve in the source document
+   */
+  public DexpiConnectionComponentInfo(String id, List<String> endpointIds,
+      List<String> connectionIds, List<String> sourceEndpointIds, List<String> sinkEndpointIds,
+      List<String> potentialMultiConnectionEndpointIds, List<String> unresolvedEndpointIds) {
+    this.id = normalize(id);
+    this.endpointIds = immutableCopy(endpointIds);
+    this.connectionIds = immutableCopy(connectionIds);
+    this.sourceEndpointIds = immutableCopy(sourceEndpointIds);
+    this.sinkEndpointIds = immutableCopy(sinkEndpointIds);
+    this.potentialMultiConnectionEndpointIds =
+        immutableCopy(potentialMultiConnectionEndpointIds);
+    this.unresolvedEndpointIds = immutableCopy(unresolvedEndpointIds);
+  }
+
+  /** @return deterministic component evidence identity */
+  public String getId() {
+    return id;
+  }
+
+  /** @return immutable endpoint identities in first-reference order */
+  public List<String> getEndpointIds() {
+    return endpointIds;
+  }
+
+  /** @return immutable connection-evidence identities in source order */
+  public List<String> getConnectionIds() {
+    return connectionIds;
+  }
+
+  /** @return immutable endpoint identities classified as source evidence */
+  public List<String> getSourceEndpointIds() {
+    return sourceEndpointIds;
+  }
+
+  /** @return immutable endpoint identities classified as sink evidence */
+  public List<String> getSinkEndpointIds() {
+    return sinkEndpointIds;
+  }
+
+  /**
+   * Returns endpoints with multiple incoming or outgoing source occurrences.
+   *
+   * @return immutable potential multi-connection endpoint identities
+   */
+  public List<String> getPotentialMultiConnectionEndpointIds() {
+    return potentialMultiConnectionEndpointIds;
+  }
+
+  /** @return immutable unresolved endpoint identities */
+  public List<String> getUnresolvedEndpointIds() {
+    return unresolvedEndpointIds;
+  }
+
+  /** @return number of explicit endpoint identities in this source-reference component */
+  public int getEndpointCount() {
+    return endpointIds.size();
+  }
+
+  /** @return number of source connection occurrences in this source-reference component */
+  public int getConnectionCount() {
+    return connectionIds.size();
+  }
+
+  /** @return whether any endpoint reference in this component is unresolved */
+  public boolean hasUnresolvedEndpoints() {
+    return !unresolvedEndpointIds.isEmpty();
+  }
+
+  /** @return whether any endpoint has multiple incoming or outgoing source occurrences */
+  public boolean hasPotentialMultiConnectionNodes() {
+    return !potentialMultiConnectionEndpointIds.isEmpty();
+  }
+
+  Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("id", id);
+    result.put("endpointCount", Integer.valueOf(getEndpointCount()));
+    result.put("connectionCount", Integer.valueOf(getConnectionCount()));
+    result.put("hasUnresolvedEndpoints", Boolean.valueOf(hasUnresolvedEndpoints()));
+    result.put(
+        "hasPotentialMultiConnectionNodes",
+        Boolean.valueOf(hasPotentialMultiConnectionNodes()));
+    result.put("endpointIds", endpointIds);
+    result.put("connectionIds", connectionIds);
+    result.put("sourceEndpointIds", sourceEndpointIds);
+    result.put("sinkEndpointIds", sinkEndpointIds);
+    result.put(
+        "potentialMultiConnectionEndpointIds", potentialMultiConnectionEndpointIds);
+    result.put("unresolvedEndpointIds", unresolvedEndpointIds);
+    return result;
+  }
+
+  private static List<String> immutableCopy(List<String> values) {
+    return Collections.unmodifiableList(new ArrayList<String>(values));
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -132,16 +132,20 @@ public final class DexpiXmlReader {
     private final List<DexpiInstrumentInfo> instruments;
     private final List<DexpiConnectionInfo> connections;
     private final List<DexpiConnectionEndpointInfo> connectionEndpoints;
+    private final List<DexpiConnectionComponentInfo> connectionComponents;
     private final List<ImportDiagnostic> diagnostics;
 
     private ImportResult(ProcessSystem processSystem, List<DexpiInstrumentInfo> instruments,
         List<DexpiConnectionInfo> connections, List<DexpiConnectionEndpointInfo> connectionEndpoints,
+        List<DexpiConnectionComponentInfo> connectionComponents,
         List<ImportDiagnostic> diagnostics) {
       this.processSystem = processSystem;
       this.instruments = Collections.unmodifiableList(new ArrayList<DexpiInstrumentInfo>(instruments));
       this.connections = Collections.unmodifiableList(new ArrayList<DexpiConnectionInfo>(connections));
       this.connectionEndpoints = Collections
           .unmodifiableList(new ArrayList<DexpiConnectionEndpointInfo>(connectionEndpoints));
+      this.connectionComponents = Collections
+          .unmodifiableList(new ArrayList<DexpiConnectionComponentInfo>(connectionComponents));
       this.diagnostics = Collections.unmodifiableList(new ArrayList<ImportDiagnostic>(diagnostics));
     }
 
@@ -184,6 +188,20 @@ public final class DexpiXmlReader {
      */
     public List<DexpiConnectionEndpointInfo> getConnectionEndpoints() {
       return connectionEndpoints;
+    }
+
+    /**
+     * Returns weakly connected groups of explicit non-empty material-connection endpoint references.
+     *
+     * <p>
+     * Components preserve source evidence only. They do not establish hydraulic continuity, fitting
+     * identity, process intent, or live process topology.
+     * </p>
+     *
+     * @return immutable source-reference components in first-endpoint order
+     */
+    public List<DexpiConnectionComponentInfo> getConnectionComponents() {
+      return connectionComponents;
     }
 
     /** @return immutable diagnostics in deterministic source-document order */
@@ -230,6 +248,12 @@ public final class DexpiXmlReader {
         endpointMaps.add(endpoint.toMap());
       }
       result.put("connectionEndpoints", endpointMaps);
+      result.put("connectionComponentCount", Integer.valueOf(connectionComponents.size()));
+      List<Map<String, Object>> componentMaps = new ArrayList<Map<String, Object>>();
+      for (DexpiConnectionComponentInfo component : connectionComponents) {
+        componentMaps.add(component.toMap());
+      }
+      result.put("connectionComponents", componentMaps);
       result.put("hasLosses", Boolean.valueOf(hasLosses()));
       result.put("hasErrors", Boolean.valueOf(hasErrors()));
       List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
@@ -424,8 +448,9 @@ public final class DexpiXmlReader {
     List<DexpiConnectionInfo> connections = new ArrayList<DexpiConnectionInfo>();
     List<ImportDiagnostic> diagnostics = new ArrayList<ImportDiagnostic>();
     loadInternal(inputStream, processSystem, templateStream, false, diagnostics, instruments, connections);
-    return new ImportResult(processSystem, instruments, connections, summarizeConnectionEndpoints(connections),
-        diagnostics);
+    List<DexpiConnectionEndpointInfo> connectionEndpoints = summarizeConnectionEndpoints(connections);
+    return new ImportResult(processSystem, instruments, connections, connectionEndpoints,
+        summarizeConnectionComponents(connections, connectionEndpoints), diagnostics);
   }
 
   /**
@@ -794,6 +819,112 @@ public final class DexpiXmlReader {
       result.add(endpoint.toInfo());
     }
     return result;
+  }
+
+  private static List<DexpiConnectionComponentInfo> summarizeConnectionComponents(
+      List<DexpiConnectionInfo> connections,
+      List<DexpiConnectionEndpointInfo> connectionEndpoints) {
+    Map<String, List<String>> adjacentEndpointIds =
+        new LinkedHashMap<String, List<String>>();
+    for (DexpiConnectionEndpointInfo endpoint : connectionEndpoints) {
+      adjacentEndpointIds.put(endpoint.getEndpointId(), new ArrayList<String>());
+    }
+    for (DexpiConnectionInfo connection : connections) {
+      String fromId = connection.getFromId();
+      String toId = connection.getToId();
+      if (!isBlank(fromId) && !isBlank(toId)) {
+        adjacentEndpointIds.get(fromId).add(toId);
+        adjacentEndpointIds.get(toId).add(fromId);
+      }
+    }
+
+    List<ConnectionComponentAccumulator> components =
+        new ArrayList<ConnectionComponentAccumulator>();
+    Map<String, Integer> componentByEndpointId = new HashMap<String, Integer>();
+    for (DexpiConnectionEndpointInfo endpoint : connectionEndpoints) {
+      if (componentByEndpointId.containsKey(endpoint.getEndpointId())) {
+        continue;
+      }
+      int componentIndex = components.size();
+      components.add(new ConnectionComponentAccumulator("component-" + (componentIndex + 1)));
+      List<String> pendingEndpointIds = new ArrayList<String>();
+      pendingEndpointIds.add(endpoint.getEndpointId());
+      componentByEndpointId.put(endpoint.getEndpointId(), Integer.valueOf(componentIndex));
+      for (int pendingIndex = 0; pendingIndex < pendingEndpointIds.size(); pendingIndex++) {
+        String endpointId = pendingEndpointIds.get(pendingIndex);
+        for (String adjacentEndpointId : adjacentEndpointIds.get(endpointId)) {
+          if (!componentByEndpointId.containsKey(adjacentEndpointId)) {
+            componentByEndpointId.put(adjacentEndpointId, Integer.valueOf(componentIndex));
+            pendingEndpointIds.add(adjacentEndpointId);
+          }
+        }
+      }
+    }
+
+    for (DexpiConnectionEndpointInfo endpoint : connectionEndpoints) {
+      Integer componentIndex = componentByEndpointId.get(endpoint.getEndpointId());
+      components.get(componentIndex.intValue()).addEndpoint(endpoint);
+    }
+    for (DexpiConnectionInfo connection : connections) {
+      Integer componentIndex = componentByEndpointId.get(connection.getFromId());
+      if (componentIndex == null) {
+        componentIndex = componentByEndpointId.get(connection.getToId());
+      }
+      if (componentIndex != null) {
+        components.get(componentIndex.intValue()).addConnection(connection.getId());
+      }
+    }
+
+    List<DexpiConnectionComponentInfo> result =
+        new ArrayList<DexpiConnectionComponentInfo>();
+    for (ConnectionComponentAccumulator component : components) {
+      result.add(component.toInfo());
+    }
+    return result;
+  }
+
+  private static final class ConnectionComponentAccumulator {
+    private final String id;
+    private final List<DexpiConnectionEndpointInfo> endpoints =
+        new ArrayList<DexpiConnectionEndpointInfo>();
+    private final List<String> connectionIds = new ArrayList<String>();
+
+    private ConnectionComponentAccumulator(String id) {
+      this.id = id;
+    }
+
+    private void addEndpoint(DexpiConnectionEndpointInfo endpoint) {
+      endpoints.add(endpoint);
+    }
+
+    private void addConnection(String connectionId) {
+      connectionIds.add(connectionId);
+    }
+
+    private DexpiConnectionComponentInfo toInfo() {
+      List<String> endpointIds = new ArrayList<String>();
+      List<String> sourceEndpointIds = new ArrayList<String>();
+      List<String> sinkEndpointIds = new ArrayList<String>();
+      List<String> potentialMultiConnectionEndpointIds = new ArrayList<String>();
+      List<String> unresolvedEndpointIds = new ArrayList<String>();
+      for (DexpiConnectionEndpointInfo endpoint : endpoints) {
+        endpointIds.add(endpoint.getEndpointId());
+        if (endpoint.getIncidenceRole() == DexpiConnectionEndpointInfo.IncidenceRole.SOURCE) {
+          sourceEndpointIds.add(endpoint.getEndpointId());
+        }
+        if (endpoint.getIncidenceRole() == DexpiConnectionEndpointInfo.IncidenceRole.SINK) {
+          sinkEndpointIds.add(endpoint.getEndpointId());
+        }
+        if (endpoint.isPotentialMultiConnectionNode()) {
+          potentialMultiConnectionEndpointIds.add(endpoint.getEndpointId());
+        }
+        if (!endpoint.isResolved()) {
+          unresolvedEndpointIds.add(endpoint.getEndpointId());
+        }
+      }
+      return new DexpiConnectionComponentInfo(id, endpointIds, connectionIds, sourceEndpointIds,
+          sinkEndpointIds, potentialMultiConnectionEndpointIds, unresolvedEndpointIds);
+    }
   }
 
   private static void addConnectionEndpointOccurrence(Map<String, ConnectionEndpointAccumulator> endpoints,

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -137,8 +137,7 @@ public final class DexpiXmlReader {
 
     private ImportResult(ProcessSystem processSystem, List<DexpiInstrumentInfo> instruments,
         List<DexpiConnectionInfo> connections, List<DexpiConnectionEndpointInfo> connectionEndpoints,
-        List<DexpiConnectionComponentInfo> connectionComponents,
-        List<ImportDiagnostic> diagnostics) {
+        List<DexpiConnectionComponentInfo> connectionComponents, List<ImportDiagnostic> diagnostics) {
       this.processSystem = processSystem;
       this.instruments = Collections.unmodifiableList(new ArrayList<DexpiInstrumentInfo>(instruments));
       this.connections = Collections.unmodifiableList(new ArrayList<DexpiConnectionInfo>(connections));
@@ -194,8 +193,8 @@ public final class DexpiXmlReader {
      * Returns weakly connected groups of explicit non-empty material-connection endpoint references.
      *
      * <p>
-     * Components preserve source evidence only. They do not establish hydraulic continuity, fitting
-     * identity, process intent, or live process topology.
+     * Components preserve source evidence only. They do not establish hydraulic continuity, fitting identity, process
+     * intent, or live process topology.
      * </p>
      *
      * @return immutable source-reference components in first-endpoint order
@@ -821,11 +820,9 @@ public final class DexpiXmlReader {
     return result;
   }
 
-  private static List<DexpiConnectionComponentInfo> summarizeConnectionComponents(
-      List<DexpiConnectionInfo> connections,
+  private static List<DexpiConnectionComponentInfo> summarizeConnectionComponents(List<DexpiConnectionInfo> connections,
       List<DexpiConnectionEndpointInfo> connectionEndpoints) {
-    Map<String, List<String>> adjacentEndpointIds =
-        new LinkedHashMap<String, List<String>>();
+    Map<String, List<String>> adjacentEndpointIds = new LinkedHashMap<String, List<String>>();
     for (DexpiConnectionEndpointInfo endpoint : connectionEndpoints) {
       adjacentEndpointIds.put(endpoint.getEndpointId(), new ArrayList<String>());
     }
@@ -838,8 +835,7 @@ public final class DexpiXmlReader {
       }
     }
 
-    List<ConnectionComponentAccumulator> components =
-        new ArrayList<ConnectionComponentAccumulator>();
+    List<ConnectionComponentAccumulator> components = new ArrayList<ConnectionComponentAccumulator>();
     Map<String, Integer> componentByEndpointId = new HashMap<String, Integer>();
     for (DexpiConnectionEndpointInfo endpoint : connectionEndpoints) {
       if (componentByEndpointId.containsKey(endpoint.getEndpointId())) {
@@ -875,8 +871,7 @@ public final class DexpiXmlReader {
       }
     }
 
-    List<DexpiConnectionComponentInfo> result =
-        new ArrayList<DexpiConnectionComponentInfo>();
+    List<DexpiConnectionComponentInfo> result = new ArrayList<DexpiConnectionComponentInfo>();
     for (ConnectionComponentAccumulator component : components) {
       result.add(component.toInfo());
     }
@@ -885,8 +880,7 @@ public final class DexpiXmlReader {
 
   private static final class ConnectionComponentAccumulator {
     private final String id;
-    private final List<DexpiConnectionEndpointInfo> endpoints =
-        new ArrayList<DexpiConnectionEndpointInfo>();
+    private final List<DexpiConnectionEndpointInfo> endpoints = new ArrayList<DexpiConnectionEndpointInfo>();
     private final List<String> connectionIds = new ArrayList<String>();
 
     private ConnectionComponentAccumulator(String id) {
@@ -922,8 +916,8 @@ public final class DexpiXmlReader {
           unresolvedEndpointIds.add(endpoint.getEndpointId());
         }
       }
-      return new DexpiConnectionComponentInfo(id, endpointIds, connectionIds, sourceEndpointIds,
-          sinkEndpointIds, potentialMultiConnectionEndpointIds, unresolvedEndpointIds);
+      return new DexpiConnectionComponentInfo(id, endpointIds, connectionIds, sourceEndpointIds, sinkEndpointIds,
+          potentialMultiConnectionEndpointIds, unresolvedEndpointIds);
     }
   }
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -498,10 +498,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         + "<PipingNetworkSegment ID=\"S-3\"><Connection ID=\"C-3\" FromID=\"N-X\" ToID=\"N-Y\"/>"
         + "</PipingNetworkSegment>"
         + "<PipingNetworkSegment ID=\"S-4\"><Connection ID=\"C-4\" FromID=\"N-X\" ToID=\"N-Y\"/>"
-        + "</PipingNetworkSegment>"
-        + "<PipingNetworkSegment ID=\"S-5\"><Connection ID=\"C-5\" FromID=\"UNKNOWN\"/>"
-        + "</PipingNetworkSegment>"
-        + "<PipingNetworkSegment ID=\"S-6\"><Connection ID=\"C-6\"/>"
+        + "</PipingNetworkSegment>" + "<PipingNetworkSegment ID=\"S-5\"><Connection ID=\"C-5\" FromID=\"UNKNOWN\"/>"
+        + "</PipingNetworkSegment>" + "<PipingNetworkSegment ID=\"S-6\"><Connection ID=\"C-6\"/>"
         + "</PipingNetworkSegment>" + "</PlantModel>";
 
     DexpiXmlReader.ImportResult first = DexpiXmlReader
@@ -528,8 +526,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("component-2", parallel.getId());
     assertEquals(Arrays.asList("N-X", "N-Y"), parallel.getEndpointIds());
     assertEquals(Arrays.asList("C-3", "C-4"), parallel.getConnectionIds());
-    assertEquals(Arrays.asList("N-X", "N-Y"),
-        parallel.getPotentialMultiConnectionEndpointIds());
+    assertEquals(Arrays.asList("N-X", "N-Y"), parallel.getPotentialMultiConnectionEndpointIds());
     assertTrue(parallel.hasPotentialMultiConnectionNodes());
 
     DexpiConnectionComponentInfo unresolved = first.getConnectionComponents().get(2);

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -483,6 +483,70 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(result.getConnectionEndpoints().get(1).isPotentialMultiConnectionNode());
   }
 
+  @Test
+  public void testReadWithDiagnosticsSummarizesConnectionReferenceComponents() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
+        + "<Equipment ID=\"E-A\"><Nozzle ID=\"N-A\"/></Equipment>"
+        + "<Equipment ID=\"E-J\"><Nozzle ID=\"N-J\"/></Equipment>"
+        + "<Equipment ID=\"E-C\"><Nozzle ID=\"N-C\"/></Equipment>"
+        + "<Equipment ID=\"E-X\"><Nozzle ID=\"N-X\"/></Equipment>"
+        + "<Equipment ID=\"E-Y\"><Nozzle ID=\"N-Y\"/></Equipment>"
+        + "<PipingNetworkSegment ID=\"S-1\"><Connection ID=\"C-1\" FromID=\"N-A\" ToID=\"N-J\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-2\"><Connection ID=\"C-2\" FromID=\"N-J\" ToID=\"N-C\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-3\"><Connection ID=\"C-3\" FromID=\"N-X\" ToID=\"N-Y\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-4\"><Connection ID=\"C-4\" FromID=\"N-X\" ToID=\"N-Y\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-5\"><Connection ID=\"C-5\" FromID=\"UNKNOWN\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-6\"><Connection ID=\"C-6\"/>"
+        + "</PipingNetworkSegment>" + "</PlantModel>";
+
+    DexpiXmlReader.ImportResult first = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    DexpiXmlReader.ImportResult second = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+    assertEquals(6, first.getConnections().size());
+    assertEquals(6, first.getConnectionEndpoints().size());
+    assertEquals(3, first.getConnectionComponents().size());
+
+    DexpiConnectionComponentInfo chain = first.getConnectionComponents().get(0);
+    assertEquals("component-1", chain.getId());
+    assertEquals(Arrays.asList("N-A", "N-J", "N-C"), chain.getEndpointIds());
+    assertEquals(Arrays.asList("C-1", "C-2"), chain.getConnectionIds());
+    assertEquals(Collections.singletonList("N-A"), chain.getSourceEndpointIds());
+    assertEquals(Collections.singletonList("N-C"), chain.getSinkEndpointIds());
+    assertEquals(3, chain.getEndpointCount());
+    assertEquals(2, chain.getConnectionCount());
+    assertFalse(chain.hasUnresolvedEndpoints());
+    assertFalse(chain.hasPotentialMultiConnectionNodes());
+
+    DexpiConnectionComponentInfo parallel = first.getConnectionComponents().get(1);
+    assertEquals("component-2", parallel.getId());
+    assertEquals(Arrays.asList("N-X", "N-Y"), parallel.getEndpointIds());
+    assertEquals(Arrays.asList("C-3", "C-4"), parallel.getConnectionIds());
+    assertEquals(Arrays.asList("N-X", "N-Y"),
+        parallel.getPotentialMultiConnectionEndpointIds());
+    assertTrue(parallel.hasPotentialMultiConnectionNodes());
+
+    DexpiConnectionComponentInfo unresolved = first.getConnectionComponents().get(2);
+    assertEquals("component-3", unresolved.getId());
+    assertEquals(Collections.singletonList("UNKNOWN"), unresolved.getEndpointIds());
+    assertEquals(Collections.singletonList("C-5"), unresolved.getConnectionIds());
+    assertEquals(Collections.singletonList("UNKNOWN"), unresolved.getSourceEndpointIds());
+    assertEquals(Collections.singletonList("UNKNOWN"), unresolved.getUnresolvedEndpointIds());
+    assertTrue(unresolved.hasUnresolvedEndpoints());
+
+    assertThrows(UnsupportedOperationException.class, () -> chain.getEndpointIds().clear());
+    assertThrows(UnsupportedOperationException.class, () -> first.getConnectionComponents().clear());
+    assertTrue(first.toJson().contains("\"connectionComponentCount\": 3"));
+    assertTrue(first.toJson().contains("\"hasUnresolvedEndpoints\": true"));
+    assertEquals(first.toJson(), second.toJson());
+  }
+
   private static int countDiagnostics(DexpiXmlReader.ImportResult result, String expectedCode) {
     int count = 0;
     for (DexpiXmlReader.ImportDiagnostic diagnostic : result.getDiagnostics()) {


### PR DESCRIPTION
## Campaign and engineering question

Advances #1332 and #2899 under the recorded shared-lane capability contract:

- #1332: https://github.com/equinor/neqsim/issues/1332#issuecomment-5495197717
- #2899: https://github.com/equinor/neqsim/issues/2899#issuecomment-5495197976

Can the Proteus-compatible DEXPI 4.1.1 reader expose deterministic weakly connected groups of explicit material-connection endpoint references so downstream reviewers can isolate source-document network regions without reconstructing or changing live NeqSim process topology?

## Exact continuity and capacity

- **Exact base:** `3f2b7339036feeabbb1e3be9b0a08376bed99add`
- **Exact head:** `ffb196f5fe2dcedb0ab737ec56723da35f6ea288`
- **Branch:** `ai/dexpi-material-network-components`
- Five commits ahead and zero behind the exact base after the formatting repair.
- Fresh ownership review found no active #1332/#2899 implementation PR.
- Current autonomous implementation portfolio becomes **3/10**, below the target and absolute global ceiling.
- No existing PR or branch was closed, replaced, rebased, force-pushed, abandoned, or otherwise disturbed.

## Capability

- Adds immutable `DexpiConnectionComponentInfo` source-reference evidence.
- Groups non-empty explicit `FromID`/`ToID` identities by weak connectivity in O(V + E).
- Preserves component first-endpoint order, endpoint first-reference order, connection source order, and parallel occurrences.
- Exposes source, sink, potential multi-connection, and unresolved endpoint subsets from the existing incidence evidence.
- Keeps one-sided explicit references as singleton components; connections with two blank references remain findings and receive no invented nodes.
- Adds deterministic JSON and the same Java/JPype getter surface.
- Adds focused coverage for disjoint components, chains, parallel occurrences, unresolved/blank references, immutability, deterministic JSON, and legacy inventories.
- Updates the DEXPI reader documentation.

## Scientific and engineering boundary

This is document evidence only. It does not establish hydraulic continuity, line identity, physical branch/junction/fitting type, process intent, flow feasibility, or executable topology. It does not rewire `ProcessSystem`, infer geometry or coordinates, create controls, change simulation-building behavior, or change rendering/export behavior.

Stops before directed path/cycle solving, fitting inference, automatic repair, DEXPI 2.0 expansion, licensed-standard mapping, external datasets, or Huldra.

## Validation and publication gates

Exact-head validation for `ffb196f5fe2dcedb0ab737ec56723da35f6ea288`:

- `python3 devtools/run_spotless.py check`: passed.
- `python3 devtools/check_documentation_search.py`: passed (681 Markdown pages and 1 standalone HTML page).
- Standard POM `DexpiXmlReaderTest`: **19 tests passed, 0 failures, 0 errors**.
- Java 8 target POM `DexpiXmlReaderTest`: **19 tests passed, 0 failures, 0 errors**.
- `git diff --check`: passed.
- Both code-quality threads are resolved: constructor-owned defensive copies are wrapped as unmodifiable, and the focused tests confirm getter-side mutation is rejected.

Whole-sheet visual gate: **N/A with evidence** — no writer, renderer, SVG, geometry, layout, or benchmark path changes.

Attached exact-head checks are authoritative for the hosted Java 8/21, Ubuntu/Windows, Javadocs, Spotless, pre-commit, documentation, notebook, performance, CodeQL, PaperLab, and agent-reference gates.

No standards-conformance, DEXPI-certification, safety-completeness, engineering-approval, or fitness-for-construction claim is made.

Generated with AI assistance.