### PR TITLE
[AI-Assisted] feat(electrolytes): expose calcium-sulfate boundary evidence

### DIFF
--- a/.github/skills/neqsim-electrolyte-systems/SKILL.md
+++ b/.github/skills/neqsim-electrolyte-systems/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-electrolyte-systems
 description: "Electrolyte and brine chemistry guidance for NeqSim. USE WHEN: modeling produced water, scale prediction, CO2/H2S in aqueous systems, MEG/DEG injection, hydrate inhibitor dosing, or any system with ions, salts, or electrolytes. Covers SystemElectrolyteCPAstatoil setup, ion components, scale risk assessment, and brine handling patterns."
-last_verified: "2026-07-04"
+last_verified: "2026-09-01"
 ---
 
 # Electrolyte Systems Guide
@@ -121,6 +121,26 @@ Before hand-rolling the flash, note these ready-made helpers (see the
   `system.chemicalReactionInit()` before `createDatabase(true)`/`setMixingRule(10)`
   and flash first (otherwise carbonate/bicarbonate/pH speciation is missing and
   the SR is wrong).
+
+### Activity-consistent calcium-sulfate equilibrium
+
+Use the pure-mineral operation when the engineering question is gypsum/anhydrite equilibrium rather than screening
+SI:
+
+```java
+MultiSaltPrecipitationResult solids =
+    new ThermodynamicOperations(brine).precipitateScales("CaSO4_A", "CaSO4_G");
+
+CalciumSulfatePhaseBoundaryQualification evidence =
+    new ThermodynamicOperations(brine).qualifyCalciumSulfatePhaseBoundary();
+```
+
+`CaSO4_G` is hydrated gypsum: the authoritative operation includes $a_{\mathrm{w}}^2$, removes or returns two water
+moles per formula unit, and reports hydrated mass. `CaSO4_A` remains water-free anhydrite. The qualification object
+separates this mineral-standard-state evidence from the Pitzer or electrolyte-CPA aqueous activity model. It is
+currently fail-closed against the CC BY 4.0 Voigt–Freyer pure-water and NaCl crossing envelopes and does not qualify
+high-pressure use; do not fit or reinterpret Pitzer interactions to hide a mineral-correlation mismatch. See
+`docs/pvtsimulation/scale_prediction_api.md` for the source matrix, numerical residuals, and limits.
 
 ### CaCO3 (Calcite) Scaling
 

--- a/docs/chemistry/mcp.md
+++ b/docs/chemistry/mcp.md
@@ -186,9 +186,18 @@ non-negative normalized aqueous phase.
 
 The result is **design-support** and reports `publicationReady: false` until an
 independent competitive mixed-brine/mineral validation envelope is registered.
-COMPSALT masses represent ion formula units; crystallization water, solid
-solutions, precipitation kinetics, deposition and inhibitor physics are not
-included.
+When both `CaSO4_A` and `CaSO4_G` are requested, the response also contains
+`calciumSulfatePhaseBoundaryQualification`. This nested view reuses
+`ThermodynamicOperations.qualifyCalciumSulfatePhaseBoundary()` and reports the
+CC BY 4.0 Voigt–Freyer pure-water and NaCl/water-activity envelopes, exact
+COMPSALT predictions, source and primary-lineage DOIs, pressure scope,
+limitations, and a deterministic fail-closed publication decision. It does not
+fit or replace any mineral or aqueous-model parameter.
+
+COMPSALT masses represent ion formula units. Encoded crystallization water is
+included: gypsum `CaSO4_G` carries two waters per formula unit in saturation,
+material balance, dissolution, and hydrated mass. Solid solutions,
+precipitation kinetics, deposition and inhibitor physics are not included.
 
 ### `electrolyteScale`
 

--- a/docs/pvtsimulation/scale_prediction_api.md
+++ b/docs/pvtsimulation/scale_prediction_api.md
@@ -310,6 +310,37 @@ independently validate the COMPSALT temperature/pressure correlations. In partic
 COMPSALT pressure-volume coefficients differ from PHREEQC mineral molar volumes, so quantitative
 high-pressure gypsum/anhydrite phase-boundary use remains outside the qualified scope.
 
+#### Calcium-sulfate phase-boundary evidence
+
+Use `ThermodynamicOperations.qualifyCalciumSulfatePhaseBoundary()` to inspect the mineral-standard-state evidence
+separately from Pitzer or electrolyte-CPA aqueous parameter qualification:
+
+```java
+CalciumSulfatePhaseBoundaryQualification evidence =
+    operations.qualifyCalciumSulfatePhaseBoundary();
+
+double transitionC = evidence.getPredictedPureWaterTransitionCelsius();
+double requiredWaterActivity25C = evidence.getRequiredWaterActivityAt25Celsius();
+boolean publicationReady = evidence.isPublicationReady();
+```
+
+The immutable Java result is available through JPype and uses the exact COMPSALT solubility-product calculation used
+by precipitation. For simultaneous anhydrite and gypsum equilibrium, the ion activities cancel and the required water
+activity is $a_{\mathrm{w}}=\sqrt{K_{sp,\mathrm{G}}/K_{sp,\mathrm{A}}}$. The registered independent evidence is Voigt
+and Freyer (2023), [DOI 10.3389/fnuen.2023.1208582](https://doi.org/10.3389/fnuen.2023.1208582), CC BY 4.0:
+
+| Observable | Independent envelope | Current COMPSALT result |
+|------------|----------------------|-------------------------|
+| Pure-water transition | 42 ± 1 °C | 60.445190 °C |
+| NaCl crossing at 25 °C | $a_{\mathrm{w}}=0.8551$–$0.8634$ | $a_{\mathrm{w}}=0.7736299$ |
+| NaCl crossing at 40 °C | $a_{\mathrm{w}}=0.9370$–$0.9587$ | $a_{\mathrm{w}}=0.8437837$ |
+
+The NaCl intervals retain Bock (1961), [DOI 10.1139/v61-228](https://doi.org/10.1139/v61-228), as their primary
+experimental lineage without redistributing the copyrighted primary table. The current correlations fail all three
+registered envelopes, so the result deliberately reports `REJECTED` and `publicationReady=false`; it does not tune a
+coefficient toward the evidence. Absolute-solubility residuals, primary-row uncertainty, mixed-brine qualification and
+the high-pressure reaction-volume convention remain explicit follow-on boundaries.
+
 The process-system test carries the solid ledger beside the residual fluid through a
 `Stream -> Heater -> ProcessSystem` calculation, then re-equilibrates it at the outlet. Its
 charge-balanced feed contains nonzero Ca++, Mg++, Cl-, and SO4--; Ca/SO4 close against the solid

--- a/src/main/java/neqsim/mcp/runners/ChemistryRunner.java
+++ b/src/main/java/neqsim/mcp/runners/ChemistryRunner.java
@@ -30,6 +30,7 @@ import neqsim.thermo.system.SystemElectrolyteCPAstatoil;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemPitzer;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
+import neqsim.thermodynamicoperations.flashops.saturationops.CalciumSulfatePhaseBoundaryQualification;
 import neqsim.thermodynamicoperations.flashops.saturationops.MultiSaltPrecipitationResult;
 import neqsim.thermodynamicoperations.flashops.saturationops.SaltPrecipitationResult;
 
@@ -494,10 +495,61 @@ public class ChemistryRunner {
           pitzerQualification.isValidatedFor(ValidationTarget.MINERAL_SATURATION_AND_PRECIPITATION));
       data.add("qualificationLimitations", GSON.toJsonTree(pitzerQualification.getLimitations()));
     }
+    if (containsCalciumSulfatePolymorphPair(equilibrium.getMineralResults().keySet())) {
+      CalciumSulfatePhaseBoundaryQualification qualification = new ThermodynamicOperations(system)
+          .qualifyCalciumSulfatePhaseBoundary();
+      data.add("calciumSulfatePhaseBoundaryQualification", calciumSulfateBoundaryEvidence(qualification));
+    }
     data.addProperty("publicationReady", false);
     data.addProperty("publicationLimitation",
-        "Numerical engineering gates pass, but no exact competitive mixed-brine mineral evidence envelope is "
-            + "registered for this state");
+        "Numerical engineering gates pass, but competitive mixed-brine absolute-solubility and high-pressure "
+            + "mineral evidence remain unqualified");
+    return data;
+  }
+
+  private static boolean containsCalciumSulfatePolymorphPair(Set<String> mineralNames) {
+    return mineralNames.contains("CaSO4_A") && mineralNames.contains("CaSO4_G");
+  }
+
+  private static JsonObject calciumSulfateBoundaryEvidence(CalciumSulfatePhaseBoundaryQualification qualification) {
+    JsonObject data = new JsonObject();
+    data.addProperty("authoritativeJavaOperation", "ThermodynamicOperations.qualifyCalciumSulfatePhaseBoundary");
+    data.addProperty("evidenceDoi", qualification.getEvidenceDoi());
+    data.addProperty("primaryLineageDoi", qualification.getPrimaryLineageDoi());
+    data.addProperty("evidenceLicense", qualification.getEvidenceLicense());
+    data.addProperty("referencePressure_bara", CalciumSulfatePhaseBoundaryQualification.REFERENCE_PRESSURE_BARA);
+    data.addProperty("evaluatedPressure_bara", qualification.getEvaluatedPressureBara());
+    data.addProperty("referencePressureEnvelopePass", qualification.isReferencePressureEnvelopePass());
+
+    JsonObject pureWater = new JsonObject();
+    pureWater.addProperty("predictedTransition_C", qualification.getPredictedPureWaterTransitionCelsius());
+    pureWater.addProperty("evidenceMinimum_C", qualification.getPureWaterEvidenceMinimumCelsius());
+    pureWater.addProperty("evidenceMaximum_C", qualification.getPureWaterEvidenceMaximumCelsius());
+    pureWater.addProperty("envelopePass", qualification.isPureWaterEnvelopePass());
+    data.add("pureWater", pureWater);
+
+    JsonObject sodiumChloride25C = new JsonObject();
+    sodiumChloride25C.addProperty("requiredWaterActivity", qualification.getRequiredWaterActivityAt25Celsius());
+    sodiumChloride25C.addProperty("evidenceMinimumWaterActivity",
+        qualification.getSodiumChloride25CWaterActivityMinimum());
+    sodiumChloride25C.addProperty("evidenceMaximumWaterActivity",
+        qualification.getSodiumChloride25CWaterActivityMaximum());
+    sodiumChloride25C.addProperty("envelopePass", qualification.isSodiumChloride25CEnvelopePass());
+    data.add("sodiumChloride25C", sodiumChloride25C);
+
+    JsonObject sodiumChloride40C = new JsonObject();
+    sodiumChloride40C.addProperty("requiredWaterActivity", qualification.getRequiredWaterActivityAt40Celsius());
+    sodiumChloride40C.addProperty("evidenceMinimumWaterActivity",
+        qualification.getSodiumChloride40CWaterActivityMinimum());
+    sodiumChloride40C.addProperty("evidenceMaximumWaterActivity",
+        qualification.getSodiumChloride40CWaterActivityMaximum());
+    sodiumChloride40C.addProperty("envelopePass", qualification.isSodiumChloride40CEnvelopePass());
+    data.add("sodiumChloride40C", sodiumChloride40C);
+
+    data.addProperty("decision", qualification.getDecision());
+    data.addProperty("publicationReady", qualification.isPublicationReady());
+    data.addProperty("diagnostic", qualification.formatDiagnostic());
+    data.add("limitations", GSON.toJsonTree(qualification.getLimitations()));
     return data;
   }
 

--- a/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
+++ b/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
@@ -45,6 +45,7 @@ import neqsim.thermodynamicoperations.flashops.saturationops.AsphalteneOnsetTemp
 import neqsim.thermodynamicoperations.flashops.saturationops.BubblePointPressureFlash;
 import neqsim.thermodynamicoperations.flashops.saturationops.BubblePointPressureFlashDer;
 import neqsim.thermodynamicoperations.flashops.saturationops.BubblePointTemperatureNoDer;
+import neqsim.thermodynamicoperations.flashops.saturationops.CalciumSulfatePhaseBoundaryQualification;
 import neqsim.thermodynamicoperations.flashops.saturationops.CalcSaltSatauration;
 import neqsim.thermodynamicoperations.flashops.saturationops.CapillaryDewPointFlash;
 import neqsim.thermodynamicoperations.flashops.saturationops.CheckScalePotential;
@@ -1368,6 +1369,21 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
    */
   public MultiSaltPrecipitationResult equilibrateScales(MultiSaltPrecipitationResult previousResult) {
     return new MultiSaltPrecipitation(system, previousResult).solve();
+  }
+
+  /**
+   * Qualifies the authoritative COMPSALT gypsum/anhydrite phase boundary against independent evidence.
+   *
+   * <p>
+   * This operation evaluates the existing mineral correlations without fitting or changing them. The result separates
+   * mineral-standard-state evidence from Pitzer or electrolyte-EOS aqueous parameter qualification and fails closed
+   * outside the registered atmospheric-pressure envelope.
+   * </p>
+   *
+   * @return immutable source-traceable calcium-sulfate phase-boundary qualification
+   */
+  public CalciumSulfatePhaseBoundaryQualification qualifyCalciumSulfatePhaseBoundary() {
+    return new CalciumSulfatePhaseBoundaryQualification(system);
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalcSaltSatauration.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalcSaltSatauration.java
@@ -598,6 +598,28 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
   }
 
   /**
+   * Returns the authoritative COMPSALT solubility product at a specified state.
+   *
+   * <p>
+   * This package-level view lets scientific qualification code reuse the exact mineral correlation and pressure
+   * correction used by precipitation calculations. It does not initialise or mutate the thermodynamic system.
+   * </p>
+   *
+   * @param temperatureK temperature in Kelvin
+   * @param pressureBara absolute pressure in bara
+   * @return solubility product on the COMPSALT standard state
+   */
+  double getSolubilityProduct(double temperatureK, double pressureBara) {
+    if (!(temperatureK > 0.0) || !Double.isFinite(temperatureK)) {
+      throw new IllegalArgumentException("Temperature must be finite and positive");
+    }
+    if (!(pressureBara > 0.0) || !Double.isFinite(pressureBara)) {
+      throw new IllegalArgumentException("Pressure must be finite and positive");
+    }
+    return calculateKsp(readSaltData(), temperatureK, pressureBara);
+  }
+
+  /**
    * Calculates Ksp from the same COMPSALT correlations used by scale-potential calculations.
    *
    * @param saltData salt data from COMPSALT

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
@@ -25,8 +25,8 @@ import neqsim.thermo.system.SystemInterface;
 public final class CalciumSulfatePhaseBoundaryQualification implements Serializable {
   private static final long serialVersionUID = 1000L;
 
-  /** Atmospheric reference pressure used by the registered evidence. */
-  public static final double REFERENCE_PRESSURE_BARA = 1.01325;
+  /** One-bar reference pressure used by the registered evidence. */
+  public static final double REFERENCE_PRESSURE_BARA = 1.0;
   /** CC BY evidence source DOI. */
   public static final String EVIDENCE_DOI = "10.3389/fnuen.2023.1208582";
   /** Primary experimental lineage DOI. */
@@ -40,7 +40,7 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
   private static final double NACL_25_WATER_ACTIVITY_MAXIMUM = 0.8634;
   private static final double NACL_40_WATER_ACTIVITY_MINIMUM = 0.9370;
   private static final double NACL_40_WATER_ACTIVITY_MAXIMUM = 0.9587;
-  private static final double REFERENCE_PRESSURE_TOLERANCE_BARA = 1.0e-6;
+  private static final double REFERENCE_PRESSURE_TOLERANCE_BARA = 0.02;
 
   private final double evaluatedPressureBara;
   private final double predictedPureWaterTransitionCelsius;
@@ -145,7 +145,7 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
     return sodiumChloride40CEnvelopePass;
   }
 
-  /** @return whether the requested use pressure matches the atmospheric evidence pressure */
+  /** @return whether the requested pressure is within 0.02 bara of the one-bar evidence pressure */
   public boolean isReferencePressureEnvelopePass() {
     return referencePressureEnvelopePass;
   }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
@@ -1,0 +1,251 @@
+package neqsim.thermodynamicoperations.flashops.saturationops;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import neqsim.thermo.system.SystemInterface;
+
+/**
+ * Independent-evidence qualification of the COMPSALT gypsum/anhydrite phase boundary.
+ *
+ * <p>
+ * The calculation reuses the authoritative {@link CalcSaltSatauration} solubility-product path. For simultaneous
+ * equilibrium of anhydrite ({@code CaSO4}) and gypsum ({@code CaSO4.2H2O}), the dissolved-ion activity product cancels
+ * and the required water activity is {@code a(H2O) = sqrt(Ksp(gypsum) / Ksp(anhydrite))}. No mineral, Pitzer,
+ * electrolyte-EOS, or reaction parameter is fitted or changed by this evidence view.
+ * </p>
+ *
+ * <p>
+ * The declared validation envelopes are from Voigt and Freyer (2023), DOI 10.3389/fnuen.2023.1208582, CC BY 4.0. Bock
+ * (1961), DOI 10.1139/v61-228, is the primary experimental lineage for the two NaCl crossing intervals; no primary
+ * table row is redistributed here.
+ * </p>
+ */
+public final class CalciumSulfatePhaseBoundaryQualification implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Atmospheric reference pressure used by the registered evidence. */
+  public static final double REFERENCE_PRESSURE_BARA = 1.01325;
+  /** CC BY evidence source DOI. */
+  public static final String EVIDENCE_DOI = "10.3389/fnuen.2023.1208582";
+  /** Primary experimental lineage DOI. */
+  public static final String PRIMARY_LINEAGE_DOI = "10.1139/v61-228";
+  /** License of the registered numerical evidence. */
+  public static final String EVIDENCE_LICENSE = "CC BY 4.0";
+
+  private static final double PURE_WATER_MINIMUM_C = 41.0;
+  private static final double PURE_WATER_MAXIMUM_C = 43.0;
+  private static final double NACL_25_WATER_ACTIVITY_MINIMUM = 0.8551;
+  private static final double NACL_25_WATER_ACTIVITY_MAXIMUM = 0.8634;
+  private static final double NACL_40_WATER_ACTIVITY_MINIMUM = 0.9370;
+  private static final double NACL_40_WATER_ACTIVITY_MAXIMUM = 0.9587;
+  private static final double REFERENCE_PRESSURE_TOLERANCE_BARA = 1.0e-6;
+
+  private final double evaluatedPressureBara;
+  private final double predictedPureWaterTransitionCelsius;
+  private final double requiredWaterActivityAt25Celsius;
+  private final double requiredWaterActivityAt40Celsius;
+  private final boolean pureWaterEnvelopePass;
+  private final boolean sodiumChloride25CEnvelopePass;
+  private final boolean sodiumChloride40CEnvelopePass;
+  private final boolean referencePressureEnvelopePass;
+
+  /**
+   * Evaluates the current COMPSALT correlations without changing the supplied system.
+   *
+   * @param system thermodynamic system whose pressure defines the requested use state
+   */
+  public CalciumSulfatePhaseBoundaryQualification(SystemInterface system) {
+    if (system == null) {
+      throw new IllegalArgumentException("Thermodynamic system must not be null");
+    }
+    evaluatedPressureBara = system.getPressure();
+    if (!(evaluatedPressureBara > 0.0) || !Double.isFinite(evaluatedPressureBara)) {
+      throw new IllegalArgumentException("System pressure must be finite and positive");
+    }
+
+    CalcSaltSatauration anhydrite = new CalcSaltSatauration(system, "CaSO4_A");
+    CalcSaltSatauration gypsum = new CalcSaltSatauration(system, "CaSO4_G");
+    predictedPureWaterTransitionCelsius = solvePureWaterTransitionCelsius(anhydrite, gypsum);
+    requiredWaterActivityAt25Celsius = requiredWaterActivity(anhydrite, gypsum, 298.15);
+    requiredWaterActivityAt40Celsius = requiredWaterActivity(anhydrite, gypsum, 313.15);
+
+    pureWaterEnvelopePass = within(predictedPureWaterTransitionCelsius, PURE_WATER_MINIMUM_C, PURE_WATER_MAXIMUM_C);
+    sodiumChloride25CEnvelopePass = within(requiredWaterActivityAt25Celsius, NACL_25_WATER_ACTIVITY_MINIMUM,
+        NACL_25_WATER_ACTIVITY_MAXIMUM);
+    sodiumChloride40CEnvelopePass = within(requiredWaterActivityAt40Celsius, NACL_40_WATER_ACTIVITY_MINIMUM,
+        NACL_40_WATER_ACTIVITY_MAXIMUM);
+    referencePressureEnvelopePass = Math
+        .abs(evaluatedPressureBara - REFERENCE_PRESSURE_BARA) <= REFERENCE_PRESSURE_TOLERANCE_BARA;
+  }
+
+  /** @return pressure of the requested use state in bara */
+  public double getEvaluatedPressureBara() {
+    return evaluatedPressureBara;
+  }
+
+  /** @return predicted atmospheric pure-water transition temperature in degrees Celsius */
+  public double getPredictedPureWaterTransitionCelsius() {
+    return predictedPureWaterTransitionCelsius;
+  }
+
+  /** @return lower independent pure-water transition limit in degrees Celsius */
+  public double getPureWaterEvidenceMinimumCelsius() {
+    return PURE_WATER_MINIMUM_C;
+  }
+
+  /** @return upper independent pure-water transition limit in degrees Celsius */
+  public double getPureWaterEvidenceMaximumCelsius() {
+    return PURE_WATER_MAXIMUM_C;
+  }
+
+  /** @return whether the predicted pure-water transition is inside 42 +/- 1 degrees Celsius */
+  public boolean isPureWaterEnvelopePass() {
+    return pureWaterEnvelopePass;
+  }
+
+  /** @return water activity required by the COMPSALT correlations at 25 degrees Celsius */
+  public double getRequiredWaterActivityAt25Celsius() {
+    return requiredWaterActivityAt25Celsius;
+  }
+
+  /** @return lower independent NaCl water-activity crossing limit at 25 degrees Celsius */
+  public double getSodiumChloride25CWaterActivityMinimum() {
+    return NACL_25_WATER_ACTIVITY_MINIMUM;
+  }
+
+  /** @return upper independent NaCl water-activity crossing limit at 25 degrees Celsius */
+  public double getSodiumChloride25CWaterActivityMaximum() {
+    return NACL_25_WATER_ACTIVITY_MAXIMUM;
+  }
+
+  /** @return whether the 25 degrees Celsius required water activity is inside the independent interval */
+  public boolean isSodiumChloride25CEnvelopePass() {
+    return sodiumChloride25CEnvelopePass;
+  }
+
+  /** @return water activity required by the COMPSALT correlations at 40 degrees Celsius */
+  public double getRequiredWaterActivityAt40Celsius() {
+    return requiredWaterActivityAt40Celsius;
+  }
+
+  /** @return lower independent NaCl water-activity crossing limit at 40 degrees Celsius */
+  public double getSodiumChloride40CWaterActivityMinimum() {
+    return NACL_40_WATER_ACTIVITY_MINIMUM;
+  }
+
+  /** @return upper independent NaCl water-activity crossing limit at 40 degrees Celsius */
+  public double getSodiumChloride40CWaterActivityMaximum() {
+    return NACL_40_WATER_ACTIVITY_MAXIMUM;
+  }
+
+  /** @return whether the 40 degrees Celsius required water activity is inside the independent interval */
+  public boolean isSodiumChloride40CEnvelopePass() {
+    return sodiumChloride40CEnvelopePass;
+  }
+
+  /** @return whether the requested use pressure matches the atmospheric evidence pressure */
+  public boolean isReferencePressureEnvelopePass() {
+    return referencePressureEnvelopePass;
+  }
+
+  /**
+   * Reports the fail-closed publication decision.
+   *
+   * @return {@code true} only when all three independent phase-boundary envelopes and pressure scope pass
+   */
+  public boolean isPublicationReady() {
+    return pureWaterEnvelopePass && sodiumChloride25CEnvelopePass && sodiumChloride40CEnvelopePass
+        && referencePressureEnvelopePass;
+  }
+
+  /** @return deterministic {@code ACCEPTED} or {@code REJECTED} decision */
+  public String getDecision() {
+    return isPublicationReady() ? "ACCEPTED" : "REJECTED";
+  }
+
+  /** @return CC BY evidence source DOI */
+  public String getEvidenceDoi() {
+    return EVIDENCE_DOI;
+  }
+
+  /** @return primary Bock experimental-lineage DOI */
+  public String getPrimaryLineageDoi() {
+    return PRIMARY_LINEAGE_DOI;
+  }
+
+  /** @return evidence license */
+  public String getEvidenceLicense() {
+    return EVIDENCE_LICENSE;
+  }
+
+  /** @return immutable scientific limitations outside this evidence registration */
+  public List<String> getLimitations() {
+    return Collections.unmodifiableList(Arrays.asList(
+        "Bock primary-table transcription, preprocessing uncertainty, and absolute-solubility "
+            + "residuals remain unqualified",
+        "High-pressure use requires a verified reaction-volume convention with aqueous partial "
+            + "or apparent molar volumes",
+        "The registered evidence covers pure-water and NaCl phase crossings, not general "
+            + "mixed-brine mineral equilibrium"));
+  }
+
+  /** @return deterministic evidence and decision diagnostic */
+  public String formatDiagnostic() {
+    return "Calcium-sulfate phase-boundary qualification: decision=" + getDecision() + ", pureWaterTransition_C="
+        + predictedPureWaterTransitionCelsius + ", pureWaterEnvelope_C=[" + PURE_WATER_MINIMUM_C + ", "
+        + PURE_WATER_MAXIMUM_C + "]" + ", requiredWaterActivity25C=" + requiredWaterActivityAt25Celsius
+        + ", evidence25C=[" + NACL_25_WATER_ACTIVITY_MINIMUM + ", " + NACL_25_WATER_ACTIVITY_MAXIMUM + "]"
+        + ", requiredWaterActivity40C=" + requiredWaterActivityAt40Celsius + ", evidence40C=["
+        + NACL_40_WATER_ACTIVITY_MINIMUM + ", " + NACL_40_WATER_ACTIVITY_MAXIMUM + "]" + ", evaluatedPressure_bara="
+        + evaluatedPressureBara + ", referencePressurePass=" + referencePressureEnvelopePass + ", evidenceDoi="
+        + EVIDENCE_DOI + ", license=" + EVIDENCE_LICENSE;
+  }
+
+  private static double solvePureWaterTransitionCelsius(CalcSaltSatauration anhydrite, CalcSaltSatauration gypsum) {
+    double lowerTemperatureK = 273.15;
+    double upperTemperatureK = 373.15;
+    double lowerResidual = logKspDifference(anhydrite, gypsum, lowerTemperatureK);
+    double upperResidual = logKspDifference(anhydrite, gypsum, upperTemperatureK);
+    if (lowerResidual == 0.0) {
+      return lowerTemperatureK - 273.15;
+    }
+    if (upperResidual == 0.0) {
+      return upperTemperatureK - 273.15;
+    }
+    if (Math.signum(lowerResidual) == Math.signum(upperResidual)) {
+      throw new IllegalStateException(
+          "COMPSALT gypsum/anhydrite correlations do not bracket a transition from 0 to 100 C");
+    }
+    for (int iteration = 0; iteration < 100; iteration++) {
+      double trialTemperatureK = 0.5 * (lowerTemperatureK + upperTemperatureK);
+      double trialResidual = logKspDifference(anhydrite, gypsum, trialTemperatureK);
+      if (Math.abs(trialResidual) <= 1.0e-12) {
+        return trialTemperatureK - 273.15;
+      }
+      if (Math.signum(trialResidual) == Math.signum(lowerResidual)) {
+        lowerTemperatureK = trialTemperatureK;
+        lowerResidual = trialResidual;
+      } else {
+        upperTemperatureK = trialTemperatureK;
+      }
+    }
+    return 0.5 * (lowerTemperatureK + upperTemperatureK) - 273.15;
+  }
+
+  private static double requiredWaterActivity(CalcSaltSatauration anhydrite, CalcSaltSatauration gypsum,
+      double temperatureK) {
+    return Math.exp(0.5 * logKspDifference(anhydrite, gypsum, temperatureK));
+  }
+
+  private static double logKspDifference(CalcSaltSatauration anhydrite, CalcSaltSatauration gypsum,
+      double temperatureK) {
+    return Math.log(gypsum.getSolubilityProduct(temperatureK, REFERENCE_PRESSURE_BARA))
+        - Math.log(anhydrite.getSolubilityProduct(temperatureK, REFERENCE_PRESSURE_BARA));
+  }
+
+  private static boolean within(double value, double minimum, double maximum) {
+    return Double.isFinite(value) && value >= minimum && value <= maximum;
+  }
+}

--- a/src/test/java/neqsim/mcp/runners/ChemistryRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/ChemistryRunnerTest.java
@@ -150,6 +150,7 @@ class ChemistryRunnerTest {
     JsonObject result = JsonParser.parseString(ChemistryRunner.run(input)).getAsJsonObject();
     JsonObject data = result.getAsJsonObject("data");
     JsonObject minerals = data.getAsJsonObject("mineralResults");
+    JsonObject boundary = data.getAsJsonObject("calciumSulfatePhaseBoundaryQualification");
 
     assertEquals("success", result.get("status").getAsString());
     assertEquals("ThermodynamicOperations.precipitateScales", data.get("authoritativeJavaOperation").getAsString());
@@ -167,6 +168,16 @@ class ChemistryRunnerTest {
         1.0e-10);
     assertTrue(data.get("engineeringGatesPass").getAsBoolean());
     assertFalse(data.get("publicationReady").getAsBoolean());
+    assertEquals("ThermodynamicOperations.qualifyCalciumSulfatePhaseBoundary",
+        boundary.get("authoritativeJavaOperation").getAsString());
+    assertEquals("CC BY 4.0", boundary.get("evidenceLicense").getAsString());
+    assertEquals(60.445190, boundary.getAsJsonObject("pureWater").get("predictedTransition_C").getAsDouble(), 1.0e-6);
+    assertEquals(0.7736299, boundary.getAsJsonObject("sodiumChloride25C").get("requiredWaterActivity").getAsDouble(),
+        1.0e-7);
+    assertEquals(0.8437837, boundary.getAsJsonObject("sodiumChloride40C").get("requiredWaterActivity").getAsDouble(),
+        1.0e-7);
+    assertEquals("REJECTED", boundary.get("decision").getAsString());
+    assertFalse(boundary.get("publicationReady").getAsBoolean());
   }
 
   @Test

--- a/src/test/java/neqsim/mcp/runners/ChemistryRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/ChemistryRunnerTest.java
@@ -171,6 +171,8 @@ class ChemistryRunnerTest {
     assertEquals("ThermodynamicOperations.qualifyCalciumSulfatePhaseBoundary",
         boundary.get("authoritativeJavaOperation").getAsString());
     assertEquals("CC BY 4.0", boundary.get("evidenceLicense").getAsString());
+    assertEquals(1.0, boundary.get("referencePressure_bara").getAsDouble(), 0.0);
+    assertTrue(boundary.get("referencePressureEnvelopePass").getAsBoolean());
     assertEquals(60.445190, boundary.getAsJsonObject("pureWater").get("predictedTransition_C").getAsDouble(), 1.0e-6);
     assertEquals(0.7736299, boundary.getAsJsonObject("sodiumChloride25C").get("requiredWaterActivity").getAsDouble(),
         1.0e-7);

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
@@ -67,8 +67,8 @@ class CalciumSulfatePhaseBoundaryQualificationTest extends neqsim.NeqSimTest {
         .qualifyCalciumSulfatePhaseBoundary();
     assertTrue(oneBar.isReferencePressureEnvelopePass());
 
-    CalciumSulfatePhaseBoundaryQualification outsideAtmosphericEnvelope =
-        new ThermodynamicOperations(new SystemSrkEos(313.15, 1.03)).qualifyCalciumSulfatePhaseBoundary();
+    CalciumSulfatePhaseBoundaryQualification outsideAtmosphericEnvelope = new ThermodynamicOperations(
+        new SystemSrkEos(313.15, 1.03)).qualifyCalciumSulfatePhaseBoundary();
     assertFalse(outsideAtmosphericEnvelope.isReferencePressureEnvelopePass());
 
     CalciumSulfatePhaseBoundaryQualification highPressure = new ThermodynamicOperations(new SystemSrkEos(313.15, 500.0))

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
@@ -3,6 +3,7 @@ package neqsim.thermodynamicoperations.flashops.saturationops;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -35,6 +36,8 @@ class CalciumSulfatePhaseBoundaryQualificationTest extends neqsim.NeqSimTest {
     assertEquals("10.3389/fnuen.2023.1208582", qualification.getEvidenceDoi());
     assertEquals("10.1139/v61-228", qualification.getPrimaryLineageDoi());
     assertEquals("CC BY 4.0", qualification.getEvidenceLicense());
+    assertEquals(1.0, CalciumSulfatePhaseBoundaryQualification.REFERENCE_PRESSURE_BARA, 0.0);
+    assertTrue(qualification.isReferencePressureEnvelopePass());
     assertEquals(originalTemperature, system.getTemperature(), 0.0);
     assertEquals(originalPressure, system.getPressure(), 0.0);
   }
@@ -58,6 +61,15 @@ class CalciumSulfatePhaseBoundaryQualificationTest extends neqsim.NeqSimTest {
       restored = (CalciumSulfatePhaseBoundaryQualification) input.readObject();
     }
     assertEquals(first.formatDiagnostic(), restored.formatDiagnostic());
+    assertTrue(first.isReferencePressureEnvelopePass());
+
+    CalciumSulfatePhaseBoundaryQualification oneBar = new ThermodynamicOperations(new SystemSrkEos(313.15, 1.0))
+        .qualifyCalciumSulfatePhaseBoundary();
+    assertTrue(oneBar.isReferencePressureEnvelopePass());
+
+    CalciumSulfatePhaseBoundaryQualification outsideAtmosphericEnvelope =
+        new ThermodynamicOperations(new SystemSrkEos(313.15, 1.03)).qualifyCalciumSulfatePhaseBoundary();
+    assertFalse(outsideAtmosphericEnvelope.isReferencePressureEnvelopePass());
 
     CalciumSulfatePhaseBoundaryQualification highPressure = new ThermodynamicOperations(new SystemSrkEos(313.15, 500.0))
         .qualifyCalciumSulfatePhaseBoundary();

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
@@ -1,0 +1,67 @@
+package neqsim.thermodynamicoperations.flashops.saturationops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Independent-evidence tests for the COMPSALT gypsum/anhydrite phase boundary. */
+class CalciumSulfatePhaseBoundaryQualificationTest extends neqsim.NeqSimTest {
+
+  @Test
+  void currentCorrelationsFailClosedAgainstIndependentAtmosphericEvidence() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    double originalTemperature = system.getTemperature();
+    double originalPressure = system.getPressure();
+
+    CalciumSulfatePhaseBoundaryQualification qualification = new ThermodynamicOperations(system)
+        .qualifyCalciumSulfatePhaseBoundary();
+
+    assertEquals(60.445190, qualification.getPredictedPureWaterTransitionCelsius(), 1.0e-6);
+    assertEquals(0.7736299, qualification.getRequiredWaterActivityAt25Celsius(), 1.0e-7);
+    assertEquals(0.8437837, qualification.getRequiredWaterActivityAt40Celsius(), 1.0e-7);
+    assertFalse(qualification.isPureWaterEnvelopePass());
+    assertFalse(qualification.isSodiumChloride25CEnvelopePass());
+    assertFalse(qualification.isSodiumChloride40CEnvelopePass());
+    assertFalse(qualification.isPublicationReady());
+    assertEquals("REJECTED", qualification.getDecision());
+    assertEquals("10.3389/fnuen.2023.1208582", qualification.getEvidenceDoi());
+    assertEquals("10.1139/v61-228", qualification.getPrimaryLineageDoi());
+    assertEquals("CC BY 4.0", qualification.getEvidenceLicense());
+    assertEquals(originalTemperature, system.getTemperature(), 0.0);
+    assertEquals(originalPressure, system.getPressure(), 0.0);
+  }
+
+  @Test
+  void evidenceObjectIsDeterministicSerializableAndPressureScoped() throws Exception {
+    CalciumSulfatePhaseBoundaryQualification first = new ThermodynamicOperations(new SystemSrkEos(313.15, 1.01325))
+        .qualifyCalciumSulfatePhaseBoundary();
+    CalciumSulfatePhaseBoundaryQualification repeated = new ThermodynamicOperations(new SystemSrkEos(313.15, 1.01325))
+        .qualifyCalciumSulfatePhaseBoundary();
+    assertEquals(first.formatDiagnostic(), repeated.formatDiagnostic());
+    assertFalse(first.getLimitations().isEmpty());
+    assertThrows(UnsupportedOperationException.class, () -> first.getLimitations().add("unexpected"));
+
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(buffer)) {
+      output.writeObject(first);
+    }
+    CalciumSulfatePhaseBoundaryQualification restored;
+    try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()))) {
+      restored = (CalciumSulfatePhaseBoundaryQualification) input.readObject();
+    }
+    assertEquals(first.formatDiagnostic(), restored.formatDiagnostic());
+
+    CalciumSulfatePhaseBoundaryQualification highPressure = new ThermodynamicOperations(new SystemSrkEos(313.15, 500.0))
+        .qualifyCalciumSulfatePhaseBoundary();
+    assertFalse(highPressure.isReferencePressureEnvelopePass());
+    assertFalse(highPressure.isPublicationReady());
+  }
+}


### PR DESCRIPTION
## Engineering question

Can NeqSim expose a deterministic, source-traceable qualification of the existing COMPSALT gypsum/anhydrite phase boundary—without changing or fitting mineral, Pitzer, electrolyte-EOS, or reaction parameters—so users cannot mistake the current correlations for independently validated calcium-sulfate equilibrium?

Advances #3144. Capability contract: https://github.com/equinor/neqsim/issues/3144#issuecomment-5501111145

## Exact continuity and capacity

- **Exact base:** `b25bfa4560a13a7ee7fdca32e2dd98b3a7126065`
- **Exact head:** `ecf59ba5139933bc5d37d3dba52a1461a77210f5`
- **Branch:** `ai/3144-calcium-sulfate-boundary-qualification`
- No active #3144 implementation PR existed before publication.
- Current positively identified autonomous implementation portfolio: **6/10**.
- Three ordered commits; no rebase, merge-from-master, force push, or replacement of another capability.

## Capability

- Adds immutable Java/JPype evidence API:
  `ThermodynamicOperations.qualifyCalciumSulfatePhaseBoundary()`.
- Reuses the exact COMPSALT solubility-product path used by precipitation; no shadow correlation.
- Registers the independent one-bar evidence separately from aqueous Pitzer/electrolyte-EOS qualification; the atmospheric envelope accepts both 1.000 bara and 1 atm (1.01325 bara) and fails closed outside 0.98–1.02 bara.
- Exposes the same nested evidence through MCP only when both `CaSO4_A` and hydrated gypsum `CaSO4_G` are requested.
- Preserves fail-closed semantics: all current crossings are outside the registered envelopes, so the decision is `REJECTED` and `publicationReady=false`.
- Documents that `CaSO4_G` already includes two waters in equilibrium, balance, dissolution, and hydrated mass.

For simultaneous anhydrite and gypsum equilibrium, dissolved-ion activities cancel:

`a_w = sqrt(Ksp_G / Ksp_A)`.

## Independent evidence and current result

Voigt and Freyer (2023), DOI [10.3389/fnuen.2023.1208582](https://doi.org/10.3389/fnuen.2023.1208582), CC BY 4.0, provides the registered envelopes. Bock (1961), DOI [10.1139/v61-228](https://doi.org/10.1139/v61-228), remains the primary experimental lineage for the NaCl crossings; no copyrighted primary table rows are redistributed.

| Observable | Registered evidence | Current COMPSALT |
|---|---:|---:|
| Pure-water transition | 42 ± 1 °C | 60.445190 °C |
| 25 °C NaCl crossing | `a_w=0.8551–0.8634` | `a_w=0.7736299` |
| 40 °C NaCl crossing | `a_w=0.9370–0.9587` | `a_w=0.8437837` |

This PR deliberately does not tune coefficients. Absolute-solubility residuals, Bock primary-row uncertainty, mixed-brine qualification, and a defensible high-pressure reaction-volume convention remain outside scope.

## Validation evidence and current exact-head status

- Current exact head `ecf59ba5139933bc5d37d3dba52a1461a77210f5`: hosted CI started and is pending. No local validation is claimed for the formatter-only repair commit.
- Previous head `4ddf1020083ac504fe9b42163a65c486a72d14c3`: Java 8/21 on Ubuntu/Windows, all slow shards, Javadocs, MCP, documentation, CodeQL, PaperLab, and the dedicated format workflow passed. Pre-commit failed only because one new test chain required the exact hosted Spotless wrap now applied.
- Original implementation head `af6e27351c4bbcc63f0f9e9a20aad14084a77911` supplied the local evidence below.
- `python3 devtools/run_spotless.py check` — pass.
- `python3 devtools/check_documentation_search.py` — pass (682 Markdown pages, 1 standalone HTML page).
- `./mvnw -B -ntp -Dtest=CalciumSulfatePhaseBoundaryQualificationTest,ChemistryRunnerTest,MultiSaltPrecipitationTest,SaltPrecipitationTest test` — **31/31 pass**.
- `./mvnw -B -ntp -f pomJava8.xml -Djacoco.skip=true -Dtest=CalciumSulfatePhaseBoundaryQualificationTest,ChemistryRunnerTest,MultiSaltPrecipitationTest,SaltPrecipitationTest clean test` — **31/31 pass**, Java target 1.8.
- Both repository pre-commit stages pass: Spotless Format, Spotless Check, and Documentation Search Coverage.
- Determinism, serialization, immutable limitations, no system mutation, exact values, atmospheric pressure scope, and high-pressure fail-close behavior are covered.
- Existing salt tests retain material-balance, electroneutrality, mineral-equilibrium, non-negativity, and deterministic behavior gates.
- Exact-base performance, three fresh JVMs: complete multi-scale operation median `72,199,180 ns` (head) vs `72,845,029 ns` (base), ratio `0.9911` (**−0.89%**, no regression). Pitzer-kernel/neutral microtimings were noisy and no neutral runtime path changed, so no unsupported microbenchmark claim is made.
- Benchmark scientific sanity retained: H2S reaction residual `4.263e-14`, elemental residual `1.193e-13`, charge residual `−1.083e-14`.
- Local Javadoc generation is unavailable because this runtime has no `javadoc` executable/JDK tool; it remains explicitly pending hosted CI.

## Stop boundary

No Ksp, `Vdelta`, Pitzer, electrolyte-EOS, reaction, kinetics, flash, absorber, or salt API parameter/semantics are changed. No high-pressure validation claim is made.

**DRAFT — VALIDATION PENDING CI**