### PR TITLE
[AI-Assisted] Fix valve outlet-pressure inversion choking

### DIFF
--- a/docs/process/ValveMechanicalDesign.md
+++ b/docs/process/ValveMechanicalDesign.md
@@ -378,12 +378,14 @@ sizing method object:
 | $x_T$ | `setxT(double)` | 0.137 | Pressure drop ratio factor at choked flow. Typical values: globe valve 0.69-0.80, butterfly 0.25-0.50, ball 0.15-0.25 |
 | $F_L$ | `setFL(double)` | 1.0 | Liquid pressure recovery factor |
 | $F_D$ | `setFD(double)` | 1.0 | Valve style modifier |
+| Choked-flow capacity limit | `setAllowChoked(boolean)` | `true` | Caps gas flow at the configured $F_\gamma x_T$ limit; the legacy `default` sizing strategy instead defaults to `false` |
 
 ```java
 // Access the sizing method and configure parameters
 mechDesign.setValveSizingStandard("IEC 60534");
 mechDesign.getValveSizingMethod().setxT(0.75);  // Globe valve typical value
 mechDesign.getValveSizingMethod().setFL(0.90);   // Liquid recovery factor
+valve.setAllowChoked(true);                      // Set explicitly for this service
 ```
 
 ### Computing and Retrieving Cv/Kv

--- a/docs/process/equipment/valves.md
+++ b/docs/process/equipment/valves.md
@@ -130,7 +130,20 @@ Setting an outlet pressure and calling `run()` performs a specified-pressure
 letdown. To solve outlet pressure from the inlet flow, coefficient, and opening,
 set the Cv/Kv and call `setIsCalcOutPressure(true)` before running the valve.
 The result depends on the selected gas/liquid sizing behavior and valid inlet
-physical properties.
+physical properties. The legacy `default` sizing strategy leaves choked-flow
+capacity limiting disabled, which keeps the forward flow and reverse pressure
+calculations continuous and mutually invertible. The named `IEC 60534`,
+`IEC 60534 full`, and `prod choke` strategies enable the limit by default. Set
+the intended behavior explicitly after selecting the sizing strategy when the
+service and configured $x_T$ require it:
+
+```java
+valve.setAllowChoked(true);
+```
+
+When capacity limiting is enabled and the requested flow reaches the choked
+limit, downstream pressure is no longer uniquely determined by flow and Kv
+alone.
 
 ## Valve characteristic and mechanical design
 

--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -79,7 +79,6 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
   private double deltaPressure = 0.0;
   private boolean allowChoked = false;
   private boolean allowLaminar = true;
-  private double xt = 0.6; // critical pressure drop ratio for choked flow
   private double lastInletTemperature = Double.NaN;
   private double lastInletPressure = Double.NaN;
   private double lastInletFlowRate = Double.NaN;
@@ -243,10 +242,11 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
     if (inThermo.getTemperature() != lastInletTemperature || inThermo.getPressure() != lastInletPressure
         || pressure != lastOutletPressure || Kv != lastKv || percentValveOpening != lastPercentValveOpening
         || requestedValveOpening != lastRequestedValveOpening || deltaPressure != lastDeltaPressure || Fp != lastFp
-        || foulingFraction != lastFoulingFraction || xt != lastXt || valveKvSet != lastValveKvSet
-        || isoThermal != lastIsoThermal || acceptNegativeDP != lastAcceptNegativeDP
-        || isCalcPressure != lastIsCalcPressure || allowChoked != lastAllowChoked || allowLaminar != lastAllowLaminar
-        || !java.util.Objects.equals(pressureUnit, lastPressureUnit)
+        || foulingFraction != lastFoulingFraction || getMechanicalDesign().getValveSizingMethod().getxT() != lastXt
+        || valveKvSet != lastValveKvSet || isoThermal != lastIsoThermal || acceptNegativeDP != lastAcceptNegativeDP
+        || isCalcPressure != lastIsCalcPressure
+        || getMechanicalDesign().getValveSizingMethod().isAllowChoked() != lastAllowChoked
+        || allowLaminar != lastAllowLaminar || !java.util.Objects.equals(pressureUnit, lastPressureUnit)
         || !java.util.Objects.equals(getSpecification(), lastSpecification)) {
       return true;
     }
@@ -284,14 +284,14 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
     lastDeltaPressure = deltaPressure;
     lastFp = Fp;
     lastFoulingFraction = foulingFraction;
-    lastXt = xt;
+    lastXt = getMechanicalDesign().getValveSizingMethod().getxT();
     lastPressureUnit = pressureUnit;
     lastSpecification = getSpecification();
     lastValveKvSet = valveKvSet;
     lastIsoThermal = isoThermal;
     lastAcceptNegativeDP = acceptNegativeDP;
     lastIsCalcPressure = isCalcPressure;
-    lastAllowChoked = allowChoked;
+    lastAllowChoked = getMechanicalDesign().getValveSizingMethod().isAllowChoked();
     lastAllowLaminar = allowLaminar;
   }
 
@@ -1258,21 +1258,27 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface,
   }
 
   /**
-   * isAllowChoked.
+   * Returns whether the active valve-sizing method applies its choked-flow capacity limit.
    *
-   * @return a boolean
+   * @return {@code true} when choked-flow capacity limiting is enabled
    */
   public boolean isAllowChoked() {
+    if (getMechanicalDesign() != null && getMechanicalDesign().getValveSizingMethod() != null) {
+      return getMechanicalDesign().getValveSizingMethod().isAllowChoked();
+    }
     return allowChoked;
   }
 
   /**
-   * Setter for the field <code>allowChoked</code>.
+   * Sets whether the active valve-sizing method applies its choked-flow capacity limit.
    *
-   * @param allowChoked a boolean
+   * @param allowChoked {@code true} to cap flow at the choked-flow limit
    */
   public void setAllowChoked(boolean allowChoked) {
     this.allowChoked = allowChoked;
+    if (getMechanicalDesign() != null && getMechanicalDesign().getValveSizingMethod() != null) {
+      getMechanicalDesign().getValveSizingMethod().setAllowChoked(allowChoked);
+    }
   }
 
   /**

--- a/src/main/java/neqsim/process/mechanicaldesign/valve/ControlValveSizing.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/valve/ControlValveSizing.java
@@ -36,7 +36,8 @@ public class ControlValveSizing implements ControlValveSizingInterface, Serializ
   static final double P_STD_KPA = 101.325;
 
   double xT = 0.137;
-  boolean allowChoked = true;
+  /** Whether the sizing equations cap flow at the choked-flow limit. */
+  boolean allowChoked = false;
 
   /**
    * Constructor for ControlValveSizing.

--- a/src/main/java/neqsim/process/mechanicaldesign/valve/ControlValveSizing_IEC_60534.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/valve/ControlValveSizing_IEC_60534.java
@@ -103,6 +103,7 @@ public class ControlValveSizing_IEC_60534 extends ControlValveSizing {
    * Constructor for ControlValveSizing_IEC_60534.
    */
   public ControlValveSizing_IEC_60534() {
+    setAllowChoked(true);
   }
 
   /**
@@ -112,6 +113,7 @@ public class ControlValveSizing_IEC_60534 extends ControlValveSizing {
    */
   public ControlValveSizing_IEC_60534(ValveMechanicalDesign valveMechanicalDesign) {
     super(valveMechanicalDesign);
+    setAllowChoked(true);
   }
 
   /**

--- a/src/main/java/neqsim/process/mechanicaldesign/valve/ControlValveSizing_simple.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/valve/ControlValveSizing_simple.java
@@ -38,6 +38,7 @@ public class ControlValveSizing_simple extends ControlValveSizing {
    * Constructor for ControlValveSizing_simple.
    */
   public ControlValveSizing_simple() {
+    setAllowChoked(true);
   }
 
   /**
@@ -47,6 +48,7 @@ public class ControlValveSizing_simple extends ControlValveSizing {
    */
   public ControlValveSizing_simple(ValveMechanicalDesign valveMechanicalDesign) {
     super(valveMechanicalDesign);
+    setAllowChoked(true);
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/valve/ThrottlingValveTest.java
+++ b/src/test/java/neqsim/process/equipment/valve/ThrottlingValveTest.java
@@ -1,6 +1,7 @@
 package neqsim.process.equipment.valve;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Map;
 import java.util.UUID;
@@ -56,6 +57,58 @@ public class ThrottlingValveTest {
 
     int getLevelThreeCalls() {
       return levelThreeCalls.get();
+    }
+  }
+
+  /** Regression test for GitHub issue #3446. */
+  @Test
+  void testCalculatedOutletPressureInvertsGasValveSizingIssue3446() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 1.9);
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.1);
+    fluid.setMixingRule("classic");
+
+    Stream inlet = new Stream("inlet", fluid);
+    inlet.setFlowRate(28500.0, "kg/hr");
+    inlet.setPressure(1.9, "bara");
+    inlet.setTemperature(25.0, "C");
+
+    ThrottlingValve valve = new ThrottlingValve("valve", inlet);
+    valve.setGasValve(true);
+    valve.setPercentValveOpening(100.0);
+    valve.setOutletPressure(1.484, "bara");
+    assertFalse(valve.isAllowChoked(), "Single-phase valve flow is not capacity-limited unless enabled explicitly");
+
+    valve.setAllowChoked(true);
+    assertTrue(valve.getMechanicalDesign().getValveSizingMethod().isAllowChoked(),
+        "The valve-level choked-flow setting must reach the active sizing method");
+    valve.setAllowChoked(false);
+
+    ProcessSystem process = new ProcessSystem("gas valve pressure inversion");
+    process.add(inlet);
+    process.add(valve);
+    process.run();
+
+    double sizedKv = valve.getKv();
+    valve.setIsCalcOutPressure(true);
+    process.run();
+
+    assertEquals(sizedKv, valve.getKv(), 0.0, "Reverse mode must retain the sized valve coefficient");
+    assertEquals(1.484, valve.getOutletStream().getPressure("bara"), 1.0e-4,
+        "Fixed-Kv pressure mode must invert the forward sizing point");
+
+    double previousPressureDrop = 0.0;
+    double[] flowRates = { 24000.0, 26500.0, 27500.0, 28000.0, 28500.0, 29000.0, 30000.0 };
+    for (double flowRate : flowRates) {
+      inlet.setFlowRate(flowRate, "kg/hr");
+      process.run();
+      double pressureDrop = inlet.getPressure("bara") - valve.getOutletStream().getPressure("bara");
+
+      assertTrue(Double.isFinite(pressureDrop), "Calculated pressure drop must remain finite");
+      assertTrue(pressureDrop > previousPressureDrop, "Pressure drop must increase smoothly with gas flow");
+      assertTrue(valve.getOutletStream().getPressure("bara") > 0.1,
+          "A nearby flow increase must not pin the outlet pressure to the solver floor");
+      previousPressureDrop = pressureDrop;
     }
   }
 


### PR DESCRIPTION
## Summary

- Make the legacy `default` valve-sizing strategy leave choked-flow capacity limiting disabled, matching `ThrottlingValve`'s public default so forward sizing and reverse outlet-pressure calculation use the same equation branch.
- Delegate `ThrottlingValve.setAllowChoked(...)` and `isAllowChoked()` to the active sizing method, and track the active method's `xT`/choking state in recalculation caching.
- Preserve capacity limiting by default for the named `IEC 60534`, `IEC 60534 full`, and `prod choke` strategies.
- Add regression coverage and document how to opt into capacity limiting and why pressure is non-unique on a choked plateau.

## Root cause and result

`ThrottlingValve` advertised `allowChoked = false`, while its active default `ControlValveSizing` silently initialized the setting to `true`. At the reported sizing point, this placed the calculation on a choked-capacity plateau. The reverse bisection therefore saw the same required Kv over a pressure range and accepted its first midpoint, producing 0.9995 bara instead of the 1.484 bara sizing target.

The regression first reproduced that exact failure. With this change, the 28,500 kg/hr sizing case round-trips to 1.484 bara (within 1e-4 bara), retains the sized Kv, and the 24,000–30,000 kg/hr sweep has finite, strictly increasing pressure drop without pinning the outlet to the solver floor.

## Validation

- `./mvnw -B test -ntp -DskipITs -Dtest='*Valve*Test'` — 217 tests passed
- `./mvnw -B clean test --file pomJava8.xml -ntp -Djacoco.skip=true -DskipITs -Dtest='ThrottlingValveTest,ControlValveSizingTest,ValveSizingMethodComparisonTest'` — 34 tests passed
- `python3 devtools/run_spotless.py check`
- `python3 devtools/check_documentation_search.py`
- pre-commit and pre-push hooks over all files

## Documentation impact

Updated `docs/process/equipment/valves.md` and `docs/process/ValveMechanicalDesign.md` with the default behavior, named-strategy behavior, explicit configuration example, and choked-plateau limitation.

Closes #3446