### PR TITLE
test(tpflash): qualify water-rich vapour appearance

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1505,46 +1505,48 @@ The complete workflow in `TPmultiflash.run()` is:
 
 Beyond stability analysis, NeqSim uses heuristic phase seeding to improve convergence:
 
-#### 3.5.1 Vapor-like Gas Phase Seeding
+#### 3.5.1 Water-rich Hydrocarbon Vapour Appearance
 
-When an aqueous phase and material hydrocarbon feed exist without a gas phase, the fallback creates a vapor-like trial
-instead of copying the water-dominated feed composition. The initial trial is
+A neutral OIL+AQUEOUS endpoint can still be unstable to a hydrocarbon vapour phase when water dominates the overall
+composition. The ordinary stability trials use that overall composition, so dilution can hide the vapour stationary
+point even though the water-free hydrocarbon sub-mixture remains between its bubble and dew points.
 
-$$x_i^{trial}=\frac{z_iK_i^{Wilson}}{\sum_j z_jK_j^{Wilson}}$$
+The fallback first applies a cheap Rachford-Rice bracketing screen to the normalized, ion-free volatile
+sub-composition. With Wilson K-values, both
 
-with
+$$\sum_i \hat z_i K_i > 1 + 10^{-3}$$
 
-$$\ln K_i^{Wilson}=\ln\left(\frac{P_{c,i}}{P}\right)+5.373(1+\omega_i)\left(1-\frac{T_{c,i}}{T}\right)$$
+and
 
-The calculation is performed in log space and bounds $\ln K_i$ to $[-50,50]$ to remain finite for large volatility
-contrasts. This is an initialization strategy only: the multiphase beta solve, component material balance, composition
-normalization, fugacity equality, phase-stability logic, and Gibbs-energy comparisons still determine whether the gas
-phase is retained.
+$$\sum_i \frac{\hat z_i}{K_i} > 1 + 10^{-3}$$
+
+must hold. The screen is considered only when multiphase checking is enabled, the converged endpoint has exactly OIL
+and AQUEOUS phases but no GAS phase, the system is non-reactive, and at least `1e-6` of the overall feed is represented
+by volatile screening components.
+
+Directly appending a gas phase is not used because `SystemInterface.addPhase()` can expose a stale phase slot whose
+requested type need not survive initialization. Instead, the algorithm snapshots the converged endpoint, clones it,
+resets the clone to a fresh two-phase GAS/liquid estimate, calls `init(0)` and `init(1)`, and runs one nested
+`TPmultiflash`. A thread-local guard and a per-operation one-shot flag prevent reciprocal recursion.
+
+The trial replaces the retained endpoint only if it preserves every original phase role, adds GAS, stays within the
+configured phase-count limit, and lowers extensive Gibbs energy. An exception, missing phase, non-improving Gibbs
+energy, or rejected trial leaves the snapshot in place; beta, phase compositions, K-values, and initialized properties
+are restored. Thus the Wilson screen triggers an equilibrium calculation but does not itself decide phase stability.
 
 ```java
-private boolean seedAdditionalPhaseFromFeed() {
-    // Only if multiphase check enabled and < 3 phases
-    if (!system.doMultiPhaseCheck() || system.getNumberOfPhases() >= 3)
-        return false;
+if (oilAndAqueousWithoutGas && neutral && wilsonSubmixtureBracketsTwoPhases) {
+    PhaseSplitSnapshot retained = snapshot(system);
+    SystemInterface trial = freshGasLiquidEstimate(system);
+    new TPmultiflash(trial, solidCheck).run();
 
-    // Need aqueous phase but no gas phase
-    boolean hasAqueous = false, hasGas = false;
-    for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
-        if (type == PhaseType.GAS) hasGas = true;
-        if (type == PhaseType.AQUEOUS) hasAqueous = true;
+    if (retainsOriginalPhaseRoles(trial)
+            && trial.hasPhaseType(PhaseType.GAS)
+            && trial.getGibbsEnergy() < retainedGibbs) {
+        restorePhaseSplit(snapshot(trial));
+    } else {
+        restorePhaseSplit(retained);
     }
-    if (!hasAqueous || hasGas) return false;
-
-    // Seed a vapor-like trial in bounded log space
-    system.addPhase();
-    system.setPhaseType(phaseIndex, PhaseType.GAS);
-    for (int comp = 0; comp < ncomp; comp++) {
-        logTrial[comp] = log(z[comp]) + clamp(log(KWilson[comp]), -50, 50);
-        xTrial[comp] = exp(logTrial[comp] - max(logTrial));
-    }
-    normalize(xTrial);
-    system.setBeta(phaseIndex, 1e-3);
-    return true;
 }
 ```
 
@@ -2225,6 +2227,30 @@ experimental uncertainty or validation of the predicted high-temperature phase s
 
 The bounded test matrix is performance evidence only. Production solver code, public APIs,
 model parameters, defaults, and runtime behavior are unchanged, so no speedup is claimed.
+
+### 6.4.10 Water-rich cubic-EOS vapour-appearance qualification
+
+The synthetic qualification uses classic-mixing `SystemSrkEos` and `SystemPrEos` at 30.8 °C and 45.62 bara. The
+water-free hydrocarbon inventory is 0.55 methane, 0.08 ethane, 0.05 propane, 0.03 n-butane, 0.02 n-pentane, 0.02
+n-hexane, 0.10 n-heptane, and 0.15 n-octane on a mole-fraction basis. Water then dilutes that normalized inventory.
+This is deterministic solver evidence, not an experimental validation of the predicted phase fractions or boundary.
+
+The historical SRK water-cut range from 0.50 through 0.95 must retain GAS+OIL+AQUEOUS equilibrium. SRK and PR are both
+qualified at a water mole fraction of 0.83 and 44.62, 45.62, and 46.62 bara. Every active phase and beta must be finite,
+bounded, and normalized within `1e-12`; maximum component material-balance residual must be below `1e-10`; maximum
+comparable interphase log-fugacity residual must be below `1e-8`; compressibility must be positive; and Gibbs energy
+and enthalpy must be finite.
+
+At the reference state, both equations of state must recover the fresh public `TPflash` endpoint from beta values
+within `1e-12` of a bound and from an ordinary two-phase endpoint passed directly to `TPmultiflash`. Reused systems
+must agree with fresh calculations after a nearby pressure change, after return to the reference pressure, and on an
+immediate deterministic repeat. A water-free GAS+OIL control verifies that the aqueous-only guard does not broaden the
+restart to dry flashes.
+
+The focused class executes 34 complete flashes. That bounded count is the performance evidence for this test-only
+qualification; no wall-clock threshold or production speedup is claimed. Production solver code, public APIs, model
+parameters/defaults, electrolyte and reactive paths, solids/wax, saturation search, Column Solver, Process Performance,
+and Huldra are outside this tranche.
 
 ### 6.5 Hybrid EOS-GE ionic-capacity safeguard
 

--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -1501,9 +1501,9 @@ The complete workflow in `TPmultiflash.run()` is:
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### 3.5 Phase Seeding Strategies
+### 3.5 Phase Seeding and Restart Strategies
 
-Beyond stability analysis, NeqSim uses heuristic phase seeding to improve convergence:
+Beyond stability analysis, NeqSim uses heuristic phase seeding and guarded restarts to improve convergence:
 
 #### 3.5.1 Water-rich Hydrocarbon Vapour Appearance
 

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashWaterRichVapourTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashWaterRichVapourTest.java
@@ -132,7 +132,8 @@ class TPmultiflashWaterRichVapourTest {
 
   private SystemInterface buildFluid(boolean pengRobinson, double waterFraction, double temperature, double pressure,
       boolean multiphaseCheck) {
-    SystemInterface fluid = pengRobinson ? new SystemPrEos(temperature, pressure) : new SystemSrkEos(temperature, pressure);
+    SystemInterface fluid = pengRobinson ? new SystemPrEos(temperature, pressure)
+        : new SystemSrkEos(temperature, pressure);
     for (int component = 0; component < HYDROCARBON_NAMES.length; component++) {
       fluid.addComponent(HYDROCARBON_NAMES[component], HYDROCARBON_FRACTIONS[component] * (1.0 - waterFraction));
     }
@@ -179,8 +180,7 @@ class TPmultiflashWaterRichVapourTest {
     assertEquals(1.0, betaTotal, NORMALIZATION_TOLERANCE, label + " beta normalization");
 
     double materialResidual = maximumComponentMaterialBalanceResidual(fluid);
-    assertTrue(materialResidual < MATERIAL_BALANCE_TOLERANCE,
-        label + " material-balance residual " + materialResidual);
+    assertTrue(materialResidual < MATERIAL_BALANCE_TOLERANCE, label + " material-balance residual " + materialResidual);
 
     double fugacityResidual = maximumComparableLogFugacityResidual(fluid);
     assertTrue(fugacityResidual < FUGACITY_TOLERANCE, label + " fugacity residual " + fugacityResidual);
@@ -196,7 +196,8 @@ class TPmultiflashWaterRichVapourTest {
     for (int expectedPhase = 0; expectedPhase < expected.getNumberOfPhases(); expectedPhase++) {
       PhaseType phaseType = expected.getPhase(expectedPhase).getType();
       int actualPhase = findPhase(actual, phaseType);
-      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), tolerance, label + " beta " + phaseType);
+      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), tolerance,
+          label + " beta " + phaseType);
       assertEquals(expected.getPhase(expectedPhase).getZ(), actual.getPhase(actualPhase).getZ(), tolerance,
           label + " compressibility " + phaseType);
       for (int component = 0; component < expected.getPhase(expectedPhase).getNumberOfComponents(); component++) {

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashWaterRichVapourTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashWaterRichVapourTest.java
@@ -1,108 +1,260 @@
 package neqsim.thermodynamicoperations.flashops;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
+
 import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
 import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 /**
- * Regression tests for the vapour phase of a water-rich hydrocarbon feed.
+ * Qualification tests for vapour appearance in water-rich neutral hydrocarbon feeds.
  *
  * <p>
- * Diluting a two-phase hydrocarbon mixture with water cannot remove its vapour phase: water is almost insoluble in the
- * hydrocarbon phases, so it forms its own aqueous phase and leaves the hydrocarbon vapour-liquid split essentially
- * untouched. The multiphase stability analysis nevertheless builds its trial compositions from the overall feed, so
- * once the water cut is high enough the hydrocarbons become a small minority of that feed and the vapour stationary
- * point is missed. The flash then returned OIL + AQUEOUS with a higher extensive Gibbs energy than the correct GAS +
- * OIL + AQUEOUS split.
+ * The synthetic methane-through-n-octane feed is a numerical regression, not an experimental PVT match. It qualifies
+ * the guarded fresh-estimate restart used when a water-dominated overall composition hides the hydrocarbon vapour
+ * stationary point from the ordinary multiphase stability trials.
  * </p>
- *
- * @author NeqSim
- * @version 1.0
  */
 class TPmultiflashWaterRichVapourTest {
-  /** Hydrocarbon components of the synthetic wellstream. */
   private static final String[] HYDROCARBON_NAMES = { "methane", "ethane", "propane", "n-butane", "n-pentane",
       "n-hexane", "n-heptane", "n-octane" };
-  /** Water-free mole fractions matching {@link #HYDROCARBON_NAMES}. */
   private static final double[] HYDROCARBON_FRACTIONS = { 0.55, 0.08, 0.05, 0.03, 0.02, 0.02, 0.10, 0.15 };
-  /** Flash pressure in bara, representative of a wellhead. */
-  private static final double PRESSURE = 45.62;
-  /** Flash temperature in K, representative of a wellhead. */
-  private static final double TEMPERATURE = 273.15 + 30.8;
+  private static final double REFERENCE_PRESSURE_BARA = 45.62;
+  private static final double REFERENCE_TEMPERATURE_K = 273.15 + 30.8;
+  private static final double REFERENCE_WATER_FRACTION = 0.83;
+  private static final double MATERIAL_BALANCE_TOLERANCE = 1.0e-10;
+  private static final double FUGACITY_TOLERANCE = 1.0e-8;
+  private static final double NORMALIZATION_TOLERANCE = 1.0e-12;
+
+  /** Qualifies the full historical SRK water-cut range with strict equilibrium gates. */
+  @Test
+  void srkWaterCutMatrixHasClosedThreePhaseEquilibrium() {
+    double[] waterFractions = { 0.50, 0.70, 0.76, 0.78, 0.80, 0.83, 0.90, 0.95 };
+    for (double waterFraction : waterFractions) {
+      SystemInterface fluid = flash(false, waterFraction, REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true);
+      assertClosedThreePhaseEquilibrium(fluid, "SRK water fraction " + waterFraction);
+    }
+  }
+
+  /** Qualifies nearby pressures with both supported neutral cubic equations of state. */
+  @Test
+  void srkAndPrNearbyPressureStatesRemainClosedAndThreePhase() {
+    for (boolean pengRobinson : new boolean[] { false, true }) {
+      String model = pengRobinson ? "PR" : "SRK";
+      for (double pressure : new double[] { 44.62, REFERENCE_PRESSURE_BARA, 46.62 }) {
+        SystemInterface fluid = flash(pengRobinson, REFERENCE_WATER_FRACTION, REFERENCE_TEMPERATURE_K, pressure, true);
+        assertClosedThreePhaseEquilibrium(fluid, model + " at " + pressure + " bara");
+      }
+    }
+  }
 
   /**
-   * Builds the synthetic wellstream at a given water mole fraction.
-   *
-   * @param waterFraction overall water mole fraction, between 0.0 and 1.0
-   * @return fluid ready for a multiphase TP flash
+   * A poor beta estimate and an ordinary two-phase warm state must recover the same multiphase endpoint as a fresh
+   * public TP flash.
    */
-  private SystemInterface buildFluid(double waterFraction) {
-    SystemInterface fluid = new SystemSrkEos(TEMPERATURE, PRESSURE);
-    for (int i = 0; i < HYDROCARBON_NAMES.length; i++) {
-      fluid.addComponent(HYDROCARBON_NAMES[i], HYDROCARBON_FRACTIONS[i] * (1.0 - waterFraction));
+  @Test
+  void poorInitializationAndExplicitMultiphaseRestartRecoverFreshReference() {
+    for (boolean pengRobinson : new boolean[] { false, true }) {
+      String model = pengRobinson ? "PR" : "SRK";
+      SystemInterface reference = flash(pengRobinson, REFERENCE_WATER_FRACTION, REFERENCE_TEMPERATURE_K,
+          REFERENCE_PRESSURE_BARA, true);
+
+      SystemInterface poorGuess = buildFluid(pengRobinson, REFERENCE_WATER_FRACTION, REFERENCE_TEMPERATURE_K,
+          REFERENCE_PRESSURE_BARA, true);
+      poorGuess.init(0);
+      poorGuess.setBeta(0, 1.0e-12);
+      poorGuess.setBeta(1, 1.0 - 1.0e-12);
+      runPublicFlash(poorGuess);
+      assertEquivalentEquilibrium(reference, poorGuess, 1.0e-8, model + " poor beta initialization");
+
+      SystemInterface explicitMultiphase = buildFluid(pengRobinson, REFERENCE_WATER_FRACTION, REFERENCE_TEMPERATURE_K,
+          REFERENCE_PRESSURE_BARA, false);
+      runPublicFlash(explicitMultiphase);
+      explicitMultiphase.setMultiPhaseCheck(true);
+      new TPmultiflash(explicitMultiphase, false).run();
+      explicitMultiphase.init(3);
+      assertEquivalentEquilibrium(reference, explicitMultiphase, 1.0e-8,
+          model + " ordinary-to-explicit-multiphase recovery");
+    }
+  }
+
+  /** Reused changed and returned states must match fresh flashes and remain deterministic. */
+  @Test
+  void changedReturnedAndRepeatedStatesRemainContinuous() {
+    for (boolean pengRobinson : new boolean[] { false, true }) {
+      String model = pengRobinson ? "PR" : "SRK";
+      SystemInterface reference = flash(pengRobinson, REFERENCE_WATER_FRACTION, REFERENCE_TEMPERATURE_K,
+          REFERENCE_PRESSURE_BARA, true);
+      SystemInterface reused = reference.clone();
+
+      reused.setPressure(46.12, "bara");
+      runPublicFlash(reused);
+      SystemInterface freshChanged = flash(pengRobinson, REFERENCE_WATER_FRACTION, REFERENCE_TEMPERATURE_K, 46.12,
+          true);
+      assertEquivalentEquilibrium(freshChanged, reused, 1.0e-8, model + " changed pressure");
+
+      reused.setPressure(REFERENCE_PRESSURE_BARA, "bara");
+      runPublicFlash(reused);
+      assertEquivalentEquilibrium(reference, reused, 1.0e-8, model + " returned pressure");
+
+      SystemInterface previous = reused.clone();
+      runPublicFlash(reused);
+      assertEquivalentEquilibrium(previous, reused, 1.0e-10, model + " deterministic repeat");
+    }
+  }
+
+  /** Dry feeds are outside the water-rich restart screen and retain the original hydrocarbon split. */
+  @Test
+  void dryControlRemainsGasOilWithoutAqueousPhase() {
+    for (boolean pengRobinson : new boolean[] { false, true }) {
+      String model = pengRobinson ? "PR" : "SRK";
+      SystemInterface fluid = flash(pengRobinson, 0.0, REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA, true);
+      assertEquals(2, fluid.getNumberOfPhases(), model + " dry topology");
+      assertTrue(fluid.hasPhaseType(PhaseType.GAS), model + " dry gas phase");
+      assertTrue(fluid.hasPhaseType(PhaseType.OIL), model + " dry oil phase");
+      assertFalse(fluid.hasPhaseType(PhaseType.AQUEOUS), model + " dry aqueous phase");
+      assertClosedEquilibrium(fluid, model + " dry control");
+    }
+  }
+
+  private SystemInterface flash(boolean pengRobinson, double waterFraction, double temperature, double pressure,
+      boolean multiphaseCheck) {
+    SystemInterface fluid = buildFluid(pengRobinson, waterFraction, temperature, pressure, multiphaseCheck);
+    runPublicFlash(fluid);
+    return fluid;
+  }
+
+  private SystemInterface buildFluid(boolean pengRobinson, double waterFraction, double temperature, double pressure,
+      boolean multiphaseCheck) {
+    SystemInterface fluid = pengRobinson ? new SystemPrEos(temperature, pressure) : new SystemSrkEos(temperature, pressure);
+    for (int component = 0; component < HYDROCARBON_NAMES.length; component++) {
+      fluid.addComponent(HYDROCARBON_NAMES[component], HYDROCARBON_FRACTIONS[component] * (1.0 - waterFraction));
     }
     if (waterFraction > 0.0) {
       fluid.addComponent("water", waterFraction);
     }
     fluid.setMixingRule("classic");
-    fluid.setMultiPhaseCheck(true);
+    fluid.setMultiPhaseCheck(multiphaseCheck);
     return fluid;
   }
 
-  /**
-   * The water-free feed must be two-phase, otherwise the dilution test below has no vapour to keep.
-   */
-  @Test
-  void waterFreeFeedIsTwoPhase() {
-    SystemInterface fluid = buildFluid(0.0);
+  private void runPublicFlash(SystemInterface fluid) {
     new ThermodynamicOperations(fluid).TPflash();
-    assertTrue(fluid.hasPhaseType(PhaseType.GAS), "water-free feed must contain a gas phase");
-    assertTrue(fluid.hasPhaseType(PhaseType.OIL), "water-free feed must contain an oil phase");
+    fluid.init(3);
   }
 
-  /**
-   * Adding water must not remove the hydrocarbon vapour phase, at any water cut.
-   */
-  @Test
-  void waterDilutionKeepsTheHydrocarbonVapourPhase() {
-    double[] waterFractions = { 0.50, 0.70, 0.76, 0.78, 0.80, 0.83, 0.90, 0.95 };
-    for (int i = 0; i < waterFractions.length; i++) {
-      double waterFraction = waterFractions[i];
-      SystemInterface fluid = buildFluid(waterFraction);
-      new ThermodynamicOperations(fluid).TPflash();
-
-      assertTrue(fluid.hasPhaseType(PhaseType.GAS), "gas phase lost at water mole fraction " + waterFraction);
-      assertTrue(fluid.hasPhaseType(PhaseType.AQUEOUS),
-          "aqueous phase missing at water mole fraction " + waterFraction);
-
-      double phaseFractionSum = 0.0;
-      for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
-        phaseFractionSum += fluid.getBeta(phase);
-      }
-      assertEquals(1.0, phaseFractionSum, 1.0e-6,
-          "phase fractions must sum to one at water mole fraction " + waterFraction);
-    }
+  private void assertClosedThreePhaseEquilibrium(SystemInterface fluid, String label) {
+    assertEquals(3, fluid.getNumberOfPhases(), label + " topology");
+    assertTrue(fluid.hasPhaseType(PhaseType.GAS), label + " gas phase");
+    assertTrue(fluid.hasPhaseType(PhaseType.OIL), label + " oil phase");
+    assertTrue(fluid.hasPhaseType(PhaseType.AQUEOUS), label + " aqueous phase");
+    assertClosedEquilibrium(fluid, label);
   }
 
-  /**
-   * The hydrocarbon phase fractions must track the hydrocarbon inventory rather than collapse.
-   */
-  @Test
-  void hydrocarbonPhaseFractionsFollowTheHydrocarbonInventory() {
-    double waterFraction = 0.83;
-    SystemInterface fluid = buildFluid(waterFraction);
-    new ThermodynamicOperations(fluid).TPflash();
-
-    double hydrocarbonBeta = 0.0;
+  private void assertClosedEquilibrium(SystemInterface fluid, String label) {
+    int componentCount = fluid.getPhase(0).getNumberOfComponents();
+    double betaTotal = 0.0;
     for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
-      if (fluid.getPhase(phase).getType() != PhaseType.AQUEOUS) {
-        hydrocarbonBeta += fluid.getBeta(phase);
+      double beta = fluid.getBeta(phase);
+      assertTrue(Double.isFinite(beta) && beta > 0.0 && beta < 1.0, label + " beta " + phase);
+      betaTotal += beta;
+
+      double compositionTotal = 0.0;
+      for (int component = 0; component < componentCount; component++) {
+        double composition = fluid.getPhase(phase).getComponent(component).getx();
+        assertTrue(Double.isFinite(composition) && composition >= 0.0 && composition <= 1.0,
+            label + " composition " + phase + "/" + component);
+        compositionTotal += composition;
+      }
+      assertEquals(1.0, compositionTotal, NORMALIZATION_TOLERANCE, label + " composition normalization " + phase);
+      assertTrue(Double.isFinite(fluid.getPhase(phase).getZ()) && fluid.getPhase(phase).getZ() > 0.0,
+          label + " compressibility " + phase);
+    }
+    assertEquals(1.0, betaTotal, NORMALIZATION_TOLERANCE, label + " beta normalization");
+
+    double materialResidual = maximumComponentMaterialBalanceResidual(fluid);
+    assertTrue(materialResidual < MATERIAL_BALANCE_TOLERANCE,
+        label + " material-balance residual " + materialResidual);
+
+    double fugacityResidual = maximumComparableLogFugacityResidual(fluid);
+    assertTrue(fugacityResidual < FUGACITY_TOLERANCE, label + " fugacity residual " + fugacityResidual);
+    assertTrue(Double.isFinite(fluid.getGibbsEnergy()), label + " Gibbs energy");
+    assertTrue(Double.isFinite(fluid.getEnthalpy()), label + " enthalpy");
+  }
+
+  private void assertEquivalentEquilibrium(SystemInterface expected, SystemInterface actual, double tolerance,
+      String label) {
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases(), label + " phase count");
+    assertClosedEquilibrium(expected, label + " expected");
+    assertClosedEquilibrium(actual, label + " actual");
+    for (int expectedPhase = 0; expectedPhase < expected.getNumberOfPhases(); expectedPhase++) {
+      PhaseType phaseType = expected.getPhase(expectedPhase).getType();
+      int actualPhase = findPhase(actual, phaseType);
+      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), tolerance, label + " beta " + phaseType);
+      assertEquals(expected.getPhase(expectedPhase).getZ(), actual.getPhase(actualPhase).getZ(), tolerance,
+          label + " compressibility " + phaseType);
+      for (int component = 0; component < expected.getPhase(expectedPhase).getNumberOfComponents(); component++) {
+        assertEquals(expected.getPhase(expectedPhase).getComponent(component).getx(),
+            actual.getPhase(actualPhase).getComponent(component).getx(), tolerance,
+            label + " composition " + phaseType + "/" + component);
       }
     }
-    assertEquals(1.0 - waterFraction, hydrocarbonBeta, 0.02, "hydrocarbon phases must carry the hydrocarbon inventory");
+    assertExtensiveEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), tolerance, label + " Gibbs energy");
+    assertExtensiveEquals(expected.getEnthalpy(), actual.getEnthalpy(), tolerance, label + " enthalpy");
+  }
+
+  private void assertExtensiveEquals(double expected, double actual, double relativeTolerance, String label) {
+    assertEquals(expected, actual, Math.max(1.0e-8, relativeTolerance * Math.abs(expected)), label);
+  }
+
+  private int findPhase(SystemInterface fluid, PhaseType phaseType) {
+    for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
+      if (fluid.getPhase(phase).getType() == phaseType) {
+        return phase;
+      }
+    }
+    throw new AssertionError("missing phase " + phaseType);
+  }
+
+  private double maximumComponentMaterialBalanceResidual(SystemInterface fluid) {
+    double maximumResidual = 0.0;
+    for (int component = 0; component < fluid.getPhase(0).getNumberOfComponents(); component++) {
+      double recovered = 0.0;
+      for (int phase = 0; phase < fluid.getNumberOfPhases(); phase++) {
+        recovered += fluid.getBeta(phase) * fluid.getPhase(phase).getComponent(component).getx();
+      }
+      maximumResidual = Math.max(maximumResidual,
+          Math.abs(fluid.getPhase(0).getComponent(component).getz() - recovered));
+    }
+    return maximumResidual;
+  }
+
+  private double maximumComparableLogFugacityResidual(SystemInterface fluid) {
+    double maximumResidual = 0.0;
+    int comparisons = 0;
+    for (int component = 0; component < fluid.getPhase(0).getNumberOfComponents(); component++) {
+      for (int firstPhase = 0; firstPhase < fluid.getNumberOfPhases(); firstPhase++) {
+        for (int secondPhase = firstPhase + 1; secondPhase < fluid.getNumberOfPhases(); secondPhase++) {
+          double firstComposition = fluid.getPhase(firstPhase).getComponent(component).getx();
+          double secondComposition = fluid.getPhase(secondPhase).getComponent(component).getx();
+          double firstCoefficient = fluid.getPhase(firstPhase).getComponent(component).getFugacityCoefficient();
+          double secondCoefficient = fluid.getPhase(secondPhase).getComponent(component).getFugacityCoefficient();
+          if (firstComposition > 1.0e-20 && secondComposition > 1.0e-20 && Double.isFinite(firstCoefficient)
+              && firstCoefficient > 0.0 && Double.isFinite(secondCoefficient) && secondCoefficient > 0.0) {
+            maximumResidual = Math.max(maximumResidual, Math
+                .abs(Math.log(firstComposition * firstCoefficient) - Math.log(secondComposition * secondCoefficient)));
+            comparisons++;
+          }
+        }
+      }
+    }
+    assertTrue(comparisons > 0, "expected at least one comparable cross-phase fugacity");
+    return maximumResidual;
   }
 }


### PR DESCRIPTION
## Summary

Qualifies the neutral cubic-EOS water-rich vapour-appearance restart introduced on master by merged PR #3419.

- Expands `TPmultiflashWaterRichVapourTest` from phase-presence checks to 34 complete SRK/PR flashes.
- Enforces GAS+OIL+AQUEOUS topology, beta/phase normalization, component material balance, comparable interphase fugacity equality, bounded compositions, positive compressibility, and finite Gibbs energy/enthalpy.
- Covers the historical water-cut range, nearby pressures, poor beta initialization, ordinary-to-explicit-multiphase recovery, changed/returned state, deterministic repeat, and a dry screen-exclusion control.
- Corrects the algorithm guide: the implementation now snapshots and runs a guarded fresh-estimate restart; it no longer directly appends a vapour seed.
- Records composition, units, synthetic provenance, validity range, performance scope, and stop boundaries.

## Capability contract

The owning [#2937 roadmap](https://github.com/equinor/neqsim/issues/2937#issuecomment-5442411208) records the capability question, target maturity, authoritative Java models, views, numerical gates, dependencies, compatibility risk, documentation impact, and explicit ownership boundary before this draft.

## Validation

**MERGED — EXACT FEATURE HEAD VALIDATED** at `92fc219928f5b65f4b7a6cb8f2668993907a27f1` (merge commit `5c94722604611d42f9ed4e7847f3c04a1166563e`).

Exact-head GitHub validation completed successfully:

- Java 21 fast suites on Ubuntu and Windows;
- Java 8 fast suites on Ubuntu and Windows;
- all four slow-test shards;
- Javadocs, Spotless, pre-commit, documentation search, CodeQL, and agent-skill checks.

Focused local evidence on the exact branch content also passed: `TPmultiflashWaterRichVapourTest` 5/5, Spotless apply/check, pre-commit/pre-push, documentation search, and `git diff --check`. The PR had no reviews, requested changes, inline comments, conversation comments, or unresolved threads.

## Documentation impact

The PR already updates the TP-flash algorithm guide for the qualified behavior. The CI repair itself is formatting-only and changes no public API, runtime behavior, units, assumptions, validity range, defaults, or recommended usage; no additional documentation change is required.

## Scope

Test and documentation only. No production solver, public API, model parameter/default, dynamics, process equipment, electrolyte/chemical, solid/wax, saturation-search, Column Solver, Process Performance, proprietary data, or Huldra changes.

Closes no issue; advances #2937.