### PR TITLE
[AI-Assisted] test(mcp): qualify simulation variable mutation

### DIFF
--- a/.github/workflows/mcp_protocol_qualification.yml
+++ b/.github/workflows/mcp_protocol_qualification.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Run focused adjustable-parameter Java contract
         run: mvn -B -Dtest=neqsim.mcp.runners.AutomationLoopRunnerTest test -ntp
 
+      - name: Run focused simulation-variable mutation Java contract
+        run: mvn -B -Dtest=neqsim.mcp.runners.AutomationVariableWriteContractTest test -ntp
+
       - name: Run focused pre-flight validator Java contract
         run: mvn -B -Dtest=neqsim.mcp.runners.ValidatorTest test -ntp
 
@@ -102,6 +105,9 @@ jobs:
 
       - name: Run focused real-MCP adjustable-parameter qualification
         run: cd neqsim-mcp-server && python test_adjustable_parameters_protocol.py
+
+      - name: Run focused real-MCP simulation-variable mutation qualification
+        run: cd neqsim-mcp-server && python test_simulation_variable_write_protocol.py
 
       - name: Run focused real-MCP pre-flight validation qualification
         run: cd neqsim-mcp-server && python test_validate_input_protocol.py

--- a/docs/simulation/process_automation.md
+++ b/docs/simulation/process_automation.md
@@ -201,7 +201,7 @@ The automation API covers 20+ equipment types:
 | `Separator` | temperature, pressure, liquidLevel + stream ports |
 | `ThreePhaseSeparator` | Same as Separator + waterLevel + waterOutStream |
 | `Tank` | temperature, pressure, liquidLevel + stream ports |
-| `Compressor` | outletPressure (INPUT), power, polytropicEfficiency, isentropicEfficiency, speed |
+| `Compressor` | outletPressure, polytropicEfficiency, isentropicEfficiency, speed (INPUT); power (OUTPUT) |
 | `CompressorTrain` | Same as Compressor (applied to first stage) |
 | `Expander` | outletPressure (INPUT), power, isentropicEfficiency |
 | `Pump` | outletPressure (INPUT), power |

--- a/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
+++ b/neqsim-mcp-server/docs/SURFACE_INVENTORY.md
@@ -16,7 +16,7 @@ manually maintained Java method list.
 | Tool implementations | 71 bindings / 60 classes | `getCapabilities.implementationInventory` | `McpImplementationInventory` |
 | Factory equipment | 207 types | `getCapabilities.implementationInventory` | `EquipmentFactory` |
 | Engineering report paths | 2 | `getCapabilities.implementationInventory` | `ReportRunner`, `TaskWorkflowBridge` |
-| MCP Java test classes | 69 | `getCapabilities.phase0EvidenceInventory` | `src/test/java/neqsim/mcp/**/*Test.java` |
+| MCP Java test classes | 70 | `getCapabilities.phase0EvidenceInventory` | `src/test/java/neqsim/mcp/**/*Test.java` |
 | MCP protocol scenarios | 94 | `getCapabilities.phase0EvidenceInventory` | `test_mcp_server.py` |
 | Focused API protocol scenarios | 3 | `getCapabilities.phase0EvidenceInventory` | `test_inspect_api_protocol.py` |
 | MCP guides | 8 | `getCapabilities.phase0EvidenceInventory` | Core guides, foundation traceability, fixtures, baseline harness, and campaign matrix |
@@ -87,7 +87,7 @@ does not claim that an external Word/HTML artifact has been generated or enginee
 ## Tests, guides, and known limitations
 
 `getCapabilities.phase0EvidenceInventory` freezes the remaining source-evidence dimensions of the
-Phase 0 inventory. The exact current source contains 69 JUnit test classes under
+Phase 0 inventory. The exact current source contains 70 JUnit test classes under
 `src/test/java/neqsim/mcp`, 94 named scenarios in the primary real-STDIO JSON-RPC harness
 `neqsim-mcp-server/test_mcp_server.py`, and three focused packaged-MCP API-inspection scenarios in
 `neqsim-mcp-server/test_inspect_api_protocol.py`. The primary protocol regression independently

--- a/neqsim-mcp-server/docs/evidence/SIMULATION_VARIABLE_WRITE_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/SIMULATION_VARIABLE_WRITE_CONTRACT.md
@@ -8,16 +8,18 @@ writes without implying numerical or plant-control authority?
 
 This Phase 0 increment qualifies that bounded software contract. Inventory remains **1.26 / 20 explicit + 25
 contract-tested + 26 confirmed gaps**, and `setSimulationVariable` remains `CONFIRMED_GAP` until a separate merged
-promotion increment updates the inventory atomically. No production runner, public schema, canonical process
-representation, thermodynamic model, deployment policy, or companion repository changes here.
+promotion increment updates the inventory atomically. The increment adds one narrow production correctness guard that
+aligns exact known OUTPUT writes with the already documented INPUT-only contract. There are no public schema, canonical
+process representation, thermodynamic model, deployment policy, or companion repository changes.
 
 ## Authoritative behavior
 
 `NeqSimTools.setSimulationVariable` applies the deployment-profile access gate, resolves an inline process definition or
 a reusable `manageModel` handle, and delegates to `AutomationRunner.setVariableAndRun`. The runner builds and executes
 the normal NeqSim `ProcessSystem`, resolves the declared address through `ProcessAutomation`, validates physical bounds,
-writes only an input variable, reruns the same process, and returns the post-run report through the standard MCP
-response envelope.
+rejects an exact address declared as an OUTPUT before mutation, writes only an input variable, reruns the same process,
+and returns the post-run report through the standard MCP response envelope. Unknown addresses retain the existing
+diagnostic and fuzzy-correction path rather than being misclassified as read-only.
 
 The qualification uses the catalogued `simple-separation` process and the writable `feed.temperature` address. A 35 °C
 setpoint is represented as the explicit pair `35.0` and `C`. The test checks the returned address, value, unit, solver
@@ -74,10 +76,12 @@ assumptions, limitations, measurements, facility constraints, and accountable en
 
 ## Documentation impact and stop boundary
 
-Documentation impact: this new evidence page records the existing user-visible mutation/rerun contract and its
-limitations; no public API guide or schema changes because production behavior and arguments are unchanged.
+Documentation impact: this evidence page records the enforced user-visible mutation/rerun contract and its limitations.
+The existing public automation guide and Javadocs already specify INPUT-only writes and read-only OUTPUT variables, so no
+guide or schema migration is required; implementation now matches that documented behavior.
 
 The increment stops at deterministic address resolution, one bounded input mutation, rerun/report sequencing,
-structured rejection, inline/model-handle equivalence, and packaged STDIO transport. It does not promote inventory,
-alter scientific trust metadata, change numerical behavior, qualify snapshot comparison, or claim model accuracy,
+structured rejection, inline/model-handle equivalence, and packaged STDIO transport. Apart from rejecting a previously
+accepted invalid OUTPUT write, it does not promote inventory, alter scientific trust metadata, change numerical
+behavior, qualify snapshot comparison, or claim model accuracy,
 optimization quality, plant authority, design certification, or accountable engineering approval.

--- a/neqsim-mcp-server/docs/evidence/SIMULATION_VARIABLE_WRITE_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/SIMULATION_VARIABLE_WRITE_CONTRACT.md
@@ -21,6 +21,9 @@ rejects an exact address declared as an OUTPUT before mutation, writes only an i
 and returns the post-run report through the standard MCP response envelope. Unknown addresses retain the existing
 diagnostic and fuzzy-correction path rather than being misclassified as read-only.
 
+Compressor `isentropicEfficiency` is declared as an INPUT, consistent with its existing setter and the corresponding
+pump and expander efficiency controls. This prevents the exact OUTPUT guard from rejecting a supported compressor input.
+
 The qualification uses the catalogued `simple-separation` process and the writable `feed.temperature` address. A 35 °C
 setpoint is represented as the explicit pair `35.0` and `C`. The test checks the returned address, value, unit, solver
 report object, validation state, and quality-gate verdict. It compares only contract fields between inline and registered

--- a/neqsim-mcp-server/docs/evidence/SIMULATION_VARIABLE_WRITE_CONTRACT.md
+++ b/neqsim-mcp-server/docs/evidence/SIMULATION_VARIABLE_WRITE_CONTRACT.md
@@ -1,0 +1,83 @@
+# Simulation-variable write contract qualification
+
+## Engineering question and maturity
+
+Can the existing `setSimulationVariable` MCP surface mutate one declared input on the canonical NeqSim process,
+rerun that process, retain requested engineering units and standard envelope evidence, and fail visibly on rejected
+writes without implying numerical or plant-control authority?
+
+This Phase 0 increment qualifies that bounded software contract. Inventory remains **1.26 / 20 explicit + 25
+contract-tested + 26 confirmed gaps**, and `setSimulationVariable` remains `CONFIRMED_GAP` until a separate merged
+promotion increment updates the inventory atomically. No production runner, public schema, canonical process
+representation, thermodynamic model, deployment policy, or companion repository changes here.
+
+## Authoritative behavior
+
+`NeqSimTools.setSimulationVariable` applies the deployment-profile access gate, resolves an inline process definition or
+a reusable `manageModel` handle, and delegates to `AutomationRunner.setVariableAndRun`. The runner builds and executes
+the normal NeqSim `ProcessSystem`, resolves the declared address through `ProcessAutomation`, validates physical bounds,
+writes only an input variable, reruns the same process, and returns the post-run report through the standard MCP
+response envelope.
+
+The qualification uses the catalogued `simple-separation` process and the writable `feed.temperature` address. A 35 °C
+setpoint is represented as the explicit pair `35.0` and `C`. The test checks the returned address, value, unit, solver
+report object, validation state, and quality-gate verdict. It compares only contract fields between inline and registered
+model-handle calls; transient report ordering or metadata is not treated as numerical equality evidence.
+
+## Rejection and state boundaries
+
+A temperature below absolute zero is rejected by the existing physical-bound diagnostics. A separator outlet temperature
+address is an output and must not be reported as a successful write. Empty process or address inputs fail closed. A
+rejected call must not claim that a post-mutation simulation report was produced.
+
+Each call reconstructs or resolves a canonical model and runs in the server process. This contract does not make the
+mutation persistent across calls, processes, restarts, clients, or deployments. Persistence remains owned by
+`manageState` and model/session lifecycle contracts. The distinct `saveSimulationState` and `compareSimulationStates`
+snapshot-diff semantics are not qualified here.
+
+## Acceptance evidence
+
+- `AutomationVariableWriteContractTest` checks a bounded Celsius write, rerun/report handoff, physical-bound rejection,
+  non-writable output rejection, standard envelope fields, and missing-input failures against
+  `ExampleCatalog.processSimpleSeparation()`.
+- `test_simulation_variable_write_protocol.py` obtains the same canonical fixture through packaged MCP, exercises inline
+  and `manageModel`-handle routes, repeats rejection cases, and proves Phase 0 accounting remains unpromoted.
+- `McpRunnerContractTest` retains the broad standard-response check for the public mutation surface.
+- `test_mcp_server.py` remains the authoritative packaged-protocol registration and accounting regression.
+- `mcp_protocol_qualification.yml` runs the focused Java and packaged-MCP mutation contracts before the comprehensive
+  protocol suite.
+
+Java and JSON/MCP views are applicable. Python is only a dependency-free protocol driver. Notebook, rendered-document,
+whole-sheet, public thermodynamic benchmark, facility-wide conservation, and optimization-quality gates are not
+applicable to this bounded software-contract qualification.
+
+## Units, assumptions, and limitations
+
+The setpoint uses degrees Celsius exactly as requested. The underlying fluid and process definition retain their
+catalogue units and normal NeqSim conversion path. Returning the requested value proves transport and address-unit
+handling; it does not independently prove the internal absolute-temperature state, phase equilibrium, equipment
+performance, or facility-wide mass and energy balances.
+
+The run assumes the public synthetic `simple-separation` fixture is sufficient to exercise one stream input mutation.
+It does not establish that every equipment input, alias, fuzzy correction, unit system, multiphase state, recycle,
+multi-area process, constraint, or operating envelope is feasible or correctly represented.
+
+## Security and advisory boundary
+
+`setSimulationVariable` is an engineering execution tool subject to `IndustrialProfile` access policy. Contract
+qualification does not grant repository, model, plant, control-system, DCS, historian, or digital-twin write permission.
+It does not create a closed-loop controller, bypass approval gates, issue operating instructions, or establish
+cybersecurity, identity, tenant-isolation, or deployment-hardening claims.
+
+The returned calculation remains advisory. Convergence, per-result provenance, warnings, validation maturity,
+assumptions, limitations, measurements, facility constraints, and accountable engineering review remain authoritative.
+
+## Documentation impact and stop boundary
+
+Documentation impact: this new evidence page records the existing user-visible mutation/rerun contract and its
+limitations; no public API guide or schema changes because production behavior and arguments are unchanged.
+
+The increment stops at deterministic address resolution, one bounded input mutation, rerun/report sequencing,
+structured rejection, inline/model-handle equivalence, and packaged STDIO transport. It does not promote inventory,
+alter scientific trust metadata, change numerical behavior, qualify snapshot comparison, or claim model accuracy,
+optimization quality, plant authority, design certification, or accountable engineering approval.

--- a/neqsim-mcp-server/test_adjustable_parameters_protocol.py
+++ b/neqsim-mcp-server/test_adjustable_parameters_protocol.py
@@ -179,7 +179,8 @@ def assert_registry(result):
         require(isinstance(unit, str), "parameter unit is not a string", parameter)
         if not unit:
             require(
-                parameter.get("targetProperty") == "polytropicEfficiency",
+                parameter.get("targetProperty")
+                in {"polytropicEfficiency", "isentropicEfficiency"},
                 "empty unit is reserved for qualified dimensionless properties",
                 parameter,
             )

--- a/neqsim-mcp-server/test_mcp_server.py
+++ b/neqsim-mcp-server/test_mcp_server.py
@@ -1499,8 +1499,8 @@ def test_capabilities():
     tests = evidence.get("tests", {})
     guides = evidence.get("guides", {})
     limitations = evidence.get("knownLimitations", {})
-    check("evidence inventory freezes 69 Java test classes",
-          tests.get("javaTestClassCount") == 69,
+    check("evidence inventory freezes 70 Java test classes",
+          tests.get("javaTestClassCount") == 70,
           str(tests))
     check("evidence inventory freezes 94 protocol scenarios",
           tests.get("protocolScenarioCount") == 94,

--- a/neqsim-mcp-server/test_simulation_variable_write_protocol.py
+++ b/neqsim-mcp-server/test_simulation_variable_write_protocol.py
@@ -1,0 +1,328 @@
+"""Focused packaged-MCP qualification for simulation-variable mutation.
+
+This dependency-free harness starts the packaged NeqSim MCP server over STDIO
+and qualifies the existing setSimulationVariable software contract against the
+canonical simple-separation process. It does not validate process accuracy,
+convergence adequacy, conservation, optimization, plant authority, or design
+approval.
+"""
+import json
+import subprocess
+import sys
+import time
+
+JAR = "target/neqsim-mcp-server-1.0.0-SNAPSHOT-runner.jar"
+
+
+class McpClient:
+    """Minimal line-delimited JSON-RPC client for packaged-server qualification."""
+
+    def __init__(self):
+        self.proc = None
+        self.message_id = 0
+
+    def next_id(self):
+        self.message_id += 1
+        return self.message_id
+
+    def send(self, message):
+        self.proc.stdin.write(json.dumps(message) + "\n")
+        self.proc.stdin.flush()
+
+    def receive(self):
+        line = self.proc.stdout.readline()
+        if not line:
+            stderr = self.proc.stderr.read() if self.proc and self.proc.stderr else ""
+            raise RuntimeError("MCP server closed stdout unexpectedly: " + stderr)
+        return json.loads(line)
+
+    def start(self):
+        self.proc = subprocess.Popen(
+            ["java", "-jar", JAR],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "neqsim-variable-write-contract-test",
+                        "version": "1.0",
+                    },
+                },
+            }
+        )
+        response = self.receive()
+        require("result" in response, "MCP initialize did not return a result", response)
+        self.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        time.sleep(0.2)
+
+    def call_tool(self, name, arguments):
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": self.next_id(),
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            }
+        )
+        response = self.receive()
+        content = response.get("result", {}).get("content", [])
+        require(content, "MCP tool call returned no content", response)
+        text = content[0].get("text", "")
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as error:
+            raise AssertionError(
+                f"MCP tool returned non-JSON content: {error}: {text}"
+            )
+
+    def manage_model(self, request):
+        return self.call_tool("manageModel", {"modelJson": json.dumps(request)})
+
+    def close(self):
+        if self.proc is None:
+            return
+        if self.proc.stdin:
+            self.proc.stdin.close()
+        try:
+            self.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.proc.terminate()
+            self.proc.wait(timeout=10)
+        self.proc = None
+
+
+def require(condition, message, detail=None):
+    """Raise a compact assertion with JSON detail when a contract fails."""
+    if condition:
+        return
+    suffix = ""
+    if detail is not None:
+        suffix = "\n" + json.dumps(detail, indent=2, sort_keys=True)
+    raise AssertionError(message + suffix)
+
+
+def payload(response):
+    """Return canonical data while retaining standardized envelope fields."""
+    data = response.get("data") if isinstance(response, dict) else None
+    if not isinstance(data, dict):
+        return response
+    merged = dict(data)
+    for key in (
+        "status",
+        "tool",
+        "code",
+        "errors",
+        "provenance",
+        "validation",
+        "qualityGate",
+    ):
+        if key in response:
+            merged.setdefault(key, response[key])
+    return merged
+
+
+def error_code(response):
+    """Return a stable error code from the standard response."""
+    result = payload(response)
+    if isinstance(result.get("code"), str):
+        return result["code"]
+    errors = result.get("errors")
+    if isinstance(errors, list) and errors and isinstance(errors[0], dict):
+        return errors[0].get("code")
+    return None
+
+
+def canonical_process(client):
+    """Retrieve the catalog process through MCP instead of duplicating model JSON."""
+    example = client.call_tool(
+        "getExample", {"category": "process", "name": "simple-separation"}
+    )
+    if isinstance(example, dict) and isinstance(example.get("data"), dict):
+        example = example["data"]
+    require(isinstance(example, dict), "simple-separation example is not an object", example)
+    require("process" in example, "simple-separation example omitted process", example)
+    return example
+
+
+def register_model(client, process):
+    """Register the same canonical definition for handle-routing qualification."""
+    result = payload(
+        client.manage_model(
+            {
+                "action": "register",
+                "name": "phase0-variable-write",
+                "version": "1.0.0",
+                "processJson": process,
+            }
+        )
+    )
+    require(result.get("status") == "success", "model registration failed", result)
+    model_id = result.get("modelId")
+    require(isinstance(model_id, str) and model_id, "registration omitted modelId", result)
+    return model_id
+
+
+def write_temperature(client, process_or_handle):
+    """Apply one bounded write in explicit Celsius units."""
+    return client.call_tool(
+        "setSimulationVariable",
+        {
+            "processJson": process_or_handle,
+            "address": "feed.temperature",
+            "value": 35.0,
+            "unit": "C",
+        },
+    )
+
+
+def assert_successful_write(response):
+    """Validate the write, rerun handoff, units, and standard envelope."""
+    result = payload(response)
+    require(result.get("status") == "success", "variable write failed", response)
+    require(result.get("tool") == "setSimulationVariable", "tool envelope drifted", response)
+    require(result.get("address") == "feed.temperature", "write address drifted", result)
+    require(result.get("value") == 35.0, "written value drifted", result)
+    require(result.get("unit") == "C", "requested Celsius unit drifted", result)
+    require(isinstance(result.get("simulationReport"), dict), "rerun report is absent", result)
+    require(
+        result.get("validation", {}).get("valid") is True,
+        "successful write lacks valid envelope",
+        response,
+    )
+    require(
+        result.get("qualityGate", {}).get("verdict") == "passed",
+        "successful write did not pass the software gate",
+        response,
+    )
+    return result
+
+
+def test_inline_write(client):
+    process = canonical_process(client)
+    assert_successful_write(write_temperature(client, json.dumps(process)))
+
+
+def test_model_handle_equivalence(client):
+    process = canonical_process(client)
+    direct = assert_successful_write(write_temperature(client, json.dumps(process)))
+    model_id = register_model(client, process)
+    try:
+        handled = assert_successful_write(write_temperature(client, model_id))
+        for key in ("status", "tool", "address", "value", "unit"):
+            require(handled.get(key) == direct.get(key), "handle write drifted", handled)
+    finally:
+        deleted = payload(client.manage_model({"action": "delete", "modelId": model_id}))
+        require(deleted.get("status") == "success", "model cleanup failed", deleted)
+
+
+def test_physical_bound_rejection(client):
+    process = canonical_process(client)
+    response = client.call_tool(
+        "setSimulationVariable",
+        {
+            "processJson": json.dumps(process),
+            "address": "feed.temperature",
+            "value": -300.0,
+            "unit": "C",
+        },
+    )
+    result = payload(response)
+    require(result.get("status") == "error", "invalid temperature was accepted", response)
+    require("simulationReport" not in result, "rejected write claimed a rerun report", response)
+    require(
+        result.get("qualityGate", {}).get("verdict") == "failed",
+        "invalid temperature did not fail the software gate",
+        response,
+    )
+
+
+def test_output_address_rejection(client):
+    process = canonical_process(client)
+    response = client.call_tool(
+        "setSimulationVariable",
+        {
+            "processJson": json.dumps(process),
+            "address": "HP Sep.gasOutStream.temperature",
+            "value": 35.0,
+            "unit": "C",
+        },
+    )
+    result = payload(response)
+    require(result.get("status") != "success", "read-only output was reported written", response)
+    require("simulationReport" not in result, "read-only rejection claimed a rerun report", response)
+    require(
+        result.get("qualityGate", {}).get("verdict") != "passed",
+        "read-only output passed the software gate",
+        response,
+    )
+
+
+def test_missing_input_fails_closed(client):
+    response = client.call_tool(
+        "setSimulationVariable",
+        {
+            "processJson": "",
+            "address": "feed.temperature",
+            "value": 35.0,
+            "unit": "C",
+        },
+    )
+    require(payload(response).get("status") == "error", "blank process was accepted", response)
+    require(error_code(response) == "INPUT_ERROR", "blank-process code drifted", response)
+
+
+def test_phase0_inventory_remains_unpromoted(client):
+    result = payload(client.call_tool("getCapabilities", {}))
+    inventory = result.get("phase0EvidenceInventory")
+    require(isinstance(inventory, dict), "capabilities omitted Phase 0 inventory", result)
+    limitations = inventory.get("knownLimitations", {})
+    record = limitations.get("coverageRecords", {}).get("setSimulationVariable", {})
+    require(inventory.get("inventoryVersion") == "1.26", "inventory version drifted", inventory)
+    require(
+        limitations.get("contractTestedToolCount") == 25
+        and limitations.get("confirmedGapToolCount") == 26,
+        "qualification changed inventory accounting",
+        limitations,
+    )
+    require(
+        record.get("coverageStatus") == "CONFIRMED_GAP",
+        "qualification prematurely promoted setSimulationVariable",
+        record,
+    )
+
+
+def main():
+    client = McpClient()
+    tests = [
+        ("inline canonical write", test_inline_write),
+        ("model-handle write equivalence", test_model_handle_equivalence),
+        ("physical-bound rejection", test_physical_bound_rejection),
+        ("read-only output rejection", test_output_address_rejection),
+        ("missing input fails closed", test_missing_input_fails_closed),
+        ("Phase 0 classification remains unpromoted", test_phase0_inventory_remains_unpromoted),
+    ]
+    try:
+        client.start()
+        for label, test in tests:
+            test(client)
+            print("PASS:", label)
+    finally:
+        client.close()
+    print(f"\n{len(tests)}/{len(tests)} variable-write contract scenarios passed.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print("FAIL:", error, file=sys.stderr)
+        sys.exit(1)

--- a/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
+++ b/src/main/java/neqsim/mcp/runners/McpEvidenceInventory.java
@@ -14,7 +14,7 @@ import com.google.gson.JsonParser;
  */
 public final class McpEvidenceInventory {
 
-  private static final int JAVA_TEST_CLASS_COUNT = 69;
+  private static final int JAVA_TEST_CLASS_COUNT = 70;
   private static final int PROTOCOL_SCENARIO_COUNT = 94;
   private static final int FOCUSED_API_PROTOCOL_SCENARIO_COUNT = 3;
 

--- a/src/main/java/neqsim/process/automation/ProcessAutomation.java
+++ b/src/main/java/neqsim/process/automation/ProcessAutomation.java
@@ -944,7 +944,7 @@ public class ProcessAutomation {
           "Compressor outlet pressure"));
       vars.add(new SimulationVariable(unitName + ".polytropicEfficiency", "polytropicEfficiency", VariableType.INPUT,
           "", "Polytropic efficiency (fraction)"));
-      vars.add(new SimulationVariable(unitName + ".isentropicEfficiency", "isentropicEfficiency", VariableType.OUTPUT,
+      vars.add(new SimulationVariable(unitName + ".isentropicEfficiency", "isentropicEfficiency", VariableType.INPUT,
           "", "Isentropic efficiency (fraction)"));
       vars.add(new SimulationVariable(unitName + ".power", "power", VariableType.OUTPUT, "kW",
           "Compressor power consumption"));

--- a/src/main/java/neqsim/process/automation/ProcessAutomation.java
+++ b/src/main/java/neqsim/process/automation/ProcessAutomation.java
@@ -628,7 +628,7 @@ public class ProcessAutomation {
     if (address == null || address.trim().isEmpty()) {
       throw new IllegalArgumentException("Address must not be null or empty");
     }
-    if (isAddressType(address, VariableType.OUTPUT)) {
+    if (!isWritableAddress(address) && isAddressType(address, VariableType.OUTPUT)) {
       throw new IllegalArgumentException("Variable is read-only: " + address);
     }
 

--- a/src/main/java/neqsim/process/automation/ProcessAutomation.java
+++ b/src/main/java/neqsim/process/automation/ProcessAutomation.java
@@ -380,6 +380,17 @@ public class ProcessAutomation {
    * @return true when the address resolves to a known INPUT variable, false otherwise (unknown or OUTPUT)
    */
   public boolean isWritableAddress(String address) {
+    return isAddressType(address, VariableType.INPUT);
+  }
+
+  /**
+   * Checks whether an exact address is declared with the requested variable type.
+   *
+   * @param address the dot-notation address, optionally area-qualified
+   * @param type the declared variable type to match
+   * @return true when the exact address is present with {@code type}
+   */
+  private boolean isAddressType(String address, VariableType type) {
     if (address == null || address.trim().isEmpty()) {
       return false;
     }
@@ -397,7 +408,7 @@ public class ProcessAutomation {
     }
     unitName = prefix + local.substring(0, dotIdx);
     try {
-      for (SimulationVariable v : getVariableList(unitName, VariableType.INPUT)) {
+      for (SimulationVariable v : getVariableList(unitName, type)) {
         if (address.equals(v.getAddress())) {
           return true;
         }
@@ -616,6 +627,9 @@ public class ProcessAutomation {
   public void setVariableValue(String address, double value, String unitOfMeasure) {
     if (address == null || address.trim().isEmpty()) {
       throw new IllegalArgumentException("Address must not be null or empty");
+    }
+    if (isAddressType(address, VariableType.OUTPUT)) {
+      throw new IllegalArgumentException("Variable is read-only: " + address);
     }
 
     // Separate area prefix if present

--- a/src/test/java/neqsim/mcp/runners/AutomationVariableWriteContractTest.java
+++ b/src/test/java/neqsim/mcp/runners/AutomationVariableWriteContractTest.java
@@ -22,7 +22,6 @@ class AutomationVariableWriteContractTest {
 
     assertEquals("success", root.get("status").getAsString());
     assertEquals("setSimulationVariable", root.get("tool").getAsString());
-    assertEquals("success", data.get("status").getAsString());
     assertEquals("feed.temperature", data.get("address").getAsString());
     assertEquals(35.0, data.get("value").getAsDouble(), 1.0e-12);
     assertEquals("C", data.get("unit").getAsString());
@@ -49,9 +48,10 @@ class AutomationVariableWriteContractTest {
         "HP Sep.gasOutStream.temperature", 35.0, "C"));
     JsonObject data = root.getAsJsonObject("data");
 
-    assertFalse("success".equals(root.get("status").getAsString()));
+    assertEquals("error", root.get("status").getAsString());
+    assertEquals("READ_ONLY_VARIABLE", data.get("category").getAsString());
     assertFalse(data.has("simulationReport"));
-    assertFalse("passed".equals(root.getAsJsonObject("qualityGate").get("verdict").getAsString()));
+    assertEquals("failed", root.getAsJsonObject("qualityGate").get("verdict").getAsString());
   }
 
   @Test

--- a/src/test/java/neqsim/mcp/runners/AutomationVariableWriteContractTest.java
+++ b/src/test/java/neqsim/mcp/runners/AutomationVariableWriteContractTest.java
@@ -16,8 +16,8 @@ class AutomationVariableWriteContractTest {
 
   @Test
   void testCanonicalTemperatureWriteRerunsAndReturnsReport() {
-    JsonObject root = parse(AutomationRunner.setVariableAndRun(ExampleCatalog.processSimpleSeparation(),
-        "feed.temperature", 35.0, "C"));
+    JsonObject root = parse(
+        AutomationRunner.setVariableAndRun(ExampleCatalog.processSimpleSeparation(), "feed.temperature", 35.0, "C"));
     JsonObject data = root.getAsJsonObject("data");
 
     assertEquals("success", root.get("status").getAsString());
@@ -34,8 +34,8 @@ class AutomationVariableWriteContractTest {
 
   @Test
   void testPhysicalBoundViolationFailsWithoutRerunClaim() {
-    JsonObject root = parse(AutomationRunner.setVariableAndRun(ExampleCatalog.processSimpleSeparation(),
-        "feed.temperature", -300.0, "C"));
+    JsonObject root = parse(
+        AutomationRunner.setVariableAndRun(ExampleCatalog.processSimpleSeparation(), "feed.temperature", -300.0, "C"));
     JsonObject data = root.getAsJsonObject("data");
 
     assertEquals("error", root.get("status").getAsString());
@@ -56,10 +56,9 @@ class AutomationVariableWriteContractTest {
 
   @Test
   void testMissingInputsFailClosed() {
-    JsonObject missingProcess =
-        parse(AutomationRunner.setVariableAndRun(null, "feed.temperature", 35.0, "C"));
-    JsonObject missingAddress =
-        parse(AutomationRunner.setVariableAndRun(ExampleCatalog.processSimpleSeparation(), null, 35.0, "C"));
+    JsonObject missingProcess = parse(AutomationRunner.setVariableAndRun(null, "feed.temperature", 35.0, "C"));
+    JsonObject missingAddress = parse(
+        AutomationRunner.setVariableAndRun(ExampleCatalog.processSimpleSeparation(), null, 35.0, "C"));
 
     assertEquals("error", missingProcess.get("status").getAsString());
     assertEquals("INPUT_ERROR", missingProcess.get("code").getAsString());

--- a/src/test/java/neqsim/mcp/runners/AutomationVariableWriteContractTest.java
+++ b/src/test/java/neqsim/mcp/runners/AutomationVariableWriteContractTest.java
@@ -1,0 +1,73 @@
+package neqsim.mcp.runners;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import neqsim.mcp.catalog.ExampleCatalog;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Focused software-contract tests for canonical simulation-variable mutation.
+ */
+class AutomationVariableWriteContractTest {
+
+  @Test
+  void testCanonicalTemperatureWriteRerunsAndReturnsReport() {
+    JsonObject root = parse(AutomationRunner.setVariableAndRun(ExampleCatalog.processSimpleSeparation(),
+        "feed.temperature", 35.0, "C"));
+    JsonObject data = root.getAsJsonObject("data");
+
+    assertEquals("success", root.get("status").getAsString());
+    assertEquals("setSimulationVariable", root.get("tool").getAsString());
+    assertEquals("success", data.get("status").getAsString());
+    assertEquals("feed.temperature", data.get("address").getAsString());
+    assertEquals(35.0, data.get("value").getAsDouble(), 1.0e-12);
+    assertEquals("C", data.get("unit").getAsString());
+    assertTrue(data.has("simulationReport"));
+    assertTrue(data.get("simulationReport").isJsonObject());
+    assertTrue(root.getAsJsonObject("validation").get("valid").getAsBoolean());
+    assertEquals("passed", root.getAsJsonObject("qualityGate").get("verdict").getAsString());
+  }
+
+  @Test
+  void testPhysicalBoundViolationFailsWithoutRerunClaim() {
+    JsonObject root = parse(AutomationRunner.setVariableAndRun(ExampleCatalog.processSimpleSeparation(),
+        "feed.temperature", -300.0, "C"));
+    JsonObject data = root.getAsJsonObject("data");
+
+    assertEquals("error", root.get("status").getAsString());
+    assertFalse(data.has("simulationReport"));
+    assertEquals("failed", root.getAsJsonObject("qualityGate").get("verdict").getAsString());
+  }
+
+  @Test
+  void testOutputAddressIsNotReportedAsSuccessfulWrite() {
+    JsonObject root = parse(AutomationRunner.setVariableAndRun(ExampleCatalog.processSimpleSeparation(),
+        "HP Sep.gasOutStream.temperature", 35.0, "C"));
+    JsonObject data = root.getAsJsonObject("data");
+
+    assertFalse("success".equals(root.get("status").getAsString()));
+    assertFalse(data.has("simulationReport"));
+    assertFalse("passed".equals(root.getAsJsonObject("qualityGate").get("verdict").getAsString()));
+  }
+
+  @Test
+  void testMissingInputsFailClosed() {
+    JsonObject missingProcess =
+        parse(AutomationRunner.setVariableAndRun(null, "feed.temperature", 35.0, "C"));
+    JsonObject missingAddress =
+        parse(AutomationRunner.setVariableAndRun(ExampleCatalog.processSimpleSeparation(), null, 35.0, "C"));
+
+    assertEquals("error", missingProcess.get("status").getAsString());
+    assertEquals("INPUT_ERROR", missingProcess.get("code").getAsString());
+    assertEquals("error", missingAddress.get("status").getAsString());
+    assertEquals("INPUT_ERROR", missingAddress.get("code").getAsString());
+  }
+
+  private static JsonObject parse(String json) {
+    return JsonParser.parseString(json).getAsJsonObject();
+  }
+}

--- a/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
+++ b/src/test/java/neqsim/mcp/runners/CapabilitiesRunnerTest.java
@@ -163,7 +163,7 @@ class CapabilitiesRunnerTest {
     JsonObject inventory = root.getAsJsonObject("phase0EvidenceInventory");
 
     JsonObject tests = inventory.getAsJsonObject("tests");
-    assertEquals(69, tests.get("javaTestClassCount").getAsInt());
+    assertEquals(70, tests.get("javaTestClassCount").getAsInt());
     assertEquals(94, tests.get("protocolScenarioCount").getAsInt());
 
     JsonObject guides = inventory.getAsJsonObject("guides");

--- a/src/test/java/neqsim/process/automation/ProcessAutomationTest.java
+++ b/src/test/java/neqsim/process/automation/ProcessAutomationTest.java
@@ -887,6 +887,7 @@ class ProcessAutomationTest {
 
   @Test
   void testCompressorIsentropicEfficiency() {
+    assertTrue(automation.isWritableAddress("Compressor.isentropicEfficiency"));
     automation.setVariableValue("Compressor.isentropicEfficiency", 0.85, null);
     double eff = automation.getVariableValue("Compressor.isentropicEfficiency", null);
     assertEquals(0.85, eff, 0.01);
@@ -1353,7 +1354,6 @@ class ProcessAutomationTest {
     // READ_ONLY_VARIABLE diagnostic via the safe accessor.
     String json = automation.setVariableValueSafe("Cooler.outletStream.temperature", 50.0, "C");
     com.google.gson.JsonObject root = com.google.gson.JsonParser.parseString(json).getAsJsonObject();
-    assertEquals("error", root.get("status").getAsString());
     assertEquals("READ_ONLY_VARIABLE", root.get("category").getAsString());
     assertFalse(automation.isDirty(), "Rejected OUTPUT write must not dirty the process");
   }

--- a/src/test/java/neqsim/process/automation/ProcessAutomationTest.java
+++ b/src/test/java/neqsim/process/automation/ProcessAutomationTest.java
@@ -1353,15 +1353,9 @@ class ProcessAutomationTest {
     // READ_ONLY_VARIABLE diagnostic via the safe accessor.
     String json = automation.setVariableValueSafe("Cooler.outletStream.temperature", 50.0, "C");
     com.google.gson.JsonObject root = com.google.gson.JsonParser.parseString(json).getAsJsonObject();
-    String status = root.get("status").getAsString();
-    if ("error".equals(status)) {
-      String cat = root.get("category").getAsString();
-      // Either READ_ONLY_VARIABLE or PROPERTY_NOT_FOUND is acceptable depending on
-      // how the underlying setter rejects the attempt.
-      assertTrue(
-          "READ_ONLY_VARIABLE".equals(cat) || "PROPERTY_NOT_FOUND".equals(cat) || "INVALID_ADDRESS_FORMAT".equals(cat),
-          "Expected error category for read-only set, got " + cat);
-    }
+    assertEquals("error", root.get("status").getAsString());
+    assertEquals("READ_ONLY_VARIABLE", root.get("category").getAsString());
+    assertFalse(automation.isDirty(), "Rejected OUTPUT write must not dirty the process");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Advances #3153 by qualifying and correcting the existing canonical `setSimulationVariable` mutation/rerun contract.

**Exact base:** `da1952aca48e46cbf6c11c75dd6a2f76be0043c2`  
**Exact head:** `a7b7426d11c19de8c2a425dbf756ea7f38a61005`

The original capability contract is recorded in [campaign #3153](https://github.com/equinor/neqsim/issues/3153#issuecomment-5551061360); the bounded repair acceptance is recorded in [the follow-up contract](https://github.com/equinor/neqsim/issues/3153#issuecomment-5552317752).

## Frozen scope

- add focused Java coverage for a bounded canonical input mutation and visible rejection paths;
- add six packaged-STDIO MCP scenarios, including inline/model-handle equivalence;
- enforce the existing INPUT-only write contract for exact, known OUTPUT addresses;
- preserve unknown-address diagnostics and fuzzy recovery;
- add explicit evidence, unit, state, security, advisory, and engineering limitations;
- run both focused gates before the comprehensive MCP protocol suite.

Exactly twelve files and seven commits are included. There are no public schema, canonical process representation, thermodynamic-model, deployment-policy, inventory, or companion-repository changes.

## Corrected behavior

`ProcessAutomation.setVariableValue` now rejects an exact address declared as `OUTPUT` before mutation. The classifier reuses the same typed variable registry as `isWritableAddress`. A dual-advertised address remains writable when it is present in both INPUT and OUTPUT views; only OUTPUT-only addresses are rejected. Unknown or misspelled addresses are not preclassified as read-only, preserving existing diagnostic and fuzzy auto-correction behavior.

The earlier branch-only envelope assertion is corrected because standard `status` belongs at the top level and is intentionally excluded from canonical `data`. Native `AutomationDiagnostics` JSON is likewise validated through its `category` field rather than an invented envelope field. The existing near-layer regression now requires `READ_ONLY_VARIABLE` and proves a rejected OUTPUT write does not dirty the process.

Compressor `isentropicEfficiency` is now declared as INPUT, matching its long-standing setter and the pump/expander efficiency descriptors. The regression explicitly preserves that supported write while the exact OUTPUT-only guard remains enforced.

## Validation

**READY TO MERGE — EXACT-HEAD VALIDATION COMPLETE**

On exact head `a7b7426d11c19de8c2a425dbf756ea7f38a61005`:

- focused Java mutation contract passes;
- packaged adjustable-parameter discovery: **3/3 passed**;
- packaged simulation-variable mutation: **6/6 passed**;
- comprehensive MCP protocol regression: **326/326 passed**;
- CodeQL, pre-commit/documentation, Spotless, PaperLab, Javadocs, and agent/skill validation pass;
- Java 21 fast suites on Ubuntu and Windows, all four Java 21 slow shards, and Java 8 suites on Ubuntu and Windows pass.

The accounting commit reconciles the canonical MCP Java test-source count from 69 to 70. The branch is exactly seven commits ahead of its recorded base. Current `master` is six non-overlapping commits beyond that base; the PR remains mergeable, so no synchronization or rebase was performed. No local Maven, Java, Python, Spotless, pre-commit, or documentation result is claimed.

Inventory remains `1.26 / 20 explicit + 25 contract-tested + 26 confirmed gaps`; `setSimulationVariable` remains `CONFIRMED_GAP` until a separate atomic promotion.

## Engineering and advisory boundary

The increment covers exact address typing, explicit Celsius handling, input mutation, rerun/report sequencing, standard envelopes, physical-bound rejection, exact read-only output rejection, fail-closed missing inputs, canonical `manageModel` handle routing, and packaged STDIO transport.

It does **not** establish numerical accuracy, convergence adequacy, component or energy closure, model completeness, mutation persistence, optimization quality, multi-area behavior, plant/control authority, design certification, cybersecurity assurance, or accountable engineering approval. The separate `saveSimulationState` and `compareSimulationStates` snapshot-diff semantics remain outside scope.

## Documentation impact

The evidence page records the enforced behavior, and the public automation variable table now identifies compressor pressure, efficiency, and speed controls as INPUT while power remains OUTPUT. No schema migration is required.

## Portfolio and overlap

Six other open autonomous implementation PRs are positively identified (#3477, #3483, #3485, #3486, #3487, and #3488); including this draft, portfolio occupancy is **7/10**, below the absolute ceiling. This remains the sole active #3153 PR, so the one-active-PR campaign rule prevents starting a second #3153 increment while it is open.

## Stop boundary

One canonical mutation capability only. Do not expand into snapshot comparison, persistence, optimization, numerical validation, generalized address redesign, or plant-control semantics.

This PR must remain draft-only. Do not merge, mark ready, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push it as part of this campaign.

Generated with AI assistance.