### PR TITLE
[AI-Assisted] test(refinery): qualify Sarir 34-tray property sensitivity

### DIFF
--- a/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
@@ -113,10 +113,11 @@ product boiling metrics rather than being numerically inert.
 
 The top pressure, condenser/reboiler settings, reflux ratio, side-draw trays, and side-draw
 fractions are fixed engineering test controls. They are not values reported by the article. The
-qualification requires rigorous convergence without fallback, external and per-component
-conservation, energy and per-tray material closure, finite non-negative candidate-stream rates, at
-least two material products, and increasing mean normal boiling point across material products in
-column order. A zero-flow candidate is permitted and excluded from composition and boiling-order
+qualification uses the repository's MESH-residual refinery-audit solver with a 0.20 K
+temperature tolerance and requires rigorous convergence without fallback, external and
+per-component conservation, energy and per-tray material closure, finite non-negative
+candidate-stream rates, at least two material products, and increasing mean normal boiling point
+across material products in column order. A zero-flow candidate is permitted and excluded from composition and boiling-order
 evaluation because the source reports light ends as not determined; the test does not synthesize
 inventory merely to force every screen stream positive.
 

--- a/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
@@ -96,3 +96,28 @@ density and molar mass remains an explicit engineering input. The factory does n
 missing light-end composition, distribute the published whole-crude sulfur among cuts, or claim
 that NeqSim reproduces the plant yields. A follow-on 34-tray comparison must preserve the plant
 rates as untouched acceptance targets and avoid tuning draw rates to the published products.
+
+## 34-tray property-profile sensitivity gate
+
+`SarirAtmosphericFractionationSensitivityTest` carries the constrained assay through 34 NeqSim
+simple trays, matching the published valve-tray count. The source feed location, tray 31 counted
+from the top, maps to NeqSim internal index 4 because NeqSim numbers simple trays from the bottom
+and reserves index 0 for the reboiler. The test also uses the published feed rate, temperature, and
+pressure.
+
+Two separate cut-density and molar-mass profiles are exercised. Both profiles are engineering
+inputs because the article does not publish cut properties, and both independently reproduce the
+published 841.5 kg/m3 bulk density and 0.2447 kg/mol average molar mass before the assay is applied.
+The bounded perturbation demonstrates that the unreported profile changes the calculated split or
+product boiling metrics rather than being numerically inert.
+
+The top pressure, condenser/reboiler settings, reflux ratio, side-draw trays, and side-draw
+fractions are fixed engineering test controls. They are not values reported by the article. The
+qualification requires rigorous convergence without fallback, external and per-component
+conservation, energy and per-tray material closure, positive product rates, and increasing mean
+normal boiling point from overhead through the two side-draw screens to bottoms.
+
+The published plant rates remain untouched read-only evidence. They are not used as product-flow
+specifications, tuning targets, or numerical acceptance thresholds. This sensitivity gate does not
+qualify plant-yield or D86 reproduction and does not model the published steam, pump-around,
+side-stripper, tray-hydraulic, or efficiency details.

--- a/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
@@ -114,8 +114,11 @@ product boiling metrics rather than being numerically inert.
 The top pressure, condenser/reboiler settings, reflux ratio, side-draw trays, and side-draw
 fractions are fixed engineering test controls. They are not values reported by the article. The
 qualification requires rigorous convergence without fallback, external and per-component
-conservation, energy and per-tray material closure, positive product rates, and increasing mean
-normal boiling point from overhead through the two side-draw screens to bottoms.
+conservation, energy and per-tray material closure, finite non-negative candidate-stream rates, at
+least two material products, and increasing mean normal boiling point across material products in
+column order. A zero-flow candidate is permitted and excluded from composition and boiling-order
+evaluation because the source reports light ends as not determined; the test does not synthesize
+inventory merely to force every screen stream positive.
 
 The published plant rates remain untouched read-only evidence. They are not used as product-flow
 specifications, tuning targets, or numerical acceptance thresholds. This sensitivity gate does not

--- a/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationSensitivityTest.java
@@ -69,7 +69,7 @@ public class SarirAtmosphericFractionationSensitivityTest {
 
     String diagnostics = column.getConvergenceDiagnostics();
     assertTrue(column.solved(), diagnostics);
-    assertEquals(DistillationColumn.SolverType.DAMPED_SUBSTITUTION, column.getLastSolverTypeUsed(), diagnostics);
+    assertEquals(DistillationColumn.SolverType.MESH_RESIDUAL, column.getLastSolverTypeUsed(), diagnostics);
     assertNotEquals(DistillationColumn.SolveStatus.FALLBACK_PRODUCTS, column.getLastSolveStatus(), diagnostics);
     assertNotEquals(DistillationColumn.SolveStatus.FAILED, column.getLastSolveStatus(), diagnostics);
     assertTrue(column.getLastIterationCount() <= 600, diagnostics);
@@ -131,10 +131,10 @@ public class SarirAtmosphericFractionationSensitivityTest {
     column.setLiquidSideDrawFraction(KEROSENE_SCREEN_TRAY, 0.08);
     column.setLiquidSideDrawFraction(DIESEL_SCREEN_TRAY, 0.15);
 
-    column.setSolverType(DistillationColumn.SolverType.DAMPED_SUBSTITUTION);
+    column.setSolverType(DistillationColumn.SolverType.MESH_RESIDUAL);
     column.setRelaxationFactor(0.30);
     column.setMaxNumberOfIterations(600, true);
-    column.setTemperatureTolerance(0.50);
+    column.setTemperatureTolerance(0.20);
     column.setMassBalanceTolerance(BALANCE_TOLERANCE);
     column.setEnthalpyBalanceTolerance(BALANCE_TOLERANCE);
     column.setEnforceEnergyBalanceTolerance(true);

--- a/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationSensitivityTest.java
@@ -87,8 +87,7 @@ public class SarirAtmosphericFractionationSensitivityTest {
     double[] materialBoilingPoints = new double[products.length];
     for (int i = 0; i < products.length; i++) {
       productMassFractions[i] = products[i].getFlowRate("kg/hr") / feedMassFlow;
-      materialBoilingPoints[i] = productMassFractions[i] > MATERIAL_FLOW_FRACTION
-          ? meanNormalBoilingPoint(products[i])
+      materialBoilingPoints[i] = productMassFractions[i] > MATERIAL_FLOW_FRACTION ? meanNormalBoilingPoint(products[i])
           : Double.NaN;
     }
     assertIncreasingMaterialBoilingPoints(materialBoilingPoints);

--- a/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationSensitivityTest.java
@@ -1,0 +1,250 @@
+package neqsim.process.equipment.distillation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.characterization.OilAssayCharacterisation;
+import neqsim.thermo.characterization.SarirAtmosphericAssay;
+import neqsim.thermo.characterization.SarirAtmosphericReference;
+import neqsim.thermo.characterization.SarirAtmosphericReference.ProductYieldReference;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Property-profile sensitivity qualification for the public Sarir atmospheric reference.
+ *
+ * <p>
+ * The source fixes the TBP cut volumes and boundaries, whole-crude density and average molar mass, 34 valve trays, and
+ * feed conditions. It does not publish per-cut density or molar-mass profiles, column endpoint conditions, or side-draw
+ * locations and fractions. Both profiles and every unreported process setting used here are explicit engineering test
+ * inputs. Published plant product rates remain read-only evidence and are not specifications or acceptance targets.
+ * </p>
+ */
+public class SarirAtmosphericFractionationSensitivityTest {
+  private static final double[] BASE_SPECIFIC_GRAVITY = { 0.641826000, 0.671826000, 0.691826000, 0.711826000,
+      0.741826000, 0.761826000, 0.781826000, 0.801826000, 0.821826000, 0.841826000, 0.861826000, 0.881826000,
+      0.901826000, 0.921826000, 0.941826000, 0.961826000, 0.981826000, 1.021826000 };
+  private static final double[] BASE_MOLAR_MASS_KG_PER_MOL = { 0.092957679997, 0.105352037330, 0.117746394663,
+      0.136337930662, 0.161126645328, 0.179718181327, 0.204506895993, 0.223098431993, 0.241689967992,
+      0.272675861324, 0.303661754657, 0.334647647989, 0.384225077321, 0.421408149319, 0.458591221318,
+      0.495774293317, 0.545351722649, 0.743661439976 };
+
+  private static final int SIMPLE_TRAY_COUNT = 34;
+  private static final int FEED_INTERNAL_INDEX = 4;
+  private static final int DIESEL_SCREEN_TRAY = 15;
+  private static final int KEROSENE_SCREEN_TRAY = 24;
+  private static final double BALANCE_TOLERANCE = 5.0e-2;
+
+  /** Require two admissible property profiles to converge, conserve, separate, and differ. */
+  @Test
+  @Timeout(value = 180, unit = TimeUnit.SECONDS)
+  public void wholeCrudeConsistentProfilesProduceBoundedThirtyFourTraySensitivity() {
+    ProductYieldReference[] publishedTargets = SarirAtmosphericReference.getProductYields();
+
+    double[] alternateSpecificGravity = createAlternateSpecificGravity();
+    double[] alternateMolarMass = createAlternateMolarMass(alternateSpecificGravity);
+    assertProfilesAdmissible(BASE_SPECIFIC_GRAVITY, BASE_MOLAR_MASS_KG_PER_MOL);
+    assertProfilesAdmissible(alternateSpecificGravity, alternateMolarMass);
+
+    ColumnResult base = runCase("base engineering profile", BASE_SPECIFIC_GRAVITY, BASE_MOLAR_MASS_KG_PER_MOL);
+    ColumnResult alternate = runCase("alternate engineering profile", alternateSpecificGravity, alternateMolarMass);
+
+    assertTrue(maximumRelativeDifference(base, alternate) > 1.0e-4,
+        "A bounded change in unreported cut properties should produce a measurable column response");
+    assertPublishedTargetsUnchanged(publishedTargets);
+  }
+
+  private static ColumnResult runCase(String label, double[] specificGravity, double[] molarMassKgPerMol) {
+    Stream feed = createFeed(label, specificGravity, molarMassKgPerMol);
+    DistillationColumn column = createColumn(label, feed);
+    column.run(UUID.randomUUID());
+
+    String diagnostics = column.getConvergenceDiagnostics();
+    assertTrue(column.solved(), diagnostics);
+    assertEquals(DistillationColumn.SolverType.DAMPED_SUBSTITUTION, column.getLastSolverTypeUsed(), diagnostics);
+    assertNotEquals(DistillationColumn.SolveStatus.FALLBACK_PRODUCTS, column.getLastSolveStatus(), diagnostics);
+    assertNotEquals(DistillationColumn.SolveStatus.FAILED, column.getLastSolveStatus(), diagnostics);
+    assertTrue(column.getLastIterationCount() <= 600, diagnostics);
+
+    StreamInterface overhead = column.getGasOutStream();
+    StreamInterface kerosene =
+        column.getSideDrawStream(KEROSENE_SCREEN_TRAY, DistillationColumn.SideDrawPhase.LIQUID);
+    StreamInterface diesel = column.getSideDrawStream(DIESEL_SCREEN_TRAY, DistillationColumn.SideDrawPhase.LIQUID);
+    StreamInterface bottoms = column.getLiquidOutStream();
+
+    assertBalances(column, feed, overhead, kerosene, diesel, bottoms);
+    double overheadBoilingPoint = meanNormalBoilingPoint(overhead);
+    double keroseneBoilingPoint = meanNormalBoilingPoint(kerosene);
+    double dieselBoilingPoint = meanNormalBoilingPoint(diesel);
+    double bottomsBoilingPoint = meanNormalBoilingPoint(bottoms);
+    assertTrue(overheadBoilingPoint < keroseneBoilingPoint);
+    assertTrue(keroseneBoilingPoint < dieselBoilingPoint);
+    assertTrue(dieselBoilingPoint < bottomsBoilingPoint);
+
+    double feedMassFlow = feed.getFlowRate("kg/hr");
+    return new ColumnResult(overhead.getFlowRate("kg/hr") / feedMassFlow,
+        kerosene.getFlowRate("kg/hr") / feedMassFlow, diesel.getFlowRate("kg/hr") / feedMassFlow,
+        bottoms.getFlowRate("kg/hr") / feedMassFlow, overheadBoilingPoint, keroseneBoilingPoint, dieselBoilingPoint,
+        bottomsBoilingPoint);
+  }
+
+  private static Stream createFeed(String label, double[] specificGravity, double[] molarMassKgPerMol) {
+    double feedTemperatureKelvin = SarirAtmosphericReference.getColumnFeedTemperatureCelsius() + 273.15;
+    double feedPressureBara = SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0;
+    SystemInterface crude = new SystemSrkEos(feedTemperatureKelvin, feedPressureBara);
+    OilAssayCharacterisation assay =
+        SarirAtmosphericAssay.create(crude, specificGravity, molarMassKgPerMol);
+    assay.apply();
+    crude.setMixingRule("classic");
+
+    Stream feed = new Stream("Sarir " + label + " feed", crude);
+    feed.setFlowRate(SarirAtmosphericReference.getColumnCrudeFeedRateKgPerHour(), "kg/hr");
+    feed.setTemperature(feedTemperatureKelvin, "K");
+    feed.setPressure(feedPressureBara, "bara");
+    feed.run();
+    return feed;
+  }
+
+  private static DistillationColumn createColumn(String label, Stream feed) {
+    assertEquals(SIMPLE_TRAY_COUNT, SarirAtmosphericReference.getColumnTrayCount());
+    assertEquals(FEED_INTERNAL_INDEX,
+        SIMPLE_TRAY_COUNT - SarirAtmosphericReference.getFeedTrayFromTop() + 1);
+
+    DistillationColumn column = new DistillationColumn("Sarir 34-tray " + label, SIMPLE_TRAY_COUNT, true, true);
+    column.addFeedStream(feed, FEED_INTERNAL_INDEX);
+    assertEquals(FEED_INTERNAL_INDEX, column.getFeedTrayNumber(feed));
+
+    // The source does not report these endpoint and side-draw settings. They are fixed engineering controls,
+    // deliberately identical between profiles and deliberately unrelated to the published plant product rates.
+    column.setTopPressure(1.20);
+    column.setBottomPressure(SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0);
+    column.setCondenserMode(DistillationColumn.CondenserMode.PARTIAL);
+    column.getReboiler().setOutTemperature(700.0);
+    column.setCondenserRefluxRatio(1.0);
+    column.setLiquidSideDrawFraction(KEROSENE_SCREEN_TRAY, 0.08);
+    column.setLiquidSideDrawFraction(DIESEL_SCREEN_TRAY, 0.15);
+
+    column.setSolverType(DistillationColumn.SolverType.DAMPED_SUBSTITUTION);
+    column.setRelaxationFactor(0.30);
+    column.setMaxNumberOfIterations(600, true);
+    column.setTemperatureTolerance(0.50);
+    column.setMassBalanceTolerance(BALANCE_TOLERANCE);
+    column.setEnthalpyBalanceTolerance(BALANCE_TOLERANCE);
+    column.setEnforceEnergyBalanceTolerance(true);
+    return column;
+  }
+
+  private static void assertProfilesAdmissible(double[] specificGravity, double[] molarMassKgPerMol) {
+    assertEquals(SarirAtmosphericReference.getCrudeDensityAt15CKgPerCubicMetre() / 1000.0,
+        SarirAtmosphericAssay.calculateBulkSpecificGravity(specificGravity), 1.0e-12);
+    assertEquals(SarirAtmosphericReference.getCrudeAverageMolarMassKgPerMol(),
+        SarirAtmosphericAssay.calculateBulkMolarMassKgPerMol(specificGravity, molarMassKgPerMol), 1.0e-12);
+  }
+
+  private static double[] createAlternateSpecificGravity() {
+    double[] volumePercent = SarirAtmosphericAssay.getCutVolumePercent();
+    double weightedIndex = 0.0;
+    for (int i = 0; i < volumePercent.length; i++) {
+      weightedIndex += volumePercent[i] / 100.0 * i;
+    }
+
+    double[] alternate = BASE_SPECIFIC_GRAVITY.clone();
+    for (int i = 0; i < alternate.length; i++) {
+      alternate[i] += 0.006 * (i - weightedIndex);
+      assertTrue(alternate[i] > 0.0);
+    }
+    return alternate;
+  }
+
+  private static double[] createAlternateMolarMass(double[] specificGravity) {
+    double[] alternate = BASE_MOLAR_MASS_KG_PER_MOL.clone();
+    for (int i = 0; i < alternate.length; i++) {
+      double normalizedPosition = (2.0 * i) / (alternate.length - 1.0) - 1.0;
+      alternate[i] *= 1.0 + 0.10 * normalizedPosition;
+    }
+    double unscaledBulk = SarirAtmosphericAssay.calculateBulkMolarMassKgPerMol(specificGravity, alternate);
+    double scale = SarirAtmosphericReference.getCrudeAverageMolarMassKgPerMol() / unscaledBulk;
+    for (int i = 0; i < alternate.length; i++) {
+      alternate[i] *= scale;
+    }
+    return alternate;
+  }
+
+  private static void assertBalances(DistillationColumn column, Stream feed, StreamInterface... products) {
+    double feedMassFlow = feed.getFlowRate("kg/hr");
+    double productMassFlow = 0.0;
+    for (StreamInterface product : products) {
+      double flow = product.getFlowRate("kg/hr");
+      assertTrue(Double.isFinite(flow) && flow > 0.0);
+      productMassFlow += flow;
+    }
+    assertEquals(feedMassFlow, productMassFlow, BALANCE_TOLERANCE * feedMassFlow);
+    assertTrue(Double.isFinite(column.getMassBalanceError()));
+    assertTrue(column.getMassBalanceError() <= BALANCE_TOLERANCE, column.getConvergenceDiagnostics());
+    assertTrue(Double.isFinite(column.getEnergyBalanceError()));
+    assertTrue(column.getEnergyBalanceError() <= BALANCE_TOLERANCE, column.getConvergenceDiagnostics());
+    assertTrue(column.getLastTrayMaterialBalanceError() <= column.getTrayMaterialBalanceTolerance(),
+        column.getConvergenceDiagnostics());
+    assertComponentMolarBalance(feed, products);
+  }
+
+  private static void assertComponentMolarBalance(Stream feed, StreamInterface... products) {
+    double feedFlow = feed.getFlowRate("mol/hr");
+    double[] feedComposition = feed.getThermoSystem().getMolarComposition();
+    for (int componentIndex = 0; componentIndex < feedComposition.length; componentIndex++) {
+      double productComponentFlow = 0.0;
+      for (StreamInterface product : products) {
+        productComponentFlow += product.getFlowRate("mol/hr")
+            * product.getThermoSystem().getMolarComposition()[componentIndex];
+      }
+      double feedComponentFlow = feedFlow * feedComposition[componentIndex];
+      assertEquals(feedComponentFlow, productComponentFlow,
+          Math.max(1.0e-7, BALANCE_TOLERANCE * Math.abs(feedComponentFlow)));
+    }
+  }
+
+  private static double meanNormalBoilingPoint(StreamInterface stream) {
+    double[] composition = stream.getThermoSystem().getMolarComposition();
+    double[] normalBoilingPoints = stream.getThermoSystem().getNormalBoilingPointTemperatures();
+    double weightedBoilingPoint = 0.0;
+    for (int i = 0; i < composition.length; i++) {
+      assertTrue(Double.isFinite(normalBoilingPoints[i]) && normalBoilingPoints[i] > 0.0);
+      weightedBoilingPoint += composition[i] * normalBoilingPoints[i];
+    }
+    return weightedBoilingPoint;
+  }
+
+  private static double maximumRelativeDifference(ColumnResult first, ColumnResult second) {
+    double maximum = 0.0;
+    for (int i = 0; i < first.values.length; i++) {
+      double scale = Math.max(1.0e-12, Math.abs(first.values[i]));
+      maximum = Math.max(maximum, Math.abs(second.values[i] - first.values[i]) / scale);
+    }
+    return maximum;
+  }
+
+  private static void assertPublishedTargetsUnchanged(ProductYieldReference[] before) {
+    ProductYieldReference[] after = SarirAtmosphericReference.getProductYields();
+    assertEquals(before.length, after.length);
+    for (int i = 0; i < before.length; i++) {
+      assertEquals(before[i].getName(), after[i].getName());
+      assertEquals(before[i].getPlantMetricTonPerDay(), after[i].getPlantMetricTonPerDay(), 0.0);
+      assertEquals(before[i].getSimulationMetricTonPerDay(), after[i].getSimulationMetricTonPerDay(), 0.0);
+    }
+  }
+
+  private static final class ColumnResult {
+    private final double[] values;
+
+    private ColumnResult(double... values) {
+      this.values = values;
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationSensitivityTest.java
@@ -32,9 +32,9 @@ public class SarirAtmosphericFractionationSensitivityTest {
       0.741826000, 0.761826000, 0.781826000, 0.801826000, 0.821826000, 0.841826000, 0.861826000, 0.881826000,
       0.901826000, 0.921826000, 0.941826000, 0.961826000, 0.981826000, 1.021826000 };
   private static final double[] BASE_MOLAR_MASS_KG_PER_MOL = { 0.092957679997, 0.105352037330, 0.117746394663,
-      0.136337930662, 0.161126645328, 0.179718181327, 0.204506895993, 0.223098431993, 0.241689967992,
-      0.272675861324, 0.303661754657, 0.334647647989, 0.384225077321, 0.421408149319, 0.458591221318,
-      0.495774293317, 0.545351722649, 0.743661439976 };
+      0.136337930662, 0.161126645328, 0.179718181327, 0.204506895993, 0.223098431993, 0.241689967992, 0.272675861324,
+      0.303661754657, 0.334647647989, 0.384225077321, 0.421408149319, 0.458591221318, 0.495774293317, 0.545351722649,
+      0.743661439976 };
 
   private static final int SIMPLE_TRAY_COUNT = 34;
   private static final int FEED_INTERNAL_INDEX = 4;
@@ -74,8 +74,7 @@ public class SarirAtmosphericFractionationSensitivityTest {
     assertTrue(column.getLastIterationCount() <= 600, diagnostics);
 
     StreamInterface overhead = column.getGasOutStream();
-    StreamInterface kerosene =
-        column.getSideDrawStream(KEROSENE_SCREEN_TRAY, DistillationColumn.SideDrawPhase.LIQUID);
+    StreamInterface kerosene = column.getSideDrawStream(KEROSENE_SCREEN_TRAY, DistillationColumn.SideDrawPhase.LIQUID);
     StreamInterface diesel = column.getSideDrawStream(DIESEL_SCREEN_TRAY, DistillationColumn.SideDrawPhase.LIQUID);
     StreamInterface bottoms = column.getLiquidOutStream();
 
@@ -89,18 +88,16 @@ public class SarirAtmosphericFractionationSensitivityTest {
     assertTrue(dieselBoilingPoint < bottomsBoilingPoint);
 
     double feedMassFlow = feed.getFlowRate("kg/hr");
-    return new ColumnResult(overhead.getFlowRate("kg/hr") / feedMassFlow,
-        kerosene.getFlowRate("kg/hr") / feedMassFlow, diesel.getFlowRate("kg/hr") / feedMassFlow,
-        bottoms.getFlowRate("kg/hr") / feedMassFlow, overheadBoilingPoint, keroseneBoilingPoint, dieselBoilingPoint,
-        bottomsBoilingPoint);
+    return new ColumnResult(overhead.getFlowRate("kg/hr") / feedMassFlow, kerosene.getFlowRate("kg/hr") / feedMassFlow,
+        diesel.getFlowRate("kg/hr") / feedMassFlow, bottoms.getFlowRate("kg/hr") / feedMassFlow, overheadBoilingPoint,
+        keroseneBoilingPoint, dieselBoilingPoint, bottomsBoilingPoint);
   }
 
   private static Stream createFeed(String label, double[] specificGravity, double[] molarMassKgPerMol) {
     double feedTemperatureKelvin = SarirAtmosphericReference.getColumnFeedTemperatureCelsius() + 273.15;
     double feedPressureBara = SarirAtmosphericReference.getColumnFeedPressureKPa() / 100.0;
     SystemInterface crude = new SystemSrkEos(feedTemperatureKelvin, feedPressureBara);
-    OilAssayCharacterisation assay =
-        SarirAtmosphericAssay.create(crude, specificGravity, molarMassKgPerMol);
+    OilAssayCharacterisation assay = SarirAtmosphericAssay.create(crude, specificGravity, molarMassKgPerMol);
     assay.apply();
     crude.setMixingRule("classic");
 
@@ -114,8 +111,7 @@ public class SarirAtmosphericFractionationSensitivityTest {
 
   private static DistillationColumn createColumn(String label, Stream feed) {
     assertEquals(SIMPLE_TRAY_COUNT, SarirAtmosphericReference.getColumnTrayCount());
-    assertEquals(FEED_INTERNAL_INDEX,
-        SIMPLE_TRAY_COUNT - SarirAtmosphericReference.getFeedTrayFromTop() + 1);
+    assertEquals(FEED_INTERNAL_INDEX, SIMPLE_TRAY_COUNT - SarirAtmosphericReference.getFeedTrayFromTop() + 1);
 
     DistillationColumn column = new DistillationColumn("Sarir 34-tray " + label, SIMPLE_TRAY_COUNT, true, true);
     column.addFeedStream(feed, FEED_INTERNAL_INDEX);

--- a/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationSensitivityTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/SarirAtmosphericFractionationSensitivityTest.java
@@ -41,6 +41,7 @@ public class SarirAtmosphericFractionationSensitivityTest {
   private static final int DIESEL_SCREEN_TRAY = 15;
   private static final int KEROSENE_SCREEN_TRAY = 24;
   private static final double BALANCE_TOLERANCE = 5.0e-2;
+  private static final double MATERIAL_FLOW_FRACTION = 1.0e-8;
 
   /** Require two admissible property profiles to converge, conserve, separate, and differ. */
   @Test
@@ -77,20 +78,24 @@ public class SarirAtmosphericFractionationSensitivityTest {
     StreamInterface kerosene = column.getSideDrawStream(KEROSENE_SCREEN_TRAY, DistillationColumn.SideDrawPhase.LIQUID);
     StreamInterface diesel = column.getSideDrawStream(DIESEL_SCREEN_TRAY, DistillationColumn.SideDrawPhase.LIQUID);
     StreamInterface bottoms = column.getLiquidOutStream();
+    StreamInterface[] products = { overhead, kerosene, diesel, bottoms };
 
-    assertBalances(column, feed, overhead, kerosene, diesel, bottoms);
-    double overheadBoilingPoint = meanNormalBoilingPoint(overhead);
-    double keroseneBoilingPoint = meanNormalBoilingPoint(kerosene);
-    double dieselBoilingPoint = meanNormalBoilingPoint(diesel);
-    double bottomsBoilingPoint = meanNormalBoilingPoint(bottoms);
-    assertTrue(overheadBoilingPoint < keroseneBoilingPoint);
-    assertTrue(keroseneBoilingPoint < dieselBoilingPoint);
-    assertTrue(dieselBoilingPoint < bottomsBoilingPoint);
+    assertBalances(column, feed, products);
 
     double feedMassFlow = feed.getFlowRate("kg/hr");
-    return new ColumnResult(overhead.getFlowRate("kg/hr") / feedMassFlow, kerosene.getFlowRate("kg/hr") / feedMassFlow,
-        diesel.getFlowRate("kg/hr") / feedMassFlow, bottoms.getFlowRate("kg/hr") / feedMassFlow, overheadBoilingPoint,
-        keroseneBoilingPoint, dieselBoilingPoint, bottomsBoilingPoint);
+    double[] productMassFractions = new double[products.length];
+    double[] materialBoilingPoints = new double[products.length];
+    for (int i = 0; i < products.length; i++) {
+      productMassFractions[i] = products[i].getFlowRate("kg/hr") / feedMassFlow;
+      materialBoilingPoints[i] = productMassFractions[i] > MATERIAL_FLOW_FRACTION
+          ? meanNormalBoilingPoint(products[i])
+          : Double.NaN;
+    }
+    assertIncreasingMaterialBoilingPoints(materialBoilingPoints);
+
+    return new ColumnResult(productMassFractions[0], productMassFractions[1], productMassFractions[2],
+        productMassFractions[3], materialBoilingPoints[0], materialBoilingPoints[1], materialBoilingPoints[2],
+        materialBoilingPoints[3]);
   }
 
   private static Stream createFeed(String label, double[] specificGravity, double[] molarMassKgPerMol) {
@@ -176,11 +181,17 @@ public class SarirAtmosphericFractionationSensitivityTest {
   private static void assertBalances(DistillationColumn column, Stream feed, StreamInterface... products) {
     double feedMassFlow = feed.getFlowRate("kg/hr");
     double productMassFlow = 0.0;
+    int materialProductCount = 0;
     for (StreamInterface product : products) {
       double flow = product.getFlowRate("kg/hr");
-      assertTrue(Double.isFinite(flow) && flow > 0.0);
+      assertTrue(Double.isFinite(flow) && flow >= 0.0);
+      if (flow > MATERIAL_FLOW_FRACTION * feedMassFlow) {
+        materialProductCount++;
+      }
       productMassFlow += flow;
     }
+    assertTrue(materialProductCount >= 2,
+        "The source-bounded assay must produce at least two material column products");
     assertEquals(feedMassFlow, productMassFlow, BALANCE_TOLERANCE * feedMassFlow);
     assertTrue(Double.isFinite(column.getMassBalanceError()));
     assertTrue(column.getMassBalanceError() <= BALANCE_TOLERANCE, column.getConvergenceDiagnostics());
@@ -193,10 +204,14 @@ public class SarirAtmosphericFractionationSensitivityTest {
 
   private static void assertComponentMolarBalance(Stream feed, StreamInterface... products) {
     double feedFlow = feed.getFlowRate("mol/hr");
+    double materialFlowThreshold = MATERIAL_FLOW_FRACTION * feed.getFlowRate("kg/hr");
     double[] feedComposition = feed.getThermoSystem().getMolarComposition();
     for (int componentIndex = 0; componentIndex < feedComposition.length; componentIndex++) {
       double productComponentFlow = 0.0;
       for (StreamInterface product : products) {
+        if (product.getFlowRate("kg/hr") <= materialFlowThreshold) {
+          continue;
+        }
         productComponentFlow += product.getFlowRate("mol/hr")
             * product.getThermoSystem().getMolarComposition()[componentIndex];
       }
@@ -217,9 +232,26 @@ public class SarirAtmosphericFractionationSensitivityTest {
     return weightedBoilingPoint;
   }
 
+  private static void assertIncreasingMaterialBoilingPoints(double[] boilingPoints) {
+    double previousBoilingPoint = Double.NEGATIVE_INFINITY;
+    int materialProductCount = 0;
+    for (double boilingPoint : boilingPoints) {
+      if (Double.isFinite(boilingPoint)) {
+        assertTrue(boilingPoint > previousBoilingPoint,
+            "Material products must become heavier from the column top to the bottoms");
+        previousBoilingPoint = boilingPoint;
+        materialProductCount++;
+      }
+    }
+    assertTrue(materialProductCount >= 2);
+  }
+
   private static double maximumRelativeDifference(ColumnResult first, ColumnResult second) {
     double maximum = 0.0;
     for (int i = 0; i < first.values.length; i++) {
+      if (!Double.isFinite(first.values[i]) || !Double.isFinite(second.values[i])) {
+        continue;
+      }
       double scale = Math.max(1.0e-12, Math.abs(first.values[i]));
       maximum = Math.max(maximum, Math.abs(second.values[i] - first.values[i]) / scale);
     }


### PR DESCRIPTION
## Summary

Advances #3305 with a bounded 34-tray sensitivity qualification for the constrained public Sarir assay.

Exact base: `71d55b17f81a9f895d91b0b50fcbfe21ee4dc1fa`  
Exact head: `e8b2bf7486852e0e243421c1dd3c8bb92a3ef18d`

## Capability contract

- Build the feed exclusively through `SarirAtmosphericAssay`, preserving all 18 source-derived volume cuts and the one-sided `70 °C−` / `550 °C+` boundaries.
- Use the source 34-valve-tray count, feed tray 31 from the top, 54,420 kg/h feed, 350 °C, and 233 kPa absolute.
- Convert tray 31-from-top to NeqSim bottom-up internal index 4, with index 0 reserved for the reboiler.
- Exercise two explicitly labelled engineering density/molar-mass profiles that independently reproduce 841.5 kg/m³ and 0.2447 kg/mol.
- Require rigorous MESH-residual convergence without fallback, finite non-negative candidate-stream rates, at least two material products, mass/energy/per-tray/component closure, ordered mean boiling points across material products, and a measurable profile response.
- Keep published plant product rates untouched and outside specifications, tuning, and acceptance.

The pre-implementation contract is recorded in the [campaign ledger](https://github.com/equinor/neqsim/issues/3305#issuecomment-5533332170).

## Engineering assumptions

The article does not publish per-cut density/molar mass, top pressure, condenser/reboiler settings, reflux, side-draw trays, or side-draw fractions. The test therefore marks every one of those values as a fixed engineering input and applies the same controls to both profiles.

The source explicitly reports light-end hydrocarbons as not determined. A candidate stream below `1e-8` of feed mass flow is therefore treated as non-material and excluded from composition and boiling-order evaluation; the test does not synthesize inventory merely to force every screen stream positive. All candidate rates must remain finite and non-negative, and at least two products must carry material flow.

The test deliberately does not model or claim the published steam, pump-around, side-stripper, tray-hydraulic, efficiency, plant-yield, or D86 behavior.

## Provenance

Source: H. E. O. Almansouri, *Simulation of Sarir Crude Oil Refinery Using Aspen HYSYS*, published March 31, 2022, DOI [10.66411/jer.v33i.46](https://doi.org/10.66411/jer.v33i.46), [open article](https://jer.ly/jer/index.php/jer/article/download/46/38/39), CC BY 4.0.

## Validation

**READY TO MERGE**

The first exact head failed pre-commit only on Spotless formatting, which was repaired without changing engineering behavior. On repaired head `e52cebc204f117ec447991e6b4389522da710929`, Windows reached a solved, non-fallback column in 0.771 seconds and then failed only at the blanket assertion requiring every candidate product to have strictly positive flow. Javadocs, agent-skill references, all four slow-test shards, pre-commit, Spotless, documentation, and CodeQL passed on that head.

The zero-flow repair aligns the assertion with the published evidence boundary: zero-flow/non-material candidates contribute no invented composition or boiling metric, while conservation still covers the full candidate set and the test still requires at least two ordered material products.

On exact head `251f5b821c66b248f1e44ffab65a08e0a219d9a1`, the column again reached `RIGOROUS_CONVERGED` without fallback in 0.718 seconds. Overall mass error was `5.348e-16` and energy error `2.204e-4`, but the explicit per-tray material gate correctly rejected `0.0303069` against the unchanged `0.02` tolerance. The test therefore did not accept that tray profile.

The current repair follows the repository's existing DOE refinery-audit pattern: use `MESH_RESIDUAL` and tighten the engineering temperature tolerance from `0.50 K` to `0.20 K`. The per-tray tolerance is not loosened. No property profile, source datum, plant target, production code, API, or default behavior changed.

On exact head `e8b2bf7486852e0e243421c1dd3c8bb92a3ef18d`, the focused Sarir sensitivity regression passed on Windows in 2.255 seconds. The complete Windows Java 21 suite passed 12,686 tests with zero failures or errors. Java 21 Ubuntu, Java 8 Ubuntu and Windows, all four Java 21 slow-test shards, Javadocs, agent-skill references, Spotless, pre-commit/documentation, documentation search, and CodeQL also passed. No exact-head job failed or remains pending.

After `master` advanced 10 commits to `b9a920cbe44f6b9311fe4b9d405bce24e61d4ea4`, GitHub briefly reported the draft as non-mergeable. A frozen-base comparison showed that those target-side commits touch neither PR-owned file, and a fresh GitHub mergeability computation now reports the preserved exact head as mergeable. No rebase, synchronization, restart, or replacement was performed.

Connector-side publication checks:

- exact base/head comparison: eight commits, two frozen files, zero commits behind the recorded base;
- source tray-number conversion and source-vs-engineering boundary inspected against current distillation documentation;
- Java 8-compatible syntax and existing public API usage inspected;
- documentation updated with the corrected material-product boundary.

No local Maven, Spotless, pre-commit, Javadocs, or runtime result is claimed because this run used the connected repository workflow without a local checkout. Hosted exact-head CI is authoritative.

## Stop boundary

Test and documentation only. No production solver, thermodynamic model, assay factory, reference data, API, plant-rate datum, or default behavior changes. This PR must remain draft-only; do not merge, mark ready, auto-merge, rebase, or synchronize it as part of this campaign.

Generated with AI assistance.