### PR TITLE
ci: fix NeqSim 3.19.0 downstream dispatch target

### DIFF
--- a/.github/release-trigger
+++ b/.github/release-trigger
@@ -1,3 +1,4 @@
 # Update this version only to retry a release publication. The merge commit title
 # must include [publish-release] to publish and dispatch downstream workflows.
 3.19.0
+# downstream-dispatch-attempt: 2

--- a/.github/workflows/release_with_jars.yml
+++ b/.github/workflows/release_with_jars.yml
@@ -245,5 +245,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # workflow_dispatch is allowed to start workflows created with GITHUB_TOKEN.
-          gh workflow run publish_to_maven_central.yml --ref "$GITHUB_REF_NAME"
-          gh workflow run mcp_server_release.yml --ref "$GITHUB_REF_NAME"
+          gh workflow run publish_to_maven_central.yml --repo "$GITHUB_REPOSITORY" --ref "$GITHUB_REF_NAME"
+          gh workflow run mcp_server_release.yml --repo "$GITHUB_REPOSITORY" --ref "$GITHUB_REF_NAME"


### PR DESCRIPTION
## Summary

- pass `--repo "$GITHUB_REPOSITORY"` to both downstream `gh workflow run` commands
- advance the 3.19.0 release trigger for a second, corrected dispatch attempt

The prior release refresh rebuilt all artifacts successfully and updated the public release, but the dispatch step failed because the release job has no repository checkout from which GitHub CLI could infer `owner/repo`.

## Validation

- `git diff --check`
- workflow YAML parse
- pre-commit and pre-push hooks

## Publication plan

Merge with title `[publish-release] ci: complete NeqSim 3.19.0 downstream publication`. The release refresh will then dispatch the Maven Central and MCP Docker workflows with an explicit repository target.
