### PR TITLE
[AI-Assisted] fix(mcp): retain implementation inventory after trimming

### DIFF
--- a/neqsim-mcp-server/MCP_CONTRACT.md
+++ b/neqsim-mcp-server/MCP_CONTRACT.md
@@ -224,9 +224,9 @@ Responses larger than 256 KiB are reduced by the shared transport guard unless
 `neqsim.mcp.maxResponseBytes` or `NEQSIM_MCP_MAX_RESPONSE_BYTES` configures another limit. The
 `truncation` block identifies omitted root fields and focused retrieval routes, and the legacy
 top-level and canonical `data` views are reduced together. For `getCapabilities`,
-`phase0EvidenceInventory` is retained because it has no equivalent selective-retrieval route;
-larger catalog sections may be queried through `getSchema`, `getExample`, `getBenchmarkTrust`, and
-the MCP catalog resources.
+`implementationInventory` and `phase0EvidenceInventory` are retained because neither has an
+equivalent selective-retrieval route; larger catalog sections may be queried through `getSchema`,
+`getExample`, `getBenchmarkTrust`, and the MCP catalog resources.
 
 ### Warning taxonomy
 

--- a/neqsim-mcp-server/docs/API_REFERENCE.md
+++ b/neqsim-mcp-server/docs/API_REFERENCE.md
@@ -235,8 +235,9 @@ guide paths, acceptance fixtures and their bounded baseline contract, the campai
 runtime reconciliation of `getBenchmarkTrust`. Its `complete` flag remains false while 51 published
 tools have explicit `CONFIRMED_GAP` coverage records instead of tool-specific trust pages. Test
 presence is not test execution, and generic `TESTED` maturity is not a benchmark, accuracy,
-applicability, or no-limitations claim. The transport response-size guard retains this inventory
-when larger capability-catalog sections must be omitted.
+applicability, or no-limitations claim. The transport response-size guard retains both
+`implementationInventory` and `phase0EvidenceInventory` when larger capability-catalog sections
+must be omitted.
 
 ---
 

--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -14,7 +14,7 @@ manually maintained Java method list.
 | Schema entries | 71 tools / 142 documents | `resources/read` | `SchemaCatalog` |
 | Example entries | 24 categories / 114 documents | `resources/read` | `ExampleCatalog` |
 | Tool implementations | 71 bindings / 60 classes | `getCapabilities.implementationInventory` | `McpImplementationInventory` |
-| Factory equipment | 205 types | `getCapabilities.implementationInventory` | `EquipmentFactory` |
+| Factory equipment | 207 types | `getCapabilities.implementationInventory` | `EquipmentFactory` |
 | Engineering report paths | 2 | `getCapabilities.implementationInventory` | `ReportRunner`, `TaskWorkflowBridge` |
 | MCP Java test classes | 69 | `getCapabilities.phase0EvidenceInventory` | `src/test/java/neqsim/mcp/**/*Test.java` |
 | MCP protocol scenarios | 94 | `getCapabilities.phase0EvidenceInventory` | `test_mcp_server.py` |
@@ -69,7 +69,7 @@ tool and load every named class from the running NeqSim version. This supplement
 
 Process construction continues through the canonical
 `neqsim.process.equipment.EquipmentFactory` and
-`neqsim.process.processmodel.JsonProcessBuilder`. The inventory exposes the same 205 name-only
+`neqsim.process.processmodel.JsonProcessBuilder`. The inventory exposes the same 207 name-only
 factory-supported equipment types as `processJsonContract.supportedEquipmentTypes`; it does not
 claim that every type has the same input grammar, validation maturity, or multi-port construction
 support. Equipment requiring additional constructor context remains outside this name-only list.
@@ -111,10 +111,10 @@ The eight MCP guides have distinct roles:
 | `neqsim-mcp-server/docs/CAMPAIGN_MATRIX.md` | All 66 campaign criteria and discipline-level trust maturity with explicit gaps |
 
 The default response-size guard may omit large capability-catalog sections when the full manifest
-exceeds 256 KiB. It retains `phase0EvidenceInventory` because that evidence contract has no
-equivalent selective-retrieval route. Omitted catalog detail remains identified in `truncation` and
-can be queried through `getSchema`, `getExample`, `getBenchmarkTrust`, and the MCP catalog
-resources.
+exceeds 256 KiB. It retains `implementationInventory` and `phase0EvidenceInventory` because those
+contracts have no equivalent selective-retrieval routes. Omitted catalog detail remains identified
+in `truncation` and can be queried through `getSchema`, `getExample`, `getBenchmarkTrust`, and the
+MCP catalog resources.
 
 `BenchmarkTrust` currently contains 20 tool-specific numerical/engineering trust pages with 64
 known-limit entries and 30 validation cases, of which 5 name a concrete `verifiedBy` test. The

--- a/src/main/java/neqsim/mcp/runners/ResponseSizeGuard.java
+++ b/src/main/java/neqsim/mcp/runners/ResponseSizeGuard.java
@@ -29,8 +29,8 @@ import com.google.gson.JsonObject;
  * </p>
  *
  * <p>
- * The {@code getCapabilities} manifest uses discovery-specific recovery guidance and retains its Phase 0 evidence
- * inventory because that contract has no separate selective-retrieval route.
+ * The {@code getCapabilities} manifest uses discovery-specific recovery guidance and retains its implementation and
+ * Phase 0 evidence inventories because those contracts have no separate selective-retrieval route.
  * </p>
  *
  * <p>
@@ -58,7 +58,7 @@ public final class ResponseSizeGuard {
 
   /** Discovery members that have no equivalent selective-retrieval route. */
   private static final List<String> PROTECTED_CAPABILITY_FIELDS = Collections
-      .unmodifiableList(java.util.Arrays.asList("phase0EvidenceInventory"));
+      .unmodifiableList(java.util.Arrays.asList("implementationInventory", "phase0EvidenceInventory"));
 
   /**
    * Private constructor — utility class.
@@ -226,7 +226,7 @@ public final class ResponseSizeGuard {
     if ("getCapabilities".equals(toolName)) {
       return "Use getSchema and getExample for focused tool contracts, getBenchmarkTrust for "
           + "tool-specific trust evidence, and MCP catalog resources for selective discovery. "
-          + "The Phase 0 evidence inventory is retained in this response.";
+          + "The implementation and Phase 0 evidence inventories are retained in this response.";
     }
     return "Register the model with manageModel(action='register'), then read only what you need via "
         + "listSimulationUnits, listUnitVariables and getSimulationVariable on the returned modelId.";

--- a/src/test/java/neqsim/mcp/runners/ResponseSizeGuardTest.java
+++ b/src/test/java/neqsim/mcp/runners/ResponseSizeGuardTest.java
@@ -101,12 +101,12 @@ class ResponseSizeGuardTest {
   }
 
   /**
-   * The Phase 0 evidence inventory has no separate selective-retrieval route, so it must remain discoverable when the
-   * larger capability catalog is trimmed.
+   * The implementation and Phase 0 evidence inventories have no separate selective-retrieval route, so they must remain
+   * discoverable when the larger capability catalog is trimmed.
    */
   @Test
-  @DisplayName("Capability trimming preserves the Phase 0 evidence contract")
-  void testCapabilitiesPreservePhase0EvidenceWhenTrimmed() {
+  @DisplayName("Capability trimming preserves implementation and Phase 0 evidence contracts")
+  void testCapabilitiesPreserveInventoriesWhenTrimmed() {
     JsonObject response = JsonParser.parseString(CapabilitiesRunner.getCapabilities()).getAsJsonObject();
     int originalBytes = GSON.toJson(response).getBytes(StandardCharsets.UTF_8).length;
     assertTrue(originalBytes > ResponseSizeGuard.getMaxBytes(),
@@ -121,11 +121,24 @@ class ResponseSizeGuardTest {
         "The non-retrievable Phase 0 evidence contract must survive trimming");
     assertTrue(response.getAsJsonObject("data").has("phase0EvidenceInventory"),
         "The canonical data view must retain the same evidence contract");
+    assertTrue(response.has("implementationInventory"),
+        "The non-retrievable implementation inventory must survive trimming");
+    assertTrue(response.getAsJsonObject("data").has("implementationInventory"),
+        "The canonical data view must retain the same implementation inventory");
+    JsonObject implementationInventory = response.getAsJsonObject("implementationInventory");
+    assertTrue(implementationInventory.get("complete").getAsBoolean());
+    assertEquals(71, implementationInventory.get("toolBindingCount").getAsInt());
+    assertEquals(60, implementationInventory.get("implementationClassCount").getAsInt());
+    assertEquals(207, implementationInventory.get("equipmentTypeCount").getAsInt());
+    assertEquals(2, implementationInventory.get("reportPathCount").getAsInt());
+    assertEquals("neqsim.mcp.runners.ProcessRunner",
+        implementationInventory.getAsJsonObject("toolImplementationBindings").get("runProcess").getAsString());
     assertTrue(response.getAsJsonObject("phase0EvidenceInventory").has("tests"));
     assertTrue(response.getAsJsonObject("phase0EvidenceInventory").has("knownLimitations"));
     JsonObject truncation = response.getAsJsonObject("truncation");
     assertEquals(originalBytes, truncation.get("originalBytes").getAsInt());
     assertEquals(trimmedBytes, truncation.get("returnedBytes").getAsInt());
+    assertFalse(truncation.getAsJsonArray("omitted").toString().contains("implementationInventory"));
     assertFalse(truncation.getAsJsonArray("omitted").toString().contains("phase0EvidenceInventory"));
     assertTrue(truncation.get("howToRetrieve").getAsString().contains("getSchema"),
         "Discovery truncation must point to focused capability retrieval");


### PR DESCRIPTION
## Summary

- preserve `getCapabilities.implementationInventory` alongside `phase0EvidenceInventory` when the 256 KiB response-size guard trims the capability manifest
- add a focused regression that verifies the retained inventory remains complete with 71 tool bindings, 60 implementation classes, 207 factory equipment types, two report paths, and the canonical `runProcess` binding
- align the MCP contract, API reference, and surface inventory with the transport behavior and current 207-type factory count

## Root cause

Commit `fa573e4` made the response-size metadata exact, causing the guard to trim one additional top-level field. Because only `phase0EvidenceInventory` was protected, the full `implementationInventory` was omitted from the packaged MCP response. The comprehensive protocol test then read an empty object and all six dependent inventory checks failed together.

## Validation

- PASS: `./mvnw -Dtest=neqsim.mcp.runners.ResponseSizeGuardTest,neqsim.mcp.runners.CapabilitiesRunnerTest,neqsim.mcp.catalog.SchemaCatalogTest test -DskipITs` — 35 tests
- PASS: `python devtools/run_spotless.py apply`
- PASS: `python devtools/run_spotless.py check`
- PASS: `python devtools/check_documentation_search.py` — 685 Markdown pages and one standalone HTML page
- PASS: `pre-commit run --all-files --hook-stage pre-commit`
- PASS: `pre-commit run --all-files --hook-stage pre-push`
- PASS (CI, Java 21): `cd neqsim-mcp-server && python test_mcp_server.py` — 322/322 checks passed, 0 failed ([MCP protocol qualification](https://github.com/equinor/neqsim/actions/runs/33720979699))

## Documentation impact

Updated `MCP_CONTRACT.md`, `docs/API_REFERENCE.md`, and `docs/SURFACE_INVENTORY.md` to document both protected non-retrievable inventories and correct the stale factory count from 205 to 207. No tool name, input schema, numerical model, or deployment default changes.

## AI-assisted contribution

This is an AI-assisted fix. I understand the change: it preserves an existing public discovery/audit contract during size trimming; it does not widen the response limit or add a second implementation path.

Base: `fa573e4af47b9ca81ef87ef91f3f5453ac531e47`
Head: `6923e217f73d40b1c0052ce37a02a209aed972cf`
