### PR TITLE
Add complete evidence to DEXPI cycle boundaries

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -196,17 +196,23 @@ across incoming and outgoing occurrences. Each immutable `DexpiConnectionCycleBo
 the connection evidence ID, original source connection ID, owning `PipingNetworkSegment` ID,
 direction relative to the cyclic group, explicit internal and external endpoint identities, whether
 each endpoint resolves, and the resolved endpoint element and Equipment/PipingComponent owner
-identities already present in the endpoint inventory. Missing source, segment, endpoint, or owner
-evidence remains an empty field. This avoids inferring boundary orientation, provenance, or ownership
-by joining separate inventories while retaining parallel and unresolved source evidence. It does not
-identify a hydraulic recycle, enumerate elementary paths, assert convergence behavior,
-repair or rewire topology, or establish process intent.
+identities already present in the endpoint inventory. Reader-produced records also expose the
+complete immutable source objects through `getConnection()`, `getInternalEndpoint()`, and
+`getExternalEndpoint()`. Java and JPype callers can therefore inspect connection direction,
+endpoint resolution and ownership, full source-ordered incidence lists, and incidence roles locally;
+`hasCompleteEvidence()` distinguishes that projection from legacy values built with the older
+constructors. Legacy object getters return `null` while their existing scalar evidence remains
+unchanged. Missing source, segment, endpoint, or owner evidence remains an empty field. This avoids
+joining separate inventories or inferring boundary orientation, provenance, or ownership while
+retaining parallel and unresolved source evidence. It does not identify a hydraulic recycle,
+enumerate elementary paths, assert convergence behavior, repair or rewire topology, or establish
+process intent.
 
 `toJson()` includes `instrumentCount`, `connectionCount`, `connectionEndpointCount`,
 `connectionComponentCount`, `connectionCycleCount`, and the ordered connection, endpoint,
 component, and directed-cycle inventories, including incidence roles, review subsets, complete
-cycle-local endpoint and internal connection occurrences, and explicit cycle-boundary occurrences,
-alongside the process-unit
+cycle-local endpoint and internal connection occurrences, and explicit cycle-boundary occurrences with
+nested connection and endpoint evidence, alongside the process-unit
 count and findings. Python callers through
 JPype use the same
 `ImportResult.getInstruments()`, `ImportResult.getConnections()`,

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleBoundaryInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleBoundaryInfo.java
@@ -40,6 +40,9 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
   private final String externalOwnerElementName;
   private final boolean internalEndpointResolved;
   private final boolean externalEndpointResolved;
+  private final DexpiConnectionInfo connection;
+  private final DexpiConnectionEndpointInfo internalEndpoint;
+  private final DexpiConnectionEndpointInfo externalEndpoint;
 
   /**
    * Creates immutable cycle-boundary source-reference evidence.
@@ -105,6 +108,34 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
       String internalOwnerElementName, String externalEndpointId, String externalEndpointElementName,
       String externalOwnerId, String externalOwnerElementName, boolean internalEndpointResolved,
       boolean externalEndpointResolved) {
+    this(connectionId, sourceId, segmentId, direction, internalEndpointId, internalEndpointElementName, internalOwnerId,
+        internalOwnerElementName, externalEndpointId, externalEndpointElementName, externalOwnerId,
+        externalOwnerElementName, internalEndpointResolved, externalEndpointResolved, null, null, null);
+  }
+
+  /**
+   * Creates complete immutable evidence for one cycle-boundary connection occurrence.
+   *
+   * @param connection complete source connection occurrence
+   * @param direction connection direction relative to the cyclic group
+   * @param internalEndpoint complete endpoint evidence inside the cyclic group
+   * @param externalEndpoint complete endpoint evidence outside the cyclic group
+   */
+  public DexpiConnectionCycleBoundaryInfo(DexpiConnectionInfo connection, Direction direction,
+      DexpiConnectionEndpointInfo internalEndpoint, DexpiConnectionEndpointInfo externalEndpoint) {
+    this(connection.getId(), connection.getSourceId(), connection.getSegmentId(), direction,
+        internalEndpoint.getEndpointId(), internalEndpoint.getElementName(), internalEndpoint.getOwnerId(),
+        internalEndpoint.getOwnerElementName(), externalEndpoint.getEndpointId(), externalEndpoint.getElementName(),
+        externalEndpoint.getOwnerId(), externalEndpoint.getOwnerElementName(), internalEndpoint.isResolved(),
+        externalEndpoint.isResolved(), connection, internalEndpoint, externalEndpoint);
+  }
+
+  private DexpiConnectionCycleBoundaryInfo(String connectionId, String sourceId, String segmentId, Direction direction,
+      String internalEndpointId, String internalEndpointElementName, String internalOwnerId,
+      String internalOwnerElementName, String externalEndpointId, String externalEndpointElementName,
+      String externalOwnerId, String externalOwnerElementName, boolean internalEndpointResolved,
+      boolean externalEndpointResolved, DexpiConnectionInfo connection, DexpiConnectionEndpointInfo internalEndpoint,
+      DexpiConnectionEndpointInfo externalEndpoint) {
     this.connectionId = normalize(connectionId);
     this.sourceId = normalize(sourceId);
     this.segmentId = normalize(segmentId);
@@ -119,6 +150,9 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
     this.externalOwnerElementName = normalize(externalOwnerElementName);
     this.internalEndpointResolved = internalEndpointResolved;
     this.externalEndpointResolved = externalEndpointResolved;
+    this.connection = connection;
+    this.internalEndpoint = internalEndpoint;
+    this.externalEndpoint = externalEndpoint;
   }
 
   /** @return connection-evidence identity */
@@ -196,6 +230,41 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
     return externalEndpointResolved;
   }
 
+  /** @return whether complete source connection evidence is available */
+  public boolean hasConnectionEvidence() {
+    return connection != null;
+  }
+
+  /** @return complete source connection evidence, or null for legacy-constructed values */
+  public DexpiConnectionInfo getConnection() {
+    return connection;
+  }
+
+  /** @return whether complete internal endpoint evidence is available */
+  public boolean hasInternalEndpointEvidence() {
+    return internalEndpoint != null;
+  }
+
+  /** @return complete internal endpoint evidence, or null for legacy-constructed values */
+  public DexpiConnectionEndpointInfo getInternalEndpoint() {
+    return internalEndpoint;
+  }
+
+  /** @return whether complete external endpoint evidence is available */
+  public boolean hasExternalEndpointEvidence() {
+    return externalEndpoint != null;
+  }
+
+  /** @return complete external endpoint evidence, or null for legacy-constructed values */
+  public DexpiConnectionEndpointInfo getExternalEndpoint() {
+    return externalEndpoint;
+  }
+
+  /** @return whether the connection and both complete endpoint records are available */
+  public boolean hasCompleteEvidence() {
+    return connection != null && internalEndpoint != null && externalEndpoint != null;
+  }
+
   Map<String, Object> toMap() {
     Map<String, Object> result = new LinkedHashMap<String, Object>();
     result.put("connectionId", connectionId);
@@ -212,6 +281,13 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
     result.put("externalOwnerElementName", externalOwnerElementName);
     result.put("internalEndpointResolved", Boolean.valueOf(internalEndpointResolved));
     result.put("externalEndpointResolved", Boolean.valueOf(externalEndpointResolved));
+    result.put("completeEvidence", Boolean.valueOf(hasCompleteEvidence()));
+    result.put("connection",
+        connection == null ? new LinkedHashMap<String, Object>() : connection.toMap());
+    result.put("internalEndpoint",
+        internalEndpoint == null ? new LinkedHashMap<String, Object>() : internalEndpoint.toMap());
+    result.put("externalEndpoint",
+        externalEndpoint == null ? new LinkedHashMap<String, Object>() : externalEndpoint.toMap());
     return result;
   }
 

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleBoundaryInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleBoundaryInfo.java
@@ -282,8 +282,7 @@ public final class DexpiConnectionCycleBoundaryInfo implements Serializable {
     result.put("internalEndpointResolved", Boolean.valueOf(internalEndpointResolved));
     result.put("externalEndpointResolved", Boolean.valueOf(externalEndpointResolved));
     result.put("completeEvidence", Boolean.valueOf(hasCompleteEvidence()));
-    result.put("connection",
-        connection == null ? new LinkedHashMap<String, Object>() : connection.toMap());
+    result.put("connection", connection == null ? new LinkedHashMap<String, Object>() : connection.toMap());
     result.put("internalEndpoint",
         internalEndpoint == null ? new LinkedHashMap<String, Object>() : internalEndpoint.toMap());
     result.put("externalEndpoint",

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1104,11 +1104,8 @@ public final class DexpiXmlReader {
     private void addBoundaryConnection(DexpiConnectionInfo connection,
         DexpiConnectionCycleBoundaryInfo.Direction direction, DexpiConnectionEndpointInfo internalEndpoint,
         DexpiConnectionEndpointInfo externalEndpoint) {
-      boundaryConnections.add(new DexpiConnectionCycleBoundaryInfo(connection.getId(), connection.getSourceId(),
-          connection.getSegmentId(), direction, internalEndpoint.getEndpointId(), internalEndpoint.getElementName(),
-          internalEndpoint.getOwnerId(), internalEndpoint.getOwnerElementName(), externalEndpoint.getEndpointId(),
-          externalEndpoint.getElementName(), externalEndpoint.getOwnerId(), externalEndpoint.getOwnerElementName(),
-          internalEndpoint.isResolved(), externalEndpoint.isResolved()));
+      boundaryConnections
+          .add(new DexpiConnectionCycleBoundaryInfo(connection, direction, internalEndpoint, externalEndpoint));
     }
 
     private DexpiConnectionCycleInfo toInfo() {

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -729,6 +729,26 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("Nozzle", boundaries.get(0).getExternalEndpointElementName());
     assertEquals("E-A", boundaries.get(0).getExternalOwnerId());
     assertEquals("Equipment", boundaries.get(0).getExternalOwnerElementName());
+    assertTrue(boundaries.get(0).hasCompleteEvidence());
+    assertTrue(boundaries.get(0).hasConnectionEvidence());
+    DexpiConnectionInfo boundaryConnection = boundaries.get(0).getConnection();
+    assertEquals("C-IN-1", boundaryConnection.getId());
+    assertEquals("C-IN-1", boundaryConnection.getSourceId());
+    assertEquals("S-IN-1", boundaryConnection.getSegmentId());
+    assertEquals("N-A", boundaryConnection.getFromId());
+    assertEquals("N-X", boundaryConnection.getToId());
+    assertTrue(boundaryConnection.isResolved());
+    assertTrue(boundaries.get(0).hasInternalEndpointEvidence());
+    DexpiConnectionEndpointInfo internalEndpoint = boundaries.get(0).getInternalEndpoint();
+    assertEquals("N-X", internalEndpoint.getEndpointId());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.MERGE, internalEndpoint.getIncidenceRole());
+    assertEquals(Arrays.asList("C-IN-1", "C-IN-2", "C-YX"), internalEndpoint.getIncomingConnectionIds());
+    assertEquals(Collections.singletonList("C-XY"), internalEndpoint.getOutgoingConnectionIds());
+    assertTrue(boundaries.get(0).hasExternalEndpointEvidence());
+    DexpiConnectionEndpointInfo externalEndpoint = boundaries.get(0).getExternalEndpoint();
+    assertEquals("N-A", externalEndpoint.getEndpointId());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.SOURCE, externalEndpoint.getIncidenceRole());
+    assertEquals(Collections.singletonList("C-IN-1"), externalEndpoint.getOutgoingConnectionIds());
     assertEquals(DexpiConnectionCycleBoundaryInfo.Direction.OUTGOING, boundaries.get(1).getDirection());
     assertEquals("C-OUT-1", boundaries.get(1).getSourceId());
     assertEquals("S-OUT-1", boundaries.get(1).getSegmentId());
@@ -744,6 +764,12 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("", boundaries.get(2).getExternalEndpointElementName());
     assertEquals("", boundaries.get(2).getExternalOwnerId());
     assertEquals("", boundaries.get(2).getExternalOwnerElementName());
+    assertTrue(boundaries.get(2).hasCompleteEvidence());
+    assertFalse(boundaries.get(2).getConnection().isResolved());
+    assertFalse(boundaries.get(2).getExternalEndpoint().isResolved());
+    assertEquals("UNKNOWN-U", boundaries.get(2).getExternalEndpoint().getEndpointId());
+    assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.SOURCE,
+        boundaries.get(2).getExternalEndpoint().getIncidenceRole());
 
     DexpiConnectionCycleInfo closedSelfReference = first.getConnectionCycles().get(1);
     assertEquals("cycle-2", closedSelfReference.getId());
@@ -759,6 +785,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertThrows(UnsupportedOperationException.class, () -> connectedCycle.getIncomingBoundaryConnectionIds().clear());
     assertThrows(UnsupportedOperationException.class, () -> connectedCycle.getOutgoingBoundaryConnectionIds().clear());
     assertThrows(UnsupportedOperationException.class, () -> connectedCycle.getBoundaryConnections().clear());
+    assertThrows(UnsupportedOperationException.class,
+        () -> boundaries.get(0).getInternalEndpoint().getIncomingConnectionIds().clear());
     DexpiConnectionCycleInfo legacy = new DexpiConnectionCycleInfo("legacy", "component-legacy",
         Collections.<String>emptyList(), Collections.<String>emptyList(), Collections.<String>emptyList(),
         Collections.<String>emptyList(), Collections.<String>emptyList(), false);
@@ -774,6 +802,10 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("", legacyBoundary.getInternalOwnerId());
     assertEquals("", legacyBoundary.getExternalEndpointElementName());
     assertEquals("", legacyBoundary.getExternalOwnerId());
+    assertFalse(legacyBoundary.hasCompleteEvidence());
+    assertFalse(legacyBoundary.hasConnectionEvidence());
+    assertFalse(legacyBoundary.hasInternalEndpointEvidence());
+    assertFalse(legacyBoundary.hasExternalEndpointEvidence());
     assertTrue(first.toJson().contains("\"incomingBoundaryConnectionCount\": 2"));
     assertTrue(first.toJson().contains("\"boundaryConnectionCount\": 4"));
     assertTrue(first.toJson().contains("\"direction\": \"INCOMING\""));
@@ -782,6 +814,11 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(first.toJson().contains("\"segmentId\": \"S-IN-1\""));
     assertTrue(first.toJson().contains("\"internalOwnerId\": \"E-X\""));
     assertTrue(first.toJson().contains("\"externalOwnerElementName\": \"Equipment\""));
+    assertTrue(first.toJson().contains("\"completeEvidence\": true"));
+    assertTrue(first.toJson().contains("\"connection\": {"));
+    assertTrue(first.toJson().contains("\"internalEndpoint\": {"));
+    assertTrue(first.toJson().contains("\"externalEndpoint\": {"));
+    assertTrue(first.toJson().contains("\"incidenceRole\": \"MERGE\""));
     assertTrue(first.toJson().contains("\"outgoingBoundaryConnectionIds\": ["));
     assertEquals(first.toJson(), second.toJson());
   }


### PR DESCRIPTION
## Summary

Expose complete immutable source-object evidence on every reader-produced directed-cycle boundary occurrence.

Java and JPype reviewers can inspect the exact `DexpiConnectionInfo` plus the internal and external `DexpiConnectionEndpointInfo` records locally, including connection provenance, endpoint resolution and ownership, source-ordered incidence lists, and incidence roles. No global-inventory join is required.

## Capability contract

- Engineering question: can reviewers inspect complete source connection and endpoint-incidence evidence for each directed-cycle boundary occurrence locally and deterministically?
- Exact base: `71d55b17f81a9f895d91b0b50fcbfe21ee4dc1fa`
- Exact head: `b5c68d6f6fafbfdd7d3e8791dba3f7044e81de5c`
- Frozen scope: four files (boundary value object, reader projection, focused reader tests, reader documentation)
- Complexity: retains O(V+E) analysis by storing already-computed immutable records
- Compatibility: every existing constructor and scalar getter remains unchanged; legacy-constructed values explicitly report absent complete evidence
- Preservation: source order, parallel occurrences, unresolved references, deterministic JSON, simulation topology, builders, writers, rendering, geometry, layout, notebooks, and exports

## Changes

- Add complete connection, internal-endpoint, and external-endpoint records to `DexpiConnectionCycleBoundaryInfo`.
- Add explicit evidence-presence getters and `hasCompleteEvidence()`.
- Populate all three immutable records from the existing cycle accumulator.
- Serialize nested connection and endpoint evidence deterministically.
- Cover resolved and unresolved boundaries, direction, provenance, ownership, incidence roles, nested-list immutability, legacy compatibility, and repeat-read JSON stability.
- Document Java and JPype access plus the evidence-only engineering boundary.

## Validation

Status: **READY TO MERGE** at exact head `b5c68d6f6fafbfdd7d3e8791dba3f7044e81de5c`.

Connector-side publication checks:

- exact base/head comparison: five commits, four frozen files, zero commits behind;
- source-object projection reuses already-computed immutable records and preserves O(V+E);
- Java 8-compatible syntax and constructor compatibility inspected;
- the exact one-line hosted Spotless format patch was applied without behavior or scope change;
- documentation impact completed in `docs/integration/dexpi-reader.md`;
- whole-sheet visual gate is N/A because no renderer, geometry, layout, notebook, writer, SVG, or export path changed.

All eight hosted workflows pass on the exact head: 19 jobs succeeded, one expected PaperLab replication job was skipped, and no job failed or remains pending. This includes Java 8/21 on Ubuntu and Windows, all four slow-test shards, Javadocs, Spotless, pre-commit/documentation, documentation search, notebook execution, engineering-diagram performance, CodeQL, PaperLab, and agent-skill reference checks.

No local Maven, Spotless, pre-commit, Javadocs, or test result is claimed because this run used the connected repository workflow without a local checkout. Exact-head hosted CI is authoritative.

## Engineering stop boundary

This change exposes source-document evidence only. It does not infer a hydraulic recycle, enumerate paths, establish hydraulic continuity or process intent, repair or rewire topology, alter simulation behavior, claim ISO/ISA/DEXPI conformance or certification, or provide accountable engineering approval.

Related roadmaps: #1332, #2899.

Generated with AI assistance.