### PR TITLE
[AI-Assisted] feat(kinetics): add aqueous H2S oxygen screen

### DIFF
--- a/docs/chemicalreactions/README.md
+++ b/docs/chemicalreactions/README.md
@@ -143,6 +143,8 @@ Use the [CO₂ hydration temperature-trajectory guide](co2_hydration_temperature
 exact, carbon-conserving propagation of the qualified neutral pair through ordered temperature segments.
 Use the [qualified CO₂ impurity execution guide](co2_impurity_qualified_execution) to bind
 public evidence to every experimental R1-R8 parameterization before fail-closed execution.
+Use the [aqueous H2S/O2 kinetics guide](h2s_oxygen_kinetics) for the primary-source,
+atmospheric-pressure total-sulfide oxidation screening correlation and its fail-closed limits.
 
 
 ---

--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -1,0 +1,82 @@
+---
+title: Aqueous H2S oxidation screening
+description: Primary-source, fail-closed screening for abiotic total-sulfide oxidation by air-saturated oxygen.
+---
+
+`AqueousHydrogenSulfideOxidationKinetics` implements the simplified correlation published by
+Millero, Hubinger, Fernandez, and Garnett (1987),
+[doi:10.1021/es00159a003](https://doi.org/10.1021/es00159a003), for loss of total dissolved
+sulfide in air-saturated water, seawater, and NaCl solutions:
+
+$$
+-\frac{d[\mathrm{H_2S}]_T}{dt}
+  = k[\mathrm{O_2}][\mathrm{H_2S}]_T,
+$$
+
+$$
+\log_{10} k = 10.50 + 0.16\,\mathrm{pH}
+  - \frac{3000}{T} + 0.44\sqrt{I}.
+$$
+
+The original source reports `k` on a kg-water mol-1 h-1 basis. Temperature is in K and
+ionic strength is supplied on the mol/kg-water scale. The implementation reproduces the source
+coefficient `0.44`. A later review by Luther et al. (2011) transcribes `0.49` in its
+summary equation; that secondary value is not used.
+
+## Evidence and validity boundary
+
+The simplified source equation is accepted only inside its published range:
+
+- temperature 278.15–338.15 K;
+- pH 4–8;
+- ionic strength 0–6 mol/kg water;
+- aqueous, air-saturated water/NaCl/seawater experiments;
+- initial total sulfide about 25 +/- 5 micromol/kg water;
+- atmospheric-pressure evidence.
+
+Every numerical input must be finite. A temperature, pH, or ionic strength outside these limits
+throws an `IllegalArgumentException` instead of extrapolating. The source reports a standard
+deviation of `0.18` in `log10(k)`. `secondOrderRateConstantRange(...)` returns the
+corresponding multiplicative interval, using a factor of `10^0.18 = 1.51356`. This interval is
+fit scatter, not complete predictive uncertainty.
+
+The source also reports nominal half-times at 298.15 K and pH 8 of 50 +/- 16 h in water and
+26 +/- 9 h in seawater. These observations are contextual checks, not independent validation data,
+because they were used in developing the same source analysis.
+
+## Constant-oxygen screening
+
+The caller must establish an air-saturated dissolved-oxygen molality independently.
+`pseudoFirstOrderRateConstant(...)` calculates `k[O2]` and
+`screenAirSaturatedExposure(...)` applies the exact constant-oxygen solution:
+
+$$
+f_{\mathrm{remaining}} = \exp(-k[\mathrm{O_2}]t).
+$$
+
+For the illustrative inputs 298.15 K, pH 8, ionic strength 0.723 mol/kg water, and dissolved
+oxygen 250 micromol/kg water, the correlation gives `k = 123.6175 kg water/(mol h)` and
+a nominal half-life of `22.4288 h`. The oxygen value is an example input, not a new
+solubility correlation or a source benchmark.
+
+The analytical update is deterministic, gives exactly one remaining fraction at zero time, remains
+bounded from zero to one, and avoids timestep error. It reports total-sulfide loss only. It does not
+assign products or consume oxygen, because the source correlation does not supply a complete
+product stoichiometry for that purpose.
+
+## Scientific stop boundary
+
+This capability does not:
+
+- calculate pH, H2S/HS- speciation, activities, or charge balance;
+- calculate oxygen solubility or verify that the supplied oxygen value is air saturated;
+- qualify elevated pressure, dense-phase CO2, free-water appearance, or gas-to-water transfer;
+- bind the correlation to experimental R1–R8 constants;
+- calculate corrosion, sulfur products, reaction heat, or material response;
+- mutate a thermodynamic system, run a flash, add a transient or pipeline source term, or expose an
+  MCP workflow.
+
+Electrolyte pH/speciation remains owned by issue #3144. TP flash, dynamics, pipeline coupling, and
+MCP publication remain coordinated with #2937, #2911, the pipeline roadmap, and #3153. Applying
+this atmospheric aqueous correlation to a Northern-Lights-type high-pressure CO2 pipeline requires
+separate phase, pressure, mass-transfer, and composition evidence.

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -1,0 +1,115 @@
+"""Contracts for the primary-source aqueous H2S/O2 kinetics guide."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDE = ROOT / "docs/chemicalreactions/h2s_oxygen_kinetics.md"
+PACKAGE_INDEX = ROOT / "docs/chemicalreactions/README.md"
+IMPLEMENTATION = (
+    ROOT
+    / "src/main/java/neqsim/process/equipment/reactor/"
+    / "AqueousHydrogenSulfideOxidationKinetics.java"
+)
+JAVA_TEST = (
+    ROOT
+    / "src/test/java/neqsim/process/equipment/reactor/"
+    / "AqueousHydrogenSulfideOxidationKineticsTest.java"
+)
+
+
+class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
+    """Protect source fidelity, validity limits, and integration boundaries."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.guide = GUIDE.read_text(encoding="utf-8")
+        cls.package_index = PACKAGE_INDEX.read_text(encoding="utf-8")
+        cls.implementation = IMPLEMENTATION.read_text(encoding="utf-8")
+        cls.java_test = JAVA_TEST.read_text(encoding="utf-8")
+        cls.normalized = " ".join(cls.guide.split())
+
+    def test_source_equation_and_units_are_explicit(self):
+        for token in (
+            "doi:10.1021/es00159a003",
+            r"\log_{10} k = 10.50 + 0.16",
+            r"\frac{3000}{T} + 0.44\sqrt{I}",
+            "kg-water mol-1 h-1 basis",
+            "0.44",
+            "0.49",
+            "secondary value is not used",
+            "0.18",
+            "10^0.18 = 1.51356",
+        ):
+            self.assertIn(token, self.normalized)
+
+    def test_published_domain_and_example_are_documented(self):
+        for token in (
+            "278.15–338.15 K",
+            "pH 4–8",
+            "0–6 mol/kg water",
+            "air-saturated water/NaCl/seawater",
+            "25 +/- 5 micromol/kg water",
+            "atmospheric-pressure evidence",
+            "123.6175 kg water/(mol h)",
+            "22.4288 h",
+            "example input",
+            "not a new solubility correlation",
+        ):
+            self.assertIn(token, self.normalized)
+
+    def test_implementation_mirrors_source_contract(self):
+        for token in (
+            'SOURCE_IDENTIFIER = "doi:10.1021/es00159a003"',
+            "MINIMUM_TEMPERATURE_K = 278.15",
+            "MAXIMUM_TEMPERATURE_K = 338.15",
+            "MINIMUM_PH = 4.0",
+            "MAXIMUM_PH = 8.0",
+            "MAXIMUM_IONIC_STRENGTH_MOL_PER_KG_WATER = 6.0",
+            "PUBLISHED_INITIAL_TOTAL_SULFIDE_MOLALITY = 25.0e-6",
+            "PUBLISHED_INITIAL_TOTAL_SULFIDE_SPREAD = 5.0e-6",
+            "LOG10_RATE_STANDARD_DEVIATION = 0.18",
+            "SQRT_IONIC_STRENGTH_COEFFICIENT = 0.44",
+            "public static double secondOrderRateConstant(",
+            "public static RateConstantRange secondOrderRateConstantRange(",
+            "public static ScreeningResult screenAirSaturatedExposure(",
+            "Math.expm1(-exposure)",
+        ):
+            self.assertIn(token, self.implementation)
+
+    def test_numerical_behavior_has_executable_java_coverage(self):
+        for token in (
+            "testPrimarySourceMetadataAndReferenceEquation",
+            "testPublishedBoundariesAreInclusiveAndExtrapolationFailsClosed",
+            "testRateIsMonotonicWithinThePublishedCorrelation",
+            "testReportedLogRateScatterIsAppliedMultiplicatively",
+            "testConstantOxygenExposureUsesExactPseudoFirstOrderSolution",
+            "testLongExposureRemainsBoundedAndInputValidationFailsClosed",
+        ):
+            self.assertIn(token, self.java_test)
+
+    def test_stop_boundary_prevents_pipeline_overclaim(self):
+        for token in (
+            "does not assign products or consume oxygen",
+            "does not:",
+            "calculate pH, H2S/HS- speciation",
+            "calculate oxygen solubility",
+            "qualify elevated pressure",
+            "bind the correlation to experimental R1–R8 constants",
+            "mutate a thermodynamic system",
+            "issue #3144",
+            "#2937",
+            "#2911",
+            "#3153",
+            "requires separate phase, pressure, mass-transfer, and composition evidence",
+        ):
+            self.assertIn(token, self.normalized)
+
+    def test_guide_is_discoverable(self):
+        self.assertIn("h2s_oxygen_kinetics", self.package_index)
+        self.assertIn("aqueous H2S/O2 kinetics guide", self.package_index)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKinetics.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKinetics.java
@@ -3,24 +3,23 @@ package neqsim.process.equipment.reactor;
 import java.io.Serializable;
 
 /**
- * Primary-source screening correlation for abiotic oxidation of total dissolved sulfide by
- * air-saturated oxygen.
+ * Primary-source screening correlation for abiotic oxidation of total dissolved sulfide by air-saturated oxygen.
  *
  * <p>
- * Millero et al. measured total-sulfide loss in air-saturated water, seawater, and NaCl
- * solutions. For pH 4-8, 278.15-338.15 K, and ionic strength 0-6 mol/kg water, their simplified
- * correlation is {@code log10(k) = 10.50 + 0.16 pH - 3000/T + 0.44 sqrt(I)}. The second-order
- * rate constant uses the reported kg-water mol-1 h-1 basis.
+ * Millero et al. measured total-sulfide loss in air-saturated water, seawater, and NaCl solutions. For pH 4-8,
+ * 278.15-338.15 K, and ionic strength 0-6 mol/kg water, their simplified correlation is
+ * {@code log10(k) = 10.50 + 0.16 pH - 3000/T + 0.44 sqrt(I)}. The second-order rate constant uses the reported kg-water
+ * mol-1 h-1 basis.
  * </p>
  *
  * <p>
- * This class does not calculate oxygen solubility, sulfide speciation, products, pressure
- * effects, or a pipeline source term. Exposure methods require the caller to supply the molality
- * of air-saturated dissolved oxygen and assume that it remains constant.
+ * This class does not calculate oxygen solubility, sulfide speciation, products, pressure effects, or a pipeline source
+ * term. Exposure methods require the caller to supply the molality of air-saturated dissolved oxygen and assume that it
+ * remains constant.
  * </p>
  *
- * @see <a href="https://doi.org/10.1021/es00159a003">Millero et al. (1987),
- *      Environmental Science &amp; Technology 21, 439-443</a>
+ * @see <a href="https://doi.org/10.1021/es00159a003">Millero et al. (1987), Environmental Science &amp; Technology 21,
+ * 439-443</a>
  * @author NeqSim Team
  * @version 1.0
  */
@@ -31,12 +30,10 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
   public static final String SOURCE_IDENTIFIER = "doi:10.1021/es00159a003";
 
   /** Human-readable primary-source citation. */
-  public static final String SOURCE_CITATION =
-      "F. J. Millero, S. Hubinger, M. Fernandez and S. Garnett, Environmental Science & Technology 21 (1987) 439-443";
+  public static final String SOURCE_CITATION = "F. J. Millero, S. Hubinger, M. Fernandez and S. Garnett, Environmental Science & Technology 21 (1987) 439-443";
 
   /** Public-access and redistribution note for the implemented source material. */
-  public static final String SOURCE_ACCESS_STATUS =
-      "Public DOI metadata and source equation; no tabulated measurements redistributed";
+  public static final String SOURCE_ACCESS_STATUS = "Public DOI metadata and source equation; no tabulated measurements redistributed";
 
   /** Minimum temperature in the simplified published correlation [K]. */
   public static final double MINIMUM_TEMPERATURE_K = 278.15;
@@ -82,11 +79,9 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
    * @return second-order rate constant [kg water/(mol h)]
    * @throws IllegalArgumentException when an input is non-finite or outside the published range
    */
-  public static double secondOrderRateConstant(double temperatureK, double pH,
-      double ionicStrengthMolPerKgWater) {
+  public static double secondOrderRateConstant(double temperatureK, double pH, double ionicStrengthMolPerKgWater) {
     requirePublishedState(temperatureK, pH, ionicStrengthMolPerKgWater);
-    double log10Rate = LOG10_INTERCEPT + PH_COEFFICIENT * pH
-        - INVERSE_TEMPERATURE_K / temperatureK
+    double log10Rate = LOG10_INTERCEPT + PH_COEFFICIENT * pH - INVERSE_TEMPERATURE_K / temperatureK
         + SQRT_IONIC_STRENGTH_COEFFICIENT * Math.sqrt(ionicStrengthMolPerKgWater);
     return Math.pow(10.0, log10Rate);
   }
@@ -95,9 +90,9 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
    * Calculate the nominal correlation and its reported one-standard-deviation fit interval.
    *
    * <p>
-   * The source reports a standard deviation of 0.18 in log10(k). The returned interval therefore
-   * multiplies and divides the nominal rate by {@code 10^0.18}. It represents regression scatter,
-   * not a complete predictive or mechanistic uncertainty.
+   * The source reports a standard deviation of 0.18 in log10(k). The returned interval therefore multiplies and divides
+   * the nominal rate by {@code 10^0.18}. It represents regression scatter, not a complete predictive or mechanistic
+   * uncertainty.
    * </p>
    *
    * @param temperatureK aqueous temperature [K]
@@ -116,20 +111,19 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
   /**
    * Calculate the pseudo-first-order rate for a supplied air-saturated oxygen molality.
    *
-   * @param airSaturatedOxygenMolality dissolved oxygen molality for an independently established
-   *        air-saturated aqueous state [mol/kg water]
+   * @param airSaturatedOxygenMolality dissolved oxygen molality for an independently established air-saturated aqueous
+   * state [mol/kg water]
    * @param temperatureK aqueous temperature [K]
    * @param pH aqueous pH on the source-compatible scale
    * @param ionicStrengthMolPerKgWater ionic strength [mol/kg water]
    * @return pseudo-first-order total-sulfide loss rate [1/h]
-   * @throws IllegalArgumentException when oxygen is not finite and positive, or the state is
-   *         outside the published range
+   * @throws IllegalArgumentException when oxygen is not finite and positive, or the state is outside the published
+   * range
    */
-  public static double pseudoFirstOrderRateConstant(double airSaturatedOxygenMolality,
-      double temperatureK, double pH, double ionicStrengthMolPerKgWater) {
+  public static double pseudoFirstOrderRateConstant(double airSaturatedOxygenMolality, double temperatureK, double pH,
+      double ionicStrengthMolPerKgWater) {
     requireFinitePositive(airSaturatedOxygenMolality, "air-saturated oxygen molality");
-    double rate = secondOrderRateConstant(temperatureK, pH, ionicStrengthMolPerKgWater)
-        * airSaturatedOxygenMolality;
+    double rate = secondOrderRateConstant(temperatureK, pH, ionicStrengthMolPerKgWater) * airSaturatedOxygenMolality;
     if (!Double.isFinite(rate) || rate <= 0.0) {
       throw new IllegalArgumentException("pseudo-first-order rate must be finite and positive");
     }
@@ -139,60 +133,56 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
   /**
    * Calculate the nominal total-sulfide half-life under constant air-saturated oxygen.
    *
-   * @param airSaturatedOxygenMolality dissolved oxygen molality for an independently established
-   *        air-saturated aqueous state [mol/kg water]
+   * @param airSaturatedOxygenMolality dissolved oxygen molality for an independently established air-saturated aqueous
+   * state [mol/kg water]
    * @param temperatureK aqueous temperature [K]
    * @param pH aqueous pH on the source-compatible scale
    * @param ionicStrengthMolPerKgWater ionic strength [mol/kg water]
    * @return nominal total-sulfide half-life [h]
-   * @throws IllegalArgumentException when oxygen is not finite and positive, or the state is
-   *         outside the published range
+   * @throws IllegalArgumentException when oxygen is not finite and positive, or the state is outside the published
+   * range
    */
-  public static double halfLifeHours(double airSaturatedOxygenMolality, double temperatureK,
-      double pH, double ionicStrengthMolPerKgWater) {
-    return Math.log(2.0) / pseudoFirstOrderRateConstant(airSaturatedOxygenMolality,
-        temperatureK, pH, ionicStrengthMolPerKgWater);
+  public static double halfLifeHours(double airSaturatedOxygenMolality, double temperatureK, double pH,
+      double ionicStrengthMolPerKgWater) {
+    return Math.log(2.0)
+        / pseudoFirstOrderRateConstant(airSaturatedOxygenMolality, temperatureK, pH, ionicStrengthMolPerKgWater);
   }
 
   /**
    * Screen total-sulfide loss for an exposure with constant air-saturated dissolved oxygen.
    *
    * <p>
-   * The remaining fraction is the exact pseudo-first-order result {@code exp(-k[O2]t)}. No
-   * reaction products or oxygen consumption are calculated.
+   * The remaining fraction is the exact pseudo-first-order result {@code exp(-k[O2]t)}. No reaction products or oxygen
+   * consumption are calculated.
    * </p>
    *
-   * @param airSaturatedOxygenMolality dissolved oxygen molality for an independently established
-   *        air-saturated aqueous state [mol/kg water]
+   * @param airSaturatedOxygenMolality dissolved oxygen molality for an independently established air-saturated aqueous
+   * state [mol/kg water]
    * @param elapsedTimeHours elapsed exposure time [h]
    * @param temperatureK aqueous temperature [K]
    * @param pH aqueous pH on the source-compatible scale
    * @param ionicStrengthMolPerKgWater ionic strength [mol/kg water]
    * @return immutable exposure-screening result
-   * @throws IllegalArgumentException when elapsed time is negative or non-finite, oxygen is not
-   *         finite and positive, or the state is outside the published range
+   * @throws IllegalArgumentException when elapsed time is negative or non-finite, oxygen is not finite and positive, or
+   * the state is outside the published range
    */
-  public static ScreeningResult screenAirSaturatedExposure(double airSaturatedOxygenMolality,
-      double elapsedTimeHours, double temperatureK, double pH,
-      double ionicStrengthMolPerKgWater) {
+  public static ScreeningResult screenAirSaturatedExposure(double airSaturatedOxygenMolality, double elapsedTimeHours,
+      double temperatureK, double pH, double ionicStrengthMolPerKgWater) {
     requireFiniteNonNegative(elapsedTimeHours, "elapsed time");
-    double secondOrderRate =
-        secondOrderRateConstant(temperatureK, pH, ionicStrengthMolPerKgWater);
-    double pseudoFirstOrderRate =
-        pseudoFirstOrderRateConstant(airSaturatedOxygenMolality, temperatureK, pH,
-            ionicStrengthMolPerKgWater);
+    double secondOrderRate = secondOrderRateConstant(temperatureK, pH, ionicStrengthMolPerKgWater);
+    double pseudoFirstOrderRate = pseudoFirstOrderRateConstant(airSaturatedOxygenMolality, temperatureK, pH,
+        ionicStrengthMolPerKgWater);
     double exposure = pseudoFirstOrderRate * elapsedTimeHours;
     if (!Double.isFinite(exposure)) {
       throw new IllegalArgumentException("kinetic exposure must be finite");
     }
     double remainingFraction = Math.exp(-exposure);
     double reactedFraction = Math.max(0.0, Math.min(1.0, -Math.expm1(-exposure)));
-    return new ScreeningResult(secondOrderRate, pseudoFirstOrderRate,
-        Math.log(2.0) / pseudoFirstOrderRate, exposure, remainingFraction, reactedFraction);
+    return new ScreeningResult(secondOrderRate, pseudoFirstOrderRate, Math.log(2.0) / pseudoFirstOrderRate, exposure,
+        remainingFraction, reactedFraction);
   }
 
-  private static void requirePublishedState(double temperatureK, double pH,
-      double ionicStrengthMolPerKgWater) {
+  private static void requirePublishedState(double temperatureK, double pH, double ionicStrengthMolPerKgWater) {
     requireRange(temperatureK, MINIMUM_TEMPERATURE_K, MAXIMUM_TEMPERATURE_K, "temperature");
     requireRange(pH, MINIMUM_PH, MAXIMUM_PH, "pH");
     requireRange(ionicStrengthMolPerKgWater, MINIMUM_IONIC_STRENGTH_MOL_PER_KG_WATER,
@@ -201,8 +191,7 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
 
   private static void requireRange(double value, double minimum, double maximum, String name) {
     if (!Double.isFinite(value) || value < minimum || value > maximum) {
-      throw new IllegalArgumentException(
-          name + " must be within the published range of " + minimum + " to " + maximum);
+      throw new IllegalArgumentException(name + " must be within the published range of " + minimum + " to " + maximum);
     }
   }
 
@@ -259,8 +248,8 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
     private final double remainingFraction;
     private final double reactedFraction;
 
-    private ScreeningResult(double secondOrderRateConstant, double pseudoFirstOrderRateConstant,
-        double halfLifeHours, double exposure, double remainingFraction, double reactedFraction) {
+    private ScreeningResult(double secondOrderRateConstant, double pseudoFirstOrderRateConstant, double halfLifeHours,
+        double exposure, double remainingFraction, double reactedFraction) {
       this.secondOrderRateConstant = secondOrderRateConstant;
       this.pseudoFirstOrderRateConstant = pseudoFirstOrderRateConstant;
       this.halfLifeHours = halfLifeHours;

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKinetics.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKinetics.java
@@ -1,0 +1,302 @@
+package neqsim.process.equipment.reactor;
+
+import java.io.Serializable;
+
+/**
+ * Primary-source screening correlation for abiotic oxidation of total dissolved sulfide by
+ * air-saturated oxygen.
+ *
+ * <p>
+ * Millero et al. measured total-sulfide loss in air-saturated water, seawater, and NaCl
+ * solutions. For pH 4-8, 278.15-338.15 K, and ionic strength 0-6 mol/kg water, their simplified
+ * correlation is {@code log10(k) = 10.50 + 0.16 pH - 3000/T + 0.44 sqrt(I)}. The second-order
+ * rate constant uses the reported kg-water mol-1 h-1 basis.
+ * </p>
+ *
+ * <p>
+ * This class does not calculate oxygen solubility, sulfide speciation, products, pressure
+ * effects, or a pipeline source term. Exposure methods require the caller to supply the molality
+ * of air-saturated dissolved oxygen and assume that it remains constant.
+ * </p>
+ *
+ * @see <a href="https://doi.org/10.1021/es00159a003">Millero et al. (1987),
+ *      Environmental Science &amp; Technology 21, 439-443</a>
+ * @author NeqSim Team
+ * @version 1.0
+ */
+public final class AqueousHydrogenSulfideOxidationKinetics implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Primary-source DOI. */
+  public static final String SOURCE_IDENTIFIER = "doi:10.1021/es00159a003";
+
+  /** Human-readable primary-source citation. */
+  public static final String SOURCE_CITATION =
+      "F. J. Millero, S. Hubinger, M. Fernandez and S. Garnett, Environmental Science & Technology 21 (1987) 439-443";
+
+  /** Public-access and redistribution note for the implemented source material. */
+  public static final String SOURCE_ACCESS_STATUS =
+      "Public DOI metadata and source equation; no tabulated measurements redistributed";
+
+  /** Minimum temperature in the simplified published correlation [K]. */
+  public static final double MINIMUM_TEMPERATURE_K = 278.15;
+
+  /** Maximum temperature in the simplified published correlation [K]. */
+  public static final double MAXIMUM_TEMPERATURE_K = 338.15;
+
+  /** Minimum pH in the simplified published correlation. */
+  public static final double MINIMUM_PH = 4.0;
+
+  /** Maximum pH in the simplified published correlation. */
+  public static final double MAXIMUM_PH = 8.0;
+
+  /** Minimum ionic strength in the simplified published correlation [mol/kg water]. */
+  public static final double MINIMUM_IONIC_STRENGTH_MOL_PER_KG_WATER = 0.0;
+
+  /** Maximum ionic strength in the simplified published correlation [mol/kg water]. */
+  public static final double MAXIMUM_IONIC_STRENGTH_MOL_PER_KG_WATER = 6.0;
+
+  /** Initial total-sulfide molality reported for the experiments [mol/kg water]. */
+  public static final double PUBLISHED_INITIAL_TOTAL_SULFIDE_MOLALITY = 25.0e-6;
+
+  /** Reported spread around the initial total-sulfide molality [mol/kg water]. */
+  public static final double PUBLISHED_INITIAL_TOTAL_SULFIDE_SPREAD = 5.0e-6;
+
+  /** Standard deviation of the simplified fit in log10(k). */
+  public static final double LOG10_RATE_STANDARD_DEVIATION = 0.18;
+
+  private static final double LOG10_INTERCEPT = 10.50;
+  private static final double PH_COEFFICIENT = 0.16;
+  private static final double INVERSE_TEMPERATURE_K = 3000.0;
+  private static final double SQRT_IONIC_STRENGTH_COEFFICIENT = 0.44;
+
+  private AqueousHydrogenSulfideOxidationKinetics() {
+  }
+
+  /**
+   * Calculate the published second-order total-sulfide oxidation rate constant.
+   *
+   * @param temperatureK aqueous temperature [K]
+   * @param pH aqueous pH on the source-compatible scale
+   * @param ionicStrengthMolPerKgWater ionic strength [mol/kg water]
+   * @return second-order rate constant [kg water/(mol h)]
+   * @throws IllegalArgumentException when an input is non-finite or outside the published range
+   */
+  public static double secondOrderRateConstant(double temperatureK, double pH,
+      double ionicStrengthMolPerKgWater) {
+    requirePublishedState(temperatureK, pH, ionicStrengthMolPerKgWater);
+    double log10Rate = LOG10_INTERCEPT + PH_COEFFICIENT * pH
+        - INVERSE_TEMPERATURE_K / temperatureK
+        + SQRT_IONIC_STRENGTH_COEFFICIENT * Math.sqrt(ionicStrengthMolPerKgWater);
+    return Math.pow(10.0, log10Rate);
+  }
+
+  /**
+   * Calculate the nominal correlation and its reported one-standard-deviation fit interval.
+   *
+   * <p>
+   * The source reports a standard deviation of 0.18 in log10(k). The returned interval therefore
+   * multiplies and divides the nominal rate by {@code 10^0.18}. It represents regression scatter,
+   * not a complete predictive or mechanistic uncertainty.
+   * </p>
+   *
+   * @param temperatureK aqueous temperature [K]
+   * @param pH aqueous pH on the source-compatible scale
+   * @param ionicStrengthMolPerKgWater ionic strength [mol/kg water]
+   * @return immutable nominal and one-standard-deviation rate interval
+   * @throws IllegalArgumentException when an input is non-finite or outside the published range
+   */
+  public static RateConstantRange secondOrderRateConstantRange(double temperatureK, double pH,
+      double ionicStrengthMolPerKgWater) {
+    double nominal = secondOrderRateConstant(temperatureK, pH, ionicStrengthMolPerKgWater);
+    double factor = Math.pow(10.0, LOG10_RATE_STANDARD_DEVIATION);
+    return new RateConstantRange(nominal / factor, nominal, nominal * factor);
+  }
+
+  /**
+   * Calculate the pseudo-first-order rate for a supplied air-saturated oxygen molality.
+   *
+   * @param airSaturatedOxygenMolality dissolved oxygen molality for an independently established
+   *        air-saturated aqueous state [mol/kg water]
+   * @param temperatureK aqueous temperature [K]
+   * @param pH aqueous pH on the source-compatible scale
+   * @param ionicStrengthMolPerKgWater ionic strength [mol/kg water]
+   * @return pseudo-first-order total-sulfide loss rate [1/h]
+   * @throws IllegalArgumentException when oxygen is not finite and positive, or the state is
+   *         outside the published range
+   */
+  public static double pseudoFirstOrderRateConstant(double airSaturatedOxygenMolality,
+      double temperatureK, double pH, double ionicStrengthMolPerKgWater) {
+    requireFinitePositive(airSaturatedOxygenMolality, "air-saturated oxygen molality");
+    double rate = secondOrderRateConstant(temperatureK, pH, ionicStrengthMolPerKgWater)
+        * airSaturatedOxygenMolality;
+    if (!Double.isFinite(rate)) {
+      throw new IllegalArgumentException("pseudo-first-order rate must be finite");
+    }
+    return rate;
+  }
+
+  /**
+   * Calculate the nominal total-sulfide half-life under constant air-saturated oxygen.
+   *
+   * @param airSaturatedOxygenMolality dissolved oxygen molality for an independently established
+   *        air-saturated aqueous state [mol/kg water]
+   * @param temperatureK aqueous temperature [K]
+   * @param pH aqueous pH on the source-compatible scale
+   * @param ionicStrengthMolPerKgWater ionic strength [mol/kg water]
+   * @return nominal total-sulfide half-life [h]
+   * @throws IllegalArgumentException when oxygen is not finite and positive, or the state is
+   *         outside the published range
+   */
+  public static double halfLifeHours(double airSaturatedOxygenMolality, double temperatureK,
+      double pH, double ionicStrengthMolPerKgWater) {
+    return Math.log(2.0) / pseudoFirstOrderRateConstant(airSaturatedOxygenMolality,
+        temperatureK, pH, ionicStrengthMolPerKgWater);
+  }
+
+  /**
+   * Screen total-sulfide loss for an exposure with constant air-saturated dissolved oxygen.
+   *
+   * <p>
+   * The remaining fraction is the exact pseudo-first-order result {@code exp(-k[O2]t)}. No
+   * reaction products or oxygen consumption are calculated.
+   * </p>
+   *
+   * @param airSaturatedOxygenMolality dissolved oxygen molality for an independently established
+   *        air-saturated aqueous state [mol/kg water]
+   * @param elapsedTimeHours elapsed exposure time [h]
+   * @param temperatureK aqueous temperature [K]
+   * @param pH aqueous pH on the source-compatible scale
+   * @param ionicStrengthMolPerKgWater ionic strength [mol/kg water]
+   * @return immutable exposure-screening result
+   * @throws IllegalArgumentException when elapsed time is negative or non-finite, oxygen is not
+   *         finite and positive, or the state is outside the published range
+   */
+  public static ScreeningResult screenAirSaturatedExposure(double airSaturatedOxygenMolality,
+      double elapsedTimeHours, double temperatureK, double pH,
+      double ionicStrengthMolPerKgWater) {
+    requireFiniteNonNegative(elapsedTimeHours, "elapsed time");
+    double secondOrderRate =
+        secondOrderRateConstant(temperatureK, pH, ionicStrengthMolPerKgWater);
+    double pseudoFirstOrderRate =
+        pseudoFirstOrderRateConstant(airSaturatedOxygenMolality, temperatureK, pH,
+            ionicStrengthMolPerKgWater);
+    double exposure = pseudoFirstOrderRate * elapsedTimeHours;
+    if (!Double.isFinite(exposure)) {
+      throw new IllegalArgumentException("kinetic exposure must be finite");
+    }
+    double remainingFraction = Math.exp(-exposure);
+    double reactedFraction = Math.max(0.0, Math.min(1.0, -Math.expm1(-exposure)));
+    return new ScreeningResult(secondOrderRate, pseudoFirstOrderRate,
+        Math.log(2.0) / pseudoFirstOrderRate, exposure, remainingFraction, reactedFraction);
+  }
+
+  private static void requirePublishedState(double temperatureK, double pH,
+      double ionicStrengthMolPerKgWater) {
+    requireRange(temperatureK, MINIMUM_TEMPERATURE_K, MAXIMUM_TEMPERATURE_K, "temperature");
+    requireRange(pH, MINIMUM_PH, MAXIMUM_PH, "pH");
+    requireRange(ionicStrengthMolPerKgWater, MINIMUM_IONIC_STRENGTH_MOL_PER_KG_WATER,
+        MAXIMUM_IONIC_STRENGTH_MOL_PER_KG_WATER, "ionic strength");
+  }
+
+  private static void requireRange(double value, double minimum, double maximum, String name) {
+    if (!Double.isFinite(value) || value < minimum || value > maximum) {
+      throw new IllegalArgumentException(
+          name + " must be within the published range of " + minimum + " to " + maximum);
+    }
+  }
+
+  private static void requireFinitePositive(double value, String name) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and positive");
+    }
+  }
+
+  private static void requireFiniteNonNegative(double value, String name) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and non-negative");
+    }
+  }
+
+  /** Immutable second-order rate-constant interval. */
+  public static final class RateConstantRange implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double lower;
+    private final double nominal;
+    private final double upper;
+
+    private RateConstantRange(double lower, double nominal, double upper) {
+      this.lower = lower;
+      this.nominal = nominal;
+      this.upper = upper;
+    }
+
+    /** @return lower one-standard-deviation rate [kg water/(mol h)]. */
+    public double getLower() {
+      return lower;
+    }
+
+    /** @return nominal rate [kg water/(mol h)]. */
+    public double getNominal() {
+      return nominal;
+    }
+
+    /** @return upper one-standard-deviation rate [kg water/(mol h)]. */
+    public double getUpper() {
+      return upper;
+    }
+  }
+
+  /** Immutable constant-oxygen exposure result. */
+  public static final class ScreeningResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double secondOrderRateConstant;
+    private final double pseudoFirstOrderRateConstant;
+    private final double halfLifeHours;
+    private final double exposure;
+    private final double remainingFraction;
+    private final double reactedFraction;
+
+    private ScreeningResult(double secondOrderRateConstant, double pseudoFirstOrderRateConstant,
+        double halfLifeHours, double exposure, double remainingFraction, double reactedFraction) {
+      this.secondOrderRateConstant = secondOrderRateConstant;
+      this.pseudoFirstOrderRateConstant = pseudoFirstOrderRateConstant;
+      this.halfLifeHours = halfLifeHours;
+      this.exposure = exposure;
+      this.remainingFraction = remainingFraction;
+      this.reactedFraction = reactedFraction;
+    }
+
+    /** @return second-order rate constant [kg water/(mol h)]. */
+    public double getSecondOrderRateConstant() {
+      return secondOrderRateConstant;
+    }
+
+    /** @return pseudo-first-order rate constant [1/h]. */
+    public double getPseudoFirstOrderRateConstant() {
+      return pseudoFirstOrderRateConstant;
+    }
+
+    /** @return nominal total-sulfide half-life [h]. */
+    public double getHalfLifeHours() {
+      return halfLifeHours;
+    }
+
+    /** @return dimensionless pseudo-first-order exposure {@code k[O2]t}. */
+    public double getExposure() {
+      return exposure;
+    }
+
+    /** @return total-sulfide fraction remaining in the interval [0, 1]. */
+    public double getRemainingFraction() {
+      return remainingFraction;
+    }
+
+    /** @return total-sulfide fraction lost in the interval [0, 1]. */
+    public double getReactedFraction() {
+      return reactedFraction;
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKinetics.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKinetics.java
@@ -130,8 +130,8 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
     requireFinitePositive(airSaturatedOxygenMolality, "air-saturated oxygen molality");
     double rate = secondOrderRateConstant(temperatureK, pH, ionicStrengthMolPerKgWater)
         * airSaturatedOxygenMolality;
-    if (!Double.isFinite(rate)) {
-      throw new IllegalArgumentException("pseudo-first-order rate must be finite");
+    if (!Double.isFinite(rate) || rate <= 0.0) {
+      throw new IllegalArgumentException("pseudo-first-order rate must be finite and positive");
     }
     return rate;
   }

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKineticsTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKineticsTest.java
@@ -1,0 +1,138 @@
+package neqsim.process.equipment.reactor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+
+/** Tests the primary-source aqueous total-sulfide oxidation screening correlation. */
+public class AqueousHydrogenSulfideOxidationKineticsTest extends NeqSimTest {
+  private static final double TEMPERATURE_K = 298.15;
+  private static final double PH = 8.0;
+  private static final double IONIC_STRENGTH = 0.723;
+  private static final double AIR_SATURATED_OXYGEN_MOLALITY = 250.0e-6;
+
+  @Test
+  void testPrimarySourceMetadataAndReferenceEquation() {
+    assertEquals("doi:10.1021/es00159a003",
+        AqueousHydrogenSulfideOxidationKinetics.SOURCE_IDENTIFIER);
+    assertEquals(25.0e-6,
+        AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_MOLALITY);
+    assertEquals(5.0e-6,
+        AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_SPREAD);
+
+    double rate = AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
+        TEMPERATURE_K, PH, IONIC_STRENGTH);
+
+    assertEquals(123.61753672611606, rate, 1.0e-10);
+    assertEquals(10.50 + 0.16 * PH - 3000.0 / TEMPERATURE_K
+        + 0.44 * Math.sqrt(IONIC_STRENGTH), Math.log10(rate), 1.0e-12);
+  }
+
+  @Test
+  void testPublishedBoundariesAreInclusiveAndExtrapolationFailsClosed() {
+    assertTrue(AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
+        278.15, 4.0, 0.0) > 0.0);
+    assertTrue(AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
+        338.15, 8.0, 6.0) > 0.0);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
+            278.15 - 1.0e-9, 4.0, 0.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
+            338.15 + 1.0e-9, 8.0, 6.0));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
+            TEMPERATURE_K, 3.999, IONIC_STRENGTH));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
+            TEMPERATURE_K, 8.001, IONIC_STRENGTH));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
+            TEMPERATURE_K, PH, -1.0e-9));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
+            TEMPERATURE_K, PH, 6.0 + 1.0e-9));
+  }
+
+  @Test
+  void testRateIsMonotonicWithinThePublishedCorrelation() {
+    double base = AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
+        TEMPERATURE_K, 6.0, 1.0);
+
+    assertTrue(AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
+        TEMPERATURE_K + 1.0, 6.0, 1.0) > base);
+    assertTrue(AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
+        TEMPERATURE_K, 6.1, 1.0) > base);
+    assertTrue(AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
+        TEMPERATURE_K, 6.0, 1.1) > base);
+  }
+
+  @Test
+  void testReportedLogRateScatterIsAppliedMultiplicatively() {
+    AqueousHydrogenSulfideOxidationKinetics.RateConstantRange range =
+        AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstantRange(
+            TEMPERATURE_K, PH, IONIC_STRENGTH);
+    double factor = Math.pow(10.0, 0.18);
+
+    assertEquals(range.getNominal() / factor, range.getLower(), 1.0e-12);
+    assertEquals(range.getNominal() * factor, range.getUpper(), 1.0e-12);
+    assertEquals(factor, range.getUpper() / range.getNominal(), 1.0e-12);
+    assertEquals(factor, range.getNominal() / range.getLower(), 1.0e-12);
+  }
+
+  @Test
+  void testConstantOxygenExposureUsesExactPseudoFirstOrderSolution() {
+    double halfLife = AqueousHydrogenSulfideOxidationKinetics.halfLifeHours(
+        AIR_SATURATED_OXYGEN_MOLALITY, TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.ScreeningResult zero =
+        AqueousHydrogenSulfideOxidationKinetics.screenAirSaturatedExposure(
+            AIR_SATURATED_OXYGEN_MOLALITY, 0.0, TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.ScreeningResult oneHalfLife =
+        AqueousHydrogenSulfideOxidationKinetics.screenAirSaturatedExposure(
+            AIR_SATURATED_OXYGEN_MOLALITY, halfLife, TEMPERATURE_K, PH,
+            IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.ScreeningResult twoHalfLives =
+        AqueousHydrogenSulfideOxidationKinetics.screenAirSaturatedExposure(
+            AIR_SATURATED_OXYGEN_MOLALITY, 2.0 * halfLife, TEMPERATURE_K, PH,
+            IONIC_STRENGTH);
+
+    assertEquals(22.428765332726698, halfLife, 1.0e-11);
+    assertEquals(1.0, zero.getRemainingFraction(), 0.0);
+    assertEquals(0.0, zero.getReactedFraction(), 0.0);
+    assertEquals(0.5, oneHalfLife.getRemainingFraction(), 1.0e-15);
+    assertEquals(0.5, oneHalfLife.getReactedFraction(), 1.0e-15);
+    assertEquals(0.25, twoHalfLives.getRemainingFraction(), 1.0e-15);
+    assertEquals(0.75, twoHalfLives.getReactedFraction(), 1.0e-15);
+    assertEquals(oneHalfLife.getSecondOrderRateConstant()
+        * AIR_SATURATED_OXYGEN_MOLALITY,
+        oneHalfLife.getPseudoFirstOrderRateConstant(), 1.0e-15);
+    assertEquals(Math.log(2.0), oneHalfLife.getExposure(), 1.0e-15);
+  }
+
+  @Test
+  void testLongExposureRemainsBoundedAndInputValidationFailsClosed() {
+    AqueousHydrogenSulfideOxidationKinetics.ScreeningResult longExposure =
+        AqueousHydrogenSulfideOxidationKinetics.screenAirSaturatedExposure(
+            AIR_SATURATED_OXYGEN_MOLALITY, 1.0e6, TEMPERATURE_K, PH,
+            IONIC_STRENGTH);
+
+    assertEquals(0.0, longExposure.getRemainingFraction(), 0.0);
+    assertEquals(1.0, longExposure.getReactedFraction(), 0.0);
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationKinetics.screenAirSaturatedExposure(
+            0.0, 1.0, TEMPERATURE_K, PH, IONIC_STRENGTH));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationKinetics.screenAirSaturatedExposure(
+            AIR_SATURATED_OXYGEN_MOLALITY, -1.0, TEMPERATURE_K, PH,
+            IONIC_STRENGTH));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
+            Double.NaN, PH, IONIC_STRENGTH));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationKinetics.pseudoFirstOrderRateConstant(
+            Double.MIN_VALUE, TEMPERATURE_K, PH, IONIC_STRENGTH));
+  }
+}

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKineticsTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKineticsTest.java
@@ -15,66 +15,49 @@ public class AqueousHydrogenSulfideOxidationKineticsTest extends NeqSimTest {
 
   @Test
   void testPrimarySourceMetadataAndReferenceEquation() {
-    assertEquals("doi:10.1021/es00159a003",
-        AqueousHydrogenSulfideOxidationKinetics.SOURCE_IDENTIFIER);
-    assertEquals(25.0e-6,
-        AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_MOLALITY);
-    assertEquals(5.0e-6,
-        AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_SPREAD);
+    assertEquals("doi:10.1021/es00159a003", AqueousHydrogenSulfideOxidationKinetics.SOURCE_IDENTIFIER);
+    assertEquals(25.0e-6, AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_MOLALITY);
+    assertEquals(5.0e-6, AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_SPREAD);
 
-    double rate = AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
-        TEMPERATURE_K, PH, IONIC_STRENGTH);
+    double rate = AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(TEMPERATURE_K, PH, IONIC_STRENGTH);
 
     assertEquals(123.61753672611606, rate, 1.0e-10);
-    assertEquals(10.50 + 0.16 * PH - 3000.0 / TEMPERATURE_K
-        + 0.44 * Math.sqrt(IONIC_STRENGTH), Math.log10(rate), 1.0e-12);
+    assertEquals(10.50 + 0.16 * PH - 3000.0 / TEMPERATURE_K + 0.44 * Math.sqrt(IONIC_STRENGTH), Math.log10(rate),
+        1.0e-12);
   }
 
   @Test
   void testPublishedBoundariesAreInclusiveAndExtrapolationFailsClosed() {
-    assertTrue(AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
-        278.15, 4.0, 0.0) > 0.0);
-    assertTrue(AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
-        338.15, 8.0, 6.0) > 0.0);
+    assertTrue(AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(278.15, 4.0, 0.0) > 0.0);
+    assertTrue(AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(338.15, 8.0, 6.0) > 0.0);
 
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
-            278.15 - 1.0e-9, 4.0, 0.0));
+        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(278.15 - 1.0e-9, 4.0, 0.0));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
-            338.15 + 1.0e-9, 8.0, 6.0));
+        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(338.15 + 1.0e-9, 8.0, 6.0));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
-            TEMPERATURE_K, 3.999, IONIC_STRENGTH));
+        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(TEMPERATURE_K, 3.999, IONIC_STRENGTH));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
-            TEMPERATURE_K, 8.001, IONIC_STRENGTH));
+        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(TEMPERATURE_K, 8.001, IONIC_STRENGTH));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
-            TEMPERATURE_K, PH, -1.0e-9));
+        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(TEMPERATURE_K, PH, -1.0e-9));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
-            TEMPERATURE_K, PH, 6.0 + 1.0e-9));
+        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(TEMPERATURE_K, PH, 6.0 + 1.0e-9));
   }
 
   @Test
   void testRateIsMonotonicWithinThePublishedCorrelation() {
-    double base = AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
-        TEMPERATURE_K, 6.0, 1.0);
+    double base = AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(TEMPERATURE_K, 6.0, 1.0);
 
-    assertTrue(AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
-        TEMPERATURE_K + 1.0, 6.0, 1.0) > base);
-    assertTrue(AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
-        TEMPERATURE_K, 6.1, 1.0) > base);
-    assertTrue(AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
-        TEMPERATURE_K, 6.0, 1.1) > base);
+    assertTrue(AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(TEMPERATURE_K + 1.0, 6.0, 1.0) > base);
+    assertTrue(AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(TEMPERATURE_K, 6.1, 1.0) > base);
+    assertTrue(AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(TEMPERATURE_K, 6.0, 1.1) > base);
   }
 
   @Test
   void testReportedLogRateScatterIsAppliedMultiplicatively() {
-    AqueousHydrogenSulfideOxidationKinetics.RateConstantRange range =
-        AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstantRange(
-            TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.RateConstantRange range = AqueousHydrogenSulfideOxidationKinetics
+        .secondOrderRateConstantRange(TEMPERATURE_K, PH, IONIC_STRENGTH);
     double factor = Math.pow(10.0, 0.18);
 
     assertEquals(range.getNominal() / factor, range.getLower(), 1.0e-12);
@@ -85,19 +68,14 @@ public class AqueousHydrogenSulfideOxidationKineticsTest extends NeqSimTest {
 
   @Test
   void testConstantOxygenExposureUsesExactPseudoFirstOrderSolution() {
-    double halfLife = AqueousHydrogenSulfideOxidationKinetics.halfLifeHours(
-        AIR_SATURATED_OXYGEN_MOLALITY, TEMPERATURE_K, PH, IONIC_STRENGTH);
-    AqueousHydrogenSulfideOxidationKinetics.ScreeningResult zero =
-        AqueousHydrogenSulfideOxidationKinetics.screenAirSaturatedExposure(
-            AIR_SATURATED_OXYGEN_MOLALITY, 0.0, TEMPERATURE_K, PH, IONIC_STRENGTH);
-    AqueousHydrogenSulfideOxidationKinetics.ScreeningResult oneHalfLife =
-        AqueousHydrogenSulfideOxidationKinetics.screenAirSaturatedExposure(
-            AIR_SATURATED_OXYGEN_MOLALITY, halfLife, TEMPERATURE_K, PH,
-            IONIC_STRENGTH);
-    AqueousHydrogenSulfideOxidationKinetics.ScreeningResult twoHalfLives =
-        AqueousHydrogenSulfideOxidationKinetics.screenAirSaturatedExposure(
-            AIR_SATURATED_OXYGEN_MOLALITY, 2.0 * halfLife, TEMPERATURE_K, PH,
-            IONIC_STRENGTH);
+    double halfLife = AqueousHydrogenSulfideOxidationKinetics.halfLifeHours(AIR_SATURATED_OXYGEN_MOLALITY,
+        TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.ScreeningResult zero = AqueousHydrogenSulfideOxidationKinetics
+        .screenAirSaturatedExposure(AIR_SATURATED_OXYGEN_MOLALITY, 0.0, TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.ScreeningResult oneHalfLife = AqueousHydrogenSulfideOxidationKinetics
+        .screenAirSaturatedExposure(AIR_SATURATED_OXYGEN_MOLALITY, halfLife, TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.ScreeningResult twoHalfLives = AqueousHydrogenSulfideOxidationKinetics
+        .screenAirSaturatedExposure(AIR_SATURATED_OXYGEN_MOLALITY, 2.0 * halfLife, TEMPERATURE_K, PH, IONIC_STRENGTH);
 
     assertEquals(22.428765332726698, halfLife, 1.0e-11);
     assertEquals(1.0, zero.getRemainingFraction(), 0.0);
@@ -106,33 +84,25 @@ public class AqueousHydrogenSulfideOxidationKineticsTest extends NeqSimTest {
     assertEquals(0.5, oneHalfLife.getReactedFraction(), 1.0e-15);
     assertEquals(0.25, twoHalfLives.getRemainingFraction(), 1.0e-15);
     assertEquals(0.75, twoHalfLives.getReactedFraction(), 1.0e-15);
-    assertEquals(oneHalfLife.getSecondOrderRateConstant()
-        * AIR_SATURATED_OXYGEN_MOLALITY,
+    assertEquals(oneHalfLife.getSecondOrderRateConstant() * AIR_SATURATED_OXYGEN_MOLALITY,
         oneHalfLife.getPseudoFirstOrderRateConstant(), 1.0e-15);
     assertEquals(Math.log(2.0), oneHalfLife.getExposure(), 1.0e-15);
   }
 
   @Test
   void testLongExposureRemainsBoundedAndInputValidationFailsClosed() {
-    AqueousHydrogenSulfideOxidationKinetics.ScreeningResult longExposure =
-        AqueousHydrogenSulfideOxidationKinetics.screenAirSaturatedExposure(
-            AIR_SATURATED_OXYGEN_MOLALITY, 1.0e6, TEMPERATURE_K, PH,
-            IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.ScreeningResult longExposure = AqueousHydrogenSulfideOxidationKinetics
+        .screenAirSaturatedExposure(AIR_SATURATED_OXYGEN_MOLALITY, 1.0e6, TEMPERATURE_K, PH, IONIC_STRENGTH);
 
     assertEquals(0.0, longExposure.getRemainingFraction(), 0.0);
     assertEquals(1.0, longExposure.getReactedFraction(), 0.0);
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
+        .screenAirSaturatedExposure(0.0, 1.0, TEMPERATURE_K, PH, IONIC_STRENGTH));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
+        .screenAirSaturatedExposure(AIR_SATURATED_OXYGEN_MOLALITY, -1.0, TEMPERATURE_K, PH, IONIC_STRENGTH));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationKinetics.screenAirSaturatedExposure(
-            0.0, 1.0, TEMPERATURE_K, PH, IONIC_STRENGTH));
-    assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationKinetics.screenAirSaturatedExposure(
-            AIR_SATURATED_OXYGEN_MOLALITY, -1.0, TEMPERATURE_K, PH,
-            IONIC_STRENGTH));
-    assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(
-            Double.NaN, PH, IONIC_STRENGTH));
-    assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationKinetics.pseudoFirstOrderRateConstant(
-            Double.MIN_VALUE, TEMPERATURE_K, PH, IONIC_STRENGTH));
+        () -> AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstant(Double.NaN, PH, IONIC_STRENGTH));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
+        .pseudoFirstOrderRateConstant(Double.MAX_VALUE, TEMPERATURE_K, PH, IONIC_STRENGTH));
   }
 }


### PR DESCRIPTION
## Summary

Advances #3318 with a primary-source, fail-closed aqueous H₂S/O₂ screening primitive.

Exact base: `71d55b17f81a9f895d91b0b50fcbfe21ee4dc1fa`  
Exact head: `9ba58cec8318efae6d63ae6dcd66e9356f2f75b9`

## Scientific evidence

Implements the simplified total-sulfide oxidation correlation from F. J. Millero, S. Hubinger, M. Fernandez and S. Garnett, *Environmental Science & Technology* 21 (1987) 439–443, [doi:10.1021/es00159a003](https://doi.org/10.1021/es00159a003):

`log10(k) = 10.50 + 0.16 pH - 3000/T + 0.44 sqrt(I)`

The primary source coefficient is 0.44. The 0.49 value transcribed in the later Luther et al. review is deliberately not used.

## Capability contract

- Fail closed outside 278.15–338.15 K, pH 4–8, and ionic strength 0–6 mol/kg water.
- Preserve the source kg-water mol⁻¹ h⁻¹ second-order rate basis.
- Record the source's low total-sulfide experiment level, 25 ± 5 µmol/kg water.
- Return the nominal rate and the reported 0.18-`log10(k)` fit-scatter interval.
- Compute constant-air-saturated-O₂ pseudo-first-order rate, half-life, and exact remaining/reacted fractions.
- Reject non-finite, negative, out-of-range, and underflowed rate inputs.

At 298.15 K, pH 8, I = 0.723 mol/kg water, and a caller-supplied air-saturated O₂ molality of 250 µmol/kg water, the implementation gives `k = 123.6175 kg water/(mol h)` and a nominal half-life of `22.4288 h`. The oxygen value is an illustrative input, not a solubility correlation or validation datum.

## Changes

- Add immutable `AqueousHydrogenSulfideOxidationKinetics`.
- Add six focused JUnit tests for equation reproduction, inclusive bounds, fail-closed extrapolation, monotonicity, uncertainty, exact exposure, and input robustness.
- Add a source/provenance and scientific-boundary guide plus executable documentation contract.
- Register the guide in the chemical-reactions index.

## Validation

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

Connector-side static checks completed:

- exact base/head comparison: five intended files, zero commits behind at publication;
- independent numerical reproduction of the documented reference result;
- source equation, units, ranges, fit scatter, and stop boundary mirrored across Java, tests, and documentation;
- Java 8-compatible syntax by inspection.

No local Maven, Spotless, Javadocs, or Python test result is claimed because this run used the repository connector without a local checkout. Exact-head hosted CI is authoritative.

## Stop boundary

This PR does not calculate oxygen solubility, pH, H₂S/HS⁻ speciation, activities, products, oxygen consumption, pressure dependence, free-water appearance, phase transfer, corrosion, reaction heat, or material response. It does not bind R1–R8, mutate a fluid, run a flash, add a transient/pipeline source term, expose MCP, or include facility-specific Northern Lights data.

Electrolyte speciation remains with #3144; flash, dynamics, pipeline, and MCP integration remain coordinated with #2937, #2911, the pipeline roadmap, and #3153. High-pressure CO₂ application requires separate evidence.