### PR TITLE
[AI-Assisted] fix(twofluid): continue transient regime sources

### DIFF
--- a/.github/skills/neqsim-dynamic-simulation/SKILL.md
+++ b/.github/skills/neqsim-dynamic-simulation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-dynamic-simulation
 description: "Dynamic simulation guidance for NeqSim. USE WHEN: running transient simulations, modeling startup/shutdown, tuning PID controllers, analyzing pressure/level dynamics, performing blowdown/depressurization, or setting up measurement devices and control loops. Covers runTransient, DynamicProcessHelper, controller tuning, and dynamic equipment configuration."
-last_verified: "2026-09-01"
+last_verified: "2026-09-05"
 ---
 
 # Dynamic Simulation Guidance
@@ -447,6 +447,21 @@ split. Record EOS, mixing rule, composition, absolute pressure, temperature, mas
 relaxation time, and units. The current hydrodynamic state transports bulk phase inventories, not a
 full component-composition vector per cell, and does not establish equivalence with any commercial
 transient multiphase simulator.
+
+## TwoFluidPipe Regime-Transition Continuation
+
+Transient wall-friction, interfacial-friction, interfacial-area, and entrainment sources must
+consume the dimensionless normalized weights from `FlowRegimeDetector.classify(...)`. Do not
+reintroduce `detectFlowRegime(...)` as a hard source switch: the steady hold-up and transient
+momentum paths would then see different closures at the same state. Keep stratified geometry active
+whenever a stratified weight is non-zero. Pure-regime endpoints must reproduce the original closure
+exactly.
+
+This continuation does not authorize changes to regime criteria, transition-band widths, hold-up
+correlations, or regime-specific friction models. It remains experimental until the public
+Tengesdal envelope, the liquid-rich 1,800 s inventory criterion, conservation, nonlinear
+convergence, nearby operating points, refinement, and runtime gates all pass. Continue to reject a
+completed time loop whose sticky coupled-solver diagnostics fire.
 
 ## TwoFluidPipe Coupled Pressure-Momentum Gate
 

--- a/.github/skills/neqsim-flow-assurance/SKILL.md
+++ b/.github/skills/neqsim-flow-assurance/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: neqsim-flow-assurance
 description: "Flow assurance analysis patterns for NeqSim. USE WHEN: predicting hydrate formation, wax appearance, asphaltene stability, CO2/H2S corrosion (NORSOK M-506, de Waard-Milliams, FeCO3 film), mineral scale (saturation index, scale kinetics, brine mixing / seawater incompatibility), scale/solids valve plugging & Cv/opening drift (ValveScaleDrift), scale/deposit remediation & dissolver/solvent/wash selection for cleaning fouled equipment (ScaleRemediationAdvisor), elemental sulfur (S8) deposition from oxygen ingress / H2S oxidation at pressure or temperature letdown (compressor inlets, valves, dry-gas seals, letdown stations), per-segment pipeline corrosion+scale profiles, inspected metal-loss screening, pipeline hydraulics, DNV-RP-F109 on-bottom stability screening, DNV-RP-F105 free-span screening, DNV-RP-F104 CO2-envelope screening, DNV-RP-F110 global-buckling response screening, DNV-RP-F114 pipe-soil screening, water/liquid hammer screening, slug flow, thermal analysis, or chemical inhibitor dosing. Covers all flow assurance threats with NeqSim code patterns and industry standards."
-last_verified: "2026-08-27"
+last_verified: "2026-09-05"
 ---
 
 # Flow Assurance Analysis with NeqSim
@@ -528,6 +528,15 @@ for (double qgMSm3d : gasRates) {
 > export line — and differ at 4 MSm3/d, where the equilibrium branch reclassifies 272 of 320
 > sections as stratified-wavy.
 
+> **Transient closure sources follow continuous regime weights.** During dynamic
+> evaluation, the existing dimensionless normalized weights from
+> `FlowRegimeDetector.classify(...)` blend wall friction, interfacial friction and area,
+> and entrainment. A non-zero stratified weight keeps the matching segment geometry active.
+> The flow map, transition bands, hold-up closure, and regime-specific formulas are unchanged,
+> and pure-regime endpoints recover their original closures. This is experimental numerical
+> continuation, not severe-slugging or liquid-rich qualification; require the public Tengesdal,
+> 1,800 s inventory, conservation, nearby-point, refinement, and solver-diagnostic gates.
+>
 > **Friction is per-phase wall shear in stratified flow.**
 > `setSeparatedFrictionModel(false)` restores the mixture correlation, which charges the whole
 > perimeter with a holdup-weighted density; on a stratified line at 41% holdup that

--- a/docs/process/TWOFLUIDPIPE_MODEL.md
+++ b/docs/process/TWOFLUIDPIPE_MODEL.md
@@ -262,6 +262,21 @@ The gas-liquid flow regime detector uses Taitel-Dukler transitions:
 | CHURN | Transition between slug and annular | ✅ |
 | BUBBLE | High liquid fraction, low gas velocity | ✅ |
 
+### Transient Regime-Transition Continuation
+
+During transient source evaluation, `FlowRegimeDetector.classify(...)` supplies the same
+dimensionless, normalized regime weights used by the steady hold-up calculation. Within a
+transition band, `TwoFluidConservationEquations` applies those weights as a convex combination
+of the existing wall-friction, interfacial-friction, interfacial-area, and entrainment results.
+A non-zero stratified share also retains stratified segment geometry, so geometry and momentum
+sources do not switch on different sides of the same transition.
+
+This continuation changes neither a dimensioned transition criterion nor any closure formula.
+At a pure-regime endpoint the original closure is recovered exactly, and separated friction
+remains limited to the regimes for which its existing implementation applies. The continuation
+is an experimental numerical-robustness capability until the public Tengesdal transient,
+liquid-rich 1,800 s inventory, nearby-point, conservation, and refinement gates pass.
+
 ### Oil-Water Flow Regime Detection
 
 For three-phase (gas-oil-water) simulations the `OilWaterFlowRegimeDetector` classifies the

--- a/docs/wiki/two_fluid_model.md
+++ b/docs/wiki/two_fluid_model.md
@@ -325,6 +325,20 @@ detector.setUseMinimumSlipCriterion(true);
 
 The **minimum slip criterion** selects the flow regime that gives the minimum slip ratio (closest to 1.0), based on the principle that the system tends toward the flow pattern with minimum phase velocity difference.
 
+### Continuous Transient Source Evaluation
+
+The dynamic conservation equations consume the detector's existing dimensionless, normalized
+transition weights. Wall shear, interfacial shear and area, and entrainment are evaluated with
+each active regime's authoritative closure and then combined by those weights. Stratified
+geometry stays active whenever its weight is non-zero. This removes a second, hard
+`STRATIFIED_WAVY`/ `SLUG` source switch while preserving the original closure at every
+pure-regime endpoint.
+
+No flow-map threshold, transition-band width, hold-up closure, or regime-specific friction
+correlation is changed. Treat this continuation as experimental until conservation, nonlinear
+robustness, Tengesdal, liquid-rich 1,800 s inventory, nearby operating point, and mesh/time-step
+refinement qualification has passed.
+
 ### Wall Friction
 
 `WallFriction` calculates wall shear using:

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -4384,9 +4384,10 @@ public class TwoFluidPipe extends Pipeline {
 
       if (coupledPressureMomentumEnabled && !timeIntegrator.isCoupledPressureMomentumConverged()) {
         if (consecutiveCoupledPressureMomentumFailures == 0) {
-          logger.warn("{}: rejecting adaptive coupled pressure-momentum substep of {} s after {}/{} iterations; "
-              + "relative cell-volume residual={}, tolerance={}, pressureCorrectionLimited={}", getName(), dtActual,
-              timeIntegrator.getCoupledPressureMomentumIterations(),
+          logger.warn(
+              "{}: rejecting adaptive coupled pressure-momentum substep of {} s after {}/{} iterations; "
+                  + "relative cell-volume residual={}, tolerance={}, pressureCorrectionLimited={}",
+              getName(), dtActual, timeIntegrator.getCoupledPressureMomentumIterations(),
               timeIntegrator.getCoupledPressureMomentumMaximumIterations(),
               timeIntegrator.getCoupledPressureMomentumVolumeResidual(),
               timeIntegrator.getCoupledPressureMomentumRelativeVolumeTolerance(),

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -4404,8 +4404,7 @@ public class TwoFluidPipe extends Pipeline {
             + timeIntegrator.getCoupledPressureMomentumMaximumIterations() + ", relativeCellVolumeResidual="
             + timeIntegrator.getCoupledPressureMomentumVolumeResidual() + ", tolerance="
             + timeIntegrator.getCoupledPressureMomentumRelativeVolumeTolerance() + ", pressureCorrectionLimited="
-            + timeIntegrator.isCoupledPressureMomentumPressureCorrectionLimited()
-            + ", minimumMassFluxCorrectionScale="
+            + timeIntegrator.isCoupledPressureMomentumPressureCorrectionLimited() + ", minimumMassFluxCorrectionScale="
             + timeIntegrator.getCoupledPressureMomentumMinimumMassFluxCorrectionScale();
         transientCoupledPressureMomentumFailureDiagnostic = transientCoupledPressureMomentumFailureDiagnostic.isEmpty()
             ? rejectionDiagnostic

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -187,6 +187,9 @@ public class TwoFluidPipe extends Pipeline {
   /** Coupled nonlinear substeps rejected since the latest steady initialization. */
   private int transientCoupledPressureMomentumRejectedSubsteps = 0;
 
+  /** Exact diagnostics for coupled nonlinear substeps rejected since steady initialization. */
+  private String transientCoupledPressureMomentumFailureDiagnostic = "";
+
   /** Optional phase-resolved compressible volume supplying the inlet pressure boundary. */
   private UpstreamCompressibleVolume upstreamCompressibleVolume = null;
 
@@ -4158,6 +4161,7 @@ public class TwoFluidPipe extends Pipeline {
     transientCoupledPressureMomentumFailureDetected = false;
     transientCoupledPressureMomentumCorrectionLimited = false;
     transientCoupledPressureMomentumRejectedSubsteps = 0;
+    transientCoupledPressureMomentumFailureDiagnostic = "";
 
     // Initialize sections
     initializeSections();
@@ -4395,6 +4399,15 @@ public class TwoFluidPipe extends Pipeline {
         }
         transientCoupledPressureMomentumFailureDetected = true;
         transientCoupledPressureMomentumRejectedSubsteps++;
+        String rejectionDiagnostic = "elapsed=" + acceptedElapsedTime + " s, attemptedDt=" + dtActual
+            + " s, iterations=" + timeIntegrator.getCoupledPressureMomentumIterations() + "/"
+            + timeIntegrator.getCoupledPressureMomentumMaximumIterations() + ", relativeCellVolumeResidual="
+            + timeIntegrator.getCoupledPressureMomentumVolumeResidual() + ", tolerance="
+            + timeIntegrator.getCoupledPressureMomentumRelativeVolumeTolerance() + ", pressureCorrectionLimited="
+            + timeIntegrator.isCoupledPressureMomentumPressureCorrectionLimited();
+        transientCoupledPressureMomentumFailureDiagnostic =
+            transientCoupledPressureMomentumFailureDiagnostic.isEmpty() ? rejectionDiagnostic
+                : transientCoupledPressureMomentumFailureDiagnostic + "; " + rejectionDiagnostic;
         consecutiveCoupledPressureMomentumFailures++;
         equations.applyState(sections, U_prev);
         if (enableAdaptiveTimestepping) {
@@ -7769,6 +7782,15 @@ public class TwoFluidPipe extends Pipeline {
    */
   public int getTransientCoupledPressureMomentumRejectedSubsteps() {
     return transientCoupledPressureMomentumRejectedSubsteps;
+  }
+
+  /**
+   * Get exact diagnostics for rejected coupled nonlinear substeps since steady initialization.
+   *
+   * @return semicolon-separated rejection diagnostics, or an empty string when none were rejected
+   */
+  public String getTransientCoupledPressureMomentumFailureDiagnostic() {
+    return transientCoupledPressureMomentumFailureDiagnostic;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -4404,7 +4404,9 @@ public class TwoFluidPipe extends Pipeline {
             + timeIntegrator.getCoupledPressureMomentumMaximumIterations() + ", relativeCellVolumeResidual="
             + timeIntegrator.getCoupledPressureMomentumVolumeResidual() + ", tolerance="
             + timeIntegrator.getCoupledPressureMomentumRelativeVolumeTolerance() + ", pressureCorrectionLimited="
-            + timeIntegrator.isCoupledPressureMomentumPressureCorrectionLimited();
+            + timeIntegrator.isCoupledPressureMomentumPressureCorrectionLimited()
+            + ", minimumMassFluxCorrectionScale="
+            + timeIntegrator.getCoupledPressureMomentumMinimumMassFluxCorrectionScale();
         transientCoupledPressureMomentumFailureDiagnostic = transientCoupledPressureMomentumFailureDiagnostic.isEmpty()
             ? rejectionDiagnostic
             : transientCoupledPressureMomentumFailureDiagnostic + "; " + rejectionDiagnostic;

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -4249,6 +4249,10 @@ public class TwoFluidPipe extends Pipeline {
     int maxSubSteps = enableAdaptiveTimestepping ? 50000 : 10000;
     int stepCount = 0;
     int consecutiveCoupledPressureMomentumFailures = 0;
+    int lastRejectedCell = -1;
+    int lastRejectedVariable = -1;
+    double lastRejectedValue = Double.NaN;
+    double lastRejectedPreviousValue = Double.NaN;
 
     while (timeRemaining > 1e-12 && stepCount < maxSubSteps) {
       stepCount++;
@@ -4409,6 +4413,10 @@ public class TwoFluidPipe extends Pipeline {
           for (int j = 0; j < U_new[i].length; j++) {
             if (Double.isNaN(U_new[i][j]) || Double.isInfinite(U_new[i][j])) {
               stepRejected = true;
+              lastRejectedCell = i;
+              lastRejectedVariable = j;
+              lastRejectedValue = U_new[i][j];
+              lastRejectedPreviousValue = U_prev[i][j];
               break;
             }
           }
@@ -4421,6 +4429,10 @@ public class TwoFluidPipe extends Pipeline {
             for (int phase = 0; phase < 3; phase++) {
               if (U_new[i][phase] < -1.0e-12) {
                 stepRejected = true;
+                lastRejectedCell = i;
+                lastRejectedVariable = phase;
+                lastRejectedValue = U_new[i][phase];
+                lastRejectedPreviousValue = U_prev[i][phase];
                 break;
               }
             }
@@ -4612,7 +4624,9 @@ public class TwoFluidPipe extends Pipeline {
               + timeIntegrator.getCoupledPressureMomentumRelativeVolumeTolerance() + ", iterations="
               + timeIntegrator.getCoupledPressureMomentumIterations() + "/"
               + timeIntegrator.getCoupledPressureMomentumMaximumIterations() + ", pressureCorrectionLimited="
-              + timeIntegrator.isCoupledPressureMomentumPressureCorrectionLimited());
+              + timeIntegrator.isCoupledPressureMomentumPressureCorrectionLimited() + ", lastRejectedCell="
+              + lastRejectedCell + ", lastRejectedVariable=" + lastRejectedVariable + ", lastRejectedValue="
+              + lastRejectedValue + ", lastRejectedPreviousValue=" + lastRejectedPreviousValue);
     }
 
     setCalculationIdentifier(id);

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -4414,13 +4414,15 @@ public class TwoFluidPipe extends Pipeline {
           }
         }
 
-        // Check for negative mass (unphysical — indicates numerical blow-up)
+        // A positivity limiter can preserve total mass while moving mass between
+        // phases, so reject materially negative phase states before correction.
         if (!stepRejected) {
-          for (int i = 0; i < U_new.length; i++) {
-            // Mass variables are indices 0 (gas) and 1 (oil/liquid)
-            if (U_new[i][0] < -1e-3 || U_new[i][1] < -1e-3) {
-              stepRejected = true;
-              break;
+          for (int i = 0; i < U_new.length && !stepRejected; i++) {
+            for (int phase = 0; phase < 3; phase++) {
+              if (U_new[i][phase] < -1.0e-12) {
+                stepRejected = true;
+                break;
+              }
             }
           }
         }

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -4405,9 +4405,9 @@ public class TwoFluidPipe extends Pipeline {
             + timeIntegrator.getCoupledPressureMomentumVolumeResidual() + ", tolerance="
             + timeIntegrator.getCoupledPressureMomentumRelativeVolumeTolerance() + ", pressureCorrectionLimited="
             + timeIntegrator.isCoupledPressureMomentumPressureCorrectionLimited();
-        transientCoupledPressureMomentumFailureDiagnostic =
-            transientCoupledPressureMomentumFailureDiagnostic.isEmpty() ? rejectionDiagnostic
-                : transientCoupledPressureMomentumFailureDiagnostic + "; " + rejectionDiagnostic;
+        transientCoupledPressureMomentumFailureDiagnostic = transientCoupledPressureMomentumFailureDiagnostic.isEmpty()
+            ? rejectionDiagnostic
+            : transientCoupledPressureMomentumFailureDiagnostic + "; " + rejectionDiagnostic;
         consecutiveCoupledPressureMomentumFailures++;
         equations.applyState(sections, U_prev);
         if (enableAdaptiveTimestepping) {

--- a/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/TwoFluidPipe.java
@@ -4383,6 +4383,15 @@ public class TwoFluidPipe extends Pipeline {
       }
 
       if (coupledPressureMomentumEnabled && !timeIntegrator.isCoupledPressureMomentumConverged()) {
+        if (consecutiveCoupledPressureMomentumFailures == 0) {
+          logger.warn("{}: rejecting adaptive coupled pressure-momentum substep of {} s after {}/{} iterations; "
+              + "relative cell-volume residual={}, tolerance={}, pressureCorrectionLimited={}", getName(), dtActual,
+              timeIntegrator.getCoupledPressureMomentumIterations(),
+              timeIntegrator.getCoupledPressureMomentumMaximumIterations(),
+              timeIntegrator.getCoupledPressureMomentumVolumeResidual(),
+              timeIntegrator.getCoupledPressureMomentumRelativeVolumeTolerance(),
+              timeIntegrator.isCoupledPressureMomentumPressureCorrectionLimited());
+        }
         transientCoupledPressureMomentumFailureDetected = true;
         transientCoupledPressureMomentumRejectedSubsteps++;
         consecutiveCoupledPressureMomentumFailures++;

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -1,6 +1,7 @@
 package neqsim.process.equipment.pipeline.twophasepipe;
 
 import java.io.Serializable;
+import java.util.Map;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.BubbleSizeClosure;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.GeometryCalculator;
 import neqsim.process.equipment.pipeline.twophasepipe.closure.InterfacialFriction;
@@ -589,36 +590,31 @@ public class TwoFluidConservationEquations implements Serializable {
     for (TwoFluidSection sec : sections) {
       sec.updateThreePhaseProperties();
 
-      // Update flow regime
-      sec.setFlowRegime(flowRegimeDetector.detectFlowRegime(sec));
+      // Classify once so transient sources consume the same continuous transition
+      // weights as the steady hold-up calculation.
+      flowRegimeDetector.classify(sec);
+      Map<PipeSection.FlowRegime, Double> regimeWeights = sec.getRegimeWeights();
 
-      // Update stratified geometry if applicable
+      // A non-zero stratified share uses the same segment geometry on both sides
+      // of the transition, avoiding a second hard switch in the source terms.
       PipeSection.FlowRegime regime = sec.getFlowRegime();
-      if (regime == PipeSection.FlowRegime.STRATIFIED_SMOOTH || regime == PipeSection.FlowRegime.STRATIFIED_WAVY) {
+      if (regime == PipeSection.FlowRegime.STRATIFIED_SMOOTH
+          || regime == PipeSection.FlowRegime.STRATIFIED_WAVY
+          || hasStratifiedShare(regimeWeights)) {
         sec.updateStratifiedGeometry();
       }
 
-      // Calculate wall friction
-      WallFriction.WallFrictionResult wallResult = wallFriction.calculate(regime, sec.getGasVelocity(),
-          sec.getLiquidVelocity(), sec.getGasDensity(), sec.getLiquidDensity(), sec.getGasViscosity(),
-          sec.getLiquidViscosity(), sec.getLiquidHoldup(), sec.getDiameter(), sec.getRoughness());
-
+      WallFriction.WallFrictionResult wallResult = calculateWallFriction(sec, regimeWeights);
       sec.setGasWallShear(wallResult.gasWallShear);
       sec.setLiquidWallShear(wallResult.liquidWallShear);
 
-      // Calculate interfacial friction
-      InterfacialFriction.InterfacialFrictionResult ifResult = interfacialFriction.calculate(regime,
-          sec.getGasVelocity(), sec.getLiquidVelocity(), sec.getGasDensity(), sec.getLiquidDensity(),
-          sec.getGasViscosity(), sec.getLiquidViscosity(), sec.getLiquidHoldup(), sec.getDiameter(),
-          sec.getSurfaceTension());
-
+      InterfacialFriction.InterfacialFrictionResult ifResult =
+          calculateInterfacialFriction(sec, regimeWeights);
       sec.setInterfacialShear(ifResult.interfacialShear);
       sec.setInterfacialWidth(ifResult.interfacialAreaPerLength);
 
-      EntrainmentDeposition.EntrainmentResult entrainment = entrainmentDeposition.calculate(regime,
-          sec.getGasVelocity(), sec.getLiquidVelocity(), sec.getGasDensity(), sec.getLiquidDensity(),
-          sec.getGasViscosity(), sec.getLiquidViscosity(), sec.getSurfaceTension(), sec.getDiameter(),
-          sec.getLiquidHoldup());
+      EntrainmentDeposition.EntrainmentResult entrainment =
+          calculateEntrainment(sec, regimeWeights);
       sec.setEntrainmentFraction(entrainment.entrainmentFraction);
       sec.setEntrainedDropletDiameter(entrainment.dropletDiameter);
 
@@ -626,6 +622,128 @@ public class TwoFluidConservationEquations implements Serializable {
       sec.setInclinedSectionGasCarryoverNumber(gasCarryoverNumber);
       sec.setInclinedSectionLiquidFallbackPotential(gasCarryoverNumber < 1.0);
     }
+  }
+
+  private static boolean hasStratifiedShare(Map<PipeSection.FlowRegime, Double> weights) {
+    return weights != null
+        && (weights.containsKey(PipeSection.FlowRegime.STRATIFIED_SMOOTH)
+            || weights.containsKey(PipeSection.FlowRegime.STRATIFIED_WAVY));
+  }
+
+  private WallFriction.WallFrictionResult calculateWallFriction(
+      TwoFluidSection sec, Map<PipeSection.FlowRegime, Double> weights) {
+    if (weights == null) {
+      return wallFriction.calculate(
+          sec.getFlowRegime(),
+          sec.getGasVelocity(),
+          sec.getLiquidVelocity(),
+          sec.getGasDensity(),
+          sec.getLiquidDensity(),
+          sec.getGasViscosity(),
+          sec.getLiquidViscosity(),
+          sec.getLiquidHoldup(),
+          sec.getDiameter(),
+          sec.getRoughness());
+    }
+
+    WallFriction.WallFrictionResult blended = new WallFriction.WallFrictionResult();
+    for (Map.Entry<PipeSection.FlowRegime, Double> entry : weights.entrySet()) {
+      WallFriction.WallFrictionResult component =
+          wallFriction.calculate(
+              entry.getKey(),
+              sec.getGasVelocity(),
+              sec.getLiquidVelocity(),
+              sec.getGasDensity(),
+              sec.getLiquidDensity(),
+              sec.getGasViscosity(),
+              sec.getLiquidViscosity(),
+              sec.getLiquidHoldup(),
+              sec.getDiameter(),
+              sec.getRoughness());
+      blended.gasWallShear += entry.getValue() * component.gasWallShear;
+      blended.liquidWallShear += entry.getValue() * component.liquidWallShear;
+    }
+    return blended;
+  }
+
+  private InterfacialFriction.InterfacialFrictionResult calculateInterfacialFriction(
+      TwoFluidSection sec, Map<PipeSection.FlowRegime, Double> weights) {
+    if (weights == null) {
+      return interfacialFriction.calculate(
+          sec.getFlowRegime(),
+          sec.getGasVelocity(),
+          sec.getLiquidVelocity(),
+          sec.getGasDensity(),
+          sec.getLiquidDensity(),
+          sec.getGasViscosity(),
+          sec.getLiquidViscosity(),
+          sec.getLiquidHoldup(),
+          sec.getDiameter(),
+          sec.getSurfaceTension());
+    }
+
+    InterfacialFriction.InterfacialFrictionResult blended =
+        new InterfacialFriction.InterfacialFrictionResult();
+    for (Map.Entry<PipeSection.FlowRegime, Double> entry : weights.entrySet()) {
+      InterfacialFriction.InterfacialFrictionResult component =
+          interfacialFriction.calculate(
+              entry.getKey(),
+              sec.getGasVelocity(),
+              sec.getLiquidVelocity(),
+              sec.getGasDensity(),
+              sec.getLiquidDensity(),
+              sec.getGasViscosity(),
+              sec.getLiquidViscosity(),
+              sec.getLiquidHoldup(),
+              sec.getDiameter(),
+              sec.getSurfaceTension());
+      blended.interfacialShear += entry.getValue() * component.interfacialShear;
+      blended.interfacialAreaPerLength +=
+          entry.getValue() * component.interfacialAreaPerLength;
+    }
+    return blended;
+  }
+
+  private EntrainmentDeposition.EntrainmentResult calculateEntrainment(
+      TwoFluidSection sec, Map<PipeSection.FlowRegime, Double> weights) {
+    if (weights == null) {
+      return entrainmentDeposition.calculate(
+          sec.getFlowRegime(),
+          sec.getGasVelocity(),
+          sec.getLiquidVelocity(),
+          sec.getGasDensity(),
+          sec.getLiquidDensity(),
+          sec.getGasViscosity(),
+          sec.getLiquidViscosity(),
+          sec.getSurfaceTension(),
+          sec.getDiameter(),
+          sec.getLiquidHoldup());
+    }
+
+    EntrainmentDeposition.EntrainmentResult blended =
+        new EntrainmentDeposition.EntrainmentResult();
+    double weightedDropletDiameter = 0.0;
+    for (Map.Entry<PipeSection.FlowRegime, Double> entry : weights.entrySet()) {
+      EntrainmentDeposition.EntrainmentResult component =
+          entrainmentDeposition.calculate(
+              entry.getKey(),
+              sec.getGasVelocity(),
+              sec.getLiquidVelocity(),
+              sec.getGasDensity(),
+              sec.getLiquidDensity(),
+              sec.getGasViscosity(),
+              sec.getLiquidViscosity(),
+              sec.getSurfaceTension(),
+              sec.getDiameter(),
+              sec.getLiquidHoldup());
+      double weightedFraction = entry.getValue() * component.entrainmentFraction;
+      blended.entrainmentFraction += weightedFraction;
+      weightedDropletDiameter += weightedFraction * component.dropletDiameter;
+    }
+    if (blended.entrainmentFraction > 0.0) {
+      blended.dropletDiameter = weightedDropletDiameter / blended.entrainmentFraction;
+    }
+    return blended;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -763,13 +763,10 @@ public class TwoFluidConservationEquations implements Serializable {
               sec.getSurfaceTension(),
               sec.getDiameter(),
               sec.getLiquidHoldup());
-      double weightedFraction = entry.getValue() * component.entrainmentFraction;
-      blended.entrainmentFraction += weightedFraction;
-      weightedDropletDiameter += weightedFraction * component.dropletDiameter;
+      blended.entrainmentFraction += entry.getValue() * component.entrainmentFraction;
+      weightedDropletDiameter += entry.getValue() * component.dropletDiameter;
     }
-    if (blended.entrainmentFraction > 0.0) {
-      blended.dropletDiameter = weightedDropletDiameter / blended.entrainmentFraction;
-    }
+    blended.dropletDiameter = weightedDropletDiameter;
     return blended;
   }
 

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -624,12 +624,25 @@ public class TwoFluidConservationEquations implements Serializable {
     }
   }
 
+  /**
+   * Returns whether continuous closure blending includes stratified geometry.
+   *
+   * @param weights dimensionless normalized regime weights, or {@code null} outside a transition
+   * @return {@code true} when a stratified closure has non-zero weight
+   */
   private static boolean hasStratifiedShare(Map<PipeSection.FlowRegime, Double> weights) {
     return weights != null
         && (weights.containsKey(PipeSection.FlowRegime.STRATIFIED_SMOOTH)
             || weights.containsKey(PipeSection.FlowRegime.STRATIFIED_WAVY));
   }
 
+  /**
+   * Calculates wall shear from the active regime or its continuous transition weights.
+   *
+   * @param sec local pipe state
+   * @param weights dimensionless normalized regime weights, or {@code null} outside a transition
+   * @return wall-friction result in Pa
+   */
   private WallFriction.WallFrictionResult calculateWallFriction(
       TwoFluidSection sec, Map<PipeSection.FlowRegime, Double> weights) {
     if (weights == null) {
@@ -666,6 +679,13 @@ public class TwoFluidConservationEquations implements Serializable {
     return blended;
   }
 
+  /**
+   * Calculates interfacial shear from the active regime or its transition weights.
+   *
+   * @param sec local pipe state
+   * @param weights dimensionless normalized regime weights, or {@code null} outside a transition
+   * @return interfacial shear in Pa and area per length in m
+   */
   private InterfacialFriction.InterfacialFrictionResult calculateInterfacialFriction(
       TwoFluidSection sec, Map<PipeSection.FlowRegime, Double> weights) {
     if (weights == null) {
@@ -704,6 +724,13 @@ public class TwoFluidConservationEquations implements Serializable {
     return blended;
   }
 
+  /**
+   * Calculates entrainment properties from the active regime or its transition weights.
+   *
+   * @param sec local pipe state
+   * @param weights dimensionless normalized regime weights, or {@code null} outside a transition
+   * @return dimensionless entrainment fraction and droplet diameter in m
+   */
   private EntrainmentDeposition.EntrainmentResult calculateEntrainment(
       TwoFluidSection sec, Map<PipeSection.FlowRegime, Double> weights) {
     if (weights == null) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/TwoFluidConservationEquations.java
@@ -598,8 +598,7 @@ public class TwoFluidConservationEquations implements Serializable {
       // A non-zero stratified share uses the same segment geometry on both sides
       // of the transition, avoiding a second hard switch in the source terms.
       PipeSection.FlowRegime regime = sec.getFlowRegime();
-      if (regime == PipeSection.FlowRegime.STRATIFIED_SMOOTH
-          || regime == PipeSection.FlowRegime.STRATIFIED_WAVY
+      if (regime == PipeSection.FlowRegime.STRATIFIED_SMOOTH || regime == PipeSection.FlowRegime.STRATIFIED_WAVY
           || hasStratifiedShare(regimeWeights)) {
         sec.updateStratifiedGeometry();
       }
@@ -608,13 +607,11 @@ public class TwoFluidConservationEquations implements Serializable {
       sec.setGasWallShear(wallResult.gasWallShear);
       sec.setLiquidWallShear(wallResult.liquidWallShear);
 
-      InterfacialFriction.InterfacialFrictionResult ifResult =
-          calculateInterfacialFriction(sec, regimeWeights);
+      InterfacialFriction.InterfacialFrictionResult ifResult = calculateInterfacialFriction(sec, regimeWeights);
       sec.setInterfacialShear(ifResult.interfacialShear);
       sec.setInterfacialWidth(ifResult.interfacialAreaPerLength);
 
-      EntrainmentDeposition.EntrainmentResult entrainment =
-          calculateEntrainment(sec, regimeWeights);
+      EntrainmentDeposition.EntrainmentResult entrainment = calculateEntrainment(sec, regimeWeights);
       sec.setEntrainmentFraction(entrainment.entrainmentFraction);
       sec.setEntrainedDropletDiameter(entrainment.dropletDiameter);
 
@@ -631,9 +628,8 @@ public class TwoFluidConservationEquations implements Serializable {
    * @return {@code true} when a stratified closure has non-zero weight
    */
   private static boolean hasStratifiedShare(Map<PipeSection.FlowRegime, Double> weights) {
-    return weights != null
-        && (weights.containsKey(PipeSection.FlowRegime.STRATIFIED_SMOOTH)
-            || weights.containsKey(PipeSection.FlowRegime.STRATIFIED_WAVY));
+    return weights != null && (weights.containsKey(PipeSection.FlowRegime.STRATIFIED_SMOOTH)
+        || weights.containsKey(PipeSection.FlowRegime.STRATIFIED_WAVY));
   }
 
   /**
@@ -643,36 +639,19 @@ public class TwoFluidConservationEquations implements Serializable {
    * @param weights dimensionless normalized regime weights, or {@code null} outside a transition
    * @return wall-friction result in Pa
    */
-  private WallFriction.WallFrictionResult calculateWallFriction(
-      TwoFluidSection sec, Map<PipeSection.FlowRegime, Double> weights) {
+  private WallFriction.WallFrictionResult calculateWallFriction(TwoFluidSection sec,
+      Map<PipeSection.FlowRegime, Double> weights) {
     if (weights == null) {
-      return wallFriction.calculate(
-          sec.getFlowRegime(),
-          sec.getGasVelocity(),
-          sec.getLiquidVelocity(),
-          sec.getGasDensity(),
-          sec.getLiquidDensity(),
-          sec.getGasViscosity(),
-          sec.getLiquidViscosity(),
-          sec.getLiquidHoldup(),
-          sec.getDiameter(),
-          sec.getRoughness());
+      return wallFriction.calculate(sec.getFlowRegime(), sec.getGasVelocity(), sec.getLiquidVelocity(),
+          sec.getGasDensity(), sec.getLiquidDensity(), sec.getGasViscosity(), sec.getLiquidViscosity(),
+          sec.getLiquidHoldup(), sec.getDiameter(), sec.getRoughness());
     }
 
     WallFriction.WallFrictionResult blended = new WallFriction.WallFrictionResult();
     for (Map.Entry<PipeSection.FlowRegime, Double> entry : weights.entrySet()) {
-      WallFriction.WallFrictionResult component =
-          wallFriction.calculate(
-              entry.getKey(),
-              sec.getGasVelocity(),
-              sec.getLiquidVelocity(),
-              sec.getGasDensity(),
-              sec.getLiquidDensity(),
-              sec.getGasViscosity(),
-              sec.getLiquidViscosity(),
-              sec.getLiquidHoldup(),
-              sec.getDiameter(),
-              sec.getRoughness());
+      WallFriction.WallFrictionResult component = wallFriction.calculate(entry.getKey(), sec.getGasVelocity(),
+          sec.getLiquidVelocity(), sec.getGasDensity(), sec.getLiquidDensity(), sec.getGasViscosity(),
+          sec.getLiquidViscosity(), sec.getLiquidHoldup(), sec.getDiameter(), sec.getRoughness());
       blended.gasWallShear += entry.getValue() * component.gasWallShear;
       blended.liquidWallShear += entry.getValue() * component.liquidWallShear;
     }
@@ -686,40 +665,22 @@ public class TwoFluidConservationEquations implements Serializable {
    * @param weights dimensionless normalized regime weights, or {@code null} outside a transition
    * @return interfacial shear in Pa and area per length in m
    */
-  private InterfacialFriction.InterfacialFrictionResult calculateInterfacialFriction(
-      TwoFluidSection sec, Map<PipeSection.FlowRegime, Double> weights) {
+  private InterfacialFriction.InterfacialFrictionResult calculateInterfacialFriction(TwoFluidSection sec,
+      Map<PipeSection.FlowRegime, Double> weights) {
     if (weights == null) {
-      return interfacialFriction.calculate(
-          sec.getFlowRegime(),
-          sec.getGasVelocity(),
-          sec.getLiquidVelocity(),
-          sec.getGasDensity(),
-          sec.getLiquidDensity(),
-          sec.getGasViscosity(),
-          sec.getLiquidViscosity(),
-          sec.getLiquidHoldup(),
-          sec.getDiameter(),
-          sec.getSurfaceTension());
+      return interfacialFriction.calculate(sec.getFlowRegime(), sec.getGasVelocity(), sec.getLiquidVelocity(),
+          sec.getGasDensity(), sec.getLiquidDensity(), sec.getGasViscosity(), sec.getLiquidViscosity(),
+          sec.getLiquidHoldup(), sec.getDiameter(), sec.getSurfaceTension());
     }
 
-    InterfacialFriction.InterfacialFrictionResult blended =
-        new InterfacialFriction.InterfacialFrictionResult();
+    InterfacialFriction.InterfacialFrictionResult blended = new InterfacialFriction.InterfacialFrictionResult();
     for (Map.Entry<PipeSection.FlowRegime, Double> entry : weights.entrySet()) {
-      InterfacialFriction.InterfacialFrictionResult component =
-          interfacialFriction.calculate(
-              entry.getKey(),
-              sec.getGasVelocity(),
-              sec.getLiquidVelocity(),
-              sec.getGasDensity(),
-              sec.getLiquidDensity(),
-              sec.getGasViscosity(),
-              sec.getLiquidViscosity(),
-              sec.getLiquidHoldup(),
-              sec.getDiameter(),
-              sec.getSurfaceTension());
+      InterfacialFriction.InterfacialFrictionResult component = interfacialFriction.calculate(entry.getKey(),
+          sec.getGasVelocity(), sec.getLiquidVelocity(), sec.getGasDensity(), sec.getLiquidDensity(),
+          sec.getGasViscosity(), sec.getLiquidViscosity(), sec.getLiquidHoldup(), sec.getDiameter(),
+          sec.getSurfaceTension());
       blended.interfacialShear += entry.getValue() * component.interfacialShear;
-      blended.interfacialAreaPerLength +=
-          entry.getValue() * component.interfacialAreaPerLength;
+      blended.interfacialAreaPerLength += entry.getValue() * component.interfacialAreaPerLength;
     }
     return blended;
   }
@@ -731,38 +692,21 @@ public class TwoFluidConservationEquations implements Serializable {
    * @param weights dimensionless normalized regime weights, or {@code null} outside a transition
    * @return dimensionless entrainment fraction and droplet diameter in m
    */
-  private EntrainmentDeposition.EntrainmentResult calculateEntrainment(
-      TwoFluidSection sec, Map<PipeSection.FlowRegime, Double> weights) {
+  private EntrainmentDeposition.EntrainmentResult calculateEntrainment(TwoFluidSection sec,
+      Map<PipeSection.FlowRegime, Double> weights) {
     if (weights == null) {
-      return entrainmentDeposition.calculate(
-          sec.getFlowRegime(),
-          sec.getGasVelocity(),
-          sec.getLiquidVelocity(),
-          sec.getGasDensity(),
-          sec.getLiquidDensity(),
-          sec.getGasViscosity(),
-          sec.getLiquidViscosity(),
-          sec.getSurfaceTension(),
-          sec.getDiameter(),
-          sec.getLiquidHoldup());
+      return entrainmentDeposition.calculate(sec.getFlowRegime(), sec.getGasVelocity(), sec.getLiquidVelocity(),
+          sec.getGasDensity(), sec.getLiquidDensity(), sec.getGasViscosity(), sec.getLiquidViscosity(),
+          sec.getSurfaceTension(), sec.getDiameter(), sec.getLiquidHoldup());
     }
 
-    EntrainmentDeposition.EntrainmentResult blended =
-        new EntrainmentDeposition.EntrainmentResult();
+    EntrainmentDeposition.EntrainmentResult blended = new EntrainmentDeposition.EntrainmentResult();
     double weightedDropletDiameter = 0.0;
     for (Map.Entry<PipeSection.FlowRegime, Double> entry : weights.entrySet()) {
-      EntrainmentDeposition.EntrainmentResult component =
-          entrainmentDeposition.calculate(
-              entry.getKey(),
-              sec.getGasVelocity(),
-              sec.getLiquidVelocity(),
-              sec.getGasDensity(),
-              sec.getLiquidDensity(),
-              sec.getGasViscosity(),
-              sec.getLiquidViscosity(),
-              sec.getSurfaceTension(),
-              sec.getDiameter(),
-              sec.getLiquidHoldup());
+      EntrainmentDeposition.EntrainmentResult component = entrainmentDeposition.calculate(entry.getKey(),
+          sec.getGasVelocity(), sec.getLiquidVelocity(), sec.getGasDensity(), sec.getLiquidDensity(),
+          sec.getGasViscosity(), sec.getLiquidViscosity(), sec.getSurfaceTension(), sec.getDiameter(),
+          sec.getLiquidHoldup());
       blended.entrainmentFraction += entry.getValue() * component.entrainmentFraction;
       weightedDropletDiameter += entry.getValue() * component.dropletDiameter;
     }

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
@@ -54,10 +54,11 @@ public final class CoupledPressureMomentumSolver implements Serializable {
     private final double maximumRelativeVolumeResidual;
     private final boolean converged;
     private final boolean pressureCorrectionLimited;
+    private final double minimumMassFluxCorrectionScale;
 
     private Result(double[][] state, double[] pressure, double[] gasDensity, double[] oilDensity, double[] waterDensity,
         double[] outletBoundaryMassCorrectionKg, int iterations, double maximumRelativeVolumeResidual,
-        boolean converged, boolean pressureCorrectionLimited) {
+        boolean converged, boolean pressureCorrectionLimited, double minimumMassFluxCorrectionScale) {
       this.state = state;
       this.pressure = pressure;
       this.gasDensity = gasDensity;
@@ -68,6 +69,7 @@ public final class CoupledPressureMomentumSolver implements Serializable {
       this.maximumRelativeVolumeResidual = maximumRelativeVolumeResidual;
       this.converged = converged;
       this.pressureCorrectionLimited = pressureCorrectionLimited;
+      this.minimumMassFluxCorrectionScale = minimumMassFluxCorrectionScale;
     }
 
     /** @return corrected conservative state */
@@ -119,6 +121,21 @@ public final class CoupledPressureMomentumSolver implements Serializable {
     public boolean isPressureCorrectionLimited() {
       return pressureCorrectionLimited;
     }
+
+    /** @return smallest phase-mass positivity scale used by the nonlinear correction */
+    public double getMinimumMassFluxCorrectionScale() {
+      return minimumMassFluxCorrectionScale;
+    }
+  }
+
+  private static final class MassFluxCorrectionResult {
+    private final double[] outletBoundaryMassCorrectionKg;
+    private final double minimumScale;
+
+    private MassFluxCorrectionResult(double[] outletBoundaryMassCorrectionKg, double minimumScale) {
+      this.outletBoundaryMassCorrectionKg = outletBoundaryMassCorrectionKg;
+      this.minimumScale = minimumScale;
+    }
   }
 
   /**
@@ -155,6 +172,7 @@ public final class CoupledPressureMomentumSolver implements Serializable {
     double[] outletBoundaryMassCorrectionKg = new double[PHASE_COUNT];
     boolean converged = false;
     boolean correctionLimited = false;
+    double minimumMassFluxCorrectionScale = 1.0;
     double maximumResidual = calculateMaximumRelativeVolumeResidual(correctedState, areas, densities);
 
     while (iterations < maximumIterations && maximumResidual > relativeVolumeTolerance) {
@@ -212,11 +230,12 @@ public final class CoupledPressureMomentumSolver implements Serializable {
         }
       }
 
-      double[] iterationOutletCorrection = applyConservativeMassFluxCorrection(correctedState, timeStep,
+      MassFluxCorrectionResult massFluxCorrection = applyConservativeMassFluxCorrection(correctedState, timeStep,
           pressureCorrection, phaseAreas, areas, lengths, densities, outletPressureFixed);
       for (int phase = 0; phase < PHASE_COUNT; phase++) {
-        outletBoundaryMassCorrectionKg[phase] += iterationOutletCorrection[phase];
+        outletBoundaryMassCorrectionKg[phase] += massFluxCorrection.outletBoundaryMassCorrectionKg[phase];
       }
+      minimumMassFluxCorrectionScale = Math.min(minimumMassFluxCorrectionScale, massFluxCorrection.minimumScale);
       applyMomentumCorrection(correctedState, timeStep, pressureCorrection, phaseAreas, lengths);
 
       for (int cell = 0; cell < cellCount; cell++) {
@@ -234,7 +253,7 @@ public final class CoupledPressureMomentumSolver implements Serializable {
     converged = maximumResidual <= relativeVolumeTolerance;
     return new Result(correctedState, correctedPressure, densities[GAS_MASS], densities[OIL_MASS],
         densities[WATER_MASS], outletBoundaryMassCorrectionKg, iterations, maximumResidual, converged,
-        correctionLimited);
+        correctionLimited, minimumMassFluxCorrectionScale);
   }
 
   private static double[][] calculatePhaseAreas(double[][] state, double[][] densities) {
@@ -262,7 +281,7 @@ public final class CoupledPressureMomentumSolver implements Serializable {
     return faceArea * mobility;
   }
 
-  private static double[] applyConservativeMassFluxCorrection(double[][] state, double timeStep,
+  private static MassFluxCorrectionResult applyConservativeMassFluxCorrection(double[][] state, double timeStep,
       double[] pressureCorrection, double[][] phaseAreas, double[] areas, double[] lengths, double[][] densities,
       boolean outletPressureFixed) {
     int cellCount = state.length;
@@ -283,7 +302,8 @@ public final class CoupledPressureMomentumSolver implements Serializable {
       }
     }
 
-    limitCorrectionFluxesForPositivity(state, timeStep, faceMassFlowCorrection, lengths);
+    double minimumScale =
+        limitCorrectionFluxesForPositivity(state, timeStep, faceMassFlowCorrection, lengths);
 
     for (int cell = 0; cell < cellCount; cell++) {
       for (int phase = 0; phase < PHASE_COUNT; phase++) {
@@ -312,7 +332,7 @@ public final class CoupledPressureMomentumSolver implements Serializable {
         outletBoundaryMassCorrectionKg[phase] -= massPerLengthCorrection * lengths[outlet];
       }
     }
-    return outletBoundaryMassCorrectionKg;
+    return new MassFluxCorrectionResult(outletBoundaryMassCorrectionKg, minimumScale);
   }
 
   /**
@@ -329,10 +349,12 @@ public final class CoupledPressureMomentumSolver implements Serializable {
    * @param timeStep correction time step in s
    * @param faceMassFlowCorrection signed phase correction fluxes in kg/s
    * @param lengths cell lengths in m
+   * @return smallest dimensionless donor scale applied to a correction flux
    */
-  private static void limitCorrectionFluxesForPositivity(double[][] state, double timeStep,
+  private static double limitCorrectionFluxesForPositivity(double[][] state, double timeStep,
       double[][] faceMassFlowCorrection, double[] lengths) {
     int cellCount = state.length;
+    double minimumScale = 1.0;
     for (int phase = 0; phase < PHASE_COUNT; phase++) {
       double[] donorScale = new double[cellCount];
       for (int cell = 0; cell < cellCount; cell++) {
@@ -373,9 +395,11 @@ public final class CoupledPressureMomentumSolver implements Serializable {
       for (int face = 1; face < cellCount; face++) {
         double correction = faceMassFlowCorrection[phase][face];
         int donorCell = correction >= 0.0 ? face - 1 : face;
+        minimumScale = Math.min(minimumScale, donorScale[donorCell]);
         faceMassFlowCorrection[phase][face] *= donorScale[donorCell];
       }
     }
+    return minimumScale;
   }
 
   private static void applyMomentumCorrection(double[][] state, double timeStep, double[] pressureCorrection,

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
@@ -314,8 +314,8 @@ public final class CoupledPressureMomentumSolver implements Serializable {
       }
     }
 
-    double minimumScale =
-        limitCorrectionFluxesForPositivity(state, timeStep, faceMassFlowCorrection, faceScale, lengths);
+    double minimumScale = limitCorrectionFluxesForPositivity(state, timeStep, faceMassFlowCorrection, faceScale,
+        lengths);
 
     for (int cell = 0; cell < cellCount; cell++) {
       for (int phase = 0; phase < PHASE_COUNT; phase++) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
@@ -131,10 +131,13 @@ public final class CoupledPressureMomentumSolver implements Serializable {
   private static final class MassFluxCorrectionResult {
     private final double[] outletBoundaryMassCorrectionKg;
     private final double minimumScale;
+    private final double[][] faceScale;
 
-    private MassFluxCorrectionResult(double[] outletBoundaryMassCorrectionKg, double minimumScale) {
+    private MassFluxCorrectionResult(double[] outletBoundaryMassCorrectionKg, double minimumScale,
+        double[][] faceScale) {
       this.outletBoundaryMassCorrectionKg = outletBoundaryMassCorrectionKg;
       this.minimumScale = minimumScale;
+      this.faceScale = faceScale;
     }
   }
 
@@ -173,6 +176,12 @@ public final class CoupledPressureMomentumSolver implements Serializable {
     boolean converged = false;
     boolean correctionLimited = false;
     double minimumMassFluxCorrectionScale = 1.0;
+    double[][] activeFaceScale = new double[PHASE_COUNT][cellCount + 1];
+    for (int phase = 0; phase < PHASE_COUNT; phase++) {
+      for (int face = 0; face <= cellCount; face++) {
+        activeFaceScale[phase][face] = 1.0;
+      }
+    }
     double maximumResidual = calculateMaximumRelativeVolumeResidual(correctedState, areas, densities);
 
     while (iterations < maximumIterations && maximumResidual > relativeVolumeTolerance) {
@@ -194,14 +203,14 @@ public final class CoupledPressureMomentumSolver implements Serializable {
         double leftCoefficient = 0.0;
         if (cell > 0) {
           double faceDistance = 0.5 * (lengths[cell - 1] + lengths[cell]);
-          double mobility = faceMobility(cell - 1, cell, phaseAreas, areas, densities);
+          double mobility = faceMobility(cell - 1, cell, phaseAreas, areas, densities, activeFaceScale);
           leftCoefficient = timeStep * timeStep * mobility / (lengths[cell] * faceDistance);
         }
 
         double rightCoefficient = 0.0;
         if (cell < cellCount - 1) {
           double faceDistance = 0.5 * (lengths[cell] + lengths[cell + 1]);
-          double mobility = faceMobility(cell, cell + 1, phaseAreas, areas, densities);
+          double mobility = faceMobility(cell, cell + 1, phaseAreas, areas, densities, activeFaceScale);
           rightCoefficient = timeStep * timeStep * mobility / (lengths[cell] * faceDistance);
         }
 
@@ -236,6 +245,7 @@ public final class CoupledPressureMomentumSolver implements Serializable {
         outletBoundaryMassCorrectionKg[phase] += massFluxCorrection.outletBoundaryMassCorrectionKg[phase];
       }
       minimumMassFluxCorrectionScale = Math.min(minimumMassFluxCorrectionScale, massFluxCorrection.minimumScale);
+      activeFaceScale = massFluxCorrection.faceScale;
       applyMomentumCorrection(correctedState, timeStep, pressureCorrection, phaseAreas, lengths);
 
       for (int cell = 0; cell < cellCount; cell++) {
@@ -268,7 +278,8 @@ public final class CoupledPressureMomentumSolver implements Serializable {
   }
 
   private static double faceMobility(int leftCell, int rightCell, double[][] phaseAreas, double[] cellAreas,
-      double[][] densities) {
+      double[][] densities, double[][] activeFaceScale) {
+    int face = rightCell;
     double faceArea = 0.5 * (cellAreas[leftCell] + cellAreas[rightCell]);
     double mobility = 0.0;
     for (int phase = 0; phase < PHASE_COUNT; phase++) {
@@ -276,7 +287,7 @@ public final class CoupledPressureMomentumSolver implements Serializable {
       double rightAlpha = Math.max(0.0, Math.min(1.0, phaseAreas[phase][rightCell] / cellAreas[rightCell]));
       double alpha = 0.5 * (leftAlpha + rightAlpha);
       double density = 0.5 * (densities[phase][leftCell] + densities[phase][rightCell]);
-      mobility += alpha / Math.max(density, MIN_DENSITY);
+      mobility += activeFaceScale[phase][face] * alpha / Math.max(density, MIN_DENSITY);
     }
     return faceArea * mobility;
   }
@@ -286,6 +297,7 @@ public final class CoupledPressureMomentumSolver implements Serializable {
       boolean outletPressureFixed) {
     int cellCount = state.length;
     double[][] faceMassFlowCorrection = new double[PHASE_COUNT][cellCount + 1];
+    double[][] faceScale = new double[PHASE_COUNT][cellCount + 1];
 
     for (int face = 1; face < cellCount; face++) {
       int leftCell = face - 1;
@@ -302,7 +314,8 @@ public final class CoupledPressureMomentumSolver implements Serializable {
       }
     }
 
-    double minimumScale = limitCorrectionFluxesForPositivity(state, timeStep, faceMassFlowCorrection, lengths);
+    double minimumScale =
+        limitCorrectionFluxesForPositivity(state, timeStep, faceMassFlowCorrection, faceScale, lengths);
 
     for (int cell = 0; cell < cellCount; cell++) {
       for (int phase = 0; phase < PHASE_COUNT; phase++) {
@@ -331,7 +344,7 @@ public final class CoupledPressureMomentumSolver implements Serializable {
         outletBoundaryMassCorrectionKg[phase] -= massPerLengthCorrection * lengths[outlet];
       }
     }
-    return new MassFluxCorrectionResult(outletBoundaryMassCorrectionKg, minimumScale);
+    return new MassFluxCorrectionResult(outletBoundaryMassCorrectionKg, minimumScale, faceScale);
   }
 
   /**
@@ -347,11 +360,12 @@ public final class CoupledPressureMomentumSolver implements Serializable {
    * @param state provisional conservative state
    * @param timeStep correction time step in s
    * @param faceMassFlowCorrection signed phase correction fluxes in kg/s
+   * @param faceScale realized dimensionless correction scale at each phase face
    * @param lengths cell lengths in m
    * @return smallest dimensionless donor scale applied to a correction flux
    */
   private static double limitCorrectionFluxesForPositivity(double[][] state, double timeStep,
-      double[][] faceMassFlowCorrection, double[] lengths) {
+      double[][] faceMassFlowCorrection, double[][] faceScale, double[] lengths) {
     int cellCount = state.length;
     double minimumScale = 1.0;
     for (int phase = 0; phase < PHASE_COUNT; phase++) {
@@ -394,8 +408,9 @@ public final class CoupledPressureMomentumSolver implements Serializable {
       for (int face = 1; face < cellCount; face++) {
         double correction = faceMassFlowCorrection[phase][face];
         int donorCell = correction >= 0.0 ? face - 1 : face;
-        minimumScale = Math.min(minimumScale, donorScale[donorCell]);
-        faceMassFlowCorrection[phase][face] *= donorScale[donorCell];
+        faceScale[phase][face] = donorScale[donorCell];
+        minimumScale = Math.min(minimumScale, faceScale[phase][face]);
+        faceMassFlowCorrection[phase][face] *= faceScale[phase][face];
       }
     }
     return minimumScale;

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
@@ -283,6 +283,8 @@ public final class CoupledPressureMomentumSolver implements Serializable {
       }
     }
 
+    limitCorrectionFluxesForPositivity(state, timeStep, faceMassFlowCorrection, lengths);
+
     for (int cell = 0; cell < cellCount; cell++) {
       for (int phase = 0; phase < PHASE_COUNT; phase++) {
         double divergence = (faceMassFlowCorrection[phase][cell + 1] - faceMassFlowCorrection[phase][cell])
@@ -311,6 +313,43 @@ public final class CoupledPressureMomentumSolver implements Serializable {
       }
     }
     return outletBoundaryMassCorrectionKg;
+  }
+
+  /**
+   * Limit each correction face by the mass available in its donor cell.
+   *
+   * <p>
+   * Scaling a shared face flux preserves phase mass exactly across internal cells while preventing a trace phase from
+   * being transported below zero. Incoming correction flux is deliberately not credited when calculating availability,
+   * which keeps the bound conservative when both faces draw from the same cell.
+   * </p>
+   *
+   * @param state provisional conservative state
+   * @param timeStep correction time step in s
+   * @param faceMassFlowCorrection signed phase correction fluxes in kg/s
+   * @param lengths cell lengths in m
+   */
+  private static void limitCorrectionFluxesForPositivity(double[][] state, double timeStep,
+      double[][] faceMassFlowCorrection, double[] lengths) {
+    int cellCount = state.length;
+    for (int phase = 0; phase < PHASE_COUNT; phase++) {
+      double[] donorScale = new double[cellCount];
+      for (int cell = 0; cell < cellCount; cell++) {
+        double leftOutflow = Math.max(-faceMassFlowCorrection[phase][cell], 0.0);
+        double rightOutflow = Math.max(faceMassFlowCorrection[phase][cell + 1], 0.0);
+        double requestedOutflowMass = timeStep * (leftOutflow + rightOutflow);
+        double availableMass = Math.max(state[cell][phase], 0.0) * lengths[cell];
+        donorScale[cell] = requestedOutflowMass > availableMass && requestedOutflowMass > 0.0
+            ? availableMass / requestedOutflowMass
+            : 1.0;
+      }
+
+      for (int face = 1; face < cellCount; face++) {
+        double correction = faceMassFlowCorrection[phase][face];
+        int donorCell = correction >= 0.0 ? face - 1 : face;
+        faceMassFlowCorrection[phase][face] *= donorScale[donorCell];
+      }
+    }
   }
 
   private static void applyMomentumCorrection(double[][] state, double timeStep, double[] pressureCorrection,

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
@@ -319,9 +319,10 @@ public final class CoupledPressureMomentumSolver implements Serializable {
    * Limit each correction face by the mass available in its donor cell.
    *
    * <p>
-   * Scaling a shared face flux preserves phase mass exactly across internal cells while preventing a trace phase from
-   * being transported below zero. Incoming correction flux is deliberately not credited when calculating availability,
-   * which keeps the bound conservative when both faces draw from the same cell.
+   * Every internal face keeps one shared scale, so its transfer remains exactly conservative. The
+   * donor scales are reduced monotonically until each cell's initial mass plus already-limited
+   * incoming correction can supply its outgoing correction. Crediting only feasible incoming mass
+   * avoids the excessive damping caused by independently limiting each cell from initial inventory.
    * </p>
    *
    * @param state provisional conservative state
@@ -335,13 +336,39 @@ public final class CoupledPressureMomentumSolver implements Serializable {
     for (int phase = 0; phase < PHASE_COUNT; phase++) {
       double[] donorScale = new double[cellCount];
       for (int cell = 0; cell < cellCount; cell++) {
-        double leftOutflow = Math.max(-faceMassFlowCorrection[phase][cell], 0.0);
-        double rightOutflow = Math.max(faceMassFlowCorrection[phase][cell + 1], 0.0);
-        double requestedOutflowMass = timeStep * (leftOutflow + rightOutflow);
-        double availableMass = Math.max(state[cell][phase], 0.0) * lengths[cell];
-        donorScale[cell] = requestedOutflowMass > availableMass && requestedOutflowMass > 0.0
-            ? availableMass / requestedOutflowMass
-            : 1.0;
+        donorScale[cell] = 1.0;
+      }
+
+      // A decrease can propagate at most one donor farther through the line per pass.
+      for (int pass = 0; pass < cellCount; pass++) {
+        boolean changed = false;
+        for (int cell = 0; cell < cellCount; cell++) {
+          double leftCorrection = faceMassFlowCorrection[phase][cell];
+          double rightCorrection = faceMassFlowCorrection[phase][cell + 1];
+          double requestedOutflowRate = Math.max(-leftCorrection, 0.0) + Math.max(rightCorrection, 0.0);
+          if (!(requestedOutflowRate > 0.0)) {
+            continue;
+          }
+
+          double feasibleIncomingRate = 0.0;
+          if (leftCorrection > 0.0 && cell > 0) {
+            feasibleIncomingRate += leftCorrection * donorScale[cell - 1];
+          }
+          if (rightCorrection < 0.0 && cell < cellCount - 1) {
+            feasibleIncomingRate -= rightCorrection * donorScale[cell + 1];
+          }
+
+          double availableMass =
+              Math.max(state[cell][phase], 0.0) * lengths[cell] + timeStep * feasibleIncomingRate;
+          double permittedScale = Math.min(1.0, availableMass / (timeStep * requestedOutflowRate));
+          if (permittedScale < donorScale[cell]) {
+            donorScale[cell] = Math.max(permittedScale, 0.0);
+            changed = true;
+          }
+        }
+        if (!changed) {
+          break;
+        }
       }
 
       for (int face = 1; face < cellCount; face++) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
@@ -319,10 +319,10 @@ public final class CoupledPressureMomentumSolver implements Serializable {
    * Limit each correction face by the mass available in its donor cell.
    *
    * <p>
-   * Every internal face keeps one shared scale, so its transfer remains exactly conservative. The
-   * donor scales are reduced monotonically until each cell's initial mass plus already-limited
-   * incoming correction can supply its outgoing correction. Crediting only feasible incoming mass
-   * avoids the excessive damping caused by independently limiting each cell from initial inventory.
+   * Every internal face keeps one shared scale, so its transfer remains exactly conservative. The donor scales are
+   * reduced monotonically until each cell's initial mass plus already-limited incoming correction can supply its
+   * outgoing correction. Crediting only feasible incoming mass avoids the excessive damping caused by independently
+   * limiting each cell from initial inventory.
    * </p>
    *
    * @param state provisional conservative state
@@ -358,8 +358,7 @@ public final class CoupledPressureMomentumSolver implements Serializable {
             feasibleIncomingRate -= rightCorrection * donorScale[cell + 1];
           }
 
-          double availableMass =
-              Math.max(state[cell][phase], 0.0) * lengths[cell] + timeStep * feasibleIncomingRate;
+          double availableMass = Math.max(state[cell][phase], 0.0) * lengths[cell] + timeStep * feasibleIncomingRate;
           double permittedScale = Math.min(1.0, availableMass / (timeStep * requestedOutflowRate));
           if (permittedScale < donorScale[cell]) {
             donorScale[cell] = Math.max(permittedScale, 0.0);

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/CoupledPressureMomentumSolver.java
@@ -302,8 +302,7 @@ public final class CoupledPressureMomentumSolver implements Serializable {
       }
     }
 
-    double minimumScale =
-        limitCorrectionFluxesForPositivity(state, timeStep, faceMassFlowCorrection, lengths);
+    double minimumScale = limitCorrectionFluxesForPositivity(state, timeStep, faceMassFlowCorrection, lengths);
 
     for (int cell = 0; cell < cellCount; cell++) {
       for (int phase = 0; phase < PHASE_COUNT; phase++) {

--- a/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/twophasepipe/numerics/TimeIntegrator.java
@@ -688,6 +688,12 @@ public class TimeIntegrator implements Serializable {
     return lastCoupledPressureMomentumResult != null && lastCoupledPressureMomentumResult.isPressureCorrectionLimited();
   }
 
+  /** @return smallest phase-mass positivity scale used by the latest correction */
+  public double getCoupledPressureMomentumMinimumMassFluxCorrectionScale() {
+    return lastCoupledPressureMomentumResult == null ? Double.NaN
+        : lastCoupledPressureMomentumResult.getMinimumMassFluxCorrectionScale();
+  }
+
   /** @return signed gas, oil, and water outlet mass corrections in kg */
   public double[] getCoupledPressureMomentumOutletMassCorrectionKg() {
     return lastCoupledPressureMomentumResult == null ? new double[3]

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/CoupledPressureMomentumTengesdalProgressTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/CoupledPressureMomentumTengesdalProgressTest.java
@@ -135,7 +135,8 @@ class CoupledPressureMomentumTengesdalProgressTest {
           "refined coupled correction failed at interval " + (step + 1));
       for (Phase phase : Phase.values()) {
         assertTrue(balance.getRelativeResidual(phase) < 1.0e-9,
-            phase + " refined-mesh mass residual exceeded tolerance at interval " + (step + 1));
+            phase + " refined-mesh mass residual exceeded tolerance at interval " + (step + 1) + ": "
+                + balance.getRelativeResidual(phase));
       }
     }
 

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/CoupledPressureMomentumTengesdalProgressTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/CoupledPressureMomentumTengesdalProgressTest.java
@@ -142,9 +142,8 @@ class CoupledPressureMomentumTengesdalProgressTest {
 
     assertEquals(5.0, pipe.getSimulationTime(), 1.0e-9);
     assertFalse(pipe.isTransientOutletBackflowClamped());
-    assertFalse(pipe.isTransientCoupledPressureMomentumFailureDetected(),
-        "refined coupled solve recorded " + pipe.getTransientCoupledPressureMomentumRejectedSubsteps()
-            + " rejected substeps");
+    assertFalse(pipe.isTransientCoupledPressureMomentumFailureDetected(), "refined coupled solve recorded "
+        + pipe.getTransientCoupledPressureMomentumRejectedSubsteps() + " rejected substeps");
     assertEquals(0, pipe.getTransientCoupledPressureMomentumRejectedSubsteps());
   }
 

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/CoupledPressureMomentumTengesdalProgressTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/CoupledPressureMomentumTengesdalProgressTest.java
@@ -143,7 +143,8 @@ class CoupledPressureMomentumTengesdalProgressTest {
     assertEquals(5.0, pipe.getSimulationTime(), 1.0e-9);
     assertFalse(pipe.isTransientOutletBackflowClamped());
     assertFalse(pipe.isTransientCoupledPressureMomentumFailureDetected(), "refined coupled solve recorded "
-        + pipe.getTransientCoupledPressureMomentumRejectedSubsteps() + " rejected substeps");
+        + pipe.getTransientCoupledPressureMomentumRejectedSubsteps() + " rejected substeps: "
+        + pipe.getTransientCoupledPressureMomentumFailureDiagnostic());
     assertEquals(0, pipe.getTransientCoupledPressureMomentumRejectedSubsteps());
   }
 

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/CoupledPressureMomentumTengesdalProgressTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/CoupledPressureMomentumTengesdalProgressTest.java
@@ -142,9 +142,9 @@ class CoupledPressureMomentumTengesdalProgressTest {
 
     assertEquals(5.0, pipe.getSimulationTime(), 1.0e-9);
     assertFalse(pipe.isTransientOutletBackflowClamped());
-    assertFalse(pipe.isTransientCoupledPressureMomentumFailureDetected(), "refined coupled solve recorded "
-        + pipe.getTransientCoupledPressureMomentumRejectedSubsteps() + " rejected substeps: "
-        + pipe.getTransientCoupledPressureMomentumFailureDiagnostic());
+    assertFalse(pipe.isTransientCoupledPressureMomentumFailureDetected(),
+        "refined coupled solve recorded " + pipe.getTransientCoupledPressureMomentumRejectedSubsteps()
+            + " rejected substeps: " + pipe.getTransientCoupledPressureMomentumFailureDiagnostic());
     assertEquals(0, pipe.getTransientCoupledPressureMomentumRejectedSubsteps());
   }
 

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/CoupledPressureMomentumTengesdalProgressTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/CoupledPressureMomentumTengesdalProgressTest.java
@@ -142,7 +142,9 @@ class CoupledPressureMomentumTengesdalProgressTest {
 
     assertEquals(5.0, pipe.getSimulationTime(), 1.0e-9);
     assertFalse(pipe.isTransientOutletBackflowClamped());
-    assertFalse(pipe.isTransientCoupledPressureMomentumFailureDetected());
+    assertFalse(pipe.isTransientCoupledPressureMomentumFailureDetected(),
+        "refined coupled solve recorded " + pipe.getTransientCoupledPressureMomentumRejectedSubsteps()
+            + " rejected substeps");
     assertEquals(0, pipe.getTransientCoupledPressureMomentumRejectedSubsteps());
   }
 

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeHorizontalTransitionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeHorizontalTransitionTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.pipeline.twophasepipe.PipeSection.FlowRegime;
+import neqsim.process.equipment.pipeline.twophasepipe.closure.InterfacialFriction;
+import neqsim.process.equipment.pipeline.twophasepipe.closure.WallFriction;
 
 /**
  * Regression tests for the horizontal annular transition in {@link FlowRegimeDetector}.
@@ -229,6 +231,131 @@ class FlowRegimeHorizontalTransitionTest {
 
     Assertions.assertTrue(largestStep < 0.2,
         "a blended transition must not step a regime weight by more than 0.2 per 0.02 m/s, but stepped " + largestStep);
+  }
+
+  /**
+   * Transient momentum sources must consume the detector's continuous regime weights.
+   *
+   * <p>
+   * This is a calculation-level check: it compares the source evaluator's stored wall and
+   * interfacial stresses with the convex combination of the same authoritative closure models.
+   * </p>
+   */
+  @Test
+  @DisplayName("Transient sources consume continuous regime weights")
+  void testTransientSourcesConsumeRegimeWeights() {
+    TwoFluidConservationEquations equations = new TwoFluidConservationEquations();
+    boolean foundTransition = false;
+
+    for (int i = 0; i <= 200; i++) {
+      double superficialGas = 0.5 + i * 0.02;
+      TwoFluidSection upstream = transientSection(0.0, superficialGas);
+      TwoFluidSection downstream = transientSection(100.0, superficialGas);
+
+      equations.calcRHS(new TwoFluidSection[] {upstream, downstream}, 100.0);
+      Map<FlowRegime, Double> weights = upstream.getRegimeWeights();
+      if (weights == null || weights.size() < 2) {
+        continue;
+      }
+      foundTransition = true;
+
+      WallFriction wallFriction = new WallFriction();
+      InterfacialFriction interfacialFriction = new InterfacialFriction();
+      double expectedGasWallShear = 0.0;
+      double expectedLiquidWallShear = 0.0;
+      double expectedInterfacialShear = 0.0;
+      double expectedInterfacialArea = 0.0;
+
+      for (Map.Entry<FlowRegime, Double> entry : weights.entrySet()) {
+        WallFriction.WallFrictionResult wall =
+            wallFriction.calculate(
+                entry.getKey(),
+                upstream.getGasVelocity(),
+                upstream.getLiquidVelocity(),
+                upstream.getGasDensity(),
+                upstream.getLiquidDensity(),
+                upstream.getGasViscosity(),
+                upstream.getLiquidViscosity(),
+                upstream.getLiquidHoldup(),
+                upstream.getDiameter(),
+                upstream.getRoughness());
+        InterfacialFriction.InterfacialFrictionResult interfacial =
+            interfacialFriction.calculate(
+                entry.getKey(),
+                upstream.getGasVelocity(),
+                upstream.getLiquidVelocity(),
+                upstream.getGasDensity(),
+                upstream.getLiquidDensity(),
+                upstream.getGasViscosity(),
+                upstream.getLiquidViscosity(),
+                upstream.getLiquidHoldup(),
+                upstream.getDiameter(),
+                upstream.getSurfaceTension());
+        expectedGasWallShear += entry.getValue() * wall.gasWallShear;
+        expectedLiquidWallShear += entry.getValue() * wall.liquidWallShear;
+        expectedInterfacialShear += entry.getValue() * interfacial.interfacialShear;
+        expectedInterfacialArea += entry.getValue() * interfacial.interfacialAreaPerLength;
+      }
+
+      assertRelativeEquals(expectedGasWallShear, upstream.getGasWallShear());
+      assertRelativeEquals(expectedLiquidWallShear, upstream.getLiquidWallShear());
+      assertRelativeEquals(expectedInterfacialShear, upstream.getInterfacialShear());
+      assertRelativeEquals(expectedInterfacialArea, upstream.getInterfacialWidth());
+      break;
+    }
+
+    Assertions.assertTrue(foundTransition, "the sweep must cross at least one blended regime transition");
+  }
+
+  /**
+   * Builds a fully initialized transient section for source evaluation.
+   *
+   * @param position axial coordinate, in m
+   * @param superficialGas superficial gas velocity, in m/s
+   * @return initialized two-fluid section
+   */
+  private TwoFluidSection transientSection(double position, double superficialGas) {
+    TwoFluidSection section = new TwoFluidSection(position, 100.0, SMALL_LINE_DIAMETER, 0.0);
+    section.setPressure(50.0e5);
+    section.setTemperature(300.0);
+    section.setGasDensity(40.0);
+    section.setOilDensity(RHO_L);
+    section.setWaterDensity(1000.0);
+    section.setLiquidDensity(RHO_L);
+    section.setGasViscosity(1.0e-5);
+    section.setOilViscosity(MU_L);
+    section.setWaterViscosity(1.0e-3);
+    section.setLiquidViscosity(MU_L);
+    section.setGasSoundSpeed(300.0);
+    section.setLiquidSoundSpeed(1200.0);
+    section.setGasEnthalpy(1.0e5);
+    section.setLiquidEnthalpy(5.0e4);
+    section.setSurfaceTension(SIGMA);
+    section.setRoughness(4.6e-5);
+    section.setGasHoldup(ALPHA_G);
+    section.setLiquidHoldup(ALPHA_L);
+    section.setOilHoldup(ALPHA_L);
+    section.setWaterHoldup(0.0);
+    section.setWaterCut(0.0);
+    section.setOilFractionInLiquid(1.0);
+    section.setGasVelocity(superficialGas / ALPHA_G);
+    section.setLiquidVelocity(0.035 / ALPHA_L);
+    section.setOilVelocity(0.035 / ALPHA_L);
+    section.setWaterVelocity(0.035 / ALPHA_L);
+    section.updateConservativeVariables();
+    section.updateDerivedQuantities();
+    return section;
+  }
+
+  /**
+   * Asserts equality with a relative tolerance suitable for closure-source calculations.
+   *
+   * @param expected expected value
+   * @param actual actual value
+   */
+  private void assertRelativeEquals(double expected, double actual) {
+    double tolerance = 1.0e-12 * Math.max(1.0, Math.abs(expected));
+    Assertions.assertEquals(expected, actual, tolerance);
   }
 
   /**

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeHorizontalTransitionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeHorizontalTransitionTest.java
@@ -252,7 +252,7 @@ class FlowRegimeHorizontalTransitionTest {
       TwoFluidSection upstream = transientSection(0.0, superficialGas);
       TwoFluidSection downstream = transientSection(100.0, superficialGas);
 
-      equations.calcRHS(new TwoFluidSection[] {upstream, downstream}, 100.0);
+      equations.calcRHS(new TwoFluidSection[] { upstream, downstream }, 100.0);
       Map<FlowRegime, Double> weights = upstream.getRegimeWeights();
       if (weights == null || weights.size() < 2) {
         continue;

--- a/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeHorizontalTransitionTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/twophasepipe/FlowRegimeHorizontalTransitionTest.java
@@ -237,8 +237,8 @@ class FlowRegimeHorizontalTransitionTest {
    * Transient momentum sources must consume the detector's continuous regime weights.
    *
    * <p>
-   * This is a calculation-level check: it compares the source evaluator's stored wall and
-   * interfacial stresses with the convex combination of the same authoritative closure models.
+   * This is a calculation-level check: it compares the source evaluator's stored wall and interfacial stresses with the
+   * convex combination of the same authoritative closure models.
    * </p>
    */
   @Test
@@ -267,30 +267,14 @@ class FlowRegimeHorizontalTransitionTest {
       double expectedInterfacialArea = 0.0;
 
       for (Map.Entry<FlowRegime, Double> entry : weights.entrySet()) {
-        WallFriction.WallFrictionResult wall =
-            wallFriction.calculate(
-                entry.getKey(),
-                upstream.getGasVelocity(),
-                upstream.getLiquidVelocity(),
-                upstream.getGasDensity(),
-                upstream.getLiquidDensity(),
-                upstream.getGasViscosity(),
-                upstream.getLiquidViscosity(),
-                upstream.getLiquidHoldup(),
-                upstream.getDiameter(),
-                upstream.getRoughness());
-        InterfacialFriction.InterfacialFrictionResult interfacial =
-            interfacialFriction.calculate(
-                entry.getKey(),
-                upstream.getGasVelocity(),
-                upstream.getLiquidVelocity(),
-                upstream.getGasDensity(),
-                upstream.getLiquidDensity(),
-                upstream.getGasViscosity(),
-                upstream.getLiquidViscosity(),
-                upstream.getLiquidHoldup(),
-                upstream.getDiameter(),
-                upstream.getSurfaceTension());
+        WallFriction.WallFrictionResult wall = wallFriction.calculate(entry.getKey(), upstream.getGasVelocity(),
+            upstream.getLiquidVelocity(), upstream.getGasDensity(), upstream.getLiquidDensity(),
+            upstream.getGasViscosity(), upstream.getLiquidViscosity(), upstream.getLiquidHoldup(),
+            upstream.getDiameter(), upstream.getRoughness());
+        InterfacialFriction.InterfacialFrictionResult interfacial = interfacialFriction.calculate(entry.getKey(),
+            upstream.getGasVelocity(), upstream.getLiquidVelocity(), upstream.getGasDensity(),
+            upstream.getLiquidDensity(), upstream.getGasViscosity(), upstream.getLiquidViscosity(),
+            upstream.getLiquidHoldup(), upstream.getDiameter(), upstream.getSurfaceTension());
         expectedGasWallShear += entry.getValue() * wall.gasWallShear;
         expectedLiquidWallShear += entry.getValue() * wall.liquidWallShear;
         expectedInterfacialShear += entry.getValue() * interfacial.interfacialShear;


### PR DESCRIPTION
## Summary

Advances #3298 with continuous transient regime-source evaluation and an active-set-consistent pressure/mass-flux coupling for the WS1/WS2 dependency chain.

**Exact base:** `2f3d4c80de9312f45c39007aaa63a2753c31e64a`  
**Exact current head:** `aaa0607e0e5ff542010611fa49666708fadff3e1`

The capability contract is recorded in the [#3298 campaign ledger](https://github.com/equinor/neqsim/issues/3298#issuecomment-5549866435).

## Engineering question

Can the transient momentum/source path consume the continuous dimensionless regime weights already produced by `FlowRegimeDetector.classify(...)`, eliminating the observed `STRATIFIED_WAVY ↔ SLUG` source two-cycle, while a conservative phase-availability active set keeps the pressure operator consistent with realized face fluxes?

## Changes

- classifies each transient section once and reuses its normalized regime weights;
- blends existing wall shear, interfacial shear/area, geometry, and entrainment outputs by those weights;
- preserves original pure-regime closures, including droplet-diameter endpoint values;
- adds calculation-level regression coverage against direct convex combinations of the authoritative closures;
- limits coupled correction fluxes by donor-cell phase availability and rejects materially negative phase states;
- carries each realized conservative face scale into the next pressure-mobility assembly, removing mobility for a phase face clipped by the positivity active set;
- adds exact-head diagnostics for adaptive nonlinear rejections;
- updates both TwoFluidPipe references and the dynamic-simulation and flow-assurance skills.

Exactly ten files and 32 ordered commits are included. The last repair is bounded to the nonlinear active-set consistency exposed by exact-head diagnostics; the final commit applies the hosted Spotless artifact without behavior change.

## Dimensional and compatibility boundary

Regime weights and face scales are dimensionless, non-negative, and bounded. Outputs retain their units: shear in Pa, interfacial area per length in m, entrainment fraction dimensionless, droplet diameter in m, pressure in Pa, and mass flux in kg/s.

No transition criterion, dimensioned threshold, transition-band width, steady hold-up closure, friction formula, outlet boundary, solver tolerance/default, iteration budget, public API, or serialization contract changes. Separated stratified geometry is not applied as a new ANNULAR closure.

## Validation

**DRAFT — BROAD EXACT-HEAD CI AND ENGINEERING QUALIFICATION PENDING**

Hosted evidence on exact head `aaa0607e0e5ff542010611fa49666708fadff3e1`:

- branch is 32 commits ahead and zero behind the recorded base;
- exactly ten intended files changed;
- Documentation search coverage, Skills and agents lint, PaperLab Replication Gate, Spotless format patch, Pre-commit checks, and CodeQL Security Analysis pass;
- Javadocs and all four Java 21 slow-test shards pass;
- `CoupledPressureMomentumTengesdalProgressTest`: 3 tests passed, 0 failed, 0 errors, 0 skipped in 8.555 s;
- the repaired refined Tengesdal case completes its full 5.0 s horizon and retains each per-phase conservation assertion below `1e-9`;
- the volume tolerance remains `1e-7`, the nonlinear budget remains 24 iterations, and no physical closure was changed;
- Java 21 Ubuntu/Windows broad fast suites pass; Java 8 Ubuntu/Windows compatibility jobs are running.

The predecessor diagnostics found two recovered adaptive rejections with `minimumMassFluxCorrectionScale=0.0` while pressure correction was not limited. This demonstrated that donor-limited phase faces remained incorrectly mobile in the next pressure equation. The exact-head repair feeds those active face scales into the next pressure linearization, and the formerly failing Tengesdal slow shard now passes.

This head is not READY TO MERGE. Engineering qualification still requires the #3298 matrix: public Tengesdal outlet behavior no worse than baseline, liquid-rich 1,800 s inventory drift below 5%, 600 s severe-slugging amplitude/period/hold-up checks, nearby operating points, time/mesh refinement, and runtime control.

## Documentation impact

Updated `docs/process/TWOFLUIDPIPE_MODEL.md`, `docs/wiki/two_fluid_model.md`, `.github/skills/neqsim-dynamic-simulation/SKILL.md`, and `.github/skills/neqsim-flow-assurance/SKILL.md`.

No additional documentation change is needed for the active-set repair because it changes no user-facing input, unit, validity range, or configuration. Controls benchmark documentation is unchanged because WS5 is already qualified and this branch does not alter controls. OLGA-agent routing is unchanged because this continuation adds no simulator-routing or interoperability surface.

## Views

Java is authoritative. Python/JPype inherits the same `TwoFluidPipe` behavior. JSON and MCP have no independent closure endpoint. A notebook is not applicable to this solver-internal continuation; engineering validation remains mandatory.

## Portfolio and overlap

Portfolio occupancy is **6/10**. The other active autonomous capabilities do not overlap this transient source path. This is the sole active #3298 PR.

## Stop boundary

Dynamic use of existing regime weights and the directly coupled phase-availability active set only. No new regime map, transition tuning, hold-up closure, drift-flux slug closure, separated ANNULAR friction, high-hold-up WS4 change, proprietary-trace tuning, controls change, or unrelated solver redesign.

This PR must remain draft-only. Do not merge, mark ready, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push it as part of this campaign.

Generated with AI assistance.