### PR TITLE
[AI-Assisted] feat(dexpi): retain cycle boundary provenance

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -186,12 +186,13 @@ IDs visible, and separately lists source-ordered connection occurrences entering
 cyclic group. Boundary lists preserve parallel references and exclude connections whose source or
 target identity is blank. `getBoundaryConnections()` additionally preserves the overall source order
 across incoming and outgoing occurrences. Each immutable `DexpiConnectionCycleBoundaryInfo` records
-the connection ID, direction relative to the cyclic group, explicit internal and external endpoint
-identities, whether each endpoint resolves, and the resolved endpoint element and Equipment/PipingComponent owner
-identities already present in the endpoint inventory. Missing or unresolved owner evidence remains an empty field.
-This avoids inferring boundary orientation or ownership by joining separate inventories while retaining parallel and
-unresolved source evidence.
-It does not identify a hydraulic recycle, enumerate elementary paths, assert convergence behavior,
+the connection evidence ID, original source connection ID, owning `PipingNetworkSegment` ID,
+direction relative to the cyclic group, explicit internal and external endpoint identities, whether
+each endpoint resolves, and the resolved endpoint element and Equipment/PipingComponent owner
+identities already present in the endpoint inventory. Missing source, segment, endpoint, or owner
+evidence remains an empty field. This avoids inferring boundary orientation, provenance, or ownership
+by joining separate inventories while retaining parallel and unresolved source evidence. It does not
+identify a hydraulic recycle, enumerate elementary paths, assert convergence behavior,
 repair or rewire topology, or establish process intent.
 
 `toJson()` includes `instrumentCount`, `connectionCount`, `connectionEndpointCount`,

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleBoundaryInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleBoundaryInfo.java
@@ -27,6 +27,8 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
   }
 
   private final String connectionId;
+  private final String sourceId;
+  private final String segmentId;
   private final Direction direction;
   private final String internalEndpointId;
   private final String internalEndpointElementName;
@@ -51,7 +53,7 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
    */
   public DexpiConnectionCycleBoundaryInfo(String connectionId, Direction direction, String internalEndpointId,
       String externalEndpointId, boolean internalEndpointResolved, boolean externalEndpointResolved) {
-    this(connectionId, direction, internalEndpointId, "", "", "", externalEndpointId, "", "", "",
+    this(connectionId, "", "", direction, internalEndpointId, "", "", "", externalEndpointId, "", "", "",
         internalEndpointResolved, externalEndpointResolved);
   }
 
@@ -75,7 +77,37 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
       String internalEndpointElementName, String internalOwnerId, String internalOwnerElementName,
       String externalEndpointId, String externalEndpointElementName, String externalOwnerId,
       String externalOwnerElementName, boolean internalEndpointResolved, boolean externalEndpointResolved) {
+    this(connectionId, "", "", direction, internalEndpointId, internalEndpointElementName, internalOwnerId,
+        internalOwnerElementName, externalEndpointId, externalEndpointElementName, externalOwnerId,
+        externalOwnerElementName, internalEndpointResolved, externalEndpointResolved);
+  }
+
+  /**
+   * Creates immutable cycle-boundary source-reference evidence with connection and endpoint provenance.
+   *
+   * @param connectionId connection-evidence identity
+   * @param sourceId original source connection identity, or empty when absent
+   * @param segmentId owning piping-network segment identity, or empty when absent
+   * @param direction connection direction relative to the cyclic group
+   * @param internalEndpointId endpoint identity inside the cyclic group
+   * @param internalEndpointElementName resolved internal endpoint XML element name, or empty
+   * @param internalOwnerId explicit internal endpoint owner identity, or empty
+   * @param internalOwnerElementName internal endpoint owner XML element name, or empty
+   * @param externalEndpointId endpoint identity outside the cyclic group
+   * @param externalEndpointElementName resolved external endpoint XML element name, or empty
+   * @param externalOwnerId explicit external endpoint owner identity, or empty
+   * @param externalOwnerElementName external endpoint owner XML element name, or empty
+   * @param internalEndpointResolved whether the internal endpoint resolves in the source document
+   * @param externalEndpointResolved whether the external endpoint resolves in the source document
+   */
+  public DexpiConnectionCycleBoundaryInfo(String connectionId, String sourceId, String segmentId,
+      Direction direction, String internalEndpointId, String internalEndpointElementName, String internalOwnerId,
+      String internalOwnerElementName, String externalEndpointId, String externalEndpointElementName,
+      String externalOwnerId, String externalOwnerElementName, boolean internalEndpointResolved,
+      boolean externalEndpointResolved) {
     this.connectionId = normalize(connectionId);
+    this.sourceId = normalize(sourceId);
+    this.segmentId = normalize(segmentId);
     this.direction = direction;
     this.internalEndpointId = normalize(internalEndpointId);
     this.internalEndpointElementName = normalize(internalEndpointElementName);
@@ -92,6 +124,21 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
   /** @return connection-evidence identity */
   public String getConnectionId() {
     return connectionId;
+  }
+
+  /** @return original source connection identity, or empty when absent */
+  public String getSourceId() {
+    return sourceId;
+  }
+
+  /** @return whether the source supplied a connection identity */
+  public boolean hasSourceId() {
+    return !sourceId.isEmpty();
+  }
+
+  /** @return owning piping-network segment identity, or empty when absent */
+  public String getSegmentId() {
+    return segmentId;
   }
 
   /** @return connection direction relative to the cyclic group */
@@ -152,6 +199,8 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
   Map<String, Object> toMap() {
     Map<String, Object> result = new LinkedHashMap<String, Object>();
     result.put("connectionId", connectionId);
+    result.put("sourceId", sourceId);
+    result.put("segmentId", segmentId);
     result.put("direction", direction.name());
     result.put("internalEndpointId", internalEndpointId);
     result.put("internalEndpointElementName", internalEndpointElementName);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleBoundaryInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleBoundaryInfo.java
@@ -100,8 +100,8 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
    * @param internalEndpointResolved whether the internal endpoint resolves in the source document
    * @param externalEndpointResolved whether the external endpoint resolves in the source document
    */
-  public DexpiConnectionCycleBoundaryInfo(String connectionId, String sourceId, String segmentId,
-      Direction direction, String internalEndpointId, String internalEndpointElementName, String internalOwnerId,
+  public DexpiConnectionCycleBoundaryInfo(String connectionId, String sourceId, String segmentId, Direction direction,
+      String internalEndpointId, String internalEndpointElementName, String internalOwnerId,
       String internalOwnerElementName, String externalEndpointId, String externalEndpointElementName,
       String externalOwnerId, String externalOwnerElementName, boolean internalEndpointResolved,
       boolean externalEndpointResolved) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1101,10 +1101,11 @@ public final class DexpiXmlReader {
         DexpiConnectionCycleBoundaryInfo.Direction direction, DexpiConnectionEndpointInfo internalEndpoint,
         DexpiConnectionEndpointInfo externalEndpoint) {
       boundaryConnections
-          .add(new DexpiConnectionCycleBoundaryInfo(connection.getId(), direction, internalEndpoint.getEndpointId(),
-              internalEndpoint.getElementName(), internalEndpoint.getOwnerId(), internalEndpoint.getOwnerElementName(),
-              externalEndpoint.getEndpointId(), externalEndpoint.getElementName(), externalEndpoint.getOwnerId(),
-              externalEndpoint.getOwnerElementName(), internalEndpoint.isResolved(), externalEndpoint.isResolved()));
+          .add(new DexpiConnectionCycleBoundaryInfo(connection.getId(), connection.getSourceId(),
+              connection.getSegmentId(), direction, internalEndpoint.getEndpointId(), internalEndpoint.getElementName(),
+              internalEndpoint.getOwnerId(), internalEndpoint.getOwnerElementName(), externalEndpoint.getEndpointId(),
+              externalEndpoint.getElementName(), externalEndpoint.getOwnerId(), externalEndpoint.getOwnerElementName(),
+              internalEndpoint.isResolved(), externalEndpoint.isResolved()));
     }
 
     private DexpiConnectionCycleInfo toInfo() {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1100,12 +1100,11 @@ public final class DexpiXmlReader {
     private void addBoundaryConnection(DexpiConnectionInfo connection,
         DexpiConnectionCycleBoundaryInfo.Direction direction, DexpiConnectionEndpointInfo internalEndpoint,
         DexpiConnectionEndpointInfo externalEndpoint) {
-      boundaryConnections
-          .add(new DexpiConnectionCycleBoundaryInfo(connection.getId(), connection.getSourceId(),
-              connection.getSegmentId(), direction, internalEndpoint.getEndpointId(), internalEndpoint.getElementName(),
-              internalEndpoint.getOwnerId(), internalEndpoint.getOwnerElementName(), externalEndpoint.getEndpointId(),
-              externalEndpoint.getElementName(), externalEndpoint.getOwnerId(), externalEndpoint.getOwnerElementName(),
-              internalEndpoint.isResolved(), externalEndpoint.isResolved()));
+      boundaryConnections.add(new DexpiConnectionCycleBoundaryInfo(connection.getId(), connection.getSourceId(),
+          connection.getSegmentId(), direction, internalEndpoint.getEndpointId(), internalEndpoint.getElementName(),
+          internalEndpoint.getOwnerId(), internalEndpoint.getOwnerElementName(), externalEndpoint.getEndpointId(),
+          externalEndpoint.getElementName(), externalEndpoint.getOwnerId(), externalEndpoint.getOwnerElementName(),
+          internalEndpoint.isResolved(), externalEndpoint.isResolved()));
     }
 
     private DexpiConnectionCycleInfo toInfo() {

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -677,6 +677,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         Arrays.asList(boundaries.get(0).getConnectionId(), boundaries.get(1).getConnectionId(),
             boundaries.get(2).getConnectionId(), boundaries.get(3).getConnectionId()));
     assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.INCOMING, boundaries.get(0).getDirection());
+    assertEquals("C-IN-1", boundaries.get(0).getSourceId());
+    assertTrue(boundaries.get(0).hasSourceId());
+    assertEquals("S-IN-1", boundaries.get(0).getSegmentId());
     assertEquals("N-X", boundaries.get(0).getInternalEndpointId());
     assertEquals("N-A", boundaries.get(0).getExternalEndpointId());
     assertTrue(boundaries.get(0).isInternalEndpointResolved());
@@ -688,6 +691,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("E-A", boundaries.get(0).getExternalOwnerId());
     assertEquals("Equipment", boundaries.get(0).getExternalOwnerElementName());
     assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING, boundaries.get(1).getDirection());
+    assertEquals("C-OUT-1", boundaries.get(1).getSourceId());
+    assertEquals("S-OUT-1", boundaries.get(1).getSegmentId());
     assertEquals("N-Y", boundaries.get(1).getInternalEndpointId());
     assertEquals("N-B", boundaries.get(1).getExternalEndpointId());
     assertEquals("E-Y", boundaries.get(1).getInternalOwnerId());
@@ -721,6 +726,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(legacy.getBoundaryConnections().isEmpty());
     DexpiConnectionCycleBoundaryInfo legacyBoundary = new DexpiConnectionCycleBoundaryInfo("legacy-boundary",
         DexpiConnectionCycleBoundaryInfo.Direction.INCOMING, "N-INTERNAL", "N-EXTERNAL", true, false);
+    assertEquals("", legacyBoundary.getSourceId());
+    assertFalse(legacyBoundary.hasSourceId());
+    assertEquals("", legacyBoundary.getSegmentId());
     assertEquals("", legacyBoundary.getInternalEndpointElementName());
     assertEquals("", legacyBoundary.getInternalOwnerId());
     assertEquals("", legacyBoundary.getExternalEndpointElementName());
@@ -729,6 +737,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(first.toJson().contains("\"boundaryConnectionCount\": 4"));
     assertTrue(first.toJson().contains("\"direction\": \"INCOMING\""));
     assertTrue(first.toJson().contains("\"externalEndpointId\": \"UNKNOWN-U\""));
+    assertTrue(first.toJson().contains("\"sourceId\": \"C-IN-1\""));
+    assertTrue(first.toJson().contains("\"segmentId\": \"S-IN-1\""));
     assertTrue(first.toJson().contains("\"internalOwnerId\": \"E-X\""));
     assertTrue(first.toJson().contains("\"externalOwnerElementName\": \"Equipment\""));
     assertTrue(first.toJson().contains("\"outgoingBoundaryConnectionIds\": ["));


### PR DESCRIPTION
## Summary

Advances #1332 and #2899 by retaining connection-level source provenance on every explicit Proteus-compatible DEXPI directed-cycle boundary occurrence.

Exact base: `fa573e4af47b9ca81ef87ef91f3f5453ac531e47`  
Exact head: `e4523ab9cd2a36fea6beb5fb3d52bb3f91e0011a`

## Engineering value

`DexpiConnectionCycleBoundaryInfo` already exposes boundary orientation, endpoint resolution, element identity, and Equipment/PipingComponent ownership. This increment also carries the original `Connection` source ID and owning `PipingNetworkSegment` ID from the existing immutable connection inventory, so reviewers and JPype callers do not need a separate inventory join.

## Scope

- Add immutable `sourceId` and `segmentId` fields, getters, and deterministic JSON.
- Preserve both existing public constructors with empty provenance defaults.
- Project only existing `DexpiConnectionInfo.getSourceId()` and `getSegmentId()` evidence.
- Cover incoming/outgoing boundaries, legacy defaults, and JSON output.
- Update Java/JPype reader documentation.

## Deliberate exclusions

No hydraulic-recycle inference, path or reachability solving, topology repair/rewiring, simulation topology, rendering, geometry, layout, writer/export behavior, native DEXPI 2.0 expansion, Huldra, external datasets, standards-conformance claim, certification, or engineering approval.

## Validation

- Connector-side exact-base/head and four-file diff integrity verified.
- Local Maven, Java, Spotless, pre-commit, Javadocs, and notebook execution were not run and are not claimed.
- Hosted CI is authoritative.
- Whole-sheet visual gate: N/A with evidence because no renderer, writer, SVG, geometry, layout, notebook, or export path changed.

Status: **VALIDATION PENDING CI**.