### PR TITLE
[AI-Assisted] feat(refinery): preserve Sarir pumparound evidence

### DIFF
--- a/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
@@ -25,6 +25,15 @@ The source then reports a `550 degC+` terminal residue reaching 100 volume%. Neq
 
 The published HYSYS case uses 34 valve trays, feeds 54,420 kg/h of crude at 350 degC and 233 kPa to tray 31 counted from the top, and includes main-column, kerosene-stripper, and diesel-stripper steam rates of 340.2, 68.04, and 226.8 kg/h. Top and bottom pump-around rates are 29,777.64 and 60,423.66 kg/h.
 
+Table 4 gives the complete numeric pump-around rows:
+
+| Source label | Draw tray | Return tray | Flow (kg/h) | Draw temperature (degC) | Return temperature (degC) | Derived drop (K) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Top pump around (TPA) | 3 | 1 | 29,777.64 | 143.9 | 80.99 | 62.91 |
+| Bottom pump around (BPA) | 22 | 19 | 60,423.66 | 232.4 | 173.99 | 58.41 |
+
+The temperature drops are direct differences of the published draw and return temperatures. Table 4 does not explicitly state whether its tray labels are counted from the top or bottom. The Java API therefore exposes them as raw source tray numbers and reports the numbering basis as unresolved. They are not automatically converted to NeqSim's bottom-up indices or used to configure a column.
+
 Four products have numeric laboratory and simulated ASTM D86 T5/T95 evidence:
 
 | Product | Lab T5 (degC) | Lab T95 (degC) | HYSYS T5 (degC) | HYSYS T95 (degC) |
@@ -57,6 +66,13 @@ SarirAtmosphericReference.ProductYieldReference diesel =
     SarirAtmosphericReference.getProductYield("Diesel");
 double plantRate = diesel.getPlantMetricTonPerDay();
 double errorPercent = diesel.getAbsoluteRelativeErrorPercent();
+
+SarirAtmosphericReference.PumparoundReference topPumparound =
+    SarirAtmosphericReference.getPumparound("Top pump around (TPA)");
+double sourceFlowKgPerHour = topPumparound.getMassFlowRateKgPerHour();
+int rawSourceDrawTray = topPumparound.getSourceDrawTrayNumber();
+boolean trayBasisIsExplicit =
+    SarirAtmosphericReference.hasExplicitPumparoundTrayNumberingBasis();
 ```
 
 Static methods are directly accessible through JPype. Arrays are defensive copies, and unknown product labels or invalid error inputs fail closed.
@@ -124,4 +140,5 @@ inventory merely to force every screen stream positive.
 The published plant rates remain untouched read-only evidence. They are not used as product-flow
 specifications, tuning targets, or numerical acceptance thresholds. This sensitivity gate does not
 qualify plant-yield or D86 reproduction and does not model the published steam, pump-around,
-side-stripper, tray-hydraulic, or efficiency details.
+side-stripper, tray-hydraulic, or efficiency details. The separate pump-around reference rows are
+source evidence only; unresolved tray-numbering direction prevents direct model configuration.

--- a/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
+++ b/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
@@ -44,6 +44,10 @@ public final class SarirAtmosphericReference {
       new ProductYieldReference("Total Naphtha", 208.95, 208.2), new ProductYieldReference("Kerosene", 22.85, 20.0),
       new ProductYieldReference("Diesel", 425.018, 393.0), new ProductYieldReference("Residual", 646.5, 706.1) };
 
+  private static final PumparoundReference[] PUMPAROUNDS = {
+      new PumparoundReference("Top pump around (TPA)", 3, 1, 29777.64, 143.9, 80.99),
+      new PumparoundReference("Bottom pump around (BPA)", 22, 19, 60423.66, 232.4, 173.99) };
+
   private SarirAtmosphericReference() {
   }
 
@@ -202,14 +206,114 @@ public final class SarirAtmosphericReference {
     return 226.8;
   }
 
+  /**
+   * Return the source pump-around table in source order.
+   *
+   * @return defensive copy of the two immutable pump-around rows
+   */
+  public static PumparoundReference[] getPumparounds() {
+    return PUMPAROUNDS.clone();
+  }
+
+  /**
+   * Find one pump-around row by its exact source-table label.
+   *
+   * @param name exact source-table label
+   * @return immutable pump-around reference
+   * @throws IllegalArgumentException if the label is null or unknown
+   */
+  public static PumparoundReference getPumparound(String name) {
+    if (name == null) {
+      throw new IllegalArgumentException("Pump-around name cannot be null");
+    }
+    for (PumparoundReference pumparound : PUMPAROUNDS) {
+      if (pumparound.getName().equals(name)) {
+        return pumparound;
+      }
+    }
+    throw new IllegalArgumentException("Unknown Sarir pump-around: " + name);
+  }
+
+  /**
+   * Report whether Table 4 explicitly defines the direction used for its tray numbers.
+   *
+   * @return always false; the raw source labels must not be mapped to NeqSim tray indices without another authority
+   */
+  public static boolean hasExplicitPumparoundTrayNumberingBasis() {
+    return false;
+  }
+
   /** @return top pump-around flow rate in kg/h */
   public static double getTopPumpAroundRateKgPerHour() {
-    return 29777.64;
+    return PUMPAROUNDS[0].getMassFlowRateKgPerHour();
   }
 
   /** @return bottom pump-around flow rate in kg/h */
   public static double getBottomPumpAroundRateKgPerHour() {
-    return 60423.66;
+    return PUMPAROUNDS[1].getMassFlowRateKgPerHour();
+  }
+
+  /**
+   * Immutable source-table pump-around row.
+   *
+   * <p>
+   * Tray numbers are retained exactly as printed in Table 4. The table does not explicitly state whether they are
+   * counted from the top or bottom, so callers must not treat them as NeqSim tray indices without additional evidence.
+   * </p>
+   */
+  public static final class PumparoundReference implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final int sourceDrawTrayNumber;
+    private final int sourceReturnTrayNumber;
+    private final double massFlowRateKgPerHour;
+    private final double drawTemperatureCelsius;
+    private final double returnTemperatureCelsius;
+
+    private PumparoundReference(String name, int sourceDrawTrayNumber, int sourceReturnTrayNumber,
+        double massFlowRateKgPerHour, double drawTemperatureCelsius, double returnTemperatureCelsius) {
+      this.name = name;
+      this.sourceDrawTrayNumber = sourceDrawTrayNumber;
+      this.sourceReturnTrayNumber = sourceReturnTrayNumber;
+      this.massFlowRateKgPerHour = massFlowRateKgPerHour;
+      this.drawTemperatureCelsius = drawTemperatureCelsius;
+      this.returnTemperatureCelsius = returnTemperatureCelsius;
+    }
+
+    /** @return exact source-table label */
+    public String getName() {
+      return name;
+    }
+
+    /** @return raw draw-tray number printed in the source table */
+    public int getSourceDrawTrayNumber() {
+      return sourceDrawTrayNumber;
+    }
+
+    /** @return raw return-tray number printed in the source table */
+    public int getSourceReturnTrayNumber() {
+      return sourceReturnTrayNumber;
+    }
+
+    /** @return source pump-around mass flow rate in kg/h */
+    public double getMassFlowRateKgPerHour() {
+      return massFlowRateKgPerHour;
+    }
+
+    /** @return source draw temperature in degrees Celsius */
+    public double getDrawTemperatureCelsius() {
+      return drawTemperatureCelsius;
+    }
+
+    /** @return source return temperature in degrees Celsius */
+    public double getReturnTemperatureCelsius() {
+      return returnTemperatureCelsius;
+    }
+
+    /** @return draw temperature minus return temperature, in kelvin */
+    public double getTemperatureDropKelvin() {
+      return drawTemperatureCelsius - returnTemperatureCelsius;
+    }
   }
 
   /** Immutable numeric ASTM D86 comparison row. */

--- a/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
+++ b/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import neqsim.thermo.characterization.SarirAtmosphericReference.ProductQualityReference;
 import neqsim.thermo.characterization.SarirAtmosphericReference.ProductYieldReference;
+import neqsim.thermo.characterization.SarirAtmosphericReference.PumparoundReference;
 
 /** Tests the public Sarir atmospheric assay and validation reference. */
 public class SarirAtmosphericReferenceTest {
@@ -44,6 +45,10 @@ public class SarirAtmosphericReferenceTest {
     ProductYieldReference[] yields = SarirAtmosphericReference.getProductYields();
     yields[0] = null;
     assertEquals("Total Naphtha", SarirAtmosphericReference.getProductYields()[0].getName());
+
+    PumparoundReference[] pumparounds = SarirAtmosphericReference.getPumparounds();
+    pumparounds[0] = null;
+    assertEquals("Top pump around (TPA)", SarirAtmosphericReference.getPumparounds()[0].getName());
   }
 
   @Test
@@ -88,15 +93,39 @@ public class SarirAtmosphericReferenceTest {
   }
 
   @Test
+  public void pumparoundRowsPreservePublishedTableWithoutInferringTrayBasis() {
+    PumparoundReference[] pumparounds = SarirAtmosphericReference.getPumparounds();
+    assertEquals(2, pumparounds.length);
+    assertPumparound(pumparounds[0], "Top pump around (TPA)", 3, 1, 29777.64, 143.9, 80.99, 62.91);
+    assertPumparound(pumparounds[1], "Bottom pump around (BPA)", 22, 19, 60423.66, 232.4, 173.99, 58.41);
+    assertFalse(SarirAtmosphericReference.hasExplicitPumparoundTrayNumberingBasis());
+    assertEquals(pumparounds[0], SarirAtmosphericReference.getPumparound("Top pump around (TPA)"));
+    assertEquals(pumparounds[1], SarirAtmosphericReference.getPumparound("Bottom pump around (BPA)"));
+  }
+
+  @Test
   public void invalidQueriesAndErrorInputsFailClosed() {
     assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getProductYield(null));
     assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getProductYield("Naphtha"));
+    assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getPumparound(null));
+    assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getPumparound("TPA"));
     assertThrows(IllegalArgumentException.class,
         () -> SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(0.0, 1.0));
     assertThrows(IllegalArgumentException.class,
         () -> SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(Double.NaN, 1.0));
     assertThrows(IllegalArgumentException.class,
         () -> SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(1.0, Double.POSITIVE_INFINITY));
+  }
+
+  private static void assertPumparound(PumparoundReference pumparound, String name, int drawTray, int returnTray,
+      double massFlowRate, double drawTemperature, double returnTemperature, double temperatureDrop) {
+    assertEquals(name, pumparound.getName());
+    assertEquals(drawTray, pumparound.getSourceDrawTrayNumber());
+    assertEquals(returnTray, pumparound.getSourceReturnTrayNumber());
+    assertEquals(massFlowRate, pumparound.getMassFlowRateKgPerHour(), 0.0);
+    assertEquals(drawTemperature, pumparound.getDrawTemperatureCelsius(), 0.0);
+    assertEquals(returnTemperature, pumparound.getReturnTemperatureCelsius(), 0.0);
+    assertEquals(temperatureDrop, pumparound.getTemperatureDropKelvin(), 1.0e-12);
   }
 
   private static void assertQuality(ProductQualityReference quality, String name, double labFive, double labNinetyFive,


### PR DESCRIPTION
## Summary

Advances #3305 by preserving the complete numeric Sarir pump-around table needed for later atmospheric-column work, without inventing a tray-index mapping.

**Exact base:** `c289259e6c1ae0a86b0810b89ab61fe5df61ca85`  
**Exact head:** `4645db0728ccdebf9f46f1a854dcac9827f35881`

The pre-implementation capability contract is recorded in [#3305](https://github.com/equinor/neqsim/issues/3305#issuecomment-5541641759).

## Capability contract

- Add immutable Java/JPype `PumparoundReference` rows in source-table order.
- Preserve the raw source name, draw tray, return tray, mass flow, draw temperature, and return temperature.
- Derive temperature drop directly from the two source temperatures.
- Expose a defensive array, exact-label lookup, and an explicit unresolved tray-numbering flag.
- Retain the existing scalar pump-around rate APIs and values.
- Fail closed for null, abbreviated, or unknown pump-around labels.

## Public provenance and values

Source: H. E. O. Almansouri, *Simulation of Sarir Crude Oil Refinery Using Aspen HYSYS*, Journal of Engineering Research issue 33, published March 31, 2022, DOI [10.66411/jer.v33i.46](https://doi.org/10.66411/jer.v33i.46), [open article](https://jer.ly/jer/index.php/jer/article/download/46/38/39), CC BY 4.0.

Table 4 reports:

- Top pump around (TPA): draw tray 3, return tray 1, 29,777.64 kg/h, 143.9 °C draw, 80.99 °C return, giving 62.91 K.
- Bottom pump around (BPA): draw tray 22, return tray 19, 60,423.66 kg/h, 232.4 °C draw, 173.99 °C return, giving 58.41 K.

The paper does not explicitly identify the numbering direction for these Table 4 tray labels. The API therefore retains raw source numbers, reports the basis as unresolved, and does not map them to NeqSim's bottom-up indices.

## Changes

- `SarirAtmosphericReference.java`: immutable pump-around evidence API and compatibility-preserving scalar delegation.
- `SarirAtmosphericReferenceTest.java`: exact transcription, source order, temperature-difference, defensive-copy, compatibility, and fail-closed checks.
- `refinery_sarir_atmospheric_reference.md`: numeric table, Java/JPype example, and modeling boundary.

## Validation

**READY TO MERGE — REMAINS DRAFT**

Every required hosted workflow passes on exact head `4645db0728ccdebf9f46f1a854dcac9827f35881`: Java 8 and 21 fast tests on Ubuntu and Windows, all four Java 21 slow-test shards, Javadocs, Spotless, pre-commit, documentation search, CodeQL, PaperLab, and agent-skill reference checks. The seven focused `SarirAtmosphericReferenceTest` cases pass.

The exact head is a tree-identical CI-refresh commit after merged #3452 repaired the unrelated transient fixture failure seen on the previous source head. Remote comparison confirms zero file changes from that submitted tree. No source, test, documentation, API, data, provenance, or engineering acceptance boundary changed in the refresh.

The PR is open, draft, unmerged, and mergeable. It has no reviews and no unresolved review threads. Hosted exact-head CI is authoritative.

## Documentation impact

Completed in the Sarir atmospheric reference guide. The change is user-visible source-data/API expansion, so documentation is included in the same three-file scope. Notebook and rendered-visual gates are not applicable.

## Portfolio and overlap

Four open autonomous implementation PRs are positively identified (#3453, #3454, #3461, and #3462), so portfolio occupancy is **4/10**, below the global ceiling. Their MCP, refinery, DEXPI, and electrolyte scopes do not overlap. This is the sole active #3305 PR.

## Engineering stop boundary

Reference evidence only. This change does not configure a pump-around, select draw/return indices, add steam, solve a column, tune product rates, validate plant yields or D86, change an assay/EOS/solver, or alter production defaults. The plant and HYSYS product rows remain untouched evidence.

This PR must remain draft-only. Do not merge, mark ready, enable auto-merge, rebase, synchronize, restart, replace, or force-push it as part of this campaign.

Generated with AI assistance.