### PR TITLE
[AI-Assisted] feat(refinery): structure Sarir steam evidence

### DIFF
--- a/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
@@ -25,6 +25,20 @@ The source then reports a `550 degC+` terminal residue reaching 100 volume%. Neq
 
 The published HYSYS case uses 34 valve trays, feeds 54,420 kg/h of crude at 350 degC and 233 kPa to tray 31 counted from the top, and includes main-column, kerosene-stripper, and diesel-stripper steam rates of 340.2, 68.04, and 226.8 kg/h. Top and bottom pump-around rates are 29,777.64 and 60,423.66 kg/h.
 
+The complete source-identified steam set is:
+
+| Source label | Service | Steam flow (kg/h) |
+| --- | --- | ---: |
+| Main atmospheric column | Main atmospheric column | 340.2 |
+| Kerosene side stripper | Kerosene side stripper | 68.04 |
+| Diesel side stripper | Diesel side stripper | 226.8 |
+| **Total** | Derived sum | **635.04** |
+
+The total is a direct sum of the three published rates. The article does not report the injection
+tray locations or the steam temperature, pressure, quality, or enthalpy. The API therefore exposes
+the rows as source evidence and reports both the location and thermodynamic state as unresolved. It
+does not create executable water streams or side-stripper topology.
+
 Table 4 gives the complete numeric pump-around rows:
 
 | Source label | Draw tray | Return tray | Flow (kg/h) | Draw temperature (degC) | Return temperature (degC) | Derived drop (K) |
@@ -73,6 +87,13 @@ double sourceFlowKgPerHour = topPumparound.getMassFlowRateKgPerHour();
 int rawSourceDrawTray = topPumparound.getSourceDrawTrayNumber();
 boolean trayBasisIsExplicit =
     SarirAtmosphericReference.hasExplicitPumparoundTrayNumberingBasis();
+
+SarirAtmosphericReference.SteamInjectionReference keroseneSteam =
+    SarirAtmosphericReference.getSteamInjection("Kerosene side stripper");
+double steamRateKgPerHour = keroseneSteam.getMassFlowRateKgPerHour();
+double totalSteamRateKgPerHour = SarirAtmosphericReference.getTotalSteamRateKgPerHour();
+boolean steamStateIsExplicit =
+    SarirAtmosphericReference.hasExplicitSteamThermodynamicState();
 ```
 
 Static methods are directly accessible through JPype. Arrays are defensive copies, and unknown product labels or invalid error inputs fail closed.
@@ -142,3 +163,5 @@ specifications, tuning targets, or numerical acceptance thresholds. This sensiti
 qualify plant-yield or D86 reproduction and does not model the published steam, pump-around,
 side-stripper, tray-hydraulic, or efficiency details. The separate pump-around reference rows are
 source evidence only; unresolved tray-numbering direction prevents direct model configuration.
+Likewise, the steam rows retain the published service allocation and rates but do not configure
+water, injection locations, steam state, side-stripper topology, or heat duties.

--- a/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
+++ b/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
@@ -315,8 +315,8 @@ public final class SarirAtmosphericReference {
    * Immutable source steam-injection row.
    *
    * <p>
-   * The source identifies the receiving service and mass-flow rate, but not an injection tray or
-   * thermodynamic steam state. This evidence must not be treated as an executable stream specification.
+   * The source identifies the receiving service and mass-flow rate, but not an injection tray or thermodynamic steam
+   * state. This evidence must not be treated as an executable stream specification.
    * </p>
    */
   public static final class SteamInjectionReference implements Serializable {

--- a/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
+++ b/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
@@ -48,6 +48,11 @@ public final class SarirAtmosphericReference {
       new PumparoundReference("Top pump around (TPA)", 3, 1, 29777.64, 143.9, 80.99),
       new PumparoundReference("Bottom pump around (BPA)", 22, 19, 60423.66, 232.4, 173.99) };
 
+  private static final SteamInjectionReference[] STEAM_INJECTIONS = {
+      new SteamInjectionReference("Main atmospheric column", SteamInjectionService.MAIN_ATMOSPHERIC_COLUMN, 340.2),
+      new SteamInjectionReference("Kerosene side stripper", SteamInjectionService.KEROSENE_SIDE_STRIPPER, 68.04),
+      new SteamInjectionReference("Diesel side stripper", SteamInjectionService.DIESEL_SIDE_STRIPPER, 226.8) };
+
   private SarirAtmosphericReference() {
   }
 
@@ -193,17 +198,60 @@ public final class SarirAtmosphericReference {
 
   /** @return main atmospheric-column steam rate in kg/h */
   public static double getMainColumnSteamRateKgPerHour() {
-    return 340.2;
+    return STEAM_INJECTIONS[0].getMassFlowRateKgPerHour();
   }
 
   /** @return kerosene side-stripper steam rate in kg/h */
   public static double getKeroseneStripperSteamRateKgPerHour() {
-    return 68.04;
+    return STEAM_INJECTIONS[1].getMassFlowRateKgPerHour();
   }
 
   /** @return diesel side-stripper steam rate in kg/h */
   public static double getDieselStripperSteamRateKgPerHour() {
-    return 226.8;
+    return STEAM_INJECTIONS[2].getMassFlowRateKgPerHour();
+  }
+
+  /** @return defensive copy of the source steam-injection rows in source order */
+  public static SteamInjectionReference[] getSteamInjections() {
+    return STEAM_INJECTIONS.clone();
+  }
+
+  /**
+   * Find one steam-injection row by its exact source label.
+   *
+   * @param name exact source label
+   * @return immutable steam-injection reference
+   * @throws IllegalArgumentException if the label is null or unknown
+   */
+  public static SteamInjectionReference getSteamInjection(String name) {
+    if (name == null) {
+      throw new IllegalArgumentException("Steam-injection name cannot be null");
+    }
+    for (SteamInjectionReference injection : STEAM_INJECTIONS) {
+      if (injection.getName().equals(name)) {
+        return injection;
+      }
+    }
+    throw new IllegalArgumentException("Unknown Sarir steam injection: " + name);
+  }
+
+  /** @return sum of all three published steam rates, in kg/h */
+  public static double getTotalSteamRateKgPerHour() {
+    double total = 0.0;
+    for (SteamInjectionReference injection : STEAM_INJECTIONS) {
+      total += injection.getMassFlowRateKgPerHour();
+    }
+    return total;
+  }
+
+  /** @return always false because the source does not report steam injection tray locations */
+  public static boolean hasExplicitSteamInjectionLocations() {
+    return false;
+  }
+
+  /** @return always false because the source does not report steam temperature, pressure, or quality */
+  public static boolean hasExplicitSteamThermodynamicState() {
+    return false;
   }
 
   /**
@@ -251,6 +299,52 @@ public final class SarirAtmosphericReference {
   /** @return bottom pump-around flow rate in kg/h */
   public static double getBottomPumpAroundRateKgPerHour() {
     return PUMPAROUNDS[1].getMassFlowRateKgPerHour();
+  }
+
+  /** Source equipment service receiving steam in the published operating case. */
+  public enum SteamInjectionService {
+    /** Main atmospheric crude column. */
+    MAIN_ATMOSPHERIC_COLUMN,
+    /** Kerosene side stripper. */
+    KEROSENE_SIDE_STRIPPER,
+    /** Diesel side stripper. */
+    DIESEL_SIDE_STRIPPER
+  }
+
+  /**
+   * Immutable source steam-injection row.
+   *
+   * <p>
+   * The source identifies the receiving service and mass-flow rate, but not an injection tray or
+   * thermodynamic steam state. This evidence must not be treated as an executable stream specification.
+   * </p>
+   */
+  public static final class SteamInjectionReference implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final SteamInjectionService service;
+    private final double massFlowRateKgPerHour;
+
+    private SteamInjectionReference(String name, SteamInjectionService service, double massFlowRateKgPerHour) {
+      this.name = name;
+      this.service = service;
+      this.massFlowRateKgPerHour = massFlowRateKgPerHour;
+    }
+
+    /** @return exact source label */
+    public String getName() {
+      return name;
+    }
+
+    /** @return receiving equipment service identified by the source */
+    public SteamInjectionService getService() {
+      return service;
+    }
+
+    /** @return source steam mass-flow rate in kg/h */
+    public double getMassFlowRateKgPerHour() {
+      return massFlowRateKgPerHour;
+    }
   }
 
   /**

--- a/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
+++ b/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
@@ -107,8 +107,7 @@ public class SarirAtmosphericReferenceTest {
     assertEquals(3, injections.length);
     assertSteamInjection(injections[0], "Main atmospheric column", SteamInjectionService.MAIN_ATMOSPHERIC_COLUMN,
         340.2);
-    assertSteamInjection(injections[1], "Kerosene side stripper", SteamInjectionService.KEROSENE_SIDE_STRIPPER,
-        68.04);
+    assertSteamInjection(injections[1], "Kerosene side stripper", SteamInjectionService.KEROSENE_SIDE_STRIPPER, 68.04);
     assertSteamInjection(injections[2], "Diesel side stripper", SteamInjectionService.DIESEL_SIDE_STRIPPER, 226.8);
     assertEquals(injections[0], SarirAtmosphericReference.getSteamInjection("Main atmospheric column"));
     assertEquals(injections[1], SarirAtmosphericReference.getSteamInjection("Kerosene side stripper"));

--- a/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
+++ b/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import neqsim.thermo.characterization.SarirAtmosphericReference.ProductQualityReference;
 import neqsim.thermo.characterization.SarirAtmosphericReference.ProductYieldReference;
 import neqsim.thermo.characterization.SarirAtmosphericReference.PumparoundReference;
+import neqsim.thermo.characterization.SarirAtmosphericReference.SteamInjectionReference;
+import neqsim.thermo.characterization.SarirAtmosphericReference.SteamInjectionService;
 
 /** Tests the public Sarir atmospheric assay and validation reference. */
 public class SarirAtmosphericReferenceTest {
@@ -49,6 +51,10 @@ public class SarirAtmosphericReferenceTest {
     PumparoundReference[] pumparounds = SarirAtmosphericReference.getPumparounds();
     pumparounds[0] = null;
     assertEquals("Top pump around (TPA)", SarirAtmosphericReference.getPumparounds()[0].getName());
+
+    SteamInjectionReference[] steamInjections = SarirAtmosphericReference.getSteamInjections();
+    steamInjections[0] = null;
+    assertEquals("Main atmospheric column", SarirAtmosphericReference.getSteamInjections()[0].getName());
   }
 
   @Test
@@ -88,8 +94,28 @@ public class SarirAtmosphericReferenceTest {
     assertEquals(350.0, SarirAtmosphericReference.getColumnFeedTemperatureCelsius(), 0.0);
     assertEquals(233.0, SarirAtmosphericReference.getColumnFeedPressureKPa(), 0.0);
     assertEquals(340.2, SarirAtmosphericReference.getMainColumnSteamRateKgPerHour(), 0.0);
+    assertEquals(68.04, SarirAtmosphericReference.getKeroseneStripperSteamRateKgPerHour(), 0.0);
+    assertEquals(226.8, SarirAtmosphericReference.getDieselStripperSteamRateKgPerHour(), 0.0);
+    assertEquals(635.04, SarirAtmosphericReference.getTotalSteamRateKgPerHour(), 1.0e-12);
     assertEquals(29777.64, SarirAtmosphericReference.getTopPumpAroundRateKgPerHour(), 0.0);
     assertEquals(60423.66, SarirAtmosphericReference.getBottomPumpAroundRateKgPerHour(), 0.0);
+  }
+
+  @Test
+  public void steamInjectionRowsPreservePublishedServicesWithoutInventingState() {
+    SteamInjectionReference[] injections = SarirAtmosphericReference.getSteamInjections();
+    assertEquals(3, injections.length);
+    assertSteamInjection(injections[0], "Main atmospheric column", SteamInjectionService.MAIN_ATMOSPHERIC_COLUMN,
+        340.2);
+    assertSteamInjection(injections[1], "Kerosene side stripper", SteamInjectionService.KEROSENE_SIDE_STRIPPER,
+        68.04);
+    assertSteamInjection(injections[2], "Diesel side stripper", SteamInjectionService.DIESEL_SIDE_STRIPPER, 226.8);
+    assertEquals(injections[0], SarirAtmosphericReference.getSteamInjection("Main atmospheric column"));
+    assertEquals(injections[1], SarirAtmosphericReference.getSteamInjection("Kerosene side stripper"));
+    assertEquals(injections[2], SarirAtmosphericReference.getSteamInjection("Diesel side stripper"));
+    assertEquals(635.04, SarirAtmosphericReference.getTotalSteamRateKgPerHour(), 1.0e-12);
+    assertFalse(SarirAtmosphericReference.hasExplicitSteamInjectionLocations());
+    assertFalse(SarirAtmosphericReference.hasExplicitSteamThermodynamicState());
   }
 
   @Test
@@ -109,12 +135,21 @@ public class SarirAtmosphericReferenceTest {
     assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getProductYield("Naphtha"));
     assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getPumparound(null));
     assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getPumparound("TPA"));
+    assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getSteamInjection(null));
+    assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getSteamInjection("Main"));
     assertThrows(IllegalArgumentException.class,
         () -> SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(0.0, 1.0));
     assertThrows(IllegalArgumentException.class,
         () -> SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(Double.NaN, 1.0));
     assertThrows(IllegalArgumentException.class,
         () -> SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(1.0, Double.POSITIVE_INFINITY));
+  }
+
+  private static void assertSteamInjection(SteamInjectionReference injection, String name,
+      SteamInjectionService service, double massFlowRate) {
+    assertEquals(name, injection.getName());
+    assertEquals(service, injection.getService());
+    assertEquals(massFlowRate, injection.getMassFlowRateKgPerHour(), 0.0);
   }
 
   private static void assertPumparound(PumparoundReference pumparound, String name, int drawTray, int returnTray,


### PR DESCRIPTION
## Summary

Advances #3305 by preserving the complete source-identified Sarir atmospheric steam set as coherent Java/JPype evidence without inventing executable steam streams or side-stripper topology.

**Exact base:** `3506714ae2d9e5383351af7c24e42639385a8f20`  
**Exact head:** `0aa2e40ce3796a06820cd32c54f9c8f0a0b63382`

The pre-implementation capability contract is recorded in [#3305](https://github.com/equinor/neqsim/issues/3305#issuecomment-5547490675).

## Capability contract

- Add immutable `SteamInjectionReference` rows in source order.
- Preserve the exact source label, receiving-service classification, and mass-flow rate.
- Expose a defensive array, exact-label lookup, derived total, and explicit unresolved-input flags.
- Retain all three existing scalar steam-rate methods and values.
- Fail closed for null, abbreviated, or unknown labels.

## Public provenance and values

Source: H. E. O. Almansouri, *Simulation of Sarir Crude Oil Refinery Using Aspen HYSYS*, Journal of Engineering Research issue 33, published March 31, 2022, DOI [10.66411/jer.v33i.46](https://doi.org/10.66411/jer.v33i.46), [open article](https://jer.ly/jer/index.php/jer/article/download/46/38/39), CC BY 4.0.

The published operating case identifies:

- main atmospheric column: `340.2 kg/h`;
- kerosene side stripper: `68.04 kg/h`;
- diesel side stripper: `226.8 kg/h`;
- direct derived total: `635.04 kg/h`.

The article does not report injection tray locations or steam temperature, pressure, quality, or enthalpy. The API reports both location and thermodynamic state as unresolved.

## Changes

- `SarirAtmosphericReference.java`: immutable source rows, service enum, defensive/exact lookup, total-flow arithmetic, unresolved-input flags, and compatibility-preserving scalar delegation.
- `SarirAtmosphericReferenceTest.java`: source order, exact values, total-flow closure, service classification, defensive-copy, compatibility, unresolved-state, and fail-closed coverage.
- `refinery_sarir_atmospheric_reference.md`: numeric evidence table, Java/JPype example, and modeling boundary.

## Validation

**READY TO MERGE**

Connector-side checks on the exact submitted content:

- six commits, three intended files, zero commits behind the recorded base;
- Java source and test brace balance passed;
- no tabs or trailing whitespace;
- source, tests, and documentation contain all three rows and the `635.04 kg/h` derived total;
- fail-closed and unresolved-location/state assertions are present;
- no Java post-8 language/library construct was introduced;
- the exact hosted Spotless artifact from prior head `f5a342aaa6488b9fbc5d7725b4d964b0ff206216` was applied as two formatting-only commits;
- current branch head was re-read immediately before this metadata update.

Exact-head hosted results:

- PR head `0aa2e40ce3796a06820cd32c54f9c8f0a0b63382` is one content-free requalification commit beyond `6b13dc1d02b6e0400c359a0ca4d8fbf639f2017b`; the comparison contains zero changed files.
- Target-side PR #3475 removed the stale UNIFAC baseline entries that caused the prior unrelated failure.
- Spotless, pre-commit, documentation search, CodeQL, PaperLab, Javadocs, Java 21 fast tests on Ubuntu and Windows, and all four Java 21 slow-test shards pass.
- Java 8 fast tests pass on both Ubuntu and Windows.
- All eight focused `SarirAtmosphericReferenceTest` cases passed on the preceding content-identical head.

No engineering limit was weakened and no unrelated repair was added to this refinery branch. Hosted exact-head CI remains authoritative.

## Documentation impact

Completed in the Sarir atmospheric reference guide. This is a user-visible source-data/API expansion, so the Java/JPype example, units, provenance, derived total, and unresolved inputs are documented. Notebook and rendered-visual gates are not applicable.

## Portfolio and overlap

At qualification, seven autonomous implementation PRs are positively identified: #3468, #3469, this #3471, #3472, #3474, #3476, and #3477. Portfolio occupancy is **7/10**, below the global ceiling. Their kinetics, DEXPI, LNG-documentation, and MCP scopes do not touch this Sarir reference-data increment. This is the sole active #3305 PR.

## Engineering stop boundary

Source evidence only. This change does not add water to a thermodynamic system, select injection trays, specify steam state or enthalpy, calculate heat duty, construct side strippers, configure pump-arounds, tune product rates, validate plant yields/D86, change the assay/EOS/solver, or alter production defaults.

This PR must remain draft-only. Do not merge, mark ready, enable auto-merge, rebase, synchronize, restart, replace, or force-push it as part of this campaign.

Generated with AI assistance.