### PR TITLE
[AI-Assisted] docs: compile standalone Java examples

### DIFF
--- a/docs/convert_notebooks.py
+++ b/docs/convert_notebooks.py
@@ -656,13 +656,14 @@ reading aid, not execution evidence.
         content += """
 ## Standalone Java source examples
 
-These files are outside Maven's compiled source tree. They are retained as source-only
-references and are not catalogued as build-verified or policy-compliant examples.
-They currently contain legacy console output; review and port the required calls into a
-tested `src/test/java` example before reuse. For a supported starting point, use the
+These files are outside Maven's main source tree. The
+`StandaloneJavaDocumentationCompilationTest` compiles the exact catalog against the
+current NeqSim API. This is build verification only, not runtime or engineering-result
+validation. The files retain legacy console output; inspect assumptions and execute the
+required workflow before engineering reuse. For a supported starting point, use the
 [Java getting-started guide](../java-getting-started.md).
 
-| Example | Stored status | Capability |
+| Example | Build status | Capability |
 |---------|---------------|------------|
 """
         for java_file in java_files:
@@ -671,7 +672,7 @@ tested `src/test/java` example before reuse. For a supported starting point, use
             encoded_name = quote(java_file.name, safe='')
             description = JAVA_EXAMPLE_DESCRIPTIONS.get(name, 'Java example')
             content += (
-                f"| [{title}]({encoded_name}) | **Source only** | "
+                f"| [{title}]({encoded_name}) | **Build-verified source** | "
                 f"{description} |\n"
             )
 

--- a/docs/convert_notebooks.py
+++ b/docs/convert_notebooks.py
@@ -656,7 +656,7 @@ reading aid, not execution evidence.
         content += """
 ## Standalone Java source examples
 
-These files are outside Maven's main source tree. The
+These files are outside Maven's compiled source tree. The
 `StandaloneJavaDocumentationCompilationTest` compiles the exact catalog against the
 current NeqSim API. This is build verification only, not runtime or engineering-result
 validation. The files retain legacy console output; inspect assumptions and execute the

--- a/docs/examples/SlugTrackingComparisonExample.java
+++ b/docs/examples/SlugTrackingComparisonExample.java
@@ -2,6 +2,8 @@ package examples;
 
 import java.util.UUID;
 import neqsim.process.equipment.pipeline.TwoFluidPipe;
+import neqsim.process.equipment.pipeline.twophasepipe.LiquidAccumulationTracker.AccumulationZone;
+import neqsim.process.equipment.pipeline.twophasepipe.SlugTracker.SlugUnit;
 import neqsim.process.equipment.pipeline.twophasepipe.TransientPipe;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemInterface;
@@ -185,7 +187,7 @@ public class SlugTrackingComparisonExample {
     int tf_outletSlugs = twoFluidPipe.getOutletSlugCount();
     double tf_maxLength = twoFluidPipe.getSlugTracker().getMaxSlugLength();
     double tf_maxVolume = 0;
-    for (var slug : twoFluidPipe.getSlugTracker().getSlugs()) {
+    for (SlugUnit slug : twoFluidPipe.getSlugTracker().getSlugs()) {
       tf_maxVolume = Math.max(tf_maxVolume, slug.liquidVolume);
     }
     int tf_accumZones = twoFluidPipe.getAccumulationTracker().getAccumulationZones().size();
@@ -231,14 +233,14 @@ public class SlugTrackingComparisonExample {
     // TransientPipe doesn't track outlet slugs separately, estimate from slugs past last section
     int df_outletSlugs = 0;
     double pipeLength = length;
-    for (var slug : driftFluxPipe.getSlugTracker().getSlugs()) {
+    for (SlugUnit slug : driftFluxPipe.getSlugTracker().getSlugs()) {
       if (slug.frontPosition >= pipeLength * 0.95) {
         df_outletSlugs++;
       }
     }
     double df_maxLength = driftFluxPipe.getSlugTracker().getMaxSlugLength();
     double df_maxVolume = 0;
-    for (var slug : driftFluxPipe.getSlugTracker().getSlugs()) {
+    for (SlugUnit slug : driftFluxPipe.getSlugTracker().getSlugs()) {
       df_maxVolume = Math.max(df_maxVolume, slug.liquidVolume);
     }
     int df_accumZones = driftFluxPipe.getAccumulationTracker().getAccumulationZones().size();
@@ -350,14 +352,14 @@ public class SlugTrackingComparisonExample {
     System.out.println("Accumulation Zone Details:");
     System.out.println();
     System.out.println("Two-Fluid Model Zones:");
-    for (var zone : twoFluidPipe.getAccumulationTracker().getAccumulationZones()) {
+    for (AccumulationZone zone : twoFluidPipe.getAccumulationTracker().getAccumulationZones()) {
       int startSec = zone.sectionIndices.isEmpty() ? -1 : zone.sectionIndices.get(0);
       System.out.printf("  Zone at section %d: volume=%.2f m³, fill=%.1f%%%n", startSec,
           zone.liquidVolume, 100.0 * zone.liquidVolume / zone.maxVolume);
     }
     System.out.println();
     System.out.println("Drift-Flux Model Zones:");
-    for (var zone : driftFluxPipe.getAccumulationTracker().getAccumulationZones()) {
+    for (AccumulationZone zone : driftFluxPipe.getAccumulationTracker().getAccumulationZones()) {
       int startSec = zone.sectionIndices.isEmpty() ? -1 : zone.sectionIndices.get(0);
       System.out.printf("  Zone at section %d: volume=%.2f m³, fill=%.1f%%%n", startSec,
           zone.liquidVolume, 100.0 * zone.liquidVolume / zone.maxVolume);

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -74,28 +74,29 @@ reading aid, not execution evidence.
 
 ## Standalone Java source examples
 
-These files are outside Maven's compiled source tree. They are retained as source-only
-references and are not catalogued as build-verified or policy-compliant examples.
-They currently contain legacy console output; review and port the required calls into a
-tested `src/test/java` example before reuse. For a supported starting point, use the
+These files are outside Maven's main source tree. The
+`StandaloneJavaDocumentationCompilationTest` compiles the exact catalog against the
+current NeqSim API. This is build verification only, not runtime or engineering-result
+validation. The files retain legacy console output; inspect assumptions and execute the
+required workflow before engineering reuse. For a supported starting point, use the
 [Java getting-started guide](../java-getting-started.md).
 
-| Example | Stored status | Capability |
+| Example | Build status | Capability |
 |---------|---------------|------------|
-| [EclipseE300ExportImportExample](EclipseE300ExportImportExample.java) | **Source only** | Eclipse E300 fluid export and import workflow |
-| [FlowRegimeDebug](FlowRegimeDebug.java) | **Source only** | Flow-regime diagnostic calculations |
-| [FlowRegimeDetectionExample](FlowRegimeDetectionExample.java) | **Source only** | Flow-regime detection across operating cases |
-| [MultiScenarioVFPExample](MultiScenarioVFPExample.java) | **Source only** | Multi-scenario vertical-flow-performance comparison |
-| [MultiphaseModelPressureDropComparison](MultiphaseModelPressureDropComparison.java) | **Source only** | Multiphase pressure-drop model comparison |
-| [OffshoreEmissionReportingExample](OffshoreEmissionReportingExample.java) | **Source only** | Offshore emissions accounting workflow |
-| [RealTimeIntegrationExample](RealTimeIntegrationExample.java) | **Source only** | Real-time process-data integration pattern |
-| [SlugTrackingComparisonExample](SlugTrackingComparisonExample.java) | **Source only** | Slug-tracking model comparison |
-| [TransientPipelineLiquidAccumulationExample](TransientPipelineLiquidAccumulationExample.java) | **Source only** | Transient pipeline liquid-accumulation study |
-| [TwoFluidPipeExample](TwoFluidPipeExample.java) | **Source only** | Two-fluid pipe setup and reporting |
-| [TwoFluidPipeSlugTrackingExample](TwoFluidPipeSlugTrackingExample.java) | **Source only** | Two-fluid slug-tracking workflow |
-| [TwoFluidPipelineLiquidAccumulationExample](TwoFluidPipelineLiquidAccumulationExample.java) | **Source only** | Two-fluid pipeline accumulation study |
-| [TwoFluidVsDriftFluxComparisonExample](TwoFluidVsDriftFluxComparisonExample.java) | **Source only** | Two-fluid and drift-flux comparison |
-| [WellToOilStabilizationExample](WellToOilStabilizationExample.java) | **Source only** | Well-to-oil-stabilization process workflow |
+| [EclipseE300ExportImportExample](EclipseE300ExportImportExample.java) | **Build-verified source** | Eclipse E300 fluid export and import workflow |
+| [FlowRegimeDebug](FlowRegimeDebug.java) | **Build-verified source** | Flow-regime diagnostic calculations |
+| [FlowRegimeDetectionExample](FlowRegimeDetectionExample.java) | **Build-verified source** | Flow-regime detection across operating cases |
+| [MultiScenarioVFPExample](MultiScenarioVFPExample.java) | **Build-verified source** | Multi-scenario vertical-flow-performance comparison |
+| [MultiphaseModelPressureDropComparison](MultiphaseModelPressureDropComparison.java) | **Build-verified source** | Multiphase pressure-drop model comparison |
+| [OffshoreEmissionReportingExample](OffshoreEmissionReportingExample.java) | **Build-verified source** | Offshore emissions accounting workflow |
+| [RealTimeIntegrationExample](RealTimeIntegrationExample.java) | **Build-verified source** | Real-time process-data integration pattern |
+| [SlugTrackingComparisonExample](SlugTrackingComparisonExample.java) | **Build-verified source** | Slug-tracking model comparison |
+| [TransientPipelineLiquidAccumulationExample](TransientPipelineLiquidAccumulationExample.java) | **Build-verified source** | Transient pipeline liquid-accumulation study |
+| [TwoFluidPipeExample](TwoFluidPipeExample.java) | **Build-verified source** | Two-fluid pipe setup and reporting |
+| [TwoFluidPipeSlugTrackingExample](TwoFluidPipeSlugTrackingExample.java) | **Build-verified source** | Two-fluid slug-tracking workflow |
+| [TwoFluidPipelineLiquidAccumulationExample](TwoFluidPipelineLiquidAccumulationExample.java) | **Build-verified source** | Two-fluid pipeline accumulation study |
+| [TwoFluidVsDriftFluxComparisonExample](TwoFluidVsDriftFluxComparisonExample.java) | **Build-verified source** | Two-fluid and drift-flux comparison |
+| [WellToOilStabilizationExample](WellToOilStabilizationExample.java) | **Build-verified source** | Well-to-oil-stabilization process workflow |
 
 ## Other Tutorials
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -74,7 +74,7 @@ reading aid, not execution evidence.
 
 ## Standalone Java source examples
 
-These files are outside Maven's main source tree. The
+These files are outside Maven's compiled source tree. The
 `StandaloneJavaDocumentationCompilationTest` compiles the exact catalog against the
 current NeqSim API. This is build verification only, not runtime or engineering-result
 validation. The files retain legacy console output; inspect assumptions and execute the

--- a/docs/test_convert_notebooks.py
+++ b/docs/test_convert_notebooks.py
@@ -419,7 +419,11 @@ class ConvertNotebooksTest(unittest.TestCase):
             )
             self.assertNotIn("See notebook for details", generated_content)
             self.assertIn(
-                "[Example](Example.java) | **Source only** |",
+                "[Example](Example.java) | **Build-verified source** |",
+                generated_content,
+            )
+            self.assertIn(
+                "build verification only, not runtime",
                 generated_content,
             )
             self.assertNotIn("no installation needed", generated_content.lower())

--- a/docs/test_examples_index_documentation.py
+++ b/docs/test_examples_index_documentation.py
@@ -108,6 +108,10 @@ class ExamplesIndexDocumentationTest(unittest.TestCase):
         java_files = sorted(EXAMPLES_DIR.glob("*.java"))
         self.assertIn("outside Maven's compiled source tree", self.java_section)
         self.assertIn("legacy console output", self.java_section)
+        self.assertIn(
+            "build verification only, not runtime or engineering-result",
+            self.java_section,
+        )
         self.assertNotIn(
             "https://github.com/equinor/neqsim/blob/master/docs/examples/",
             self.java_section,
@@ -121,7 +125,7 @@ class ExamplesIndexDocumentationTest(unittest.TestCase):
                 for line in self.java_section.splitlines()
                 if link in line
             )
-            self.assertIn("| **Source only** |", row)
+            self.assertIn("| **Build-verified source** |", row)
 
     def test_catalog_does_not_overpromise_colab_execution(self):
         self.assertNotIn("no installation needed", self.index.lower())

--- a/src/test/java/neqsim/StandaloneJavaDocumentationCompilationTest.java
+++ b/src/test/java/neqsim/StandaloneJavaDocumentationCompilationTest.java
@@ -1,0 +1,100 @@
+package neqsim;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Compiles every standalone Java source linked from the documentation examples catalog.
+ *
+ * @author esol
+ * @version 1.0
+ */
+public class StandaloneJavaDocumentationCompilationTest {
+  private static final int EXPECTED_EXAMPLE_COUNT = 14;
+
+  @TempDir Path compilationOutput;
+
+  /** Verifies that the complete standalone documentation-example corpus matches the current API. */
+  @Test
+  void testStandaloneDocumentationExamplesCompile() throws IOException {
+    Path examplesDirectory =
+        Paths.get(System.getProperty("user.dir"), "docs", "examples").toAbsolutePath();
+    List<File> sourceFiles;
+    try (Stream<Path> paths = Files.list(examplesDirectory)) {
+      sourceFiles =
+          paths
+              .filter(path -> path.getFileName().toString().endsWith(".java"))
+              .sorted()
+              .map(Path::toFile)
+              .collect(Collectors.toList());
+    }
+
+    assertEquals(
+        EXPECTED_EXAMPLE_COUNT,
+        sourceFiles.size(),
+        "The compilation contract must track every catalogued standalone Java example");
+
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    assertNotNull(compiler, "A full JDK is required to verify documentation examples");
+    DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<JavaFileObject>();
+
+    try (StandardJavaFileManager fileManager =
+        compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8)) {
+      Iterable<? extends JavaFileObject> compilationUnits =
+          fileManager.getJavaFileObjectsFromFiles(sourceFiles);
+      List<String> options =
+          Arrays.asList(
+              "-classpath",
+              System.getProperty("java.class.path"),
+              "-d",
+              compilationOutput.toString(),
+              "-encoding",
+              StandardCharsets.UTF_8.name(),
+              "-proc:none");
+
+      Boolean compiled =
+          compiler
+              .getTask(null, fileManager, diagnostics, options, null, compilationUnits)
+              .call();
+      assertTrue(Boolean.TRUE.equals(compiled), formatDiagnostics(diagnostics));
+    }
+  }
+
+  private static String formatDiagnostics(DiagnosticCollector<JavaFileObject> diagnostics) {
+    return diagnostics.getDiagnostics().stream()
+        .map(
+            diagnostic ->
+                (diagnostic.getSource() == null
+                        ? "<compiler>"
+                        : diagnostic.getSource().getName())
+                    + ":"
+                    + diagnostic.getLineNumber()
+                    + ": "
+                    + diagnostic.getKind()
+                    + ": "
+                    + diagnostic.getMessage(null))
+        .collect(Collectors.joining(System.lineSeparator()));
+  }
+}

--- a/src/test/java/neqsim/StandaloneJavaDocumentationCompilationTest.java
+++ b/src/test/java/neqsim/StandaloneJavaDocumentationCompilationTest.java
@@ -34,67 +34,41 @@ import org.junit.jupiter.api.io.TempDir;
 public class StandaloneJavaDocumentationCompilationTest {
   private static final int EXPECTED_EXAMPLE_COUNT = 14;
 
-  @TempDir Path compilationOutput;
+  @TempDir
+  Path compilationOutput;
 
   /** Verifies that the complete standalone documentation-example corpus matches the current API. */
   @Test
   void testStandaloneDocumentationExamplesCompile() throws IOException {
-    Path examplesDirectory =
-        Paths.get(System.getProperty("user.dir"), "docs", "examples").toAbsolutePath();
+    Path examplesDirectory = Paths.get(System.getProperty("user.dir"), "docs", "examples").toAbsolutePath();
     List<File> sourceFiles;
     try (Stream<Path> paths = Files.list(examplesDirectory)) {
-      sourceFiles =
-          paths
-              .filter(path -> path.getFileName().toString().endsWith(".java"))
-              .sorted()
-              .map(Path::toFile)
-              .collect(Collectors.toList());
+      sourceFiles = paths.filter(path -> path.getFileName().toString().endsWith(".java")).sorted().map(Path::toFile)
+          .collect(Collectors.toList());
     }
 
-    assertEquals(
-        EXPECTED_EXAMPLE_COUNT,
-        sourceFiles.size(),
+    assertEquals(EXPECTED_EXAMPLE_COUNT, sourceFiles.size(),
         "The compilation contract must track every catalogued standalone Java example");
 
     JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     assertNotNull(compiler, "A full JDK is required to verify documentation examples");
     DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<JavaFileObject>();
 
-    try (StandardJavaFileManager fileManager =
-        compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8)) {
-      Iterable<? extends JavaFileObject> compilationUnits =
-          fileManager.getJavaFileObjectsFromFiles(sourceFiles);
-      List<String> options =
-          Arrays.asList(
-              "-classpath",
-              System.getProperty("java.class.path"),
-              "-d",
-              compilationOutput.toString(),
-              "-encoding",
-              StandardCharsets.UTF_8.name(),
-              "-proc:none");
+    try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnostics, null,
+        StandardCharsets.UTF_8)) {
+      Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromFiles(sourceFiles);
+      List<String> options = Arrays.asList("-classpath", System.getProperty("java.class.path"), "-d",
+          compilationOutput.toString(), "-encoding", StandardCharsets.UTF_8.name(), "-proc:none");
 
-      Boolean compiled =
-          compiler
-              .getTask(null, fileManager, diagnostics, options, null, compilationUnits)
-              .call();
+      Boolean compiled = compiler.getTask(null, fileManager, diagnostics, options, null, compilationUnits).call();
       assertTrue(Boolean.TRUE.equals(compiled), formatDiagnostics(diagnostics));
     }
   }
 
   private static String formatDiagnostics(DiagnosticCollector<JavaFileObject> diagnostics) {
     return diagnostics.getDiagnostics().stream()
-        .map(
-            diagnostic ->
-                (diagnostic.getSource() == null
-                        ? "<compiler>"
-                        : diagnostic.getSource().getName())
-                    + ":"
-                    + diagnostic.getLineNumber()
-                    + ": "
-                    + diagnostic.getKind()
-                    + ": "
-                    + diagnostic.getMessage(null))
+        .map(diagnostic -> (diagnostic.getSource() == null ? "<compiler>" : diagnostic.getSource().getName()) + ":"
+            + diagnostic.getLineNumber() + ": " + diagnostic.getKind() + ": " + diagnostic.getMessage(null))
         .collect(Collectors.joining(System.lineSeparator()));
   }
 }


### PR DESCRIPTION
## Summary

Advances #2499 D120 by bringing all 14 standalone Java documentation examples under an executable compilation contract and making the generated catalog report that evidence precisely.

Frozen publication base: `18e26159b182a654f89e835ded7f51ba8b059854`  
Exact head: `7260512180c37b67a467b2ed9c88e560bfaacdd7`

## Frozen scope

- `src/test/java/neqsim/StandaloneJavaDocumentationCompilationTest.java`
- `docs/convert_notebooks.py`
- `docs/examples/SlugTrackingComparisonExample.java`
- `docs/examples/index.md`
- `docs/test_convert_notebooks.py`
- `docs/test_examples_index_documentation.py`

The sixth file is the only confirmed compiler-defect repair inside the exact 14-source corpus.

## Changes

- Compile every catalogued standalone Java source against the current Maven test classpath with the JDK compiler.
- Fail if the corpus count drifts from 14.
- Report complete file, line, diagnostic kind, and compiler message on failure.
- Preserve Java 8 source compatibility and disable annotation processing for the documentation-only compilation.
- Generate and commit the precise status **Build-verified source**.
- State explicitly that compilation is not runtime or engineering-result validation.
- Align both existing catalog contracts with the new build-only evidence.
- Replace five Java 10+ `var` declarations in the slug-tracking example with the exact Java 8-compatible `SlugUnit` and `AccumulationZone` types.
- Apply the exact Spotless-generated format to the new Java test.

## Validation

- PASS: Python AST parsing and catalog consistency for exactly 14 Java rows.
- PASS: documentation/Jekyll/search, pre-commit, Spotless, CodeQL, Javadocs, and agent-skill references.
- PASS: Java 8 Ubuntu and Windows.
- PASS: Java 21 Ubuntu and Windows fast suites.
- PASS: slow-test shards 1, 3, and 4.
- ACTIVE: slow-test shard 2 targeted retry. Its first attempt was blocked before testing by a transient Maven Central HTTP 429 while resolving Surefire; the retry is executing without a reported test failure.
- PASS: connector review — open draft, mergeable, six frozen files, no reviews or unresolved threads.
- Current `master` has advanced independently; this exact head is three commits behind and is intentionally preserved without synchronization or rebase.

**VALIDATION PENDING CI — SLOW SHARD 2 TRANSIENT-INFRASTRUCTURE RETRY ACTIVE**

## Documentation impact and stop boundary

The generated and committed examples catalog now identifies the exact level of evidence. No example is executed and no engineering result is qualified. No production API, physical model, notebook, JSON/MCP surface, external-link policy, active refinery file, DEXPI/PFD surface, or Huldra work is changed.

## AI-assisted contribution

This is an AI-assisted documentation-quality increment. The test compiles the exact published Java source corpus rather than a copied or simplified surrogate.