### PR TITLE
[AI-Assisted] feat(refinery): derive C5-175 molar mass from DOE PIANO

### DIFF
--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -51,12 +51,13 @@ For crude/petroleum assays, use `OilAssayCharacterisation` rather than manually 
 - exact API-gravity/SG60/60 round-tripping and explicit bulk density at 60 degF;
 - forward and inverse UOP/Watson characterization between representative boiling point and specific gravity;
 - mass-basis mapping of known assay light ends to authoritative NeqSim standard components;
+- number-average molar mass from mass-basis PIANO family/carbon-number data;
 - per-cut total-sulfur and total-nitrogen inputs with mass-basis whole-assay reconstruction;
 - pre-binned cumulative TBP cut-boundary ingestion;
 - preserved finite and one-sided lower/upper boiling boundaries;
 - closure, duplicate-name, monotonicity, and repeated-application guards.
 
-See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data bookkeeping evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation), whole-assay density/API evidence in [DOE/OEDI COA bulk density qualification](refinery_oedi_coa_bulk_density_validation), per-cut characterization evidence in [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation), terminal representative-temperature evidence in [DOE Big Hill terminal-Watson qualification](refinery_big_hill_watson_terminal_validation), composition-resolved light-end evidence in [DOE Big Hill light-end qualification](refinery_big_hill_light_ends_validation), assay-quality evidence in [DOE Big Hill sulfur qualification](refinery_big_hill_sulfur_validation) and [DOE Big Hill nitrogen qualification](refinery_big_hill_nitrogen_validation), terminal-boundary evidence in [DOE Big Hill terminal-cut qualification](refinery_big_hill_terminal_boundary_validation), and the process-integration gate in [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation).
+See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data bookkeeping evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation), whole-assay density/API evidence in [DOE/OEDI COA bulk density qualification](refinery_oedi_coa_bulk_density_validation), per-cut characterization evidence in [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation), terminal representative-temperature evidence in [DOE Big Hill terminal-Watson qualification](refinery_big_hill_watson_terminal_validation), composition-resolved light-end evidence in [DOE Big Hill light-end qualification](refinery_big_hill_light_ends_validation), PIANO aggregate molar-mass evidence in [DOE Big Hill C5-175 degF qualification](refinery_big_hill_piano_molar_mass_validation), assay-quality evidence in [DOE Big Hill sulfur qualification](refinery_big_hill_sulfur_validation) and [DOE Big Hill nitrogen qualification](refinery_big_hill_nitrogen_validation), terminal-boundary evidence in [DOE Big Hill terminal-cut qualification](refinery_big_hill_terminal_boundary_validation), and the process-integration gate in [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation).
 
 ## TBP fraction models
 
@@ -143,6 +144,7 @@ A bookkeeping regression does not by itself validate a petroleum-property correl
 - [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation)
 - [DOE Big Hill terminal-Watson qualification](refinery_big_hill_watson_terminal_validation)
 - [DOE Big Hill composition-resolved light-end qualification](refinery_big_hill_light_ends_validation)
+- [DOE Big Hill C5-175 degF PIANO molar-mass qualification](refinery_big_hill_piano_molar_mass_validation)
 - [DOE Big Hill assay sulfur qualification](refinery_big_hill_sulfur_validation)
 - [DOE Big Hill assay nitrogen qualification](refinery_big_hill_nitrogen_validation)
 - [DOE Big Hill terminal-cut boundary qualification](refinery_big_hill_terminal_boundary_validation)

--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -180,6 +180,20 @@ reported C2-C4 subset and applies the independently reported 1.70 mass% whole-cr
 qualifies standard-component identity plus exact mass/mole bookkeeping. It does not qualify VLE,
 flash recovery, or C5-175 degF properties.
 
+## PIANO-derived assay-cut molar mass
+
+When a public assay reports hydrocarbon family and carbon number on a mass basis, use
+`calculatePianoMolarMassKgPerMol(...)` to obtain the number-average molar mass for an explicit
+pseudo-component. The helper supports paraffin, iso-paraffin, aromatic, and naphthene groups using
+their ideal homologous-series formulas and conventional C/H atomic weights. It normalizes small
+source-table rounding errors but fails closed for invalid formulas, weights, or closure.
+
+The [DOE Big Hill C5-175 degF PIANO qualification](refinery_big_hill_piano_molar_mass_validation)
+freezes the public family/carbon-number table and derives 0.0791538366563 kg/mol. Together with the
+reported 5.22 mass% yield, SG60/60 = 0.6731, and one-sided 175 degF upper boundary, this supplies a
+reproducible explicit-molar-mass cut without inventing a lower or representative boiling point. It
+does not resolve isomers or validate critical properties, VLE, or fractionation yields.
+
 ## Open-ended terminal boiling boundaries
 
 Terminal assay cuts often publish only one boiling limit. Use
@@ -251,7 +265,7 @@ The regression suite for this API currently verifies:
 - whole-assay total-nitrogen reconstruction against the public DOE Big Hill Sweet 2021 assay;
 - input-order independence and no thermodynamic-system mutation for bulk-property queries.
 
-These tests establish software/bookkeeping correctness, qualify ideal-additive-volume SG/API screening over the frozen COA matrix (published crude SG 0.765-0.847; maximum observed errors 0.006 SG and 1.5 degrees API), qualify per-cut Watson factors over the frozen DOE matrix (375-1050 degF; maximum observed error 0.0122), qualify the DOE residue's Watson-derived representative temperature, qualify the DOE C2-C4 standard-component split, and qualify linear assay sulfur and nitrogen bookkeeping over one complete DOE crude slate. They do **not** qualify temperature correction, contraction, molecular-weight or critical-property correlations, sulfur/nitrogen species or reactions, or atmospheric/vacuum fractionation; those remain separate campaign gates in issue #3305.
+These tests establish software/bookkeeping correctness, qualify ideal-additive-volume SG/API screening over the frozen COA matrix (published crude SG 0.765-0.847; maximum observed errors 0.006 SG and 1.5 degrees API), qualify per-cut Watson factors over the frozen DOE matrix (375-1050 degF; maximum observed error 0.0122), qualify the DOE residue's Watson-derived representative temperature, qualify the DOE C2-C4 standard-component split, qualify the DOE C5-175 degF PIANO aggregate molar mass, and qualify linear assay sulfur and nitrogen bookkeeping over one complete DOE crude slate. They do **not** qualify temperature correction, contraction, generic molecular-weight or critical-property correlations, sulfur/nitrogen species or reactions, or atmospheric/vacuum fractionation; those remain separate campaign gates in issue #3305.
 
 ## Refinery capability inventory after this increment
 
@@ -263,6 +277,7 @@ These tests establish software/bookkeeping correctness, qualify ideal-additive-v
 | Open-ended terminal boiling limits | Unit-explicit one-sided `AssayCut` boundaries | DOE-qualified for metadata and fail-closed preparation |
 | Watson-derived terminal representative point | `withWatsonCharacterizationFactor(...)` | DOE-qualified for the Big Hill 1050 degF+ residue |
 | Composition-resolved standard light ends | `AssayCut.withStandardComponent(...)` | DOE-qualified for the Big Hill C2-C4 composition and mass/mole bookkeeping |
+| PIANO family/carbon-number molar mass | `calculatePianoMolarMassKgPerMol(...)` | DOE-qualified for the Big Hill C5-175 degF aggregate and explicit-molar-mass bookkeeping |
 | Per-cut UOP/Watson characterization factor | `AssayCut.getWatsonCharacterizationFactor()` | DOE-qualified for assay screening over 375-1050 degF |
 | Assay-carried total sulfur | `getBulkSulfurMassFraction/Percent()` | DOE-qualified for linear bookkeeping over one complete crude slate |
 | Assay-carried total nitrogen | `getBulkNitrogenMassFraction/Percent()` | DOE-qualified for linear bookkeeping over one complete crude slate |
@@ -279,4 +294,4 @@ These tests establish software/bookkeeping correctness, qualify ideal-additive-v
 
 ## Next campaign step
 
-The next dependency-ready characterization increment should establish a defensible C5-175 degF representative property treatment from public evidence. With the C2-C4 composition and residue terminal treatment now explicit, the process benchmark can then advance from the bounded DOE atmospheric integration case to a complete crude slate with independent cut-yield and boiling-range evidence before vacuum fractionation.
+The next dependency-ready characterization increment should assemble the qualified C2-C4, C5-175 degF, bounded distillate, and terminal-residue treatments into a complete reproducible crude slate. The process benchmark can then advance from the bounded DOE atmospheric integration case to independent cut-yield and boiling-range evidence before vacuum fractionation.

--- a/docs/thermo/characterization/refinery_big_hill_piano_molar_mass_validation.md
+++ b/docs/thermo/characterization/refinery_big_hill_piano_molar_mass_validation.md
@@ -1,0 +1,90 @@
+---
+title: "DOE Big Hill C5-175 degF PIANO molar-mass qualification"
+description: "Public-data qualification of a PIANO family and carbon-number aggregate molar mass for the DOE Big Hill Sweet light naphtha cut."
+---
+
+# DOE Big Hill C5-175 degF PIANO molar-mass qualification
+
+## Scope
+
+This qualification freezes public U.S. Department of Energy Strategic Petroleum Reserve data for
+the Big Hill Sweet C5-175 degF fraction and exercises
+`OilAssayCharacterisation.calculatePianoMolarMassKgPerMol(...)`. The helper converts a mass-basis
+PIANO family/carbon-number table into the mixture number-average molar mass required by NeqSim's
+existing explicit-molar-mass pseudo-component path.
+
+This is a composition and mass-bookkeeping qualification. It does not identify individual
+isomers, infer a missing lower boiling boundary, or validate critical-property, VLE, flash,
+distillation-yield, or conversion-unit predictions.
+
+## Public evidence and provenance
+
+The numerical inputs are taken from the official DOE SPR Big Hill Sweet workbooks:
+
+- [comprehensive assay](https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx): C5-175
+  degF yield 5.22 mass%, SG60/60 0.6731, and upper boundary 175 degF;
+- [PIANO analysis](https://www.spr.doe.gov/reports/Assays/2021/BigHillSwPIANO.xlsx): the
+  hydrocarbon-family/carbon-number mass table used below.
+
+Both workbooks report 24 September 2021. Only cited numerical facts are reproduced in NeqSim; the
+source workbooks are not redistributed. The calculation uses the conventional atomic weights
+C = 12.011 and H = 1.008 g/mol, which are within the current standard atomic-weight intervals
+published by the [CIAAW](https://www.ciaaw.org/atomic-weights.htm).
+
+## Frozen PIANO inputs
+
+| Family | Carbon number | Mass% |
+| --- | ---: | ---: |
+| Paraffin | 3 | 0.32 |
+| Paraffin | 4 | 3.49 |
+| Paraffin | 5 | 21.47 |
+| Paraffin | 6 | 15.28 |
+| Paraffin | 7 | 0.94 |
+| Iso-paraffin | 4 | 0.59 |
+| Iso-paraffin | 5 | 10.96 |
+| Iso-paraffin | 6 | 17.99 |
+| Iso-paraffin | 7 | 4.04 |
+| Iso-paraffin | 8 | 0.05 |
+| Aromatic | 6 | 3.34 |
+| Aromatic | 7 | 0.12 |
+| Naphthene | 5 | 3.39 |
+| Naphthene | 6 | 14.38 |
+| Naphthene | 7 | 3.60 |
+| Naphthene | 8 | 0.05 |
+
+The row sum is 100.01 mass% because the source reports two decimals. The implementation therefore
+accepts a small source-rounding closure error and normalizes by the actual submitted total. Frozen
+family sums are 41.50% paraffins, 33.63% iso-paraffins, 3.46% aromatics, and 21.42% naphthenes.
+
+## Calculation
+
+The family formulas are paraffin and iso-paraffin `CnH(2n+2)`, naphthene `CnH(2n)`, and aromatic
+`CnH(2n-6)`. For mass fractions `w_i` and species-group molar masses `M_i`, the number-average
+mixture molar mass is
+
+```text
+M_n = 1 / sum_i(w_i / M_i)
+```
+
+The frozen expected result is `0.0791538366563 kg/mol`. The API is intentionally O(n), independent
+of input row order, and rejects null families, impossible family/carbon-number combinations,
+non-finite or negative weights, and totals outside the documented rounding tolerance.
+
+## Application and acceptance criteria
+
+The regression applies the published 5.22 mass% C5-175 degF cut to a 1 kg assay using:
+
+- the PIANO-derived explicit molar mass;
+- the measured SG60/60 of 0.6731;
+- only the published 175 degF upper boiling boundary.
+
+Acceptance requires:
+
+1. PIANO row closure within 0.02 percentage point and the expected molar mass within `1e-14 kg/mol`;
+2. identical output after reversing source-row order;
+3. exact 0.0522 kg pseudo-component mass closure within `1e-10 kg`;
+4. retention of the one-sided 175 degF boundary without creating a lower boundary; and
+5. fail-closed invalid-input behavior before the thermodynamic system is mutated.
+
+No individual species distribution or mean boiling point is claimed. The resulting molar mass is a
+reproducible family/carbon-number aggregate suitable for the explicit assay-cut bookkeeping path.

--- a/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
+++ b/src/main/java/neqsim/thermo/characterization/OilAssayCharacterisation.java
@@ -48,6 +48,9 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
   private static final double KELVIN_OFFSET = 273.15;
   private static final double GRAMS_PER_KILOGRAM = 1000.0;
   private static final double WATER_DENSITY_60F_KG_M3 = 999.016;
+  private static final double CARBON_ATOMIC_WEIGHT_GRAM_PER_MOL = 12.011;
+  private static final double HYDROGEN_ATOMIC_WEIGHT_GRAM_PER_MOL = 1.008;
+  private static final double PIANO_PERCENT_CLOSURE_TOLERANCE = 0.1;
 
   private transient SystemInterface system;
   private double totalAssayMass = 1.0;
@@ -69,6 +72,97 @@ public class OilAssayCharacterisation implements Cloneable, Serializable {
    */
   public void setThermoSystem(SystemInterface system) {
     this.system = Objects.requireNonNull(system, "system");
+  }
+
+  /** Hydrocarbon families reported by a PIANO refinery-assay analysis. */
+  public enum PianoHydrocarbonFamily {
+    PARAFFIN, ISO_PARAFFIN, AROMATIC, NAPHTHENE
+  }
+
+  /**
+   * Calculate the number-average molar mass represented by PIANO mass-percent lumps.
+   *
+   * <p>
+   * Each entry is defined by a hydrocarbon family, carbon number, and mass percentage. Ideal family formulas are used:
+   * paraffins and iso-paraffins are CnH(2n+2), naphthenes are CnH(2n), and aromatics are CnH(2n-6). The calculation
+   * uses conventional atomic weights C = 12.011 g/mol and H = 1.008 g/mol and returns the mixture number-average molar
+   * mass from the reciprocal mass-weighted sum. Percentages may differ from 100 by at most 0.1 percentage point to
+   * accommodate source-table rounding and are normalized by their actual sum.
+   * </p>
+   *
+   * @param families PIANO hydrocarbon family for each lump
+   * @param carbonNumbers carbon number for each lump
+   * @param massPercent mass percentage for each lump
+   * @return number-average molar mass in kg/mol
+   */
+  public static double calculatePianoMolarMassKgPerMol(PianoHydrocarbonFamily[] families, int[] carbonNumbers,
+      double[] massPercent) {
+    if (families == null || carbonNumbers == null || massPercent == null) {
+      throw new IllegalArgumentException("PIANO family, carbon-number, and mass-percent arrays cannot be null");
+    }
+    if (families.length == 0 || families.length != carbonNumbers.length || families.length != massPercent.length) {
+      throw new IllegalArgumentException("PIANO arrays must be non-empty and have equal length");
+    }
+
+    double totalMassPercent = 0.0;
+    double molesPerHundredGram = 0.0;
+    for (int i = 0; i < families.length; i++) {
+      PianoHydrocarbonFamily family = families[i];
+      if (family == null) {
+        throw new IllegalArgumentException("PIANO hydrocarbon family cannot be null");
+      }
+      int carbonNumber = carbonNumbers[i];
+      int hydrogenNumber = resolvePianoHydrogenNumber(family, carbonNumber);
+      double entryMassPercent = massPercent[i];
+      if (!Double.isFinite(entryMassPercent) || entryMassPercent < 0.0 || entryMassPercent > 100.0) {
+        throw new IllegalArgumentException("PIANO mass percentages must be finite and between 0 and 100");
+      }
+
+      double componentMolarMassGramPerMol = carbonNumber * CARBON_ATOMIC_WEIGHT_GRAM_PER_MOL
+          + hydrogenNumber * HYDROGEN_ATOMIC_WEIGHT_GRAM_PER_MOL;
+      totalMassPercent += entryMassPercent;
+      molesPerHundredGram += entryMassPercent / componentMolarMassGramPerMol;
+    }
+
+    if (!Double.isFinite(totalMassPercent) || Math.abs(totalMassPercent - 100.0) > PIANO_PERCENT_CLOSURE_TOLERANCE) {
+      throw new IllegalArgumentException("PIANO mass percentages must close to 100 within 0.1 percentage point");
+    }
+    if (!Double.isFinite(molesPerHundredGram) || !(molesPerHundredGram > 0.0)) {
+      throw new IllegalArgumentException("PIANO composition must contain positive mass");
+    }
+
+    double molarMassKgPerMol = totalMassPercent / molesPerHundredGram / GRAMS_PER_KILOGRAM;
+    if (!Double.isFinite(molarMassKgPerMol) || !(molarMassKgPerMol > 0.0)) {
+      throw new IllegalStateException("Unable to calculate a finite positive PIANO molar mass");
+    }
+    return molarMassKgPerMol;
+  }
+
+  private static int resolvePianoHydrogenNumber(PianoHydrocarbonFamily family, int carbonNumber) {
+    switch (family) {
+    case PARAFFIN:
+      if (carbonNumber < 1) {
+        throw new IllegalArgumentException("Paraffin carbon number must be at least 1");
+      }
+      return 2 * carbonNumber + 2;
+    case ISO_PARAFFIN:
+      if (carbonNumber < 4) {
+        throw new IllegalArgumentException("Iso-paraffin carbon number must be at least 4");
+      }
+      return 2 * carbonNumber + 2;
+    case NAPHTHENE:
+      if (carbonNumber < 3) {
+        throw new IllegalArgumentException("Naphthene carbon number must be at least 3");
+      }
+      return 2 * carbonNumber;
+    case AROMATIC:
+      if (carbonNumber < 6) {
+        throw new IllegalArgumentException("Aromatic carbon number must be at least 6");
+      }
+      return 2 * carbonNumber - 6;
+    default:
+      throw new IllegalArgumentException("Unsupported PIANO hydrocarbon family");
+    }
   }
 
   /**

--- a/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillPianoTest.java
+++ b/src/test/java/neqsim/thermo/characterization/OilAssayCharacterisationDoeBigHillPianoTest.java
@@ -1,0 +1,128 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.characterization.OilAssayCharacterisation.PianoHydrocarbonFamily;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Public DOE qualification of PIANO-derived C5-175 degF representative molar mass. */
+public class OilAssayCharacterisationDoeBigHillPianoTest {
+  private static final PianoHydrocarbonFamily P = PianoHydrocarbonFamily.PARAFFIN;
+  private static final PianoHydrocarbonFamily I = PianoHydrocarbonFamily.ISO_PARAFFIN;
+  private static final PianoHydrocarbonFamily A = PianoHydrocarbonFamily.AROMATIC;
+  private static final PianoHydrocarbonFamily N = PianoHydrocarbonFamily.NAPHTHENE;
+  private static final PianoHydrocarbonFamily[] FAMILIES = { P, P, P, P, P, I, I, I, I, I, A, A, N, N, N, N };
+  private static final int[] CARBON_NUMBERS = { 3, 4, 5, 6, 7, 4, 5, 6, 7, 8, 6, 7, 5, 6, 7, 8 };
+  private static final double[] MASS_PERCENT = { 0.32, 3.49, 21.47, 15.28, 0.94, 0.59, 10.96, 17.99, 4.04, 0.05, 3.34,
+      0.12, 3.39, 14.38, 3.60, 0.05 };
+  private static final double EXPECTED_MOLAR_MASS_KG_PER_MOL = 0.07915383665629189;
+
+  @Test
+  public void doePianoGroupsCloseAndCalculateRepresentativeMolarMass() {
+    assertEquals(41.50, sumFamily(P), 1.0e-12);
+    assertEquals(33.63, sumFamily(I), 1.0e-12);
+    assertEquals(3.46, sumFamily(A), 1.0e-12);
+    assertEquals(21.42, sumFamily(N), 1.0e-12);
+    assertEquals(100.01, sum(MASS_PERCENT), 1.0e-12);
+
+    double molarMass = OilAssayCharacterisation.calculatePianoMolarMassKgPerMol(FAMILIES, CARBON_NUMBERS, MASS_PERCENT);
+    assertEquals(EXPECTED_MOLAR_MASS_KG_PER_MOL, molarMass, 1.0e-14);
+
+    PianoHydrocarbonFamily[] reversedFamilies = reverse(FAMILIES);
+    int[] reversedCarbonNumbers = reverse(CARBON_NUMBERS);
+    double[] reversedMassPercent = reverse(MASS_PERCENT);
+    assertEquals(molarMass, OilAssayCharacterisation.calculatePianoMolarMassKgPerMol(reversedFamilies,
+        reversedCarbonNumbers, reversedMassPercent), 1.0e-14);
+  }
+
+  @Test
+  public void doeC5To175CutUsesPianoMolarMassWithoutInventingLowerBoundary() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
+    assay.setTotalAssayMass(0.0522);
+    AssayCut cut = new AssayCut("DOE_BH_C5_175").withMassFraction(1.0).withSpecificGravity(0.6731)
+        .withMolarMassKgPerMol(EXPECTED_MOLAR_MASS_KG_PER_MOL).withUpperBoilingPointFahrenheit(175.0);
+    assay.addCut(cut);
+
+    assay.apply();
+
+    ComponentInterface component = system.getComponent("DOE_BH_C5_175_PC");
+    assertEquals(1, system.getNumberOfComponents());
+    assertEquals(EXPECTED_MOLAR_MASS_KG_PER_MOL, component.getMolarMass(), 1.0e-14);
+    assertEquals(0.0522, component.getNumberOfmoles() * component.getMolarMass(), 1.0e-10);
+    assertTrue(cut.hasUpperBoilingPoint());
+    assertFalse(cut.hasLowerBoilingPoint());
+    assertEquals(352.59444444444443, cut.getUpperBoilingPointKelvin(), 1.0e-12);
+  }
+
+  @Test
+  public void invalidPianoInputsFailClosed() {
+    assertThrows(IllegalArgumentException.class,
+        () -> OilAssayCharacterisation.calculatePianoMolarMassKgPerMol(null, CARBON_NUMBERS, MASS_PERCENT));
+    assertThrows(IllegalArgumentException.class, () -> OilAssayCharacterisation
+        .calculatePianoMolarMassKgPerMol(new PianoHydrocarbonFamily[] { P }, new int[] {}, new double[] { 100.0 }));
+    assertThrows(IllegalArgumentException.class, () -> OilAssayCharacterisation
+        .calculatePianoMolarMassKgPerMol(new PianoHydrocarbonFamily[] {}, new int[] {}, new double[] {}));
+    assertThrows(IllegalArgumentException.class,
+        () -> OilAssayCharacterisation.calculatePianoMolarMassKgPerMol(new PianoHydrocarbonFamily[] { null },
+            new int[] { 5 }, new double[] { 100.0 }));
+    assertThrows(IllegalArgumentException.class, () -> OilAssayCharacterisation
+        .calculatePianoMolarMassKgPerMol(new PianoHydrocarbonFamily[] { A }, new int[] { 5 }, new double[] { 100.0 }));
+    assertThrows(IllegalArgumentException.class, () -> OilAssayCharacterisation
+        .calculatePianoMolarMassKgPerMol(new PianoHydrocarbonFamily[] { P }, new int[] { 5 }, new double[] { -1.0 }));
+    assertThrows(IllegalArgumentException.class,
+        () -> OilAssayCharacterisation.calculatePianoMolarMassKgPerMol(new PianoHydrocarbonFamily[] { P },
+            new int[] { 5 }, new double[] { Double.NaN }));
+    assertThrows(IllegalArgumentException.class, () -> OilAssayCharacterisation
+        .calculatePianoMolarMassKgPerMol(new PianoHydrocarbonFamily[] { P }, new int[] { 5 }, new double[] { 99.0 }));
+  }
+
+  private static double sumFamily(PianoHydrocarbonFamily family) {
+    double total = 0.0;
+    for (int i = 0; i < FAMILIES.length; i++) {
+      if (FAMILIES[i] == family) {
+        total += MASS_PERCENT[i];
+      }
+    }
+    return total;
+  }
+
+  private static double sum(double[] values) {
+    double total = 0.0;
+    for (double value : values) {
+      total += value;
+    }
+    return total;
+  }
+
+  private static PianoHydrocarbonFamily[] reverse(PianoHydrocarbonFamily[] values) {
+    PianoHydrocarbonFamily[] reversed = new PianoHydrocarbonFamily[values.length];
+    for (int i = 0; i < values.length; i++) {
+      reversed[i] = values[values.length - 1 - i];
+    }
+    return reversed;
+  }
+
+  private static int[] reverse(int[] values) {
+    int[] reversed = new int[values.length];
+    for (int i = 0; i < values.length; i++) {
+      reversed[i] = values[values.length - 1 - i];
+    }
+    return reversed;
+  }
+
+  private static double[] reverse(double[] values) {
+    double[] reversed = new double[values.length];
+    for (int i = 0; i < values.length; i++) {
+      reversed[i] = values[values.length - 1 - i];
+    }
+    return reversed;
+  }
+}


### PR DESCRIPTION
## Capability contract

Advances #3305 under the contract recorded in [the campaign ledger](https://github.com/equinor/neqsim/issues/3305#issuecomment-5499870400).

Exact base: `25d0977d120070aa42cfeb8cb815ec3cf1115cd5`  
Exact head: `1ac236d842c362319447186a50f09abee7f363b6`

## Capability

Adds an O(n), unit-explicit Java API for calculating the number-average molar mass of mass-basis PIANO hydrocarbon-family/carbon-number data:

- paraffin and iso-paraffin: CnH(2n+2)
- naphthene: CnH(2n)
- aromatic: CnH(2n-6)
- conventional atomic weights C = 12.011 and H = 1.008 g/mol
- small source-table rounding errors are normalized; invalid arrays, formulas, values, and closure fail closed
- the public Java enum and static method are automatically available to Python through JPype

## Public benchmark

Sources:

- DOE SPR [Big Hill Sweet comprehensive assay](https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx)
- DOE SPR [Big Hill Sweet PIANO analysis](https://www.spr.doe.gov/reports/Assays/2021/BigHillSwPIANO.xlsx)
- [CIAAW standard atomic weights](https://www.ciaaw.org/atomic-weights.htm)

The frozen C5-175 °F PIANO rows close to 100.01 mass% after source rounding and yield:

- number-average molar mass: `0.07915383665629189 kg/mol`
- whole-crude cut yield: `5.22 mass%`
- measured SG60/60: `0.6731`
- published boundary: upper `175 °F` only

The regression applies the cut as a real NeqSim pseudo-component and requires `1e-10 kg` mass closure while retaining the one-sided upper boundary without inventing a lower or representative boiling point.

## Validation

Local exact-diff gates passed:

- Spotless apply/check
- documentation search audit: 683 Markdown pages and one standalone HTML page
- 31 focused Java tests: the new DOE PIANO suite, the neighboring DOE light-end suite, and the core assay suite
- `git diff --check`

Hosted CI is intentionally pending on this draft's exact head.

## Evidence boundary

This qualifies family/carbon-number aggregate molar-mass and explicit-cut bookkeeping only. It does not identify individual isomers or validate critical-property correlations, VLE, flash recovery, atmospheric yields, vacuum fractionation, or conversion units. The DOE workbooks are cited but not redistributed.

Portfolio occupancy before publication was 3/10 autonomous capabilities. This is the sole active #3305 implementation PR.