### PR TITLE
[AI-Assisted] test(mcp): qualify result-validation contract

### DIFF
--- a/.github/workflows/mcp_protocol_qualification.yml
+++ b/.github/workflows/mcp_protocol_qualification.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Run focused pre-flight validator Java contract
         run: mvn -B -Dtest=neqsim.mcp.runners.ValidatorTest test -ntp
 
+      - name: Run focused result-validator Java contract
+        run: mvn -B -Dtest=neqsim.mcp.runners.EngineeringValidatorTest test -ntp
+
       - name: Build exact MCP server package
         shell: bash
         run: |
@@ -96,6 +99,9 @@ jobs:
 
       - name: Run focused real-MCP pre-flight validation qualification
         run: cd neqsim-mcp-server && python test_validate_input_protocol.py
+
+      - name: Run focused real-MCP result-validation qualification
+        run: cd neqsim-mcp-server && python test_validate_results_protocol.py
 
       - name: Run comprehensive real-MCP protocol regression
         run: cd neqsim-mcp-server && python test_mcp_server.py

--- a/neqsim-mcp-server/docs/evidence/VALIDATE_RESULTS_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/VALIDATE_RESULTS_CONTRACT.md
@@ -1,0 +1,65 @@
+# `validateResults` software-contract qualification
+
+## Engineering question and maturity
+
+Can the MCP surface deterministically apply NeqSim's existing engineering-result rules, preserve structured findings and
+fail closed on malformed result JSON without presenting the validator as new scientific evidence?
+
+This increment targets a **qualified software contract**. Phase 0 inventory 1.23 deliberately keeps
+`validateResults=CONFIRMED_GAP` until this prerequisite merges and a later atomic promotion updates every inventory and
+protocol view together.
+
+## Authoritative behavior
+
+`NeqSimTools.validateResults` delegates to `EngineeringValidator.validate(resultsJson, context)` and then applies the
+standard MCP response envelope and response-size guard. No MCP-only calculation or validation model is introduced.
+
+The input is a JSON object containing a result package plus a context string. The validator recursively selects the
+first numeric value for each implemented field name and applies deterministic rules for:
+
+- temperature and pressure bounds;
+- compressor efficiency, ratio, discharge temperature and power;
+- separator residence time and gas velocity;
+- heat-exchanger approach and duty;
+- pipeline velocity and pressure-drop ratio;
+- water-dew-point indication;
+- supplied mass- and energy-balance error fields; and
+- supplied convergence status.
+
+The output reports `validationContext`, finding counts, `passed`, `verdict`, and findings with stable code, severity,
+message and remediation fields. Parse failure is blocking. Warnings and information remain non-blocking.
+
+## Units, assumptions and validity range
+
+The validator does not infer or convert unit metadata. Implemented bare numeric fields use the rule's documented basis:
+temperature in degrees Celsius, pressure in bara, velocity in m/s, power in kW, residence time in seconds, and mass- or
+energy-balance errors as fractions. Callers must normalize producer output to those field names and bases before relying
+on a rule. Missing fields are skipped; validation is therefore not proof that a result package is complete.
+
+The mass- and energy-balance checks assess only supplied aggregate error values. They do not independently recompute
+component, total-mass, enthalpy or facility-wide closure from a canonical `ProcessSystem`.
+
+## Acceptance evidence
+
+- `EngineeringValidatorTest` covers clean, warning-only, blocking, nested and malformed inputs.
+- `test_validate_results_protocol.py` repeats those boundaries through the real packaged STDIO server and proves that
+  the inventory remains conservative at 1.23 / 20 explicit + 21 contract-tested + 30 confirmed gaps.
+- `test_mcp_server.py` retains the broad real-protocol `validateResults` call.
+- `mcp_protocol_qualification.yml` runs the focused Java and packaged-MCP contracts before the comprehensive suite.
+
+The contract requires deterministic findings, fail-closed malformed JSON, standard envelope fields, no mutation, and
+successful focused plus comprehensive protocol checks. The one production compatibility change is intentional:
+malformed/non-object JSON changes from warning-pass to error-fail while retaining the existing `PARSE_ERROR` code,
+message and remediation.
+
+## Explicit limitations and stop boundary
+
+This evidence does **not** establish simulation execution, thermodynamic or equipment-model fidelity, convergence,
+component or facility-wide conservation, numerical robustness of an upstream calculation, standards currency, causal
+diagnosis, safe operating limits, plant or control authority, design certification, or accountable engineering
+approval. The supplied result's units, provenance, assumptions, convergence evidence, limitations and independent
+benchmarks remain authoritative.
+
+Java and JSON/MCP views are applicable and qualified by this increment. A separate Python calculation and notebook are
+not applicable because the capability is a Java-backed transport/software contract. No schema, tool-name, agent/skill,
+deployment-profile, companion-repository or live-system integration change is included.

--- a/neqsim-mcp-server/test_validate_results_protocol.py
+++ b/neqsim-mcp-server/test_validate_results_protocol.py
@@ -1,0 +1,288 @@
+"""Focused real-MCP qualification for post-calculation result validation.
+
+This dependency-free harness starts the packaged NeqSim MCP server over STDIO
+and qualifies the existing advisory ``validateResults`` route. It verifies the
+implemented engineering-rule software contract only. It does not execute a
+simulation, generate independent physical evidence, certify conservation, or
+grant facility, plant-control, design, or engineering-approval authority.
+"""
+import json
+import subprocess
+import sys
+import time
+
+JAR = "target/neqsim-mcp-server-1.0.0-SNAPSHOT-runner.jar"
+
+
+class McpClient:
+    """Minimal line-delimited JSON-RPC client for packaged-server qualification."""
+
+    def __init__(self):
+        self.proc = None
+        self.message_id = 0
+
+    def next_id(self):
+        self.message_id += 1
+        return self.message_id
+
+    def send(self, message):
+        self.proc.stdin.write(json.dumps(message) + "\n")
+        self.proc.stdin.flush()
+
+    def receive(self):
+        line = self.proc.stdout.readline()
+        if not line:
+            stderr = self.proc.stderr.read() if self.proc and self.proc.stderr else ""
+            raise RuntimeError("MCP server closed stdout unexpectedly: " + stderr)
+        return json.loads(line)
+
+    def start(self):
+        self.proc = subprocess.Popen(
+            ["java", "-jar", JAR],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "neqsim-validate-results-contract-test",
+                        "version": "1.0",
+                    },
+                },
+            }
+        )
+        response = self.receive()
+        require("result" in response, "MCP initialize did not return a result", response)
+        self.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        time.sleep(0.2)
+
+    def call_tool(self, name, arguments):
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            }
+        )
+        response = self.receive()
+        content = response.get("result", {}).get("content", [])
+        require(content, "MCP tool call returned no content", response)
+        text = content[0].get("text", "")
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as error:
+            raise AssertionError(
+                f"MCP tool returned non-JSON content: {error}: {text}"
+            )
+
+    def validate(self, results, context="general"):
+        value = results if isinstance(results, str) else json.dumps(results)
+        return self.call_tool(
+            "validateResults", {"resultsJson": value, "context": context}
+        )
+
+    def close(self):
+        if self.proc is None:
+            return
+        if self.proc.stdin:
+            self.proc.stdin.close()
+        try:
+            self.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.proc.terminate()
+            self.proc.wait(timeout=10)
+        self.proc = None
+
+
+def require(condition, message, detail=None):
+    """Raise a compact assertion with JSON detail when a contract fails."""
+    if condition:
+        return
+    suffix = ""
+    if detail is not None:
+        suffix = "\n" + json.dumps(detail, indent=2, sort_keys=True)
+    raise AssertionError(message + suffix)
+
+
+def payload(response):
+    """Return canonical data while retaining standardized envelope fields."""
+    data = response.get("data") if isinstance(response, dict) else None
+    if not isinstance(data, dict):
+        return response
+    merged = dict(data)
+    for key in (
+        "status",
+        "tool",
+        "provenance",
+        "validation",
+        "qualityGate",
+        "warnings",
+        "errors",
+    ):
+        if key in response:
+            merged.setdefault(key, response[key])
+    return merged
+
+
+def finding_codes(result):
+    """Return stable machine-readable finding codes."""
+    return {
+        item.get("code")
+        for item in result.get("findings", [])
+        if isinstance(item, dict)
+    }
+
+
+def assert_report(response, context):
+    """Verify the stable advisory response shape."""
+    result = payload(response)
+    require(result.get("status") == "success", "validation transport failed", response)
+    require(result.get("validationContext") == context, "context was not preserved", result)
+    require(isinstance(result.get("passed"), bool), "passed flag is absent", result)
+    for field in ("totalFindings", "errors", "warnings", "infos"):
+        require(isinstance(result.get(field), int), field + " count is absent", result)
+    require(isinstance(result.get("verdict"), str), "verdict is absent", result)
+    require(isinstance(result.get("findings"), list), "findings array is absent", result)
+    for finding in result["findings"]:
+        require(
+            {"code", "severity", "message", "remediation"}.issubset(finding),
+            "finding record is incomplete",
+            finding,
+        )
+        require(
+            finding["severity"] in {"ERROR", "WARNING", "INFO"},
+            "finding severity drifted",
+            finding,
+        )
+    return result
+
+
+def test_clean_result_passes(client):
+    result = assert_report(
+        client.validate(
+            {
+                "converged": True,
+                "temperature": 25.0,
+                "pressure": 50.0,
+                "massBalanceError": 0.0,
+                "energyBalanceError": 0.0,
+            },
+            "process",
+        ),
+        "process",
+    )
+    require(result.get("passed") is True, "clean result was rejected", result)
+    require(result.get("totalFindings") == 0, "clean result produced findings", result)
+    require(result.get("verdict", "").startswith("PASS"), "pass verdict drifted", result)
+
+
+def test_warning_remains_non_blocking(client):
+    result = assert_report(
+        client.validate({"converged": True, "polytropicEfficiency": 0.40}, "compressor"),
+        "compressor",
+    )
+    require(result.get("passed") is True, "warning blocked the result", result)
+    require(result.get("errors") == 0 and result.get("warnings") == 1, "warning counts drifted", result)
+    require("LOW_EFFICIENCY" in finding_codes(result), "efficiency warning is absent", result)
+    require(
+        result.get("verdict", "").startswith("PASS_WITH_WARNINGS"),
+        "warning verdict drifted",
+        result,
+    )
+
+
+def test_blocking_findings_fail(client):
+    result = assert_report(
+        client.validate(
+            {"converged": False, "pressure": -1.0, "massBalanceError": 0.02},
+            "process",
+        ),
+        "process",
+    )
+    require(result.get("passed") is False, "blocking result was accepted", result)
+    require(result.get("errors") == 3, "blocking error count drifted", result)
+    require(
+        {"NEGATIVE_PRESSURE", "MASS_BALANCE", "NOT_CONVERGED"}.issubset(
+            finding_codes(result)
+        ),
+        "blocking findings are incomplete",
+        result,
+    )
+
+
+def test_nested_fields_are_discovered(client):
+    request = {
+        "equipment": {
+            "compressor": {"outletTemperature": 220.0, "compressionRatio": 5.0}
+        }
+    }
+    first = assert_report(client.validate(request, "process"), "process")
+    second = assert_report(client.validate(request, "process"), "process")
+    require(first == second, "nested validation is not deterministic", {"first": first, "second": second})
+    require(
+        {"HIGH_DISCHARGE_TEMP", "HIGH_COMPRESSION_RATIO"}.issubset(
+            finding_codes(first)
+        ),
+        "nested equipment findings are incomplete",
+        first,
+    )
+
+
+def test_malformed_json_fails_closed(client):
+    result = assert_report(client.validate("{bad json}", "general"), "general")
+    require(result.get("passed") is False, "malformed JSON was accepted", result)
+    require(result.get("errors") == 1, "parse error count drifted", result)
+    require("PARSE_ERROR" in finding_codes(result), "parse finding is absent", result)
+
+
+def test_phase0_inventory_remains_conservative(client):
+    result = payload(client.call_tool("getCapabilities", {}))
+    inventory = result.get("phase0EvidenceInventory")
+    require(isinstance(inventory, dict), "capabilities omitted Phase 0 inventory", result)
+    limitations = inventory.get("knownLimitations", {})
+    record = limitations.get("coverageRecords", {}).get("validateResults", {})
+    require(inventory.get("inventoryVersion") == "1.23", "inventory version drifted", inventory)
+    require(
+        limitations.get("contractTestedToolCount") == 21
+        and limitations.get("confirmedGapToolCount") == 30
+        and record.get("coverageStatus") == "CONFIRMED_GAP",
+        "qualification prematurely promoted validateResults",
+        limitations,
+    )
+
+
+def main():
+    client = McpClient()
+    tests = [
+        ("clean result passes", test_clean_result_passes),
+        ("warning remains non-blocking", test_warning_remains_non_blocking),
+        ("blocking findings fail", test_blocking_findings_fail),
+        ("nested fields are discovered", test_nested_fields_are_discovered),
+        ("malformed JSON fails closed", test_malformed_json_fails_closed),
+        ("Phase 0 inventory remains conservative", test_phase0_inventory_remains_conservative),
+    ]
+    try:
+        client.start()
+        for label, test in tests:
+            test(client)
+            print("PASS:", label)
+    finally:
+        client.close()
+    print(f"\n{len(tests)}/{len(tests)} validateResults contract scenarios passed.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print("FAIL:", error, file=sys.stderr)
+        sys.exit(1)

--- a/neqsim-mcp-server/test_validate_results_protocol.py
+++ b/neqsim-mcp-server/test_validate_results_protocol.py
@@ -142,14 +142,23 @@ def finding_codes(result):
     }
 
 
+def finding_warning_count(result):
+    """Count engineering warnings without confusing the MCP envelope warning array."""
+    return sum(
+        1
+        for item in result.get("findings", [])
+        if isinstance(item, dict) and item.get("severity") == "WARNING"
+    )
+
+
 def assert_report(response, context):
     """Verify the stable advisory response shape."""
     result = payload(response)
     require(result.get("status") == "success", "validation transport failed", response)
     require(result.get("validationContext") == context, "context was not preserved", result)
     require(isinstance(result.get("passed"), bool), "passed flag is absent", result)
-    for field in ("totalFindings", "errors", "warnings", "infos"):
-        require(isinstance(result.get(field), int), field + " count is absent", result)
+    for field in ("totalFindings", "errors", "infos"):
+        require(type(result.get(field)) is int, field + " count is absent", result)
     require(isinstance(result.get("verdict"), str), "verdict is absent", result)
     require(isinstance(result.get("findings"), list), "findings array is absent", result)
     for finding in result["findings"]:
@@ -163,6 +172,21 @@ def assert_report(response, context):
             "finding severity drifted",
             finding,
         )
+    warning_count = finding_warning_count(result)
+    envelope_warnings = result.get("warnings")
+    require(
+        isinstance(envelope_warnings, (int, list)),
+        "standard warnings field is absent",
+        result,
+    )
+    if type(envelope_warnings) is int:
+        require(envelope_warnings == warning_count, "warning count drifted", result)
+    require(
+        result["totalFindings"]
+        == result["errors"] + warning_count + result["infos"],
+        "finding counts do not close",
+        result,
+    )
     return result
 
 
@@ -191,7 +215,11 @@ def test_warning_remains_non_blocking(client):
         "compressor",
     )
     require(result.get("passed") is True, "warning blocked the result", result)
-    require(result.get("errors") == 0 and result.get("warnings") == 1, "warning counts drifted", result)
+    require(
+        result.get("errors") == 0 and finding_warning_count(result) == 1,
+        "warning counts drifted",
+        result,
+    )
     require("LOW_EFFICIENCY" in finding_codes(result), "efficiency warning is absent", result)
     require(
         result.get("verdict", "").startswith("PASS_WITH_WARNINGS"),

--- a/src/main/java/neqsim/mcp/runners/EngineeringValidator.java
+++ b/src/main/java/neqsim/mcp/runners/EngineeringValidator.java
@@ -59,7 +59,7 @@ public final class EngineeringValidator {
       checkConvergence(results, findings);
 
     } catch (Exception e) {
-      findings.add(new ValidationFinding("PARSE_ERROR", Severity.WARNING,
+      findings.add(new ValidationFinding("PARSE_ERROR", Severity.ERROR,
           "Could not parse results for validation: " + e.getMessage(), "Ensure results JSON is well-formed"));
     }
 

--- a/src/test/java/neqsim/mcp/runners/EngineeringValidatorTest.java
+++ b/src/test/java/neqsim/mcp/runners/EngineeringValidatorTest.java
@@ -1,5 +1,7 @@
 package neqsim.mcp.runners;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
@@ -26,6 +28,9 @@ class EngineeringValidatorTest {
     JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
     assertTrue(obj.has("verdict"), "Should return a verdict");
     assertTrue(obj.has("findings"), "Should return findings array");
+    assertTrue(obj.get("passed").getAsBoolean());
+    assertEquals("process", obj.get("validationContext").getAsString());
+    assertEquals(0, obj.get("errors").getAsInt());
   }
 
   @Test
@@ -44,6 +49,52 @@ class EngineeringValidatorTest {
     String result = EngineeringValidator.validate("not json", "general");
     assertNotNull(result);
     JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
-    assertTrue(obj.has("verdict"));
+    assertFalse(obj.get("passed").getAsBoolean());
+    assertEquals(1, obj.get("errors").getAsInt());
+    assertEquals("PARSE_ERROR", obj.getAsJsonArray("findings").get(0).getAsJsonObject().get("code").getAsString());
+    assertEquals("ERROR", obj.getAsJsonArray("findings").get(0).getAsJsonObject().get("severity").getAsString());
+  }
+
+  @Test
+  void testWarningsRemainNonBlocking() {
+    String result = EngineeringValidator.validate("{\"converged\":true,\"polytropicEfficiency\":0.40}",
+        "compressor");
+    JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
+
+    assertTrue(obj.get("passed").getAsBoolean());
+    assertEquals(0, obj.get("errors").getAsInt());
+    assertEquals(1, obj.get("warnings").getAsInt());
+    assertTrue(obj.get("verdict").getAsString().startsWith("PASS_WITH_WARNINGS"));
+    assertEquals("LOW_EFFICIENCY",
+        obj.getAsJsonArray("findings").get(0).getAsJsonObject().get("code").getAsString());
+  }
+
+  @Test
+  void testBlockingPhysicalAndConvergenceFindingsFail() {
+    String result = EngineeringValidator.validate(
+        "{\"converged\":false,\"pressure\":-1.0,\"massBalanceError\":0.02}", "process");
+    JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
+
+    assertFalse(obj.get("passed").getAsBoolean());
+    assertEquals(3, obj.get("errors").getAsInt());
+    String findings = obj.getAsJsonArray("findings").toString();
+    assertTrue(findings.contains("NEGATIVE_PRESSURE"));
+    assertTrue(findings.contains("MASS_BALANCE"));
+    assertTrue(findings.contains("NOT_CONVERGED"));
+  }
+
+  @Test
+  void testNestedEquipmentFieldsAreValidatedDeterministically() {
+    String input = "{\"equipment\":{\"compressor\":{\"outletTemperature\":220.0,"
+        + "\"compressionRatio\":5.0}}}";
+    JsonObject first = JsonParser.parseString(EngineeringValidator.validate(input, "process")).getAsJsonObject();
+    JsonObject second = JsonParser.parseString(EngineeringValidator.validate(input, "process")).getAsJsonObject();
+
+    assertEquals(first, second);
+    assertTrue(first.get("passed").getAsBoolean());
+    assertEquals(2, first.get("warnings").getAsInt());
+    String findings = first.getAsJsonArray("findings").toString();
+    assertTrue(findings.contains("HIGH_DISCHARGE_TEMP"));
+    assertTrue(findings.contains("HIGH_COMPRESSION_RATIO"));
   }
 }

--- a/src/test/java/neqsim/mcp/runners/EngineeringValidatorTest.java
+++ b/src/test/java/neqsim/mcp/runners/EngineeringValidatorTest.java
@@ -57,22 +57,20 @@ class EngineeringValidatorTest {
 
   @Test
   void testWarningsRemainNonBlocking() {
-    String result = EngineeringValidator.validate("{\"converged\":true,\"polytropicEfficiency\":0.40}",
-        "compressor");
+    String result = EngineeringValidator.validate("{\"converged\":true,\"polytropicEfficiency\":0.40}", "compressor");
     JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
 
     assertTrue(obj.get("passed").getAsBoolean());
     assertEquals(0, obj.get("errors").getAsInt());
     assertEquals(1, obj.get("warnings").getAsInt());
     assertTrue(obj.get("verdict").getAsString().startsWith("PASS_WITH_WARNINGS"));
-    assertEquals("LOW_EFFICIENCY",
-        obj.getAsJsonArray("findings").get(0).getAsJsonObject().get("code").getAsString());
+    assertEquals("LOW_EFFICIENCY", obj.getAsJsonArray("findings").get(0).getAsJsonObject().get("code").getAsString());
   }
 
   @Test
   void testBlockingPhysicalAndConvergenceFindingsFail() {
-    String result = EngineeringValidator.validate(
-        "{\"converged\":false,\"pressure\":-1.0,\"massBalanceError\":0.02}", "process");
+    String result = EngineeringValidator.validate("{\"converged\":false,\"pressure\":-1.0,\"massBalanceError\":0.02}",
+        "process");
     JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
 
     assertFalse(obj.get("passed").getAsBoolean());
@@ -85,8 +83,7 @@ class EngineeringValidatorTest {
 
   @Test
   void testNestedEquipmentFieldsAreValidatedDeterministically() {
-    String input = "{\"equipment\":{\"compressor\":{\"outletTemperature\":220.0,"
-        + "\"compressionRatio\":5.0}}}";
+    String input = "{\"equipment\":{\"compressor\":{\"outletTemperature\":220.0," + "\"compressionRatio\":5.0}}}";
     JsonObject first = JsonParser.parseString(EngineeringValidator.validate(input, "process")).getAsJsonObject();
     JsonObject second = JsonParser.parseString(EngineeringValidator.validate(input, "process")).getAsJsonObject();
 


### PR DESCRIPTION
## Capability contract and continuity

Advances #3153 under the capability contract recorded at https://github.com/equinor/neqsim/issues/3153#issuecomment-5505226528 and fail-closed amendment https://github.com/equinor/neqsim/issues/3153#issuecomment-5505243026.

- **Exact base:** `184a65c837e4afe7f93ffeb24d7b699a65902e7f`
- **Exact head:** `7cb2deb39dcaedc3228472e0cac60b0a2b21ddf9`
- **Branch:** `ai/mcp-validate-results-qualification-3153`
- #3396 was verified merged before this branch was created.
- Current positively identified autonomous portfolio: **4/10** (#3403, #3404, #3406, #3408).
- No existing PR or branch was closed, replaced, rebased, synchronized or abandoned.

## Engineering question

Can the existing `validateResults` surface deterministically apply NeqSim's engineering-result rules, preserve structured findings and fail closed on malformed JSON without presenting the validator as new scientific evidence?

## Implementation

This five-file increment:

- changes malformed/non-object result JSON from warning-pass to `PARSE_ERROR/ERROR` fail-closed behavior;
- strengthens `EngineeringValidatorTest` for clean, warning-only, blocking, nested, deterministic and malformed cases;
- adds six real packaged-MCP STDIO scenarios;
- runs the focused Java and packaged-MCP contracts in the existing Java 21 qualification workflow; and
- documents units, assumptions, evidence, compatibility and stop boundaries.

The authoritative behavior remains `NeqSimTools.validateResults` → `EngineeringValidator.validate`. No duplicate validator or MCP-only simulator is introduced. Inventory deliberately remains **1.23 / 20 `EXPLICIT_TRUST` + 21 `CONTRACT_TESTED` + 30 `CONFIRMED_GAP`**; `validateResults` is not promoted by this prerequisite.

## Validation

Locally available static checks:

- `python3 -m py_compile neqsim-mcp-server/test_validate_results_protocol.py` — passed.
- documentation-search source audit — passed on the available checkout (677 Markdown pages and one standalone HTML page); hosted exact-head documentation/pre-commit is authoritative.
- Java compilation and `EngineeringValidatorTest` — **VALIDATION BLOCKED BY INFRASTRUCTURE** because Maven Central DNS prevented `maven-enforcer-plugin:3.6.3` resolution.
- Spotless apply/check — **VALIDATION BLOCKED BY INFRASTRUCTURE** because the plugin was unavailable and Maven Central resolution failed.

Exact-head hosted evidence on `7cb2deb39dcaedc3228472e0cac60b0a2b21ddf9`:

- MCP protocol qualification, CodeQL, pre-commit/documentation, Spotless and PaperLab pass.
- The focused packaged-MCP `validateResults` contract passes.
- Build/test/Javadocs fails only on Java 21 Windows at `ResponseSizeGuardTest.testCapabilitiesPreservePhase0EvidenceWhenTrimmed`: current-`master` merge ref `9e1f80e` measures 262,262 bytes against the 262,144-byte limit.
- Independent PR #3408, based on current `master` `fccf28968ed87bd917deaf0cd2417373a1a2814c`, reproduces the identical Windows failure and byte count on merge ref `71a58df`. The preceding #3406 head passed the full build matrix before `master` advanced.

**VALIDATION BLOCKED BY BASE DEFECT** — current `master` must restore response-size headroom before #3406 can receive an exact-head READY classification. The defect is outside this frozen `validateResults` scope, so no source compaction, branch synchronization or unrelated repair is included here.

## Engineering and compatibility boundary

The validator assumes implemented bare numeric fields are already normalized: temperature in °C, pressure in bara, velocity in m/s, power in kW, residence time in seconds, and balance errors as fractions. Missing fields are skipped. Aggregate supplied mass/energy errors are checked but are not independently recomputed.

This evidence does **not** establish upstream simulation execution, thermodynamic/model fidelity, convergence, component or facility-wide conservation, numerical robustness, standards currency, causal diagnosis, plant/control authority, design certification or accountable engineering approval.

## Documentation impact and stop boundary

Adds `VALIDATE_RESULTS_CONTRACT.md`. Python calculation and notebook views are not applicable because this is a Java-backed transport/software contract. No tool name, schema, inventory promotion, deployment profile, agent/skill, companion repository or live-system integration changes.

Stops before modifying any other engineering rule, repairing unrelated response-size behavior or claiming scientific validation. Draft only; do not merge, enable auto-merge or mark ready for review as part of the autonomous campaign.