### PR TITLE
[AI-Assisted] feat(refinery): add complete DOE Big Hill assay slate

### DIFF
--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -59,6 +59,9 @@ For crude/petroleum assays, use `OilAssayCharacterisation` rather than manually 
 
 See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the complete contract and the refinery campaign gap matrix. Independent public-data bookkeeping evidence is tracked in [DOE Big Hill Sweet refinery assay validation](refinery_big_hill_validation), whole-assay density/API evidence in [DOE/OEDI COA bulk density qualification](refinery_oedi_coa_bulk_density_validation), per-cut characterization evidence in [DOE Big Hill Watson-factor qualification](refinery_big_hill_watson_validation), terminal representative-temperature evidence in [DOE Big Hill terminal-Watson qualification](refinery_big_hill_watson_terminal_validation), composition-resolved light-end evidence in [DOE Big Hill light-end qualification](refinery_big_hill_light_ends_validation), PIANO aggregate molar-mass evidence in [DOE Big Hill C5-175 degF qualification](refinery_big_hill_piano_molar_mass_validation), assay-quality evidence in [DOE Big Hill sulfur qualification](refinery_big_hill_sulfur_validation) and [DOE Big Hill nitrogen qualification](refinery_big_hill_nitrogen_validation), terminal-boundary evidence in [DOE Big Hill terminal-cut qualification](refinery_big_hill_terminal_boundary_validation), and the process-integration gate in [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation).
 
+The qualified inputs are assembled into one reusable reference composition by
+[DOE Big Hill Sweet complete modeled assay slate](refinery_big_hill_complete_slate).
+
 ## TBP fraction models
 
 TBP models estimate the properties needed to represent petroleum pseudo-components in an EOS. Available implementations include Pedersen SRK/PR variants, Lee-Kesler, Riazi-Daubert, Twu, Cavett, and Standing.
@@ -145,6 +148,7 @@ A bookkeeping regression does not by itself validate a petroleum-property correl
 - [DOE Big Hill terminal-Watson qualification](refinery_big_hill_watson_terminal_validation)
 - [DOE Big Hill composition-resolved light-end qualification](refinery_big_hill_light_ends_validation)
 - [DOE Big Hill C5-175 degF PIANO molar-mass qualification](refinery_big_hill_piano_molar_mass_validation)
+- [DOE Big Hill Sweet complete modeled assay slate](refinery_big_hill_complete_slate)
 - [DOE Big Hill assay sulfur qualification](refinery_big_hill_sulfur_validation)
 - [DOE Big Hill assay nitrogen qualification](refinery_big_hill_nitrogen_validation)
 - [DOE Big Hill terminal-cut boundary qualification](refinery_big_hill_terminal_boundary_validation)

--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -194,6 +194,18 @@ reported 5.22 mass% yield, SG60/60 = 0.6731, and one-sided 175 degF upper bounda
 reproducible explicit-molar-mass cut without inventing a lower or representative boiling point. It
 does not resolve isomers or validate critical properties, VLE, or fractionation yields.
 
+## Complete public reference slate
+
+`DoeBigHillSweetAssay.create(system, totalMassKg)` composes the qualified DOE Big Hill inputs into a
+complete source-specific mass-basis assay. It configures four standard C2-C4 components plus eight
+petroleum cuts without automatically mutating the thermodynamic component list. The caller inspects
+the returned `OilAssayCharacterisation` and invokes `apply()` explicitly.
+
+The [complete modeled-slate contract and provenance](refinery_big_hill_complete_slate) document the
+2021 workbook values, the normalized C2-C4 allocation assumption, the blank sulfur/nitrogen screening
+assumptions, exact mass closure, and the boundary between reproducibility and property/process
+validation.
+
 ## Open-ended terminal boiling boundaries
 
 Terminal assay cuts often publish only one boiling limit. Use
@@ -263,6 +275,8 @@ The regression suite for this API currently verifies:
 - composition-resolved standard-component ingestion for the DOE Big Hill C2-C4 light ends;
 - whole-assay total-sulfur reconstruction against the public DOE Big Hill Sweet 2021 assay;
 - whole-assay total-nitrogen reconstruction against the public DOE Big Hill Sweet 2021 assay;
+- deterministic complete-slate construction with four standard light molecules, eight petroleum
+  pseudo-components, exact assay-mass closure, and preserved terminal evidence boundaries;
 - input-order independence and no thermodynamic-system mutation for bulk-property queries.
 
 These tests establish software/bookkeeping correctness, qualify ideal-additive-volume SG/API screening over the frozen COA matrix (published crude SG 0.765-0.847; maximum observed errors 0.006 SG and 1.5 degrees API), qualify per-cut Watson factors over the frozen DOE matrix (375-1050 degF; maximum observed error 0.0122), qualify the DOE residue's Watson-derived representative temperature, qualify the DOE C2-C4 standard-component split, qualify the DOE C5-175 degF PIANO aggregate molar mass, and qualify linear assay sulfur and nitrogen bookkeeping over one complete DOE crude slate. They do **not** qualify temperature correction, contraction, generic molecular-weight or critical-property correlations, sulfur/nitrogen species or reactions, or atmospheric/vacuum fractionation; those remain separate campaign gates in issue #3305.
@@ -281,6 +295,7 @@ These tests establish software/bookkeeping correctness, qualify ideal-additive-v
 | Per-cut UOP/Watson characterization factor | `AssayCut.getWatsonCharacterizationFactor()` | DOE-qualified for assay screening over 375-1050 degF |
 | Assay-carried total sulfur | `getBulkSulfurMassFraction/Percent()` | DOE-qualified for linear bookkeeping over one complete crude slate |
 | Assay-carried total nitrogen | `getBulkNitrogenMassFraction/Percent()` | DOE-qualified for linear bookkeeping over one complete crude slate |
+| Complete public reference slate | `DoeBigHillSweetAssay` | Reproducible modeled 2021 DOE composition; property and process validation remain separate gates |
 | TBP pseudo-component properties | Pedersen, Lee-Kesler, Riazi-Daubert, Twu, Cavett, Standing and related models | Existing; needs refinery-range independent validation |
 | Plus-fraction splitting/lumping | `Characterise`, plus-fraction and lumping models | Existing; refinery assay integration still to be qualified |
 | Oil density/API and volatility standards | Oil-quality standards package, RVP/TVP workflows | Whole-assay SG/API, per-cut Watson and linear sulfur/nitrogen bookkeeping qualified over frozen public matrices; broader stream properties remain open |
@@ -294,4 +309,6 @@ These tests establish software/bookkeeping correctness, qualify ideal-additive-v
 
 ## Next campaign step
 
-The next dependency-ready characterization increment should assemble the qualified C2-C4, C5-175 degF, bounded distillate, and terminal-residue treatments into a complete reproducible crude slate. The process benchmark can then advance from the bounded DOE atmospheric integration case to independent cut-yield and boiling-range evidence before vacuum fractionation.
+The next dependency-ready process increment should advance the bounded DOE atmospheric integration
+case to this complete modeled slate and compare product yields and boiling ranges against independent
+public evidence before vacuum fractionation.

--- a/docs/thermo/characterization/refinery_big_hill_complete_slate.md
+++ b/docs/thermo/characterization/refinery_big_hill_complete_slate.md
@@ -1,0 +1,71 @@
+---
+title: "DOE Big Hill Sweet complete modeled assay slate"
+description: "Reproducible full-crude reference composition assembled from qualified DOE comprehensive-assay and PIANO inputs."
+---
+
+# DOE Big Hill Sweet complete modeled assay slate
+
+`DoeBigHillSweetAssay` assembles the refinery campaign's qualified public inputs into one reusable
+Java/JPype assay definition. The factory configures an `OilAssayCharacterisation` on a caller-selected
+mass basis and deliberately requires a separate `apply()` call before the thermodynamic system is
+mutated.
+
+## Primary public sources
+
+- DOE SPR [Big Hill Sweet comprehensive assay](https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx),
+  reported 24 September 2021;
+- DOE SPR [Big Hill Sweet PIANO workbook](https://www.spr.doe.gov/reports/Assays/2021/BigHillSwPIANO.xlsx).
+
+The comprehensive workbook reports the following non-overlapping mass-basis cuts. The mass yields
+close to exactly 100.00% at the displayed precision.
+
+| Cut | Mass % | SG60/60 | Sulfur mass % | Nitrogen mass % | Characterization |
+| --- | ---: | ---: | ---: | ---: | --- |
+| C2-C4 gas | 1.70 | — | 0 assumed | 0 assumed | DOE PIANO C2-C4 subset normalized over the whole gas slice |
+| C5-175 degF | 5.22 | 0.6731 | 0.0008 | 0 assumed | PIANO-derived 0.0791538366563 kg/mol; upper boundary only |
+| 175-250 degF | 8.32 | 0.7432 | 0.0026 | 0 assumed | finite DOE cut boundaries |
+| 250-375 degF | 12.55 | 0.7817 | 0.019 | 0 assumed | finite DOE cut boundaries |
+| 375-530 degF | 16.19 | 0.8297 | 0.096 | 0.0018 | finite DOE cut boundaries |
+| 530-650 degF | 13.18 | 0.8604 | 0.313 | 0.0186 | finite DOE cut boundaries |
+| 650-850 degF | 18.44 | 0.9039 | 0.534 | 0.102 | finite DOE cut boundaries |
+| 850-1050 degF | 12.84 | 0.9336 | 0.752 | 0.234 | finite DOE cut boundaries |
+| 1050 degF+ | 11.56 | 1.0089 | 1.334 | 0.501 | lower boundary only; DOE Watson factor 11.7 |
+
+DOE leaves sulfur blank for the gas cut and nitrogen blank through the 250-375 degF cut. The zeros
+above are the same explicit screening assumptions used by the independently qualified sulfur and
+nitrogen bookkeeping tests; they are not reported measurements.
+
+## Light-end allocation assumption
+
+The PIANO debutanization table reports ethane 0.09, propane 10.38, i-butane 10.21, and n-butane
+45.95 wt%, totaling the reported 66.63 wt% C2-C4 subset. The reference factory normalizes those four
+weights and allocates the full 1.70 mass% gas cut between them. This preserves the published gas-cut
+mass while supplying real NeqSim standard components, but it is not a measured complete gas analysis.
+
+## Usage
+
+```java
+SystemInterface crude = new SystemSrkEos(298.15, 1.01325);
+OilAssayCharacterisation assay = DoeBigHillSweetAssay.create(crude, 1.0); // kg
+
+// Inspect mass fractions, sulfur/nitrogen, and boundaries before mutation.
+double sulfurMassPercent = assay.getBulkSulfurMassPercent();
+assay.apply();
+```
+
+The one-kilogram regression requires 12 positive components (four standard light molecules and eight
+petroleum pseudo-components), reconstructed component mass closure within `1e-10 kg`, sulfur
+0.40867518 mass%, and nitrogen 0.1095129 mass%. A second construction must produce the identical
+resolved mass vector.
+
+## Evidence and validity boundary
+
+This class is a source-specific reproducible reference composition. It does not mix the older 1998
+five-cut table with the 2021 nine-cut workbook. It also does not validate the normalized gas allocation,
+generated critical properties, acentric factors, vapor-liquid equilibrium, atmospheric product yields,
+or conversion-unit performance. DOE publishes the workbook for information purposes with no warranty
+of accuracy or completeness; users remain responsible for its application.
+
+The next validation gate is to run this complete slate through the atmospheric-column workflow and
+compare product yields and boiling ranges against independent public evidence before advancing to
+vacuum fractionation.

--- a/src/main/java/neqsim/thermo/characterization/DoeBigHillSweetAssay.java
+++ b/src/main/java/neqsim/thermo/characterization/DoeBigHillSweetAssay.java
@@ -1,0 +1,111 @@
+package neqsim.thermo.characterization;
+
+import java.util.Objects;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.system.SystemInterface;
+
+/**
+ * Reproducible modeled assay slate for the DOE SPR Big Hill Sweet reference crude.
+ *
+ * <p>
+ * The mass yields, liquid specific gravities, boiling boundaries, sulfur, nitrogen, and terminal-residue Watson factor
+ * are frozen from the U.S. Department of Energy Strategic Petroleum Reserve Big Hill Sweet comprehensive assay reported
+ * 24 September 2021. The C2-C4 composition and the C5-175 degF number-average molar mass use the companion DOE PIANO
+ * workbook.
+ * </p>
+ *
+ * <p>
+ * DOE reports a 1.70 mass% gas cut but the PIANO debutanization table reports a C2-C4 subset rather than a complete gas
+ * composition. This reference slate therefore normalizes the reported ethane, propane, i-butane, and n-butane weights
+ * over that subset and allocates the complete gas-cut mass to those four components. That allocation and the zero
+ * sulfur/nitrogen values used where DOE leaves a cut blank are explicit modeling assumptions, not additional
+ * measurements.
+ * </p>
+ *
+ * <p>
+ * {@link #create(SystemInterface, double)} configures the assay attached to the supplied system but does not add
+ * thermodynamic components. Call {@link OilAssayCharacterisation#apply()} explicitly after inspecting or modifying the
+ * returned characterization.
+ * </p>
+ */
+public final class DoeBigHillSweetAssay {
+  /** Official DOE SPR comprehensive-assay workbook. */
+  public static final String COMPREHENSIVE_ASSAY_URL = "https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx";
+
+  /** Official DOE SPR PIANO workbook. */
+  public static final String PIANO_ASSAY_URL = "https://www.spr.doe.gov/reports/Assays/2021/BigHillSwPIANO.xlsx";
+
+  private static final double GAS_MASS_PERCENT = 1.70;
+  private static final String[] GAS_COMPONENT_NAMES = { "ethane", "propane", "i-butane", "n-butane" };
+  private static final double[] GAS_COMPONENT_WEIGHT_PERCENT = { 0.09, 10.38, 10.21, 45.95 };
+  private static final double GAS_SUBSET_WEIGHT_PERCENT = 66.63;
+  private static final double C5_175_MOLAR_MASS_KG_PER_MOL = 0.07915383665629189;
+
+  private DoeBigHillSweetAssay() {
+  }
+
+  /**
+   * Configure a complete modeled Big Hill Sweet assay on a one-kilogram basis.
+   *
+   * @param system empty or caller-owned thermodynamic system
+   * @return configured assay; no component has been added to {@code system}
+   */
+  public static OilAssayCharacterisation create(SystemInterface system) {
+    return create(system, 1.0);
+  }
+
+  /**
+   * Configure a complete modeled Big Hill Sweet assay.
+   *
+   * @param system empty or caller-owned thermodynamic system
+   * @param totalAssayMassKg positive total assay mass in kg
+   * @return configured assay; no component has been added to {@code system}
+   */
+  public static OilAssayCharacterisation create(SystemInterface system, double totalAssayMassKg) {
+    Objects.requireNonNull(system, "system");
+    if (!Double.isFinite(totalAssayMassKg) || !(totalAssayMassKg > 0.0)) {
+      throw new IllegalArgumentException("Total assay mass must be finite and positive");
+    }
+
+    OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
+    assay.clearCuts();
+    assay.setTotalAssayMass(totalAssayMassKg);
+
+    addModeledGasCut(assay);
+    assay.addCut(new AssayCut("DOE_BH_C5_175").withWeightPercent(5.22).withSpecificGravity(0.6731)
+        .withMolarMassKgPerMol(C5_175_MOLAR_MASS_KG_PER_MOL).withUpperBoilingPointFahrenheit(175.0)
+        .withSulfurMassPercent(0.0008).withNitrogenMassPercent(0.0));
+
+    addBoundedCut(assay, "DOE_BH_175_250", 8.32, 0.7432, 175.0, 250.0, 0.0026, 0.0);
+    addBoundedCut(assay, "DOE_BH_250_375", 12.55, 0.7817, 250.0, 375.0, 0.019, 0.0);
+    addBoundedCut(assay, "DOE_BH_375_530", 16.19, 0.8297, 375.0, 530.0, 0.096, 0.0018);
+    addBoundedCut(assay, "DOE_BH_530_650", 13.18, 0.8604, 530.0, 650.0, 0.313, 0.0186);
+    addBoundedCut(assay, "DOE_BH_650_850", 18.44, 0.9039, 650.0, 850.0, 0.534, 0.102);
+    addBoundedCut(assay, "DOE_BH_850_1050", 12.84, 0.9336, 850.0, 1050.0, 0.752, 0.234);
+
+    assay.addCut(new AssayCut("DOE_BH_1050_PLUS").withWeightPercent(11.56).withSpecificGravity(1.0089)
+        .withLowerBoilingPointFahrenheit(1050.0).withWatsonCharacterizationFactor(11.7).withSulfurMassPercent(1.334)
+        .withNitrogenMassPercent(0.501));
+    return assay;
+  }
+
+  private static void addModeledGasCut(OilAssayCharacterisation assay) {
+    for (int i = 0; i < GAS_COMPONENT_NAMES.length; i++) {
+      double wholeCrudeWeightPercent = GAS_MASS_PERCENT * GAS_COMPONENT_WEIGHT_PERCENT[i] / GAS_SUBSET_WEIGHT_PERCENT;
+      assay.addCut(new AssayCut("DOE_BH_GAS_" + (i + 1)).withWeightPercent(wholeCrudeWeightPercent)
+          .withStandardComponent(GAS_COMPONENT_NAMES[i]).withSulfurMassPercent(0.0).withNitrogenMassPercent(0.0));
+    }
+  }
+
+  private static void addBoundedCut(OilAssayCharacterisation assay, String name, double weightPercent,
+      double specificGravity, double lowerFahrenheit, double upperFahrenheit, double sulfurMassPercent,
+      double nitrogenMassPercent) {
+    assay.addCut(new AssayCut(name).withWeightPercent(weightPercent).withSpecificGravity(specificGravity)
+        .withBoilingRangeCelsius(fahrenheitToCelsius(lowerFahrenheit), fahrenheitToCelsius(upperFahrenheit))
+        .withSulfurMassPercent(sulfurMassPercent).withNitrogenMassPercent(nitrogenMassPercent));
+  }
+
+  private static double fahrenheitToCelsius(double temperatureFahrenheit) {
+    return (temperatureFahrenheit - 32.0) * 5.0 / 9.0;
+  }
+}

--- a/src/test/java/neqsim/thermo/characterization/DoeBigHillSweetAssayTest.java
+++ b/src/test/java/neqsim/thermo/characterization/DoeBigHillSweetAssayTest.java
@@ -1,0 +1,118 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests the reproducible DOE Big Hill Sweet complete modeled assay slate. */
+public class DoeBigHillSweetAssayTest {
+  private static final String[] STANDARD_COMPONENTS = { "ethane", "propane", "i-butane", "n-butane" };
+  private static final String[] PSEUDO_COMPONENTS = { "DOE_BH_C5_175_PC", "DOE_BH_175_250_PC", "DOE_BH_250_375_PC",
+      "DOE_BH_375_530_PC", "DOE_BH_530_650_PC", "DOE_BH_650_850_PC", "DOE_BH_850_1050_PC", "DOE_BH_1050_PLUS_PC" };
+
+  @Test
+  public void completeSlateClosesAndPreservesEvidenceBoundaries() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation assay = DoeBigHillSweetAssay.create(system);
+
+    assertEquals(0, system.getNumberOfComponents());
+    assertEquals(12, assay.getCuts().size());
+    assertEquals(1.0, sum(assay.getResolvedMassFractions()), 1.0e-12);
+    assertEquals(0.017, sum(assay.getResolvedMassFractions(), 0, 4), 1.0e-12);
+    assertEquals(0.40867518, assay.getBulkSulfurMassPercent(), 1.0e-12);
+    assertEquals(0.1095129, assay.getBulkNitrogenMassPercent(), 1.0e-12);
+
+    AssayCut c5Cut = assay.getCuts().get(4);
+    assertFalse(c5Cut.hasLowerBoilingPoint());
+    assertTrue(c5Cut.hasUpperBoilingPoint());
+    assertTrue(c5Cut.hasMolarMass());
+
+    AssayCut residue = assay.getCuts().get(11);
+    assertTrue(residue.hasLowerBoilingPoint());
+    assertFalse(residue.hasUpperBoilingPoint());
+    assertTrue(residue.hasWatsonCharacterizationFactor());
+    assertEquals(913.7543263803914, residue.resolveAverageBoilingPoint(), 1.0e-9);
+
+    assay.apply();
+
+    assertEquals(12, system.getNumberOfComponents());
+    for (String componentName : STANDARD_COMPONENTS) {
+      assertPositiveFiniteComponent(system.getComponent(componentName));
+    }
+    for (String componentName : PSEUDO_COMPONENTS) {
+      assertPositiveFiniteComponent(system.getComponent(componentName));
+    }
+    assertEquals(1.0, reconstructedMassKg(system), 1.0e-10);
+  }
+
+  @Test
+  public void constructionIsDeterministicAndScalesAppliedMass() {
+    SystemInterface firstSystem = new SystemSrkEos(298.15, 1.01325);
+    SystemInterface secondSystem = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation first = DoeBigHillSweetAssay.create(firstSystem, 2.5);
+    OilAssayCharacterisation second = DoeBigHillSweetAssay.create(secondSystem, 2.5);
+
+    assertArrayEquals(first.getResolvedMassFractions(), second.getResolvedMassFractions(), 0.0);
+    assertEquals(2.5, first.getTotalAssayMass(), 0.0);
+    assertEquals(2.5, second.getTotalAssayMass(), 0.0);
+
+    first.apply();
+    second.apply();
+    assertEquals(2.5, reconstructedMassKg(firstSystem), 1.0e-10);
+    assertEquals(2.5, reconstructedMassKg(secondSystem), 1.0e-10);
+  }
+
+  @Test
+  public void invalidMassFailsBeforeChangingExistingAssayOrSystem() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation existing = system.getOilAssayCharacterisation();
+    existing.clearCuts();
+    existing.addCut(
+        new AssayCut("Existing").withMassFraction(1.0).withSpecificGravity(0.8).withAverageBoilingPointKelvin(400.0));
+
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillSweetAssay.create(system, Double.NaN));
+    assertThrows(IllegalArgumentException.class, () -> DoeBigHillSweetAssay.create(system, 0.0));
+    assertEquals(1, existing.getCuts().size());
+    assertEquals("Existing", existing.getCuts().get(0).getName());
+    assertEquals(0, system.getNumberOfComponents());
+    assertThrows(NullPointerException.class, () -> DoeBigHillSweetAssay.create(null));
+  }
+
+  private static void assertPositiveFiniteComponent(ComponentInterface component) {
+    assertNotNull(component);
+    assertTrue(Double.isFinite(component.getNumberOfmoles()));
+    assertTrue(component.getNumberOfmoles() > 0.0);
+    assertTrue(Double.isFinite(component.getMolarMass()));
+    assertTrue(component.getMolarMass() > 0.0);
+  }
+
+  private static double reconstructedMassKg(SystemInterface system) {
+    double mass = 0.0;
+    for (int i = 0; i < system.getNumberOfComponents(); i++) {
+      ComponentInterface component = system.getComponent(i);
+      mass += component.getNumberOfmoles() * component.getMolarMass();
+    }
+    return mass;
+  }
+
+  private static double sum(double[] values) {
+    return sum(values, 0, values.length);
+  }
+
+  private static double sum(double[] values, int start, int end) {
+    double total = 0.0;
+    for (int i = start; i < end; i++) {
+      total += values[i];
+    }
+    return total;
+  }
+}


### PR DESCRIPTION
## Engineering question

Can NeqSim expose one reproducible, complete DOE SPR Big Hill Sweet modeled crude slate by composing the refinery campaign's already-qualified public assay, PIANO, terminal-cut, and quality-bookkeeping inputs without implying that unmeasured light-end composition or downstream properties have been validated?

Advances #3305. Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5504748750

## Exact continuity and capacity

- **Exact base:** `184a65c837e4afe7f93ffeb24d7b699a65902e7f`
- **Exact head:** `0c66e9016ccdf2656956b0ddefe6c3c524551131`
- **Branch:** `ai/refinery-big-hill-complete-slate`
- Predecessor #3398 is merged; no active or overlapping #3305 refinery PR existed before publication.
- Two positively identified autonomous implementation PRs were open immediately before publication; this draft makes **3/10**, below the target and absolute global ceiling.
- No active branch or PR was closed, replaced, rebased, synchronized, or moved.

## Capability

Adds public Java/JPype reference factory `DoeBigHillSweetAssay`:

- configures, but does not automatically apply, a caller-selected total assay mass;
- preserves the official 2021 nine-cut mass-yield table at exactly 100.00 mass%;
- maps the DOE PIANO C2-C4 subset to authoritative NeqSim standard components;
- uses the qualified C5-175 degF PIANO-derived molar mass;
- preserves six finite DOE distillate ranges and their SG60/60 values;
- preserves the 1050 degF+ lower boundary and derives only its source-supported Watson representative point;
- carries the qualified cut sulfur and nitrogen metadata;
- returns an inspectable `OilAssayCharacterisation` and leaves mutation behind the existing explicit `apply()` gate.

The applied one-kilogram reference case produces four standard components plus eight petroleum pseudo-components.

## Public evidence and assumptions

Primary public sources:

- DOE SPR [Big Hill Sweet comprehensive assay](https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx), reported 24 September 2021;
- DOE SPR [Big Hill Sweet PIANO workbook](https://www.spr.doe.gov/reports/Assays/2021/BigHillSwPIANO.xlsx).

DOE reports a 1.70 mass% gas cut, while its PIANO debutanization table reports a 66.63 wt% C2-C4 subset. The factory explicitly normalizes the reported ethane, propane, i-butane, and n-butane weights over that subset and allocates the whole gas-cut mass between them. This is a reproducible modeling assumption, not a complete measured gas analysis.

DOE leaves sulfur blank for the gas cut and nitrogen blank through 250-375 degF. The factory uses the same explicit zero screening assumptions already qualified in the merged campaign tests. The implementation does not mix the older 1998 five-cut table with the 2021 nine-cut workbook.

## Acceptance evidence

Focused regressions require:

- configuration leaves the system component list unchanged until `apply()`;
- 12 configured entries and resolved mass-fraction closure to 1.0;
- the gas entries sum to exactly 0.017 mass fraction;
- bulk sulfur = `0.40867518 mass%`;
- bulk nitrogen = `0.1095129 mass%`;
- C5-175 retains only its published upper boundary plus explicit qualified molar mass;
- 1050 degF+ retains only its lower boundary plus DOE Watson factor, deriving `913.7543263803914 K`;
- all 12 applied components are positive and finite;
- reconstructed component mass closes to `1e-10 kg`;
- repeated construction is deterministic and total-mass scaling remains exact;
- invalid total mass fails before the existing assay or system is changed.

## Local validation

- production compilation: passed;
- `DoeBigHillSweetAssayTest`: 3/3 passed;
- complete `neqsim.thermo.characterization.*Test` suite: passed;
- Java-8-targeted `DoeBigHillSweetAssayTest`: 3/3 passed;
- `python devtools/run_spotless.py apply`: passed and stable;
- `python devtools/run_spotless.py check`: passed;
- `python devtools/check_documentation_search.py`: passed (684 Markdown pages and one standalone HTML page);
- pre-commit stage: passed;
- pre-push stage: passed;
- `git diff --check`: passed.

Local Javadoc generation could not run because this execution image has no `javadoc` executable. No local Javadoc result is claimed; hosted exact-head CI remains authoritative.

**VALIDATION PENDING CI**

## Documentation impact

Adds a dedicated source table, usage example, assumptions, DOE disclaimer boundary, quantitative acceptance evidence, and next process-validation gate. The characterization guide and package index now expose the reusable reference slate.

## Scientific stop boundary

This PR does not validate the normalized gas allocation, generated critical properties, acentric factors, VLE, whole-crude atmospheric yields or boiling ranges, vacuum fractionation, blending, or conversion units. The next dependency is full-slate atmospheric fractionation against independent public product-yield and boiling-range evidence.

Draft only. Do not merge, mark ready for review, or enable auto-merge as part of the autonomous campaign.

Generated with AI assistance.