### PR TITLE
[AI-Assisted] feat(dexpi): preserve loop member provenance

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -171,8 +171,11 @@ safety-instrumented or safeguard functions.
 `DexpiInstrumentationLoopInfo`. The record retains the loop ID, component class, explicit loop
 number, and every direct `is a collection including` occurrence in source order. Membership
 evidence preserves duplicate, blank, and unresolved references together with resolution status and
-the resolved XML element name. It does not infer control intent, verify functional completeness,
-construct executable control topology, or classify SIS or safeguard functions.
+the resolved XML element name. For each resolved member, it also preserves the source object's
+explicit `ComponentClass`, `ComponentName`, and `TagName`; absent source metadata and unresolved
+references remain empty strings without invented values. It does not infer control intent, verify
+functional completeness, construct executable control topology, or classify SIS or safeguard
+functions.
 
 The same result also preserves every source `Connection` in document order, including parallel
 connections between the same endpoints. Each immutable `DexpiConnectionInfo` retains the owning

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiInstrumentationLoopInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiInstrumentationLoopInfo.java
@@ -27,6 +27,9 @@ public final class DexpiInstrumentationLoopInfo implements Serializable {
     private final String memberId;
     private final boolean resolved;
     private final String elementName;
+    private final String memberComponentClass;
+    private final String memberComponentName;
+    private final String memberTagName;
 
     /**
      * Creates evidence for one source loop-membership occurrence.
@@ -36,9 +39,27 @@ public final class DexpiInstrumentationLoopInfo implements Serializable {
      * @param elementName resolved XML element name, or an empty string
      */
     public Member(String memberId, boolean resolved, String elementName) {
+      this(memberId, resolved, elementName, "", "", "");
+    }
+
+    /**
+     * Creates evidence with explicit metadata from the resolved member element.
+     *
+     * @param memberId referenced source identity, or an empty string when absent
+     * @param resolved whether the reference resolves to a source element
+     * @param elementName resolved XML element name, or an empty string
+     * @param memberComponentClass explicit member component class, or an empty string
+     * @param memberComponentName explicit member component name, or an empty string
+     * @param memberTagName explicit member tag name, or an empty string
+     */
+    public Member(String memberId, boolean resolved, String elementName, String memberComponentClass,
+        String memberComponentName, String memberTagName) {
       this.memberId = normalize(memberId);
       this.resolved = resolved;
       this.elementName = normalize(elementName);
+      this.memberComponentClass = normalize(memberComponentClass);
+      this.memberComponentName = normalize(memberComponentName);
+      this.memberTagName = normalize(memberTagName);
     }
 
     /** @return referenced source identity, or an empty string when absent */
@@ -56,11 +77,29 @@ public final class DexpiInstrumentationLoopInfo implements Serializable {
       return elementName;
     }
 
+    /** @return explicit member component class, or an empty string */
+    public String getMemberComponentClass() {
+      return memberComponentClass;
+    }
+
+    /** @return explicit member component name, or an empty string */
+    public String getMemberComponentName() {
+      return memberComponentName;
+    }
+
+    /** @return explicit member tag name, or an empty string */
+    public String getMemberTagName() {
+      return memberTagName;
+    }
+
     private Map<String, Object> toMap() {
       Map<String, Object> result = new LinkedHashMap<String, Object>();
       result.put("memberId", memberId);
       result.put("resolved", Boolean.valueOf(resolved));
       result.put("elementName", elementName);
+      result.put("memberComponentClass", memberComponentClass);
+      result.put("memberComponentName", memberComponentName);
+      result.put("memberTagName", memberTagName);
       return result;
     }
   }

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -871,7 +871,9 @@ public final class DexpiXmlReader {
         }
         String memberId = association.getAttribute("ItemID");
         Element member = elementsById.get(memberId);
-        members.add(new DexpiInstrumentationLoopInfo.Member(memberId, member != null, elementName(member)));
+        members.add(new DexpiInstrumentationLoopInfo.Member(memberId, member != null, elementName(member),
+            explicitAttribute(member, "ComponentClass"), explicitAttribute(member, "ComponentName"),
+            explicitTagName(member)));
       }
       result.add(new DexpiInstrumentationLoopInfo(loop.getAttribute("ID"), loop.getAttribute("ComponentClass"),
           getGenericAttribute(loop, DexpiMetadata.LOOP_NUMBER), members));

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -266,11 +266,23 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("InstrumentationLoopFunction", loop.getComponentClass());
     assertEquals("100", loop.getLoopNumber());
     assertEquals(3, loop.getMembers().size());
-    assertEquals("PIF-PT-100", loop.getMembers().get(0).getMemberId());
-    assertTrue(loop.getMembers().get(0).isResolved());
-    assertEquals("ProcessInstrumentationFunction", loop.getMembers().get(0).getElementName());
-    assertEquals("PIF-PC-100", loop.getMembers().get(1).getMemberId());
-    assertEquals("PIF-PC-100", loop.getMembers().get(2).getMemberId());
+    DexpiInstrumentationLoopInfo.Member transmitterMember = loop.getMembers().get(0);
+    assertEquals("PIF-PT-100", transmitterMember.getMemberId());
+    assertTrue(transmitterMember.isResolved());
+    assertEquals("ProcessInstrumentationFunction", transmitterMember.getElementName());
+    assertEquals("ProcessInstrumentationFunction", transmitterMember.getMemberComponentClass());
+    assertEquals("TransmitterShape", transmitterMember.getMemberComponentName());
+    assertEquals("PT-100", transmitterMember.getMemberTagName());
+    DexpiInstrumentationLoopInfo.Member firstControllerMember = loop.getMembers().get(1);
+    assertEquals("PIF-PC-100", firstControllerMember.getMemberId());
+    assertEquals("ProcessControlFunction", firstControllerMember.getMemberComponentClass());
+    assertEquals("ControllerShape", firstControllerMember.getMemberComponentName());
+    assertEquals("PC-100", firstControllerMember.getMemberTagName());
+    DexpiInstrumentationLoopInfo.Member repeatedControllerMember = loop.getMembers().get(2);
+    assertEquals("PIF-PC-100", repeatedControllerMember.getMemberId());
+    assertEquals("ProcessControlFunction", repeatedControllerMember.getMemberComponentClass());
+    assertEquals("ControllerShape", repeatedControllerMember.getMemberComponentName());
+    assertEquals("PC-100", repeatedControllerMember.getMemberTagName());
     assertThrows(UnsupportedOperationException.class, () -> instrumentationLoops.clear());
     assertThrows(UnsupportedOperationException.class, () -> loop.getMembers().clear());
 
@@ -361,6 +373,8 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(first.toJson().contains("\"instrumentCount\": 2"));
     assertTrue(first.toJson().contains("\"instrumentationLoopCount\": 1"));
     assertTrue(first.toJson().contains("\"memberCount\": 3"));
+    assertTrue(first.toJson().contains("\"memberComponentName\": \"TransmitterShape\""));
+    assertTrue(first.toJson().contains("\"memberTagName\": \"PT-100\""));
     assertTrue(first.toJson().contains("\"actuatingFunctionCount\": 1"));
     assertTrue(first.toJson().contains("\"finalControlElementResolved\": true"));
     assertTrue(first.toJson().contains("\"finalControlElementTagName\": \"XV-100\""));
@@ -405,6 +419,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("UNKNOWN-MEMBER", loop.getMembers().get(0).getMemberId());
     assertFalse(loop.getMembers().get(0).isResolved());
     assertEquals("", loop.getMembers().get(0).getElementName());
+    assertEquals("", loop.getMembers().get(0).getMemberComponentClass());
+    assertEquals("", loop.getMembers().get(0).getMemberComponentName());
+    assertEquals("", loop.getMembers().get(0).getMemberTagName());
     List<DexpiActuatingFunctionInfo> actuatingFunctions = first.getActuatingFunctions();
     assertEquals(1, actuatingFunctions.size());
     DexpiActuatingFunctionInfo actuatingFunction = actuatingFunctions.get(0);


### PR DESCRIPTION
Advances #1332 and #2899.

## Capability

Preserves explicit source metadata for every resolved DEXPI instrumentation-loop membership occurrence. Java and JPype consumers can inspect a member's source `ComponentClass`, `ComponentName`, and `TagName` beside the existing identity, resolution, and XML-element evidence without reparsing XML.

Capability contracts:
- https://github.com/equinor/neqsim/issues/1332#issuecomment-5553036073
- https://github.com/equinor/neqsim/issues/2899#issuecomment-5553037331

**Exact base:** `9ec5900e8391b6cb5b298b7331524c3b98aaf9d0`  
**Exact current head:** `8880c232bf7702a67ad279ac69012acedbdebf48`

## Changes

- extends immutable `DexpiInstrumentationLoopInfo.Member` evidence with explicit metadata from resolved source elements;
- retains the original public constructor and every existing getter and JSON field;
- preserves source ordering and duplicate membership occurrences;
- normalizes absent metadata and unresolved references to empty strings without invented values;
- adds focused resolved, duplicate, unresolved, JSON, defensive-immutability, and deterministic-repeat coverage;
- documents the Java/JPype evidence contract and semantic stop boundary.

Exactly four ordered commits and four intended files are included.

## Semantic and compatibility boundary

This is source-document membership evidence only. It does not construct an executable loop, infer control intent, judge loop completeness, classify final elements, safeguards, or SIS functions, establish hydraulic connectivity, or change live simulation topology. Java 8 compatibility and the existing one-pass document identity index are preserved.

No rendering, geometry, layout, symbol, export, simulation, notebook, or process-model behavior changes. The whole-sheet visual defect gate is therefore not applicable.

## Validation

**DRAFT — READY TO MERGE (classification only)**

No local checkout was available, so no local Maven, Spotless, Javadocs, pre-commit, or documentation-search command is claimed as passed. Connector-side checks establish:

- four commits ahead and zero behind the recorded base;
- exactly four intended files;
- no tabs or trailing whitespace;
- balanced production-source braces;
- original constructor retained;
- production, parser, resolved-reference, duplicate-reference, unresolved-reference, JSON, deterministic-repeat, and documentation markers present.

All eight exact-head workflows pass: 19 successful jobs, one expected PaperLab skip, zero failures, and zero pending jobs. Java 8 and Java 21 pass on Ubuntu and Windows; all four Java 21 slow-test shards, Javadocs, Spotless, pre-commit, documentation search, engineering-diagram performance, process-to-engineering notebook, CodeQL, and reference checks pass. The initial unrelated Java 8 Ubuntu numerical failure cleared on the bounded exact-head retry without source or branch-history changes. Hosted exact-head CI, scope, mergeability, and review gates now support READY TO MERGE classification.

## Documentation and standards status

The DEXPI reader guide now describes the added member-provenance fields and empty-value behavior. This is evidence for NeqSim's supported import subset only; it is not a claim of DEXPI, ISO 10628, IEC 62424, or ISA-5.1 conformance, certification, functional-safety verification, or engineering approval.

## Portfolio and ownership

The shared #1332/#2899 lane was free after #3479 merged externally as `515ebd9c704b2d2c4f5f37031ad6920dda39fc15`. Open autonomous drafts #3477, #3478, #3483, #3484, and #3485 do not overlap this reader scope. Including this draft, the positively identified autonomous implementation portfolio is **6/10**.

## Stop boundary

Explicit metadata projection for already resolved instrumentation-loop members only. No loop reconstruction, completeness judgment, control/safety inference, rendering, topology, export, or unrelated refactor.

This PR must remain draft-only. Do not merge, mark ready, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push it as part of this campaign.

Generated with AI assistance.