### PR TITLE
ci: dispatch downstream workflows for NeqSim 3.19.0

### DIFF
--- a/.github/release-trigger
+++ b/.github/release-trigger
@@ -1,0 +1,3 @@
+# Update this version only to retry a release publication. The merge commit title
+# must include [publish-release] to publish and dispatch downstream workflows.
+3.19.0

--- a/.github/workflows/release_with_jars.yml
+++ b/.github/workflows/release_with_jars.yml
@@ -244,5 +244,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # workflow_dispatch is allowed to start workflows created with GITHUB_TOKEN.
           gh workflow run publish_to_maven_central.yml --ref "$GITHUB_REF_NAME"
           gh workflow run mcp_server_release.yml --ref "$GITHUB_REF_NAME"

--- a/.github/workflows/release_with_jars.yml
+++ b/.github/workflows/release_with_jars.yml
@@ -11,6 +11,7 @@ on:
       - release/*
     paths:
       - 'pom*.xml'
+      - '.github/release-trigger'
 
 jobs:
   get_versions:
@@ -130,6 +131,7 @@ jobs:
     name: Create release v${{ needs.get_versions.outputs.version_8 }}
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
     needs: [get_versions, compile_java, compile_java_8, compile_mcp_server]
 
@@ -167,7 +169,7 @@ jobs:
           draft: ${{ steps.publication.outputs.draft }}
           generateReleaseNotes: true
           allowUpdates: true
-          updateOnlyUnreleased: true
+          updateOnlyUnreleased: ${{ steps.publication.outputs.draft == 'true' }}
           artifacts: "*.jar,*.sha256"
           artifactContentType: application/java-archive
           body: |
@@ -236,3 +238,11 @@ jobs:
             ## Release notes
 
             GitHub-generated release notes are included with this release and list the commits and pull requests since the previous version.
+
+      - name: Trigger downstream release workflows
+        if: steps.publication.outputs.draft == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run publish_to_maven_central.yml --ref "$GITHUB_REF_NAME"
+          gh workflow run mcp_server_release.yml --ref "$GITHUB_REF_NAME"


### PR DESCRIPTION
## Summary

- explicitly dispatch Maven Central and MCP container publication after a marked public release
- grant the release job narrowly scoped Actions write permission for those two `workflow_dispatch` calls
- add a versioned release trigger so the already-published 3.19.0 release can run the corrected path once
- keep ordinary release-branch runs as drafts and allow marked publication runs to refresh an already-public release safely

GitHub suppresses ordinary events produced by `GITHUB_TOKEN`, but explicitly allows `workflow_dispatch` events to start workflows. Both downstream workflows already support that event.

## Validation

- `git diff --check`
- YAML parse and trigger/path assertions
- pre-commit and pre-push hooks (Java/Docs hooks correctly skipped because no Java or documentation files changed)
- GitHub Actions behavior checked against the official triggering-a-workflow documentation

## Publication plan

Merge with title `[publish-release] ci: dispatch NeqSim 3.19.0 downstream publication`. The trigger file starts the release workflow on master, refreshes the six public assets, and dispatches the existing Maven Central and MCP Docker workflows.
