### PR TITLE
[AI-Assisted] test(refinery): qualify complete DOE atmospheric integration

### DIFF
--- a/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
+++ b/docs/thermo/characterization/refinery_big_hill_atmospheric_fractionation.md
@@ -1,11 +1,11 @@
 ---
 title: "DOE Big Hill atmospheric fractionation qualification"
-description: "Rigorous-column integration benchmark for the bounded DOE Big Hill Sweet refinery-assay slice."
+description: "Rigorous-column integration benchmarks for bounded and complete modeled DOE Big Hill Sweet assay slates."
 ---
 
 # DOE Big Hill atmospheric fractionation qualification
 
-Issue #3305 separates refinery validation into explicit quality gates. The first DOE Big Hill increment qualified refinery-assay bookkeeping. This benchmark advances the next gate by sending the same public assay basis through NeqSim's rigorous `DistillationColumn` and checking process-level conservation, boiling-order separation, and repeatability.
+Issue #3305 separates refinery validation into explicit quality gates. The first DOE Big Hill increment qualified refinery-assay bookkeeping. These benchmarks advance the next gate by sending public assay representations through NeqSim's rigorous `DistillationColumn` and checking process-level conservation, boiling-order separation, and repeatability.
 
 ## Public source and evidence boundary
 
@@ -29,7 +29,7 @@ This benchmark uses the **measured mass-yield basis** for the five intervals tha
 
 The five bounded cuts are normalized on their own basis. The C5-/175 degF light tail and 1050 degF+ vacuum residuum are **not** included because assigning finite boiling limits to those open-ended fractions would invent data that the published table does not provide.
 
-Accordingly, this is an **integration and numerical-robustness qualification**, not an independent validation of full crude-column product yields. It does not claim that the normalized five-cut slate represents the complete Big Hill crude.
+Accordingly, this first tier is an **integration and numerical-robustness qualification**, not an independent validation of full crude-column product yields. It does not claim that the normalized five-cut slate represents the complete Big Hill crude.
 
 ## Column benchmark
 
@@ -82,19 +82,52 @@ The regression requires all of the following on each accepted solve:
 
 The 5% process-balance gates are screening tolerances for this first broad-boiling integration case. They are intentionally much looser than the `1e-10` pseudo-component creation mass-closure gate because the column itself is an iterative process solver. Tighter refinery-specific balance gates should be introduced only after this public heavy-slate case establishes a stable baseline.
 
+## Complete modeled slate benchmark
+
+`DoeBigHillCompleteAtmosphericFractionationTest` adds a second integration tier using the reusable `DoeBigHillSweetAssay` factory. Its primary sources are the official DOE SPR [Big Hill Sweet comprehensive assay](https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx), reported 24 September 2021, and companion [PIANO workbook](https://www.spr.doe.gov/reports/Assays/2021/BigHillSwPIANO.xlsx).
+
+The complete modeled feed contains all 12 components qualified by the characterization campaign:
+
+- ethane, propane, i-butane, and n-butane allocated across the 1.70 mass% gas slice by normalizing DOE's reported C2-C4 PIANO subset;
+- the C5-175 degF cut with its PIANO-derived number-average molar mass and published upper boundary;
+- six bounded 175-1050 degF petroleum cuts;
+- the 1050 degF+ residue with its published lower boundary, specific gravity, and Watson factor.
+
+The light-end allocation and zero sulfur or nitrogen values used where DOE leaves a cell blank remain explicit modeling assumptions. They are not additional measurements.
+
+The complete-slate screening point deliberately reuses the proven bounded-column topology:
+
+| Quantity | Complete-slate benchmark value |
+| --- | ---: |
+| Feed flow | 5000 kg/h |
+| Feed temperature | 550 K |
+| Feed pressure | 1.5 bara |
+| Internal trays | 8 |
+| Feed tray | 4, bottom-up |
+| Top pressure | 1.2 bara |
+| Bottom pressure | 1.5 bara |
+| Condenser mode | Partial |
+| Reboiler temperature | 650 K |
+| Condenser reflux ratio | 1.0 |
+| Liquid side draw | 10% of tray-4 liquid traffic |
+
+The test requires all 12 components to reach the column, a non-fallback `MESH_RESIDUAL` solution, positive overhead/side-draw/bottoms products, external mass closure, enforced energy closure, internal tray material closure, and per-component molar conservation. It also requires C2-C4 enrichment toward the overhead, 1050 degF+ enrichment toward the bottoms, composition-weighted normal-boiling-point ordering of **overhead < side draw < bottoms**, and 1% repeated-solve agreement for product flows and boiling descriptors. A 120 s timeout fails closed on a solver stall.
+
+The complete-slate case is still an integration qualification. The DOE workbooks do not publish a matching atmospheric-column tray count, feed condition, pressure profile, furnace duty, stripping steam, reflux, pump-around duties, or product specifications. Therefore agreement with the DOE assay cut table would not by itself validate simulated plant product yields.
+
 ## What this benchmark advances
 
 This increment exercises, in one regression:
 
-`DOE assay facts -> OilAssayCharacterisation -> TBP pseudo-components -> Stream -> rigorous DistillationColumn -> three refinery-style product draws`
+`DOE assay facts -> reusable complete modeled slate -> standard and TBP components -> Stream -> rigorous DistillationColumn -> three refinery-style product draws`
 
 That closes an important integration gap between the characterization foundation and the refinery fractionation workstream. It also protects against future changes that would make heavy pseudo-components impossible to use in a near-atmospheric column even when assay bookkeeping still passes.
 
 ## Remaining scientific gaps
 
-This benchmark does **not** validate:
+These benchmarks do **not** validate:
 
-- the omitted light-end and 1050 degF+ tails;
+- the normalized C2-C4 allocation as a complete measured gas analysis;
 - generated pseudo-component molecular weights, critical properties, or acentric factors against independent laboratory property data;
 - full-crude atmospheric product yields or cut-point recovery;
 - pump-around heat duties, side strippers, or a refinery preheat/furnace train;
@@ -102,4 +135,4 @@ This benchmark does **not** validate:
 - ASTM D86/D1160-to-TBP conversions;
 - refinery conversion units.
 
-The next dependency-ready refinery increment should ingest a complete openly reproducible assay representation with defensible light/residue treatment and compare atmospheric product yields/boiling ranges against independent public evidence. Only after that gate should #3305 advance to vacuum fractionation or conversion-unit models.
+The next scientific gate should use a public atmospheric operating case that includes enough column design and operating information to compare product yields and boiling ranges without tuning to an under-specified target. Only after that gate should #3305 advance to vacuum fractionation or conversion-unit models.

--- a/src/test/java/neqsim/process/equipment/distillation/DoeBigHillCompleteAtmosphericFractionationTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DoeBigHillCompleteAtmosphericFractionationTest.java
@@ -1,0 +1,216 @@
+package neqsim.process.equipment.distillation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.characterization.DoeBigHillSweetAssay;
+import neqsim.thermo.characterization.OilAssayCharacterisation;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Complete-slate atmospheric-column integration qualification for the public DOE Big Hill Sweet modeled assay.
+ *
+ * <p>
+ * The feed is built exclusively through {@link DoeBigHillSweetAssay}, preserving the public 2021 DOE
+ * comprehensive-assay and PIANO provenance, terminal-cut assumptions, and mass basis already qualified by the refinery
+ * campaign. This test extends the earlier bounded-cut benchmark by exercising all four standard light-end components
+ * and all eight petroleum pseudo-components in one rigorous column solve.
+ * </p>
+ *
+ * <p>
+ * This is an integration, conservation, separation-direction, convergence, and repeatability qualification. It is not a
+ * plant-yield validation because the public assay does not define a matching atmospheric-column design, pressure
+ * profile, heat duties, reflux, steam, or product specifications.
+ * </p>
+ */
+public class DoeBigHillCompleteAtmosphericFractionationTest {
+  private static final int STANDARD_COMPONENT_COUNT = 4;
+  private static final int TOTAL_COMPONENT_COUNT = 12;
+  private static final int SIDE_DRAW_TRAY = 4;
+  private static final double BALANCE_TOLERANCE = 5.0e-2;
+  private static final double REPEAT_TOLERANCE = 1.0e-2;
+
+  /**
+   * Require the complete public modeled slate to form conservative, ordered, repeatable products.
+   */
+  @Test
+  @Timeout(value = 120, unit = TimeUnit.SECONDS)
+  public void completeModeledSlateRunsReproduciblyThroughAtmosphericColumn() {
+    Stream feed = createCompleteDoeFeed();
+    DistillationColumn column = createAtmosphericColumn(feed);
+
+    long startNanos = System.nanoTime();
+    column.run(UUID.randomUUID());
+    double firstRunSeconds = (System.nanoTime() - startNanos) / 1.0e9;
+
+    assertAcceptedSolve(column);
+    assertTrue(Double.isFinite(firstRunSeconds) && firstRunSeconds >= 0.0);
+    assertPhysicalProductsAndBalances(column, feed);
+
+    StreamInterface overhead = column.getGasOutStream();
+    StreamInterface sideDraw = column.getSideDrawStream(SIDE_DRAW_TRAY, DistillationColumn.SideDrawPhase.LIQUID);
+    StreamInterface bottoms = column.getLiquidOutStream();
+
+    double firstOverheadMassFlow = overhead.getFlowRate("kg/hr");
+    double firstSideDrawMassFlow = sideDraw.getFlowRate("kg/hr");
+    double firstBottomsMassFlow = bottoms.getFlowRate("kg/hr");
+    double firstOverheadMeanBoilingPoint = meanNormalBoilingPoint(overhead);
+    double firstSideDrawMeanBoilingPoint = meanNormalBoilingPoint(sideDraw);
+    double firstBottomsMeanBoilingPoint = meanNormalBoilingPoint(bottoms);
+
+    column.run(UUID.randomUUID());
+
+    assertAcceptedSolve(column);
+    assertPhysicalProductsAndBalances(column, feed);
+    assertRelativeRepeat(firstOverheadMassFlow, overhead.getFlowRate("kg/hr"));
+    assertRelativeRepeat(firstSideDrawMassFlow, sideDraw.getFlowRate("kg/hr"));
+    assertRelativeRepeat(firstBottomsMassFlow, bottoms.getFlowRate("kg/hr"));
+    assertRelativeRepeat(firstOverheadMeanBoilingPoint, meanNormalBoilingPoint(overhead));
+    assertRelativeRepeat(firstSideDrawMeanBoilingPoint, meanNormalBoilingPoint(sideDraw));
+    assertRelativeRepeat(firstBottomsMeanBoilingPoint, meanNormalBoilingPoint(bottoms));
+  }
+
+  private static Stream createCompleteDoeFeed() {
+    SystemInterface crude = new SystemSrkEos(550.0, 1.5);
+    OilAssayCharacterisation assay = DoeBigHillSweetAssay.create(crude);
+    assay.apply();
+    crude.setMixingRule("classic");
+
+    assertEquals(TOTAL_COMPONENT_COUNT, crude.getNumberOfComponents());
+    Stream feed = new Stream("DOE Big Hill complete modeled assay feed", crude);
+    feed.setFlowRate(5000.0, "kg/hr");
+    feed.setTemperature(550.0, "K");
+    feed.setPressure(1.5, "bara");
+    feed.run();
+    return feed;
+  }
+
+  private static DistillationColumn createAtmosphericColumn(Stream feed) {
+    DistillationColumn column = new DistillationColumn("DOE Big Hill complete atmospheric benchmark", 8, true, true);
+    column.addFeedStream(feed, 4);
+    column.setTopPressure(1.2);
+    column.setBottomPressure(1.5);
+    column.setCondenserMode(DistillationColumn.CondenserMode.PARTIAL);
+    column.getReboiler().setOutTemperature(650.0);
+    column.setCondenserRefluxRatio(1.0);
+    column.setLiquidSideDrawFraction(SIDE_DRAW_TRAY, 0.10);
+    column.setSolverType(DistillationColumn.SolverType.MESH_RESIDUAL);
+    column.setMaxNumberOfIterations(300);
+    column.setTemperatureTolerance(0.20);
+    column.setMassBalanceTolerance(BALANCE_TOLERANCE);
+    column.setEnthalpyBalanceTolerance(BALANCE_TOLERANCE);
+    column.setEnforceEnergyBalanceTolerance(true);
+    return column;
+  }
+
+  private static void assertAcceptedSolve(DistillationColumn column) {
+    String diagnostics = column.getConvergenceDiagnostics();
+    assertTrue(column.solved(), diagnostics);
+    assertEquals(DistillationColumn.SolverType.MESH_RESIDUAL, column.getLastSolverTypeUsed(), diagnostics);
+    assertNotEquals(DistillationColumn.SolveStatus.FALLBACK_PRODUCTS, column.getLastSolveStatus(), diagnostics);
+    assertTrue(column.getLastMeshResidualNorm() <= column.getMeshResidualTolerance(), diagnostics);
+  }
+
+  private static void assertPhysicalProductsAndBalances(DistillationColumn column, Stream feed) {
+    StreamInterface overhead = column.getGasOutStream();
+    StreamInterface sideDraw = column.getSideDrawStream(SIDE_DRAW_TRAY, DistillationColumn.SideDrawPhase.LIQUID);
+    StreamInterface bottoms = column.getLiquidOutStream();
+
+    double feedMassFlow = feed.getFlowRate("kg/hr");
+    double overheadMassFlow = overhead.getFlowRate("kg/hr");
+    double sideDrawMassFlow = sideDraw.getFlowRate("kg/hr");
+    double bottomsMassFlow = bottoms.getFlowRate("kg/hr");
+
+    assertPositiveFinite(overheadMassFlow);
+    assertPositiveFinite(sideDrawMassFlow);
+    assertPositiveFinite(bottomsMassFlow);
+    assertEquals(feedMassFlow, overheadMassFlow + sideDrawMassFlow + bottomsMassFlow, BALANCE_TOLERANCE * feedMassFlow);
+    assertTrue(Double.isFinite(column.getMassBalanceError()));
+    assertTrue(column.getMassBalanceError() <= BALANCE_TOLERANCE, column.getConvergenceDiagnostics());
+    assertTrue(Double.isFinite(column.getEnergyBalanceError()));
+    assertTrue(column.getEnergyBalanceError() <= BALANCE_TOLERANCE, column.getConvergenceDiagnostics());
+    assertTrue(column.getLastTrayMaterialBalanceError() <= column.getTrayMaterialBalanceTolerance(),
+        column.getConvergenceDiagnostics());
+
+    assertComponentMolarBalance(feed, overhead, sideDraw, bottoms);
+
+    double[] overheadComposition = overhead.getThermoSystem().getMolarComposition();
+    double[] sideDrawComposition = sideDraw.getThermoSystem().getMolarComposition();
+    double[] bottomsComposition = bottoms.getThermoSystem().getMolarComposition();
+    assertEquals(TOTAL_COMPONENT_COUNT, overheadComposition.length);
+    assertEquals(TOTAL_COMPONENT_COUNT, sideDrawComposition.length);
+    assertEquals(TOTAL_COMPONENT_COUNT, bottomsComposition.length);
+
+    assertTrue(
+        sum(overheadComposition, 0, STANDARD_COMPONENT_COUNT) > sum(bottomsComposition, 0, STANDARD_COMPONENT_COUNT),
+        "The modeled C2-C4 light ends should be enriched in overhead relative to bottoms");
+    assertTrue(bottomsComposition[TOTAL_COMPONENT_COUNT - 1] > overheadComposition[TOTAL_COMPONENT_COUNT - 1],
+        "The 1050 degF+ residue should be enriched in bottoms relative to overhead");
+
+    double overheadMeanBoilingPoint = meanNormalBoilingPoint(overhead);
+    double sideDrawMeanBoilingPoint = meanNormalBoilingPoint(sideDraw);
+    double bottomsMeanBoilingPoint = meanNormalBoilingPoint(bottoms);
+    assertTrue(overheadMeanBoilingPoint < sideDrawMeanBoilingPoint,
+        "Overhead should have a lower mean normal boiling point than the liquid side draw");
+    assertTrue(sideDrawMeanBoilingPoint < bottomsMeanBoilingPoint,
+        "The liquid side draw should have a lower mean normal boiling point than bottoms");
+    assertNotEquals(DistillationColumn.SolveStatus.FAILED, column.getLastSolveStatus());
+  }
+
+  private static void assertComponentMolarBalance(Stream feed, StreamInterface overhead, StreamInterface sideDraw,
+      StreamInterface bottoms) {
+    double feedFlow = feed.getFlowRate("mol/hr");
+    double overheadFlow = overhead.getFlowRate("mol/hr");
+    double sideDrawFlow = sideDraw.getFlowRate("mol/hr");
+    double bottomsFlow = bottoms.getFlowRate("mol/hr");
+    double[] feedComposition = feed.getThermoSystem().getMolarComposition();
+    double[] overheadComposition = overhead.getThermoSystem().getMolarComposition();
+    double[] sideDrawComposition = sideDraw.getThermoSystem().getMolarComposition();
+    double[] bottomsComposition = bottoms.getThermoSystem().getMolarComposition();
+
+    for (int componentIndex = 0; componentIndex < feedComposition.length; componentIndex++) {
+      double feedComponentFlow = feedFlow * feedComposition[componentIndex];
+      double productComponentFlow = overheadFlow * overheadComposition[componentIndex]
+          + sideDrawFlow * sideDrawComposition[componentIndex] + bottomsFlow * bottomsComposition[componentIndex];
+      assertEquals(feedComponentFlow, productComponentFlow,
+          Math.max(1.0e-7, BALANCE_TOLERANCE * Math.abs(feedComponentFlow)));
+    }
+  }
+
+  private static double meanNormalBoilingPoint(StreamInterface stream) {
+    double[] composition = stream.getThermoSystem().getMolarComposition();
+    double[] normalBoilingPoints = stream.getThermoSystem().getNormalBoilingPointTemperatures();
+    double weightedBoilingPoint = 0.0;
+    for (int i = 0; i < composition.length; i++) {
+      assertTrue(Double.isFinite(normalBoilingPoints[i]) && normalBoilingPoints[i] > 0.0);
+      weightedBoilingPoint += composition[i] * normalBoilingPoints[i];
+    }
+    return weightedBoilingPoint;
+  }
+
+  private static double sum(double[] values, int start, int end) {
+    double total = 0.0;
+    for (int i = start; i < end; i++) {
+      total += values[i];
+    }
+    return total;
+  }
+
+  private static void assertPositiveFinite(double value) {
+    assertTrue(Double.isFinite(value) && value > 0.0);
+  }
+
+  private static void assertRelativeRepeat(double expected, double actual) {
+    assertTrue(Double.isFinite(expected));
+    assertTrue(Double.isFinite(actual));
+    assertEquals(expected, actual, Math.max(1.0e-8, REPEAT_TOLERANCE * Math.abs(expected)));
+  }
+}


### PR DESCRIPTION
## Engineering question

Can the complete public DOE Big Hill Sweet modeled assay slate—four C2-C4 standard components plus eight petroleum pseudo-components—run through NeqSim's rigorous atmospheric `DistillationColumn` with conservative, physically ordered, and repeatable products?

Advances #3305. Capability contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5515693831

## Exact lineage and scope

- Frozen base: `b066ed8bddc5d0cfcdd5831ed96371e4ab2fda70`
- Exact head: `af88c4529ac60407c8af1c2777ba372f63e9174c`
- Predecessor #3404 merged as `3751a4bc1ab0dc9951542778bc771690d4074cf1`
- Two files changed; production Java is unchanged
- Portfolio before publication: 4/10 autonomous implementation capabilities
- No other open refinery/assay/Big Hill/atmospheric implementation PR was found

## Capability

This adds `DoeBigHillCompleteAtmosphericFractionationTest`, which:

- builds the complete modeled slate exclusively through `DoeBigHillSweetAssay`;
- sends all 12 components at 5000 kg/h, 550 K, and 1.5 bara to an eight-tray column;
- uses the residual-monitored `MESH_RESIDUAL` solver with no accepted fallback products;
- applies a partial condenser, 650 K equilibrium reboiler, 1.0 reflux ratio, 1.2-1.5 bara pressure profile, and a 10% liquid side draw from tray 4;
- fails closed after 120 seconds.

The regression requires three positive products, external and internal material closure, enforced energy closure, per-component molar conservation, C2-C4 enrichment toward overhead, 1050 °F+ enrichment toward bottoms, composition-weighted normal-boiling-point ordering `overhead < side draw < bottoms`, and repeated-solve agreement within 1%.

## Public provenance

Primary data remain the official DOE SPR workbooks:

- Comprehensive assay: https://www.spr.doe.gov/reports/Assays/2024/BigHillSwAssay.xlsx
- PIANO composition: https://www.spr.doe.gov/reports/Assays/2021/BigHillSwPIANO.xlsx

The documentation records the published facts separately from the explicit modeling assumptions already carried by `DoeBigHillSweetAssay`, including normalized C2-C4 allocation and zero sulfur/nitrogen values where DOE leaves cells blank.

## Validation

Passed locally on the exact content published here:

- Spotless apply and check
- documentation search: 685 Markdown files plus one standalone HTML file
- focused normal-POM suite: `DoeBigHillCompleteAtmosphericFractionationTest,DoeBigHillAtmosphericFractionationTest,DoeBigHillSweetAssayTest`
- Java 8 POM focused test: `DoeBigHillCompleteAtmosphericFractionationTest`
- pre-commit and pre-push gates with the repository Maven bootstrap
- `git diff --check`

The accepted reduced topology solved in about 5.7 seconds locally. The JUnit timeout is a fail-closed numerical-robustness gate, not a performance claim.

## Scientific boundary

This is an integration, conservation, separation-direction, convergence, and repeatability qualification. It is **not** an independent validation of atmospheric plant yields: the DOE assay does not publish a matching tray count, feed condition, pressure profile, furnace duty, stripping steam, reflux, pump-around duties, or product specifications.

The next scientific gate remains a public atmospheric operating case with enough design and operating information to compare product yields and boiling ranges without tuning to an under-specified target. Vacuum fractionation and conversion remain out of scope.

## Documentation impact

Updated `refinery_big_hill_atmospheric_fractionation.md` with the complete-slate benchmark, its sources, operating point, acceptance contract, assumptions, and validation boundary.

## Status

**VALIDATION BLOCKED BY BASE DEFECT**

Exact-head hosted evidence:

- Spotless, pre-commit, documentation search, CodeQL, and Java 21 Javadocs pass.
- The new complete-column regression passes on Windows in 4.392 s; the bounded-column and complete-assay tests also pass.
- The full matrix fails only in unrelated `neqsim.mcp.runners.ResponseSizeGuardTest.testCapabilitiesPreservePhase0EvidenceWhenTrimmed`: the trimmed MCP capability response is 262,262 bytes against a 262,144-byte ceiling (118 bytes over).
- This PR changes only the refinery regression and its documentation; it does not change MCP production or test code.
- No redundant rerun or speculative refinery change was made.

Draft only. Do not merge, rebase, synchronize, or mark ready for review as part of the autonomous workflow.