### PR TITLE
[AI-Assisted] feat(dexpi): expose cycle transition evidence

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -208,16 +208,28 @@ retaining parallel and unresolved source evidence. It does not identify a hydrau
 enumerate elementary paths, assert convergence behavior, repair or rewire topology, or establish
 process intent.
 
+`ImportResult.getConnectionCycleTransitions()` provides a global source-ordered inventory of
+connection occurrences crossing directed-cycle boundaries. Each immutable
+`DexpiConnectionCycleTransitionInfo` contains the complete `DexpiConnectionInfo`, complete
+from/to `DexpiConnectionEndpointInfo` records, optional from/to cycle IDs, and an `ENTERING`,
+`LEAVING`, or `BETWEEN_CYCLES` classification. A connection from one cyclic strongly connected
+group to another appears once with both cycle IDs; callers do not need to reconcile the outgoing
+boundary projection of one cycle with the incoming projection of the other. Parallel occurrences
+remain distinct, unresolved non-empty endpoints remain visible, and connections with a blank endpoint
+stay in the global connection and diagnostic evidence because a transition cannot assign them to a
+cycle. This exact-once inventory remains source-reference evidence only; it does not prove hydraulic
+continuity, identify a physical recycle, enumerate paths, or alter simulation topology.
+
 `toJson()` includes `instrumentCount`, `connectionCount`, `connectionEndpointCount`,
-`connectionComponentCount`, `connectionCycleCount`, and the ordered connection, endpoint,
-component, and directed-cycle inventories, including incidence roles, review subsets, complete
-cycle-local endpoint and internal connection occurrences, and explicit cycle-boundary occurrences with
-nested connection and endpoint evidence, alongside the process-unit
-count and findings. Python callers through
-JPype use the same
-`ImportResult.getInstruments()`, `ImportResult.getConnections()`,
-`ImportResult.getConnectionEndpoints()`, `ImportResult.getConnectionComponents()`, and
-`ImportResult.getConnectionCycles()` getters; there is no separate Python reconstruction model.
+`connectionComponentCount`, `connectionCycleCount`, `connectionCycleTransitionCount`, and
+the ordered connection, endpoint, component, directed-cycle, and cycle-transition inventories,
+including incidence roles, review subsets, complete cycle-local endpoint and internal connection
+occurrences, explicit cycle-boundary occurrences, and exact-once transitions with nested connection
+and endpoint evidence, alongside the process-unit count and findings. Python callers through JPype
+use the same `ImportResult.getInstruments()`, `ImportResult.getConnections()`,
+`ImportResult.getConnectionEndpoints()`, `ImportResult.getConnectionComponents()`,
+`ImportResult.getConnectionCycles()`, and `ImportResult.getConnectionCycleTransitions()`
+getters; there is no separate Python reconstruction model.
 
 `INFO` entries carry provenance and do not make `hasLosses()` true by themselves. `WARNING` and
 `ERROR` entries do. The diagnostic sequence and JSON are deterministic for the same XML and template.

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
@@ -1,0 +1,134 @@
+package neqsim.process.processmodel.dexpi;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable source evidence for one connection occurrence crossing directed-cycle boundaries.
+ *
+ * <p>
+ * A transition is retained once in source order even when it leaves one cyclic strongly connected
+ * group and enters another. This record does not establish hydraulic continuity, a physical
+ * recycle, process intent, or live {@code ProcessSystem} topology.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class DexpiConnectionCycleTransitionInfo implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Classification of one explicit connection occurrence relative to cyclic groups. */
+  public enum Kind {
+    /** The connection source is outside every cyclic group and its target is inside one. */
+    ENTERING,
+    /** The connection source is inside a cyclic group and its target is outside every cyclic group. */
+    LEAVING,
+    /** The connection leaves one cyclic group and enters a distinct cyclic group. */
+    BETWEEN_CYCLES
+  }
+
+  private final String fromCycleId;
+  private final String toCycleId;
+  private final Kind kind;
+  private final DexpiConnectionInfo connection;
+  private final DexpiConnectionEndpointInfo fromEndpoint;
+  private final DexpiConnectionEndpointInfo toEndpoint;
+
+  /**
+   * Creates complete immutable evidence for one source connection crossing a cycle boundary.
+   *
+   * @param connection complete source connection occurrence
+   * @param fromEndpoint complete source-endpoint evidence
+   * @param toEndpoint complete target-endpoint evidence
+   * @param fromCycleId source directed-cycle identity, or empty when outside every cycle
+   * @param toCycleId target directed-cycle identity, or empty when outside every cycle
+   * @throws NullPointerException if connection or endpoint evidence is null
+   * @throws IllegalArgumentException if neither endpoint belongs to a cycle, or both identify the same cycle
+   */
+  public DexpiConnectionCycleTransitionInfo(DexpiConnectionInfo connection,
+      DexpiConnectionEndpointInfo fromEndpoint, DexpiConnectionEndpointInfo toEndpoint,
+      String fromCycleId, String toCycleId) {
+    this.connection = Objects.requireNonNull(connection, "connection");
+    this.fromEndpoint = Objects.requireNonNull(fromEndpoint, "fromEndpoint");
+    this.toEndpoint = Objects.requireNonNull(toEndpoint, "toEndpoint");
+    this.fromCycleId = normalize(fromCycleId);
+    this.toCycleId = normalize(toCycleId);
+    if (this.fromCycleId.isEmpty() && this.toCycleId.isEmpty()) {
+      throw new IllegalArgumentException("At least one endpoint must belong to a directed cycle");
+    }
+    if (!this.fromCycleId.isEmpty() && this.fromCycleId.equals(this.toCycleId)) {
+      throw new IllegalArgumentException("A transition must cross a directed-cycle boundary");
+    }
+    if (this.fromCycleId.isEmpty()) {
+      kind = Kind.ENTERING;
+    } else if (this.toCycleId.isEmpty()) {
+      kind = Kind.LEAVING;
+    } else {
+      kind = Kind.BETWEEN_CYCLES;
+    }
+  }
+
+  /** @return connection-evidence identity */
+  public String getConnectionId() {
+    return connection.getId();
+  }
+
+  /** @return source directed-cycle identity, or empty when outside every cyclic group */
+  public String getFromCycleId() {
+    return fromCycleId;
+  }
+
+  /** @return whether the source endpoint belongs to a directed-cycle group */
+  public boolean hasFromCycle() {
+    return !fromCycleId.isEmpty();
+  }
+
+  /** @return target directed-cycle identity, or empty when outside every cyclic group */
+  public String getToCycleId() {
+    return toCycleId;
+  }
+
+  /** @return whether the target endpoint belongs to a directed-cycle group */
+  public boolean hasToCycle() {
+    return !toCycleId.isEmpty();
+  }
+
+  /** @return transition classification relative to the cyclic groups */
+  public Kind getKind() {
+    return kind;
+  }
+
+  /** @return complete source connection evidence */
+  public DexpiConnectionInfo getConnection() {
+    return connection;
+  }
+
+  /** @return complete source-endpoint evidence */
+  public DexpiConnectionEndpointInfo getFromEndpoint() {
+    return fromEndpoint;
+  }
+
+  /** @return complete target-endpoint evidence */
+  public DexpiConnectionEndpointInfo getToEndpoint() {
+    return toEndpoint;
+  }
+
+  Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("connectionId", connection.getId());
+    result.put("fromCycleId", fromCycleId);
+    result.put("toCycleId", toCycleId);
+    result.put("kind", kind.name());
+    result.put("connection", connection.toMap());
+    result.put("fromEndpoint", fromEndpoint.toMap());
+    result.put("toEndpoint", toEndpoint.toMap());
+    return result;
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionCycleTransitionInfo.java
@@ -9,9 +9,9 @@ import java.util.Objects;
  * Immutable source evidence for one connection occurrence crossing directed-cycle boundaries.
  *
  * <p>
- * A transition is retained once in source order even when it leaves one cyclic strongly connected
- * group and enters another. This record does not establish hydraulic continuity, a physical
- * recycle, process intent, or live {@code ProcessSystem} topology.
+ * A transition is retained once in source order even when it leaves one cyclic strongly connected group and enters
+ * another. This record does not establish hydraulic continuity, a physical recycle, process intent, or live
+ * {@code ProcessSystem} topology.
  * </p>
  *
  * @author NeqSim
@@ -48,9 +48,8 @@ public final class DexpiConnectionCycleTransitionInfo implements Serializable {
    * @throws NullPointerException if connection or endpoint evidence is null
    * @throws IllegalArgumentException if neither endpoint belongs to a cycle, or both identify the same cycle
    */
-  public DexpiConnectionCycleTransitionInfo(DexpiConnectionInfo connection,
-      DexpiConnectionEndpointInfo fromEndpoint, DexpiConnectionEndpointInfo toEndpoint,
-      String fromCycleId, String toCycleId) {
+  public DexpiConnectionCycleTransitionInfo(DexpiConnectionInfo connection, DexpiConnectionEndpointInfo fromEndpoint,
+      DexpiConnectionEndpointInfo toEndpoint, String fromCycleId, String toCycleId) {
     this.connection = Objects.requireNonNull(connection, "connection");
     this.fromEndpoint = Objects.requireNonNull(fromEndpoint, "fromEndpoint");
     this.toEndpoint = Objects.requireNonNull(toEndpoint, "toEndpoint");

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -134,12 +134,13 @@ public final class DexpiXmlReader {
     private final List<DexpiConnectionEndpointInfo> connectionEndpoints;
     private final List<DexpiConnectionComponentInfo> connectionComponents;
     private final List<DexpiConnectionCycleInfo> connectionCycles;
+    private final List<DexpiConnectionCycleTransitionInfo> connectionCycleTransitions;
     private final List<ImportDiagnostic> diagnostics;
 
     private ImportResult(ProcessSystem processSystem, List<DexpiInstrumentInfo> instruments,
         List<DexpiConnectionInfo> connections, List<DexpiConnectionEndpointInfo> connectionEndpoints,
         List<DexpiConnectionComponentInfo> connectionComponents, List<DexpiConnectionCycleInfo> connectionCycles,
-        List<ImportDiagnostic> diagnostics) {
+        List<DexpiConnectionCycleTransitionInfo> connectionCycleTransitions, List<ImportDiagnostic> diagnostics) {
       this.processSystem = processSystem;
       this.instruments = Collections.unmodifiableList(new ArrayList<DexpiInstrumentInfo>(instruments));
       this.connections = Collections.unmodifiableList(new ArrayList<DexpiConnectionInfo>(connections));
@@ -148,6 +149,8 @@ public final class DexpiXmlReader {
       this.connectionComponents = Collections
           .unmodifiableList(new ArrayList<DexpiConnectionComponentInfo>(connectionComponents));
       this.connectionCycles = Collections.unmodifiableList(new ArrayList<DexpiConnectionCycleInfo>(connectionCycles));
+      this.connectionCycleTransitions = Collections
+          .unmodifiableList(new ArrayList<DexpiConnectionCycleTransitionInfo>(connectionCycleTransitions));
       this.diagnostics = Collections.unmodifiableList(new ArrayList<ImportDiagnostic>(diagnostics));
     }
 
@@ -221,6 +224,20 @@ public final class DexpiXmlReader {
       return connectionCycles;
     }
 
+    /**
+     * Returns source-ordered connection occurrences crossing directed-cycle boundaries.
+     *
+     * <p>
+     * Each occurrence appears once even when it leaves one cyclic group and enters another. These records preserve
+     * source evidence only; they do not establish hydraulic continuity, a physical recycle, or live process topology.
+     * </p>
+     *
+     * @return immutable cycle-transition evidence in source-document order
+     */
+    public List<DexpiConnectionCycleTransitionInfo> getConnectionCycleTransitions() {
+      return connectionCycleTransitions;
+    }
+
     /** @return immutable diagnostics in deterministic source-document order */
     public List<ImportDiagnostic> getDiagnostics() {
       return diagnostics;
@@ -277,6 +294,12 @@ public final class DexpiXmlReader {
         cycleMaps.add(cycle.toMap());
       }
       result.put("connectionCycles", cycleMaps);
+      result.put("connectionCycleTransitionCount", Integer.valueOf(connectionCycleTransitions.size()));
+      List<Map<String, Object>> transitionMaps = new ArrayList<Map<String, Object>>();
+      for (DexpiConnectionCycleTransitionInfo transition : connectionCycleTransitions) {
+        transitionMaps.add(transition.toMap());
+      }
+      result.put("connectionCycleTransitions", transitionMaps);
       result.put("hasLosses", Boolean.valueOf(hasLosses()));
       result.put("hasErrors", Boolean.valueOf(hasErrors()));
       List<Map<String, Object>> diagnosticMaps = new ArrayList<Map<String, Object>>();
@@ -476,8 +499,10 @@ public final class DexpiXmlReader {
         connectionEndpoints);
     List<DexpiConnectionCycleInfo> connectionCycles = summarizeConnectionCycles(connections, connectionEndpoints,
         connectionComponents);
+    List<DexpiConnectionCycleTransitionInfo> connectionCycleTransitions = summarizeConnectionCycleTransitions(
+        connections, connectionEndpoints, connectionCycles);
     return new ImportResult(processSystem, instruments, connections, connectionEndpoints, connectionComponents,
-        connectionCycles, diagnostics);
+        connectionCycles, connectionCycleTransitions, diagnostics);
   }
 
   /**
@@ -1049,6 +1074,40 @@ public final class DexpiXmlReader {
     List<DexpiConnectionCycleInfo> result = new ArrayList<DexpiConnectionCycleInfo>();
     for (ConnectionCycleAccumulator cycle : cycles) {
       result.add(cycle.toInfo());
+    }
+    return result;
+  }
+
+  private static List<DexpiConnectionCycleTransitionInfo> summarizeConnectionCycleTransitions(
+      List<DexpiConnectionInfo> connections, List<DexpiConnectionEndpointInfo> connectionEndpoints,
+      List<DexpiConnectionCycleInfo> connectionCycles) {
+    Map<String, DexpiConnectionEndpointInfo> endpointById = new HashMap<String, DexpiConnectionEndpointInfo>();
+    for (DexpiConnectionEndpointInfo endpoint : connectionEndpoints) {
+      endpointById.put(endpoint.getEndpointId(), endpoint);
+    }
+
+    Map<String, String> cycleByEndpointId = new HashMap<String, String>();
+    for (DexpiConnectionCycleInfo cycle : connectionCycles) {
+      for (String endpointId : cycle.getEndpointIds()) {
+        cycleByEndpointId.put(endpointId, cycle.getId());
+      }
+    }
+
+    List<DexpiConnectionCycleTransitionInfo> result = new ArrayList<DexpiConnectionCycleTransitionInfo>();
+    for (DexpiConnectionInfo connection : connections) {
+      if (isBlank(connection.getFromId()) || isBlank(connection.getToId())) {
+        continue;
+      }
+      String fromCycleId = cycleByEndpointId.get(connection.getFromId());
+      String toCycleId = cycleByEndpointId.get(connection.getToId());
+      if (fromCycleId == null && toCycleId == null) {
+        continue;
+      }
+      if (fromCycleId != null && fromCycleId.equals(toCycleId)) {
+        continue;
+      }
+      result.add(new DexpiConnectionCycleTransitionInfo(connection, endpointById.get(connection.getFromId()),
+          endpointById.get(connection.getToId()), fromCycleId, toCycleId));
     }
     return result;
   }

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -823,6 +823,97 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(first.toJson(), second.toJson());
   }
 
+  @Test
+  public void testReadWithDiagnosticsSummarizesCycleTransitionsExactlyOnce() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
+        + "<Equipment ID=\"E-A\"><Nozzle ID=\"N-A\"/></Equipment>"
+        + "<Equipment ID=\"E-B\"><Nozzle ID=\"N-B\"/></Equipment>"
+        + "<Equipment ID=\"E-X\"><Nozzle ID=\"N-X\"/></Equipment>"
+        + "<Equipment ID=\"E-Y\"><Nozzle ID=\"N-Y\"/></Equipment>"
+        + "<Equipment ID=\"E-V\"><Nozzle ID=\"N-V\"/></Equipment>"
+        + "<PipingNetworkSegment ID=\"S-IN-1\"><Connection ID=\"C-IN-1\" FromID=\"UNKNOWN-U\" ToID=\"N-A\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-IN-2\"><Connection ID=\"C-IN-2\" FromID=\"UNKNOWN-U\" ToID=\"N-A\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-AB\"><Connection ID=\"C-AB\" FromID=\"N-A\" ToID=\"N-B\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-BA\"><Connection ID=\"C-BA\" FromID=\"N-B\" ToID=\"N-A\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-BX\"><Connection ID=\"C-BX\" FromID=\"N-B\" ToID=\"N-X\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-XY\"><Connection ID=\"C-XY\" FromID=\"N-X\" ToID=\"N-Y\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-YX\"><Connection ID=\"C-YX\" FromID=\"N-Y\" ToID=\"N-X\"/>"
+        + "</PipingNetworkSegment>"
+        + "<PipingNetworkSegment ID=\"S-OUT\"><Connection ID=\"C-OUT\" FromID=\"N-Y\" ToID=\"N-V\"/>"
+        + "</PipingNetworkSegment>" + "</PlantModel>";
+
+    DexpiXmlReader.ImportResult first = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    DexpiXmlReader.ImportResult second = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+    assertEquals(2, first.getConnectionCycles().size());
+    List<DexpiConnectionCycleTransitionInfo> transitions = first.getConnectionCycleTransitions();
+    assertEquals(4, transitions.size());
+    assertEquals(Arrays.asList("C-IN-1", "C-IN-2", "C-BX", "C-OUT"),
+        Arrays.asList(transitions.get(0).getConnectionId(), transitions.get(1).getConnectionId(),
+            transitions.get(2).getConnectionId(), transitions.get(3).getConnectionId()));
+
+    DexpiConnectionCycleTransitionInfo entering = transitions.get(0);
+    assertEquals(DexpiConnectionCycleTransitionInfo.Kind.ENTERING, entering.getKind());
+    assertEquals("", entering.getFromCycleId());
+    assertFalse(entering.hasFromCycle());
+    assertEquals("cycle-1", entering.getToCycleId());
+    assertTrue(entering.hasToCycle());
+    assertEquals("S-IN-1", entering.getConnection().getSegmentId());
+    assertEquals("UNKNOWN-U", entering.getFromEndpoint().getEndpointId());
+    assertFalse(entering.getFromEndpoint().isResolved());
+    assertEquals("N-A", entering.getToEndpoint().getEndpointId());
+    assertEquals("E-A", entering.getToEndpoint().getOwnerId());
+    assertEquals(Arrays.asList("C-IN-1", "C-IN-2", "C-BA"),
+        entering.getToEndpoint().getIncomingConnectionIds());
+    assertEquals(Collections.singletonList("C-AB"), entering.getToEndpoint().getOutgoingConnectionIds());
+
+    DexpiConnectionCycleTransitionInfo parallelEntering = transitions.get(1);
+    assertEquals(DexpiConnectionCycleTransitionInfo.Kind.ENTERING, parallelEntering.getKind());
+    assertEquals("cycle-1", parallelEntering.getToCycleId());
+    assertEquals("S-IN-2", parallelEntering.getConnection().getSegmentId());
+
+    DexpiConnectionCycleTransitionInfo between = transitions.get(2);
+    assertEquals(DexpiConnectionCycleTransitionInfo.Kind.BETWEEN_CYCLES, between.getKind());
+    assertEquals("cycle-1", between.getFromCycleId());
+    assertEquals("cycle-2", between.getToCycleId());
+    assertTrue(between.hasFromCycle());
+    assertTrue(between.hasToCycle());
+    assertEquals("N-B", between.getFromEndpoint().getEndpointId());
+    assertEquals("N-X", between.getToEndpoint().getEndpointId());
+
+    DexpiConnectionCycleTransitionInfo leaving = transitions.get(3);
+    assertEquals(DexpiConnectionCycleTransitionInfo.Kind.LEAVING, leaving.getKind());
+    assertEquals("cycle-2", leaving.getFromCycleId());
+    assertEquals("", leaving.getToCycleId());
+    assertTrue(leaving.hasFromCycle());
+    assertFalse(leaving.hasToCycle());
+    assertEquals("E-V", leaving.getToEndpoint().getOwnerId());
+
+    assertThrows(UnsupportedOperationException.class, () -> transitions.clear());
+    assertThrows(UnsupportedOperationException.class, () -> entering.getToEndpoint().getIncomingConnectionIds().clear());
+    assertThrows(IllegalArgumentException.class,
+        () -> new DexpiConnectionCycleTransitionInfo(entering.getConnection(), entering.getFromEndpoint(),
+            entering.getToEndpoint(), "", ""));
+    assertThrows(IllegalArgumentException.class,
+        () -> new DexpiConnectionCycleTransitionInfo(between.getConnection(), between.getFromEndpoint(),
+            between.getToEndpoint(), "cycle-1", "cycle-1"));
+    assertTrue(first.toJson().contains("\"connectionCycleTransitionCount\": 4"));
+    assertTrue(first.toJson().contains("\"kind\": \"BETWEEN_CYCLES\""));
+    assertTrue(first.toJson().contains("\"fromCycleId\": \"cycle-1\""));
+    assertTrue(first.toJson().contains("\"toCycleId\": \"cycle-2\""));
+    assertTrue(first.toJson().contains("\"fromEndpoint\": {"));
+    assertTrue(first.toJson().contains("\"toEndpoint\": {"));
+    assertEquals(first.toJson(), second.toJson());
+  }
+
   private static int countDiagnostics(DexpiXmlReader.ImportResult result, String expectedCode) {
     int count = 0;
     for (DexpiXmlReader.ImportDiagnostic diagnostic : result.getDiagnostics()) {

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -871,8 +871,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertFalse(entering.getFromEndpoint().isResolved());
     assertEquals("N-A", entering.getToEndpoint().getEndpointId());
     assertEquals("E-A", entering.getToEndpoint().getOwnerId());
-    assertEquals(Arrays.asList("C-IN-1", "C-IN-2", "C-BA"),
-        entering.getToEndpoint().getIncomingConnectionIds());
+    assertEquals(Arrays.asList("C-IN-1", "C-IN-2", "C-BA"), entering.getToEndpoint().getIncomingConnectionIds());
     assertEquals(Collections.singletonList("C-AB"), entering.getToEndpoint().getOutgoingConnectionIds());
 
     DexpiConnectionCycleTransitionInfo parallelEntering = transitions.get(1);
@@ -898,13 +897,12 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("E-V", leaving.getToEndpoint().getOwnerId());
 
     assertThrows(UnsupportedOperationException.class, () -> transitions.clear());
-    assertThrows(UnsupportedOperationException.class, () -> entering.getToEndpoint().getIncomingConnectionIds().clear());
-    assertThrows(IllegalArgumentException.class,
-        () -> new DexpiConnectionCycleTransitionInfo(entering.getConnection(), entering.getFromEndpoint(),
-            entering.getToEndpoint(), "", ""));
-    assertThrows(IllegalArgumentException.class,
-        () -> new DexpiConnectionCycleTransitionInfo(between.getConnection(), between.getFromEndpoint(),
-            between.getToEndpoint(), "cycle-1", "cycle-1"));
+    assertThrows(UnsupportedOperationException.class,
+        () -> entering.getToEndpoint().getIncomingConnectionIds().clear());
+    assertThrows(IllegalArgumentException.class, () -> new DexpiConnectionCycleTransitionInfo(entering.getConnection(),
+        entering.getFromEndpoint(), entering.getToEndpoint(), "", ""));
+    assertThrows(IllegalArgumentException.class, () -> new DexpiConnectionCycleTransitionInfo(between.getConnection(),
+        between.getFromEndpoint(), between.getToEndpoint(), "cycle-1", "cycle-1"));
     assertTrue(first.toJson().contains("\"connectionCycleTransitionCount\": 4"));
     assertTrue(first.toJson().contains("\"kind\": \"BETWEEN_CYCLES\""));
     assertTrue(first.toJson().contains("\"fromCycleId\": \"cycle-1\""));


### PR DESCRIPTION
## Summary

Advances #1332 and #2899 with a source-ordered, exact-once inventory of material connections crossing directed-cycle boundaries.

Exact base: `fbbada84426cb0dd1158498e4433042a17a93bbb`  
Exact head: `b96ec1cbec533e5e0813aacfcaa21c52b86f9ef4`

## Capability contract

- Add immutable `DexpiConnectionCycleTransitionInfo` values containing the complete source connection, complete from/to endpoint evidence, and optional from/to cycle identities.
- Classify each retained occurrence as `ENTERING`, `LEAVING`, or `BETWEEN_CYCLES`.
- Retain a connection between distinct cyclic SCCs once with both cycle IDs instead of requiring callers to reconcile two per-cycle boundary projections.
- Preserve source order, parallel occurrences, unresolved non-empty endpoints, deterministic JSON, and O(V+E) analysis.
- Keep all existing connection, endpoint, component, cycle, and boundary APIs unchanged.
- Add focused regressions and Java/JPype documentation.

The pre-implementation contract is recorded in [#1332](https://github.com/equinor/neqsim/issues/1332#issuecomment-5535497630) and [#2899](https://github.com/equinor/neqsim/issues/2899#issuecomment-5535497798).

## Changes

- Add the immutable transition value and `ENTERING` / `LEAVING` / `BETWEEN_CYCLES` classification.
- Add `ImportResult.getConnectionCycleTransitions()` plus deterministic transition count and nested JSON evidence.
- Build the inventory in one source-order scan after SCC evidence, retaining parallel and unresolved non-empty endpoint records.
- Add focused coverage for two cycle groups, parallel entering occurrences, an unresolved source, an inter-cycle edge, a leaving edge, immutability, constructor invariants, and repeatable JSON.
- Document the Java and JPype surface and evidence boundary.

## Validation

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

Exact-head evidence at `b96ec1cbec533e5e0813aacfcaa21c52b86f9ef4`:

- Seven of eight workflows pass: PaperLab, Spotless, pre-commit, diagram performance, notebook, documentation search coverage, and CodeQL.
- Java 21 Ubuntu/Windows, all four slow-test shards, Javadocs, agent-skill references, and change detection pass.
- Only Java 8 Ubuntu and Windows remain active. Zero failures are reported.
- The automated mutability finding was disproved by the constructor's defensive immutable copy and the focused mutation regression, then answered and resolved without source changes.
- Exact scope remains six commits across four intended files. The draft is mergeable.
- Current `master` is one unrelated H₂S-kinetics commit ahead. Per exact-head continuity policy, this draft was not rebased or synchronized.

The initial exact head failed only Spotless formatting in the new class and focused test. The exact hosted patch was applied without changing behavior or scope.

No local Maven, Spotless, pre-commit, Javadocs, or runtime result is claimed because this run uses the connected repository workflow without a local checkout. Exact-head hosted CI is authoritative.

## Documentation impact

Updated `docs/integration/dexpi-reader.md` for the public Java/JPype getter, record contents, exact-once semantics, JSON fields, and non-hydraulic boundary.

## Whole-sheet gate

N/A: no rendering, geometry, layout, notebook, SVG, or export path changed.

## Stop boundary

No simulation topology mutation, elementary-path enumeration, hydraulic recycle inference, convergence analysis, rendering/export behavior, DEXPI/ISO/ISA conformance claim, certification, or engineering approval.

Generated with AI assistance.