### PR TITLE
[AI-Assisted] feat(dexpi): expose instrumentation-loop evidence

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -105,6 +105,7 @@ DexpiXmlReader.ImportResult result =
     DexpiXmlReader.readWithDiagnostics(xmlFile.toFile(), template);
 ProcessSystem process = result.getProcessSystem();
 List<DexpiInstrumentInfo> instruments = result.getInstruments();
+List<DexpiInstrumentationLoopInfo> instrumentationLoops = result.getInstrumentationLoops();
 List<DexpiInformationFlowInfo> informationFlows = result.getInformationFlows();
 List<DexpiConnectionInfo> connections = result.getConnections();
 
@@ -149,6 +150,14 @@ lines additionally retain explicit attachment identity and resolution; signal li
 diagnostics, so Java and JPype callers do not need to reparse XML or invent endpoints. These records
 do not create live transmitters or controllers, infer control-loop intent, verify a loop, or classify
 safety-instrumented or safeguard functions.
+
+`ImportResult.getInstrumentationLoops()` exposes each source
+`InstrumentationLoopFunction` as an immutable, source-ordered
+`DexpiInstrumentationLoopInfo`. The record retains the loop ID, component class, explicit loop
+number, and every direct `is a collection including` occurrence in source order. Membership
+evidence preserves duplicate, blank, and unresolved references together with resolution status and
+the resolved XML element name. It does not infer control intent, verify functional completeness,
+construct executable control topology, or classify SIS or safeguard functions.
 
 The same result also preserves every source `Connection` in document order, including parallel
 connections between the same endpoints. Each immutable `DexpiConnectionInfo` retains the owning
@@ -231,15 +240,16 @@ stay in the global connection and diagnostic evidence because a transition canno
 cycle. This exact-once inventory remains source-reference evidence only; it does not prove hydraulic
 continuity, identify a physical recycle, enumerate paths, or alter simulation topology.
 
-`toJson()` includes `instrumentCount`, `informationFlowCount`, `connectionCount`,
+`toJson()` includes `instrumentCount`, `instrumentationLoopCount`,
+`informationFlowCount`, `connectionCount`,
 `connectionEndpointCount`, `connectionComponentCount`, `connectionCycleCount`,
-`connectionCycleTransitionCount`, and the ordered information-flow, connection, endpoint,
-component, directed-cycle, and cycle-transition inventories, including reference resolution,
+`connectionCycleTransitionCount`, and the ordered instrumentation-loop, information-flow, connection, endpoint, component,
+directed-cycle, and cycle-transition inventories, including reference resolution,
 incidence roles, review subsets, complete cycle-local endpoint and internal connection occurrences,
 explicit cycle-boundary occurrences, and exact-once transitions with nested connection and endpoint
 evidence, alongside the process-unit count and findings. Python callers through JPype use the same
-`ImportResult.getInstruments()`, `ImportResult.getInformationFlows()`,
-`ImportResult.getConnections()`, `ImportResult.getConnectionEndpoints()`,
+`ImportResult.getInstruments()`, `ImportResult.getInstrumentationLoops()`,
+`ImportResult.getInformationFlows()`, `ImportResult.getConnections()`, `ImportResult.getConnectionEndpoints()`,
 `ImportResult.getConnectionComponents()`, `ImportResult.getConnectionCycles()`, and
 `ImportResult.getConnectionCycleTransitions()` getters; there is no separate Python reconstruction
 model.

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiInstrumentationLoopInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiInstrumentationLoopInfo.java
@@ -1,0 +1,125 @@
+package neqsim.process.processmodel.dexpi;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Immutable source evidence for one DEXPI instrumentation-loop grouping occurrence.
+ *
+ * <p>
+ * The record preserves explicit source-document membership without constructing live controllers, inferring control
+ * intent, verifying loop function, or classifying safeguards.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class DexpiInstrumentationLoopInfo implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Immutable evidence for one source loop-membership occurrence. */
+  public static final class Member implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String memberId;
+    private final boolean resolved;
+    private final String elementName;
+
+    /**
+     * Creates evidence for one source loop-membership occurrence.
+     *
+     * @param memberId referenced source identity, or an empty string when absent
+     * @param resolved whether the reference resolves to a source element
+     * @param elementName resolved XML element name, or an empty string
+     */
+    public Member(String memberId, boolean resolved, String elementName) {
+      this.memberId = normalize(memberId);
+      this.resolved = resolved;
+      this.elementName = normalize(elementName);
+    }
+
+    /** @return referenced source identity, or an empty string when absent */
+    public String getMemberId() {
+      return memberId;
+    }
+
+    /** @return whether the member reference resolves to a source element */
+    public boolean isResolved() {
+      return resolved;
+    }
+
+    /** @return resolved member XML element name, or an empty string */
+    public String getElementName() {
+      return elementName;
+    }
+
+    private Map<String, Object> toMap() {
+      Map<String, Object> result = new LinkedHashMap<String, Object>();
+      result.put("memberId", memberId);
+      result.put("resolved", Boolean.valueOf(resolved));
+      result.put("elementName", elementName);
+      return result;
+    }
+  }
+
+  private final String id;
+  private final String componentClass;
+  private final String loopNumber;
+  private final List<Member> members;
+
+  /**
+   * Creates immutable evidence for one instrumentation-loop grouping.
+   *
+   * @param id source XML identity, or an empty string when absent
+   * @param componentClass source component class
+   * @param loopNumber explicit source loop-number metadata, or an empty string when absent
+   * @param members membership occurrences in source-document order
+   */
+  public DexpiInstrumentationLoopInfo(String id, String componentClass, String loopNumber, List<Member> members) {
+    this.id = normalize(id);
+    this.componentClass = normalize(componentClass);
+    this.loopNumber = normalize(loopNumber);
+    this.members = Collections.unmodifiableList(new ArrayList<Member>(members));
+  }
+
+  /** @return source XML identity, or an empty string when absent */
+  public String getId() {
+    return id;
+  }
+
+  /** @return source component class */
+  public String getComponentClass() {
+    return componentClass;
+  }
+
+  /** @return explicit source loop-number metadata, or an empty string when absent */
+  public String getLoopNumber() {
+    return loopNumber;
+  }
+
+  /** @return immutable membership occurrences in source-document order */
+  public List<Member> getMembers() {
+    return members;
+  }
+
+  Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("id", id);
+    result.put("componentClass", componentClass);
+    result.put("loopNumber", loopNumber);
+    result.put("memberCount", Integer.valueOf(members.size()));
+    List<Map<String, Object>> memberMaps = new ArrayList<Map<String, Object>>();
+    for (Member member : members) {
+      memberMaps.add(member.toMap());
+    }
+    result.put("members", memberMaps);
+    return result;
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -130,6 +130,7 @@ public final class DexpiXmlReader {
     private static final long serialVersionUID = 1000L;
     private final ProcessSystem processSystem;
     private final List<DexpiInstrumentInfo> instruments;
+    private final List<DexpiInstrumentationLoopInfo> instrumentationLoops;
     private final List<DexpiInformationFlowInfo> informationFlows;
     private final List<DexpiConnectionInfo> connections;
     private final List<DexpiConnectionEndpointInfo> connectionEndpoints;
@@ -139,12 +140,15 @@ public final class DexpiXmlReader {
     private final List<ImportDiagnostic> diagnostics;
 
     private ImportResult(ProcessSystem processSystem, List<DexpiInstrumentInfo> instruments,
-        List<DexpiInformationFlowInfo> informationFlows, List<DexpiConnectionInfo> connections,
+        List<DexpiInstrumentationLoopInfo> instrumentationLoops, List<DexpiInformationFlowInfo> informationFlows,
+        List<DexpiConnectionInfo> connections,
         List<DexpiConnectionEndpointInfo> connectionEndpoints, List<DexpiConnectionComponentInfo> connectionComponents,
         List<DexpiConnectionCycleInfo> connectionCycles,
         List<DexpiConnectionCycleTransitionInfo> connectionCycleTransitions, List<ImportDiagnostic> diagnostics) {
       this.processSystem = processSystem;
       this.instruments = Collections.unmodifiableList(new ArrayList<DexpiInstrumentInfo>(instruments));
+      this.instrumentationLoops = Collections
+          .unmodifiableList(new ArrayList<DexpiInstrumentationLoopInfo>(instrumentationLoops));
       this.informationFlows = Collections.unmodifiableList(new ArrayList<DexpiInformationFlowInfo>(informationFlows));
       this.connections = Collections.unmodifiableList(new ArrayList<DexpiConnectionInfo>(connections));
       this.connectionEndpoints = Collections
@@ -173,6 +177,20 @@ public final class DexpiXmlReader {
      */
     public List<DexpiInstrumentInfo> getInstruments() {
       return instruments;
+    }
+
+    /**
+     * Returns instrumentation-loop grouping evidence in source-document order.
+     *
+     * <p>
+     * Membership occurrences retain only explicit source references and resolution evidence. They do not construct
+     * live control topology, infer control intent, verify loop function, or classify safeguards.
+     * </p>
+     *
+     * @return immutable instrumentation-loop records
+     */
+    public List<DexpiInstrumentationLoopInfo> getInstrumentationLoops() {
+      return instrumentationLoops;
     }
 
     /**
@@ -287,6 +305,12 @@ public final class DexpiXmlReader {
       result.put("profile", "Proteus-compatible DEXPI Plant/P&ID 4.1.1 supported subset");
       result.put("importedUnitCount", Integer.valueOf(processSystem.getAllUnitNames().size()));
       result.put("instrumentCount", Integer.valueOf(instruments.size()));
+      result.put("instrumentationLoopCount", Integer.valueOf(instrumentationLoops.size()));
+      List<Map<String, Object>> instrumentationLoopMaps = new ArrayList<Map<String, Object>>();
+      for (DexpiInstrumentationLoopInfo instrumentationLoop : instrumentationLoops) {
+        instrumentationLoopMaps.add(instrumentationLoop.toMap());
+      }
+      result.put("instrumentationLoops", instrumentationLoopMaps);
       result.put("informationFlowCount", Integer.valueOf(informationFlows.size()));
       List<Map<String, Object>> informationFlowMaps = new ArrayList<Map<String, Object>>();
       for (DexpiInformationFlowInfo informationFlow : informationFlows) {
@@ -514,11 +538,12 @@ public final class DexpiXmlReader {
       throws IOException, DexpiXmlReaderException {
     ProcessSystem processSystem = new ProcessSystem("DEXPI process");
     List<DexpiInstrumentInfo> instruments = new ArrayList<DexpiInstrumentInfo>();
+    List<DexpiInstrumentationLoopInfo> instrumentationLoops = new ArrayList<DexpiInstrumentationLoopInfo>();
     List<DexpiInformationFlowInfo> informationFlows = new ArrayList<DexpiInformationFlowInfo>();
     List<DexpiConnectionInfo> connections = new ArrayList<DexpiConnectionInfo>();
     List<ImportDiagnostic> diagnostics = new ArrayList<ImportDiagnostic>();
-    loadInternal(inputStream, processSystem, templateStream, false, diagnostics, instruments, informationFlows,
-        connections);
+    loadInternal(inputStream, processSystem, templateStream, false, diagnostics, instruments, instrumentationLoops,
+        informationFlows, connections);
     List<DexpiConnectionEndpointInfo> connectionEndpoints = summarizeConnectionEndpoints(connections);
     List<DexpiConnectionComponentInfo> connectionComponents = summarizeConnectionComponents(connections,
         connectionEndpoints);
@@ -526,7 +551,8 @@ public final class DexpiXmlReader {
         connectionComponents);
     List<DexpiConnectionCycleTransitionInfo> connectionCycleTransitions = summarizeConnectionCycleTransitions(
         connections, connectionEndpoints, connectionCycles);
-    return new ImportResult(processSystem, instruments, informationFlows, connections, connectionEndpoints,
+    return new ImportResult(processSystem, instruments, instrumentationLoops, informationFlows, connections,
+        connectionEndpoints,
         connectionComponents, connectionCycles, connectionCycleTransitions, diagnostics);
   }
 
@@ -602,12 +628,13 @@ public final class DexpiXmlReader {
    */
   public static void load(InputStream inputStream, ProcessSystem processSystem, Stream templateStream,
       boolean namespaceAware) throws IOException, DexpiXmlReaderException {
-    loadInternal(inputStream, processSystem, templateStream, namespaceAware, null, null, null, null);
+    loadInternal(inputStream, processSystem, templateStream, namespaceAware, null, null, null, null, null);
   }
 
   private static void loadInternal(InputStream inputStream, ProcessSystem processSystem, Stream templateStream,
       boolean namespaceAware, List<ImportDiagnostic> diagnostics, List<DexpiInstrumentInfo> instruments,
-      List<DexpiInformationFlowInfo> informationFlows, List<DexpiConnectionInfo> connections)
+      List<DexpiInstrumentationLoopInfo> instrumentationLoops, List<DexpiInformationFlowInfo> informationFlows,
+      List<DexpiConnectionInfo> connections)
       throws IOException, DexpiXmlReaderException {
     Objects.requireNonNull(inputStream, "inputStream");
     Objects.requireNonNull(processSystem, "processSystem");
@@ -631,6 +658,9 @@ public final class DexpiXmlReader {
     addPipingSegments(document, processSystem, streamTemplate, diagnostics);
     if (instruments != null) {
       instruments.addAll(parseInstruments(document));
+    }
+    if (instrumentationLoops != null) {
+      instrumentationLoops.addAll(parseInstrumentationLoops(document));
     }
     if (informationFlows != null) {
       informationFlows.addAll(parseInformationFlows(document));
@@ -781,6 +811,45 @@ public final class DexpiXmlReader {
 
     logger.info("Parsed {} instruments from DEXPI XML", instruments.size());
     return instruments;
+  }
+
+  private static List<DexpiInstrumentationLoopInfo> parseInstrumentationLoops(Document document) {
+    List<DexpiInstrumentationLoopInfo> result = new ArrayList<DexpiInstrumentationLoopInfo>();
+    Map<String, Element> elementsById = new HashMap<String, Element>();
+    NodeList allElements = document.getElementsByTagName("*");
+    for (int i = 0; i < allElements.getLength(); i++) {
+      Node node = allElements.item(i);
+      if (node.getNodeType() != Node.ELEMENT_NODE || isInsideShapeCatalogue(node)) {
+        continue;
+      }
+      Element element = (Element) node;
+      String id = element.getAttribute("ID");
+      if (!isBlank(id) && !elementsById.containsKey(id)) {
+        elementsById.put(id, element);
+      }
+    }
+
+    NodeList loopNodes = document.getElementsByTagName("InstrumentationLoopFunction");
+    for (int i = 0; i < loopNodes.getLength(); i++) {
+      Node node = loopNodes.item(i);
+      if (node.getNodeType() != Node.ELEMENT_NODE || isInsideShapeCatalogue(node)) {
+        continue;
+      }
+      Element loop = (Element) node;
+      List<DexpiInstrumentationLoopInfo.Member> members =
+          new ArrayList<DexpiInstrumentationLoopInfo.Member>();
+      for (Element association : directChildElements(loop, "Association")) {
+        if (!"is a collection including".equals(association.getAttribute("Type"))) {
+          continue;
+        }
+        String memberId = association.getAttribute("ItemID");
+        Element member = elementsById.get(memberId);
+        members.add(new DexpiInstrumentationLoopInfo.Member(memberId, member != null, elementName(member)));
+      }
+      result.add(new DexpiInstrumentationLoopInfo(loop.getAttribute("ID"), loop.getAttribute("ComponentClass"),
+          getGenericAttribute(loop, DexpiMetadata.LOOP_NUMBER), members));
+    }
+    return result;
   }
 
   private static List<DexpiInformationFlowInfo> parseInformationFlows(Document document) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -141,9 +141,8 @@ public final class DexpiXmlReader {
 
     private ImportResult(ProcessSystem processSystem, List<DexpiInstrumentInfo> instruments,
         List<DexpiInstrumentationLoopInfo> instrumentationLoops, List<DexpiInformationFlowInfo> informationFlows,
-        List<DexpiConnectionInfo> connections,
-        List<DexpiConnectionEndpointInfo> connectionEndpoints, List<DexpiConnectionComponentInfo> connectionComponents,
-        List<DexpiConnectionCycleInfo> connectionCycles,
+        List<DexpiConnectionInfo> connections, List<DexpiConnectionEndpointInfo> connectionEndpoints,
+        List<DexpiConnectionComponentInfo> connectionComponents, List<DexpiConnectionCycleInfo> connectionCycles,
         List<DexpiConnectionCycleTransitionInfo> connectionCycleTransitions, List<ImportDiagnostic> diagnostics) {
       this.processSystem = processSystem;
       this.instruments = Collections.unmodifiableList(new ArrayList<DexpiInstrumentInfo>(instruments));
@@ -183,8 +182,8 @@ public final class DexpiXmlReader {
      * Returns instrumentation-loop grouping evidence in source-document order.
      *
      * <p>
-     * Membership occurrences retain only explicit source references and resolution evidence. They do not construct
-     * live control topology, infer control intent, verify loop function, or classify safeguards.
+     * Membership occurrences retain only explicit source references and resolution evidence. They do not construct live
+     * control topology, infer control intent, verify loop function, or classify safeguards.
      * </p>
      *
      * @return immutable instrumentation-loop records
@@ -552,8 +551,7 @@ public final class DexpiXmlReader {
     List<DexpiConnectionCycleTransitionInfo> connectionCycleTransitions = summarizeConnectionCycleTransitions(
         connections, connectionEndpoints, connectionCycles);
     return new ImportResult(processSystem, instruments, instrumentationLoops, informationFlows, connections,
-        connectionEndpoints,
-        connectionComponents, connectionCycles, connectionCycleTransitions, diagnostics);
+        connectionEndpoints, connectionComponents, connectionCycles, connectionCycleTransitions, diagnostics);
   }
 
   /**
@@ -634,8 +632,7 @@ public final class DexpiXmlReader {
   private static void loadInternal(InputStream inputStream, ProcessSystem processSystem, Stream templateStream,
       boolean namespaceAware, List<ImportDiagnostic> diagnostics, List<DexpiInstrumentInfo> instruments,
       List<DexpiInstrumentationLoopInfo> instrumentationLoops, List<DexpiInformationFlowInfo> informationFlows,
-      List<DexpiConnectionInfo> connections)
-      throws IOException, DexpiXmlReaderException {
+      List<DexpiConnectionInfo> connections) throws IOException, DexpiXmlReaderException {
     Objects.requireNonNull(inputStream, "inputStream");
     Objects.requireNonNull(processSystem, "processSystem");
 
@@ -836,8 +833,7 @@ public final class DexpiXmlReader {
         continue;
       }
       Element loop = (Element) node;
-      List<DexpiInstrumentationLoopInfo.Member> members =
-          new ArrayList<DexpiInstrumentationLoopInfo.Member>();
+      List<DexpiInstrumentationLoopInfo.Member> members = new ArrayList<DexpiInstrumentationLoopInfo.Member>();
       for (Element association : directChildElements(loop, "Association")) {
         if (!"is a collection including".equals(association.getAttribute("Type"))) {
           continue;

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -236,6 +236,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         + "<GenericAttributes><GenericAttribute Name=\"InstrumentationLoopFunctionNumberAssignmentClass\" Value=\"100\"/>"
         + "</GenericAttributes><Association Type=\"is a collection including\" ItemID=\"PIF-PT-100\"/>"
         + "<Association Type=\"is a collection including\" ItemID=\"PIF-PC-100\"/>"
+        + "<Association Type=\"is a collection including\" ItemID=\"PIF-PC-100\"/>"
         + "</InstrumentationLoopFunction></PlantModel>";
 
     DexpiXmlReader.ImportResult first = DexpiXmlReader
@@ -248,6 +249,21 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("100", first.getInstruments().get(0).getLoopNumber());
     assertEquals("PC-100", first.getInstruments().get(1).getTagName());
     assertEquals("PC-100", first.getInstruments().get(1).getActuatingTag());
+
+    List<DexpiInstrumentationLoopInfo> instrumentationLoops = first.getInstrumentationLoops();
+    assertEquals(1, instrumentationLoops.size());
+    DexpiInstrumentationLoopInfo loop = instrumentationLoops.get(0);
+    assertEquals("LOOP-100", loop.getId());
+    assertEquals("InstrumentationLoopFunction", loop.getComponentClass());
+    assertEquals("100", loop.getLoopNumber());
+    assertEquals(3, loop.getMembers().size());
+    assertEquals("PIF-PT-100", loop.getMembers().get(0).getMemberId());
+    assertTrue(loop.getMembers().get(0).isResolved());
+    assertEquals("ProcessInstrumentationFunction", loop.getMembers().get(0).getElementName());
+    assertEquals("PIF-PC-100", loop.getMembers().get(1).getMemberId());
+    assertEquals("PIF-PC-100", loop.getMembers().get(2).getMemberId());
+    assertThrows(UnsupportedOperationException.class, () -> instrumentationLoops.clear());
+    assertThrows(UnsupportedOperationException.class, () -> loop.getMembers().clear());
 
     List<DexpiInformationFlowInfo> informationFlows = first.getInformationFlows();
     assertEquals(3, informationFlows.size());
@@ -289,6 +305,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(first.getDiagnostics().isEmpty());
     assertFalse(first.hasLosses());
     assertTrue(first.toJson().contains("\"instrumentCount\": 2"));
+    assertTrue(first.toJson().contains("\"instrumentationLoopCount\": 1"));
+    assertTrue(first.toJson().contains("\"memberCount\": 3"));
     assertTrue(first.toJson().contains("\"informationFlowCount\": 3"));
     assertTrue(first.toJson().contains("\"kind\": \"MEASURING_LINE\""));
     assertTrue(first.toJson().contains("\"signalConveyingType\": \"ElectricalSignalConveying\""));
@@ -317,6 +335,15 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
 
     assertEquals(1, first.getInstruments().size());
+    assertEquals(1, first.getInstrumentationLoops().size());
+    DexpiInstrumentationLoopInfo loop = first.getInstrumentationLoops().get(0);
+    assertEquals("", loop.getId());
+    assertEquals("InstrumentationLoopFunction", loop.getComponentClass());
+    assertEquals("", loop.getLoopNumber());
+    assertEquals(1, loop.getMembers().size());
+    assertEquals("UNKNOWN-MEMBER", loop.getMembers().get(0).getMemberId());
+    assertFalse(loop.getMembers().get(0).isResolved());
+    assertEquals("", loop.getMembers().get(0).getElementName());
     assertDiagnostic(first, "DEXPI_IMPORT_INSTRUMENT_ID_MISSING");
     assertDiagnostic(first, "DEXPI_IMPORT_INSTRUMENT_FUNCTION_METADATA_MISSING");
     assertDiagnostic(first, "DEXPI_IMPORT_INSTRUMENT_NUMBER_MISSING");


### PR DESCRIPTION
## Summary
- expose immutable, source-ordered `InstrumentationLoopFunction` evidence
- retain explicit loop identity, component class, loop number, and every membership occurrence
- preserve duplicate, blank, and unresolved member references with resolution evidence
- add deterministic JSON, focused regression coverage, and Java/JPype documentation

## Capability contract
This PR adds evidence only. It does not construct live transmitters or controllers, infer control-loop intent, verify functional completeness, solve paths, classify SIS/safeguard functions, or alter simulation topology.

Existing reader/load APIs, source ordering, material connectivity, rendering, and exports remain unchanged.

## Validation
- exact base: `78a37355789d9fdacfe1186f821a78e8cc44cc5c`
- exact head: `d97511e5da1c7d13b720b8639930a42d18e6d0da`
- five commits across four intended files
- exact hosted Spotless repair applied without behavior or scope change
- all eight hosted workflows pass: 19 successful jobs, one expected PaperLab skip, zero failures or pending jobs
- Java 8/21 Ubuntu/Windows, all slow shards, Javadocs, formatting, pre-commit, documentation, notebook, engineering-diagram performance, CodeQL, and reference checks pass
- both review threads are resolved without source changes
- whole-sheet visual gate: N/A (no rendering, geometry, layout, notebook, or export path changed)

Status: **READY TO MERGE**. The PR intentionally remains draft and unmerged.

## Campaign
Advances #1332 and #2899 under the shared engineering-diagram lane. Positively identified autonomous implementation portfolio: 4/10.

AI-assisted change; draft only. No standards-conformance, certification, loop-function verification, SIS/safeguard classification, or engineering-approval claim.