### PR TITLE
[AI-Assisted] feat(scale): expose calcium-sulfate pressure diagnostics

### DIFF
--- a/docs/pvtsimulation/scale_prediction_api.md
+++ b/docs/pvtsimulation/scale_prediction_api.md
@@ -349,6 +349,8 @@ CalciumSulfatePhaseBoundaryQualification evidence =
     operations.qualifyCalciumSulfatePhaseBoundary();
 
 double transitionC = evidence.getPredictedPureWaterTransitionCelsius();
+double transitionAtPressureC = evidence.getPredictedPureWaterTransitionAtEvaluatedPressureCelsius();
+double anhydriteVdelta = evidence.getAnhydriteLumpedReactionVolumeCm3PerMol();
 double requiredWaterActivity25C = evidence.getRequiredWaterActivityAt25Celsius();
 boolean publicationReady = evidence.isPublicationReady();
 ```
@@ -369,6 +371,16 @@ experimental lineage without redistributing the copyrighted primary table. The c
 registered envelopes, so the result deliberately reports `REJECTED` and `publicationReady=false`; it does not tune a
 coefficient toward the evidence. Absolute-solubility residuals, primary-row uncertainty, mixed-brine qualification and
 the high-pressure reaction-volume convention remain explicit follow-on boundaries.
+
+The pressure diagnostic reproduces the exact constant-volume correction used by the authoritative COMPSALT Ksp path,
+with a 1.01325 bara correlation reference. It reports `Vdelta=-52.4 cm3/mol` for anhydrite and
+`Vdelta=-33.0 cm3/mol` for gypsum, their separate logarithmic Ksp corrections at the evaluated state, and the resulting
+pure-water transition prediction. These are lumped reaction-volume coefficients—not pure-mineral molar volumes. The
+diagnostic therefore always reports `aqueousSpeciesVolumeResolved=false` and `highPressureQualified=false`. The primary
+high-pressure anhydrite-solubility lineage is Dickson, Blount and Tunell (1963),
+[DOI 10.2475/ajs.261.1.61](https://doi.org/10.2475/ajs.261.1.61); no copyrighted table rows or fitted coefficients are
+redistributed. Quantitative adoption still requires a complete primary-row audit, aqueous-species volume mapping, and
+an uncertainty-aware held-out acceptance criterion.
 
 The process-system test carries the solid ledger beside the residual fluid through a
 `Stream -> Heater -> ProcessSystem` calculation, then re-equilibrates it at the outlet. Its

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalcSaltSatauration.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalcSaltSatauration.java
@@ -18,6 +18,8 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
   private static final long serialVersionUID = 1000;
   private static final int MAX_SATURATION_ITERATIONS = 80;
   private static final double SATURATION_RATIO_TOLERANCE = 1.0e-6;
+  static final double PRESSURE_CORRECTION_REFERENCE_BARA = 1.01325;
+  private static final double GAS_CONSTANT_CM3_BAR_PER_MOL_K = 83.1446;
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(CalcSaltSatauration.class);
 
@@ -658,6 +660,37 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
   }
 
   /**
+   * Returns the lumped constant reaction-volume coefficient used by the COMPSALT pressure correction.
+   *
+   * <p>
+   * This is a reaction-volume parameter, not a pure-mineral molar volume. The current correlation does not separately
+   * resolve aqueous-species partial or apparent molar volumes.
+   * </p>
+   *
+   * @return COMPSALT {@code Vdelta} in cm3/mol
+   */
+  double getLumpedReactionVolumeCm3PerMol() {
+    return readSaltData().vdelta;
+  }
+
+  /**
+   * Returns the exact logarithmic pressure correction applied by the COMPSALT Ksp path.
+   *
+   * @param temperatureK temperature in Kelvin
+   * @param pressureBara absolute pressure in bara
+   * @return {@code ln(Ksp(T,P)/Ksp(T,P0))}
+   */
+  double getLogPressureCorrection(double temperatureK, double pressureBara) {
+    if (!(temperatureK > 0.0) || !Double.isFinite(temperatureK)) {
+      throw new IllegalArgumentException("Temperature must be finite and positive");
+    }
+    if (!(pressureBara > 0.0) || !Double.isFinite(pressureBara)) {
+      throw new IllegalArgumentException("Pressure must be finite and positive");
+    }
+    return calculateLogPressureCorrection(readSaltData().vdelta, temperatureK, pressureBara);
+  }
+
+  /**
    * Calculates Ksp from the same COMPSALT correlations used by scale-potential calculations.
    *
    * @param saltData salt data from COMPSALT
@@ -681,18 +714,24 @@ public class CalcSaltSatauration extends ConstantDutyTemperatureFlash {
           + temperatureK * saltData.kspwater4 + saltData.kspwater5 / (temperatureK * temperatureK);
       ksp = Math.exp(lnKsp);
     }
-    if (Math.abs(saltData.vdelta) > 1.0e-10 && pressureBara > 1.013) {
-      double gasConstantCm3Bar = 83.1446;
-      double deltaPbar = pressureBara - 1.01325;
-      double lnCorrection = -saltData.vdelta * deltaPbar / (gasConstantCm3Bar * temperatureK);
-      if (lnCorrection > 50.0) {
-        lnCorrection = 50.0;
-      } else if (lnCorrection < -50.0) {
-        lnCorrection = -50.0;
-      }
-      ksp *= Math.exp(lnCorrection);
-    }
+    ksp *= Math.exp(calculateLogPressureCorrection(saltData.vdelta, temperatureK, pressureBara));
     return ksp;
+  }
+
+  private static double calculateLogPressureCorrection(double reactionVolumeCm3PerMol, double temperatureK,
+      double pressureBara) {
+    if (Math.abs(reactionVolumeCm3PerMol) <= 1.0e-10 || pressureBara <= 1.013) {
+      return 0.0;
+    }
+    double deltaPbar = pressureBara - PRESSURE_CORRECTION_REFERENCE_BARA;
+    double lnCorrection = -reactionVolumeCm3PerMol * deltaPbar / (GAS_CONSTANT_CM3_BAR_PER_MOL_K * temperatureK);
+    if (lnCorrection > 50.0) {
+      return 50.0;
+    }
+    if (lnCorrection < -50.0) {
+      return -50.0;
+    }
+    return lnCorrection;
   }
 
   /**

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
@@ -31,8 +31,12 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
   public static final String EVIDENCE_DOI = "10.3389/fnuen.2023.1208582";
   /** Primary experimental lineage DOI. */
   public static final String PRIMARY_LINEAGE_DOI = "10.1139/v61-228";
+  /** Primary high-pressure anhydrite-solubility lineage DOI. */
+  public static final String HIGH_PRESSURE_LINEAGE_DOI = "10.2475/ajs.261.1.61";
   /** License of the registered numerical evidence. */
   public static final String EVIDENCE_LICENSE = "CC BY 4.0";
+  /** Reference pressure of the COMPSALT constant-volume correction. */
+  public static final double COMPSALT_PRESSURE_CORRECTION_REFERENCE_BARA = CalcSaltSatauration.PRESSURE_CORRECTION_REFERENCE_BARA;
 
   private static final double PURE_WATER_MINIMUM_C = 41.0;
   private static final double PURE_WATER_MAXIMUM_C = 43.0;
@@ -43,9 +47,15 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
   private static final double REFERENCE_PRESSURE_TOLERANCE_BARA = 0.02;
 
   private final double evaluatedPressureBara;
+  private final double evaluatedTemperatureKelvin;
   private final double predictedPureWaterTransitionCelsius;
+  private final double predictedPureWaterTransitionAtEvaluatedPressureCelsius;
   private final double requiredWaterActivityAt25Celsius;
   private final double requiredWaterActivityAt40Celsius;
+  private final double anhydriteLumpedReactionVolumeCm3PerMol;
+  private final double gypsumLumpedReactionVolumeCm3PerMol;
+  private final double anhydriteLogKspPressureCorrection;
+  private final double gypsumLogKspPressureCorrection;
   private final boolean pureWaterEnvelopePass;
   private final boolean sodiumChloride25CEnvelopePass;
   private final boolean sodiumChloride40CEnvelopePass;
@@ -61,15 +71,29 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
       throw new IllegalArgumentException("Thermodynamic system must not be null");
     }
     evaluatedPressureBara = system.getPressure();
+    evaluatedTemperatureKelvin = system.getTemperature();
     if (!(evaluatedPressureBara > 0.0) || !Double.isFinite(evaluatedPressureBara)) {
       throw new IllegalArgumentException("System pressure must be finite and positive");
+    }
+    if (!(evaluatedTemperatureKelvin > 0.0) || !Double.isFinite(evaluatedTemperatureKelvin)) {
+      throw new IllegalArgumentException("System temperature must be finite and positive");
     }
 
     CalcSaltSatauration anhydrite = new CalcSaltSatauration(system, "CaSO4_A");
     CalcSaltSatauration gypsum = new CalcSaltSatauration(system, "CaSO4_G");
-    predictedPureWaterTransitionCelsius = solvePureWaterTransitionCelsius(anhydrite, gypsum);
+    predictedPureWaterTransitionCelsius = solvePureWaterTransitionCelsius(anhydrite, gypsum, REFERENCE_PRESSURE_BARA);
+    boolean pressureCorrectionIsZero = evaluatedPressureBara <= 1.013
+        || evaluatedPressureBara == COMPSALT_PRESSURE_CORRECTION_REFERENCE_BARA;
+    predictedPureWaterTransitionAtEvaluatedPressureCelsius = pressureCorrectionIsZero
+        ? predictedPureWaterTransitionCelsius
+        : solvePureWaterTransitionCelsius(anhydrite, gypsum, evaluatedPressureBara);
     requiredWaterActivityAt25Celsius = requiredWaterActivity(anhydrite, gypsum, 298.15);
     requiredWaterActivityAt40Celsius = requiredWaterActivity(anhydrite, gypsum, 313.15);
+    anhydriteLumpedReactionVolumeCm3PerMol = anhydrite.getLumpedReactionVolumeCm3PerMol();
+    gypsumLumpedReactionVolumeCm3PerMol = gypsum.getLumpedReactionVolumeCm3PerMol();
+    anhydriteLogKspPressureCorrection = anhydrite.getLogPressureCorrection(evaluatedTemperatureKelvin,
+        evaluatedPressureBara);
+    gypsumLogKspPressureCorrection = gypsum.getLogPressureCorrection(evaluatedTemperatureKelvin, evaluatedPressureBara);
 
     pureWaterEnvelopePass = within(predictedPureWaterTransitionCelsius, PURE_WATER_MINIMUM_C, PURE_WATER_MAXIMUM_C);
     sodiumChloride25CEnvelopePass = within(requiredWaterActivityAt25Celsius, NACL_25_WATER_ACTIVITY_MINIMUM,
@@ -85,9 +109,63 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
     return evaluatedPressureBara;
   }
 
+  /** @return temperature of the requested use state in Kelvin */
+  public double getEvaluatedTemperatureKelvin() {
+    return evaluatedTemperatureKelvin;
+  }
+
   /** @return predicted atmospheric pure-water transition temperature in degrees Celsius */
   public double getPredictedPureWaterTransitionCelsius() {
     return predictedPureWaterTransitionCelsius;
+  }
+
+  /**
+   * Returns the COMPSALT pure-water transition prediction at the requested pressure.
+   *
+   * <p>
+   * This is a reproducibility diagnostic only. It is not high-pressure qualification because the constant lumped
+   * reaction-volume convention does not separately resolve aqueous-species volumes.
+   * </p>
+   *
+   * @return predicted transition temperature in degrees Celsius at the evaluated pressure
+   */
+  public double getPredictedPureWaterTransitionAtEvaluatedPressureCelsius() {
+    return predictedPureWaterTransitionAtEvaluatedPressureCelsius;
+  }
+
+  /** @return COMPSALT anhydrite lumped reaction-volume coefficient in cm3/mol */
+  public double getAnhydriteLumpedReactionVolumeCm3PerMol() {
+    return anhydriteLumpedReactionVolumeCm3PerMol;
+  }
+
+  /** @return COMPSALT gypsum lumped reaction-volume coefficient in cm3/mol */
+  public double getGypsumLumpedReactionVolumeCm3PerMol() {
+    return gypsumLumpedReactionVolumeCm3PerMol;
+  }
+
+  /** @return logarithmic anhydrite Ksp pressure correction at the evaluated state */
+  public double getAnhydriteLogKspPressureCorrection() {
+    return anhydriteLogKspPressureCorrection;
+  }
+
+  /** @return logarithmic gypsum Ksp pressure correction at the evaluated state */
+  public double getGypsumLogKspPressureCorrection() {
+    return gypsumLogKspPressureCorrection;
+  }
+
+  /** @return {@code false}; aqueous-species volume contributions are not separately resolved */
+  public boolean isAqueousSpeciesVolumeResolved() {
+    return false;
+  }
+
+  /** @return {@code false}; the high-pressure reaction-volume convention remains unqualified */
+  public boolean isHighPressureQualified() {
+    return false;
+  }
+
+  /** @return primary high-pressure anhydrite-solubility lineage DOI */
+  public String getHighPressureLineageDoi() {
+    return HIGH_PRESSURE_LINEAGE_DOI;
   }
 
   /** @return lower independent pure-water transition limit in degrees Celsius */
@@ -185,7 +263,8 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
     return Collections.unmodifiableList(Arrays.asList(
         "Bock primary-table transcription, preprocessing uncertainty, and absolute-solubility "
             + "residuals remain unqualified",
-        "High-pressure use requires a verified reaction-volume convention with aqueous partial "
+        "COMPSALT Vdelta is a constant lumped reaction-volume coefficient, not a pure-mineral molar volume",
+        "High-pressure use requires a verified reaction-volume convention that separately resolves aqueous partial "
             + "or apparent molar volumes",
         "The registered evidence covers pure-water and NaCl phase crossings, not general "
             + "mixed-brine mineral equilibrium"));
@@ -199,15 +278,20 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
         + ", evidence25C=[" + NACL_25_WATER_ACTIVITY_MINIMUM + ", " + NACL_25_WATER_ACTIVITY_MAXIMUM + "]"
         + ", requiredWaterActivity40C=" + requiredWaterActivityAt40Celsius + ", evidence40C=["
         + NACL_40_WATER_ACTIVITY_MINIMUM + ", " + NACL_40_WATER_ACTIVITY_MAXIMUM + "]" + ", evaluatedPressure_bara="
-        + evaluatedPressureBara + ", referencePressurePass=" + referencePressureEnvelopePass + ", evidenceDoi="
+        + evaluatedPressureBara + ", evaluatedPressureTransition_C="
+        + predictedPureWaterTransitionAtEvaluatedPressureCelsius + ", anhydriteVdelta_cm3_per_mol="
+        + anhydriteLumpedReactionVolumeCm3PerMol + ", gypsumVdelta_cm3_per_mol=" + gypsumLumpedReactionVolumeCm3PerMol
+        + ", aqueousSpeciesVolumeResolved=" + isAqueousSpeciesVolumeResolved() + ", highPressureQualified="
+        + isHighPressureQualified() + ", referencePressurePass=" + referencePressureEnvelopePass + ", evidenceDoi="
         + EVIDENCE_DOI + ", license=" + EVIDENCE_LICENSE;
   }
 
-  private static double solvePureWaterTransitionCelsius(CalcSaltSatauration anhydrite, CalcSaltSatauration gypsum) {
+  private static double solvePureWaterTransitionCelsius(CalcSaltSatauration anhydrite, CalcSaltSatauration gypsum,
+      double pressureBara) {
     double lowerTemperatureK = 273.15;
     double upperTemperatureK = 373.15;
-    double lowerResidual = logKspDifference(anhydrite, gypsum, lowerTemperatureK);
-    double upperResidual = logKspDifference(anhydrite, gypsum, upperTemperatureK);
+    double lowerResidual = logKspDifference(anhydrite, gypsum, lowerTemperatureK, pressureBara);
+    double upperResidual = logKspDifference(anhydrite, gypsum, upperTemperatureK, pressureBara);
     if (lowerResidual == 0.0) {
       return lowerTemperatureK - 273.15;
     }
@@ -220,7 +304,7 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
     }
     for (int iteration = 0; iteration < 100; iteration++) {
       double trialTemperatureK = 0.5 * (lowerTemperatureK + upperTemperatureK);
-      double trialResidual = logKspDifference(anhydrite, gypsum, trialTemperatureK);
+      double trialResidual = logKspDifference(anhydrite, gypsum, trialTemperatureK, pressureBara);
       if (Math.abs(trialResidual) <= 1.0e-12) {
         return trialTemperatureK - 273.15;
       }
@@ -236,13 +320,13 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
 
   private static double requiredWaterActivity(CalcSaltSatauration anhydrite, CalcSaltSatauration gypsum,
       double temperatureK) {
-    return Math.exp(0.5 * logKspDifference(anhydrite, gypsum, temperatureK));
+    return Math.exp(0.5 * logKspDifference(anhydrite, gypsum, temperatureK, REFERENCE_PRESSURE_BARA));
   }
 
-  private static double logKspDifference(CalcSaltSatauration anhydrite, CalcSaltSatauration gypsum,
-      double temperatureK) {
-    return Math.log(gypsum.getSolubilityProduct(temperatureK, REFERENCE_PRESSURE_BARA))
-        - Math.log(anhydrite.getSolubilityProduct(temperatureK, REFERENCE_PRESSURE_BARA));
+  private static double logKspDifference(CalcSaltSatauration anhydrite, CalcSaltSatauration gypsum, double temperatureK,
+      double pressureBara) {
+    return Math.log(gypsum.getSolubilityProduct(temperatureK, pressureBara))
+        - Math.log(anhydrite.getSolubilityProduct(temperatureK, pressureBara));
   }
 
   private static boolean within(double value, double minimum, double maximum) {

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
@@ -26,6 +26,15 @@ class CalciumSulfatePhaseBoundaryQualificationTest extends neqsim.NeqSimTest {
         .qualifyCalciumSulfatePhaseBoundary();
 
     assertEquals(60.445190, qualification.getPredictedPureWaterTransitionCelsius(), 1.0e-6);
+    assertEquals(60.445190, qualification.getPredictedPureWaterTransitionAtEvaluatedPressureCelsius(), 1.0e-6);
+    assertEquals(-52.4, qualification.getAnhydriteLumpedReactionVolumeCm3PerMol(), 0.0);
+    assertEquals(-33.0, qualification.getGypsumLumpedReactionVolumeCm3PerMol(), 0.0);
+    assertEquals(0.0, qualification.getAnhydriteLogKspPressureCorrection(), 0.0);
+    assertEquals(0.0, qualification.getGypsumLogKspPressureCorrection(), 0.0);
+    assertFalse(qualification.isAqueousSpeciesVolumeResolved());
+    assertFalse(qualification.isHighPressureQualified());
+    assertEquals("10.2475/ajs.261.1.61", qualification.getHighPressureLineageDoi());
+    assertEquals(1.01325, CalciumSulfatePhaseBoundaryQualification.COMPSALT_PRESSURE_CORRECTION_REFERENCE_BARA, 0.0);
     assertEquals(0.7736299, qualification.getRequiredWaterActivityAt25Celsius(), 1.0e-7);
     assertEquals(0.8437837, qualification.getRequiredWaterActivityAt40Celsius(), 1.0e-7);
     assertFalse(qualification.isPureWaterEnvelopePass());
@@ -75,5 +84,11 @@ class CalciumSulfatePhaseBoundaryQualificationTest extends neqsim.NeqSimTest {
         .qualifyCalciumSulfatePhaseBoundary();
     assertFalse(highPressure.isReferencePressureEnvelopePass());
     assertFalse(highPressure.isPublicationReady());
+    assertEquals(75.92, highPressure.getPredictedPureWaterTransitionAtEvaluatedPressureCelsius(), 0.01);
+    assertEquals(52.4 * (500.0 - 1.01325) / (83.1446 * 313.15), highPressure.getAnhydriteLogKspPressureCorrection(),
+        1.0e-12);
+    assertEquals(33.0 * (500.0 - 1.01325) / (83.1446 * 313.15), highPressure.getGypsumLogKspPressureCorrection(),
+        1.0e-12);
+    assertTrue(highPressure.formatDiagnostic().contains("highPressureQualified=false"));
   }
 }


### PR DESCRIPTION
## Summary

Advances #3144 with an immutable, fail-closed diagnostic for the exact COMPSALT calcium-sulfate pressure correction.

Exact base: `18e26159b182a654f89e835ded7f51ba8b059854`  
Exact head: `de1391729ec543fb9f96c83651f3bfc07d781bcb`

## Capability contract

- Reuse the authoritative `CalcSaltSatauration` Ksp path; do not create a parallel thermodynamic calculation.
- Expose the exact constant lumped `Vdelta` values and logarithmic Ksp pressure corrections for anhydrite and gypsum.
- Report the COMPSALT pure-water polymorph transition at the caller's evaluated pressure.
- Distinguish the one-bar evidence reference from the 1.01325-bara pressure-correction reference.
- State explicitly that `Vdelta` is not a pure-mineral molar volume and that aqueous-species partial/apparent molar volumes are unresolved.
- Keep high-pressure use unqualified and publication fail-closed.
- Preserve all thermodynamic parameters, Ksp coefficients, reaction rows, solver tolerances, activity conventions, phase behavior, and neutral paths.

## Scientific provenance

- Atmospheric phase-boundary evidence: Voigt and Freyer (2023), DOI [10.3389/fnuen.2023.1208582](https://doi.org/10.3389/fnuen.2023.1208582), CC BY 4.0.
- NaCl crossing lineage: Bock (1961), DOI [10.1139/v61-228](https://doi.org/10.1139/v61-228).
- High-pressure anhydrite-solubility lineage: Dickson, Blount and Tunell (1963), DOI [10.2475/ajs.261.1.61](https://doi.org/10.2475/ajs.261.1.61).

No copyrighted primary-table rows or fitted coefficients are redistributed.

## Changes

- Factors the existing pressure expression into one internal function used by both Ksp calculation and diagnostics.
- Adds immutable getters for evaluated state, lumped reaction volumes, log-pressure corrections, and evaluated-pressure transition.
- Records `aqueousSpeciesVolumeResolved=false` and `highPressureQualified=false`.
- Documents the model semantics and adoption boundary.
- Adds serialization, exact-coefficient, zero-correction, and 500-bara transition regressions.

At 500 bara, the unchanged COMPSALT formulation predicts a pure-water transition of approximately 75.92 °C. This is model-reproduction evidence, not scientific acceptance.

## Validation

- PASS: exact-head Java 8 tests on Ubuntu and Windows.
- PASS: exact-head Java 21 fast tests on Ubuntu and Windows.
- PASS: all four exact-head Java 21 slow-test shards.
- PASS: exact-head Java 21 Javadocs.
- PASS: exact-head pre-commit, Spotless, documentation search, CodeQL, PaperLab, and agent-skill reference gates.
- PASS: `CalciumSulfatePhaseBoundaryQualificationTest` — 2 focused tests.
- PASS: slow `SaltSaturationTest` — 6 tests, including the existing authoritative scale paths.
- PASS: `git diff --check`.
- No reviews or unresolved threads; GitHub reports the exact head mergeable.

### Exact-ref performance evidence

Nine interleaved fresh JVM pairs compared exact base `18e26159b182a654f89e835ded7f51ba8b059854` with exact head `de1391729ec543fb9f96c83651f3bfc07d781bcb`. Each JVM used 50 warmup operations and seven fixed-work batches; qualification batches contained 200 complete operations and neutral-control batches contained 50 complete SRK TP flashes.

- Normal 1.01325-bara qualification median: **136,801 ns head versus 137,263 ns base (−0.34%)**.
- Explicit 500-bara qualification median: **125,331 ns head versus 129,555 ns base (−3.26%)**.
- Neutral SRK control median: 2,362,547 ns head versus 2,244,377 ns base (+5.27%), with paired ratios ranging from −15.28% to +38.08%. The changed files do not intersect the neutral path, so this broad bidirectional spread is runner noise rather than an attributable regression.
- Neutral-normalized paired medians: **−3.77%** for normal qualification and **−8.94%** for the explicit 500-bara path.

Static accounting agrees: no new flash, thermodynamic initialization, database query, or neutral-system path. At the normal 1.01325-bara evidence state, the existing transition result is reused. A second bounded bisection occurs only for an explicit non-reference-pressure qualification request.

**DRAFT — EXACT-HEAD CI AND PERFORMANCE VALIDATED; HIGH-PRESSURE SCIENTIFIC USE REMAINS UNQUALIFIED**

## Stop boundary

This PR does not modify COMPSALT data, infer aqueous-species volumes, fit `Vdelta`, accept the 54-row high-pressure dataset, change calcium-sulfate qualification, extend mixed-brine validity, or alter JSON/MCP response size. Quantitative high-pressure adoption remains blocked by the complete primary-row audit, exact reaction-volume mapping, and an uncertainty-aware held-out acceptance criterion.