### PR TITLE
fix: repair data reconciliation example notebook

### DIFF
--- a/docs/calibration/data_reconciliation_parameter_estimation.md
+++ b/docs/calibration/data_reconciliation_parameter_estimation.md
@@ -59,20 +59,38 @@ This guide describes the complete workflow for tuning a NeqSim process model to 
 
 ### 1. Data Reconciliation
 
+For a measurement vector $\mathbf{y}$, diagonal covariance matrix
+$\mathbf{V}=\mathrm{diag}(\sigma_i^2)$, and linear constraints
+$\mathbf{A}\hat{\mathbf{x}}=0$, the engine uses the weighted least-squares
+solution:
+
+$$\hat{\mathbf{x}}=\mathbf{y}-\mathbf{V}\mathbf{A}^{T}(\mathbf{A}\mathbf{V}\mathbf{A}^{T})^{-1}\mathbf{A}\mathbf{y}$$
+
+Each `ReconciliationVariable` stores one measured value and its positive
+standard uncertainty $\sigma_i$ in the same engineering unit.
+
 ```java
 DataReconciliationEngine recon = new DataReconciliationEngine();
 
-// Add measured variables: name, value, uncertainty
-recon.addVariable("flow_in1", 5000.0, 100.0);
-recon.addVariable("flow_in2", 5100.0, 100.0);
-recon.addVariable("flow_out", 10200.0, 150.0);
+// Add measured variables: name, value, standard uncertainty
+recon.addVariable(new ReconciliationVariable("flow_in1", 5000.0, 100.0).setUnit("kg/hr"));
+recon.addVariable(new ReconciliationVariable("flow_in2", 5100.0, 100.0).setUnit("kg/hr"));
+recon.addVariable(new ReconciliationVariable("flow_out", 10200.0, 150.0).setUnit("kg/hr"));
 
 // Mass balance: flow_in1 + flow_in2 - flow_out = 0
 recon.addConstraint(new double[]{1.0, 1.0, -1.0});
 
 ReconciliationResult result = recon.reconcile();
-// Or with automatic gross error elimination:
-// ReconciliationResult result = recon.reconcileWithGrossErrorElimination();
+double chiSquare = result.getChiSquareStatistic();
+
+// Iterate over all variables, or retrieve one by its unique name.
+for (ReconciliationVariable variable : recon.getVariables()) {
+    double reconciledValue = variable.getReconciledValue();
+}
+ReconciliationVariable inlet = recon.getVariable("flow_in1");
+
+// Alternatively, allow the engine to eliminate at most one gross error.
+ReconciliationResult grossErrorResult = recon.reconcileWithGrossErrorElimination(1);
 ```
 
 ### 2. Batch Parameter Estimation
@@ -153,12 +171,67 @@ The `BatchParameterEstimator` uses reflection-based property paths to access equ
 See the example notebook: [data_reconciliation_parameter_estimation.ipynb](https://github.com/equinor/neqsim/blob/master/examples/notebooks/data_reconciliation_parameter_estimation.ipynb)
 
 ```python
-from neqsim_dev_setup import neqsim_init
-ns = neqsim_init(project_root="path/to/neqsim2")
+import os
+import sys
+from pathlib import Path
 
 import jpype
-BatchParameterEstimator = jpype.JClass("neqsim.process.calibration.BatchParameterEstimator")
-HashMap = jpype.JClass("java.util.HashMap")
+
+
+def find_neqsim_project_root():
+    configured_root = os.environ.get("NEQSIM_PROJECT_ROOT")
+    candidates = []
+    if configured_root:
+        candidates.append(Path(configured_root).resolve())
+
+    current_directory = Path.cwd().resolve()
+    candidates.extend([current_directory, *current_directory.parents])
+
+    for candidate in candidates:
+        has_project_file = (candidate / "pom.xml").exists()
+        has_devtools = (
+            candidate / "devtools" / "neqsim_dev_setup.py"
+        ).exists()
+        if has_project_file and has_devtools:
+            return candidate
+
+    raise RuntimeError(
+        "Could not find the NeqSim project root. Set NEQSIM_PROJECT_ROOT."
+    )
+
+
+PROJECT_ROOT = find_neqsim_project_root()
+sys.path.insert(0, str(PROJECT_ROOT / "devtools"))
+
+from neqsim_dev_setup import neqsim_classes, neqsim_init
+
+ns = neqsim_init(project_root=PROJECT_ROOT, recompile=False, verbose=False)
+ns = neqsim_classes(ns)
+
+DataReconciliationEngine = ns.JClass(
+    "neqsim.process.util.reconciliation.DataReconciliationEngine"
+)
+ReconciliationVariable = ns.JClass(
+    "neqsim.process.util.reconciliation.ReconciliationVariable"
+)
+BatchParameterEstimator = ns.JClass(
+    "neqsim.process.calibration.BatchParameterEstimator"
+)
+HashMap = ns.JClass("java.util.HashMap")
+
+recon = DataReconciliationEngine()
+recon.addVariable(ReconciliationVariable("feed", 1000.0, 20.0))
+recon.addVariable(ReconciliationVariable("gas", 600.0, 15.0))
+recon.addVariable(ReconciliationVariable("liquid", 390.0, 10.0))
+recon.addConstraint([1.0, -1.0, -1.0])
+reconciliation_result = recon.reconcile()
+
+assert reconciliation_result.isConverged()
+assert reconciliation_result.getChiSquareStatistic() >= 0.0
+assert recon.getVariable("feed").getName() == "feed"
+
+for variable in recon.getVariables():
+    print(variable.getName(), variable.getReconciledValue())
 
 estimator = BatchParameterEstimator(process)
 estimator.addTunableParameter("comp.polytropicEfficiency", "", 0.50, 0.95, 0.65)

--- a/examples/notebooks/data_reconciliation_parameter_estimation.ipynb
+++ b/examples/notebooks/data_reconciliation_parameter_estimation.ipynb
@@ -13,7 +13,7 @@
     "|------|------|--------------|\n",
     "| 1 | Collect plant measurements | Python / DCS |\n",
     "| 2 | Reconcile measurements (close mass/energy balances) | `DataReconciliationEngine` |\n",
-    "| 3 | Detect and remove gross errors | `reconcileWithGrossErrorElimination()` |\n",
+    "| 3 | Detect and remove gross errors | `DataReconciliationEngine` |\n",
     "| 4 | Feed reconciled values into parameter estimation | `BatchParameterEstimator` |\n",
     "| 5 | Solve for best-fit model parameters (L-M) | `BatchParameterEstimator.solve()` |\n",
     "| 6 | Update process model with tuned parameters | Apply `BatchResult` |\n",
@@ -29,45 +29,94 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "f7f08ceb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "All NeqSim classes imported OK\n",
+      "Loaded NeqSim workspace: /workspace/scratch/3816fe0e85e8/neqsim\n"
+     ]
+    }
+   ],
    "source": [
-    "# Cell 1 — Start JVM with latest NeqSim build\n",
-    "from neqsim_dev_setup import neqsim_init\n",
-    "ns = neqsim_init(project_root=r\"C:\\Users\\ESOL\\Documents\\GitHub\\neqsim2\", recompile=False)"
+    "# Cell 1 — Start JVM with the latest NeqSim workspace build\n",
+    "import os\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "\n",
+    "def find_neqsim_project_root():\n",
+    "    configured_root = os.environ.get(\"NEQSIM_PROJECT_ROOT\")\n",
+    "    candidates = []\n",
+    "    if configured_root:\n",
+    "        candidates.append(Path(configured_root).resolve())\n",
+    "\n",
+    "    current_directory = Path.cwd().resolve()\n",
+    "    candidates.extend([current_directory, *current_directory.parents])\n",
+    "\n",
+    "    for candidate in candidates:\n",
+    "        has_project_file = (candidate / \"pom.xml\").exists()\n",
+    "        has_devtools = (candidate / \"devtools\" / \"neqsim_dev_setup.py\").exists()\n",
+    "        if has_project_file and has_devtools:\n",
+    "            return candidate\n",
+    "\n",
+    "    raise RuntimeError(\n",
+    "        \"Could not find the NeqSim project root. Set NEQSIM_PROJECT_ROOT.\"\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "PROJECT_ROOT = find_neqsim_project_root()\n",
+    "sys.path.insert(0, str(PROJECT_ROOT / \"devtools\"))\n",
+    "\n",
+    "from neqsim_dev_setup import neqsim_classes, neqsim_init\n",
+    "\n",
+    "ns = neqsim_init(project_root=PROJECT_ROOT, recompile=False, verbose=False)\n",
+    "ns = neqsim_classes(ns)\n",
+    "print(f\"Loaded NeqSim workspace: {PROJECT_ROOT}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "d0c32fb9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "All classes loaded.\n"
+     ]
+    }
+   ],
    "source": [
-    "# Cell 2 — Import all needed Java classes via jpype\n",
+    "# Cell 2 — Import the Java classes used below\n",
     "import jpype\n",
     "\n",
-    "# Thermo\n",
-    "SystemSrkEos = jpype.JClass(\"neqsim.thermo.system.SystemSrkEos\")\n",
-    "\n",
-    "# Process equipment\n",
-    "ProcessSystem = jpype.JClass(\"neqsim.process.processmodel.ProcessSystem\")\n",
-    "Stream = jpype.JClass(\"neqsim.process.equipment.stream.Stream\")\n",
-    "Compressor = jpype.JClass(\"neqsim.process.equipment.compressor.Compressor\")\n",
-    "Heater = jpype.JClass(\"neqsim.process.equipment.heatexchanger.Heater\")\n",
-    "Separator = jpype.JClass(\"neqsim.process.equipment.separator.Separator\")\n",
-    "Mixer = jpype.JClass(\"neqsim.process.equipment.mixer.Mixer\")\n",
+    "SystemSrkEos = ns.SystemSrkEos\n",
+    "ProcessSystem = ns.ProcessSystem\n",
+    "Stream = ns.Stream\n",
+    "Compressor = ns.Compressor\n",
     "\n",
     "# Data Reconciliation\n",
-    "DataReconciliationEngine = jpype.JClass(\"neqsim.process.util.reconciliation.DataReconciliationEngine\")\n",
+    "DataReconciliationEngine = ns.JClass(\n",
+    "    \"neqsim.process.util.reconciliation.DataReconciliationEngine\"\n",
+    ")\n",
+    "ReconciliationVariable = ns.JClass(\n",
+    "    \"neqsim.process.util.reconciliation.ReconciliationVariable\"\n",
+    ")\n",
     "\n",
     "# Parameter Estimation\n",
-    "BatchParameterEstimator = jpype.JClass(\"neqsim.process.calibration.BatchParameterEstimator\")\n",
+    "BatchParameterEstimator = ns.JClass(\n",
+    "    \"neqsim.process.calibration.BatchParameterEstimator\"\n",
+    ")\n",
     "\n",
     "# Java collections\n",
-    "HashMap = jpype.JClass(\"java.util.HashMap\")\n",
+    "HashMap = ns.JClass(\"java.util.HashMap\")\n",
     "\n",
     "print(\"All classes loaded.\")"
    ]
@@ -87,10 +136,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "46437c9a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Outlet temperature: 105.1 °C\n",
+      "Power: 494.0 kW\n"
+     ]
+    }
+   ],
    "source": [
     "# Cell 3 — Build the process model\n",
     "fluid = SystemSrkEos(288.15, 30.0)  # 15°C, 30 bara\n",
@@ -131,10 +189,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "940e403c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  P_out=50 bara → T_true=58.67°C, T_meas=58.63°C\n",
+      "  P_out=60 bara → T_true=75.16°C, T_meas=75.11°C\n",
+      "  P_out=70 bara → T_true=89.47°C, T_meas=89.44°C\n",
+      "  P_out=80 bara → T_true=102.13°C, T_meas=102.34°C\n",
+      "  P_out=90 bara → T_true=113.50°C, T_meas=113.46°C\n",
+      "  P_out=100 bara → T_true=123.83°C, T_meas=123.38°C\n",
+      "\n",
+      "Generated 6 plant data points\n"
+     ]
+    }
+   ],
    "source": [
     "# Cell 4 — Generate synthetic plant data\n",
     "import random\n",
@@ -155,7 +228,10 @@
     "    true_temp = float(comp.getOutletStream().getTemperature())\n",
     "    noisy_temp = true_temp + random.gauss(0, MEASUREMENT_NOISE_K)\n",
     "    plant_measurements.append((p_out, noisy_temp))\n",
-    "    print(f\"  P_out={p_out:.0f} bara → T_true={true_temp-273.15:.2f}°C, T_meas={noisy_temp-273.15:.2f}°C\")\n",
+    "    print(\n",
+    "        f\"  P_out={p_out:.0f} bara → T_true={true_temp - 273.15:.2f}°C, \"\n",
+    "        f\"T_meas={noisy_temp - 273.15:.2f}°C\"\n",
+    "    )\n",
     "\n",
     "print(f\"\\nGenerated {len(plant_measurements)} plant data points\")"
    ]
@@ -171,16 +247,40 @@
     "mass/energy balance constraints. The `DataReconciliationEngine` uses Weighted Least\n",
     "Squares (WLS) and can detect gross errors (bad sensors).\n",
     "\n",
+    "For measurement vector $\\mathbf{y}$, covariance matrix $\\mathbf{V}=\\mathrm{diag}(\\sigma_i^2)$,\n",
+    "and linear constraints $\\mathbf{A}\\hat{\\mathbf{x}}=0$, the reconciled values are\n",
+    "\n",
+    "$$\\hat{\\mathbf{x}}=\\mathbf{y}-\\mathbf{V}\\mathbf{A}^{T}(\\mathbf{A}\\mathbf{V}\\mathbf{A}^{T})^{-1}\\mathbf{A}\\mathbf{y}$$\n",
+    "\n",
+    "Here, each $\\sigma_i$ is the measurement standard deviation in the same engineering\n",
+    "unit as its measurement. The example below uses mass flow in kg/hr.\n",
+    "\n",
     "For this single-stream example we demonstrate the API — in a real multi-stream\n",
     "network the reconciliation would adjust all flow rates to close the mass balance."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "9130df29",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Data Reconciliation Results ===\n",
+      "Converged: True\n",
+      "Chi-square: 0.2353\n",
+      "Global test passed: True\n",
+      "Mass-balance residual: 0.000e+00 kg/hr\n",
+      "\n",
+      "  flow_in1: measured=5000.0, reconciled=5023.5, adjustment=23.53\n",
+      "  flow_in2: measured=5100.0, reconciled=5123.5, adjustment=23.53\n",
+      "  flow_out: measured=10200.0, reconciled=10147.1, adjustment=-52.94\n"
+     ]
+    }
+   ],
    "source": [
     "# Cell 5 — Data Reconciliation (demonstrating the API)\n",
     "#\n",
@@ -191,28 +291,41 @@
     "\n",
     "# Add measured flow variables (e.g., three streams that should sum to zero\n",
     "# at a mixer: flow_in1 + flow_in2 - flow_out = 0)\n",
-    "recon.addVariable(\"flow_in1\", 5000.0, 100.0)   # measured value, uncertainty (kg/hr)\n",
-    "recon.addVariable(\"flow_in2\", 5100.0, 100.0)\n",
-    "recon.addVariable(\"flow_out\", 10200.0, 150.0)   # slightly biased\n",
+    "recon.addVariable(\n",
+    "    ReconciliationVariable(\"flow_in1\", 5000.0, 100.0).setUnit(\"kg/hr\")\n",
+    ")\n",
+    "recon.addVariable(\n",
+    "    ReconciliationVariable(\"flow_in2\", 5100.0, 100.0).setUnit(\"kg/hr\")\n",
+    ")\n",
+    "recon.addVariable(\n",
+    "    ReconciliationVariable(\"flow_out\", 10200.0, 150.0).setUnit(\"kg/hr\")\n",
+    ")\n",
     "\n",
     "# Mass balance constraint: flow_in1 + flow_in2 - flow_out = 0\n",
     "# Constraint matrix row: [1.0, 1.0, -1.0]\n",
     "recon.addConstraint([1.0, 1.0, -1.0])\n",
     "\n",
     "result = recon.reconcile()\n",
+    "assert result.isConverged()\n",
+    "assert result.getChiSquareStatistic() >= 0.0\n",
+    "assert recon.getVariable(\"flow_in1\").getName() == \"flow_in1\"\n",
+    "balance_residual = float(result.getConstraintResidualsAfter()[0])\n",
+    "assert abs(balance_residual) < 1.0e-8\n",
     "\n",
     "print(\"=== Data Reconciliation Results ===\")\n",
     "print(f\"Converged: {result.isConverged()}\")\n",
-    "print(f\"Chi-square: {result.getChiSquareValue():.4f}\")\n",
+    "print(f\"Chi-square: {result.getChiSquareStatistic():.4f}\")\n",
     "print(f\"Global test passed: {result.isGlobalTestPassed()}\")\n",
+    "print(f\"Mass-balance residual: {balance_residual:.3e} kg/hr\")\n",
     "print()\n",
     "\n",
-    "# Show reconciled values  \n",
-    "for i in range(recon.getVariableCount()):\n",
-    "    v = recon.getVariable(i)\n",
-    "    print(f\"  {v.getName()}: measured={v.getMeasuredValue():.1f}, \"\n",
-    "          f\"reconciled={v.getReconciledValue():.1f}, \"\n",
-    "          f\"adjustment={v.getAdjustment():.2f}\")"
+    "# Iterate through the public collection API; named lookup is shown above.\n",
+    "for variable in recon.getVariables():\n",
+    "    print(\n",
+    "        f\"  {variable.getName()}: measured={variable.getMeasuredValue():.1f}, \"\n",
+    "        f\"reconciled={variable.getReconciledValue():.1f}, \"\n",
+    "        f\"adjustment={variable.getAdjustment():.2f}\"\n",
+    "    )"
    ]
   },
   {
@@ -224,36 +337,66 @@
     "\n",
     "The reconciliation engine can identify sensors with gross errors using the\n",
     "normalized residual test. Sensors exceeding the z-threshold (default 1.96 for 95%)\n",
-    "are flagged and can be iteratively removed."
+    "are flagged and can be iteratively removed. The two independent balances below\n",
+    "provide enough redundancy to isolate a biased intermediate-flow measurement."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "0eeadab8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Gross Error Detection ===\n",
+      "Global test passed: True\n",
+      "  feed: measured=1000.0, reconciled=1010.4\n",
+      "  intermediate_bad: measured=552.0, reconciled=520.8 *** GROSS ERROR\n",
+      "  product: measured=500.0, reconciled=520.8\n",
+      "  side_stream: measured=500.0, reconciled=489.6\n"
+     ]
+    }
+   ],
    "source": [
     "# Cell 6 — Gross error detection demo\n",
     "recon2 = DataReconciliationEngine()\n",
     "\n",
-    "# Same flows but with a gross error on flow_out (sensor reads 12000 instead of ~10000)\n",
-    "recon2.addVariable(\"flow_in1\", 5000.0, 100.0)\n",
-    "recon2.addVariable(\"flow_in2\", 5100.0, 100.0)\n",
-    "recon2.addVariable(\"flow_out_bad\", 12000.0, 150.0)  # gross error!\n",
+    "# A two-node network with a 52 kg/hr bias on the intermediate-flow sensor.\n",
+    "recon2.addVariable(\n",
+    "    ReconciliationVariable(\"feed\", 1000.0, 20.0).setUnit(\"kg/hr\")\n",
+    ")\n",
+    "recon2.addVariable(\n",
+    "    ReconciliationVariable(\"intermediate_bad\", 552.0, 20.0).setUnit(\"kg/hr\")\n",
+    ")\n",
+    "recon2.addVariable(\n",
+    "    ReconciliationVariable(\"product\", 500.0, 20.0).setUnit(\"kg/hr\")\n",
+    ")\n",
+    "recon2.addVariable(\n",
+    "    ReconciliationVariable(\"side_stream\", 500.0, 20.0).setUnit(\"kg/hr\")\n",
+    ")\n",
     "\n",
-    "recon2.addConstraint([1.0, 1.0, -1.0])\n",
+    "# Node 1: feed - intermediate - side_stream = 0\n",
+    "recon2.addConstraint([1.0, -1.0, 0.0, -1.0])\n",
+    "# Node 2: intermediate - product = 0\n",
+    "recon2.addConstraint([0.0, 1.0, -1.0, 0.0])\n",
     "\n",
-    "result2 = recon2.reconcileWithGrossErrorElimination()\n",
+    "result2 = recon2.reconcileWithGrossErrorElimination(1)\n",
+    "assert result2.isConverged()\n",
+    "assert result2.getGrossErrors().size() == 1\n",
+    "assert result2.getGrossErrors().get(0).getName() == \"intermediate_bad\"\n",
     "\n",
     "print(\"=== Gross Error Detection ===\")\n",
     "print(f\"Global test passed: {result2.isGlobalTestPassed()}\")\n",
     "\n",
-    "for i in range(recon2.getVariableCount()):\n",
-    "    v = recon2.getVariable(i)\n",
-    "    flag = \" *** GROSS ERROR\" if v.isGrossError() else \"\"\n",
-    "    print(f\"  {v.getName()}: measured={v.getMeasuredValue():.1f}, \"\n",
-    "          f\"reconciled={v.getReconciledValue():.1f}{flag}\")"
+    "for variable in recon2.getVariables():\n",
+    "    flag = \" *** GROSS ERROR\" if variable.isGrossError() else \"\"\n",
+    "    print(\n",
+    "        f\"  {variable.getName()}: measured={variable.getMeasuredValue():.1f}, \"\n",
+    "        f\"reconciled={variable.getReconciledValue():.1f}{flag}\"\n",
+    "    )"
    ]
   },
   {
@@ -291,14 +434,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "9f5e7645",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Configuration:\n",
+      "  Parameters to tune: ['comp.polytropicEfficiency']\n",
+      "  Measurements: ['comp.outletStream.temperature']\n",
+      "  Data points: 6\n",
+      "  Initial guess: 0.65\n",
+      "  True value: 0.78\n"
+     ]
+    }
+   ],
    "source": [
     "# Cell 7 — Set up and run BatchParameterEstimator\n",
     "\n",
-    "# Reset the efficiency to a wrong initial guess — this is what the estimator starts from\n",
+    "# Start the estimator from a deliberately wrong efficiency.\n",
     "comp.setPolytropicEfficiency(0.65)  # deliberately wrong\n",
     "\n",
     "estimator = BatchParameterEstimator(process)\n",
@@ -341,10 +497,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "b1530169",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x 0.0  val: 331.77397775507075 exp val 331.77520815617146  deviation 3.708538403309461E-4\n",
+      "x 1.0  val: 348.2525576864245 exp val 348.26270709980895  deviation 0.002914298079451049\n",
+      "x 2.0  val: 362.5454033985503 exp val 362.5896528710533  deviation 0.01220373282928007\n",
+      "x 3.0  val: 375.18967957944807 exp val 375.4920864285889  deviation 0.08053614445436115\n",
+      "x 4.0  val: 386.5440944880134 exp val 386.6106683408193  deviation 0.017219869563251083\n",
+      "x 5.0  val: 396.86064271468075 exp val 396.52842799660635  deviation 0.0837808072810457\n",
+      "Shi-Square: 2.3145682165073787\n",
+      "bias dev: -0.004910681914271434\n",
+      "abs dev 0.032837617674620005\n",
+      "rms dev 18.63290724702151\n",
+      "\n",
+      "======================================================================\n",
+      "=== Batch Parameter Estimation Results ===\n",
+      "Converged: true\n",
+      "Iterations: 100\n",
+      "Data points: 6\n",
+      "Degrees of freedom: 5\n",
+      "\n",
+      "Goodness of Fit:\n",
+      "  Chi-square: 2.314568\n",
+      "  Reduced chi-square: 0.462914\n",
+      "  RMSE: 0.621097\n",
+      "  Mean absolute deviation: 0.126137\n",
+      "  Bias: 0.015399\n",
+      "  R-squared: 0.999929\n",
+      "\n",
+      "Parameter Estimates:\n",
+      "Parameter                                       Value      Std Dev               95% CI\n",
+      "--------------------------------------------------------------------------------------\n",
+      "comp.polytropicEfficiency                    0.780984     0.001394 [  0.7783,   0.7837]\n",
+      "======================================================================\n",
+      "\n",
+      ">>> True efficiency:      0.7800\n",
+      ">>> Estimated efficiency: 0.7810 ± 0.0014\n",
+      ">>> Error:                0.000984\n",
+      ">>> R-squared:            0.999929\n",
+      ">>> Converged:            True\n"
+     ]
+    }
+   ],
    "source": [
     "# Cell 8 — Solve!\n",
     "result = estimator.solve()\n",
@@ -376,16 +576,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "356d846f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model vs Plant comparison after tuning:\n",
+      "P_out (bara) T_plant (°C) T_model (°C)   Error (°C)\n",
+      "----------------------------------------------------\n",
+      "          50        58.63        58.62        0.001\n",
+      "          60        75.11        75.10        0.010\n",
+      "          70        89.44        89.40        0.044\n",
+      "          80       102.34       102.04        0.302\n",
+      "          90       113.46       113.39        0.067\n",
+      "         100       123.38       123.71       -0.332\n"
+     ]
+    }
+   ],
    "source": [
     "# Cell 9 — Apply tuned parameters and compare\n",
     "comp.setPolytropicEfficiency(estimated_eff)\n",
     "\n",
     "print(\"Model vs Plant comparison after tuning:\")\n",
-    "print(f\"{'P_out (bara)':>12} {'T_plant (°C)':>12} {'T_model (°C)':>12} {'Error (°C)':>12}\")\n",
+    "print(\n",
+    "    f\"{'P_out (bara)':>12} {'T_plant (°C)':>12} \"\n",
+    "    f\"{'T_model (°C)':>12} {'Error (°C)':>12}\"\n",
+    ")\n",
     "print(\"-\" * 52)\n",
     "\n",
     "for p_out, t_meas in plant_measurements:\n",
@@ -393,7 +612,10 @@
     "    process.run()\n",
     "    t_model = float(comp.getOutletStream().getTemperature())\n",
     "    error = (t_meas - t_model)\n",
-    "    print(f\"{p_out:12.0f} {t_meas - 273.15:12.2f} {t_model - 273.15:12.2f} {error:12.3f}\")"
+    "    print(\n",
+    "        f\"{p_out:12.0f} {t_meas - 273.15:12.2f} \"\n",
+    "        f\"{t_model - 273.15:12.2f} {error:12.3f}\"\n",
+    "    )"
    ]
   },
   {
@@ -410,10 +632,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "e1b2a8c9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Helper function defined.\n"
+     ]
+    }
+   ],
    "source": [
     "# Cell 10 — Reusable helper: reconcile → estimate → update\n",
     "\n",
@@ -484,6 +714,8 @@
     "        'estimates': estimates,\n",
     "        'uncertainties': uncertainties,\n",
     "        'r_squared': float(result.getRSquared()),\n",
+    "        # BatchResult uses getChiSquare(); ReconciliationResult uses\n",
+    "        # getChiSquareStatistic().\n",
     "        'chi_square': float(result.getChiSquare()),\n",
     "        'converged': bool(result.isConverged()),\n",
     "        'result': result  # Java object for further inspection\n",
@@ -494,10 +726,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "4360fb5d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x 0.0  val: 331.7739777550709 exp val 331.77520815617146  deviation 3.7085384027954677E-4\n",
+      "x 1.0  val: 348.2525576864246 exp val 348.26270709980895  deviation 0.002914298079418405\n",
+      "x 2.0  val: 362.5454033985504 exp val 362.5896528710533  deviation 0.012203732829264392\n",
+      "x 3.0  val: 375.18967957944835 exp val 375.4920864285889  deviation 0.08053614445428546\n",
+      "x 4.0  val: 386.5440944880136 exp val 386.6106683408193  deviation 0.01721986956319227\n",
+      "x 5.0  val: 396.8606427146811 exp val 396.52842799660635  deviation 0.08378080728113171\n",
+      "Shi-Square: 2.3145682165075643\n",
+      "bias dev: -0.00491068191421806\n",
+      "abs dev 0.0328376176745953\n",
+      "rms dev 18.632907247022256\n",
+      "Converged: True\n",
+      "Estimates: {'comp.polytropicEfficiency': 0.7809835274262955}\n",
+      "Uncertainties: {'comp.polytropicEfficiency': 0.0013935274587300297}\n",
+      "R²: 0.999929\n",
+      "\n",
+      "True value: 0.78, Estimated: 0.780984\n"
+     ]
+    }
+   ],
    "source": [
     "# Cell 11 — Use the helper\n",
     "\n",
@@ -531,7 +786,13 @@
     "print(f\"Estimates: {output['estimates']}\")\n",
     "print(f\"Uncertainties: {output['uncertainties']}\")\n",
     "print(f\"R²: {output['r_squared']:.6f}\")\n",
-    "print(f\"\\nTrue value: {TRUE_EFFICIENCY}, Estimated: {output['estimates']['comp.polytropicEfficiency']:.6f}\")"
+    "estimated_value = output['estimates']['comp.polytropicEfficiency']\n",
+    "assert output['converged']\n",
+    "assert abs(estimated_value - TRUE_EFFICIENCY) < 0.01\n",
+    "print(\n",
+    "    f\"\\nTrue value: {TRUE_EFFICIENCY}, \"\n",
+    "    f\"Estimated: {estimated_value:.6f}\"\n",
+    ")"
    ]
   },
   {
@@ -545,12 +806,12 @@
     "\n",
     "| Capability | Class | Status |\n",
     "|-----------|-------|--------|\n",
-    "| WLS data reconciliation | `DataReconciliationEngine` | ✅ Working |\n",
-    "| Gross error detection & elimination | `reconcileWithGrossErrorElimination()` | ✅ Working |\n",
-    "| Steady-state detection | `SteadyStateDetector` | ✅ Working |\n",
-    "| Batch parameter estimation (L-M) | `BatchParameterEstimator` | ✅ Working (verified E2E) |\n",
-    "| Online estimation (EnKF) | `EnKFParameterEstimator` | ✅ Working (≤2 measurements) |\n",
-    "| Result statistics | `BatchResult` | ✅ chi², R², CI, covariance |\n",
+    "| WLS data reconciliation | `DataReconciliationEngine` | Verified |\n",
+    "| Gross error detection & elimination | `DataReconciliationEngine` | Verified |\n",
+    "| Steady-state detection | `SteadyStateDetector` | Available |\n",
+    "| Batch parameter estimation (L-M) | `BatchParameterEstimator` | Verified end-to-end |\n",
+    "| Online estimation (EnKF) | `EnKFParameterEstimator` | Available (≤2 measurements) |\n",
+    "| Result statistics | `BatchResult` | chi², R², CI, covariance |\n",
     "\n",
     "### Property path reference\n",
     "\n",
@@ -577,8 +838,14 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "name": "python",
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/src/test/java/neqsim/DocExamplesCompilationTest.java
+++ b/src/test/java/neqsim/DocExamplesCompilationTest.java
@@ -77,6 +77,9 @@ import neqsim.process.util.optimizer.DebottleneckAnalyzer;
 import neqsim.process.util.optimizer.MonteCarloSimulator;
 import neqsim.process.util.optimizer.ProcessModelSimulationEvaluator;
 import neqsim.process.util.optimizer.SensitivityAnalysis;
+import neqsim.process.util.reconciliation.DataReconciliationEngine;
+import neqsim.process.util.reconciliation.ReconciliationResult;
+import neqsim.process.util.reconciliation.ReconciliationVariable;
 import neqsim.process.util.report.HeatMaterialBalance;
 import neqsim.process.util.report.ProcessValidator;
 import neqsim.pvtsimulation.flowassurance.BariteCelestiteSolidSolution;
@@ -2215,6 +2218,32 @@ public class DocExamplesCompilationTest {
 
     assertTrue(massFlow > 0.0);
     assertEquals(0.4, wedgeRatio, 1.0e-9);
+  }
+
+  /**
+   * Data reconciliation example from docs/calibration/data_reconciliation_parameter_estimation.md.
+   */
+  @Test
+  public void testDataReconciliationDocumentationExample() {
+    DataReconciliationEngine recon = new DataReconciliationEngine();
+    recon.addVariable(new ReconciliationVariable("flow_in1", 5000.0, 100.0).setUnit("kg/hr"));
+    recon.addVariable(new ReconciliationVariable("flow_in2", 5100.0, 100.0).setUnit("kg/hr"));
+    recon.addVariable(new ReconciliationVariable("flow_out", 10200.0, 150.0).setUnit("kg/hr"));
+    recon.addConstraint(new double[] { 1.0, 1.0, -1.0 });
+
+    ReconciliationResult result = recon.reconcile();
+
+    assertTrue(result.isConverged());
+    assertTrue(result.getChiSquareStatistic() >= 0.0);
+    assertEquals(0.0, result.getConstraintResidualsAfter()[0], 1.0e-8);
+    assertEquals("flow_in1", recon.getVariable("flow_in1").getName());
+    assertEquals(3, recon.getVariables().size());
+    for (ReconciliationVariable variable : recon.getVariables()) {
+      assertTrue(Double.isFinite(variable.getReconciledValue()));
+    }
+
+    ReconciliationResult grossErrorResult = recon.reconcileWithGrossErrorElimination(1);
+    assertTrue(grossErrorResult.isConverged());
   }
 
 }


### PR DESCRIPTION
# Pull Request

## Summary

- migrate the data-reconciliation notebook to the current object-based variable API, `getChiSquareStatistic()`, named/list variable access, and bounded gross-error elimination
- replace the machine-specific development path with automatic repository-root discovery
- make the gross-error example observably detect `intermediate_bad`, add current weighted-least-squares notation, and retain clean execution outputs
- update the adjacent calibration guide and add executable JUnit coverage for the documented API

Closes #3393

## Validation

- `./mvnw -q -Dtest=DocExamplesCompilationTest#testDataReconciliationDocumentationExample,DataReconciliationEngineTest test`
- `devtools/run_spotless.py check`
- pre-commit and pre-push repository hooks
- documentation search audit: 688 Markdown pages and 1 standalone HTML page
- notebook skill checker and `devtools/verify_notebooks.py`: 11/11 code cells executed, 0 issues
- `nbformat.validate`: valid notebook, sequential execution counts, 0 error outputs
- top-to-bottom execution in a fresh Python 3.12.13 process with stored outputs
- HTML/KaTeX render plus visual inspection of all 12 PDF pages

Standard Jupyter kernel transport is blocked by the execution environment's socket policy, so the clean execution used a fresh in-process runner while preserving notebook cell order, shared state, outputs, and execution counts.

## Representative notebook results

- reconciled mass-balance residual: `0.000e+00 kg/hr`
- gross-error case: exactly `intermediate_bad` identified
- estimated efficiency: `0.780984 ± 0.0014`, with `R² = 0.999929`

## Documentation impact

Updated `docs/calibration/data_reconciliation_parameter_estimation.md`, which duplicated the obsolete calls and setup. The separate process data-reconciliation guide already uses the current API.

## Repository checklist

- [ ] Confirm full `./mvnw test` runs successfully (focused affected tests pass; full suite left to CI)
- [x] Verify code formatting using the repository Spotless checks
- [x] Update relevant documentation
- [x] Link to an associated issue
- [ ] Request applicable CODEOWNERS/domain review
- [x] NRC and migration note are not applicable; this does not change a public contract
