### PR TITLE
[AI-Assisted] feat(refinery): add Sarir validation reference

### DIFF
--- a/docs/thermo/characterization/README.md
+++ b/docs/thermo/characterization/README.md
@@ -69,6 +69,11 @@ temperatures remain explicitly separate from the complete DOE modeled slate. The
 source fixed its HYSYS product rates, so those values are operating specifications
 rather than independent yield-validation evidence.
 
+[Sarir atmospheric validation reference](refinery_sarir_atmospheric_reference)
+adds a CC BY 4.0, complete-range TBP case with 34-tray operating data, numeric
+product ASTM D86 endpoints, and plant product rates that remain independent
+validation targets.
+
 ## TBP fraction models
 
 TBP models estimate the properties needed to represent petroleum pseudo-components in an EOS. Available implementations include Pedersen SRK/PR variants, Lee-Kesler, Riazi-Daubert, Twu, Cavett, and Standing.
@@ -161,6 +166,7 @@ A bookkeeping regression does not by itself validate a petroleum-property correl
 - [DOE Big Hill terminal-cut boundary qualification](refinery_big_hill_terminal_boundary_validation)
 - [DOE Big Hill atmospheric fractionation qualification](refinery_big_hill_atmospheric_fractionation)
 - [Al-Diwiniya atmospheric operating reference](refinery_al_diwiniya_atmospheric_reference)
+- [Sarir atmospheric validation reference](refinery_sarir_atmospheric_reference)
 - [DOE/OEDI COA bulk density and API qualification](refinery_oedi_coa_bulk_density_validation)
 - [Fluid Characterization Guide](../../wiki/fluid_characterization)
 - [TBP Fraction Models](../../wiki/tbp_fraction_models)

--- a/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
@@ -1,0 +1,66 @@
+---
+title: "Sarir atmospheric validation reference"
+description: "Public complete-range TBP, atmospheric-unit operating data, and independent plant-yield evidence."
+---
+
+# Sarir atmospheric validation reference
+
+`SarirAtmosphericReference` exposes a public refinery case to Java and Python/JPype callers while preserving the distinction between measured evidence, simulated results, and missing source data.
+
+## Source and license
+
+The source is Hamza E. Omran Almansouri, *Simulation of Sarir Crude Oil Refinery Using Aspen HYSYS*, Journal of Engineering Research (Libya), issue 33, pages 51-64, published 31 March 2022, DOI [10.66411/jer.v33i.46](https://doi.org/10.66411/jer.v33i.46). The [open-access article](https://jer.ly/jer/index.php/jer/article/download/46/38/39) is licensed CC BY 4.0.
+
+The paper reports a Sarir crude density of 841.5 kg/m3 at 15 degC, API gravity 36.5 at 60 degF, sulfur 0.120 mass%, average molar mass 0.2447 kg/mol, and a public TBP assay originally prepared by the Libyan Petroleum Institute.
+
+## Preserved TBP evidence
+
+| TBP temperature (degC) | 70 | 90 | 110 | 150 | 195 | 215 | 255 | 275 | 295 | 335 | 370 | 400 | 460 | 480 | 500 | 520 | 550 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Cumulative liquid volume (%) | 7.44 | 10.47 | 13.83 | 21.16 | 28.52 | 31.54 | 38.03 | 41.76 | 44.68 | 51.97 | 59.19 | 63.50 | 72.52 | 75.61 | 78.66 | 81.05 | 83.70 |
+
+The source then reports a `550 degC+` terminal residue reaching 100 volume%. NeqSim retains 550 degC as a one-sided lower boundary and computes the implied 16.30 volume% residue; it does not invent a finite 100% endpoint or an upper boiling limit. The source marks light-end hydrocarbons as not determined, so no light-end composition is synthesized.
+
+## Atmospheric operating case
+
+The published HYSYS case uses 34 valve trays, feeds 54,420 kg/h of crude at 350 degC and 233 kPa to tray 31 counted from the top, and includes main-column, kerosene-stripper, and diesel-stripper steam rates of 340.2, 68.04, and 226.8 kg/h. Top and bottom pump-around rates are 29,777.64 and 60,423.66 kg/h.
+
+Four products have numeric laboratory and simulated ASTM D86 T5/T95 evidence:
+
+| Product | Lab T5 (degC) | Lab T95 (degC) | HYSYS T5 (degC) | HYSYS T95 (degC) |
+| --- | ---: | ---: | ---: | ---: |
+| Light naphtha | 42 | 90 | -9 | 97 |
+| Heavy naphtha | 96 | 160 | 83 | 153 |
+| Kerosene | 185 | 221 | 159 | 214 |
+| Diesel | 262 | 346 | 235 | 339 |
+
+The residual laboratory curve is explicitly excluded from the numeric API because the paper states that it was unavailable and presents a non-numeric `550+` limit.
+
+## Independent product-rate evidence
+
+| Product | Plant (metric t/day) | HYSYS (metric t/day) | Absolute error (%) |
+| --- | ---: | ---: | ---: |
+| Total naphtha | 208.95 | 208.2 | 0.359 |
+| Kerosene | 22.85 | 20.0 | 12.473 |
+| Diesel | 425.018 | 393.0 | 7.533 |
+| Residual | 646.5 | 706.1 | 9.219 |
+
+Unlike the Al-Diwiniya reference, the Sarir paper does not say these HYSYS rates were imposed. It describes calculated production rates compared with actual refinery data, so the rows are retained as independent validation targets. The API recomputes absolute relative errors from the raw published values instead of copying rounded percentages.
+
+## Java and Python access
+
+```java
+double[] volumePercent = SarirAtmosphericReference.getTbpCumulativeVolumePercent();
+double residuePercent = SarirAtmosphericReference.getTerminalResidueVolumePercent();
+
+SarirAtmosphericReference.ProductYieldReference diesel =
+    SarirAtmosphericReference.getProductYield("Diesel");
+double plantRate = diesel.getPlantMetricTonPerDay();
+double errorPercent = diesel.getAbsoluteRelativeErrorPercent();
+```
+
+Static methods are directly accessible through JPype. Arrays are defensive copies, and unknown product labels or invalid error inputs fail closed.
+
+## Scientific boundary
+
+This increment qualifies source transcription, units, open-ended TBP treatment, and evidence classification. It does not yet construct a Sarir pseudo-component slate or claim that NeqSim reproduces the plant yields. A follow-on process-model comparison must keep the plant rates as untouched acceptance targets, document the missing light-end allocation, and avoid tuning draw rates to the published products.

--- a/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
+++ b/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
@@ -1,0 +1,293 @@
+package neqsim.thermo.characterization;
+
+import java.io.Serializable;
+
+/**
+ * Public assay and operating reference for the Sarir refinery atmospheric distillation unit.
+ *
+ * <p>
+ * Values are transcribed from H. E. O. Almansouri, "Simulation of Sarir Crude Oil Refinery Using Aspen HYSYS", Journal
+ * of Engineering Research (Libya), issue 33, pages 51-64, published 31 March 2022. The article is licensed CC BY 4.0.
+ * </p>
+ *
+ * <p>
+ * The published assay gives numeric TBP coordinates only through 83.70 liquid volume percent at 550 degrees Celsius,
+ * followed by a 550 degrees Celsius-plus terminal residue. This class preserves that one-sided boundary and does not
+ * invent a numeric 100-percent endpoint or a resolved light-end composition.
+ * </p>
+ */
+public final class SarirAtmosphericReference {
+  /** Digital object identifier for the source article. */
+  public static final String DOI = "10.66411/jer.v33i.46";
+
+  /** Open-access source article. */
+  public static final String ARTICLE_URL = "https://jer.ly/jer/index.php/jer/article/download/46/38/39";
+
+  /** Source license identifier. */
+  public static final String LICENSE = "CC BY 4.0";
+
+  /** Source publication date in ISO-8601 format. */
+  public static final String PUBLICATION_DATE = "2022-03-31";
+
+  private static final double[] TBP_TEMPERATURE_CELSIUS = { 70.0, 90.0, 110.0, 150.0, 195.0, 215.0, 255.0, 275.0, 295.0,
+      335.0, 370.0, 400.0, 460.0, 480.0, 500.0, 520.0, 550.0 };
+  private static final double[] TBP_VOLUME_PERCENT = { 7.44, 10.47, 13.83, 21.16, 28.52, 31.54, 38.03, 41.76, 44.68,
+      51.97, 59.19, 63.50, 72.52, 75.61, 78.66, 81.05, 83.70 };
+
+  private static final ProductQualityReference[] PRODUCT_QUALITIES = {
+      new ProductQualityReference("Light Naphtha", 42.0, 90.0, -9.0, 97.0),
+      new ProductQualityReference("Heavy Naphtha", 96.0, 160.0, 83.0, 153.0),
+      new ProductQualityReference("Kerosene", 185.0, 221.0, 159.0, 214.0),
+      new ProductQualityReference("Diesel", 262.0, 346.0, 235.0, 339.0) };
+
+  private static final ProductYieldReference[] PRODUCT_YIELDS = {
+      new ProductYieldReference("Total Naphtha", 208.95, 208.2), new ProductYieldReference("Kerosene", 22.85, 20.0),
+      new ProductYieldReference("Diesel", 425.018, 393.0), new ProductYieldReference("Residual", 646.5, 706.1) };
+
+  private SarirAtmosphericReference() {
+  }
+
+  /** @return defensive copy of the numeric cumulative liquid-volume coordinates, in percent */
+  public static double[] getTbpCumulativeVolumePercent() {
+    return TBP_VOLUME_PERCENT.clone();
+  }
+
+  /** @return defensive copy of the numeric TBP temperatures, in degrees Celsius */
+  public static double[] getTbpTemperatureCelsius() {
+    return TBP_TEMPERATURE_CELSIUS.clone();
+  }
+
+  /** @return newly allocated numeric TBP temperature array in kelvin */
+  public static double[] getTbpTemperatureKelvin() {
+    double[] kelvin = new double[TBP_TEMPERATURE_CELSIUS.length];
+    for (int i = 0; i < kelvin.length; i++) {
+      kelvin[i] = TBP_TEMPERATURE_CELSIUS[i] + 273.15;
+    }
+    return kelvin;
+  }
+
+  /** @return always false because the source gives a one-sided 550 degrees Celsius-plus residue */
+  public static boolean hasCompleteNumericTbpCurve() {
+    return false;
+  }
+
+  /** @return always false because the source reports the light-end analysis as not determined */
+  public static boolean hasResolvedLightEndComposition() {
+    return false;
+  }
+
+  /** @return lower boiling boundary of the terminal residue, in degrees Celsius */
+  public static double getTerminalResidueLowerBoundaryCelsius() {
+    return 550.0;
+  }
+
+  /** @return terminal residue fraction implied by the final numeric cumulative TBP point, in volume percent */
+  public static double getTerminalResidueVolumePercent() {
+    return 100.0 - TBP_VOLUME_PERCENT[TBP_VOLUME_PERCENT.length - 1];
+  }
+
+  /** @return true because plant rates were compared with calculated rather than imposed simulation rates */
+  public static boolean isIndependentYieldValidationCase() {
+    return true;
+  }
+
+  /** @return false because the article does not state that the HYSYS product rates were fixed */
+  public static boolean areSimulationProductRatesImposedSpecifications() {
+    return false;
+  }
+
+  /** @return defensive copy of numeric laboratory/simulation ASTM D86 comparison rows */
+  public static ProductQualityReference[] getProductQualities() {
+    return PRODUCT_QUALITIES.clone();
+  }
+
+  /** @return defensive copy of independent plant/simulation product-yield comparison rows */
+  public static ProductYieldReference[] getProductYields() {
+    return PRODUCT_YIELDS.clone();
+  }
+
+  /**
+   * Find one yield row by its exact source-table label.
+   *
+   * @param productName exact source-table product label
+   * @return immutable yield reference
+   * @throws IllegalArgumentException if the label is null or unknown
+   */
+  public static ProductYieldReference getProductYield(String productName) {
+    if (productName == null) {
+      throw new IllegalArgumentException("Product name cannot be null");
+    }
+    for (ProductYieldReference product : PRODUCT_YIELDS) {
+      if (product.getName().equals(productName)) {
+        return product;
+      }
+    }
+    throw new IllegalArgumentException("Unknown Sarir product yield: " + productName);
+  }
+
+  /**
+   * Calculate absolute relative error against the measured plant value.
+   *
+   * @param plantValue measured plant value
+   * @param simulatedValue simulated value
+   * @return {@code 100 * abs(simulated - plant) / plant}, in percent
+   */
+  public static double calculateAbsoluteRelativeErrorPercent(double plantValue, double simulatedValue) {
+    if (!Double.isFinite(plantValue) || plantValue <= 0.0) {
+      throw new IllegalArgumentException("Plant value must be finite and positive");
+    }
+    if (!Double.isFinite(simulatedValue)) {
+      throw new IllegalArgumentException("Simulated value must be finite");
+    }
+    return 100.0 * Math.abs(simulatedValue - plantValue) / plantValue;
+  }
+
+  /** @return crude density at 15 degrees Celsius, in kg/m3 */
+  public static double getCrudeDensityAt15CKgPerCubicMetre() {
+    return 841.5;
+  }
+
+  /** @return crude API gravity at 60 degrees Fahrenheit */
+  public static double getCrudeApiGravityAt60F() {
+    return 36.5;
+  }
+
+  /** @return crude sulfur content in mass percent */
+  public static double getCrudeSulfurMassPercent() {
+    return 0.120;
+  }
+
+  /** @return crude average molar mass in kg/mol */
+  public static double getCrudeAverageMolarMassKgPerMol() {
+    return 0.2447;
+  }
+
+  /** @return atmospheric-column valve-tray count */
+  public static int getColumnTrayCount() {
+    return 34;
+  }
+
+  /** @return feed tray number used by the source, counted from the top */
+  public static int getFeedTrayFromTop() {
+    return 31;
+  }
+
+  /** @return crude feed rate to the atmospheric column in kg/h */
+  public static double getColumnCrudeFeedRateKgPerHour() {
+    return 54420.0;
+  }
+
+  /** @return atmospheric-column feed temperature in degrees Celsius */
+  public static double getColumnFeedTemperatureCelsius() {
+    return 350.0;
+  }
+
+  /** @return atmospheric-column feed pressure in kPa absolute as reported */
+  public static double getColumnFeedPressureKPa() {
+    return 233.0;
+  }
+
+  /** @return main atmospheric-column steam rate in kg/h */
+  public static double getMainColumnSteamRateKgPerHour() {
+    return 340.2;
+  }
+
+  /** @return kerosene side-stripper steam rate in kg/h */
+  public static double getKeroseneStripperSteamRateKgPerHour() {
+    return 68.04;
+  }
+
+  /** @return diesel side-stripper steam rate in kg/h */
+  public static double getDieselStripperSteamRateKgPerHour() {
+    return 226.8;
+  }
+
+  /** @return top pump-around flow rate in kg/h */
+  public static double getTopPumpAroundRateKgPerHour() {
+    return 29777.64;
+  }
+
+  /** @return bottom pump-around flow rate in kg/h */
+  public static double getBottomPumpAroundRateKgPerHour() {
+    return 60423.66;
+  }
+
+  /** Immutable numeric ASTM D86 comparison row. */
+  public static final class ProductQualityReference implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final double laboratoryFivePercentCelsius;
+    private final double laboratoryNinetyFivePercentCelsius;
+    private final double simulationFivePercentCelsius;
+    private final double simulationNinetyFivePercentCelsius;
+
+    private ProductQualityReference(String name, double laboratoryFivePercentCelsius,
+        double laboratoryNinetyFivePercentCelsius, double simulationFivePercentCelsius,
+        double simulationNinetyFivePercentCelsius) {
+      this.name = name;
+      this.laboratoryFivePercentCelsius = laboratoryFivePercentCelsius;
+      this.laboratoryNinetyFivePercentCelsius = laboratoryNinetyFivePercentCelsius;
+      this.simulationFivePercentCelsius = simulationFivePercentCelsius;
+      this.simulationNinetyFivePercentCelsius = simulationNinetyFivePercentCelsius;
+    }
+
+    /** @return exact source-table product label */
+    public String getName() {
+      return name;
+    }
+
+    /** @return measured ASTM D86 T5 in degrees Celsius */
+    public double getLaboratoryFivePercentCelsius() {
+      return laboratoryFivePercentCelsius;
+    }
+
+    /** @return measured ASTM D86 T95 in degrees Celsius */
+    public double getLaboratoryNinetyFivePercentCelsius() {
+      return laboratoryNinetyFivePercentCelsius;
+    }
+
+    /** @return simulated ASTM D86 T5 in degrees Celsius */
+    public double getSimulationFivePercentCelsius() {
+      return simulationFivePercentCelsius;
+    }
+
+    /** @return simulated ASTM D86 T95 in degrees Celsius */
+    public double getSimulationNinetyFivePercentCelsius() {
+      return simulationNinetyFivePercentCelsius;
+    }
+  }
+
+  /** Immutable plant/simulation product-yield comparison row. */
+  public static final class ProductYieldReference implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final double plantMetricTonPerDay;
+    private final double simulationMetricTonPerDay;
+
+    private ProductYieldReference(String name, double plantMetricTonPerDay, double simulationMetricTonPerDay) {
+      this.name = name;
+      this.plantMetricTonPerDay = plantMetricTonPerDay;
+      this.simulationMetricTonPerDay = simulationMetricTonPerDay;
+    }
+
+    /** @return exact source-table product label */
+    public String getName() {
+      return name;
+    }
+
+    /** @return measured refinery product rate in metric tonnes/day */
+    public double getPlantMetricTonPerDay() {
+      return plantMetricTonPerDay;
+    }
+
+    /** @return simulated product rate in metric tonnes/day */
+    public double getSimulationMetricTonPerDay() {
+      return simulationMetricTonPerDay;
+    }
+
+    /** @return absolute relative rate error against the measured plant value, in percent */
+    public double getAbsoluteRelativeErrorPercent() {
+      return calculateAbsoluteRelativeErrorPercent(plantMetricTonPerDay, simulationMetricTonPerDay);
+    }
+  }
+}

--- a/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
+++ b/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
@@ -1,0 +1,124 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.SarirAtmosphericReference.ProductQualityReference;
+import neqsim.thermo.characterization.SarirAtmosphericReference.ProductYieldReference;
+
+/** Tests the public Sarir atmospheric assay and validation reference. */
+public class SarirAtmosphericReferenceTest {
+  @Test
+  public void tbpEvidencePreservesNumericCurveAndOpenEndedResidue() {
+    double[] expectedTemperatureCelsius = { 70.0, 90.0, 110.0, 150.0, 195.0, 215.0, 255.0, 275.0, 295.0, 335.0, 370.0,
+        400.0, 460.0, 480.0, 500.0, 520.0, 550.0 };
+    double[] expectedVolumePercent = { 7.44, 10.47, 13.83, 21.16, 28.52, 31.54, 38.03, 41.76, 44.68, 51.97, 59.19,
+        63.50, 72.52, 75.61, 78.66, 81.05, 83.70 };
+
+    assertArrayEquals(expectedTemperatureCelsius, SarirAtmosphericReference.getTbpTemperatureCelsius(), 0.0);
+    assertArrayEquals(expectedVolumePercent, SarirAtmosphericReference.getTbpCumulativeVolumePercent(), 0.0);
+    assertEquals(343.15, SarirAtmosphericReference.getTbpTemperatureKelvin()[0], 1.0e-12);
+    assertEquals(823.15, SarirAtmosphericReference.getTbpTemperatureKelvin()[16], 1.0e-12);
+    assertEquals(550.0, SarirAtmosphericReference.getTerminalResidueLowerBoundaryCelsius(), 0.0);
+    assertEquals(16.30, SarirAtmosphericReference.getTerminalResidueVolumePercent(), 1.0e-12);
+    assertFalse(SarirAtmosphericReference.hasCompleteNumericTbpCurve());
+    assertFalse(SarirAtmosphericReference.hasResolvedLightEndComposition());
+    assertStrictlyIncreasing(expectedTemperatureCelsius);
+    assertStrictlyIncreasing(expectedVolumePercent);
+  }
+
+  @Test
+  public void returnedArraysCannotMutateFrozenReference() {
+    double[] volumes = SarirAtmosphericReference.getTbpCumulativeVolumePercent();
+    volumes[0] = 0.0;
+    assertEquals(7.44, SarirAtmosphericReference.getTbpCumulativeVolumePercent()[0], 0.0);
+
+    ProductQualityReference[] quality = SarirAtmosphericReference.getProductQualities();
+    quality[0] = null;
+    assertEquals("Light Naphtha", SarirAtmosphericReference.getProductQualities()[0].getName());
+
+    ProductYieldReference[] yields = SarirAtmosphericReference.getProductYields();
+    yields[0] = null;
+    assertEquals("Total Naphtha", SarirAtmosphericReference.getProductYields()[0].getName());
+  }
+
+  @Test
+  public void numericProductQualityRowsMatchPublishedTable() {
+    ProductQualityReference[] quality = SarirAtmosphericReference.getProductQualities();
+    assertEquals(4, quality.length);
+    assertQuality(quality[0], "Light Naphtha", 42.0, 90.0, -9.0, 97.0);
+    assertQuality(quality[1], "Heavy Naphtha", 96.0, 160.0, 83.0, 153.0);
+    assertQuality(quality[2], "Kerosene", 185.0, 221.0, 159.0, 214.0);
+    assertQuality(quality[3], "Diesel", 262.0, 346.0, 235.0, 339.0);
+  }
+
+  @Test
+  public void plantYieldRowsRemainIndependentValidationEvidence() {
+    ProductYieldReference[] yields = SarirAtmosphericReference.getProductYields();
+    assertEquals(4, yields.length);
+    assertYield(yields[0], "Total Naphtha", 208.95, 208.2, 0.35893754486719315);
+    assertYield(yields[1], "Kerosene", 22.85, 20.0, 12.472647702407006);
+    assertYield(yields[2], "Diesel", 425.018, 393.0, 7.533328000225867);
+    assertYield(yields[3], "Residual", 646.5, 706.1, 9.218870843000776);
+    assertTrue(SarirAtmosphericReference.isIndependentYieldValidationCase());
+    assertFalse(SarirAtmosphericReference.areSimulationProductRatesImposedSpecifications());
+  }
+
+  @Test
+  public void operatingConfigurationAndProvenanceAreExplicit() {
+    assertEquals("10.66411/jer.v33i.46", SarirAtmosphericReference.DOI);
+    assertEquals("CC BY 4.0", SarirAtmosphericReference.LICENSE);
+    assertEquals("2022-03-31", SarirAtmosphericReference.PUBLICATION_DATE);
+    assertEquals(841.5, SarirAtmosphericReference.getCrudeDensityAt15CKgPerCubicMetre(), 0.0);
+    assertEquals(36.5, SarirAtmosphericReference.getCrudeApiGravityAt60F(), 0.0);
+    assertEquals(0.120, SarirAtmosphericReference.getCrudeSulfurMassPercent(), 0.0);
+    assertEquals(0.2447, SarirAtmosphericReference.getCrudeAverageMolarMassKgPerMol(), 0.0);
+    assertEquals(34, SarirAtmosphericReference.getColumnTrayCount());
+    assertEquals(31, SarirAtmosphericReference.getFeedTrayFromTop());
+    assertEquals(54420.0, SarirAtmosphericReference.getColumnCrudeFeedRateKgPerHour(), 0.0);
+    assertEquals(350.0, SarirAtmosphericReference.getColumnFeedTemperatureCelsius(), 0.0);
+    assertEquals(233.0, SarirAtmosphericReference.getColumnFeedPressureKPa(), 0.0);
+    assertEquals(340.2, SarirAtmosphericReference.getMainColumnSteamRateKgPerHour(), 0.0);
+    assertEquals(29777.64, SarirAtmosphericReference.getTopPumpAroundRateKgPerHour(), 0.0);
+    assertEquals(60423.66, SarirAtmosphericReference.getBottomPumpAroundRateKgPerHour(), 0.0);
+  }
+
+  @Test
+  public void invalidQueriesAndErrorInputsFailClosed() {
+    assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getProductYield(null));
+    assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getProductYield("Naphtha"));
+    assertThrows(IllegalArgumentException.class,
+        () -> SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(0.0, 1.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(Double.NaN, 1.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(1.0, Double.POSITIVE_INFINITY));
+  }
+
+  private static void assertQuality(ProductQualityReference quality, String name, double labFive, double labNinetyFive,
+      double simulationFive, double simulationNinetyFive) {
+    assertEquals(name, quality.getName());
+    assertEquals(labFive, quality.getLaboratoryFivePercentCelsius(), 0.0);
+    assertEquals(labNinetyFive, quality.getLaboratoryNinetyFivePercentCelsius(), 0.0);
+    assertEquals(simulationFive, quality.getSimulationFivePercentCelsius(), 0.0);
+    assertEquals(simulationNinetyFive, quality.getSimulationNinetyFivePercentCelsius(), 0.0);
+  }
+
+  private static void assertYield(ProductYieldReference yield, String name, double plant, double simulation,
+      double errorPercent) {
+    assertEquals(name, yield.getName());
+    assertEquals(plant, yield.getPlantMetricTonPerDay(), 0.0);
+    assertEquals(simulation, yield.getSimulationMetricTonPerDay(), 0.0);
+    assertEquals(errorPercent, yield.getAbsoluteRelativeErrorPercent(), 1.0e-9);
+  }
+
+  private static void assertStrictlyIncreasing(double[] values) {
+    for (int i = 1; i < values.length; i++) {
+      assertTrue(values[i] > values[i - 1]);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Advances #3305 by adding a Java/JPype-friendly public Sarir refinery reference with complete-range TBP evidence, atmospheric-unit operating data, numeric product ASTM D86 endpoints, and independent plant product-rate targets.

Exact base: `c5a3f43f86f9e7cb77473a737e85ccd83e07488f`  
Exact head: `e4e5d8a6b4a0104d6a4d42f5850c4690f99c13fc`

## Capability contract

- Preserve all 17 numeric Sarir TBP coordinates through 83.70 liquid vol% at 550 degC.
- Represent the remaining 16.30 vol% as a one-sided 550 degC+ terminal residue without inventing a numeric 100% endpoint or upper boundary.
- Expose the published 34-tray operating case, feed, stripping-steam, and pump-around inputs.
- Retain four numeric laboratory/HYSYS ASTM D86 T5/T95 rows.
- Retain four plant/HYSYS product-rate rows as independent validation targets and recompute absolute errors from raw source values.
- Fail closed for unknown product labels and invalid error inputs; return defensive copies for arrays.

## Public provenance and licensing

Source: H. E. O. Almansouri, *Simulation of Sarir Crude Oil Refinery Using Aspen HYSYS*, Journal of Engineering Research (Libya), issue 33, 51-64, published 31 March 2022, [DOI 10.66411/jer.v33i.46](https://doi.org/10.66411/jer.v33i.46), [open article](https://jer.ly/jer/index.php/jer/article/download/46/38/39).

The journal licenses the article under CC BY 4.0. The source publishes the Libyan Petroleum Institute assay, laboratory ASTM D86 endpoints, operating inputs, and actual plant rates. It describes calculated production rates compared with refinery data and does not state that product rates were imposed.

## Validation

- PASS: Spotless apply/check.
- PASS: documentation search source audit (687 Markdown pages and one standalone HTML page).
- PASS: focused Maven regression: 12 tests across Sarir and Al-Diwiniya reference suites.
- PASS: `git diff --check`.
- Local `pre-commit` executable was unavailable; no local pre-commit result is claimed.
- Hosted CI is authoritative.

## Scientific boundary

This increment qualifies transcription, units, one-sided TBP treatment, provenance, and evidence classification. It does not yet build a Sarir pseudo-component slate or claim that NeqSim reproduces the plant yields. The follow-on gate must keep plant rates untouched, document the unresolved light-end allocation, and avoid tuning product draws to the published targets.

Status: **VALIDATION PENDING CI**.