### PR TITLE
Resolve component synonyms in Phase.getComponent

### DIFF
--- a/src/main/java/neqsim/thermo/phase/Phase.java
+++ b/src/main/java/neqsim/thermo/phase/Phase.java
@@ -2493,7 +2493,19 @@ public abstract class Phase implements PhaseInterface {
         return componentArray[i];
       }
     }
-    logger.error("could not find component " + name + " in fluid, returning null");
+    // Only consult the synonym table once an exact database name has failed, so an exact name
+    // never pays for the lookup and can never be redirected. A name the resolver considers
+    // ambiguous resolves to itself and therefore still fails rather than picking a near match.
+    String resolved = ComponentInterface.getComponentNameFromAlias(name);
+    if (!resolved.equals(name)) {
+      for (int i = 0; i < numberOfComponents; i++) {
+        if (componentArray[i].getName().equals(resolved)) {
+          return componentArray[i];
+        }
+      }
+    }
+    logger.error("could not find component {} in fluid, and it is not a known synonym of any "
+        + "component present, returning null", name);
     return null;
   }
 

--- a/src/test/java/neqsim/thermo/component/ComponentAliasApiSymmetryTest.java
+++ b/src/test/java/neqsim/thermo/component/ComponentAliasApiSymmetryTest.java
@@ -1,0 +1,94 @@
+package neqsim.thermo.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * A name accepted by {@code addComponent} must also be accepted by every other name-taking method.
+ *
+ * <p>
+ * Component construction resolved synonyms but {@code Phase.getComponent} did not, so a component could be created
+ * under a systematic name and then be unreachable by that same name. The pairing was actively misleading:
+ * {@code hasComponent} resolved the name and returned true while {@code getComponent} returned null, so a caller that
+ * correctly guarded with {@code hasComponent} still received a null, and anything that dereferenced it threw a
+ * NullPointerException.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class ComponentAliasApiSymmetryTest {
+  /** A systematic name held in the synonym table. */
+  private static final String SYNONYM = "2,2,4-trimethylpentane";
+
+  /** The database name that synonym denotes. */
+  private static final String DATABASE_NAME = "224-TM-C5";
+
+  /**
+   * Build a fluid holding one component added under the given name.
+   *
+   * @param name component name or synonym to add
+   * @return the fluid, with a mixing rule set so binary interaction parameters exist
+   */
+  private static SystemInterface fluidWith(String name) {
+    SystemInterface fluid = new SystemSrkEos(298.15, 10.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.addComponent(name, 1.0);
+    fluid.setMixingRule("classic");
+    return fluid;
+  }
+
+  /** A systematic name must reach the component it created. */
+  @Test
+  public void aSynonymReachesTheComponentItCreated() {
+    SystemInterface fluid = fluidWith(SYNONYM);
+    assertEquals(DATABASE_NAME, fluid.getPhase(0).getComponent(1).getComponentName(),
+        "addComponent should store the database name");
+    assertNotNull(fluid.getComponent(SYNONYM), "getComponent must accept the name addComponent accepted");
+    assertEquals(DATABASE_NAME, fluid.getComponent(SYNONYM).getComponentName());
+    assertNotNull(fluid.getPhase(0).getComponent(SYNONYM));
+    assertEquals(DATABASE_NAME, fluid.getPhase(0).getComponent(SYNONYM).getComponentName());
+  }
+
+  /** hasComponent and getComponent must agree, otherwise a guarded call still fails. */
+  @Test
+  public void hasComponentAndGetComponentAgree() {
+    SystemInterface fluid = fluidWith(SYNONYM);
+    String[] names = new String[] { SYNONYM, DATABASE_NAME };
+    for (int i = 0; i < names.length; i++) {
+      if (fluid.hasComponent(names[i])) {
+        assertNotNull(fluid.getComponent(names[i]),
+            "hasComponent reported '" + names[i] + "' present but getComponent returned null");
+      }
+    }
+  }
+
+  /** An unknown name must still return null rather than resolving to something near it. */
+  @Test
+  public void anUnknownNameIsNotGuessed() {
+    SystemInterface fluid = fluidWith(SYNONYM);
+    assertNull(fluid.getPhase(0).getComponent("not-a-real-component"));
+    assertNull(fluid.getPhase(0).getComponent("methan"), "a near miss must not resolve to methane");
+  }
+
+  /** The remaining name-taking methods must accept the same synonym. */
+  @Test
+  public void otherNameTakingMethodsAcceptTheSynonym() {
+    SystemInterface fluid = fluidWith(SYNONYM);
+    fluid.setComponentCriticalParameters(SYNONYM, 999.0, 27.0, 0.35);
+    assertEquals(999.0, fluid.getComponent(DATABASE_NAME).getTC(), 1e-9,
+        "setComponentCriticalParameters must act on the component the synonym denotes");
+
+    SystemInterface second = fluidWith(SYNONYM);
+    second.setBinaryInteractionParameter("methane", SYNONYM, 0.01);
+
+    SystemInterface third = fluidWith(SYNONYM);
+    int before = third.getNumberOfComponents();
+    third.removeComponent(SYNONYM);
+    assertEquals(before - 1, third.getNumberOfComponents(), "removeComponent must accept the synonym");
+  }
+}


### PR DESCRIPTION
## What this fixes

A name accepted by `addComponent` could not be used to reach the component it created.

Component construction resolves synonyms, but [`Phase.getComponent`](https://github.com/equinor/neqsim/blob/master/src/main/java/neqsim/thermo/phase/Phase.java) compared the raw string:

```java
if (componentArray[i].getName().equals(name)) { ... }
logger.error("could not find component " + name + " in fluid, returning null");
```

while its twin `hasComponent` resolved it:

```java
if (componentArray[i].getComponentName().equals(ComponentInterface.getComponentNameFromAlias(name)))
```

Measured on master, adding `2,2,4-trimethylpentane` (stored as `224-TM-C5`) and then using that same name:

| call | before | after |
|---|---|---|
| `hasComponent` | true | true |
| `getComponent` | **null** | the component |
| `getPhase(0).getComponent` | **null** | the component |
| `getPhase(0).getWtFrac` | **NullPointerException** | value |
| `changeComponentName` | **NullPointerException** | renames |

The worst part is the first two together: **`hasComponent` returned true while `getComponent` returned null**, so a caller who correctly guarded with `hasComponent` still got a null, and anything that dereferenced it threw. Everything that funnels through `getComponent` inherited the failure.

## Approach

Exact database name first, synonym table only once that has failed.

Three properties this gives:

- **No cost on the hot path.** An exact name returns from the first loop, exactly as before.
- **Nothing existing can regress.** An exact match can never be redirected, so behaviour for already-working names is bit-identical.
- **No approximate matching.** A name the resolver treats as ambiguous resolves to itself and therefore still fails. An unknown name still returns null rather than the nearest candidate — deliberately, since silently picking a near match on a component name would be worse than failing.

`removeComponent`, `setComponentCriticalParameters` and `setBinaryInteractionParameter` already resolved names via `getComponentIndex`, so they were unaffected and are covered by the new test to keep it that way.

## Verification

New `ComponentAliasApiSymmetryTest` — a synonym reaches the component it created, `hasComponent` and `getComponent` agree, an unknown name is not guessed, and the remaining name-taking methods accept the same synonym.

`neqsim.thermo.phase.**` plus `ComponentNameResolverTest` — **277 tests, 0 failures, 0 errors**, 2 pre-existing skips. `spotless:check` clean.

## Follow-up, not in this PR

`CANONICAL_NAMES` in `ComponentNameResolver` is a hand-maintained mirror of `COMP.csv`. It happens to be in sync on master today, but it drifts the moment components are added — every new row is then resolvable only when spelled with exactly the stored letter case. Deriving it from the database at load removes that failure mode permanently. That change, and moving the synonym table into an editable resource file, are worth doing separately since they interact with in-flight `COMP.csv` work.
