### PR TITLE
[AI-Assisted] feat(refinery): expose Sarir bulk crude properties

### DIFF
--- a/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
@@ -1,6 +1,6 @@
 ---
 title: "Sarir atmospheric validation reference"
-description: "Public complete-range TBP, atmospheric-unit operating data, and independent plant-yield evidence."
+description: "Public whole-crude properties, TBP, atmospheric-unit operating data, and independent plant-yield evidence."
 ---
 
 # Sarir atmospheric validation reference
@@ -12,6 +12,32 @@ description: "Public complete-range TBP, atmospheric-unit operating data, and in
 The source is Hamza E. Omran Almansouri, *Simulation of Sarir Crude Oil Refinery Using Aspen HYSYS*, Journal of Engineering Research (Libya), issue 33, pages 51-64, published 31 March 2022, DOI [10.66411/jer.v33i.46](https://doi.org/10.66411/jer.v33i.46). The [open-access article](https://jer.ly/jer/index.php/jer/article/download/46/38/39) is licensed CC BY 4.0.
 
 The paper reports a Sarir crude density of 841.5 kg/m3 at 15 degC, API gravity 36.5 at 60 degF, sulfur 0.120 mass%, average molar mass 0.2447 kg/mol, and a public TBP assay originally prepared by the Libyan Petroleum Institute.
+
+## Whole-crude property evidence
+
+Table 1 gives the following numeric bulk measurements:
+
+| Property | Published value | Basis |
+| --- | ---: | --- |
+| Density | 841.5 kg/m3 | 15 degC |
+| API gravity | 36.5 | 60 degF |
+| Total sulfur | 0.120 mass% | Whole crude |
+| Asphaltenes | 0.20 mass% | Whole crude |
+| Mercaptan sulfur | 8 ppm by mass | Whole crude |
+| Water and sediment | 0.05 volume% | Whole crude |
+| Cloud point | 48.7-49.6 degC | Published interval |
+| Pour point | +21 degC | Whole crude |
+| Kinematic viscosity | 10.63 cSt | 100 degF; the source prose gives the rounded equivalent 37.7 degC |
+| Average molar mass | 0.2447 kg/mol | Whole crude |
+
+The Java API keeps the cloud point as separate lower and upper endpoints. It also exposes both
+published viscosity reference-temperature forms: 100 degF from Table 1 and 37.7 degC from the
+source prose. An exact unit conversion gives 37.777777... degC; the API does not silently replace
+the reported rounded Celsius value.
+
+These are whole-crude reference measurements. The source does not publish uncertainty bounds or
+per-cut allocations for these properties, so they are not distributed across pseudo-components and
+do not qualify a wax, asphaltene, viscosity, water, or sulfur prediction model.
 
 ## Preserved TBP evidence
 
@@ -75,6 +101,10 @@ Unlike the Al-Diwiniya reference, the Sarir paper does not say these HYSYS rates
 ```java
 double[] volumePercent = SarirAtmosphericReference.getTbpCumulativeVolumePercent();
 double residuePercent = SarirAtmosphericReference.getTerminalResidueVolumePercent();
+
+double cloudPointLowerCelsius = SarirAtmosphericReference.getCrudeCloudPointLowerCelsius();
+double cloudPointUpperCelsius = SarirAtmosphericReference.getCrudeCloudPointUpperCelsius();
+double viscosityCst = SarirAtmosphericReference.getCrudeKinematicViscosityAt100FCst();
 
 SarirAtmosphericReference.ProductYieldReference diesel =
     SarirAtmosphericReference.getProductYield("Diesel");

--- a/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
+++ b/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
@@ -171,6 +171,51 @@ public final class SarirAtmosphericReference {
     return 0.2447;
   }
 
+  /** @return crude asphaltenes content in mass percent */
+  public static double getCrudeAsphaltenesMassPercent() {
+    return 0.20;
+  }
+
+  /** @return crude mercaptan sulfur content in ppm by mass */
+  public static double getCrudeMercaptanSulfurMassPpm() {
+    return 8.0;
+  }
+
+  /** @return crude water and sediment content in volume percent */
+  public static double getCrudeWaterAndSedimentVolumePercent() {
+    return 0.05;
+  }
+
+  /** @return lower endpoint of the published crude cloud-point interval in degrees Celsius */
+  public static double getCrudeCloudPointLowerCelsius() {
+    return 48.7;
+  }
+
+  /** @return upper endpoint of the published crude cloud-point interval in degrees Celsius */
+  public static double getCrudeCloudPointUpperCelsius() {
+    return 49.6;
+  }
+
+  /** @return crude pour point in degrees Celsius */
+  public static double getCrudePourPointCelsius() {
+    return 21.0;
+  }
+
+  /** @return crude kinematic viscosity at 100 degrees Fahrenheit in cSt */
+  public static double getCrudeKinematicViscosityAt100FCst() {
+    return 10.63;
+  }
+
+  /** @return Fahrenheit reference temperature for the published crude viscosity */
+  public static double getCrudeKinematicViscosityReferenceTemperatureFahrenheit() {
+    return 100.0;
+  }
+
+  /** @return rounded Celsius reference temperature reported in the source prose */
+  public static double getCrudeKinematicViscosityReferenceTemperatureCelsius() {
+    return 37.7;
+  }
+
   /** @return atmospheric-column valve-tray count */
   public static int getColumnTrayCount() {
     return 34;

--- a/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
+++ b/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
@@ -102,6 +102,26 @@ public class SarirAtmosphericReferenceTest {
   }
 
   @Test
+  public void wholeCrudePropertyEvidencePreservesValuesAndMeasurementBases() {
+    assertEquals(0.20, SarirAtmosphericReference.getCrudeAsphaltenesMassPercent(), 0.0);
+    assertEquals(8.0, SarirAtmosphericReference.getCrudeMercaptanSulfurMassPpm(), 0.0);
+    assertEquals(0.05, SarirAtmosphericReference.getCrudeWaterAndSedimentVolumePercent(), 0.0);
+    assertEquals(48.7, SarirAtmosphericReference.getCrudeCloudPointLowerCelsius(), 0.0);
+    assertEquals(49.6, SarirAtmosphericReference.getCrudeCloudPointUpperCelsius(), 0.0);
+    assertTrue(SarirAtmosphericReference.getCrudeCloudPointLowerCelsius()
+        <= SarirAtmosphericReference.getCrudeCloudPointUpperCelsius());
+    assertEquals(21.0, SarirAtmosphericReference.getCrudePourPointCelsius(), 0.0);
+    assertEquals(10.63, SarirAtmosphericReference.getCrudeKinematicViscosityAt100FCst(), 0.0);
+    assertEquals(100.0, SarirAtmosphericReference.getCrudeKinematicViscosityReferenceTemperatureFahrenheit(), 0.0);
+    assertEquals(37.7, SarirAtmosphericReference.getCrudeKinematicViscosityReferenceTemperatureCelsius(), 0.0);
+
+    double exactCelsiusConversion = (100.0 - 32.0) * 5.0 / 9.0;
+    assertEquals(37.77777777777778, exactCelsiusConversion, 1.0e-12);
+    assertTrue(Math.abs(exactCelsiusConversion
+        - SarirAtmosphericReference.getCrudeKinematicViscosityReferenceTemperatureCelsius()) < 0.1);
+  }
+
+  @Test
   public void steamInjectionRowsPreservePublishedServicesWithoutInventingState() {
     SteamInjectionReference[] injections = SarirAtmosphericReference.getSteamInjections();
     assertEquals(3, injections.length);

--- a/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
+++ b/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
@@ -108,8 +108,8 @@ public class SarirAtmosphericReferenceTest {
     assertEquals(0.05, SarirAtmosphericReference.getCrudeWaterAndSedimentVolumePercent(), 0.0);
     assertEquals(48.7, SarirAtmosphericReference.getCrudeCloudPointLowerCelsius(), 0.0);
     assertEquals(49.6, SarirAtmosphericReference.getCrudeCloudPointUpperCelsius(), 0.0);
-    assertTrue(SarirAtmosphericReference.getCrudeCloudPointLowerCelsius()
-        <= SarirAtmosphericReference.getCrudeCloudPointUpperCelsius());
+    assertTrue(SarirAtmosphericReference.getCrudeCloudPointLowerCelsius() <= SarirAtmosphericReference
+        .getCrudeCloudPointUpperCelsius());
     assertEquals(21.0, SarirAtmosphericReference.getCrudePourPointCelsius(), 0.0);
     assertEquals(10.63, SarirAtmosphericReference.getCrudeKinematicViscosityAt100FCst(), 0.0);
     assertEquals(100.0, SarirAtmosphericReference.getCrudeKinematicViscosityReferenceTemperatureFahrenheit(), 0.0);


### PR DESCRIPTION
## Summary

Continues #3305 with the missing numeric whole-crude property slice from Table 1 of the public Sarir atmospheric reference.

- exposes asphaltenes `0.20 mass%`;
- exposes mercaptan sulfur `8 ppm by mass`;
- exposes water and sediment `0.05 volume%`;
- preserves cloud point as the published `48.7-49.6 degC` interval;
- exposes pour point `+21 degC`;
- exposes kinematic viscosity `10.63 cSt` at `100 degF`, together with the source prose's rounded `37.7 degC` reference temperature;
- adds focused Java tests and Java/JPype documentation.

## Public provenance

Hamza E. Omran Almansouri, *Simulation of Sarir Crude Oil Refinery Using Aspen HYSYS*, Journal of Engineering Research (Libya), issue 33, pages 51-64, published 2022-03-31.

- DOI: https://doi.org/10.66411/jer.v33i.46
- Open article: https://jer.ly/jer/index.php/jer/article/download/46/38/39
- License: CC BY 4.0

The article reproduces the Table 1 measurements from the cited Libyan Petroleum Institute/SGS crude-property sources.

## Engineering boundary

These are whole-crude reference measurements only. This change does not distribute properties across pseudo-components, infer uncertainty, or qualify a wax, asphaltene, viscosity, water, sulfur, assay, EOS, or process model. It changes no streams, column settings, steam, pump-around data, product targets, solver controls, or defaults.

The cloud point remains an interval. The API preserves both source temperature forms for viscosity: Table 1's exact `100 degF` and the prose's rounded `37.7 degC`; it does not silently replace one with an exact converted value.

## Validation

Connector-side exact-tree checks on repaired head `6c16138b8e002ff20f0631c7e2d0d7487fd8d6bd`:

- branch is four commits ahead and zero behind exact base `da1952aca48e46cbf6c11c75dd6a2f76be0043c2`;
- exactly three intended files changed;
- Java braces balance;
- no tabs or trailing whitespace;
- production and focused-test Java lines are at most 120 characters;
- no post-Java-8 construct was introduced;
- the final commit applies the exact one-line wrap printed by hosted Spotless; engineering behavior is unchanged.

Hosted exact-head CI is authoritative and pending.

## Campaign continuity

Predecessor #3471 merged unchanged from qualified exact head `0aa2e40ce3796a06820cd32c54f9c8f0a0b63382`. This is the sole active #3305 implementation PR and remains draft-only.