### PR TITLE
[AI-Assisted] feat(refinery): add constrained Sarir assay input

### DIFF
--- a/docs/thermo/characterization/refinery_assay.md
+++ b/docs/thermo/characterization/refinery_assay.md
@@ -206,6 +206,19 @@ The [complete modeled-slate contract and provenance](refinery_big_hill_complete_
 assumptions, exact mass closure, and the boundary between reproducibility and property/process
 validation.
 
+## Constrained Sarir pseudo-component input
+
+`SarirAtmosphericAssay.create(...)` converts the public Sarir cumulative TBP evidence into 18
+volume-basis cuts while preserving the `70 degC-` and `550 degC+` terminal intervals as one-sided.
+The source does not publish cut density or molar-mass profiles, so both are required caller inputs.
+The factory accepts a profile only when it reconciles the reported 841.5 kg/m3 whole-crude density
+within 1.0 kg/m3 and the reported 0.2447 kg/mol average molar mass within 0.001 kg/mol.
+
+This capability makes the missing-property boundary executable instead of silently filling it.
+It does not resolve Sarir light-end composition, distribute whole-crude sulfur, or qualify
+fractionation yields. The [Sarir reference and input contract](refinery_sarir_atmospheric_reference)
+provide provenance, Java/JPype usage, and the process-validation stop boundary.
+
 ## Open-ended terminal boiling boundaries
 
 Terminal assay cuts often publish only one boiling limit. Use

--- a/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
@@ -61,6 +61,38 @@ double errorPercent = diesel.getAbsoluteRelativeErrorPercent();
 
 Static methods are directly accessible through JPype. Arrays are defensive copies, and unknown product labels or invalid error inputs fail closed.
 
+## Constrained pseudo-component input
+
+`SarirAtmosphericAssay` converts the published cumulative TBP coordinates into 18 liquid-volume
+cuts: a 7.44 vol% `70 degC-` cut, 16 bounded intervals, and the 16.30 vol% `550 degC+`
+residue. The first and last cuts remain one-sided; the factory does not invent a numeric
+initial boiling point, residue endpoint, light-end composition, or per-cut property.
+
+The article reports only whole-crude density and average molar mass. Callers must therefore
+supply 18 cut specific gravities and 18 cut molar masses. Before changing the attached assay,
+the factory requires the volume-weighted density profile to reproduce 841.5 kg/m3 within
+1.0 kg/m3 and the mass-weighted number-average molar mass to reproduce 0.2447 kg/mol within
+0.001 kg/mol. These tolerances are deterministic model-consistency gates, not estimates of
+experimental uncertainty.
+
+```java
+double[] cutSpecificGravity = engineeringDensityProfile;
+double[] cutMolarMassKgPerMol = engineeringMolarMassProfile;
+
+OilAssayCharacterisation assay = SarirAtmosphericAssay.create(
+    system, 1000.0, cutSpecificGravity, cutMolarMassKgPerMol);
+assay.apply();
+```
+
+`calculateBulkSpecificGravity(...)`, `calculateBulkMolarMassKgPerMol(...)`, and
+`getCutVolumePercent()` are available to Java and Python/JPype callers for preflight and
+traceability. Profile validation completes before existing assay data or thermodynamic
+components are modified.
+
 ## Scientific boundary
 
-This increment qualifies source transcription, units, open-ended TBP treatment, and evidence classification. It does not yet construct a Sarir pseudo-component slate or claim that NeqSim reproduces the plant yields. A follow-on process-model comparison must keep the plant rates as untouched acceptance targets, document the missing light-end allocation, and avoid tuning draw rates to the published products.
+The source-derived volumes and boiling boundaries are reproducible, while every supplied cut
+density and molar mass remains an explicit engineering input. The factory does not resolve the
+missing light-end composition, distribute the published whole-crude sulfur among cuts, or claim
+that NeqSim reproduces the plant yields. A follow-on 34-tray comparison must preserve the plant
+rates as untouched acceptance targets and avoid tuning draw rates to the published products.

--- a/src/main/java/neqsim/thermo/characterization/SarirAtmosphericAssay.java
+++ b/src/main/java/neqsim/thermo/characterization/SarirAtmosphericAssay.java
@@ -1,0 +1,188 @@
+package neqsim.thermo.characterization;
+
+import java.util.Objects;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.system.SystemInterface;
+
+/**
+ * Constrained pseudo-component input factory for the public Sarir refinery TBP reference.
+ *
+ * <p>
+ * The source publishes cumulative liquid-volume TBP evidence, whole-crude density, and whole-crude average molar mass,
+ * but does not publish density or molar mass for each boiling interval. This factory therefore derives cut yields and
+ * boundaries only from {@link SarirAtmosphericReference} and requires callers to supply the missing per-cut property
+ * profiles. It does not silently synthesize light-end composition or heavy-end properties.
+ * </p>
+ *
+ * <p>
+ * Supplied profiles must reproduce the reported 841.5 kg/m3 whole-crude density within 1.0 kg/m3 and the reported
+ * 0.2447 kg/mol number-average molar mass within 0.001 kg/mol. These are model-consistency gates, not estimates of
+ * source uncertainty. The first 7.44 liquid vol% cut retains only the published 70 degrees Celsius upper boundary; the
+ * final 16.30 liquid vol% cut retains only the published 550 degrees Celsius lower boundary.
+ * </p>
+ */
+public final class SarirAtmosphericAssay {
+  /** Number of source-derived boiling intervals, including the two one-sided terminal cuts. */
+  public static final int CUT_COUNT = 18;
+
+  /** Maximum absolute mismatch from the reported whole-crude density, in kg/m3. */
+  public static final double BULK_DENSITY_TOLERANCE_KG_PER_CUBIC_METRE = 1.0;
+
+  /** Maximum absolute mismatch from the reported whole-crude average molar mass, in kg/mol. */
+  public static final double BULK_MOLAR_MASS_TOLERANCE_KG_PER_MOL = 0.001;
+
+  private static final double KILOGRAM_PER_CUBIC_METRE_PER_SPECIFIC_GRAVITY = 1000.0;
+  private static final double[] CUT_VOLUME_PERCENT = { 7.44, 3.03, 3.36, 7.33, 7.36, 3.02, 6.49, 3.73, 2.92, 7.29,
+      7.22, 4.31, 9.02, 3.09, 3.05, 2.39, 2.65, 16.30 };
+  private static final String[] CUT_NAMES = { "SARIR_TBP_70_MINUS", "SARIR_TBP_70_90", "SARIR_TBP_90_110",
+      "SARIR_TBP_110_150", "SARIR_TBP_150_195", "SARIR_TBP_195_215", "SARIR_TBP_215_255",
+      "SARIR_TBP_255_275", "SARIR_TBP_275_295", "SARIR_TBP_295_335", "SARIR_TBP_335_370",
+      "SARIR_TBP_370_400", "SARIR_TBP_400_460", "SARIR_TBP_460_480", "SARIR_TBP_480_500",
+      "SARIR_TBP_500_520", "SARIR_TBP_520_550", "SARIR_TBP_550_PLUS" };
+
+  private SarirAtmosphericAssay() {
+  }
+
+  /**
+   * Return the source-derived liquid-volume percentage of every modeled cut.
+   *
+   * @return defensive copy of the 18 cut yields, in liquid volume percent
+   */
+  public static double[] getCutVolumePercent() {
+    return CUT_VOLUME_PERCENT.clone();
+  }
+
+  /**
+   * Calculate bulk density-correlation input from a cut specific-gravity profile.
+   *
+   * <p>
+   * Because the source yields are on a liquid-volume basis, the bulk value is the volume-weighted arithmetic mean of
+   * the cut specific gravities.
+   * </p>
+   *
+   * @param cutSpecificGravity dimensionless specific gravity for each source-derived cut
+   * @return volume-weighted bulk specific gravity
+   */
+  public static double calculateBulkSpecificGravity(double[] cutSpecificGravity) {
+    validatePositiveProfile(cutSpecificGravity, "Cut specific gravity");
+    double bulkSpecificGravity = 0.0;
+    for (int i = 0; i < CUT_COUNT; i++) {
+      bulkSpecificGravity += CUT_VOLUME_PERCENT[i] / 100.0 * cutSpecificGravity[i];
+    }
+    return bulkSpecificGravity;
+  }
+
+  /**
+   * Calculate the modeled whole-crude number-average molar mass.
+   *
+   * <p>
+   * Cut volume yields are first converted to relative masses with the supplied specific gravities. The mixture molar
+   * mass is then {@code total mass / total moles}.
+   * </p>
+   *
+   * @param cutSpecificGravity dimensionless specific gravity for each source-derived cut
+   * @param cutMolarMassKgPerMol molar mass for each source-derived cut, in kg/mol
+   * @return modeled whole-crude number-average molar mass, in kg/mol
+   */
+  public static double calculateBulkMolarMassKgPerMol(double[] cutSpecificGravity, double[] cutMolarMassKgPerMol) {
+    validatePositiveProfile(cutSpecificGravity, "Cut specific gravity");
+    validatePositiveProfile(cutMolarMassKgPerMol, "Cut molar mass");
+
+    double relativeMass = 0.0;
+    double relativeMoles = 0.0;
+    for (int i = 0; i < CUT_COUNT; i++) {
+      double cutRelativeMass = CUT_VOLUME_PERCENT[i] / 100.0 * cutSpecificGravity[i];
+      relativeMass += cutRelativeMass;
+      relativeMoles += cutRelativeMass / cutMolarMassKgPerMol[i];
+    }
+    if (!Double.isFinite(relativeMass) || !Double.isFinite(relativeMoles) || !(relativeMass > 0.0)
+        || !(relativeMoles > 0.0)) {
+      throw new IllegalArgumentException("Cut profiles do not produce finite positive bulk properties");
+    }
+    return relativeMass / relativeMoles;
+  }
+
+  /**
+   * Configure a constrained Sarir assay on a one-kilogram basis.
+   *
+   * @param system empty or caller-owned thermodynamic system
+   * @param cutSpecificGravity dimensionless specific gravity for each source-derived cut
+   * @param cutMolarMassKgPerMol molar mass for each source-derived cut, in kg/mol
+   * @return configured assay; no component has been added to {@code system}
+   */
+  public static OilAssayCharacterisation create(SystemInterface system, double[] cutSpecificGravity,
+      double[] cutMolarMassKgPerMol) {
+    return create(system, 1.0, cutSpecificGravity, cutMolarMassKgPerMol);
+  }
+
+  /**
+   * Configure a constrained Sarir assay.
+   *
+   * <p>
+   * Validation completes before the attached assay is cleared, so invalid profiles do not modify existing assay data
+   * or the thermodynamic component list.
+   * </p>
+   *
+   * @param system empty or caller-owned thermodynamic system
+   * @param totalAssayMassKg positive total modeled assay mass, in kg
+   * @param cutSpecificGravity dimensionless specific gravity for each source-derived cut
+   * @param cutMolarMassKgPerMol molar mass for each source-derived cut, in kg/mol
+   * @return configured assay; no component has been added to {@code system}
+   */
+  public static OilAssayCharacterisation create(SystemInterface system, double totalAssayMassKg,
+      double[] cutSpecificGravity, double[] cutMolarMassKgPerMol) {
+    Objects.requireNonNull(system, "system");
+    if (!Double.isFinite(totalAssayMassKg) || !(totalAssayMassKg > 0.0)) {
+      throw new IllegalArgumentException("Total assay mass must be finite and positive");
+    }
+
+    double bulkSpecificGravity = calculateBulkSpecificGravity(cutSpecificGravity);
+    double bulkDensityKgPerCubicMetre =
+        bulkSpecificGravity * KILOGRAM_PER_CUBIC_METRE_PER_SPECIFIC_GRAVITY;
+    double sourceDensityKgPerCubicMetre = SarirAtmosphericReference.getCrudeDensityAt15CKgPerCubicMetre();
+    if (Math.abs(bulkDensityKgPerCubicMetre - sourceDensityKgPerCubicMetre)
+        > BULK_DENSITY_TOLERANCE_KG_PER_CUBIC_METRE) {
+      throw new IllegalArgumentException("Cut density profile does not reproduce the reported Sarir bulk density");
+    }
+
+    double bulkMolarMassKgPerMol =
+        calculateBulkMolarMassKgPerMol(cutSpecificGravity, cutMolarMassKgPerMol);
+    double sourceMolarMassKgPerMol = SarirAtmosphericReference.getCrudeAverageMolarMassKgPerMol();
+    if (Math.abs(bulkMolarMassKgPerMol - sourceMolarMassKgPerMol)
+        > BULK_MOLAR_MASS_TOLERANCE_KG_PER_MOL) {
+      throw new IllegalArgumentException(
+          "Cut molar-mass profile does not reproduce the reported Sarir average molar mass");
+    }
+
+    OilAssayCharacterisation assay = system.getOilAssayCharacterisation();
+    assay.clearCuts();
+    assay.setTotalAssayMass(totalAssayMassKg);
+
+    double[] tbpTemperatureCelsius = SarirAtmosphericReference.getTbpTemperatureCelsius();
+    for (int i = 0; i < CUT_COUNT; i++) {
+      AssayCut cut = new AssayCut(CUT_NAMES[i]).withVolumePercent(CUT_VOLUME_PERCENT[i])
+          .withSpecificGravity(cutSpecificGravity[i]).withMolarMassKgPerMol(cutMolarMassKgPerMol[i]);
+      if (i == 0) {
+        cut.withUpperBoilingPointCelsius(tbpTemperatureCelsius[0]);
+      } else if (i == CUT_COUNT - 1) {
+        cut.withLowerBoilingPointCelsius(
+            SarirAtmosphericReference.getTerminalResidueLowerBoundaryCelsius());
+      } else {
+        cut.withBoilingRangeCelsius(tbpTemperatureCelsius[i - 1], tbpTemperatureCelsius[i]);
+      }
+      assay.addCut(cut);
+    }
+    return assay;
+  }
+
+  private static void validatePositiveProfile(double[] profile, String label) {
+    if (profile == null || profile.length != CUT_COUNT) {
+      throw new IllegalArgumentException(label + " profile must contain exactly " + CUT_COUNT + " values");
+    }
+    for (double value : profile) {
+      if (!Double.isFinite(value) || !(value > 0.0)) {
+        throw new IllegalArgumentException(label + " values must be finite and positive");
+      }
+    }
+  }
+}

--- a/src/main/java/neqsim/thermo/characterization/SarirAtmosphericAssay.java
+++ b/src/main/java/neqsim/thermo/characterization/SarirAtmosphericAssay.java
@@ -32,13 +32,12 @@ public final class SarirAtmosphericAssay {
   public static final double BULK_MOLAR_MASS_TOLERANCE_KG_PER_MOL = 0.001;
 
   private static final double KILOGRAM_PER_CUBIC_METRE_PER_SPECIFIC_GRAVITY = 1000.0;
-  private static final double[] CUT_VOLUME_PERCENT = { 7.44, 3.03, 3.36, 7.33, 7.36, 3.02, 6.49, 3.73, 2.92, 7.29,
-      7.22, 4.31, 9.02, 3.09, 3.05, 2.39, 2.65, 16.30 };
+  private static final double[] CUT_VOLUME_PERCENT = { 7.44, 3.03, 3.36, 7.33, 7.36, 3.02, 6.49, 3.73, 2.92, 7.29, 7.22,
+      4.31, 9.02, 3.09, 3.05, 2.39, 2.65, 16.30 };
   private static final String[] CUT_NAMES = { "SARIR_TBP_70_MINUS", "SARIR_TBP_70_90", "SARIR_TBP_90_110",
-      "SARIR_TBP_110_150", "SARIR_TBP_150_195", "SARIR_TBP_195_215", "SARIR_TBP_215_255",
-      "SARIR_TBP_255_275", "SARIR_TBP_275_295", "SARIR_TBP_295_335", "SARIR_TBP_335_370",
-      "SARIR_TBP_370_400", "SARIR_TBP_400_460", "SARIR_TBP_460_480", "SARIR_TBP_480_500",
-      "SARIR_TBP_500_520", "SARIR_TBP_520_550", "SARIR_TBP_550_PLUS" };
+      "SARIR_TBP_110_150", "SARIR_TBP_150_195", "SARIR_TBP_195_215", "SARIR_TBP_215_255", "SARIR_TBP_255_275",
+      "SARIR_TBP_275_295", "SARIR_TBP_295_335", "SARIR_TBP_335_370", "SARIR_TBP_370_400", "SARIR_TBP_400_460",
+      "SARIR_TBP_460_480", "SARIR_TBP_480_500", "SARIR_TBP_500_520", "SARIR_TBP_520_550", "SARIR_TBP_550_PLUS" };
 
   private SarirAtmosphericAssay() {
   }
@@ -119,8 +118,8 @@ public final class SarirAtmosphericAssay {
    * Configure a constrained Sarir assay.
    *
    * <p>
-   * Validation completes before the attached assay is cleared, so invalid profiles do not modify existing assay data
-   * or the thermodynamic component list.
+   * Validation completes before the attached assay is cleared, so invalid profiles do not modify existing assay data or
+   * the thermodynamic component list.
    * </p>
    *
    * @param system empty or caller-owned thermodynamic system
@@ -137,19 +136,16 @@ public final class SarirAtmosphericAssay {
     }
 
     double bulkSpecificGravity = calculateBulkSpecificGravity(cutSpecificGravity);
-    double bulkDensityKgPerCubicMetre =
-        bulkSpecificGravity * KILOGRAM_PER_CUBIC_METRE_PER_SPECIFIC_GRAVITY;
+    double bulkDensityKgPerCubicMetre = bulkSpecificGravity * KILOGRAM_PER_CUBIC_METRE_PER_SPECIFIC_GRAVITY;
     double sourceDensityKgPerCubicMetre = SarirAtmosphericReference.getCrudeDensityAt15CKgPerCubicMetre();
-    if (Math.abs(bulkDensityKgPerCubicMetre - sourceDensityKgPerCubicMetre)
-        > BULK_DENSITY_TOLERANCE_KG_PER_CUBIC_METRE) {
+    if (Math
+        .abs(bulkDensityKgPerCubicMetre - sourceDensityKgPerCubicMetre) > BULK_DENSITY_TOLERANCE_KG_PER_CUBIC_METRE) {
       throw new IllegalArgumentException("Cut density profile does not reproduce the reported Sarir bulk density");
     }
 
-    double bulkMolarMassKgPerMol =
-        calculateBulkMolarMassKgPerMol(cutSpecificGravity, cutMolarMassKgPerMol);
+    double bulkMolarMassKgPerMol = calculateBulkMolarMassKgPerMol(cutSpecificGravity, cutMolarMassKgPerMol);
     double sourceMolarMassKgPerMol = SarirAtmosphericReference.getCrudeAverageMolarMassKgPerMol();
-    if (Math.abs(bulkMolarMassKgPerMol - sourceMolarMassKgPerMol)
-        > BULK_MOLAR_MASS_TOLERANCE_KG_PER_MOL) {
+    if (Math.abs(bulkMolarMassKgPerMol - sourceMolarMassKgPerMol) > BULK_MOLAR_MASS_TOLERANCE_KG_PER_MOL) {
       throw new IllegalArgumentException(
           "Cut molar-mass profile does not reproduce the reported Sarir average molar mass");
     }
@@ -165,8 +161,7 @@ public final class SarirAtmosphericAssay {
       if (i == 0) {
         cut.withUpperBoilingPointCelsius(tbpTemperatureCelsius[0]);
       } else if (i == CUT_COUNT - 1) {
-        cut.withLowerBoilingPointCelsius(
-            SarirAtmosphericReference.getTerminalResidueLowerBoundaryCelsius());
+        cut.withLowerBoilingPointCelsius(SarirAtmosphericReference.getTerminalResidueLowerBoundaryCelsius());
       } else {
         cut.withBoilingRangeCelsius(tbpTemperatureCelsius[i - 1], tbpTemperatureCelsius[i]);
       }

--- a/src/test/java/neqsim/thermo/characterization/SarirAtmosphericAssayTest.java
+++ b/src/test/java/neqsim/thermo/characterization/SarirAtmosphericAssayTest.java
@@ -19,14 +19,14 @@ public class SarirAtmosphericAssayTest {
       0.761826000, 0.781826000, 0.801826000, 0.821826000, 0.841826000, 0.861826000, 0.881826000, 0.901826000,
       0.921826000, 0.941826000, 0.961826000, 0.981826000, 1.021826000 };
   private static final double[] MOLAR_MASS_KG_PER_MOL = { 0.092957679997, 0.105352037330, 0.117746394663,
-      0.136337930662, 0.161126645328, 0.179718181327, 0.204506895993, 0.223098431993, 0.241689967992,
-      0.272675861324, 0.303661754657, 0.334647647989, 0.384225077321, 0.421408149319, 0.458591221318,
-      0.495774293317, 0.545351722649, 0.743661439976 };
+      0.136337930662, 0.161126645328, 0.179718181327, 0.204506895993, 0.223098431993, 0.241689967992, 0.272675861324,
+      0.303661754657, 0.334647647989, 0.384225077321, 0.421408149319, 0.458591221318, 0.495774293317, 0.545351722649,
+      0.743661439976 };
 
   @Test
   public void sourceDerivedCutYieldsCloseAndCannotBeMutated() {
-    double[] expected = { 7.44, 3.03, 3.36, 7.33, 7.36, 3.02, 6.49, 3.73, 2.92, 7.29, 7.22, 4.31, 9.02, 3.09,
-        3.05, 2.39, 2.65, 16.30 };
+    double[] expected = { 7.44, 3.03, 3.36, 7.33, 7.36, 3.02, 6.49, 3.73, 2.92, 7.29, 7.22, 4.31, 9.02, 3.09, 3.05,
+        2.39, 2.65, 16.30 };
     assertArrayEquals(expected, SarirAtmosphericAssay.getCutVolumePercent(), 0.0);
     assertEquals(100.0, sum(expected), 1.0e-12);
 
@@ -38,15 +38,14 @@ public class SarirAtmosphericAssayTest {
   @Test
   public void suppliedProfilesReconcilePublishedWholeCrudeProperties() {
     assertEquals(0.8415, SarirAtmosphericAssay.calculateBulkSpecificGravity(SPECIFIC_GRAVITY), 1.0e-12);
-    assertEquals(0.2447,
-        SarirAtmosphericAssay.calculateBulkMolarMassKgPerMol(SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL), 1.0e-12);
+    assertEquals(0.2447, SarirAtmosphericAssay.calculateBulkMolarMassKgPerMol(SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL),
+        1.0e-12);
   }
 
   @Test
   public void completeVolumeSlatePreservesTerminalEvidenceAndAppliedMass() {
     SystemInterface system = new SystemSrkEos(298.15, 1.01325);
-    OilAssayCharacterisation assay =
-        SarirAtmosphericAssay.create(system, 2.5, SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL);
+    OilAssayCharacterisation assay = SarirAtmosphericAssay.create(system, 2.5, SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL);
 
     assertEquals(0, system.getNumberOfComponents());
     assertEquals(SarirAtmosphericAssay.CUT_COUNT, assay.getCuts().size());

--- a/src/test/java/neqsim/thermo/characterization/SarirAtmosphericAssayTest.java
+++ b/src/test/java/neqsim/thermo/characterization/SarirAtmosphericAssayTest.java
@@ -1,0 +1,155 @@
+package neqsim.thermo.characterization;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.OilAssayCharacterisation.AssayCut;
+import neqsim.thermo.component.ComponentInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests the constrained Sarir pseudo-component assay input factory. */
+public class SarirAtmosphericAssayTest {
+  private static final double[] SPECIFIC_GRAVITY = { 0.641826000, 0.671826000, 0.691826000, 0.711826000, 0.741826000,
+      0.761826000, 0.781826000, 0.801826000, 0.821826000, 0.841826000, 0.861826000, 0.881826000, 0.901826000,
+      0.921826000, 0.941826000, 0.961826000, 0.981826000, 1.021826000 };
+  private static final double[] MOLAR_MASS_KG_PER_MOL = { 0.092957679997, 0.105352037330, 0.117746394663,
+      0.136337930662, 0.161126645328, 0.179718181327, 0.204506895993, 0.223098431993, 0.241689967992,
+      0.272675861324, 0.303661754657, 0.334647647989, 0.384225077321, 0.421408149319, 0.458591221318,
+      0.495774293317, 0.545351722649, 0.743661439976 };
+
+  @Test
+  public void sourceDerivedCutYieldsCloseAndCannotBeMutated() {
+    double[] expected = { 7.44, 3.03, 3.36, 7.33, 7.36, 3.02, 6.49, 3.73, 2.92, 7.29, 7.22, 4.31, 9.02, 3.09,
+        3.05, 2.39, 2.65, 16.30 };
+    assertArrayEquals(expected, SarirAtmosphericAssay.getCutVolumePercent(), 0.0);
+    assertEquals(100.0, sum(expected), 1.0e-12);
+
+    double[] returned = SarirAtmosphericAssay.getCutVolumePercent();
+    returned[0] = 0.0;
+    assertEquals(7.44, SarirAtmosphericAssay.getCutVolumePercent()[0], 0.0);
+  }
+
+  @Test
+  public void suppliedProfilesReconcilePublishedWholeCrudeProperties() {
+    assertEquals(0.8415, SarirAtmosphericAssay.calculateBulkSpecificGravity(SPECIFIC_GRAVITY), 1.0e-12);
+    assertEquals(0.2447,
+        SarirAtmosphericAssay.calculateBulkMolarMassKgPerMol(SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL), 1.0e-12);
+  }
+
+  @Test
+  public void completeVolumeSlatePreservesTerminalEvidenceAndAppliedMass() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation assay =
+        SarirAtmosphericAssay.create(system, 2.5, SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL);
+
+    assertEquals(0, system.getNumberOfComponents());
+    assertEquals(SarirAtmosphericAssay.CUT_COUNT, assay.getCuts().size());
+    assertEquals(1.0, sumVolumeFractions(assay), 1.0e-12);
+    assertEquals(2.5, assay.getTotalAssayMass(), 0.0);
+    assertEquals(0.8415, assay.getBulkSpecificGravity(), 1.0e-12);
+
+    AssayCut first = assay.getCuts().get(0);
+    assertEquals("SARIR_TBP_70_MINUS", first.getName());
+    assertFalse(first.hasLowerBoilingPoint());
+    assertTrue(first.hasUpperBoilingPoint());
+    assertEquals(343.15, first.getUpperBoilingPointKelvin(), 1.0e-12);
+    assertTrue(first.hasMolarMass());
+    assertFalse(first.isStandardComponent());
+
+    AssayCut bounded = assay.getCuts().get(1);
+    assertTrue(bounded.hasBoilingRange());
+    assertEquals(343.15, bounded.getLowerBoilingPointKelvin(), 1.0e-12);
+    assertEquals(363.15, bounded.getUpperBoilingPointKelvin(), 1.0e-12);
+
+    AssayCut residue = assay.getCuts().get(SarirAtmosphericAssay.CUT_COUNT - 1);
+    assertEquals("SARIR_TBP_550_PLUS", residue.getName());
+    assertTrue(residue.hasLowerBoilingPoint());
+    assertFalse(residue.hasUpperBoilingPoint());
+    assertEquals(823.15, residue.getLowerBoilingPointKelvin(), 1.0e-12);
+    assertTrue(residue.hasMolarMass());
+
+    assay.apply();
+    assertEquals(SarirAtmosphericAssay.CUT_COUNT, system.getNumberOfComponents());
+    assertEquals(2.5, reconstructedMassKg(system), 1.0e-10);
+    for (int i = 0; i < system.getNumberOfComponents(); i++) {
+      assertPositiveFiniteComponent(system.getComponent(i));
+    }
+  }
+
+  @Test
+  public void invalidProfilesFailBeforeChangingExistingAssayOrSystem() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.01325);
+    OilAssayCharacterisation existing = system.getOilAssayCharacterisation();
+    existing.clearCuts();
+    existing.addCut(
+        new AssayCut("Existing").withMassFraction(1.0).withSpecificGravity(0.8).withAverageBoilingPointKelvin(400.0));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> SarirAtmosphericAssay.create(system, new double[0], MOLAR_MASS_KG_PER_MOL));
+    assertThrows(IllegalArgumentException.class,
+        () -> SarirAtmosphericAssay.create(system, SPECIFIC_GRAVITY, new double[0]));
+
+    double[] invalidDensity = SPECIFIC_GRAVITY.clone();
+    invalidDensity[0] = Double.NaN;
+    assertThrows(IllegalArgumentException.class,
+        () -> SarirAtmosphericAssay.create(system, invalidDensity, MOLAR_MASS_KG_PER_MOL));
+
+    double[] inconsistentDensity = SPECIFIC_GRAVITY.clone();
+    inconsistentDensity[0] += 0.1;
+    assertThrows(IllegalArgumentException.class,
+        () -> SarirAtmosphericAssay.create(system, inconsistentDensity, MOLAR_MASS_KG_PER_MOL));
+
+    double[] inconsistentMolarMass = MOLAR_MASS_KG_PER_MOL.clone();
+    inconsistentMolarMass[17] *= 0.5;
+    assertThrows(IllegalArgumentException.class,
+        () -> SarirAtmosphericAssay.create(system, SPECIFIC_GRAVITY, inconsistentMolarMass));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> SarirAtmosphericAssay.create(system, 0.0, SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL));
+    assertThrows(NullPointerException.class,
+        () -> SarirAtmosphericAssay.create(null, SPECIFIC_GRAVITY, MOLAR_MASS_KG_PER_MOL));
+
+    assertEquals(1, existing.getCuts().size());
+    assertEquals("Existing", existing.getCuts().get(0).getName());
+    assertEquals(0, system.getNumberOfComponents());
+  }
+
+  private static double sumVolumeFractions(OilAssayCharacterisation assay) {
+    double total = 0.0;
+    for (AssayCut cut : assay.getCuts()) {
+      total += cut.getVolumeFraction();
+    }
+    return total;
+  }
+
+  private static void assertPositiveFiniteComponent(ComponentInterface component) {
+    assertNotNull(component);
+    assertTrue(Double.isFinite(component.getNumberOfmoles()));
+    assertTrue(component.getNumberOfmoles() > 0.0);
+    assertTrue(Double.isFinite(component.getMolarMass()));
+    assertTrue(component.getMolarMass() > 0.0);
+  }
+
+  private static double reconstructedMassKg(SystemInterface system) {
+    double mass = 0.0;
+    for (int i = 0; i < system.getNumberOfComponents(); i++) {
+      ComponentInterface component = system.getComponent(i);
+      mass += component.getNumberOfmoles() * component.getMolarMass();
+    }
+    return mass;
+  }
+
+  private static double sum(double[] values) {
+    double total = 0.0;
+    for (double value : values) {
+      total += value;
+    }
+    return total;
+  }
+}


### PR DESCRIPTION
## Summary

Advances #3305 with a constrained Java/JPype pseudo-component input factory for the public Sarir refinery TBP reference.

Exact base: `18e26159b182a654f89e835ded7f51ba8b059854`  
Exact head: `5f4a8d753520e8808f7821cde27d44bc822351b0`

## Capability contract

- Derive all 18 liquid-volume cut yields from the published 17 cumulative TBP coordinates plus the explicit 550 °C+ terminal residue.
- Preserve the first 7.44 vol% cut as 70 °C minus and the final 16.30 vol% cut as 550 °C plus; do not invent terminal endpoints.
- Require callers to supply all 18 cut specific gravities and molar masses because the source does not publish those profiles.
- Reconcile supplied profiles against the reported 841.5 kg/m3 whole-crude density within 1.0 kg/m3 and 0.2447 kg/mol average molar mass within 0.001 kg/mol before modifying existing assay data.
- Configure volume-basis `AssayCut` pseudo-components without automatically mutating the thermodynamic system.
- Fail closed for null, incomplete, non-finite, non-positive, or bulk-inconsistent profiles.

## Public provenance and licensing

Source: H. E. O. Almansouri, *Simulation of Sarir Crude Oil Refinery Using Aspen HYSYS*, Journal of Engineering Research (Libya), issue 33, pages 51–64, published 31 March 2022, [DOI 10.66411/jer.v33i.46](https://doi.org/10.66411/jer.v33i.46), [open article](https://jer.ly/jer/index.php/jer/article/download/46/38/39). The journal licenses the article under CC BY 4.0.

Only the source TBP coordinates, bulk properties, and terminal-boundary semantics are encoded. The numerical cut-property arrays in the regression are explicit synthetic controls constructed to reproduce the published bulk density and molar mass; they are not presented as measured Sarir cut data.

## Validation

- PASS: independent arithmetic check of the 18 source-derived volume increments; closure is 100.00 vol%.
- PASS: synthetic control density profile reproduces 0.8415 bulk correlation input exactly.
- PASS: synthetic control profile reproduces 0.2447 kg/mol number-average molar mass to numerical precision.
- PASS: connector-side exact-base/head comparison; four files, four commits, zero commits behind.
- PASS: Java 8 source audit; no post-Java-8 language/library constructs detected.
- PASS: brace and documentation-presence checks.
- Local Maven, Spotless, pre-commit, and documentation commands were unavailable because no repository checkout is present; no local result is claimed.
- Hosted exact-head CI is authoritative.

Status: **VALIDATION PENDING CI**.

## Documentation impact

Updates the Sarir reference page with the Java/JPype factory contract, tolerances, usage, and scientific boundary, and registers the capability in the refinery assay guide.

## Scientific boundary

This PR does not infer a resolved light-end composition, distribute the reported whole-crude sulfur among cuts, claim that the synthetic regression profile is Sarir measurement data, simulate the 34-tray unit, tune product draws, or claim NeqSim yield agreement. The next process gate must keep the published plant rates untouched as independent validation targets.