### PR TITLE
[AI-Assisted] feat(refinery): preserve Sarir product specifications

### DIFF
--- a/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
+++ b/docs/thermo/characterization/refinery_sarir_atmospheric_reference.md
@@ -47,6 +47,25 @@ do not qualify a wax, asphaltene, viscosity, water, or sulfur prediction model.
 
 The source then reports a `550 degC+` terminal residue reaching 100 volume%. NeqSim retains 550 degC as a one-sided lower boundary and computes the implied 16.30 volume% residue; it does not invent a finite 100% endpoint or an upper boiling limit. The source marks light-end hydrocarbons as not determined, so no light-end composition is synthesized.
 
+## Product specifications
+
+Table 2 reports ASTM D86 temperatures at 95 liquid volume percent as product specifications:
+
+| Product | Test basis | Published specification |
+| --- | --- | ---: |
+| Light Naphtha | ASTM D86 at 95 volume% | 90 degC |
+| Heavy Naphtha | ASTM D86 at 95 volume% | 160 degC |
+| Kerosene | ASTM D86 at 95 volume% | 221 degC |
+| Diesel | ASTM D86 at 95 volume% | 327 degC |
+| Residual | ASTM D86 at 95 volume% | `<550+` |
+
+The Java API keeps these five specification rows separate from the Table 5 laboratory/HYSYS
+results. In particular, the 327 degC diesel specification is not replaced by the 346 degC
+laboratory result or the 339 degC HYSYS result. The residual value is retained as the source's
+nonnumeric, open-ended boundary; requesting a numeric specification temperature for that row
+fails closed. These rows are source design/reference criteria, not independently reproduced
+measurements and not evidence that NeqSim meets the specifications.
+
 ## Atmospheric operating case
 
 The published HYSYS case uses 34 valve trays and feeds crude to tray 31 counted from the top.
@@ -122,6 +141,16 @@ double feedRateKgPerHour = crudeFeed.getMassFlowRateKgPerHour();
 double tableClosure =
     SarirAtmosphericReference.calculatePublishedAduMassBalanceErrorFraction();
 
+SarirAtmosphericReference.ProductSpecificationReference dieselSpecification =
+    SarirAtmosphericReference.getProductSpecification("Diesel");
+double dieselSpecificationCelsius =
+    dieselSpecification.getSpecificationTemperatureCelsius();
+
+SarirAtmosphericReference.ProductSpecificationReference residualSpecification =
+    SarirAtmosphericReference.getProductSpecification("Residual");
+boolean residualSpecificationIsNumeric =
+    residualSpecification.hasNumericSpecificationTemperature();
+
 SarirAtmosphericReference.ProductYieldReference diesel =
     SarirAtmosphericReference.getProductYield("Diesel");
 double plantRate = diesel.getPlantMetricTonPerDay();
@@ -177,8 +206,10 @@ components are modified.
 
 ## Scientific boundary
 
-The source-derived volumes and boiling boundaries are reproducible, while every supplied cut
-density and molar mass remains an explicit engineering input. The factory does not resolve the
+The source-derived volumes, boiling boundaries, and product-specification rows are reproducible,
+while every supplied cut density and molar mass remains an explicit engineering input. Product
+specifications are not laboratory results, independent validation targets, or a claim of NeqSim
+product compliance. The residual specification remains nonnumeric and open-ended. The factory does not resolve the
 missing light-end composition, distribute the published whole-crude sulfur among cuts, or claim
 that NeqSim reproduces the plant yields. A follow-on 34-tray comparison must preserve the plant
 rates as untouched acceptance targets and avoid tuning draw rates to the published products.

--- a/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
+++ b/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
@@ -641,8 +641,8 @@ public final class SarirAtmosphericReference {
    * Immutable product-specification row from source Table 2.
    *
    * <p>
-   * Numeric access fails closed for the residual row because the source reports an open-ended
-   * {@code <550+} boundary rather than a numeric ASTM D86 T95.
+   * Numeric access fails closed for the residual row because the source reports an open-ended {@code <550+} boundary
+   * rather than a numeric ASTM D86 T95.
    * </p>
    */
   public static final class ProductSpecificationReference implements Serializable {

--- a/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
+++ b/src/main/java/neqsim/thermo/characterization/SarirAtmosphericReference.java
@@ -40,6 +40,13 @@ public final class SarirAtmosphericReference {
       new ProductQualityReference("Kerosene", 185.0, 221.0, 159.0, 214.0),
       new ProductQualityReference("Diesel", 262.0, 346.0, 235.0, 339.0) };
 
+  private static final ProductSpecificationReference[] PRODUCT_SPECIFICATIONS = {
+      new ProductSpecificationReference("Light Naphtha", 90.0, "90", false),
+      new ProductSpecificationReference("Heavy Naphtha", 160.0, "160", false),
+      new ProductSpecificationReference("Kerosene", 221.0, "221", false),
+      new ProductSpecificationReference("Diesel", 327.0, "327", false),
+      new ProductSpecificationReference("Residual", Double.NaN, "<550+", true) };
+
   private static final ProductYieldReference[] PRODUCT_YIELDS = {
       new ProductYieldReference("Total Naphtha", 208.95, 208.2), new ProductYieldReference("Kerosene", 22.85, 20.0),
       new ProductYieldReference("Diesel", 425.018, 393.0), new ProductYieldReference("Residual", 646.5, 706.1) };
@@ -123,6 +130,35 @@ public final class SarirAtmosphericReference {
   /** @return defensive copy of numeric laboratory/simulation ASTM D86 comparison rows */
   public static ProductQualityReference[] getProductQualities() {
     return PRODUCT_QUALITIES.clone();
+  }
+
+  /** @return defensive copy of the five source Table 2 product-specification rows */
+  public static ProductSpecificationReference[] getProductSpecifications() {
+    return PRODUCT_SPECIFICATIONS.clone();
+  }
+
+  /**
+   * Find one product-specification row by its exact source-table label.
+   *
+   * @param productName exact source-table product label
+   * @return immutable product specification
+   * @throws IllegalArgumentException if the label is null or unknown
+   */
+  public static ProductSpecificationReference getProductSpecification(String productName) {
+    if (productName == null) {
+      throw new IllegalArgumentException("Product name cannot be null");
+    }
+    for (ProductSpecificationReference product : PRODUCT_SPECIFICATIONS) {
+      if (product.getName().equals(productName)) {
+        return product;
+      }
+    }
+    throw new IllegalArgumentException("Unknown Sarir product specification: " + productName);
+  }
+
+  /** @return false because source Table 2 specifications are criteria, not reproduced results */
+  public static boolean areProductSpecificationsIndependentValidationResults() {
+    return false;
   }
 
   /** @return defensive copy of independent plant/simulation product-yield comparison rows */
@@ -598,6 +634,78 @@ public final class SarirAtmosphericReference {
     /** @return draw temperature minus return temperature, in kelvin */
     public double getTemperatureDropKelvin() {
       return drawTemperatureCelsius - returnTemperatureCelsius;
+    }
+  }
+
+  /**
+   * Immutable product-specification row from source Table 2.
+   *
+   * <p>
+   * Numeric access fails closed for the residual row because the source reports an open-ended
+   * {@code <550+} boundary rather than a numeric ASTM D86 T95.
+   * </p>
+   */
+  public static final class ProductSpecificationReference implements Serializable {
+    private static final long serialVersionUID = 1000L;
+    private final String name;
+    private final double specificationTemperatureCelsius;
+    private final String sourceValue;
+    private final boolean openEndedBoundary;
+
+    private ProductSpecificationReference(String name, double specificationTemperatureCelsius, String sourceValue,
+        boolean openEndedBoundary) {
+      this.name = name;
+      this.specificationTemperatureCelsius = specificationTemperatureCelsius;
+      this.sourceValue = sourceValue;
+      this.openEndedBoundary = openEndedBoundary;
+    }
+
+    /** @return exact source-table product label */
+    public String getName() {
+      return name;
+    }
+
+    /** @return source test method, always ASTM D86 */
+    public String getTestMethod() {
+      return "ASTM D86";
+    }
+
+    /** @return source distillation percentage, always 95 liquid volume percent */
+    public double getDistilledVolumePercent() {
+      return 95.0;
+    }
+
+    /** @return whether this row has a finite numeric specification temperature */
+    public boolean hasNumericSpecificationTemperature() {
+      return Double.isFinite(specificationTemperatureCelsius);
+    }
+
+    /**
+     * Return the numeric specification temperature.
+     *
+     * @return specification temperature in degrees Celsius
+     * @throws IllegalStateException if the source row is nonnumeric and open-ended
+     */
+    public double getSpecificationTemperatureCelsius() {
+      if (!hasNumericSpecificationTemperature()) {
+        throw new IllegalStateException("Sarir product specification is nonnumeric: " + sourceValue);
+      }
+      return specificationTemperatureCelsius;
+    }
+
+    /** @return exact value text transcribed from source Table 2 */
+    public String getSourceValue() {
+      return sourceValue;
+    }
+
+    /** @return whether the source row is an open-ended boundary rather than a numeric T95 */
+    public boolean isOpenEndedBoundary() {
+      return openEndedBoundary;
+    }
+
+    /** @return false because a source specification is not an independently reproduced result */
+    public boolean isIndependentValidationResult() {
+      return false;
     }
   }
 

--- a/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
+++ b/src/test/java/neqsim/thermo/characterization/SarirAtmosphericReferenceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import neqsim.thermo.characterization.SarirAtmosphericReference.AduStreamDirection;
 import neqsim.thermo.characterization.SarirAtmosphericReference.AduStreamReference;
 import neqsim.thermo.characterization.SarirAtmosphericReference.ProductQualityReference;
+import neqsim.thermo.characterization.SarirAtmosphericReference.ProductSpecificationReference;
 import neqsim.thermo.characterization.SarirAtmosphericReference.ProductYieldReference;
 import neqsim.thermo.characterization.SarirAtmosphericReference.PumparoundReference;
 import neqsim.thermo.characterization.SarirAtmosphericReference.SteamInjectionReference;
@@ -46,6 +47,10 @@ public class SarirAtmosphericReferenceTest {
     quality[0] = null;
     assertEquals("Light Naphtha", SarirAtmosphericReference.getProductQualities()[0].getName());
 
+    ProductSpecificationReference[] specifications = SarirAtmosphericReference.getProductSpecifications();
+    specifications[0] = null;
+    assertEquals("Light Naphtha", SarirAtmosphericReference.getProductSpecifications()[0].getName());
+
     ProductYieldReference[] yields = SarirAtmosphericReference.getProductYields();
     yields[0] = null;
     assertEquals("Total Naphtha", SarirAtmosphericReference.getProductYields()[0].getName());
@@ -71,6 +76,35 @@ public class SarirAtmosphericReferenceTest {
     assertQuality(quality[1], "Heavy Naphtha", 96.0, 160.0, 83.0, 153.0);
     assertQuality(quality[2], "Kerosene", 185.0, 221.0, 159.0, 214.0);
     assertQuality(quality[3], "Diesel", 262.0, 346.0, 235.0, 339.0);
+  }
+
+  @Test
+  public void productSpecificationsPreserveTableTwoWithoutBecomingValidationResults() {
+    ProductSpecificationReference[] specifications = SarirAtmosphericReference.getProductSpecifications();
+    assertEquals(5, specifications.length);
+    assertNumericSpecification(specifications[0], "Light Naphtha", 90.0, "90");
+    assertNumericSpecification(specifications[1], "Heavy Naphtha", 160.0, "160");
+    assertNumericSpecification(specifications[2], "Kerosene", 221.0, "221");
+    assertNumericSpecification(specifications[3], "Diesel", 327.0, "327");
+
+    ProductSpecificationReference residual = specifications[4];
+    assertEquals("Residual", residual.getName());
+    assertEquals("ASTM D86", residual.getTestMethod());
+    assertEquals(95.0, residual.getDistilledVolumePercent(), 0.0);
+    assertEquals("<550+", residual.getSourceValue());
+    assertFalse(residual.hasNumericSpecificationTemperature());
+    assertTrue(residual.isOpenEndedBoundary());
+    assertFalse(residual.isIndependentValidationResult());
+    assertThrows(IllegalStateException.class, residual::getSpecificationTemperatureCelsius);
+
+    assertEquals(specifications[3], SarirAtmosphericReference.getProductSpecification("Diesel"));
+    assertEquals(residual, SarirAtmosphericReference.getProductSpecification("Residual"));
+    assertFalse(SarirAtmosphericReference.areProductSpecificationsIndependentValidationResults());
+
+    ProductQualityReference dieselResult = SarirAtmosphericReference.getProductQualities()[3];
+    assertEquals(327.0, specifications[3].getSpecificationTemperatureCelsius(), 0.0);
+    assertEquals(346.0, dieselResult.getLaboratoryNinetyFivePercentCelsius(), 0.0);
+    assertEquals(339.0, dieselResult.getSimulationNinetyFivePercentCelsius(), 0.0);
   }
 
   @Test
@@ -184,6 +218,8 @@ public class SarirAtmosphericReferenceTest {
 
   @Test
   public void invalidQueriesAndErrorInputsFailClosed() {
+    assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getProductSpecification(null));
+    assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getProductSpecification("Naphtha"));
     assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getProductYield(null));
     assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getProductYield("Naphtha"));
     assertThrows(IllegalArgumentException.class, () -> SarirAtmosphericReference.getAduStream(null));
@@ -227,6 +263,18 @@ public class SarirAtmosphericReferenceTest {
     assertEquals(drawTemperature, pumparound.getDrawTemperatureCelsius(), 0.0);
     assertEquals(returnTemperature, pumparound.getReturnTemperatureCelsius(), 0.0);
     assertEquals(temperatureDrop, pumparound.getTemperatureDropKelvin(), 1.0e-12);
+  }
+
+  private static void assertNumericSpecification(ProductSpecificationReference specification, String name,
+      double temperatureCelsius, String sourceValue) {
+    assertEquals(name, specification.getName());
+    assertEquals("ASTM D86", specification.getTestMethod());
+    assertEquals(95.0, specification.getDistilledVolumePercent(), 0.0);
+    assertTrue(specification.hasNumericSpecificationTemperature());
+    assertEquals(temperatureCelsius, specification.getSpecificationTemperatureCelsius(), 0.0);
+    assertEquals(sourceValue, specification.getSourceValue());
+    assertFalse(specification.isOpenEndedBoundary());
+    assertFalse(specification.isIndependentValidationResult());
   }
 
   private static void assertQuality(ProductQualityReference quality, String name, double labFive, double labNinetyFive,


### PR DESCRIPTION
## Summary

Advances #3305 with a source-faithful, Java/JPype-accessible representation of the Sarir ADU Table 2 product specifications.

**Exact base:** `4e3ea7808470066d1406ef62660713086a813624`  
**Exact publication head:** `acc253e94113bdd0c51b39b7c275a56116b5db6f`

The frozen capability contract is recorded in the [#3305 campaign ledger](https://github.com/equinor/neqsim/issues/3305#issuecomment-5554480172).

## Capability

- preserves all five Table 2 rows in source order and with exact product labels;
- records ASTM D86 at 95 liquid volume percent as the source test basis;
- exposes numeric specifications of 90, 160, 221, and 327 °C for Light Naphtha, Heavy Naphtha, Kerosene, and Diesel;
- retains the Residual `<550+` entry as a nonnumeric, open-ended boundary;
- rejects numeric-temperature access for that residual row;
- keeps Table 2 specifications separate from Table 5 laboratory/HYSYS results and plant-rate validation evidence;
- provides immutable rows, defensive-copy access, exact-label lookup, tests, and documentation.

## Scientific boundary

The specifications are source design/reference criteria, not independently reproduced measurements, NeqSim predictions, or compliance claims. In particular, the 327 °C diesel specification remains distinct from the Table 5 laboratory 346 °C and HYSYS 339 °C results. No product-cut tuning, executable column configuration, pseudo-component inference, solver change, blending, or conversion model is included.

## Provenance and license

Hamza E. Omran Almansouri, *Simulation of Sarir Crude Oil Refinery Using Aspen HYSYS*, Journal of Engineering Research (Libya), issue 33, pp. 51–64, published 2022-03-31, DOI [10.66411/jer.v33i.46](https://doi.org/10.66411/jer.v33i.46). The [open article](https://jer.ly/jer/index.php/jer/article/download/46/38/39) is licensed CC BY 4.0.

## Validation

**DRAFT — READY TO MERGE**

All required hosted workflows pass on exact head `acc253e94113bdd0c51b39b7c275a56116b5db6f`:

- Java 8 and Java 21 tests on Ubuntu and Windows;
- all four Java 21 slow-test shards;
- full tests and Javadocs;
- Spotless and pre-commit;
- documentation search coverage;
- CodeQL Security Analysis;
- PaperLab Replication Gate and agent-skill checks.

The branch is exactly four commits ahead of the recorded base and changes only the three frozen files. There are no reviews or unresolved review threads, and GitHub reports the PR mergeable.

## Portfolio and overlap

Portfolio occupancy is **5/10** including this draft. The four other positively identified autonomous capabilities do not overlap these refinery-owned files. This is the sole active #3305 PR.

## Stop boundary

Draft-only. Do not merge, mark ready for review, enable auto-merge, rebase, synchronize, replace, close, abandon, or force-push this PR as part of the campaign.

Generated with AI assistance.