### PR TITLE
[AI-Assisted] feat(dexpi): preserve information-flow reference provenance

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -156,8 +156,11 @@ infer control intent, identify a safeguard or SIS function, or alter live simula
 `ImportResult.getInformationFlows()` exposes the corresponding source-ordered
 `MeasuringLineFunction` and `SignalLineFunction` evidence as immutable
 `DexpiInformationFlowInfo` records. Each record retains its source ID and component class, logical
-start and end IDs, whether those references resolve, and their resolved XML element names. Measuring
-lines additionally retain explicit attachment identity and resolution; signal lines retain the source
+start and end IDs, whether those references resolve, and their resolved XML element names. For each
+resolved logical source, logical target, and process attachment, the record also preserves the source
+object's explicit `ComponentClass`, `ComponentName`, and `TagName`; absent source metadata and
+unresolved references remain empty strings without invented values. Measuring lines additionally
+retain explicit attachment identity and resolution; signal lines retain the source
 `SignalConveyingTypeSpecialization`. Missing and unresolved references remain present beside the
 diagnostics, so Java and JPype callers do not need to reparse XML or invent endpoints. These records
 do not create live transmitters or controllers, infer control-loop intent, verify a loop, or classify

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiInformationFlowInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiInformationFlowInfo.java
@@ -33,12 +33,21 @@ public final class DexpiInformationFlowInfo implements Serializable {
   private final String sourceId;
   private final boolean sourceResolved;
   private final String sourceElementName;
+  private final String sourceComponentClass;
+  private final String sourceComponentName;
+  private final String sourceTagName;
   private final String targetId;
   private final boolean targetResolved;
   private final String targetElementName;
+  private final String targetComponentClass;
+  private final String targetComponentName;
+  private final String targetTagName;
   private final String attachmentId;
   private final boolean attachmentResolved;
   private final String attachmentElementName;
+  private final String attachmentComponentClass;
+  private final String attachmentComponentName;
+  private final String attachmentTagName;
   private final String signalConveyingType;
 
   /**
@@ -61,18 +70,64 @@ public final class DexpiInformationFlowInfo implements Serializable {
   public DexpiInformationFlowInfo(String id, Kind kind, String componentClass, String sourceId, boolean sourceResolved,
       String sourceElementName, String targetId, boolean targetResolved, String targetElementName, String attachmentId,
       boolean attachmentResolved, String attachmentElementName, String signalConveyingType) {
+    this(id, kind, componentClass, sourceId, sourceResolved, sourceElementName, "", "", "", targetId, targetResolved,
+        targetElementName, "", "", "", attachmentId, attachmentResolved, attachmentElementName, "", "", "",
+        signalConveyingType);
+  }
+
+  /**
+   * Creates immutable evidence with explicit metadata from resolved referenced elements.
+   *
+   * @param id source XML identity, or an empty string when absent
+   * @param kind supported information-flow kind
+   * @param componentClass source component class
+   * @param sourceId logical source identity, or an empty string when absent
+   * @param sourceResolved whether the logical source resolves to a source element
+   * @param sourceElementName resolved logical-source XML element name, or an empty string
+   * @param sourceComponentClass explicit logical-source component class, or an empty string
+   * @param sourceComponentName explicit logical-source component name, or an empty string
+   * @param sourceTagName explicit logical-source tag name, or an empty string
+   * @param targetId logical target identity, or an empty string when absent
+   * @param targetResolved whether the logical target resolves to a source element
+   * @param targetElementName resolved logical-target XML element name, or an empty string
+   * @param targetComponentClass explicit logical-target component class, or an empty string
+   * @param targetComponentName explicit logical-target component name, or an empty string
+   * @param targetTagName explicit logical-target tag name, or an empty string
+   * @param attachmentId process-attachment identity, or an empty string when absent
+   * @param attachmentResolved whether the process attachment resolves to a source element
+   * @param attachmentElementName resolved attachment XML element name, or an empty string
+   * @param attachmentComponentClass explicit attachment component class, or an empty string
+   * @param attachmentComponentName explicit attachment component name, or an empty string
+   * @param attachmentTagName explicit attachment tag name, or an empty string
+   * @param signalConveyingType signal medium/type, or an empty string when absent or not applicable
+   */
+  public DexpiInformationFlowInfo(String id, Kind kind, String componentClass, String sourceId, boolean sourceResolved,
+      String sourceElementName, String sourceComponentClass, String sourceComponentName, String sourceTagName,
+      String targetId, boolean targetResolved, String targetElementName, String targetComponentClass,
+      String targetComponentName, String targetTagName, String attachmentId, boolean attachmentResolved,
+      String attachmentElementName, String attachmentComponentClass, String attachmentComponentName,
+      String attachmentTagName, String signalConveyingType) {
     this.id = normalize(id);
     this.kind = Objects.requireNonNull(kind, "kind");
     this.componentClass = normalize(componentClass);
     this.sourceId = normalize(sourceId);
     this.sourceResolved = sourceResolved;
     this.sourceElementName = normalize(sourceElementName);
+    this.sourceComponentClass = normalize(sourceComponentClass);
+    this.sourceComponentName = normalize(sourceComponentName);
+    this.sourceTagName = normalize(sourceTagName);
     this.targetId = normalize(targetId);
     this.targetResolved = targetResolved;
     this.targetElementName = normalize(targetElementName);
+    this.targetComponentClass = normalize(targetComponentClass);
+    this.targetComponentName = normalize(targetComponentName);
+    this.targetTagName = normalize(targetTagName);
     this.attachmentId = normalize(attachmentId);
     this.attachmentResolved = attachmentResolved;
     this.attachmentElementName = normalize(attachmentElementName);
+    this.attachmentComponentClass = normalize(attachmentComponentClass);
+    this.attachmentComponentName = normalize(attachmentComponentName);
+    this.attachmentTagName = normalize(attachmentTagName);
     this.signalConveyingType = normalize(signalConveyingType);
   }
 
@@ -106,6 +161,21 @@ public final class DexpiInformationFlowInfo implements Serializable {
     return sourceElementName;
   }
 
+  /** @return explicit logical-source component class, or an empty string */
+  public String getSourceComponentClass() {
+    return sourceComponentClass;
+  }
+
+  /** @return explicit logical-source component name, or an empty string */
+  public String getSourceComponentName() {
+    return sourceComponentName;
+  }
+
+  /** @return explicit logical-source tag name, or an empty string */
+  public String getSourceTagName() {
+    return sourceTagName;
+  }
+
   /** @return logical target identity, or an empty string when absent */
   public String getTargetId() {
     return targetId;
@@ -119,6 +189,21 @@ public final class DexpiInformationFlowInfo implements Serializable {
   /** @return resolved logical-target XML element name, or an empty string */
   public String getTargetElementName() {
     return targetElementName;
+  }
+
+  /** @return explicit logical-target component class, or an empty string */
+  public String getTargetComponentClass() {
+    return targetComponentClass;
+  }
+
+  /** @return explicit logical-target component name, or an empty string */
+  public String getTargetComponentName() {
+    return targetComponentName;
+  }
+
+  /** @return explicit logical-target tag name, or an empty string */
+  public String getTargetTagName() {
+    return targetTagName;
   }
 
   /** @return process-attachment identity, or an empty string when absent */
@@ -141,6 +226,21 @@ public final class DexpiInformationFlowInfo implements Serializable {
     return attachmentElementName;
   }
 
+  /** @return explicit process-attachment component class, or an empty string */
+  public String getAttachmentComponentClass() {
+    return attachmentComponentClass;
+  }
+
+  /** @return explicit process-attachment component name, or an empty string */
+  public String getAttachmentComponentName() {
+    return attachmentComponentName;
+  }
+
+  /** @return explicit process-attachment tag name, or an empty string */
+  public String getAttachmentTagName() {
+    return attachmentTagName;
+  }
+
   /** @return signal medium/type, or an empty string when absent or not applicable */
   public String getSignalConveyingType() {
     return signalConveyingType;
@@ -154,12 +254,21 @@ public final class DexpiInformationFlowInfo implements Serializable {
     result.put("sourceId", sourceId);
     result.put("sourceResolved", Boolean.valueOf(sourceResolved));
     result.put("sourceElementName", sourceElementName);
+    result.put("sourceComponentClass", sourceComponentClass);
+    result.put("sourceComponentName", sourceComponentName);
+    result.put("sourceTagName", sourceTagName);
     result.put("targetId", targetId);
     result.put("targetResolved", Boolean.valueOf(targetResolved));
     result.put("targetElementName", targetElementName);
+    result.put("targetComponentClass", targetComponentClass);
+    result.put("targetComponentName", targetComponentName);
+    result.put("targetTagName", targetTagName);
     result.put("attachmentId", attachmentId);
     result.put("attachmentResolved", Boolean.valueOf(attachmentResolved));
     result.put("attachmentElementName", attachmentElementName);
+    result.put("attachmentComponentClass", attachmentComponentClass);
+    result.put("attachmentComponentName", attachmentComponentName);
+    result.put("attachmentTagName", attachmentTagName);
     result.put("signalConveyingType", signalConveyingType);
     return result;
   }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -214,8 +214,9 @@ public final class DexpiXmlReader {
      * Returns supported instrumentation information-flow occurrences in source-document order.
      *
      * <p>
-     * These records retain logical references and resolution evidence only. They do not construct live control
-     * topology, infer control intent, or verify loop function.
+     * These records retain logical references, resolution evidence, and explicit metadata from resolved source, target,
+     * and process-attachment elements. They do not construct live control topology, infer control intent, or verify loop
+     * function.
      * </p>
      *
      * @return immutable signal-line and measuring-line evidence
@@ -990,8 +991,13 @@ public final class DexpiXmlReader {
       Element targetElement = elementsById.get(targetId);
       Element attachmentElement = elementsById.get(attachmentId);
       result.add(new DexpiInformationFlowInfo(element.getAttribute("ID"), kind, componentClass, sourceId,
-          sourceElement != null, elementName(sourceElement), targetId, targetElement != null,
-          elementName(targetElement), attachmentId, attachmentElement != null, elementName(attachmentElement),
+          sourceElement != null, elementName(sourceElement), explicitAttribute(sourceElement, "ComponentClass"),
+          explicitAttribute(sourceElement, "ComponentName"), explicitTagName(sourceElement), targetId,
+          targetElement != null, elementName(targetElement), explicitAttribute(targetElement, "ComponentClass"),
+          explicitAttribute(targetElement, "ComponentName"), explicitTagName(targetElement), attachmentId,
+          attachmentElement != null, elementName(attachmentElement),
+          explicitAttribute(attachmentElement, "ComponentClass"),
+          explicitAttribute(attachmentElement, "ComponentName"), explicitTagName(attachmentElement),
           getGenericAttribute(element, "SignalConveyingTypeSpecialization")));
     }
     return result;

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -215,8 +215,8 @@ public final class DexpiXmlReader {
      *
      * <p>
      * These records retain logical references, resolution evidence, and explicit metadata from resolved source, target,
-     * and process-attachment elements. They do not construct live control topology, infer control intent, or verify loop
-     * function.
+     * and process-attachment elements. They do not construct live control topology, infer control intent, or verify
+     * loop function.
      * </p>
      *
      * @return immutable signal-line and measuring-line evidence
@@ -996,9 +996,8 @@ public final class DexpiXmlReader {
           targetElement != null, elementName(targetElement), explicitAttribute(targetElement, "ComponentClass"),
           explicitAttribute(targetElement, "ComponentName"), explicitTagName(targetElement), attachmentId,
           attachmentElement != null, elementName(attachmentElement),
-          explicitAttribute(attachmentElement, "ComponentClass"),
-          explicitAttribute(attachmentElement, "ComponentName"), explicitTagName(attachmentElement),
-          getGenericAttribute(element, "SignalConveyingTypeSpecialization")));
+          explicitAttribute(attachmentElement, "ComponentClass"), explicitAttribute(attachmentElement, "ComponentName"),
+          explicitTagName(attachmentElement), getGenericAttribute(element, "SignalConveyingTypeSpecialization")));
     }
     return result;
   }

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -214,25 +214,34 @@ public class DexpiXmlReaderTest extends NeqSimTest {
   @Test
   public void testReadWithDiagnosticsIncludesValidInstrumentationInventory() throws Exception {
     String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
-        + "<Nozzle ID=\"N-SENSE\"/><Nozzle ID=\"N-ACT\" ComponentClass=\"Nozzle\" ComponentName=\"NozzleShape\">"
+        + "<Nozzle ID=\"N-SENSE\" ComponentClass=\"Nozzle\" ComponentName=\"SenseNozzleShape\">"
+        + "<GenericAttributes><GenericAttribute Name=\"TagNameAssignmentClass\" Value=\"NS-100\"/>"
+        + "</GenericAttributes></Nozzle>"
+        + "<Nozzle ID=\"N-ACT\" ComponentClass=\"Nozzle\" ComponentName=\"NozzleShape\">"
         + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"NZ-100\"/></GenericAttributes></Nozzle>"
         + "<FinalControlElement ID=\"V-100\" ComponentClass=\"GateValve\" ComponentName=\"GateValveShape\">"
         + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"XV-100\"/></GenericAttributes>"
         + "</FinalControlElement>"
-        + "<ProcessInstrumentationFunction ComponentClass=\"ProcessInstrumentationFunction\" ID=\"PIF-PT-100\">"
+        + "<ProcessInstrumentationFunction ComponentClass=\"ProcessInstrumentationFunction\""
+        + " ComponentName=\"TransmitterShape\" ID=\"PIF-PT-100\">"
         + instrumentAttributes("PT-100", "P", "T", "100")
         + "<InformationFlow ComponentClass=\"MeasuringLineFunction\" ID=\"MLF-100\">"
         + "<Association Type=\"has logical start\" ItemID=\"PSGF-100\"/>"
         + "<Association Type=\"has logical end\" ItemID=\"PIF-PT-100\"/>"
         + "<Association Type=\"is attached to\" ItemID=\"N-SENSE\"/>" + "</InformationFlow>"
-        + "<ProcessSignalGeneratingFunction ComponentClass=\"ProcessSignalGeneratingFunction\" ID=\"PSGF-100\"/>"
+        + "<ProcessSignalGeneratingFunction ComponentClass=\"ProcessSignalGeneratingFunction\""
+        + " ComponentName=\"PressureSignalShape\" ID=\"PSGF-100\">"
+        + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"PSGF-100-TAG\"/>"
+        + "</GenericAttributes></ProcessSignalGeneratingFunction>"
         + "</ProcessInstrumentationFunction>"
-        + "<ProcessInstrumentationFunction ComponentClass=\"ProcessControlFunction\" ID=\"PIF-PC-100\">"
+        + "<ProcessInstrumentationFunction ComponentClass=\"ProcessControlFunction\""
+        + " ComponentName=\"ControllerShape\" ID=\"PIF-PC-100\">"
         + instrumentAttributes("PC-100", "P", "C", "100")
         + signalFlow("SIG-MEASURED", "PIF-PT-100", "PIF-PC-100", "ElectricalSignalConveying")
-        + "<ActuatingFunction ComponentClass=\"ActuatingFunction\" ID=\"AF-100\">"
+        + "<ActuatingFunction ComponentClass=\"ActuatingFunction\" ComponentName=\"ActuatorShape\" ID=\"AF-100\">"
         + "<GenericAttributes><GenericAttribute Name=\"ActuatingFunctionNumberAssignmentClass\" Value=\"PC-100\"/>"
         + "<GenericAttribute Name=\"FinalControlElementID\" Value=\"V-100\"/>"
+        + "<GenericAttribute Name=\"TagName\" Value=\"AF-100-TAG\"/>"
         + "</GenericAttributes><Association Type=\"is located in\" ItemID=\"N-ACT\"/>" + "</ActuatingFunction>"
         + signalFlow("SIG-ACTUATE", "PIF-PC-100", "AF-100", "PneumaticSignalConveying")
         + "</ProcessInstrumentationFunction>"
@@ -301,13 +310,22 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("PSGF-100", measuring.getSourceId());
     assertTrue(measuring.isSourceResolved());
     assertEquals("ProcessSignalGeneratingFunction", measuring.getSourceElementName());
+    assertEquals("ProcessSignalGeneratingFunction", measuring.getSourceComponentClass());
+    assertEquals("PressureSignalShape", measuring.getSourceComponentName());
+    assertEquals("PSGF-100-TAG", measuring.getSourceTagName());
     assertEquals("PIF-PT-100", measuring.getTargetId());
     assertTrue(measuring.isTargetResolved());
     assertEquals("ProcessInstrumentationFunction", measuring.getTargetElementName());
+    assertEquals("ProcessInstrumentationFunction", measuring.getTargetComponentClass());
+    assertEquals("TransmitterShape", measuring.getTargetComponentName());
+    assertEquals("PT-100", measuring.getTargetTagName());
     assertTrue(measuring.hasAttachment());
     assertEquals("N-SENSE", measuring.getAttachmentId());
     assertTrue(measuring.isAttachmentResolved());
     assertEquals("Nozzle", measuring.getAttachmentElementName());
+    assertEquals("Nozzle", measuring.getAttachmentComponentClass());
+    assertEquals("SenseNozzleShape", measuring.getAttachmentComponentName());
+    assertEquals("NS-100", measuring.getAttachmentTagName());
     assertEquals("", measuring.getSignalConveyingType());
 
     DexpiInformationFlowInfo measuredSignal = informationFlows.get(1);
@@ -316,10 +334,19 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("PIF-PT-100", measuredSignal.getSourceId());
     assertTrue(measuredSignal.isSourceResolved());
     assertEquals("ProcessInstrumentationFunction", measuredSignal.getSourceElementName());
+    assertEquals("ProcessInstrumentationFunction", measuredSignal.getSourceComponentClass());
+    assertEquals("TransmitterShape", measuredSignal.getSourceComponentName());
+    assertEquals("PT-100", measuredSignal.getSourceTagName());
     assertEquals("PIF-PC-100", measuredSignal.getTargetId());
     assertTrue(measuredSignal.isTargetResolved());
     assertEquals("ProcessInstrumentationFunction", measuredSignal.getTargetElementName());
+    assertEquals("ProcessControlFunction", measuredSignal.getTargetComponentClass());
+    assertEquals("ControllerShape", measuredSignal.getTargetComponentName());
+    assertEquals("PC-100", measuredSignal.getTargetTagName());
     assertFalse(measuredSignal.hasAttachment());
+    assertEquals("", measuredSignal.getAttachmentComponentClass());
+    assertEquals("", measuredSignal.getAttachmentComponentName());
+    assertEquals("", measuredSignal.getAttachmentTagName());
     assertEquals("ElectricalSignalConveying", measuredSignal.getSignalConveyingType());
 
     DexpiInformationFlowInfo actuatingSignal = informationFlows.get(2);
@@ -327,6 +354,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("AF-100", actuatingSignal.getTargetId());
     assertTrue(actuatingSignal.isTargetResolved());
     assertEquals("ActuatingFunction", actuatingSignal.getTargetElementName());
+    assertEquals("ActuatingFunction", actuatingSignal.getTargetComponentClass());
+    assertEquals("ActuatorShape", actuatingSignal.getTargetComponentName());
+    assertEquals("AF-100-TAG", actuatingSignal.getTargetTagName());
     assertEquals("PneumaticSignalConveying", actuatingSignal.getSignalConveyingType());
     assertThrows(UnsupportedOperationException.class, () -> informationFlows.clear());
 
@@ -341,6 +371,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(first.toJson().contains("\"locationTagName\": \"NZ-100\""));
     assertTrue(first.toJson().contains("\"informationFlowCount\": 3"));
     assertTrue(first.toJson().contains("\"kind\": \"MEASURING_LINE\""));
+    assertTrue(first.toJson().contains("\"sourceComponentName\": \"PressureSignalShape\""));
+    assertTrue(first.toJson().contains("\"targetTagName\": \"PT-100\""));
+    assertTrue(first.toJson().contains("\"attachmentTagName\": \"NS-100\""));
     assertTrue(first.toJson().contains("\"signalConveyingType\": \"ElectricalSignalConveying\""));
     assertEquals(first.toJson(), second.toJson());
   }
@@ -422,18 +455,33 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals(DexpiInformationFlowInfo.Kind.MEASURING_LINE, measuring.getKind());
     assertEquals("", measuring.getSourceId());
     assertFalse(measuring.isSourceResolved());
+    assertEquals("", measuring.getSourceComponentClass());
+    assertEquals("", measuring.getSourceComponentName());
+    assertEquals("", measuring.getSourceTagName());
     assertEquals("UNKNOWN-INSTRUMENT", measuring.getTargetId());
     assertFalse(measuring.isTargetResolved());
+    assertEquals("", measuring.getTargetComponentClass());
+    assertEquals("", measuring.getTargetComponentName());
+    assertEquals("", measuring.getTargetTagName());
     assertFalse(measuring.hasAttachment());
     assertFalse(measuring.isAttachmentResolved());
+    assertEquals("", measuring.getAttachmentComponentClass());
+    assertEquals("", measuring.getAttachmentComponentName());
+    assertEquals("", measuring.getAttachmentTagName());
 
     DexpiInformationFlowInfo signal = informationFlows.get(1);
     assertEquals("SIG-BROKEN", signal.getId());
     assertEquals(DexpiInformationFlowInfo.Kind.SIGNAL_LINE, signal.getKind());
     assertEquals("UNKNOWN-SOURCE", signal.getSourceId());
     assertFalse(signal.isSourceResolved());
+    assertEquals("", signal.getSourceComponentClass());
+    assertEquals("", signal.getSourceComponentName());
+    assertEquals("", signal.getSourceTagName());
     assertEquals("", signal.getTargetId());
     assertFalse(signal.isTargetResolved());
+    assertEquals("", signal.getTargetComponentClass());
+    assertEquals("", signal.getTargetComponentName());
+    assertEquals("", signal.getTargetTagName());
     assertEquals("", signal.getSignalConveyingType());
 
     assertTrue(first.hasLosses());

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -221,10 +221,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"NZ-100\"/></GenericAttributes></Nozzle>"
         + "<FinalControlElement ID=\"V-100\" ComponentClass=\"GateValve\" ComponentName=\"GateValveShape\">"
         + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"XV-100\"/></GenericAttributes>"
-        + "</FinalControlElement>"
-        + "<ProcessInstrumentationFunction ComponentClass=\"ProcessInstrumentationFunction\""
-        + " ComponentName=\"TransmitterShape\" ID=\"PIF-PT-100\">"
-        + instrumentAttributes("PT-100", "P", "T", "100")
+        + "</FinalControlElement>" + "<ProcessInstrumentationFunction ComponentClass=\"ProcessInstrumentationFunction\""
+        + " ComponentName=\"TransmitterShape\" ID=\"PIF-PT-100\">" + instrumentAttributes("PT-100", "P", "T", "100")
         + "<InformationFlow ComponentClass=\"MeasuringLineFunction\" ID=\"MLF-100\">"
         + "<Association Type=\"has logical start\" ItemID=\"PSGF-100\"/>"
         + "<Association Type=\"has logical end\" ItemID=\"PIF-PT-100\"/>"
@@ -232,11 +230,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
         + "<ProcessSignalGeneratingFunction ComponentClass=\"ProcessSignalGeneratingFunction\""
         + " ComponentName=\"PressureSignalShape\" ID=\"PSGF-100\">"
         + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"PSGF-100-TAG\"/>"
-        + "</GenericAttributes></ProcessSignalGeneratingFunction>"
-        + "</ProcessInstrumentationFunction>"
+        + "</GenericAttributes></ProcessSignalGeneratingFunction>" + "</ProcessInstrumentationFunction>"
         + "<ProcessInstrumentationFunction ComponentClass=\"ProcessControlFunction\""
-        + " ComponentName=\"ControllerShape\" ID=\"PIF-PC-100\">"
-        + instrumentAttributes("PC-100", "P", "C", "100")
+        + " ComponentName=\"ControllerShape\" ID=\"PIF-PC-100\">" + instrumentAttributes("PC-100", "P", "C", "100")
         + signalFlow("SIG-MEASURED", "PIF-PT-100", "PIF-PC-100", "ElectricalSignalConveying")
         + "<ActuatingFunction ComponentClass=\"ActuatingFunction\" ComponentName=\"ActuatorShape\" ID=\"AF-100\">"
         + "<GenericAttributes><GenericAttribute Name=\"ActuatingFunctionNumberAssignmentClass\" Value=\"PC-100\"/>"


### PR DESCRIPTION
Advances #1332 and #2899.

## Capability

Preserves explicit source metadata for every resolved DEXPI instrumentation information-flow reference. Logical sources, logical targets, and process attachments now expose their source `ComponentClass`, `ComponentName`, and `TagName` alongside the existing identity, resolution, and XML-element evidence.

Capability contracts:
- https://github.com/equinor/neqsim/issues/1332#issuecomment-5551055826
- https://github.com/equinor/neqsim/issues/2899#issuecomment-5551056743

**Exact base:** `da1952aca48e46cbf6c11c75dd6a2f76be0043c2`
**Exact current head:** `267227122ac0d6843e75e920adc7d8416df2f9f7`

## Changes

- extends immutable `DexpiInformationFlowInfo` evidence with explicit metadata for resolved source, target, and attachment elements;
- preserves the original public constructor, existing getters, source ordering, parallel occurrences, and JSON fields;
- normalizes absent metadata and unresolved references to empty strings without invented values;
- accepts both explicit `TagName` and the established `TagNameAssignmentClass` compatibility form;
- adds focused resolved, malformed-reference, JSON, and deterministic-repeat regression coverage;
- documents the reader contract and its semantic stop boundary.

Exactly six commits and four intended files are included; the final two commits are the exact hosted Spotless formatting artifact.

## Semantic and compatibility boundary

This is reader evidence only. It does not construct controllers or loops, infer control intent, classify final elements, grant safeguard or SIS credit, establish hydraulic connectivity, or change live process topology. Java 8 compatibility and O(V+E) document indexing are preserved.

No rendering, geometry, layout, symbol, export, simulation, notebook, or process-model behavior changes. The whole-sheet visual defect gate is therefore not applicable.

## Validation

**READY TO MERGE**

No local checkout was available, so no local Maven, Spotless, Javadocs, or documentation command is claimed as passed. Connector-side exact-head checks establish:

- six commits ahead and zero behind the recorded base;
- exactly four intended files;
- no tabs or trailing whitespace;
- the exact hosted Spotless artifact from the first CI cycle was applied without changing behavior or file scope;
- production, parser, resolved-reference, malformed-reference, JSON, and documentation markers present;
- original constructor retained and unresolved metadata explicitly covered as empty evidence.

All eight exact-head workflows pass. Java 8 and Java 21 pass on Ubuntu and Windows; all four Java 21 slow-test shards, Javadocs, formatting, pre-commit, documentation, notebook, engineering-diagram performance, CodeQL, PaperLab, change-detection, and reference checks pass. The final diff remains six commits across four intended files, zero behind current master, and the draft is mergeable with no reviews or unresolved threads.

## Documentation and standards status

The DEXPI reader documentation now describes the additional explicit provenance fields and their empty-value behavior. This remains evidence for NeqSim's supported subset only; it is not a claim of DEXPI, ISO 10628, IEC 62424, or ISA-5.1 conformance, certification, functional-safety verification, or engineering approval.

## Portfolio and ownership

The shared #1332/#2899 lane was free after #3469 merged externally. Open autonomous drafts #3476, #3477, #3478, #3480, and #3481 do not overlap this reader scope. Including this draft, the positively identified autonomous implementation portfolio is **6/10**.

## Stop boundary

Explicit metadata projection for already resolved information-flow references only. No control-loop reconstruction, completeness judgment, final-element classification, safety inference, rendering, topology, export, or unrelated refactor.

This PR must remain draft-only. Do not merge, mark ready, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push it as part of this campaign.

Generated with AI assistance.