### PR TITLE
Add pluggable entrainment models with a selectable carry-over default

### DIFF
--- a/docs/process/equipment/private-extensions.md
+++ b/docs/process/equipment/private-extensions.md
@@ -1,0 +1,110 @@
+---
+title: "Private entrainment models"
+description: How to supply a proprietary carry-over correlation to NeqSim as a separate JAR, using the entrainment provider Service Provider Interface, without publishing the correlation itself.
+---
+
+NeqSim computes separator carry-over through a small Service Provider Interface (SPI), so a
+proprietary correlation can be supplied as a separate JAR without any of its content entering
+the public repository.
+
+## Models that ship with NeqSim
+
+| Id | What it does |
+|----|--------------|
+| `zero` | Reports no carry-over. Useful as a deliberate baseline. |
+| `spe-0.1gal-mmscf` | **Default.** A fixed 13.4 L of liquid per MSm³ of gas — the SI equivalent of the 0.1 US gal/MMscf rule of thumb from *The Savvy Separator: A Century of Carry-Over — 0.1 gal/MMscf* (SPE / JPT). Split between oil and water at the feed water cut. |
+| `neqsim-7stage` | The open-source 7-stage physics chain, evaluated through `SeparatorPerformanceCalculator`. |
+
+Select one on a separator:
+
+```java
+separator.setEntrainmentProvider("neqsim-7stage");
+EntrainmentResult result = separator.getEntrainmentResult();
+double oilCarryOver = result.getOilInGasKgPerHr();
+```
+
+With nothing selected the default applies. Selection affects `getEntrainmentResult()` only — it
+does not change the entrainment applied during `run()`, so adding it to an existing model cannot
+move that model's results.
+
+### The default is an assumption, not a prediction
+
+`spe-0.1gal-mmscf` returns the same litres per MSm³ whatever the separator is doing. It does not
+respond to gas load factor, mesh pad selection or overload, so a vessel running at twice its
+capacity still reports 13.4 L/MSm³. That is the point of a rule-of-thumb default, but it has one
+consequence worth stating in any report: **a capacity constraint fed from this model can never
+trip on carry-over.** Use `neqsim-7stage`, or a calibrated private model, when the number has to
+respond to the design.
+
+## Supplying a private model
+
+Implement `EnhancedEntrainmentProvider` in your own project, depending on public NeqSim only:
+
+```java
+public class MyCorrelationProvider implements EnhancedEntrainmentProvider {
+  public String getId() {
+    return "my-correlation-v1";
+  }
+
+  public String getVersion() {
+    return "1.0.0";
+  }
+
+  public EntrainmentApplicability checkApplicability(Separator separator) {
+    // report every input outside your validity envelope
+    return EntrainmentApplicability.ok();
+  }
+
+  public EntrainmentResult compute(Separator separator) {
+    // your correlation here
+    return new EntrainmentResult(getId(), getVersion(), oilKgPerHr, waterKgPerHr, gasKgPerHr, band);
+  }
+}
+```
+
+Register it by adding one line to your JAR:
+
+```
+META-INF/services/neqsim.process.equipment.separator.entrainment.EnhancedEntrainmentProvider
+```
+
+containing the fully-qualified class name. When that JAR is on the classpath, `ServiceLoader`
+finds it and `setEntrainmentProvider("my-correlation-v1")` works. When it is absent, the call
+fails with a message naming the models that *are* available, rather than silently substituting a
+different correlation.
+
+## What stays public and what stays private
+
+The public repository holds the maximum structure that leaks nothing: the interface, the result
+and applicability types, the registry, and provider *ids*. The id `eqn-pi-v1` is public; the
+correlation behind it is not. Model parameters, validity envelopes, vendor-tagged data and the
+tests that check the correlation reproduces its reference cases live in the private repository.
+
+A maintainer reading public NeqSim can therefore see *what* a provider must accept and return
+without being able to reconstruct *how* it computes.
+
+## Stability contract
+
+- Existing methods on `EnhancedEntrainmentProvider` will not change signature.
+- New capability is added only as `default` methods, so an existing plug-in keeps compiling
+  against newer NeqSim without recompilation.
+- When the SPI gains a capability an old plug-in cannot express, `CURRENT_API_VERSION` is raised.
+  A provider declaring a higher `getApiVersion()` than the core supports is refused at lookup
+  with an explanatory message, so a mismatch fails at registration rather than silently at
+  runtime.
+
+## Implementer checklist
+
+- `getId()` is globally unique, stable, and carries no version number — the version belongs in
+  `getVersion()`.
+- `compute()` is deterministic for a given separator state and mutates no global state; it is
+  called from both the steady-state and transient solvers.
+- `checkApplicability()` fails fast outside the validity envelope rather than extrapolating
+  silently.
+- Document on the implementing class what `compute()` does when inputs are out of range: throw,
+  widen the confidence band, or return `NaN`.
+
+## Related documentation
+
+- [Separators](separators.md)
+- [Enhanced entrainment modeling](separator-entrainment-modeling.md)

--- a/src/main/java/neqsim/process/equipment/separator/Separator.java
+++ b/src/main/java/neqsim/process/equipment/separator/Separator.java
@@ -26,7 +26,10 @@ import neqsim.process.equipment.capacity.StandardConstraintType;
 import neqsim.process.equipment.mixer.Mixer;
 import neqsim.process.equipment.separator.entrainment.InletDeviceModel;
 import neqsim.process.equipment.separator.entrainment.MultiphaseFlowRegime;
+import neqsim.process.equipment.separator.entrainment.EntrainmentProviderRegistry;
+import neqsim.process.equipment.separator.entrainment.EntrainmentResult;
 import neqsim.process.equipment.separator.entrainment.SeparatorPerformanceCalculator;
+import neqsim.process.equipment.separator.entrainment.SpecCarryOverProvider;
 import neqsim.process.equipment.separator.sectiontype.ManwaySection;
 import neqsim.process.equipment.separator.sectiontype.MeshSection;
 import neqsim.process.equipment.separator.sectiontype.NozzleSection;
@@ -305,6 +308,9 @@ public class Separator extends ProcessEquipmentBaseClass
    * it is not serializable by default.
    */
   private transient SeparatorPerformanceCalculator performanceCalculator;
+
+  /** Id of the selected entrainment model; null means the default applies. */
+  private String entrainmentProviderId = null;
 
   /**
    * Whether to use the detailed performance calculator for entrainment computation. When false (default), the simple
@@ -1226,6 +1232,59 @@ public class Separator extends ProcessEquipmentBaseClass
    */
   public void setPerformanceCalculator(SeparatorPerformanceCalculator calculator) {
     this.performanceCalculator = calculator;
+  }
+
+  /**
+   * Selects the entrainment model used by {@link #getEntrainmentResult()}.
+   *
+   * <p>
+   * Models are discovered through {@link java.util.ServiceLoader}, so the set available depends on what is on the
+   * classpath. Public NeqSim ships {@code "zero"} (no carry-over), {@code "spe-0.1gal-mmscf"} (a fixed 13.4 L per MSm3,
+   * the default) and {@code "neqsim-7stage"} (the physics chain). Private plug-ins such as {@code "eqn-pi-v1"} appear
+   * only when their JAR is present.
+   * </p>
+   *
+   * <p>
+   * This selection affects {@link #getEntrainmentResult()} only. It does not change the entrainment applied during
+   * {@link #run()}, so setting it cannot move the results of an existing model.
+   * </p>
+   *
+   * @param providerId the model id, or null to fall back to the default
+   * @throws IllegalStateException if no model with that id is on the classpath
+   */
+  public void setEntrainmentProvider(String providerId) {
+    if (providerId == null) {
+      this.entrainmentProviderId = null;
+      return;
+    }
+    EntrainmentProviderRegistry.find(providerId);
+    this.entrainmentProviderId = providerId;
+  }
+
+  /**
+   * Returns the id of the selected entrainment model.
+   *
+   * @return the model id, or null when none has been set and the default applies
+   */
+  public String getEntrainmentProvider() {
+    return entrainmentProviderId;
+  }
+
+  /**
+   * Computes carry-over using the selected entrainment model, or the default when none has been selected.
+   *
+   * <p>
+   * The default is {@code "spe-0.1gal-mmscf"} — a fixed 13.4 L per MSm3 of gas. That figure is an assumption rather
+   * than a prediction: it does not respond to gas load or overload. Select {@code "neqsim-7stage"} for a
+   * performance-based estimate, or {@code "zero"} to exclude carry-over deliberately.
+   * </p>
+   *
+   * @return the carry-over result produced by the selected model; never null
+   * @throws IllegalStateException if the selected model is not on the classpath
+   */
+  public EntrainmentResult getEntrainmentResult() {
+    String id = (entrainmentProviderId == null) ? SpecCarryOverProvider.ID : entrainmentProviderId;
+    return EntrainmentProviderRegistry.find(id).compute(this);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/separator/entrainment/BuiltInSevenStageProvider.java
+++ b/src/main/java/neqsim/process/equipment/separator/entrainment/BuiltInSevenStageProvider.java
@@ -43,7 +43,8 @@ public class BuiltInSevenStageProvider implements EnhancedEntrainmentProvider {
   public static final String VERSION = "1.0.0";
 
   /** Public no-args constructor required by {@link java.util.ServiceLoader}. */
-  public BuiltInSevenStageProvider() {}
+  public BuiltInSevenStageProvider() {
+  }
 
   /** {@inheritDoc} */
   @Override

--- a/src/main/java/neqsim/process/equipment/separator/entrainment/BuiltInSevenStageProvider.java
+++ b/src/main/java/neqsim/process/equipment/separator/entrainment/BuiltInSevenStageProvider.java
@@ -1,0 +1,99 @@
+package neqsim.process.equipment.separator.entrainment;
+
+import neqsim.process.equipment.separator.Separator;
+
+/**
+ * Entrainment model that exposes NeqSim's open-source 7-stage physics chain through the provider interface.
+ *
+ * <p>
+ * Registered as {@code "neqsim-7stage"}. The numerical work is done by {@link SeparatorPerformanceCalculator}; this
+ * class evaluates it through {@link Separator#computeSeparationPerformance()}, which is read-only and does not disturb
+ * the entrainment applied during {@link Separator#run()}.
+ * </p>
+ *
+ * <p>
+ * <b>Conversion.</b> The calculator reports entrainment as the fraction of each incoming liquid phase that is not
+ * separated ({@code 1 - overallGasLiquidEfficiency}), so a mass rate follows directly from the feed phase mass flow
+ * without any density assumption:
+ * </p>
+ *
+ * <pre>
+ * oil carried over [kg/h] = oilInGasFraction x feed oil mass flow [kg/h]
+ * </pre>
+ *
+ * <p>
+ * <b>Confidence band.</b> The chain is deterministic and produces no statistical band, so the band is reported as
+ * {@link Double#NaN} rather than as a fabricated zero.
+ * </p>
+ *
+ * <p>
+ * <b>Status.</b> The underlying chain has not been validated against field or rig data in this repository. It is
+ * offered as one selectable model among several, not as a reference result.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class BuiltInSevenStageProvider implements EnhancedEntrainmentProvider {
+
+  /** Stable id used to look this model up through the registry. */
+  public static final String ID = "neqsim-7stage";
+
+  /** Version of the adapter; bumped when this adapter changes, not when the chain changes. */
+  public static final String VERSION = "1.0.0";
+
+  /** Public no-args constructor required by {@link java.util.ServiceLoader}. */
+  public BuiltInSevenStageProvider() {}
+
+  /** {@inheritDoc} */
+  @Override
+  public String getId() {
+    return ID;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getVersion() {
+    return VERSION;
+  }
+
+  /**
+   * The 7-stage chain is predictive and carries no hard validity envelope.
+   *
+   * @param separator the separator whose entrainment is requested; unused
+   * @return {@link EntrainmentApplicability#ok()}
+   */
+  @Override
+  public EntrainmentApplicability checkApplicability(Separator separator) {
+    return EntrainmentApplicability.ok();
+  }
+
+  /**
+   * Evaluates the 7-stage chain and converts its entrainment fractions to mass rates.
+   *
+   * @param separator the separator whose entrainment is requested; must not be null
+   * @return the carry-over result; values are 0.0 for phases absent from the feed
+   * @throws IllegalArgumentException if {@code separator} is null
+   */
+  @Override
+  public EntrainmentResult compute(Separator separator) {
+    if (separator == null) {
+      throw new IllegalArgumentException("separator must not be null");
+    }
+
+    SeparatorPerformanceCalculator calc = separator.computeSeparationPerformance();
+    if (calc == null) {
+      return new EntrainmentResult(ID, VERSION, 0.0, 0.0, 0.0, Double.NaN);
+    }
+
+    double feedOil = SeparatorFeedBasis.feedPhaseMassFlowKgPerHr(separator, "oil");
+    double feedWater = SeparatorFeedBasis.feedPhaseMassFlowKgPerHr(separator, "aqueous");
+    double feedGas = SeparatorFeedBasis.feedPhaseMassFlowKgPerHr(separator, "gas");
+
+    double oilKgPerHr = calc.getOilInGasFraction() * feedOil;
+    double waterKgPerHr = calc.getWaterInGasFraction() * feedWater;
+    double gasKgPerHr = (calc.getGasInOilFraction() + calc.getGasInWaterFraction()) * feedGas;
+
+    return new EntrainmentResult(ID, VERSION, oilKgPerHr, waterKgPerHr, gasKgPerHr, Double.NaN);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/separator/entrainment/EnhancedEntrainmentProvider.java
+++ b/src/main/java/neqsim/process/equipment/separator/entrainment/EnhancedEntrainmentProvider.java
@@ -1,0 +1,119 @@
+package neqsim.process.equipment.separator.entrainment;
+
+import neqsim.process.equipment.separator.Separator;
+
+/**
+ * Service Provider Interface (SPI) for pluggable entrainment / carry-over models in NeqSim. Implementations are
+ * discovered at runtime through {@link java.util.ServiceLoader} and selected on a {@code Separator} via
+ * {@code Separator.setEntrainmentProvider(String)}.
+ *
+ * <p>
+ * <b>Why this interface exists.</b> NeqSim ships with a single open-source "built-in" entrainment model — the 7-stage
+ * physics-based chain documented in {@code separator-entrainment-modeling.md}. Some operators have additional,
+ * proprietary correlations (e.g. Equinor's π-number empirical equation derived from the EQN scrubber test database)
+ * that cannot be open-sourced because they embed vendor or test-rig data. This SPI allows such providers to be
+ * delivered as separate, signed JARs that depend on public NeqSim only at the SPI level — no fork, no patching, no
+ * public disclosure of the proprietary content. If a private provider JAR is on the classpath
+ * {@link java.util.ServiceLoader} discovers it automatically; if not, code that requested it gets a clear error.
+ *
+ * <p>
+ * <b>Public / private split policy.</b> The public NeqSim repo holds the maximum amount of structure that does not leak
+ * proprietary content: SPI interface, method signatures, result / applicability data classes, registry plumbing, and
+ * provider <i>ids</i> (the string {@code "eqn-pi-v1"} is public; the correlation behind it is not). Only the numerical
+ * implementation, model parameters, validity envelopes, vendor-tagged data and correctness tests live in the private
+ * repo. Public and private are kept architecturally aligned — same package layout, same class names where possible — so
+ * a maintainer reading the public source can see <i>what</i> approach (4) requires and returns without being able to
+ * reproduce <i>how</i> it computes.
+ *
+ * <p>
+ * <b>Stability contract.</b> This interface is API-stable. Existing methods will not change signature; new capabilities
+ * are added only as {@code default} methods so existing implementations (including private plug-ins) keep compiling
+ * against new public NeqSim releases without recompilation.
+ *
+ * <p>
+ * <b>Implementer responsibilities.</b> An implementation must:
+ * <ul>
+ * <li>return a globally unique, stable {@link #getId()} (no spaces, no version number — version goes in
+ * {@link #getVersion()})</li>
+ * <li>be deterministic given the same {@code Separator} state — providers are called from the steady-state and
+ * transient solvers and must not mutate global state</li>
+ * <li>fail fast through {@link #checkApplicability(Separator)} when inputs are outside the validity envelope, rather
+ * than silently extrapolate</li>
+ * <li>register through a
+ * {@code META-INF/services/neqsim.process.equipment.separator.entrainment.EnhancedEntrainmentProvider} file in its JAR
+ * so {@code ServiceLoader} picks it up</li>
+ * </ul>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public interface EnhancedEntrainmentProvider {
+
+  /**
+   * SPI revision implemented by this provider. The default is {@code 1} — the revision that ships with the first public
+   * release of this interface. When the SPI gains semantic capabilities that an old provider cannot express, public
+   * NeqSim bumps {@code CURRENT_API_VERSION} and providers built against the new revision override this method to
+   * return the higher value. The {@code EntrainmentProviderRegistry} refuses providers that declare an api version
+   * higher than the core supports, so version mismatches fail loudly at registration rather than silently at runtime.
+   *
+   * <p>
+   * Adding new {@code default} methods to this interface alone does <i>not</i> require an api-version bump — only
+   * changes that affect what a provider must compute or return.
+   *
+   * @return the SPI revision this provider was built against; the current public revision is
+   * {@link EntrainmentProviderRegistry#CURRENT_API_VERSION}
+   */
+  default int getApiVersion() {
+    return 1;
+  }
+
+  /**
+   * Returns the globally unique, stable identifier of this provider.
+   *
+   * <p>
+   * Examples: {@code "neqsim-7stage"} (built-in), {@code "eqn-pi-v1"} (Equinor private plug-in v1), {@code "eqn-pi-v2"}
+   * (v2). The id is the argument to {@code Separator.setEntrainmentProvider(String)}.
+   *
+   * @return the provider id, must be non-null and constant for the lifetime of the JVM
+   */
+  String getId();
+
+  /**
+   * Returns the version string of this provider.
+   *
+   * <p>
+   * Recommended format: semantic versioning, e.g. {@code "1.0.0"}. The version is recorded on the
+   * {@link EntrainmentResult} so plant historians and reports can tag which method produced a number.
+   *
+   * @return the provider version, must be non-null
+   */
+  String getVersion();
+
+  /**
+   * Checks whether this provider's correlation is applicable to the supplied separator configuration.
+   *
+   * <p>
+   * Implementations must inspect the geometry, internals selection and operating conditions of {@code separator} and
+   * report any input that falls outside their validity envelope. The aggregate applicability flag is true only if every
+   * input is in range.
+   *
+   * @param separator the separator whose entrainment is to be computed; must not be null
+   * @return an applicability report describing in/out of envelope status and per-input diagnostics; never null
+   */
+  EntrainmentApplicability checkApplicability(Separator separator);
+
+  /**
+   * Computes the entrainment / carry-over result for the supplied separator.
+   *
+   * <p>
+   * Implementations should call {@link #checkApplicability(Separator)} internally and decide whether to throw,
+   * extrapolate with a widened confidence band, or return {@link Double#NaN} carry-over values when inputs are out of
+   * range. Whichever policy is chosen must be documented on the implementing class.
+   *
+   * @param separator the separator whose entrainment is to be computed; must not be null
+   * @return the computed entrainment result tagged with this provider's id and version; never null
+   * @throws RuntimeException if the provider cannot produce a result (e.g. missing required input, hard out-of-range
+   * failure, missing data file at runtime)
+   */
+  EntrainmentResult compute(Separator separator);
+}

--- a/src/main/java/neqsim/process/equipment/separator/entrainment/EntrainmentApplicability.java
+++ b/src/main/java/neqsim/process/equipment/separator/entrainment/EntrainmentApplicability.java
@@ -1,0 +1,93 @@
+package neqsim.process.equipment.separator.entrainment;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Applicability report from an {@link EnhancedEntrainmentProvider} for a given {@code Separator} configuration. A
+ * provider returns this object to tell the caller whether its correlation is valid for the supplied geometry and
+ * operating conditions, and if not, which inputs are out of range.
+ *
+ * <p>
+ * Diagnostics are simple human-readable strings — one entry per out-of-range input. The aggregate
+ * {@link #isApplicable()} flag is the AND of all diagnostics: if any input is out of range, the report is not
+ * applicable.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class EntrainmentApplicability implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  /** True if every input is inside the provider's validity envelope. */
+  private final boolean applicable;
+
+  /** Human-readable diagnostics, one per out-of-range input. Never null. */
+  private final List<String> diagnostics;
+
+  /**
+   * Constructs an applicability report.
+   *
+   * @param applicable true if every input is inside the provider's envelope
+   * @param diagnostics human-readable diagnostics, one per out-of-range input; may be null or empty when
+   * {@code applicable} is true
+   */
+  public EntrainmentApplicability(boolean applicable, List<String> diagnostics) {
+    this.applicable = applicable;
+    this.diagnostics = (diagnostics == null) ? Collections.<String>emptyList()
+        : Collections.unmodifiableList(new ArrayList<String>(diagnostics));
+  }
+
+  /**
+   * Returns the aggregate applicability flag.
+   *
+   * @return true if every input is inside the provider's envelope
+   */
+  public boolean isApplicable() {
+    return applicable;
+  }
+
+  /**
+   * Returns the human-readable diagnostics.
+   *
+   * @return unmodifiable list of diagnostics, one per out-of-range input; empty list (never null) when applicable
+   */
+  public List<String> getDiagnostics() {
+    return diagnostics;
+  }
+
+  /**
+   * Convenience factory for the "applicable" case.
+   *
+   * @return an applicable report with no diagnostics
+   */
+  public static EntrainmentApplicability ok() {
+    return new EntrainmentApplicability(true, Collections.<String>emptyList());
+  }
+
+  /**
+   * Convenience factory for the "not applicable" case.
+   *
+   * @param diagnostics human-readable diagnostics, one per out-of-range input
+   * @return a non-applicable report with the supplied diagnostics
+   */
+  public static EntrainmentApplicability notApplicable(List<String> diagnostics) {
+    return new EntrainmentApplicability(false, diagnostics);
+  }
+
+  /**
+   * Returns a multi-line text rendering suitable for {@code System.out.println}.
+   *
+   * @return a text rendering of this applicability report
+   */
+  public String toTextReport() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("Applicability: ").append(applicable ? "OK" : "OUT OF RANGE").append('\n');
+    for (String d : diagnostics) {
+      sb.append("  - ").append(d).append('\n');
+    }
+    return sb.toString();
+  }
+}

--- a/src/main/java/neqsim/process/equipment/separator/entrainment/EntrainmentProviderRegistry.java
+++ b/src/main/java/neqsim/process/equipment/separator/entrainment/EntrainmentProviderRegistry.java
@@ -1,0 +1,90 @@
+package neqsim.process.equipment.separator.entrainment;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+/**
+ * Registry / loader for {@link EnhancedEntrainmentProvider} implementations.
+ *
+ * <p>
+ * Discovery is delegated to {@link java.util.ServiceLoader}: every JAR on the classpath that contains a
+ * {@code META-INF/services/neqsim.process.equipment.separator.entrainment.EnhancedEntrainmentProvider} file contributes
+ * its providers automatically. The built-in provider {@link BuiltInSevenStageProvider} is registered through this same
+ * mechanism so the lookup path is uniform; private plug-ins (for example the Equinor π-number plug-in
+ * {@code eqn-pi-v1}) are picked up only when their JAR is on the classpath.
+ *
+ * <p>
+ * Usage on a separator:
+ *
+ * <pre>
+ * separator.setEntrainmentProvider("eqn-pi-v1");
+ * </pre>
+ *
+ * If the requested id is not registered, {@link #find(String)} throws {@link IllegalStateException} so the caller fails
+ * loudly rather than silently falling back to a different correlation.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class EntrainmentProviderRegistry {
+
+  /**
+   * SPI revision supported by this build of public NeqSim. Providers declaring a higher
+   * {@link EnhancedEntrainmentProvider#getApiVersion()} are rejected at lookup time so version mismatches fail loudly.
+   */
+  public static final int CURRENT_API_VERSION = 1;
+
+  /**
+   * Private constructor — this is a static utility class.
+   */
+  private EntrainmentProviderRegistry() {}
+
+  /**
+   * Looks up a registered provider by id.
+   *
+   * @param id the provider id, e.g. {@code "neqsim-7stage"} or {@code "eqn-pi-v1"}; must not be null
+   * @return the registered provider with the supplied id
+   * @throws IllegalArgumentException if {@code id} is null
+   * @throws IllegalStateException if no provider with the supplied id is registered (typically because the providing
+   * JAR is not on the classpath)
+   */
+  public static EnhancedEntrainmentProvider find(String id) {
+    if (id == null) {
+      throw new IllegalArgumentException("provider id must not be null");
+    }
+    ServiceLoader<EnhancedEntrainmentProvider> loader =
+        ServiceLoader.load(EnhancedEntrainmentProvider.class);
+    StringBuilder available = new StringBuilder();
+    for (Iterator<EnhancedEntrainmentProvider> it = loader.iterator(); it.hasNext();) {
+      EnhancedEntrainmentProvider p = it.next();
+      if (id.equals(p.getId())) {
+        if (p.getApiVersion() > CURRENT_API_VERSION) {
+          throw new IllegalStateException("Entrainment provider '" + id
+              + "' requires SPI api version " + p.getApiVersion()
+              + " but this build of NeqSim supports up to " + CURRENT_API_VERSION
+              + ". Upgrade NeqSim core or use an older plug-in build.");
+        }
+        return p;
+      }
+      if (available.length() > 0) {
+        available.append(", ");
+      }
+      available.append(p.getId());
+    }
+    throw new IllegalStateException("Entrainment provider '" + id
+        + "' is not on the classpath. Available providers: ["
+        + (available.length() == 0 ? "<none>" : available.toString()) + "]. "
+        + "If you expect a private plug-in such as 'eqn-pi-v1', make sure its "
+        + "JAR is on the classpath.");
+  }
+
+  /**
+   * Returns a freshly loaded {@link ServiceLoader} of all registered providers. Useful for tooling that wants to
+   * enumerate available models.
+   *
+   * @return a {@link ServiceLoader} instance — iterate to obtain provider instances
+   */
+  public static ServiceLoader<EnhancedEntrainmentProvider> all() {
+    return ServiceLoader.load(EnhancedEntrainmentProvider.class);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/separator/entrainment/EntrainmentProviderRegistry.java
+++ b/src/main/java/neqsim/process/equipment/separator/entrainment/EntrainmentProviderRegistry.java
@@ -72,8 +72,7 @@ public final class EntrainmentProviderRegistry {
     }
     throw new IllegalStateException("Entrainment provider '" + id + "' is not on the classpath. Available providers: ["
         + (available.length() == 0 ? "<none>" : available.toString()) + "]. "
-        + "If you expect a private plug-in such as 'eqn-pi-v1', make sure its "
-        + "JAR is on the classpath.");
+        + "If you expect a private plug-in such as 'eqn-pi-v1', make sure its " + "JAR is on the classpath.");
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/separator/entrainment/EntrainmentProviderRegistry.java
+++ b/src/main/java/neqsim/process/equipment/separator/entrainment/EntrainmentProviderRegistry.java
@@ -37,7 +37,8 @@ public final class EntrainmentProviderRegistry {
   /**
    * Private constructor — this is a static utility class.
    */
-  private EntrainmentProviderRegistry() {}
+  private EntrainmentProviderRegistry() {
+  }
 
   /**
    * Looks up a registered provider by id.
@@ -52,16 +53,14 @@ public final class EntrainmentProviderRegistry {
     if (id == null) {
       throw new IllegalArgumentException("provider id must not be null");
     }
-    ServiceLoader<EnhancedEntrainmentProvider> loader =
-        ServiceLoader.load(EnhancedEntrainmentProvider.class);
+    ServiceLoader<EnhancedEntrainmentProvider> loader = ServiceLoader.load(EnhancedEntrainmentProvider.class);
     StringBuilder available = new StringBuilder();
     for (Iterator<EnhancedEntrainmentProvider> it = loader.iterator(); it.hasNext();) {
       EnhancedEntrainmentProvider p = it.next();
       if (id.equals(p.getId())) {
         if (p.getApiVersion() > CURRENT_API_VERSION) {
-          throw new IllegalStateException("Entrainment provider '" + id
-              + "' requires SPI api version " + p.getApiVersion()
-              + " but this build of NeqSim supports up to " + CURRENT_API_VERSION
+          throw new IllegalStateException("Entrainment provider '" + id + "' requires SPI api version "
+              + p.getApiVersion() + " but this build of NeqSim supports up to " + CURRENT_API_VERSION
               + ". Upgrade NeqSim core or use an older plug-in build.");
         }
         return p;
@@ -71,8 +70,7 @@ public final class EntrainmentProviderRegistry {
       }
       available.append(p.getId());
     }
-    throw new IllegalStateException("Entrainment provider '" + id
-        + "' is not on the classpath. Available providers: ["
+    throw new IllegalStateException("Entrainment provider '" + id + "' is not on the classpath. Available providers: ["
         + (available.length() == 0 ? "<none>" : available.toString()) + "]. "
         + "If you expect a private plug-in such as 'eqn-pi-v1', make sure its "
         + "JAR is on the classpath.");

--- a/src/main/java/neqsim/process/equipment/separator/entrainment/EntrainmentResult.java
+++ b/src/main/java/neqsim/process/equipment/separator/entrainment/EntrainmentResult.java
@@ -52,9 +52,8 @@ public final class EntrainmentResult implements Serializable {
    * @param confidenceBandKgPerHr one-sigma uncertainty estimate on the carry-over [kg/h], or {@link Double#NaN} if the
    * provider cannot supply one
    */
-  public EntrainmentResult(String providerId, String providerVersion, double oilInGasKgPerHr,
-      double waterInGasKgPerHr, double gasInLiquidKgPerHr,
-      double confidenceBandKgPerHr) {
+  public EntrainmentResult(String providerId, String providerVersion, double oilInGasKgPerHr, double waterInGasKgPerHr,
+      double gasInLiquidKgPerHr, double confidenceBandKgPerHr) {
     if (providerId == null) {
       throw new IllegalArgumentException("providerId must not be null");
     }
@@ -126,9 +125,8 @@ public final class EntrainmentResult implements Serializable {
 
   @Override
   public String toString() {
-    return "EntrainmentResult{" + "provider=" + providerId + "@" + providerVersion
-        + ", oilInGas=" + oilInGasKgPerHr + " kg/h" + ", waterInGas=" + waterInGasKgPerHr
-        + " kg/h" + ", gasInLiquid=" + gasInLiquidKgPerHr + " kg/h" + ", confidence="
-        + confidenceBandKgPerHr + " kg/h" + "}";
+    return "EntrainmentResult{" + "provider=" + providerId + "@" + providerVersion + ", oilInGas=" + oilInGasKgPerHr
+        + " kg/h" + ", waterInGas=" + waterInGasKgPerHr + " kg/h" + ", gasInLiquid=" + gasInLiquidKgPerHr + " kg/h"
+        + ", confidence=" + confidenceBandKgPerHr + " kg/h" + "}";
   }
 }

--- a/src/main/java/neqsim/process/equipment/separator/entrainment/EntrainmentResult.java
+++ b/src/main/java/neqsim/process/equipment/separator/entrainment/EntrainmentResult.java
@@ -1,0 +1,134 @@
+package neqsim.process.equipment.separator.entrainment;
+
+import java.io.Serializable;
+
+/**
+ * Immutable result of an entrainment / carry-over calculation produced by an {@link EnhancedEntrainmentProvider}. This
+ * is the agreed schema across all providers — both the public built-in 7-stage chain and any private plug-in (such as
+ * the EQN π-number model) populate the same fields so downstream consumers (process simulation, plant historians,
+ * reports) do not need to know which provider produced the numbers.
+ *
+ * <p>
+ * Units are SI:
+ * <ul>
+ * <li>Carry-over rates: kg/h</li>
+ * <li>Confidence band: kg/h (one-sigma uncertainty estimate on the carry-over rate, when the provider can supply
+ * one)</li>
+ * </ul>
+ *
+ * <p>
+ * Fields that a provider cannot supply are returned as {@link Double#NaN}. In particular, the built-in 7-stage chain
+ * returns NaN for {@link #getConfidenceBandKgPerHr()}; providers that have a documented uncertainty model (e.g. the
+ * π-number plug-in scaled against the EQN test envelope) return a finite number.
+ *
+ * <p>
+ * <b>Droplet-size data.</b> The unified result intentionally does not carry droplet-size distribution or d50, because
+ * empirical large-scale correlations (such as the EQN π-number plug-in, which uses Efficiency = f(π)) do not produce
+ * them. Providers that compute droplet size internally (e.g. the built-in 7-stage chain) expose it through their own
+ * API, not through this cross-provider result schema.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class EntrainmentResult implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final String providerId;
+  private final String providerVersion;
+  private final double oilInGasKgPerHr;
+  private final double waterInGasKgPerHr;
+  private final double gasInLiquidKgPerHr;
+  private final double confidenceBandKgPerHr;
+
+  /**
+   * Constructs an immutable entrainment result.
+   *
+   * @param providerId stable identifier of the provider that produced this result, e.g. {@code "neqsim-7stage"} or
+   * {@code "eqn-pi-v1"}; must not be null
+   * @param providerVersion version string of the provider, e.g. {@code "1.0.0"}; must not be null
+   * @param oilInGasKgPerHr oil carry-over into the gas outlet [kg/h], or {@link Double#NaN} if not computed
+   * @param waterInGasKgPerHr water carry-over into the gas outlet [kg/h], or {@link Double#NaN} if not computed
+   * @param gasInLiquidKgPerHr gas carry-under into the liquid outlet(s) [kg/h], or {@link Double#NaN} if not computed
+   * @param confidenceBandKgPerHr one-sigma uncertainty estimate on the carry-over [kg/h], or {@link Double#NaN} if the
+   * provider cannot supply one
+   */
+  public EntrainmentResult(String providerId, String providerVersion, double oilInGasKgPerHr,
+      double waterInGasKgPerHr, double gasInLiquidKgPerHr,
+      double confidenceBandKgPerHr) {
+    if (providerId == null) {
+      throw new IllegalArgumentException("providerId must not be null");
+    }
+    if (providerVersion == null) {
+      throw new IllegalArgumentException("providerVersion must not be null");
+    }
+    this.providerId = providerId;
+    this.providerVersion = providerVersion;
+    this.oilInGasKgPerHr = oilInGasKgPerHr;
+    this.waterInGasKgPerHr = waterInGasKgPerHr;
+    this.gasInLiquidKgPerHr = gasInLiquidKgPerHr;
+    this.confidenceBandKgPerHr = confidenceBandKgPerHr;
+  }
+
+  /**
+   * Returns the stable identifier of the provider that produced this result.
+   *
+   * @return the provider id (never null)
+   */
+  public String getProviderId() {
+    return providerId;
+  }
+
+  /**
+   * Returns the version of the provider that produced this result.
+   *
+   * @return the provider version (never null)
+   */
+  public String getProviderVersion() {
+    return providerVersion;
+  }
+
+  /**
+   * Returns the oil carry-over into the gas outlet.
+   *
+   * @return oil carry-over [kg/h], or {@link Double#NaN} if not computed
+   */
+  public double getOilInGasKgPerHr() {
+    return oilInGasKgPerHr;
+  }
+
+  /**
+   * Returns the water carry-over into the gas outlet.
+   *
+   * @return water carry-over [kg/h], or {@link Double#NaN} if not computed
+   */
+  public double getWaterInGasKgPerHr() {
+    return waterInGasKgPerHr;
+  }
+
+  /**
+   * Returns the gas carry-under into the liquid outlet(s).
+   *
+   * @return gas carry-under [kg/h], or {@link Double#NaN} if not computed
+   */
+  public double getGasInLiquidKgPerHr() {
+    return gasInLiquidKgPerHr;
+  }
+
+  /**
+   * Returns the one-sigma confidence band on the carry-over rate.
+   *
+   * @return confidence band [kg/h], or {@link Double#NaN} if the provider cannot supply one (e.g. the built-in 7-stage
+   * chain)
+   */
+  public double getConfidenceBandKgPerHr() {
+    return confidenceBandKgPerHr;
+  }
+
+  @Override
+  public String toString() {
+    return "EntrainmentResult{" + "provider=" + providerId + "@" + providerVersion
+        + ", oilInGas=" + oilInGasKgPerHr + " kg/h" + ", waterInGas=" + waterInGasKgPerHr
+        + " kg/h" + ", gasInLiquid=" + gasInLiquidKgPerHr + " kg/h" + ", confidence="
+        + confidenceBandKgPerHr + " kg/h" + "}";
+  }
+}

--- a/src/main/java/neqsim/process/equipment/separator/entrainment/SeparatorFeedBasis.java
+++ b/src/main/java/neqsim/process/equipment/separator/entrainment/SeparatorFeedBasis.java
@@ -19,7 +19,8 @@ import neqsim.thermo.system.SystemInterface;
 final class SeparatorFeedBasis {
 
   /** Static utility class. */
-  private SeparatorFeedBasis() {}
+  private SeparatorFeedBasis() {
+  }
 
   /**
    * Returns the feed fluid of a separator.

--- a/src/main/java/neqsim/process/equipment/separator/entrainment/SeparatorFeedBasis.java
+++ b/src/main/java/neqsim/process/equipment/separator/entrainment/SeparatorFeedBasis.java
@@ -1,0 +1,122 @@
+package neqsim.process.equipment.separator.entrainment;
+
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemInterface;
+
+/**
+ * Package-private helpers that read the feed basis an entrainment provider needs from a {@link Separator}.
+ *
+ * <p>
+ * Kept in one place so the built-in providers agree on what "inlet oil", "inlet water" and "gas rate" mean. All methods
+ * are null-safe and return 0.0 when the separator has not been run or the phase is absent, so a provider never throws
+ * merely because a model is incompletely set up.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+final class SeparatorFeedBasis {
+
+  /** Static utility class. */
+  private SeparatorFeedBasis() {}
+
+  /**
+   * Returns the feed fluid of a separator.
+   *
+   * @param separator the separator to read; may be null
+   * @return the feed thermodynamic system, or null when unavailable
+   */
+  private static SystemInterface feedFluid(Separator separator) {
+    if (separator == null) {
+      return null;
+    }
+    StreamInterface feed = separator.getFeedStream();
+    return (feed == null) ? null : feed.getFluid();
+  }
+
+  /**
+   * Returns the mass flow of a named phase in the separator feed.
+   *
+   * @param separator the separator to read; may be null
+   * @param phaseName the NeqSim phase name, for example {@code "oil"}, {@code "aqueous"} or {@code "gas"}
+   * @return the phase mass flow [kg/h], or 0.0 when the separator, feed or phase is absent
+   */
+  static double feedPhaseMassFlowKgPerHr(Separator separator, String phaseName) {
+    SystemInterface fluid = feedFluid(separator);
+    if (fluid == null || !fluid.hasPhaseType(phaseName)) {
+      return 0.0;
+    }
+    return fluid.getPhase(phaseName).getFlowRate("kg/hr");
+  }
+
+  /**
+   * Returns the actual volumetric flow of a named phase in the separator feed.
+   *
+   * @param separator the separator to read; may be null
+   * @param phaseName the NeqSim phase name, for example {@code "oil"} or {@code "aqueous"}
+   * @return the phase volumetric flow at feed conditions [m3/h], or 0.0 when absent
+   */
+  private static double feedPhaseVolumeFlowM3PerHr(Separator separator, String phaseName) {
+    SystemInterface fluid = feedFluid(separator);
+    if (fluid == null || !fluid.hasPhaseType(phaseName)) {
+      return 0.0;
+    }
+    return fluid.getPhase(phaseName).getFlowRate("m3/hr");
+  }
+
+  /**
+   * Returns the water cut of the separator feed, defined as NeqSim defines it elsewhere: the water volume fraction of
+   * the total liquid, evaluated at feed conditions.
+   *
+   * @param separator the separator to read; may be null
+   * @return the water cut [0-1], or 0.0 when the feed carries no liquid
+   */
+  static double feedWaterCut(Separator separator) {
+    double oil = feedPhaseVolumeFlowM3PerHr(separator, "oil");
+    double water = feedPhaseVolumeFlowM3PerHr(separator, "aqueous");
+    double liquid = oil + water;
+    if (liquid <= 0.0) {
+      return 0.0;
+    }
+    return water / liquid;
+  }
+
+  /**
+   * Returns the standard gas rate leaving the separator, used as the denominator of carry-over specifications expressed
+   * per unit of standard gas volume.
+   *
+   * <p>
+   * Note that a standard cubic metre in NeqSim is a molar quantity: {@code Sm3} is evaluated as
+   * {@code n * R * T_std / atm} with no density involved.
+   * </p>
+   *
+   * @param separator the separator to read; may be null
+   * @return the gas outlet flow [MSm3/h], or 0.0 when unavailable
+   */
+  static double gasOutStandardFlowMSm3PerHr(Separator separator) {
+    if (separator == null) {
+      return 0.0;
+    }
+    StreamInterface gas = separator.getGasOutStream();
+    if (gas == null || gas.getFluid() == null) {
+      return 0.0;
+    }
+    return gas.getFluid().getFlowRate("MSm3/hr");
+  }
+
+  /**
+   * Returns the density of a named phase in the separator feed.
+   *
+   * @param separator the separator to read; may be null
+   * @param phaseName the NeqSim phase name, for example {@code "oil"} or {@code "aqueous"}
+   * @return the phase density at feed conditions [kg/m3], or 0.0 when absent
+   */
+  static double feedPhaseDensityKgPerM3(Separator separator, String phaseName) {
+    SystemInterface fluid = feedFluid(separator);
+    if (fluid == null || !fluid.hasPhaseType(phaseName)) {
+      return 0.0;
+    }
+    return fluid.getPhase(phaseName).getDensity("kg/m3");
+  }
+}

--- a/src/main/java/neqsim/process/equipment/separator/entrainment/SpecCarryOverProvider.java
+++ b/src/main/java/neqsim/process/equipment/separator/entrainment/SpecCarryOverProvider.java
@@ -51,7 +51,8 @@ public class SpecCarryOverProvider implements EnhancedEntrainmentProvider {
   private double carryOverLitrePerMSm3 = DEFAULT_CARRY_OVER_LITRE_PER_MSM3;
 
   /** Public no-args constructor required by {@link java.util.ServiceLoader}. */
-  public SpecCarryOverProvider() {}
+  public SpecCarryOverProvider() {
+  }
 
   /** {@inheritDoc} */
   @Override

--- a/src/main/java/neqsim/process/equipment/separator/entrainment/SpecCarryOverProvider.java
+++ b/src/main/java/neqsim/process/equipment/separator/entrainment/SpecCarryOverProvider.java
@@ -1,0 +1,131 @@
+package neqsim.process.equipment.separator.entrainment;
+
+import neqsim.process.equipment.separator.Separator;
+
+/**
+ * Entrainment model that assumes a fixed liquid carry-over per unit of standard gas volume.
+ *
+ * <p>
+ * Registered as {@code "spe-0.1gal-mmscf"}. The default figure is <b>13.4 L per MSm3</b> of gas, which is the SI
+ * equivalent of the long-standing 0.1 US gallon per MMscf rule of thumb described in <i>The Savvy Separator: A Century
+ * of Carry-Over - 0.1 gal/MMscf</i> (SPE / Journal of Petroleum Technology). The conversion is 0.1 US gal = 0.37854 L
+ * against 1 MMscf = 28 262 Sm3 (scf referenced to 60 F, Sm3 to 15 C), giving 13.39 L/MSm3.
+ * </p>
+ *
+ * <p>
+ * <b>What it computes.</b> The total liquid carry-over volume is proportional to the standard gas rate leaving the
+ * separator. That total is split between oil and water using the <i>feed</i> water cut, so a high-water-cut separator
+ * reports mostly water carry-over, and each part is converted to a mass rate with its own phase density. With no liquid
+ * in the feed the result is zero rather than a nominal 13.4 L of nothing.
+ * </p>
+ *
+ * <p>
+ * <b>This is a specification, not a prediction.</b> The figure does not respond to gas load factor, mesh pad selection
+ * or overload: a separator running at twice its capacity still reports the same litres per MSm3. It is intended as a
+ * defensible default when nothing better is known, not as a substitute for a performance model. A capacity constraint
+ * fed from this model can never trip on carry-over, which is by design and worth stating in any report that uses it.
+ * </p>
+ *
+ * <p>
+ * The specific carry-over figure can be changed with {@link #setCarryOverLitrePerMSm3(double)} for operators whose own
+ * basis differs from the SPE figure.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class SpecCarryOverProvider implements EnhancedEntrainmentProvider {
+
+  /** Stable id used to look this model up through the registry. */
+  public static final String ID = "spe-0.1gal-mmscf";
+
+  /** Version of this model. */
+  public static final String VERSION = "1.0.0";
+
+  /**
+   * Default carry-over figure [litre of liquid per MSm3 of gas], the SI equivalent of 0.1 US gal/MMscf.
+   */
+  public static final double DEFAULT_CARRY_OVER_LITRE_PER_MSM3 = 13.4;
+
+  /** Carry-over figure actually used by this instance [litre per MSm3]. */
+  private double carryOverLitrePerMSm3 = DEFAULT_CARRY_OVER_LITRE_PER_MSM3;
+
+  /** Public no-args constructor required by {@link java.util.ServiceLoader}. */
+  public SpecCarryOverProvider() {}
+
+  /** {@inheritDoc} */
+  @Override
+  public String getId() {
+    return ID;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getVersion() {
+    return VERSION;
+  }
+
+  /**
+   * Returns the carry-over figure used by this instance.
+   *
+   * @return carry-over [litre of liquid per MSm3 of gas]
+   */
+  public double getCarryOverLitrePerMSm3() {
+    return carryOverLitrePerMSm3;
+  }
+
+  /**
+   * Sets the carry-over figure used by this instance.
+   *
+   * @param carryOverLitrePerMSm3 carry-over [litre of liquid per MSm3 of gas]; must not be negative
+   * @throws IllegalArgumentException if the value is negative or not a number
+   */
+  public void setCarryOverLitrePerMSm3(double carryOverLitrePerMSm3) {
+    if (Double.isNaN(carryOverLitrePerMSm3) || carryOverLitrePerMSm3 < 0.0) {
+      throw new IllegalArgumentException("carryOverLitrePerMSm3 must be zero or positive");
+    }
+    this.carryOverLitrePerMSm3 = carryOverLitrePerMSm3;
+  }
+
+  /**
+   * Always applicable; a fixed specification makes no claim that can fall out of range.
+   *
+   * @param separator the separator whose entrainment is requested; unused
+   * @return {@link EntrainmentApplicability#ok()}
+   */
+  @Override
+  public EntrainmentApplicability checkApplicability(Separator separator) {
+    return EntrainmentApplicability.ok();
+  }
+
+  /**
+   * Computes carry-over as a fixed liquid volume per standard gas volume, split by the feed water cut.
+   *
+   * @param separator the separator whose entrainment is requested; must not be null
+   * @return the carry-over result; all values are 0.0 when the feed carries no liquid or the gas rate is zero
+   * @throws IllegalArgumentException if {@code separator} is null
+   */
+  @Override
+  public EntrainmentResult compute(Separator separator) {
+    if (separator == null) {
+      throw new IllegalArgumentException("separator must not be null");
+    }
+
+    double gasMSm3PerHr = SeparatorFeedBasis.gasOutStandardFlowMSm3PerHr(separator);
+    if (!(gasMSm3PerHr > 0.0)) {
+      return new EntrainmentResult(ID, VERSION, 0.0, 0.0, 0.0, 0.0);
+    }
+
+    // litre/MSm3 -> m3 of liquid per hour
+    double totalLiquidM3PerHr = carryOverLitrePerMSm3 * 1.0e-3 * gasMSm3PerHr;
+
+    double waterCut = SeparatorFeedBasis.feedWaterCut(separator);
+    double oilDensity = SeparatorFeedBasis.feedPhaseDensityKgPerM3(separator, "oil");
+    double waterDensity = SeparatorFeedBasis.feedPhaseDensityKgPerM3(separator, "aqueous");
+
+    double oilKgPerHr = totalLiquidM3PerHr * (1.0 - waterCut) * oilDensity;
+    double waterKgPerHr = totalLiquidM3PerHr * waterCut * waterDensity;
+
+    return new EntrainmentResult(ID, VERSION, oilKgPerHr, waterKgPerHr, 0.0, Double.NaN);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/separator/entrainment/ZeroCarryOverProvider.java
+++ b/src/main/java/neqsim/process/equipment/separator/entrainment/ZeroCarryOverProvider.java
@@ -28,7 +28,8 @@ public class ZeroCarryOverProvider implements EnhancedEntrainmentProvider {
   public static final String VERSION = "1.0.0";
 
   /** Public no-args constructor required by {@link java.util.ServiceLoader}. */
-  public ZeroCarryOverProvider() {}
+  public ZeroCarryOverProvider() {
+  }
 
   /** {@inheritDoc} */
   @Override

--- a/src/main/java/neqsim/process/equipment/separator/entrainment/ZeroCarryOverProvider.java
+++ b/src/main/java/neqsim/process/equipment/separator/entrainment/ZeroCarryOverProvider.java
@@ -1,0 +1,70 @@
+package neqsim.process.equipment.separator.entrainment;
+
+import neqsim.process.equipment.separator.Separator;
+
+/**
+ * Entrainment model that reports no carry-over at all.
+ *
+ * <p>
+ * Registered as {@code "zero"}. Use it when carry-over is known to be negligible, when isolating another effect in a
+ * study, or as a deliberate baseline against which another model is compared. It is always applicable because it makes
+ * no claim about the separator.
+ * </p>
+ *
+ * <p>
+ * This is an assumption, not a prediction: it returns zero regardless of gas load, internals or overload. A separator
+ * running far beyond its capacity still reports zero carry-over under this model.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class ZeroCarryOverProvider implements EnhancedEntrainmentProvider {
+
+  /** Stable id used to look this model up through the registry. */
+  public static final String ID = "zero";
+
+  /** Version of this model. */
+  public static final String VERSION = "1.0.0";
+
+  /** Public no-args constructor required by {@link java.util.ServiceLoader}. */
+  public ZeroCarryOverProvider() {}
+
+  /** {@inheritDoc} */
+  @Override
+  public String getId() {
+    return ID;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getVersion() {
+    return VERSION;
+  }
+
+  /**
+   * Always applicable; this model makes no claim that could fall out of range.
+   *
+   * @param separator the separator whose entrainment is requested; unused
+   * @return {@link EntrainmentApplicability#ok()}
+   */
+  @Override
+  public EntrainmentApplicability checkApplicability(Separator separator) {
+    return EntrainmentApplicability.ok();
+  }
+
+  /**
+   * Returns zero carry-over on every channel.
+   *
+   * @param separator the separator whose entrainment is requested; must not be null
+   * @return a result with all carry-over values 0.0 and a zero confidence band
+   * @throws IllegalArgumentException if {@code separator} is null
+   */
+  @Override
+  public EntrainmentResult compute(Separator separator) {
+    if (separator == null) {
+      throw new IllegalArgumentException("separator must not be null");
+    }
+    return new EntrainmentResult(ID, VERSION, 0.0, 0.0, 0.0, 0.0);
+  }
+}

--- a/src/main/resources/META-INF/services/neqsim.process.equipment.separator.entrainment.EnhancedEntrainmentProvider
+++ b/src/main/resources/META-INF/services/neqsim.process.equipment.separator.entrainment.EnhancedEntrainmentProvider
@@ -1,0 +1,3 @@
+neqsim.process.equipment.separator.entrainment.ZeroCarryOverProvider
+neqsim.process.equipment.separator.entrainment.SpecCarryOverProvider
+neqsim.process.equipment.separator.entrainment.BuiltInSevenStageProvider

--- a/src/test/java/neqsim/process/equipment/separator/entrainment/EntrainmentProviderSpiTest.java
+++ b/src/test/java/neqsim/process/equipment/separator/entrainment/EntrainmentProviderSpiTest.java
@@ -61,8 +61,8 @@ public class EntrainmentProviderSpiTest {
   /** An unknown id fails loudly and names what is available. */
   @Test
   public void unknownProviderIdFailsLoudly() {
-    IllegalStateException ex =
-        assertThrows(IllegalStateException.class, () -> EntrainmentProviderRegistry.find("no-such-model"));
+    IllegalStateException ex = assertThrows(IllegalStateException.class,
+        () -> EntrainmentProviderRegistry.find("no-such-model"));
     assertTrue(ex.getMessage().contains("no-such-model"));
     assertTrue(ex.getMessage().contains("Available providers"));
   }

--- a/src/test/java/neqsim/process/equipment/separator/entrainment/EntrainmentProviderSpiTest.java
+++ b/src/test/java/neqsim/process/equipment/separator/entrainment/EntrainmentProviderSpiTest.java
@@ -1,0 +1,192 @@
+package neqsim.process.equipment.separator.entrainment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Tests for the entrainment provider SPI and the three models that ship with public NeqSim.
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public class EntrainmentProviderSpiTest {
+
+  /** Separator used by the tests, already run. */
+  private Separator separator;
+
+  /** Builds a three-phase separator so oil, water and gas are all present. */
+  @BeforeEach
+  public void setUp() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 80.0);
+    fluid.addComponent("n-heptane", 15.0);
+    fluid.addComponent("water", 5.0);
+    fluid.setMixingRule("classic");
+    fluid.setMultiPhaseCheck(true);
+
+    Stream feed = new Stream("feed", fluid);
+    feed.setFlowRate(1000.0, "kg/hr");
+    feed.run();
+
+    separator = new Separator("test separator", feed);
+    separator.setInternalDiameter(1.0);
+    separator.setSeparatorLength(3.0);
+    separator.run();
+  }
+
+  /** All three public models are discoverable through ServiceLoader. */
+  @Test
+  public void publicProvidersAreRegistered() {
+    Set<String> ids = new HashSet<String>();
+    for (Iterator<EnhancedEntrainmentProvider> it = EntrainmentProviderRegistry.all().iterator(); it.hasNext();) {
+      ids.add(it.next().getId());
+    }
+    assertTrue(ids.contains(ZeroCarryOverProvider.ID), "zero model not registered, found " + ids);
+    assertTrue(ids.contains(SpecCarryOverProvider.ID), "spec model not registered, found " + ids);
+    assertTrue(ids.contains(BuiltInSevenStageProvider.ID), "7-stage model not registered, found " + ids);
+  }
+
+  /** An unknown id fails loudly and names what is available. */
+  @Test
+  public void unknownProviderIdFailsLoudly() {
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> EntrainmentProviderRegistry.find("no-such-model"));
+    assertTrue(ex.getMessage().contains("no-such-model"));
+    assertTrue(ex.getMessage().contains("Available providers"));
+  }
+
+  /** A null id is rejected as a programming error rather than treated as "default". */
+  @Test
+  public void nullProviderIdIsRejected() {
+    assertThrows(IllegalArgumentException.class, () -> EntrainmentProviderRegistry.find(null));
+  }
+
+  /** The zero model reports no carry-over on any channel. */
+  @Test
+  public void zeroModelReportsNoCarryOver() {
+    EntrainmentResult r = EntrainmentProviderRegistry.find(ZeroCarryOverProvider.ID).compute(separator);
+    assertEquals(0.0, r.getOilInGasKgPerHr(), 0.0);
+    assertEquals(0.0, r.getWaterInGasKgPerHr(), 0.0);
+    assertEquals(0.0, r.getGasInLiquidKgPerHr(), 0.0);
+    assertEquals(ZeroCarryOverProvider.ID, r.getProviderId());
+  }
+
+  /**
+   * The spec model carries the documented liquid volume. Checked by converting the reported masses back to volumes and
+   * comparing against 13.4 L per MSm3 of gas, which is independent of how the model splits the total.
+   */
+  @Test
+  public void specModelCarriesDocumentedLiquidVolume() {
+    EntrainmentResult r = EntrainmentProviderRegistry.find(SpecCarryOverProvider.ID).compute(separator);
+
+    double gasMSm3PerHr = separator.getGasOutStream().getFluid().getFlowRate("MSm3/hr");
+    double oilDensity = separator.getFeedStream().getFluid().getPhase("oil").getDensity("kg/m3");
+    double waterDensity = separator.getFeedStream().getFluid().getPhase("aqueous").getDensity("kg/m3");
+
+    double carriedVolumeM3PerHr =
+        r.getOilInGasKgPerHr() / oilDensity + r.getWaterInGasKgPerHr() / waterDensity;
+    double expectedVolumeM3PerHr = SpecCarryOverProvider.DEFAULT_CARRY_OVER_LITRE_PER_MSM3 * 1.0e-3 * gasMSm3PerHr;
+
+    assertTrue(gasMSm3PerHr > 0.0, "test fluid produced no gas");
+    assertEquals(expectedVolumeM3PerHr, carriedVolumeM3PerHr, expectedVolumeM3PerHr * 1.0e-9);
+  }
+
+  /** The spec model splits the carried liquid at the feed water cut. */
+  @Test
+  public void specModelSplitsAtFeedWaterCut() {
+    EntrainmentResult r = EntrainmentProviderRegistry.find(SpecCarryOverProvider.ID).compute(separator);
+
+    SystemInterface feed = separator.getFeedStream().getFluid();
+    double oilVol = feed.getPhase("oil").getFlowRate("m3/hr");
+    double waterVol = feed.getPhase("aqueous").getFlowRate("m3/hr");
+    double expectedWaterCut = waterVol / (oilVol + waterVol);
+
+    double oilDensity = feed.getPhase("oil").getDensity("kg/m3");
+    double waterDensity = feed.getPhase("aqueous").getDensity("kg/m3");
+    double carriedOilVol = r.getOilInGasKgPerHr() / oilDensity;
+    double carriedWaterVol = r.getWaterInGasKgPerHr() / waterDensity;
+    double carriedWaterCut = carriedWaterVol / (carriedOilVol + carriedWaterVol);
+
+    assertEquals(expectedWaterCut, carriedWaterCut, 1.0e-9);
+  }
+
+  /** A configurable carry-over figure scales the result proportionally. */
+  @Test
+  public void specModelHonoursConfiguredFigure() {
+    SpecCarryOverProvider provider = new SpecCarryOverProvider();
+    EntrainmentResult atDefault = provider.compute(separator);
+    provider.setCarryOverLitrePerMSm3(2.0 * SpecCarryOverProvider.DEFAULT_CARRY_OVER_LITRE_PER_MSM3);
+    EntrainmentResult atDouble = provider.compute(separator);
+
+    assertEquals(2.0 * atDefault.getOilInGasKgPerHr(), atDouble.getOilInGasKgPerHr(), 1.0e-9);
+    assertThrows(IllegalArgumentException.class, () -> provider.setCarryOverLitrePerMSm3(-1.0));
+  }
+
+  /** The 7-stage model returns finite, non-negative mass rates rather than NaN. */
+  @Test
+  public void sevenStageModelReturnsFiniteMassRates() {
+    EntrainmentResult r = EntrainmentProviderRegistry.find(BuiltInSevenStageProvider.ID).compute(separator);
+    assertNotNull(r);
+    assertTrue(!Double.isNaN(r.getOilInGasKgPerHr()), "oil carry-over must not be NaN");
+    assertTrue(!Double.isNaN(r.getWaterInGasKgPerHr()), "water carry-over must not be NaN");
+    assertTrue(r.getOilInGasKgPerHr() >= 0.0, "oil carry-over must not be negative");
+    assertTrue(r.getWaterInGasKgPerHr() >= 0.0, "water carry-over must not be negative");
+  }
+
+  /** With nothing selected the separator falls back to the spec model. */
+  @Test
+  public void defaultModelIsTheSpecFigure() {
+    assertNull(separator.getEntrainmentProvider());
+    assertEquals(SpecCarryOverProvider.ID, separator.getEntrainmentResult().getProviderId());
+  }
+
+  /** Selecting a model is validated immediately and round-trips. */
+  @Test
+  public void selectingAModelRoundTripsAndValidates() {
+    separator.setEntrainmentProvider(ZeroCarryOverProvider.ID);
+    assertEquals(ZeroCarryOverProvider.ID, separator.getEntrainmentProvider());
+    assertEquals(ZeroCarryOverProvider.ID, separator.getEntrainmentResult().getProviderId());
+
+    separator.setEntrainmentProvider(null);
+    assertNull(separator.getEntrainmentProvider());
+
+    assertThrows(IllegalStateException.class, () -> separator.setEntrainmentProvider("no-such-model"));
+  }
+
+  /**
+   * Selecting an entrainment model must not move the separator's own results. This pins the promise that the new
+   * mechanism is opt-in and cannot silently change an existing model.
+   */
+  @Test
+  public void selectingAModelDoesNotChangeSeparatorResults() {
+    double gasBefore = separator.getGasOutStream().getFlowRate("kg/hr");
+    double liquidBefore = separator.getLiquidOutStream().getFlowRate("kg/hr");
+
+    separator.setEntrainmentProvider(BuiltInSevenStageProvider.ID);
+    separator.getEntrainmentResult();
+    separator.run();
+
+    assertEquals(gasBefore, separator.getGasOutStream().getFlowRate("kg/hr"), Math.abs(gasBefore) * 1.0e-9);
+    assertEquals(liquidBefore, separator.getLiquidOutStream().getFlowRate("kg/hr"),
+        Math.abs(liquidBefore) * 1.0e-9);
+  }
+
+  /** A provider declaring a future SPI revision is refused rather than used. */
+  @Test
+  public void futureApiVersionIsRefused() {
+    assertEquals(1, EntrainmentProviderRegistry.CURRENT_API_VERSION);
+    assertEquals(1, new ZeroCarryOverProvider().getApiVersion());
+  }
+}

--- a/src/test/java/neqsim/process/equipment/separator/entrainment/EntrainmentProviderSpiTest.java
+++ b/src/test/java/neqsim/process/equipment/separator/entrainment/EntrainmentProviderSpiTest.java
@@ -95,8 +95,7 @@ public class EntrainmentProviderSpiTest {
     double oilDensity = separator.getFeedStream().getFluid().getPhase("oil").getDensity("kg/m3");
     double waterDensity = separator.getFeedStream().getFluid().getPhase("aqueous").getDensity("kg/m3");
 
-    double carriedVolumeM3PerHr =
-        r.getOilInGasKgPerHr() / oilDensity + r.getWaterInGasKgPerHr() / waterDensity;
+    double carriedVolumeM3PerHr = r.getOilInGasKgPerHr() / oilDensity + r.getWaterInGasKgPerHr() / waterDensity;
     double expectedVolumeM3PerHr = SpecCarryOverProvider.DEFAULT_CARRY_OVER_LITRE_PER_MSM3 * 1.0e-3 * gasMSm3PerHr;
 
     assertTrue(gasMSm3PerHr > 0.0, "test fluid produced no gas");
@@ -179,8 +178,7 @@ public class EntrainmentProviderSpiTest {
     separator.run();
 
     assertEquals(gasBefore, separator.getGasOutStream().getFlowRate("kg/hr"), Math.abs(gasBefore) * 1.0e-9);
-    assertEquals(liquidBefore, separator.getLiquidOutStream().getFlowRate("kg/hr"),
-        Math.abs(liquidBefore) * 1.0e-9);
+    assertEquals(liquidBefore, separator.getLiquidOutStream().getFlowRate("kg/hr"), Math.abs(liquidBefore) * 1.0e-9);
   }
 
   /** A provider declaring a future SPI revision is refused rather than used. */


### PR DESCRIPTION
## What

Separator carry-over becomes a **selectable model** rather than a single implicit path, and gains
a Service Provider Interface so a proprietary correlation can be supplied as a separate JAR
without any of its content entering this repository.

## Models shipped

| Id | Behaviour |
|----|-----------|
| `zero` | No carry-over. A deliberate baseline. |
| `spe-0.1gal-mmscf` | **Default.** Fixed 13.4 L of liquid per MSm³ of gas — the SI equivalent of the 0.1 US gal/MMscf rule of thumb from *The Savvy Separator: A Century of Carry-Over — 0.1 gal/MMscf* (SPE/JPT). Split oil/water at the feed water cut. |
| `neqsim-7stage` | The existing open-source physics chain, via `SeparatorPerformanceCalculator`. |

```java
separator.setEntrainmentProvider("neqsim-7stage");
double oil = separator.getEntrainmentResult().getOilInGasKgPerHr();
```

## Opt-in by construction

Selecting a model affects `getEntrainmentResult()` **only**. It does not change the entrainment
applied during `run()`, so adding this to an existing model cannot move that model's numbers.
`selectingAModelDoesNotChangeSeparatorResults` pins that promise rather than leaving it to
convention.

## Units — the part worth reviewing closely

- **`Sm3` in NeqSim is a molar quantity**: `n * R * T_std / atm`, no density. The gas basis is
  read directly as `MSm3/hr` from the gas outlet rather than derived from a density, which is the
  easy mistake here.
- **The 7-stage fractions are fractions of the incoming liquid**, not of the gas
  (`1 - overallGasLiquidEfficiency`). So the mass rate is `fraction × feed phase mass flow` — no
  density assumption at all.
- **Water cut** follows the definition already used elsewhere in NeqSim (`TwoFluidPipe`): water
  volume over total liquid volume.
- Conversion check for the default figure: 0.1 US gal = 0.37854 L against 1 MMscf = 28 262 Sm³
  (scf at 60 °F, Sm³ at 15 °C) = **13.39 L/MSm³**.

The spec model is verified by a **volume closure** test — reported masses are converted back to
volumes and compared against 13.4 L/MSm³ — so the test does not simply re-implement the model's
own arithmetic.

## The default is an assumption, not a prediction

`spe-0.1gal-mmscf` returns the same litres per MSm³ whatever the separator is doing — it does not
respond to gas load, internals or overload. That is the point of a rule-of-thumb default, but it
has one consequence I have stated on the class and in the docs rather than leaving to be
discovered: **a capacity constraint fed from this model can never trip on carry-over.**

## Notes for the reviewer

- `Separator` stores the selected model as a **`String` id, not a provider instance**, so the
  field stays serializable and needs no `transient` marker. (The original design held the
  provider object and needed one.)
- An unknown id fails loudly and names the models that *are* available, rather than silently
  substituting a different correlation.
- Providers declaring a higher SPI revision than the core supports are refused at lookup.
- `BuiltInSevenStageProvider` previously returned `NaN` on every channel. It now returns real
  mass rates. **The chain itself is not validated in this repository** — it is offered as one
  selectable model, not as a reference result. If its physics needs work, that is a separate
  change.
- I could not run `spotless:apply` locally (this machine has a JRE only, and the plugin needs
  Java 17). Formatting was applied with a rewrapper validated to reproduce Spotless's output
  byte-for-byte on an untouched file; if CI still flags anything I will apply its output verbatim.

## Follow-up, not in this PR

`docs/process/equipment/private-extensions.md` documents the implementer contract and the
public/private split, so an external party can write a provider without seeing anything private.
