### PR TITLE
[AI-Assisted] feat(dexpi): expose information-flow evidence

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -105,6 +105,7 @@ DexpiXmlReader.ImportResult result =
     DexpiXmlReader.readWithDiagnostics(xmlFile.toFile(), template);
 ProcessSystem process = result.getProcessSystem();
 List<DexpiInstrumentInfo> instruments = result.getInstruments();
+List<DexpiInformationFlowInfo> informationFlows = result.getInformationFlows();
 List<DexpiConnectionInfo> connections = result.getConnections();
 
 for (DexpiXmlReader.ImportDiagnostic diagnostic : result.getDiagnostics()) {
@@ -138,6 +139,16 @@ source/target references, missing signal medium, and incomplete final-element or
 evidence. Valid source references resolve against the complete non-catalogue document identity set,
 including equipment nozzles and actuating functions. The reader never promotes measurement-only or
 incomplete source content into closed-loop control intent.
+
+`ImportResult.getInformationFlows()` exposes the corresponding source-ordered
+`MeasuringLineFunction` and `SignalLineFunction` evidence as immutable
+`DexpiInformationFlowInfo` records. Each record retains its source ID and component class, logical
+start and end IDs, whether those references resolve, and their resolved XML element names. Measuring
+lines additionally retain explicit attachment identity and resolution; signal lines retain the source
+`SignalConveyingTypeSpecialization`. Missing and unresolved references remain present beside the
+diagnostics, so Java and JPype callers do not need to reparse XML or invent endpoints. These records
+do not create live transmitters or controllers, infer control-loop intent, verify a loop, or classify
+safety-instrumented or safeguard functions.
 
 The same result also preserves every source `Connection` in document order, including parallel
 connections between the same endpoints. Each immutable `DexpiConnectionInfo` retains the owning
@@ -220,16 +231,18 @@ stay in the global connection and diagnostic evidence because a transition canno
 cycle. This exact-once inventory remains source-reference evidence only; it does not prove hydraulic
 continuity, identify a physical recycle, enumerate paths, or alter simulation topology.
 
-`toJson()` includes `instrumentCount`, `connectionCount`, `connectionEndpointCount`,
-`connectionComponentCount`, `connectionCycleCount`, `connectionCycleTransitionCount`, and
-the ordered connection, endpoint, component, directed-cycle, and cycle-transition inventories,
-including incidence roles, review subsets, complete cycle-local endpoint and internal connection
-occurrences, explicit cycle-boundary occurrences, and exact-once transitions with nested connection
-and endpoint evidence, alongside the process-unit count and findings. Python callers through JPype
-use the same `ImportResult.getInstruments()`, `ImportResult.getConnections()`,
-`ImportResult.getConnectionEndpoints()`, `ImportResult.getConnectionComponents()`,
-`ImportResult.getConnectionCycles()`, and `ImportResult.getConnectionCycleTransitions()`
-getters; there is no separate Python reconstruction model.
+`toJson()` includes `instrumentCount`, `informationFlowCount`, `connectionCount`,
+`connectionEndpointCount`, `connectionComponentCount`, `connectionCycleCount`,
+`connectionCycleTransitionCount`, and the ordered information-flow, connection, endpoint,
+component, directed-cycle, and cycle-transition inventories, including reference resolution,
+incidence roles, review subsets, complete cycle-local endpoint and internal connection occurrences,
+explicit cycle-boundary occurrences, and exact-once transitions with nested connection and endpoint
+evidence, alongside the process-unit count and findings. Python callers through JPype use the same
+`ImportResult.getInstruments()`, `ImportResult.getInformationFlows()`,
+`ImportResult.getConnections()`, `ImportResult.getConnectionEndpoints()`,
+`ImportResult.getConnectionComponents()`, `ImportResult.getConnectionCycles()`, and
+`ImportResult.getConnectionCycleTransitions()` getters; there is no separate Python reconstruction
+model.
 
 `INFO` entries carry provenance and do not make `hasLosses()` true by themselves. `WARNING` and
 `ERROR` entries do. The diagnostic sequence and JSON are deterministic for the same XML and template.

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiInformationFlowInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiInformationFlowInfo.java
@@ -58,10 +58,9 @@ public final class DexpiInformationFlowInfo implements Serializable {
    * @param attachmentElementName resolved attachment XML element name, or an empty string
    * @param signalConveyingType signal medium/type, or an empty string when absent or not applicable
    */
-  public DexpiInformationFlowInfo(String id, Kind kind, String componentClass, String sourceId,
-      boolean sourceResolved, String sourceElementName, String targetId, boolean targetResolved,
-      String targetElementName, String attachmentId, boolean attachmentResolved, String attachmentElementName,
-      String signalConveyingType) {
+  public DexpiInformationFlowInfo(String id, Kind kind, String componentClass, String sourceId, boolean sourceResolved,
+      String sourceElementName, String targetId, boolean targetResolved, String targetElementName, String attachmentId,
+      boolean attachmentResolved, String attachmentElementName, String signalConveyingType) {
     this.id = normalize(id);
     this.kind = Objects.requireNonNull(kind, "kind");
     this.componentClass = normalize(componentClass);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiInformationFlowInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiInformationFlowInfo.java
@@ -1,0 +1,171 @@
+package neqsim.process.processmodel.dexpi;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable source evidence for one supported DEXPI instrumentation information-flow occurrence.
+ *
+ * <p>
+ * The record preserves explicit source-document relationships without constructing live transmitters, controllers,
+ * safeguards, or executable control topology.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class DexpiInformationFlowInfo implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Supported source information-flow kinds. */
+  public enum Kind {
+    /** A logical signal connection between instrumentation functions. */
+    SIGNAL_LINE,
+    /** A measuring relationship from a sensing function to an instrument and process attachment. */
+    MEASURING_LINE
+  }
+
+  private final String id;
+  private final Kind kind;
+  private final String componentClass;
+  private final String sourceId;
+  private final boolean sourceResolved;
+  private final String sourceElementName;
+  private final String targetId;
+  private final boolean targetResolved;
+  private final String targetElementName;
+  private final String attachmentId;
+  private final boolean attachmentResolved;
+  private final String attachmentElementName;
+  private final String signalConveyingType;
+
+  /**
+   * Creates immutable evidence for one information-flow occurrence.
+   *
+   * @param id source XML identity, or an empty string when absent
+   * @param kind supported information-flow kind
+   * @param componentClass source component class
+   * @param sourceId logical source identity, or an empty string when absent
+   * @param sourceResolved whether the logical source resolves to a source element
+   * @param sourceElementName resolved logical-source XML element name, or an empty string
+   * @param targetId logical target identity, or an empty string when absent
+   * @param targetResolved whether the logical target resolves to a source element
+   * @param targetElementName resolved logical-target XML element name, or an empty string
+   * @param attachmentId process-attachment identity, or an empty string when absent
+   * @param attachmentResolved whether the process attachment resolves to a source element
+   * @param attachmentElementName resolved attachment XML element name, or an empty string
+   * @param signalConveyingType signal medium/type, or an empty string when absent or not applicable
+   */
+  public DexpiInformationFlowInfo(String id, Kind kind, String componentClass, String sourceId,
+      boolean sourceResolved, String sourceElementName, String targetId, boolean targetResolved,
+      String targetElementName, String attachmentId, boolean attachmentResolved, String attachmentElementName,
+      String signalConveyingType) {
+    this.id = normalize(id);
+    this.kind = Objects.requireNonNull(kind, "kind");
+    this.componentClass = normalize(componentClass);
+    this.sourceId = normalize(sourceId);
+    this.sourceResolved = sourceResolved;
+    this.sourceElementName = normalize(sourceElementName);
+    this.targetId = normalize(targetId);
+    this.targetResolved = targetResolved;
+    this.targetElementName = normalize(targetElementName);
+    this.attachmentId = normalize(attachmentId);
+    this.attachmentResolved = attachmentResolved;
+    this.attachmentElementName = normalize(attachmentElementName);
+    this.signalConveyingType = normalize(signalConveyingType);
+  }
+
+  /** @return source XML identity, or an empty string when absent */
+  public String getId() {
+    return id;
+  }
+
+  /** @return supported information-flow kind */
+  public Kind getKind() {
+    return kind;
+  }
+
+  /** @return source component class */
+  public String getComponentClass() {
+    return componentClass;
+  }
+
+  /** @return logical source identity, or an empty string when absent */
+  public String getSourceId() {
+    return sourceId;
+  }
+
+  /** @return whether the logical source resolves to a source element */
+  public boolean isSourceResolved() {
+    return sourceResolved;
+  }
+
+  /** @return resolved logical-source XML element name, or an empty string */
+  public String getSourceElementName() {
+    return sourceElementName;
+  }
+
+  /** @return logical target identity, or an empty string when absent */
+  public String getTargetId() {
+    return targetId;
+  }
+
+  /** @return whether the logical target resolves to a source element */
+  public boolean isTargetResolved() {
+    return targetResolved;
+  }
+
+  /** @return resolved logical-target XML element name, or an empty string */
+  public String getTargetElementName() {
+    return targetElementName;
+  }
+
+  /** @return process-attachment identity, or an empty string when absent */
+  public String getAttachmentId() {
+    return attachmentId;
+  }
+
+  /** @return whether the source contains a process-attachment reference */
+  public boolean hasAttachment() {
+    return !attachmentId.isEmpty();
+  }
+
+  /** @return whether the process attachment resolves to a source element */
+  public boolean isAttachmentResolved() {
+    return attachmentResolved;
+  }
+
+  /** @return resolved process-attachment XML element name, or an empty string */
+  public String getAttachmentElementName() {
+    return attachmentElementName;
+  }
+
+  /** @return signal medium/type, or an empty string when absent or not applicable */
+  public String getSignalConveyingType() {
+    return signalConveyingType;
+  }
+
+  Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("id", id);
+    result.put("kind", kind.name());
+    result.put("componentClass", componentClass);
+    result.put("sourceId", sourceId);
+    result.put("sourceResolved", Boolean.valueOf(sourceResolved));
+    result.put("sourceElementName", sourceElementName);
+    result.put("targetId", targetId);
+    result.put("targetResolved", Boolean.valueOf(targetResolved));
+    result.put("targetElementName", targetElementName);
+    result.put("attachmentId", attachmentId);
+    result.put("attachmentResolved", Boolean.valueOf(attachmentResolved));
+    result.put("attachmentElementName", attachmentElementName);
+    result.put("signalConveyingType", signalConveyingType);
+    return result;
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -130,6 +130,7 @@ public final class DexpiXmlReader {
     private static final long serialVersionUID = 1000L;
     private final ProcessSystem processSystem;
     private final List<DexpiInstrumentInfo> instruments;
+    private final List<DexpiInformationFlowInfo> informationFlows;
     private final List<DexpiConnectionInfo> connections;
     private final List<DexpiConnectionEndpointInfo> connectionEndpoints;
     private final List<DexpiConnectionComponentInfo> connectionComponents;
@@ -138,11 +139,13 @@ public final class DexpiXmlReader {
     private final List<ImportDiagnostic> diagnostics;
 
     private ImportResult(ProcessSystem processSystem, List<DexpiInstrumentInfo> instruments,
-        List<DexpiConnectionInfo> connections, List<DexpiConnectionEndpointInfo> connectionEndpoints,
+        List<DexpiInformationFlowInfo> informationFlows, List<DexpiConnectionInfo> connections,
+        List<DexpiConnectionEndpointInfo> connectionEndpoints,
         List<DexpiConnectionComponentInfo> connectionComponents, List<DexpiConnectionCycleInfo> connectionCycles,
         List<DexpiConnectionCycleTransitionInfo> connectionCycleTransitions, List<ImportDiagnostic> diagnostics) {
       this.processSystem = processSystem;
       this.instruments = Collections.unmodifiableList(new ArrayList<DexpiInstrumentInfo>(instruments));
+      this.informationFlows = Collections.unmodifiableList(new ArrayList<DexpiInformationFlowInfo>(informationFlows));
       this.connections = Collections.unmodifiableList(new ArrayList<DexpiConnectionInfo>(connections));
       this.connectionEndpoints = Collections
           .unmodifiableList(new ArrayList<DexpiConnectionEndpointInfo>(connectionEndpoints));
@@ -170,6 +173,20 @@ public final class DexpiXmlReader {
      */
     public List<DexpiInstrumentInfo> getInstruments() {
       return instruments;
+    }
+
+    /**
+     * Returns supported instrumentation information-flow occurrences in source-document order.
+     *
+     * <p>
+     * These records retain logical references and resolution evidence only. They do not construct live control
+     * topology, infer control intent, or verify loop function.
+     * </p>
+     *
+     * @return immutable signal-line and measuring-line evidence
+     */
+    public List<DexpiInformationFlowInfo> getInformationFlows() {
+      return informationFlows;
     }
 
     /**
@@ -270,6 +287,12 @@ public final class DexpiXmlReader {
       result.put("profile", "Proteus-compatible DEXPI Plant/P&ID 4.1.1 supported subset");
       result.put("importedUnitCount", Integer.valueOf(processSystem.getAllUnitNames().size()));
       result.put("instrumentCount", Integer.valueOf(instruments.size()));
+      result.put("informationFlowCount", Integer.valueOf(informationFlows.size()));
+      List<Map<String, Object>> informationFlowMaps = new ArrayList<Map<String, Object>>();
+      for (DexpiInformationFlowInfo informationFlow : informationFlows) {
+        informationFlowMaps.add(informationFlow.toMap());
+      }
+      result.put("informationFlows", informationFlowMaps);
       result.put("connectionCount", Integer.valueOf(connections.size()));
       List<Map<String, Object>> connectionMaps = new ArrayList<Map<String, Object>>();
       for (DexpiConnectionInfo connection : connections) {
@@ -491,9 +514,11 @@ public final class DexpiXmlReader {
       throws IOException, DexpiXmlReaderException {
     ProcessSystem processSystem = new ProcessSystem("DEXPI process");
     List<DexpiInstrumentInfo> instruments = new ArrayList<DexpiInstrumentInfo>();
+    List<DexpiInformationFlowInfo> informationFlows = new ArrayList<DexpiInformationFlowInfo>();
     List<DexpiConnectionInfo> connections = new ArrayList<DexpiConnectionInfo>();
     List<ImportDiagnostic> diagnostics = new ArrayList<ImportDiagnostic>();
-    loadInternal(inputStream, processSystem, templateStream, false, diagnostics, instruments, connections);
+    loadInternal(inputStream, processSystem, templateStream, false, diagnostics, instruments, informationFlows,
+        connections);
     List<DexpiConnectionEndpointInfo> connectionEndpoints = summarizeConnectionEndpoints(connections);
     List<DexpiConnectionComponentInfo> connectionComponents = summarizeConnectionComponents(connections,
         connectionEndpoints);
@@ -501,8 +526,8 @@ public final class DexpiXmlReader {
         connectionComponents);
     List<DexpiConnectionCycleTransitionInfo> connectionCycleTransitions = summarizeConnectionCycleTransitions(
         connections, connectionEndpoints, connectionCycles);
-    return new ImportResult(processSystem, instruments, connections, connectionEndpoints, connectionComponents,
-        connectionCycles, connectionCycleTransitions, diagnostics);
+    return new ImportResult(processSystem, instruments, informationFlows, connections, connectionEndpoints,
+        connectionComponents, connectionCycles, connectionCycleTransitions, diagnostics);
   }
 
   /**
@@ -577,12 +602,13 @@ public final class DexpiXmlReader {
    */
   public static void load(InputStream inputStream, ProcessSystem processSystem, Stream templateStream,
       boolean namespaceAware) throws IOException, DexpiXmlReaderException {
-    loadInternal(inputStream, processSystem, templateStream, namespaceAware, null, null, null);
+    loadInternal(inputStream, processSystem, templateStream, namespaceAware, null, null, null, null);
   }
 
   private static void loadInternal(InputStream inputStream, ProcessSystem processSystem, Stream templateStream,
       boolean namespaceAware, List<ImportDiagnostic> diagnostics, List<DexpiInstrumentInfo> instruments,
-      List<DexpiConnectionInfo> connections) throws IOException, DexpiXmlReaderException {
+      List<DexpiInformationFlowInfo> informationFlows, List<DexpiConnectionInfo> connections)
+      throws IOException, DexpiXmlReaderException {
     Objects.requireNonNull(inputStream, "inputStream");
     Objects.requireNonNull(processSystem, "processSystem");
 
@@ -605,6 +631,9 @@ public final class DexpiXmlReader {
     addPipingSegments(document, processSystem, streamTemplate, diagnostics);
     if (instruments != null) {
       instruments.addAll(parseInstruments(document));
+    }
+    if (informationFlows != null) {
+      informationFlows.addAll(parseInformationFlows(document));
     }
     if (connections != null) {
       connections.addAll(parseConnections(document, diagnostics));
@@ -752,6 +781,66 @@ public final class DexpiXmlReader {
 
     logger.info("Parsed {} instruments from DEXPI XML", instruments.size());
     return instruments;
+  }
+
+  private static List<DexpiInformationFlowInfo> parseInformationFlows(Document document) {
+    List<DexpiInformationFlowInfo> result = new ArrayList<DexpiInformationFlowInfo>();
+    Map<String, Element> elementsById = new HashMap<String, Element>();
+    NodeList allElements = document.getElementsByTagName("*");
+    for (int i = 0; i < allElements.getLength(); i++) {
+      Node node = allElements.item(i);
+      if (node.getNodeType() != Node.ELEMENT_NODE || isInsideShapeCatalogue(node)) {
+        continue;
+      }
+      Element element = (Element) node;
+      String id = element.getAttribute("ID");
+      if (!isBlank(id) && !elementsById.containsKey(id)) {
+        elementsById.put(id, element);
+      }
+    }
+
+    NodeList informationFlowNodes = document.getElementsByTagName("InformationFlow");
+    for (int i = 0; i < informationFlowNodes.getLength(); i++) {
+      Node node = informationFlowNodes.item(i);
+      if (node.getNodeType() != Node.ELEMENT_NODE || isInsideShapeCatalogue(node)) {
+        continue;
+      }
+      Element element = (Element) node;
+      String componentClass = element.getAttribute("ComponentClass");
+      DexpiInformationFlowInfo.Kind kind;
+      if ("SignalLineFunction".equals(componentClass)) {
+        kind = DexpiInformationFlowInfo.Kind.SIGNAL_LINE;
+      } else if ("MeasuringLineFunction".equals(componentClass)) {
+        kind = DexpiInformationFlowInfo.Kind.MEASURING_LINE;
+      } else {
+        continue;
+      }
+
+      String sourceId = associationItemId(element, "has logical start");
+      String targetId = associationItemId(element, "has logical end");
+      String attachmentId = associationItemId(element, "is attached to");
+      Element sourceElement = elementsById.get(sourceId);
+      Element targetElement = elementsById.get(targetId);
+      Element attachmentElement = elementsById.get(attachmentId);
+      result.add(new DexpiInformationFlowInfo(element.getAttribute("ID"), kind, componentClass, sourceId,
+          sourceElement != null, elementName(sourceElement), targetId, targetElement != null,
+          elementName(targetElement), attachmentId, attachmentElement != null, elementName(attachmentElement),
+          getGenericAttribute(element, "SignalConveyingTypeSpecialization")));
+    }
+    return result;
+  }
+
+  private static String associationItemId(Element element, String associationType) {
+    for (Element association : directChildElements(element, "Association")) {
+      if (associationType.equals(association.getAttribute("Type"))) {
+        return association.getAttribute("ItemID");
+      }
+    }
+    return "";
+  }
+
+  private static String elementName(Element element) {
+    return element == null ? "" : element.getTagName();
   }
 
   private static List<DexpiConnectionInfo> parseConnections(Document document, List<ImportDiagnostic> diagnostics) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -140,8 +140,8 @@ public final class DexpiXmlReader {
 
     private ImportResult(ProcessSystem processSystem, List<DexpiInstrumentInfo> instruments,
         List<DexpiInformationFlowInfo> informationFlows, List<DexpiConnectionInfo> connections,
-        List<DexpiConnectionEndpointInfo> connectionEndpoints,
-        List<DexpiConnectionComponentInfo> connectionComponents, List<DexpiConnectionCycleInfo> connectionCycles,
+        List<DexpiConnectionEndpointInfo> connectionEndpoints, List<DexpiConnectionComponentInfo> connectionComponents,
+        List<DexpiConnectionCycleInfo> connectionCycles,
         List<DexpiConnectionCycleTransitionInfo> connectionCycleTransitions, List<ImportDiagnostic> diagnostics) {
       this.processSystem = processSystem;
       this.instruments = Collections.unmodifiableList(new ArrayList<DexpiInstrumentInfo>(instruments));

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -248,9 +248,50 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("100", first.getInstruments().get(0).getLoopNumber());
     assertEquals("PC-100", first.getInstruments().get(1).getTagName());
     assertEquals("PC-100", first.getInstruments().get(1).getActuatingTag());
+
+    List<DexpiInformationFlowInfo> informationFlows = first.getInformationFlows();
+    assertEquals(3, informationFlows.size());
+    DexpiInformationFlowInfo measuring = informationFlows.get(0);
+    assertEquals("MLF-100", measuring.getId());
+    assertEquals(DexpiInformationFlowInfo.Kind.MEASURING_LINE, measuring.getKind());
+    assertEquals("PSGF-100", measuring.getSourceId());
+    assertTrue(measuring.isSourceResolved());
+    assertEquals("ProcessSignalGeneratingFunction", measuring.getSourceElementName());
+    assertEquals("PIF-PT-100", measuring.getTargetId());
+    assertTrue(measuring.isTargetResolved());
+    assertEquals("ProcessInstrumentationFunction", measuring.getTargetElementName());
+    assertTrue(measuring.hasAttachment());
+    assertEquals("N-SENSE", measuring.getAttachmentId());
+    assertTrue(measuring.isAttachmentResolved());
+    assertEquals("Nozzle", measuring.getAttachmentElementName());
+    assertEquals("", measuring.getSignalConveyingType());
+
+    DexpiInformationFlowInfo measuredSignal = informationFlows.get(1);
+    assertEquals("SIG-MEASURED", measuredSignal.getId());
+    assertEquals(DexpiInformationFlowInfo.Kind.SIGNAL_LINE, measuredSignal.getKind());
+    assertEquals("PIF-PT-100", measuredSignal.getSourceId());
+    assertTrue(measuredSignal.isSourceResolved());
+    assertEquals("ProcessInstrumentationFunction", measuredSignal.getSourceElementName());
+    assertEquals("PIF-PC-100", measuredSignal.getTargetId());
+    assertTrue(measuredSignal.isTargetResolved());
+    assertEquals("ProcessInstrumentationFunction", measuredSignal.getTargetElementName());
+    assertFalse(measuredSignal.hasAttachment());
+    assertEquals("ElectricalSignalConveying", measuredSignal.getSignalConveyingType());
+
+    DexpiInformationFlowInfo actuatingSignal = informationFlows.get(2);
+    assertEquals("SIG-ACTUATE", actuatingSignal.getId());
+    assertEquals("AF-100", actuatingSignal.getTargetId());
+    assertTrue(actuatingSignal.isTargetResolved());
+    assertEquals("ActuatingFunction", actuatingSignal.getTargetElementName());
+    assertEquals("PneumaticSignalConveying", actuatingSignal.getSignalConveyingType());
+    assertThrows(UnsupportedOperationException.class, () -> informationFlows.clear());
+
     assertTrue(first.getDiagnostics().isEmpty());
     assertFalse(first.hasLosses());
     assertTrue(first.toJson().contains("\"instrumentCount\": 2"));
+    assertTrue(first.toJson().contains("\"informationFlowCount\": 3"));
+    assertTrue(first.toJson().contains("\"kind\": \"MEASURING_LINE\""));
+    assertTrue(first.toJson().contains("\"signalConveyingType\": \"ElectricalSignalConveying\""));
     assertEquals(first.toJson(), second.toJson());
   }
 
@@ -292,8 +333,31 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertDiagnostic(first, "DEXPI_IMPORT_SIGNAL_MEDIUM_MISSING");
     assertDiagnostic(first, "DEXPI_IMPORT_FINAL_ELEMENT_UNRESOLVED");
     assertDiagnostic(first, "DEXPI_IMPORT_ACTUATION_LOCATION_MISSING");
+
+    List<DexpiInformationFlowInfo> informationFlows = first.getInformationFlows();
+    assertEquals(2, informationFlows.size());
+    DexpiInformationFlowInfo measuring = informationFlows.get(0);
+    assertEquals("MLF-BROKEN", measuring.getId());
+    assertEquals(DexpiInformationFlowInfo.Kind.MEASURING_LINE, measuring.getKind());
+    assertEquals("", measuring.getSourceId());
+    assertFalse(measuring.isSourceResolved());
+    assertEquals("UNKNOWN-INSTRUMENT", measuring.getTargetId());
+    assertFalse(measuring.isTargetResolved());
+    assertFalse(measuring.hasAttachment());
+    assertFalse(measuring.isAttachmentResolved());
+
+    DexpiInformationFlowInfo signal = informationFlows.get(1);
+    assertEquals("SIG-BROKEN", signal.getId());
+    assertEquals(DexpiInformationFlowInfo.Kind.SIGNAL_LINE, signal.getKind());
+    assertEquals("UNKNOWN-SOURCE", signal.getSourceId());
+    assertFalse(signal.isSourceResolved());
+    assertEquals("", signal.getTargetId());
+    assertFalse(signal.isTargetResolved());
+    assertEquals("", signal.getSignalConveyingType());
+
     assertTrue(first.hasLosses());
     assertFalse(first.hasErrors());
+    assertTrue(first.toJson().contains("\"informationFlowCount\": 2"));
     assertEquals(first.toJson(), second.toJson());
   }
 


### PR DESCRIPTION
## Summary

Advances #1332 and #2899 with one bounded DEXPI import-evidence increment:

- expose immutable, source-ordered `MeasuringLineFunction` and `SignalLineFunction` records;
- preserve logical start/end identity, reference resolution, resolved XML element names, measuring-line attachment evidence, and signal-conveying type;
- retain missing and unresolved source references beside existing deterministic diagnostics;
- add focused valid and broken-topology regressions plus deterministic JSON; and
- document the same Java and JPype inspection boundary.

**Exact base:** `b9a920cbe44f6b9311fe4b9d405bce24e61d4ea4`  
**Exact head:** `d96132a3556655f362bc116e216b1165523cac3a`

The pre-implementation capability contract is recorded in [#1332](https://github.com/equinor/neqsim/issues/1332#issuecomment-5537595583) and [#2899](https://github.com/equinor/neqsim/issues/2899#issuecomment-5537595847).

## Capability contract

- Preserve source-document order for supported information flows.
- Preserve source IDs/classes and explicit start, end, attachment, and signal-medium evidence.
- Resolve references only against explicit non-catalogue XML identities.
- Keep missing and unresolved references visible without inventing endpoints.
- Expose an immutable result list and deterministic JSON count/list.
- Preserve all existing APIs, import behavior, simulation topology, rendering, and exports.

## Validation

**READY TO MERGE**

The first hosted run compiled successfully and exposed only Spotless layout differences. The exact hosted repair artifact was applied without changing behavior or the four-file scope.

Exact-head hosted evidence on `d96132a3556655f362bc116e216b1165523cac3a`:

- all eight workflows complete;
- 19 successful jobs, one expected PaperLab skip, zero failures or pending jobs;
- Java 8 and Java 21 fast-test suites pass on Ubuntu and Windows;
- all four Java 21 slow-test shards and Javadocs pass;
- Spotless, pre-commit, documentation search/build, notebook handover, diagram performance, CodeQL, agent-skill references, and change detection pass;
- focused valid and broken-topology regressions cover source order, kinds, reference resolution, resolved element names, measuring attachment evidence, signal medium, immutability, and deterministic JSON; and
- the sole automated mutability finding was disproved by the constructor's defensive immutable snapshot and focused mutation regression, then resolved without source changes.

All required exact-head gates are complete. `READY TO MERGE` is a classification only; the pull request remains open, mergeable, unmerged, and draft.

Whole-sheet visual gate is N/A: no rendering, geometry, layout, notebook, or export path changed.

## Overlap and portfolio

The #1332/#2899 shared implementation lane remains owned only by this draft. The current positively identified autonomous implementation portfolio is **4/10** (#3436, #3440, #3442, and #3444), below the global ceiling of 10. The refinery, MCP reporting, and aqueous-H₂S trajectory increments do not overlap this bounded DEXPI reader scope. Current `master` remains the recorded exact base `b9a920cbe44f6b9311fe4b9d405bce24e61d4ea4`; no rebase or synchronization was needed or performed.

## Engineering stop boundary

This is source-reference evidence only. It does not instantiate live transmitters or controllers, infer control intent, verify a loop, classify SIS/safeguard functions, prove DEXPI/ISO/ISA conformance, certify a drawing, or provide engineering approval.

This PR must remain draft-only. Do not merge, mark ready, auto-merge, rebase, or synchronize it as part of this campaign.

Generated with AI assistance.