### PR TITLE
[AI-Assisted] feat(refinery): preserve Sarir ADU stream table

### DIFF
--- a/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
@@ -49,21 +49,31 @@ The source then reports a `550 degC+` terminal residue reaching 100 volume%. Neq
 
 ## Atmospheric operating case
 
-The published HYSYS case uses 34 valve trays, feeds 54,420 kg/h of crude at 350 degC and 233 kPa to tray 31 counted from the top, and includes main-column, kerosene-stripper, and diesel-stripper steam rates of 340.2, 68.04, and 226.8 kg/h. Top and bottom pump-around rates are 29,777.64 and 60,423.66 kg/h.
+The published HYSYS case uses 34 valve trays and feeds crude to tray 31 counted from the top.
+Table 3 publishes the complete ADU inlet/outlet stream set:
 
-The complete source-identified steam set is:
+| Source label | Direction | Temperature (degC) | Pressure (kPa) | Mass flow (kg/h) |
+| --- | --- | ---: | ---: | ---: |
+| Crude oil tower | Inlet | 350 | 233 | 54,420 |
+| Steam | Inlet | 150 | 476 | 340.2 |
+| Kerosene steam | Inlet | 150 | 476 | 68.04 |
+| Diesel steam | Inlet | 150 | 476 | 226.8 |
+| Gas To Flare | Outlet | 49 | 140 | 6.985e-6 |
+| Naphtha | Outlet | 49 | 140 | 8,706 |
+| Kerosene product | Outlet | 126.3 | 210 | 952.2 |
+| Diesel product | Outlet | 214.8 | 219.1 | 17,709.24 |
+| Residual | Outlet | 341.9 | 230 | 26,937.99 |
+| Water draw | Outlet | 49 | 140 | 745.5 |
 
-| Source label | Service | Steam flow (kg/h) |
-| --- | --- | ---: |
-| Main atmospheric column | Main atmospheric column | 340.2 |
-| Kerosene side stripper | Kerosene side stripper | 68.04 |
-| Diesel side stripper | Diesel side stripper | 226.8 |
-| **Total** | Derived sum | **635.04** |
+The four published inlet flows sum to 55,055.04 kg/h and the six outlet flows sum to
+55,050.930006985 kg/h. Their 4.109993015 kg/h difference is less than `1e-4` of the inlet flow.
+This is a transcription and source-rounding check, not an independent plant conservation claim.
 
-The total is a direct sum of the three published rates. The article does not report the injection
-tray locations or the steam temperature, pressure, quality, or enthalpy. The API therefore exposes
-the rows as source evidence and reports both the location and thermodynamic state as unresolved. It
-does not create executable water streams or side-stripper topology.
+The three steam rows total 635.04 kg/h. Table 3 explicitly reports 150 degC and 476 kPa for each
+steam service, correcting the earlier incomplete guide statement. The source does not report steam
+quality, enthalpy, or injection tray locations, so temperature and pressure alone are not treated as
+a complete thermodynamic state. The API exposes the rows as evidence and does not create executable
+water streams or side-stripper topology.
 
 Table 4 gives the complete numeric pump-around rows:
 
@@ -106,6 +116,12 @@ double cloudPointLowerCelsius = SarirAtmosphericReference.getCrudeCloudPointLowe
 double cloudPointUpperCelsius = SarirAtmosphericReference.getCrudeCloudPointUpperCelsius();
 double viscosityCst = SarirAtmosphericReference.getCrudeKinematicViscosityAt100FCst();
 
+SarirAtmosphericReference.AduStreamReference crudeFeed =
+    SarirAtmosphericReference.getAduStream("Crude oil tower");
+double feedRateKgPerHour = crudeFeed.getMassFlowRateKgPerHour();
+double tableClosure =
+    SarirAtmosphericReference.calculatePublishedAduMassBalanceErrorFraction();
+
 SarirAtmosphericReference.ProductYieldReference diesel =
     SarirAtmosphericReference.getProductYield("Diesel");
 double plantRate = diesel.getPlantMetricTonPerDay();
@@ -122,6 +138,9 @@ SarirAtmosphericReference.SteamInjectionReference keroseneSteam =
     SarirAtmosphericReference.getSteamInjection("Kerosene side stripper");
 double steamRateKgPerHour = keroseneSteam.getMassFlowRateKgPerHour();
 double totalSteamRateKgPerHour = SarirAtmosphericReference.getTotalSteamRateKgPerHour();
+boolean steamTemperatureAndPressureAreExplicit =
+    SarirAtmosphericReference.hasExplicitSteamTemperatureAndPressure();
+boolean steamQualityIsExplicit = SarirAtmosphericReference.hasExplicitSteamQuality();
 boolean steamStateIsExplicit =
     SarirAtmosphericReference.hasExplicitSteamThermodynamicState();
 ```
@@ -193,5 +212,6 @@ specifications, tuning targets, or numerical acceptance thresholds. This sensiti
 qualify plant-yield or D86 reproduction and does not model the published steam, pump-around,
 side-stripper, tray-hydraulic, or efficiency details. The separate pump-around reference rows are
 source evidence only; unresolved tray-numbering direction prevents direct model configuration.
-Likewise, the steam rows retain the published service allocation and rates but do not configure
-water, injection locations, steam state, side-stripper topology, or heat duties.
+Likewise, the steam rows retain the published service allocation, rates, temperatures, and
+pressures but do not infer quality or enthalpy or configure water, injection locations, side-stripper
+topology, or heat duties.

--- a/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
+++ b/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
@@ -49,9 +49,24 @@ public final class SarirAtmosphericReference {
       new PumparoundReference("Bottom pump around (BPA)", 22, 19, 60423.66, 232.4, 173.99) };
 
   private static final SteamInjectionReference[] STEAM_INJECTIONS = {
-      new SteamInjectionReference("Main atmospheric column", SteamInjectionService.MAIN_ATMOSPHERIC_COLUMN, 340.2),
-      new SteamInjectionReference("Kerosene side stripper", SteamInjectionService.KEROSENE_SIDE_STRIPPER, 68.04),
-      new SteamInjectionReference("Diesel side stripper", SteamInjectionService.DIESEL_SIDE_STRIPPER, 226.8) };
+      new SteamInjectionReference("Main atmospheric column", SteamInjectionService.MAIN_ATMOSPHERIC_COLUMN, 340.2,
+          150.0, 476.0),
+      new SteamInjectionReference("Kerosene side stripper", SteamInjectionService.KEROSENE_SIDE_STRIPPER, 68.04, 150.0,
+          476.0),
+      new SteamInjectionReference("Diesel side stripper", SteamInjectionService.DIESEL_SIDE_STRIPPER, 226.8, 150.0,
+          476.0) };
+
+  private static final AduStreamReference[] ADU_STREAMS = {
+      new AduStreamReference("Crude oil tower", AduStreamDirection.INLET, 350.0, 233.0, 54420.0),
+      new AduStreamReference("Steam", AduStreamDirection.INLET, 150.0, 476.0, 340.2),
+      new AduStreamReference("Kerosene steam", AduStreamDirection.INLET, 150.0, 476.0, 68.04),
+      new AduStreamReference("Diesel steam", AduStreamDirection.INLET, 150.0, 476.0, 226.8),
+      new AduStreamReference("Gas To Flare", AduStreamDirection.OUTLET, 49.0, 140.0, 6.985e-6),
+      new AduStreamReference("Naphtha", AduStreamDirection.OUTLET, 49.0, 140.0, 8706.0),
+      new AduStreamReference("Kerosene product", AduStreamDirection.OUTLET, 126.3, 210.0, 952.2),
+      new AduStreamReference("Diesel product", AduStreamDirection.OUTLET, 214.8, 219.1, 17709.24),
+      new AduStreamReference("Residual", AduStreamDirection.OUTLET, 341.9, 230.0, 26937.99),
+      new AduStreamReference("Water draw", AduStreamDirection.OUTLET, 49.0, 140.0, 745.5) };
 
   private SarirAtmosphericReference() {
   }
@@ -228,17 +243,71 @@ public final class SarirAtmosphericReference {
 
   /** @return crude feed rate to the atmospheric column in kg/h */
   public static double getColumnCrudeFeedRateKgPerHour() {
-    return 54420.0;
+    return ADU_STREAMS[0].getMassFlowRateKgPerHour();
   }
 
   /** @return atmospheric-column feed temperature in degrees Celsius */
   public static double getColumnFeedTemperatureCelsius() {
-    return 350.0;
+    return ADU_STREAMS[0].getTemperatureCelsius();
   }
 
   /** @return atmospheric-column feed pressure in kPa absolute as reported */
   public static double getColumnFeedPressureKPa() {
-    return 233.0;
+    return ADU_STREAMS[0].getPressureKPa();
+  }
+
+  /** @return defensive copy of the complete published ADU stream table in source order */
+  public static AduStreamReference[] getAduStreams() {
+    return ADU_STREAMS.clone();
+  }
+
+  /**
+   * Find one ADU stream row by its exact source-table label.
+   *
+   * @param name exact source-table stream label
+   * @return immutable ADU stream reference
+   * @throws IllegalArgumentException if the label is null or unknown
+   */
+  public static AduStreamReference getAduStream(String name) {
+    if (name == null) {
+      throw new IllegalArgumentException("ADU stream name cannot be null");
+    }
+    for (AduStreamReference stream : ADU_STREAMS) {
+      if (stream.getName().equals(name)) {
+        return stream;
+      }
+    }
+    throw new IllegalArgumentException("Unknown Sarir ADU stream: " + name);
+  }
+
+  /** @return sum of the four published ADU inlet mass flows in kg/h */
+  public static double getPublishedAduInletMassFlowTotalKgPerHour() {
+    return sumAduStreamMassFlow(AduStreamDirection.INLET);
+  }
+
+  /** @return sum of the six published ADU outlet mass flows in kg/h */
+  public static double getPublishedAduOutletMassFlowTotalKgPerHour() {
+    return sumAduStreamMassFlow(AduStreamDirection.OUTLET);
+  }
+
+  /**
+   * Calculate the absolute fractional imbalance of the published ADU stream table.
+   *
+   * @return absolute inlet-minus-outlet mass-flow difference divided by inlet flow
+   */
+  public static double calculatePublishedAduMassBalanceErrorFraction() {
+    double inlet = getPublishedAduInletMassFlowTotalKgPerHour();
+    return Math.abs(inlet - getPublishedAduOutletMassFlowTotalKgPerHour()) / inlet;
+  }
+
+  private static double sumAduStreamMassFlow(AduStreamDirection direction) {
+    double total = 0.0;
+    for (AduStreamReference stream : ADU_STREAMS) {
+      if (stream.getDirection() == direction) {
+        total += stream.getMassFlowRateKgPerHour();
+      }
+    }
+    return total;
   }
 
   /** @return main atmospheric-column steam rate in kg/h */
@@ -294,7 +363,17 @@ public final class SarirAtmosphericReference {
     return false;
   }
 
-  /** @return always false because the source does not report steam temperature, pressure, or quality */
+  /** @return true because Table 3 reports 150 degrees Celsius and 476 kPa for each steam row */
+  public static boolean hasExplicitSteamTemperatureAndPressure() {
+    return true;
+  }
+
+  /** @return always false because the source does not report steam quality */
+  public static boolean hasExplicitSteamQuality() {
+    return false;
+  }
+
+  /** @return always false because temperature and pressure alone do not resolve saturated-steam state */
   public static boolean hasExplicitSteamThermodynamicState() {
     return false;
   }
@@ -346,6 +425,58 @@ public final class SarirAtmosphericReference {
     return PUMPAROUNDS[1].getMassFlowRateKgPerHour();
   }
 
+  /** Direction of one stream in the published ADU inlet/outlet table. */
+  public enum AduStreamDirection {
+    /** Stream enters the atmospheric distillation unit. */
+    INLET,
+    /** Stream leaves the atmospheric distillation unit. */
+    OUTLET
+  }
+
+  /** Immutable row from the published ADU inlet/outlet stream table. */
+  public static final class AduStreamReference implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final AduStreamDirection direction;
+    private final double temperatureCelsius;
+    private final double pressureKPa;
+    private final double massFlowRateKgPerHour;
+
+    private AduStreamReference(String name, AduStreamDirection direction, double temperatureCelsius,
+        double pressureKPa, double massFlowRateKgPerHour) {
+      this.name = name;
+      this.direction = direction;
+      this.temperatureCelsius = temperatureCelsius;
+      this.pressureKPa = pressureKPa;
+      this.massFlowRateKgPerHour = massFlowRateKgPerHour;
+    }
+
+    /** @return exact source-table stream label */
+    public String getName() {
+      return name;
+    }
+
+    /** @return inlet or outlet direction in the published table */
+    public AduStreamDirection getDirection() {
+      return direction;
+    }
+
+    /** @return source temperature in degrees Celsius */
+    public double getTemperatureCelsius() {
+      return temperatureCelsius;
+    }
+
+    /** @return source pressure in kPa as reported */
+    public double getPressureKPa() {
+      return pressureKPa;
+    }
+
+    /** @return source mass-flow rate in kg/h */
+    public double getMassFlowRateKgPerHour() {
+      return massFlowRateKgPerHour;
+    }
+  }
+
   /** Source equipment service receiving steam in the published operating case. */
   public enum SteamInjectionService {
     /** Main atmospheric crude column. */
@@ -369,11 +500,16 @@ public final class SarirAtmosphericReference {
     private final String name;
     private final SteamInjectionService service;
     private final double massFlowRateKgPerHour;
+    private final double temperatureCelsius;
+    private final double pressureKPa;
 
-    private SteamInjectionReference(String name, SteamInjectionService service, double massFlowRateKgPerHour) {
+    private SteamInjectionReference(String name, SteamInjectionService service, double massFlowRateKgPerHour,
+        double temperatureCelsius, double pressureKPa) {
       this.name = name;
       this.service = service;
       this.massFlowRateKgPerHour = massFlowRateKgPerHour;
+      this.temperatureCelsius = temperatureCelsius;
+      this.pressureKPa = pressureKPa;
     }
 
     /** @return exact source label */
@@ -389,6 +525,16 @@ public final class SarirAtmosphericReference {
     /** @return source steam mass-flow rate in kg/h */
     public double getMassFlowRateKgPerHour() {
       return massFlowRateKgPerHour;
+    }
+
+    /** @return source steam temperature in degrees Celsius */
+    public double getTemperatureCelsius() {
+      return temperatureCelsius;
+    }
+
+    /** @return source steam pressure in kPa as reported */
+    public double getPressureKPa() {
+      return pressureKPa;
     }
   }
 

--- a/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
+++ b/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
@@ -442,8 +442,8 @@ public final class SarirAtmosphericReference {
     private final double pressureKPa;
     private final double massFlowRateKgPerHour;
 
-    private AduStreamReference(String name, AduStreamDirection direction, double temperatureCelsius,
-        double pressureKPa, double massFlowRateKgPerHour) {
+    private AduStreamReference(String name, AduStreamDirection direction, double temperatureCelsius, double pressureKPa,
+        double massFlowRateKgPerHour) {
       this.name = name;
       this.direction = direction;
       this.temperatureCelsius = temperatureCelsius;

--- a/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
+++ b/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import neqsim.thermo.characterization.SarirAtmosphericReference.AduStreamDirection;
+import neqsim.thermo.characterization.SarirAtmosphericReference.AduStreamReference;
 import neqsim.thermo.characterization.SarirAtmosphericReference.ProductQualityReference;
 import neqsim.thermo.characterization.SarirAtmosphericReference.ProductYieldReference;
 import neqsim.thermo.characterization.SarirAtmosphericReference.PumparoundReference;
@@ -55,6 +57,10 @@ public class SarirAtmosphericReferenceTest {
     SteamInjectionReference[] steamInjections = SarirAtmosphericReference.getSteamInjections();
     steamInjections[0] = null;
     assertEquals("Main atmospheric column", SarirAtmosphericReference.getSteamInjections()[0].getName());
+
+    AduStreamReference[] streams = SarirAtmosphericReference.getAduStreams();
+    streams[0] = null;
+    assertEquals("Crude oil tower", SarirAtmosphericReference.getAduStreams()[0].getName());
   }
 
   @Test
@@ -122,18 +128,48 @@ public class SarirAtmosphericReferenceTest {
   }
 
   @Test
+  public void aduStreamRowsPreservePublishedTableAndMassClosure() {
+    AduStreamReference[] streams = SarirAtmosphericReference.getAduStreams();
+    assertEquals(10, streams.length);
+    assertAduStream(streams[0], "Crude oil tower", AduStreamDirection.INLET, 350.0, 233.0, 54420.0);
+    assertAduStream(streams[1], "Steam", AduStreamDirection.INLET, 150.0, 476.0, 340.2);
+    assertAduStream(streams[2], "Kerosene steam", AduStreamDirection.INLET, 150.0, 476.0, 68.04);
+    assertAduStream(streams[3], "Diesel steam", AduStreamDirection.INLET, 150.0, 476.0, 226.8);
+    assertAduStream(streams[4], "Gas To Flare", AduStreamDirection.OUTLET, 49.0, 140.0, 6.985e-6);
+    assertAduStream(streams[5], "Naphtha", AduStreamDirection.OUTLET, 49.0, 140.0, 8706.0);
+    assertAduStream(streams[6], "Kerosene product", AduStreamDirection.OUTLET, 126.3, 210.0, 952.2);
+    assertAduStream(streams[7], "Diesel product", AduStreamDirection.OUTLET, 214.8, 219.1, 17709.24);
+    assertAduStream(streams[8], "Residual", AduStreamDirection.OUTLET, 341.9, 230.0, 26937.99);
+    assertAduStream(streams[9], "Water draw", AduStreamDirection.OUTLET, 49.0, 140.0, 745.5);
+
+    assertEquals(55055.04, SarirAtmosphericReference.getPublishedAduInletMassFlowTotalKgPerHour(), 1.0e-9);
+    assertEquals(55050.930006985, SarirAtmosphericReference.getPublishedAduOutletMassFlowTotalKgPerHour(), 1.0e-9);
+    assertEquals(4.109993015,
+        SarirAtmosphericReference.getPublishedAduInletMassFlowTotalKgPerHour()
+            - SarirAtmosphericReference.getPublishedAduOutletMassFlowTotalKgPerHour(),
+        1.0e-9);
+    assertTrue(SarirAtmosphericReference.calculatePublishedAduMassBalanceErrorFraction() < 1.0e-4);
+    assertEquals(streams[0], SarirAtmosphericReference.getAduStream("Crude oil tower"));
+    assertEquals(streams[9], SarirAtmosphericReference.getAduStream("Water draw"));
+  }
+
+  @Test
   public void steamInjectionRowsPreservePublishedServicesWithoutInventingState() {
     SteamInjectionReference[] injections = SarirAtmosphericReference.getSteamInjections();
     assertEquals(3, injections.length);
     assertSteamInjection(injections[0], "Main atmospheric column", SteamInjectionService.MAIN_ATMOSPHERIC_COLUMN,
-        340.2);
-    assertSteamInjection(injections[1], "Kerosene side stripper", SteamInjectionService.KEROSENE_SIDE_STRIPPER, 68.04);
-    assertSteamInjection(injections[2], "Diesel side stripper", SteamInjectionService.DIESEL_SIDE_STRIPPER, 226.8);
+        340.2, 150.0, 476.0);
+    assertSteamInjection(injections[1], "Kerosene side stripper", SteamInjectionService.KEROSENE_SIDE_STRIPPER, 68.04,
+        150.0, 476.0);
+    assertSteamInjection(injections[2], "Diesel side stripper", SteamInjectionService.DIESEL_SIDE_STRIPPER, 226.8,
+        150.0, 476.0);
     assertEquals(injections[0], SarirAtmosphericReference.getSteamInjection("Main atmospheric column"));
     assertEquals(injections[1], SarirAtmosphericReference.getSteamInjection("Kerosene side stripper"));
     assertEquals(injections[2], SarirAtmosphericReference.getSteamInjection("Diesel side stripper"));
     assertEquals(635.04, SarirAtmosphericReference.getTotalSteamRateKgPerHour(), 1.0e-12);
     assertFalse(SarirAtmosphericReference.hasExplicitSteamInjectionLocations());
+    assertTrue(SarirAtmosphericReference.hasExplicitSteamTemperatureAndPressure());
+    assertFalse(SarirAtmosphericReference.hasExplicitSteamQuality());
     assertFalse(SarirAtmosphericReference.hasExplicitSteamThermodynamicState());
   }
 
@@ -152,6 +188,8 @@ public class SarirAtmosphericReferenceTest {
   public void invalidQueriesAndErrorInputsFailClosed() {
     assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getProductYield(null));
     assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getProductYield("Naphtha"));
+    assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getAduStream(null));
+    assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getAduStream("Crude"));
     assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getPumparound(null));
     assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getPumparound("TPA"));
     assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getSteamInjection(null));
@@ -164,11 +202,22 @@ public class SarirAtmosphericReferenceTest {
         () -> SarirAtmosphericReference.calculateAbsoluteRelativeErrorPercent(1.0, Double.POSITIVE_INFINITY));
   }
 
+  private static void assertAduStream(AduStreamReference stream, String name, AduStreamDirection direction,
+      double temperatureCelsius, double pressureKPa, double massFlowRate) {
+    assertEquals(name, stream.getName());
+    assertEquals(direction, stream.getDirection());
+    assertEquals(temperatureCelsius, stream.getTemperatureCelsius(), 0.0);
+    assertEquals(pressureKPa, stream.getPressureKPa(), 0.0);
+    assertEquals(massFlowRate, stream.getMassFlowRateKgPerHour(), 0.0);
+  }
+
   private static void assertSteamInjection(SteamInjectionReference injection, String name,
-      SteamInjectionService service, double massFlowRate) {
+      SteamInjectionService service, double massFlowRate, double temperatureCelsius, double pressureKPa) {
     assertEquals(name, injection.getName());
     assertEquals(service, injection.getService());
     assertEquals(massFlowRate, injection.getMassFlowRateKgPerHour(), 0.0);
+    assertEquals(temperatureCelsius, injection.getTemperatureCelsius(), 0.0);
+    assertEquals(pressureKPa, injection.getPressureKPa(), 0.0);
   }
 
   private static void assertPumparound(PumparoundReference pumparound, String name, int drawTray, int returnTray,

--- a/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
+++ b/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
@@ -144,10 +144,8 @@ public class SarirAtmosphericReferenceTest {
 
     assertEquals(55055.04, SarirAtmosphericReference.getPublishedAduInletMassFlowTotalKgPerHour(), 1.0e-9);
     assertEquals(55050.930006985, SarirAtmosphericReference.getPublishedAduOutletMassFlowTotalKgPerHour(), 1.0e-9);
-    assertEquals(4.109993015,
-        SarirAtmosphericReference.getPublishedAduInletMassFlowTotalKgPerHour()
-            - SarirAtmosphericReference.getPublishedAduOutletMassFlowTotalKgPerHour(),
-        1.0e-9);
+    assertEquals(4.109993015, SarirAtmosphericReference.getPublishedAduInletMassFlowTotalKgPerHour()
+        - SarirAtmosphericReference.getPublishedAduOutletMassFlowTotalKgPerHour(), 1.0e-9);
     assertTrue(SarirAtmosphericReference.calculatePublishedAduMassBalanceErrorFraction() < 1.0e-4);
     assertEquals(streams[0], SarirAtmosphericReference.getAduStream("Crude oil tower"));
     assertEquals(streams[9], SarirAtmosphericReference.getAduStream("Water draw"));
@@ -157,8 +155,8 @@ public class SarirAtmosphericReferenceTest {
   public void steamInjectionRowsPreservePublishedServicesWithoutInventingState() {
     SteamInjectionReference[] injections = SarirAtmosphericReference.getSteamInjections();
     assertEquals(3, injections.length);
-    assertSteamInjection(injections[0], "Main atmospheric column", SteamInjectionService.MAIN_ATMOSPHERIC_COLUMN,
-        340.2, 150.0, 476.0);
+    assertSteamInjection(injections[0], "Main atmospheric column", SteamInjectionService.MAIN_ATMOSPHERIC_COLUMN, 340.2,
+        150.0, 476.0);
     assertSteamInjection(injections[1], "Kerosene side stripper", SteamInjectionService.KEROSENE_SIDE_STRIPPER, 68.04,
         150.0, 476.0);
     assertSteamInjection(injections[2], "Diesel side stripper", SteamInjectionService.DIESEL_SIDE_STRIPPER, 226.8,


### PR DESCRIPTION
## Summary

Continues #3305 by preserving all ten numeric inlet/outlet rows from Sarir ADU Table 3 as immutable Java/JPype reference evidence.

- adds exact stream labels, direction, temperature, pressure, and mass flow in source order;
- exposes defensive array access and exact-label lookup;
- derives published inlet/outlet totals and a bounded table-closure metric;
- extends the existing steam rows with the published `150 degC` and `476 kPa`;
- distinguishes known steam temperature/pressure from unresolved quality, enthalpy, and injection location;
- preserves existing scalar crude-feed and steam-rate APIs;
- corrects the Sarir guide's prior statement that steam temperature and pressure were absent.

## Published Table 3 closure

- Four inlets: `55,055.04 kg/h`
- Six outlets: `55,050.930006985 kg/h`
- Absolute difference: `4.109993015 kg/h`
- Fractional imbalance: below `1e-4` of inlet flow

This is a source transcription/rounding check, not an independent plant conservation claim.

## Public provenance

Hamza E. Omran Almansouri, *Simulation of Sarir Crude Oil Refinery Using Aspen HYSYS*, Journal of Engineering Research (Libya), issue 33, pages 51-64, published 2022-03-31.

- DOI: https://doi.org/10.66411/jer.v33i.46
- Open article: https://jer.ly/jer/index.php/jer/article/download/46/38/39
- License: CC BY 4.0

## Engineering boundary

The rows are immutable reference data. This change does not create process streams, add water, infer steam phase or quality, calculate enthalpy, choose injection trays, construct side strippers, configure pump-arounds, tune products, or change assay, pseudo-components, EOS, solver controls, or defaults.

## Validation

Connector-side exact-tree checks on repaired head `c2b4f3e558c3ed31c08b3192ca96a1e7eec97c33`:

- five commits ahead and zero behind exact base `9ec5900e8391b6cb5b298b7331524c3b98aaf9d0`;
- exactly three intended files changed;
- ten ADU rows and three steam rows present;
- ten focused reference tests;
- balanced Java braces with no tabs or trailing whitespace;
- production and test Java lines are at most 120 characters;
- no post-Java-8 construct introduced;
- the final two commits apply exactly the source and test wraps printed by hosted Spotless; engineering behavior is unchanged.

Hosted exact-head CI is authoritative and pending.

## Campaign continuity

Predecessor #3480 merged unchanged from qualified exact head `6c16138b8e002ff20f0631c7e2d0d7487fd8d6bd`. This is the sole active #3305 implementation PR and remains draft-only.