### PR TITLE
[AI-Assisted] feat(kinetics): add piecewise H2S exposure trajectory

### DIFF
--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -64,6 +64,37 @@ bounded from zero to one, and avoids timestep error. It reports total-sulfide lo
 assign products or consume oxygen, because the source correlation does not supply a complete
 product stoichiometry for that purpose.
 
+## Piecewise exposure trajectory
+
+`AqueousHydrogenSulfideOxidationTrajectory.advance(...)` propagates the same correlation through
+a non-empty ordered list of constant-state segments. For segment `i`, it computes
+
+$
+E_i = k_i[\mathrm{O_2}]_i\Delta t_i, \qquad
+[\mathrm{H_2S}]_{T,n} = [\mathrm{H_2S}]_{T,0}
+\exp\left(-\sum_{i=1}^{n}E_i\right).
+$
+
+This analytical composition of exponentials has no numerical timestep error. Segment splitting at
+an unchanged state therefore leaves the result invariant. The implementation preserves source
+order and reports each segment's second-order rate, pseudo-first-order rate, individual exposure,
+and cumulative exposure for audit. Zero-duration segments are accepted as exact identity steps.
+
+Initial total sulfide must be within the source experiment interval of 20–30 micromol/kg water.
+Every segment independently applies the temperature, pH, ionic-strength, and caller-supplied
+air-saturated-O2 gates above. A pressure value is deliberately not part of the segment contract.
+
+The reported `0.18` scatter in `log10(k)` is propagated as one common multiplicative correlation
+envelope across the trajectory. The result reports nominal, lower-rate, and upper-rate cumulative
+exposures and final molalities. Treating this as one systematic envelope avoids implying that
+successive segments contain independent experimental errors. It remains fit scatter rather than a
+complete uncertainty model.
+
+The trajectory reports total-sulfide inventory closure as initial minus final minus reacted
+molality. It retains the same constant-oxygen and unidentified-product boundary as the single-state
+screen. Within this first-order screening model, only cumulative exposure controls the final
+fraction; the ordered diagnostics do not introduce path-dependent chemistry.
+
 ## Scientific stop boundary
 
 This capability does not:

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -17,6 +17,16 @@ JAVA_TEST = (
     / "src/test/java/neqsim/process/equipment/reactor/"
     / "AqueousHydrogenSulfideOxidationKineticsTest.java"
 )
+TRAJECTORY = (
+    ROOT
+    / "src/main/java/neqsim/process/equipment/reactor/"
+    / "AqueousHydrogenSulfideOxidationTrajectory.java"
+)
+TRAJECTORY_TEST = (
+    ROOT
+    / "src/test/java/neqsim/process/equipment/reactor/"
+    / "AqueousHydrogenSulfideOxidationTrajectoryTest.java"
+)
 
 
 class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
@@ -28,6 +38,8 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
         cls.package_index = PACKAGE_INDEX.read_text(encoding="utf-8")
         cls.implementation = IMPLEMENTATION.read_text(encoding="utf-8")
         cls.java_test = JAVA_TEST.read_text(encoding="utf-8")
+        cls.trajectory = TRAJECTORY.read_text(encoding="utf-8")
+        cls.trajectory_test = TRAJECTORY_TEST.read_text(encoding="utf-8")
         cls.normalized = " ".join(cls.guide.split())
 
     def test_source_equation_and_units_are_explicit(self):
@@ -88,6 +100,47 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
             "testLongExposureRemainsBoundedAndInputValidationFailsClosed",
         ):
             self.assertIn(token, self.java_test)
+
+    def test_piecewise_trajectory_contract_is_documented_and_executable(self):
+        for token in (
+            "Piecewise exposure trajectory",
+            "`AqueousHydrogenSulfideOxidationTrajectory.advance(...)`",
+            r"E_i = k_i[\mathrm{O_2}]_i\Delta t_i",
+            r"\exp\left(-\sum_{i=1}^{n}E_i\right)",
+            "20–30 micromol/kg water",
+            "A pressure value is deliberately not part",
+            "one common multiplicative correlation envelope",
+            "no numerical timestep error",
+            "Segment splitting",
+            "total-sulfide inventory closure",
+            "only cumulative exposure controls the final fraction",
+        ):
+            self.assertIn(token, self.normalized)
+
+        for token in (
+            "public static Result advance(",
+            "MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY",
+            "MAXIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY",
+            "Collections.unmodifiableList",
+            "finiteSum(",
+            "public static final class Segment",
+            "public static final class SegmentResult",
+            "public static final class Result",
+            "Math.exp(-nominalExposure)",
+            "getTotalSulfideClosureResidual()",
+        ):
+            self.assertIn(token, self.trajectory)
+
+        for token in (
+            "testTwoHalfLivesGiveExactInventoryAndClosure",
+            "testSegmentSplittingIsInvariant",
+            "testVaryingSegmentsReuseAuthoritativeSingleStateRates",
+            "testFitScatterEnvelopeHasCorrectPhysicalOrdering",
+            "testZeroDurationAndDeterministicRepeat",
+            "testResultsAreDefensiveAndSourceOrdered",
+            "testEvidenceAndNumericalInputsFailClosed",
+        ):
+            self.assertIn(token, self.trajectory_test)
 
     def test_stop_boundary_prevents_pipeline_overclaim(self):
         for token in (

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectory.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectory.java
@@ -1,0 +1,454 @@
+package neqsim.process.equipment.reactor;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Exact piecewise-constant exposure trajectory for the published aqueous total-sulfide/O2
+ * screening correlation.
+ *
+ * <p>
+ * Each segment delegates its rate calculation to
+ * {@link AqueousHydrogenSulfideOxidationKinetics}. The total-sulfide fraction therefore follows
+ * {@code exp(-sum(k_i [O2]_i dt_i))} without numerical timestep error. The reported
+ * one-standard-deviation log-rate scatter is propagated as one common multiplicative correlation
+ * envelope.
+ * </p>
+ *
+ * <p>
+ * This class neither consumes oxygen nor assigns sulfur products. It does not accept pressure and
+ * does not qualify a dense-phase CO2 or pipeline calculation.
+ * </p>
+ *
+ * @author NeqSim Team
+ * @version 1.0
+ */
+public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Minimum initial total-sulfide molality covered by the source experiment [mol/kg water]. */
+  public static final double MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY =
+      AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_MOLALITY
+          - AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_SPREAD;
+
+  /** Maximum initial total-sulfide molality covered by the source experiment [mol/kg water]. */
+  public static final double MAXIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY =
+      AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_MOLALITY
+          + AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_SPREAD;
+
+  private AqueousHydrogenSulfideOxidationTrajectory() {
+  }
+
+  /**
+   * Propagate total dissolved sulfide through ordered constant-state exposure segments.
+   *
+   * @param initialTotalSulfideMolality initial total-sulfide molality [mol/kg water]
+   * @param segments non-empty ordered exposure segments
+   * @return immutable trajectory result with per-segment evidence
+   * @throws IllegalArgumentException when the initial molality is outside the source experiment,
+   *         the segment list is null or empty, a segment is null, or an accumulated value is not
+   *         finite
+   */
+  public static Result advance(double initialTotalSulfideMolality, List<Segment> segments) {
+    requireInitialTotalSulfide(initialTotalSulfideMolality);
+    if (segments == null || segments.isEmpty()) {
+      throw new IllegalArgumentException("at least one exposure segment is required");
+    }
+
+    List<SegmentResult> segmentResults = new ArrayList<SegmentResult>();
+    double totalTimeHours = 0.0;
+    double nominalExposure = 0.0;
+    double lowerRateExposure = 0.0;
+    double upperRateExposure = 0.0;
+
+    for (int index = 0; index < segments.size(); index++) {
+      Segment segment = segments.get(index);
+      if (segment == null) {
+        throw new IllegalArgumentException("exposure segment " + index + " cannot be null");
+      }
+
+      AqueousHydrogenSulfideOxidationKinetics.RateConstantRange rateRange =
+          AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstantRange(
+              segment.getTemperatureK(), segment.getPH(),
+              segment.getIonicStrengthMolPerKgWater());
+      double nominalPseudoFirstOrderRate =
+          AqueousHydrogenSulfideOxidationKinetics.pseudoFirstOrderRateConstant(
+              segment.getAirSaturatedOxygenMolality(), segment.getTemperatureK(),
+              segment.getPH(), segment.getIonicStrengthMolPerKgWater());
+      double lowerPseudoFirstOrderRate =
+          rateRange.getLower() * segment.getAirSaturatedOxygenMolality();
+      double upperPseudoFirstOrderRate =
+          rateRange.getUpper() * segment.getAirSaturatedOxygenMolality();
+      requireFinitePositive(lowerPseudoFirstOrderRate, "lower pseudo-first-order rate");
+      requireFinitePositive(upperPseudoFirstOrderRate, "upper pseudo-first-order rate");
+
+      double segmentNominalExposure =
+          nominalPseudoFirstOrderRate * segment.getDurationHours();
+      double segmentLowerRateExposure =
+          lowerPseudoFirstOrderRate * segment.getDurationHours();
+      double segmentUpperRateExposure =
+          upperPseudoFirstOrderRate * segment.getDurationHours();
+      requireFiniteNonNegative(segmentNominalExposure, "segment nominal exposure");
+      requireFiniteNonNegative(segmentLowerRateExposure, "segment lower-rate exposure");
+      requireFiniteNonNegative(segmentUpperRateExposure, "segment upper-rate exposure");
+
+      totalTimeHours = finiteSum(totalTimeHours, segment.getDurationHours(), "total time");
+      nominalExposure =
+          finiteSum(nominalExposure, segmentNominalExposure, "nominal cumulative exposure");
+      lowerRateExposure =
+          finiteSum(lowerRateExposure, segmentLowerRateExposure,
+              "lower-rate cumulative exposure");
+      upperRateExposure =
+          finiteSum(upperRateExposure, segmentUpperRateExposure,
+              "upper-rate cumulative exposure");
+
+      segmentResults.add(new SegmentResult(index, segment, rateRange.getLower(),
+          rateRange.getNominal(), rateRange.getUpper(), lowerPseudoFirstOrderRate,
+          nominalPseudoFirstOrderRate, upperPseudoFirstOrderRate,
+          segmentLowerRateExposure, segmentNominalExposure, segmentUpperRateExposure,
+          lowerRateExposure, nominalExposure, upperRateExposure));
+    }
+
+    double nominalRemainingFraction = Math.exp(-nominalExposure);
+    double lowerRateRemainingFraction = Math.exp(-lowerRateExposure);
+    double upperRateRemainingFraction = Math.exp(-upperRateExposure);
+    double finalTotalSulfideMolality =
+        initialTotalSulfideMolality * nominalRemainingFraction;
+    double finalAtLowerRate =
+        initialTotalSulfideMolality * lowerRateRemainingFraction;
+    double finalAtUpperRate =
+        initialTotalSulfideMolality * upperRateRemainingFraction;
+    double reactedTotalSulfideMolality =
+        initialTotalSulfideMolality - finalTotalSulfideMolality;
+    double closureResidual = initialTotalSulfideMolality - finalTotalSulfideMolality
+        - reactedTotalSulfideMolality;
+
+    return new Result(initialTotalSulfideMolality, finalTotalSulfideMolality,
+        reactedTotalSulfideMolality, finalAtLowerRate, finalAtUpperRate, totalTimeHours,
+        nominalExposure, lowerRateExposure, upperRateExposure, nominalRemainingFraction,
+        lowerRateRemainingFraction, upperRateRemainingFraction, closureResidual,
+        segmentResults);
+  }
+
+  private static void requireInitialTotalSulfide(double molality) {
+    if (!Double.isFinite(molality)
+        || molality < MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY
+        || molality > MAXIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY) {
+      throw new IllegalArgumentException(
+          "initial total-sulfide molality must be within the source experiment range of "
+              + MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY + " to "
+              + MAXIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY + " mol/kg water");
+    }
+  }
+
+  private static double finiteSum(double current, double increment, String name) {
+    double sum = current + increment;
+    if (!Double.isFinite(sum)) {
+      throw new IllegalArgumentException(name + " must be finite");
+    }
+    return sum;
+  }
+
+  private static void requireFinitePositive(double value, String name) {
+    if (!Double.isFinite(value) || value <= 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and positive");
+    }
+  }
+
+  private static void requireFiniteNonNegative(double value, String name) {
+    if (!Double.isFinite(value) || value < 0.0) {
+      throw new IllegalArgumentException(name + " must be finite and non-negative");
+    }
+  }
+
+  /** Immutable piecewise-constant aqueous exposure definition. */
+  public static final class Segment implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double durationHours;
+    private final double temperatureK;
+    private final double pH;
+    private final double ionicStrengthMolPerKgWater;
+    private final double airSaturatedOxygenMolality;
+
+    /**
+     * Create one constant-state exposure segment.
+     *
+     * @param durationHours segment duration [h]
+     * @param temperatureK aqueous temperature [K]
+     * @param pH aqueous pH on the source-compatible scale
+     * @param ionicStrengthMolPerKgWater ionic strength [mol/kg water]
+     * @param airSaturatedOxygenMolality independently established air-saturated dissolved
+     *        oxygen molality [mol/kg water]
+     * @throws IllegalArgumentException when duration is negative or non-finite, oxygen is not
+     *         finite and positive, or the thermochemical state is outside the source range
+     */
+    public Segment(double durationHours, double temperatureK, double pH,
+        double ionicStrengthMolPerKgWater, double airSaturatedOxygenMolality) {
+      requireFiniteNonNegative(durationHours, "segment duration");
+      AqueousHydrogenSulfideOxidationKinetics.pseudoFirstOrderRateConstant(
+          airSaturatedOxygenMolality, temperatureK, pH, ionicStrengthMolPerKgWater);
+      this.durationHours = durationHours;
+      this.temperatureK = temperatureK;
+      this.pH = pH;
+      this.ionicStrengthMolPerKgWater = ionicStrengthMolPerKgWater;
+      this.airSaturatedOxygenMolality = airSaturatedOxygenMolality;
+    }
+
+    /** @return segment duration [h]. */
+    public double getDurationHours() {
+      return durationHours;
+    }
+
+    /** @return aqueous temperature [K]. */
+    public double getTemperatureK() {
+      return temperatureK;
+    }
+
+    /** @return aqueous pH on the caller's source-compatible scale. */
+    public double getPH() {
+      return pH;
+    }
+
+    /** @return ionic strength [mol/kg water]. */
+    public double getIonicStrengthMolPerKgWater() {
+      return ionicStrengthMolPerKgWater;
+    }
+
+    /** @return caller-supplied air-saturated dissolved oxygen molality [mol/kg water]. */
+    public double getAirSaturatedOxygenMolality() {
+      return airSaturatedOxygenMolality;
+    }
+  }
+
+  /** Immutable calculated evidence for one exposure segment. */
+  public static final class SegmentResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final int index;
+    private final Segment segment;
+    private final double lowerSecondOrderRate;
+    private final double nominalSecondOrderRate;
+    private final double upperSecondOrderRate;
+    private final double lowerPseudoFirstOrderRate;
+    private final double nominalPseudoFirstOrderRate;
+    private final double upperPseudoFirstOrderRate;
+    private final double lowerRateExposure;
+    private final double nominalExposure;
+    private final double upperRateExposure;
+    private final double cumulativeLowerRateExposure;
+    private final double cumulativeNominalExposure;
+    private final double cumulativeUpperRateExposure;
+
+    private SegmentResult(int index, Segment segment, double lowerSecondOrderRate,
+        double nominalSecondOrderRate, double upperSecondOrderRate,
+        double lowerPseudoFirstOrderRate, double nominalPseudoFirstOrderRate,
+        double upperPseudoFirstOrderRate, double lowerRateExposure,
+        double nominalExposure, double upperRateExposure,
+        double cumulativeLowerRateExposure, double cumulativeNominalExposure,
+        double cumulativeUpperRateExposure) {
+      this.index = index;
+      this.segment = segment;
+      this.lowerSecondOrderRate = lowerSecondOrderRate;
+      this.nominalSecondOrderRate = nominalSecondOrderRate;
+      this.upperSecondOrderRate = upperSecondOrderRate;
+      this.lowerPseudoFirstOrderRate = lowerPseudoFirstOrderRate;
+      this.nominalPseudoFirstOrderRate = nominalPseudoFirstOrderRate;
+      this.upperPseudoFirstOrderRate = upperPseudoFirstOrderRate;
+      this.lowerRateExposure = lowerRateExposure;
+      this.nominalExposure = nominalExposure;
+      this.upperRateExposure = upperRateExposure;
+      this.cumulativeLowerRateExposure = cumulativeLowerRateExposure;
+      this.cumulativeNominalExposure = cumulativeNominalExposure;
+      this.cumulativeUpperRateExposure = cumulativeUpperRateExposure;
+    }
+
+    /** @return zero-based source-order segment index. */
+    public int getIndex() {
+      return index;
+    }
+
+    /** @return immutable segment input. */
+    public Segment getSegment() {
+      return segment;
+    }
+
+    /** @return lower second-order rate [kg water/(mol h)]. */
+    public double getLowerSecondOrderRate() {
+      return lowerSecondOrderRate;
+    }
+
+    /** @return nominal second-order rate [kg water/(mol h)]. */
+    public double getNominalSecondOrderRate() {
+      return nominalSecondOrderRate;
+    }
+
+    /** @return upper second-order rate [kg water/(mol h)]. */
+    public double getUpperSecondOrderRate() {
+      return upperSecondOrderRate;
+    }
+
+    /** @return lower pseudo-first-order rate [1/h]. */
+    public double getLowerPseudoFirstOrderRate() {
+      return lowerPseudoFirstOrderRate;
+    }
+
+    /** @return nominal pseudo-first-order rate [1/h]. */
+    public double getNominalPseudoFirstOrderRate() {
+      return nominalPseudoFirstOrderRate;
+    }
+
+    /** @return upper pseudo-first-order rate [1/h]. */
+    public double getUpperPseudoFirstOrderRate() {
+      return upperPseudoFirstOrderRate;
+    }
+
+    /** @return lower-rate segment exposure. */
+    public double getLowerRateExposure() {
+      return lowerRateExposure;
+    }
+
+    /** @return nominal segment exposure. */
+    public double getNominalExposure() {
+      return nominalExposure;
+    }
+
+    /** @return upper-rate segment exposure. */
+    public double getUpperRateExposure() {
+      return upperRateExposure;
+    }
+
+    /** @return cumulative lower-rate exposure through this segment. */
+    public double getCumulativeLowerRateExposure() {
+      return cumulativeLowerRateExposure;
+    }
+
+    /** @return cumulative nominal exposure through this segment. */
+    public double getCumulativeNominalExposure() {
+      return cumulativeNominalExposure;
+    }
+
+    /** @return cumulative upper-rate exposure through this segment. */
+    public double getCumulativeUpperRateExposure() {
+      return cumulativeUpperRateExposure;
+    }
+  }
+
+  /** Immutable result of an exact piecewise exposure trajectory. */
+  public static final class Result implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double initialTotalSulfideMolality;
+    private final double finalTotalSulfideMolality;
+    private final double reactedTotalSulfideMolality;
+    private final double finalTotalSulfideMolalityAtLowerRate;
+    private final double finalTotalSulfideMolalityAtUpperRate;
+    private final double totalTimeHours;
+    private final double nominalExposure;
+    private final double lowerRateExposure;
+    private final double upperRateExposure;
+    private final double nominalRemainingFraction;
+    private final double lowerRateRemainingFraction;
+    private final double upperRateRemainingFraction;
+    private final double totalSulfideClosureResidual;
+    private final List<SegmentResult> segmentResults;
+
+    private Result(double initialTotalSulfideMolality, double finalTotalSulfideMolality,
+        double reactedTotalSulfideMolality, double finalTotalSulfideMolalityAtLowerRate,
+        double finalTotalSulfideMolalityAtUpperRate, double totalTimeHours,
+        double nominalExposure, double lowerRateExposure, double upperRateExposure,
+        double nominalRemainingFraction, double lowerRateRemainingFraction,
+        double upperRateRemainingFraction, double totalSulfideClosureResidual,
+        List<SegmentResult> segmentResults) {
+      this.initialTotalSulfideMolality = initialTotalSulfideMolality;
+      this.finalTotalSulfideMolality = finalTotalSulfideMolality;
+      this.reactedTotalSulfideMolality = reactedTotalSulfideMolality;
+      this.finalTotalSulfideMolalityAtLowerRate =
+          finalTotalSulfideMolalityAtLowerRate;
+      this.finalTotalSulfideMolalityAtUpperRate =
+          finalTotalSulfideMolalityAtUpperRate;
+      this.totalTimeHours = totalTimeHours;
+      this.nominalExposure = nominalExposure;
+      this.lowerRateExposure = lowerRateExposure;
+      this.upperRateExposure = upperRateExposure;
+      this.nominalRemainingFraction = nominalRemainingFraction;
+      this.lowerRateRemainingFraction = lowerRateRemainingFraction;
+      this.upperRateRemainingFraction = upperRateRemainingFraction;
+      this.totalSulfideClosureResidual = totalSulfideClosureResidual;
+      this.segmentResults =
+          Collections.unmodifiableList(new ArrayList<SegmentResult>(segmentResults));
+    }
+
+    /** @return initial total-sulfide molality [mol/kg water]. */
+    public double getInitialTotalSulfideMolality() {
+      return initialTotalSulfideMolality;
+    }
+
+    /** @return nominal final total-sulfide molality [mol/kg water]. */
+    public double getFinalTotalSulfideMolality() {
+      return finalTotalSulfideMolality;
+    }
+
+    /** @return nominal reacted total-sulfide molality [mol/kg water]. */
+    public double getReactedTotalSulfideMolality() {
+      return reactedTotalSulfideMolality;
+    }
+
+    /** @return final molality at the lower fit-scatter rate [mol/kg water]. */
+    public double getFinalTotalSulfideMolalityAtLowerRate() {
+      return finalTotalSulfideMolalityAtLowerRate;
+    }
+
+    /** @return final molality at the upper fit-scatter rate [mol/kg water]. */
+    public double getFinalTotalSulfideMolalityAtUpperRate() {
+      return finalTotalSulfideMolalityAtUpperRate;
+    }
+
+    /** @return total segment duration [h]. */
+    public double getTotalTimeHours() {
+      return totalTimeHours;
+    }
+
+    /** @return cumulative nominal dimensionless exposure. */
+    public double getNominalExposure() {
+      return nominalExposure;
+    }
+
+    /** @return cumulative lower-rate dimensionless exposure. */
+    public double getLowerRateExposure() {
+      return lowerRateExposure;
+    }
+
+    /** @return cumulative upper-rate dimensionless exposure. */
+    public double getUpperRateExposure() {
+      return upperRateExposure;
+    }
+
+    /** @return nominal remaining total-sulfide fraction. */
+    public double getNominalRemainingFraction() {
+      return nominalRemainingFraction;
+    }
+
+    /** @return remaining fraction at the lower fit-scatter rate. */
+    public double getLowerRateRemainingFraction() {
+      return lowerRateRemainingFraction;
+    }
+
+    /** @return remaining fraction at the upper fit-scatter rate. */
+    public double getUpperRateRemainingFraction() {
+      return upperRateRemainingFraction;
+    }
+
+    /** @return total-sulfide closure residual [mol/kg water]. */
+    public double getTotalSulfideClosureResidual() {
+      return totalSulfideClosureResidual;
+    }
+
+    /** @return immutable source-ordered segment diagnostics. */
+    public List<SegmentResult> getSegmentResults() {
+      return segmentResults;
+    }
+  }
+}

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectory.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectory.java
@@ -6,20 +6,17 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Exact piecewise-constant exposure trajectory for the published aqueous total-sulfide/O2
- * screening correlation.
+ * Exact piecewise-constant exposure trajectory for the published aqueous total-sulfide/O2 screening correlation.
  *
  * <p>
- * Each segment delegates its rate calculation to
- * {@link AqueousHydrogenSulfideOxidationKinetics}. The total-sulfide fraction therefore follows
- * {@code exp(-sum(k_i [O2]_i dt_i))} without numerical timestep error. The reported
- * one-standard-deviation log-rate scatter is propagated as one common multiplicative correlation
- * envelope.
+ * Each segment delegates its rate calculation to {@link AqueousHydrogenSulfideOxidationKinetics}. The total-sulfide
+ * fraction therefore follows {@code exp(-sum(k_i [O2]_i dt_i))} without numerical timestep error. The reported
+ * one-standard-deviation log-rate scatter is propagated as one common multiplicative correlation envelope.
  * </p>
  *
  * <p>
- * This class neither consumes oxygen nor assigns sulfur products. It does not accept pressure and
- * does not qualify a dense-phase CO2 or pipeline calculation.
+ * This class neither consumes oxygen nor assigns sulfur products. It does not accept pressure and does not qualify a
+ * dense-phase CO2 or pipeline calculation.
  * </p>
  *
  * @author NeqSim Team
@@ -29,14 +26,12 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
   private static final long serialVersionUID = 1000L;
 
   /** Minimum initial total-sulfide molality covered by the source experiment [mol/kg water]. */
-  public static final double MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY =
-      AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_MOLALITY
-          - AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_SPREAD;
+  public static final double MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY = AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_MOLALITY
+      - AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_SPREAD;
 
   /** Maximum initial total-sulfide molality covered by the source experiment [mol/kg water]. */
-  public static final double MAXIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY =
-      AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_MOLALITY
-          + AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_SPREAD;
+  public static final double MAXIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY = AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_MOLALITY
+      + AqueousHydrogenSulfideOxidationKinetics.PUBLISHED_INITIAL_TOTAL_SULFIDE_SPREAD;
 
   private AqueousHydrogenSulfideOxidationTrajectory() {
   }
@@ -47,9 +42,8 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
    * @param initialTotalSulfideMolality initial total-sulfide molality [mol/kg water]
    * @param segments non-empty ordered exposure segments
    * @return immutable trajectory result with per-segment evidence
-   * @throws IllegalArgumentException when the initial molality is outside the source experiment,
-   *         the segment list is null or empty, a segment is null, or an accumulated value is not
-   *         finite
+   * @throws IllegalArgumentException when the initial molality is outside the source experiment, the segment list is
+   * null or empty, a segment is null, or an accumulated value is not finite
    */
   public static Result advance(double initialTotalSulfideMolality, List<Segment> segments) {
     requireInitialTotalSulfide(initialTotalSulfideMolality);
@@ -69,77 +63,55 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
         throw new IllegalArgumentException("exposure segment " + index + " cannot be null");
       }
 
-      AqueousHydrogenSulfideOxidationKinetics.RateConstantRange rateRange =
-          AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstantRange(
-              segment.getTemperatureK(), segment.getPH(),
+      AqueousHydrogenSulfideOxidationKinetics.RateConstantRange rateRange = AqueousHydrogenSulfideOxidationKinetics
+          .secondOrderRateConstantRange(segment.getTemperatureK(), segment.getPH(),
               segment.getIonicStrengthMolPerKgWater());
-      double nominalPseudoFirstOrderRate =
-          AqueousHydrogenSulfideOxidationKinetics.pseudoFirstOrderRateConstant(
-              segment.getAirSaturatedOxygenMolality(), segment.getTemperatureK(),
-              segment.getPH(), segment.getIonicStrengthMolPerKgWater());
-      double lowerPseudoFirstOrderRate =
-          rateRange.getLower() * segment.getAirSaturatedOxygenMolality();
-      double upperPseudoFirstOrderRate =
-          rateRange.getUpper() * segment.getAirSaturatedOxygenMolality();
+      double nominalPseudoFirstOrderRate = AqueousHydrogenSulfideOxidationKinetics.pseudoFirstOrderRateConstant(
+          segment.getAirSaturatedOxygenMolality(), segment.getTemperatureK(), segment.getPH(),
+          segment.getIonicStrengthMolPerKgWater());
+      double lowerPseudoFirstOrderRate = rateRange.getLower() * segment.getAirSaturatedOxygenMolality();
+      double upperPseudoFirstOrderRate = rateRange.getUpper() * segment.getAirSaturatedOxygenMolality();
       requireFinitePositive(lowerPseudoFirstOrderRate, "lower pseudo-first-order rate");
       requireFinitePositive(upperPseudoFirstOrderRate, "upper pseudo-first-order rate");
 
-      double segmentNominalExposure =
-          nominalPseudoFirstOrderRate * segment.getDurationHours();
-      double segmentLowerRateExposure =
-          lowerPseudoFirstOrderRate * segment.getDurationHours();
-      double segmentUpperRateExposure =
-          upperPseudoFirstOrderRate * segment.getDurationHours();
+      double segmentNominalExposure = nominalPseudoFirstOrderRate * segment.getDurationHours();
+      double segmentLowerRateExposure = lowerPseudoFirstOrderRate * segment.getDurationHours();
+      double segmentUpperRateExposure = upperPseudoFirstOrderRate * segment.getDurationHours();
       requireFiniteNonNegative(segmentNominalExposure, "segment nominal exposure");
       requireFiniteNonNegative(segmentLowerRateExposure, "segment lower-rate exposure");
       requireFiniteNonNegative(segmentUpperRateExposure, "segment upper-rate exposure");
 
       totalTimeHours = finiteSum(totalTimeHours, segment.getDurationHours(), "total time");
-      nominalExposure =
-          finiteSum(nominalExposure, segmentNominalExposure, "nominal cumulative exposure");
-      lowerRateExposure =
-          finiteSum(lowerRateExposure, segmentLowerRateExposure,
-              "lower-rate cumulative exposure");
-      upperRateExposure =
-          finiteSum(upperRateExposure, segmentUpperRateExposure,
-              "upper-rate cumulative exposure");
+      nominalExposure = finiteSum(nominalExposure, segmentNominalExposure, "nominal cumulative exposure");
+      lowerRateExposure = finiteSum(lowerRateExposure, segmentLowerRateExposure, "lower-rate cumulative exposure");
+      upperRateExposure = finiteSum(upperRateExposure, segmentUpperRateExposure, "upper-rate cumulative exposure");
 
-      segmentResults.add(new SegmentResult(index, segment, rateRange.getLower(),
-          rateRange.getNominal(), rateRange.getUpper(), lowerPseudoFirstOrderRate,
-          nominalPseudoFirstOrderRate, upperPseudoFirstOrderRate,
-          segmentLowerRateExposure, segmentNominalExposure, segmentUpperRateExposure,
-          lowerRateExposure, nominalExposure, upperRateExposure));
+      segmentResults.add(new SegmentResult(index, segment, rateRange.getLower(), rateRange.getNominal(),
+          rateRange.getUpper(), lowerPseudoFirstOrderRate, nominalPseudoFirstOrderRate, upperPseudoFirstOrderRate,
+          segmentLowerRateExposure, segmentNominalExposure, segmentUpperRateExposure, lowerRateExposure,
+          nominalExposure, upperRateExposure));
     }
 
     double nominalRemainingFraction = Math.exp(-nominalExposure);
     double lowerRateRemainingFraction = Math.exp(-lowerRateExposure);
     double upperRateRemainingFraction = Math.exp(-upperRateExposure);
-    double finalTotalSulfideMolality =
-        initialTotalSulfideMolality * nominalRemainingFraction;
-    double finalAtLowerRate =
-        initialTotalSulfideMolality * lowerRateRemainingFraction;
-    double finalAtUpperRate =
-        initialTotalSulfideMolality * upperRateRemainingFraction;
-    double reactedTotalSulfideMolality =
-        initialTotalSulfideMolality - finalTotalSulfideMolality;
-    double closureResidual = initialTotalSulfideMolality - finalTotalSulfideMolality
-        - reactedTotalSulfideMolality;
+    double finalTotalSulfideMolality = initialTotalSulfideMolality * nominalRemainingFraction;
+    double finalAtLowerRate = initialTotalSulfideMolality * lowerRateRemainingFraction;
+    double finalAtUpperRate = initialTotalSulfideMolality * upperRateRemainingFraction;
+    double reactedTotalSulfideMolality = initialTotalSulfideMolality - finalTotalSulfideMolality;
+    double closureResidual = initialTotalSulfideMolality - finalTotalSulfideMolality - reactedTotalSulfideMolality;
 
-    return new Result(initialTotalSulfideMolality, finalTotalSulfideMolality,
-        reactedTotalSulfideMolality, finalAtLowerRate, finalAtUpperRate, totalTimeHours,
-        nominalExposure, lowerRateExposure, upperRateExposure, nominalRemainingFraction,
-        lowerRateRemainingFraction, upperRateRemainingFraction, closureResidual,
+    return new Result(initialTotalSulfideMolality, finalTotalSulfideMolality, reactedTotalSulfideMolality,
+        finalAtLowerRate, finalAtUpperRate, totalTimeHours, nominalExposure, lowerRateExposure, upperRateExposure,
+        nominalRemainingFraction, lowerRateRemainingFraction, upperRateRemainingFraction, closureResidual,
         segmentResults);
   }
 
   private static void requireInitialTotalSulfide(double molality) {
-    if (!Double.isFinite(molality)
-        || molality < MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY
+    if (!Double.isFinite(molality) || molality < MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY
         || molality > MAXIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY) {
-      throw new IllegalArgumentException(
-          "initial total-sulfide molality must be within the source experiment range of "
-              + MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY + " to "
-              + MAXIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY + " mol/kg water");
+      throw new IllegalArgumentException("initial total-sulfide molality must be within the source experiment range of "
+          + MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY + " to " + MAXIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY + " mol/kg water");
     }
   }
 
@@ -180,16 +152,16 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
      * @param temperatureK aqueous temperature [K]
      * @param pH aqueous pH on the source-compatible scale
      * @param ionicStrengthMolPerKgWater ionic strength [mol/kg water]
-     * @param airSaturatedOxygenMolality independently established air-saturated dissolved
-     *        oxygen molality [mol/kg water]
-     * @throws IllegalArgumentException when duration is negative or non-finite, oxygen is not
-     *         finite and positive, or the thermochemical state is outside the source range
+     * @param airSaturatedOxygenMolality independently established air-saturated dissolved oxygen molality [mol/kg
+     * water]
+     * @throws IllegalArgumentException when duration is negative or non-finite, oxygen is not finite and positive, or
+     * the thermochemical state is outside the source range
      */
-    public Segment(double durationHours, double temperatureK, double pH,
-        double ionicStrengthMolPerKgWater, double airSaturatedOxygenMolality) {
+    public Segment(double durationHours, double temperatureK, double pH, double ionicStrengthMolPerKgWater,
+        double airSaturatedOxygenMolality) {
       requireFiniteNonNegative(durationHours, "segment duration");
-      AqueousHydrogenSulfideOxidationKinetics.pseudoFirstOrderRateConstant(
-          airSaturatedOxygenMolality, temperatureK, pH, ionicStrengthMolPerKgWater);
+      AqueousHydrogenSulfideOxidationKinetics.pseudoFirstOrderRateConstant(airSaturatedOxygenMolality, temperatureK, pH,
+          ionicStrengthMolPerKgWater);
       this.durationHours = durationHours;
       this.temperatureK = temperatureK;
       this.pH = pH;
@@ -242,13 +214,10 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
     private final double cumulativeNominalExposure;
     private final double cumulativeUpperRateExposure;
 
-    private SegmentResult(int index, Segment segment, double lowerSecondOrderRate,
-        double nominalSecondOrderRate, double upperSecondOrderRate,
-        double lowerPseudoFirstOrderRate, double nominalPseudoFirstOrderRate,
-        double upperPseudoFirstOrderRate, double lowerRateExposure,
-        double nominalExposure, double upperRateExposure,
-        double cumulativeLowerRateExposure, double cumulativeNominalExposure,
-        double cumulativeUpperRateExposure) {
+    private SegmentResult(int index, Segment segment, double lowerSecondOrderRate, double nominalSecondOrderRate,
+        double upperSecondOrderRate, double lowerPseudoFirstOrderRate, double nominalPseudoFirstOrderRate,
+        double upperPseudoFirstOrderRate, double lowerRateExposure, double nominalExposure, double upperRateExposure,
+        double cumulativeLowerRateExposure, double cumulativeNominalExposure, double cumulativeUpperRateExposure) {
       this.index = index;
       this.segment = segment;
       this.lowerSecondOrderRate = lowerSecondOrderRate;
@@ -357,18 +326,15 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
 
     private Result(double initialTotalSulfideMolality, double finalTotalSulfideMolality,
         double reactedTotalSulfideMolality, double finalTotalSulfideMolalityAtLowerRate,
-        double finalTotalSulfideMolalityAtUpperRate, double totalTimeHours,
-        double nominalExposure, double lowerRateExposure, double upperRateExposure,
-        double nominalRemainingFraction, double lowerRateRemainingFraction,
-        double upperRateRemainingFraction, double totalSulfideClosureResidual,
+        double finalTotalSulfideMolalityAtUpperRate, double totalTimeHours, double nominalExposure,
+        double lowerRateExposure, double upperRateExposure, double nominalRemainingFraction,
+        double lowerRateRemainingFraction, double upperRateRemainingFraction, double totalSulfideClosureResidual,
         List<SegmentResult> segmentResults) {
       this.initialTotalSulfideMolality = initialTotalSulfideMolality;
       this.finalTotalSulfideMolality = finalTotalSulfideMolality;
       this.reactedTotalSulfideMolality = reactedTotalSulfideMolality;
-      this.finalTotalSulfideMolalityAtLowerRate =
-          finalTotalSulfideMolalityAtLowerRate;
-      this.finalTotalSulfideMolalityAtUpperRate =
-          finalTotalSulfideMolalityAtUpperRate;
+      this.finalTotalSulfideMolalityAtLowerRate = finalTotalSulfideMolalityAtLowerRate;
+      this.finalTotalSulfideMolalityAtUpperRate = finalTotalSulfideMolalityAtUpperRate;
       this.totalTimeHours = totalTimeHours;
       this.nominalExposure = nominalExposure;
       this.lowerRateExposure = lowerRateExposure;
@@ -377,8 +343,7 @@ public final class AqueousHydrogenSulfideOxidationTrajectory implements Serializ
       this.lowerRateRemainingFraction = lowerRateRemainingFraction;
       this.upperRateRemainingFraction = upperRateRemainingFraction;
       this.totalSulfideClosureResidual = totalSulfideClosureResidual;
-      this.segmentResults =
-          Collections.unmodifiableList(new ArrayList<SegmentResult>(segmentResults));
+      this.segmentResults = Collections.unmodifiableList(new ArrayList<SegmentResult>(segmentResults));
     }
 
     /** @return initial total-sulfide molality [mol/kg water]. */

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
@@ -20,14 +20,13 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
 
   @Test
   void testTwoHalfLivesGiveExactInventoryAndClosure() {
-    double halfLife = AqueousHydrogenSulfideOxidationKinetics.halfLifeHours(
-        AIR_SATURATED_OXYGEN_MOLALITY, TEMPERATURE_K, PH, IONIC_STRENGTH);
+    double halfLife = AqueousHydrogenSulfideOxidationKinetics.halfLifeHours(AIR_SATURATED_OXYGEN_MOLALITY,
+        TEMPERATURE_K, PH, IONIC_STRENGTH);
     AqueousHydrogenSulfideOxidationTrajectory.Segment first = referenceSegment(halfLife);
     AqueousHydrogenSulfideOxidationTrajectory.Segment second = referenceSegment(halfLife);
 
-    AqueousHydrogenSulfideOxidationTrajectory.Result result =
-        AqueousHydrogenSulfideOxidationTrajectory.advance(
-            INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(first, second));
+    AqueousHydrogenSulfideOxidationTrajectory.Result result = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(first, second));
 
     assertEquals(2.0 * halfLife, result.getTotalTimeHours(), 1.0e-14);
     assertEquals(2.0 * Math.log(2.0), result.getNominalExposure(), 1.0e-14);
@@ -36,169 +35,122 @@ public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
     assertEquals(18.75e-6, result.getReactedTotalSulfideMolality(), 1.0e-20);
     assertEquals(0.0, result.getTotalSulfideClosureResidual(), 0.0);
     assertEquals(INITIAL_TOTAL_SULFIDE_MOLALITY,
-        result.getFinalTotalSulfideMolality() + result.getReactedTotalSulfideMolality(),
-        0.0);
+        result.getFinalTotalSulfideMolality() + result.getReactedTotalSulfideMolality(), 0.0);
   }
 
   @Test
   void testSegmentSplittingIsInvariant() {
-    double halfLife = AqueousHydrogenSulfideOxidationKinetics.halfLifeHours(
-        AIR_SATURATED_OXYGEN_MOLALITY, TEMPERATURE_K, PH, IONIC_STRENGTH);
-    AqueousHydrogenSulfideOxidationTrajectory.Result unsplit =
-        AqueousHydrogenSulfideOxidationTrajectory.advance(
-            INITIAL_TOTAL_SULFIDE_MOLALITY,
-            Collections.singletonList(referenceSegment(2.0 * halfLife)));
-    AqueousHydrogenSulfideOxidationTrajectory.Result split =
-        AqueousHydrogenSulfideOxidationTrajectory.advance(
-            INITIAL_TOTAL_SULFIDE_MOLALITY,
-            Arrays.asList(referenceSegment(halfLife), referenceSegment(halfLife)));
+    double halfLife = AqueousHydrogenSulfideOxidationKinetics.halfLifeHours(AIR_SATURATED_OXYGEN_MOLALITY,
+        TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationTrajectory.Result unsplit = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(referenceSegment(2.0 * halfLife)));
+    AqueousHydrogenSulfideOxidationTrajectory.Result split = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(referenceSegment(halfLife), referenceSegment(halfLife)));
 
     assertEquals(unsplit.getNominalExposure(), split.getNominalExposure(), 1.0e-15);
-    assertEquals(unsplit.getFinalTotalSulfideMolality(),
-        split.getFinalTotalSulfideMolality(), 1.0e-20);
+    assertEquals(unsplit.getFinalTotalSulfideMolality(), split.getFinalTotalSulfideMolality(), 1.0e-20);
     assertEquals(unsplit.getLowerRateExposure(), split.getLowerRateExposure(), 1.0e-15);
     assertEquals(unsplit.getUpperRateExposure(), split.getUpperRateExposure(), 1.0e-15);
   }
 
   @Test
   void testVaryingSegmentsReuseAuthoritativeSingleStateRates() {
-    AqueousHydrogenSulfideOxidationTrajectory.Segment first =
-        new AqueousHydrogenSulfideOxidationTrajectory.Segment(
-            3.0, 288.15, 5.0, 0.1, 300.0e-6);
-    AqueousHydrogenSulfideOxidationTrajectory.Segment second =
-        new AqueousHydrogenSulfideOxidationTrajectory.Segment(
-            7.0, 310.15, 7.0, 1.5, 220.0e-6);
-    AqueousHydrogenSulfideOxidationTrajectory.Result result =
-        AqueousHydrogenSulfideOxidationTrajectory.advance(
-            INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(first, second));
+    AqueousHydrogenSulfideOxidationTrajectory.Segment first = new AqueousHydrogenSulfideOxidationTrajectory.Segment(3.0,
+        288.15, 5.0, 0.1, 300.0e-6);
+    AqueousHydrogenSulfideOxidationTrajectory.Segment second = new AqueousHydrogenSulfideOxidationTrajectory.Segment(
+        7.0, 310.15, 7.0, 1.5, 220.0e-6);
+    AqueousHydrogenSulfideOxidationTrajectory.Result result = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(first, second));
 
-    double expectedFirstExposure =
-        AqueousHydrogenSulfideOxidationKinetics.pseudoFirstOrderRateConstant(
-            first.getAirSaturatedOxygenMolality(), first.getTemperatureK(), first.getPH(),
-            first.getIonicStrengthMolPerKgWater()) * first.getDurationHours();
-    double expectedSecondExposure =
-        AqueousHydrogenSulfideOxidationKinetics.pseudoFirstOrderRateConstant(
-            second.getAirSaturatedOxygenMolality(), second.getTemperatureK(), second.getPH(),
-            second.getIonicStrengthMolPerKgWater()) * second.getDurationHours();
+    double expectedFirstExposure = AqueousHydrogenSulfideOxidationKinetics.pseudoFirstOrderRateConstant(
+        first.getAirSaturatedOxygenMolality(), first.getTemperatureK(), first.getPH(),
+        first.getIonicStrengthMolPerKgWater()) * first.getDurationHours();
+    double expectedSecondExposure = AqueousHydrogenSulfideOxidationKinetics.pseudoFirstOrderRateConstant(
+        second.getAirSaturatedOxygenMolality(), second.getTemperatureK(), second.getPH(),
+        second.getIonicStrengthMolPerKgWater()) * second.getDurationHours();
 
-    assertEquals(expectedFirstExposure,
-        result.getSegmentResults().get(0).getNominalExposure(), 0.0);
-    assertEquals(expectedFirstExposure + expectedSecondExposure,
-        result.getNominalExposure(), 1.0e-15);
-    assertEquals(result.getNominalExposure(),
-        result.getSegmentResults().get(1).getCumulativeNominalExposure(), 0.0);
-    assertTrue(result.getSegmentResults().get(1).getNominalSecondOrderRate()
-        > result.getSegmentResults().get(0).getNominalSecondOrderRate());
+    assertEquals(expectedFirstExposure, result.getSegmentResults().get(0).getNominalExposure(), 0.0);
+    assertEquals(expectedFirstExposure + expectedSecondExposure, result.getNominalExposure(), 1.0e-15);
+    assertEquals(result.getNominalExposure(), result.getSegmentResults().get(1).getCumulativeNominalExposure(), 0.0);
+    assertTrue(result.getSegmentResults().get(1).getNominalSecondOrderRate() > result.getSegmentResults().get(0)
+        .getNominalSecondOrderRate());
   }
 
   @Test
   void testFitScatterEnvelopeHasCorrectPhysicalOrdering() {
-    AqueousHydrogenSulfideOxidationTrajectory.Result result =
-        AqueousHydrogenSulfideOxidationTrajectory.advance(
-            INITIAL_TOTAL_SULFIDE_MOLALITY,
-            Collections.singletonList(referenceSegment(24.0)));
+    AqueousHydrogenSulfideOxidationTrajectory.Result result = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(referenceSegment(24.0)));
 
     assertTrue(result.getLowerRateExposure() < result.getNominalExposure());
     assertTrue(result.getNominalExposure() < result.getUpperRateExposure());
-    assertTrue(result.getFinalTotalSulfideMolalityAtUpperRate()
-        < result.getFinalTotalSulfideMolality());
-    assertTrue(result.getFinalTotalSulfideMolality()
-        < result.getFinalTotalSulfideMolalityAtLowerRate());
-    assertTrue(result.getUpperRateRemainingFraction()
-        < result.getNominalRemainingFraction());
-    assertTrue(result.getNominalRemainingFraction()
-        < result.getLowerRateRemainingFraction());
+    assertTrue(result.getFinalTotalSulfideMolalityAtUpperRate() < result.getFinalTotalSulfideMolality());
+    assertTrue(result.getFinalTotalSulfideMolality() < result.getFinalTotalSulfideMolalityAtLowerRate());
+    assertTrue(result.getUpperRateRemainingFraction() < result.getNominalRemainingFraction());
+    assertTrue(result.getNominalRemainingFraction() < result.getLowerRateRemainingFraction());
   }
 
   @Test
   void testZeroDurationAndDeterministicRepeat() {
     AqueousHydrogenSulfideOxidationTrajectory.Segment zero = referenceSegment(0.0);
 
-    AqueousHydrogenSulfideOxidationTrajectory.Result first =
-        AqueousHydrogenSulfideOxidationTrajectory.advance(
-            INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(zero));
-    AqueousHydrogenSulfideOxidationTrajectory.Result second =
-        AqueousHydrogenSulfideOxidationTrajectory.advance(
-            INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(zero));
+    AqueousHydrogenSulfideOxidationTrajectory.Result first = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(zero));
+    AqueousHydrogenSulfideOxidationTrajectory.Result second = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(zero));
 
-    assertEquals(INITIAL_TOTAL_SULFIDE_MOLALITY,
-        first.getFinalTotalSulfideMolality(), 0.0);
+    assertEquals(INITIAL_TOTAL_SULFIDE_MOLALITY, first.getFinalTotalSulfideMolality(), 0.0);
     assertEquals(0.0, first.getReactedTotalSulfideMolality(), 0.0);
     assertEquals(0.0, first.getNominalExposure(), 0.0);
     assertEquals(1.0, first.getNominalRemainingFraction(), 0.0);
-    assertEquals(first.getFinalTotalSulfideMolality(),
-        second.getFinalTotalSulfideMolality(), 0.0);
+    assertEquals(first.getFinalTotalSulfideMolality(), second.getFinalTotalSulfideMolality(), 0.0);
     assertEquals(first.getNominalExposure(), second.getNominalExposure(), 0.0);
   }
 
   @Test
   void testResultsAreDefensiveAndSourceOrdered() {
-    List<AqueousHydrogenSulfideOxidationTrajectory.Segment> source =
-        new ArrayList<AqueousHydrogenSulfideOxidationTrajectory.Segment>();
+    List<AqueousHydrogenSulfideOxidationTrajectory.Segment> source = new ArrayList<AqueousHydrogenSulfideOxidationTrajectory.Segment>();
     source.add(referenceSegment(1.0));
     source.add(referenceSegment(2.0));
-    AqueousHydrogenSulfideOxidationTrajectory.Result result =
-        AqueousHydrogenSulfideOxidationTrajectory.advance(
-            INITIAL_TOTAL_SULFIDE_MOLALITY, source);
+    AqueousHydrogenSulfideOxidationTrajectory.Result result = AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, source);
     source.clear();
 
     assertEquals(2, result.getSegmentResults().size());
     assertEquals(0, result.getSegmentResults().get(0).getIndex());
     assertEquals(1, result.getSegmentResults().get(1).getIndex());
-    assertEquals(1.0,
-        result.getSegmentResults().get(0).getSegment().getDurationHours(), 0.0);
-    assertEquals(2.0,
-        result.getSegmentResults().get(1).getSegment().getDurationHours(), 0.0);
-    assertThrows(UnsupportedOperationException.class,
-        () -> result.getSegmentResults().add(null));
+    assertEquals(1.0, result.getSegmentResults().get(0).getSegment().getDurationHours(), 0.0);
+    assertEquals(2.0, result.getSegmentResults().get(1).getSegment().getDurationHours(), 0.0);
+    assertThrows(UnsupportedOperationException.class, () -> result.getSegmentResults().add(null));
   }
 
   @Test
   void testEvidenceAndNumericalInputsFailClosed() {
-    assertEquals(20.0e-6,
-        AqueousHydrogenSulfideOxidationTrajectory.MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY,
-        1.0e-20);
-    assertEquals(30.0e-6,
-        AqueousHydrogenSulfideOxidationTrajectory.MAXIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY,
-        1.0e-20);
+    assertEquals(20.0e-6, AqueousHydrogenSulfideOxidationTrajectory.MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY, 1.0e-20);
+    assertEquals(30.0e-6, AqueousHydrogenSulfideOxidationTrajectory.MAXIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY, 1.0e-20);
 
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationTrajectory.advance(19.999e-6,
+        Collections.singletonList(referenceSegment(1.0))));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationTrajectory.advance(30.001e-6,
+        Collections.singletonList(referenceSegment(1.0))));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationTrajectory.advance(
-            19.999e-6, Collections.singletonList(referenceSegment(1.0))));
+        () -> AqueousHydrogenSulfideOxidationTrajectory.advance(INITIAL_TOTAL_SULFIDE_MOLALITY, null));
     assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationTrajectory.advance(
-            30.001e-6, Collections.singletonList(referenceSegment(1.0))));
-    assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationTrajectory.advance(
-            INITIAL_TOTAL_SULFIDE_MOLALITY, null));
-    assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationTrajectory.advance(
-            INITIAL_TOTAL_SULFIDE_MOLALITY,
+        () -> AqueousHydrogenSulfideOxidationTrajectory.advance(INITIAL_TOTAL_SULFIDE_MOLALITY,
             Collections.<AqueousHydrogenSulfideOxidationTrajectory.Segment>emptyList()));
-    assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationTrajectory.advance(
-            INITIAL_TOTAL_SULFIDE_MOLALITY,
-            Collections.singletonList(null)));
-    assertThrows(IllegalArgumentException.class,
-        () -> new AqueousHydrogenSulfideOxidationTrajectory.Segment(
-            -1.0, TEMPERATURE_K, PH, IONIC_STRENGTH,
-            AIR_SATURATED_OXYGEN_MOLALITY));
-    assertThrows(IllegalArgumentException.class,
-        () -> new AqueousHydrogenSulfideOxidationTrajectory.Segment(
-            1.0, TEMPERATURE_K, 8.01, IONIC_STRENGTH,
-            AIR_SATURATED_OXYGEN_MOLALITY));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(null)));
+    assertThrows(IllegalArgumentException.class, () -> new AqueousHydrogenSulfideOxidationTrajectory.Segment(-1.0,
+        TEMPERATURE_K, PH, IONIC_STRENGTH, AIR_SATURATED_OXYGEN_MOLALITY));
+    assertThrows(IllegalArgumentException.class, () -> new AqueousHydrogenSulfideOxidationTrajectory.Segment(1.0,
+        TEMPERATURE_K, 8.01, IONIC_STRENGTH, AIR_SATURATED_OXYGEN_MOLALITY));
 
-    AqueousHydrogenSulfideOxidationTrajectory.Segment overflow =
-        referenceSegment(Double.MAX_VALUE);
-    assertThrows(IllegalArgumentException.class,
-        () -> AqueousHydrogenSulfideOxidationTrajectory.advance(
-            INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(overflow)));
+    AqueousHydrogenSulfideOxidationTrajectory.Segment overflow = referenceSegment(Double.MAX_VALUE);
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationTrajectory
+        .advance(INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(overflow, overflow)));
   }
 
-  private static AqueousHydrogenSulfideOxidationTrajectory.Segment referenceSegment(
-      double durationHours) {
-    return new AqueousHydrogenSulfideOxidationTrajectory.Segment(
-        durationHours, TEMPERATURE_K, PH, IONIC_STRENGTH,
+  private static AqueousHydrogenSulfideOxidationTrajectory.Segment referenceSegment(double durationHours) {
+    return new AqueousHydrogenSulfideOxidationTrajectory.Segment(durationHours, TEMPERATURE_K, PH, IONIC_STRENGTH,
         AIR_SATURATED_OXYGEN_MOLALITY);
   }
 }

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationTrajectoryTest.java
@@ -1,0 +1,204 @@
+package neqsim.process.equipment.reactor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import neqsim.NeqSimTest;
+
+/** Tests exact piecewise propagation of the published aqueous H2S/O2 screening model. */
+public class AqueousHydrogenSulfideOxidationTrajectoryTest extends NeqSimTest {
+  private static final double INITIAL_TOTAL_SULFIDE_MOLALITY = 25.0e-6;
+  private static final double TEMPERATURE_K = 298.15;
+  private static final double PH = 8.0;
+  private static final double IONIC_STRENGTH = 0.723;
+  private static final double AIR_SATURATED_OXYGEN_MOLALITY = 250.0e-6;
+
+  @Test
+  void testTwoHalfLivesGiveExactInventoryAndClosure() {
+    double halfLife = AqueousHydrogenSulfideOxidationKinetics.halfLifeHours(
+        AIR_SATURATED_OXYGEN_MOLALITY, TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationTrajectory.Segment first = referenceSegment(halfLife);
+    AqueousHydrogenSulfideOxidationTrajectory.Segment second = referenceSegment(halfLife);
+
+    AqueousHydrogenSulfideOxidationTrajectory.Result result =
+        AqueousHydrogenSulfideOxidationTrajectory.advance(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(first, second));
+
+    assertEquals(2.0 * halfLife, result.getTotalTimeHours(), 1.0e-14);
+    assertEquals(2.0 * Math.log(2.0), result.getNominalExposure(), 1.0e-14);
+    assertEquals(0.25, result.getNominalRemainingFraction(), 1.0e-15);
+    assertEquals(6.25e-6, result.getFinalTotalSulfideMolality(), 1.0e-20);
+    assertEquals(18.75e-6, result.getReactedTotalSulfideMolality(), 1.0e-20);
+    assertEquals(0.0, result.getTotalSulfideClosureResidual(), 0.0);
+    assertEquals(INITIAL_TOTAL_SULFIDE_MOLALITY,
+        result.getFinalTotalSulfideMolality() + result.getReactedTotalSulfideMolality(),
+        0.0);
+  }
+
+  @Test
+  void testSegmentSplittingIsInvariant() {
+    double halfLife = AqueousHydrogenSulfideOxidationKinetics.halfLifeHours(
+        AIR_SATURATED_OXYGEN_MOLALITY, TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationTrajectory.Result unsplit =
+        AqueousHydrogenSulfideOxidationTrajectory.advance(
+            INITIAL_TOTAL_SULFIDE_MOLALITY,
+            Collections.singletonList(referenceSegment(2.0 * halfLife)));
+    AqueousHydrogenSulfideOxidationTrajectory.Result split =
+        AqueousHydrogenSulfideOxidationTrajectory.advance(
+            INITIAL_TOTAL_SULFIDE_MOLALITY,
+            Arrays.asList(referenceSegment(halfLife), referenceSegment(halfLife)));
+
+    assertEquals(unsplit.getNominalExposure(), split.getNominalExposure(), 1.0e-15);
+    assertEquals(unsplit.getFinalTotalSulfideMolality(),
+        split.getFinalTotalSulfideMolality(), 1.0e-20);
+    assertEquals(unsplit.getLowerRateExposure(), split.getLowerRateExposure(), 1.0e-15);
+    assertEquals(unsplit.getUpperRateExposure(), split.getUpperRateExposure(), 1.0e-15);
+  }
+
+  @Test
+  void testVaryingSegmentsReuseAuthoritativeSingleStateRates() {
+    AqueousHydrogenSulfideOxidationTrajectory.Segment first =
+        new AqueousHydrogenSulfideOxidationTrajectory.Segment(
+            3.0, 288.15, 5.0, 0.1, 300.0e-6);
+    AqueousHydrogenSulfideOxidationTrajectory.Segment second =
+        new AqueousHydrogenSulfideOxidationTrajectory.Segment(
+            7.0, 310.15, 7.0, 1.5, 220.0e-6);
+    AqueousHydrogenSulfideOxidationTrajectory.Result result =
+        AqueousHydrogenSulfideOxidationTrajectory.advance(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, Arrays.asList(first, second));
+
+    double expectedFirstExposure =
+        AqueousHydrogenSulfideOxidationKinetics.pseudoFirstOrderRateConstant(
+            first.getAirSaturatedOxygenMolality(), first.getTemperatureK(), first.getPH(),
+            first.getIonicStrengthMolPerKgWater()) * first.getDurationHours();
+    double expectedSecondExposure =
+        AqueousHydrogenSulfideOxidationKinetics.pseudoFirstOrderRateConstant(
+            second.getAirSaturatedOxygenMolality(), second.getTemperatureK(), second.getPH(),
+            second.getIonicStrengthMolPerKgWater()) * second.getDurationHours();
+
+    assertEquals(expectedFirstExposure,
+        result.getSegmentResults().get(0).getNominalExposure(), 0.0);
+    assertEquals(expectedFirstExposure + expectedSecondExposure,
+        result.getNominalExposure(), 1.0e-15);
+    assertEquals(result.getNominalExposure(),
+        result.getSegmentResults().get(1).getCumulativeNominalExposure(), 0.0);
+    assertTrue(result.getSegmentResults().get(1).getNominalSecondOrderRate()
+        > result.getSegmentResults().get(0).getNominalSecondOrderRate());
+  }
+
+  @Test
+  void testFitScatterEnvelopeHasCorrectPhysicalOrdering() {
+    AqueousHydrogenSulfideOxidationTrajectory.Result result =
+        AqueousHydrogenSulfideOxidationTrajectory.advance(
+            INITIAL_TOTAL_SULFIDE_MOLALITY,
+            Collections.singletonList(referenceSegment(24.0)));
+
+    assertTrue(result.getLowerRateExposure() < result.getNominalExposure());
+    assertTrue(result.getNominalExposure() < result.getUpperRateExposure());
+    assertTrue(result.getFinalTotalSulfideMolalityAtUpperRate()
+        < result.getFinalTotalSulfideMolality());
+    assertTrue(result.getFinalTotalSulfideMolality()
+        < result.getFinalTotalSulfideMolalityAtLowerRate());
+    assertTrue(result.getUpperRateRemainingFraction()
+        < result.getNominalRemainingFraction());
+    assertTrue(result.getNominalRemainingFraction()
+        < result.getLowerRateRemainingFraction());
+  }
+
+  @Test
+  void testZeroDurationAndDeterministicRepeat() {
+    AqueousHydrogenSulfideOxidationTrajectory.Segment zero = referenceSegment(0.0);
+
+    AqueousHydrogenSulfideOxidationTrajectory.Result first =
+        AqueousHydrogenSulfideOxidationTrajectory.advance(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(zero));
+    AqueousHydrogenSulfideOxidationTrajectory.Result second =
+        AqueousHydrogenSulfideOxidationTrajectory.advance(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(zero));
+
+    assertEquals(INITIAL_TOTAL_SULFIDE_MOLALITY,
+        first.getFinalTotalSulfideMolality(), 0.0);
+    assertEquals(0.0, first.getReactedTotalSulfideMolality(), 0.0);
+    assertEquals(0.0, first.getNominalExposure(), 0.0);
+    assertEquals(1.0, first.getNominalRemainingFraction(), 0.0);
+    assertEquals(first.getFinalTotalSulfideMolality(),
+        second.getFinalTotalSulfideMolality(), 0.0);
+    assertEquals(first.getNominalExposure(), second.getNominalExposure(), 0.0);
+  }
+
+  @Test
+  void testResultsAreDefensiveAndSourceOrdered() {
+    List<AqueousHydrogenSulfideOxidationTrajectory.Segment> source =
+        new ArrayList<AqueousHydrogenSulfideOxidationTrajectory.Segment>();
+    source.add(referenceSegment(1.0));
+    source.add(referenceSegment(2.0));
+    AqueousHydrogenSulfideOxidationTrajectory.Result result =
+        AqueousHydrogenSulfideOxidationTrajectory.advance(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, source);
+    source.clear();
+
+    assertEquals(2, result.getSegmentResults().size());
+    assertEquals(0, result.getSegmentResults().get(0).getIndex());
+    assertEquals(1, result.getSegmentResults().get(1).getIndex());
+    assertEquals(1.0,
+        result.getSegmentResults().get(0).getSegment().getDurationHours(), 0.0);
+    assertEquals(2.0,
+        result.getSegmentResults().get(1).getSegment().getDurationHours(), 0.0);
+    assertThrows(UnsupportedOperationException.class,
+        () -> result.getSegmentResults().add(null));
+  }
+
+  @Test
+  void testEvidenceAndNumericalInputsFailClosed() {
+    assertEquals(20.0e-6,
+        AqueousHydrogenSulfideOxidationTrajectory.MINIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY,
+        1.0e-20);
+    assertEquals(30.0e-6,
+        AqueousHydrogenSulfideOxidationTrajectory.MAXIMUM_INITIAL_TOTAL_SULFIDE_MOLALITY,
+        1.0e-20);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationTrajectory.advance(
+            19.999e-6, Collections.singletonList(referenceSegment(1.0))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationTrajectory.advance(
+            30.001e-6, Collections.singletonList(referenceSegment(1.0))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationTrajectory.advance(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, null));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationTrajectory.advance(
+            INITIAL_TOTAL_SULFIDE_MOLALITY,
+            Collections.<AqueousHydrogenSulfideOxidationTrajectory.Segment>emptyList()));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationTrajectory.advance(
+            INITIAL_TOTAL_SULFIDE_MOLALITY,
+            Collections.singletonList(null)));
+    assertThrows(IllegalArgumentException.class,
+        () -> new AqueousHydrogenSulfideOxidationTrajectory.Segment(
+            -1.0, TEMPERATURE_K, PH, IONIC_STRENGTH,
+            AIR_SATURATED_OXYGEN_MOLALITY));
+    assertThrows(IllegalArgumentException.class,
+        () -> new AqueousHydrogenSulfideOxidationTrajectory.Segment(
+            1.0, TEMPERATURE_K, 8.01, IONIC_STRENGTH,
+            AIR_SATURATED_OXYGEN_MOLALITY));
+
+    AqueousHydrogenSulfideOxidationTrajectory.Segment overflow =
+        referenceSegment(Double.MAX_VALUE);
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationTrajectory.advance(
+            INITIAL_TOTAL_SULFIDE_MOLALITY, Collections.singletonList(overflow)));
+  }
+
+  private static AqueousHydrogenSulfideOxidationTrajectory.Segment referenceSegment(
+      double durationHours) {
+    return new AqueousHydrogenSulfideOxidationTrajectory.Segment(
+        durationHours, TEMPERATURE_K, PH, IONIC_STRENGTH,
+        AIR_SATURATED_OXYGEN_MOLALITY);
+  }
+}


### PR DESCRIPTION
## Summary

Advances #3318 with exact piecewise propagation of the merged primary-source aqueous H₂S/O₂ screening correlation.

**Exact base:** `b9a920cbe44f6b9311fe4b9d405bce24e61d4ea4`  
**Exact head:** `d5205f6d8ad07c2d927df7e3893b2dacd739cfbc`

The pre-publication capability contract is recorded in [#3318](https://github.com/equinor/neqsim/issues/3318#issuecomment-5538042031).

## Capability

- Reuses `AqueousHydrogenSulfideOxidationKinetics` as the only rate-correlation authority.
- Propagates total sulfide through ordered piecewise-constant aqueous exposure segments with `exp(-sum(k_i [O2]_i dt_i))`.
- Reports immutable per-segment second-order rate, pseudo-first-order rate, individual exposure, and cumulative exposure evidence.
- Reports nominal, lower-rate, and upper-rate exposure/final-molality results using the source's 0.18-`log10(k)` fit scatter as one common multiplicative envelope.
- Enforces the source experiment's initial total-sulfide interval of 20–30 µmol/kg water.
- Preserves exact zero-duration identity, deterministic repeat, non-negative inventories, and total-sulfide closure.

## Evidence and validity

The physical correlation remains Millero et al. (1987), [doi:10.1021/es00159a003](https://doi.org/10.1021/es00159a003), already merged through #3433.

Every segment independently fails closed outside 278.15–338.15 K, pH 4–8, ionic strength 0–6 mol/kg water, or a finite positive caller-supplied air-saturated O₂ molality. Pressure is deliberately absent from the segment API.

The fit-scatter multiplier is applied coherently across all segments. It is not sampled as independent segment error and is not represented as complete predictive uncertainty.

## Changes

- Add immutable `AqueousHydrogenSulfideOxidationTrajectory`.
- Add seven focused JUnit tests covering two-half-life inventory, splitting invariance, authoritative rate reuse, uncertainty ordering, zero-time identity, defensive/source ordering, and fail-closed numerical/evidence inputs.
- Extend the H₂S/O₂ guide with the analytical trajectory, uncertainty, closure, and stop-boundary contract.
- Extend the executable documentation contract.

## Validation

**DRAFT — VALIDATION PENDING EXACT-HEAD CI**

Connector-side checks:

- exact base/head comparison: four intended files, four commits, zero commits behind the recorded base;
- independent analytical check: two identical half-life segments give remaining fraction 0.25, final 6.25 µmol/kg from 25 µmol/kg, and reacted 18.75 µmol/kg;
- API calls and Java 8-compatible syntax inspected against the exact merged source;
- documentation impact completed in the same four-file scope.

No local Maven, Spotless, pre-commit, Javadocs, or Python result is claimed. Hosted exact-head CI is authoritative under the campaign's resilient draft-publication policy.

## Portfolio and overlap

The #3318 lane was free after the verified merge of #3433. Three autonomous campaign PRs were positively identified before publication (#3436, #3440, #3442); this draft makes the portfolio 4/10. Existing heads were not modified.

## Stop boundary

No oxygen depletion/solubility, sulfur products, pH/HS⁻ speciation, activities, pressure dependence, water appearance, phase transfer, corrosion, reaction heat, R1–R8 binding, flash, transient solver, pipeline source term, or MCP exposure. No facility-specific Northern Lights data.

Coordination remains with #3144, #2937, #2911, pipeline work, and #3153. This PR must remain draft-only and must not be rebased or synchronized by this campaign.