### PR TITLE
[AI-Assisted] feat(dexpi): expose cycle boundary evidence

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -181,10 +181,12 @@ of explicit non-empty material-connection endpoint references. A group is report
 than one endpoint, or when a singleton endpoint has an explicit self-reference. Cycle groups are
 ordered by their first endpoint; endpoint IDs retain first-reference order and internal connection
 IDs retain source order, including parallel occurrences. Each immutable
-`DexpiConnectionCycleInfo` links to its owning weak connection component and keeps unresolved
-endpoint IDs visible. This is graph-source evidence only: it does not identify a hydraulic recycle,
-enumerate elementary paths, assert convergence behavior, repair or rewire topology, or establish
-process intent.
+`DexpiConnectionCycleInfo` links to its owning weak connection component, keeps unresolved endpoint
+IDs visible, and separately lists source-ordered connection occurrences entering and leaving the
+cyclic group. Boundary lists preserve parallel references and exclude connections whose source or
+target identity is blank. This is graph-source evidence only: it does not identify a hydraulic
+recycle, enumerate elementary paths, assert convergence behavior, repair or rewire topology, or
+establish process intent.
 
 `toJson()` includes `instrumentCount`, `connectionCount`, `connectionEndpointCount`,
 `connectionComponentCount`, `connectionCycleCount`, and the ordered connection, endpoint,

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
@@ -25,6 +25,8 @@ public final class DexpiConnectionCycleInfo implements Serializable {
   private final String connectionComponentId;
   private final List<String> endpointIds;
   private final List<String> connectionIds;
+  private final List<String> incomingBoundaryConnectionIds;
+  private final List<String> outgoingBoundaryConnectionIds;
   private final List<String> unresolvedEndpointIds;
   private final boolean selfReference;
 
@@ -35,15 +37,20 @@ public final class DexpiConnectionCycleInfo implements Serializable {
    * @param connectionComponentId owning weak connection-component evidence identity
    * @param endpointIds endpoint identities in first-reference order
    * @param connectionIds internal connection-evidence identities in source order
+   * @param incomingBoundaryConnectionIds connection-evidence identities entering the cyclic group in source order
+   * @param outgoingBoundaryConnectionIds connection-evidence identities leaving the cyclic group in source order
    * @param unresolvedEndpointIds endpoint identities that do not resolve in the source document
    * @param selfReference whether the group contains an explicit self-reference connection
    */
   public DexpiConnectionCycleInfo(String id, String connectionComponentId, List<String> endpointIds,
-      List<String> connectionIds, List<String> unresolvedEndpointIds, boolean selfReference) {
+      List<String> connectionIds, List<String> incomingBoundaryConnectionIds,
+      List<String> outgoingBoundaryConnectionIds, List<String> unresolvedEndpointIds, boolean selfReference) {
     this.id = normalize(id);
     this.connectionComponentId = normalize(connectionComponentId);
     this.endpointIds = immutableCopy(endpointIds);
     this.connectionIds = immutableCopy(connectionIds);
+    this.incomingBoundaryConnectionIds = immutableCopy(incomingBoundaryConnectionIds);
+    this.outgoingBoundaryConnectionIds = immutableCopy(outgoingBoundaryConnectionIds);
     this.unresolvedEndpointIds = immutableCopy(unresolvedEndpointIds);
     this.selfReference = selfReference;
   }
@@ -68,6 +75,16 @@ public final class DexpiConnectionCycleInfo implements Serializable {
     return connectionIds;
   }
 
+  /** @return immutable connection-evidence identities entering this cyclic group in source order */
+  public List<String> getIncomingBoundaryConnectionIds() {
+    return incomingBoundaryConnectionIds;
+  }
+
+  /** @return immutable connection-evidence identities leaving this cyclic group in source order */
+  public List<String> getOutgoingBoundaryConnectionIds() {
+    return outgoingBoundaryConnectionIds;
+  }
+
   /** @return immutable unresolved endpoint identities */
   public List<String> getUnresolvedEndpointIds() {
     return unresolvedEndpointIds;
@@ -81,6 +98,16 @@ public final class DexpiConnectionCycleInfo implements Serializable {
   /** @return number of internal source connection occurrences */
   public int getConnectionCount() {
     return connectionIds.size();
+  }
+
+  /** @return number of source connection occurrences entering this cyclic group */
+  public int getIncomingBoundaryConnectionCount() {
+    return incomingBoundaryConnectionIds.size();
+  }
+
+  /** @return number of source connection occurrences leaving this cyclic group */
+  public int getOutgoingBoundaryConnectionCount() {
+    return outgoingBoundaryConnectionIds.size();
   }
 
   /** @return whether the group contains an explicit self-reference connection */
@@ -99,10 +126,14 @@ public final class DexpiConnectionCycleInfo implements Serializable {
     result.put("connectionComponentId", connectionComponentId);
     result.put("endpointCount", Integer.valueOf(getEndpointCount()));
     result.put("connectionCount", Integer.valueOf(getConnectionCount()));
+    result.put("incomingBoundaryConnectionCount", Integer.valueOf(getIncomingBoundaryConnectionCount()));
+    result.put("outgoingBoundaryConnectionCount", Integer.valueOf(getOutgoingBoundaryConnectionCount()));
     result.put("selfReference", Boolean.valueOf(selfReference));
     result.put("hasUnresolvedEndpoints", Boolean.valueOf(hasUnresolvedEndpoints()));
     result.put("endpointIds", endpointIds);
     result.put("connectionIds", connectionIds);
+    result.put("incomingBoundaryConnectionIds", incomingBoundaryConnectionIds);
+    result.put("outgoingBoundaryConnectionIds", outgoingBoundaryConnectionIds);
     result.put("unresolvedEndpointIds", unresolvedEndpointIds);
     return result;
   }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1025,10 +1025,20 @@ public final class DexpiXmlReader {
     }
 
     for (DexpiConnectionInfo connection : connections) {
+      if (isBlank(connection.getFromId()) || isBlank(connection.getToId())) {
+        continue;
+      }
       Integer fromCycleIndex = cycleByEndpointId.get(connection.getFromId());
       Integer toCycleIndex = cycleByEndpointId.get(connection.getToId());
       if (fromCycleIndex != null && fromCycleIndex.equals(toCycleIndex)) {
         cycles.get(fromCycleIndex.intValue()).addConnection(connection);
+      } else {
+        if (toCycleIndex != null) {
+          cycles.get(toCycleIndex.intValue()).addIncomingBoundaryConnection(connection);
+        }
+        if (fromCycleIndex != null) {
+          cycles.get(fromCycleIndex.intValue()).addOutgoingBoundaryConnection(connection);
+        }
       }
     }
 
@@ -1044,6 +1054,8 @@ public final class DexpiXmlReader {
     private final String connectionComponentId;
     private final List<String> endpointIds = new ArrayList<String>();
     private final List<String> connectionIds = new ArrayList<String>();
+    private final List<String> incomingBoundaryConnectionIds = new ArrayList<String>();
+    private final List<String> outgoingBoundaryConnectionIds = new ArrayList<String>();
     private final List<String> unresolvedEndpointIds = new ArrayList<String>();
     private boolean selfReference;
 
@@ -1066,9 +1078,17 @@ public final class DexpiXmlReader {
       }
     }
 
+    private void addIncomingBoundaryConnection(DexpiConnectionInfo connection) {
+      incomingBoundaryConnectionIds.add(connection.getId());
+    }
+
+    private void addOutgoingBoundaryConnection(DexpiConnectionInfo connection) {
+      outgoingBoundaryConnectionIds.add(connection.getId());
+    }
+
     private DexpiConnectionCycleInfo toInfo() {
-      return new DexpiConnectionCycleInfo(id, connectionComponentId, endpointIds, connectionIds, unresolvedEndpointIds,
-          selfReference);
+      return new DexpiConnectionCycleInfo(id, connectionComponentId, endpointIds, connectionIds,
+          incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds, unresolvedEndpointIds, selfReference);
     }
   }
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -680,10 +680,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
       assertFalse(cycle.getEndpointIds().contains("N-P"));
       assertFalse(cycle.getEndpointIds().contains("N-Q"));
     }
-    assertThrows(UnsupportedOperationException.class,
-        () -> connectedCycle.getIncomingBoundaryConnectionIds().clear());
-    assertThrows(UnsupportedOperationException.class,
-        () -> connectedCycle.getOutgoingBoundaryConnectionIds().clear());
+    assertThrows(UnsupportedOperationException.class, () -> connectedCycle.getIncomingBoundaryConnectionIds().clear());
+    assertThrows(UnsupportedOperationException.class, () -> connectedCycle.getOutgoingBoundaryConnectionIds().clear());
     assertTrue(first.toJson().contains("\"incomingBoundaryConnectionCount\": 2"));
     assertTrue(first.toJson().contains("\"outgoingBoundaryConnectionIds\": ["));
     assertEquals(first.toJson(), second.toJson());

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -626,6 +626,69 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(first.toJson(), second.toJson());
   }
 
+  @Test
+  public void testReadWithDiagnosticsSummarizesDirectedCycleBoundaries() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
+        + "<Equipment ID=\"E-A\"><Nozzle ID=\"N-A\"/></Equipment>"
+        + "<Equipment ID=\"E-X\"><Nozzle ID=\"N-X\"/></Equipment>"
+        + "<Equipment ID=\"E-Y\"><Nozzle ID=\"N-Y\"/></Equipment>"
+        + "<Equipment ID=\"E-B\"><Nozzle ID=\"N-B\"/></Equipment>"
+        + "<Equipment ID=\"E-S\"><Nozzle ID=\"N-S\"/></Equipment>"
+        + "<Equipment ID=\"E-P\"><Nozzle ID=\"N-P\"/></Equipment>"
+        + "<Equipment ID=\"E-Q\"><Nozzle ID=\"N-Q\"/></Equipment>"
+        + "<PipingNetworkSegment ID=\"S-IN-1\"><Connection ID=\"C-IN-1\" FromID=\"N-A\" ToID=\"N-X\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-IN-2\"><Connection ID=\"C-IN-2\" FromID=\"UNKNOWN-U\" ToID=\"N-X\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-XY\"><Connection ID=\"C-XY\" FromID=\"N-X\" ToID=\"N-Y\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-YX\"><Connection ID=\"C-YX\" FromID=\"N-Y\" ToID=\"N-X\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-OUT-1\"><Connection ID=\"C-OUT-1\" FromID=\"N-Y\" ToID=\"N-B\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-OUT-2\"><Connection ID=\"C-OUT-2\" FromID=\"N-Y\" ToID=\"N-B\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-SELF\"><Connection ID=\"C-SELF\" FromID=\"N-S\" ToID=\"N-S\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-PQ\"><Connection ID=\"C-PQ\" FromID=\"N-P\" ToID=\"N-Q\"/>"
+        + "</PipingNetworkSegment>" + "</PlantModel>";
+
+    DexpiXmlReader.ImportResult first = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    DexpiXmlReader.ImportResult second = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+    assertEquals(2, first.getConnectionCycles().size());
+
+    DexpiConnectionCycleInfo connectedCycle = first.getConnectionCycles().get(0);
+    assertEquals("cycle-1", connectedCycle.getId());
+    assertEquals("component-1", connectedCycle.getConnectionComponentId());
+    assertEquals(Arrays.asList("N-X", "N-Y"), connectedCycle.getEndpointIds());
+    assertEquals(Arrays.asList("C-XY", "C-YX"), connectedCycle.getConnectionIds());
+    assertEquals(Arrays.asList("C-IN-1", "C-IN-2"), connectedCycle.getIncomingBoundaryConnectionIds());
+    assertEquals(Arrays.asList("C-OUT-1", "C-OUT-2"), connectedCycle.getOutgoingBoundaryConnectionIds());
+    assertEquals(2, connectedCycle.getIncomingBoundaryConnectionCount());
+    assertEquals(2, connectedCycle.getOutgoingBoundaryConnectionCount());
+
+    DexpiConnectionCycleInfo closedSelfReference = first.getConnectionCycles().get(1);
+    assertEquals("cycle-2", closedSelfReference.getId());
+    assertEquals(Collections.singletonList("C-SELF"), closedSelfReference.getConnectionIds());
+    assertTrue(closedSelfReference.getIncomingBoundaryConnectionIds().isEmpty());
+    assertTrue(closedSelfReference.getOutgoingBoundaryConnectionIds().isEmpty());
+
+    for (DexpiConnectionCycleInfo cycle : first.getConnectionCycles()) {
+      assertFalse(cycle.getEndpointIds().contains("N-P"));
+      assertFalse(cycle.getEndpointIds().contains("N-Q"));
+    }
+    assertThrows(UnsupportedOperationException.class,
+        () -> connectedCycle.getIncomingBoundaryConnectionIds().clear());
+    assertThrows(UnsupportedOperationException.class,
+        () -> connectedCycle.getOutgoingBoundaryConnectionIds().clear());
+    assertTrue(first.toJson().contains("\"incomingBoundaryConnectionCount\": 2"));
+    assertTrue(first.toJson().contains("\"outgoingBoundaryConnectionIds\": ["));
+    assertEquals(first.toJson(), second.toJson());
+  }
+
   private static int countDiagnostics(DexpiXmlReader.ImportResult result, String expectedCode) {
     int count = 0;
     for (DexpiXmlReader.ImportDiagnostic diagnostic : result.getDiagnostics()) {


### PR DESCRIPTION
## Capability contract

Roadmap capability: directed-cycle boundary reference evidence for the Proteus-compatible DEXPI Plant/P&ID 4.1.1 supported subset.

- Contract recorded in #1332 and #2899.
- Exact base: `b25bfa4560a13a7ee7fdca32e2dd98b3a7126065`
- Exact publication head: `8b0a3eb4d963a202960df377ec18d8849750170a`
- Shared #1332/#2899 lane was free before publication.
- Positively identified autonomous implementation portfolio: 5/10 including this draft.

## Engineering question

Can the reader expose which explicit material-reference connections enter and leave each cyclic strongly connected group without claiming that the group is a hydraulic recycle or executable process topology?

## Change

- Extends immutable `DexpiConnectionCycleInfo` with incoming and outgoing boundary connection evidence.
- Classifies only explicit non-empty `FromID -> ToID` references.
- Preserves connection source order and parallel occurrences.
- Keeps internal connections distinct from boundary connections.
- Adds deterministic JSON, Java/JPype documentation, and focused regression coverage.
- Retains the O(V+E) reader analysis.

## Validation scope

Focused tests cover a multi-endpoint cycle with parallel incoming and outgoing boundaries, an unresolved external reference, a closed self-reference cycle, a one-way non-cycle component, immutable lists, and deterministic JSON.

Hosted workflows are authoritative. The first run identified only a test-line wrapping delta; the exact hosted Spotless repair was applied without behavior or scope changes. Status: **VALIDATION PENDING CI**.

## Safety and standards boundaries

This is source-reference graph evidence only. It does not establish connected fluid, feasible flow, a hydraulic recycle, open-valve state, convergence behavior, process intent, or live `ProcessSystem` topology. It does not enumerate paths, repair/rewire topology, infer fittings, or change simulation, layout, rendering, geometry, or export behavior.

Visual whole-sheet gate: **N/A** because no rendering or geometry path changes.

No native DEXPI 2.0 expansion, ISO/ISA standards-conformance claim, DEXPI certification, engineering approval, Huldra, or external-dataset work is included.

Draft only. Do not merge or mark ready as part of the autonomous campaign.