### PR TITLE
[AI-Assisted] docs: harden PVT rendering integrity

### DIFF
--- a/docs/pvtsimulation/flowassurance/asphaltene_cpa_calculations.md
+++ b/docs/pvtsimulation/flowassurance/asphaltene_cpa_calculations.md
@@ -301,7 +301,6 @@ When asphaltene precipitates, it forms a distinct phase with `PhaseType.ASPHALTE
 | Thermal Conductivity | 0.20 | W/mK | Typical for organic solids |
 | Viscosity | ~10,000 | Pa·s | Arrhenius correlation at 350K |
 | Speed of Sound | ~1745 | m/s | EOS-based calculation |
-```
 
 ## Tuning to Experimental Data
 

--- a/docs/standards/iso6976_calorific_values.md
+++ b/docs/standards/iso6976_calorific_values.md
@@ -3,8 +3,6 @@ title: "ISO 6976 - Calorific Values, Density, Relative Density and Wobbe Indices
 description: "Comprehensive guide to ISO 6976 in NeqSim: calculating calorific values (GCV/LCV), density, relative density, Wobbe indices and compressibility factor from natural gas composition. Covers both the 1995 and 2016 editions, mathematical derivations, and usage from fluids, streams, and Python."
 ---
 
-# ISO 6976 - Calorific Values from Composition
-
 ISO 6976 provides standardised methods for calculating calorific values, density,
 relative density and Wobbe indices of natural gas mixtures from their molar
 composition, without direct calorimetric measurement. It is the primary standard

--- a/docs/test_pvt_flow_assurance_standards_documentation.py
+++ b/docs/test_pvt_flow_assurance_standards_documentation.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 import re
 import unittest
+from urllib.parse import unquote, urlsplit
 
 
 DOCS = Path(__file__).resolve().parent
@@ -82,43 +83,52 @@ def parse_front_matter(source):
 
 
 def remove_fenced_code(source):
-    """Remove backtick and tilde code fences before inspecting rendered Markdown."""
+    """Remove fenced examples and reject unmatched backtick or tilde fences."""
     rendered = []
-    marker = None
+    fence_character = None
     for line in source.splitlines():
-        stripped = line.lstrip()
-        if marker is None and (
-            stripped.startswith(("\x60\x60\x60", "~~~"))
-        ):
-            marker = stripped[:3]
-            continue
+        marker = re.match(r"^\s*(\x60{3,}|~{3,})", line)
         if marker is not None:
-            if stripped.startswith(marker):
-                marker = None
+            character = marker.group(1)[0]
+            if fence_character is None:
+                fence_character = character
+            elif character == fence_character:
+                fence_character = None
             continue
-        rendered.append(line)
+        if fence_character is None:
+            rendered.append(line)
+
+    if fence_character is not None:
+        raise AssertionError("Unclosed fenced code block")
     return "\n".join(rendered)
 
 
-def link_candidates(page, raw_target):
-    """Return repository-source candidates for one relative documentation link."""
-    target = raw_target.split("#", 1)[0].split("?", 1)[0].strip().strip("<>")
-    if target.startswith("/"):
-        candidate = DOCS / target.lstrip("/")
+def target_candidates(source, target):
+    """Return repository-source candidates for one documentation target."""
+    parsed = urlsplit(target.strip().strip("<>"))
+    if parsed.scheme or parsed.netloc or target.startswith("#"):
+        return ()
+
+    relative = unquote(parsed.path)
+    if not relative:
+        return ()
+    if relative.startswith("/"):
+        destination = (DOCS / relative.lstrip("/")).resolve()
     else:
-        candidate = page.parent / target
-    if candidate.suffix:
-        stem = candidate.with_suffix("")
-        return (
-            candidate,
-            stem / "README.md",
-            stem / "index.md",
+        destination = (source.parent / relative).resolve()
+
+    candidates = [destination]
+    if destination.suffix == ".html":
+        candidates.append(destination.with_suffix(".md"))
+    if relative.endswith("/") or not destination.suffix:
+        candidates.extend(
+            (
+                destination / "index.md",
+                destination / "README.md",
+                destination.with_suffix(".md"),
+            )
         )
-    return (
-        candidate.with_suffix(".md"),
-        candidate / "README.md",
-        candidate / "index.md",
-    )
+    return tuple(candidates)
 
 
 class PvtFlowAssuranceStandardsDocumentationContractTest(unittest.TestCase):
@@ -142,12 +152,20 @@ class PvtFlowAssuranceStandardsDocumentationContractTest(unittest.TestCase):
     def test_front_matter_title_is_not_repeated_as_h1(self):
         for page in SCOPE_PAGES:
             with self.subTest(page=page):
-                title, _description, body = parse_front_matter(
+                _title, _description, body = parse_front_matter(
                     page.read_text(encoding="utf-8")
                 )
                 rendered = remove_fenced_code(body)
                 headings = re.findall(r"^#\s+(.+?)\s*$", rendered, re.MULTILINE)
-                self.assertNotIn(title, headings)
+                self.assertEqual([], headings)
+
+    def test_pages_have_balanced_fenced_code(self):
+        for page in SCOPE_PAGES:
+            with self.subTest(page=page):
+                _title, _description, body = parse_front_matter(
+                    page.read_text(encoding="utf-8")
+                )
+                remove_fenced_code(body)
 
     def test_pages_use_supported_math_delimiters(self):
         unsupported = re.compile(r"\\\[|\\\]|\\\(|\\\)")
@@ -159,22 +177,25 @@ class PvtFlowAssuranceStandardsDocumentationContractTest(unittest.TestCase):
                 self.assertIsNone(unsupported.search(remove_fenced_code(body)))
 
     def test_relative_source_links_resolve(self):
-        link_pattern = re.compile(r"(?<!!)\[[^\]\n]+\]\(([^)\n]+)\)")
-        scheme = re.compile(r"^[a-z][a-z0-9+.-]*:", re.IGNORECASE)
+        markdown_link = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+        html_link = re.compile(r"""(?:href|src)=["']([^"']+)["']""")
         for page in SCOPE_PAGES:
-            rendered = remove_fenced_code(page.read_text(encoding="utf-8"))
+            _title, _description, body = parse_front_matter(
+                page.read_text(encoding="utf-8")
+            )
+            rendered = remove_fenced_code(body)
             with self.subTest(page=page, check="single-line destinations"):
                 self.assertNotRegex(rendered, r"\]\([^\n)]*\n")
-            for match in link_pattern.finditer(rendered):
-                raw_target = match.group(1).strip().split()[0]
-                if raw_target.startswith("#") or scheme.match(raw_target):
+            targets = markdown_link.findall(rendered)
+            targets.extend(html_link.findall(rendered))
+            for target in targets:
+                candidates = target_candidates(page, target)
+                if not candidates:
                     continue
-                candidates = link_candidates(page, raw_target)
-                with self.subTest(page=page, target=raw_target):
+                with self.subTest(page=page, target=target):
                     self.assertTrue(
-                        any(candidate.is_file() for candidate in candidates),
-                        msg="Missing target; tried: "
-                        + ", ".join(str(candidate) for candidate in candidates),
+                        any(candidate.exists() for candidate in candidates),
+                        "Unresolved repository-relative target",
                     )
 
 


### PR DESCRIPTION
## Capability

Qualify the frozen 38-page PVT, flow-assurance, and standards documentation corpus for deterministic Jekyll rendering and repository navigation.

Advances #2499 under the D117 capability contract recorded in the campaign ledger: https://github.com/equinor/neqsim/issues/2499#issuecomment-5432666687

## Exact continuity and capacity

- **Exact base:** `b066ed8bddc5d0cfcdd5831ed96371e4ab2fda70`
- **Exact head:** `dbb05d38b0dadbbac1ec100df79e763065cbc10a`
- **Branch:** `ai/docs-pvt-flow-standards-rendering-d117`
- D116/#3409 was independently merged, fully validated, and byte-verified on current `master` before this branch was created.
- Five positively identified autonomous implementation capabilities were open before publication; this draft makes **6/10**, below the target and absolute ceiling.
- No active #2499 implementation PR or overlapping PVT/flow-assurance/standards documentation PR existed before publication.
- No active branch or PR was closed, replaced, rebased, synchronized, or moved.

## Scope

This exact three-file increment:

- removes the surplus fence that hid the latter part of the CPA asphaltene guide from normal Markdown rendering;
- removes the semantically duplicate visible H1 from the ISO 6976 guide;
- strengthens the existing 38-page regression contract to reject every visible H1 and unmatched backtick or tilde fence;
- URL-decodes repository targets and validates Markdown links, images, and HTML `href`/`src` targets; and
- retains front-matter, supported-math, and single-line destination coverage.

The complete proposed corpus has zero visible H1 headings, zero unmatched fences, zero unsupported math delimiters, and all **166** visible repository-target occurrences resolve.

## Validation

Connector-backed checks on the exact published content:

- all 38 frozen corpus pages inspected;
- all 166 visible repository-relative targets resolved against the exact base tree;
- strengthened Python contract parses successfully with `ast.parse`;
- exact branch is one commit ahead and zero commits behind the base;
- exact diff contains only the three frozen files.

Hosted exact-head validation is terminal: documentation/Jekyll/search, pre-commit, Spotless, CodeQL, and the documentation-only build/Javadoc gate all pass.

**READY TO MERGE**

## Documentation impact and boundary

Documentation impact is the entire intended change: two rendering defects are repaired and the existing regression contract is hardened. No production Java, public API, model behavior, inputs, outputs, units, assumptions, validity range, conservation behavior, numerical result, performance, notebook source/output, JSON/MCP surface, DEXPI/PFD work, external-link availability policy, or Huldra work changes.

This is rendering and repository-navigation qualification, not PVT-model, flow-assurance-method, or ISO standards-conformance qualification.

I understand the changes: both source edits remove markup that incorrectly affects the rendered document, and the test change makes the already established corpus contract detect the same defect classes consistently.

Draft only. Do not merge, mark ready for review, rebase, or enable auto-merge as part of the autonomous workflow.

Generated with AI assistance.