### PR TITLE
[AI-Assisted] feat(kinetics): screen H2S residence-time range

### DIFF
--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -64,6 +64,30 @@ bounded from zero to one, and avoids timestep error. It reports total-sulfide lo
 assign products or consume oxygen, because the source correlation does not supply a complete
 product stoichiometry for that purpose.
 
+## Residence-time range
+
+`screenResidenceTimeRange(...)` compares a caller-provided aqueous residence time with the
+Millero pseudo-first-order chemical time over the published fit-scatter interval:
+
+$
+\tau = \frac{1}{k[\mathrm{O_2}]}, \qquad
+\mathrm{Da} = \frac{t_{\mathrm{res}}}{\tau}
+             = k[\mathrm{O_2}]t_{\mathrm{res}}.
+$
+
+The immutable result reports lower, nominal, and upper pseudo-first-order rates, chemical times,
+Damkohler numbers, and remaining fractions. Lower and upper refer to the source's
+one-standard-deviation `log10(k)` fit interval. At the illustrative nominal half-life of
+`22.4288 h`, the nominal Damkohler number is `ln(2)` and the nominal remaining fraction is
+exactly `0.5`; the lower-rate result retains more sulfide and the upper-rate result retains less.
+
+A zero residence time is an exact identity. Increasing residence time monotonically reduces every
+reported remaining fraction. Non-finite inputs or any multiplication/reciprocal overflow fail
+closed. The method deliberately reports continuous Damkohler evidence and does not add categorical
+reaction/transport thresholds. A caller may compare this diagnostic with an independently
+established transport time, but that does not constitute a pipeline source-term coupling or
+high-pressure qualification.
+
 ## Piecewise exposure trajectory
 
 `AqueousHydrogenSulfideOxidationTrajectory.advance(...)` propagates the same correlation through

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -86,6 +86,9 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
             "public static double secondOrderRateConstant(",
             "public static RateConstantRange secondOrderRateConstantRange(",
             "public static ScreeningResult screenAirSaturatedExposure(",
+            "public static ResidenceTimeRangeResult screenResidenceTimeRange(",
+            "public static final class ResidenceTimeRangeResult",
+            "finiteProduct(",
             "Math.expm1(-exposure)",
         ):
             self.assertIn(token, self.implementation)
@@ -97,9 +100,27 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
             "testRateIsMonotonicWithinThePublishedCorrelation",
             "testReportedLogRateScatterIsAppliedMultiplicatively",
             "testConstantOxygenExposureUsesExactPseudoFirstOrderSolution",
+            "testResidenceTimeRangePropagatesPublishedFitScatter",
+            "testResidenceTimeRangeIsMonotonicDeterministicAndExactAtZero",
+            "testResidenceTimeRangeFailsClosedOnInvalidOrOverflowingInputs",
             "testLongExposureRemainsBoundedAndInputValidationFailsClosed",
         ):
             self.assertIn(token, self.java_test)
+
+    def test_residence_time_range_contract_is_documented(self):
+        for token in (
+            "Residence-time range",
+            "`screenResidenceTimeRange(...)`",
+            r"\mathrm{Da} = \frac{t_{\mathrm{res}}}{\tau}",
+            r"k[\mathrm{O_2}]t_{\mathrm{res}}",
+            "lower, nominal, and upper pseudo-first-order rates",
+            "nominal Damkohler number is `ln(2)`",
+            "nominal remaining fraction is exactly `0.5`",
+            "continuous Damkohler evidence",
+            "does not add categorical reaction/transport thresholds",
+            "does not constitute a pipeline source-term coupling",
+        ):
+            self.assertIn(token, self.normalized)
 
     def test_piecewise_trajectory_contract_is_documented_and_executable(self):
         for token in (

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKinetics.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKinetics.java
@@ -182,6 +182,49 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
         remainingFraction, reactedFraction);
   }
 
+  /**
+   * Screen a residence time against the published correlation and its reported fit scatter.
+   *
+   * <p>
+   * The dimensionless Damkohler exposure is {@code Da = k[O2]t = t/tau}, where
+   * {@code tau = 1/(k[O2])}. Lower, nominal, and upper results use the source's one-standard-deviation
+   * {@code log10(k)} interval. No categorical regime threshold is imposed.
+   * </p>
+   *
+   * @param airSaturatedOxygenMolality dissolved oxygen molality for an independently established air-saturated aqueous
+   * state [mol/kg water]
+   * @param residenceTimeHours caller-provided aqueous residence time [h]
+   * @param temperatureK aqueous temperature [K]
+   * @param pH aqueous pH on the source-compatible scale
+   * @param ionicStrengthMolPerKgWater ionic strength [mol/kg water]
+   * @return immutable uncertainty-aware residence-time result
+   * @throws IllegalArgumentException when residence time is negative or non-finite, oxygen is not finite and positive,
+   * the state is outside the published range, or an intermediate result is not finite
+   */
+  public static ResidenceTimeRangeResult screenResidenceTimeRange(double airSaturatedOxygenMolality,
+      double residenceTimeHours, double temperatureK, double pH, double ionicStrengthMolPerKgWater) {
+    requireFiniteNonNegative(residenceTimeHours, "residence time");
+    RateConstantRange secondOrderRates = secondOrderRateConstantRange(temperatureK, pH,
+        ionicStrengthMolPerKgWater);
+    double nominalRate = pseudoFirstOrderRateConstant(airSaturatedOxygenMolality, temperatureK, pH,
+        ionicStrengthMolPerKgWater);
+    double lowerRate = secondOrderRates.getLower() * airSaturatedOxygenMolality;
+    double upperRate = secondOrderRates.getUpper() * airSaturatedOxygenMolality;
+    requireFinitePositive(lowerRate, "lower pseudo-first-order rate");
+    requireFinitePositive(upperRate, "upper pseudo-first-order rate");
+
+    double lowerChemicalTime = reciprocalFinitePositive(lowerRate, "lower-rate chemical time");
+    double nominalChemicalTime = reciprocalFinitePositive(nominalRate, "nominal chemical time");
+    double upperChemicalTime = reciprocalFinitePositive(upperRate, "upper-rate chemical time");
+    double lowerDamkohler = finiteProduct(lowerRate, residenceTimeHours, "lower-rate Damkohler number");
+    double nominalDamkohler = finiteProduct(nominalRate, residenceTimeHours, "nominal Damkohler number");
+    double upperDamkohler = finiteProduct(upperRate, residenceTimeHours, "upper-rate Damkohler number");
+
+    return new ResidenceTimeRangeResult(lowerRate, nominalRate, upperRate, lowerChemicalTime,
+        nominalChemicalTime, upperChemicalTime, lowerDamkohler, nominalDamkohler, upperDamkohler,
+        Math.exp(-lowerDamkohler), Math.exp(-nominalDamkohler), Math.exp(-upperDamkohler));
+  }
+
   private static void requirePublishedState(double temperatureK, double pH, double ionicStrengthMolPerKgWater) {
     requireRange(temperatureK, MINIMUM_TEMPERATURE_K, MAXIMUM_TEMPERATURE_K, "temperature");
     requireRange(pH, MINIMUM_PH, MAXIMUM_PH, "pH");
@@ -205,6 +248,18 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
     if (!Double.isFinite(value) || value < 0.0) {
       throw new IllegalArgumentException(name + " must be finite and non-negative");
     }
+  }
+
+  private static double reciprocalFinitePositive(double rate, String name) {
+    double reciprocal = 1.0 / rate;
+    requireFinitePositive(reciprocal, name);
+    return reciprocal;
+  }
+
+  private static double finiteProduct(double first, double second, String name) {
+    double product = first * second;
+    requireFiniteNonNegative(product, name);
+    return product;
   }
 
   /** Immutable second-order rate-constant interval. */
@@ -234,6 +289,103 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
     /** @return upper one-standard-deviation rate [kg water/(mol h)]. */
     public double getUpper() {
       return upper;
+    }
+  }
+
+  /** Immutable uncertainty-aware residence-time screening result. */
+  public static final class ResidenceTimeRangeResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double lowerPseudoFirstOrderRate;
+    private final double nominalPseudoFirstOrderRate;
+    private final double upperPseudoFirstOrderRate;
+    private final double lowerRateChemicalTimeHours;
+    private final double nominalChemicalTimeHours;
+    private final double upperRateChemicalTimeHours;
+    private final double lowerRateDamkohlerNumber;
+    private final double nominalDamkohlerNumber;
+    private final double upperRateDamkohlerNumber;
+    private final double lowerRateRemainingFraction;
+    private final double nominalRemainingFraction;
+    private final double upperRateRemainingFraction;
+
+    private ResidenceTimeRangeResult(double lowerPseudoFirstOrderRate, double nominalPseudoFirstOrderRate,
+        double upperPseudoFirstOrderRate, double lowerRateChemicalTimeHours, double nominalChemicalTimeHours,
+        double upperRateChemicalTimeHours, double lowerRateDamkohlerNumber, double nominalDamkohlerNumber,
+        double upperRateDamkohlerNumber, double lowerRateRemainingFraction, double nominalRemainingFraction,
+        double upperRateRemainingFraction) {
+      this.lowerPseudoFirstOrderRate = lowerPseudoFirstOrderRate;
+      this.nominalPseudoFirstOrderRate = nominalPseudoFirstOrderRate;
+      this.upperPseudoFirstOrderRate = upperPseudoFirstOrderRate;
+      this.lowerRateChemicalTimeHours = lowerRateChemicalTimeHours;
+      this.nominalChemicalTimeHours = nominalChemicalTimeHours;
+      this.upperRateChemicalTimeHours = upperRateChemicalTimeHours;
+      this.lowerRateDamkohlerNumber = lowerRateDamkohlerNumber;
+      this.nominalDamkohlerNumber = nominalDamkohlerNumber;
+      this.upperRateDamkohlerNumber = upperRateDamkohlerNumber;
+      this.lowerRateRemainingFraction = lowerRateRemainingFraction;
+      this.nominalRemainingFraction = nominalRemainingFraction;
+      this.upperRateRemainingFraction = upperRateRemainingFraction;
+    }
+
+    /** @return lower pseudo-first-order rate [1/h]. */
+    public double getLowerPseudoFirstOrderRate() {
+      return lowerPseudoFirstOrderRate;
+    }
+
+    /** @return nominal pseudo-first-order rate [1/h]. */
+    public double getNominalPseudoFirstOrderRate() {
+      return nominalPseudoFirstOrderRate;
+    }
+
+    /** @return upper pseudo-first-order rate [1/h]. */
+    public double getUpperPseudoFirstOrderRate() {
+      return upperPseudoFirstOrderRate;
+    }
+
+    /** @return chemical time at the lower fit-scatter rate [h]. */
+    public double getLowerRateChemicalTimeHours() {
+      return lowerRateChemicalTimeHours;
+    }
+
+    /** @return nominal chemical time [h]. */
+    public double getNominalChemicalTimeHours() {
+      return nominalChemicalTimeHours;
+    }
+
+    /** @return chemical time at the upper fit-scatter rate [h]. */
+    public double getUpperRateChemicalTimeHours() {
+      return upperRateChemicalTimeHours;
+    }
+
+    /** @return Damkohler number at the lower fit-scatter rate. */
+    public double getLowerRateDamkohlerNumber() {
+      return lowerRateDamkohlerNumber;
+    }
+
+    /** @return nominal Damkohler number. */
+    public double getNominalDamkohlerNumber() {
+      return nominalDamkohlerNumber;
+    }
+
+    /** @return Damkohler number at the upper fit-scatter rate. */
+    public double getUpperRateDamkohlerNumber() {
+      return upperRateDamkohlerNumber;
+    }
+
+    /** @return remaining fraction at the lower fit-scatter rate. */
+    public double getLowerRateRemainingFraction() {
+      return lowerRateRemainingFraction;
+    }
+
+    /** @return nominal remaining fraction. */
+    public double getNominalRemainingFraction() {
+      return nominalRemainingFraction;
+    }
+
+    /** @return remaining fraction at the upper fit-scatter rate. */
+    public double getUpperRateRemainingFraction() {
+      return upperRateRemainingFraction;
     }
   }
 

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKinetics.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKinetics.java
@@ -186,9 +186,9 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
    * Screen a residence time against the published correlation and its reported fit scatter.
    *
    * <p>
-   * The dimensionless Damkohler exposure is {@code Da = k[O2]t = t/tau}, where
-   * {@code tau = 1/(k[O2])}. Lower, nominal, and upper results use the source's one-standard-deviation
-   * {@code log10(k)} interval. No categorical regime threshold is imposed.
+   * The dimensionless Damkohler exposure is {@code Da = k[O2]t = t/tau}, where {@code tau = 1/(k[O2])}. Lower, nominal,
+   * and upper results use the source's one-standard-deviation {@code log10(k)} interval. No categorical regime
+   * threshold is imposed.
    * </p>
    *
    * @param airSaturatedOxygenMolality dissolved oxygen molality for an independently established air-saturated aqueous
@@ -204,8 +204,7 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
   public static ResidenceTimeRangeResult screenResidenceTimeRange(double airSaturatedOxygenMolality,
       double residenceTimeHours, double temperatureK, double pH, double ionicStrengthMolPerKgWater) {
     requireFiniteNonNegative(residenceTimeHours, "residence time");
-    RateConstantRange secondOrderRates = secondOrderRateConstantRange(temperatureK, pH,
-        ionicStrengthMolPerKgWater);
+    RateConstantRange secondOrderRates = secondOrderRateConstantRange(temperatureK, pH, ionicStrengthMolPerKgWater);
     double nominalRate = pseudoFirstOrderRateConstant(airSaturatedOxygenMolality, temperatureK, pH,
         ionicStrengthMolPerKgWater);
     double lowerRate = secondOrderRates.getLower() * airSaturatedOxygenMolality;
@@ -220,9 +219,9 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
     double nominalDamkohler = finiteProduct(nominalRate, residenceTimeHours, "nominal Damkohler number");
     double upperDamkohler = finiteProduct(upperRate, residenceTimeHours, "upper-rate Damkohler number");
 
-    return new ResidenceTimeRangeResult(lowerRate, nominalRate, upperRate, lowerChemicalTime,
-        nominalChemicalTime, upperChemicalTime, lowerDamkohler, nominalDamkohler, upperDamkohler,
-        Math.exp(-lowerDamkohler), Math.exp(-nominalDamkohler), Math.exp(-upperDamkohler));
+    return new ResidenceTimeRangeResult(lowerRate, nominalRate, upperRate, lowerChemicalTime, nominalChemicalTime,
+        upperChemicalTime, lowerDamkohler, nominalDamkohler, upperDamkohler, Math.exp(-lowerDamkohler),
+        Math.exp(-nominalDamkohler), Math.exp(-upperDamkohler));
   }
 
   private static void requirePublishedState(double temperatureK, double pH, double ionicStrengthMolPerKgWater) {

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKineticsTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKineticsTest.java
@@ -117,14 +117,11 @@ public class AqueousHydrogenSulfideOxidationKineticsTest extends NeqSimTest {
     AqueousHydrogenSulfideOxidationKinetics.ResidenceTimeRangeResult zero = AqueousHydrogenSulfideOxidationKinetics
         .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, 0.0, TEMPERATURE_K, PH, IONIC_STRENGTH);
     AqueousHydrogenSulfideOxidationKinetics.ResidenceTimeRangeResult shortResidence = AqueousHydrogenSulfideOxidationKinetics
-        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, 0.5 * halfLife, TEMPERATURE_K, PH,
-            IONIC_STRENGTH);
+        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, 0.5 * halfLife, TEMPERATURE_K, PH, IONIC_STRENGTH);
     AqueousHydrogenSulfideOxidationKinetics.ResidenceTimeRangeResult longResidence = AqueousHydrogenSulfideOxidationKinetics
-        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, 2.0 * halfLife, TEMPERATURE_K, PH,
-            IONIC_STRENGTH);
+        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, 2.0 * halfLife, TEMPERATURE_K, PH, IONIC_STRENGTH);
     AqueousHydrogenSulfideOxidationKinetics.ResidenceTimeRangeResult repeated = AqueousHydrogenSulfideOxidationKinetics
-        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, 2.0 * halfLife, TEMPERATURE_K, PH,
-            IONIC_STRENGTH);
+        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, 2.0 * halfLife, TEMPERATURE_K, PH, IONIC_STRENGTH);
 
     assertEquals(0.0, zero.getLowerRateDamkohlerNumber(), 0.0);
     assertEquals(0.0, zero.getNominalDamkohlerNumber(), 0.0);
@@ -143,14 +140,13 @@ public class AqueousHydrogenSulfideOxidationKineticsTest extends NeqSimTest {
   void testResidenceTimeRangeFailsClosedOnInvalidOrOverflowingInputs() {
     assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
         .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, -1.0, TEMPERATURE_K, PH, IONIC_STRENGTH));
-    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
-        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, Double.POSITIVE_INFINITY, TEMPERATURE_K, PH,
-            IONIC_STRENGTH));
+    assertThrows(IllegalArgumentException.class,
+        () -> AqueousHydrogenSulfideOxidationKinetics.screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY,
+            Double.POSITIVE_INFINITY, TEMPERATURE_K, PH, IONIC_STRENGTH));
     assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
         .screenResidenceTimeRange(Double.MIN_VALUE, 1.0, TEMPERATURE_K, PH, IONIC_STRENGTH));
     assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
-        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, Double.MAX_VALUE, TEMPERATURE_K, PH,
-            IONIC_STRENGTH));
+        .screenResidenceTimeRange(1.0, Double.MAX_VALUE, TEMPERATURE_K, PH, IONIC_STRENGTH));
   }
 
   @Test

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKineticsTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKineticsTest.java
@@ -90,6 +90,70 @@ public class AqueousHydrogenSulfideOxidationKineticsTest extends NeqSimTest {
   }
 
   @Test
+  void testResidenceTimeRangePropagatesPublishedFitScatter() {
+    double halfLife = AqueousHydrogenSulfideOxidationKinetics.halfLifeHours(AIR_SATURATED_OXYGEN_MOLALITY,
+        TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.ResidenceTimeRangeResult result = AqueousHydrogenSulfideOxidationKinetics
+        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, halfLife, TEMPERATURE_K, PH, IONIC_STRENGTH);
+    double factor = Math.pow(10.0, AqueousHydrogenSulfideOxidationKinetics.LOG10_RATE_STANDARD_DEVIATION);
+
+    assertEquals(result.getNominalPseudoFirstOrderRate() / factor, result.getLowerPseudoFirstOrderRate(), 1.0e-15);
+    assertEquals(result.getNominalPseudoFirstOrderRate() * factor, result.getUpperPseudoFirstOrderRate(), 1.0e-15);
+    assertEquals(1.0 / result.getLowerPseudoFirstOrderRate(), result.getLowerRateChemicalTimeHours(), 1.0e-12);
+    assertEquals(1.0 / result.getNominalPseudoFirstOrderRate(), result.getNominalChemicalTimeHours(), 1.0e-12);
+    assertEquals(1.0 / result.getUpperPseudoFirstOrderRate(), result.getUpperRateChemicalTimeHours(), 1.0e-12);
+    assertEquals(Math.log(2.0) / factor, result.getLowerRateDamkohlerNumber(), 1.0e-15);
+    assertEquals(Math.log(2.0), result.getNominalDamkohlerNumber(), 1.0e-15);
+    assertEquals(Math.log(2.0) * factor, result.getUpperRateDamkohlerNumber(), 1.0e-15);
+    assertEquals(0.5, result.getNominalRemainingFraction(), 1.0e-15);
+    assertTrue(result.getLowerRateRemainingFraction() > result.getNominalRemainingFraction());
+    assertTrue(result.getNominalRemainingFraction() > result.getUpperRateRemainingFraction());
+  }
+
+  @Test
+  void testResidenceTimeRangeIsMonotonicDeterministicAndExactAtZero() {
+    double halfLife = AqueousHydrogenSulfideOxidationKinetics.halfLifeHours(AIR_SATURATED_OXYGEN_MOLALITY,
+        TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.ResidenceTimeRangeResult zero = AqueousHydrogenSulfideOxidationKinetics
+        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, 0.0, TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.ResidenceTimeRangeResult shortResidence = AqueousHydrogenSulfideOxidationKinetics
+        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, 0.5 * halfLife, TEMPERATURE_K, PH,
+            IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.ResidenceTimeRangeResult longResidence = AqueousHydrogenSulfideOxidationKinetics
+        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, 2.0 * halfLife, TEMPERATURE_K, PH,
+            IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.ResidenceTimeRangeResult repeated = AqueousHydrogenSulfideOxidationKinetics
+        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, 2.0 * halfLife, TEMPERATURE_K, PH,
+            IONIC_STRENGTH);
+
+    assertEquals(0.0, zero.getLowerRateDamkohlerNumber(), 0.0);
+    assertEquals(0.0, zero.getNominalDamkohlerNumber(), 0.0);
+    assertEquals(0.0, zero.getUpperRateDamkohlerNumber(), 0.0);
+    assertEquals(1.0, zero.getLowerRateRemainingFraction(), 0.0);
+    assertEquals(1.0, zero.getNominalRemainingFraction(), 0.0);
+    assertEquals(1.0, zero.getUpperRateRemainingFraction(), 0.0);
+    assertTrue(longResidence.getLowerRateRemainingFraction() < shortResidence.getLowerRateRemainingFraction());
+    assertTrue(longResidence.getNominalRemainingFraction() < shortResidence.getNominalRemainingFraction());
+    assertTrue(longResidence.getUpperRateRemainingFraction() < shortResidence.getUpperRateRemainingFraction());
+    assertEquals(longResidence.getNominalDamkohlerNumber(), repeated.getNominalDamkohlerNumber(), 0.0);
+    assertEquals(longResidence.getNominalRemainingFraction(), repeated.getNominalRemainingFraction(), 0.0);
+  }
+
+  @Test
+  void testResidenceTimeRangeFailsClosedOnInvalidOrOverflowingInputs() {
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
+        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, -1.0, TEMPERATURE_K, PH, IONIC_STRENGTH));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
+        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, Double.POSITIVE_INFINITY, TEMPERATURE_K, PH,
+            IONIC_STRENGTH));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
+        .screenResidenceTimeRange(Double.MIN_VALUE, 1.0, TEMPERATURE_K, PH, IONIC_STRENGTH));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
+        .screenResidenceTimeRange(AIR_SATURATED_OXYGEN_MOLALITY, Double.MAX_VALUE, TEMPERATURE_K, PH,
+            IONIC_STRENGTH));
+  }
+
+  @Test
   void testLongExposureRemainsBoundedAndInputValidationFailsClosed() {
     AqueousHydrogenSulfideOxidationKinetics.ScreeningResult longExposure = AqueousHydrogenSulfideOxidationKinetics
         .screenAirSaturatedExposure(AIR_SATURATED_OXYGEN_MOLALITY, 1.0e6, TEMPERATURE_K, PH, IONIC_STRENGTH);


### PR DESCRIPTION
## Summary

Advances #3318 with uncertainty-aware residence-time screening for the merged primary-source aqueous H₂S/O₂ correlation.

**Exact base:** `81ef817f75a0778e715293bc72386c58f87f2e64`  
**Exact current head:** `9a583af14df53166020f6427085d0a4c21b759fb`

The pre-publication capability contract is recorded in [#3318](https://github.com/equinor/neqsim/issues/3318#issuecomment-5546350153).

## Capability

- Reuses `AqueousHydrogenSulfideOxidationKinetics.secondOrderRateConstantRange(...)` as the only rate-correlation authority.
- Computes lower, nominal, and upper pseudo-first-order rates and chemical times.
- Computes continuous Damköhler exposures `Da = t/tau = k[O2]t` for a caller-provided aqueous residence time.
- Computes the corresponding remaining-total-sulfide fractions exactly with `exp(-Da)`.
- Returns an immutable result and adds no categorical reaction/transport threshold.

## Evidence and validity

The physical correlation remains Millero et al. (1987), [doi:10.1021/es00159a003](https://doi.org/10.1021/es00159a003). Its reported 0.18-`log10(k)` fit scatter is propagated coherently as a lower/nominal/upper range; it is not presented as complete predictive uncertainty.

The method fails closed outside 278.15–338.15 K, pH 4–8, ionic strength 0–6 mol/kg water, finite positive caller-supplied air-saturated O₂, and finite non-negative residence time. Pressure is absent.

## Numerical gates

- exact identity at zero residence time;
- nominal one-half-life result: `Da = ln(2)`, remaining fraction `0.5`;
- physical lower/nominal/upper rate, chemical-time, exposure, and remaining-fraction ordering;
- monotonic remaining fraction with residence time;
- deterministic repeat;
- fail closed on non-finite input, underflowed rate, reciprocal overflow, or exposure overflow.

## Validation

**READY TO MERGE — REMAINS DRAFT**

Exact-head hosted evidence:

- all six workflow groups pass on `9a583af14df53166020f6427085d0a4c21b759fb`: build/test/Javadocs, Spotless, pre-commit, documentation search, CodeQL, and PaperLab;
- Java 21 fast tests pass on Ubuntu and Windows, all four Java 21 slow-test shards pass, and Java 8 fast tests pass on Ubuntu and Windows;
- the focused `AqueousHydrogenSulfideOxidationKineticsTest` passed 9/9 on the repaired content head, including the deterministic overflow gate;
- the exact hosted Spotless artifact was applied to the two Java files without changing correlation behavior;
- the final head is an empty-tree CI refresh after unrelated UNIFAC baseline repair #3475 merged to `master`; it does not rebase or synchronize this branch;
- four intended files, seven commits, no reviews, no unresolved threads, and the PR is open, mergeable, and draft.

No local Maven, Spotless, pre-commit, Python, or Javadocs result is claimed. Hosted exact-head CI is authoritative. Documentation impact is complete in the H₂S/O₂ kinetics guide and executable documentation contract.

## Portfolio and overlap

Seven autonomous implementation PRs are positively identified (#3468, #3469, #3471, #3472, #3474, #3476, #3477), so portfolio occupancy is **7/10**, below the target and absolute ceiling. Their DEXPI, refinery, LNG-documentation, MCP, TP-flash, and dynamics scopes do not overlap these four H₂S/O₂ files. This is the sole active #3318 PR. Existing heads were not modified.

## Stop boundary

Atmospheric aqueous diagnostic screening only. No oxygen depletion/solubility, sulfur products, pH/HS⁻ speciation, activities, pressure dependence, water appearance, phase transfer, corrosion, reaction heat, R1–R8 binding, thermodynamic mutation, flash, transient solver, pipeline source term, MCP exposure, or facility-specific Northern Lights data.

Coordination remains with #3144, #2937, #2911, pipeline work, and #3153. This PR must remain draft-only and must not be rebased, synchronized, marked ready, replaced, force-pushed, or merged by this campaign.

Generated with AI assistance.