### PR TITLE
[AI-Assisted] feat(electrolyte): expose salt saturation diagnostics

### DIFF
--- a/docs/pvtsimulation/scale_prediction_api.md
+++ b/docs/pvtsimulation/scale_prediction_api.md
@@ -211,6 +211,35 @@ for i in range(1, len(table)):
 - MEG-aware (temporarily replaces MEG with water for calculation)
 - Returns **saturation ratio** (SR = IAP/Ksp), where SR > 1 = supersaturated
 
+### Dissolved-salt saturation diagnostics
+
+`calcSaltSaturation(String)` adds dissociated salt formula units until the aqueous ion activity
+product reaches the COMPSALT solubility product. Use
+`calcSaltSaturationWithDiagnostics(String)` for the same system mutation plus immutable convergence
+and work diagnostics:
+
+```java
+SystemPitzer fluid = new SystemPitzer(404.15, 995.0);
+fluid.addComponent("water", 55.508);
+fluid.setMixingRule("classic");
+
+ThermodynamicOperations operations = new ThermodynamicOperations(fluid);
+SaltSaturationResult result =
+    operations.calcSaltSaturationWithDiagnostics("CaSO4_A");
+
+double initialSaturationRatio = result.getInitialSaturationRatio();
+double finalSaturationRatio = result.getFinalSaturationRatio();
+double addedFormulaUnitsMol = result.getAddedSaltMoles();
+int fullThermodynamicInitializations = result.getThermodynamicInitializationCount();
+boolean converged = result.isConverged();
+```
+
+The result also reports bracket and bisection evaluation counts, whether the input was already
+saturated, whether the solve reached its iteration limit, and the absolute residual from unit
+saturation. These diagnostics expose the existing calculation's work without adding flashes or
+changing its `1e-6` saturation-ratio tolerance. They do not create a solid phase, describe
+precipitated mass, or qualify the COMPSALT, Ksp, reaction-volume, or activity-model parameters.
+
 ### Activity-consistent pure-mineral precipitation
 
 `ThermodynamicOperations.precipitateScale(String)` removes one named COMPSALT mineral

--- a/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
+++ b/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
@@ -69,6 +69,7 @@ import neqsim.thermodynamicoperations.flashops.saturationops.MultiSaltPrecipitat
 import neqsim.thermodynamicoperations.flashops.saturationops.MultiSaltPrecipitationResult;
 import neqsim.thermodynamicoperations.flashops.saturationops.SolidComplexTemperatureCalc;
 import neqsim.thermodynamicoperations.flashops.saturationops.SaltPrecipitationResult;
+import neqsim.thermodynamicoperations.flashops.saturationops.SaltSaturationResult;
 import neqsim.thermodynamicoperations.flashops.saturationops.WATcalc;
 import neqsim.thermodynamicoperations.flashops.saturationops.WaterDewPointEquilibriumLine;
 import neqsim.thermodynamicoperations.flashops.saturationops.WaterDewPointTemperatureFlash;
@@ -1315,18 +1316,37 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
   }
 
   /**
-   * calcSaltSaturation.
+   * Adds a dissolved salt to activity saturation.
    *
-   * @param saltName a {@link java.lang.String} object
-   * @throws neqsim.util.exception.IsNaNException if any.
+   * @param saltName salt name from the COMPSALT database
+   * @throws neqsim.util.exception.IsNaNException if the calculation returns an invalid state
    */
   public void calcSaltSaturation(String saltName) throws IsNaNException {
-    operation = new CalcSaltSatauration(system, saltName);
-    getOperation().run();
+    calcSaltSaturationWithDiagnostics(saltName);
+  }
+
+  /**
+   * Adds a dissolved salt to activity saturation and returns convergence diagnostics.
+   *
+   * <p>
+   * This method uses the same calculation and mutates the system in the same way as
+   * {@link #calcSaltSaturation(String)}. The result reports the existing solver's work and does not represent a solid
+   * phase or qualify the underlying thermodynamic parameters.
+   * </p>
+   *
+   * @param saltName salt name from the COMPSALT database
+   * @return immutable saturation-ratio, added-amount and convergence diagnostics
+   * @throws neqsim.util.exception.IsNaNException if the calculation returns an invalid state
+   */
+  public SaltSaturationResult calcSaltSaturationWithDiagnostics(String saltName) throws IsNaNException {
+    CalcSaltSatauration saltOperation = new CalcSaltSatauration(system, saltName);
+    operation = saltOperation;
+    saltOperation.run();
     if (Double.isNaN(system.getTemperature())) {
-      throw new neqsim.util.exception.IsNaNException(this, "calcSaltSaturation",
+      throw new neqsim.util.exception.IsNaNException(this, "calcSaltSaturationWithDiagnostics",
           "Could not find solution - possible no dew point exists");
     }
+    return saltOperation.getResult();
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalcSaltSatauration.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalcSaltSatauration.java
@@ -16,11 +16,15 @@ import neqsim.thermodynamicoperations.flashops.TPflash;
 public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
   /** Serialization version UID. */
   private static final long serialVersionUID = 1000;
+  private static final int MAX_SATURATION_ITERATIONS = 80;
+  private static final double SATURATION_RATIO_TOLERANCE = 1.0e-6;
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(CalcSaltSatauration.class);
 
   String saltName;
   private transient SaltData saltDataCache;
+  private transient SaltSaturationResult result;
+  private transient int thermodynamicInitializationCount;
 
   /**
    * Constructor for calcSaltSatauration.
@@ -37,6 +41,9 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
   /** {@inheritDoc} */
   @Override
   public void run() {
+    result = null;
+    thermodynamicInitializationCount = 0;
+
     SaltData saltData = readSaltData();
     ensureSaltIonsPresent(saltData);
 
@@ -44,7 +51,11 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
     int aqueousPhaseNumber = getAqueousPhaseNumber();
 
     double saturationRatio = calculateSaturationRatio(saltData, aqueousPhaseNumber);
+    double initialSaturationRatio = saturationRatio;
     if (saturationRatio >= 1.0) {
+      boolean converged = Math.abs(saturationRatio - 1.0) < SATURATION_RATIO_TOLERANCE;
+      result = new SaltSaturationResult(saltName, initialSaturationRatio, saturationRatio, 0.0, 0, 0,
+          thermodynamicInitializationCount, true, converged, false);
       logger.info("{} is already saturated, SR={}", saltName, saturationRatio);
       return;
     }
@@ -52,12 +63,14 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
     double lowerAddition = 0.0;
     double upperAddition = 1.0e-6;
     double upperSaturationRatio = saturationRatio;
+    double acceptedAddition = 0.0;
     int bracketIterations = 0;
+    int solveIterations = 0;
 
     SystemInterface baseSystem = system.clone();
 
     if (system instanceof neqsim.thermo.system.SystemPitzer || "FeCO3".equals(saltName)) {
-      while (upperSaturationRatio < 1.0 && bracketIterations < 80) {
+      while (upperSaturationRatio < 1.0 && bracketIterations < MAX_SATURATION_ITERATIONS) {
         upperSaturationRatio = calculateSaturationRatioForAddition(baseSystem, saltData, upperAddition);
         if (upperSaturationRatio < 1.0) {
           lowerAddition = upperAddition;
@@ -70,11 +83,12 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
         throw new IllegalStateException("Could not bracket salt saturation for " + saltName);
       }
 
-      for (int i = 0; i < 80; i++) {
+      for (int i = 0; i < MAX_SATURATION_ITERATIONS; i++) {
         double trialAddition = 0.5 * (lowerAddition + upperAddition);
         saturationRatio = calculateSaturationRatioForAddition(baseSystem, saltData, trialAddition);
+        solveIterations++;
 
-        if (Math.abs(saturationRatio - 1.0) < 1.0e-6) {
+        if (Math.abs(saturationRatio - 1.0) < SATURATION_RATIO_TOLERANCE) {
           lowerAddition = trialAddition;
           upperAddition = trialAddition;
           break;
@@ -86,13 +100,13 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
         }
       }
 
-      double finalAddition = 0.5 * (lowerAddition + upperAddition);
-      addSaltAmount(saltData, finalAddition);
+      acceptedAddition = 0.5 * (lowerAddition + upperAddition);
+      addSaltAmount(saltData, acceptedAddition);
       initialiseSystem();
     } else {
       double currentAddition = 0.0;
 
-      while (upperSaturationRatio < 1.0 && bracketIterations < 80) {
+      while (upperSaturationRatio < 1.0 && bracketIterations < MAX_SATURATION_ITERATIONS) {
         lowerAddition = currentAddition;
         addSaltAmount(saltData, upperAddition - currentAddition);
         currentAddition = upperAddition;
@@ -109,15 +123,16 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
         throw new IllegalStateException("Could not bracket salt saturation for " + saltName);
       }
 
-      for (int i = 0; i < 80; i++) {
+      for (int i = 0; i < MAX_SATURATION_ITERATIONS; i++) {
         double trialAddition = 0.5 * (lowerAddition + upperAddition);
         addSaltAmount(saltData, trialAddition - currentAddition);
         currentAddition = trialAddition;
         initialiseSystem();
         aqueousPhaseNumber = getAqueousPhaseNumber();
         saturationRatio = calculateSaturationRatio(saltData, aqueousPhaseNumber);
+        solveIterations++;
 
-        if (Math.abs(saturationRatio - 1.0) < 1.0e-6) {
+        if (Math.abs(saturationRatio - 1.0) < SATURATION_RATIO_TOLERANCE) {
           break;
         }
         if (saturationRatio < 1.0) {
@@ -126,12 +141,31 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
           upperAddition = trialAddition;
         }
       }
+      acceptedAddition = currentAddition;
     }
 
     aqueousPhaseNumber = getAqueousPhaseNumber();
     saturationRatio = calculateSaturationRatio(saltData, aqueousPhaseNumber);
+    boolean converged = Math.abs(saturationRatio - 1.0) < SATURATION_RATIO_TOLERANCE;
+    boolean iterationLimitReached = !converged && solveIterations >= MAX_SATURATION_ITERATIONS;
+    result = new SaltSaturationResult(saltName, initialSaturationRatio, saturationRatio, acceptedAddition,
+        bracketIterations, solveIterations, thermodynamicInitializationCount, false, converged,
+        iterationLimitReached);
 
     logger.info("solution found for {} in calcSaltSatauration(), SR={}", saltName, saturationRatio);
+  }
+
+  /**
+   * Returns diagnostics for the completed dissolved-salt saturation calculation.
+   *
+   * @return immutable convergence and work diagnostics
+   * @throws java.lang.IllegalStateException if {@link #run()} has not completed successfully
+   */
+  public SaltSaturationResult getResult() {
+    if (result == null) {
+      throw new IllegalStateException("Salt saturation has not completed for " + saltName);
+    }
+    return result;
   }
 
   /**
@@ -478,6 +512,7 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
    * Initialises thermodynamic and physical properties for the current system state.
    */
   private void initialiseSystem() {
+    thermodynamicInitializationCount++;
     if (system instanceof neqsim.thermo.system.SystemPitzer) {
       neqsim.thermo.system.SystemPitzer pitzerSystem = (neqsim.thermo.system.SystemPitzer) system;
       system.init(0);

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalcSaltSatauration.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalcSaltSatauration.java
@@ -149,8 +149,7 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
     boolean converged = Math.abs(saturationRatio - 1.0) < SATURATION_RATIO_TOLERANCE;
     boolean iterationLimitReached = !converged && solveIterations >= MAX_SATURATION_ITERATIONS;
     result = new SaltSaturationResult(saltName, initialSaturationRatio, saturationRatio, acceptedAddition,
-        bracketIterations, solveIterations, thermodynamicInitializationCount, false, converged,
-        iterationLimitReached);
+        bracketIterations, solveIterations, thermodynamicInitializationCount, false, converged, iterationLimitReached);
 
     logger.info("solution found for {} in calcSaltSatauration(), SR={}", saltName, saturationRatio);
   }

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltSaturationResult.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltSaturationResult.java
@@ -1,0 +1,101 @@
+package neqsim.thermodynamicoperations.flashops.saturationops;
+
+import java.io.Serializable;
+
+/**
+ * Immutable diagnostics from adding a dissolved salt to activity saturation.
+ *
+ * <p>
+ * The added amount is expressed as salt formula units. The result describes the existing
+ * {@link CalcSaltSatauration} bracket and bisection calculation; it does not represent a solid phase or qualify the
+ * underlying COMPSALT or activity-model parameters.
+ * </p>
+ *
+ * @author Even Solbraa
+ * @version 1.0
+ */
+public final class SaltSaturationResult implements Serializable {
+  /** Serialization version UID. */
+  private static final long serialVersionUID = 1000L;
+
+  private final String saltName;
+  private final double initialSaturationRatio;
+  private final double finalSaturationRatio;
+  private final double addedSaltMoles;
+  private final int bracketIterations;
+  private final int solveIterations;
+  private final int thermodynamicInitializationCount;
+  private final boolean alreadySaturated;
+  private final boolean converged;
+  private final boolean iterationLimitReached;
+
+  SaltSaturationResult(String saltName, double initialSaturationRatio, double finalSaturationRatio,
+      double addedSaltMoles, int bracketIterations, int solveIterations, int thermodynamicInitializationCount,
+      boolean alreadySaturated, boolean converged, boolean iterationLimitReached) {
+    this.saltName = saltName;
+    this.initialSaturationRatio = initialSaturationRatio;
+    this.finalSaturationRatio = finalSaturationRatio;
+    this.addedSaltMoles = addedSaltMoles;
+    this.bracketIterations = bracketIterations;
+    this.solveIterations = solveIterations;
+    this.thermodynamicInitializationCount = thermodynamicInitializationCount;
+    this.alreadySaturated = alreadySaturated;
+    this.converged = converged;
+    this.iterationLimitReached = iterationLimitReached;
+  }
+
+  /** @return COMPSALT salt name */
+  public String getSaltName() {
+    return saltName;
+  }
+
+  /** @return ion activity product divided by Ksp before salt addition */
+  public double getInitialSaturationRatio() {
+    return initialSaturationRatio;
+  }
+
+  /** @return ion activity product divided by Ksp after the accepted addition */
+  public double getFinalSaturationRatio() {
+    return finalSaturationRatio;
+  }
+
+  /** @return added dissolved salt formula units in mol */
+  public double getAddedSaltMoles() {
+    return addedSaltMoles;
+  }
+
+  /** @return number of upper-bound expansion evaluations */
+  public int getBracketIterations() {
+    return bracketIterations;
+  }
+
+  /** @return number of bisection evaluations */
+  public int getSolveIterations() {
+    return solveIterations;
+  }
+
+  /** @return number of complete thermodynamic initializations performed by the calculation */
+  public int getThermodynamicInitializationCount() {
+    return thermodynamicInitializationCount;
+  }
+
+  /** @return true when the input state was already at or above unit saturation */
+  public boolean isAlreadySaturated() {
+    return alreadySaturated;
+  }
+
+  /** @return true when the final saturation-ratio residual meets the solver tolerance */
+  public boolean isConverged() {
+    return converged;
+  }
+
+  /** @return true when the bisection stopped at its iteration limit without convergence */
+  public boolean isIterationLimitReached() {
+    return iterationLimitReached;
+  }
+
+  /** @return absolute residual from unit saturation */
+  public double getAbsoluteSaturationRatioResidual() {
+    return Math.abs(finalSaturationRatio - 1.0);
+  }
+}

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltSaturationResult.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/SaltSaturationResult.java
@@ -6,9 +6,9 @@ import java.io.Serializable;
  * Immutable diagnostics from adding a dissolved salt to activity saturation.
  *
  * <p>
- * The added amount is expressed as salt formula units. The result describes the existing
- * {@link CalcSaltSatauration} bracket and bisection calculation; it does not represent a solid phase or qualify the
- * underlying COMPSALT or activity-model parameters.
+ * The added amount is expressed as salt formula units. The result describes the existing {@link CalcSaltSatauration}
+ * bracket and bisection calculation; it does not represent a solid phase or qualify the underlying COMPSALT or
+ * activity-model parameters.
  * </p>
  *
  * @author Even Solbraa

--- a/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
@@ -290,10 +290,10 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
     secondSystem.addComponent("water", 55.508);
     secondSystem.setMixingRule("classic");
 
-    SaltSaturationResult firstResult =
-        new ThermodynamicOperations(firstSystem).calcSaltSaturationWithDiagnostics("CaSO4_A");
-    SaltSaturationResult secondResult =
-        new ThermodynamicOperations(secondSystem).calcSaltSaturationWithDiagnostics("CaSO4_A");
+    SaltSaturationResult firstResult = new ThermodynamicOperations(firstSystem)
+        .calcSaltSaturationWithDiagnostics("CaSO4_A");
+    SaltSaturationResult secondResult = new ThermodynamicOperations(secondSystem)
+        .calcSaltSaturationWithDiagnostics("CaSO4_A");
 
     assertEquals("CaSO4_A", firstResult.getSaltName());
     assertTrue(firstResult.getInitialSaturationRatio() >= 0.0);
@@ -314,8 +314,7 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
     assertEquals(firstResult.getFinalSaturationRatio(), secondResult.getFinalSaturationRatio(), 1.0e-12);
     assertEquals(firstResult.getBracketIterations(), secondResult.getBracketIterations());
     assertEquals(firstResult.getSolveIterations(), secondResult.getSolveIterations());
-    assertEquals(firstResult.getThermodynamicInitializationCount(),
-        secondResult.getThermodynamicInitializationCount());
+    assertEquals(firstResult.getThermodynamicInitializationCount(), secondResult.getThermodynamicInitializationCount());
   }
 
   /** Verifies that salt saturation preserves the explicit legacy compatibility selection. */

--- a/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPitzerTest.java
@@ -15,6 +15,7 @@ import neqsim.thermo.phase.PhaseInterface;
 import neqsim.thermo.phase.PhasePitzer;
 import neqsim.thermo.phase.PitzerParameterDatasets;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
+import neqsim.thermodynamicoperations.flashops.saturationops.SaltSaturationResult;
 
 /**
  * Consolidated regression tests for the Pitzer activity model in thermodynamic systems.
@@ -274,6 +275,47 @@ public class SystemPitzerTest extends neqsim.NeqSimTest {
     assertEquals(1.0, earlyIonOperations.getRelativeScalePotential("CaSO4_A"), 1.0e-3);
     assertEquals(earlyIonSystem.getComponent("Ca++").getNumberOfmoles(),
         lateIonSystem.getComponent("Ca++").getNumberOfmoles(), 1.0e-8);
+  }
+
+  /**
+   * Verifies that dissolved-salt saturation diagnostics report the existing Pitzer solve deterministically.
+   */
+  @Test
+  public void testCalcSaltSaturationDiagnosticsAreDeterministic() throws Exception {
+    SystemPitzer firstSystem = new SystemPitzer(404.15, 995.0);
+    firstSystem.addComponent("water", 55.508);
+    firstSystem.setMixingRule("classic");
+
+    SystemPitzer secondSystem = new SystemPitzer(404.15, 995.0);
+    secondSystem.addComponent("water", 55.508);
+    secondSystem.setMixingRule("classic");
+
+    SaltSaturationResult firstResult =
+        new ThermodynamicOperations(firstSystem).calcSaltSaturationWithDiagnostics("CaSO4_A");
+    SaltSaturationResult secondResult =
+        new ThermodynamicOperations(secondSystem).calcSaltSaturationWithDiagnostics("CaSO4_A");
+
+    assertEquals("CaSO4_A", firstResult.getSaltName());
+    assertTrue(firstResult.getInitialSaturationRatio() >= 0.0);
+    assertTrue(firstResult.getInitialSaturationRatio() < 1.0);
+    assertEquals(1.0, firstResult.getFinalSaturationRatio(), 1.0e-3);
+    assertTrue(firstResult.getAddedSaltMoles() > 0.0);
+    assertTrue(firstResult.getBracketIterations() > 0);
+    assertTrue(firstResult.getSolveIterations() > 0);
+    assertEquals(firstResult.getBracketIterations() + firstResult.getSolveIterations() + 2,
+        firstResult.getThermodynamicInitializationCount());
+    assertFalse(firstResult.isAlreadySaturated());
+    assertTrue(firstResult.isConverged());
+    assertFalse(firstResult.isIterationLimitReached());
+    assertEquals(Math.abs(firstResult.getFinalSaturationRatio() - 1.0),
+        firstResult.getAbsoluteSaturationRatioResidual(), 0.0);
+
+    assertEquals(firstResult.getAddedSaltMoles(), secondResult.getAddedSaltMoles(), 1.0e-10);
+    assertEquals(firstResult.getFinalSaturationRatio(), secondResult.getFinalSaturationRatio(), 1.0e-12);
+    assertEquals(firstResult.getBracketIterations(), secondResult.getBracketIterations());
+    assertEquals(firstResult.getSolveIterations(), secondResult.getSolveIterations());
+    assertEquals(firstResult.getThermodynamicInitializationCount(),
+        secondResult.getThermodynamicInitializationCount());
   }
 
   /** Verifies that salt saturation preserves the explicit legacy compatibility selection. */


### PR DESCRIPTION
## Summary

Adds immutable convergence and work diagnostics to the existing dissolved-salt saturation operation.

- introduces `SaltSaturationResult`
- adds `ThermodynamicOperations.calcSaltSaturationWithDiagnostics(String)`
- preserves `calcSaltSaturation(String)` source and binary compatibility
- reports initial/final activity saturation ratio, added formula units, bracket and solve iterations, complete thermodynamic initialization count, terminal status, and absolute residual
- documents the API and adds deterministic late-ion Pitzer regression coverage

## Capability contract

Campaign: #3144  
Contract evidence: https://github.com/equinor/neqsim/issues/3144#issuecomment-5520750725  
Exact base: `fa573e4af47b9ca81ef87ef91f3f5453ac531e47`  
Exact head: `610ff0535e7e3a45bd113e4d27db1e9e3e05c6e9`  
Autonomous portfolio at publication: 2/10 including this draft

## Scientific and model boundaries

This increment instruments the existing bracket/bisection calculation. It does not change its TP flashes, trial states, `1e-6` saturation-ratio tolerance, accepted salt amount, Ksp values, COMPSALT rows, reaction volumes, Pitzer parameters, dataset-selection policy, phase semantics, or pure-mineral precipitation operations. The result describes added dissolved salt formula units; it is not a solid-phase or parameter-qualification result.

The high-pressure calcium-sulfate comparison remains rejected (54-row MARE 0.7003), and no result here changes that qualification boundary.

## Validation

Status: **DRAFT — VALIDATION PENDING EXACT-HEAD CI**

GitHub's exact Spotless artifact from the first head was applied byte-for-byte in the second commit. The formatting-only commit changes line wrapping in three Java files and no behavior.

The scheduled workspace had no retained repository checkout, so no local formatter, compilation, test, Javadoc, or performance run is claimed for this exact head. Hosted CI is the authoritative validation path. The regression additions cover late-ion Pitzer convergence, final unit saturation, diagnostic accounting, and deterministic repeated results.

Performance semantics: diagnostic accounting is performed inside the existing evaluations and adds no thermodynamic initialization or trial flash. Unrelated operations do not execute this code path. Exact-head performance evidence remains pending.

## Documentation impact

Updated `docs/pvtsimulation/scale_prediction_api.md` with the new public API, units, status meanings, solver tolerance, and explicit non-qualification boundaries.

## Scope

Five files; no generated datasets, coefficients, reaction rows, or dependency changes. This PR remains draft until exact-head gates and review evidence are complete.