### PR TITLE
[AI-Assisted] feat(kinetics): invert H2S target residence time

### DIFF
--- a/docs/chemicalreactions/h2s_oxygen_kinetics.md
+++ b/docs/chemicalreactions/h2s_oxygen_kinetics.md
@@ -88,6 +88,33 @@ reaction/transport thresholds. A caller may compare this diagnostic with an inde
 established transport time, but that does not constitute a pipeline source-term coupling or
 high-pressure qualification.
 
+## Target-time inversion
+
+`timeToRemainingFractionRange(...)` inverts the same constant-oxygen first-order solution for a
+requested remaining-total-sulfide fraction `f`:
+
+$
+E_{\mathrm{required}} = -\ln f, \qquad
+t_{\mathrm{required}} = \frac{-\ln f}{k[\mathrm{O_2}]}.
+$
+
+The immutable result reports the target fraction, required dimensionless exposure, lower/nominal/
+upper pseudo-first-order rates, and the shortest, nominal, and longest required times. The shortest
+time uses the upper fit-scatter rate; the longest uses the lower rate. For the illustrative state
+above, a target fraction of `0.5` reproduces the nominal half-life of `22.4288 h`. Substituting
+each reported time and its corresponding rate back into `exp(-k[O2]t)` recovers the requested
+fraction.
+
+A target fraction of exactly one returns zero required exposure and zero time. The valid target
+interval is `(0, 1]`; exact zero is rejected because the first-order model approaches zero only
+as time tends to infinity. Stricter targets require monotonically longer times. Non-finite inputs,
+underflowed rates, or a required-time overflow fail closed.
+
+This inverse calculation is a screening diagnostic, not an equipment-sizing guarantee. It retains
+the same air-saturated constant-oxygen, atmospheric-pressure, fit-scatter, and unidentified-product
+limitations. It does not establish a pipeline residence time, mass-transfer rate, or high-pressure
+reaction extent.
+
 ## Piecewise exposure trajectory
 
 `AqueousHydrogenSulfideOxidationTrajectory.advance(...)` propagates the same correlation through

--- a/docs/test_h2s_oxygen_kinetics_documentation.py
+++ b/docs/test_h2s_oxygen_kinetics_documentation.py
@@ -87,8 +87,11 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
             "public static RateConstantRange secondOrderRateConstantRange(",
             "public static ScreeningResult screenAirSaturatedExposure(",
             "public static ResidenceTimeRangeResult screenResidenceTimeRange(",
+            "public static TargetTimeRangeResult timeToRemainingFractionRange(",
             "public static final class ResidenceTimeRangeResult",
+            "public static final class TargetTimeRangeResult",
             "finiteProduct(",
+            "finiteQuotient(",
             "Math.expm1(-exposure)",
         ):
             self.assertIn(token, self.implementation)
@@ -103,6 +106,9 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
             "testResidenceTimeRangePropagatesPublishedFitScatter",
             "testResidenceTimeRangeIsMonotonicDeterministicAndExactAtZero",
             "testResidenceTimeRangeFailsClosedOnInvalidOrOverflowingInputs",
+            "testTargetTimeRangeReproducesHalfLifeAndForwardSolution",
+            "testTargetTimeRangeIdentityMonotonicityAndDeterminism",
+            "testTargetTimeRangeFailsClosedOnInvalidTargetsAndOverflow",
             "testLongExposureRemainsBoundedAndInputValidationFailsClosed",
         ):
             self.assertIn(token, self.java_test)
@@ -119,6 +125,22 @@ class HydrogenSulfideOxygenKineticsDocumentationTest(unittest.TestCase):
             "continuous Damkohler evidence",
             "does not add categorical reaction/transport thresholds",
             "does not constitute a pipeline source-term coupling",
+        ):
+            self.assertIn(token, self.normalized)
+
+    def test_target_time_inversion_contract_is_documented(self):
+        for token in (
+            "Target-time inversion",
+            "`timeToRemainingFractionRange(...)`",
+            r"E_{\mathrm{required}} = -\ln f",
+            r"t_{\mathrm{required}} = \frac{-\ln f}{k[\mathrm{O_2}]}",
+            "shortest, nominal, and longest required times",
+            "target fraction of `0.5`",
+            "nominal half-life of `22.4288 h`",
+            "valid target interval is `(0, 1]`",
+            "exact zero is rejected",
+            "not an equipment-sizing guarantee",
+            "does not establish a pipeline residence time",
         ):
             self.assertIn(token, self.normalized)
 

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKinetics.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKinetics.java
@@ -246,8 +246,7 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
    */
   public static TargetTimeRangeResult timeToRemainingFractionRange(double airSaturatedOxygenMolality,
       double targetRemainingFraction, double temperatureK, double pH, double ionicStrengthMolPerKgWater) {
-    if (!Double.isFinite(targetRemainingFraction) || targetRemainingFraction <= 0.0
-        || targetRemainingFraction > 1.0) {
+    if (!Double.isFinite(targetRemainingFraction) || targetRemainingFraction <= 0.0 || targetRemainingFraction > 1.0) {
       throw new IllegalArgumentException("target remaining fraction must be finite and in the interval (0, 1]");
     }
 

--- a/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKinetics.java
+++ b/src/main/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKinetics.java
@@ -224,6 +224,51 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
         Math.exp(-nominalDamkohler), Math.exp(-upperDamkohler));
   }
 
+  /**
+   * Calculate the time required to reach a target remaining-total-sulfide fraction.
+   *
+   * <p>
+   * The required dimensionless exposure is {@code -ln(fRemaining)}. The shortest, nominal, and longest times use the
+   * upper, nominal, and lower pseudo-first-order rates from the source's one-standard-deviation {@code log10(k)}
+   * interval. A target of one requires exactly zero time; zero is rejected because finite first-order time cannot reach
+   * an exactly zero remaining fraction.
+   * </p>
+   *
+   * @param airSaturatedOxygenMolality dissolved oxygen molality for an independently established air-saturated aqueous
+   * state [mol/kg water]
+   * @param targetRemainingFraction target total-sulfide fraction in the interval (0, 1]
+   * @param temperatureK aqueous temperature [K]
+   * @param pH aqueous pH on the source-compatible scale
+   * @param ionicStrengthMolPerKgWater ionic strength [mol/kg water]
+   * @return immutable target-time range
+   * @throws IllegalArgumentException when the target is not finite and in (0, 1], oxygen is not finite and positive,
+   * the state is outside the published range, or a calculated time is not finite
+   */
+  public static TargetTimeRangeResult timeToRemainingFractionRange(double airSaturatedOxygenMolality,
+      double targetRemainingFraction, double temperatureK, double pH, double ionicStrengthMolPerKgWater) {
+    if (!Double.isFinite(targetRemainingFraction) || targetRemainingFraction <= 0.0
+        || targetRemainingFraction > 1.0) {
+      throw new IllegalArgumentException("target remaining fraction must be finite and in the interval (0, 1]");
+    }
+
+    RateConstantRange secondOrderRates = secondOrderRateConstantRange(temperatureK, pH, ionicStrengthMolPerKgWater);
+    double nominalRate = pseudoFirstOrderRateConstant(airSaturatedOxygenMolality, temperatureK, pH,
+        ionicStrengthMolPerKgWater);
+    double lowerRate = secondOrderRates.getLower() * airSaturatedOxygenMolality;
+    double upperRate = secondOrderRates.getUpper() * airSaturatedOxygenMolality;
+    requireFinitePositive(lowerRate, "lower pseudo-first-order rate");
+    requireFinitePositive(upperRate, "upper pseudo-first-order rate");
+
+    double requiredExposure = targetRemainingFraction == 1.0 ? 0.0 : -Math.log(targetRemainingFraction);
+    requireFiniteNonNegative(requiredExposure, "required exposure");
+    double shortestTime = finiteQuotient(requiredExposure, upperRate, "shortest required time");
+    double nominalTime = finiteQuotient(requiredExposure, nominalRate, "nominal required time");
+    double longestTime = finiteQuotient(requiredExposure, lowerRate, "longest required time");
+
+    return new TargetTimeRangeResult(targetRemainingFraction, requiredExposure, lowerRate, nominalRate, upperRate,
+        shortestTime, nominalTime, longestTime);
+  }
+
   private static void requirePublishedState(double temperatureK, double pH, double ionicStrengthMolPerKgWater) {
     requireRange(temperatureK, MINIMUM_TEMPERATURE_K, MAXIMUM_TEMPERATURE_K, "temperature");
     requireRange(pH, MINIMUM_PH, MAXIMUM_PH, "pH");
@@ -261,6 +306,12 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
     return product;
   }
 
+  private static double finiteQuotient(double numerator, double denominator, String name) {
+    double quotient = numerator / denominator;
+    requireFiniteNonNegative(quotient, name);
+    return quotient;
+  }
+
   /** Immutable second-order rate-constant interval. */
   public static final class RateConstantRange implements Serializable {
     private static final long serialVersionUID = 1000L;
@@ -288,6 +339,73 @@ public final class AqueousHydrogenSulfideOxidationKinetics implements Serializab
     /** @return upper one-standard-deviation rate [kg water/(mol h)]. */
     public double getUpper() {
       return upper;
+    }
+  }
+
+  /** Immutable inverse target-time result for the published fit-scatter range. */
+  public static final class TargetTimeRangeResult implements Serializable {
+    private static final long serialVersionUID = 1000L;
+
+    private final double targetRemainingFraction;
+    private final double requiredExposure;
+    private final double lowerPseudoFirstOrderRate;
+    private final double nominalPseudoFirstOrderRate;
+    private final double upperPseudoFirstOrderRate;
+    private final double shortestRequiredTimeHours;
+    private final double nominalRequiredTimeHours;
+    private final double longestRequiredTimeHours;
+
+    private TargetTimeRangeResult(double targetRemainingFraction, double requiredExposure,
+        double lowerPseudoFirstOrderRate, double nominalPseudoFirstOrderRate, double upperPseudoFirstOrderRate,
+        double shortestRequiredTimeHours, double nominalRequiredTimeHours, double longestRequiredTimeHours) {
+      this.targetRemainingFraction = targetRemainingFraction;
+      this.requiredExposure = requiredExposure;
+      this.lowerPseudoFirstOrderRate = lowerPseudoFirstOrderRate;
+      this.nominalPseudoFirstOrderRate = nominalPseudoFirstOrderRate;
+      this.upperPseudoFirstOrderRate = upperPseudoFirstOrderRate;
+      this.shortestRequiredTimeHours = shortestRequiredTimeHours;
+      this.nominalRequiredTimeHours = nominalRequiredTimeHours;
+      this.longestRequiredTimeHours = longestRequiredTimeHours;
+    }
+
+    /** @return requested remaining total-sulfide fraction. */
+    public double getTargetRemainingFraction() {
+      return targetRemainingFraction;
+    }
+
+    /** @return dimensionless exposure required to reach the target. */
+    public double getRequiredExposure() {
+      return requiredExposure;
+    }
+
+    /** @return lower pseudo-first-order rate [1/h]. */
+    public double getLowerPseudoFirstOrderRate() {
+      return lowerPseudoFirstOrderRate;
+    }
+
+    /** @return nominal pseudo-first-order rate [1/h]. */
+    public double getNominalPseudoFirstOrderRate() {
+      return nominalPseudoFirstOrderRate;
+    }
+
+    /** @return upper pseudo-first-order rate [1/h]. */
+    public double getUpperPseudoFirstOrderRate() {
+      return upperPseudoFirstOrderRate;
+    }
+
+    /** @return shortest required time, obtained with the upper fit-scatter rate [h]. */
+    public double getShortestRequiredTimeHours() {
+      return shortestRequiredTimeHours;
+    }
+
+    /** @return nominal required time [h]. */
+    public double getNominalRequiredTimeHours() {
+      return nominalRequiredTimeHours;
+    }
+
+    /** @return longest required time, obtained with the lower fit-scatter rate [h]. */
+    public double getLongestRequiredTimeHours() {
+      return longestRequiredTimeHours;
     }
   }
 

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKineticsTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKineticsTest.java
@@ -150,6 +150,63 @@ public class AqueousHydrogenSulfideOxidationKineticsTest extends NeqSimTest {
   }
 
   @Test
+  void testTargetTimeRangeReproducesHalfLifeAndForwardSolution() {
+    AqueousHydrogenSulfideOxidationKinetics.TargetTimeRangeResult result = AqueousHydrogenSulfideOxidationKinetics
+        .timeToRemainingFractionRange(AIR_SATURATED_OXYGEN_MOLALITY, 0.5, TEMPERATURE_K, PH, IONIC_STRENGTH);
+    double halfLife = AqueousHydrogenSulfideOxidationKinetics.halfLifeHours(AIR_SATURATED_OXYGEN_MOLALITY,
+        TEMPERATURE_K, PH, IONIC_STRENGTH);
+
+    assertEquals(0.5, result.getTargetRemainingFraction(), 0.0);
+    assertEquals(Math.log(2.0), result.getRequiredExposure(), 1.0e-15);
+    assertEquals(halfLife, result.getNominalRequiredTimeHours(), 1.0e-12);
+    assertTrue(result.getShortestRequiredTimeHours() < result.getNominalRequiredTimeHours());
+    assertTrue(result.getNominalRequiredTimeHours() < result.getLongestRequiredTimeHours());
+    assertEquals(0.5,
+        Math.exp(-result.getUpperPseudoFirstOrderRate() * result.getShortestRequiredTimeHours()), 1.0e-15);
+    assertEquals(0.5,
+        Math.exp(-result.getNominalPseudoFirstOrderRate() * result.getNominalRequiredTimeHours()), 1.0e-15);
+    assertEquals(0.5,
+        Math.exp(-result.getLowerPseudoFirstOrderRate() * result.getLongestRequiredTimeHours()), 1.0e-15);
+  }
+
+  @Test
+  void testTargetTimeRangeIdentityMonotonicityAndDeterminism() {
+    AqueousHydrogenSulfideOxidationKinetics.TargetTimeRangeResult identity = AqueousHydrogenSulfideOxidationKinetics
+        .timeToRemainingFractionRange(AIR_SATURATED_OXYGEN_MOLALITY, 1.0, TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.TargetTimeRangeResult half = AqueousHydrogenSulfideOxidationKinetics
+        .timeToRemainingFractionRange(AIR_SATURATED_OXYGEN_MOLALITY, 0.5, TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.TargetTimeRangeResult tenth = AqueousHydrogenSulfideOxidationKinetics
+        .timeToRemainingFractionRange(AIR_SATURATED_OXYGEN_MOLALITY, 0.1, TEMPERATURE_K, PH, IONIC_STRENGTH);
+    AqueousHydrogenSulfideOxidationKinetics.TargetTimeRangeResult repeated = AqueousHydrogenSulfideOxidationKinetics
+        .timeToRemainingFractionRange(AIR_SATURATED_OXYGEN_MOLALITY, 0.1, TEMPERATURE_K, PH, IONIC_STRENGTH);
+
+    assertEquals(0.0, identity.getRequiredExposure(), 0.0);
+    assertEquals(0.0, identity.getShortestRequiredTimeHours(), 0.0);
+    assertEquals(0.0, identity.getNominalRequiredTimeHours(), 0.0);
+    assertEquals(0.0, identity.getLongestRequiredTimeHours(), 0.0);
+    assertTrue(tenth.getShortestRequiredTimeHours() > half.getShortestRequiredTimeHours());
+    assertTrue(tenth.getNominalRequiredTimeHours() > half.getNominalRequiredTimeHours());
+    assertTrue(tenth.getLongestRequiredTimeHours() > half.getLongestRequiredTimeHours());
+    assertEquals(tenth.getRequiredExposure(), repeated.getRequiredExposure(), 0.0);
+    assertEquals(tenth.getNominalRequiredTimeHours(), repeated.getNominalRequiredTimeHours(), 0.0);
+  }
+
+  @Test
+  void testTargetTimeRangeFailsClosedOnInvalidTargetsAndOverflow() {
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
+        .timeToRemainingFractionRange(AIR_SATURATED_OXYGEN_MOLALITY, 0.0, TEMPERATURE_K, PH, IONIC_STRENGTH));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
+        .timeToRemainingFractionRange(AIR_SATURATED_OXYGEN_MOLALITY, -0.1, TEMPERATURE_K, PH, IONIC_STRENGTH));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
+        .timeToRemainingFractionRange(AIR_SATURATED_OXYGEN_MOLALITY, 1.0001, TEMPERATURE_K, PH, IONIC_STRENGTH));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
+        .timeToRemainingFractionRange(AIR_SATURATED_OXYGEN_MOLALITY, Double.NaN, TEMPERATURE_K, PH,
+            IONIC_STRENGTH));
+    assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
+        .timeToRemainingFractionRange(Double.MIN_VALUE, 0.5, TEMPERATURE_K, PH, IONIC_STRENGTH));
+  }
+
+  @Test
   void testLongExposureRemainsBoundedAndInputValidationFailsClosed() {
     AqueousHydrogenSulfideOxidationKinetics.ScreeningResult longExposure = AqueousHydrogenSulfideOxidationKinetics
         .screenAirSaturatedExposure(AIR_SATURATED_OXYGEN_MOLALITY, 1.0e6, TEMPERATURE_K, PH, IONIC_STRENGTH);

--- a/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKineticsTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/AqueousHydrogenSulfideOxidationKineticsTest.java
@@ -161,12 +161,11 @@ public class AqueousHydrogenSulfideOxidationKineticsTest extends NeqSimTest {
     assertEquals(halfLife, result.getNominalRequiredTimeHours(), 1.0e-12);
     assertTrue(result.getShortestRequiredTimeHours() < result.getNominalRequiredTimeHours());
     assertTrue(result.getNominalRequiredTimeHours() < result.getLongestRequiredTimeHours());
-    assertEquals(0.5,
-        Math.exp(-result.getUpperPseudoFirstOrderRate() * result.getShortestRequiredTimeHours()), 1.0e-15);
-    assertEquals(0.5,
-        Math.exp(-result.getNominalPseudoFirstOrderRate() * result.getNominalRequiredTimeHours()), 1.0e-15);
-    assertEquals(0.5,
-        Math.exp(-result.getLowerPseudoFirstOrderRate() * result.getLongestRequiredTimeHours()), 1.0e-15);
+    assertEquals(0.5, Math.exp(-result.getUpperPseudoFirstOrderRate() * result.getShortestRequiredTimeHours()),
+        1.0e-15);
+    assertEquals(0.5, Math.exp(-result.getNominalPseudoFirstOrderRate() * result.getNominalRequiredTimeHours()),
+        1.0e-15);
+    assertEquals(0.5, Math.exp(-result.getLowerPseudoFirstOrderRate() * result.getLongestRequiredTimeHours()), 1.0e-15);
   }
 
   @Test
@@ -200,8 +199,7 @@ public class AqueousHydrogenSulfideOxidationKineticsTest extends NeqSimTest {
     assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
         .timeToRemainingFractionRange(AIR_SATURATED_OXYGEN_MOLALITY, 1.0001, TEMPERATURE_K, PH, IONIC_STRENGTH));
     assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
-        .timeToRemainingFractionRange(AIR_SATURATED_OXYGEN_MOLALITY, Double.NaN, TEMPERATURE_K, PH,
-            IONIC_STRENGTH));
+        .timeToRemainingFractionRange(AIR_SATURATED_OXYGEN_MOLALITY, Double.NaN, TEMPERATURE_K, PH, IONIC_STRENGTH));
     assertThrows(IllegalArgumentException.class, () -> AqueousHydrogenSulfideOxidationKinetics
         .timeToRemainingFractionRange(Double.MIN_VALUE, 0.5, TEMPERATURE_K, PH, IONIC_STRENGTH));
   }


### PR DESCRIPTION
## Summary

Advances #3318 with a bounded inverse-screening capability for the published aqueous H₂S/O₂ kinetics already in NeqSim.

- Computes the shortest, nominal, and longest residence time required to reach a caller-supplied remaining sulfide fraction.
- Reuses the Millero et al. rate correlation and its published `0.18` scatter in `log10(k)`; no new fitted constants are introduced.
- Uses the analytical first-order inversion `E_required = -ln(f)` and `t_required = E_required / (k[O₂])`.
- Keeps results immutable and fails closed for invalid targets, invalid source-domain inputs, or non-finite numerical results.

Scientific source: Millero et al. (1987), https://doi.org/10.1021/es00159a003

Capability contract and overlap gate: https://github.com/equinor/neqsim/issues/3318#issuecomment-5554699654

## Exact-head contract

- Base: `4e3ea7808470066d1406ef62660713086a813624`
- Head: `a045bec82fde39eafe8189b8b0c950f5fb7631fd`
- Branch: `codex/3318-h2s-target-time-range`
- Six ordered commits across four intended files; the two repair commits apply only CI's exact hosted Spotless artifact.

## Validity and numerical gates

- Source domain remains 278.15–338.15 K, pH 4–8, and ionic strength 0–6 mol/kg water.
- Requires finite positive caller-supplied air-saturated O₂ molality.
- Target remaining fraction is `(0, 1]`; exact zero is rejected because finite first-order kinetics does not reach zero in finite time.
- `f = 1` returns exact zero time.
- `f = 0.5` reproduces the nominal half-life.
- Forward propagation recovers the requested fraction; uncertainty ordering, monotonicity, determinism, and overflow handling are tested.

At the documented reference condition, the nominal rate is `0.030904384181529014 h⁻¹`; the inverse result for `f = 0.5` is `22.428765332726698 h`, and forward propagation returns exactly `0.5`.

## Validation status

**READY TO MERGE AT EXACT HEAD `a045bec82fde39eafe8189b8b0c950f5fb7631fd`**

All exact-head hosted gates pass: Java 8/21 on Ubuntu and Windows, all four slow shards, Javadocs, Spotless, pre-commit, documentation/search, PaperLab, CodeQL, and agent-skill reference checks.

The first Windows Java 21 pass completed 12,792 tests with one unrelated transient timing assertion in `NewtonSolverAnalysisTest.benchmarkInitLevelBreakdown`; a targeted retry passed. The cancelled Ubuntu fast-test job was then retried successfully, unlocking both Java 8 lanes, which also passed. No scientific, numerical, API, documentation, or Huldra change was made during qualification.

No local Maven, Java, Spotless, pre-commit, or documentation result is claimed; GitHub Actions on the exact PR head are authoritative.

## Coordination and scope boundary

This is the sole active #3318 implementation PR. Current autonomous implementation-portfolio occupancy is **7/10**, below the ten-capability ceiling. It does not modify or couple electrolyte #3144, TP-flash #2937, dynamics #2911, pipeline work, MCP #3153, or the other active campaign branches.

This result is screening only: it is not an equipment-sizing guarantee and adds no arbitrary regime threshold, O₂ depletion/solubility model, reaction products, speciation, pressure correction, flash/transient/pipeline coupling, corrosion model, R1–R8 qualification, facility-specific data, or Huldra change.

Keep this PR draft-only; do not rebase, replace, close, merge, synchronize with `master`, enable auto-merge, or mark ready for capacity management.