### PR TITLE
[AI-Assisted] feat(refinery): add public atmospheric operating reference

### DIFF
--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -62,6 +62,13 @@ See [Refinery Assay and TBP Cut Characterization](refinery_assay) for the comple
 The qualified inputs are assembled into one reusable reference composition by
 [DOE Big Hill Sweet complete modeled assay slate](refinery_big_hill_complete_slate).
 
+A second public operating case is retained by
+[Al-Diwiniya atmospheric operating reference](refinery_al_diwiniya_atmospheric_reference).
+Its 2-60 liquid-vol% partial TBP curve, plant configuration, product rates, and draw
+temperatures remain explicitly separate from the complete DOE modeled slate. The
+source fixed its HYSYS product rates, so those values are operating specifications
+rather than independent yield-validation evidence.
+
 ## TBP fraction models
 
 TBP models estimate the properties needed to represent petroleum pseudo-components in an EOS. Available implementations include Pedersen SRK/PR variants, Lee-Kesler, Riazi-Daubert, Twu, Cavett, and Standing.
@@ -153,6 +160,7 @@ A bookkeeping regression does not by itself validate a petroleum-property correl
 - [DOE Big Hill assay nitrogen qualification](refinery_big_hill_nitrogen_validation)
 - [DOE Big Hill terminal-cut boundary qualification](refinery_big_hill_terminal_boundary_validation)
 - [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation)
+- [Al-Diwiniya atmospheric operating reference](refinery_al_diwiniya_atmospheric_reference)
 - [DOE/OEDI COA bulk density and API qualification](refinery_oedi_coa_bulk_density_validation)
 - [Fluid Characterization Guide](../../wiki/fluid_characterization)
 - [TBP Fraction Models](../../wiki/tbp_fraction_models)

--- a/docs/thermo/characterization/refinery_al_diwiniya_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_al_diwiniya_atmospheric_reference.md
@@ -1,0 +1,67 @@
+---
+title: "Al-Diwiniya atmospheric operating reference"
+description: "Public partial-TBP and atmospheric crude-unit operating evidence, with explicit validation limits."
+---
+
+# Al-Diwiniya atmospheric operating reference
+
+`AlDiwiniyaAtmosphericReference` makes a public atmospheric crude-unit case available to Java and Python/JPype callers without turning missing source data into model inputs.
+
+## Source and license
+
+The source is Ahmed Qasim, Hyfaa Yousif, and Nazar Qasim, *Simulation of Atmospheric Distillation Unit for AL-Diwiniya Crude Oil Refinery by Using Aspen Hysys*, Journal of Petroleum Research and Studies 15(3), 85-97, published 21 September 2025, DOI [10.52716/jprs.v15i3.965](https://doi.org/10.52716/jprs.v15i3.965). The [open-access article](https://jprs.gov.iq/index.php/jprs/article/download/965/614/5888) is licensed CC BY 4.0.
+
+The case describes a 10,000 barrel/day Al-Diwiniya refinery atmospheric unit processing 66 m3/h of 2021 Basra medium crude. The reported crude has API gravity 29.8 at 15 degC, density 876 kg/m3 at an unstated reference temperature, sulfur 3 mass%, salt 159 ppm, water and bottom sediment 0.15 vol%, and kinematic viscosity 12.7 cSt at 20 degC.
+
+## Preserved evidence
+
+The reference preserves all 17 published crude TBP coordinates:
+
+| Cumulative liquid volume (%) | 2 | 3.5 | 5 | 7.5 | 10 | 12.5 | 15 | 17.5 | 20 | 25 | 30 | 35 | 40 | 45 | 50 | 55 | 60 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| TBP temperature (degC) | 40 | 52 | 62 | 77 | 95 | 112 | 128 | 143 | 159 | 189 | 218 | 249 | 279 | 310 | 342 | 373 | 405 |
+
+This is explicitly a **partial curve**. NeqSim does not create synthetic 0 or 100 vol% endpoints, interpolate the unreported 60-100 vol% residue, or assign one bulk density to all TBP intervals.
+
+The operating reference also records:
+
+- crude preheat from 25 to 150 degC and furnace heating to a 300 degC column feed;
+- 29 stages, with the feed flash zone between trays 3 and 4;
+- 1.5 barg feed pressure, 0.75 barg top pressure, and 1.2 barg bottom pressure;
+- heavy-naphtha draws at trays 24 and 22, kerosene at tray 15, and gasoil at tray 9;
+- a 3 m3/h gasoil pump-around returned at 60 degC;
+- four-stage kerosene and gasoil side strippers using 75 and 125 kg/h steam;
+- 300 kg/h bottom steam at 220 degC and 5 barg.
+
+## Product operating rows
+
+| Product | Plant rate (m3/h) | HYSYS rate (m3/h) | Plant draw (degC) | HYSYS draw (degC) |
+| --- | ---: | ---: | ---: | ---: |
+| Light naphtha | 8 | 8 | 110 | 109 |
+| Total heavy naphtha | 2 | 2 | 135 | 140 |
+| Kerosene | 4 | 4 | 180 | 190 |
+| Gasoil | 10 | 10 | 240 | 235 |
+| Atmospheric residue | 41 | 41.25 | 295 | 295 |
+| Off gas | 1 | 0.75 | 60 | 65 |
+
+The source uses signed relative error `100 * (plant - HYSYS) / plant`. `ProductReference` exposes the raw values and recomputes that convention. The five measured hydrocarbon-liquid product rates total 65 m3/h, or 98.4848% of the 66 m3/h crude feed. Off-gas and the separately reported 0.4 m3/h water stream are retained but excluded from this liquid-volume closure because the source does not state compatible reference conditions.
+
+## Java and Python access
+
+```java
+double[] volumePercent = AlDiwiniyaAtmosphericReference.getTbpCumulativeVolumePercent();
+double[] temperatureCelsius = AlDiwiniyaAtmosphericReference.getTbpTemperatureCelsius();
+
+AlDiwiniyaAtmosphericReference.ProductReference kerosene =
+    AlDiwiniyaAtmosphericReference.getProduct("Kerosene");
+double plantDrawCelsius = kerosene.getPlantDrawTemperatureCelsius();
+double signedErrorPercent = kerosene.getDrawTemperatureRelativeErrorPercent();
+```
+
+The static methods are directly accessible through JPype. Returned arrays are defensive copies; changing a Python or Java copy cannot mutate the frozen source data.
+
+## Scientific boundary
+
+The paper states that all HYSYS product flow rates were fixed. Equality of light-naphtha, heavy-naphtha, kerosene, and gasoil rates is therefore **not independent product-yield validation**. Product draw temperatures were calculated and can support a future operating-envelope comparison, but the source does not publish the cut-density curve, molecular-weight curve, complete crude TBP tail, numeric product ASTM D86 tables, reflux rate, or all heat duties needed for an independently reproducible 29-stage crude-column model.
+
+This increment qualifies public data retention, units, error conventions, and evidence classification. It does not claim to validate NeqSim product yields, pseudo-component properties, or the Al-Diwiniya column. A future process-model comparison must add sufficient public assay and product-quality data without tuning to imposed rates.

--- a/src/main/java/neqsim/thermo/characterization/AlDiwiniyaAtmosphericReference.java
+++ b/src/main/java/neqsim/thermo/characterization/AlDiwiniyaAtmosphericReference.java
@@ -1,0 +1,392 @@
+package neqsim.thermo.characterization;
+
+import java.io.Serializable;
+
+/**
+ * Public operating reference for the Al-Diwiniya refinery atmospheric distillation unit.
+ *
+ * <p>
+ * Values are transcribed from A. Qasim, H. Yousif, and N. Qasim, "Simulation of Atmospheric Distillation Unit for
+ * AL-Diwiniya Crude Oil Refinery by Using Aspen Hysys", Journal of Petroleum Research and Studies 15(3), 85-97,
+ * published 21 September 2025. The article is licensed CC BY 4.0.
+ * </p>
+ *
+ * <p>
+ * The published TBP curve covers only 2-60 liquid volume percent. This class preserves that partial evidence and does
+ * not extrapolate it to 0 or 100 percent. The paper also states that all HYSYS product flow rates were fixed.
+ * Consequently, the HYSYS rates retained here are operating specifications and must not be used as independent
+ * yield-prediction validation.
+ * </p>
+ */
+public final class AlDiwiniyaAtmosphericReference {
+  /** Digital object identifier for the source article. */
+  public static final String DOI = "10.52716/jprs.v15i3.965";
+
+  /** Open-access source article. */
+  public static final String ARTICLE_URL = "https://jprs.gov.iq/index.php/jprs/article/download/965/614/5888";
+
+  /** Source license identifier. */
+  public static final String LICENSE = "CC BY 4.0";
+
+  /** Source publication date in ISO-8601 format. */
+  public static final String PUBLICATION_DATE = "2025-09-21";
+
+  private static final double[] TBP_VOLUME_PERCENT = { 2.0, 3.5, 5.0, 7.5, 10.0, 12.5, 15.0, 17.5, 20.0, 25.0, 30.0,
+      35.0, 40.0, 45.0, 50.0, 55.0, 60.0 };
+  private static final double[] TBP_TEMPERATURE_CELSIUS = { 40.0, 52.0, 62.0, 77.0, 95.0, 112.0, 128.0, 143.0, 159.0,
+      189.0, 218.0, 249.0, 279.0, 310.0, 342.0, 373.0, 405.0 };
+
+  private static final ProductReference[] PRODUCTS = {
+      new ProductReference("Light Naphtha", true, 8.0, 8.0, 110.0, 109.0),
+      new ProductReference("Total Heavy Naphtha", true, 2.0, 2.0, 135.0, 140.0),
+      new ProductReference("Kerosene", true, 4.0, 4.0, 180.0, 190.0),
+      new ProductReference("Gasoil", true, 10.0, 10.0, 240.0, 235.0),
+      new ProductReference("Atmospheric residue", true, 41.0, 41.25, 295.0, 295.0),
+      new ProductReference("Off gas", false, 1.0, 0.75, 60.0, 65.0) };
+
+  private AlDiwiniyaAtmosphericReference() {
+  }
+
+  /**
+   * Return the published cumulative TBP liquid-volume coordinates.
+   *
+   * @return defensive copy of cumulative liquid volume in percent
+   */
+  public static double[] getTbpCumulativeVolumePercent() {
+    return TBP_VOLUME_PERCENT.clone();
+  }
+
+  /**
+   * Return the published TBP temperatures.
+   *
+   * @return defensive copy of temperatures in degrees Celsius
+   */
+  public static double[] getTbpTemperatureCelsius() {
+    return TBP_TEMPERATURE_CELSIUS.clone();
+  }
+
+  /**
+   * Return the published TBP temperatures in kelvin.
+   *
+   * @return newly allocated temperature array in kelvin
+   */
+  public static double[] getTbpTemperatureKelvin() {
+    double[] temperaturesKelvin = new double[TBP_TEMPERATURE_CELSIUS.length];
+    for (int i = 0; i < temperaturesKelvin.length; i++) {
+      temperaturesKelvin[i] = TBP_TEMPERATURE_CELSIUS[i] + 273.15;
+    }
+    return temperaturesKelvin;
+  }
+
+  /**
+   * Return whether the source supplies a complete 0-100 liquid-volume-percent TBP curve.
+   *
+   * @return always false for this partial published curve
+   */
+  public static boolean hasCompleteTbpCurve() {
+    return false;
+  }
+
+  /**
+   * Return whether the source fixed the HYSYS product rates as simulation specifications.
+   *
+   * @return always true for this source case
+   */
+  public static boolean areHysysProductRatesImposedSpecifications() {
+    return true;
+  }
+
+  /**
+   * Return whether this source supports an independent product-yield validation claim.
+   *
+   * @return always false because the simulated product rates were imposed
+   */
+  public static boolean isIndependentYieldValidationCase() {
+    return false;
+  }
+
+  /**
+   * Return independent immutable copies of the product-reference rows.
+   *
+   * @return product operating references in source-table order
+   */
+  public static ProductReference[] getProducts() {
+    return PRODUCTS.clone();
+  }
+
+  /**
+   * Find one product reference by its exact published label.
+   *
+   * @param productName exact product label
+   * @return immutable product reference
+   * @throws IllegalArgumentException when the label is null or unknown
+   */
+  public static ProductReference getProduct(String productName) {
+    if (productName == null) {
+      throw new IllegalArgumentException("Product name cannot be null");
+    }
+    for (ProductReference product : PRODUCTS) {
+      if (product.getName().equals(productName)) {
+        return product;
+      }
+    }
+    throw new IllegalArgumentException("Unknown Al-Diwiniya product: " + productName);
+  }
+
+  /**
+   * Calculate the signed relative error convention used by the source article.
+   *
+   * @param actualValue plant value
+   * @param simulatedValue HYSYS value
+   * @return {@code 100 * (actual - simulated) / actual}, in percent
+   */
+  public static double calculateSignedRelativeErrorPercent(double actualValue, double simulatedValue) {
+    if (!Double.isFinite(actualValue) || actualValue == 0.0) {
+      throw new IllegalArgumentException("Actual value must be finite and non-zero");
+    }
+    if (!Double.isFinite(simulatedValue)) {
+      throw new IllegalArgumentException("Simulated value must be finite");
+    }
+    return 100.0 * (actualValue - simulatedValue) / actualValue;
+  }
+
+  /**
+   * Sum the five measured hydrocarbon-liquid product rates.
+   *
+   * <p>
+   * Off-gas and the separately reported 0.4 m3/h water stream are excluded because their measurement/reference states
+   * are not supplied and are not silently commensurate with crude liquid volume.
+   * </p>
+   *
+   * @return measured hydrocarbon-liquid product total in m3/h
+   */
+  public static double getMeasuredHydrocarbonLiquidProductRateM3PerHour() {
+    double total = 0.0;
+    for (ProductReference product : PRODUCTS) {
+      if (product.isHydrocarbonLiquid()) {
+        total += product.getPlantRateM3PerHour();
+      }
+    }
+    return total;
+  }
+
+  /**
+   * Return measured-liquid closure relative to the published crude feed rate.
+   *
+   * @return liquid-product rate divided by crude-feed rate, in percent
+   */
+  public static double getMeasuredHydrocarbonLiquidClosurePercent() {
+    return 100.0 * getMeasuredHydrocarbonLiquidProductRateM3PerHour() / getCrudeFeedRateM3PerHour();
+  }
+
+  /** @return refinery crude capacity in barrels per day */
+  public static double getCrudeCapacityBarrelsPerDay() {
+    return 10000.0;
+  }
+
+  /** @return published crude feed rate in m3/h */
+  public static double getCrudeFeedRateM3PerHour() {
+    return 66.0;
+  }
+
+  /** @return published crude API gravity at 15 degrees Celsius */
+  public static double getCrudeApiGravityAt15C() {
+    return 29.8;
+  }
+
+  /** @return published crude density in kg/m3; source temperature is not stated */
+  public static double getCrudeDensityKgPerCubicMetre() {
+    return 876.0;
+  }
+
+  /** @return published crude total sulfur in mass percent */
+  public static double getCrudeSulfurMassPercent() {
+    return 3.0;
+  }
+
+  /** @return published crude salt content in ppm */
+  public static double getCrudeSaltPpm() {
+    return 159.0;
+  }
+
+  /** @return published water-and-bottom-sediment content in volume percent */
+  public static double getWaterAndBottomSedimentVolumePercent() {
+    return 0.15;
+  }
+
+  /** @return published kinematic viscosity at 20 degrees Celsius in cSt */
+  public static double getKinematicViscosityAt20CCst() {
+    return 12.7;
+  }
+
+  /** @return crude temperature after the preheat train in degrees Celsius */
+  public static double getPreheatOutletTemperatureCelsius() {
+    return 150.0;
+  }
+
+  /** @return furnace/column-feed temperature in degrees Celsius */
+  public static double getColumnFeedTemperatureCelsius() {
+    return 300.0;
+  }
+
+  /** @return published column-feed gauge pressure in bar */
+  public static double getColumnFeedPressureBarGauge() {
+    return 1.5;
+  }
+
+  /** @return number of published atmospheric-column stages */
+  public static int getColumnStageCount() {
+    return 29;
+  }
+
+  /** @return lower tray bordering the feed flash zone */
+  public static int getFeedFlashZoneLowerTray() {
+    return 3;
+  }
+
+  /** @return upper tray bordering the feed flash zone */
+  public static int getFeedFlashZoneUpperTray() {
+    return 4;
+  }
+
+  /** @return published top gauge pressure in bar */
+  public static double getColumnTopPressureBarGauge() {
+    return 0.75;
+  }
+
+  /** @return published bottom gauge pressure in bar */
+  public static double getColumnBottomPressureBarGauge() {
+    return 1.2;
+  }
+
+  /** @return defensive copy of heavy-naphtha draw tray numbers */
+  public static int[] getHeavyNaphthaDrawTrays() {
+    return new int[] { 24, 22 };
+  }
+
+  /** @return kerosene draw tray number */
+  public static int getKeroseneDrawTray() {
+    return 15;
+  }
+
+  /** @return gasoil draw tray number */
+  public static int getGasoilDrawTray() {
+    return 9;
+  }
+
+  /** @return gasoil pump-around rate in m3/h */
+  public static double getGasoilPumpAroundRateM3PerHour() {
+    return 3.0;
+  }
+
+  /** @return gasoil pump-around return temperature in degrees Celsius */
+  public static double getGasoilPumpAroundReturnTemperatureCelsius() {
+    return 60.0;
+  }
+
+  /** @return number of stages in each published side stripper */
+  public static int getSideStripperStageCount() {
+    return 4;
+  }
+
+  /** @return kerosene-stripper steam rate in kg/h */
+  public static double getKeroseneStripperSteamRateKgPerHour() {
+    return 75.0;
+  }
+
+  /** @return gasoil-stripper steam rate in kg/h */
+  public static double getGasoilStripperSteamRateKgPerHour() {
+    return 125.0;
+  }
+
+  /** @return bottom stripping-steam rate in kg/h */
+  public static double getBottomSteamRateKgPerHour() {
+    return 300.0;
+  }
+
+  /** @return bottom stripping-steam temperature in degrees Celsius */
+  public static double getBottomSteamTemperatureCelsius() {
+    return 220.0;
+  }
+
+  /** @return bottom stripping-steam gauge pressure in bar */
+  public static double getBottomSteamPressureBarGauge() {
+    return 5.0;
+  }
+
+  /** @return measured overhead water rate in m3/h */
+  public static double getOverheadWaterRateM3PerHour() {
+    return 0.4;
+  }
+
+  /**
+   * Immutable published product operating-reference row.
+   */
+  public static final class ProductReference implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final boolean hydrocarbonLiquid;
+    private final double plantRateM3PerHour;
+    private final double hysysRateM3PerHour;
+    private final double plantDrawTemperatureCelsius;
+    private final double hysysDrawTemperatureCelsius;
+
+    private ProductReference(String name, boolean hydrocarbonLiquid, double plantRateM3PerHour,
+        double hysysRateM3PerHour, double plantDrawTemperatureCelsius, double hysysDrawTemperatureCelsius) {
+      this.name = name;
+      this.hydrocarbonLiquid = hydrocarbonLiquid;
+      this.plantRateM3PerHour = plantRateM3PerHour;
+      this.hysysRateM3PerHour = hysysRateM3PerHour;
+      this.plantDrawTemperatureCelsius = plantDrawTemperatureCelsius;
+      this.hysysDrawTemperatureCelsius = hysysDrawTemperatureCelsius;
+    }
+
+    /** @return exact source product label */
+    public String getName() {
+      return name;
+    }
+
+    /** @return true for the five liquid hydrocarbon product rows */
+    public boolean isHydrocarbonLiquid() {
+      return hydrocarbonLiquid;
+    }
+
+    /** @return measured plant product rate in m3/h */
+    public double getPlantRateM3PerHour() {
+      return plantRateM3PerHour;
+    }
+
+    /** @return imposed HYSYS product rate in m3/h */
+    public double getHysysRateM3PerHour() {
+      return hysysRateM3PerHour;
+    }
+
+    /** @return measured plant draw temperature in degrees Celsius */
+    public double getPlantDrawTemperatureCelsius() {
+      return plantDrawTemperatureCelsius;
+    }
+
+    /** @return calculated HYSYS draw temperature in degrees Celsius */
+    public double getHysysDrawTemperatureCelsius() {
+      return hysysDrawTemperatureCelsius;
+    }
+
+    /** @return signed source-convention rate error in percent */
+    public double getRateRelativeErrorPercent() {
+      return calculateSignedRelativeErrorPercent(plantRateM3PerHour, hysysRateM3PerHour);
+    }
+
+    /** @return signed source-convention draw-temperature error in percent */
+    public double getDrawTemperatureRelativeErrorPercent() {
+      return calculateSignedRelativeErrorPercent(plantDrawTemperatureCelsius, hysysDrawTemperatureCelsius);
+    }
+
+    @Override
+    public String toString() {
+      return "ProductReference{" + "name='" + name + '\'' + ", hydrocarbonLiquid=" + hydrocarbonLiquid
+          + ", plantRateM3PerHour=" + plantRateM3PerHour + ", hysysRateM3PerHour=" + hysysRateM3PerHour
+          + ", plantDrawTemperatureCelsius=" + plantDrawTemperatureCelsius + ", hysysDrawTemperatureCelsius="
+          + hysysDrawTemperatureCelsius + '}';
+    }
+  }
+}

--- a/src/test/java/neqsim/thermo/characterization/AlDiwiniyaAtmosphericReferenceTest.java
+++ b/src/test/java/neqsim/thermo/characterization/AlDiwiniyaAtmosphericReferenceTest.java
@@ -1,0 +1,116 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.AlDiwiniyaAtmosphericReference.ProductReference;
+
+/** Tests the public Al-Diwiniya atmospheric operating reference. */
+public class AlDiwiniyaAtmosphericReferenceTest {
+  @Test
+  public void partialTbpCurvePreservesAllPublishedCoordinates() {
+    double[] expectedVolumePercent = { 2.0, 3.5, 5.0, 7.5, 10.0, 12.5, 15.0, 17.5, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0,
+        50.0, 55.0, 60.0 };
+    double[] expectedCelsius = { 40.0, 52.0, 62.0, 77.0, 95.0, 112.0, 128.0, 143.0, 159.0, 189.0, 218.0, 249.0, 279.0,
+        310.0, 342.0, 373.0, 405.0 };
+
+    assertArrayEquals(expectedVolumePercent, AlDiwiniyaAtmosphericReference.getTbpCumulativeVolumePercent(), 0.0);
+    assertArrayEquals(expectedCelsius, AlDiwiniyaAtmosphericReference.getTbpTemperatureCelsius(), 0.0);
+    assertEquals(313.15, AlDiwiniyaAtmosphericReference.getTbpTemperatureKelvin()[0], 1.0e-12);
+    assertEquals(678.15, AlDiwiniyaAtmosphericReference.getTbpTemperatureKelvin()[16], 1.0e-12);
+    assertFalse(AlDiwiniyaAtmosphericReference.hasCompleteTbpCurve());
+    assertFalse(AlDiwiniyaAtmosphericReference.isIndependentYieldValidationCase());
+    assertTrue(AlDiwiniyaAtmosphericReference.areHysysProductRatesImposedSpecifications());
+
+    assertStrictlyIncreasing(expectedVolumePercent);
+    assertStrictlyIncreasing(expectedCelsius);
+  }
+
+  @Test
+  public void returnedArraysCannotMutateTheFrozenReference() {
+    double[] volumes = AlDiwiniyaAtmosphericReference.getTbpCumulativeVolumePercent();
+    volumes[0] = 0.0;
+    assertEquals(2.0, AlDiwiniyaAtmosphericReference.getTbpCumulativeVolumePercent()[0], 0.0);
+
+    ProductReference[] products = AlDiwiniyaAtmosphericReference.getProducts();
+    products[0] = null;
+    assertEquals("Light Naphtha", AlDiwiniyaAtmosphericReference.getProducts()[0].getName());
+
+    int[] trays = AlDiwiniyaAtmosphericReference.getHeavyNaphthaDrawTrays();
+    trays[0] = 1;
+    assertArrayEquals(new int[] { 24, 22 }, AlDiwiniyaAtmosphericReference.getHeavyNaphthaDrawTrays());
+  }
+
+  @Test
+  public void productRowsReproducePublishedRatesTemperaturesAndErrors() {
+    ProductReference[] products = AlDiwiniyaAtmosphericReference.getProducts();
+    assertEquals(6, products.length);
+
+    assertProduct(products[0], "Light Naphtha", 8.0, 8.0, 110.0, 109.0, 0.0, 0.9090909090909091);
+    assertProduct(products[1], "Total Heavy Naphtha", 2.0, 2.0, 135.0, 140.0, 0.0, -3.7037037037037037);
+    assertProduct(products[2], "Kerosene", 4.0, 4.0, 180.0, 190.0, 0.0, -5.555555555555555);
+    assertProduct(products[3], "Gasoil", 10.0, 10.0, 240.0, 235.0, 0.0, 2.0833333333333335);
+    assertProduct(products[4], "Atmospheric residue", 41.0, 41.25, 295.0, 295.0, -0.6097560975609756, 0.0);
+    assertProduct(products[5], "Off gas", 1.0, 0.75, 60.0, 65.0, 25.0, -8.333333333333334);
+  }
+
+  @Test
+  public void liquidClosureExcludesIncompatibleOffGasAndWaterBases() {
+    assertEquals(66.0, AlDiwiniyaAtmosphericReference.getCrudeFeedRateM3PerHour(), 0.0);
+    assertEquals(65.0, AlDiwiniyaAtmosphericReference.getMeasuredHydrocarbonLiquidProductRateM3PerHour(), 0.0);
+    assertEquals(98.48484848484848, AlDiwiniyaAtmosphericReference.getMeasuredHydrocarbonLiquidClosurePercent(),
+        1.0e-12);
+    assertEquals(0.4, AlDiwiniyaAtmosphericReference.getOverheadWaterRateM3PerHour(), 0.0);
+    assertFalse(AlDiwiniyaAtmosphericReference.getProduct("Off gas").isHydrocarbonLiquid());
+  }
+
+  @Test
+  public void operatingConfigurationAndProvenanceAreExplicit() {
+    assertEquals("10.52716/jprs.v15i3.965", AlDiwiniyaAtmosphericReference.DOI);
+    assertEquals("CC BY 4.0", AlDiwiniyaAtmosphericReference.LICENSE);
+    assertEquals("2025-09-21", AlDiwiniyaAtmosphericReference.PUBLICATION_DATE);
+    assertEquals(10000.0, AlDiwiniyaAtmosphericReference.getCrudeCapacityBarrelsPerDay(), 0.0);
+    assertEquals(29, AlDiwiniyaAtmosphericReference.getColumnStageCount());
+    assertEquals(300.0, AlDiwiniyaAtmosphericReference.getColumnFeedTemperatureCelsius(), 0.0);
+    assertEquals(1.5, AlDiwiniyaAtmosphericReference.getColumnFeedPressureBarGauge(), 0.0);
+    assertEquals(0.75, AlDiwiniyaAtmosphericReference.getColumnTopPressureBarGauge(), 0.0);
+    assertEquals(1.2, AlDiwiniyaAtmosphericReference.getColumnBottomPressureBarGauge(), 0.0);
+    assertEquals(3.0, AlDiwiniyaAtmosphericReference.getGasoilPumpAroundRateM3PerHour(), 0.0);
+    assertEquals(75.0, AlDiwiniyaAtmosphericReference.getKeroseneStripperSteamRateKgPerHour(), 0.0);
+    assertEquals(125.0, AlDiwiniyaAtmosphericReference.getGasoilStripperSteamRateKgPerHour(), 0.0);
+    assertEquals(300.0, AlDiwiniyaAtmosphericReference.getBottomSteamRateKgPerHour(), 0.0);
+  }
+
+  @Test
+  public void invalidQueriesAndRelativeErrorInputsFailClosed() {
+    assertThrows(IllegalArgumentException.class, () -> AlDiwiniyaAtmosphericReference.getProduct(null));
+    assertThrows(IllegalArgumentException.class, () -> AlDiwiniyaAtmosphericReference.getProduct("Naphtha"));
+    assertThrows(IllegalArgumentException.class,
+        () -> AlDiwiniyaAtmosphericReference.calculateSignedRelativeErrorPercent(0.0, 1.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> AlDiwiniyaAtmosphericReference.calculateSignedRelativeErrorPercent(Double.NaN, 1.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> AlDiwiniyaAtmosphericReference.calculateSignedRelativeErrorPercent(1.0, Double.POSITIVE_INFINITY));
+  }
+
+  private static void assertProduct(ProductReference product, String name, double plantRate, double hysysRate,
+      double plantTemperature, double hysysTemperature, double expectedRateError, double expectedTemperatureError) {
+    assertEquals(name, product.getName());
+    assertEquals(plantRate, product.getPlantRateM3PerHour(), 0.0);
+    assertEquals(hysysRate, product.getHysysRateM3PerHour(), 0.0);
+    assertEquals(plantTemperature, product.getPlantDrawTemperatureCelsius(), 0.0);
+    assertEquals(hysysTemperature, product.getHysysDrawTemperatureCelsius(), 0.0);
+    assertEquals(expectedRateError, product.getRateRelativeErrorPercent(), 1.0e-12);
+    assertEquals(expectedTemperatureError, product.getDrawTemperatureRelativeErrorPercent(), 1.0e-12);
+  }
+
+  private static void assertStrictlyIncreasing(double[] values) {
+    for (int i = 1; i < values.length; i++) {
+      assertFalse(values[i] <= values[i - 1]);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds an immutable Java/JPype-friendly public operating reference for the Al-Diwiniya atmospheric crude unit.

- preserves all 17 published partial-TBP points from 2 to 60 liquid vol% without extrapolating the missing tails
- records the 29-stage column configuration, feed/preheat conditions, draw locations, pump-around, stripping-steam settings, product rates, and draw temperatures
- retains plant and HYSYS values separately and reproduces the source's signed relative-error convention
- exposes machine-readable evidence flags that HYSYS product rates were imposed specifications and this is not an independent yield-validation case
- documents provenance, license, units, liquid-volume closure, JPype access, and the scientific stop boundary

## Capability contract

Campaign: #3305  
Contract: https://github.com/equinor/neqsim/issues/3305#issuecomment-5520859443  
Exact base: `fa573e4af47b9ca81ef87ef91f3f5453ac531e47`  
Exact head: `f2861f3ee3baf37860fc8ade3a408a803d1f6ae2`  
Autonomous portfolio at publication: 3/10 including this draft

## Public source and licensing

Ahmed Qasim, Hyfaa Yousif, and Nazar Qasim, *Simulation of Atmospheric Distillation Unit for AL-Diwiniya Crude Oil Refinery by Using Aspen Hysys*, Journal of Petroleum Research and Studies 15(3), 85-97, published 21 September 2025.

- DOI: https://doi.org/10.52716/jprs.v15i3.965
- Open-access PDF: https://jprs.gov.iq/index.php/jprs/article/download/965/614/5888
- License stated in the article: CC BY 4.0

Only numeric facts, units, attribution, and short descriptive labels are retained; no figures or substantial article text are copied.

## Engineering acceptance

- 17 source TBP coordinates remain strictly monotonic and explicitly partial.
- Array getters return defensive copies.
- Six product rows reproduce source rates, draw temperatures, and calculated signed errors.
- Measured hydrocarbon-liquid products total 65 m3/h versus 66 m3/h crude feed: 98.4848484848% liquid-volume closure.
- Off-gas and the separately reported 0.4 m3/h water stream remain outside that closure because compatible reference states are not published.
- Unknown product labels and non-finite/zero error inputs fail closed.
- Source provenance and the imposed-rate limitation are queryable from the public API.

## Validation

Status: **DRAFT — VALIDATION PENDING EXACT-HEAD CI**

Local checks on the exact published tree:

- focused `AlDiwiniyaAtmosphericReferenceTest`: 6 tests, 0 failures/errors
- complete `neqsim.thermo.characterization.*Test` selection: 194 tests, 0 failures/errors
- `spotless:apply` and `spotless:check`: pass
- Checkstyle: pass
- documentation-search source audit: pass (686 Markdown pages, 1 standalone HTML page)
- `git diff --check`: pass

Local Javadoc generation could not run because this workspace has a Java runtime but no `javadoc` executable. Local `pre-commit` is also unavailable. Neither is claimed; hosted CI is authoritative for those gates.

## Scientific boundary

The paper explicitly states that all HYSYS product flow rates were fixed. Their agreement with plant rates is therefore not independent yield-prediction validation. The source also lacks a cut-density curve, molecular-weight curve, complete 0-100 vol% TBP curve, numeric product ASTM D86 tables, reflux rate, and all heat duties needed for an independently reproducible plant model.

This PR does not invent missing TBP tails, cut properties, digitized curves, or a tuned 29-stage NeqSim reproduction. It qualifies public reference-data retention and evidence classification. A future process-model comparison remains gated on a sufficiently specified public assay and product-quality dataset.

## Scope

Four files; no equation-of-state, petroleum-correlation, column-solver, generated dataset, or dependency change. The PR remains draft-only.