### PR TITLE
[AI-Assisted] docs: document symmetric component aliases

### DIFF
--- a/docs/test_component_alias_api_documentation.py
+++ b/docs/test_component_alias_api_documentation.py
@@ -64,7 +64,7 @@ class ComponentAliasApiDocumentationContractTest(unittest.TestCase):
             'fluid.getPhase(0).getComponent("ISOOCTANE")',
             "`hasComponent(String)`",
             "near-miss inputs are not guessed",
-            "../component_list.md#component-name-resolution",
+            "../component_list#component-name-resolution",
         ):
             with self.subTest(token=token):
                 self.assertIn(token, self.component_package)

--- a/docs/test_component_alias_api_documentation.py
+++ b/docs/test_component_alias_api_documentation.py
@@ -1,0 +1,120 @@
+"""Contracts for the documented component-name alias API."""
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT_LIST = ROOT / "docs" / "thermo" / "component_list.md"
+COMPONENT_PACKAGE = ROOT / "docs" / "thermo" / "component" / "README.md"
+PHASE_SOURCE = ROOT / "src" / "main" / "java" / "neqsim" / "thermo" / "phase" / "Phase.java"
+SYSTEM_INTERFACE = (
+    ROOT
+    / "src"
+    / "main"
+    / "java"
+    / "neqsim"
+    / "thermo"
+    / "system"
+    / "SystemInterface.java"
+)
+EXECUTABLE_REGRESSION = (
+    ROOT
+    / "src"
+    / "test"
+    / "java"
+    / "neqsim"
+    / "thermo"
+    / "component"
+    / "ComponentAliasApiSymmetryTest.java"
+)
+
+
+class ComponentAliasApiDocumentationContractTest(unittest.TestCase):
+    """Keep the component guides aligned with the executable alias contract."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.component_list = COMPONENT_LIST.read_text(encoding="utf-8")
+        cls.component_package = COMPONENT_PACKAGE.read_text(encoding="utf-8")
+        cls.phase_source = PHASE_SOURCE.read_text(encoding="utf-8")
+        cls.system_interface = SYSTEM_INTERFACE.read_text(encoding="utf-8")
+        cls.executable_regression = EXECUTABLE_REGRESSION.read_text(encoding="utf-8")
+
+    def test_guides_state_symmetric_lookup_and_fail_closed_behavior(self) -> None:
+        for token in (
+            "Name resolution is symmetric",
+            'fluid.getComponent("2,2,4-trimethylpentane")',
+            'fluid.getPhase(0).getComponent("isooctane")',
+            'fluid.hasComponent("ISOOCTANE")',
+            "setComponentCriticalParameters",
+            "setBinaryInteractionParameter",
+            "removeComponent",
+            'getComponent("methan")',
+            "returns `null`",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, self.component_list)
+
+        for token in (
+            "Recognized aliases, systematic names, and case variants",
+            'fluid.addComponent("2,2,4-trimethylpentane", 1.0)',
+            'fluid.getComponent("isooctane")',
+            'fluid.getPhase(0).getComponent("ISOOCTANE")',
+            "`hasComponent(String)`",
+            "Unknown, ambiguous, and near-miss inputs are not guessed",
+            "../component_list.md#component-name-resolution",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, self.component_package)
+
+    def test_guides_remain_renderable(self) -> None:
+        for path, content in (
+            (COMPONENT_LIST, self.component_list),
+            (COMPONENT_PACKAGE, self.component_package),
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(content.startswith("---\n"))
+                front_matter = content.split("---", 2)[1]
+                self.assertRegex(front_matter, r"(?m)^title:\s*\S")
+                self.assertRegex(front_matter, r"(?m)^description:\s*\S")
+                self.assertEqual(
+                    0,
+                    len(re.findall(r"(?m)^#\s+", content)),
+                    "Jekyll supplies the visible page title; a Markdown H1 duplicates it",
+                )
+                self.assertEqual(0, content.count("```") % 2)
+
+    def test_documented_resolution_matches_current_source(self) -> None:
+        for token in (
+            "public ComponentInterface getComponent(String name)",
+            "ComponentInterface.getComponentNameFromAlias(name)",
+            "if (!resolved.equals(name))",
+            "return null;",
+            "public boolean hasComponent(String name, boolean normalized)",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, self.phase_source)
+
+        self.assertIn(
+            "return getPhase(0).getComponent(name);",
+            self.system_interface,
+        )
+
+    def test_existing_executable_regression_covers_every_documented_api(self) -> None:
+        for token in (
+            "aSynonymReachesTheComponentItCreated",
+            "hasComponentAndGetComponentAgree",
+            "anUnknownNameIsNotGuessed",
+            "otherNameTakingMethodsAcceptTheSynonym",
+            "setComponentCriticalParameters",
+            "setBinaryInteractionParameter",
+            "removeComponent",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, self.executable_regression)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/test_component_alias_api_documentation.py
+++ b/docs/test_component_alias_api_documentation.py
@@ -63,7 +63,7 @@ class ComponentAliasApiDocumentationContractTest(unittest.TestCase):
             'fluid.getComponent("isooctane")',
             'fluid.getPhase(0).getComponent("ISOOCTANE")',
             "`hasComponent(String)`",
-            "Unknown, ambiguous, and near-miss inputs are not guessed",
+            "near-miss inputs are not guessed",
             "../component_list.md#component-name-resolution",
         ):
             with self.subTest(token=token):
@@ -79,12 +79,18 @@ class ComponentAliasApiDocumentationContractTest(unittest.TestCase):
                 front_matter = content.split("---", 2)[1]
                 self.assertRegex(front_matter, r"(?m)^title:\s*\S")
                 self.assertRegex(front_matter, r"(?m)^description:\s*\S")
+                self.assertEqual(0, content.count("```") % 2)
+                visible_markdown = re.sub(
+                    r"```.*?```",
+                    "",
+                    content,
+                    flags=re.DOTALL,
+                )
                 self.assertEqual(
                     0,
-                    len(re.findall(r"(?m)^#\s+", content)),
+                    len(re.findall(r"(?m)^#\s+", visible_markdown)),
                     "Jekyll supplies the visible page title; a Markdown H1 duplicates it",
                 )
-                self.assertEqual(0, content.count("```") % 2)
 
     def test_documented_resolution_matches_current_source(self) -> None:
         for token in (

--- a/docs/thermo/component/README.md
+++ b/docs/thermo/component/README.md
@@ -54,7 +54,7 @@ ComponentInterface fromPhase =
 Both lookups return the component stored under its canonical database name, `224-TM-C5`.
 `hasComponent(String)` follows the same normalized-name contract. Unknown, ambiguous, and
 near-miss inputs are not guessed, and `getComponent(String)` returns `null` when no exact or
-recognized alias is present. See the [component reference list](../component_list.md#component-name-resolution)
+recognized alias is present. See the [component reference list](../component_list#component-name-resolution)
 for the supported naming conventions and mutation/removal APIs.
 
 ### Common Methods

--- a/docs/thermo/component/README.md
+++ b/docs/thermo/component/README.md
@@ -38,6 +38,25 @@ ComponentInterface comp = fluid.getComponent(0);
 ComponentInterface methaneInGas = fluid.getGasPhase().getComponent("methane");
 ```
 
+Recognized aliases, systematic names, and case variants use the same resolver for addition and
+retrieval. The name accepted by `addComponent` can therefore be reused through the system or a
+specific phase:
+
+```java
+fluid.addComponent("2,2,4-trimethylpentane", 1.0);
+
+ComponentInterface fromSystem =
+    fluid.getComponent("isooctane");
+ComponentInterface fromPhase =
+    fluid.getPhase(0).getComponent("ISOOCTANE");
+```
+
+Both lookups return the component stored under its canonical database name, `224-TM-C5`.
+`hasComponent(String)` follows the same normalized-name contract. Unknown, ambiguous, and
+near-miss inputs are not guessed, and `getComponent(String)` returns `null` when no exact or
+recognized alias is present. See the [component reference list](../component_list.md#component-name-resolution)
+for the supported naming conventions and mutation/removal APIs.
+
 ### Common Methods
 
 ```java

--- a/docs/thermo/component_list.md
+++ b/docs/thermo/component_list.md
@@ -3,7 +3,7 @@ title: NeqSim Component Reference List
 description: Complete list of all components available in NeqSim including hydrocarbons, gases, water, glycols, amines, and plus fractions. Includes component names, CAS numbers, and EoS availability.
 ---
 
-This document provides a comprehensive list of all components available in NeqSim. Use the exact component name (case-insensitive) when adding components to your fluid.
+This document provides a comprehensive list of all components available in NeqSim. Use a canonical database name or a recognized alias when adding or retrieving components; name matching is case-insensitive but never fuzzy.
 
 ## Quick Reference
 
@@ -133,6 +133,28 @@ fluid.addComponent("2,2,4-trimethylpentane", 1.0);  // systematic name
 fluid.addComponent("isooctane", 1.0);               // trivial name
 fluid.addComponent("ISOOCTANE", 1.0);               // any letter case
 ```
+
+Name resolution is symmetric across the name-taking fluid APIs. A recognized name accepted by
+`addComponent` can be reused with `hasComponent`, `getComponent`, phase-level
+`getComponent`, `setComponentCriticalParameters`, `setBinaryInteractionParameter`, and
+`removeComponent`:
+
+```java
+ComponentInterface component = fluid.getComponent("2,2,4-trimethylpentane");
+ComponentInterface phaseComponent =
+    fluid.getPhase(0).getComponent("isooctane");
+
+if (fluid.hasComponent("ISOOCTANE")) {
+    // Both lookups return the component stored under the canonical name 224-TM-C5.
+    String canonicalName = component.getComponentName();
+}
+```
+
+Exact canonical names are checked first. Only after an exact lookup fails does `getComponent`
+consult the alias table. Unknown, ambiguous, and near-miss names are not guessed:
+`getComponent("methan")` returns `null`. Check user-supplied names with `hasComponent` before
+dereferencing the result. The executable
+`ComponentAliasApiSymmetryTest` protects the same lookup, mutation, and removal contract.
 
 The resolver recognises:
 


### PR DESCRIPTION
## Summary

Advances #2499 D121 by documenting the component-name alias symmetry delivered in merged commit `18e26159b182a654f89e835ded7f51ba8b059854`.

Exact base: `9b61df137109f3c664bfcd152b85c49c25ccb99c`  
Exact head: `5ff31717dee303c845d6ef5834fcc05794514964`

## Capability contract

1. **Capability and question:** recent merged code versus documentation coverage — can every recognized component name accepted by `addComponent` be reused safely across lookup, guarded lookup, parameter mutation, interaction-parameter mutation, and removal?
2. **Maturity:** current documentation was **proposed/incomplete** because it described aliases only for addition; target is **qualified** against current source and the executable regression.
3. **Authoritative implementation:** `ComponentNameResolver`, `Phase.getComponent(String)`, `Phase.hasComponent(String, boolean)`, the `SystemInterface` delegation, and `ComponentAliasApiSymmetryTest`. Exact canonical names are checked first; recognized aliases are resolved only after an exact miss; unknown, ambiguous, and near-miss names are never guessed.
4. **Views:** Java API and Markdown documentation apply. Python gateway behavior is inherited from the same Java API but no Python example, notebook, JSON, MCP, or engineering calculation changes.
5. **Acceptance:** both guides state the symmetric API contract and fail-closed `null` behavior; code samples match the existing executable regression; a source-linked Python contract protects guide rendering, implementation tokens, and all covered API operations.
6. **Stop boundary:** documentation and its contract only. No resolver table, component database, production Java, thermodynamic model, numerical result, API behavior, notebook, DEXPI/PFD, MCP, refinery, release, or Huldra change.

## Confirmed defects repaired

- Replace the misleading instruction that only exact component names may be used.
- Extend alias guidance beyond `addComponent` to system and phase retrieval.
- State the shared `hasComponent` guard contract.
- Document exact-name-first resolution and fail-closed unknown/ambiguous/near-miss behavior.
- Document the same alias semantics for critical-parameter, binary-interaction, and removal APIs.
- Add durable source- and executable-regression-linked documentation coverage.

## Frozen scope

- `docs/thermo/component_list.md`
- `docs/thermo/component/README.md`
- `docs/test_component_alias_api_documentation.py`

The branch is six ordered commits, exactly three files, and zero commits behind the exact base.

## Validation

Connector-backed proposed-corpus validation passes:

- all documented API and failure-boundary tokens match current `Phase.java`, `SystemInterface.java`, and `ComponentAliasApiSymmetryTest.java`;
- both guides retain Jekyll front matter and non-empty title/description metadata;
- code fences are balanced;
- fenced code is excluded from heading analysis and neither page contains a visible duplicate H1;
- the regression contract covers alias creation/retrieval, `hasComponent` agreement, unknown-name rejection, critical-parameter update, binary-interaction update, and removal.

First-run exact-head build/test/Javadocs and Spotless passed. Documentation/search and pre-commit found one attributable defect: the new internal link retained a `.md` suffix. The link now uses the extensionless published URL and the regression token matches it. All five repaired-head workflows now pass: documentation/Jekyll/search, pre-commit, Spotless, CodeQL, and build/test/Javadocs. **READY TO MERGE**.

The existing Java regression supplies runtime evidence for every newly documented name-taking API; this PR changes no Java source.

## Documentation impact

The component reference and package guide now reflect current public API behavior and explicitly distinguish recognized aliases from fuzzy matching. No numerical or engineering result is added or changed.

## Coordination

The pre-publication autonomous portfolio was 3/10: refinery #3436, DEXPI #3437, and release #3438. This frozen batch does not overlap their changed files. The current positively identified autonomous portfolio is 5/10 after publication of #3440; this draft remains the sole active #2499 implementation PR.

Generated with AI assistance.