### PR TITLE
[AI-Assisted] feat(dynamics): close built-in capability audit

### DIFF
--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-dynamic-simulation
 description: "Dynamic simulation guidance for NeqSim. USE WHEN: running transient simulations, modeling startup/shutdown, tuning PID controllers, analyzing pressure/level dynamics, performing blowdown/depressurization, or setting up measurement devices and control loops. Covers runTransient, DynamicProcessHelper, controller tuning, and dynamic equipment configuration."
-last_verified: "2026-08-31"
+last_verified: "2026-09-01"
 ---
 
 # Dynamic Simulation Guidance
@@ -619,6 +619,26 @@ TransferFunctionBlock leadLag = new TransferFunctionBlock();
 ```
 
 ## Common Pitfalls
+
+Before relying on a mixed transient flowsheet, inspect its state-ownership inventory separately from runtime activation
+and physics qualification:
+
+```java
+neqsim.process.dynamics.DynamicCapabilityReport report =
+    neqsim.process.dynamics.DynamicCapabilityReport.from(process);
+if (!report.isFullyAudited()) {
+  throw new IllegalStateException(report.getReviewItems().toString());
+}
+report.assertStrictTransientReady();
+```
+
+All built-in process-element declarations of `runTransient(double, UUID)` are mapped, and CI rejects a new built-in
+override unless it is classified or cites an explicit repository ADR. Custom/downstream overrides remain
+`UNCLASSIFIED_DYNAMIC` until reviewed. `isFullyAudited()` is an inventory signal only: it does not certify numerical
+stability, conservation, benchmark parity, controls performance, or safety suitability. In particular,
+`PipeBeggsAndBrills` has distributed profile state but no conservative line-pack/storage term; do not use its capability
+label to claim severe-slugging or liquid-rich transient validity. Route those studies to the qualified `TwoFluidPipe`
+path and apply the relevant numerical and public-benchmark gates.
 
 1. **Always run steady state first**: Call `process.run()` before `runTransient()`
 2. **Timestep size**: Start with 1.0 s, reduce if oscillating (0.1-0.5 s)

--- a/docs/process/dynamic-capability-contract.md
+++ b/docs/process/dynamic-capability-contract.md
@@ -38,6 +38,7 @@ report.getActivationCounts();
 report.getExecutionIssues();
 report.getBlockingIssues();
 report.getReviewItems();
+report.isFullyAudited();
 report.getUnverifiedActivationElements();
 report.getInactiveAuditedDynamicElements();
 String json = report.toJson();
@@ -257,18 +258,43 @@ the report as a complete nested-unit inventory.
 Identity-based de-duplication prevents the same process element or nested `ProcessSystem` object from being counted
 repeatedly and prevents accidental recursive container cycles from causing unbounded traversal.
 
-## Initial audited mapping
+## Built-in audited mapping
 
-The initial contract intentionally classifies only core implementations whose current source contains clear stored-state
-semantics:
+Every built-in `ProcessElementInterface` class that declares the standard two-argument `runTransient(double, UUID)`
+boundary has an audited state-ownership category:
 
-- algebraic: standard `Stream` execution, composite module containers, `EnergyNetworkSolver`, ISO-5167 `Orifice`, and
-  `WellFlow` IPR pressure-flow relations;
-- lumped: separators, tanks, two-stream heat exchangers, compressors/expanders, pumps, throttling/control valves,
-  `EnergyConverter`-based motors/generators/gearboxes/inverters/transformers, and `BatteryStorage`;
-- distributed: `OnePhasePipeLine`, `TwoFluidPipe`, drift-flux `TransientPipe`, and `WaterHammerPipe`;
-- boundary: `SimpleReservoir`;
+- algebraic: standard `Stream` execution, composite module containers, `EnergyNetworkSolver`, ISO-5167 `Orifice`,
+  `WellFlow` IPR pressure-flow relations, `Heater`, `Mixer`, `Splitter`, `MembraneSeparator`, and the quasi-steady
+  `AdiabaticPipe`;
+- lumped: separators, tanks and `VesselDepressurization`, two-stream heat exchangers, compressors/expanders, pumps,
+  throttling/control/safety valves, `EnergyConverter` families, `BatteryStorage`, `Filter`,
+  `CommittedEnergyGenerator`, and `Electrolyzer`;
+- distributed: `OnePhasePipeLine`, `TwoFluidPipe`, drift-flux `TransientPipe`, `WaterHammerPipe`, the generic
+  `Pipeline` family (including `MultiphasePipe` and `PipeBeggsAndBrills`), `DistillationColumn`, `AdsorptionBed`,
+  `MercuryRemovalBed`, `PipeFlowNetwork`, and `WellFlowlineNetwork`;
+- boundary: `SimpleReservoir` and `IronSulfideOxidationSource`;
 - control: registered controllers and measurement devices.
+
+`DynamicCapabilityReport.isFullyAudited()` is true when a concrete report contains no
+`UNCLASSIFIED_DYNAMIC` entries. It is intentionally separate from `isStrictPreflightReady()`: a fully classified
+inventory can still have an unsupported runtime request, incomplete activation, unsafe execution mode, or inadequate
+numerical/benchmark evidence.
+
+### Built-in source-inventory CI gate
+
+`DynamicCapabilityBuiltInInventoryTest` scans production process sources for declarations of the standard transient
+boundary. A new built-in `ProcessElementInterface` override fails CI unless its declaring class has an explicit mapping
+in `DynamicCapabilityResolver` or cites an existing repository-relative Markdown ADR in the resolver's exemption
+registry. The WS6 closure has no ADR exemptions. A user or downstream subclass that overrides an audited built-in method
+still resolves fail-closed to `UNCLASSIFIED_DYNAMIC`; a subclass that merely inherits the built-in method inherits its
+audited category.
+
+An audit category states what kind of state the implementation owns. It does **not** establish conservation,
+timestep/mesh independence, transient stability, benchmark parity, restart, rollback, controls, or safety maturity.
+In particular, `PipeBeggsAndBrills` owns spatially distributed transient profile state but has no conservative
+mass-storage/line-pack term. Its distributed category must not be used as evidence for severe slugging, liquid-rich
+transients, line pack, or another storage-driven claim; route those studies to the separately qualified `TwoFluidPipe`
+path and apply the relevant numerical and public-benchmark gates.
 
 The `OnePhasePipeLine` distributed classification is supported by merged ProcessSystem-level quantitative evidence for
 the conservative one-phase, positive-flow finite-volume path: the pipeline owns spatial hydraulic/species state,
@@ -305,9 +331,9 @@ clock contract. `Orifice` is a custom pressure-driven transient relation, but st
 relation is re-evaluated for every requested refinement while its local execution clock and calculation ID follow the
 same A/refine-A/B physical-step contract as other algebraic equipment, including the negligible-flow early return.
 
-Other custom transient implementations remain `UNCLASSIFIED_DYNAMIC` until their state variables, conservation equations,
+Custom transient implementations remain `UNCLASSIFIED_DYNAMIC` until their state variables, conservation equations,
 initialization, timestep constraints, event behaviour, snapshot/restart semantics, and quantitative validation are
-reviewed. The mapping is expected to expand as that audit is completed.
+reviewed. Built-in exceptions require an explicit ADR and are rejected by CI when the cited document is absent.
 
 ## Event-scheduler rollback boundary
 

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityReport.java
@@ -396,6 +396,21 @@ public final class DynamicCapabilityReport implements Serializable {
   }
 
   /**
+   * Whether every element in this report has an audited capability category.
+   *
+   * <p>
+   * This predicate is deliberately narrower than {@link #isStrictPreflightReady()}. A fully audited report can still
+   * contain a runtime configuration, activation, or process-execution issue. It is an inventory-completion signal, not
+   * a numerical-validation, engineering-readiness, or safety certificate.
+   * </p>
+   *
+   * @return true when no entry is classified {@link DynamicCapability#UNCLASSIFIED_DYNAMIC}
+   */
+  public boolean isFullyAudited() {
+    return getReviewItems().isEmpty();
+  }
+
+  /**
    * Returns elements with explicit dynamic capability whose type-specific runtime activation is still unaudited.
    *
    * <p>

--- a/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
+++ b/src/main/java/neqsim/process/dynamics/DynamicCapabilityResolver.java
@@ -1,26 +1,55 @@
 package neqsim.process.dynamics;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 import neqsim.process.ProcessElementInterface;
 import neqsim.process.SimulationInterface;
 import neqsim.process.controllerdevice.ControllerDeviceInterface;
+import neqsim.process.equipment.adsorber.AdsorptionBed;
+import neqsim.process.equipment.adsorber.MercuryRemovalBed;
 import neqsim.process.equipment.battery.BatteryStorage;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.diffpressure.Orifice;
+import neqsim.process.equipment.distillation.DistillationColumn;
+import neqsim.process.equipment.electrolyzer.Electrolyzer;
+import neqsim.process.equipment.energy.CommittedEnergyGenerator;
 import neqsim.process.equipment.energy.EnergyConverter;
 import neqsim.process.equipment.energy.EnergyNetworkSolver;
+import neqsim.process.equipment.energy.Inverter;
+import neqsim.process.equipment.expander.Expander;
+import neqsim.process.equipment.filter.Filter;
 import neqsim.process.equipment.heatexchanger.HeatExchanger;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.membrane.MembraneSeparator;
+import neqsim.process.equipment.mixer.Mixer;
+import neqsim.process.equipment.network.PipeFlowNetwork;
+import neqsim.process.equipment.network.WellFlowlineNetwork;
+import neqsim.process.equipment.pipeline.AdiabaticPipe;
+import neqsim.process.equipment.pipeline.MultiphasePipe;
 import neqsim.process.equipment.pipeline.OnePhasePipeLine;
+import neqsim.process.equipment.pipeline.PipeBeggsAndBrills;
+import neqsim.process.equipment.pipeline.Pipeline;
 import neqsim.process.equipment.pipeline.TwoFluidPipe;
 import neqsim.process.equipment.pipeline.WaterHammerPipe;
 import neqsim.process.equipment.pipeline.twophasepipe.TransientPipe;
 import neqsim.process.equipment.pump.Pump;
+import neqsim.process.equipment.reactor.IronSulfideOxidationSource;
 import neqsim.process.equipment.reservoir.SimpleReservoir;
 import neqsim.process.equipment.reservoir.WellFlow;
 import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.separator.ThreePhaseSeparator;
+import neqsim.process.equipment.splitter.Splitter;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.tank.Tank;
+import neqsim.process.equipment.tank.VesselDepressurization;
+import neqsim.process.equipment.valve.BlowdownValve;
+import neqsim.process.equipment.valve.ESDValve;
+import neqsim.process.equipment.valve.HIPPSValve;
+import neqsim.process.equipment.valve.PSDValve;
+import neqsim.process.equipment.valve.RuptureDisk;
+import neqsim.process.equipment.valve.SafetyValve;
 import neqsim.process.equipment.valve.ThrottlingValve;
 import neqsim.process.measurementdevice.MeasurementDeviceInterface;
 import neqsim.process.processmodel.ModuleInterface;
@@ -38,9 +67,19 @@ import neqsim.process.processmodel.ModuleInterface;
  * </p>
  *
  * @author Even Solbraa
- * @version 1.0
+ * @version 1.1
  */
 public final class DynamicCapabilityResolver {
+  /**
+   * Explicit ADR exemptions for built-in transient implementations that intentionally remain unclassified.
+   *
+   * <p>
+   * Entries must map a declaring class to an existing repository-relative Markdown ADR. The source-inventory test
+   * rejects absent files. There are no exemptions after the WS6 audit closure.
+   * </p>
+   */
+  private static final Map<Class<?>, String> UNCLASSIFIED_BUILT_IN_ADRS = Collections.emptyMap();
+
   /** Utility class. */
   private DynamicCapabilityResolver() {
   }
@@ -64,30 +103,13 @@ public final class DynamicCapabilityResolver {
       return DynamicCapability.ALGEBRAIC;
     }
 
-    if (element instanceof EnergyNetworkSolver || element instanceof Orifice || element instanceof WellFlow) {
-      return DynamicCapability.ALGEBRAIC;
+    Class<?> transientOwner = getTransientImplementationClass(element);
+    DynamicCapability audited = resolveAuditedBuiltInClass(transientOwner);
+    if (audited != null) {
+      return audited;
     }
 
-    if (element instanceof OnePhasePipeLine || element instanceof TwoFluidPipe || element instanceof TransientPipe
-        || element instanceof WaterHammerPipe) {
-      return DynamicCapability.DYNAMIC_DISTRIBUTED;
-    }
-
-    if (element instanceof SimpleReservoir) {
-      return DynamicCapability.BOUNDARY_DYNAMIC;
-    }
-
-    if (element instanceof Separator || element instanceof Tank || element instanceof HeatExchanger
-        || element instanceof Compressor || element instanceof Pump || element instanceof ThrottlingValve
-        || element instanceof EnergyConverter || element instanceof BatteryStorage) {
-      return DynamicCapability.DYNAMIC_LUMPED;
-    }
-
-    if (element instanceof Stream && usesStandardStreamTransientBoundary(element)) {
-      return DynamicCapability.ALGEBRAIC;
-    }
-
-    if (hasCustomTransientImplementation(element)) {
+    if (transientOwner != null && transientOwner != SimulationInterface.class) {
       return DynamicCapability.UNCLASSIFIED_DYNAMIC;
     }
 
@@ -95,26 +117,75 @@ public final class DynamicCapabilityResolver {
   }
 
   /**
-   * Whether a stream uses NeqSim's established algebraic transient boundary.
+   * Resolve one built-in class that declares the standard two-argument transient boundary.
    *
    * <p>
-   * {@link Stream#runTransient(double, UUID)} re-evaluates the stream and advances its execution clock, but it does not
-   * integrate stored physical state. Stream subclasses that inherit that method remain algebraic; subclasses that
-   * override it continue through the conservative custom-implementation audit below.
+   * Classification is based on the class that declares the effective method, not merely the runtime subtype. A custom
+   * subclass that inherits an audited built-in implementation keeps that implementation's category. A subclass that
+   * overrides the method becomes {@link DynamicCapability#UNCLASSIFIED_DYNAMIC} until its own implementation is
+   * audited.
    * </p>
    *
-   * @param element stream element to inspect
-   * @return true when the effective transient method is declared by {@link Stream}
+   * @param type class declaring {@code runTransient(double, UUID)}
+   * @return audited capability, or null when the declaring class has no audit mapping
    */
-  private static boolean usesStandardStreamTransientBoundary(ProcessElementInterface element) {
-    try {
-      Method method = element.getClass().getMethod("runTransient", Double.TYPE, UUID.class);
-      return method.getDeclaringClass() == Stream.class;
-    } catch (NoSuchMethodException ex) {
-      return false;
-    } catch (SecurityException ex) {
-      return false;
+  static DynamicCapability resolveAuditedBuiltInClass(Class<?> type) {
+    if (type == null) {
+      return null;
     }
+
+    if (ControllerDeviceInterface.class.isAssignableFrom(type)
+        || MeasurementDeviceInterface.class.isAssignableFrom(type)) {
+      return DynamicCapability.CONTROL_DYNAMIC;
+    }
+
+    if (ModuleInterface.class.isAssignableFrom(type)) {
+      return DynamicCapability.ALGEBRAIC;
+    }
+
+    if (isOneOf(type, EnergyNetworkSolver.class, Orifice.class, WellFlow.class, Stream.class, Heater.class, Mixer.class,
+        Splitter.class, MembraneSeparator.class, AdiabaticPipe.class)) {
+      return DynamicCapability.ALGEBRAIC;
+    }
+
+    if (isOneOf(type, Separator.class, ThreePhaseSeparator.class, Tank.class, VesselDepressurization.class,
+        HeatExchanger.class, Compressor.class, Expander.class, Pump.class, ThrottlingValve.class, BlowdownValve.class,
+        ESDValve.class, HIPPSValve.class, PSDValve.class, RuptureDisk.class, SafetyValve.class, EnergyConverter.class,
+        Inverter.class, BatteryStorage.class, Filter.class, CommittedEnergyGenerator.class, Electrolyzer.class)) {
+      return DynamicCapability.DYNAMIC_LUMPED;
+    }
+
+    if (isOneOf(type, OnePhasePipeLine.class, TwoFluidPipe.class, TransientPipe.class, WaterHammerPipe.class,
+        Pipeline.class, MultiphasePipe.class, PipeBeggsAndBrills.class, DistillationColumn.class, AdsorptionBed.class,
+        MercuryRemovalBed.class, PipeFlowNetwork.class, WellFlowlineNetwork.class)) {
+      return DynamicCapability.DYNAMIC_DISTRIBUTED;
+    }
+
+    if (isOneOf(type, SimpleReservoir.class, IronSulfideOxidationSource.class)) {
+      return DynamicCapability.BOUNDARY_DYNAMIC;
+    }
+
+    return null;
+  }
+
+  /**
+   * Repository ADR for an intentionally unclassified built-in transient implementation.
+   *
+   * @param type class declaring the transient implementation
+   * @return repository-relative Markdown path, or null when no exemption is recorded
+   */
+  static String getUnclassifiedBuiltInAdr(Class<?> type) {
+    return UNCLASSIFIED_BUILT_IN_ADRS.get(type);
+  }
+
+  /** Compare a class against a compact exact-class inventory. */
+  private static boolean isOneOf(Class<?> type, Class<?>... candidates) {
+    for (Class<?> candidate : candidates) {
+      if (type == candidate) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -133,13 +204,24 @@ public final class DynamicCapabilityResolver {
     if (!(element instanceof SimulationInterface)) {
       return false;
     }
+    Class<?> transientOwner = getTransientImplementationClass(element);
+    return transientOwner != null && transientOwner != SimulationInterface.class;
+  }
+
+  /**
+   * Class that declares the effective standard transient boundary.
+   *
+   * @param element process element to inspect
+   * @return declaring class, or null when reflection cannot resolve the boundary
+   */
+  private static Class<?> getTransientImplementationClass(ProcessElementInterface element) {
     try {
       Method method = element.getClass().getMethod("runTransient", Double.TYPE, UUID.class);
-      return method.getDeclaringClass() != SimulationInterface.class;
+      return method.getDeclaringClass();
     } catch (NoSuchMethodException ex) {
-      return false;
+      return null;
     } catch (SecurityException ex) {
-      return false;
+      return null;
     }
   }
 }

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityBuiltInInventoryTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityBuiltInInventoryTest.java
@@ -1,0 +1,111 @@
+package neqsim.process.dynamics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import neqsim.process.ProcessElementInterface;
+import neqsim.process.equipment.adsorber.AdsorptionBed;
+import neqsim.process.equipment.adsorber.MercuryRemovalBed;
+import neqsim.process.equipment.distillation.DistillationColumn;
+import neqsim.process.equipment.electrolyzer.Electrolyzer;
+import neqsim.process.equipment.energy.CommittedEnergyGenerator;
+import neqsim.process.equipment.filter.Filter;
+import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.equipment.membrane.MembraneSeparator;
+import neqsim.process.equipment.mixer.Mixer;
+import neqsim.process.equipment.network.PipeFlowNetwork;
+import neqsim.process.equipment.network.WellFlowlineNetwork;
+import neqsim.process.equipment.pipeline.AdiabaticPipe;
+import neqsim.process.equipment.pipeline.MultiphasePipe;
+import neqsim.process.equipment.pipeline.PipeBeggsAndBrills;
+import neqsim.process.equipment.pipeline.Pipeline;
+import neqsim.process.equipment.reactor.IronSulfideOxidationSource;
+import neqsim.process.equipment.splitter.Splitter;
+import neqsim.process.equipment.tank.VesselDepressurization;
+
+/** CI inventory gate for built-in implementations of the standard transient boundary. */
+public class DynamicCapabilityBuiltInInventoryTest extends neqsim.NeqSimTest {
+  private static final Path SOURCE_ROOT = Paths.get("src", "main", "java");
+  private static final Path PROCESS_SOURCE_ROOT = SOURCE_ROOT.resolve(Paths.get("neqsim", "process"));
+  private static final Pattern STANDARD_TRANSIENT_OVERRIDE = Pattern.compile(
+      "\\bvoid\\s+runTransient\\s*\\(\\s*(?:final\\s+)?double\\s+\\w+\\s*,\\s*(?:final\\s+)?(?:java\\.util\\.)?UUID\\s+\\w+");
+
+  /** Every built-in ProcessElement transient override must be mapped or cite an existing explicit ADR. */
+  @Test
+  public void everyBuiltInTransientOverrideIsMappedOrHasAdr() throws Exception {
+    assertTrue(Files.isDirectory(PROCESS_SOURCE_ROOT), "production process source tree is missing");
+
+    List<Path> sources;
+    try (Stream<Path> paths = Files.walk(PROCESS_SOURCE_ROOT)) {
+      sources = paths.filter(path -> path.toString().endsWith(".java")).collect(Collectors.toList());
+    }
+    Collections.sort(sources);
+
+    List<String> missingAudits = new ArrayList<String>();
+    for (Path sourcePath : sources) {
+      String source = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
+      if (!STANDARD_TRANSIENT_OVERRIDE.matcher(source).find()) {
+        continue;
+      }
+
+      Class<?> type = Class.forName(toClassName(sourcePath), false,
+          DynamicCapabilityBuiltInInventoryTest.class.getClassLoader());
+      if (!ProcessElementInterface.class.isAssignableFrom(type)) {
+        continue;
+      }
+
+      if (DynamicCapabilityResolver.resolveAuditedBuiltInClass(type) != null) {
+        continue;
+      }
+
+      String adr = DynamicCapabilityResolver.getUnclassifiedBuiltInAdr(type);
+      if (adr == null || adr.trim().isEmpty()) {
+        missingAudits.add(type.getName() + " has no capability mapping or ADR");
+        continue;
+      }
+
+      Path adrPath = Paths.get(adr);
+      if (adrPath.isAbsolute() || !adr.endsWith(".md") || !Files.isRegularFile(adrPath)) {
+        missingAudits.add(type.getName() + " cites missing or invalid ADR " + adr);
+      }
+    }
+
+    assertTrue(missingAudits.isEmpty(),
+        "Built-in transient capability inventory is incomplete: " + String.join("; ", missingAudits));
+  }
+
+  /** WS6 classifications follow the state owned by each audited implementation. */
+  @Test
+  public void ws6BuiltInDeclarationsHaveExpectedStateOwnership() {
+    assertCapability(DynamicCapability.ALGEBRAIC, Heater.class, Mixer.class, Splitter.class, MembraneSeparator.class,
+        AdiabaticPipe.class);
+    assertCapability(DynamicCapability.DYNAMIC_LUMPED, Filter.class, CommittedEnergyGenerator.class,
+        VesselDepressurization.class, Electrolyzer.class);
+    assertCapability(DynamicCapability.DYNAMIC_DISTRIBUTED, DistillationColumn.class, AdsorptionBed.class,
+        MercuryRemovalBed.class, Pipeline.class, MultiphasePipe.class, PipeBeggsAndBrills.class, PipeFlowNetwork.class,
+        WellFlowlineNetwork.class);
+    assertCapability(DynamicCapability.BOUNDARY_DYNAMIC, IronSulfideOxidationSource.class);
+  }
+
+  private static String toClassName(Path sourcePath) {
+    String relative = SOURCE_ROOT.relativize(sourcePath).toString();
+    return relative.substring(0, relative.length() - ".java".length()).replace(File.separatorChar, '.');
+  }
+
+  private static void assertCapability(DynamicCapability expected, Class<?>... types) {
+    for (Class<?> type : types) {
+      assertEquals(expected, DynamicCapabilityResolver.resolveAuditedBuiltInClass(type), type.getName());
+    }
+  }
+}

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityModuleContainerTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityModuleContainerTest.java
@@ -1,7 +1,6 @@
 package neqsim.process.dynamics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.stream.Stream;
@@ -37,12 +36,8 @@ public class DynamicCapabilityModuleContainerTest extends neqsim.NeqSimTest {
 
     DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
     assertTrue(report.getEntries().size() > 10);
-    assertTrue(report.getReviewItems().size() > 0,
-        "Unaudited child implementations must remain visible through recursive module audit");
-
-    for (String reviewItem : report.getReviewItems()) {
-      assertFalse(reviewItem.startsWith("separation train has a custom transient implementation"),
-          "The composite module container itself must not create a false strict-preflight review item");
-    }
+    assertTrue(report.getReviewItems().isEmpty());
+    assertTrue(report.isFullyAudited());
+    assertTrue(report.isStrictPreflightReady());
   }
 }

--- a/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
+++ b/src/test/java/neqsim/process/dynamics/DynamicCapabilityReportTest.java
@@ -86,6 +86,7 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
 
     DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
     assertTrue(report.isStrictPreflightReady());
+    assertTrue(report.isFullyAudited());
     assertTrue(report.getReviewItems().isEmpty());
     assertTrue(report.getExecutionIssues().isEmpty());
     assertEquals(1, report.getCapabilityCounts().get(DynamicCapability.ALGEBRAIC).intValue());
@@ -146,6 +147,7 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
 
     assertFalse(report.hasBlockingIssues());
     assertEquals(1, report.getReviewItems().size());
+    assertFalse(report.isFullyAudited());
     assertTrue(report.getReviewItems().get(0).contains("custom"));
     assertFalse(report.isStrictPreflightReady());
     assertEquals(1, report.getStrictPreflightIssues().size());
@@ -153,14 +155,14 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     assertTrue(exception.getMessage().contains("custom"));
   }
 
-  /** Audited battery state no longer hides the still-unaudited adsorption model in the capability inventory. */
+  /** Adsorption and battery state both remain visible after their built-in capability audits. */
   @Test
-  public void auditedBatteryDoesNotMaskUnauditedAdsorption() {
+  public void adsorptionAndBatteryAreFullyAudited() {
     Stream feed = createFeed("adsorption feed");
     AdsorptionBed bed = new AdsorptionBed("adsorption bed", feed);
     BatteryStorage battery = new BatteryStorage("battery", 1000.0);
 
-    assertEquals(DynamicCapability.UNCLASSIFIED_DYNAMIC, bed.getDynamicCapability());
+    assertEquals(DynamicCapability.DYNAMIC_DISTRIBUTED, bed.getDynamicCapability());
     assertEquals(DynamicCapability.DYNAMIC_LUMPED, battery.getDynamicCapability());
 
     ProcessSystem process = new ProcessSystem("treatment and power");
@@ -170,12 +172,12 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
 
     DynamicCapabilityReport report = DynamicCapabilityReport.from(process);
 
-    assertEquals(1, report.getCapabilityCounts().get(DynamicCapability.UNCLASSIFIED_DYNAMIC).intValue());
+    assertEquals(0, report.getCapabilityCounts().get(DynamicCapability.UNCLASSIFIED_DYNAMIC).intValue());
+    assertEquals(1, report.getCapabilityCounts().get(DynamicCapability.DYNAMIC_DISTRIBUTED).intValue());
     assertEquals(1, report.getCapabilityCounts().get(DynamicCapability.DYNAMIC_LUMPED).intValue());
-    assertEquals(1, report.getReviewItems().size());
-    assertFalse(report.isStrictPreflightReady());
-    assertTrue(containsDiagnostic(report.getReviewItems(), "adsorption bed"));
-    assertFalse(containsDiagnostic(report.getReviewItems(), "battery"));
+    assertTrue(report.getReviewItems().isEmpty());
+    assertTrue(report.isFullyAudited());
+    assertTrue(report.isStrictPreflightReady());
   }
 
   /** Runtime activation is a separate audited dimension from state ownership and requested dynamic mode. */
@@ -295,9 +297,9 @@ public class DynamicCapabilityReportTest extends neqsim.NeqSimTest {
     assertTrue(hasQualifiedEntry(report, "separation train::Inlet separator"));
     assertTrue(hasQualifiedEntry(report, "separation train::HP gas scrubber"));
     assertTrue(report.getCapabilityCounts().get(DynamicCapability.DYNAMIC_LUMPED).intValue() > 0);
-    assertTrue(report.getCapabilityCounts().get(DynamicCapability.UNCLASSIFIED_DYNAMIC).intValue() > 0);
-    assertFalse(report.isStrictPreflightReady());
-    assertTrue(report.getStrictPreflightIssues().get(0).contains("separation train"));
+    assertEquals(0, report.getCapabilityCounts().get(DynamicCapability.UNCLASSIFIED_DYNAMIC).intValue());
+    assertTrue(report.isFullyAudited());
+    assertTrue(report.isStrictPreflightReady());
   }
 
   /** Nested module paths remain area-qualified in multi-area ProcessModel reports. */


### PR DESCRIPTION
## Summary

Advances #3298 WS6 (capability audit closure) under the frozen [capability contract](https://github.com/equinor/neqsim/issues/3298#issuecomment-5497758994).

- classify every built-in `ProcessElementInterface` declaration of `runTransient(double, UUID)` by owned state;
- resolve categories from the effective method's declaring class so inherited built-in behavior stays audited while a custom override remains fail-closed;
- add `DynamicCapabilityReport.isFullyAudited()`;
- add a source-inventory CI test that requires every new built-in override to be mapped or cite an existing repository Markdown ADR;
- update the dynamic capability contract and `neqsim-dynamic-simulation` guidance.

## Exact-head and capacity record

- frozen base: `master@74c6a3125bdd1f646e7c24921d94b1cc2dfecfb6`
- exact head: `d6e2285e717c5bc649080119da70c3effdf84c94`
- branch: `ai/3298-dynamic-capability-audit`
- publication occupancy: **4/10** autonomous draft PRs
- active #3298 PRs after publication: **1**

`master` advanced after the contract only through the already-audited, non-overlapping refinery PR #3392. This branch deliberately preserves the frozen exact base; it was not rebased or force-updated.

## State-ownership audit

- **ALGEBRAIC:** heater, mixer, splitter, membrane separator, quasi-steady adiabatic pipe, and previously audited algebraic families
- **DYNAMIC_LUMPED:** filter, committed generator, depressurization, electrolyzer, and previously audited lumped families
- **DYNAMIC_DISTRIBUTED:** distillation, adsorption/removal beds, pipeline families, and flow-network orchestrators
- **BOUNDARY_DYNAMIC:** iron-sulfide oxidation source and reservoir boundary state

These labels describe state ownership only. They do not promote numerical, benchmark, safety, controls, line-pack, severe-slugging, or liquid-rich maturity. In particular, `PipeBeggsAndBrills` remains explicitly unqualified for conservative storage/line-pack claims; those studies remain routed to the qualified `TwoFluidPipe` path and the unresolved WS1/WS2 gates.

## Validation

Passed on the exact submitted tree:

- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- `bash devtools/run_spotless.sh apply`
- `bash devtools/run_spotless.sh check`
- `python devtools/check_documentation_search.py`
- focused capability/activation suite:
  `DynamicCapabilityBuiltInInventoryTest,DynamicCapabilityReportTest,DynamicCapabilityModuleContainerTest,DynamicActivationReportTest,PressureFlowDynamicCapabilityTest`
- #3298 regression set:
  `ControlsBenchmarkSuiteTest,AgentBenchmarkSuiteTest,SevereSluggingExperimentalBenchmarkTest,SevereSluggingBenchmarkHarnessTest,TwoFluidPipeTransientNullTest,CoupledPressureMomentumTengesdalProgressTest`

The local `pre-commit` executable/module is unavailable, so its configured Spotless and documentation-search hooks were executed directly and passed. An optional full `-DskipITs test` run progressed without observed failures through the dynamic, distillation, `TwoFluidPipe`, water-hammer, and terrain/network groups, then was stopped at the campaign fast-validation budget; exact-head draft CI is authoritative for the remaining repository breadth.

## Documentation impact

Updated:

- `docs/process/dynamic-capability-contract.md`
- `.github/skills/neqsim-dynamic-simulation/SKILL.md`

The docs distinguish full inventory audit from strict runtime preflight and quantitative/public-benchmark qualification.

## Frozen stop boundary

No transient equations, solver/IMEX/outlet boundary, regime map, closure, activation policy, benchmark data, or runtime equipment behavior changed. No commercial trace was used. WS1, WS2, WS4, and final routing/qualification work remain open in #3298.

Draft only. Do not mark ready, merge, rebase, force-push, close, replace, or abandon for capacity reasons.