### PR TITLE
[AI-Assisted] feat(dexpi): expose actuating-function evidence

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -34,6 +34,7 @@ NeqSim provides a complete [DEXPI](https://dexpi.org/) integration that supports
 | `DexpiStream` | Lightweight piping segment with DEXPI class, line number, and fluid code |
 | `DexpiProcessUnit` | Imported equipment with original DEXPI class and mapped `EquipmentEnum` |
 | `DexpiInstrumentInfo` | Instrument metadata (tag, type, function letter) |
+| `DexpiActuatingFunctionInfo` | Immutable source-order actuating-function identity and reference evidence |
 | `DexpiConnectionInfo` | Immutable source-order material-connection evidence and endpoint resolution |
 
 ---
@@ -106,6 +107,7 @@ DexpiXmlReader.ImportResult result =
 ProcessSystem process = result.getProcessSystem();
 List<DexpiInstrumentInfo> instruments = result.getInstruments();
 List<DexpiInstrumentationLoopInfo> instrumentationLoops = result.getInstrumentationLoops();
+List<DexpiActuatingFunctionInfo> actuatingFunctions = result.getActuatingFunctions();
 List<DexpiInformationFlowInfo> informationFlows = result.getInformationFlows();
 List<DexpiConnectionInfo> connections = result.getConnections();
 
@@ -140,6 +142,14 @@ source/target references, missing signal medium, and incomplete final-element or
 evidence. Valid source references resolve against the complete non-catalogue document identity set,
 including equipment nozzles and actuating functions. The reader never promotes measurement-only or
 incomplete source content into closed-loop control intent.
+
+`ImportResult.getActuatingFunctions()` exposes source-ordered `ActuatingFunction` and
+`ActuatingElectricalFunction` occurrences as immutable `DexpiActuatingFunctionInfo` records. Each
+record retains the explicit source kind, ID, component class, function number, enclosing
+`ProcessInstrumentationFunction` identity, `FinalControlElementID`, and `is located in` identity,
+together with resolution flags and resolved XML element names. Missing and unresolved references
+remain visible. The API does not classify final-element type, infer control intent, identify a
+safeguard or SIS function, or alter live simulation topology.
 
 `ImportResult.getInformationFlows()` exposes the corresponding source-ordered
 `MeasuringLineFunction` and `SignalLineFunction` evidence as immutable
@@ -241,15 +251,16 @@ cycle. This exact-once inventory remains source-reference evidence only; it does
 continuity, identify a physical recycle, enumerate paths, or alter simulation topology.
 
 `toJson()` includes `instrumentCount`, `instrumentationLoopCount`,
-`informationFlowCount`, `connectionCount`,
+`actuatingFunctionCount`, `informationFlowCount`, `connectionCount`,
 `connectionEndpointCount`, `connectionComponentCount`, `connectionCycleCount`,
-`connectionCycleTransitionCount`, and the ordered instrumentation-loop, information-flow, connection, endpoint, component,
-directed-cycle, and cycle-transition inventories, including reference resolution,
+`connectionCycleTransitionCount`, and the ordered instrumentation-loop, actuating-function, information-flow, connection, endpoint,
+component, directed-cycle, and cycle-transition inventories, including reference resolution,
 incidence roles, review subsets, complete cycle-local endpoint and internal connection occurrences,
 explicit cycle-boundary occurrences, and exact-once transitions with nested connection and endpoint
 evidence, alongside the process-unit count and findings. Python callers through JPype use the same
 `ImportResult.getInstruments()`, `ImportResult.getInstrumentationLoops()`,
-`ImportResult.getInformationFlows()`, `ImportResult.getConnections()`, `ImportResult.getConnectionEndpoints()`,
+`ImportResult.getActuatingFunctions()`, `ImportResult.getInformationFlows()`,
+`ImportResult.getConnections()`, `ImportResult.getConnectionEndpoints()`,
 `ImportResult.getConnectionComponents()`, `ImportResult.getConnectionCycles()`, and
 `ImportResult.getConnectionCycleTransitions()` getters; there is no separate Python reconstruction
 model.

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiActuatingFunctionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiActuatingFunctionInfo.java
@@ -1,0 +1,165 @@
+package neqsim.process.processmodel.dexpi;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Immutable source evidence for one DEXPI actuating-function occurrence.
+ *
+ * <p>
+ * This record preserves explicit XML identity and references without inferring control intent, final-element type,
+ * safeguard classification, or live simulation topology.
+ * </p>
+ *
+ * @author NeqSim
+ * @version 1.0
+ */
+public final class DexpiActuatingFunctionInfo implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Explicit DEXPI actuating-function kind. */
+  public enum Kind {
+    /** Mechanical or otherwise non-electrical actuating function. */
+    ACTUATING_FUNCTION,
+    /** Electrical actuating function. */
+    ACTUATING_ELECTRICAL_FUNCTION
+  }
+
+  private final String id;
+  private final Kind kind;
+  private final String componentClass;
+  private final String functionNumber;
+  private final String instrumentationFunctionId;
+  private final boolean instrumentationFunctionResolved;
+  private final String instrumentationFunctionElementName;
+  private final String finalControlElementId;
+  private final boolean finalControlElementResolved;
+  private final String finalControlElementName;
+  private final String locationId;
+  private final boolean locationResolved;
+  private final String locationElementName;
+
+  /**
+   * Creates immutable evidence for one actuating-function occurrence.
+   *
+   * @param id source XML identity, or an empty string when absent
+   * @param kind explicit source kind
+   * @param componentClass source component class
+   * @param functionNumber explicit source function-number metadata, or an empty string
+   * @param instrumentationFunctionId enclosing instrumentation-function identity, or an empty string
+   * @param instrumentationFunctionResolved whether the enclosing identity resolves to the enclosing source element
+   * @param instrumentationFunctionElementName enclosing XML element name, or an empty string
+   * @param finalControlElementId explicit final-control-element reference, or an empty string
+   * @param finalControlElementResolved whether the final-control-element reference resolves
+   * @param finalControlElementName resolved final-control-element XML name, or an empty string
+   * @param locationId explicit {@code is located in} reference, or an empty string
+   * @param locationResolved whether the location reference resolves
+   * @param locationElementName resolved location XML name, or an empty string
+   */
+  public DexpiActuatingFunctionInfo(String id, Kind kind, String componentClass, String functionNumber,
+      String instrumentationFunctionId, boolean instrumentationFunctionResolved,
+      String instrumentationFunctionElementName, String finalControlElementId, boolean finalControlElementResolved,
+      String finalControlElementName, String locationId, boolean locationResolved, String locationElementName) {
+    this.id = normalize(id);
+    this.kind = kind;
+    this.componentClass = normalize(componentClass);
+    this.functionNumber = normalize(functionNumber);
+    this.instrumentationFunctionId = normalize(instrumentationFunctionId);
+    this.instrumentationFunctionResolved = instrumentationFunctionResolved;
+    this.instrumentationFunctionElementName = normalize(instrumentationFunctionElementName);
+    this.finalControlElementId = normalize(finalControlElementId);
+    this.finalControlElementResolved = finalControlElementResolved;
+    this.finalControlElementName = normalize(finalControlElementName);
+    this.locationId = normalize(locationId);
+    this.locationResolved = locationResolved;
+    this.locationElementName = normalize(locationElementName);
+  }
+
+  /** @return source XML identity, or an empty string when absent */
+  public String getId() {
+    return id;
+  }
+
+  /** @return explicit source actuating-function kind */
+  public Kind getKind() {
+    return kind;
+  }
+
+  /** @return source component class */
+  public String getComponentClass() {
+    return componentClass;
+  }
+
+  /** @return explicit source function-number metadata, or an empty string */
+  public String getFunctionNumber() {
+    return functionNumber;
+  }
+
+  /** @return enclosing instrumentation-function identity, or an empty string */
+  public String getInstrumentationFunctionId() {
+    return instrumentationFunctionId;
+  }
+
+  /** @return whether the enclosing identity resolves to the enclosing source element */
+  public boolean isInstrumentationFunctionResolved() {
+    return instrumentationFunctionResolved;
+  }
+
+  /** @return enclosing XML element name, or an empty string */
+  public String getInstrumentationFunctionElementName() {
+    return instrumentationFunctionElementName;
+  }
+
+  /** @return explicit final-control-element reference, or an empty string */
+  public String getFinalControlElementId() {
+    return finalControlElementId;
+  }
+
+  /** @return whether the final-control-element reference resolves */
+  public boolean isFinalControlElementResolved() {
+    return finalControlElementResolved;
+  }
+
+  /** @return resolved final-control-element XML name, or an empty string */
+  public String getFinalControlElementName() {
+    return finalControlElementName;
+  }
+
+  /** @return explicit {@code is located in} reference, or an empty string */
+  public String getLocationId() {
+    return locationId;
+  }
+
+  /** @return whether the location reference resolves */
+  public boolean isLocationResolved() {
+    return locationResolved;
+  }
+
+  /** @return resolved location XML name, or an empty string */
+  public String getLocationElementName() {
+    return locationElementName;
+  }
+
+  Map<String, Object> toMap() {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    result.put("id", id);
+    result.put("kind", kind.name());
+    result.put("componentClass", componentClass);
+    result.put("functionNumber", functionNumber);
+    result.put("instrumentationFunctionId", instrumentationFunctionId);
+    result.put("instrumentationFunctionResolved", Boolean.valueOf(instrumentationFunctionResolved));
+    result.put("instrumentationFunctionElementName", instrumentationFunctionElementName);
+    result.put("finalControlElementId", finalControlElementId);
+    result.put("finalControlElementResolved", Boolean.valueOf(finalControlElementResolved));
+    result.put("finalControlElementName", finalControlElementName);
+    result.put("locationId", locationId);
+    result.put("locationResolved", Boolean.valueOf(locationResolved));
+    result.put("locationElementName", locationElementName);
+    return result;
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -131,6 +131,7 @@ public final class DexpiXmlReader {
     private final ProcessSystem processSystem;
     private final List<DexpiInstrumentInfo> instruments;
     private final List<DexpiInstrumentationLoopInfo> instrumentationLoops;
+    private final List<DexpiActuatingFunctionInfo> actuatingFunctions;
     private final List<DexpiInformationFlowInfo> informationFlows;
     private final List<DexpiConnectionInfo> connections;
     private final List<DexpiConnectionEndpointInfo> connectionEndpoints;
@@ -140,7 +141,8 @@ public final class DexpiXmlReader {
     private final List<ImportDiagnostic> diagnostics;
 
     private ImportResult(ProcessSystem processSystem, List<DexpiInstrumentInfo> instruments,
-        List<DexpiInstrumentationLoopInfo> instrumentationLoops, List<DexpiInformationFlowInfo> informationFlows,
+        List<DexpiInstrumentationLoopInfo> instrumentationLoops,
+        List<DexpiActuatingFunctionInfo> actuatingFunctions, List<DexpiInformationFlowInfo> informationFlows,
         List<DexpiConnectionInfo> connections, List<DexpiConnectionEndpointInfo> connectionEndpoints,
         List<DexpiConnectionComponentInfo> connectionComponents, List<DexpiConnectionCycleInfo> connectionCycles,
         List<DexpiConnectionCycleTransitionInfo> connectionCycleTransitions, List<ImportDiagnostic> diagnostics) {
@@ -148,6 +150,8 @@ public final class DexpiXmlReader {
       this.instruments = Collections.unmodifiableList(new ArrayList<DexpiInstrumentInfo>(instruments));
       this.instrumentationLoops = Collections
           .unmodifiableList(new ArrayList<DexpiInstrumentationLoopInfo>(instrumentationLoops));
+      this.actuatingFunctions = Collections
+          .unmodifiableList(new ArrayList<DexpiActuatingFunctionInfo>(actuatingFunctions));
       this.informationFlows = Collections.unmodifiableList(new ArrayList<DexpiInformationFlowInfo>(informationFlows));
       this.connections = Collections.unmodifiableList(new ArrayList<DexpiConnectionInfo>(connections));
       this.connectionEndpoints = Collections
@@ -190,6 +194,20 @@ public final class DexpiXmlReader {
      */
     public List<DexpiInstrumentationLoopInfo> getInstrumentationLoops() {
       return instrumentationLoops;
+    }
+
+    /**
+     * Returns explicit actuating-function occurrences in source-document order.
+     *
+     * <p>
+     * These records retain only source identity, enclosing instrumentation-function provenance, final-element
+     * references, and location references. They do not infer control intent, final-element type, or safeguards.
+     * </p>
+     *
+     * @return immutable actuating-function evidence
+     */
+    public List<DexpiActuatingFunctionInfo> getActuatingFunctions() {
+      return actuatingFunctions;
     }
 
     /**
@@ -310,6 +328,12 @@ public final class DexpiXmlReader {
         instrumentationLoopMaps.add(instrumentationLoop.toMap());
       }
       result.put("instrumentationLoops", instrumentationLoopMaps);
+      result.put("actuatingFunctionCount", Integer.valueOf(actuatingFunctions.size()));
+      List<Map<String, Object>> actuatingFunctionMaps = new ArrayList<Map<String, Object>>();
+      for (DexpiActuatingFunctionInfo actuatingFunction : actuatingFunctions) {
+        actuatingFunctionMaps.add(actuatingFunction.toMap());
+      }
+      result.put("actuatingFunctions", actuatingFunctionMaps);
       result.put("informationFlowCount", Integer.valueOf(informationFlows.size()));
       List<Map<String, Object>> informationFlowMaps = new ArrayList<Map<String, Object>>();
       for (DexpiInformationFlowInfo informationFlow : informationFlows) {
@@ -538,11 +562,12 @@ public final class DexpiXmlReader {
     ProcessSystem processSystem = new ProcessSystem("DEXPI process");
     List<DexpiInstrumentInfo> instruments = new ArrayList<DexpiInstrumentInfo>();
     List<DexpiInstrumentationLoopInfo> instrumentationLoops = new ArrayList<DexpiInstrumentationLoopInfo>();
+    List<DexpiActuatingFunctionInfo> actuatingFunctions = new ArrayList<DexpiActuatingFunctionInfo>();
     List<DexpiInformationFlowInfo> informationFlows = new ArrayList<DexpiInformationFlowInfo>();
     List<DexpiConnectionInfo> connections = new ArrayList<DexpiConnectionInfo>();
     List<ImportDiagnostic> diagnostics = new ArrayList<ImportDiagnostic>();
     loadInternal(inputStream, processSystem, templateStream, false, diagnostics, instruments, instrumentationLoops,
-        informationFlows, connections);
+        actuatingFunctions, informationFlows, connections);
     List<DexpiConnectionEndpointInfo> connectionEndpoints = summarizeConnectionEndpoints(connections);
     List<DexpiConnectionComponentInfo> connectionComponents = summarizeConnectionComponents(connections,
         connectionEndpoints);
@@ -550,8 +575,9 @@ public final class DexpiXmlReader {
         connectionComponents);
     List<DexpiConnectionCycleTransitionInfo> connectionCycleTransitions = summarizeConnectionCycleTransitions(
         connections, connectionEndpoints, connectionCycles);
-    return new ImportResult(processSystem, instruments, instrumentationLoops, informationFlows, connections,
-        connectionEndpoints, connectionComponents, connectionCycles, connectionCycleTransitions, diagnostics);
+    return new ImportResult(processSystem, instruments, instrumentationLoops, actuatingFunctions, informationFlows,
+        connections, connectionEndpoints, connectionComponents, connectionCycles, connectionCycleTransitions,
+        diagnostics);
   }
 
   /**
@@ -626,13 +652,14 @@ public final class DexpiXmlReader {
    */
   public static void load(InputStream inputStream, ProcessSystem processSystem, Stream templateStream,
       boolean namespaceAware) throws IOException, DexpiXmlReaderException {
-    loadInternal(inputStream, processSystem, templateStream, namespaceAware, null, null, null, null, null);
+    loadInternal(inputStream, processSystem, templateStream, namespaceAware, null, null, null, null, null, null);
   }
 
   private static void loadInternal(InputStream inputStream, ProcessSystem processSystem, Stream templateStream,
       boolean namespaceAware, List<ImportDiagnostic> diagnostics, List<DexpiInstrumentInfo> instruments,
-      List<DexpiInstrumentationLoopInfo> instrumentationLoops, List<DexpiInformationFlowInfo> informationFlows,
-      List<DexpiConnectionInfo> connections) throws IOException, DexpiXmlReaderException {
+      List<DexpiInstrumentationLoopInfo> instrumentationLoops, List<DexpiActuatingFunctionInfo> actuatingFunctions,
+      List<DexpiInformationFlowInfo> informationFlows, List<DexpiConnectionInfo> connections)
+      throws IOException, DexpiXmlReaderException {
     Objects.requireNonNull(inputStream, "inputStream");
     Objects.requireNonNull(processSystem, "processSystem");
 
@@ -658,6 +685,9 @@ public final class DexpiXmlReader {
     }
     if (instrumentationLoops != null) {
       instrumentationLoops.addAll(parseInstrumentationLoops(document));
+    }
+    if (actuatingFunctions != null) {
+      actuatingFunctions.addAll(parseActuatingFunctions(document));
     }
     if (informationFlows != null) {
       informationFlows.addAll(parseInformationFlows(document));
@@ -844,6 +874,58 @@ public final class DexpiXmlReader {
       }
       result.add(new DexpiInstrumentationLoopInfo(loop.getAttribute("ID"), loop.getAttribute("ComponentClass"),
           getGenericAttribute(loop, DexpiMetadata.LOOP_NUMBER), members));
+    }
+    return result;
+  }
+
+  private static List<DexpiActuatingFunctionInfo> parseActuatingFunctions(Document document) {
+    List<DexpiActuatingFunctionInfo> result = new ArrayList<DexpiActuatingFunctionInfo>();
+    Map<String, Element> elementsById = new HashMap<String, Element>();
+    NodeList allElements = document.getElementsByTagName("*");
+    for (int i = 0; i < allElements.getLength(); i++) {
+      Node node = allElements.item(i);
+      if (node.getNodeType() != Node.ELEMENT_NODE || isInsideShapeCatalogue(node)) {
+        continue;
+      }
+      Element element = (Element) node;
+      String id = element.getAttribute("ID");
+      if (!isBlank(id) && !elementsById.containsKey(id)) {
+        elementsById.put(id, element);
+      }
+    }
+
+    for (int i = 0; i < allElements.getLength(); i++) {
+      Node node = allElements.item(i);
+      if (node.getNodeType() != Node.ELEMENT_NODE || isInsideShapeCatalogue(node)) {
+        continue;
+      }
+      Element element = (Element) node;
+      String elementName = element.getTagName();
+      String componentClass = element.getAttribute("ComponentClass");
+      DexpiActuatingFunctionInfo.Kind kind;
+      if ("ActuatingElectricalFunction".equals(elementName)
+          || "ActuatingElectricalFunction".equals(componentClass)) {
+        kind = DexpiActuatingFunctionInfo.Kind.ACTUATING_ELECTRICAL_FUNCTION;
+      } else if ("ActuatingFunction".equals(elementName) || "ActuatingFunction".equals(componentClass)) {
+        kind = DexpiActuatingFunctionInfo.Kind.ACTUATING_FUNCTION;
+      } else {
+        continue;
+      }
+
+      Element instrumentationFunction = findAncestorElement(element, "ProcessInstrumentationFunction");
+      String instrumentationFunctionId =
+          instrumentationFunction == null ? "" : instrumentationFunction.getAttribute("ID");
+      boolean instrumentationFunctionResolved = !isBlank(instrumentationFunctionId)
+          && elementsById.get(instrumentationFunctionId) == instrumentationFunction;
+      String finalControlElementId = getGenericAttribute(element, "FinalControlElementID");
+      String locationId = associationItemId(element, "is located in");
+      Element finalControlElement = elementsById.get(finalControlElementId);
+      Element location = elementsById.get(locationId);
+      result.add(new DexpiActuatingFunctionInfo(element.getAttribute("ID"), kind, componentClass,
+          getGenericAttribute(element, DexpiMetadata.ACTUATING_FUNCTION_NUMBER), instrumentationFunctionId,
+          instrumentationFunctionResolved, elementName(instrumentationFunction), finalControlElementId,
+          finalControlElement != null, elementName(finalControlElement), locationId, location != null,
+          elementName(location)));
     }
     return result;
   }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -141,10 +141,10 @@ public final class DexpiXmlReader {
     private final List<ImportDiagnostic> diagnostics;
 
     private ImportResult(ProcessSystem processSystem, List<DexpiInstrumentInfo> instruments,
-        List<DexpiInstrumentationLoopInfo> instrumentationLoops,
-        List<DexpiActuatingFunctionInfo> actuatingFunctions, List<DexpiInformationFlowInfo> informationFlows,
-        List<DexpiConnectionInfo> connections, List<DexpiConnectionEndpointInfo> connectionEndpoints,
-        List<DexpiConnectionComponentInfo> connectionComponents, List<DexpiConnectionCycleInfo> connectionCycles,
+        List<DexpiInstrumentationLoopInfo> instrumentationLoops, List<DexpiActuatingFunctionInfo> actuatingFunctions,
+        List<DexpiInformationFlowInfo> informationFlows, List<DexpiConnectionInfo> connections,
+        List<DexpiConnectionEndpointInfo> connectionEndpoints, List<DexpiConnectionComponentInfo> connectionComponents,
+        List<DexpiConnectionCycleInfo> connectionCycles,
         List<DexpiConnectionCycleTransitionInfo> connectionCycleTransitions, List<ImportDiagnostic> diagnostics) {
       this.processSystem = processSystem;
       this.instruments = Collections.unmodifiableList(new ArrayList<DexpiInstrumentInfo>(instruments));
@@ -903,8 +903,7 @@ public final class DexpiXmlReader {
       String elementName = element.getTagName();
       String componentClass = element.getAttribute("ComponentClass");
       DexpiActuatingFunctionInfo.Kind kind;
-      if ("ActuatingElectricalFunction".equals(elementName)
-          || "ActuatingElectricalFunction".equals(componentClass)) {
+      if ("ActuatingElectricalFunction".equals(elementName) || "ActuatingElectricalFunction".equals(componentClass)) {
         kind = DexpiActuatingFunctionInfo.Kind.ACTUATING_ELECTRICAL_FUNCTION;
       } else if ("ActuatingFunction".equals(elementName) || "ActuatingFunction".equals(componentClass)) {
         kind = DexpiActuatingFunctionInfo.Kind.ACTUATING_FUNCTION;
@@ -913,8 +912,8 @@ public final class DexpiXmlReader {
       }
 
       Element instrumentationFunction = findAncestorElement(element, "ProcessInstrumentationFunction");
-      String instrumentationFunctionId =
-          instrumentationFunction == null ? "" : instrumentationFunction.getAttribute("ID");
+      String instrumentationFunctionId = instrumentationFunction == null ? ""
+          : instrumentationFunction.getAttribute("ID");
       boolean instrumentationFunctionResolved = !isBlank(instrumentationFunctionId)
           && elementsById.get(instrumentationFunctionId) == instrumentationFunction;
       String finalControlElementId = getGenericAttribute(element, "FinalControlElementID");

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -431,8 +431,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
         + "<Nozzle ID=\"N-ELECTRICAL\"/><FinalControlElement ID=\"M-200\"/>"
         + "<ActuatingElectricalFunction ComponentClass=\"ActuatingElectricalFunction\" ID=\"AEF-200\">"
-        + "<GenericAttributes>"
-        + "<GenericAttribute Name=\"ActuatingFunctionNumberAssignmentClass\" Value=\"YC-200\"/>"
+        + "<GenericAttributes>" + "<GenericAttribute Name=\"ActuatingFunctionNumberAssignmentClass\" Value=\"YC-200\"/>"
         + "<GenericAttribute Name=\"FinalControlElementID\" Value=\"M-200\"/>"
         + "</GenericAttributes><Association Type=\"is located in\" ItemID=\"N-ELECTRICAL\"/>"
         + "</ActuatingElectricalFunction></PlantModel>";

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -265,6 +265,24 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertThrows(UnsupportedOperationException.class, () -> instrumentationLoops.clear());
     assertThrows(UnsupportedOperationException.class, () -> loop.getMembers().clear());
 
+    List<DexpiActuatingFunctionInfo> actuatingFunctions = first.getActuatingFunctions();
+    assertEquals(1, actuatingFunctions.size());
+    DexpiActuatingFunctionInfo actuatingFunction = actuatingFunctions.get(0);
+    assertEquals("AF-100", actuatingFunction.getId());
+    assertEquals(DexpiActuatingFunctionInfo.Kind.ACTUATING_FUNCTION, actuatingFunction.getKind());
+    assertEquals("ActuatingFunction", actuatingFunction.getComponentClass());
+    assertEquals("PC-100", actuatingFunction.getFunctionNumber());
+    assertEquals("PIF-PC-100", actuatingFunction.getInstrumentationFunctionId());
+    assertTrue(actuatingFunction.isInstrumentationFunctionResolved());
+    assertEquals("ProcessInstrumentationFunction", actuatingFunction.getInstrumentationFunctionElementName());
+    assertEquals("V-100", actuatingFunction.getFinalControlElementId());
+    assertTrue(actuatingFunction.isFinalControlElementResolved());
+    assertEquals("FinalControlElement", actuatingFunction.getFinalControlElementName());
+    assertEquals("N-ACT", actuatingFunction.getLocationId());
+    assertTrue(actuatingFunction.isLocationResolved());
+    assertEquals("Nozzle", actuatingFunction.getLocationElementName());
+    assertThrows(UnsupportedOperationException.class, () -> actuatingFunctions.clear());
+
     List<DexpiInformationFlowInfo> informationFlows = first.getInformationFlows();
     assertEquals(3, informationFlows.size());
     DexpiInformationFlowInfo measuring = informationFlows.get(0);
@@ -307,6 +325,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(first.toJson().contains("\"instrumentCount\": 2"));
     assertTrue(first.toJson().contains("\"instrumentationLoopCount\": 1"));
     assertTrue(first.toJson().contains("\"memberCount\": 3"));
+    assertTrue(first.toJson().contains("\"actuatingFunctionCount\": 1"));
+    assertTrue(first.toJson().contains("\"finalControlElementResolved\": true"));
     assertTrue(first.toJson().contains("\"informationFlowCount\": 3"));
     assertTrue(first.toJson().contains("\"kind\": \"MEASURING_LINE\""));
     assertTrue(first.toJson().contains("\"signalConveyingType\": \"ElectricalSignalConveying\""));
@@ -344,6 +364,22 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("UNKNOWN-MEMBER", loop.getMembers().get(0).getMemberId());
     assertFalse(loop.getMembers().get(0).isResolved());
     assertEquals("", loop.getMembers().get(0).getElementName());
+    List<DexpiActuatingFunctionInfo> actuatingFunctions = first.getActuatingFunctions();
+    assertEquals(1, actuatingFunctions.size());
+    DexpiActuatingFunctionInfo actuatingFunction = actuatingFunctions.get(0);
+    assertEquals("AF-BROKEN", actuatingFunction.getId());
+    assertEquals(DexpiActuatingFunctionInfo.Kind.ACTUATING_FUNCTION, actuatingFunction.getKind());
+    assertEquals("", actuatingFunction.getFunctionNumber());
+    assertEquals("", actuatingFunction.getInstrumentationFunctionId());
+    assertFalse(actuatingFunction.isInstrumentationFunctionResolved());
+    assertEquals("", actuatingFunction.getInstrumentationFunctionElementName());
+    assertEquals("UNKNOWN-FINAL", actuatingFunction.getFinalControlElementId());
+    assertFalse(actuatingFunction.isFinalControlElementResolved());
+    assertEquals("", actuatingFunction.getFinalControlElementName());
+    assertEquals("", actuatingFunction.getLocationId());
+    assertFalse(actuatingFunction.isLocationResolved());
+    assertEquals("", actuatingFunction.getLocationElementName());
+
     assertDiagnostic(first, "DEXPI_IMPORT_INSTRUMENT_ID_MISSING");
     assertDiagnostic(first, "DEXPI_IMPORT_INSTRUMENT_FUNCTION_METADATA_MISSING");
     assertDiagnostic(first, "DEXPI_IMPORT_INSTRUMENT_NUMBER_MISSING");
@@ -384,8 +420,37 @@ public class DexpiXmlReaderTest extends NeqSimTest {
 
     assertTrue(first.hasLosses());
     assertFalse(first.hasErrors());
+    assertTrue(first.toJson().contains("\"actuatingFunctionCount\": 1"));
+    assertTrue(first.toJson().contains("\"finalControlElementResolved\": false"));
     assertTrue(first.toJson().contains("\"informationFlowCount\": 2"));
     assertEquals(first.toJson(), second.toJson());
+  }
+
+  @Test
+  public void testReadWithDiagnosticsPreservesActuatingElectricalFunctionKind() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
+        + "<Nozzle ID=\"N-ELECTRICAL\"/><FinalControlElement ID=\"M-200\"/>"
+        + "<ActuatingElectricalFunction ComponentClass=\"ActuatingElectricalFunction\" ID=\"AEF-200\">"
+        + "<GenericAttributes>"
+        + "<GenericAttribute Name=\"ActuatingFunctionNumberAssignmentClass\" Value=\"YC-200\"/>"
+        + "<GenericAttribute Name=\"FinalControlElementID\" Value=\"M-200\"/>"
+        + "</GenericAttributes><Association Type=\"is located in\" ItemID=\"N-ELECTRICAL\"/>"
+        + "</ActuatingElectricalFunction></PlantModel>";
+
+    DexpiXmlReader.ImportResult result = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+    assertEquals(1, result.getActuatingFunctions().size());
+    DexpiActuatingFunctionInfo function = result.getActuatingFunctions().get(0);
+    assertEquals(DexpiActuatingFunctionInfo.Kind.ACTUATING_ELECTRICAL_FUNCTION, function.getKind());
+    assertEquals("AEF-200", function.getId());
+    assertEquals("YC-200", function.getFunctionNumber());
+    assertEquals("M-200", function.getFinalControlElementId());
+    assertTrue(function.isFinalControlElementResolved());
+    assertEquals("FinalControlElement", function.getFinalControlElementName());
+    assertEquals("N-ELECTRICAL", function.getLocationId());
+    assertTrue(function.isLocationResolved());
+    assertTrue(result.getDiagnostics().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds immutable, source-ordered DEXPI actuating-function evidence to the supported-subset reader.

- preserves `ActuatingFunction` and `ActuatingElectricalFunction` source kind, ID, component class, and explicit function number
- exposes enclosing `ProcessInstrumentationFunction`, `FinalControlElementID`, and `is located in` references with resolution provenance
- preserves missing and unresolved evidence without inventing identities
- adds deterministic JSON, defensive-copy API coverage, focused Java regressions, and Java/JPype documentation

## Capability contract

Exact base: `4c3168274cb34b9ea66e2a1d6653a0ff6f17ae0d`
Exact current head: `0ed9ebcce2c6e30c08732b1733cb79a1566bc84c`

This increment does not infer control intent, final-element type, safeguard/SIS classification, hydraulic behavior, or engineering approval. It does not change simulation topology, rendering, geometry, layout, notebooks, or exports. The whole-sheet visual gate is therefore N/A.

## Validation

**READY TO MERGE** at exact head `0ed9ebcce2c6e30c08732b1733cb79a1566bc84c`.

All eight hosted workflows pass: Java 8/21 on Ubuntu and Windows, all four slow-test shards, Javadocs, Spotless, pre-commit, documentation search, notebook execution, diagram performance, CodeQL, PaperLab, and agent-reference checks. The sole review thread is resolved without source changes. The draft remains open, unmerged, and mergeable.

Tracks #1332 and #2899. Positively identified autonomous implementation portfolio: 5/10.