### PR TITLE
release: prepare NeqSim 3.19.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -87,7 +87,7 @@ git add <the reformatted files>
 - **Package and Update Python**: When the user says "package and update python" or similar, run these commands:
   ```powershell
   .\mvnw.cmd package -DskipTests
-   Copy-Item -Path "C:\Users\ESOL\Documents\GitHub\neqsim\target\neqsim-3.18.0.jar" -Destination "C:\Users\ESOL\AppData\Roaming\Python\Python312\site-packages\neqsim\lib\" -Force
+   Copy-Item -Path "C:\Users\ESOL\Documents\GitHub\neqsim\target\neqsim-3.19.0.jar" -Destination "C:\Users\ESOL\AppData\Roaming\Python\Python312\site-packages\neqsim\lib\" -Force
   ```
   This builds the NeqSim JAR and copies it to the Python neqsim package for immediate use. Note: the runtime loads `lib/*` (flat), so copy the JAR directly into `neqsim\lib\`, not a `java11`/`java8` subfolder.
 

--- a/.github/workflows/release_with_jars.yml
+++ b/.github/workflows/release_with_jars.yml
@@ -89,7 +89,7 @@ jobs:
           path: staging
 
   compile_mcp_server:
-    name: Build MCP Server (Java 17)
+    name: Build MCP Server (Java 21)
     needs: get_versions
 
     if: ${{ needs.get_versions.outputs.version_8 == needs.get_versions.outputs.version }}
@@ -147,12 +147,24 @@ jobs:
         with:
           name: jarfiles-mcp-server
 
+      - name: Determine release publication mode
+        id: publication
+        env:
+          RELEASE_EVENT: ${{ github.event_name }}
+          RELEASE_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          if [[ "$RELEASE_EVENT" == "push" && "$RELEASE_COMMIT_MESSAGE" == *"[publish-release]"* ]]; then
+            echo "draft=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "draft=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create release v${{ needs.get_versions.outputs.version_8 }}
         uses: ncipollo/release-action@v1.21.0
         with:
           name: NeqSim ${{ needs.get_versions.outputs.version_8 }}
           tag: v${{ needs.get_versions.outputs.version_8 }}
-          draft: true
+          draft: ${{ steps.publication.outputs.draft }}
           generateReleaseNotes: true
           skipIfReleaseExists: true
           artifacts: "*.jar,*.sha256"

--- a/.github/workflows/release_with_jars.yml
+++ b/.github/workflows/release_with_jars.yml
@@ -166,7 +166,8 @@ jobs:
           tag: v${{ needs.get_versions.outputs.version_8 }}
           draft: ${{ steps.publication.outputs.draft }}
           generateReleaseNotes: true
-          skipIfReleaseExists: true
+          allowUpdates: true
+          updateOnlyUnreleased: true
           artifacts: "*.jar,*.sha256"
           artifactContentType: application/java-archive
           body: |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
   - PVT
   - oil-and-gas
   - CCS
-version: "3.18.0"
-date-released: "2026-08-18"
+version: "3.19.0"
+date-released: "2026-09-04"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,7 +26,7 @@ runs the full workflow including PR creation.
 
 Java library for thermodynamic fluid properties and process simulation.
 Developed at NTNU, maintained by Equinor. Apache-2.0 license.
-`com.equinor.neqsim:neqsim` version 3.18.0 — **must compile with Java 8**.
+`com.equinor.neqsim:neqsim` version 3.19.0 — **must compile with Java 8**.
 
 ## Repo Map
 
@@ -131,7 +131,7 @@ devtools/                Unified CLI (`neqsim` command), Jupyter dev setup, task
 
 # Package JAR + copy to Python
 .\mvnw.cmd package -DskipTests
-Copy-Item target\neqsim-3.18.0.jar C:\Users\ESOL\AppData\Roaming\Python\Python312\site-packages\neqsim\lib\ -Force
+Copy-Item target\neqsim-3.19.0.jar C:\Users\ESOL\AppData\Roaming\Python\Python312\site-packages\neqsim\lib\ -Force
 ```
 
 ## Code Patterns — Copy-Paste Starters

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See [neqsim-python](https://github.com/equinor/neqsim-python) for more details.
 <dependency>
   <groupId>com.equinor.neqsim</groupId>
   <artifactId>neqsim</artifactId>
-  <version>3.18.0</version>
+  <version>3.19.0</version>
 </dependency>
 ```
 
@@ -332,7 +332,7 @@ See [VISION_AGENTS.md](VISION_AGENTS.md) and the [Where Does This Go? guide](htt
 <dependency>
   <groupId>com.equinor.neqsim</groupId>
   <artifactId>neqsim</artifactId>
-  <version>3.18.0</version>
+  <version>3.19.0</version>
 </dependency>
 ```
 

--- a/docs/integration/mcp_getting_started.md
+++ b/docs/integration/mcp_getting_started.md
@@ -268,7 +268,7 @@ Use this to:
 
 | Problem | Solution |
 |---|---|
-| Server doesn't start | Check JDK 17+ is installed: `java -version` |
+| Server doesn't start | Check JDK 21+ is installed: `java -version` |
 | "Component not found" | Use `searchComponents` to find the correct name |
 | Zero density/viscosity | The flash may not have converged — check `provenance.converged` |
 | Slow batch calculations | Reduce case count (max 500) or use `getPropertyTable` for uniform sweeps |

--- a/docs/integration/mcp_server_guide.md
+++ b/docs/integration/mcp_server_guide.md
@@ -796,9 +796,9 @@ cd ..  # parent neqsim directory
 ./mvnw install -DskipTests -Dmaven.javadoc.skip=true
 ```
 
-### "No matching toolchain found for JDK 17+"
+### "No matching toolchain found for JDK 21+"
 
-The MCP server requires JDK 17+. Check with `java -version`. The parent neqsim
+The MCP server requires JDK 21+. Check with `java -version`. The parent neqsim
 project compiles with Java 8 — both can coexist.
 
 ### Server Hangs or Returns Garbled Output

--- a/docs/quickstart/java-quickstart.md
+++ b/docs/quickstart/java-quickstart.md
@@ -6,7 +6,7 @@ description: Get started with NeqSim in Java. Maven setup, first flash calculati
 # Java Quickstart
 
 Get NeqSim running in a Java project with one thermodynamic calculation and one composable
-process simulation. The examples use NeqSim 3.18.0; check
+process simulation. The examples use NeqSim 3.19.0; check
 [Maven Central](https://central.sonatype.com/artifact/com.equinor.neqsim/neqsim) for a newer
 published version before starting a new project.
 
@@ -18,7 +18,7 @@ Add the dependency to your `pom.xml`:
 <dependency>
   <groupId>com.equinor.neqsim</groupId>
   <artifactId>neqsim</artifactId>
-  <version>3.18.0</version>
+  <version>3.19.0</version>
 </dependency>
 ```
 
@@ -40,7 +40,7 @@ already configure it:
 With Gradle:
 
 ```groovy
-implementation 'com.equinor.neqsim:neqsim:3.18.0'
+implementation 'com.equinor.neqsim:neqsim:3.19.0'
 ```
 
 ## Step 2: first flash calculation

--- a/docs/wiki/Getting-started-with-NeqSim-and-Github.md
+++ b/docs/wiki/Getting-started-with-NeqSim-and-Github.md
@@ -14,7 +14,7 @@ Add the current project version to a Maven build:
 <dependency>
   <groupId>com.equinor.neqsim</groupId>
   <artifactId>neqsim</artifactId>
-  <version>3.18.0</version>
+  <version>3.19.0</version>
 </dependency>
 ```
 

--- a/docs/wiki/faq.md
+++ b/docs/wiki/faq.md
@@ -53,13 +53,13 @@ NeqSim requires Java 8 or higher. Java 11+ is recommended for best performance.
 <dependency>
     <groupId>com.equinor.neqsim</groupId>
     <artifactId>neqsim</artifactId>
-    <version>3.18.0</version>
+    <version>3.19.0</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation 'com.equinor.neqsim:neqsim:3.18.0'
+implementation 'com.equinor.neqsim:neqsim:3.19.0'
 ```
 
 **Direct Download:**

--- a/docs/wiki/getting_started.md
+++ b/docs/wiki/getting_started.md
@@ -15,7 +15,7 @@ Add the current release to a Maven project:
 <dependency>
   <groupId>com.equinor.neqsim</groupId>
   <artifactId>neqsim</artifactId>
-  <version>3.18.0</version>
+  <version>3.19.0</version>
 </dependency>
 ```
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -142,7 +142,7 @@ public final class NeqSimQuickStart {
 <dependency>
     <groupId>com.equinor.neqsim</groupId>
     <artifactId>neqsim</artifactId>
-    <version>3.18.0</version>
+    <version>3.19.0</version>
 </dependency>
 ```
 

--- a/neqsim-mcp-server/README.md
+++ b/neqsim-mcp-server/README.md
@@ -321,11 +321,11 @@ Pick **jar** or **Docker** — both are first-class paths.
 
 | OS                              | Command                                           |
 | ------------------------------- | ------------------------------------------------- |
-| **macOS**                 | `brew install openjdk@17`                       |
-| **Linux (Ubuntu/Debian)** | `sudo apt install openjdk-17-jdk`               |
-| **Windows**               | `winget install EclipseAdoptium.Temurin.17.JDK` |
+| **macOS**                 | `brew install openjdk@21`                       |
+| **Linux (Ubuntu/Debian)** | `sudo apt install openjdk-21-jdk`               |
+| **Windows**               | `winget install EclipseAdoptium.Temurin.21.JDK` |
 
-Verify: `java -version` should show 17 or higher.
+Verify: `java -version` should show 21 or higher.
 
 </details>
 
@@ -1012,11 +1012,11 @@ cd ..  # go to parent neqsim directory
 ./mvnw install -DskipTests -Dmaven.javadoc.skip=true
 ```
 
-### Build Fails — "No matching toolchain found for JDK 17+"
+### Build Fails — "No matching toolchain found for JDK 21+"
 
-This project requires JDK 17+. Check with `java -version`.
+This project requires JDK 21+. Check with `java -version`.
 The parent neqsim project compiles with Java 8. Both can coexist — just ensure
-`JAVA_HOME` points to JDK 17+ when building this project.
+`JAVA_HOME` points to JDK 21+ when building this project.
 
 ### Server Hangs or Returns Garbled Output
 

--- a/neqsim-mcp-server/pom.xml
+++ b/neqsim-mcp-server/pom.xml
@@ -14,7 +14,7 @@
         <quarkus.version>3.37.0</quarkus.version>
         <mcp-server.version>1.13.0</mcp-server.version>
         <!-- Keep in sync with ../pom.xml <revision> property until a parent/module build is used. -->
-        <revision>3.18.0</revision>
+        <revision>3.19.0</revision>
         <neqsim.version>${revision}</neqsim.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	</scm>
 
 	<properties>
-		<revision>3.18.0</revision>
+		<revision>3.19.0</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<checkstyle.config.location>.config/checkstyle_neqsim.xml</checkstyle.config.location>

--- a/pomJava8.xml
+++ b/pomJava8.xml
@@ -19,7 +19,7 @@
 	</scm>
 
 	<properties>
-		<revision>3.18.0</revision>
+		<revision>3.19.0</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<sha1 />


### PR DESCRIPTION
## Summary

- set NeqSim core, Java 8, and MCP dependency references to 3.19.0
- update citation metadata and current-version documentation
- align MCP installation guidance and release labeling with its Java 21 runtime
- let a deliberate `[publish-release]` merge update the release-branch draft and publish it, while ordinary release-branch pushes remain drafts

## Documentation impact

Updated README, Java quickstart, wiki getting-started/FAQ pages, MCP guides, `CONTEXT.md`, `CITATION.cff`, and Copilot instructions. Historical notebook outputs and parser fixtures were intentionally preserved.

## Validation

- `git diff --check`
- release POM/CFF/workflow parsing and version assertions
- `python devtools/check_documentation_search.py`
- `python -m unittest docs.test_java_quickstart_documentation docs.test_landing_page_documentation` — 12 passed
- `python devtools/run_spotless.py apply`
- `python devtools/run_spotless.py check`
- pre-commit and pre-push hooks
- `./mvnw -B -ntp -U clean install -DskipTests -Djacoco.skip=true` — Java 21 build passed
- `./mvnw -B -ntp -U clean package --file pomJava8.xml -DskipTests -Djacoco.skip=true` — Java 8 artifact build passed
- MCP package build plus `python test_mcp_server.py` — 323/323 passed, 71 tools registered

The exact master base commit was green in Build/Test/Javadoc, CodeQL, Code Quality, and Push workflows before this release branch.

## Release plan

After required checks pass, merge with commit title `[publish-release] release: NeqSim 3.19.0`. The master push will publish the v3.19.0 draft and trigger the Maven Central and MCP container release workflows.
