### PR TITLE
[AI-Assisted] feat(dexpi): preserve actuation target provenance

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -34,7 +34,7 @@ NeqSim provides a complete [DEXPI](https://dexpi.org/) integration that supports
 | `DexpiStream` | Lightweight piping segment with DEXPI class, line number, and fluid code |
 | `DexpiProcessUnit` | Imported equipment with original DEXPI class and mapped `EquipmentEnum` |
 | `DexpiInstrumentInfo` | Instrument metadata (tag, type, function letter) |
-| `DexpiActuatingFunctionInfo` | Immutable source-order actuating-function identity and reference evidence |
+| `DexpiActuatingFunctionInfo` | Immutable source-order actuating-function identity, reference, and resolved-target provenance |
 | `DexpiConnectionInfo` | Immutable source-order material-connection evidence and endpoint resolution |
 
 ---
@@ -147,9 +147,11 @@ incomplete source content into closed-loop control intent.
 `ActuatingElectricalFunction` occurrences as immutable `DexpiActuatingFunctionInfo` records. Each
 record retains the explicit source kind, ID, component class, function number, enclosing
 `ProcessInstrumentationFunction` identity, `FinalControlElementID`, and `is located in` identity,
-together with resolution flags and resolved XML element names. Missing and unresolved references
-remain visible. The API does not classify final-element type, infer control intent, identify a
-safeguard or SIS function, or alter live simulation topology.
+together with resolution flags and resolved XML element names. For each resolved final-element and
+location target, it also preserves the source object's explicit `ComponentClass`, `ComponentName`,
+and `TagName`; absent source metadata remains an empty string. Missing and unresolved references
+remain visible without invented target metadata. The API does not classify final-element type,
+infer control intent, identify a safeguard or SIS function, or alter live simulation topology.
 
 `ImportResult.getInformationFlows()` exposes the corresponding source-ordered
 `MeasuringLineFunction` and `SignalLineFunction` evidence as immutable

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiActuatingFunctionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiActuatingFunctionInfo.java
@@ -36,9 +36,15 @@ public final class DexpiActuatingFunctionInfo implements Serializable {
   private final String finalControlElementId;
   private final boolean finalControlElementResolved;
   private final String finalControlElementName;
+  private final String finalControlElementComponentClass;
+  private final String finalControlElementComponentName;
+  private final String finalControlElementTagName;
   private final String locationId;
   private final boolean locationResolved;
   private final String locationElementName;
+  private final String locationComponentClass;
+  private final String locationComponentName;
+  private final String locationTagName;
 
   /**
    * Creates immutable evidence for one actuating-function occurrence.
@@ -61,6 +67,41 @@ public final class DexpiActuatingFunctionInfo implements Serializable {
       String instrumentationFunctionId, boolean instrumentationFunctionResolved,
       String instrumentationFunctionElementName, String finalControlElementId, boolean finalControlElementResolved,
       String finalControlElementName, String locationId, boolean locationResolved, String locationElementName) {
+    this(id, kind, componentClass, functionNumber, instrumentationFunctionId, instrumentationFunctionResolved,
+        instrumentationFunctionElementName, finalControlElementId, finalControlElementResolved,
+        finalControlElementName, "", "", "", locationId, locationResolved, locationElementName, "", "", "");
+  }
+
+  /**
+   * Creates immutable evidence for one actuating-function occurrence with explicit resolved-target metadata.
+   *
+   * @param id source XML identity, or an empty string when absent
+   * @param kind explicit source kind
+   * @param componentClass source component class
+   * @param functionNumber explicit source function-number metadata, or an empty string
+   * @param instrumentationFunctionId enclosing instrumentation-function identity, or an empty string
+   * @param instrumentationFunctionResolved whether the enclosing identity resolves to the enclosing source element
+   * @param instrumentationFunctionElementName enclosing XML element name, or an empty string
+   * @param finalControlElementId explicit final-control-element reference, or an empty string
+   * @param finalControlElementResolved whether the final-control-element reference resolves
+   * @param finalControlElementName resolved final-control-element XML name, or an empty string
+   * @param finalControlElementComponentClass explicit resolved target component class, or an empty string
+   * @param finalControlElementComponentName explicit resolved target component name, or an empty string
+   * @param finalControlElementTagName explicit resolved target tag name, or an empty string
+   * @param locationId explicit {@code is located in} reference, or an empty string
+   * @param locationResolved whether the location reference resolves
+   * @param locationElementName resolved location XML name, or an empty string
+   * @param locationComponentClass explicit resolved location component class, or an empty string
+   * @param locationComponentName explicit resolved location component name, or an empty string
+   * @param locationTagName explicit resolved location tag name, or an empty string
+   */
+  public DexpiActuatingFunctionInfo(String id, Kind kind, String componentClass, String functionNumber,
+      String instrumentationFunctionId, boolean instrumentationFunctionResolved,
+      String instrumentationFunctionElementName, String finalControlElementId, boolean finalControlElementResolved,
+      String finalControlElementName, String finalControlElementComponentClass,
+      String finalControlElementComponentName, String finalControlElementTagName, String locationId,
+      boolean locationResolved, String locationElementName, String locationComponentClass,
+      String locationComponentName, String locationTagName) {
     this.id = normalize(id);
     this.kind = kind;
     this.componentClass = normalize(componentClass);
@@ -71,9 +112,15 @@ public final class DexpiActuatingFunctionInfo implements Serializable {
     this.finalControlElementId = normalize(finalControlElementId);
     this.finalControlElementResolved = finalControlElementResolved;
     this.finalControlElementName = normalize(finalControlElementName);
+    this.finalControlElementComponentClass = normalize(finalControlElementComponentClass);
+    this.finalControlElementComponentName = normalize(finalControlElementComponentName);
+    this.finalControlElementTagName = normalize(finalControlElementTagName);
     this.locationId = normalize(locationId);
     this.locationResolved = locationResolved;
     this.locationElementName = normalize(locationElementName);
+    this.locationComponentClass = normalize(locationComponentClass);
+    this.locationComponentName = normalize(locationComponentName);
+    this.locationTagName = normalize(locationTagName);
   }
 
   /** @return source XML identity, or an empty string when absent */
@@ -126,6 +173,21 @@ public final class DexpiActuatingFunctionInfo implements Serializable {
     return finalControlElementName;
   }
 
+  /** @return explicit component class of the resolved final-control-element target, or an empty string */
+  public String getFinalControlElementComponentClass() {
+    return finalControlElementComponentClass;
+  }
+
+  /** @return explicit component name of the resolved final-control-element target, or an empty string */
+  public String getFinalControlElementComponentName() {
+    return finalControlElementComponentName;
+  }
+
+  /** @return explicit tag name of the resolved final-control-element target, or an empty string */
+  public String getFinalControlElementTagName() {
+    return finalControlElementTagName;
+  }
+
   /** @return explicit {@code is located in} reference, or an empty string */
   public String getLocationId() {
     return locationId;
@@ -141,6 +203,21 @@ public final class DexpiActuatingFunctionInfo implements Serializable {
     return locationElementName;
   }
 
+  /** @return explicit component class of the resolved actuation-location target, or an empty string */
+  public String getLocationComponentClass() {
+    return locationComponentClass;
+  }
+
+  /** @return explicit component name of the resolved actuation-location target, or an empty string */
+  public String getLocationComponentName() {
+    return locationComponentName;
+  }
+
+  /** @return explicit tag name of the resolved actuation-location target, or an empty string */
+  public String getLocationTagName() {
+    return locationTagName;
+  }
+
   Map<String, Object> toMap() {
     Map<String, Object> result = new LinkedHashMap<String, Object>();
     result.put("id", id);
@@ -153,9 +230,15 @@ public final class DexpiActuatingFunctionInfo implements Serializable {
     result.put("finalControlElementId", finalControlElementId);
     result.put("finalControlElementResolved", Boolean.valueOf(finalControlElementResolved));
     result.put("finalControlElementName", finalControlElementName);
+    result.put("finalControlElementComponentClass", finalControlElementComponentClass);
+    result.put("finalControlElementComponentName", finalControlElementComponentName);
+    result.put("finalControlElementTagName", finalControlElementTagName);
     result.put("locationId", locationId);
     result.put("locationResolved", Boolean.valueOf(locationResolved));
     result.put("locationElementName", locationElementName);
+    result.put("locationComponentClass", locationComponentClass);
+    result.put("locationComponentName", locationComponentName);
+    result.put("locationTagName", locationTagName);
     return result;
   }
 

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiActuatingFunctionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiActuatingFunctionInfo.java
@@ -68,8 +68,8 @@ public final class DexpiActuatingFunctionInfo implements Serializable {
       String instrumentationFunctionElementName, String finalControlElementId, boolean finalControlElementResolved,
       String finalControlElementName, String locationId, boolean locationResolved, String locationElementName) {
     this(id, kind, componentClass, functionNumber, instrumentationFunctionId, instrumentationFunctionResolved,
-        instrumentationFunctionElementName, finalControlElementId, finalControlElementResolved,
-        finalControlElementName, "", "", "", locationId, locationResolved, locationElementName, "", "", "");
+        instrumentationFunctionElementName, finalControlElementId, finalControlElementResolved, finalControlElementName,
+        "", "", "", locationId, locationResolved, locationElementName, "", "", "");
   }
 
   /**
@@ -98,10 +98,9 @@ public final class DexpiActuatingFunctionInfo implements Serializable {
   public DexpiActuatingFunctionInfo(String id, Kind kind, String componentClass, String functionNumber,
       String instrumentationFunctionId, boolean instrumentationFunctionResolved,
       String instrumentationFunctionElementName, String finalControlElementId, boolean finalControlElementResolved,
-      String finalControlElementName, String finalControlElementComponentClass,
-      String finalControlElementComponentName, String finalControlElementTagName, String locationId,
-      boolean locationResolved, String locationElementName, String locationComponentClass,
-      String locationComponentName, String locationTagName) {
+      String finalControlElementName, String finalControlElementComponentClass, String finalControlElementComponentName,
+      String finalControlElementTagName, String locationId, boolean locationResolved, String locationElementName,
+      String locationComponentClass, String locationComponentName, String locationTagName) {
     this.id = normalize(id);
     this.kind = kind;
     this.componentClass = normalize(componentClass);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -928,8 +928,7 @@ public final class DexpiXmlReader {
           explicitAttribute(finalControlElement, "ComponentName"),
           explicitGenericAttribute(finalControlElement, DexpiMetadata.TAG_NAME), locationId, location != null,
           elementName(location), explicitAttribute(location, "ComponentClass"),
-          explicitAttribute(location, "ComponentName"),
-          explicitGenericAttribute(location, DexpiMetadata.TAG_NAME)));
+          explicitAttribute(location, "ComponentName"), explicitGenericAttribute(location, DexpiMetadata.TAG_NAME)));
     }
     return result;
   }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -926,9 +926,9 @@ public final class DexpiXmlReader {
           finalControlElement != null, elementName(finalControlElement),
           explicitAttribute(finalControlElement, "ComponentClass"),
           explicitAttribute(finalControlElement, "ComponentName"),
-          explicitGenericAttribute(finalControlElement, DexpiMetadata.TAG_NAME), locationId, location != null,
+          explicitTagName(finalControlElement), locationId, location != null,
           elementName(location), explicitAttribute(location, "ComponentClass"),
-          explicitAttribute(location, "ComponentName"), explicitGenericAttribute(location, DexpiMetadata.TAG_NAME)));
+          explicitAttribute(location, "ComponentName"), explicitTagName(location)));
     }
     return result;
   }
@@ -942,6 +942,12 @@ public final class DexpiXmlReader {
       return "";
     }
     String value = getGenericAttribute(element, attributeName);
+    return value == null ? "" : value;
+  }
+
+  private static String explicitTagName(Element element) {
+    String value = firstNonEmpty(explicitGenericAttribute(element, "TagName"),
+        explicitGenericAttribute(element, DexpiMetadata.TAG_NAME));
     return value == null ? "" : value;
   }
 

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -923,10 +923,27 @@ public final class DexpiXmlReader {
       result.add(new DexpiActuatingFunctionInfo(element.getAttribute("ID"), kind, componentClass,
           getGenericAttribute(element, DexpiMetadata.ACTUATING_FUNCTION_NUMBER), instrumentationFunctionId,
           instrumentationFunctionResolved, elementName(instrumentationFunction), finalControlElementId,
-          finalControlElement != null, elementName(finalControlElement), locationId, location != null,
-          elementName(location)));
+          finalControlElement != null, elementName(finalControlElement),
+          explicitAttribute(finalControlElement, "ComponentClass"),
+          explicitAttribute(finalControlElement, "ComponentName"),
+          explicitGenericAttribute(finalControlElement, DexpiMetadata.TAG_NAME), locationId, location != null,
+          elementName(location), explicitAttribute(location, "ComponentClass"),
+          explicitAttribute(location, "ComponentName"),
+          explicitGenericAttribute(location, DexpiMetadata.TAG_NAME)));
     }
     return result;
+  }
+
+  private static String explicitAttribute(Element element, String attributeName) {
+    return element == null ? "" : element.getAttribute(attributeName);
+  }
+
+  private static String explicitGenericAttribute(Element element, String attributeName) {
+    if (element == null) {
+      return "";
+    }
+    String value = getGenericAttribute(element, attributeName);
+    return value == null ? "" : value;
   }
 
   private static List<DexpiInformationFlowInfo> parseInformationFlows(Document document) {

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -925,9 +925,8 @@ public final class DexpiXmlReader {
           instrumentationFunctionResolved, elementName(instrumentationFunction), finalControlElementId,
           finalControlElement != null, elementName(finalControlElement),
           explicitAttribute(finalControlElement, "ComponentClass"),
-          explicitAttribute(finalControlElement, "ComponentName"),
-          explicitTagName(finalControlElement), locationId, location != null,
-          elementName(location), explicitAttribute(location, "ComponentClass"),
+          explicitAttribute(finalControlElement, "ComponentName"), explicitTagName(finalControlElement), locationId,
+          location != null, elementName(location), explicitAttribute(location, "ComponentClass"),
           explicitAttribute(location, "ComponentName"), explicitTagName(location)));
     }
     return result;

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -214,7 +214,11 @@ public class DexpiXmlReaderTest extends NeqSimTest {
   @Test
   public void testReadWithDiagnosticsIncludesValidInstrumentationInventory() throws Exception {
     String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
-        + "<Nozzle ID=\"N-SENSE\"/><Nozzle ID=\"N-ACT\"/><FinalControlElement ID=\"V-100\"/>"
+        + "<Nozzle ID=\"N-SENSE\"/><Nozzle ID=\"N-ACT\" ComponentClass=\"Nozzle\" ComponentName=\"NozzleShape\">"
+        + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"NZ-100\"/></GenericAttributes></Nozzle>"
+        + "<FinalControlElement ID=\"V-100\" ComponentClass=\"GateValve\" ComponentName=\"GateValveShape\">"
+        + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"XV-100\"/></GenericAttributes>"
+        + "</FinalControlElement>"
         + "<ProcessInstrumentationFunction ComponentClass=\"ProcessInstrumentationFunction\" ID=\"PIF-PT-100\">"
         + instrumentAttributes("PT-100", "P", "T", "100")
         + "<InformationFlow ComponentClass=\"MeasuringLineFunction\" ID=\"MLF-100\">"
@@ -278,9 +282,15 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("V-100", actuatingFunction.getFinalControlElementId());
     assertTrue(actuatingFunction.isFinalControlElementResolved());
     assertEquals("FinalControlElement", actuatingFunction.getFinalControlElementName());
+    assertEquals("GateValve", actuatingFunction.getFinalControlElementComponentClass());
+    assertEquals("GateValveShape", actuatingFunction.getFinalControlElementComponentName());
+    assertEquals("XV-100", actuatingFunction.getFinalControlElementTagName());
     assertEquals("N-ACT", actuatingFunction.getLocationId());
     assertTrue(actuatingFunction.isLocationResolved());
     assertEquals("Nozzle", actuatingFunction.getLocationElementName());
+    assertEquals("Nozzle", actuatingFunction.getLocationComponentClass());
+    assertEquals("NozzleShape", actuatingFunction.getLocationComponentName());
+    assertEquals("NZ-100", actuatingFunction.getLocationTagName());
     assertThrows(UnsupportedOperationException.class, () -> actuatingFunctions.clear());
 
     List<DexpiInformationFlowInfo> informationFlows = first.getInformationFlows();
@@ -327,6 +337,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(first.toJson().contains("\"memberCount\": 3"));
     assertTrue(first.toJson().contains("\"actuatingFunctionCount\": 1"));
     assertTrue(first.toJson().contains("\"finalControlElementResolved\": true"));
+    assertTrue(first.toJson().contains("\"finalControlElementTagName\": \"XV-100\""));
+    assertTrue(first.toJson().contains("\"locationTagName\": \"NZ-100\""));
     assertTrue(first.toJson().contains("\"informationFlowCount\": 3"));
     assertTrue(first.toJson().contains("\"kind\": \"MEASURING_LINE\""));
     assertTrue(first.toJson().contains("\"signalConveyingType\": \"ElectricalSignalConveying\""));
@@ -376,9 +388,15 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("UNKNOWN-FINAL", actuatingFunction.getFinalControlElementId());
     assertFalse(actuatingFunction.isFinalControlElementResolved());
     assertEquals("", actuatingFunction.getFinalControlElementName());
+    assertEquals("", actuatingFunction.getFinalControlElementComponentClass());
+    assertEquals("", actuatingFunction.getFinalControlElementComponentName());
+    assertEquals("", actuatingFunction.getFinalControlElementTagName());
     assertEquals("", actuatingFunction.getLocationId());
     assertFalse(actuatingFunction.isLocationResolved());
     assertEquals("", actuatingFunction.getLocationElementName());
+    assertEquals("", actuatingFunction.getLocationComponentClass());
+    assertEquals("", actuatingFunction.getLocationComponentName());
+    assertEquals("", actuatingFunction.getLocationTagName());
 
     assertDiagnostic(first, "DEXPI_IMPORT_INSTRUMENT_ID_MISSING");
     assertDiagnostic(first, "DEXPI_IMPORT_INSTRUMENT_FUNCTION_METADATA_MISSING");
@@ -429,7 +447,11 @@ public class DexpiXmlReaderTest extends NeqSimTest {
   @Test
   public void testReadWithDiagnosticsPreservesActuatingElectricalFunctionKind() throws Exception {
     String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
-        + "<Nozzle ID=\"N-ELECTRICAL\"/><FinalControlElement ID=\"M-200\"/>"
+        + "<Nozzle ID=\"N-ELECTRICAL\" ComponentClass=\"Nozzle\" ComponentName=\"MotorNozzle\">"
+        + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"NZ-200\"/></GenericAttributes></Nozzle>"
+        + "<FinalControlElement ID=\"M-200\" ComponentClass=\"ElectricMotor\" ComponentName=\"MotorShape\">"
+        + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"M-200\"/></GenericAttributes>"
+        + "</FinalControlElement>"
         + "<ActuatingElectricalFunction ComponentClass=\"ActuatingElectricalFunction\" ID=\"AEF-200\">"
         + "<GenericAttributes>" + "<GenericAttribute Name=\"ActuatingFunctionNumberAssignmentClass\" Value=\"YC-200\"/>"
         + "<GenericAttribute Name=\"FinalControlElementID\" Value=\"M-200\"/>"
@@ -447,8 +469,14 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("M-200", function.getFinalControlElementId());
     assertTrue(function.isFinalControlElementResolved());
     assertEquals("FinalControlElement", function.getFinalControlElementName());
+    assertEquals("ElectricMotor", function.getFinalControlElementComponentClass());
+    assertEquals("MotorShape", function.getFinalControlElementComponentName());
+    assertEquals("M-200", function.getFinalControlElementTagName());
     assertEquals("N-ELECTRICAL", function.getLocationId());
     assertTrue(function.isLocationResolved());
+    assertEquals("Nozzle", function.getLocationComponentClass());
+    assertEquals("MotorNozzle", function.getLocationComponentName());
+    assertEquals("NZ-200", function.getLocationTagName());
     assertTrue(result.getDiagnostics().isEmpty());
   }
 


### PR DESCRIPTION
## Summary

Preserves explicit source metadata for resolved DEXPI actuating-function targets.

- adds final-control-element and actuation-location `ComponentClass`, `ComponentName`, and `TagName` evidence
- keeps missing and unresolved target metadata empty instead of inventing identities
- preserves the original public constructor, getters, JSON fields, source ordering, and Java 8 compatibility
- adds resolved, unresolved, electrical-actuation, deterministic-JSON, and documentation coverage

## Capability contract

Exact base: `3506714ae2d9e5383351af7c24e42639385a8f20`
Exact current head: `5e1b9b0b1627e56edbb885f7600017c5efd24c20`

This is source-document provenance only. It does not classify final-element type, infer control intent, award safeguard/SIS credit, verify hydraulic behavior, or change simulation topology, writers, rendering, geometry, layout, notebooks, or exports. Whole-sheet visual gate: N/A.

## Validation

**READY TO MERGE**

All eight hosted workflows pass on the exact current head: Java 8 and Java 21 fast tests on Ubuntu and Windows, all four Java 21 slow-test shards, Javadocs, agent-skill references, Spotless, pre-commit, documentation search, notebook execution, engineering-diagram performance, CodeQL, and PaperLab. The matrix contains 19 successful jobs, one expected PaperLab skip, and zero failed or pending jobs.

The shared UNIFAC baseline defect was repaired on `master` by #3475. The final empty-tree requalification commit changes no PR file or engineering behavior and does not rebase or synchronize this branch. The final scope remains four intended files and nine commits, with no reviews or unresolved threads. The PR remains open, unmerged, draft, and mergeable.

Tracks #1332 and #2899. Positively identified autonomous implementation portfolio: **7/10** (#3468, #3469, #3471, #3472, #3474, #3476, and #3477).