### PR TITLE
fix(thermo): remove repaired UNIFAC baseline entries

### DIFF
--- a/src/test/resources/data/unifac_known_issues.tsv
+++ b/src/test/resources/data/unifac_known_issues.tsv
@@ -7,11 +7,8 @@ molar_mass_mismatch	UNIFACcomp/1.cis-2.trans-4-TMcyC5
 molar_mass_mismatch	UNIFACcomp/11-DM-cy-C5
 molar_mass_mismatch	UNIFACcomp/113-TM-cy-C5
 molar_mass_mismatch	UNIFACcomp/2-E-p-xylene
-molar_mass_mismatch	UNIFACcomp/2-M-C8
-molar_mass_mismatch	UNIFACcomp/3-M-C8
 molar_mass_mismatch	UNIFACcomp/TEG
 molar_mass_mismatch	UNIFACcomp/cis-13-DM-cy-C6
-molar_mass_mismatch	UNIFACcomp/ethylcyclohexane
 molar_mass_mismatch	UNIFACcomp/nC10-Benzene
 molar_mass_mismatch	UNIFACcomp/nC19
 molar_mass_mismatch	UNIFACcomp/nC22
@@ -31,10 +28,7 @@ molar_mass_mismatch	UNIFACcompUMRPRU/1.cis-2.trans-4-TMcyC5
 molar_mass_mismatch	UNIFACcompUMRPRU/11-DM-cy-C5
 molar_mass_mismatch	UNIFACcompUMRPRU/113-TM-cy-C5
 molar_mass_mismatch	UNIFACcompUMRPRU/2-E-p-xylene
-molar_mass_mismatch	UNIFACcompUMRPRU/2-M-C8
-molar_mass_mismatch	UNIFACcompUMRPRU/3-M-C8
 molar_mass_mismatch	UNIFACcompUMRPRU/cis-13-DM-cy-C6
-molar_mass_mismatch	UNIFACcompUMRPRU/ethylcyclohexane
 molar_mass_mismatch	UNIFACcompUMRPRU/nC10-Benzene
 molar_mass_mismatch	UNIFACcompUMRPRU/nC19
 molar_mass_mismatch	UNIFACcompUMRPRU/nC22


### PR DESCRIPTION
## Summary

Removes six obsolete `molar_mass_mismatch` entries from the UNIFAC known-issues baseline after the corresponding component molar masses were repaired.

The integrity gate correctly reported that these baseline exceptions no longer exist:

- `2-M-C8`, `3-M-C8`, and `ethylcyclohexane` in `UNIFACcomp`;
- the same three components in `UNIFACcompUMRPRU`.

This is the shared base failure currently blocking #3468, #3469, #3471, #3472, and #3474. No active thermodynamic data, UNIFAC group assignment, model equation, tolerance, or production behavior is changed.

## Validation

Passed on the exact one-file content before publication:

- `./mvnw -B -Dtest=UnifacDatabaseIntegrityTest test -DskipITs -Djacoco.skip=true -ntp`: **2 tests, 0 failures**;
- `python3 devtools/run_spotless.py check`;
- `python3 devtools/check_documentation_search.py`;
- `git diff --check`.

The local `pre-commit` executable was unavailable. Hosted CI remains authoritative for the configured pre-commit and pre-push hooks.

## Documentation impact

Documentation impact: none — this removes stale test-baseline exceptions after data corrections already merged; it does not alter user-visible behavior or APIs.