### PR TITLE
[AI-Assisted] test(mcp): qualify reporting handoff contracts

### DIFF
--- a/.github/workflows/mcp_protocol_qualification.yml
+++ b/.github/workflows/mcp_protocol_qualification.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Run focused result-validator Java contract
         run: mvn -B -Dtest=neqsim.mcp.runners.EngineeringValidatorTest test -ntp
 
+      - name: Run focused reporting Java contracts
+        run: mvn -B -Dtest=neqsim.mcp.runners.ReportRunnerTest test -ntp
+
       - name: Build exact MCP server package
         shell: bash
         run: |
@@ -102,6 +105,9 @@ jobs:
 
       - name: Run focused real-MCP result-validation qualification
         run: cd neqsim-mcp-server && python test_validate_results_protocol.py
+
+      - name: Run focused real-MCP reporting qualification
+        run: cd neqsim-mcp-server && python test_reporting_protocol.py
 
       - name: Run comprehensive real-MCP protocol regression
         run: cd neqsim-mcp-server && python test_mcp_server.py

--- a/neqsim-mcp-server/docs/evidence/REPORTING_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/REPORTING_CONTRACT.md
@@ -18,7 +18,8 @@ and response-size guard. A successful response preserves the requested title, au
 - transient Markdown containing input, result and conclusion sections;
 - a structured summary table of recursively discovered numeric fields, capped at 100 rows;
 - optional chart-ready records for numeric arrays, capped at 20 records;
-- optional advisory `EngineeringValidator` output; and
+- optional embedded advisory `EngineeringValidator` output (separate from the always-present standard MCP envelope
+  validation); and
 - shallow top-level numeric, object, array and total-field counts.
 
 `NeqSimTools.bridgeTaskWorkflow` delegates to `TaskWorkflowBridge.run(bridgeJson)` and applies the same transport guard.

--- a/neqsim-mcp-server/docs/evidence/REPORTING_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/REPORTING_CONTRACT.md
@@ -1,0 +1,73 @@
+# Reporting and task-workflow handoff qualification
+
+## Engineering question and maturity
+
+Can the paired MCP reporting surfaces preserve structured, machine-readable simulation handoff data, generate transient
+Markdown and plotting inputs, and reject invalid requests without claiming that they produced an approved engineering
+deliverable?
+
+This increment qualifies the existing `generateReport` and `bridgeTaskWorkflow` software contracts. It deliberately
+leaves Phase 0 inventory at **1.24 / 20 explicit + 22 contract-tested + 29 confirmed gaps**. Promotion is a separate,
+atomic increment after this evidence has merged and passed the complete exact-head gate set.
+
+## Authoritative behavior
+
+`NeqSimTools.generateReport` delegates to `ReportRunner.run(reportJson)` and applies the standard MCP response envelope
+and response-size guard. A successful response preserves the requested title, author and report type, and returns:
+
+- transient Markdown containing input, result and conclusion sections;
+- a structured summary table of recursively discovered numeric fields, capped at 100 rows;
+- optional chart-ready records for numeric arrays, capped at 20 records;
+- optional advisory `EngineeringValidator` output; and
+- shallow top-level numeric, object, array and total-field counts.
+
+`NeqSimTools.bridgeTaskWorkflow` delegates to `TaskWorkflowBridge.run(bridgeJson)` and applies the same transport guard.
+`getSchema` exposes the task-solve `results.json` fields. `toResultsJson` maps supported source-runner fields into
+`key_results`, carries supplied or status-derived validation, preserves approach and conclusions, creates the standard
+empty reporting placeholders, and records MCP source metadata. Unsupported source runners receive only a generic status
+handoff. Neither route invokes a simulation or persists a file.
+
+Malformed/non-object report JSON returns `status: error` with `REPORT_ERROR`. The bridge returns `status: error` for
+malformed/non-object input, unknown actions, or a missing/non-object `toolOutput`. These errors remain structured through
+the packaged STDIO MCP transport.
+
+## Units, assumptions and determinism
+
+The report table infers display units from field names only. Temperature-like fields are labelled `C`, pressure-like
+fields `bara`, power-like fields `kW`, mass-flow-like fields `kg/hr`, density-like fields `kg/m3`, viscosity-like fields
+`cP`, efficiency and `_pct` fields `%`, velocity-like fields `m/s`, and length/diameter-like fields `m`. This is a
+presentation heuristic, not unit conversion or dimensional validation. Callers remain responsible for normalized values
+and authoritative unit metadata.
+
+The `runFlash` bridge converts `temperature_K` to `temperature_C` and renames selected existing fields; other supported
+runner mappings copy selected values under their documented labels. The bridge does not independently recompute or
+validate them.
+
+Array order, table traversal, schema content and bridge output are deterministic for a fixed request. `generatedAt` and
+the Markdown date use the host clock and are intentionally nondeterministic metadata; qualification checks their shape,
+not an exact value. JSON object insertion order controls table row order.
+
+## Acceptance evidence
+
+- `ReportRunnerTest` covers structured report metadata, inferred-unit table rows, chart extraction, request flags,
+  summary counts, report failures, bridge extraction, schema shape, provenance and bridge failures.
+- `test_reporting_protocol.py` repeats those boundaries through the real packaged STDIO server and proves inventory 1.24
+  remains qualification-only for both tools.
+- `test_mcp_server.py` retains the broad real-protocol calls and the 71-tool registration/accounting checks.
+- `mcp_protocol_qualification.yml` runs the focused Java and packaged-MCP reporting contracts before the comprehensive
+  protocol regression.
+
+Java and JSON/MCP views are applicable. A separate Python calculation, notebook, rendered document and whole-sheet
+visual gate are not applicable because this increment qualifies a Java-backed transient transport/software contract.
+
+## Explicit limitations and stop boundary
+
+This evidence does **not** establish simulation execution, thermodynamic or equipment-model fidelity, convergence,
+component or facility-wide conservation, numerical robustness, uncertainty coverage, standards currency, causal
+diagnosis, safe operating limits, report completeness, or independent benchmark agreement. It does not create, save,
+render or approve Word, HTML, PDF or other external artifacts. It grants no plant, control, design, certification,
+regulatory or accountable engineering authority.
+
+The underlying simulation result, canonical model, units, assumptions, provenance, convergence evidence, limitations and
+independent benchmarks remain authoritative. No production runner, tool schema, inventory classification, numerical
+model, deployment profile, companion repository, persisted state or live-system integration changes in this increment.

--- a/neqsim-mcp-server/test_reporting_protocol.py
+++ b/neqsim-mcp-server/test_reporting_protocol.py
@@ -1,0 +1,337 @@
+"""Focused real-MCP qualification for reporting and task-workflow handoff.
+
+This dependency-free harness starts the packaged NeqSim MCP server over STDIO
+and qualifies the existing ``generateReport`` and ``bridgeTaskWorkflow``
+software contracts. It uses synthetic data and does not execute a simulation,
+persist a report, render Word/HTML, validate physical fidelity, or grant plant,
+design, control, certification, or engineering-approval authority.
+"""
+import json
+import subprocess
+import sys
+import time
+
+JAR = "target/neqsim-mcp-server-1.0.0-SNAPSHOT-runner.jar"
+
+
+class McpClient:
+    """Minimal line-delimited JSON-RPC client for packaged-server qualification."""
+
+    def __init__(self):
+        self.proc = None
+        self.message_id = 0
+
+    def next_id(self):
+        self.message_id += 1
+        return self.message_id
+
+    def send(self, message):
+        self.proc.stdin.write(json.dumps(message) + "\n")
+        self.proc.stdin.flush()
+
+    def receive(self):
+        line = self.proc.stdout.readline()
+        if not line:
+            stderr = self.proc.stderr.read() if self.proc and self.proc.stderr else ""
+            raise RuntimeError("MCP server closed stdout unexpectedly: " + stderr)
+        return json.loads(line)
+
+    def start(self):
+        self.proc = subprocess.Popen(
+            ["java", "-jar", JAR],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "neqsim-reporting-contract-test",
+                        "version": "1.0",
+                    },
+                },
+            }
+        )
+        response = self.receive()
+        require("result" in response, "MCP initialize did not return a result", response)
+        self.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        time.sleep(0.2)
+
+    def call_tool(self, name, argument_name, value):
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "tools/call",
+                "params": {
+                    "name": name,
+                    "arguments": {argument_name: value},
+                },
+            }
+        )
+        response = self.receive()
+        content = response.get("result", {}).get("content", [])
+        require(content, "MCP tool call returned no content", response)
+        text = content[0].get("text", "")
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as error:
+            raise AssertionError(
+                f"MCP tool returned non-JSON content: {error}: {text}"
+            )
+
+    def call_no_arg_tool(self, name):
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "tools/call",
+                "params": {"name": name, "arguments": {}},
+            }
+        )
+        response = self.receive()
+        content = response.get("result", {}).get("content", [])
+        require(content, "MCP tool call returned no content", response)
+        return json.loads(content[0].get("text", ""))
+
+    def report(self, request):
+        value = request if isinstance(request, str) else json.dumps(request)
+        return self.call_tool("generateReport", "reportJson", value)
+
+    def bridge(self, request):
+        value = request if isinstance(request, str) else json.dumps(request)
+        return self.call_tool("bridgeTaskWorkflow", "bridgeJson", value)
+
+    def close(self):
+        if self.proc is None:
+            return
+        if self.proc.stdin:
+            self.proc.stdin.close()
+        try:
+            self.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.proc.terminate()
+            self.proc.wait(timeout=10)
+        self.proc = None
+
+
+def require(condition, message, detail=None):
+    """Raise a compact assertion with JSON detail when a contract fails."""
+    if condition:
+        return
+    suffix = ""
+    if detail is not None:
+        suffix = "\n" + json.dumps(detail, indent=2, sort_keys=True)
+    raise AssertionError(message + suffix)
+
+
+def payload(response):
+    """Return canonical data while retaining standardized envelope fields."""
+    data = response.get("data") if isinstance(response, dict) else None
+    if not isinstance(data, dict):
+        return response
+    merged = dict(data)
+    for key in (
+        "status",
+        "tool",
+        "provenance",
+        "validation",
+        "qualityGate",
+        "warnings",
+        "errors",
+    ):
+        if key in response:
+            merged.setdefault(key, response[key])
+    return merged
+
+
+def test_structured_report(client):
+    result = payload(
+        client.report(
+            {
+                "reportType": "custom",
+                "title": "Compression review",
+                "author": "Packaged MCP contract",
+                "includeValidation": False,
+                "data": {
+                    "temperature_C": 25.0,
+                    "pressure_bar": 50.0,
+                    "curve": [1.0, 2.0, 3.0],
+                    "conclusions": "Synthetic evidence only.",
+                },
+            }
+        )
+    )
+    require(result.get("status") == "success", "report transport failed", result)
+    require(result.get("title") == "Compression review", "report title drifted", result)
+    require(result.get("author") == "Packaged MCP contract", "report author drifted", result)
+    require(result.get("reportType") == "custom", "report type drifted", result)
+    require(isinstance(result.get("generatedAt"), str), "generation timestamp is absent", result)
+    require("# Compression review" in result.get("markdown", ""), "Markdown title is absent", result)
+    require("Synthetic evidence only." in result.get("markdown", ""), "conclusion is absent", result)
+    require(len(result.get("tables", [])) == 1, "structured table is absent", result)
+    require(len(result.get("chartData", [])) == 1, "chart-ready array is absent", result)
+    require(result["chartData"][0].get("name") == "curve", "chart source drifted", result)
+    require("validation" not in result, "disabled validation was emitted", result)
+    require(
+        result.get("summary")
+        == {"numericFields": 2, "objectFields": 0, "arrayFields": 1, "totalFields": 4},
+        "summary counts drifted",
+        result,
+    )
+    rows = result["tables"][0].get("rows", [])
+    require(rows[0] == ["temperature_C", 25.0, "C"], "temperature row drifted", rows)
+    require(rows[1] == ["pressure_bar", 50.0, "bara"], "pressure row drifted", rows)
+
+
+def test_report_switches_and_fail_closed_input(client):
+    result = payload(
+        client.report(
+            {"includeChartData": False, "includeValidation": False, "data": {}}
+        )
+    )
+    require(result.get("status") == "success", "minimal report failed", result)
+    require("chartData" not in result, "disabled chart data was emitted", result)
+    require("validation" not in result, "disabled validation was emitted", result)
+    require(isinstance(result.get("tables"), list), "tables field is absent", result)
+
+    for malformed in ("{bad json}", "[]"):
+        error = payload(client.report(malformed))
+        require(error.get("status") == "error", "malformed report input was accepted", error)
+        errors = error.get("errors", [])
+        require(errors and errors[0].get("code") == "REPORT_ERROR", "report error code drifted", error)
+
+
+def test_bridge_results_json(client):
+    result = payload(
+        client.bridge(
+            {
+                "action": "toResultsJson",
+                "sourceRunner": "runFlash",
+                "approach": "Synthetic SRK handoff",
+                "conclusions": "Contract shape only",
+                "toolOutput": {
+                    "status": "success",
+                    "fluid": {
+                        "conditions": {
+                            "temperature_K": 300.0,
+                            "pressure_bara": 42.0,
+                        },
+                        "properties": {
+                            "density_kgm3": 10.5,
+                            "molarMass_kgmol": 0.020,
+                        },
+                    },
+                    "flash": {"numberOfPhases": 2},
+                },
+            }
+        )
+    )
+    require(result.get("status") == "success", "bridge transport failed", result)
+    handoff = result.get("resultsJson", {})
+    key_results = handoff.get("key_results", {})
+    require(abs(key_results.get("temperature_C", 0.0) - 26.85) < 1.0e-10, "temperature conversion drifted", handoff)
+    require(key_results.get("pressure_bar") == 42.0, "pressure handoff drifted", handoff)
+    require(key_results.get("density_kgm3") == 10.5, "density handoff drifted", handoff)
+    require(key_results.get("number_of_phases") == 2, "phase count drifted", handoff)
+    require(handoff.get("validation", {}).get("acceptance_criteria_met") is True, "validation handoff drifted", handoff)
+    require(handoff.get("approach") == "Synthetic SRK handoff", "approach drifted", handoff)
+    require(handoff.get("conclusions") == "Contract shape only", "conclusions drifted", handoff)
+    require(handoff.get("_meta", {}).get("tool") == "runFlash", "source metadata drifted", handoff)
+    for field, expected_type in (
+        ("figure_captions", dict),
+        ("figure_discussion", list),
+        ("equations", list),
+        ("tables", list),
+        ("references", list),
+    ):
+        require(isinstance(handoff.get(field), expected_type), field + " shape drifted", handoff)
+
+
+def test_bridge_schema(client):
+    result = payload(client.bridge({"action": "getSchema"}))
+    require(result.get("status") == "success", "bridge schema failed", result)
+    fields = result.get("fields", {})
+    expected = {
+        "key_results",
+        "validation",
+        "approach",
+        "conclusions",
+        "figure_captions",
+        "figure_discussion",
+        "equations",
+        "tables",
+        "references",
+        "uncertainty",
+        "risk_evaluation",
+        "benchmark_validation",
+    }
+    require(expected.issubset(fields), "bridge schema is incomplete", result)
+    require(result.get("schema") == fields, "schema alias drifted", result)
+
+
+def test_bridge_fail_closed_input(client):
+    for request in (
+        "{bad json}",
+        {"action": "unknown"},
+        {"action": "toResultsJson"},
+    ):
+        result = payload(client.bridge(request))
+        require(result.get("status") == "error", "invalid bridge request was accepted", result)
+        require(isinstance(result.get("message"), str), "bridge error message is absent", result)
+
+
+def test_phase0_inventory_remains_qualification_only(client):
+    result = payload(client.call_no_arg_tool("getCapabilities"))
+    inventory = result.get("phase0EvidenceInventory")
+    require(isinstance(inventory, dict), "capabilities omitted Phase 0 inventory", result)
+    limitations = inventory.get("knownLimitations", {})
+    records = limitations.get("coverageRecords", {})
+    require(inventory.get("inventoryVersion") == "1.24", "inventory version drifted", inventory)
+    require(
+        limitations.get("contractTestedToolCount") == 22
+        and limitations.get("confirmedGapToolCount") == 29,
+        "qualification changed inventory counts prematurely",
+        limitations,
+    )
+    for tool in ("generateReport", "bridgeTaskWorkflow"):
+        require(
+            records.get(tool, {}).get("coverageStatus") == "CONFIRMED_GAP",
+            tool + " was promoted before qualification merged",
+            records.get(tool),
+        )
+
+
+def main():
+    client = McpClient()
+    tests = [
+        ("structured report", test_structured_report),
+        ("report switches and fail-closed input", test_report_switches_and_fail_closed_input),
+        ("results.json bridge", test_bridge_results_json),
+        ("bridge schema", test_bridge_schema),
+        ("bridge fail-closed input", test_bridge_fail_closed_input),
+        ("Phase 0 remains qualification-only", test_phase0_inventory_remains_qualification_only),
+    ]
+    try:
+        client.start()
+        for label, test in tests:
+            test(client)
+            print("PASS:", label)
+    finally:
+        client.close()
+    print(f"\n{len(tests)}/{len(tests)} reporting contract scenarios passed.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print("FAIL:", error, file=sys.stderr)
+        sys.exit(1)

--- a/neqsim-mcp-server/test_reporting_protocol.py
+++ b/neqsim-mcp-server/test_reporting_protocol.py
@@ -153,22 +153,22 @@ def payload(response):
 
 
 def test_structured_report(client):
-    result = payload(
-        client.report(
-            {
-                "reportType": "custom",
-                "title": "Compression review",
-                "author": "Packaged MCP contract",
-                "includeValidation": False,
-                "data": {
-                    "temperature_C": 25.0,
-                    "pressure_bar": 50.0,
-                    "curve": [1.0, 2.0, 3.0],
-                    "conclusions": "Synthetic evidence only.",
-                },
-            }
-        )
+    response = client.report(
+        {
+            "reportType": "custom",
+            "title": "Compression review",
+            "author": "Packaged MCP contract",
+            "includeValidation": False,
+            "data": {
+                "temperature_C": 25.0,
+                "pressure_bar": 50.0,
+                "curve": [1.0, 2.0, 3.0],
+                "conclusions": "Synthetic evidence only.",
+            },
+        }
     )
+    report = response.get("data", response)
+    result = payload(response)
     require(result.get("status") == "success", "report transport failed", result)
     require(result.get("title") == "Compression review", "report title drifted", result)
     require(result.get("author") == "Packaged MCP contract", "report author drifted", result)
@@ -179,7 +179,12 @@ def test_structured_report(client):
     require(len(result.get("tables", [])) == 1, "structured table is absent", result)
     require(len(result.get("chartData", [])) == 1, "chart-ready array is absent", result)
     require(result["chartData"][0].get("name") == "curve", "chart source drifted", result)
-    require("validation" not in result, "disabled validation was emitted", result)
+    require("validation" not in report, "disabled report validation was emitted", report)
+    require(
+        response.get("validation", {}).get("valid") is True,
+        "standard MCP envelope validation is absent",
+        response,
+    )
     require(
         result.get("summary")
         == {"numericFields": 2, "objectFields": 0, "arrayFields": 1, "totalFields": 4},
@@ -192,14 +197,14 @@ def test_structured_report(client):
 
 
 def test_report_switches_and_fail_closed_input(client):
-    result = payload(
-        client.report(
-            {"includeChartData": False, "includeValidation": False, "data": {}}
-        )
+    response = client.report(
+        {"includeChartData": False, "includeValidation": False, "data": {}}
     )
+    report = response.get("data", response)
+    result = payload(response)
     require(result.get("status") == "success", "minimal report failed", result)
-    require("chartData" not in result, "disabled chart data was emitted", result)
-    require("validation" not in result, "disabled validation was emitted", result)
+    require("chartData" not in report, "disabled chart data was emitted", report)
+    require("validation" not in report, "disabled report validation was emitted", report)
     require(isinstance(result.get("tables"), list), "tables field is absent", result)
 
     for malformed in ("{bad json}", "[]"):

--- a/src/test/java/neqsim/mcp/runners/ReportRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/ReportRunnerTest.java
@@ -1,14 +1,16 @@
 package neqsim.mcp.runners;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 /**
- * Tests for {@link ReportRunner}.
+ * Software-contract tests for the paired reporting and task-workflow handoff surfaces.
  *
  * @author Even Solbraa
  * @version 1.0
@@ -16,28 +18,117 @@ import com.google.gson.JsonParser;
 class ReportRunnerTest {
 
   @Test
-  void testProcessSummaryReport() {
-    String json = "{" + "\"reportType\": \"process_summary\"," + "\"title\": \"HP Separation Results\"," + "\"data\": {"
-        + "  \"status\": \"success\"," + "  \"report\": {"
-        + "    \"feed\": {\"temperature_C\": 25.0, \"pressure_bara\": 50.0,"
-        + "              \"flowRate_kg_hr\": 10000.0},"
-        + "    \"HP Sep\": {\"gasOut_temperature_C\": 25.0, \"gasOut_pressure_bara\": 50.0}" + "  }" + "}" + "}";
+  void structuredReportPreservesMetadataTablesChartsAndSummary() {
+    String request = "{\"reportType\":\"custom\",\"title\":\"Compression review\","
+        + "\"author\":\"Contract test\",\"includeValidation\":false,\"data\":{"
+        + "\"temperature_C\":25.0,\"pressure_bar\":50.0,"
+        + "\"curve\":[1.0,2.0,3.0],\"conclusions\":\"Synthetic evidence only.\"}}";
 
-    String result = ReportRunner.run(json);
-    assertNotNull(result);
-    JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
-    // Success responses have no status field; error responses have status=error
-    if (obj.has("status")) {
-      assertEquals("error", obj.get("status").getAsString());
-    } else {
-      assertTrue(obj.has("markdown"), "Should contain markdown report: " + result);
-    }
+    JsonObject report = JsonParser.parseString(ReportRunner.run(request)).getAsJsonObject();
+
+    assertFalse(report.has("status"));
+    assertEquals("Compression review", report.get("title").getAsString());
+    assertEquals("Contract test", report.get("author").getAsString());
+    assertEquals("custom", report.get("reportType").getAsString());
+    assertFalse(report.get("generatedAt").getAsString().isEmpty());
+    assertTrue(report.get("markdown").getAsString().contains("# Compression review"));
+    assertTrue(report.get("markdown").getAsString().contains("Synthetic evidence only."));
+    assertEquals(1, report.getAsJsonArray("tables").size());
+    assertEquals(1, report.getAsJsonArray("chartData").size());
+    assertEquals("curve", report.getAsJsonArray("chartData").get(0).getAsJsonObject().get("name").getAsString());
+    assertFalse(report.has("validation"));
+
+    JsonObject summary = report.getAsJsonObject("summary");
+    assertEquals(2, summary.get("numericFields").getAsInt());
+    assertEquals(0, summary.get("objectFields").getAsInt());
+    assertEquals(1, summary.get("arrayFields").getAsInt());
+    assertEquals(4, summary.get("totalFields").getAsInt());
+
+    JsonArray rows = report.getAsJsonArray("tables").get(0).getAsJsonObject().getAsJsonArray("rows");
+    assertEquals("temperature_C", rows.get(0).getAsJsonArray().get(0).getAsString());
+    assertEquals("C", rows.get(0).getAsJsonArray().get(2).getAsString());
+    assertEquals("bara", rows.get(1).getAsJsonArray().get(2).getAsString());
   }
 
   @Test
-  void testNullInput() {
-    String result = ReportRunner.run(null);
-    JsonObject obj = JsonParser.parseString(result).getAsJsonObject();
-    assertEquals("error", obj.get("status").getAsString());
+  void reportOptionalSectionsFollowRequestFlags() {
+    JsonObject report = JsonParser
+        .parseString(ReportRunner.run("{\"includeChartData\":false,\"includeValidation\":false,\"data\":{}}"))
+        .getAsJsonObject();
+
+    assertFalse(report.has("chartData"));
+    assertFalse(report.has("validation"));
+    assertTrue(report.has("tables"));
+    assertTrue(report.has("summary"));
+  }
+
+  @Test
+  void reportInputFailuresAreStructuredAndFailClosed() {
+    assertReportError(ReportRunner.run(null));
+    assertReportError(ReportRunner.run("{bad json}"));
+    assertReportError(ReportRunner.run("[]"));
+  }
+
+  @Test
+  void taskWorkflowBridgeCreatesResultsJsonWithProvenance() {
+    String request = "{\"action\":\"toResultsJson\",\"sourceRunner\":\"runFlash\","
+        + "\"approach\":\"Synthetic SRK handoff\",\"conclusions\":\"Contract shape only\","
+        + "\"toolOutput\":{\"status\":\"success\",\"fluid\":{"
+        + "\"conditions\":{\"temperature_K\":300.0,\"pressure_bara\":42.0},"
+        + "\"properties\":{\"density_kgm3\":10.5,\"molarMass_kgmol\":0.020}},"
+        + "\"flash\":{\"numberOfPhases\":2}}}";
+
+    JsonObject response = JsonParser.parseString(TaskWorkflowBridge.run(request)).getAsJsonObject();
+
+    assertEquals("success", response.get("status").getAsString());
+    JsonObject results = response.getAsJsonObject("resultsJson");
+    JsonObject keyResults = results.getAsJsonObject("key_results");
+    assertEquals(26.85, keyResults.get("temperature_C").getAsDouble(), 1.0e-10);
+    assertEquals(42.0, keyResults.get("pressure_bar").getAsDouble(), 0.0);
+    assertEquals(10.5, keyResults.get("density_kgm3").getAsDouble(), 0.0);
+    assertEquals(2, keyResults.get("number_of_phases").getAsInt());
+    assertEquals("success", results.getAsJsonObject("validation").get("status").getAsString());
+    assertTrue(results.getAsJsonObject("validation").get("acceptance_criteria_met").getAsBoolean());
+    assertEquals("Synthetic SRK handoff", results.get("approach").getAsString());
+    assertEquals("Contract shape only", results.get("conclusions").getAsString());
+    assertTrue(results.get("figure_captions").isJsonObject());
+    assertTrue(results.get("figure_discussion").isJsonArray());
+    assertTrue(results.get("equations").isJsonArray());
+    assertTrue(results.get("tables").isJsonArray());
+    assertTrue(results.get("references").isJsonArray());
+    assertEquals("neqsim-mcp-server", results.getAsJsonObject("_meta").get("source").getAsString());
+    assertEquals("runFlash", results.getAsJsonObject("_meta").get("tool").getAsString());
+    assertEquals("TaskWorkflowBridge", results.getAsJsonObject("_meta").get("generated_by").getAsString());
+  }
+
+  @Test
+  void taskWorkflowBridgePublishesSchemaAndRejectsInvalidRequests() {
+    JsonObject schema = JsonParser.parseString(TaskWorkflowBridge.run("{\"action\":\"getSchema\"}"))
+        .getAsJsonObject();
+    assertEquals("success", schema.get("status").getAsString());
+    for (String field : new String[] { "key_results", "validation", "approach", "conclusions", "uncertainty",
+        "risk_evaluation", "benchmark_validation" }) {
+      assertTrue(schema.getAsJsonObject("fields").has(field), "Missing schema field " + field);
+    }
+
+    assertBridgeError(TaskWorkflowBridge.run(null));
+    assertBridgeError(TaskWorkflowBridge.run("{bad json}"));
+    assertBridgeError(TaskWorkflowBridge.run("{\"action\":\"unknown\"}"));
+    assertBridgeError(TaskWorkflowBridge.run("{\"action\":\"toResultsJson\"}"));
+  }
+
+  private static void assertReportError(String result) {
+    assertNotNull(result);
+    JsonObject error = JsonParser.parseString(result).getAsJsonObject();
+    assertEquals("error", error.get("status").getAsString());
+    assertEquals("REPORT_ERROR",
+        error.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
+  }
+
+  private static void assertBridgeError(String result) {
+    assertNotNull(result);
+    JsonObject error = JsonParser.parseString(result).getAsJsonObject();
+    assertEquals("error", error.get("status").getAsString());
+    assertFalse(error.get("message").getAsString().isEmpty());
   }
 }

--- a/src/test/java/neqsim/mcp/runners/ReportRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/ReportRunnerTest.java
@@ -75,8 +75,7 @@ class ReportRunnerTest {
         + "\"approach\":\"Synthetic SRK handoff\",\"conclusions\":\"Contract shape only\","
         + "\"toolOutput\":{\"status\":\"success\",\"fluid\":{"
         + "\"conditions\":{\"temperature_K\":300.0,\"pressure_bara\":42.0},"
-        + "\"properties\":{\"density_kgm3\":10.5,\"molarMass_kgmol\":0.020}},"
-        + "\"flash\":{\"numberOfPhases\":2}}}";
+        + "\"properties\":{\"density_kgm3\":10.5,\"molarMass_kgmol\":0.020}}," + "\"flash\":{\"numberOfPhases\":2}}}";
 
     JsonObject response = JsonParser.parseString(TaskWorkflowBridge.run(request)).getAsJsonObject();
 
@@ -103,8 +102,7 @@ class ReportRunnerTest {
 
   @Test
   void taskWorkflowBridgePublishesSchemaAndRejectsInvalidRequests() {
-    JsonObject schema = JsonParser.parseString(TaskWorkflowBridge.run("{\"action\":\"getSchema\"}"))
-        .getAsJsonObject();
+    JsonObject schema = JsonParser.parseString(TaskWorkflowBridge.run("{\"action\":\"getSchema\"}")).getAsJsonObject();
     assertEquals("success", schema.get("status").getAsString());
     for (String field : new String[] { "key_results", "validation", "approach", "conclusions", "uncertainty",
         "risk_evaluation", "benchmark_validation" }) {
@@ -121,8 +119,7 @@ class ReportRunnerTest {
     assertNotNull(result);
     JsonObject error = JsonParser.parseString(result).getAsJsonObject();
     assertEquals("error", error.get("status").getAsString());
-    assertEquals("REPORT_ERROR",
-        error.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
+    assertEquals("REPORT_ERROR", error.getAsJsonArray("errors").get(0).getAsJsonObject().get("code").getAsString());
   }
 
   private static void assertBridgeError(String result) {


### PR DESCRIPTION
## Summary

Advances #3153 with one bounded qualification increment for the paired MCP reporting handoff surfaces:

- strengthen Java coverage for `generateReport` / `ReportRunner` and `bridgeTaskWorkflow` / `TaskWorkflowBridge`;
- add six focused packaged-STDIO scenarios for structure, switches, schema, provenance, fail-closed input, and inventory discipline;
- wire the focused Java and real-MCP checks before the comprehensive protocol regression; and
- document units, assumptions, nondeterministic timestamps, provenance, authority, and the no-artifact/no-approval boundary.

**Exact base:** `9b61df137109f3c664bfcd152b85c49c25ccb99c`  
**Exact head:** `43fa9a1942e973f697f8337373e3926fed6ba521`

The pre-implementation capability contract is recorded in [#3153](https://github.com/equinor/neqsim/issues/3153#issuecomment-5536408419).

## Capability contract

### `generateReport`

- Preserve requested title, author and report type.
- Return transient Markdown, structured numeric tables, optional chart-ready arrays, optional advisory validation, and shallow summary counts.
- Qualify field-name-based display-unit inference without treating it as unit conversion.
- Treat the host-clock `generatedAt` and Markdown date as intentionally nondeterministic metadata.
- Fail closed with structured `REPORT_ERROR` evidence for malformed or non-object JSON.

### `bridgeTaskWorkflow`

- Preserve `getSchema` and `toResultsJson`.
- Qualify supported source-runner key-result extraction, status-derived validation, approach/conclusion handoff, task-solve placeholder shape, and MCP provenance metadata.
- Fail closed for malformed/non-object JSON, unknown actions, and missing/non-object `toolOutput`.

## Phase-0 inventory

This is qualification only. Inventory intentionally remains **1.24 / 20 explicit + 22 contract-tested + 29 confirmed gaps**. Both tools remain `CONFIRMED_GAP` until a later atomic promotion after this evidence merges.

No production behavior, runner, tool schema, numerical model, deployment profile, persisted state, or companion repository changes.

## Validation

**READY TO MERGE**

The first exact head failed pre-commit only on three Spotless layout differences in `ReportRunnerTest`; the exact hosted formatter output was applied. The next focused packaged-MCP run exposed that disabled embedded report validation is distinct from the always-present standard MCP envelope validation. The assertion and evidence text now check those two layers separately. Both repairs preserve production behavior and the four-file scope.

Local/static evidence:

- `python -m py_compile neqsim-mcp-server/test_reporting_protocol.py` (performed on the exact submitted content)
- trailing-whitespace and tab inspection passed
- exact branch comparison: three commits, four intended files, zero commits behind its recorded base

Exact-head hosted evidence on `43fa9a1942e973f697f8337373e3926fed6ba521`:

- focused reporting Java contract: **5/5 passed**
- focused packaged-MCP reporting contract: **6/6 passed**
- comprehensive packaged-MCP regression: **323/323 passed**
- Java 8 and Java 21 fast-test suites: passed on Ubuntu and Windows
- all four Java 21 slow-test shards and Javadocs: passed
- pre-commit/documentation, Spotless, CodeQL, agent/skill references, and change detection: passed
- no reviews or unresolved review threads

All required exact-head gates are complete. READY TO MERGE is a classification only; this pull request remains open, mergeable, and draft.

## Overlap and portfolio

The current autonomous implementation portfolio is **4/10** (#3436, #3440, #3442, and #3444), below the global ceiling of 10. The refinery, DEXPI information-flow, and aqueous-H₂S trajectory increments do not touch this MCP scope. Current `master` is the recorded exact base `9b61df137109f3c664bfcd152b85c49c25ccb99c`; no synchronization is needed or performed.

## Security and engineering stop boundary

Synthetic input only. No secrets, external files, network calls, plugins, state mutation, plant/control action, or persistence.

The generated Markdown and JSON are transient content, not an approved Word/HTML/PDF artifact, design basis, calculation certificate, standards-compliance record, or accountable engineering approval. This evidence does not establish simulation execution, model fidelity, convergence, conservation, numerical robustness, uncertainty coverage, standards currency, safe operating limits, report completeness, or independent benchmark agreement. Underlying simulation evidence, units, assumptions, provenance, limitations and independent benchmarks remain authoritative.

This PR must remain draft-only. Do not merge, mark ready, auto-merge, rebase, or synchronize it as part of this campaign.

Generated with AI assistance.