### PR TITLE
[AI-Assisted] feat(dexpi): expose cycle boundary occurrences

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -184,14 +184,19 @@ IDs retain source order, including parallel occurrences. Each immutable
 `DexpiConnectionCycleInfo` links to its owning weak connection component, keeps unresolved endpoint
 IDs visible, and separately lists source-ordered connection occurrences entering and leaving the
 cyclic group. Boundary lists preserve parallel references and exclude connections whose source or
-target identity is blank. This is graph-source evidence only: it does not identify a hydraulic
-recycle, enumerate elementary paths, assert convergence behavior, repair or rewire topology, or
-establish process intent.
+target identity is blank. `getBoundaryConnections()` additionally preserves the overall source order
+across incoming and outgoing occurrences. Each immutable `DexpiConnectionCycleBoundaryInfo` records
+the connection ID, direction relative to the cyclic group, explicit internal and external endpoint
+identities, and whether each endpoint resolves in the source document. This avoids inferring boundary
+orientation by joining separate inventories while retaining parallel and unresolved source evidence.
+It does not identify a hydraulic recycle, enumerate elementary paths, assert convergence behavior,
+repair or rewire topology, or establish process intent.
 
 `toJson()` includes `instrumentCount`, `connectionCount`, `connectionEndpointCount`,
 `connectionComponentCount`, `connectionCycleCount`, and the ordered connection, endpoint,
-component, and directed-cycle inventories, including incidence roles and review subsets, alongside
-the process-unit count and findings. Python callers through JPype use the same
+component, and directed-cycle inventories, including incidence roles, review subsets, and explicit
+cycle-boundary occurrences, alongside the process-unit count and findings. Python callers through
+JPype use the same
 `ImportResult.getInstruments()`, `ImportResult.getConnections()`,
 `ImportResult.getConnectionEndpoints()`, `ImportResult.getConnectionComponents()`, and
 `ImportResult.getConnectionCycles()` getters; there is no separate Python reconstruction model.

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleBoundaryInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleBoundaryInfo.java
@@ -1,0 +1,100 @@
+package neqsim.process.processmodel.dexpi;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Immutable source evidence for one connection occurrence crossing a directed-cycle boundary.
+ *
+ * <p>
+ * The internal and external endpoints are oriented relative to one cyclic strongly connected group. This record does
+ * not establish hydraulic continuity, a physical recycle, process intent, or live {@code ProcessSystem} topology.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Direction of one explicit connection occurrence relative to the cyclic group. */
+  public enum Direction {
+    /** The connection source is outside and its target is inside the cyclic group. */
+    INCOMING,
+    /** The connection source is inside and its target is outside the cyclic group. */
+    OUTGOING
+  }
+
+  private final String connectionId;
+  private final Direction direction;
+  private final String internalEndpointId;
+  private final String externalEndpointId;
+  private final boolean internalEndpointResolved;
+  private final boolean externalEndpointResolved;
+
+  /**
+   * Creates immutable cycle-boundary source-reference evidence.
+   *
+   * @param connectionId connection-evidence identity
+   * @param direction connection direction relative to the cyclic group
+   * @param internalEndpointId endpoint identity inside the cyclic group
+   * @param externalEndpointId endpoint identity outside the cyclic group
+   * @param internalEndpointResolved whether the internal endpoint resolves in the source document
+   * @param externalEndpointResolved whether the external endpoint resolves in the source document
+   */
+  public DexpiConnectionCycleBoundaryInfo(String connectionId, Direction direction, String internalEndpointId,
+      String externalEndpointId, boolean internalEndpointResolved, boolean externalEndpointResolved) {
+    this.connectionId = normalize(connectionId);
+    this.direction = direction;
+    this.internalEndpointId = normalize(internalEndpointId);
+    this.externalEndpointId = normalize(externalEndpointId);
+    this.internalEndpointResolved = internalEndpointResolved;
+    this.externalEndpointResolved = externalEndpointResolved;
+  }
+
+  /** @return connection-evidence identity */
+  public String getConnectionId() {
+    return connectionId;
+  }
+
+  /** @return connection direction relative to the cyclic group */
+  public Direction getDirection() {
+    return direction;
+  }
+
+  /** @return endpoint identity inside the cyclic group */
+  public String getInternalEndpointId() {
+    return internalEndpointId;
+  }
+
+  /** @return endpoint identity outside the cyclic group */
+  public String getExternalEndpointId() {
+    return externalEndpointId;
+  }
+
+  /** @return whether the internal endpoint resolves in the source document */
+  public boolean isInternalEndpointResolved() {
+    return internalEndpointResolved;
+  }
+
+  /** @return whether the external endpoint resolves in the source document */
+  public boolean isExternalEndpointResolved() {
+    return externalEndpointResolved;
+  }
+
+  Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("connectionId", connectionId);
+    result.put("direction", direction.name());
+    result.put("internalEndpointId", internalEndpointId);
+    result.put("externalEndpointId", externalEndpointId);
+    result.put("internalEndpointResolved", Boolean.valueOf(internalEndpointResolved));
+    result.put("externalEndpointResolved", Boolean.valueOf(externalEndpointResolved));
+    return result;
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
@@ -27,6 +27,7 @@ public final class DexpiConnectionCycleInfo implements Serializable {
   private final List<String> connectionIds;
   private final List<String> incomingBoundaryConnectionIds;
   private final List<String> outgoingBoundaryConnectionIds;
+  private final List<DexpiConnectionCycleBoundaryInfo> boundaryConnections;
   private final List<String> unresolvedEndpointIds;
   private final boolean selfReference;
 
@@ -45,12 +46,36 @@ public final class DexpiConnectionCycleInfo implements Serializable {
   public DexpiConnectionCycleInfo(String id, String connectionComponentId, List<String> endpointIds,
       List<String> connectionIds, List<String> incomingBoundaryConnectionIds,
       List<String> outgoingBoundaryConnectionIds, List<String> unresolvedEndpointIds, boolean selfReference) {
+    this(id, connectionComponentId, endpointIds, connectionIds, incomingBoundaryConnectionIds,
+        outgoingBoundaryConnectionIds, Collections.<DexpiConnectionCycleBoundaryInfo>emptyList(), unresolvedEndpointIds,
+        selfReference);
+  }
+
+  /**
+   * Creates immutable directed-cycle source-reference evidence with explicit boundary occurrences.
+   *
+   * @param id deterministic cycle-group evidence identity
+   * @param connectionComponentId owning weak connection-component evidence identity
+   * @param endpointIds endpoint identities in first-reference order
+   * @param connectionIds internal connection-evidence identities in source order
+   * @param incomingBoundaryConnectionIds connection-evidence identities entering the cyclic group in source order
+   * @param outgoingBoundaryConnectionIds connection-evidence identities leaving the cyclic group in source order
+   * @param boundaryConnections boundary occurrences in overall source-document order
+   * @param unresolvedEndpointIds endpoint identities that do not resolve in the source document
+   * @param selfReference whether the group contains an explicit self-reference connection
+   */
+  public DexpiConnectionCycleInfo(String id, String connectionComponentId, List<String> endpointIds,
+      List<String> connectionIds, List<String> incomingBoundaryConnectionIds,
+      List<String> outgoingBoundaryConnectionIds, List<DexpiConnectionCycleBoundaryInfo> boundaryConnections,
+      List<String> unresolvedEndpointIds, boolean selfReference) {
     this.id = normalize(id);
     this.connectionComponentId = normalize(connectionComponentId);
     this.endpointIds = immutableCopy(endpointIds);
     this.connectionIds = immutableCopy(connectionIds);
     this.incomingBoundaryConnectionIds = immutableCopy(incomingBoundaryConnectionIds);
     this.outgoingBoundaryConnectionIds = immutableCopy(outgoingBoundaryConnectionIds);
+    this.boundaryConnections = Collections
+        .unmodifiableList(new ArrayList<DexpiConnectionCycleBoundaryInfo>(boundaryConnections));
     this.unresolvedEndpointIds = immutableCopy(unresolvedEndpointIds);
     this.selfReference = selfReference;
   }
@@ -85,6 +110,11 @@ public final class DexpiConnectionCycleInfo implements Serializable {
     return outgoingBoundaryConnectionIds;
   }
 
+  /** @return immutable boundary occurrences in overall source-document order */
+  public List<DexpiConnectionCycleBoundaryInfo> getBoundaryConnections() {
+    return boundaryConnections;
+  }
+
   /** @return immutable unresolved endpoint identities */
   public List<String> getUnresolvedEndpointIds() {
     return unresolvedEndpointIds;
@@ -110,6 +140,11 @@ public final class DexpiConnectionCycleInfo implements Serializable {
     return outgoingBoundaryConnectionIds.size();
   }
 
+  /** @return number of source connection occurrences crossing this cyclic-group boundary */
+  public int getBoundaryConnectionCount() {
+    return boundaryConnections.size();
+  }
+
   /** @return whether the group contains an explicit self-reference connection */
   public boolean hasSelfReference() {
     return selfReference;
@@ -128,12 +163,18 @@ public final class DexpiConnectionCycleInfo implements Serializable {
     result.put("connectionCount", Integer.valueOf(getConnectionCount()));
     result.put("incomingBoundaryConnectionCount", Integer.valueOf(getIncomingBoundaryConnectionCount()));
     result.put("outgoingBoundaryConnectionCount", Integer.valueOf(getOutgoingBoundaryConnectionCount()));
+    result.put("boundaryConnectionCount", Integer.valueOf(getBoundaryConnectionCount()));
     result.put("selfReference", Boolean.valueOf(selfReference));
     result.put("hasUnresolvedEndpoints", Boolean.valueOf(hasUnresolvedEndpoints()));
     result.put("endpointIds", endpointIds);
     result.put("connectionIds", connectionIds);
     result.put("incomingBoundaryConnectionIds", incomingBoundaryConnectionIds);
     result.put("outgoingBoundaryConnectionIds", outgoingBoundaryConnectionIds);
+    List<Map<String, Object>> boundaryMaps = new ArrayList<Map<String, Object>>();
+    for (DexpiConnectionCycleBoundaryInfo boundary : boundaryConnections) {
+      boundaryMaps.add(boundary.toMap());
+    }
+    result.put("boundaryConnections", boundaryMaps);
     result.put("unresolvedEndpointIds", unresolvedEndpointIds);
     return result;
   }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1056,6 +1056,7 @@ public final class DexpiXmlReader {
     private final List<String> connectionIds = new ArrayList<String>();
     private final List<String> incomingBoundaryConnectionIds = new ArrayList<String>();
     private final List<String> outgoingBoundaryConnectionIds = new ArrayList<String>();
+    private final List<DexpiConnectionCycleBoundaryInfo> boundaryConnections = new ArrayList<DexpiConnectionCycleBoundaryInfo>();
     private final List<String> unresolvedEndpointIds = new ArrayList<String>();
     private boolean selfReference;
 
@@ -1080,15 +1081,22 @@ public final class DexpiXmlReader {
 
     private void addIncomingBoundaryConnection(DexpiConnectionInfo connection) {
       incomingBoundaryConnectionIds.add(connection.getId());
+      boundaryConnections.add(
+          new DexpiConnectionCycleBoundaryInfo(connection.getId(), DexpiConnectionCycleBoundaryInfo.Direction.INCOMING,
+              connection.getToId(), connection.getFromId(), connection.isToResolved(), connection.isFromResolved()));
     }
 
     private void addOutgoingBoundaryConnection(DexpiConnectionInfo connection) {
       outgoingBoundaryConnectionIds.add(connection.getId());
+      boundaryConnections.add(
+          new DexpiConnectionCycleBoundaryInfo(connection.getId(), DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING,
+              connection.getFromId(), connection.getToId(), connection.isFromResolved(), connection.isToResolved()));
     }
 
     private DexpiConnectionCycleInfo toInfo() {
       return new DexpiConnectionCycleInfo(id, connectionComponentId, endpointIds, connectionIds,
-          incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds, unresolvedEndpointIds, selfReference);
+          incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds, boundaryConnections, unresolvedEndpointIds,
+          selfReference);
     }
   }
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -14,6 +14,7 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import neqsim.NeqSimTest;
 import neqsim.process.equipment.EquipmentEnum;
@@ -638,13 +639,13 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         + "<Equipment ID=\"E-Q\"><Nozzle ID=\"N-Q\"/></Equipment>"
         + "<PipingNetworkSegment ID=\"S-IN-1\"><Connection ID=\"C-IN-1\" FromID=\"N-A\" ToID=\"N-X\"/>"
         + "</PipingNetworkSegment>"
-        + "<PipingNetworkSegment ID=\"S-IN-2\"><Connection ID=\"C-IN-2\" FromID=\"UNKNOWN-U\" ToID=\"N-X\"/>"
-        + "</PipingNetworkSegment>"
         + "<PipingNetworkSegment ID=\"S-XY\"><Connection ID=\"C-XY\" FromID=\"N-X\" ToID=\"N-Y\"/>"
         + "</PipingNetworkSegment>"
-        + "<PipingNetworkSegment ID=\"S-YX\"><Connection ID=\"C-YX\" FromID=\"N-Y\" ToID=\"N-X\"/>"
-        + "</PipingNetworkSegment>"
         + "<PipingNetworkSegment ID=\"S-OUT-1\"><Connection ID=\"C-OUT-1\" FromID=\"N-Y\" ToID=\"N-B\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-IN-2\"><Connection ID=\"C-IN-2\" FromID=\"UNKNOWN-U\" ToID=\"N-X\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-YX\"><Connection ID=\"C-YX\" FromID=\"N-Y\" ToID=\"N-X\"/>"
         + "</PipingNetworkSegment>"
         + "<PipingNetworkSegment ID=\"S-OUT-2\"><Connection ID=\"C-OUT-2\" FromID=\"N-Y\" ToID=\"N-B\"/>"
         + "</PipingNetworkSegment>"
@@ -669,12 +670,32 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(Arrays.asList("C-OUT-1", "C-OUT-2"), connectedCycle.getOutgoingBoundaryConnectionIds());
     assertEquals(2, connectedCycle.getIncomingBoundaryConnectionCount());
     assertEquals(2, connectedCycle.getOutgoingBoundaryConnectionCount());
+    assertEquals(4, connectedCycle.getBoundaryConnectionCount());
+
+    List<DexpiConnectionCycleBoundaryInfo> boundaries = connectedCycle.getBoundaryConnections();
+    assertEquals(Arrays.asList("C-IN-1", "C-OUT-1", "C-IN-2", "C-OUT-2"),
+        Arrays.asList(boundaries.get(0).getConnectionId(), boundaries.get(1).getConnectionId(),
+            boundaries.get(2).getConnectionId(), boundaries.get(3).getConnectionId()));
+    assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.INCOMING, boundaries.get(0).getDirection());
+    assertEquals("N-X", boundaries.get(0).getInternalEndpointId());
+    assertEquals("N-A", boundaries.get(0).getExternalEndpointId());
+    assertTrue(boundaries.get(0).isInternalEndpointResolved());
+    assertTrue(boundaries.get(0).isExternalEndpointResolved());
+    assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING, boundaries.get(1).getDirection());
+    assertEquals("N-Y", boundaries.get(1).getInternalEndpointId());
+    assertEquals("N-B", boundaries.get(1).getExternalEndpointId());
+    assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.INCOMING, boundaries.get(2).getDirection());
+    assertEquals("N-X", boundaries.get(2).getInternalEndpointId());
+    assertEquals("UNKNOWN-U", boundaries.get(2).getExternalEndpointId());
+    assertTrue(boundaries.get(2).isInternalEndpointResolved());
+    assertFalse(boundaries.get(2).isExternalEndpointResolved());
 
     DexpiConnectionCycleInfo closedSelfReference = first.getConnectionCycles().get(1);
     assertEquals("cycle-2", closedSelfReference.getId());
     assertEquals(Collections.singletonList("C-SELF"), closedSelfReference.getConnectionIds());
     assertTrue(closedSelfReference.getIncomingBoundaryConnectionIds().isEmpty());
     assertTrue(closedSelfReference.getOutgoingBoundaryConnectionIds().isEmpty());
+    assertTrue(closedSelfReference.getBoundaryConnections().isEmpty());
 
     for (DexpiConnectionCycleInfo cycle : first.getConnectionCycles()) {
       assertFalse(cycle.getEndpointIds().contains("N-P"));
@@ -682,7 +703,15 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     }
     assertThrows(UnsupportedOperationException.class, () -> connectedCycle.getIncomingBoundaryConnectionIds().clear());
     assertThrows(UnsupportedOperationException.class, () -> connectedCycle.getOutgoingBoundaryConnectionIds().clear());
+    assertThrows(UnsupportedOperationException.class, () -> connectedCycle.getBoundaryConnections().clear());
+    DexpiConnectionCycleInfo legacy = new DexpiConnectionCycleInfo("legacy", "component-legacy",
+        Collections.<String>emptyList(), Collections.<String>emptyList(), Collections.<String>emptyList(),
+        Collections.<String>emptyList(), Collections.<String>emptyList(), false);
+    assertTrue(legacy.getBoundaryConnections().isEmpty());
     assertTrue(first.toJson().contains("\"incomingBoundaryConnectionCount\": 2"));
+    assertTrue(first.toJson().contains("\"boundaryConnectionCount\": 4"));
+    assertTrue(first.toJson().contains("\"direction\": \"INCOMING\""));
+    assertTrue(first.toJson().contains("\"externalEndpointId\": \"UNKNOWN-U\""));
     assertTrue(first.toJson().contains("\"outgoingBoundaryConnectionIds\": ["));
     assertEquals(first.toJson(), second.toJson());
   }


### PR DESCRIPTION
## Capability contract

Advances #1332 and #2899 under their shared engineering-diagram lane.

- **Exact base:** `184a65c837e4afe7f93ffeb24d7b699a65902e7f`
- **Exact publication head:** `8730a36adf7a7da4cf0aa4e17aa207166da2958c`
- **Branch:** `ai/dexpi-cycle-boundary-occurrences`
- Shared #1332/#2899 lane was free immediately before publication.
- One positively identified autonomous implementation PR was open before publication; this draft makes **2/10**, below the target and absolute global ceiling.

## Engineering question

Can the Proteus-compatible DEXPI 4.1.1 reader expose each directed-cycle boundary connection as an immutable source-ordered occurrence with explicit internal/external endpoint identities and resolution evidence, without inferring hydraulic continuity or executable topology?

## Change

- Adds immutable `DexpiConnectionCycleBoundaryInfo` evidence with:
  - connection-evidence ID;
  - `INCOMING` or `OUTGOING` direction relative to the cyclic group;
  - explicit internal and external endpoint identities;
  - independent source-document resolution flags.
- Extends `DexpiConnectionCycleInfo` with an immutable overall source-ordered boundary inventory and count.
- Preserves the existing incoming/outgoing boundary-ID APIs and adds a compatibility-preserving constructor overload.
- Preserves interleaved source order, parallel boundary occurrences, and unresolved non-empty endpoint references.
- Adds deterministic JSON and the same Java/JPype API surface.
- Keeps the existing O(V + E) reader analysis and all reader, simulation, writer, renderer, geometry, layout, and export behavior unchanged.

## Focused evidence

Regressions cover:

- interleaved incoming and outgoing boundary occurrences;
- parallel outgoing occurrences;
- correct internal/external orientation for both directions;
- unresolved external endpoint evidence;
- closed self-reference cycles with no boundaries;
- immutable boundary collections;
- legacy constructor/API compatibility;
- deterministic JSON.

## Local validation

- `python3 devtools/run_spotless.py apply`: passed and stable.
- `python3 devtools/run_spotless.py check`: passed.
- `python3 devtools/check_documentation_search.py`: passed; 683 Markdown pages and one standalone HTML page.
- Standard POM focused/adjacent DEXPI suite: **61 tests passed, 0 failures/errors/skips** (`DexpiXmlReaderTest`, `DexpiInstrumentTest`, `DexpiXmlWriterTest`).
- Clean Java-8-target POM focused reader suite: **18 tests passed, 0 failures/errors/skips** after compiling 3,279 production and 1,907 test sources with target 1.8.
- `git diff --check`: passed.
- Local `pre-commit` was unavailable; installing it in a task-specific environment was blocked by the runtime's network-approval policy. The direct Spotless and documentation gates above passed.
- Local Javadoc generation was blocked because this runtime has no usable `javadoc` command/`JAVA_HOME`; no local Javadoc pass is claimed. Hosted CI remains authoritative.

Status: **VALIDATION PENDING CI**.

## Documentation and whole-sheet impact

Updated `docs/integration/dexpi-reader.md` for Java/JPype and JSON boundary-occurrence semantics.

Whole-sheet visual gate: **N/A with evidence**. No writer, renderer, SVG, geometry, layout, graphical primitive, notebook, or drawing benchmark path changed. Hosted notebook and engineering-diagram workflows remain compatibility gates.

## Engineering boundary

This is source-reference graph evidence only. It does not prove connected fluid, feasible flow, a hydraulic recycle, open-valve state, process intent, convergence behavior, fitting identity, or runnable `ProcessSystem` topology.

Stops before elementary-path enumeration, reachability solving, automatic repair/rewiring, fitting inference, native DEXPI 2.0 expansion, licensed-standard mapping, DEXPI certification, accountable engineering approval, Huldra, or external datasets.

Draft only. Do not merge, mark ready for review, or enable auto-merge as part of the autonomous campaign.

Generated with AI assistance.