### PR TITLE
[AI-Assisted] test(dynamics): preserve choked valve reference case

### DIFF
--- a/src/test/java/neqsim/process/processmodel/ProcessSystemRunTransientTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemRunTransientTest.java
@@ -893,6 +893,8 @@ public class ProcessSystemRunTransientTest extends neqsim.NeqSimTest {
         "valve_1", stream1);
     valve1.setOutletPressure(5.0);
     valve1.setPercentValveOpening(30.0);
+    // Keep this established dynamic reference case on the explicitly choked sizing path.
+    valve1.setAllowChoked(true);
     valve1.setCalculateSteadyState(false);
 
     neqsim.process.equipment.separator.Separator separator1 = new neqsim.process.equipment.separator.Separator(
@@ -913,6 +915,7 @@ public class ProcessSystemRunTransientTest extends neqsim.NeqSimTest {
         "valve_3", separator1.getGasOutStream());
     valve3.setOutletPressure(1.0);
     valve3.setPercentValveOpening(30.0);
+    valve3.setAllowChoked(true);
     valve3.setCalculateSteadyState(false);
 
     neqsim.process.measurementdevice.VolumeFlowTransmitter flowTransmitter = new neqsim.process.measurementdevice.VolumeFlowTransmitter(


### PR DESCRIPTION
## Summary

Restore the failing `ProcessSystemRunTransientTest.testDynamicCalculation1` reference case after #3448 made the legacy valve-sizing strategy unchoked by default.

The test's stored Cv anchors were generated on the choked IEC gas-sizing path. It now opts both gas valves into `setAllowChoked(true)` explicitly, preserving that established transient scenario while retaining #3448's new default and forward/inverse pressure consistency for ordinary callers.

## Root cause

#3448 intentionally changed the legacy `ControlValveSizing` choked-flow capacity limit from implicit-on to explicit-off. The dynamic test still expected its former choked Cv values, so the first SI Kv assertion changed from `1.1225433733413146` to `0.5133077841818874`.

This is a test-fixture configuration repair; no production behavior or public API changes.

## Validation

Local environment: OpenJDK 17.0.20, Maven 3.9.16.

- Reproduced the exact failure on current `master`.
- `./mvnw -q -Dtest=ProcessSystemRunTransientTest#testDynamicCalculation1 test` — passed after the repair.
- `./mvnw -q -Dtest=ProcessSystemRunTransientTest,ThrottlingValveTest test` — 32 tests passed, 0 failures/errors/skips.
- `python3 devtools/run_spotless.py apply` — passed.
- `python3 devtools/run_spotless.py check` — passed.
- `python3 devtools/check_documentation_search.py` — passed (688 Markdown + 1 standalone HTML page).
- `pre-commit run --all-files --hook-stage pre-commit` — passed.
- `pre-commit run --all-files --hook-stage pre-push` — passed.

Full repository matrix was not rerun locally; hosted CI remains authoritative for Java 8 and broad-suite validation.

## Documentation impact

Documentation impact: none. Only an existing test fixture now explicitly selects the already-documented choked-flow option; runtime behavior, API, units, defaults, and user guidance are unchanged.