### PR TITLE
[AI-Assisted] feat(dexpi): expose internal cycle connections

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -180,11 +180,14 @@ continuous line or executable process network.
 of explicit non-empty material-connection endpoint references. A group is reported when it has more
 than one endpoint, or when a singleton endpoint has an explicit self-reference. Cycle groups are
 ordered by their first endpoint; endpoint IDs retain first-reference order and internal connection
-IDs retain source order, including parallel occurrences. Each immutable
-`DexpiConnectionCycleInfo` links to its owning weak connection component, keeps unresolved endpoint
-IDs visible, and separately lists source-ordered connection occurrences entering and leaving the
-cyclic group. Boundary lists preserve parallel references and exclude connections whose source or
-target identity is blank. `getBoundaryConnections()` additionally preserves the overall source order
+IDs retain source order, including parallel occurrences. `getConnections()` exposes the corresponding
+immutable `DexpiConnectionInfo` records in the same order, including source connection and owning
+`PipingNetworkSegment` identities, endpoint resolution, resolved element names, and explicit
+Equipment/PipingComponent ownership. Each immutable `DexpiConnectionCycleInfo` links to its owning
+weak connection component, keeps unresolved endpoint IDs visible, and separately lists source-ordered
+connection occurrences entering and leaving the cyclic group. Boundary lists preserve parallel
+references and exclude connections whose source or target identity is blank.
+`getBoundaryConnections()` additionally preserves the overall source order
 across incoming and outgoing occurrences. Each immutable `DexpiConnectionCycleBoundaryInfo` records
 the connection evidence ID, original source connection ID, owning `PipingNetworkSegment` ID,
 direction relative to the cyclic group, explicit internal and external endpoint identities, whether
@@ -197,8 +200,9 @@ repair or rewire topology, or establish process intent.
 
 `toJson()` includes `instrumentCount`, `connectionCount`, `connectionEndpointCount`,
 `connectionComponentCount`, `connectionCycleCount`, and the ordered connection, endpoint,
-component, and directed-cycle inventories, including incidence roles, review subsets, and explicit
-cycle-boundary occurrences, alongside the process-unit count and findings. Python callers through
+component, and directed-cycle inventories, including incidence roles, review subsets, complete
+internal connection occurrences, and explicit cycle-boundary occurrences, alongside the process-unit
+count and findings. Python callers through
 JPype use the same
 `ImportResult.getInstruments()`, `ImportResult.getConnections()`,
 `ImportResult.getConnectionEndpoints()`, `ImportResult.getConnectionComponents()`, and

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
@@ -25,6 +25,7 @@ public final class DexpiConnectionCycleInfo implements Serializable {
   private final String connectionComponentId;
   private final List<String> endpointIds;
   private final List<String> connectionIds;
+  private final List<DexpiConnectionInfo> connections;
   private final List<String> incomingBoundaryConnectionIds;
   private final List<String> outgoingBoundaryConnectionIds;
   private final List<DexpiConnectionCycleBoundaryInfo> boundaryConnections;
@@ -46,9 +47,9 @@ public final class DexpiConnectionCycleInfo implements Serializable {
   public DexpiConnectionCycleInfo(String id, String connectionComponentId, List<String> endpointIds,
       List<String> connectionIds, List<String> incomingBoundaryConnectionIds,
       List<String> outgoingBoundaryConnectionIds, List<String> unresolvedEndpointIds, boolean selfReference) {
-    this(id, connectionComponentId, endpointIds, connectionIds, incomingBoundaryConnectionIds,
-        outgoingBoundaryConnectionIds, Collections.<DexpiConnectionCycleBoundaryInfo>emptyList(), unresolvedEndpointIds,
-        selfReference);
+    this(id, connectionComponentId, endpointIds, connectionIds,
+        Collections.<DexpiConnectionInfo>emptyList(), incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds,
+        Collections.<DexpiConnectionCycleBoundaryInfo>emptyList(), unresolvedEndpointIds, selfReference);
   }
 
   /**
@@ -68,10 +69,35 @@ public final class DexpiConnectionCycleInfo implements Serializable {
       List<String> connectionIds, List<String> incomingBoundaryConnectionIds,
       List<String> outgoingBoundaryConnectionIds, List<DexpiConnectionCycleBoundaryInfo> boundaryConnections,
       List<String> unresolvedEndpointIds, boolean selfReference) {
+    this(id, connectionComponentId, endpointIds, connectionIds,
+        Collections.<DexpiConnectionInfo>emptyList(), incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds,
+        boundaryConnections, unresolvedEndpointIds, selfReference);
+  }
+
+  /**
+   * Creates immutable directed-cycle source-reference evidence with complete internal and boundary occurrences.
+   *
+   * @param id deterministic cycle-group evidence identity
+   * @param connectionComponentId owning weak connection-component evidence identity
+   * @param endpointIds endpoint identities in first-reference order
+   * @param connectionIds internal connection-evidence identities in source order
+   * @param connections internal connection occurrences in source order
+   * @param incomingBoundaryConnectionIds connection-evidence identities entering the cyclic group in source order
+   * @param outgoingBoundaryConnectionIds connection-evidence identities leaving the cyclic group in source order
+   * @param boundaryConnections boundary occurrences in overall source-document order
+   * @param unresolvedEndpointIds endpoint identities that do not resolve in the source document
+   * @param selfReference whether the group contains an explicit self-reference connection
+   */
+  public DexpiConnectionCycleInfo(String id, String connectionComponentId, List<String> endpointIds,
+      List<String> connectionIds, List<DexpiConnectionInfo> connections,
+      List<String> incomingBoundaryConnectionIds, List<String> outgoingBoundaryConnectionIds,
+      List<DexpiConnectionCycleBoundaryInfo> boundaryConnections, List<String> unresolvedEndpointIds,
+      boolean selfReference) {
     this.id = normalize(id);
     this.connectionComponentId = normalize(connectionComponentId);
     this.endpointIds = immutableCopy(endpointIds);
     this.connectionIds = immutableCopy(connectionIds);
+    this.connections = Collections.unmodifiableList(new ArrayList<DexpiConnectionInfo>(connections));
     this.incomingBoundaryConnectionIds = immutableCopy(incomingBoundaryConnectionIds);
     this.outgoingBoundaryConnectionIds = immutableCopy(outgoingBoundaryConnectionIds);
     this.boundaryConnections = Collections
@@ -98,6 +124,11 @@ public final class DexpiConnectionCycleInfo implements Serializable {
   /** @return immutable internal connection-evidence identities in source order */
   public List<String> getConnectionIds() {
     return connectionIds;
+  }
+
+  /** @return immutable internal connection occurrences in source order */
+  public List<DexpiConnectionInfo> getConnections() {
+    return connections;
   }
 
   /** @return immutable connection-evidence identities entering this cyclic group in source order */
@@ -168,6 +199,11 @@ public final class DexpiConnectionCycleInfo implements Serializable {
     result.put("hasUnresolvedEndpoints", Boolean.valueOf(hasUnresolvedEndpoints()));
     result.put("endpointIds", endpointIds);
     result.put("connectionIds", connectionIds);
+    List<Map<String, Object>> connectionMaps = new ArrayList<Map<String, Object>>();
+    for (DexpiConnectionInfo connection : connections) {
+      connectionMaps.add(connection.toMap());
+    }
+    result.put("connections", connectionMaps);
     result.put("incomingBoundaryConnectionIds", incomingBoundaryConnectionIds);
     result.put("outgoingBoundaryConnectionIds", outgoingBoundaryConnectionIds);
     List<Map<String, Object>> boundaryMaps = new ArrayList<Map<String, Object>>();

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
@@ -47,8 +47,8 @@ public final class DexpiConnectionCycleInfo implements Serializable {
   public DexpiConnectionCycleInfo(String id, String connectionComponentId, List<String> endpointIds,
       List<String> connectionIds, List<String> incomingBoundaryConnectionIds,
       List<String> outgoingBoundaryConnectionIds, List<String> unresolvedEndpointIds, boolean selfReference) {
-    this(id, connectionComponentId, endpointIds, connectionIds,
-        Collections.<DexpiConnectionInfo>emptyList(), incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds,
+    this(id, connectionComponentId, endpointIds, connectionIds, Collections.<DexpiConnectionInfo>emptyList(),
+        incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds,
         Collections.<DexpiConnectionCycleBoundaryInfo>emptyList(), unresolvedEndpointIds, selfReference);
   }
 
@@ -69,9 +69,9 @@ public final class DexpiConnectionCycleInfo implements Serializable {
       List<String> connectionIds, List<String> incomingBoundaryConnectionIds,
       List<String> outgoingBoundaryConnectionIds, List<DexpiConnectionCycleBoundaryInfo> boundaryConnections,
       List<String> unresolvedEndpointIds, boolean selfReference) {
-    this(id, connectionComponentId, endpointIds, connectionIds,
-        Collections.<DexpiConnectionInfo>emptyList(), incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds,
-        boundaryConnections, unresolvedEndpointIds, selfReference);
+    this(id, connectionComponentId, endpointIds, connectionIds, Collections.<DexpiConnectionInfo>emptyList(),
+        incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds, boundaryConnections, unresolvedEndpointIds,
+        selfReference);
   }
 
   /**
@@ -89,10 +89,9 @@ public final class DexpiConnectionCycleInfo implements Serializable {
    * @param selfReference whether the group contains an explicit self-reference connection
    */
   public DexpiConnectionCycleInfo(String id, String connectionComponentId, List<String> endpointIds,
-      List<String> connectionIds, List<DexpiConnectionInfo> connections,
-      List<String> incomingBoundaryConnectionIds, List<String> outgoingBoundaryConnectionIds,
-      List<DexpiConnectionCycleBoundaryInfo> boundaryConnections, List<String> unresolvedEndpointIds,
-      boolean selfReference) {
+      List<String> connectionIds, List<DexpiConnectionInfo> connections, List<String> incomingBoundaryConnectionIds,
+      List<String> outgoingBoundaryConnectionIds, List<DexpiConnectionCycleBoundaryInfo> boundaryConnections,
+      List<String> unresolvedEndpointIds, boolean selfReference) {
     this.id = normalize(id);
     this.connectionComponentId = normalize(connectionComponentId);
     this.endpointIds = immutableCopy(endpointIds);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1058,6 +1058,7 @@ public final class DexpiXmlReader {
     private final String connectionComponentId;
     private final List<String> endpointIds = new ArrayList<String>();
     private final List<String> connectionIds = new ArrayList<String>();
+    private final List<DexpiConnectionInfo> connections = new ArrayList<DexpiConnectionInfo>();
     private final List<String> incomingBoundaryConnectionIds = new ArrayList<String>();
     private final List<String> outgoingBoundaryConnectionIds = new ArrayList<String>();
     private final List<DexpiConnectionCycleBoundaryInfo> boundaryConnections = new ArrayList<DexpiConnectionCycleBoundaryInfo>();
@@ -1078,6 +1079,7 @@ public final class DexpiXmlReader {
 
     private void addConnection(DexpiConnectionInfo connection) {
       connectionIds.add(connection.getId());
+      connections.add(connection);
       if (connection.getFromId().equals(connection.getToId())) {
         selfReference = true;
       }
@@ -1108,7 +1110,7 @@ public final class DexpiXmlReader {
     }
 
     private DexpiConnectionCycleInfo toInfo() {
-      return new DexpiConnectionCycleInfo(id, connectionComponentId, endpointIds, connectionIds,
+      return new DexpiConnectionCycleInfo(id, connectionComponentId, endpointIds, connectionIds, connections,
           incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds, boundaryConnections, unresolvedEndpointIds,
           selfReference);
     }

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -595,6 +595,18 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("component-2", threeEndpointCycle.getConnectionComponentId());
     assertEquals(Arrays.asList("N-X", "N-Y", "N-Z"), threeEndpointCycle.getEndpointIds());
     assertEquals(Arrays.asList("C-3", "C-3P", "C-4", "C-5"), threeEndpointCycle.getConnectionIds());
+    List<DexpiConnectionInfo> internalConnections = threeEndpointCycle.getConnections();
+    assertEquals(Arrays.asList("C-3", "C-3P", "C-4", "C-5"),
+        Arrays.asList(internalConnections.get(0).getId(), internalConnections.get(1).getId(),
+            internalConnections.get(2).getId(), internalConnections.get(3).getId()));
+    assertEquals("C-3", internalConnections.get(0).getSourceId());
+    assertEquals("S-3", internalConnections.get(0).getSegmentId());
+    assertEquals("N-X", internalConnections.get(0).getFromId());
+    assertEquals("N-Y", internalConnections.get(0).getToId());
+    assertEquals("E-X", internalConnections.get(0).getFromOwnerId());
+    assertEquals("E-Y", internalConnections.get(0).getToOwnerId());
+    assertTrue(internalConnections.get(0).isResolved());
+    assertEquals("S-3P", internalConnections.get(1).getSegmentId());
     assertEquals(3, threeEndpointCycle.getEndpointCount());
     assertEquals(4, threeEndpointCycle.getConnectionCount());
     assertFalse(threeEndpointCycle.hasSelfReference());
@@ -605,6 +617,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("component-4", selfReference.getConnectionComponentId());
     assertEquals(Collections.singletonList("N-S"), selfReference.getEndpointIds());
     assertEquals(Collections.singletonList("C-8"), selfReference.getConnectionIds());
+    assertEquals("C-8", selfReference.getConnections().get(0).getSourceId());
+    assertEquals("S-8", selfReference.getConnections().get(0).getSegmentId());
+    assertTrue(selfReference.getConnections().get(0).isSelfReference());
     assertTrue(selfReference.hasSelfReference());
 
     DexpiConnectionCycleInfo unresolved = first.getConnectionCycles().get(2);
@@ -612,6 +627,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("component-5", unresolved.getConnectionComponentId());
     assertEquals(Arrays.asList("UNKNOWN-1", "UNKNOWN-2"), unresolved.getEndpointIds());
     assertEquals(Arrays.asList("C-9", "C-10"), unresolved.getConnectionIds());
+    assertEquals(2, unresolved.getConnections().size());
+    assertEquals("S-9", unresolved.getConnections().get(0).getSegmentId());
+    assertFalse(unresolved.getConnections().get(0).isResolved());
     assertEquals(Arrays.asList("UNKNOWN-1", "UNKNOWN-2"), unresolved.getUnresolvedEndpointIds());
     assertTrue(unresolved.hasUnresolvedEndpoints());
 
@@ -620,8 +638,11 @@ public class DexpiXmlReaderTest extends NeqSimTest {
       assertFalse(cycle.getEndpointIds().contains("N-Q"));
     }
     assertThrows(UnsupportedOperationException.class, () -> threeEndpointCycle.getEndpointIds().clear());
+    assertThrows(UnsupportedOperationException.class, () -> threeEndpointCycle.getConnections().clear());
     assertThrows(UnsupportedOperationException.class, () -> first.getConnectionCycles().clear());
     assertTrue(first.toJson().contains("\"connectionCycleCount\": 3"));
+    assertTrue(first.toJson().contains("\"connections\": ["));
+    assertTrue(first.toJson().contains("\"segmentId\": \"S-3\""));
     assertTrue(first.toJson().contains("\"connectionComponentId\": \"component-4\""));
     assertTrue(first.toJson().contains("\"selfReference\": true"));
     assertEquals(first.toJson(), second.toJson());
@@ -723,6 +744,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     DexpiConnectionCycleInfo legacy = new DexpiConnectionCycleInfo("legacy", "component-legacy",
         Collections.<String>emptyList(), Collections.<String>emptyList(), Collections.<String>emptyList(),
         Collections.<String>emptyList(), Collections.<String>emptyList(), false);
+    assertTrue(legacy.getConnections().isEmpty());
     assertTrue(legacy.getBoundaryConnections().isEmpty());
     DexpiConnectionCycleBoundaryInfo legacyBoundary = new DexpiConnectionCycleBoundaryInfo("legacy-boundary",
         DexpiConnectionCycleBoundaryInfo.Direction.INCOMING, "N-INTERNAL", "N-EXTERNAL", true, false);

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -596,9 +596,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(Arrays.asList("N-X", "N-Y", "N-Z"), threeEndpointCycle.getEndpointIds());
     assertEquals(Arrays.asList("C-3", "C-3P", "C-4", "C-5"), threeEndpointCycle.getConnectionIds());
     List<DexpiConnectionInfo> internalConnections = threeEndpointCycle.getConnections();
-    assertEquals(Arrays.asList("C-3", "C-3P", "C-4", "C-5"),
-        Arrays.asList(internalConnections.get(0).getId(), internalConnections.get(1).getId(),
-            internalConnections.get(2).getId(), internalConnections.get(3).getId()));
+    assertEquals(Arrays.asList("C-3", "C-3P", "C-4", "C-5"), Arrays.asList(internalConnections.get(0).getId(),
+        internalConnections.get(1).getId(), internalConnections.get(2).getId(), internalConnections.get(3).getId()));
     assertEquals("C-3", internalConnections.get(0).getSourceId());
     assertEquals("S-3", internalConnections.get(0).getSegmentId());
     assertEquals("N-X", internalConnections.get(0).getFromId());


### PR DESCRIPTION
## Summary

Advances #1332 and #2899 by exposing complete source-ordered internal connection occurrences for every explicit Proteus-compatible DEXPI directed cycle.

Exact base: `c5a3f43f86f9e7cb77473a737e85ccd83e07488f`  
Exact head: `893d112bbe5e37e3eccfab196390ca45d8d90ee7`

## Engineering value

`DexpiConnectionCycleInfo` already exposes internal connection IDs and complete boundary occurrences. This increment also retains the existing immutable `DexpiConnectionInfo` records for internal edges, so Java and JPype reviewers can inspect source connection and `PipingNetworkSegment` identity, endpoints, resolution, and Equipment/PipingComponent ownership without joining the global connection inventory.

## Scope

- Add immutable `getConnections()` cycle evidence in source order.
- Preserve both existing public constructors and the `getConnectionIds()` API.
- Reuse existing parsed `DexpiConnectionInfo` instances during the existing O(V+E) cycle pass.
- Preserve parallel occurrences, self-references, unresolved endpoints, deterministic cycle/component identity, and JSON ordering.
- Add focused regressions and Java/JPype reader documentation.

## Deliberate exclusions

No hydraulic-recycle inference, elementary-path or reachability solving, topology repair/rewiring, process-intent inference, simulation topology, rendering, geometry, layout, writer/export behavior, native DEXPI 2.0 expansion, Huldra, external datasets, standards-conformance claim, certification, or engineering approval.

## Validation

- Connector-side exact-base/head and four-file diff integrity verified.
- Local Maven, Java, Spotless, pre-commit, Javadocs, and notebook execution were not run and are not claimed.
- Hosted CI is authoritative.
- Documentation impact: updated `docs/integration/dexpi-reader.md` for the additive Java/JPype API and deterministic JSON evidence.
- Whole-sheet visual gate: N/A because no renderer, writer, SVG, geometry, layout, notebook, or export path changed.

Status: **VALIDATION PENDING CI**.