### PR TITLE
[AI-Assisted] feat(dexpi): expose cycle boundary ownership

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -187,8 +187,10 @@ cyclic group. Boundary lists preserve parallel references and exclude connection
 target identity is blank. `getBoundaryConnections()` additionally preserves the overall source order
 across incoming and outgoing occurrences. Each immutable `DexpiConnectionCycleBoundaryInfo` records
 the connection ID, direction relative to the cyclic group, explicit internal and external endpoint
-identities, and whether each endpoint resolves in the source document. This avoids inferring boundary
-orientation by joining separate inventories while retaining parallel and unresolved source evidence.
+identities, whether each endpoint resolves, and the resolved endpoint element and Equipment/PipingComponent owner
+identities already present in the endpoint inventory. Missing or unresolved owner evidence remains an empty field.
+This avoids inferring boundary orientation or ownership by joining separate inventories while retaining parallel and
+unresolved source evidence.
 It does not identify a hydraulic recycle, enumerate elementary paths, assert convergence behavior,
 repair or rewire topology, or establish process intent.
 

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleBoundaryInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleBoundaryInfo.java
@@ -29,7 +29,13 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
   private final String connectionId;
   private final Direction direction;
   private final String internalEndpointId;
+  private final String internalEndpointElementName;
+  private final String internalOwnerId;
+  private final String internalOwnerElementName;
   private final String externalEndpointId;
+  private final String externalEndpointElementName;
+  private final String externalOwnerId;
+  private final String externalOwnerElementName;
   private final boolean internalEndpointResolved;
   private final boolean externalEndpointResolved;
 
@@ -45,10 +51,40 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
    */
   public DexpiConnectionCycleBoundaryInfo(String connectionId, Direction direction, String internalEndpointId,
       String externalEndpointId, boolean internalEndpointResolved, boolean externalEndpointResolved) {
+    this(connectionId, direction, internalEndpointId, "", "", "", externalEndpointId, "", "", "",
+        internalEndpointResolved, externalEndpointResolved);
+  }
+
+  /**
+   * Creates immutable cycle-boundary source-reference evidence with endpoint ownership.
+   *
+   * @param connectionId connection-evidence identity
+   * @param direction connection direction relative to the cyclic group
+   * @param internalEndpointId endpoint identity inside the cyclic group
+   * @param internalEndpointElementName resolved internal endpoint XML element name, or empty
+   * @param internalOwnerId explicit internal endpoint owner identity, or empty
+   * @param internalOwnerElementName internal endpoint owner XML element name, or empty
+   * @param externalEndpointId endpoint identity outside the cyclic group
+   * @param externalEndpointElementName resolved external endpoint XML element name, or empty
+   * @param externalOwnerId explicit external endpoint owner identity, or empty
+   * @param externalOwnerElementName external endpoint owner XML element name, or empty
+   * @param internalEndpointResolved whether the internal endpoint resolves in the source document
+   * @param externalEndpointResolved whether the external endpoint resolves in the source document
+   */
+  public DexpiConnectionCycleBoundaryInfo(String connectionId, Direction direction, String internalEndpointId,
+      String internalEndpointElementName, String internalOwnerId, String internalOwnerElementName,
+      String externalEndpointId, String externalEndpointElementName, String externalOwnerId,
+      String externalOwnerElementName, boolean internalEndpointResolved, boolean externalEndpointResolved) {
     this.connectionId = normalize(connectionId);
     this.direction = direction;
     this.internalEndpointId = normalize(internalEndpointId);
+    this.internalEndpointElementName = normalize(internalEndpointElementName);
+    this.internalOwnerId = normalize(internalOwnerId);
+    this.internalOwnerElementName = normalize(internalOwnerElementName);
     this.externalEndpointId = normalize(externalEndpointId);
+    this.externalEndpointElementName = normalize(externalEndpointElementName);
+    this.externalOwnerId = normalize(externalOwnerId);
+    this.externalOwnerElementName = normalize(externalOwnerElementName);
     this.internalEndpointResolved = internalEndpointResolved;
     this.externalEndpointResolved = externalEndpointResolved;
   }
@@ -68,9 +104,39 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
     return internalEndpointId;
   }
 
+  /** @return resolved internal endpoint XML element name, or empty */
+  public String getInternalEndpointElementName() {
+    return internalEndpointElementName;
+  }
+
+  /** @return explicit internal endpoint owner identity, or empty */
+  public String getInternalOwnerId() {
+    return internalOwnerId;
+  }
+
+  /** @return internal endpoint owner XML element name, or empty */
+  public String getInternalOwnerElementName() {
+    return internalOwnerElementName;
+  }
+
   /** @return endpoint identity outside the cyclic group */
   public String getExternalEndpointId() {
     return externalEndpointId;
+  }
+
+  /** @return resolved external endpoint XML element name, or empty */
+  public String getExternalEndpointElementName() {
+    return externalEndpointElementName;
+  }
+
+  /** @return explicit external endpoint owner identity, or empty */
+  public String getExternalOwnerId() {
+    return externalOwnerId;
+  }
+
+  /** @return external endpoint owner XML element name, or empty */
+  public String getExternalOwnerElementName() {
+    return externalOwnerElementName;
   }
 
   /** @return whether the internal endpoint resolves in the source document */
@@ -88,7 +154,13 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
     result.put("connectionId", connectionId);
     result.put("direction", direction.name());
     result.put("internalEndpointId", internalEndpointId);
+    result.put("internalEndpointElementName", internalEndpointElementName);
+    result.put("internalOwnerId", internalOwnerId);
+    result.put("internalOwnerElementName", internalOwnerElementName);
     result.put("externalEndpointId", externalEndpointId);
+    result.put("externalEndpointElementName", externalEndpointElementName);
+    result.put("externalOwnerId", externalOwnerId);
+    result.put("externalOwnerElementName", externalOwnerElementName);
     result.put("internalEndpointResolved", Boolean.valueOf(internalEndpointResolved));
     result.put("externalEndpointResolved", Boolean.valueOf(externalEndpointResolved));
     return result;

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -910,9 +910,12 @@ public final class DexpiXmlReader {
       List<DexpiConnectionEndpointInfo> connectionEndpoints, List<DexpiConnectionComponentInfo> connectionComponents) {
     Map<String, List<String>> outgoingEndpointIds = new LinkedHashMap<String, List<String>>();
     Map<String, List<String>> incomingEndpointIds = new LinkedHashMap<String, List<String>>();
+    Map<String, DexpiConnectionEndpointInfo> endpointById =
+        new LinkedHashMap<String, DexpiConnectionEndpointInfo>();
     for (DexpiConnectionEndpointInfo endpoint : connectionEndpoints) {
       outgoingEndpointIds.put(endpoint.getEndpointId(), new ArrayList<String>());
       incomingEndpointIds.put(endpoint.getEndpointId(), new ArrayList<String>());
+      endpointById.put(endpoint.getEndpointId(), endpoint);
     }
     for (DexpiConnectionInfo connection : connections) {
       String fromId = connection.getFromId();
@@ -1034,10 +1037,12 @@ public final class DexpiXmlReader {
         cycles.get(fromCycleIndex.intValue()).addConnection(connection);
       } else {
         if (toCycleIndex != null) {
-          cycles.get(toCycleIndex.intValue()).addIncomingBoundaryConnection(connection);
+          cycles.get(toCycleIndex.intValue()).addIncomingBoundaryConnection(connection,
+              endpointById.get(connection.getToId()), endpointById.get(connection.getFromId()));
         }
         if (fromCycleIndex != null) {
-          cycles.get(fromCycleIndex.intValue()).addOutgoingBoundaryConnection(connection);
+          cycles.get(fromCycleIndex.intValue()).addOutgoingBoundaryConnection(connection,
+              endpointById.get(connection.getFromId()), endpointById.get(connection.getToId()));
         }
       }
     }
@@ -1079,18 +1084,28 @@ public final class DexpiXmlReader {
       }
     }
 
-    private void addIncomingBoundaryConnection(DexpiConnectionInfo connection) {
+    private void addIncomingBoundaryConnection(DexpiConnectionInfo connection,
+        DexpiConnectionEndpointInfo internalEndpoint, DexpiConnectionEndpointInfo externalEndpoint) {
       incomingBoundaryConnectionIds.add(connection.getId());
-      boundaryConnections.add(
-          new DexpiConnectionCycleBoundaryInfo(connection.getId(), DexpiConnectionCycleBoundaryInfo.Direction.INCOMING,
-              connection.getToId(), connection.getFromId(), connection.isToResolved(), connection.isFromResolved()));
+      addBoundaryConnection(connection, DexpiConnectionCycleBoundaryInfo.Direction.INCOMING, internalEndpoint,
+          externalEndpoint);
     }
 
-    private void addOutgoingBoundaryConnection(DexpiConnectionInfo connection) {
+    private void addOutgoingBoundaryConnection(DexpiConnectionInfo connection,
+        DexpiConnectionEndpointInfo internalEndpoint, DexpiConnectionEndpointInfo externalEndpoint) {
       outgoingBoundaryConnectionIds.add(connection.getId());
-      boundaryConnections.add(
-          new DexpiConnectionCycleBoundaryInfo(connection.getId(), DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING,
-              connection.getFromId(), connection.getToId(), connection.isFromResolved(), connection.isToResolved()));
+      addBoundaryConnection(connection, DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING, internalEndpoint,
+          externalEndpoint);
+    }
+
+    private void addBoundaryConnection(DexpiConnectionInfo connection,
+        DexpiConnectionCycleBoundaryInfo.Direction direction, DexpiConnectionEndpointInfo internalEndpoint,
+        DexpiConnectionEndpointInfo externalEndpoint) {
+      boundaryConnections.add(new DexpiConnectionCycleBoundaryInfo(connection.getId(), direction,
+          internalEndpoint.getEndpointId(), internalEndpoint.getElementName(), internalEndpoint.getOwnerId(),
+          internalEndpoint.getOwnerElementName(), externalEndpoint.getEndpointId(), externalEndpoint.getElementName(),
+          externalEndpoint.getOwnerId(), externalEndpoint.getOwnerElementName(), internalEndpoint.isResolved(),
+          externalEndpoint.isResolved()));
     }
 
     private DexpiConnectionCycleInfo toInfo() {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -910,8 +910,7 @@ public final class DexpiXmlReader {
       List<DexpiConnectionEndpointInfo> connectionEndpoints, List<DexpiConnectionComponentInfo> connectionComponents) {
     Map<String, List<String>> outgoingEndpointIds = new LinkedHashMap<String, List<String>>();
     Map<String, List<String>> incomingEndpointIds = new LinkedHashMap<String, List<String>>();
-    Map<String, DexpiConnectionEndpointInfo> endpointById =
-        new LinkedHashMap<String, DexpiConnectionEndpointInfo>();
+    Map<String, DexpiConnectionEndpointInfo> endpointById = new LinkedHashMap<String, DexpiConnectionEndpointInfo>();
     for (DexpiConnectionEndpointInfo endpoint : connectionEndpoints) {
       outgoingEndpointIds.put(endpoint.getEndpointId(), new ArrayList<String>());
       incomingEndpointIds.put(endpoint.getEndpointId(), new ArrayList<String>());
@@ -1101,11 +1100,11 @@ public final class DexpiXmlReader {
     private void addBoundaryConnection(DexpiConnectionInfo connection,
         DexpiConnectionCycleBoundaryInfo.Direction direction, DexpiConnectionEndpointInfo internalEndpoint,
         DexpiConnectionEndpointInfo externalEndpoint) {
-      boundaryConnections.add(new DexpiConnectionCycleBoundaryInfo(connection.getId(), direction,
-          internalEndpoint.getEndpointId(), internalEndpoint.getElementName(), internalEndpoint.getOwnerId(),
-          internalEndpoint.getOwnerElementName(), externalEndpoint.getEndpointId(), externalEndpoint.getElementName(),
-          externalEndpoint.getOwnerId(), externalEndpoint.getOwnerElementName(), internalEndpoint.isResolved(),
-          externalEndpoint.isResolved()));
+      boundaryConnections
+          .add(new DexpiConnectionCycleBoundaryInfo(connection.getId(), direction, internalEndpoint.getEndpointId(),
+              internalEndpoint.getElementName(), internalEndpoint.getOwnerId(), internalEndpoint.getOwnerElementName(),
+              externalEndpoint.getEndpointId(), externalEndpoint.getElementName(), externalEndpoint.getOwnerId(),
+              externalEndpoint.getOwnerElementName(), internalEndpoint.isResolved(), externalEndpoint.isResolved()));
     }
 
     private DexpiConnectionCycleInfo toInfo() {

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -681,14 +681,25 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("N-A", boundaries.get(0).getExternalEndpointId());
     assertTrue(boundaries.get(0).isInternalEndpointResolved());
     assertTrue(boundaries.get(0).isExternalEndpointResolved());
+    assertEquals("Nozzle", boundaries.get(0).getInternalEndpointElementName());
+    assertEquals("E-X", boundaries.get(0).getInternalOwnerId());
+    assertEquals("Equipment", boundaries.get(0).getInternalOwnerElementName());
+    assertEquals("Nozzle", boundaries.get(0).getExternalEndpointElementName());
+    assertEquals("E-A", boundaries.get(0).getExternalOwnerId());
+    assertEquals("Equipment", boundaries.get(0).getExternalOwnerElementName());
     assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING, boundaries.get(1).getDirection());
     assertEquals("N-Y", boundaries.get(1).getInternalEndpointId());
     assertEquals("N-B", boundaries.get(1).getExternalEndpointId());
+    assertEquals("E-Y", boundaries.get(1).getInternalOwnerId());
+    assertEquals("E-B", boundaries.get(1).getExternalOwnerId());
     assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.INCOMING, boundaries.get(2).getDirection());
     assertEquals("N-X", boundaries.get(2).getInternalEndpointId());
     assertEquals("UNKNOWN-U", boundaries.get(2).getExternalEndpointId());
     assertTrue(boundaries.get(2).isInternalEndpointResolved());
     assertFalse(boundaries.get(2).isExternalEndpointResolved());
+    assertEquals("", boundaries.get(2).getExternalEndpointElementName());
+    assertEquals("", boundaries.get(2).getExternalOwnerId());
+    assertEquals("", boundaries.get(2).getExternalOwnerElementName());
 
     DexpiConnectionCycleInfo closedSelfReference = first.getConnectionCycles().get(1);
     assertEquals("cycle-2", closedSelfReference.getId());
@@ -708,10 +719,18 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         Collections.<String>emptyList(), Collections.<String>emptyList(), Collections.<String>emptyList(),
         Collections.<String>emptyList(), Collections.<String>emptyList(), false);
     assertTrue(legacy.getBoundaryConnections().isEmpty());
+    DexpiConnectionCycleBoundaryInfo legacyBoundary = new DexpiConnectionCycleBoundaryInfo("legacy-boundary",
+        DexpiConnectionCycleBoundaryInfo.Direction.INCOMING, "N-INTERNAL", "N-EXTERNAL", true, false);
+    assertEquals("", legacyBoundary.getInternalEndpointElementName());
+    assertEquals("", legacyBoundary.getInternalOwnerId());
+    assertEquals("", legacyBoundary.getExternalEndpointElementName());
+    assertEquals("", legacyBoundary.getExternalOwnerId());
     assertTrue(first.toJson().contains("\"incomingBoundaryConnectionCount\": 2"));
     assertTrue(first.toJson().contains("\"boundaryConnectionCount\": 4"));
     assertTrue(first.toJson().contains("\"direction\": \"INCOMING\""));
     assertTrue(first.toJson().contains("\"externalEndpointId\": \"UNKNOWN-U\""));
+    assertTrue(first.toJson().contains("\"internalOwnerId\": \"E-X\""));
+    assertTrue(first.toJson().contains("\"externalOwnerElementName\": \"Equipment\""));
     assertTrue(first.toJson().contains("\"outgoingBoundaryConnectionIds\": ["));
     assertEquals(first.toJson(), second.toJson());
   }


### PR DESCRIPTION
## Capability

Expose explicit endpoint element and Equipment/PipingComponent ownership evidence on each Proteus-compatible DEXPI 4.1.1 directed-cycle boundary occurrence.

## Exact continuity

- Base: `b066ed8bddc5d0cfcdd5831ed96371e4ab2fda70`
- Head: `24e9166a0f0dff10e4cae18a840988d815786688`
- Shared campaign lane: #1332 + #2899
- Autonomous implementation portfolio before publication: 3/10

## Scope

- Adds internal/external endpoint element name, owner ID, and owner element name to immutable `DexpiConnectionCycleBoundaryInfo`.
- Reuses the already parsed `DexpiConnectionEndpointInfo` evidence.
- Preserves the existing public constructor, existing fields, cycle/component identity, source order, parallel occurrences, unresolved non-empty references, and O(V+E) analysis.
- Adds focused coverage for Equipment-owned endpoints, both directions, unresolved external endpoints with empty owner evidence, compatibility, and deterministic JSON.
- Updates Java/JPype reader documentation.

## Engineering boundaries

This is source-document graph evidence only. It does not establish hydraulic continuity, a physical recycle, process intent, fitting identity, feasible flow, live `ProcessSystem` topology, standards conformance, DEXPI certification, or accountable engineering approval.

No simulation-builder, writer, renderer, SVG, geometry, layout, notebook, native DEXPI 2.0, Proteus export, Classic/DOT, Huldra, or external-dataset path changed. Whole-sheet visual gate is N/A with this path-based evidence.

## Validation

- Connector-side exact-head and four-file diff integrity checks pass.
- Constructor/API compatibility anchors, owner projection, unresolved-empty-owner regression, deterministic JSON assertions, documentation coverage, and brace balance were inspected at the exact head.
- Local Maven, Java, Spotless, pre-commit, Javadocs, and notebooks were not run in this connector-only publication path and are not claimed.
- Hosted CI is authoritative.

Status: **VALIDATION BLOCKED BY BASE RESPONSE-SIZE DEFECT**.