### PR TITLE
Add endpoint evidence to DEXPI connection cycles

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -180,8 +180,12 @@ continuous line or executable process network.
 of explicit non-empty material-connection endpoint references. A group is reported when it has more
 than one endpoint, or when a singleton endpoint has an explicit self-reference. Cycle groups are
 ordered by their first endpoint; endpoint IDs retain first-reference order and internal connection
-IDs retain source order, including parallel occurrences. `getConnections()` exposes the corresponding
-immutable `DexpiConnectionInfo` records in the same order, including source connection and owning
+IDs retain source order, including parallel occurrences. `getEndpoints()` exposes the corresponding
+immutable `DexpiConnectionEndpointInfo` records in first-reference order, including incidence role,
+resolution state, resolved XML element name, and Equipment/PipingComponent ownership. This lets Java
+and JPype reviewers inspect complete cycle-local endpoint evidence without joining against the global
+endpoint inventory. `getConnections()` exposes the corresponding immutable
+`DexpiConnectionInfo` records in the same order, including source connection and owning
 `PipingNetworkSegment` identities, endpoint resolution, resolved element names, and explicit
 Equipment/PipingComponent ownership. Each immutable `DexpiConnectionCycleInfo` links to its owning
 weak connection component, keeps unresolved endpoint IDs visible, and separately lists source-ordered
@@ -201,7 +205,8 @@ repair or rewire topology, or establish process intent.
 `toJson()` includes `instrumentCount`, `connectionCount`, `connectionEndpointCount`,
 `connectionComponentCount`, `connectionCycleCount`, and the ordered connection, endpoint,
 component, and directed-cycle inventories, including incidence roles, review subsets, complete
-internal connection occurrences, and explicit cycle-boundary occurrences, alongside the process-unit
+cycle-local endpoint and internal connection occurrences, and explicit cycle-boundary occurrences,
+alongside the process-unit
 count and findings. Python callers through
 JPype use the same
 `ImportResult.getInstruments()`, `ImportResult.getConnections()`,

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleInfo.java
@@ -24,6 +24,7 @@ public final class DexpiConnectionCycleInfo implements Serializable {
   private final String id;
   private final String connectionComponentId;
   private final List<String> endpointIds;
+  private final List<DexpiConnectionEndpointInfo> endpoints;
   private final List<String> connectionIds;
   private final List<DexpiConnectionInfo> connections;
   private final List<String> incomingBoundaryConnectionIds;
@@ -92,9 +93,36 @@ public final class DexpiConnectionCycleInfo implements Serializable {
       List<String> connectionIds, List<DexpiConnectionInfo> connections, List<String> incomingBoundaryConnectionIds,
       List<String> outgoingBoundaryConnectionIds, List<DexpiConnectionCycleBoundaryInfo> boundaryConnections,
       List<String> unresolvedEndpointIds, boolean selfReference) {
+    this(id, connectionComponentId, endpointIds, Collections.<DexpiConnectionEndpointInfo>emptyList(), connectionIds,
+        connections, incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds, boundaryConnections,
+        unresolvedEndpointIds, selfReference);
+  }
+
+  /**
+   * Creates immutable directed-cycle source-reference evidence with complete endpoint, internal, and boundary
+   * occurrences.
+   *
+   * @param id deterministic cycle-group evidence identity
+   * @param connectionComponentId owning weak connection-component evidence identity
+   * @param endpointIds endpoint identities in first-reference order
+   * @param endpoints endpoint evidence records in first-reference order
+   * @param connectionIds internal connection-evidence identities in source order
+   * @param connections internal connection occurrences in source order
+   * @param incomingBoundaryConnectionIds connection-evidence identities entering the cyclic group in source order
+   * @param outgoingBoundaryConnectionIds connection-evidence identities leaving the cyclic group in source order
+   * @param boundaryConnections boundary occurrences in overall source-document order
+   * @param unresolvedEndpointIds endpoint identities that do not resolve in the source document
+   * @param selfReference whether the group contains an explicit self-reference connection
+   */
+  public DexpiConnectionCycleInfo(String id, String connectionComponentId, List<String> endpointIds,
+      List<DexpiConnectionEndpointInfo> endpoints, List<String> connectionIds, List<DexpiConnectionInfo> connections,
+      List<String> incomingBoundaryConnectionIds, List<String> outgoingBoundaryConnectionIds,
+      List<DexpiConnectionCycleBoundaryInfo> boundaryConnections, List<String> unresolvedEndpointIds,
+      boolean selfReference) {
     this.id = normalize(id);
     this.connectionComponentId = normalize(connectionComponentId);
     this.endpointIds = immutableCopy(endpointIds);
+    this.endpoints = Collections.unmodifiableList(new ArrayList<DexpiConnectionEndpointInfo>(endpoints));
     this.connectionIds = immutableCopy(connectionIds);
     this.connections = Collections.unmodifiableList(new ArrayList<DexpiConnectionInfo>(connections));
     this.incomingBoundaryConnectionIds = immutableCopy(incomingBoundaryConnectionIds);
@@ -118,6 +146,11 @@ public final class DexpiConnectionCycleInfo implements Serializable {
   /** @return immutable endpoint identities in first-reference order */
   public List<String> getEndpointIds() {
     return endpointIds;
+  }
+
+  /** @return immutable endpoint evidence records in first-reference order */
+  public List<DexpiConnectionEndpointInfo> getEndpoints() {
+    return endpoints;
   }
 
   /** @return immutable internal connection-evidence identities in source order */
@@ -197,6 +230,11 @@ public final class DexpiConnectionCycleInfo implements Serializable {
     result.put("selfReference", Boolean.valueOf(selfReference));
     result.put("hasUnresolvedEndpoints", Boolean.valueOf(hasUnresolvedEndpoints()));
     result.put("endpointIds", endpointIds);
+    List<Map<String, Object>> endpointMaps = new ArrayList<Map<String, Object>>();
+    for (DexpiConnectionEndpointInfo endpoint : endpoints) {
+      endpointMaps.add(endpoint.toMap());
+    }
+    result.put("endpoints", endpointMaps);
     result.put("connectionIds", connectionIds);
     List<Map<String, Object>> connectionMaps = new ArrayList<Map<String, Object>>();
     for (DexpiConnectionInfo connection : connections) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1057,6 +1057,7 @@ public final class DexpiXmlReader {
     private final String id;
     private final String connectionComponentId;
     private final List<String> endpointIds = new ArrayList<String>();
+    private final List<DexpiConnectionEndpointInfo> endpoints = new ArrayList<DexpiConnectionEndpointInfo>();
     private final List<String> connectionIds = new ArrayList<String>();
     private final List<DexpiConnectionInfo> connections = new ArrayList<DexpiConnectionInfo>();
     private final List<String> incomingBoundaryConnectionIds = new ArrayList<String>();
@@ -1072,6 +1073,7 @@ public final class DexpiXmlReader {
 
     private void addEndpoint(DexpiConnectionEndpointInfo endpoint) {
       endpointIds.add(endpoint.getEndpointId());
+      endpoints.add(endpoint);
       if (!endpoint.isResolved()) {
         unresolvedEndpointIds.add(endpoint.getEndpointId());
       }
@@ -1110,9 +1112,9 @@ public final class DexpiXmlReader {
     }
 
     private DexpiConnectionCycleInfo toInfo() {
-      return new DexpiConnectionCycleInfo(id, connectionComponentId, endpointIds, connectionIds, connections,
-          incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds, boundaryConnections, unresolvedEndpointIds,
-          selfReference);
+      return new DexpiConnectionCycleInfo(id, connectionComponentId, endpointIds, endpoints, connectionIds,
+          connections, incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds, boundaryConnections,
+          unresolvedEndpointIds, selfReference);
     }
   }
 

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1112,9 +1112,9 @@ public final class DexpiXmlReader {
     }
 
     private DexpiConnectionCycleInfo toInfo() {
-      return new DexpiConnectionCycleInfo(id, connectionComponentId, endpointIds, endpoints, connectionIds,
-          connections, incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds, boundaryConnections,
-          unresolvedEndpointIds, selfReference);
+      return new DexpiConnectionCycleInfo(id, connectionComponentId, endpointIds, endpoints, connectionIds, connections,
+          incomingBoundaryConnectionIds, outgoingBoundaryConnectionIds, boundaryConnections, unresolvedEndpointIds,
+          selfReference);
     }
   }
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -594,6 +594,19 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("cycle-1", threeEndpointCycle.getId());
     assertEquals("component-2", threeEndpointCycle.getConnectionComponentId());
     assertEquals(Arrays.asList("N-X", "N-Y", "N-Z"), threeEndpointCycle.getEndpointIds());
+    List<DexpiConnectionEndpointInfo> cycleEndpoints = threeEndpointCycle.getEndpoints();
+    assertEquals(3, cycleEndpoints.size());
+    assertEquals("N-X", cycleEndpoints.get(0).getEndpointId());
+    assertEquals("Nozzle", cycleEndpoints.get(0).getElementName());
+    assertEquals("E-X", cycleEndpoints.get(0).getOwnerId());
+    assertEquals("Equipment", cycleEndpoints.get(0).getOwnerElementName());
+    assertTrue(cycleEndpoints.get(0).isResolved());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.SPLIT, cycleEndpoints.get(0).getIncidenceRole());
+    assertEquals("N-Y", cycleEndpoints.get(1).getEndpointId());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.MERGE, cycleEndpoints.get(1).getIncidenceRole());
+    assertEquals("N-Z", cycleEndpoints.get(2).getEndpointId());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.PASS_THROUGH,
+        cycleEndpoints.get(2).getIncidenceRole());
     assertEquals(Arrays.asList("C-3", "C-3P", "C-4", "C-5"), threeEndpointCycle.getConnectionIds());
     List<DexpiConnectionInfo> internalConnections = threeEndpointCycle.getConnections();
     assertEquals(Arrays.asList("C-3", "C-3P", "C-4", "C-5"), Arrays.asList(internalConnections.get(0).getId(),
@@ -629,6 +642,11 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(2, unresolved.getConnections().size());
     assertEquals("S-9", unresolved.getConnections().get(0).getSegmentId());
     assertFalse(unresolved.getConnections().get(0).isResolved());
+    assertEquals(2, unresolved.getEndpoints().size());
+    assertEquals("UNKNOWN-1", unresolved.getEndpoints().get(0).getEndpointId());
+    assertFalse(unresolved.getEndpoints().get(0).isResolved());
+    assertEquals("", unresolved.getEndpoints().get(0).getElementName());
+    assertEquals("", unresolved.getEndpoints().get(0).getOwnerId());
     assertEquals(Arrays.asList("UNKNOWN-1", "UNKNOWN-2"), unresolved.getUnresolvedEndpointIds());
     assertTrue(unresolved.hasUnresolvedEndpoints());
 
@@ -637,9 +655,11 @@ public class DexpiXmlReaderTest extends NeqSimTest {
       assertFalse(cycle.getEndpointIds().contains("N-Q"));
     }
     assertThrows(UnsupportedOperationException.class, () -> threeEndpointCycle.getEndpointIds().clear());
+    assertThrows(UnsupportedOperationException.class, () -> threeEndpointCycle.getEndpoints().clear());
     assertThrows(UnsupportedOperationException.class, () -> threeEndpointCycle.getConnections().clear());
     assertThrows(UnsupportedOperationException.class, () -> first.getConnectionCycles().clear());
     assertTrue(first.toJson().contains("\"connectionCycleCount\": 3"));
+    assertTrue(first.toJson().contains("\"endpoints\": ["));
     assertTrue(first.toJson().contains("\"connections\": ["));
     assertTrue(first.toJson().contains("\"segmentId\": \"S-3\""));
     assertTrue(first.toJson().contains("\"connectionComponentId\": \"component-4\""));
@@ -743,6 +763,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     DexpiConnectionCycleInfo legacy = new DexpiConnectionCycleInfo("legacy", "component-legacy",
         Collections.<String>emptyList(), Collections.<String>emptyList(), Collections.<String>emptyList(),
         Collections.<String>emptyList(), Collections.<String>emptyList(), false);
+    assertTrue(legacy.getEndpoints().isEmpty());
     assertTrue(legacy.getConnections().isEmpty());
     assertTrue(legacy.getBoundaryConnections().isEmpty());
     DexpiConnectionCycleBoundaryInfo legacyBoundary = new DexpiConnectionCycleBoundaryInfo("legacy-boundary",

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -605,8 +605,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("N-Y", cycleEndpoints.get(1).getEndpointId());
     assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.MERGE, cycleEndpoints.get(1).getIncidenceRole());
     assertEquals("N-Z", cycleEndpoints.get(2).getEndpointId());
-    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.PASS_THROUGH,
-        cycleEndpoints.get(2).getIncidenceRole());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.PASS_THROUGH, cycleEndpoints.get(2).getIncidenceRole());
     assertEquals(Arrays.asList("C-3", "C-3P", "C-4", "C-5"), threeEndpointCycle.getConnectionIds());
     List<DexpiConnectionInfo> internalConnections = threeEndpointCycle.getConnections();
     assertEquals(Arrays.asList("C-3", "C-3P", "C-4", "C-5"), Arrays.asList(internalConnections.get(0).getId(),


### PR DESCRIPTION
## Summary

Expose immutable, first-reference-ordered `DexpiConnectionEndpointInfo` records directly on each detected directed connection cycle.

This lets Java and JPype reviewers inspect cycle-local endpoint incidence roles, resolution state, XML element type, and Equipment/PipingComponent ownership without joining `getEndpointIds()` against the global endpoint inventory.

## Capability contract

- Engineering question: can reviewers inspect complete endpoint evidence for a directed cycle locally and deterministically?
- Exact base: `18e26159b182a654f89e835ded7f51ba8b059854`
- Exact head: `cbfe58656d09a1f77eef1a73050dbc99b7ac6d2e`
- Frozen scope: four files (cycle value object, reader accumulator, focused reader tests, reader documentation)
- Complexity: retains O(V+E) analysis by storing already-computed endpoint records
- Compatibility: existing constructors and ID/connection APIs remain unchanged; legacy constructors expose an empty endpoint-record list
- Preservation: source order, parallel occurrences, unresolved references, deterministic JSON, simulation topology, rendering, geometry, layout, and export behavior

## Validation

Status: **READY TO MERGE** at exact head `cbfe58656d09a1f77eef1a73050dbc99b7ac6d2e`.

All eight hosted workflows pass: 19 jobs succeeded, one expected PaperLab replication job was skipped, and no job failed or remains pending. This includes Java 8/21 on Ubuntu and Windows, all four slow-test shards, Javadocs, Spotless, pre-commit, documentation coverage, the simulator notebook, engineering-diagram performance, CodeQL, and agent-skill reference checks.

The sole automated mutability finding was answered and resolved using the existing defensive-copy, immutable value-object, and focused mutation-regression evidence; no source change was required.

Focused regressions cover:

- resolved endpoint identity, element type, owner identity/type, and incidence role
- unresolved endpoint evidence
- immutable endpoint lists
- legacy-constructor empty defaults
- repeat-read JSON determinism

Documentation covers the Java and JPype access path.

## Visual and engineering gates

Whole-sheet visual gate is N/A because no rendering, geometry, layout, notebook, writer, or export path changed.

This change does not infer hydraulic recycles, solve paths, repair or rewire topology, claim standards conformance or DEXPI certification, or provide engineering approval.

Related roadmaps: #1332, #2899.