### PR TITLE
[AI-Assisted] feat(kinetics): explain impurity qualification failures

### DIFF
--- a/docs/chemicalreactions/co2_impurity_qualified_execution.md
+++ b/docs/chemicalreactions/co2_impurity_qualified_execution.md
@@ -42,6 +42,18 @@ range. Qualified execution requires corresponding metadata for every required id
 `getUnqualifiedReactionIds(T, P)` reports missing, unvalidated, and out-of-range entries.
 `requireValidatedKineticsAt(T, P)` applies the same gate without running the reactor.
 
+## Structured preflight report
+
+`getQualificationReport(T, P)` returns an immutable, source-ordered entry for every required
+reaction identifier. Each entry is classified as `QUALIFIED`, `MISSING`, `NOT_VALIDATED`, or
+`OUT_OF_RANGE`. Missing metadata takes precedence over validation and range checks; an explicitly
+non-validated entry takes precedence over its range. The report records the evaluated temperature,
+absolute pressure, and material selection so the selected R8 family remains auditable.
+
+`getUnqualifiedReactionIds(T, P)` delegates to the same report and therefore preserves the existing
+fail-closed result and identifier ordering. The report is diagnostic evidence only: it neither
+executes chemistry nor supplies citations, parameter values, validation status, or validity ranges.
+
 ## Parameter binding and execution
 
 Calling `setReactionConstants(...)` replaces an Arrhenius parameter pair and automatically removes

--- a/docs/test_co2_impurity_qualified_execution_documentation.py
+++ b/docs/test_co2_impurity_qualified_execution_documentation.py
@@ -12,6 +12,11 @@ IMPLEMENTATION = (
     / "src/main/java/neqsim/process/equipment/reactor/"
     / "QualifiedCO2ImpurityKineticReactor.java"
 )
+REPORT = (
+    ROOT
+    / "src/main/java/neqsim/process/equipment/reactor/"
+    / "CO2ImpurityKineticsQualificationReport.java"
+)
 JAVA_TEST = (
     ROOT
     / "src/test/java/neqsim/process/equipment/reactor/"
@@ -27,6 +32,7 @@ class QualifiedCO2ImpurityExecutionDocumentationTest(unittest.TestCase):
         cls.guide = GUIDE.read_text(encoding="utf-8")
         cls.package_index = PACKAGE_INDEX.read_text(encoding="utf-8")
         cls.implementation = IMPLEMENTATION.read_text(encoding="utf-8")
+        cls.report = REPORT.read_text(encoding="utf-8")
         cls.java_test = JAVA_TEST.read_text(encoding="utf-8")
         cls.normalized = " ".join(cls.guide.split())
 
@@ -82,6 +88,39 @@ class QualifiedCO2ImpurityExecutionDocumentationTest(unittest.TestCase):
             "testMaterialSelectionUsesOnlySelectedR8Family",
         ):
             self.assertIn(token, self.java_test)
+
+    def test_structured_report_contract_is_documented_and_executable(self):
+        for token in (
+            "Structured preflight report",
+            "`getQualificationReport(T, P)`",
+            "`QUALIFIED`",
+            "`MISSING`",
+            "`NOT_VALIDATED`",
+            "`OUT_OF_RANGE`",
+            "diagnostic evidence only",
+        ):
+            self.assertIn(token, self.normalized)
+
+        for token in (
+            "public CO2ImpurityKineticsQualificationReport getQualificationReport(",
+            "QualificationState.MISSING",
+            "QualificationState.NOT_VALIDATED",
+            "QualificationState.OUT_OF_RANGE",
+            "getQualificationReport(temperatureK, pressureBara).getBlockedReactionIds()",
+        ):
+            self.assertIn(token, self.implementation)
+
+        for token in (
+            "public enum QualificationState",
+            "Collections.unmodifiableList",
+            "public String[] getBlockedReactionIds()",
+        ):
+            self.assertIn(token, self.report)
+
+        self.assertIn(
+            "testQualificationReportExplainsFailureReasonsAndPreservesLegacyOrder",
+            self.java_test,
+        )
 
     def test_guide_is_discoverable(self):
         self.assertIn("co2_impurity_qualified_execution", self.package_index)

--- a/src/main/java/neqsim/process/equipment/reactor/CO2ImpurityKineticsQualificationReport.java
+++ b/src/main/java/neqsim/process/equipment/reactor/CO2ImpurityKineticsQualificationReport.java
@@ -9,8 +9,8 @@ import java.util.List;
  * Immutable result of evaluating the evidence registered for a CO2 impurity reactor.
  *
  * <p>
- * The report explains whether every material-selected R1-R8 parameterization is qualified at one
- * temperature and pressure. It contains no kinetic parameters and does not execute chemistry.
+ * The report explains whether every material-selected R1-R8 parameterization is qualified at one temperature and
+ * pressure. It contains no kinetic parameters and does not execute chemistry.
  * </p>
  *
  * @author NeqSim Team

--- a/src/main/java/neqsim/process/equipment/reactor/CO2ImpurityKineticsQualificationReport.java
+++ b/src/main/java/neqsim/process/equipment/reactor/CO2ImpurityKineticsQualificationReport.java
@@ -1,0 +1,125 @@
+package neqsim.process.equipment.reactor;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable result of evaluating the evidence registered for a CO2 impurity reactor.
+ *
+ * <p>
+ * The report explains whether every material-selected R1-R8 parameterization is qualified at one
+ * temperature and pressure. It contains no kinetic parameters and does not execute chemistry.
+ * </p>
+ *
+ * @author NeqSim Team
+ * @version 1.0
+ */
+public final class CO2ImpurityKineticsQualificationReport implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Qualification result for one required reaction parameterization. */
+  public enum QualificationState {
+    /** No evidence metadata is registered. */
+    MISSING,
+    /** Evidence metadata exists but is not independently validated. */
+    NOT_VALIDATED,
+    /** Validated evidence exists but the requested state is outside its declared range. */
+    OUT_OF_RANGE,
+    /** Validated evidence covers the requested state. */
+    QUALIFIED
+  }
+
+  /** Immutable qualification result for one required reaction identifier. */
+  public static final class Entry implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final String reactionId;
+    private final QualificationState state;
+
+    Entry(String reactionId, QualificationState state) {
+      if (reactionId == null || reactionId.trim().isEmpty()) {
+        throw new IllegalArgumentException("reaction identifier cannot be empty");
+      }
+      if (state == null) {
+        throw new IllegalArgumentException("qualification state cannot be null");
+      }
+      this.reactionId = reactionId;
+      this.state = state;
+    }
+
+    /** @return normalized reaction parameter identifier. */
+    public String getReactionId() {
+      return reactionId;
+    }
+
+    /** @return evidence qualification state at the evaluated temperature and pressure. */
+    public QualificationState getState() {
+      return state;
+    }
+
+    /** @return true only when validated evidence covers the evaluated state. */
+    public boolean isQualified() {
+      return state == QualificationState.QUALIFIED;
+    }
+  }
+
+  private final double temperatureK;
+  private final double pressureBara;
+  private final String material;
+  private final List<Entry> entries;
+
+  CO2ImpurityKineticsQualificationReport(double temperatureK, double pressureBara, String material,
+      List<Entry> entries) {
+    this.temperatureK = temperatureK;
+    this.pressureBara = pressureBara;
+    this.material = material;
+    this.entries = Collections.unmodifiableList(new ArrayList<>(entries));
+  }
+
+  /** @return evaluated temperature [K]. */
+  public double getTemperatureK() {
+    return temperatureK;
+  }
+
+  /** @return evaluated absolute pressure [bara]. */
+  public double getPressureBara() {
+    return pressureBara;
+  }
+
+  /** @return reactor material selection used to choose the R8 family. */
+  public String getMaterial() {
+    return material;
+  }
+
+  /** @return immutable source-ordered qualification entries. */
+  public List<Entry> getEntries() {
+    return entries;
+  }
+
+  /** @return true only when every required parameterization is qualified. */
+  public boolean isQualified() {
+    for (Entry entry : entries) {
+      if (!entry.isQualified()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Return identifiers that block qualified execution.
+   *
+   * @return new source-ordered array of missing, unvalidated, or out-of-range identifiers
+   */
+  public String[] getBlockedReactionIds() {
+    List<String> blocked = new ArrayList<>();
+    for (Entry entry : entries) {
+      if (!entry.isQualified()) {
+        blocked.add(entry.getReactionId());
+      }
+    }
+    return blocked.toArray(new String[blocked.size()]);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/reactor/QualifiedCO2ImpurityKineticReactor.java
+++ b/src/main/java/neqsim/process/equipment/reactor/QualifiedCO2ImpurityKineticReactor.java
@@ -94,15 +94,13 @@ public class QualifiedCO2ImpurityKineticReactor extends CO2ImpurityKineticReacto
   }
 
   /**
-   * Evaluate every required parameterization and explain why qualified execution is allowed or
-   * blocked.
+   * Evaluate every required parameterization and explain why qualified execution is allowed or blocked.
    *
    * @param temperatureK temperature [K]
    * @param pressureBara absolute pressure [bara]
    * @return immutable source-ordered qualification report
    */
-  public CO2ImpurityKineticsQualificationReport getQualificationReport(double temperatureK,
-      double pressureBara) {
+  public CO2ImpurityKineticsQualificationReport getQualificationReport(double temperatureK, double pressureBara) {
     requireFinitePositive(temperatureK, "temperature");
     requireFinitePositive(pressureBara, "pressure");
     List<CO2ImpurityKineticsQualificationReport.Entry> entries = new ArrayList<>();

--- a/src/main/java/neqsim/process/equipment/reactor/QualifiedCO2ImpurityKineticReactor.java
+++ b/src/main/java/neqsim/process/equipment/reactor/QualifiedCO2ImpurityKineticReactor.java
@@ -94,6 +94,36 @@ public class QualifiedCO2ImpurityKineticReactor extends CO2ImpurityKineticReacto
   }
 
   /**
+   * Evaluate every required parameterization and explain why qualified execution is allowed or
+   * blocked.
+   *
+   * @param temperatureK temperature [K]
+   * @param pressureBara absolute pressure [bara]
+   * @return immutable source-ordered qualification report
+   */
+  public CO2ImpurityKineticsQualificationReport getQualificationReport(double temperatureK,
+      double pressureBara) {
+    requireFinitePositive(temperatureK, "temperature");
+    requireFinitePositive(pressureBara, "pressure");
+    List<CO2ImpurityKineticsQualificationReport.Entry> entries = new ArrayList<>();
+    for (String reactionId : getRequiredReactionIds()) {
+      KineticReactionQualification qualification = qualifications.get(reactionId);
+      CO2ImpurityKineticsQualificationReport.QualificationState state;
+      if (qualification == null) {
+        state = CO2ImpurityKineticsQualificationReport.QualificationState.MISSING;
+      } else if (qualification.getValidationStatus() != ChemicalReactionValidationStatus.VALIDATED) {
+        state = CO2ImpurityKineticsQualificationReport.QualificationState.NOT_VALIDATED;
+      } else if (!qualification.isWithinRange(temperatureK, pressureBara)) {
+        state = CO2ImpurityKineticsQualificationReport.QualificationState.OUT_OF_RANGE;
+      } else {
+        state = CO2ImpurityKineticsQualificationReport.QualificationState.QUALIFIED;
+      }
+      entries.add(new CO2ImpurityKineticsQualificationReport.Entry(reactionId, state));
+    }
+    return new CO2ImpurityKineticsQualificationReport(temperatureK, pressureBara, getMaterial(), entries);
+  }
+
+  /**
    * Identify missing, unvalidated, or out-of-range reaction parameterizations.
    *
    * @param temperatureK temperature [K]
@@ -101,17 +131,7 @@ public class QualifiedCO2ImpurityKineticReactor extends CO2ImpurityKineticReacto
    * @return ordered identifiers that cannot be used for qualified execution at the supplied state
    */
   public String[] getUnqualifiedReactionIds(double temperatureK, double pressureBara) {
-    requireFinitePositive(temperatureK, "temperature");
-    requireFinitePositive(pressureBara, "pressure");
-    List<String> unqualified = new ArrayList<>();
-    for (String reactionId : getRequiredReactionIds()) {
-      KineticReactionQualification qualification = qualifications.get(reactionId);
-      if (qualification == null || qualification.getValidationStatus() != ChemicalReactionValidationStatus.VALIDATED
-          || !qualification.isWithinRange(temperatureK, pressureBara)) {
-        unqualified.add(reactionId);
-      }
-    }
-    return unqualified.toArray(new String[unqualified.size()]);
+    return getQualificationReport(temperatureK, pressureBara).getBlockedReactionIds();
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/reactor/QualifiedCO2ImpurityKineticReactorTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/QualifiedCO2ImpurityKineticReactorTest.java
@@ -2,7 +2,9 @@ package neqsim.process.equipment.reactor;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
 import neqsim.NeqSimTest;
@@ -70,6 +72,36 @@ public class QualifiedCO2ImpurityKineticReactorTest extends NeqSimTest {
     reactor.requireValidatedKineticsAt(TEMPERATURE_K, PRESSURE_BARA);
     reactor.setReactionConstants("R8", 3.0, 40.0);
     assertArrayEquals(new String[] { "R8SS" }, reactor.getUnqualifiedReactionIds(TEMPERATURE_K, PRESSURE_BARA));
+  }
+
+  @Test
+  void testQualificationReportExplainsFailureReasonsAndPreservesLegacyOrder() {
+    QualifiedCO2ImpurityKineticReactor reactor = qualifiedReactor();
+    reactor.setReactionQualification("R2", qualification("R2", ChemicalReactionValidationStatus.UNVALIDATED));
+    reactor.setReactionConstants("R3A", 2.0, 30.0);
+
+    CO2ImpurityKineticsQualificationReport report =
+        reactor.getQualificationReport(312.0, PRESSURE_BARA);
+
+    assertEquals(312.0, report.getTemperatureK());
+    assertEquals(PRESSURE_BARA, report.getPressureBara());
+    assertEquals("carbon_steel", report.getMaterial());
+    assertFalse(report.isQualified());
+    assertEquals(CO2ImpurityKineticsQualificationReport.QualificationState.OUT_OF_RANGE,
+        report.getEntries().get(0).getState());
+    assertEquals(CO2ImpurityKineticsQualificationReport.QualificationState.NOT_VALIDATED,
+        report.getEntries().get(1).getState());
+    assertEquals(CO2ImpurityKineticsQualificationReport.QualificationState.MISSING,
+        report.getEntries().get(2).getState());
+    assertEquals("R8CS", report.getEntries().get(8).getReactionId());
+    assertArrayEquals(reactor.getUnqualifiedReactionIds(312.0, PRESSURE_BARA),
+        report.getBlockedReactionIds());
+    assertThrows(UnsupportedOperationException.class, () -> report.getEntries().add(null));
+
+    String[] blocked = report.getBlockedReactionIds();
+    blocked[0] = "changed";
+    assertEquals("R1", report.getBlockedReactionIds()[0]);
+    assertTrue(qualifiedReactor().getQualificationReport(TEMPERATURE_K, PRESSURE_BARA).isQualified());
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/reactor/QualifiedCO2ImpurityKineticReactorTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/QualifiedCO2ImpurityKineticReactorTest.java
@@ -80,8 +80,7 @@ public class QualifiedCO2ImpurityKineticReactorTest extends NeqSimTest {
     reactor.setReactionQualification("R2", qualification("R2", ChemicalReactionValidationStatus.UNVALIDATED));
     reactor.setReactionConstants("R3A", 2.0, 30.0);
 
-    CO2ImpurityKineticsQualificationReport report =
-        reactor.getQualificationReport(312.0, PRESSURE_BARA);
+    CO2ImpurityKineticsQualificationReport report = reactor.getQualificationReport(312.0, PRESSURE_BARA);
 
     assertEquals(312.0, report.getTemperatureK());
     assertEquals(PRESSURE_BARA, report.getPressureBara());
@@ -94,8 +93,7 @@ public class QualifiedCO2ImpurityKineticReactorTest extends NeqSimTest {
     assertEquals(CO2ImpurityKineticsQualificationReport.QualificationState.MISSING,
         report.getEntries().get(2).getState());
     assertEquals("R8CS", report.getEntries().get(8).getReactionId());
-    assertArrayEquals(reactor.getUnqualifiedReactionIds(312.0, PRESSURE_BARA),
-        report.getBlockedReactionIds());
+    assertArrayEquals(reactor.getUnqualifiedReactionIds(312.0, PRESSURE_BARA), report.getBlockedReactionIds());
     assertThrows(UnsupportedOperationException.class, () -> report.getEntries().add(null));
 
     String[] blocked = report.getBlockedReactionIds();


### PR DESCRIPTION
## Engineering question

Can callers obtain a deterministic, immutable, per-reaction explanation of why the experimental CO2 impurity network is qualified or blocked at one T/P state, while preserving the existing fail-closed execution result and adding no scientific parameters?

Advances #3318. Capability contract: https://github.com/equinor/neqsim/issues/3318#issuecomment-5507020896

## Exact continuity and capacity

- **Exact base:** `fccf28968ed87bd917deaf0cd2417373a1a2814c`
- **Exact head:** `b3d8660da036f9e66ac36927687f94102033f239`
- **Branch:** `ai/co2-impurity-qualification-report-3318`
- #3399 is verified merged and no other active #3318 PR existed before publication.
- Three positively identified autonomous implementation PRs were open before publication; this draft makes **4/10**, below the target and absolute global ceiling.
- No existing PR or branch was closed, replaced, rebased, synchronized or moved.

## Implementation

This five-file increment:

- adds immutable, serializable `CO2ImpurityKineticsQualificationReport`;
- records the evaluated temperature, absolute pressure and material selection;
- classifies each required identifier as `QUALIFIED`, `MISSING`, `NOT_VALIDATED` or `OUT_OF_RANGE`;
- preserves source-stable R1-R7 plus material-selected R8 ordering;
- uses explicit precedence: missing metadata, then validation status, then declared T/P range;
- makes `getUnqualifiedReactionIds(T, P)` delegate to the report, preserving the existing fail-closed result;
- returns an immutable entry collection and fresh blocked-ID arrays; and
- documents and protects the structured preflight contract.

## Scientific and coordination boundary

- no kinetic constant, rate expression, reaction order, stoichiometry, material factor, evidence source, validity range or validation status is added or promoted;
- no chemistry is executed by the report;
- no electrolyte/speciation (#3144), flash/stability (#2937), transient state (#2911), pipeline source term or MCP schema (#3153) change;
- no phase transfer, water dropout, pH, corrosion, scale, reaction heat or facility-specific Northern Lights data.

The report explains evidence completeness only. It does not establish applicability of the experimental mechanism or populate the evidence registry.

## Validation

Available pre-publication checks on the exact remote files:

- five intended changed files;
- no trailing whitespace or tab indentation;
- all changed Java lines at or below 120 characters;
- deterministic documentation-contract tokens and executable coverage links present;
- all files end with a newline.

A local repository checkout with JDK/Maven/Spotless/pre-commit was unavailable, so no Java compilation, formatter or repository-wide local result is claimed. Hosted exact-head CI is authoritative.

Exact-head repair applied CI's exact three-file Spotless patch without behavioral change. The automated immutability finding was answered and resolved from the constructor's fresh unmodifiable copy plus the focused mutation regression. Fresh hosted CI is authoritative.

Exact-head hosted evidence on `b3d8660da036f9e66ac36927687f94102033f239`:

- documentation search, pre-commit, Spotless, PaperLab, CodeQL, Javadocs, agent-reference checks, and all four Java 21 slow shards pass;
- Java 21 Windows ran 12,624 tests and failed only in unchanged `ResponseSizeGuardTest.testCapabilitiesPreservePhase0EvidenceWhenTrimmed`: 262262 bytes against the unchanged 262144-byte limit;
- the identical byte count and failure were independently reproduced on #3406; neither PR changes the capability-payload implementation;
- Java 21 Ubuntu was cancelled and Java 8 lanes were skipped by fail-fast after the Windows base failure.

**VALIDATION BLOCKED BY BASE RESPONSE-SIZE DEFECT**

## Acceptance gates

- Java 8-compatible compilation and Javadocs;
- focused and adjacent JUnit tests;
- exact parity between report-blocked entries and the legacy unqualified-ID result;
- deterministic ordering, reason precedence and defensive immutability;
- Spotless, documentation search, pre-commit, build/test/Javadocs, CodeQL and PaperLab;
- no unresolved review threads.

## Stop boundary

No JSON/MCP transport contract, pipeline coupling or evidence-registry population in this increment.

Draft only. Do not merge, mark ready for review or enable auto-merge as part of the autonomous campaign.

Generated with AI assistance.