### PR TITLE
[AI-Assisted] docs(lng): make exchanger quickstart executable

### DIFF
--- a/docs/process/equipment/LNGHeatExchanger.md
+++ b/docs/process/equipment/LNGHeatExchanger.md
@@ -128,6 +128,7 @@ public final class LNGHeatExchangerQuickStart {
     logger.info("Second-law efficiency: {} %", mche.getSecondLawEfficiency() * 100.0);
   }
 }
+```
 
 ### Python (Jupyter)
 

--- a/docs/process/equipment/LNGHeatExchanger.md
+++ b/docs/process/equipment/LNGHeatExchanger.md
@@ -74,52 +74,60 @@ LNGHeatExchanger (process equipment)
 
 ### Java
 
+The complete Java 8 example below is exercised by `LNGHeatExchangerQuickStartTest`. Its MITA and
+second-law-efficiency values are simulation diagnostics, not vendor design guarantees.
+
 ```java
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.heatexchanger.LNGHeatExchanger;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 
-// 1. Create fluids
-SystemInterface hotFluid = new SystemSrkEos(273.15 + 30.0, 50.0);
-hotFluid.addComponent("methane", 0.90);
-hotFluid.addComponent("ethane", 0.05);
-hotFluid.addComponent("propane", 0.03);
-hotFluid.addComponent("nitrogen", 0.02);
-hotFluid.setMixingRule("classic");
+public final class LNGHeatExchangerQuickStart {
+  private static final Logger logger = LogManager.getLogger(LNGHeatExchangerQuickStart.class);
 
-SystemInterface coldFluid = new SystemSrkEos(273.15 - 33.0, 3.0);
-coldFluid.addComponent("methane", 0.40);
-coldFluid.addComponent("ethane", 0.30);
-coldFluid.addComponent("propane", 0.30);
-coldFluid.setMixingRule("classic");
+  private LNGHeatExchangerQuickStart() {}
 
-// 2. Create streams
-Stream hotStream = new Stream("NG Feed", hotFluid);
-hotStream.setFlowRate(100000.0, "kg/hr");
+  public static void main(String[] args) {
+    SystemInterface hotFluid = new SystemSrkEos(273.15 + 30.0, 50.0);
+    hotFluid.addComponent("methane", 0.90);
+    hotFluid.addComponent("ethane", 0.05);
+    hotFluid.addComponent("propane", 0.03);
+    hotFluid.addComponent("nitrogen", 0.02);
+    hotFluid.setMixingRule("classic");
 
-Stream coldStream = new Stream("MR Return", coldFluid);
-coldStream.setFlowRate(150000.0, "kg/hr");
+    SystemInterface coldFluid = new SystemSrkEos(273.15 - 33.0, 3.0);
+    coldFluid.addComponent("methane", 0.40);
+    coldFluid.addComponent("ethane", 0.30);
+    coldFluid.addComponent("propane", 0.30);
+    coldFluid.setMixingRule("classic");
 
-// 3. Configure BAHX
-LNGHeatExchanger mche = new LNGHeatExchanger("MCHE");
-mche.addInStream(hotStream);
-mche.addInStream(coldStream);
-mche.setNumberOfZones(15);
-mche.setStreamPressureDrop(0, 1.5);  // 1.5 bar on hot side
-mche.setStreamPressureDrop(1, 0.3);  // 0.3 bar on cold side
+    Stream hotStream = new Stream("NG Feed", hotFluid);
+    hotStream.setFlowRate(100000.0, "kg/hr");
 
-// 4. Run in process system
-ProcessSystem process = new ProcessSystem();
-process.add(hotStream);
-process.add(coldStream);
-process.add(mche);
-process.run();
+    Stream coldStream = new Stream("MR Return", coldFluid);
+    coldStream.setFlowRate(150000.0, "kg/hr");
 
-// 5. Read results
-System.out.println("MITA: " + mche.getMITA() + " °C");
-System.out.println("η_II: " + mche.getSecondLawEfficiency() * 100 + " %");
-```
+    LNGHeatExchanger mche = new LNGHeatExchanger("MCHE");
+    mche.addInStream(hotStream);
+    mche.addInStream(coldStream);
+    mche.setNumberOfZones(15);
+    mche.setStreamPressureDrop(0, 1.5);
+    mche.setStreamPressureDrop(1, 0.3);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(hotStream);
+    process.add(coldStream);
+    process.add(mche);
+    process.run();
+
+    logger.info("MITA: {} degC", mche.getMITA());
+    logger.info("Second-law efficiency: {} %", mche.getSecondLawEfficiency() * 100.0);
+  }
+}
 
 ### Python (Jupyter)
 

--- a/docs/test_process_documentation_rendering.py
+++ b/docs/test_process_documentation_rendering.py
@@ -235,5 +235,49 @@ class ProcessDocumentationRenderingContractTest(unittest.TestCase):
                 self.assertIsNone(unsupported.search(rendered_markdown))
 
 
+    def test_lng_quickstart_is_complete_and_executable(self):
+        page = DOCS / "process/equipment/LNGHeatExchanger.md"
+        _title, _description, body = parse_front_matter(
+            page.read_text(encoding="utf-8")
+        )
+        match = re.search(
+            r"### Java.*?```java\n(?P<source>.*?)\n```",
+            body,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match)
+        source = match.group("source")
+        for token in (
+            "import org.apache.logging.log4j.LogManager;",
+            "import org.apache.logging.log4j.Logger;",
+            "import neqsim.thermo.system.SystemInterface;",
+            "public final class LNGHeatExchangerQuickStart",
+            "public static void main(String[] args)",
+            "mche.setStreamPressureDrop(0, 1.5);",
+            "mche.setStreamPressureDrop(1, 0.3);",
+            'logger.info("MITA: {} degC", mche.getMITA());',
+            "mche.getSecondLawEfficiency()",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, source)
+        self.assertNotIn("System.out", source)
+        self.assertNotIn("System.err", source)
+
+        regression = (
+            DOCS.parent
+            / "src/test/java/neqsim/documentation/LNGHeatExchangerQuickStartTest.java"
+        ).read_text(encoding="utf-8")
+        for token in (
+            "testDocumentedQuickStartRunsAndReturnsBoundedDiagnostics",
+            "assertTrue(Double.isFinite(mitaC));",
+            "assertTrue(mitaC >= 0.0);",
+            "assertTrue(Double.isFinite(secondLawEfficiency));",
+            "assertTrue(secondLawEfficiency > 0.0);",
+            "assertTrue(secondLawEfficiency <= 1.0);",
+        ):
+            with self.subTest(regression_token=token):
+                self.assertIn(token, regression)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/test/java/neqsim/documentation/LNGHeatExchangerQuickStartTest.java
+++ b/src/test/java/neqsim/documentation/LNGHeatExchangerQuickStartTest.java
@@ -1,0 +1,60 @@
+package neqsim.documentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.heatexchanger.LNGHeatExchanger;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Executes the complete Java quickstart in docs/process/equipment/LNGHeatExchanger.md. */
+class LNGHeatExchangerQuickStartTest {
+
+  @Test
+  void testDocumentedQuickStartRunsAndReturnsBoundedDiagnostics() {
+    SystemInterface hotFluid = new SystemSrkEos(273.15 + 30.0, 50.0);
+    hotFluid.addComponent("methane", 0.90);
+    hotFluid.addComponent("ethane", 0.05);
+    hotFluid.addComponent("propane", 0.03);
+    hotFluid.addComponent("nitrogen", 0.02);
+    hotFluid.setMixingRule("classic");
+
+    SystemInterface coldFluid = new SystemSrkEos(273.15 - 33.0, 3.0);
+    coldFluid.addComponent("methane", 0.40);
+    coldFluid.addComponent("ethane", 0.30);
+    coldFluid.addComponent("propane", 0.30);
+    coldFluid.setMixingRule("classic");
+
+    Stream hotStream = new Stream("NG Feed", hotFluid);
+    hotStream.setFlowRate(100000.0, "kg/hr");
+
+    Stream coldStream = new Stream("MR Return", coldFluid);
+    coldStream.setFlowRate(150000.0, "kg/hr");
+
+    LNGHeatExchanger mche = new LNGHeatExchanger("MCHE");
+    mche.addInStream(hotStream);
+    mche.addInStream(coldStream);
+    mche.setNumberOfZones(15);
+    mche.setStreamPressureDrop(0, 1.5);
+    mche.setStreamPressureDrop(1, 0.3);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(hotStream);
+    process.add(coldStream);
+    process.add(mche);
+    process.run();
+
+    double mitaC = mche.getMITA();
+    double secondLawEfficiency = mche.getSecondLawEfficiency();
+
+    assertEquals(1.5, mche.getStreamPressureDrop(0), 1.0e-12);
+    assertEquals(0.3, mche.getStreamPressureDrop(1), 1.0e-12);
+    assertTrue(Double.isFinite(mitaC));
+    assertTrue(mitaC >= 0.0);
+    assertTrue(Double.isFinite(secondLawEfficiency));
+    assertTrue(secondLawEfficiency > 0.0);
+    assertTrue(secondLawEfficiency <= 1.0);
+  }
+}


### PR DESCRIPTION
## Summary

Advances #2499 with an executable Java 8 quickstart for the LNG cryogenic multi-stream heat exchanger.

**Exact base:** `3506714ae2d9e5383351af7c24e42639385a8f20`  
**Exact head:** `23029d0121e566af0352900f9befe11a7da0db91`

The pre-publication D124 capability contract is recorded in the [campaign ledger](https://github.com/equinor/neqsim/issues/2499#issuecomment-5432666687).

## Frozen scope

- completes the documented Java imports, including `SystemInterface`;
- wraps the quickstart as a copyable Java 8 class;
- replaces forbidden `System.out` calls with parameterized Log4j2 output;
- adds an executable regression for the exact documented two-stream process;
- asserts finite non-negative MITA and finite second-law efficiency in `(0, 1]`;
- binds those invariants to the page through the existing 80-page process-documentation contract.

Exactly three files and five ordered commits are included; the final commit is an empty-tree CI refresh after the unrelated UNIFAC baseline repair.

## Validation

**VALIDATION BLOCKED BY BASE UNIFAC BASELINE DEFECT**

Connector-side checks on the exact submitted content:

- three intended files and five commits; the final empty-tree commit changes no file content or behavior;
- the attributable unclosed-fence finding from the first documentation run was repaired;
- Python contract syntax compiles;
- Java brace balance passes;
- no `System.out` or `System.err` remains in the repaired example or new regression;
- documentation contract confirms the complete imports, class wrapper, pressure-drop calls, logger output, runtime regression, and physical bounds.

Exact-head hosted results:

- `LNGHeatExchangerQuickStartTest` passes 1/1;
- Spotless, pre-commit, documentation search, CodeQL, Javadocs, all four Java 21 slow-test shards, and agent-skill checks pass;
- Windows Java 21 ran 12,770 tests with one unrelated failure in `UnifacDatabaseIntegrityTest.unifacBaselineListsNothingAlreadyFixed`;
- the stale baseline lists six already-fixed `molar_mass_mismatch` entries for `2-M-C8`, `3-M-C8`, and `ethylcyclohexane` in both UNIFAC tables;
- the workflow's fail-fast behavior cancelled Ubuntu fast tests and skipped Java 8 after that unrelated Windows failure.

PR #3472 changes only the LNG guide, its executable documentation contract, and the focused regression. It touches no UNIFAC data, baseline, or component properties. A deterministic retry is not justified, and no unrelated repair was added to this documentation branch. Hosted exact-head CI remains authoritative; no local Maven, Spotless, pre-commit, Javadocs, or Java result is claimed.

## Documentation impact

Completed in `docs/process/equipment/LNGHeatExchanger.md`. The quickstart now states that MITA and second-law efficiency are simulation diagnostics, not vendor design guarantees. No notebook or rendered-visual artifact changed.

## Portfolio and overlap

Five autonomous implementation PRs are positively identified: #3468, #3469, #3471, this #3472, and #3474. Portfolio occupancy is **5/10**, below the global ceiling. Their kinetics, DEXPI, refinery-evidence, and MCP-security scopes do not overlap this frozen documentation batch. The non-autonomous release PR #3460 is not counted. This is the sole active #2499 PR.

## Stop boundary

Documentation and regressions only. No production heat-exchanger equations, solver settings, correlations, defaults, engineering-result certification, notebook output, DEXPI/PFD, MCP, refinery, release, or Huldra work.

This PR must remain draft-only. Do not merge, mark ready, enable auto-merge, rebase, synchronize, replace, force-push, or abandon it as part of this campaign.

Generated with AI assistance.