### PR TITLE
[AI-Assisted] fix(separator): recalculate when pressure drop changes

### DIFF
--- a/src/main/java/neqsim/process/equipment/separator/Separator.java
+++ b/src/main/java/neqsim/process/equipment/separator/Separator.java
@@ -248,6 +248,7 @@ public class Separator extends ProcessEquipmentBaseClass
   private double lastEnthalpy;
   private double lastFlowRate;
   private double lastPressure;
+  private double lastPressureDrop;
 
   // Heat input capabilities
   private boolean setHeatInput = false;
@@ -675,13 +676,14 @@ public class Separator extends ProcessEquipmentBaseClass
     double flow = inletStreamMixer.getOutletStream().getFlowRate("kg/hr");
     double pres = inletStreamMixer.getOutletStream().getPressure();
     if (Math.abs((lastEnthalpy - enthalpy) / enthalpy) < 1e-6 && Math.abs((lastFlowRate - flow) / flow) < 1e-6
-        && Math.abs((lastPressure - pres) / pres) < 1e-6) {
+        && Math.abs((lastPressure - pres) / pres) < 1e-6 && lastPressureDrop == pressureDrop) {
       setCalculationIdentifier(id);
       return;
     }
     lastEnthalpy = inletStreamMixer.getOutletStream().getFluid().getEnthalpy();
     lastFlowRate = inletStreamMixer.getOutletStream().getFlowRate("kg/hr");
     lastPressure = inletStreamMixer.getOutletStream().getPressure();
+    lastPressureDrop = pressureDrop;
     thermoSystem2 = inletStreamMixer.getOutletStream().getThermoSystem().clone();
     thermoSystem2.setPressure(thermoSystem2.getPressure() - pressureDrop);
 

--- a/src/main/java/neqsim/process/equipment/separator/ThreePhaseSeparator.java
+++ b/src/main/java/neqsim/process/equipment/separator/ThreePhaseSeparator.java
@@ -58,6 +58,7 @@ public class ThreePhaseSeparator extends Separator {
   private double lastEnthalpy;
   private double lastFlowRate;
   private double lastPressure;
+  private double lastPressureDrop;
 
   /**
    * Water level height in meters (bottom of separator to water-oil interface).
@@ -475,13 +476,14 @@ public class ThreePhaseSeparator extends Separator {
     double flow = inletStreamMixer.getOutletStream().getFlowRate("kg/hr");
     double pres = inletStreamMixer.getOutletStream().getPressure();
     if (Math.abs((lastEnthalpy - enthalpy) / enthalpy) < 1e-6 && Math.abs((lastFlowRate - flow) / flow) < 1e-6
-        && Math.abs((lastPressure - pres) / pres) < 1e-6) {
+        && Math.abs((lastPressure - pres) / pres) < 1e-6 && lastPressureDrop == getPressureDrop()) {
       setCalculationIdentifier(id);
       return;
     }
     lastEnthalpy = inletStreamMixer.getOutletStream().getFluid().getEnthalpy();
     lastFlowRate = inletStreamMixer.getOutletStream().getFlowRate("kg/hr");
     lastPressure = inletStreamMixer.getOutletStream().getPressure();
+    lastPressureDrop = getPressureDrop();
     thermoSystem2 = inletStreamMixer.getOutletStream().getThermoSystem().clone();
 
     // Apply the vessel pressure drop before flashing so all three product phases

--- a/src/test/java/neqsim/process/equipment/separator/SeparatorTest.java
+++ b/src/test/java/neqsim/process/equipment/separator/SeparatorTest.java
@@ -58,6 +58,33 @@ class SeparatorTest extends neqsim.NeqSimTest {
     Assertions.assertEquals(lt.getMeasuredValue() * 100, lt.getMeasuredPercentValue(), 1e-12);
   }
 
+  /** Regression test for GitHub issue #3445. */
+  @Test
+  void testPressureDropChangeRecalculatesUnchangedInlet() {
+    SystemInterface fluid = new neqsim.thermo.system.SystemSrkEos(298.15, 1.9);
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.1);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(15000.0, "kg/hr");
+    feed.setPressure(1.9, "bara");
+    feed.setTemperature(25.0, "C");
+
+    Separator separator = new Separator("separator", feed);
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(separator);
+
+    separator.setPressureDrop(0.3);
+    process.run();
+    Assertions.assertEquals(1.6, separator.getGasOutStream().getPressure("bara"), 1.0e-10);
+
+    separator.setPressureDrop(0.8);
+    process.run();
+    Assertions.assertEquals(1.1, separator.getGasOutStream().getPressure("bara"), 1.0e-10);
+  }
+
   @Test
   void testEntropyProductionUsesEntropyUnitOnlyForResult() {
     ((StreamInterface) processOps.getUnit("inlet stream")).setFlowRate(1.0, "MSm3/day");

--- a/src/test/java/neqsim/process/equipment/separator/ThreePhaseSeparatorTest.java
+++ b/src/test/java/neqsim/process/equipment/separator/ThreePhaseSeparatorTest.java
@@ -1309,5 +1309,15 @@ class ThreePhaseSeparatorTest {
         "oil outlet should be inlet - pressureDrop");
     Assertions.assertEquals(9.8, sep.getWaterOutStream().getPressure("bara"), 1e-6,
         "water outlet should be inlet - pressureDrop");
+
+    sep.setPressureDrop(0.5);
+    sep.run();
+
+    Assertions.assertEquals(9.5, sep.getGasOutStream().getPressure("bara"), 1e-6,
+        "gas outlet should reflect a changed pressureDrop with an unchanged inlet");
+    Assertions.assertEquals(9.5, sep.getOilOutStream().getPressure("bara"), 1e-6,
+        "oil outlet should reflect a changed pressureDrop with an unchanged inlet");
+    Assertions.assertEquals(9.5, sep.getWaterOutStream().getPressure("bara"), 1e-6,
+        "water outlet should reflect a changed pressureDrop with an unchanged inlet");
   }
 }


### PR DESCRIPTION
## Summary

- include `pressureDrop` in the recalculation cache key for `Separator.run(UUID)`
- apply the same correction to the independently cached `ThreePhaseSeparator.run(UUID)`
- add a regression matching issue #3445: changing only the drop from 0.3 to 0.8 bar now changes the gas outlet from 1.6 to 1.1 bara
- extend three-phase coverage to verify gas, oil, and water outlets all respond to a changed drop with an unchanged inlet

## Root cause

The early-return cache compared only inlet enthalpy, mass flow, and pressure. A changed equipment pressure-drop specification therefore looked like a cache hit and skipped the flash that applies the new outlet pressure. Both separator implementations now store and compare the last applied pressure drop before taking that early return.

## Validation

- pre-fix regression: **failed as expected** — expected 1.1 bara, observed 1.5999999999999999 bara
- `./mvnw -q -Dtest='SeparatorTest#testPressureDropChangeRecalculatesUnchangedInlet,ThreePhaseSeparatorTest#testPressureDropAppliedToAllPhases' test`: **passed**
- `./mvnw -q -Dtest='SeparatorTest,ThreePhaseSeparatorTest' test`: **passed**
- `./mvnw -q -f pomJava8.xml -DskipTests compile`: **passed**
- `python3 devtools/run_spotless.py apply`: **passed**
- `python3 devtools/run_spotless.py check`: **passed**
- `python3 devtools/check_documentation_search.py`: **passed** (688 Markdown pages and 1 standalone HTML page)
- optional local `pre-commit`: executable unavailable; task-local installation was blocked by environment network policy. The direct mandatory Spotless and documentation checks above passed.
- the focused `pomJava8.xml` test run could not execute under the available JDK 17 because that profile's runtime classpath lacked `org.ejml.simple.ConstMatrix`; Java 8 source-target compilation passed, and GitHub CI will run the profile on an actual JDK 8.

## Documentation impact

Documentation impact: none. This restores the existing `setPressureDrop(double)` contract; there is no public API, unit, default, configuration, or recommended-usage change.

Closes #3445
