### PR TITLE
fix(thermo): stop addTBPfraction discarding the acentric factor it is given

### DIFF
--- a/docs/cookbook/thermodynamics-recipes.md
+++ b/docs/cookbook/thermodynamics-recipes.md
@@ -67,6 +67,24 @@ by `characterisePlusFraction()` when a residual fraction is to be split and lump
 characterization parser does not safely parse that name. Use a numeric terminal carbon label such
 as `C7` when calling `characterisePlusFraction()`.
 
+#### Choosing an `addTBPfraction` overload
+
+| Overload | Supply | Derived from correlations |
+|----------|--------|---------------------------|
+| `addTBPfraction(name, moles, molarMass, density)` | molar mass, density | TC, PC, acentric factor, boiling point |
+| `addTBPfraction(name, moles, molarMass, density, TC, PC, acentricFactor)` | molar mass, density, TC, PC, acentric factor | boiling point |
+| `addTBPfraction2(name, moles, molarMass, boilingPoint)` | molar mass, boiling point | density, TC, PC, acentric factor |
+| `addTBPfraction3(name, moles, density, boilingPoint)` | density, boiling point | molar mass, TC, PC, acentric factor |
+
+Units: `molarMass` in kg/mol, `density` as relative density (g/cm3), `TC` in K, `PC` in bara,
+`boilingPoint` in K, `acentricFactor` dimensionless.
+
+The seven argument overload exists so that measured or externally regressed values can be used
+instead of correlations. The values passed for `TC`, `PC` and `acentricFactor` are stored as
+given; the attractive term derives its `m` parameter from the supplied acentric factor rather
+than from the `calcm` correlation. Use the four argument overload when correlated values are
+wanted.
+
 ### Create a CO₂-Water Fluid with CPA
 
 ```python

--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -1112,7 +1112,6 @@ public abstract class SystemThermo implements SystemInterface {
     SystemInterface refSystem = null;
     double TC = 0.0;
     double PC = 0.0;
-    double m = 0.0;
     double TB = 0.0;
     double acs = 0.0;
     // double penelouxC = 0.0;
@@ -1132,7 +1131,6 @@ public abstract class SystemThermo implements SystemInterface {
       TC = criticalTemperature;
       // characterization.getTBPModel().calcPC(molarMass, density);
       PC = criticalPressure;
-      m = characterization.getTBPModel().calcm(molarMass, density);
       // acentracentrcharacterization.getTBPModel().calcAcentricFactor(molarMass,
       // density);
       acs = acentricFactor;
@@ -1147,10 +1145,9 @@ public abstract class SystemThermo implements SystemInterface {
         refSystem.getPhase(i).getComponent(0).setPC(PC);
         refSystem.getPhase(i).getComponent(0).setComponentType("TBPfraction");
         refSystem.getPhase(i).getComponent(0).setIsTBPfraction(true);
-        if (characterization.getTBPModel().isCalcm()) {
-          refSystem.getPhase(i).getComponent(0).getAttractiveTerm().setm(m);
-          acs = refSystem.getPhase(i).getComponent(0).getAcentricFactor();
-        }
+        // The caller supplied the acentric factor explicitly, so the calcm
+        // correlation must not override it; the attractive term derives m from
+        // the supplied value instead.
       }
 
       refSystem.setTemperature(273.15 + 15.0);

--- a/src/test/java/neqsim/thermo/system/AddTBPfractionAcentricFactorTest.java
+++ b/src/test/java/neqsim/thermo/system/AddTBPfractionAcentricFactorTest.java
@@ -1,0 +1,74 @@
+package neqsim.thermo.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the seven argument addTBPfraction overload honours the critical properties and acentric factor it is
+ * given.
+ *
+ * <p>
+ * The four argument overload derives every property from correlations, which is its purpose. The seven argument
+ * overload exists so a caller can supply measured or externally regressed values, so silently replacing them by a
+ * correlation defeats the point of the overload.
+ * </p>
+ *
+ * @author NeqSim
+ * @version $Id: $Id
+ */
+public class AddTBPfractionAcentricFactorTest {
+  /** Molar mass of the test fraction in kg/mol. */
+  private static final double MOLAR_MASS = 0.1;
+
+  /** Relative liquid density of the test fraction, dimensionless. */
+  private static final double DENSITY = 0.75;
+
+  /**
+   * The supplied acentric factor must survive, not be replaced by the calcm correlation.
+   */
+  @Test
+  public void suppliedAcentricFactorIsRetained() {
+    double suppliedAcentricFactor = 0.49;
+    SystemInterface fluid = new SystemSrkEos(298.15, 10.0);
+    fluid.addTBPfraction("testfraction", 1.0, MOLAR_MASS, DENSITY, 650.0, 20.0, suppliedAcentricFactor);
+    fluid.setMixingRule("classic");
+
+    assertEquals(suppliedAcentricFactor, fluid.getPhase(0).getComponent("testfraction_PC").getAcentricFactor(), 1.0e-9,
+        "addTBPfraction discarded the acentric factor it was given");
+  }
+
+  /**
+   * The supplied critical temperature and pressure must survive as well.
+   */
+  @Test
+  public void suppliedCriticalPropertiesAreRetained() {
+    double criticalTemperature = 650.0;
+    double criticalPressure = 20.0;
+    SystemInterface fluid = new SystemSrkEos(298.15, 10.0);
+    fluid.addTBPfraction("testfraction", 1.0, MOLAR_MASS, DENSITY, criticalTemperature, criticalPressure, 0.49);
+    fluid.setMixingRule("classic");
+
+    assertEquals(criticalTemperature, fluid.getPhase(0).getComponent("testfraction_PC").getTC(), 1.0e-9,
+        "addTBPfraction discarded the critical temperature it was given");
+    assertEquals(criticalPressure, fluid.getPhase(0).getComponent("testfraction_PC").getPC(), 1.0e-9,
+        "addTBPfraction discarded the critical pressure it was given");
+  }
+
+  /**
+   * A second, different acentric factor must give a different stored value, which rules out the assertion passing by
+   * coincidence.
+   */
+  @Test
+  public void differentAcentricFactorsGiveDifferentResults() {
+    SystemInterface low = new SystemSrkEos(298.15, 10.0);
+    low.addTBPfraction("testfraction", 1.0, MOLAR_MASS, DENSITY, 650.0, 20.0, 0.35);
+    low.setMixingRule("classic");
+
+    SystemInterface high = new SystemSrkEos(298.15, 10.0);
+    high.addTBPfraction("testfraction", 1.0, MOLAR_MASS, DENSITY, 650.0, 20.0, 0.65);
+    high.setMixingRule("classic");
+
+    assertEquals(0.35, low.getPhase(0).getComponent("testfraction_PC").getAcentricFactor(), 1.0e-9);
+    assertEquals(0.65, high.getPhase(0).getComponent("testfraction_PC").getAcentricFactor(), 1.0e-9);
+  }
+}


### PR DESCRIPTION
## Problem

The seven-argument overload

```java
addTBPfraction(name, moles, molarMass, density, TC, PC, acentricFactor)
```

exists so a caller can supply **measured or externally regressed** values instead of correlations. It honoured `TC` and `PC` but **silently replaced the acentric factor**:

```java
acs = acentricFactor;                          // caller's value
...
if (characterization.getTBPModel().isCalcm()) {
  ...getAttractiveTerm().setm(m);              // m from calcm(molarMass, density)
  acs = ...getAcentricFactor();                // ← caller's value destroyed
}
```

`m` comes from a correlation. Pushing it onto the attractive term and reading the acentric factor back overwrites whatever was passed in. That same value was then read from the reference system when populating the real component, so the argument had **no effect at all**.

Supplying `0.49` gave `0.4796`.

This is the same class of defect as #3425 (`addTBPfraction2` discarding its boiling point): an overload that accepts a value and then ignores it.

## Fix

The correlation no longer overrides an explicitly supplied acentric factor. The attractive term derives its `m` parameter from the supplied value instead, which is self-consistent with the `TC` and `PC` that are already honoured.

**The four-argument overload is untouched** — deriving every property from correlations is its purpose.

## Verification

`AddTBPfractionAcentricFactorTest`, three cases:

1. the supplied acentric factor is retained
2. the supplied critical temperature and pressure are retained
3. two *different* acentric factors give two *different* stored values — so the test cannot pass by coincidence

**Negative control** — with the fix reverted, 2 of 3 fail with exactly the reported symptom:

```
expected: <0.49> but was: <0.47958681250883073>
```

**Regression** — `neqsim.thermo.**`, `neqsim.pvtsimulation.**`, `neqsim.thermodynamicoperations.**`: **2273 tests, 0 failures, 0 errors**.

## Documentation

`docs/cookbook/thermodynamics-recipes.md` gains an overload-selection table stating the unit of every argument and which values are honoured as given versus correlated:

| Overload | Supply | Derived from correlations |
|----------|--------|---------------------------|
| 4-arg | molar mass, density | TC, PC, acentric factor, boiling point |
| 7-arg | molar mass, density, TC, PC, acentric factor | boiling point |
| `addTBPfraction2` | molar mass, boiling point | density, TC, PC, acentric factor |
| `addTBPfraction3` | density, boiling point | molar mass, TC, PC, acentric factor |

## Note on behaviour change

Callers of the 7-argument overload will now get the acentric factor they asked for. Results will move for anyone who was passing a value that differed from the `calcm` correlation — which is the point of the fix.
