### PR TITLE
Add ConstraintSource provenance axis and EmpiricalCarryOverConstraint

### DIFF
--- a/docs/process/equipment/separators.md
+++ b/docs/process/equipment/separators.md
@@ -1342,6 +1342,99 @@ per train — matching the format of the standard Sulzer
 
 ---
 
+## Constraint provenance: where a limit comes from
+
+Every `CapacityConstraint` carries two independent descriptors, and it is worth
+keeping them apart when reading a capacity report:
+
+| Descriptor | Question it answers | Type |
+|------------|---------------------|------|
+| `ConstraintSeverity` | How is a violation handled? | `CRITICAL`, `HARD`, `SOFT`, `ADVISORY` |
+| `ConstraintSource`   | What authority backs the number? | `CONFORMITY_STANDARD`, `VENDOR_DATASHEET`, `PROCESS_EMPIRICAL`, `USER_RULE`, `AUTO_SIZE`, `DEFAULT` |
+
+A vendor surge limit and a company K-factor may both be `HARD`, but they are not
+renegotiable on the same terms — the first is a machine limit, the second is a
+policy choice. Recording the source lets a report say *why* a limit binds.
+
+```java
+constraint.setSource(CapacityConstraint.ConstraintSource.CONFORMITY_STANDARD, "API 12J");
+constraint.getSource();           // CONFORMITY_STANDARD
+constraint.getSourceReference();  // "API 12J"
+```
+
+`ConstraintSource` is distinct from the free-text `dataSource`. The data source
+records *which part of the model* supplied the number (`"equipment"`,
+`"mechanicalDesign"`, `"installed_capacity_table"`); the constraint source
+classifies the underlying authority. Both are emitted per constraint in the
+`getUtilizationSnapshot()` JSON.
+
+### Hard, binding constraints from empirical observations
+
+The constraint that actually limits production on many field cases is not a
+standard's K-factor; it is an empirical relationship between an operating
+variable (gas rate, suction pressure) and a downstream consequence — typically
+liquid carry-over from the last scrubber accumulating in the suction drum of a
+compressor or expander downstream.
+
+`EmpiricalCarryOverConstraint` packages this pattern as a piecewise-linear
+correlation calibrated against measured points, for example suction-drum level
+instrumentation:
+
+```java
+import neqsim.process.equipment.capacity.CapacityConstraint;
+import neqsim.process.equipment.capacity.EmpiricalCarryOverConstraint;
+
+double[] gasRate   = {2.0, 3.0, 4.5, 5.5};   // Am3/s at the scrubber gas outlet
+double[] carryOver = {0.0, 0.5, 3.0, 12.0};  // kg/h observed downstream
+double maxCarry = 5.0;                       // kg/h, the binding limit
+
+EmpiricalCarryOverConstraint co = EmpiricalCarryOverConstraint.fromObservations(
+    "carryOver", "kg/h",
+    () -> scrubber.getThermoSystem().getPhase(0).getFlowRate("m3/sec"),
+    gasRate, carryOver, maxCarry);
+co.setSourceReference("Suction drum level instrument, May-Aug 2025");
+scrubber.addCapacityConstraint(co);
+```
+
+The `xPoints` and `yPoints` arrays carry no implied units. The driver supplier
+must return the operating variable in the unit of `xPoints`, and `yPoints` and
+`maxAllowable` must share the unit passed as the constraint unit.
+
+Behaviour:
+
+- Created as a `HARD` constraint with severity `HARD` and source
+  `PROCESS_EMPIRICAL`, so exceeding the allowable carry-over shows up both in
+  `isViolated()` and in `isHardLimitExceeded()`, and therefore in the plant-wide
+  `anyHardLimitExceeded` feasibility gate.
+- Below the lowest calibration point the value clamps to the first observation.
+  Above the highest, the slope of the last segment is extrapolated, which keeps
+  the correlation conservative outside the calibrated envelope.
+- It is an ordinary `CapacityConstraint`, so it participates in bottleneck
+  detection, the utilization snapshot, and the production optimiser.
+
+Because it extrapolates, a value far above the calibration range is an
+engineering judgement, not a measurement. Keep the calibration envelope in
+`getSourceReference()` so a reader can see where the data ends.
+
+### Choosing what is binding
+
+A reasonable default for a gas-export train:
+
+| Layer | Source | Severity | Effect on optimiser |
+|-------|--------|----------|---------------------|
+| Standard K-factor  | `CONFORMITY_STANDARD` | `SOFT`     | Reported, does not block |
+| Standard inlet ρv² | `CONFORMITY_STANDARD` | `SOFT`     | Reported, does not block |
+| Drainage head %    | `CONFORMITY_STANDARD` | `SOFT`     | Reported, does not block |
+| Carry-over kg/h    | `PROCESS_EMPIRICAL`   | `HARD`     | **Binds capacity** |
+| Compressor surge   | `VENDOR_DATASHEET`    | `CRITICAL` | Stops optimisation immediately |
+
+This separation lets you produce a single capacity report that shows both *what
+limits production today* — the empirical and vendor constraints — and *what
+would limit production if conformity were enforced* — the standards-driven
+constraints.
+
+---
+
 ## Related Documentation
 
 - [Process Package](../) - Package overview

--- a/src/main/java/neqsim/process/equipment/capacity/CapacityConstraint.java
+++ b/src/main/java/neqsim/process/equipment/capacity/CapacityConstraint.java
@@ -96,6 +96,73 @@ public class CapacityConstraint implements Serializable {
     ADVISORY
   }
 
+  /**
+   * Enum describing the provenance of a constraint limit - the kind of authority that backs the number.
+   *
+   * <p>
+   * This is a separate axis from {@link ConstraintSeverity}: severity says <em>how a violation is handled</em>,
+   * whereas the source says <em>why the limit exists and who stands behind it</em>. A vendor surge limit and a
+   * company standard may both be HARD, but they are not renegotiable on the same terms.
+   * </p>
+   *
+   * <p>
+   * It is also distinct from {@link CapacityConstraint#getDataSource()}. The data source is a free-text label
+   * identifying which part of the model supplied the number ("equipment", "mechanicalDesign",
+   * "installed_capacity_table"); the constraint source classifies the underlying authority. A limit with
+   * {@code dataSource = "mechanicalDesign"} may have a source of {@link #CONFORMITY_STANDARD} or
+   * {@link #VENDOR_DATASHEET} depending on how the design was set.
+   * </p>
+   *
+   * <p>
+   * Recommended pairings with severity:
+   * </p>
+   * <ul>
+   * <li>{@link #CONFORMITY_STANDARD} - typically SOFT or ADVISORY, unless company policy makes it binding</li>
+   * <li>{@link #USER_RULE} - severity chosen by operations</li>
+   * <li>{@link #PROCESS_EMPIRICAL} - typically HARD, calibrated against observed plant behaviour</li>
+   * <li>{@link #VENDOR_DATASHEET} - typically HARD or CRITICAL for mechanical and surge limits</li>
+   * <li>{@link #AUTO_SIZE} - design point produced by sizing code; usually SOFT</li>
+   * <li>{@link #DEFAULT} - built-in constraint with no declared provenance</li>
+   * </ul>
+   */
+  public enum ConstraintSource {
+    /**
+     * Limit comes from an industry or company standard (API 12J, NORSOK P-002, ISO, ASME, DNV, or a company
+     * technical requirement). The specific document is recorded in
+     * {@link CapacityConstraint#getSourceReference()}.
+     */
+    CONFORMITY_STANDARD,
+
+    /**
+     * Limit defined by the user, operations, or the asset team. Examples: a maximum compressor speed imposed for
+     * vibration management, or a separator load factor derived from operating experience.
+     */
+    USER_RULE,
+
+    /**
+     * Limit derived from empirical observation of plant behaviour. Typically a correlation between an operating
+     * variable (rate, pressure) and a downstream consequence (carry-over, fouling, scaling) fitted to historian
+     * data. See {@link EmpiricalCarryOverConstraint}.
+     */
+    PROCESS_EMPIRICAL,
+
+    /**
+     * Limit taken from a vendor or OEM datasheet - compressor surge curve, valve trim Cv, mechanical overspeed,
+     * sealing pressure.
+     */
+    VENDOR_DATASHEET,
+
+    /**
+     * Limit generated automatically by equipment sizing code, such as an {@code autoSize()} call.
+     */
+    AUTO_SIZE,
+
+    /**
+     * Default fallback, used by built-in constraints where no provenance has been declared.
+     */
+    DEFAULT
+  }
+
   /** Name of the constraint (e.g., "speed", "gasLoadFactor"). */
   private final String name;
 
@@ -110,6 +177,15 @@ public class CapacityConstraint implements Serializable {
 
   /** Severity level for optimization (CRITICAL, HARD, SOFT, ADVISORY). */
   private ConstraintSeverity severity = ConstraintSeverity.HARD;
+
+  /** Provenance of the limit - the kind of authority that backs it. */
+  private ConstraintSource source = ConstraintSource.DEFAULT;
+
+  /**
+   * Free-text reference identifying the source: the standard number ("API 12J"), the team that imposed the rule, or
+   * the historian tag set used to fit an empirical correlation. Optional.
+   */
+  private String sourceReference = "";
 
   /** Design/rated value for this constraint. */
   private double designValue = Double.MAX_VALUE;
@@ -289,6 +365,64 @@ public class CapacityConstraint implements Serializable {
    */
   public ConstraintSeverity getSeverity() {
     return severity;
+  }
+
+  /**
+   * Sets the provenance of this constraint.
+   *
+   * @param source the kind of authority backing the limit; {@code null} is treated as
+   *        {@link ConstraintSource#DEFAULT}
+   * @return this constraint for method chaining
+   */
+  public CapacityConstraint setSource(ConstraintSource source) {
+    this.source = source == null ? ConstraintSource.DEFAULT : source;
+    return this;
+  }
+
+  /**
+   * Sets the provenance together with a free-text reference identifying the specific source.
+   *
+   * @param source the kind of authority backing the limit; {@code null} is treated as
+   *        {@link ConstraintSource#DEFAULT}
+   * @param sourceReference free-text identifier such as a standard number, an owning team, or the historian tag set
+   *        used to fit the limit; {@code null} is stored as an empty string
+   * @return this constraint for method chaining
+   */
+  public CapacityConstraint setSource(ConstraintSource source, String sourceReference) {
+    this.source = source == null ? ConstraintSource.DEFAULT : source;
+    this.sourceReference = sourceReference == null ? "" : sourceReference;
+    return this;
+  }
+
+  /**
+   * Sets only the free-text source reference, leaving the {@link ConstraintSource} unchanged. Useful for constraint
+   * subclasses that already declare their own source in the constructor.
+   *
+   * @param sourceReference free-text identifier such as a standard number, an owning team, or the historian tag set
+   *        used to fit the limit; {@code null} is stored as an empty string
+   * @return this constraint for method chaining
+   */
+  public CapacityConstraint setSourceReference(String sourceReference) {
+    this.sourceReference = sourceReference == null ? "" : sourceReference;
+    return this;
+  }
+
+  /**
+   * Gets the provenance of this constraint.
+   *
+   * @return the source, never {@code null}; defaults to {@link ConstraintSource#DEFAULT}
+   */
+  public ConstraintSource getSource() {
+    return source;
+  }
+
+  /**
+   * Gets the free-text source reference, such as a standard number, owning team, or historian tag set.
+   *
+   * @return the reference string, empty if none has been set
+   */
+  public String getSourceReference() {
+    return sourceReference;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/capacity/CapacityConstraint.java
+++ b/src/main/java/neqsim/process/equipment/capacity/CapacityConstraint.java
@@ -100,9 +100,9 @@ public class CapacityConstraint implements Serializable {
    * Enum describing the provenance of a constraint limit - the kind of authority that backs the number.
    *
    * <p>
-   * This is a separate axis from {@link ConstraintSeverity}: severity says <em>how a violation is handled</em>,
-   * whereas the source says <em>why the limit exists and who stands behind it</em>. A vendor surge limit and a
-   * company standard may both be HARD, but they are not renegotiable on the same terms.
+   * This is a separate axis from {@link ConstraintSeverity}: severity says <em>how a violation is handled</em>, whereas
+   * the source says <em>why the limit exists and who stands behind it</em>. A vendor surge limit and a company standard
+   * may both be HARD, but they are not renegotiable on the same terms.
    * </p>
    *
    * <p>
@@ -127,9 +127,8 @@ public class CapacityConstraint implements Serializable {
    */
   public enum ConstraintSource {
     /**
-     * Limit comes from an industry or company standard (API 12J, NORSOK P-002, ISO, ASME, DNV, or a company
-     * technical requirement). The specific document is recorded in
-     * {@link CapacityConstraint#getSourceReference()}.
+     * Limit comes from an industry or company standard (API 12J, NORSOK P-002, ISO, ASME, DNV, or a company technical
+     * requirement). The specific document is recorded in {@link CapacityConstraint#getSourceReference()}.
      */
     CONFORMITY_STANDARD,
 
@@ -141,14 +140,14 @@ public class CapacityConstraint implements Serializable {
 
     /**
      * Limit derived from empirical observation of plant behaviour. Typically a correlation between an operating
-     * variable (rate, pressure) and a downstream consequence (carry-over, fouling, scaling) fitted to historian
-     * data. See {@link EmpiricalCarryOverConstraint}.
+     * variable (rate, pressure) and a downstream consequence (carry-over, fouling, scaling) fitted to historian data.
+     * See {@link EmpiricalCarryOverConstraint}.
      */
     PROCESS_EMPIRICAL,
 
     /**
-     * Limit taken from a vendor or OEM datasheet - compressor surge curve, valve trim Cv, mechanical overspeed,
-     * sealing pressure.
+     * Limit taken from a vendor or OEM datasheet - compressor surge curve, valve trim Cv, mechanical overspeed, sealing
+     * pressure.
      */
     VENDOR_DATASHEET,
 
@@ -182,8 +181,8 @@ public class CapacityConstraint implements Serializable {
   private ConstraintSource source = ConstraintSource.DEFAULT;
 
   /**
-   * Free-text reference identifying the source: the standard number ("API 12J"), the team that imposed the rule, or
-   * the historian tag set used to fit an empirical correlation. Optional.
+   * Free-text reference identifying the source: the standard number ("API 12J"), the team that imposed the rule, or the
+   * historian tag set used to fit an empirical correlation. Optional.
    */
   private String sourceReference = "";
 
@@ -370,8 +369,7 @@ public class CapacityConstraint implements Serializable {
   /**
    * Sets the provenance of this constraint.
    *
-   * @param source the kind of authority backing the limit; {@code null} is treated as
-   *        {@link ConstraintSource#DEFAULT}
+   * @param source the kind of authority backing the limit; {@code null} is treated as {@link ConstraintSource#DEFAULT}
    * @return this constraint for method chaining
    */
   public CapacityConstraint setSource(ConstraintSource source) {
@@ -382,10 +380,9 @@ public class CapacityConstraint implements Serializable {
   /**
    * Sets the provenance together with a free-text reference identifying the specific source.
    *
-   * @param source the kind of authority backing the limit; {@code null} is treated as
-   *        {@link ConstraintSource#DEFAULT}
+   * @param source the kind of authority backing the limit; {@code null} is treated as {@link ConstraintSource#DEFAULT}
    * @param sourceReference free-text identifier such as a standard number, an owning team, or the historian tag set
-   *        used to fit the limit; {@code null} is stored as an empty string
+   * used to fit the limit; {@code null} is stored as an empty string
    * @return this constraint for method chaining
    */
   public CapacityConstraint setSource(ConstraintSource source, String sourceReference) {
@@ -399,7 +396,7 @@ public class CapacityConstraint implements Serializable {
    * subclasses that already declare their own source in the constructor.
    *
    * @param sourceReference free-text identifier such as a standard number, an owning team, or the historian tag set
-   *        used to fit the limit; {@code null} is stored as an empty string
+   * used to fit the limit; {@code null} is stored as an empty string
    * @return this constraint for method chaining
    */
   public CapacityConstraint setSourceReference(String sourceReference) {

--- a/src/main/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraint.java
+++ b/src/main/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraint.java
@@ -31,11 +31,11 @@ import java.util.function.DoubleSupplier;
  * DoubleSupplier rate = () -&gt; scrubber.getThermoSystem().getPhase(0).getFlowRate("m3/sec");
  *
  * // Calibration points (gas rate Am3/s, observed carry-over kg/h)
- * double[] x = {2.0, 3.0, 4.5, 5.5};
- * double[] y = {0.0, 0.5, 3.0, 12.0};
+ * double[] x = { 2.0, 3.0, 4.5, 5.5 };
+ * double[] y = { 0.0, 0.5, 3.0, 12.0 };
  *
- * EmpiricalCarryOverConstraint co =
- *     EmpiricalCarryOverConstraint.fromObservations("carryOver", "kg/h", rate, x, y, 5.0);
+ * EmpiricalCarryOverConstraint co = EmpiricalCarryOverConstraint.fromObservations("carryOver", "kg/h", rate, x, y,
+ *     5.0);
  * co.setSourceReference("Suction drum LT-2103, May-Aug 2025");
  * separator.addCapacityConstraint(co);
  * </pre>
@@ -76,13 +76,11 @@ public class EmpiricalCarryOverConstraint extends CapacityConstraint {
    * @throws IllegalArgumentException if the arrays are null, empty, of unequal length, or if {@code xPoints} is not
    * strictly ascending
    */
-  public EmpiricalCarryOverConstraint(String name, String unit, DoubleSupplier driverSupplier,
-      double[] xPoints, double[] yPoints, double maxAllowable) {
+  public EmpiricalCarryOverConstraint(String name, String unit, DoubleSupplier driverSupplier, double[] xPoints,
+      double[] yPoints, double maxAllowable) {
     super(name, unit, ConstraintType.HARD);
-    if (xPoints == null || yPoints == null || xPoints.length == 0
-        || xPoints.length != yPoints.length) {
-      throw new IllegalArgumentException(
-          "xPoints and yPoints must be non-null, equal-length, non-empty arrays");
+    if (xPoints == null || yPoints == null || xPoints.length == 0 || xPoints.length != yPoints.length) {
+      throw new IllegalArgumentException("xPoints and yPoints must be non-null, equal-length, non-empty arrays");
     }
     for (int i = 1; i < xPoints.length; i++) {
       if (xPoints[i] <= xPoints[i - 1]) {
@@ -114,10 +112,9 @@ public class EmpiricalCarryOverConstraint extends CapacityConstraint {
    * @throws IllegalArgumentException if the arrays are null, empty, of unequal length, or if {@code xPoints} is not
    * strictly ascending
    */
-  public static EmpiricalCarryOverConstraint fromObservations(String name, String unit,
-      DoubleSupplier driverSupplier, double[] xPoints, double[] yPoints, double maxAllowable) {
-    return new EmpiricalCarryOverConstraint(name, unit, driverSupplier, xPoints, yPoints,
-        maxAllowable);
+  public static EmpiricalCarryOverConstraint fromObservations(String name, String unit, DoubleSupplier driverSupplier,
+      double[] xPoints, double[] yPoints, double maxAllowable) {
+    return new EmpiricalCarryOverConstraint(name, unit, driverSupplier, xPoints, yPoints, maxAllowable);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraint.java
+++ b/src/main/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraint.java
@@ -1,0 +1,173 @@
+package neqsim.process.equipment.capacity;
+
+import java.util.Arrays;
+import java.util.function.DoubleSupplier;
+
+/**
+ * Empirical, calibrated carry-over constraint for a separator or scrubber.
+ *
+ * <p>
+ * This constraint type addresses the situation where the binding limit on a piece of equipment is <em>not</em> set by
+ * an industry standard (K-factor, droplet cut size) but by an observed downstream consequence - most commonly liquid
+ * carry-over from a scrubber accumulating in the suction drum of a downstream compressor. Field measurements give
+ * pairs of (operating variable, observed carry-over rate), and a piecewise-linear map is fitted through the measured
+ * points.
+ * </p>
+ *
+ * <p>
+ * The constraint is built on the standard {@link CapacityConstraint} machinery, so it integrates with bottleneck
+ * detection, optimizer feasibility checks and capacity reporting. It declares
+ * {@link CapacityConstraint.ConstraintSource#PROCESS_EMPIRICAL} so consumers can distinguish a calibrated limit from
+ * a standards-driven one, and it is created as a {@link CapacityConstraint.ConstraintType#HARD} constraint so that
+ * exceeding the allowable carry-over registers in {@code isHardLimitExceeded()} and in the plant-wide
+ * {@code anyHardLimitExceeded} feasibility gate.
+ * </p>
+ *
+ * <p>
+ * <strong>Typical use:</strong>
+ * </p>
+ *
+ * <pre>
+ * // Operating variable: actual gas volume rate at the scrubber [Am3/s]
+ * DoubleSupplier rate = () -&gt; scrubber.getThermoSystem().getPhase(0).getFlowRate("m3/sec");
+ *
+ * // Calibration points (gas rate Am3/s, observed carry-over kg/h)
+ * double[] x = {2.0, 3.0, 4.5, 5.5};
+ * double[] y = {0.0, 0.5, 3.0, 12.0};
+ *
+ * EmpiricalCarryOverConstraint co =
+ *     EmpiricalCarryOverConstraint.fromObservations("carryOver", "kg/h", rate, x, y, 5.0);
+ * co.setSourceReference("Suction drum LT-2103, May-Aug 2025");
+ * separator.addCapacityConstraint(co);
+ * </pre>
+ *
+ * <p>
+ * Units are not interpreted by this class. The {@code unit} argument labels the carry-over axis, and the caller is
+ * responsible for supplying {@code yPoints} and {@code maxAllowable} in that same unit, and for supplying a driver in
+ * the unit implied by {@code xPoints}.
+ * </p>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public class EmpiricalCarryOverConstraint extends CapacityConstraint {
+  private static final long serialVersionUID = 1000L;
+
+  /** Ascending operating-variable values used for piecewise-linear interpolation. */
+  private final double[] xPoints;
+
+  /** Carry-over values observed at each calibration point. */
+  private final double[] yPoints;
+
+  /** Supplier for the operating variable that drives the correlation. */
+  private final transient DoubleSupplier driverSupplier;
+
+  /**
+   * Constructs a piecewise-linear empirical carry-over constraint.
+   *
+   * @param name display name for the constraint, for example "carryOver"
+   * @param unit unit of the carry-over value, for example "kg/h"; also the unit of {@code yPoints} and
+   *        {@code maxAllowable}
+   * @param driverSupplier supplier of the operating variable the correlation depends on (gas rate, pressure ratio,
+   *        and so on), expressed in the unit of {@code xPoints}
+   * @param xPoints strictly ascending operating-variable calibration points
+   * @param yPoints carry-over observed at each calibration point, same length as {@code xPoints}
+   * @param maxAllowable maximum allowable carry-over, in the same unit as {@code yPoints}, above which the
+   *        constraint is violated
+   * @throws IllegalArgumentException if the arrays are null, empty, of unequal length, or if {@code xPoints} is not
+   *         strictly ascending
+   */
+  public EmpiricalCarryOverConstraint(String name, String unit, DoubleSupplier driverSupplier,
+      double[] xPoints, double[] yPoints, double maxAllowable) {
+    super(name, unit, ConstraintType.HARD);
+    if (xPoints == null || yPoints == null || xPoints.length == 0
+        || xPoints.length != yPoints.length) {
+      throw new IllegalArgumentException(
+          "xPoints and yPoints must be non-null, equal-length, non-empty arrays");
+    }
+    for (int i = 1; i < xPoints.length; i++) {
+      if (xPoints[i] <= xPoints[i - 1]) {
+        throw new IllegalArgumentException("xPoints must be strictly ascending");
+      }
+    }
+    this.xPoints = Arrays.copyOf(xPoints, xPoints.length);
+    this.yPoints = Arrays.copyOf(yPoints, yPoints.length);
+    this.driverSupplier = driverSupplier;
+    setDesignValue(maxAllowable);
+    setMaxValue(maxAllowable);
+    setSeverity(ConstraintSeverity.HARD);
+    setSource(ConstraintSource.PROCESS_EMPIRICAL);
+    setDataSource("empirical_correlation");
+    setDescription("Empirical carry-over correlation calibrated against downstream measurements");
+    setValueSupplier(this::evaluateCorrelation);
+  }
+
+  /**
+   * Convenience factory that mirrors the constructor.
+   *
+   * @param name display name for the constraint
+   * @param unit unit of the carry-over value, also the unit of {@code yPoints} and {@code maxAllowable}
+   * @param driverSupplier supplier for the driving operating variable
+   * @param xPoints strictly ascending calibration x-values
+   * @param yPoints carry-over y-values at each x
+   * @param maxAllowable maximum allowable carry-over
+   * @return a configured constraint
+   * @throws IllegalArgumentException if the arrays are null, empty, of unequal length, or if {@code xPoints} is not
+   *         strictly ascending
+   */
+  public static EmpiricalCarryOverConstraint fromObservations(String name, String unit,
+      DoubleSupplier driverSupplier, double[] xPoints, double[] yPoints, double maxAllowable) {
+    return new EmpiricalCarryOverConstraint(name, unit, driverSupplier, xPoints, yPoints,
+        maxAllowable);
+  }
+
+  /**
+   * Evaluates the piecewise-linear correlation at the current driver value. A driver below the first calibration
+   * point returns the first observation; a driver above the last point is linearly extrapolated using the slope of
+   * the final segment, which keeps the correlation conservative outside the calibration envelope.
+   *
+   * @return interpolated or extrapolated carry-over value, in the unit of {@code yPoints}, or 0.0 if no driver
+   *         supplier is available
+   */
+  private double evaluateCorrelation() {
+    if (driverSupplier == null) {
+      return 0.0;
+    }
+    double x = driverSupplier.getAsDouble();
+    if (x <= xPoints[0]) {
+      return yPoints[0];
+    }
+    int last = xPoints.length - 1;
+    if (x >= xPoints[last]) {
+      if (last == 0) {
+        return yPoints[0];
+      }
+      double slope = (yPoints[last] - yPoints[last - 1]) / (xPoints[last] - xPoints[last - 1]);
+      return yPoints[last] + slope * (x - xPoints[last]);
+    }
+    int i = 1;
+    while (xPoints[i] < x) {
+      i++;
+    }
+    double t = (x - xPoints[i - 1]) / (xPoints[i] - xPoints[i - 1]);
+    return yPoints[i - 1] + t * (yPoints[i] - yPoints[i - 1]);
+  }
+
+  /**
+   * Returns a defensive copy of the calibration x-values.
+   *
+   * @return ascending operating-variable calibration points
+   */
+  public double[] getCalibrationX() {
+    return Arrays.copyOf(xPoints, xPoints.length);
+  }
+
+  /**
+   * Returns a defensive copy of the calibration y-values.
+   *
+   * @return carry-over observations at each calibration point
+   */
+  public double[] getCalibrationY() {
+    return Arrays.copyOf(yPoints, yPoints.length);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraint.java
+++ b/src/main/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraint.java
@@ -9,16 +9,15 @@ import java.util.function.DoubleSupplier;
  * <p>
  * This constraint type addresses the situation where the binding limit on a piece of equipment is <em>not</em> set by
  * an industry standard (K-factor, droplet cut size) but by an observed downstream consequence - most commonly liquid
- * carry-over from a scrubber accumulating in the suction drum of a downstream compressor. Field measurements give
- * pairs of (operating variable, observed carry-over rate), and a piecewise-linear map is fitted through the measured
- * points.
+ * carry-over from a scrubber accumulating in the suction drum of a downstream compressor. Field measurements give pairs
+ * of (operating variable, observed carry-over rate), and a piecewise-linear map is fitted through the measured points.
  * </p>
  *
  * <p>
  * The constraint is built on the standard {@link CapacityConstraint} machinery, so it integrates with bottleneck
  * detection, optimizer feasibility checks and capacity reporting. It declares
- * {@link CapacityConstraint.ConstraintSource#PROCESS_EMPIRICAL} so consumers can distinguish a calibrated limit from
- * a standards-driven one, and it is created as a {@link CapacityConstraint.ConstraintType#HARD} constraint so that
+ * {@link CapacityConstraint.ConstraintSource#PROCESS_EMPIRICAL} so consumers can distinguish a calibrated limit from a
+ * standards-driven one, and it is created as a {@link CapacityConstraint.ConstraintType#HARD} constraint so that
  * exceeding the allowable carry-over registers in {@code isHardLimitExceeded()} and in the plant-wide
  * {@code anyHardLimitExceeded} feasibility gate.
  * </p>
@@ -67,15 +66,15 @@ public class EmpiricalCarryOverConstraint extends CapacityConstraint {
    *
    * @param name display name for the constraint, for example "carryOver"
    * @param unit unit of the carry-over value, for example "kg/h"; also the unit of {@code yPoints} and
-   *        {@code maxAllowable}
-   * @param driverSupplier supplier of the operating variable the correlation depends on (gas rate, pressure ratio,
-   *        and so on), expressed in the unit of {@code xPoints}
+   * {@code maxAllowable}
+   * @param driverSupplier supplier of the operating variable the correlation depends on (gas rate, pressure ratio, and
+   * so on), expressed in the unit of {@code xPoints}
    * @param xPoints strictly ascending operating-variable calibration points
    * @param yPoints carry-over observed at each calibration point, same length as {@code xPoints}
-   * @param maxAllowable maximum allowable carry-over, in the same unit as {@code yPoints}, above which the
-   *        constraint is violated
+   * @param maxAllowable maximum allowable carry-over, in the same unit as {@code yPoints}, above which the constraint
+   * is violated
    * @throws IllegalArgumentException if the arrays are null, empty, of unequal length, or if {@code xPoints} is not
-   *         strictly ascending
+   * strictly ascending
    */
   public EmpiricalCarryOverConstraint(String name, String unit, DoubleSupplier driverSupplier,
       double[] xPoints, double[] yPoints, double maxAllowable) {
@@ -113,7 +112,7 @@ public class EmpiricalCarryOverConstraint extends CapacityConstraint {
    * @param maxAllowable maximum allowable carry-over
    * @return a configured constraint
    * @throws IllegalArgumentException if the arrays are null, empty, of unequal length, or if {@code xPoints} is not
-   *         strictly ascending
+   * strictly ascending
    */
   public static EmpiricalCarryOverConstraint fromObservations(String name, String unit,
       DoubleSupplier driverSupplier, double[] xPoints, double[] yPoints, double maxAllowable) {
@@ -122,12 +121,12 @@ public class EmpiricalCarryOverConstraint extends CapacityConstraint {
   }
 
   /**
-   * Evaluates the piecewise-linear correlation at the current driver value. A driver below the first calibration
-   * point returns the first observation; a driver above the last point is linearly extrapolated using the slope of
-   * the final segment, which keeps the correlation conservative outside the calibration envelope.
+   * Evaluates the piecewise-linear correlation at the current driver value. A driver below the first calibration point
+   * returns the first observation; a driver above the last point is linearly extrapolated using the slope of the final
+   * segment, which keeps the correlation conservative outside the calibration envelope.
    *
-   * @return interpolated or extrapolated carry-over value, in the unit of {@code yPoints}, or 0.0 if no driver
-   *         supplier is available
+   * @return interpolated or extrapolated carry-over value, in the unit of {@code yPoints}, or 0.0 if no driver supplier
+   * is available
    */
   private double evaluateCorrelation() {
     if (driverSupplier == null) {

--- a/src/main/java/neqsim/process/equipment/separator/Separator.java
+++ b/src/main/java/neqsim/process/equipment/separator/Separator.java
@@ -67,8 +67,9 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * <li><b>Design gas load factor (K-factor)</b> — {@link #setDesignGasLoadFactor(double)} [m/s]. Default: 0.11 m/s. This
  * is the design K-factor from the Souders-Brown equation. Typical range: 0.07–0.15 m/s for horizontal separators,
  * 0.04–0.10 m/s for vertical scrubbers.</li>
- * <li><b>Design liquid level fraction</b> (vertical only) — {@link #setDesignLiquidLevelFraction(double)}. Default:
- * 0.8. The fraction of cross-sectional area occupied by liquid at design conditions.</li>
+ * <li><b>Design liquid level fraction</b> (horizontal only) — {@link #setDesignLiquidLevelFraction(double)}. Default:
+ * 0.8. The fraction of cross-sectional area occupied by liquid at design conditions. A vertical separator uses the
+ * full cross-section for gas flow, so this value does not affect it.</li>
  * </ol>
  *
  * <p>
@@ -1678,7 +1679,7 @@ public class Separator extends ProcessEquipmentBaseClass
    * <li>{@link #setSeparatorLength(double)} — separator length [m]</li>
    * <li>{@link #setDesignGasLoadFactor(double)} — design K-factor [m/s]</li>
    * <li>{@link #setOrientation(String)} — "horizontal" or "vertical"</li>
-   * <li>{@link #setDesignLiquidLevelFraction(double)} — for vertical separators</li>
+   * <li>{@link #setDesignLiquidLevelFraction(double)} — for horizontal separators</li>
    * </ul>
    *
    * @return capacity utilization fraction (0.0 to 1.0+ if overloaded), or 0.0 if liquid-only (no gas separation
@@ -2731,7 +2732,13 @@ public class Separator extends ProcessEquipmentBaseClass
   /**
    * Getter for the field <code>designLiquidLevelFraction</code>.
    *
-   * @return the designGasLevelFraction
+   * <p>
+   * The fraction of the vessel cross-sectional area occupied by liquid at design conditions. It derates the gas
+   * area for a horizontal separator; a vertical separator uses the full cross-section for gas flow and is therefore
+   * unaffected.
+   * </p>
+   *
+   * @return the design liquid level fraction (0.0 to 1.0)
    */
   public double getDesignLiquidLevelFraction() {
     return designLiquidLevelFraction;
@@ -2740,7 +2747,13 @@ public class Separator extends ProcessEquipmentBaseClass
   /**
    * Setter for the field <code>designLiquidLevelFraction</code>.
    *
-   * @param designLiquidLevelFraction a double
+   * <p>
+   * Only affects horizontal separators, where the gas area is derated by
+   * {@code (1 - designLiquidLevelFraction)}. A vertical separator uses the full cross-section for gas flow.
+   * </p>
+   *
+   * @param designLiquidLevelFraction fraction of the cross-sectional area occupied by liquid at design conditions,
+   *        in the range 0.0 to 1.0
    */
   public void setDesignLiquidLevelFraction(double designLiquidLevelFraction) {
     this.designLiquidLevelFraction = designLiquidLevelFraction;

--- a/src/main/java/neqsim/process/equipment/separator/Separator.java
+++ b/src/main/java/neqsim/process/equipment/separator/Separator.java
@@ -68,8 +68,8 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
  * is the design K-factor from the Souders-Brown equation. Typical range: 0.07–0.15 m/s for horizontal separators,
  * 0.04–0.10 m/s for vertical scrubbers.</li>
  * <li><b>Design liquid level fraction</b> (horizontal only) — {@link #setDesignLiquidLevelFraction(double)}. Default:
- * 0.8. The fraction of cross-sectional area occupied by liquid at design conditions. A vertical separator uses the
- * full cross-section for gas flow, so this value does not affect it.</li>
+ * 0.8. The fraction of cross-sectional area occupied by liquid at design conditions. A vertical separator uses the full
+ * cross-section for gas flow, so this value does not affect it.</li>
  * </ol>
  *
  * <p>
@@ -2733,8 +2733,8 @@ public class Separator extends ProcessEquipmentBaseClass
    * Getter for the field <code>designLiquidLevelFraction</code>.
    *
    * <p>
-   * The fraction of the vessel cross-sectional area occupied by liquid at design conditions. It derates the gas
-   * area for a horizontal separator; a vertical separator uses the full cross-section for gas flow and is therefore
+   * The fraction of the vessel cross-sectional area occupied by liquid at design conditions. It derates the gas area
+   * for a horizontal separator; a vertical separator uses the full cross-section for gas flow and is therefore
    * unaffected.
    * </p>
    *
@@ -2748,12 +2748,12 @@ public class Separator extends ProcessEquipmentBaseClass
    * Setter for the field <code>designLiquidLevelFraction</code>.
    *
    * <p>
-   * Only affects horizontal separators, where the gas area is derated by
-   * {@code (1 - designLiquidLevelFraction)}. A vertical separator uses the full cross-section for gas flow.
+   * Only affects horizontal separators, where the gas area is derated by {@code (1 - designLiquidLevelFraction)}. A
+   * vertical separator uses the full cross-section for gas flow.
    * </p>
    *
-   * @param designLiquidLevelFraction fraction of the cross-sectional area occupied by liquid at design conditions,
-   *        in the range 0.0 to 1.0
+   * @param designLiquidLevelFraction fraction of the cross-sectional area occupied by liquid at design conditions, in
+   * the range 0.0 to 1.0
    */
   public void setDesignLiquidLevelFraction(double designLiquidLevelFraction) {
     this.designLiquidLevelFraction = designLiquidLevelFraction;

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -8939,6 +8939,12 @@ public class ProcessSystem extends SimulationBaseClass {
             if (c.getDataSource() != null) {
               co.addProperty("dataSource", c.getDataSource());
             }
+            if (c.getSource() != null) {
+              co.addProperty("source", c.getSource().name());
+            }
+            if (c.getSourceReference() != null && !c.getSourceReference().trim().isEmpty()) {
+              co.addProperty("sourceReference", c.getSourceReference());
+            }
             constraintsArr.add(co);
           }
         } catch (Exception e) {

--- a/src/test/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraintTest.java
+++ b/src/test/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraintTest.java
@@ -30,10 +30,10 @@ public class EmpiricalCarryOverConstraintTest {
   private static final double EXACT = 1.0e-12;
 
   /** Calibration operating-variable points [Am3/s]. */
-  private static final double[] X_POINTS = {2.0, 3.0, 4.5, 5.5};
+  private static final double[] X_POINTS = { 2.0, 3.0, 4.5, 5.5 };
 
   /** Calibration carry-over observations [kg/h]. */
-  private static final double[] Y_POINTS = {0.0, 0.5, 3.0, 12.0};
+  private static final double[] Y_POINTS = { 0.0, 0.5, 3.0, 12.0 };
 
   /** Maximum allowable carry-over [kg/h]. */
   private static final double MAX_ALLOWABLE = 5.0;
@@ -76,8 +76,7 @@ public class EmpiricalCarryOverConstraintTest {
 
     for (int i = 0; i < X_POINTS.length; i++) {
       driver[0] = X_POINTS[i];
-      assertEquals(Y_POINTS[i], constraint.getCurrentValue(), EXACT,
-          "mismatch at calibration point x=" + X_POINTS[i]);
+      assertEquals(Y_POINTS[i], constraint.getCurrentValue(), EXACT, "mismatch at calibration point x=" + X_POINTS[i]);
     }
   }
 
@@ -128,8 +127,7 @@ public class EmpiricalCarryOverConstraintTest {
 
     driver[0] = 6.0;
     assertTrue(constraint.isViolated(), "16.5 kg/h exceeds the 5.0 kg/h limit");
-    assertTrue(constraint.isHardLimitExceeded(),
-        "an empirical carry-over limit must be a HARD constraint to bind");
+    assertTrue(constraint.isHardLimitExceeded(), "an empirical carry-over limit must be a HARD constraint to bind");
   }
 
   /** The constraint declares empirical provenance and hard severity. */
@@ -161,8 +159,8 @@ public class EmpiricalCarryOverConstraintTest {
   /** Calibration arrays are defensively copied on both input and output. */
   @Test
   public void calibrationArraysAreDefensivelyCopied() {
-    double[] mutableX = {2.0, 3.0, 4.5, 5.5};
-    double[] mutableY = {0.0, 0.5, 3.0, 12.0};
+    double[] mutableX = { 2.0, 3.0, 4.5, 5.5 };
+    double[] mutableY = { 0.0, 0.5, 3.0, 12.0 };
     EmpiricalCarryOverConstraint constraint = new EmpiricalCarryOverConstraint("carryOver", "kg/h",
         new DoubleSupplier() {
           @Override
@@ -204,16 +202,16 @@ public class EmpiricalCarryOverConstraintTest {
 
     assertThrows(IllegalArgumentException.class,
         () -> EmpiricalCarryOverConstraint.fromObservations("co", "kg/h", supplier,
-            new double[] {2.0, 3.0}, new double[] {0.0, 0.5, 3.0}, MAX_ALLOWABLE));
+            new double[] { 2.0, 3.0 }, new double[] { 0.0, 0.5, 3.0 }, MAX_ALLOWABLE));
 
     // Not strictly ascending.
     assertThrows(IllegalArgumentException.class,
         () -> EmpiricalCarryOverConstraint.fromObservations("co", "kg/h", supplier,
-            new double[] {2.0, 3.0, 3.0}, new double[] {0.0, 0.5, 3.0}, MAX_ALLOWABLE));
+            new double[] { 2.0, 3.0, 3.0 }, new double[] { 0.0, 0.5, 3.0 }, MAX_ALLOWABLE));
 
     assertThrows(IllegalArgumentException.class,
         () -> EmpiricalCarryOverConstraint.fromObservations("co", "kg/h", supplier,
-            new double[] {4.0, 3.0}, new double[] {0.0, 0.5}, MAX_ALLOWABLE));
+            new double[] { 4.0, 3.0 }, new double[] { 0.0, 0.5 }, MAX_ALLOWABLE));
   }
 
   /** A single calibration point degenerates to a constant rather than dividing by zero. */
@@ -225,7 +223,7 @@ public class EmpiricalCarryOverConstraintTest {
           public double getAsDouble() {
             return driver[0];
           }
-        }, new double[] {3.0}, new double[] {1.25}, MAX_ALLOWABLE);
+        }, new double[] { 3.0 }, new double[] { 1.25 }, MAX_ALLOWABLE);
 
     driver[0] = 1.0;
     assertEquals(1.25, constraint.getCurrentValue(), EXACT);

--- a/src/test/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraintTest.java
+++ b/src/test/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraintTest.java
@@ -53,8 +53,8 @@ public class EmpiricalCarryOverConstraintTest {
         return driver[0];
       }
     };
-    return EmpiricalCarryOverConstraint.fromObservations("carryOver", "kg/h", supplier, X_POINTS,
-        Y_POINTS, MAX_ALLOWABLE);
+    return EmpiricalCarryOverConstraint.fromObservations("carryOver", "kg/h", supplier, X_POINTS, Y_POINTS,
+        MAX_ALLOWABLE);
   }
 
   /** A driver at or below the first calibration point returns the first observation. */
@@ -191,27 +191,24 @@ public class EmpiricalCarryOverConstraintTest {
       }
     };
 
-    assertThrows(IllegalArgumentException.class, () -> EmpiricalCarryOverConstraint
-        .fromObservations("co", "kg/h", supplier, null, Y_POINTS, MAX_ALLOWABLE));
-
-    assertThrows(IllegalArgumentException.class, () -> EmpiricalCarryOverConstraint
-        .fromObservations("co", "kg/h", supplier, X_POINTS, null, MAX_ALLOWABLE));
-
-    assertThrows(IllegalArgumentException.class, () -> EmpiricalCarryOverConstraint
-        .fromObservations("co", "kg/h", supplier, new double[0], new double[0], MAX_ALLOWABLE));
+    assertThrows(IllegalArgumentException.class,
+        () -> EmpiricalCarryOverConstraint.fromObservations("co", "kg/h", supplier, null, Y_POINTS, MAX_ALLOWABLE));
 
     assertThrows(IllegalArgumentException.class,
-        () -> EmpiricalCarryOverConstraint.fromObservations("co", "kg/h", supplier,
-            new double[] { 2.0, 3.0 }, new double[] { 0.0, 0.5, 3.0 }, MAX_ALLOWABLE));
+        () -> EmpiricalCarryOverConstraint.fromObservations("co", "kg/h", supplier, X_POINTS, null, MAX_ALLOWABLE));
+
+    assertThrows(IllegalArgumentException.class, () -> EmpiricalCarryOverConstraint.fromObservations("co", "kg/h",
+        supplier, new double[0], new double[0], MAX_ALLOWABLE));
+
+    assertThrows(IllegalArgumentException.class, () -> EmpiricalCarryOverConstraint.fromObservations("co", "kg/h",
+        supplier, new double[] { 2.0, 3.0 }, new double[] { 0.0, 0.5, 3.0 }, MAX_ALLOWABLE));
 
     // Not strictly ascending.
-    assertThrows(IllegalArgumentException.class,
-        () -> EmpiricalCarryOverConstraint.fromObservations("co", "kg/h", supplier,
-            new double[] { 2.0, 3.0, 3.0 }, new double[] { 0.0, 0.5, 3.0 }, MAX_ALLOWABLE));
+    assertThrows(IllegalArgumentException.class, () -> EmpiricalCarryOverConstraint.fromObservations("co", "kg/h",
+        supplier, new double[] { 2.0, 3.0, 3.0 }, new double[] { 0.0, 0.5, 3.0 }, MAX_ALLOWABLE));
 
-    assertThrows(IllegalArgumentException.class,
-        () -> EmpiricalCarryOverConstraint.fromObservations("co", "kg/h", supplier,
-            new double[] { 4.0, 3.0 }, new double[] { 0.0, 0.5 }, MAX_ALLOWABLE));
+    assertThrows(IllegalArgumentException.class, () -> EmpiricalCarryOverConstraint.fromObservations("co", "kg/h",
+        supplier, new double[] { 4.0, 3.0 }, new double[] { 0.0, 0.5 }, MAX_ALLOWABLE));
   }
 
   /** A single calibration point degenerates to a constant rather than dividing by zero. */

--- a/src/test/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraintTest.java
+++ b/src/test/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraintTest.java
@@ -16,8 +16,8 @@ import neqsim.process.equipment.separator.Separator;
  * Unit tests for {@link EmpiricalCarryOverConstraint}.
  *
  * <p>
- * The calibration used throughout is (gas rate [Am3/s], carry-over [kg/h]) = (2.0, 0.0), (3.0, 0.5), (4.5, 3.0),
- * (5.5, 12.0) with a maximum allowable carry-over of 5.0 kg/h. Expected values below are computed by hand from the
+ * The calibration used throughout is (gas rate [Am3/s], carry-over [kg/h]) = (2.0, 0.0), (3.0, 0.5), (4.5, 3.0), (5.5,
+ * 12.0) with a maximum allowable carry-over of 5.0 kg/h. Expected values below are computed by hand from the
  * piecewise-linear definition so that a change in the interpolation logic is detected rather than accommodated.
  * </p>
  *
@@ -119,8 +119,8 @@ public class EmpiricalCarryOverConstraintTest {
   }
 
   /**
-   * Exceeding the allowable carry-over registers both as a violation and as a hard-limit exceedance, so the
-   * constraint participates in the plant-wide feasibility gate.
+   * Exceeding the allowable carry-over registers both as a violation and as a hard-limit exceedance, so the constraint
+   * participates in the plant-wide feasibility gate.
    */
   @Test
   public void exceedingAllowableCarryOverTripsHardLimit() {

--- a/src/test/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraintTest.java
+++ b/src/test/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraintTest.java
@@ -1,0 +1,250 @@
+package neqsim.process.equipment.capacity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.function.DoubleSupplier;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintSeverity;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintSource;
+import neqsim.process.equipment.capacity.CapacityConstraint.ConstraintType;
+import neqsim.process.equipment.separator.Separator;
+
+/**
+ * Unit tests for {@link EmpiricalCarryOverConstraint}.
+ *
+ * <p>
+ * The calibration used throughout is (gas rate [Am3/s], carry-over [kg/h]) = (2.0, 0.0), (3.0, 0.5), (4.5, 3.0),
+ * (5.5, 12.0) with a maximum allowable carry-over of 5.0 kg/h. Expected values below are computed by hand from the
+ * piecewise-linear definition so that a change in the interpolation logic is detected rather than accommodated.
+ * </p>
+ *
+ * @author NeqSim Development Team
+ * @version 1.0
+ */
+public class EmpiricalCarryOverConstraintTest {
+
+  /** Tolerance for exactly representable binary floating point results. */
+  private static final double EXACT = 1.0e-12;
+
+  /** Calibration operating-variable points [Am3/s]. */
+  private static final double[] X_POINTS = {2.0, 3.0, 4.5, 5.5};
+
+  /** Calibration carry-over observations [kg/h]. */
+  private static final double[] Y_POINTS = {0.0, 0.5, 3.0, 12.0};
+
+  /** Maximum allowable carry-over [kg/h]. */
+  private static final double MAX_ALLOWABLE = 5.0;
+
+  /** Mutable driver value written by each test and read through the supplier. */
+  private final double[] driver = new double[1];
+
+  /**
+   * Builds a constraint whose driver reads the mutable {@link #driver} holder.
+   *
+   * @return a configured constraint
+   */
+  private EmpiricalCarryOverConstraint newConstraint() {
+    DoubleSupplier supplier = new DoubleSupplier() {
+      @Override
+      public double getAsDouble() {
+        return driver[0];
+      }
+    };
+    return EmpiricalCarryOverConstraint.fromObservations("carryOver", "kg/h", supplier, X_POINTS,
+        Y_POINTS, MAX_ALLOWABLE);
+  }
+
+  /** A driver at or below the first calibration point returns the first observation. */
+  @Test
+  public void belowCalibrationRangeClampsToFirstObservation() {
+    EmpiricalCarryOverConstraint constraint = newConstraint();
+
+    driver[0] = 1.0;
+    assertEquals(0.0, constraint.getCurrentValue(), EXACT);
+
+    driver[0] = 2.0;
+    assertEquals(0.0, constraint.getCurrentValue(), EXACT);
+  }
+
+  /** The correlation reproduces the observations exactly at each calibration point. */
+  @Test
+  public void returnsObservedValueAtEachCalibrationPoint() {
+    EmpiricalCarryOverConstraint constraint = newConstraint();
+
+    for (int i = 0; i < X_POINTS.length; i++) {
+      driver[0] = X_POINTS[i];
+      assertEquals(Y_POINTS[i], constraint.getCurrentValue(), EXACT,
+          "mismatch at calibration point x=" + X_POINTS[i]);
+    }
+  }
+
+  /** Between two calibration points the correlation is linear. */
+  @Test
+  public void interpolatesLinearlyBetweenCalibrationPoints() {
+    EmpiricalCarryOverConstraint constraint = newConstraint();
+
+    // Midpoint of the segment (3.0, 0.5) - (4.5, 3.0): 0.5 + 0.5 * (3.0 - 0.5) = 1.75
+    driver[0] = 3.75;
+    assertEquals(1.75, constraint.getCurrentValue(), EXACT);
+
+    // Quarter point of the segment (2.0, 0.0) - (3.0, 0.5): 0.0 + 0.25 * 0.5 = 0.125
+    driver[0] = 2.25;
+    assertEquals(0.125, constraint.getCurrentValue(), EXACT);
+  }
+
+  /** Above the calibration envelope the last segment slope is extrapolated. */
+  @Test
+  public void extrapolatesAboveCalibrationRangeUsingLastSegmentSlope() {
+    EmpiricalCarryOverConstraint constraint = newConstraint();
+
+    // Slope of last segment = (12.0 - 3.0) / (5.5 - 4.5) = 9.0 kg/h per Am3/s.
+    // At 6.0: 12.0 + 9.0 * 0.5 = 16.5
+    driver[0] = 6.0;
+    assertEquals(16.5, constraint.getCurrentValue(), EXACT);
+  }
+
+  /** Utilization is the correlated carry-over divided by the maximum allowable. */
+  @Test
+  public void utilizationIsRelativeToMaximumAllowable() {
+    EmpiricalCarryOverConstraint constraint = newConstraint();
+
+    driver[0] = 3.75;
+    assertEquals(1.75 / MAX_ALLOWABLE, constraint.getUtilization(), 1.0e-12);
+    assertEquals(35.0, constraint.getUtilizationPercent(), 1.0e-9);
+    assertFalse(constraint.isViolated(), "1.75 kg/h is below the 5.0 kg/h limit");
+    assertFalse(constraint.isHardLimitExceeded());
+  }
+
+  /**
+   * Exceeding the allowable carry-over registers both as a violation and as a hard-limit exceedance, so the
+   * constraint participates in the plant-wide feasibility gate.
+   */
+  @Test
+  public void exceedingAllowableCarryOverTripsHardLimit() {
+    EmpiricalCarryOverConstraint constraint = newConstraint();
+
+    driver[0] = 6.0;
+    assertTrue(constraint.isViolated(), "16.5 kg/h exceeds the 5.0 kg/h limit");
+    assertTrue(constraint.isHardLimitExceeded(),
+        "an empirical carry-over limit must be a HARD constraint to bind");
+  }
+
+  /** The constraint declares empirical provenance and hard severity. */
+  @Test
+  public void declaresEmpiricalProvenanceAndHardSeverity() {
+    EmpiricalCarryOverConstraint constraint = newConstraint();
+
+    assertEquals(ConstraintSource.PROCESS_EMPIRICAL, constraint.getSource());
+    assertEquals(ConstraintSeverity.HARD, constraint.getSeverity());
+    assertEquals(ConstraintType.HARD, constraint.getType());
+    assertEquals("kg/h", constraint.getUnit());
+    assertEquals("carryOver", constraint.getName());
+  }
+
+  /** The source reference can be attached without disturbing the declared source. */
+  @Test
+  public void sourceReferenceIsRecorded() {
+    EmpiricalCarryOverConstraint constraint = newConstraint();
+
+    assertEquals("", constraint.getSourceReference());
+    assertSame(constraint, constraint.setSourceReference("Suction drum LT-2103, May-Aug 2025"));
+    assertEquals("Suction drum LT-2103, May-Aug 2025", constraint.getSourceReference());
+    assertEquals(ConstraintSource.PROCESS_EMPIRICAL, constraint.getSource());
+
+    constraint.setSourceReference(null);
+    assertEquals("", constraint.getSourceReference());
+  }
+
+  /** Calibration arrays are defensively copied on both input and output. */
+  @Test
+  public void calibrationArraysAreDefensivelyCopied() {
+    double[] mutableX = {2.0, 3.0, 4.5, 5.5};
+    double[] mutableY = {0.0, 0.5, 3.0, 12.0};
+    EmpiricalCarryOverConstraint constraint = new EmpiricalCarryOverConstraint("carryOver", "kg/h",
+        new DoubleSupplier() {
+          @Override
+          public double getAsDouble() {
+            return driver[0];
+          }
+        }, mutableX, mutableY, MAX_ALLOWABLE);
+
+    // Mutating the caller's arrays must not change the fitted correlation.
+    mutableY[3] = 999.0;
+    driver[0] = 5.5;
+    assertEquals(12.0, constraint.getCurrentValue(), EXACT);
+
+    // Mutating the returned arrays must not change it either.
+    double[] returned = constraint.getCalibrationY();
+    returned[3] = -1.0;
+    assertEquals(12.0, constraint.getCalibrationY()[3], EXACT);
+    assertEquals(2.0, constraint.getCalibrationX()[0], EXACT);
+  }
+
+  /** Malformed calibration data is rejected rather than silently producing a wrong correlation. */
+  @Test
+  public void rejectsInvalidCalibrationData() {
+    DoubleSupplier supplier = new DoubleSupplier() {
+      @Override
+      public double getAsDouble() {
+        return 0.0;
+      }
+    };
+
+    assertThrows(IllegalArgumentException.class, () -> EmpiricalCarryOverConstraint
+        .fromObservations("co", "kg/h", supplier, null, Y_POINTS, MAX_ALLOWABLE));
+
+    assertThrows(IllegalArgumentException.class, () -> EmpiricalCarryOverConstraint
+        .fromObservations("co", "kg/h", supplier, X_POINTS, null, MAX_ALLOWABLE));
+
+    assertThrows(IllegalArgumentException.class, () -> EmpiricalCarryOverConstraint
+        .fromObservations("co", "kg/h", supplier, new double[0], new double[0], MAX_ALLOWABLE));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> EmpiricalCarryOverConstraint.fromObservations("co", "kg/h", supplier,
+            new double[] {2.0, 3.0}, new double[] {0.0, 0.5, 3.0}, MAX_ALLOWABLE));
+
+    // Not strictly ascending.
+    assertThrows(IllegalArgumentException.class,
+        () -> EmpiricalCarryOverConstraint.fromObservations("co", "kg/h", supplier,
+            new double[] {2.0, 3.0, 3.0}, new double[] {0.0, 0.5, 3.0}, MAX_ALLOWABLE));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> EmpiricalCarryOverConstraint.fromObservations("co", "kg/h", supplier,
+            new double[] {4.0, 3.0}, new double[] {0.0, 0.5}, MAX_ALLOWABLE));
+  }
+
+  /** A single calibration point degenerates to a constant rather than dividing by zero. */
+  @Test
+  public void singleCalibrationPointBehavesAsConstant() {
+    EmpiricalCarryOverConstraint constraint = EmpiricalCarryOverConstraint.fromObservations("co",
+        "kg/h", new DoubleSupplier() {
+          @Override
+          public double getAsDouble() {
+            return driver[0];
+          }
+        }, new double[] {3.0}, new double[] {1.25}, MAX_ALLOWABLE);
+
+    driver[0] = 1.0;
+    assertEquals(1.25, constraint.getCurrentValue(), EXACT);
+
+    driver[0] = 3.0;
+    assertEquals(1.25, constraint.getCurrentValue(), EXACT);
+
+    driver[0] = 50.0;
+    assertEquals(1.25, constraint.getCurrentValue(), EXACT);
+  }
+
+  /** The constraint registers on a separator like any other capacity constraint. */
+  @Test
+  public void registersOnSeparatorAsCapacityConstraint() {
+    Separator separator = new Separator("Kollsnes scrubber");
+    EmpiricalCarryOverConstraint constraint = newConstraint();
+    separator.addCapacityConstraint(constraint);
+
+    assertTrue(separator.getCapacityConstraints().containsKey("carryOver"));
+    assertSame(constraint, separator.getCapacityConstraints().get("carryOver"));
+  }
+}

--- a/src/test/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraintTest.java
+++ b/src/test/java/neqsim/process/equipment/capacity/EmpiricalCarryOverConstraintTest.java
@@ -214,8 +214,8 @@ public class EmpiricalCarryOverConstraintTest {
   /** A single calibration point degenerates to a constant rather than dividing by zero. */
   @Test
   public void singleCalibrationPointBehavesAsConstant() {
-    EmpiricalCarryOverConstraint constraint = EmpiricalCarryOverConstraint.fromObservations("co",
-        "kg/h", new DoubleSupplier() {
+    EmpiricalCarryOverConstraint constraint = EmpiricalCarryOverConstraint.fromObservations("co", "kg/h",
+        new DoubleSupplier() {
           @Override
           public double getAsDouble() {
             return driver[0];


### PR DESCRIPTION
## What

Completes the **two-axis capacity-constraint model**. The severity axis
(`ConstraintSeverity` — *how* a violation is handled) is already on master. This
adds the provenance axis (`ConstraintSource` — *what authority backs the limit*),
plus the first constraint type that depends on it.

A vendor surge limit and a company K-factor may both be `HARD`, but they are not
renegotiable on the same terms. Recording the source lets a capacity report state
both *what limits production today* and *what would limit it if conformity were
enforced*.

## Changes

### `CapacityConstraint`
- New `ConstraintSource` enum: `CONFORMITY_STANDARD`, `USER_RULE`,
  `PROCESS_EMPIRICAL`, `VENDOR_DATASHEET`, `AUTO_SIZE`, `DEFAULT`.
- `setSource(source)`, `setSource(source, reference)`,
  `setSourceReference(reference)`, `getSource()`, `getSourceReference()`.
- All additive; default is `DEFAULT`, so existing constraints are unaffected.

### `EmpiricalCarryOverConstraint` (new)
Packages the common field situation where the binding limit is **not** a
standard's K-factor but an observed downstream consequence — liquid carry-over
from the last scrubber accumulating in a downstream compressor suction drum. It
is a piecewise-linear correlation calibrated against measured points, and an
ordinary `CapacityConstraint`, so it participates in bottleneck detection, the
utilization snapshot, and the optimiser.

### `ProcessSystem`
`getUtilizationSnapshot()` now emits `source` and `sourceReference` per
constraint alongside the existing `dataSource`, so the new axis is visible to
agents and reports rather than being write-only.

### `Separator` — JavaDoc only, no behaviour change
`designLiquidLevelFraction` was documented **twice** as "vertical only". The code
derates the gas area by `(1 - fraction)` only for **horizontal** separators
(lines 1437, 1655, 1926, 2097, 2146); a vertical separator uses the full
cross-section. Both statements corrected, plus the getter, which documented
`@return the designGasLevelFraction` — the wrong field.

### Docs
New sections in `docs/process/equipment/separators.md`: constraint provenance,
empirical carry-over constraints, and choosing which layer binds.

## Correctness fixes made while migrating

These are worth flagging because they change behaviour relative to the draft this
was migrated from:

1. **`ConstraintType.HARD`, not `SOFT`.** `isHardLimitExceeded()` returns `false`
   unless `type == ConstraintType.HARD`. The draft constructed the constraint as
   `SOFT` while setting severity `HARD` and documenting it as "hard, binding", so
   a carry-over blow-past would never have raised the plant-wide
   `anyHardLimitExceeded` feasibility gate.
2. **Single-calibration-point guard.** With one point, the extrapolation branch
   indexed `yPoints[-1]`. It now degenerates to a constant.
3. **Unit contract stated explicitly.** The class does not interpret units; the
   JavaDoc states that the driver must match `xPoints`, and that `yPoints` and
   `maxAllowable` share the constraint unit.

## Tests

`EmpiricalCarryOverConstraintTest` — hand-computed expected values (no
"looks reasonable" assertions): clamping below range, exact reproduction at every
knot, linear interpolation, last-segment extrapolation, utilization, hard-limit
tripping, provenance defaults, defensive copying on input and output, rejection
of null/empty/mismatched/non-ascending arrays, single-point degeneration, and
registration on a `Separator`.

## For the reviewer

- **`ConstraintSource` vs the existing `dataSource`.** These overlap and I want a
  second opinion on the split. My reading: `dataSource` is a free-text label for
  *which part of the model* supplied the number (`"equipment"`,
  `"mechanicalDesign"`, `"installed_capacity_table"`) and is already consumed in
  ~40 places (JSON snapshot, `PlantConstraintRegistry.provenance(...)`,
  debottleneck CSV, the `"not_set"` checks). `ConstraintSource` classifies the
  *authority* behind the number. I kept them independent and documented the
  distinction rather than overloading `dataSource`, so nothing downstream changes
  meaning. Happy to merge them if you prefer one field.
- **Spotless.** I have no JDK on this machine (JRE only), so I could not run
  `spotless:apply` locally. If CI flags formatting I will apply its output
  verbatim.
