### PR TITLE
[AI-Assisted] test(tpflash): qualify water-rich CPA lifecycle

### DIFF
--- a/docs/thermodynamicoperations/TPflash_algorithm.md
+++ b/docs/thermodynamicoperations/TPflash_algorithm.md
@@ -2252,6 +2252,36 @@ qualification; no wall-clock threshold or production speedup is claimed. Product
 parameters/defaults, electrolyte and reactive paths, solids/wax, saturation search, Column Solver, Process Performance,
 and Huldra are outside this tranche.
 
+### 6.4.11 Water-rich SRK-CPA three-phase lifecycle qualification
+
+The associating-fluid qualification uses `SystemSrkCPAstatoil` with mixing rule 10 at 313.15 K and 20.0 bara. The dry
+inventory contains 25 mol methane, 5 mol ethane, 5 mol propane, 4 mol n-butane, 4 mol n-pentane, 6 mol n-hexane, 8 mol
+n-heptane, 8 mol n-octane, 15 mol of a C10 TBP fraction with molar mass 0.142 kg/mol and density 0.78 kg/L, and 20 mol
+of a C20 TBP fraction with molar mass 0.282 kg/mol and density 0.88 kg/L. Water is added from the requested mass
+fraction $w$ as $n_{water}=(11.29556/0.01801528)w/(1-w)$ mol. The constants use kilograms and kilograms per mole, so
+the resulting amount is in moles.
+
+Water mass fractions from 0.40 through 0.80 must retain GAS+OIL+AQUEOUS equilibrium. The established gas-beta anchors
+decrease continuously from `0.0441902453511` at 0.40 water mass fraction to `0.00844359351489` at 0.80. Nearby states
+at 312.65 K/19.5 bara, 313.15 K/20.0 bara, and 313.65 K/20.5 bara must recover the same topology from an initial beta
+of `1e-10`.
+
+Every qualified state requires finite bounded phase fractions and compositions, beta and phase normalization within
+`1e-12`, component material balance below `1e-10`, and maximum comparable interphase log-fugacity residual below
+`1e-8`. Each phase must also have positive finite compressibility and density, while total Gibbs energy and enthalpy
+must remain finite. Phases are matched by `PhaseType`, so phase-array reordering cannot hide a lifecycle mismatch.
+
+A reused reference system is moved from 20.0 to 20.5 bara, compared with a fresh calculation, returned to 20.0 bara,
+and flashed again. The changed state, returned state, and immediate repeat must reproduce the corresponding fresh or
+retained equilibria within the frozen per-property tolerances. The existing `ThreePhaseSeparator` sweep remains a
+process-composability check without changing process-equipment production code.
+
+The focused class performs 22 explicit complete TP flashes plus four bounded separator cases. This fixed workload is
+performance evidence only; no wall-clock threshold or production speedup is claimed. The composition is synthetic
+numerical evidence, not experimental validation of CPA parameters or the predicted phase fractions. Production solver
+code, public APIs, association parameters, mixing-rule defaults, electrolyte/reaction models, saturation search,
+Column Solver, generic Process Performance, proprietary data, and Huldra are outside this tranche.
+
 ### 6.5 Hybrid EOS-GE ionic-capacity safeguard
 
 In a fixed-role EOS-gas/GE-aqueous calculation, ions are excluded from every non-aqueous role.

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashHighWaterGasSeedTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashHighWaterGasSeedTest.java
@@ -10,8 +10,14 @@ import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkCPAstatoil;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
-/** Regression coverage for gas-phase persistence in water-dominated CPA flashes. */
+/** Qualification coverage for gas-phase persistence in water-dominated CPA flashes. */
 class TPmultiflashHighWaterGasSeedTest {
+  private static final double REFERENCE_TEMPERATURE_K = 313.15;
+  private static final double REFERENCE_PRESSURE_BARA = 20.0;
+  private static final double NORMALIZATION_TOLERANCE = 1.0e-12;
+  private static final double MATERIAL_BALANCE_TOLERANCE = 1.0e-10;
+  private static final double FUGACITY_TOLERANCE = 1.0e-8;
+  private static final double STATE_TOLERANCE = 1.0e-8;
   private static final double[] WATER_MASS_FRACTIONS = { 0.40, 0.45, 0.50, 0.55, 0.60, 0.70, 0.80 };
   private static final double[] EXPECTED_GAS_BETAS = { 0.0441902453511, 0.0372773421590, 0.0313666680101,
       0.0262550011428, 0.0217905845743, 0.0143670367332, 0.00844359351489 };
@@ -22,7 +28,7 @@ class TPmultiflashHighWaterGasSeedTest {
     for (int point = 0; point < WATER_MASS_FRACTIONS.length; point++) {
       double waterMassFraction = WATER_MASS_FRACTIONS[point];
       SystemInterface system = createFluid(waterMassFraction);
-      new ThermodynamicOperations(system).TPflash();
+      flash(system);
 
       assertEquals(3, system.getNumberOfPhases(), "Expected gas-oil-aqueous equilibrium at " + waterMassFraction);
       assertTrue(system.hasPhaseType(PhaseType.GAS),
@@ -40,7 +46,7 @@ class TPmultiflashHighWaterGasSeedTest {
       previousGasMoles = gasMoles;
       assertFlashClosure(system);
 
-      new ThermodynamicOperations(system).TPflash();
+      flash(system);
       assertEquals(3, system.getNumberOfPhases(), "Repeated flash phase count at " + waterMassFraction);
       assertEquals(EXPECTED_GAS_BETAS[point], system.getBeta(system.getPhaseNumberOfPhase("gas")), 1.0e-8,
           "Repeated flash gas fraction at " + waterMassFraction);
@@ -59,12 +65,34 @@ class TPmultiflashHighWaterGasSeedTest {
       system.setBeta(0, 1.0e-10);
       system.setBeta(1, 1.0 - 1.0e-10);
 
-      new ThermodynamicOperations(system).TPflash();
+      flash(system);
 
       assertEquals(3, system.getNumberOfPhases(),
           "Expected gas-oil-aqueous equilibrium at T=" + condition[0] + " K, P=" + condition[1] + " bara");
       assertFlashClosure(system);
     }
+  }
+
+  @Test
+  void changedReturnedAndRepeatedPressureStatesMatchFreshEquilibrium() {
+    SystemInterface reference = createFluid(0.55);
+    flash(reference);
+    SystemInterface reused = reference.clone();
+
+    reused.setPressure(20.5, "bara");
+    flash(reused);
+    SystemInterface freshChanged = createFluid(0.55);
+    freshChanged.setPressure(20.5, "bara");
+    flash(freshChanged);
+    assertEquivalentEquilibrium(freshChanged, reused, STATE_TOLERANCE, "changed pressure");
+
+    reused.setPressure(REFERENCE_PRESSURE_BARA, "bara");
+    flash(reused);
+    assertEquivalentEquilibrium(reference, reused, STATE_TOLERANCE, "returned pressure");
+
+    SystemInterface repeatedReference = reused.clone();
+    flash(reused);
+    assertEquivalentEquilibrium(repeatedReference, reused, 1.0e-10, "deterministic repeat");
   }
 
   @Test
@@ -100,32 +128,96 @@ class TPmultiflashHighWaterGasSeedTest {
             "Phase composition must be finite and bounded");
         compositionSum += composition;
       }
-      assertEquals(1.0, compositionSum, 1.0e-8, "Phase composition must be normalized");
+      assertEquals(1.0, compositionSum, NORMALIZATION_TOLERANCE, "Phase composition must be normalized");
+      assertTrue(Double.isFinite(system.getPhase(phase).getZ()) && system.getPhase(phase).getZ() > 0.0,
+          "Compressibility factor must be finite and positive");
+      assertTrue(Double.isFinite(system.getPhase(phase).getDensity()) && system.getPhase(phase).getDensity() > 0.0,
+          "Density must be finite and positive");
     }
-    assertEquals(1.0, betaSum, 1.0e-8, "Phase fractions must be normalized");
+    assertEquals(1.0, betaSum, NORMALIZATION_TOLERANCE, "Phase fractions must be normalized");
 
+    double maximumMaterialResidual = 0.0;
+    double maximumFugacityResidual = 0.0;
+    int fugacityComparisons = 0;
     for (int component = 0; component < system.getPhase(0).getNumberOfComponents(); component++) {
       double recoveredComposition = 0.0;
-      double referenceLogFugacity = Double.NaN;
       for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
         double composition = system.getPhase(phase).getComponent(component).getx();
         recoveredComposition += system.getBeta(phase) * composition;
-        double logFugacity = Math.log(Math.max(composition, Double.MIN_NORMAL))
-            + Math.log(system.getPhase(phase).getComponent(component).getFugacityCoefficient());
-        assertTrue(Double.isFinite(logFugacity), "Component log fugacity must be finite");
-        if (phase == 0) {
-          referenceLogFugacity = logFugacity;
-        } else {
-          assertEquals(referenceLogFugacity, logFugacity, 2.0e-8, "Component fugacity must be equal across phases");
+      }
+      maximumMaterialResidual = Math.max(maximumMaterialResidual,
+          Math.abs(system.getPhase(0).getComponent(component).getz() - recoveredComposition));
+
+      for (int firstPhase = 0; firstPhase < system.getNumberOfPhases(); firstPhase++) {
+        for (int secondPhase = firstPhase + 1; secondPhase < system.getNumberOfPhases(); secondPhase++) {
+          double firstComposition = system.getPhase(firstPhase).getComponent(component).getx();
+          double secondComposition = system.getPhase(secondPhase).getComponent(component).getx();
+          double firstCoefficient = system.getPhase(firstPhase).getComponent(component).getFugacityCoefficient();
+          double secondCoefficient = system.getPhase(secondPhase).getComponent(component).getFugacityCoefficient();
+          if (firstComposition > 1.0e-20 && secondComposition > 1.0e-20 && Double.isFinite(firstCoefficient)
+              && firstCoefficient > 0.0 && Double.isFinite(secondCoefficient) && secondCoefficient > 0.0) {
+            double firstLogFugacity = Math.log(firstComposition * firstCoefficient);
+            double secondLogFugacity = Math.log(secondComposition * secondCoefficient);
+            maximumFugacityResidual = Math.max(maximumFugacityResidual, Math.abs(firstLogFugacity - secondLogFugacity));
+            fugacityComparisons++;
+          }
         }
       }
-      assertEquals(system.getPhase(0).getComponent(component).getz(), recoveredComposition, 2.0e-8,
-          "Component material balance must close");
     }
+    assertTrue(maximumMaterialResidual < MATERIAL_BALANCE_TOLERANCE,
+        "Component material balance must close, residual=" + maximumMaterialResidual);
+    assertTrue(fugacityComparisons > 0, "Expected comparable cross-phase fugacities");
+    assertTrue(maximumFugacityResidual < FUGACITY_TOLERANCE,
+        "Component fugacity must be equal across phases, residual=" + maximumFugacityResidual);
+    assertTrue(Double.isFinite(system.getGibbsEnergy()), "Gibbs energy must be finite");
+    assertTrue(Double.isFinite(system.getEnthalpy()), "Enthalpy must be finite");
+  }
+
+  private void assertEquivalentEquilibrium(SystemInterface expected, SystemInterface actual, double tolerance,
+      String label) {
+    assertEquals(expected.getNumberOfPhases(), actual.getNumberOfPhases(), label + " phase count");
+    assertFlashClosure(expected);
+    assertFlashClosure(actual);
+    for (int expectedPhase = 0; expectedPhase < expected.getNumberOfPhases(); expectedPhase++) {
+      PhaseType phaseType = expected.getPhase(expectedPhase).getType();
+      int actualPhase = findPhase(actual, phaseType);
+      assertEquals(expected.getBeta(expectedPhase), actual.getBeta(actualPhase), tolerance,
+          label + " beta " + phaseType);
+      assertEquals(expected.getPhase(expectedPhase).getZ(), actual.getPhase(actualPhase).getZ(), tolerance,
+          label + " compressibility " + phaseType);
+      assertEquals(expected.getPhase(expectedPhase).getDensity(), actual.getPhase(actualPhase).getDensity(),
+          Math.max(1.0e-8, tolerance * Math.abs(expected.getPhase(expectedPhase).getDensity())),
+          label + " density " + phaseType);
+      for (int component = 0; component < expected.getPhase(expectedPhase).getNumberOfComponents(); component++) {
+        assertEquals(expected.getPhase(expectedPhase).getComponent(component).getx(),
+            actual.getPhase(actualPhase).getComponent(component).getx(), tolerance,
+            label + " composition " + phaseType + "/" + component);
+      }
+    }
+    assertExtensiveEquals(expected.getGibbsEnergy(), actual.getGibbsEnergy(), tolerance, label + " Gibbs energy");
+    assertExtensiveEquals(expected.getEnthalpy(), actual.getEnthalpy(), tolerance, label + " enthalpy");
+  }
+
+  private void assertExtensiveEquals(double expected, double actual, double relativeTolerance, String label) {
+    assertEquals(expected, actual, Math.max(1.0e-8, relativeTolerance * Math.abs(expected)), label);
+  }
+
+  private int findPhase(SystemInterface system, PhaseType phaseType) {
+    for (int phase = 0; phase < system.getNumberOfPhases(); phase++) {
+      if (system.getPhase(phase).getType() == phaseType) {
+        return phase;
+      }
+    }
+    throw new AssertionError("Missing phase " + phaseType);
+  }
+
+  private void flash(SystemInterface system) {
+    new ThermodynamicOperations(system).TPflash();
+    system.initProperties();
   }
 
   private SystemInterface createFluid(double waterMassFraction) {
-    SystemInterface system = new SystemSrkCPAstatoil(313.15, 20.0);
+    SystemInterface system = new SystemSrkCPAstatoil(REFERENCE_TEMPERATURE_K, REFERENCE_PRESSURE_BARA);
     system.addComponent("methane", 25.0);
     system.addComponent("ethane", 5.0);
     system.addComponent("propane", 5.0);


### PR DESCRIPTION
## Engineering question

Can NeqSim promote the existing water-dominated SRK-CPA GAS+OIL+AQUEOUS regression from permissive closure checks to the frozen #2937 numerical and lifecycle contract without changing the production solver?

Advances #2937. The full capability contract was frozen in the [campaign ledger](https://github.com/equinor/neqsim/issues/2937#issuecomment-5532658292) before implementation.

## Exact continuity and capacity

- **Exact base/master:** `71d55b17f81a9f895d91b0b50fcbfe21ee4dc1fa`
- **Exact head:** `62a4b345b006c648c74e4abe79b030d3f1f56ab9`
- **Branch:** `ai/tpflash-water-rich-cpa-qualification-2937`
- Four positively identified autonomous implementation PRs were open before publication, below the target and absolute ceiling of ten.
- No active #2937 implementation PR or overlapping water-rich CPA draft existed.
- No existing PR was closed, replaced, rebased, force-pushed, abandoned, or otherwise changed for capacity.

## Frozen scope

- `src/test/java/neqsim/thermodynamicoperations/flashops/TPmultiflashHighWaterGasSeedTest.java`
- `docs/thermodynamicoperations/TPflash_algorithm.md`
- `SystemSrkCPAstatoil`, mixing rule 10, synthetic methane-through-n-octane/C10/C20/water inventory
- 313.15 K and 20.0 bara reference; water mass fractions 0.40–0.80; nearby 312.65–313.65 K and 19.5–20.5 bara
- Test and documentation qualification only

## Changes

- Tightens beta and phase-composition normalization from `1e-8` to `1e-12`.
- Tightens component material balance from `2e-8` to below `1e-10`.
- Tightens comparable interphase log-fugacity residual from `2e-8` to below `1e-8`.
- Requires finite bounded phase state, positive finite compressibility and density, and finite Gibbs energy and enthalpy.
- Adds phase-type-matched fresh versus reused comparisons after a pressure change, return to the reference pressure, and deterministic repeat.
- Retains the historical gas-beta anchors, monotone gas inventory, poor-beta nearby-state matrix, and bounded `ThreePhaseSeparator` composability checks.
- Documents the complete synthetic composition, units, water mass-fraction conversion, state matrix, numerical gates, performance scope, and independent-validation limitation.

## Numerical acceptance

Every qualified TP flash must retain GAS+OIL+AQUEOUS topology and satisfy:

- finite beta and compositions in physical bounds;
- beta and phase normalization within `1e-12`;
- maximum component material-balance residual below `1e-10`;
- maximum comparable interphase log-fugacity residual below `1e-8`;
- positive finite compressibility and density;
- finite Gibbs energy and enthalpy;
- phase-type-matched lifecycle agreement within the frozen per-property tolerances.

The gas beta remains anchored from `0.0441902453511` at water mass fraction 0.40 to `0.00844359351489` at 0.80. This is deterministic solver qualification, not experimental PVT validation or CPA parameter fitting.

## Validation

**MERGED — EXACT FEATURE HEAD VALIDATED** at `62a4b345b006c648c74e4abe79b030d3f1f56ab9` (merge commit `300839e12df4e9e4f1646cd30d0894ba76b25173`).

Exact-head GitHub validation completed successfully:

- Java 21 fast suites on Ubuntu and Windows;
- Java 8 fast suites on Ubuntu and Windows;
- all four slow-test shards;
- Javadocs, Spotless, pre-commit, documentation search, CodeQL, and agent-skill checks.

Local exact-branch evidence also passed: the updated `TPmultiflashHighWaterGasSeedTest` 4/4, the complete discoverable `TPflash*` / `TPmultiflash*` suite 106/106, Spotless apply/check, documentation search, and `git diff --check`. The local `pre-commit` executable was unavailable, so no local result is claimed; the authoritative hosted pre-commit check passed. The PR had no reviews, requested changes, inline comments, conversation comments, or unresolved threads.

## Documentation impact

Updated `docs/thermodynamicoperations/TPflash_algorithm.md` because the numerical and lifecycle acceptance contract is user-visible qualification evidence. It records composition, units, conversion, bounds, tolerances, matrix, fixed-work performance evidence, and limitations.

## Performance and stop boundary

The class performs 22 explicit complete TP flashes plus four bounded separator cases. This fixed workload is performance evidence only; no wall-clock threshold or speedup is claimed. Production solver code and runtime paths are unchanged.

No public API, EOS/association parameter, mixing-rule default, electrolyte/reaction model, saturation search, process-equipment production code, Column Solver, generic Process Performance, proprietary data, or Huldra work is included. The PR remains draft-only; this campaign does not merge, enable auto-merge, or mark it ready.

Generated with AI assistance.