### PR TITLE
[AI-Assisted] fix(pitzer): stabilize late-ion salt saturation

### DIFF
--- a/src/main/java/neqsim/thermo/phase/PitzerParameterDatasets.java
+++ b/src/main/java/neqsim/thermo/phase/PitzerParameterDatasets.java
@@ -204,7 +204,7 @@ public final class PitzerParameterDatasets {
    * @param phase Pitzer aqueous role
    * @return {@code true} when the complete source topology was found and applied
    */
-  static boolean tryApplyCompletePhreeqcPitzerCatalog(PhasePitzer phase) {
+  public static boolean tryApplyCompletePhreeqcPitzerCatalog(PhasePitzer phase) {
     if (phase == null) {
       throw new IllegalArgumentException("Pitzer phase must not be null");
     }

--- a/src/main/java/neqsim/thermo/system/SystemPitzer.java
+++ b/src/main/java/neqsim/thermo/system/SystemPitzer.java
@@ -86,6 +86,25 @@ public class SystemPitzer extends SystemEosGE {
   }
 
   /**
+   * Refreshes catalog-first parameter selection after the active aqueous topology changes.
+   *
+   * <p>
+   * Component identities can be added after an earlier property evaluation selected the legacy fallback for a
+   * water-only topology. This method re-runs the complete catalog audit for the now-active species without changing an
+   * explicit {@link #useLegacyPitzerParameters()} selection. Missing catalog rows leave the existing coherent fallback
+   * untouched.
+   * </p>
+   *
+   * @return {@code true} when the complete PHREEQC catalog was applied to the active topology
+   */
+  public boolean refreshDefaultPitzerParameterSelection() {
+    if (!isUsingPhreeqcPitzerParametersByDefault()) {
+      return false;
+    }
+    return PitzerParameterDatasets.tryApplyCompletePhreeqcPitzerCatalog((PhasePitzer) phaseArray[1]);
+  }
+
+  /**
    * Returns scientific qualification metadata for the selected Pitzer parameter dataset.
    *
    * <p>

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalcSaltSatauration.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalcSaltSatauration.java
@@ -405,6 +405,7 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
    * @param saltData salt data from COMPSALT
    */
   private void ensureSaltIonsPresent(SaltData saltData) {
+    boolean hadChemicalReactionOperations = system.getChemicalReactionOperations() != null;
     boolean addedComponent = false;
     if (!hasComponent(saltData.name1)) {
       system.addComponent(saltData.name1, 1.0e-20);
@@ -415,10 +416,14 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
       addedComponent = true;
     }
     if (addedComponent) {
-      try {
-        system.chemicalReactionInit();
-      } catch (Exception ex) {
-        throw new IllegalStateException("Failed initializing chemical reactions for " + saltName, ex);
+      boolean preserveNonreactivePitzerTopology = system instanceof neqsim.thermo.system.SystemPitzer
+          && !hadChemicalReactionOperations;
+      if (!preserveNonreactivePitzerTopology) {
+        try {
+          system.chemicalReactionInit();
+        } catch (Exception ex) {
+          throw new IllegalStateException("Failed initializing chemical reactions for " + saltName, ex);
+        }
       }
       system.createDatabase(true);
       if (system instanceof neqsim.thermo.system.SystemPitzer) {
@@ -474,10 +479,9 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
    */
   private void initialiseSystem() {
     if (system instanceof neqsim.thermo.system.SystemPitzer) {
+      neqsim.thermo.system.SystemPitzer pitzerSystem = (neqsim.thermo.system.SystemPitzer) system;
       system.init(0);
-      system.init(1);
-      system.initPhysicalProperties();
-      return;
+      pitzerSystem.refreshDefaultPitzerParameterSelection();
     }
     try {
       new TPflash(system).run();

--- a/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
@@ -13,6 +13,7 @@ import neqsim.chemicalreactions.chemicalreaction.ChemicalReactionConcentrationBa
 import neqsim.thermo.component.IapwsHenryLaw;
 import neqsim.thermo.phase.PhaseInterface;
 import neqsim.thermo.phase.PhasePitzer;
+import neqsim.thermo.phase.PitzerParameterDatasets;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 /**
@@ -242,6 +243,74 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
     double naclKsp = 92.78 - 0.407 * 298.15 + 0.000747 * 298.15 * 298.15;
 
     assertEquals(1.0, gammaNa * naMolality * gammaCl * clMolality / naclKsp, 1.0e-3);
+  }
+
+  /**
+   * Verifies that adding saturation ions after water-only initialization refreshes the default catalog and is
+   * independent of component initialization order.
+   */
+  @Test
+  public void testCalcSaltSaturationRefreshesCatalogAfterWaterOnlyInitialization() throws Exception {
+    SystemPitzer lateIonSystem = new SystemPitzer(404.15, 995.0);
+    lateIonSystem.addComponent("water", 55.508);
+    lateIonSystem.setMixingRule("classic");
+
+    SystemPitzer earlyIonSystem = new SystemPitzer(404.15, 995.0);
+    earlyIonSystem.addComponent("water", 55.508);
+    earlyIonSystem.addComponent("Ca++", 1.0e-12);
+    earlyIonSystem.addComponent("SO4--", 1.0e-12);
+    earlyIonSystem.setMixingRule("classic");
+
+    ThermodynamicOperations lateIonOperations = new ThermodynamicOperations(lateIonSystem);
+    ThermodynamicOperations earlyIonOperations = new ThermodynamicOperations(earlyIonSystem);
+    lateIonOperations.calcSaltSaturation("CaSO4_A");
+    earlyIonOperations.calcSaltSaturation("CaSO4_A");
+
+    assertEquals(PitzerParameterDatasets.PHREEQC_PITZER_CATALOG_ID,
+        lateIonSystem.getPitzerParameterQualification().getDatasetId());
+    assertEquals(PitzerParameterDatasets.PHREEQC_PITZER_CATALOG_ID,
+        earlyIonSystem.getPitzerParameterQualification().getDatasetId());
+    assertEquals(1.0, lateIonOperations.getRelativeScalePotential("CaSO4_A"), 1.0e-3);
+    assertEquals(1.0, earlyIonOperations.getRelativeScalePotential("CaSO4_A"), 1.0e-3);
+    assertEquals(earlyIonSystem.getComponent("Ca++").getNumberOfmoles(),
+        lateIonSystem.getComponent("Ca++").getNumberOfmoles(), 1.0e-8);
+  }
+
+  /** Verifies that salt saturation preserves the explicit legacy compatibility selection. */
+  @Test
+  public void testCalcSaltSaturationPreservesExplicitLegacyParameters() throws Exception {
+    SystemPitzer system = new SystemPitzer(298.15, 1.01325);
+    system.useLegacyPitzerParameters();
+    system.addComponent("water", 55.508);
+    system.setMixingRule("classic");
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+    operations.calcSaltSaturation("NaCl");
+
+    assertEquals(PhasePitzer.DEFAULT_PARAMETER_DATASET_ID, system.getPitzerParameterQualification().getDatasetId());
+    assertEquals(1.0, operations.getRelativeScalePotential("NaCl"), 1.0e-3);
+  }
+
+  /** Verifies that adding a saturation ion preserves an already initialized reactive Pitzer topology. */
+  @Test
+  public void testCalcSaltSaturationPreservesReactivePitzerTopology() throws Exception {
+    SystemPitzer system = new SystemPitzer(298.15, 10.0);
+    system.addComponent("CO2", 0.01);
+    system.addComponent("water", 55.508);
+    system.addComponent("Na+", 1.0e-3);
+    system.addComponent("Cl-", 1.0e-3);
+    system.chemicalReactionInit();
+    system.createDatabase(true);
+    system.setMixingRule("classic");
+
+    ThermodynamicOperations operations = new ThermodynamicOperations(system);
+    IllegalStateException exception = assertThrows(IllegalStateException.class,
+        () -> operations.calcSaltSaturation("CaCO3"));
+
+    assertTrue(system.isChemicalSystem());
+    assertTrue(exception.getMessage().contains("Failed running TPflash"));
+    assertTrue(exception.getCause().getMessage().contains("Pitzer parameter coverage incomplete"));
+    assertFalse(exception.getCause().getMessage().contains("reaction state is stale"));
   }
 
   /** Pitzer reaction quotients use solute molality with solvent mole-fraction activity. */


### PR DESCRIPTION
## Engineering question

Can `calcSaltSaturation` add ions after a water-only `SystemPitzer` has already initialized, while preserving the catalog-first/explicit-legacy contract and returning a fully flashed state whose saturation ratio is actually unity?

Advances #3144 under the capability contract recorded at https://github.com/equinor/neqsim/issues/3144#issuecomment-5513728674.

## Exact continuity and capacity

- **Exact base:** `fccf28968ed87bd917deaf0cd2417373a1a2814c`
- **Exact head:** `9826192de7c26284024f8da4d22e9c8a53f4aea6`
- **Branch:** `ai/pitzer-late-ion-saturation-3144`
- No active #3144 implementation PR or overlapping open PR existed before publication.
- Five autonomous implementation PRs were open before publication; this draft makes **6/10**, below the target and absolute ceiling.
- No active branch or PR was closed, replaced, rebased, synchronized or moved.

## Reproduced limitation

At 131 °C and 999 bara for `CaSO4_A`, 0.0022980918 mol salt gave:

- ions before initial mixing-rule evaluation: PHREEQC catalog, SR **1.001560468**;
- the same ions after water-only initialization: legacy dataset, SR **0.293854719**.

The old Pitzer no-flash bisection also accepted a 998-bara state that became SR **10.517682293** after the authoritative TP flash. Root causes were premature lazy dataset locking, unconditional creation of an unintended chemical-reaction topology for a nonreactive Pitzer system, and solving a pre-flash state different from the returned state.

## Implementation

This four-file increment:

- makes the existing complete-topology PHREEQC catalog probe reusable;
- adds `SystemPitzer.refreshDefaultPitzerParameterSelection()`;
- refreshes only catalog-first systems after `init(0)` exposes late active ions;
- preserves explicit `useLegacyPitzerParameters()`;
- avoids inventing reactions for an initially nonreactive Pitzer salt-saturation calculation;
- snapshots and reinitializes any pre-existing reactive topology before component mutation can make it stale;
- uses a complete TP flash for every Pitzer saturation trial and the accepted state; and
- adds initialization-order, unit-SR, explicit-legacy and reactive fail-closed regressions.

## Scientific evidence and boundary

Primary audit: Dickson, Blount & Tunell (1963), https://doi.org/10.2475/ajs.261.1.61.

All 54 primary anhydrite observations were cross-read against the CC-BY compilation https://doi.org/10.17632/phmrfngcxn.1. Pressure, time and concentration values match, but 19 temperatures differ (18 lost 0.5 °C precision; sample `k1` is 156 instead of the primary 155 °C), and the compilation omits sample/method identifiers.

No data are redistributed and no coefficient, Ksp, reaction row or qualification status changes. With the consistent full-flash path, the existing COMPSALT/PHREEQC prediction remains scientifically rejected against those 54 observations: MARE **0.7003**, RMSRE **0.7057**, MAXARE **0.9140**. The PR repairs calculation semantics; it does not validate high-pressure CaSO4.

## Local validation

- Spotless apply/check: passed and stable.
- Four focused new/adjacent Pitzer saturation gates: **4 passed**.
- Complete `SystemPitzerTest`: **28 passed**.
- Slow `SaltSaturationTest`: **6 passed**, 0 failures/errors/skips.
- The 54-case diagnostic completed in **2.14 s** on this head versus **19.71 s** on exact base in the same runtime (single-run engineering diagnostic, not a statistical benchmark).
- Neutral/non-Pitzer paths retain the existing branch and are not changed.
- Local Javadocs: **not run** because this runtime has no usable `javadoc` command/`JAVA_HOME`; hosted exact-head CI is authoritative.

Exact-head hosted evidence:

- Pre-commit, Spotless, PaperLab, CodeQL, agent-reference checks, Java 21 Javadocs, and all four Java 21 slow shards pass.
- Java 21 Windows ran 12,626 tests and failed only in unchanged `ResponseSizeGuardTest.testCapabilitiesPreservePhase0EvidenceWhenTrimmed`: 262,262 bytes against the unchanged 262,144-byte limit.
- The identical failure and byte count were independently reproduced on #3406 and #3408; this PR changes no MCP capability-payload production code.
- Java 21 Ubuntu was cancelled and Java 8 lanes were skipped by fail-fast after the Windows base failure.

**VALIDATION BLOCKED BY BASE RESPONSE-SIZE DEFECT**

## Compatibility and stop boundary

Public behavior changes only where the previous result violated the documented default Pitzer dataset policy or returned a state not saturated after its authoritative flash. Explicit legacy compatibility is retained and regression-tested. Existing reactive topologies are reinitialized; incomplete mixed-ion coverage continues to fail closed.

No JSON/MCP schema, electrolyte-CPA path, neutral path, precipitation API, thermodynamic parameter, mineral constant, reaction database, high-pressure volume mapping or documentation page changes.

Draft only. Do not merge, mark ready for review or enable auto-merge as part of the autonomous campaign.

Generated with AI assistance.