### PR TITLE
[AI-Assisted] fix(mcp): budget truncation metadata in response limit

### DIFF
--- a/src/main/java/neqsim/mcp/runners/ResponseSizeGuard.java
+++ b/src/main/java/neqsim/mcp/runners/ResponseSizeGuard.java
@@ -86,12 +86,13 @@ public final class ResponseSizeGuard {
     if (response == null || MAX_BYTES <= 0) {
       return false;
     }
-    int size = serializedSize(response);
-    if (size <= MAX_BYTES) {
+    int originalBytes = serializedSize(response);
+    if (originalBytes <= MAX_BYTES) {
       return false;
     }
 
     JsonArray omitted = new JsonArray();
+    JsonObject truncation = null;
     for (String field : trimCandidates(response, toolName)) {
       JsonElement removed = response.remove(field);
       if (removed == null) {
@@ -107,8 +108,11 @@ public final class ResponseSizeGuard {
       if (response.has("data") && response.get("data").isJsonObject()) {
         response.getAsJsonObject("data").remove(field);
       }
-      size = serializedSize(response);
-      if (size <= MAX_BYTES) {
+
+      if (truncation == null) {
+        truncation = addTruncationMetadata(response, toolName, originalBytes, omitted);
+      }
+      if (updateReturnedBytes(response, truncation) <= MAX_BYTES) {
         break;
       }
     }
@@ -117,13 +121,27 @@ public final class ResponseSizeGuard {
       return false;
     }
 
+    updateReturnedBytes(response, truncation);
+    return true;
+  }
+
+  /**
+   * Adds the truncation description and warning before the final response size is evaluated.
+   *
+   * @param response response being trimmed
+   * @param toolName MCP tool that produced the response
+   * @param originalBytes serialized size before trimming
+   * @param omitted live array describing removed fields
+   * @return the added truncation block
+   */
+  private static JsonObject addTruncationMetadata(JsonObject response, String toolName, int originalBytes,
+      JsonArray omitted) {
     JsonObject truncation = new JsonObject();
     truncation.addProperty("truncated", true);
     truncation.addProperty("reason",
         "Response exceeded the " + MAX_BYTES + " byte limit. Large payloads exhaust an agent's context "
             + "and can break the stdio transport, so bulk detail was omitted rather than returned.");
-    truncation.addProperty("originalBytes", size + estimatedBytes(omitted));
-    truncation.addProperty("returnedBytes", size);
+    truncation.addProperty("originalBytes", originalBytes);
     truncation.addProperty("limitBytes", MAX_BYTES);
     truncation.add("omitted", omitted);
     truncation.addProperty("howToRetrieve", recoveryGuidance(toolName));
@@ -136,7 +154,25 @@ public final class ResponseSizeGuard {
         : new JsonArray();
     warnings.add("Response truncated for tool '" + toolName + "'. See the 'truncation' block.");
     response.add("warnings", warnings);
-    return true;
+    return truncation;
+  }
+
+  /**
+   * Records and returns the exact serialized response size, including the size field itself.
+   *
+   * @param response response containing the truncation block
+   * @param truncation truncation block to update
+   * @return exact serialized size in bytes
+   */
+  private static int updateReturnedBytes(JsonObject response, JsonObject truncation) {
+    int previousSize = -1;
+    int size = serializedSize(response);
+    while (size != previousSize) {
+      previousSize = size;
+      truncation.addProperty("returnedBytes", size);
+      size = serializedSize(response);
+    }
+    return size;
   }
 
   /**
@@ -224,23 +260,6 @@ public final class ResponseSizeGuard {
       return "array with " + element.getAsJsonArray().size() + " entries";
     }
     return "scalar value";
-  }
-
-  /**
-   * Sums the approximate byte sizes recorded for omitted entries.
-   *
-   * @param omitted the omitted-entry array
-   * @return total approximate bytes
-   */
-  private static int estimatedBytes(JsonArray omitted) {
-    int total = 0;
-    for (JsonElement element : omitted) {
-      JsonObject entry = element.getAsJsonObject();
-      if (entry.has("approximateBytes")) {
-        total += entry.get("approximateBytes").getAsInt();
-      }
-    }
-    return total;
   }
 
   /**

--- a/src/test/java/neqsim/mcp/runners/ResponseSizeGuardTest.java
+++ b/src/test/java/neqsim/mcp/runners/ResponseSizeGuardTest.java
@@ -1,5 +1,6 @@
 package neqsim.mcp.runners;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.charset.StandardCharsets;
@@ -91,6 +92,8 @@ class ResponseSizeGuardTest {
 
     JsonObject truncation = response.getAsJsonObject("truncation");
     assertTrue(truncation.get("truncated").getAsBoolean());
+    assertEquals(originalBytes, truncation.get("originalBytes").getAsInt());
+    assertEquals(trimmedBytes, truncation.get("returnedBytes").getAsInt());
     assertTrue(truncation.getAsJsonArray("omitted").size() > 0, "Omitted members must be listed");
     assertTrue(truncation.get("howToRetrieve").getAsString().contains("manageModel"),
         "Guidance must point at the model-handle drill-down path");
@@ -121,6 +124,8 @@ class ResponseSizeGuardTest {
     assertTrue(response.getAsJsonObject("phase0EvidenceInventory").has("tests"));
     assertTrue(response.getAsJsonObject("phase0EvidenceInventory").has("knownLimitations"));
     JsonObject truncation = response.getAsJsonObject("truncation");
+    assertEquals(originalBytes, truncation.get("originalBytes").getAsInt());
+    assertEquals(trimmedBytes, truncation.get("returnedBytes").getAsInt());
     assertFalse(truncation.getAsJsonArray("omitted").toString().contains("phase0EvidenceInventory"));
     assertTrue(truncation.get("howToRetrieve").getAsString().contains("getSchema"),
         "Discovery truncation must point to focused capability retrieval");


### PR DESCRIPTION
## Summary

- include the final `truncation` block and warning in the response-size budget before deciding that trimming is complete
- continue removing eligible capability fields until the complete serialized response is within the configured limit
- report exact pre-trim `originalBytes` and final `returnedBytes`
- preserve the non-retrievable Phase 0 evidence inventory in both the legacy root and canonical `data` views

## Root cause

`ResponseSizeGuard.enforce` stopped removing fields as soon as the payload without truncation metadata fell below 262,144 bytes. It then appended the metadata and warning, making the capability response 262,262 bytes and failing `ResponseSizeGuardTest.testCapabilitiesPreservePhase0EvidenceWhenTrimmed`.

The guard now installs the final metadata before evaluating the byte limit and updates `returnedBytes` to a fixed point so the recorded value includes its own serialized representation.

## Validation

- Reproduced before the change:
  - `./mvnw -Dtest=ResponseSizeGuardTest#testCapabilitiesPreservePhase0EvidenceWhenTrimmed test`
  - failed at 262,262 bytes
- `./mvnw -Dtest=ResponseSizeGuardTest test`
  - 4 tests passed
- `./mvnw -Dtest=ResponseSizeGuardTest,CapabilitiesRunnerTest,McpEvidenceInventoryFoundationTests,McpToolSurfaceContractTest,McpAcceptanceBaselineRunnerTests test`
  - 29 tests passed
- `./mvnw -B test --file pomJava8.xml -ntp -Dtest=ResponseSizeGuardTest -Djacoco.skip=true`
  - 4 tests passed with Java 8 source/target profile (executed on JDK 17)
- `python devtools/run_spotless.py apply`
  - passed
- `python devtools/run_spotless.py check`
  - passed
- `python devtools/check_documentation_search.py`
  - passed
- `pre-commit run --all-files --hook-stage pre-commit`
  - passed
- `pre-commit run --all-files --hook-stage pre-push`
  - passed
- Full `./mvnw test` was allowed to run for about 20 minutes and had no failures through all completed tests, including the MCP suite, but was interrupted during later unrelated pipeline tests to respect the bounded local-validation policy. GitHub CI remains authoritative for the complete matrix.

## Documentation impact

Documentation impact: none. This restores the already documented 256 KiB response contract and does not change the public API, configuration keys, or retrieval guidance.

## AI-assisted contribution

This change was prepared with AI assistance. I understand the fix: the transport guard must budget the metadata it adds and must not discard the Phase 0 evidence contract while doing so.