### PR TITLE
[AI-Assisted] feat(refinery): ingest DOE composition-resolved light ends

### DIFF
--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -50,12 +50,13 @@ For crude/petroleum assays, use `OilAssayCharacterisation` rather than manually 
 - specific-gravity, kg/m3, and API-gravity density inputs;
 - exact API-gravity/SG60/60 round-tripping and explicit bulk density at 60 degF;
 - forward and inverse UOP/Watson characterization between representative boiling point and specific gravity;
+- mass-basis mapping of known assay light ends to authoritative NeqSim standard components;
 - per-cut total-sulfur and total-nitrogen inputs with mass-basis whole-assay reconstruction;
 - pre-binned cumulative TBP cut-boundary ingestion;
 - preserved finite and one-sided lower/upper boiling boundaries;
 - closure, duplicate-name, monotonicity, and repeated-application guards.
 
-See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data bookkeeping evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation), whole-assay density/API evidence in [DOE/OEDI COA bulk density qualification](refinery_oedi_coa_bulk_density_validation), per-cut characterization evidence in [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation), terminal representative-temperature evidence in [DOE Big Hill terminal-Watson qualification](refinery_big_hill_watson_terminal_validation), assay-quality evidence in [DOE Big Hill sulfur qualification](refinery_big_hill_sulfur_validation) and [DOE Big Hill nitrogen qualification](refinery_big_hill_nitrogen_validation), terminal-boundary evidence in [DOE Big Hill terminal-cut qualification](refinery_big_hill_terminal_boundary_validation), and the process-integration gate in [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation).
+See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data bookkeeping evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation), whole-assay density/API evidence in [DOE/OEDI COA bulk density qualification](refinery_oedi_coa_bulk_density_validation), per-cut characterization evidence in [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation), terminal representative-temperature evidence in [DOE Big Hill terminal-Watson qualification](refinery_big_hill_watson_terminal_validation), composition-resolved light-end evidence in [DOE Big Hill light-end qualification](refinery_big_hill_light_ends_validation), assay-quality evidence in [DOE Big Hill sulfur qualification](refinery_big_hill_sulfur_validation) and [DOE Big Hill nitrogen qualification](refinery_big_hill_nitrogen_validation), terminal-boundary evidence in [DOE Big Hill terminal-cut qualification](refinery_big_hill_terminal_boundary_validation), and the process-integration gate in [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation).
 
 ## TBP fraction models
 
@@ -141,6 +142,7 @@ A bookkeeping regression does not by itself validate a petroleum-property correl
 - [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation)
 - [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation)
 - [DOE Big Hill terminal-Watson qualification](refinery_big_hill_watson_terminal_validation)
+- [DOE Big Hill composition-resolved light-end qualification](refinery_big_hill_light_ends_validation)
 - [DOE Big Hill assay sulfur qualification](refinery_big_hill_sulfur_validation)
 - [DOE Big Hill assay nitrogen qualification](refinery_big_hill_nitrogen_validation)
 - [DOE Big Hill terminal-cut boundary qualification](refinery_big_hill_terminal_boundary_validation)

--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -166,6 +166,20 @@ uses the reported 1050 degF+ residue values SG60/60 = 1.0089 and UOP K = 11.7. T
 source-derived representative temperature for the existing pseudo-component path; it does not
 independently validate the molecular weight or downstream properties produced by that path.
 
+## Composition-resolved standard light ends
+
+When an assay source reports known light molecules, mark each mass-basis cut with
+`withStandardComponent(componentName)`. NeqSim then uses the attached Java thermodynamic system's
+standard-component database and authoritative molar mass instead of creating a petroleum `_PC`
+component. Preparation is performed on a clone so unknown or inconsistent inputs fail before the
+original system is mutated.
+
+The [DOE Big Hill composition-resolved light-end qualification](refinery_big_hill_light_ends_validation)
+normalizes DOE's reported ethane, propane, i-butane, and n-butane debutanization weights over the
+reported C2-C4 subset and applies the independently reported 1.70 mass% whole-crude gas yield. It
+qualifies standard-component identity plus exact mass/mole bookkeeping. It does not qualify VLE,
+flash recovery, or C5-175 degF properties.
+
 ## Open-ended terminal boiling boundaries
 
 Terminal assay cuts often publish only one boiling limit. Use
@@ -232,11 +246,12 @@ The regression suite for this API currently verifies:
 - whole-assay SG/API agreement across all five complete four-category rows in the public DOE/OEDI COA summary workbook;
 - per-cut UOP/Watson factors against four bounded cuts in the public DOE SPR Big Hill Sweet 2021 assay;
 - Watson-derived representative boiling point for the DOE Big Hill 1050 degF+ terminal residue;
+- composition-resolved standard-component ingestion for the DOE Big Hill C2-C4 light ends;
 - whole-assay total-sulfur reconstruction against the public DOE Big Hill Sweet 2021 assay;
 - whole-assay total-nitrogen reconstruction against the public DOE Big Hill Sweet 2021 assay;
 - input-order independence and no thermodynamic-system mutation for bulk-property queries.
 
-These tests establish software/bookkeeping correctness, qualify ideal-additive-volume SG/API screening over the frozen COA matrix (published crude SG 0.765-0.847; maximum observed errors 0.006 SG and 1.5 degrees API), qualify per-cut Watson factors over the frozen DOE matrix (375-1050 degF; maximum observed error 0.0122), qualify the DOE residue's Watson-derived representative temperature, and qualify linear assay sulfur and nitrogen bookkeeping over one complete DOE crude slate. They do **not** qualify temperature correction, contraction, molecular-weight or critical-property correlations, sulfur/nitrogen species or reactions, or atmospheric/vacuum fractionation; those remain separate campaign gates in issue #3305.
+These tests establish software/bookkeeping correctness, qualify ideal-additive-volume SG/API screening over the frozen COA matrix (published crude SG 0.765-0.847; maximum observed errors 0.006 SG and 1.5 degrees API), qualify per-cut Watson factors over the frozen DOE matrix (375-1050 degF; maximum observed error 0.0122), qualify the DOE residue's Watson-derived representative temperature, qualify the DOE C2-C4 standard-component split, and qualify linear assay sulfur and nitrogen bookkeeping over one complete DOE crude slate. They do **not** qualify temperature correction, contraction, molecular-weight or critical-property correlations, sulfur/nitrogen species or reactions, or atmospheric/vacuum fractionation; those remain separate campaign gates in issue #3305.
 
 ## Refinery capability inventory after this increment
 
@@ -247,6 +262,7 @@ These tests establish software/bookkeeping correctness, qualify ideal-additive-v
 | Pre-binned cumulative TBP cut boundaries | `addTBPCutBoundariesCelsius/Kelvin` | Initial implementation in #3305 |
 | Open-ended terminal boiling limits | Unit-explicit one-sided `AssayCut` boundaries | DOE-qualified for metadata and fail-closed preparation |
 | Watson-derived terminal representative point | `withWatsonCharacterizationFactor(...)` | DOE-qualified for the Big Hill 1050 degF+ residue |
+| Composition-resolved standard light ends | `AssayCut.withStandardComponent(...)` | DOE-qualified for the Big Hill C2-C4 composition and mass/mole bookkeeping |
 | Per-cut UOP/Watson characterization factor | `AssayCut.getWatsonCharacterizationFactor()` | DOE-qualified for assay screening over 375-1050 degF |
 | Assay-carried total sulfur | `getBulkSulfurMassFraction/Percent()` | DOE-qualified for linear bookkeeping over one complete crude slate |
 | Assay-carried total nitrogen | `getBulkNitrogenMassFraction/Percent()` | DOE-qualified for linear bookkeeping over one complete crude slate |
@@ -263,4 +279,4 @@ These tests establish software/bookkeeping correctness, qualify ideal-additive-v
 
 ## Next campaign step
 
-The next dependency-ready characterization increment should establish a defensible C2-C4 composition and C5-175 degF representative property treatment from public evidence. With the residue's terminal boundary and representative temperature explicit, the process benchmark can then advance from the bounded DOE atmospheric integration case to a complete crude slate with independent cut-yield and boiling-range evidence before vacuum fractionation.
+The next dependency-ready characterization increment should establish a defensible C5-175 degF representative property treatment from public evidence. With the C2-C4 composition and residue terminal treatment now explicit, the process benchmark can then advance from the bounded DOE atmospheric integration case to a complete crude slate with independent cut-yield and boiling-range evidence before vacuum fractionation.

--- a/docs/thermo/characterization/refinery_big_hill_light_ends_validation.md
+++ b/docs/thermo/characterization/refinery_big_hill_light_ends_validation.md
@@ -1,0 +1,60 @@
+---
+title: "DOE Big Hill composition-resolved light-end qualification"
+description: "Public-data qualification of standard-component C2-C4 ingestion for the DOE Big Hill Sweet crude assay."
+---
+
+# DOE Big Hill composition-resolved light-end qualification
+
+This benchmark qualifies a source-traceable C2-C4 composition view for refinery assay light ends. Known molecules are added as NeqSim standard components rather than being sent through a petroleum pseudo-component correlation.
+
+## Sources and provenance
+
+The public U.S. Department of Energy Strategic Petroleum Reserve sources are:
+
+- comprehensive Big Hill Sweet assay workbook:
+  <https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx>
+- Big Hill Sweet gas-chromatographic/PIANO workbook:
+  <https://www.spr.doe.gov/reports/Assays/2021/BigHillSwPIANO.xlsx>
+- DOE assay landing page:
+  <https://www.spr.doe.gov/reports/Crude_Oil_Assays.html>
+- report date recorded in both workbooks: **24 September 2021**
+
+DOE/SPR distributes these workbooks for informational use and does not provide a separate license statement. The regression freezes only the attributed numerical facts below; it does not redistribute either workbook.
+
+## Composition calculation
+
+The comprehensive assay reports the aggregate C2-C4 cut as **1.70 mass% of whole crude**. The PIANO workbook reports this debutanization composition on a weight basis:
+
+| Component | Reported debutanization wt% | Normalized C2-C4 mass fraction | Mass in a 1 kg whole-crude basis, kg |
+| --- | ---: | ---: | ---: |
+| ethane | 0.09 | 0.0013507429 | 0.0000229626 |
+| propane | 10.38 | 0.1557856821 | 0.0026483566 |
+| i-butane | 10.21 | 0.1532342789 | 0.0026049827 |
+| n-butane | 45.95 | 0.6896292961 | 0.0117236980 |
+| **C2-C4 subset** | **66.63** | **1.0000000000** | **0.0170000000** |
+
+The normalization excludes DOE's separately reported i-pentane, n-pentane, 2,2-dimethylpropane, and C6+ entries. Methane is reported as 0.00 wt% and is not invented. This is a transparent combination of two DOE views, not an independent compositional measurement.
+
+## Java and Python contract
+
+Use `AssayCut.withStandardComponent(componentName)` on a mass-basis cut. During `apply()`, NeqSim preflights each identifier on a clone, reads the standard component's authoritative molar mass from the Java thermodynamic system, converts the configured assay mass to moles, and then adds the known molecule with `SystemInterface.addComponent`.
+
+The same Java behavior is available from Python through JPype. A standard component cannot also carry pseudo-component density, boiling-point, Watson-factor, boundary, or explicit molar-mass inputs. Volume-basis standard-component cuts fail closed because no independent light-end liquid-density conversion is claimed.
+
+## Acceptance and maturity
+
+`OilAssayCharacterisationDoeBigHillLightEndsTest` requires:
+
+- exact reproduction of DOE's 66.63 wt% C2-C4 subset and normalized composition;
+- exact reconstruction of the 0.017 kg gas slice on a 1 kg whole-crude basis within 1e-10 kg;
+- positive finite standard-component molar masses and mole amounts;
+- identical component amounts under reversed source order;
+- no petroleum `_PC` component for a known molecule;
+- clone retention; and
+- fail-closed unknown, duplicate, ambiguous, and volume-basis inputs without original-system mutation.
+
+The implementation is O(n) in the number of assay cuts. The capability is **qualified for DOE Big Hill C2-C4 composition ingestion and mass/mole bookkeeping**.
+
+## Evidence boundary
+
+This benchmark does not validate gas-liquid equilibrium, an EOS or mixing rule, flash recovery, C5-175 degF representative properties, full-crude light-end material balance, atmospheric product yields, vacuum fractionation, blending, or conversion models. The PIANO subset normalization is an inference explicitly recorded above. C5-175 degF representative-property qualification remains the next characterization dependency.

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -393,17 +393,15 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
           validationSystem.addComponent(standardComponentName, 1.0);
           validationComponent = validationSystem.getComponent(standardComponentName);
         } catch (Exception ex) {
-          throw new IllegalStateException(
-              "Unknown or unavailable assay standard component: " + standardComponentName, ex);
+          throw new IllegalStateException("Unknown or unavailable assay standard component: " + standardComponentName,
+              ex);
         }
         if (validationComponent == null) {
-          throw new IllegalStateException(
-              "Unknown or unavailable assay standard component: " + standardComponentName);
+          throw new IllegalStateException("Unknown or unavailable assay standard component: " + standardComponentName);
         }
         double molarMass = validationComponent.getMolarMass();
         if (!Double.isFinite(molarMass) || !(molarMass > 0.0)) {
-          throw new IllegalStateException(
-              "Invalid molar mass for assay standard component: " + standardComponentName);
+          throw new IllegalStateException("Invalid molar mass for assay standard component: " + standardComponentName);
         }
         double moles = totalAssayMass * massFraction / molarMass;
         if (!Double.isFinite(moles) || !(moles > 0.0)) {
@@ -510,8 +508,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     for (AssayCut cut : cuts) {
       if (cut.isStandardComponent()
           && !componentNames.add(cut.getStandardComponentName().toLowerCase(java.util.Locale.ROOT))) {
-        throw new IllegalStateException(
-            "Duplicate assay standard component: " + cut.getStandardComponentName());
+        throw new IllegalStateException("Duplicate assay standard component: " + cut.getStandardComponentName());
       }
     }
   }

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import neqsim.thermo.component.ComponentInterface;
 import neqsim.thermo.system.SystemInterface;
 
 /**
@@ -355,14 +356,62 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     }
 
     validateUniqueCutNames();
+    validateUniqueStandardComponentNames();
     double[] massFractions = resolveMassFractions();
     List<ResolvedCut> resolvedCuts = new ArrayList<ResolvedCut>();
     double reconstructedMass = 0.0;
+    SystemInterface validationSystem = null;
 
     for (int i = 0; i < cuts.size(); i++) {
       AssayCut cut = cuts.get(i);
       double massFraction = massFractions[i];
       if (!(massFraction > 0.0)) {
+        continue;
+      }
+
+      if (cut.isStandardComponent()) {
+        if (cut.hasVolumeFraction()) {
+          throw new IllegalStateException(
+              "Standard components require a mass-basis assay fraction for cut " + cut.getName());
+        }
+        if (cut.hasPetroleumPseudoComponentDefinition()) {
+          throw new IllegalStateException(
+              "Standard component cut cannot also define petroleum pseudo-component properties: " + cut.getName());
+        }
+
+        String standardComponentName = cut.getStandardComponentName();
+        if (system.hasComponent(standardComponentName, false)) {
+          throw new IllegalStateException(
+              "Assay standard component already exists in system: " + standardComponentName);
+        }
+
+        if (validationSystem == null) {
+          validationSystem = system.clone();
+        }
+        try {
+          validationSystem.addComponent(standardComponentName, 1.0);
+        } catch (Exception ex) {
+          throw new IllegalStateException(
+              "Unknown or unavailable assay standard component: " + standardComponentName, ex);
+        }
+        ComponentInterface validationComponent = validationSystem.getComponent(standardComponentName);
+        if (validationComponent == null) {
+          throw new IllegalStateException(
+              "Unknown or unavailable assay standard component: " + standardComponentName);
+        }
+        double molarMass = validationComponent.getMolarMass();
+        if (!Double.isFinite(molarMass) || !(molarMass > 0.0)) {
+          throw new IllegalStateException(
+              "Invalid molar mass for assay standard component: " + standardComponentName);
+        }
+        double moles = totalAssayMass * massFraction / molarMass;
+        if (!Double.isFinite(moles) || !(moles > 0.0)) {
+          throw new IllegalStateException(
+              "Calculated mole amount for assay cut " + cut.getName() + " is not finite and positive");
+        }
+
+        resolvedCuts.add(new ResolvedCut(cut, standardComponentName, Double.NaN, molarMass, moles));
+        reconstructedMass += moles * molarMass;
         continue;
       }
 
@@ -386,7 +435,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
             "Calculated mole amount for assay cut " + cut.getName() + " is not finite and positive");
       }
 
-      resolvedCuts.add(new ResolvedCut(cut, density, molarMass, moles));
+      resolvedCuts.add(new ResolvedCut(cut, null, density, molarMass, moles));
       reconstructedMass += moles * molarMass;
     }
 
@@ -397,7 +446,11 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     }
 
     for (ResolvedCut resolvedCut : resolvedCuts) {
-      system.addTBPfraction(resolvedCut.cut.getName(), resolvedCut.moles, resolvedCut.molarMass, resolvedCut.density);
+      if (resolvedCut.standardComponentName != null) {
+        system.addComponent(resolvedCut.standardComponentName, resolvedCut.moles);
+      } else {
+        system.addTBPfraction(resolvedCut.cut.getName(), resolvedCut.moles, resolvedCut.molarMass, resolvedCut.density);
+      }
     }
   }
 
@@ -447,6 +500,17 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     for (AssayCut cut : cuts) {
       if (!names.add(cut.getName())) {
         throw new IllegalStateException("Duplicate assay cut name: " + cut.getName());
+      }
+    }
+  }
+
+  private void validateUniqueStandardComponentNames() {
+    Set<String> componentNames = new HashSet<String>();
+    for (AssayCut cut : cuts) {
+      if (cut.isStandardComponent()
+          && !componentNames.add(cut.getStandardComponentName().toLowerCase(java.util.Locale.ROOT))) {
+        throw new IllegalStateException(
+            "Duplicate assay standard component: " + cut.getStandardComponentName());
       }
     }
   }
@@ -534,12 +598,14 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
 
   private static final class ResolvedCut {
     private final AssayCut cut;
+    private final String standardComponentName;
     private final double density;
     private final double molarMass;
     private final double moles;
 
-    private ResolvedCut(AssayCut cut, double density, double molarMass, double moles) {
+    private ResolvedCut(AssayCut cut, String standardComponentName, double density, double molarMass, double moles) {
       this.cut = cut;
+      this.standardComponentName = standardComponentName;
       this.density = density;
       this.molarMass = molarMass;
       this.moles = moles;
@@ -561,6 +627,7 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     private Double sulfurMassFraction;
     private Double nitrogenMassFraction;
     private Double watsonCharacterizationFactor;
+    private String standardComponentName;
 
     /**
      * Create an assay cut.
@@ -605,6 +672,28 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
      */
     public AssayCut withWeightPercent(double weightPercent) {
       this.massFraction = sanitisePercent(weightPercent);
+      return this;
+    }
+
+
+    /**
+     * Mark this mass-basis assay cut as an authoritative NeqSim standard component.
+     *
+     * <p>
+     * Standard components use the attached thermodynamic system's component database and molar mass. They are added with
+     * {@link SystemInterface#addComponent(String, double)} rather than the petroleum pseudo-component correlation. Density,
+     * boiling-point, Watson-factor, and explicit molar-mass inputs are therefore not applicable and fail during
+     * preflight.
+     * </p>
+     *
+     * @param componentName exact NeqSim standard-component identifier
+     * @return this cut
+     */
+    public AssayCut withStandardComponent(String componentName) {
+      if (componentName == null || componentName.trim().isEmpty()) {
+        throw new IllegalArgumentException("Standard component name cannot be empty");
+      }
+      this.standardComponentName = componentName.trim();
       return this;
     }
 
@@ -1076,6 +1165,35 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
      */
     public boolean hasMolarMass() {
       return molarMass != null;
+    }
+
+
+    /**
+     * Return whether this cut maps to a NeqSim standard component.
+     *
+     * @return true when a standard-component identifier is stored
+     */
+    public boolean isStandardComponent() {
+      return standardComponentName != null;
+    }
+
+    /**
+     * Return the configured NeqSim standard-component identifier.
+     *
+     * @return standard-component identifier
+     * @throws IllegalStateException if this cut is a petroleum pseudo-component
+     */
+    public String getStandardComponentName() {
+      if (standardComponentName == null) {
+        throw new IllegalStateException("Standard component name not set for cut " + name);
+      }
+      return standardComponentName;
+    }
+
+    private boolean hasPetroleumPseudoComponentDefinition() {
+      return density != null || apiGravity != null || averageBoilingPointKelvin != null
+          || lowerBoilingPointKelvin != null || upperBoilingPointKelvin != null || molarMass != null
+          || watsonCharacterizationFactor != null;
     }
 
     /**

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -388,13 +388,14 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
         if (validationSystem == null) {
           validationSystem = system.clone();
         }
+        ComponentInterface validationComponent;
         try {
           validationSystem.addComponent(standardComponentName, 1.0);
+          validationComponent = validationSystem.getComponent(standardComponentName);
         } catch (Exception ex) {
           throw new IllegalStateException(
               "Unknown or unavailable assay standard component: " + standardComponentName, ex);
         }
-        ComponentInterface validationComponent = validationSystem.getComponent(standardComponentName);
         if (validationComponent == null) {
           throw new IllegalStateException(
               "Unknown or unavailable assay standard component: " + standardComponentName);
@@ -675,15 +676,14 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
       return this;
     }
 
-
     /**
      * Mark this mass-basis assay cut as an authoritative NeqSim standard component.
      *
      * <p>
-     * Standard components use the attached thermodynamic system's component database and molar mass. They are added with
-     * {@link SystemInterface#addComponent(String, double)} rather than the petroleum pseudo-component correlation. Density,
-     * boiling-point, Watson-factor, and explicit molar-mass inputs are therefore not applicable and fail during
-     * preflight.
+     * Standard components use the attached thermodynamic system's component database and molar mass. They are added
+     * with {@link SystemInterface#addComponent(String, double)} rather than the petroleum pseudo-component correlation.
+     * Density, boiling-point, Watson-factor, and explicit molar-mass inputs are therefore not applicable and fail
+     * during preflight.
      * </p>
      *
      * @param componentName exact NeqSim standard-component identifier
@@ -1166,7 +1166,6 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
     public boolean hasMolarMass() {
       return molarMass != null;
     }
-
 
     /**
      * Return whether this cut maps to a NeqSim standard component.

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillLightEndsTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillLightEndsTest.java
@@ -14,8 +14,8 @@ import neqsim.thermo.system.SystemSrkEos;
 
 /** Public DOE qualification of composition-resolved C2-C4 assay light ends. */
 public class OilAssayCharacterisationDoeBigHillLightEndsTest {
-  private static final String[] COMPONENT_NAMES = {"ethane", "propane", "i-butane", "n-butane"};
-  private static final double[] DOE_DEBUTANIZATION_WEIGHT_PERCENT = {0.09, 10.38, 10.21, 45.95};
+  private static final String[] COMPONENT_NAMES = { "ethane", "propane", "i-butane", "n-butane" };
+  private static final double[] DOE_DEBUTANIZATION_WEIGHT_PERCENT = { 0.09, 10.38, 10.21, 45.95 };
   private static final double DOE_C2_C4_SUBSET_WEIGHT_PERCENT = 66.63;
   private static final double DOE_C2_C4_WHOLE_CRUDE_MASS_PERCENT = 1.70;
 
@@ -30,10 +30,9 @@ public class OilAssayCharacterisationDoeBigHillLightEndsTest {
 
     assertEquals(DOE_C2_C4_SUBSET_WEIGHT_PERCENT, reportedSubset, 1.0e-12);
     assertEquals(1.0, normalizedSubset, 1.0e-12);
-    assertEquals(0.0013507429085997298,
-        DOE_DEBUTANIZATION_WEIGHT_PERCENT[0] / DOE_C2_C4_SUBSET_WEIGHT_PERCENT, 1.0e-15);
-    assertEquals(0.6896292961128622,
-        DOE_DEBUTANIZATION_WEIGHT_PERCENT[3] / DOE_C2_C4_SUBSET_WEIGHT_PERCENT, 1.0e-15);
+    assertEquals(0.0013507429085997298, DOE_DEBUTANIZATION_WEIGHT_PERCENT[0] / DOE_C2_C4_SUBSET_WEIGHT_PERCENT,
+        1.0e-15);
+    assertEquals(0.6896292961128622, DOE_DEBUTANIZATION_WEIGHT_PERCENT[3] / DOE_C2_C4_SUBSET_WEIGHT_PERCENT, 1.0e-15);
   }
 
   @Test
@@ -65,8 +64,7 @@ public class OilAssayCharacterisationDoeBigHillLightEndsTest {
     SystemInterface unknownSystem = new SystemSrkEos(298.15, 1.01325);
     OilAssayCharacterisation unknownAssay = unknownSystem.getOilAssayCharacterisation();
     unknownAssay.addCut(new AssayCut("Known").withMassFraction(0.5).withStandardComponent("ethane"));
-    unknownAssay
-        .addCut(new AssayCut("Unknown").withMassFraction(0.5).withStandardComponent("not-a-neqsim-component"));
+    unknownAssay.addCut(new AssayCut("Unknown").withMassFraction(0.5).withStandardComponent("not-a-neqsim-component"));
     assertThrows(IllegalStateException.class, unknownAssay::apply);
     assertEquals(0, unknownSystem.getNumberOfComponents());
 
@@ -79,8 +77,8 @@ public class OilAssayCharacterisationDoeBigHillLightEndsTest {
 
     SystemInterface ambiguousSystem = new SystemSrkEos(298.15, 1.01325);
     OilAssayCharacterisation ambiguousAssay = ambiguousSystem.getOilAssayCharacterisation();
-    ambiguousAssay.addCut(new AssayCut("Ambiguous").withMassFraction(1.0).withSpecificGravity(0.6)
-        .withStandardComponent("propane"));
+    ambiguousAssay.addCut(
+        new AssayCut("Ambiguous").withMassFraction(1.0).withSpecificGravity(0.6).withStandardComponent("propane"));
     assertThrows(IllegalStateException.class, ambiguousAssay::apply);
     assertEquals(0, ambiguousSystem.getNumberOfComponents());
   }
@@ -98,8 +96,7 @@ public class OilAssayCharacterisationDoeBigHillLightEndsTest {
 
     SystemInterface volumeSystem = new SystemSrkEos(298.15, 1.01325);
     OilAssayCharacterisation volumeAssay = volumeSystem.getOilAssayCharacterisation();
-    volumeAssay
-        .addCut(new AssayCut("VolumeEthane").withVolumeFraction(1.0).withStandardComponent("ethane"));
+    volumeAssay.addCut(new AssayCut("VolumeEthane").withVolumeFraction(1.0).withStandardComponent("ethane"));
     assertThrows(IllegalStateException.class, volumeAssay::apply);
     assertEquals(0, volumeSystem.getNumberOfComponents());
 
@@ -114,10 +111,9 @@ public class OilAssayCharacterisationDoeBigHillLightEndsTest {
     for (int position = 0; position < COMPONENT_NAMES.length; position++) {
       int index = reverseOrder ? COMPONENT_NAMES.length - 1 - position : position;
       String componentName = COMPONENT_NAMES[index];
-      double normalizedMassFraction =
-          DOE_DEBUTANIZATION_WEIGHT_PERCENT[index] / DOE_C2_C4_SUBSET_WEIGHT_PERCENT;
-      assay.addCut(new AssayCut("DOE_BH_" + componentName.toUpperCase())
-          .withMassFraction(normalizedMassFraction).withStandardComponent(componentName));
+      double normalizedMassFraction = DOE_DEBUTANIZATION_WEIGHT_PERCENT[index] / DOE_C2_C4_SUBSET_WEIGHT_PERCENT;
+      assay.addCut(new AssayCut("DOE_BH_" + componentName.toUpperCase()).withMassFraction(normalizedMassFraction)
+          .withStandardComponent(componentName));
     }
 
     assay.apply();

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillLightEndsTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillLightEndsTest.java
@@ -1,0 +1,124 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Public DOE qualification of composition-resolved C2-C4 assay light ends. */
+public class OilAssayCharacterisationDoeBigHillLightEndsTest {
+  private static final String[] COMPONENT_NAMES = {"ethane", "propane", "i-butane", "n-butane"};
+  private static final double[] DOE_DEBUTANIZATION_WEIGHT_PERCENT = {0.09, 10.38, 10.21, 45.95};
+  private static final double DOE_C2_C4_SUBSET_WEIGHT_PERCENT = 66.63;
+  private static final double DOE_C2_C4_WHOLE_CRUDE_MASS_PERCENT = 1.70;
+
+  @Test
+  public void doePianoCompositionNormalizesOnlyTheReportedC2C4Subset() {
+    double reportedSubset = 0.0;
+    double normalizedSubset = 0.0;
+    for (double weightPercent : DOE_DEBUTANIZATION_WEIGHT_PERCENT) {
+      reportedSubset += weightPercent;
+      normalizedSubset += weightPercent / DOE_C2_C4_SUBSET_WEIGHT_PERCENT;
+    }
+
+    assertEquals(DOE_C2_C4_SUBSET_WEIGHT_PERCENT, reportedSubset, 1.0e-12);
+    assertEquals(1.0, normalizedSubset, 1.0e-12);
+    assertEquals(0.0013507429085997298,
+        DOE_DEBUTANIZATION_WEIGHT_PERCENT[0] / DOE_C2_C4_SUBSET_WEIGHT_PERCENT, 1.0e-15);
+    assertEquals(0.6896292961128622,
+        DOE_DEBUTANIZATION_WEIGHT_PERCENT[3] / DOE_C2_C4_SUBSET_WEIGHT_PERCENT, 1.0e-15);
+  }
+
+  @Test
+  public void standardComponentsUseAuthoritativeMolarMassAndCloseGasSlice() {
+    SystemInterface forward = buildGasSlice(false);
+    SystemInterface reverse = buildGasSlice(true);
+
+    double expectedMassKg = DOE_C2_C4_WHOLE_CRUDE_MASS_PERCENT / 100.0;
+    double reconstructedMassKg = 0.0;
+    for (String componentName : COMPONENT_NAMES) {
+      ComponentInterface component = forward.getComponent(componentName);
+      ComponentInterface reversedComponent = reverse.getComponent(componentName);
+      assertNotNull(component);
+      assertNotNull(reversedComponent);
+      assertTrue(Double.isFinite(component.getMolarMass()));
+      assertTrue(component.getMolarMass() > 0.0);
+      assertTrue(component.getNumberOfmoles() > 0.0);
+      assertEquals(component.getNumberOfmoles(), reversedComponent.getNumberOfmoles(), 1.0e-12);
+      reconstructedMassKg += component.getNumberOfmoles() * component.getMolarMass();
+      assertFalse(forward.hasComponent("DOE_BH_" + componentName.toUpperCase() + "_PC", false));
+    }
+    assertEquals(expectedMassKg, reconstructedMassKg, 1.0e-10);
+  }
+
+  @Test
+  public void invalidStandardComponentsFailBeforeOriginalSystemMutation() {
+    SystemInterface unknownSystem = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation unknownAssay = unknownSystem.getOilAssayCharacterisation();
+    unknownAssay.addCut(new AssayCut("Known").withMassFraction(0.5).withStandardComponent("ethane"));
+    unknownAssay
+        .addCut(new AssayCut("Unknown").withMassFraction(0.5).withStandardComponent("not-a-neqsim-component"));
+    assertThrows(IllegalStateException.class, unknownAssay::apply);
+    assertEquals(0, unknownSystem.getNumberOfComponents());
+
+    SystemInterface duplicateSystem = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation duplicateAssay = duplicateSystem.getOilAssayCharacterisation();
+    duplicateAssay.addCut(new AssayCut("EthaneOne").withMassFraction(0.5).withStandardComponent("ethane"));
+    duplicateAssay.addCut(new AssayCut("EthaneTwo").withMassFraction(0.5).withStandardComponent("ETHANE"));
+    assertThrows(IllegalStateException.class, duplicateAssay::apply);
+    assertEquals(0, duplicateSystem.getNumberOfComponents());
+
+    SystemInterface ambiguousSystem = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation ambiguousAssay = ambiguousSystem.getOilAssayCharacterisation();
+    ambiguousAssay.addCut(new AssayCut("Ambiguous").withMassFraction(1.0).withSpecificGravity(0.6)
+        .withStandardComponent("propane"));
+    assertThrows(IllegalStateException.class, ambiguousAssay::apply);
+    assertEquals(0, ambiguousSystem.getNumberOfComponents());
+  }
+
+  @Test
+  public void standardComponentMetadataSurvivesCloneAndRequiresMassBasis() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
+    assay.addCut(new AssayCut("DOE_BH_ETHANE").withMassFraction(1.0).withStandardComponent("ethane"));
+
+    SystemInterface clone = system.clone();
+    AssayCut clonedCut = clone.getOilAssayCharacterisation().getCuts().get(0);
+    assertTrue(clonedCut.isStandardComponent());
+    assertEquals("ethane", clonedCut.getStandardComponentName());
+
+    SystemInterface volumeSystem = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation volumeAssay = volumeSystem.getOilAssayCharacterisation();
+    volumeAssay
+        .addCut(new AssayCut("VolumeEthane").withVolumeFraction(1.0).withStandardComponent("ethane"));
+    assertThrows(IllegalStateException.class, volumeAssay::apply);
+    assertEquals(0, volumeSystem.getNumberOfComponents());
+
+    assertThrows(IllegalArgumentException.class, () -> new AssayCut("Blank").withStandardComponent(" "));
+  }
+
+  private static SystemInterface buildGasSlice(boolean reverseOrder) {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
+    assay.setTotalAssayMass(DOE_C2_C4_WHOLE_CRUDE_MASS_PERCENT / 100.0);
+
+    for (int position = 0; position < COMPONENT_NAMES.length; position++) {
+      int index = reverseOrder ? COMPONENT_NAMES.length - 1 - position : position;
+      String componentName = COMPONENT_NAMES[index];
+      double normalizedMassFraction =
+          DOE_DEBUTANIZATION_WEIGHT_PERCENT[index] / DOE_C2_C4_SUBSET_WEIGHT_PERCENT;
+      assay.addCut(new AssayCut("DOE_BH_" + componentName.toUpperCase())
+          .withMassFraction(normalizedMassFraction).withStandardComponent(componentName));
+    }
+
+    assay.apply();
+    return system;
+  }
+}

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillLightEndsTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillLightEndsTest.java
@@ -40,6 +40,8 @@ public class OilAssayCharacterisationDoeBigHillLightEndsTest {
   public void standardComponentsUseAuthoritativeMolarMassAndCloseGasSlice() {
     SystemInterface forward = buildGasSlice(false);
     SystemInterface reverse = buildGasSlice(true);
+    assertEquals(COMPONENT_NAMES.length, forward.getNumberOfComponents());
+    assertEquals(COMPONENT_NAMES.length, reverse.getNumberOfComponents());
 
     double expectedMassKg = DOE_C2_C4_WHOLE_CRUDE_MASS_PERCENT / 100.0;
     double reconstructedMassKg = 0.0;


### PR DESCRIPTION
## Campaign and engineering question

Advances #3305 under the recorded capability contract:
https://github.com/equinor/neqsim/issues/3305#issuecomment-5495403767

Can refinery assay light ends that are known molecules remain authoritative NeqSim standard components, preserving a public DOE C2-C4 composition and exact mass/mole bookkeeping without passing those molecules through petroleum pseudo-component correlations?

## Exact continuity and capacity

- Exact base: `3f2b7339036feeabbb1e3be9b0a08376bed99add`
- Exact head: `3b85bed1a95bd75fca47c6b3317c2ead22863dc0`
- Branch: `ai/refinery-doe-light-ends-3305`
- Five commits ahead and zero behind the exact base after the formatting repair.
- No active #3305 implementation PR existed before publication.
- Autonomous capability usage becomes **5/10**, below the target and absolute ceiling.
- No existing branch or PR was closed, replaced, rebased, force-pushed, or abandoned.

## Capability

- Adds opt-in `AssayCut.withStandardComponent(componentName)`.
- Preflights exact component identifiers on a cloned thermodynamic system.
- Uses NeqSim's standard-component database and authoritative molar mass.
- Converts the configured assay mass to moles and calls `SystemInterface.addComponent`.
- Keeps known molecules out of the petroleum `_PC` path.
- Rejects volume-basis, unknown, duplicate, and pseudo-property-ambiguous standard components before original-system mutation.
- Preserves behavior through cloning and exposes the same Java authority to Python through JPype.
- Complexity is O(n) in configured assay cuts.

## Public DOE benchmark

Sources reported 24 September 2021:

- comprehensive assay: https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx
- gas chromatographic/PIANO analysis: https://www.spr.doe.gov/reports/Assays/2021/BigHillSwPIANO.xlsx
- DOE catalog: https://www.spr.doe.gov/reports/Crude_Oil_Assays.html

The comprehensive assay reports C2-C4 as 1.70 mass% of whole crude. The PIANO workbook reports ethane 0.09, propane 10.38, i-butane 10.21, and n-butane 45.95 wt%; those entries sum to 66.63 wt% and are normalized only over the C2-C4 subset. Methane is reported as 0.00 wt% and is not invented. Higher components are excluded.

The focused regression requires exact source/normalization closure, exact reconstruction of the 0.017 kg gas slice on a 1 kg whole-crude basis within 1e-10 kg, positive finite molar masses and moles, source-order independence, clone retention, and no original-system mutation on failed preflight.

## Evidence boundary

This is qualified for DOE Big Hill C2-C4 composition ingestion and mass/mole bookkeeping. It does not validate VLE, EOS selection, mixing rules, flash recovery, C5-175 degF representative properties, full-crude light-end balance, atmospheric product yields, vacuum fractionation, blending, or conversion models. The C2-C4 subset normalization is an explicit inference from two DOE views, not an independent compositional measurement.

## Validation

Exact-head validation for `3b85bed1a95bd75fca47c6b3317c2ead22863dc0`:

- Standard POM focused characterization suite: **30 tests passed, 0 failures, 0 errors**.
- Java 8 target POM focused characterization suite: **30 tests passed, 0 failures, 0 errors**.
- `python3 devtools/run_spotless.py apply`: passed.
- `python3 devtools/run_spotless.py check`: passed.
- `python3 devtools/check_documentation_search.py`: passed (682 Markdown pages and 1 standalone HTML page).
- pre-commit and pre-push hooks: passed.
- `git diff --check`: passed.
- Remote blobs for both formatting repairs match the validated local files exactly.

Attached exact-head checks are authoritative for the full hosted matrix.

## Documentation impact

Adds a dedicated DOE light-end provenance/acceptance page, updates the refinery assay capability matrix and next dependency, and indexes the new behavior in the characterization guide.

Generated with AI assistance.