### PR TITLE
[AI-Assisted] feat(electrolyte): expose crystallographic reaction-volume evidence

### DIFF
--- a/docs/pvtsimulation/scale_prediction_api.md
+++ b/docs/pvtsimulation/scale_prediction_api.md
@@ -351,6 +351,10 @@ CalciumSulfatePhaseBoundaryQualification evidence =
 double transitionC = evidence.getPredictedPureWaterTransitionCelsius();
 double transitionAtPressureC = evidence.getPredictedPureWaterTransitionAtEvaluatedPressureCelsius();
 double anhydriteVdelta = evidence.getAnhydriteLumpedReactionVolumeCm3PerMol();
+double ambientReactionVolume =
+    evidence.getCrystallographicTransitionReactionVolumeCm3PerMol();
+double compsaltReactionVolume =
+    evidence.getCompsaltTransitionReactionVolumeCm3PerMol();
 double requiredWaterActivity25C = evidence.getRequiredWaterActivityAt25Celsius();
 boolean publicationReady = evidence.isPublicationReady();
 ```
@@ -381,6 +385,23 @@ high-pressure anhydrite-solubility lineage is Dickson, Blount and Tunell (1963),
 [DOI 10.2475/ajs.261.1.61](https://doi.org/10.2475/ajs.261.1.61); no copyrighted table rows or fitted coefficients are
 redistributed. Quantitative adoption still requires a complete primary-row audit, aqueous-species volume mapping, and
 an uncertainty-aware held-out acceptance criterion.
+
+The same result exposes an independent ambient structural check without changing either COMPSALT
+coefficient. Antao (2011), [DOI 10.1154/1.3659285](https://doi.org/10.1154/1.3659285), reports an
+anhydrite synchrotron unit-cell volume of 305.487(1) Å3 with four formula units per cell. De la
+Torre et al. (2004), [DOI 10.1154/1.1725254](https://doi.org/10.1154/1.1725254), report a gypsum
+synchrotron unit-cell volume of 494.536(5) Å3, also with four formula units per cell. Together with
+the Pátek et al. (2009) liquid-water reference density at 298.15 K and 0.1 MPa,
+[DOI 10.1063/1.3043575](https://doi.org/10.1063/1.3043575), the nominal ambient cycle
+
+`V(anhydrite) + 2 V(H2O,l) - V(gypsum)`
+
+is +7.67528 cm3/mol. The difference between the existing lumped COMPSALT values is +19.4 cm3/mol,
+or 2.52759 times the measurement-derived cycle. This independently confirms that the current
+pressure response is not a pure-mineral-volume mapping. It is a diagnostic, not a replacement
+`Vdelta`: published cell standard errors do not bound thermal expansion, compressibility, sample
+and other systematic effects, or aqueous partial molar volumes. Consequently
+`highPressureQualified` and `aqueousSpeciesVolumeResolved` remain false.
 
 The process-system test carries the solid ledger beside the residual fluid through a
 `Stream -> Heater -> ProcessSystem` calculation, then re-equilibrates it at the outlet. Its

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
@@ -187,25 +187,24 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
   }
 
   /**
-   * Returns the nominal ambient crystallographic reaction volume for gypsum transforming to
-   * anhydrite plus two liquid-water molecules.
+   * Returns the nominal ambient crystallographic reaction volume for gypsum transforming to anhydrite plus two
+   * liquid-water molecules.
    *
    * <p>
-   * This is a measurement-derived structural diagnostic, not a fitted COMPSALT parameter or a
-   * high-pressure qualification.
+   * This is a measurement-derived structural diagnostic, not a fitted COMPSALT parameter or a high-pressure
+   * qualification.
    * </p>
    *
    * @return nominal reaction volume in cm3/mol
    */
   public double getCrystallographicTransitionReactionVolumeCm3PerMol() {
-    return getAnhydriteCrystallographicMolarVolumeCm3PerMol()
-        + 2.0 * getLiquidWaterReferenceMolarVolumeCm3PerMol()
+    return getAnhydriteCrystallographicMolarVolumeCm3PerMol() + 2.0 * getLiquidWaterReferenceMolarVolumeCm3PerMol()
         - getGypsumCrystallographicMolarVolumeCm3PerMol();
   }
 
   /**
-   * Returns the transition reaction volume implied by the difference between the existing lumped
-   * COMPSALT gypsum and anhydrite coefficients.
+   * Returns the transition reaction volume implied by the difference between the existing lumped COMPSALT gypsum and
+   * anhydrite coefficients.
    *
    * @return COMPSALT transition reaction volume in cm3/mol
    */
@@ -215,14 +214,12 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
 
   /** @return COMPSALT minus crystallographic transition reaction volume in cm3/mol */
   public double getTransitionReactionVolumeDifferenceCm3PerMol() {
-    return getCompsaltTransitionReactionVolumeCm3PerMol()
-        - getCrystallographicTransitionReactionVolumeCm3PerMol();
+    return getCompsaltTransitionReactionVolumeCm3PerMol() - getCrystallographicTransitionReactionVolumeCm3PerMol();
   }
 
   /** @return ratio of COMPSALT to crystallographic transition reaction volume */
   public double getTransitionReactionVolumeRatio() {
-    return getCompsaltTransitionReactionVolumeCm3PerMol()
-        / getCrystallographicTransitionReactionVolumeCm3PerMol();
+    return getCompsaltTransitionReactionVolumeCm3PerMol() / getCrystallographicTransitionReactionVolumeCm3PerMol();
   }
 
   /** @return primary anhydrite synchrotron crystallography DOI */
@@ -384,9 +381,9 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
         + ", compsaltTransitionV_cm3_per_mol=" + getCompsaltTransitionReactionVolumeCm3PerMol()
         + ", transitionVdifference_cm3_per_mol=" + getTransitionReactionVolumeDifferenceCm3PerMol()
         + ", transitionVratio=" + getTransitionReactionVolumeRatio() + ", aqueousSpeciesVolumeResolved="
-        + isAqueousSpeciesVolumeResolved() + ", highPressureQualified="
-        + isHighPressureQualified() + ", referencePressurePass=" + referencePressureEnvelopePass + ", evidenceDoi="
-        + EVIDENCE_DOI + ", license=" + EVIDENCE_LICENSE;
+        + isAqueousSpeciesVolumeResolved() + ", highPressureQualified=" + isHighPressureQualified()
+        + ", referencePressurePass=" + referencePressureEnvelopePass + ", evidenceDoi=" + EVIDENCE_DOI + ", license="
+        + EVIDENCE_LICENSE;
   }
 
   private static double solvePureWaterTransitionCelsius(CalcSaltSatauration anhydrite, CalcSaltSatauration gypsum,

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
@@ -41,10 +41,10 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
   public static final String GYPSUM_CRYSTALLOGRAPHY_DOI = "10.1154/1.1725254";
   /** Liquid-water density reference-correlation DOI. */
   public static final String WATER_DENSITY_REFERENCE_DOI = "10.1063/1.3043575";
-  /** Temperature of the ambient crystallographic reaction-volume diagnostic. */
-  public static final double CRYSTALLOGRAPHIC_REFERENCE_TEMPERATURE_K = 298.15;
-  /** Pressure of the ambient crystallographic reaction-volume diagnostic. */
-  public static final double CRYSTALLOGRAPHIC_REFERENCE_PRESSURE_BARA = 1.0;
+  /** Temperature of the liquid-water density reference. */
+  public static final double WATER_DENSITY_REFERENCE_TEMPERATURE_K = 298.15;
+  /** Pressure of the liquid-water density reference. */
+  public static final double WATER_DENSITY_REFERENCE_PRESSURE_BARA = 1.0;
   /** Reference pressure of the COMPSALT constant-volume correction. */
   public static final double COMPSALT_PRESSURE_CORRECTION_REFERENCE_BARA = CalcSaltSatauration.PRESSURE_CORRECTION_REFERENCE_BARA;
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualification.java
@@ -35,6 +35,16 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
   public static final String HIGH_PRESSURE_LINEAGE_DOI = "10.2475/ajs.261.1.61";
   /** License of the registered numerical evidence. */
   public static final String EVIDENCE_LICENSE = "CC BY 4.0";
+  /** Primary anhydrite synchrotron crystallography DOI. */
+  public static final String ANHYDRITE_CRYSTALLOGRAPHY_DOI = "10.1154/1.3659285";
+  /** Primary gypsum synchrotron crystallography DOI. */
+  public static final String GYPSUM_CRYSTALLOGRAPHY_DOI = "10.1154/1.1725254";
+  /** Liquid-water density reference-correlation DOI. */
+  public static final String WATER_DENSITY_REFERENCE_DOI = "10.1063/1.3043575";
+  /** Temperature of the ambient crystallographic reaction-volume diagnostic. */
+  public static final double CRYSTALLOGRAPHIC_REFERENCE_TEMPERATURE_K = 298.15;
+  /** Pressure of the ambient crystallographic reaction-volume diagnostic. */
+  public static final double CRYSTALLOGRAPHIC_REFERENCE_PRESSURE_BARA = 1.0;
   /** Reference pressure of the COMPSALT constant-volume correction. */
   public static final double COMPSALT_PRESSURE_CORRECTION_REFERENCE_BARA = CalcSaltSatauration.PRESSURE_CORRECTION_REFERENCE_BARA;
 
@@ -45,6 +55,12 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
   private static final double NACL_40_WATER_ACTIVITY_MINIMUM = 0.9370;
   private static final double NACL_40_WATER_ACTIVITY_MAXIMUM = 0.9587;
   private static final double REFERENCE_PRESSURE_TOLERANCE_BARA = 0.02;
+  private static final double AVOGADRO_ANGSTROM3_TO_CM3_PER_MOL = 0.602214076;
+  private static final double ANHYDRITE_CELL_VOLUME_ANGSTROM3 = 305.487;
+  private static final double GYPSUM_CELL_VOLUME_ANGSTROM3 = 494.536;
+  private static final double FORMULA_UNITS_PER_CELL = 4.0;
+  private static final double WATER_MOLAR_MASS_G_PER_MOL = 18.01528;
+  private static final double WATER_DENSITY_KG_PER_M3 = 997.047013;
 
   private final double evaluatedPressureBara;
   private final double evaluatedTemperatureKelvin;
@@ -141,6 +157,87 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
   /** @return COMPSALT gypsum lumped reaction-volume coefficient in cm3/mol */
   public double getGypsumLumpedReactionVolumeCm3PerMol() {
     return gypsumLumpedReactionVolumeCm3PerMol;
+  }
+
+  /**
+   * Returns the nominal ambient molar volume derived from the published anhydrite unit cell.
+   *
+   * @return anhydrite molar volume in cm3/mol
+   */
+  public double getAnhydriteCrystallographicMolarVolumeCm3PerMol() {
+    return ANHYDRITE_CELL_VOLUME_ANGSTROM3 * AVOGADRO_ANGSTROM3_TO_CM3_PER_MOL / FORMULA_UNITS_PER_CELL;
+  }
+
+  /**
+   * Returns the nominal ambient molar volume derived from the published gypsum unit cell.
+   *
+   * @return gypsum molar volume in cm3/mol
+   */
+  public double getGypsumCrystallographicMolarVolumeCm3PerMol() {
+    return GYPSUM_CELL_VOLUME_ANGSTROM3 * AVOGADRO_ANGSTROM3_TO_CM3_PER_MOL / FORMULA_UNITS_PER_CELL;
+  }
+
+  /**
+   * Returns the liquid-water molar volume from the 298.15 K, 0.1 MPa reference density.
+   *
+   * @return liquid-water molar volume in cm3/mol
+   */
+  public double getLiquidWaterReferenceMolarVolumeCm3PerMol() {
+    return WATER_MOLAR_MASS_G_PER_MOL / (WATER_DENSITY_KG_PER_M3 / 1000.0);
+  }
+
+  /**
+   * Returns the nominal ambient crystallographic reaction volume for gypsum transforming to
+   * anhydrite plus two liquid-water molecules.
+   *
+   * <p>
+   * This is a measurement-derived structural diagnostic, not a fitted COMPSALT parameter or a
+   * high-pressure qualification.
+   * </p>
+   *
+   * @return nominal reaction volume in cm3/mol
+   */
+  public double getCrystallographicTransitionReactionVolumeCm3PerMol() {
+    return getAnhydriteCrystallographicMolarVolumeCm3PerMol()
+        + 2.0 * getLiquidWaterReferenceMolarVolumeCm3PerMol()
+        - getGypsumCrystallographicMolarVolumeCm3PerMol();
+  }
+
+  /**
+   * Returns the transition reaction volume implied by the difference between the existing lumped
+   * COMPSALT gypsum and anhydrite coefficients.
+   *
+   * @return COMPSALT transition reaction volume in cm3/mol
+   */
+  public double getCompsaltTransitionReactionVolumeCm3PerMol() {
+    return gypsumLumpedReactionVolumeCm3PerMol - anhydriteLumpedReactionVolumeCm3PerMol;
+  }
+
+  /** @return COMPSALT minus crystallographic transition reaction volume in cm3/mol */
+  public double getTransitionReactionVolumeDifferenceCm3PerMol() {
+    return getCompsaltTransitionReactionVolumeCm3PerMol()
+        - getCrystallographicTransitionReactionVolumeCm3PerMol();
+  }
+
+  /** @return ratio of COMPSALT to crystallographic transition reaction volume */
+  public double getTransitionReactionVolumeRatio() {
+    return getCompsaltTransitionReactionVolumeCm3PerMol()
+        / getCrystallographicTransitionReactionVolumeCm3PerMol();
+  }
+
+  /** @return primary anhydrite synchrotron crystallography DOI */
+  public String getAnhydriteCrystallographyDoi() {
+    return ANHYDRITE_CRYSTALLOGRAPHY_DOI;
+  }
+
+  /** @return primary gypsum synchrotron crystallography DOI */
+  public String getGypsumCrystallographyDoi() {
+    return GYPSUM_CRYSTALLOGRAPHY_DOI;
+  }
+
+  /** @return liquid-water density reference-correlation DOI */
+  public String getWaterDensityReferenceDoi() {
+    return WATER_DENSITY_REFERENCE_DOI;
   }
 
   /** @return logarithmic anhydrite Ksp pressure correction at the evaluated state */
@@ -264,6 +361,8 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
         "Bock primary-table transcription, preprocessing uncertainty, and absolute-solubility "
             + "residuals remain unqualified",
         "COMPSALT Vdelta is a constant lumped reaction-volume coefficient, not a pure-mineral molar volume",
+        "The ambient crystallographic reaction-volume cycle is a diagnostic only; its reported cell errors do not "
+            + "bound thermal expansion, compressibility, sample, or other systematic effects",
         "High-pressure use requires a verified reaction-volume convention that separately resolves aqueous partial "
             + "or apparent molar volumes",
         "The registered evidence covers pure-water and NaCl phase crossings, not general "
@@ -281,7 +380,11 @@ public final class CalciumSulfatePhaseBoundaryQualification implements Serializa
         + evaluatedPressureBara + ", evaluatedPressureTransition_C="
         + predictedPureWaterTransitionAtEvaluatedPressureCelsius + ", anhydriteVdelta_cm3_per_mol="
         + anhydriteLumpedReactionVolumeCm3PerMol + ", gypsumVdelta_cm3_per_mol=" + gypsumLumpedReactionVolumeCm3PerMol
-        + ", aqueousSpeciesVolumeResolved=" + isAqueousSpeciesVolumeResolved() + ", highPressureQualified="
+        + ", crystallographicTransitionV_cm3_per_mol=" + getCrystallographicTransitionReactionVolumeCm3PerMol()
+        + ", compsaltTransitionV_cm3_per_mol=" + getCompsaltTransitionReactionVolumeCm3PerMol()
+        + ", transitionVdifference_cm3_per_mol=" + getTransitionReactionVolumeDifferenceCm3PerMol()
+        + ", transitionVratio=" + getTransitionReactionVolumeRatio() + ", aqueousSpeciesVolumeResolved="
+        + isAqueousSpeciesVolumeResolved() + ", highPressureQualified="
         + isHighPressureQualified() + ", referencePressurePass=" + referencePressureEnvelopePass + ", evidenceDoi="
         + EVIDENCE_DOI + ", license=" + EVIDENCE_LICENSE;
   }

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
@@ -29,6 +29,18 @@ class CalciumSulfatePhaseBoundaryQualificationTest extends neqsim.NeqSimTest {
     assertEquals(60.445190, qualification.getPredictedPureWaterTransitionAtEvaluatedPressureCelsius(), 1.0e-6);
     assertEquals(-52.4, qualification.getAnhydriteLumpedReactionVolumeCm3PerMol(), 0.0);
     assertEquals(-33.0, qualification.getGypsumLumpedReactionVolumeCm3PerMol(), 0.0);
+    assertEquals(45.992142858753, qualification.getAnhydriteCrystallographicMolarVolumeCm3PerMol(), 1.0e-12);
+    assertEquals(74.454135072184, qualification.getGypsumCrystallographicMolarVolumeCm3PerMol(), 1.0e-12);
+    assertEquals(18.068636448540, qualification.getLiquidWaterReferenceMolarVolumeCm3PerMol(), 1.0e-12);
+    assertEquals(7.675280683650, qualification.getCrystallographicTransitionReactionVolumeCm3PerMol(), 1.0e-12);
+    assertEquals(19.4, qualification.getCompsaltTransitionReactionVolumeCm3PerMol(), 0.0);
+    assertEquals(11.724719316350, qualification.getTransitionReactionVolumeDifferenceCm3PerMol(), 1.0e-12);
+    assertEquals(2.527594859342, qualification.getTransitionReactionVolumeRatio(), 1.0e-12);
+    assertEquals("10.1154/1.3659285", qualification.getAnhydriteCrystallographyDoi());
+    assertEquals("10.1154/1.1725254", qualification.getGypsumCrystallographyDoi());
+    assertEquals("10.1063/1.3043575", qualification.getWaterDensityReferenceDoi());
+    assertEquals(298.15, CalciumSulfatePhaseBoundaryQualification.CRYSTALLOGRAPHIC_REFERENCE_TEMPERATURE_K, 0.0);
+    assertEquals(1.0, CalciumSulfatePhaseBoundaryQualification.CRYSTALLOGRAPHIC_REFERENCE_PRESSURE_BARA, 0.0);
     assertEquals(0.0, qualification.getAnhydriteLogKspPressureCorrection(), 0.0);
     assertEquals(0.0, qualification.getGypsumLogKspPressureCorrection(), 0.0);
     assertFalse(qualification.isAqueousSpeciesVolumeResolved());
@@ -58,6 +70,8 @@ class CalciumSulfatePhaseBoundaryQualificationTest extends neqsim.NeqSimTest {
     CalciumSulfatePhaseBoundaryQualification repeated = new ThermodynamicOperations(new SystemSrkEos(313.15, 1.01325))
         .qualifyCalciumSulfatePhaseBoundary();
     assertEquals(first.formatDiagnostic(), repeated.formatDiagnostic());
+    assertTrue(first.formatDiagnostic().contains("crystallographicTransitionV_cm3_per_mol=7.675280683649"));
+    assertTrue(first.formatDiagnostic().contains("compsaltTransitionV_cm3_per_mol=19.4"));
     assertFalse(first.getLimitations().isEmpty());
     assertThrows(UnsupportedOperationException.class, () -> first.getLimitations().add("unexpected"));
 

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/CalciumSulfatePhaseBoundaryQualificationTest.java
@@ -39,8 +39,8 @@ class CalciumSulfatePhaseBoundaryQualificationTest extends neqsim.NeqSimTest {
     assertEquals("10.1154/1.3659285", qualification.getAnhydriteCrystallographyDoi());
     assertEquals("10.1154/1.1725254", qualification.getGypsumCrystallographyDoi());
     assertEquals("10.1063/1.3043575", qualification.getWaterDensityReferenceDoi());
-    assertEquals(298.15, CalciumSulfatePhaseBoundaryQualification.CRYSTALLOGRAPHIC_REFERENCE_TEMPERATURE_K, 0.0);
-    assertEquals(1.0, CalciumSulfatePhaseBoundaryQualification.CRYSTALLOGRAPHIC_REFERENCE_PRESSURE_BARA, 0.0);
+    assertEquals(298.15, CalciumSulfatePhaseBoundaryQualification.WATER_DENSITY_REFERENCE_TEMPERATURE_K, 0.0);
+    assertEquals(1.0, CalciumSulfatePhaseBoundaryQualification.WATER_DENSITY_REFERENCE_PRESSURE_BARA, 0.0);
     assertEquals(0.0, qualification.getAnhydriteLogKspPressureCorrection(), 0.0);
     assertEquals(0.0, qualification.getGypsumLogKspPressureCorrection(), 0.0);
     assertFalse(qualification.isAqueousSpeciesVolumeResolved());


### PR DESCRIPTION
## Summary

Advances #3144 with an independent, measurement-derived ambient reaction-volume diagnostic for the gypsum → anhydrite + 2 H2O transition.

**Exact base:** `c2b3734cf0dc45643c908114f1bd5f173b052e73`  
**Exact head:** `f7434f1c5eb2d9b52f2b11b51e750fd5e32da990`

The pre-implementation capability contract is recorded in [#3144](https://github.com/equinor/neqsim/issues/3144#issuecomment-5543922414).

## Evidence and calculation

The immutable qualification view now retains these public source identifiers and reported reference values:

- Antao (2011), anhydrite synchrotron HRPXRD, [DOI 10.1154/1.3659285](https://doi.org/10.1154/1.3659285): `Vcell = 305.487(1) Å³`, `Z = 4`.
- De la Torre et al. (2004), gypsum synchrotron Rietveld study, [DOI 10.1154/1.1725254](https://doi.org/10.1154/1.1725254): `Vcell = 494.536(5) Å³`, `Z = 4`.
- Pátek et al. (2009), liquid-water reference correlation, [DOI 10.1063/1.3043575](https://doi.org/10.1063/1.3043575): `ρ(298.15 K, 0.1 MPa) = 997.047013 kg/m³`.

Using the exact Avogadro constant and `V(anhydrite) + 2 V(H2O,l) - V(gypsum)`, the nominal ambient reaction volume is:

- anhydrite: `45.992142858753 cm³/mol`
- gypsum: `74.454135072184 cm³/mol`
- liquid water: `18.068636448540 cm³/mol`
- crystallographic cycle: `+7.675280683650 cm³/mol`

The unchanged COMPSALT lumped values imply `(-33.0) - (-52.4) = +19.4 cm³/mol`, a difference of `+11.724719316350 cm³/mol` and a ratio of `2.527594859342`.

## Scope and model semantics

- Adds deterministic Java/JPype getters, source DOI getters, focused regression assertions, limitations, and scale-API documentation.
- Does **not** change COMPSALT rows, `Vdelta`, Ksp coefficients, Pitzer parameters, reaction rows, precipitation behavior, solver tolerances, phases, MCP payloads, or neutral paths.
- Keeps `aqueousSpeciesVolumeResolved=false` and `highPressureQualified=false`.
- Introduces no adoption/pass flag: unit-cell statistical errors do not cover thermal expansion, compressibility, sample/systematic effects, or aqueous partial molar volumes.
- The diagnostic is independent structural evidence, not a fitted parameter and not quantitative high-pressure validation.

## Validation

**READY TO MERGE — REMAINS DRAFT**

Connector-side checks on the exact submitted content:

- six commits, three intended files, zero commits behind the recorded base;
- exact deterministic arithmetic and provenance assertions are present;
- Java source/test brace balance passed;
- no tabs or trailing whitespace;
- no additional flash, thermodynamic initialization, database load, or iteration;
- documentation is updated in `docs/pvtsimulation/scale_prediction_api.md`.

The exact Spotless artifact from the initial hosted run was applied without changing scientific content. Every exact-head hosted gate passes: Java 8 and 21 fast tests on Ubuntu and Windows, all four Java 21 slow-test shards, Javadocs, Spotless, pre-commit, documentation search, CodeQL, PaperLab, and agent-skill reference checks. No local Maven or runtime result is claimed because this run uses the connected repository workflow. The implementation adds only explicit diagnostic getters and formatting arithmetic; it introduces no flash, thermodynamic initialization, database load, or iterative path. A separate timing benchmark is therefore not required for qualification. Notebook, rendered-document, and whole-sheet visual gates are not applicable.

## Coordination and stop boundary

Three autonomous implementation PRs were positively identified immediately before publication (#3453, #3454, #3461); this draft makes the portfolio **4/10**, below the global ceiling. Their MCP, refinery, and DEXPI scopes do not overlap these three calcium-sulfate files. This is the sole active #3144 PR.

Do not infer or install a replacement `Vdelta`, import PHREEQC parameters, or claim high-pressure qualification from this evidence. Parameter adoption remains blocked by a provenance-qualified aqueous-volume model, thermal/pressure mapping, uncertainty-aware grouped held-out validation, and redistribution review for any dataset rows.

This PR must remain draft-only. Do not merge, mark ready, enable auto-merge, rebase, synchronize, force-push, restart, or replace it as part of this campaign.

Generated with AI assistance.