### PR TITLE
[AI-Assisted] feat(dexpi): expose directed cycle evidence

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -176,13 +176,23 @@ with two blank endpoint references remains diagnostic evidence and is not assign
 This grouping is a document-review aid, not proof that the grouped references form a hydraulically
 continuous line or executable process network.
 
+`ImportResult.getConnectionCycles()` exposes cyclic strongly connected groups in the directed graph
+of explicit non-empty material-connection endpoint references. A group is reported when it has more
+than one endpoint, or when a singleton endpoint has an explicit self-reference. Cycle groups are
+ordered by their first endpoint; endpoint IDs retain first-reference order and internal connection
+IDs retain source order, including parallel occurrences. Each immutable
+`DexpiConnectionCycleInfo` links to its owning weak connection component and keeps unresolved
+endpoint IDs visible. This is graph-source evidence only: it does not identify a hydraulic recycle,
+enumerate elementary paths, assert convergence behavior, repair or rewire topology, or establish
+process intent.
+
 `toJson()` includes `instrumentCount`, `connectionCount`, `connectionEndpointCount`,
-`connectionComponentCount`, and the ordered connection, endpoint, and component inventories,
-including incidence roles and component review subsets, alongside the process-unit count and
-findings. Python callers through JPype use the same `ImportResult.getInstruments()`,
-`ImportResult.getConnections()`, `ImportResult.getConnectionEndpoints()`, and
-`ImportResult.getConnectionComponents()` getters; there is no separate Python reconstruction
-model.
+`connectionComponentCount`, `connectionCycleCount`, and the ordered connection, endpoint,
+component, and directed-cycle inventories, including incidence roles and review subsets, alongside
+the process-unit count and findings. Python callers through JPype use the same
+`ImportResult.getInstruments()`, `ImportResult.getConnections()`,
+`ImportResult.getConnectionEndpoints()`, `ImportResult.getConnectionComponents()`, and
+`ImportResult.getConnectionCycles()` getters; there is no separate Python reconstruction model.
 
 `INFO` entries carry provenance and do not make `hasLosses()` true by themselves. `WARNING` and
 `ERROR` entries do. The diagnostic sequence and JSON are deterministic for the same XML and template.

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
@@ -1,0 +1,119 @@
+package neqsim.process.processmodel.dexpi;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Immutable evidence for one cyclic strongly connected group of explicit DEXPI material-connection
+ * endpoint references.
+ *
+ * <p>
+ * This record describes source-document graph evidence only. It does not establish hydraulic
+ * continuity, a physical recycle, process intent, or live {@code ProcessSystem} topology.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class DexpiConnectionCycleInfo implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private final String id;
+  private final String connectionComponentId;
+  private final List<String> endpointIds;
+  private final List<String> connectionIds;
+  private final List<String> unresolvedEndpointIds;
+  private final boolean selfReference;
+
+  /**
+   * Creates immutable directed-cycle source-reference evidence.
+   *
+   * @param id deterministic cycle-group evidence identity
+   * @param connectionComponentId owning weak connection-component evidence identity
+   * @param endpointIds endpoint identities in first-reference order
+   * @param connectionIds internal connection-evidence identities in source order
+   * @param unresolvedEndpointIds endpoint identities that do not resolve in the source document
+   * @param selfReference whether the group contains an explicit self-reference connection
+   */
+  public DexpiConnectionCycleInfo(String id, String connectionComponentId,
+      List<String> endpointIds, List<String> connectionIds, List<String> unresolvedEndpointIds,
+      boolean selfReference) {
+    this.id = normalize(id);
+    this.connectionComponentId = normalize(connectionComponentId);
+    this.endpointIds = immutableCopy(endpointIds);
+    this.connectionIds = immutableCopy(connectionIds);
+    this.unresolvedEndpointIds = immutableCopy(unresolvedEndpointIds);
+    this.selfReference = selfReference;
+  }
+
+  /** @return deterministic cycle-group evidence identity */
+  public String getId() {
+    return id;
+  }
+
+  /** @return owning weak connection-component evidence identity */
+  public String getConnectionComponentId() {
+    return connectionComponentId;
+  }
+
+  /** @return immutable endpoint identities in first-reference order */
+  public List<String> getEndpointIds() {
+    return endpointIds;
+  }
+
+  /** @return immutable internal connection-evidence identities in source order */
+  public List<String> getConnectionIds() {
+    return connectionIds;
+  }
+
+  /** @return immutable unresolved endpoint identities */
+  public List<String> getUnresolvedEndpointIds() {
+    return unresolvedEndpointIds;
+  }
+
+  /** @return number of endpoints in this cyclic source-reference group */
+  public int getEndpointCount() {
+    return endpointIds.size();
+  }
+
+  /** @return number of internal source connection occurrences */
+  public int getConnectionCount() {
+    return connectionIds.size();
+  }
+
+  /** @return whether the group contains an explicit self-reference connection */
+  public boolean hasSelfReference() {
+    return selfReference;
+  }
+
+  /** @return whether any endpoint reference in this group is unresolved */
+  public boolean hasUnresolvedEndpoints() {
+    return !unresolvedEndpointIds.isEmpty();
+  }
+
+  Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("id", id);
+    result.put("connectionComponentId", connectionComponentId);
+    result.put("endpointCount", Integer.valueOf(getEndpointCount()));
+    result.put("connectionCount", Integer.valueOf(getConnectionCount()));
+    result.put("selfReference", Boolean.valueOf(selfReference));
+    result.put("hasUnresolvedEndpoints", Boolean.valueOf(hasUnresolvedEndpoints()));
+    result.put("endpointIds", endpointIds);
+    result.put("connectionIds", connectionIds);
+    result.put("unresolvedEndpointIds", unresolvedEndpointIds);
+    return result;
+  }
+
+  private static List<String> immutableCopy(List<String> values) {
+    return Collections.unmodifiableList(new ArrayList<String>(values));
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
@@ -8,12 +8,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Immutable evidence for one cyclic strongly connected group of explicit DEXPI material-connection
- * endpoint references.
+ * Immutable evidence for one cyclic strongly connected group of explicit DEXPI material-connection endpoint references.
  *
  * <p>
- * This record describes source-document graph evidence only. It does not establish hydraulic
- * continuity, a physical recycle, process intent, or live {@code ProcessSystem} topology.
+ * This record describes source-document graph evidence only. It does not establish hydraulic continuity, a physical
+ * recycle, process intent, or live {@code ProcessSystem} topology.
  * </p>
  *
  * @author NeqSim
@@ -39,9 +38,8 @@ public final class DexpiConnectionCycleInfo implements Serializable {
    * @param unresolvedEndpointIds endpoint identities that do not resolve in the source document
    * @param selfReference whether the group contains an explicit self-reference connection
    */
-  public DexpiConnectionCycleInfo(String id, String connectionComponentId,
-      List<String> endpointIds, List<String> connectionIds, List<String> unresolvedEndpointIds,
-      boolean selfReference) {
+  public DexpiConnectionCycleInfo(String id, String connectionComponentId, List<String> endpointIds,
+      List<String> connectionIds, List<String> unresolvedEndpointIds, boolean selfReference) {
     this.id = normalize(id);
     this.connectionComponentId = normalize(connectionComponentId);
     this.endpointIds = immutableCopy(endpointIds);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -133,11 +133,13 @@ public final class DexpiXmlReader {
     private final List<DexpiConnectionInfo> connections;
     private final List<DexpiConnectionEndpointInfo> connectionEndpoints;
     private final List<DexpiConnectionComponentInfo> connectionComponents;
+    private final List<DexpiConnectionCycleInfo> connectionCycles;
     private final List<ImportDiagnostic> diagnostics;
 
     private ImportResult(ProcessSystem processSystem, List<DexpiInstrumentInfo> instruments,
         List<DexpiConnectionInfo> connections, List<DexpiConnectionEndpointInfo> connectionEndpoints,
-        List<DexpiConnectionComponentInfo> connectionComponents, List<ImportDiagnostic> diagnostics) {
+        List<DexpiConnectionComponentInfo> connectionComponents,
+        List<DexpiConnectionCycleInfo> connectionCycles, List<ImportDiagnostic> diagnostics) {
       this.processSystem = processSystem;
       this.instruments = Collections.unmodifiableList(new ArrayList<DexpiInstrumentInfo>(instruments));
       this.connections = Collections.unmodifiableList(new ArrayList<DexpiConnectionInfo>(connections));
@@ -145,6 +147,8 @@ public final class DexpiXmlReader {
           .unmodifiableList(new ArrayList<DexpiConnectionEndpointInfo>(connectionEndpoints));
       this.connectionComponents = Collections
           .unmodifiableList(new ArrayList<DexpiConnectionComponentInfo>(connectionComponents));
+      this.connectionCycles = Collections
+          .unmodifiableList(new ArrayList<DexpiConnectionCycleInfo>(connectionCycles));
       this.diagnostics = Collections.unmodifiableList(new ArrayList<ImportDiagnostic>(diagnostics));
     }
 
@@ -203,6 +207,21 @@ public final class DexpiXmlReader {
       return connectionComponents;
     }
 
+    /**
+     * Returns directed strongly connected groups from explicit non-empty material-connection references.
+     *
+     * <p>
+     * A group is included when it contains more than one endpoint, or when a single endpoint has an explicit
+     * self-reference. This is source evidence only and does not establish a hydraulic recycle, process intent,
+     * convergence behavior, or live process topology.
+     * </p>
+     *
+     * @return immutable directed-cycle evidence in first-endpoint order
+     */
+    public List<DexpiConnectionCycleInfo> getConnectionCycles() {
+      return connectionCycles;
+    }
+
     /** @return immutable diagnostics in deterministic source-document order */
     public List<ImportDiagnostic> getDiagnostics() {
       return diagnostics;
@@ -253,6 +272,12 @@ public final class DexpiXmlReader {
         componentMaps.add(component.toMap());
       }
       result.put("connectionComponents", componentMaps);
+      result.put("connectionCycleCount", Integer.valueOf(connectionCycles.size()));
+      List<Map<String, Object>> cycleMaps = new ArrayList<Map<String, Object>>();
+      for (DexpiConnectionCycleInfo cycle : connectionCycles) {
+        cycleMaps.add(cycle.toMap());
+      }
+      result.put("connectionCycles", cycleMaps);
       result.put("hasLosses", Boolean.valueOf(hasLosses()));
       result.put("hasErrors", Boolean.valueOf(hasErrors()));
       List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
@@ -448,8 +473,12 @@ public final class DexpiXmlReader {
     List<ImportDiagnostic> diagnostics = new ArrayList<ImportDiagnostic>();
     loadInternal(inputStream, processSystem, templateStream, false, diagnostics, instruments, connections);
     List<DexpiConnectionEndpointInfo> connectionEndpoints = summarizeConnectionEndpoints(connections);
-    return new ImportResult(processSystem, instruments, connections, connectionEndpoints,
-        summarizeConnectionComponents(connections, connectionEndpoints), diagnostics);
+    List<DexpiConnectionComponentInfo> connectionComponents =
+        summarizeConnectionComponents(connections, connectionEndpoints);
+    List<DexpiConnectionCycleInfo> connectionCycles =
+        summarizeConnectionCycles(connections, connectionEndpoints, connectionComponents);
+    return new ImportResult(processSystem, instruments, connections, connectionEndpoints, connectionComponents,
+        connectionCycles, diagnostics);
   }
 
   /**
@@ -876,6 +905,173 @@ public final class DexpiXmlReader {
       result.add(component.toInfo());
     }
     return result;
+  }
+
+  private static List<DexpiConnectionCycleInfo> summarizeConnectionCycles(
+      List<DexpiConnectionInfo> connections, List<DexpiConnectionEndpointInfo> connectionEndpoints,
+      List<DexpiConnectionComponentInfo> connectionComponents) {
+    Map<String, List<String>> outgoingEndpointIds = new LinkedHashMap<String, List<String>>();
+    Map<String, List<String>> incomingEndpointIds = new LinkedHashMap<String, List<String>>();
+    for (DexpiConnectionEndpointInfo endpoint : connectionEndpoints) {
+      outgoingEndpointIds.put(endpoint.getEndpointId(), new ArrayList<String>());
+      incomingEndpointIds.put(endpoint.getEndpointId(), new ArrayList<String>());
+    }
+    for (DexpiConnectionInfo connection : connections) {
+      String fromId = connection.getFromId();
+      String toId = connection.getToId();
+      if (!isBlank(fromId) && !isBlank(toId)) {
+        outgoingEndpointIds.get(fromId).add(toId);
+        incomingEndpointIds.get(toId).add(fromId);
+      }
+    }
+
+    Set<String> visitedEndpointIds = new HashSet<String>();
+    List<String> finishOrder = new ArrayList<String>();
+    for (DexpiConnectionEndpointInfo endpoint : connectionEndpoints) {
+      String startId = endpoint.getEndpointId();
+      if (visitedEndpointIds.contains(startId)) {
+        continue;
+      }
+      List<String> endpointStack = new ArrayList<String>();
+      List<Integer> nextAdjacentIndexStack = new ArrayList<Integer>();
+      endpointStack.add(startId);
+      nextAdjacentIndexStack.add(Integer.valueOf(0));
+      visitedEndpointIds.add(startId);
+      while (!endpointStack.isEmpty()) {
+        int stackIndex = endpointStack.size() - 1;
+        String endpointId = endpointStack.get(stackIndex);
+        int nextAdjacentIndex = nextAdjacentIndexStack.get(stackIndex).intValue();
+        List<String> adjacentEndpointIds = outgoingEndpointIds.get(endpointId);
+        if (nextAdjacentIndex < adjacentEndpointIds.size()) {
+          String adjacentEndpointId = adjacentEndpointIds.get(nextAdjacentIndex);
+          nextAdjacentIndexStack.set(stackIndex, Integer.valueOf(nextAdjacentIndex + 1));
+          if (!visitedEndpointIds.contains(adjacentEndpointId)) {
+            visitedEndpointIds.add(adjacentEndpointId);
+            endpointStack.add(adjacentEndpointId);
+            nextAdjacentIndexStack.add(Integer.valueOf(0));
+          }
+        } else {
+          endpointStack.remove(stackIndex);
+          nextAdjacentIndexStack.remove(stackIndex);
+          finishOrder.add(endpointId);
+        }
+      }
+    }
+
+    visitedEndpointIds.clear();
+    List<Set<String>> cyclicStrongComponents = new ArrayList<Set<String>>();
+    Map<String, Integer> cyclicComponentByEndpointId = new HashMap<String, Integer>();
+    for (int finishIndex = finishOrder.size() - 1; finishIndex >= 0; finishIndex--) {
+      String startId = finishOrder.get(finishIndex);
+      if (visitedEndpointIds.contains(startId)) {
+        continue;
+      }
+      Set<String> strongComponentEndpointIds = new HashSet<String>();
+      List<String> pendingEndpointIds = new ArrayList<String>();
+      pendingEndpointIds.add(startId);
+      visitedEndpointIds.add(startId);
+      for (int pendingIndex = 0; pendingIndex < pendingEndpointIds.size(); pendingIndex++) {
+        String endpointId = pendingEndpointIds.get(pendingIndex);
+        strongComponentEndpointIds.add(endpointId);
+        for (String adjacentEndpointId : incomingEndpointIds.get(endpointId)) {
+          if (!visitedEndpointIds.contains(adjacentEndpointId)) {
+            visitedEndpointIds.add(adjacentEndpointId);
+            pendingEndpointIds.add(adjacentEndpointId);
+          }
+        }
+      }
+
+      boolean cyclic = strongComponentEndpointIds.size() > 1;
+      if (!cyclic) {
+        String endpointId = strongComponentEndpointIds.iterator().next();
+        for (String adjacentEndpointId : outgoingEndpointIds.get(endpointId)) {
+          if (endpointId.equals(adjacentEndpointId)) {
+            cyclic = true;
+            break;
+          }
+        }
+      }
+      if (cyclic) {
+        int cyclicComponentIndex = cyclicStrongComponents.size();
+        cyclicStrongComponents.add(strongComponentEndpointIds);
+        for (String endpointId : strongComponentEndpointIds) {
+          cyclicComponentByEndpointId.put(endpointId, Integer.valueOf(cyclicComponentIndex));
+        }
+      }
+    }
+
+    Map<String, String> connectionComponentByEndpointId = new HashMap<String, String>();
+    for (DexpiConnectionComponentInfo component : connectionComponents) {
+      for (String endpointId : component.getEndpointIds()) {
+        connectionComponentByEndpointId.put(endpointId, component.getId());
+      }
+    }
+
+    List<ConnectionCycleAccumulator> cycles = new ArrayList<ConnectionCycleAccumulator>();
+    Map<Integer, Integer> cycleByStrongComponent = new HashMap<Integer, Integer>();
+    Map<String, Integer> cycleByEndpointId = new HashMap<String, Integer>();
+    for (DexpiConnectionEndpointInfo endpoint : connectionEndpoints) {
+      Integer strongComponentIndex = cyclicComponentByEndpointId.get(endpoint.getEndpointId());
+      if (strongComponentIndex == null) {
+        continue;
+      }
+      Integer cycleIndex = cycleByStrongComponent.get(strongComponentIndex);
+      if (cycleIndex == null) {
+        cycleIndex = Integer.valueOf(cycles.size());
+        cycleByStrongComponent.put(strongComponentIndex, cycleIndex);
+        cycles.add(new ConnectionCycleAccumulator("cycle-" + (cycleIndex.intValue() + 1),
+            connectionComponentByEndpointId.get(endpoint.getEndpointId())));
+      }
+      cycles.get(cycleIndex.intValue()).addEndpoint(endpoint);
+      cycleByEndpointId.put(endpoint.getEndpointId(), cycleIndex);
+    }
+
+    for (DexpiConnectionInfo connection : connections) {
+      Integer fromCycleIndex = cycleByEndpointId.get(connection.getFromId());
+      Integer toCycleIndex = cycleByEndpointId.get(connection.getToId());
+      if (fromCycleIndex != null && fromCycleIndex.equals(toCycleIndex)) {
+        cycles.get(fromCycleIndex.intValue()).addConnection(connection);
+      }
+    }
+
+    List<DexpiConnectionCycleInfo> result = new ArrayList<DexpiConnectionCycleInfo>();
+    for (ConnectionCycleAccumulator cycle : cycles) {
+      result.add(cycle.toInfo());
+    }
+    return result;
+  }
+
+  private static final class ConnectionCycleAccumulator {
+    private final String id;
+    private final String connectionComponentId;
+    private final List<String> endpointIds = new ArrayList<String>();
+    private final List<String> connectionIds = new ArrayList<String>();
+    private final List<String> unresolvedEndpointIds = new ArrayList<String>();
+    private boolean selfReference;
+
+    private ConnectionCycleAccumulator(String id, String connectionComponentId) {
+      this.id = id;
+      this.connectionComponentId = connectionComponentId;
+    }
+
+    private void addEndpoint(DexpiConnectionEndpointInfo endpoint) {
+      endpointIds.add(endpoint.getEndpointId());
+      if (!endpoint.isResolved()) {
+        unresolvedEndpointIds.add(endpoint.getEndpointId());
+      }
+    }
+
+    private void addConnection(DexpiConnectionInfo connection) {
+      connectionIds.add(connection.getId());
+      if (connection.getFromId().equals(connection.getToId())) {
+        selfReference = true;
+      }
+    }
+
+    private DexpiConnectionCycleInfo toInfo() {
+      return new DexpiConnectionCycleInfo(id, connectionComponentId, endpointIds, connectionIds,
+          unresolvedEndpointIds, selfReference);
+    }
   }
 
   private static final class ConnectionComponentAccumulator {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -138,8 +138,8 @@ public final class DexpiXmlReader {
 
     private ImportResult(ProcessSystem processSystem, List<DexpiInstrumentInfo> instruments,
         List<DexpiConnectionInfo> connections, List<DexpiConnectionEndpointInfo> connectionEndpoints,
-        List<DexpiConnectionComponentInfo> connectionComponents,
-        List<DexpiConnectionCycleInfo> connectionCycles, List<ImportDiagnostic> diagnostics) {
+        List<DexpiConnectionComponentInfo> connectionComponents, List<DexpiConnectionCycleInfo> connectionCycles,
+        List<ImportDiagnostic> diagnostics) {
       this.processSystem = processSystem;
       this.instruments = Collections.unmodifiableList(new ArrayList<DexpiInstrumentInfo>(instruments));
       this.connections = Collections.unmodifiableList(new ArrayList<DexpiConnectionInfo>(connections));
@@ -147,8 +147,7 @@ public final class DexpiXmlReader {
           .unmodifiableList(new ArrayList<DexpiConnectionEndpointInfo>(connectionEndpoints));
       this.connectionComponents = Collections
           .unmodifiableList(new ArrayList<DexpiConnectionComponentInfo>(connectionComponents));
-      this.connectionCycles = Collections
-          .unmodifiableList(new ArrayList<DexpiConnectionCycleInfo>(connectionCycles));
+      this.connectionCycles = Collections.unmodifiableList(new ArrayList<DexpiConnectionCycleInfo>(connectionCycles));
       this.diagnostics = Collections.unmodifiableList(new ArrayList<ImportDiagnostic>(diagnostics));
     }
 
@@ -473,10 +472,10 @@ public final class DexpiXmlReader {
     List<ImportDiagnostic> diagnostics = new ArrayList<ImportDiagnostic>();
     loadInternal(inputStream, processSystem, templateStream, false, diagnostics, instruments, connections);
     List<DexpiConnectionEndpointInfo> connectionEndpoints = summarizeConnectionEndpoints(connections);
-    List<DexpiConnectionComponentInfo> connectionComponents =
-        summarizeConnectionComponents(connections, connectionEndpoints);
-    List<DexpiConnectionCycleInfo> connectionCycles =
-        summarizeConnectionCycles(connections, connectionEndpoints, connectionComponents);
+    List<DexpiConnectionComponentInfo> connectionComponents = summarizeConnectionComponents(connections,
+        connectionEndpoints);
+    List<DexpiConnectionCycleInfo> connectionCycles = summarizeConnectionCycles(connections, connectionEndpoints,
+        connectionComponents);
     return new ImportResult(processSystem, instruments, connections, connectionEndpoints, connectionComponents,
         connectionCycles, diagnostics);
   }
@@ -907,9 +906,8 @@ public final class DexpiXmlReader {
     return result;
   }
 
-  private static List<DexpiConnectionCycleInfo> summarizeConnectionCycles(
-      List<DexpiConnectionInfo> connections, List<DexpiConnectionEndpointInfo> connectionEndpoints,
-      List<DexpiConnectionComponentInfo> connectionComponents) {
+  private static List<DexpiConnectionCycleInfo> summarizeConnectionCycles(List<DexpiConnectionInfo> connections,
+      List<DexpiConnectionEndpointInfo> connectionEndpoints, List<DexpiConnectionComponentInfo> connectionComponents) {
     Map<String, List<String>> outgoingEndpointIds = new LinkedHashMap<String, List<String>>();
     Map<String, List<String>> incomingEndpointIds = new LinkedHashMap<String, List<String>>();
     for (DexpiConnectionEndpointInfo endpoint : connectionEndpoints) {
@@ -1069,8 +1067,8 @@ public final class DexpiXmlReader {
     }
 
     private DexpiConnectionCycleInfo toInfo() {
-      return new DexpiConnectionCycleInfo(id, connectionComponentId, endpointIds, connectionIds,
-          unresolvedEndpointIds, selfReference);
+      return new DexpiConnectionCycleInfo(id, connectionComponentId, endpointIds, connectionIds, unresolvedEndpointIds,
+          selfReference);
     }
   }
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -544,6 +544,85 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(first.toJson(), second.toJson());
   }
 
+  @Test
+  public void testReadWithDiagnosticsSummarizesDirectedConnectionCycles() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
+        + "<Equipment ID=\"E-A\"><Nozzle ID=\"N-A\"/></Equipment>"
+        + "<Equipment ID=\"E-B\"><Nozzle ID=\"N-B\"/></Equipment>"
+        + "<Equipment ID=\"E-C\"><Nozzle ID=\"N-C\"/></Equipment>"
+        + "<Equipment ID=\"E-X\"><Nozzle ID=\"N-X\"/></Equipment>"
+        + "<Equipment ID=\"E-Y\"><Nozzle ID=\"N-Y\"/></Equipment>"
+        + "<Equipment ID=\"E-Z\"><Nozzle ID=\"N-Z\"/></Equipment>"
+        + "<Equipment ID=\"E-P\"><Nozzle ID=\"N-P\"/></Equipment>"
+        + "<Equipment ID=\"E-Q\"><Nozzle ID=\"N-Q\"/></Equipment>"
+        + "<Equipment ID=\"E-S\"><Nozzle ID=\"N-S\"/></Equipment>"
+        + "<PipingNetworkSegment ID=\"S-1\"><Connection ID=\"C-1\" FromID=\"N-A\" ToID=\"N-B\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-2\"><Connection ID=\"C-2\" FromID=\"N-B\" ToID=\"N-C\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-3\"><Connection ID=\"C-3\" FromID=\"N-X\" ToID=\"N-Y\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-3P\"><Connection ID=\"C-3P\" FromID=\"N-X\" ToID=\"N-Y\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-4\"><Connection ID=\"C-4\" FromID=\"N-Y\" ToID=\"N-Z\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-5\"><Connection ID=\"C-5\" FromID=\"N-Z\" ToID=\"N-X\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-6\"><Connection ID=\"C-6\" FromID=\"N-P\" ToID=\"N-Q\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-7\"><Connection ID=\"C-7\" FromID=\"N-P\" ToID=\"N-Q\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-8\"><Connection ID=\"C-8\" FromID=\"N-S\" ToID=\"N-S\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-9\"><Connection ID=\"C-9\" FromID=\"UNKNOWN-1\" ToID=\"UNKNOWN-2\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-10\"><Connection ID=\"C-10\" FromID=\"UNKNOWN-2\" ToID=\"UNKNOWN-1\"/>"
+        + "</PipingNetworkSegment>" + "</PlantModel>";
+
+    DexpiXmlReader.ImportResult first = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    DexpiXmlReader.ImportResult second = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+    assertEquals(11, first.getConnections().size());
+    assertEquals(11, first.getConnectionEndpoints().size());
+    assertEquals(5, first.getConnectionComponents().size());
+    assertEquals(3, first.getConnectionCycles().size());
+
+    DexpiConnectionCycleInfo threeEndpointCycle = first.getConnectionCycles().get(0);
+    assertEquals("cycle-1", threeEndpointCycle.getId());
+    assertEquals("component-2", threeEndpointCycle.getConnectionComponentId());
+    assertEquals(Arrays.asList("N-X", "N-Y", "N-Z"), threeEndpointCycle.getEndpointIds());
+    assertEquals(Arrays.asList("C-3", "C-3P", "C-4", "C-5"), threeEndpointCycle.getConnectionIds());
+    assertEquals(3, threeEndpointCycle.getEndpointCount());
+    assertEquals(4, threeEndpointCycle.getConnectionCount());
+    assertFalse(threeEndpointCycle.hasSelfReference());
+    assertFalse(threeEndpointCycle.hasUnresolvedEndpoints());
+
+    DexpiConnectionCycleInfo selfReference = first.getConnectionCycles().get(1);
+    assertEquals("cycle-2", selfReference.getId());
+    assertEquals("component-4", selfReference.getConnectionComponentId());
+    assertEquals(Collections.singletonList("N-S"), selfReference.getEndpointIds());
+    assertEquals(Collections.singletonList("C-8"), selfReference.getConnectionIds());
+    assertTrue(selfReference.hasSelfReference());
+
+    DexpiConnectionCycleInfo unresolved = first.getConnectionCycles().get(2);
+    assertEquals("cycle-3", unresolved.getId());
+    assertEquals("component-5", unresolved.getConnectionComponentId());
+    assertEquals(Arrays.asList("UNKNOWN-1", "UNKNOWN-2"), unresolved.getEndpointIds());
+    assertEquals(Arrays.asList("C-9", "C-10"), unresolved.getConnectionIds());
+    assertEquals(Arrays.asList("UNKNOWN-1", "UNKNOWN-2"), unresolved.getUnresolvedEndpointIds());
+    assertTrue(unresolved.hasUnresolvedEndpoints());
+
+    assertFalse(first.getConnectionCycles().toString().contains("N-P"));
+    assertThrows(UnsupportedOperationException.class, () -> threeEndpointCycle.getEndpointIds().clear());
+    assertThrows(UnsupportedOperationException.class, () -> first.getConnectionCycles().clear());
+    assertTrue(first.toJson().contains("\"connectionCycleCount\": 3"));
+    assertTrue(first.toJson().contains("\"connectionComponentId\": \"component-4\""));
+    assertTrue(first.toJson().contains("\"selfReference\": true"));
+    assertEquals(first.toJson(), second.toJson());
+  }
+
   private static int countDiagnostics(DexpiXmlReader.ImportResult result, String expectedCode) {
     int count = 0;
     for (DexpiXmlReader.ImportDiagnostic diagnostic : result.getDiagnostics()) {

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -614,7 +614,10 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(Arrays.asList("UNKNOWN-1", "UNKNOWN-2"), unresolved.getUnresolvedEndpointIds());
     assertTrue(unresolved.hasUnresolvedEndpoints());
 
-    assertFalse(first.getConnectionCycles().toString().contains("N-P"));
+    for (DexpiConnectionCycleInfo cycle : first.getConnectionCycles()) {
+      assertFalse(cycle.getEndpointIds().contains("N-P"));
+      assertFalse(cycle.getEndpointIds().contains("N-Q"));
+    }
     assertThrows(UnsupportedOperationException.class, () -> threeEndpointCycle.getEndpointIds().clear());
     assertThrows(UnsupportedOperationException.class, () -> first.getConnectionCycles().clear());
     assertTrue(first.toJson().contains("\"connectionCycleCount\": 3"));


### PR DESCRIPTION
## Capability contract

Roadmap capability: directed-cycle reference evidence for the Proteus-compatible DEXPI Plant/P&ID 4.1.1 supported subset.

- Contract recorded in #1332 and #2899.
- Exact base: `c7068cece4fc3583799743a1cd098948124b0aab`
- Exact publication head: `171f6efe0a7fced509bf79fc7015baec4c2eb8ea`
- Shared #1332/#2899 lane was free before publication.
- Autonomous implementation portfolio: 1/10.

## Engineering question

Can the reader expose deterministic cyclic groups in the explicit directed material-reference graph without claiming that those groups are physical or hydraulic recycles?

## Change

- Adds immutable `DexpiConnectionCycleInfo` evidence.
- Finds strongly connected endpoint groups in O(V+E).
- Reports multi-endpoint SCCs and singleton explicit self-references.
- Orders groups by first endpoint, endpoints by first reference, and internal connections by source order.
- Preserves parallel connection occurrences and unresolved non-empty endpoint IDs.
- Links each cycle group to its owning weak connection-component evidence.
- Adds deterministic JSON, Java/JPype documentation, and focused regression coverage.

## Validation scope

Focused tests cover:

- an acyclic directed chain;
- a three-endpoint cycle with an internal parallel occurrence;
- parallel one-way references that must not become a cycle;
- an explicit self-reference;
- an unresolved two-endpoint cycle;
- immutable evidence and deterministic JSON.

Hosted workflows are authoritative. The first run identified only the branch-attributable Spotless repair; the exact hosted patch was applied without behavior or scope changes. Status: **VALIDATION PENDING CI**.

## Safety and standards boundaries

This is source-graph evidence only. It does not enumerate elementary cycles, solve paths, infer a hydraulic recycle, assert convergence, repair or rewire topology, infer fittings, or change simulation, layout, rendering, geometry, or export behavior.

Visual whole-sheet gate: **N/A** because no rendering or geometry path changes.

No native DEXPI 2.0, ISO/ISA standards-conformance, DEXPI certification, engineering-approval, Huldra, or external-dataset claim is made.

Draft only. Do not merge or mark ready as part of the autonomous campaign.