### PR TITLE
[AI-Assisted] feat(dexpi): preserve connection owner provenance

### DIFF
--- a/docs/integration/dexpi-reader.md
+++ b/docs/integration/dexpi-reader.md
@@ -186,15 +186,20 @@ inventory does not infer connectivity or rewire the returned `ProcessSystem`.
 
 For resolved nozzle endpoints, the same record exposes only explicit source ownership: the nearest
 ancestor `Equipment` or `PipingComponent` identity and XML element name. Direct equipment or
-piping-component endpoints own themselves. Orphaned nozzles and owner elements without source IDs
-remain deterministic warnings; the reader does not derive ownership from coordinates, tags,
-stream order, or simulation state.
+piping-component endpoints own themselves. For each resolved owner, the connection occurrence also
+preserves the owner's explicit `ComponentClass`, `ComponentName`, and `TagName`; absent source
+metadata remains an empty string. Orphaned nozzles and owner elements without source IDs remain
+deterministic warnings; unresolved owners receive no invented metadata. The reader does not derive
+ownership or owner metadata from coordinates, endpoint tags, stream order, simulation state, or
+class heuristics.
 
 `ImportResult.getConnectionEndpoints()` provides a distinct endpoint inventory in first-reference
-order. Each immutable `DexpiConnectionEndpointInfo` records the resolved element and explicit owner
-evidence plus the incoming and outgoing connection-evidence IDs in source order. Counts retain every
-occurrence, including parallel connections. Blank endpoint references remain findings and are omitted
-from this keyed inventory; unresolved non-empty IDs remain visible.
+order. Each immutable `DexpiConnectionEndpointInfo` records the resolved element, explicit owner
+identity and XML element name, and the owner's explicit `ComponentClass`, `ComponentName`, and
+`TagName`, plus the incoming and outgoing connection-evidence IDs in source order. Counts retain
+every occurrence, including parallel connections. Blank endpoint references remain findings and are
+omitted from this keyed inventory; unresolved non-empty IDs remain visible with empty owner
+provenance.
 
 `getIncidenceRole()` classifies only this directed source evidence: zero incoming and one outgoing
 is `SOURCE`; one incoming and zero outgoing is `SINK`; one of each is `PASS_THROUGH`; one

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionEndpointInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionEndpointInfo.java
@@ -48,6 +48,9 @@ public final class DexpiConnectionEndpointInfo implements Serializable {
   private final String elementName;
   private final String ownerId;
   private final String ownerElementName;
+  private final String ownerComponentClass;
+  private final String ownerComponentName;
+  private final String ownerTagName;
   private final boolean resolved;
   private final List<String> incomingConnectionIds;
   private final List<String> outgoingConnectionIds;
@@ -65,10 +68,34 @@ public final class DexpiConnectionEndpointInfo implements Serializable {
    */
   public DexpiConnectionEndpointInfo(String endpointId, String elementName, String ownerId, String ownerElementName,
       boolean resolved, List<String> incomingConnectionIds, List<String> outgoingConnectionIds) {
+    this(endpointId, elementName, ownerId, ownerElementName, "", "", "", resolved, incomingConnectionIds,
+        outgoingConnectionIds);
+  }
+
+  /**
+   * Creates immutable endpoint-incidence evidence with explicit owner provenance.
+   *
+   * @param endpointId explicit source endpoint identity
+   * @param elementName resolved endpoint XML element name, or empty when unresolved
+   * @param ownerId explicit endpoint owner identity, or empty when absent
+   * @param ownerElementName endpoint owner XML element name, or empty when absent
+   * @param ownerComponentClass explicit owner ComponentClass, or empty when absent
+   * @param ownerComponentName explicit owner ComponentName, or empty when absent
+   * @param ownerTagName explicit owner TagName, or empty when absent
+   * @param resolved whether the endpoint resolves in the source document
+   * @param incomingConnectionIds incoming connection-evidence IDs in source order
+   * @param outgoingConnectionIds outgoing connection-evidence IDs in source order
+   */
+  public DexpiConnectionEndpointInfo(String endpointId, String elementName, String ownerId, String ownerElementName,
+      String ownerComponentClass, String ownerComponentName, String ownerTagName, boolean resolved,
+      List<String> incomingConnectionIds, List<String> outgoingConnectionIds) {
     this.endpointId = normalize(endpointId);
     this.elementName = normalize(elementName);
     this.ownerId = normalize(ownerId);
     this.ownerElementName = normalize(ownerElementName);
+    this.ownerComponentClass = normalize(ownerComponentClass);
+    this.ownerComponentName = normalize(ownerComponentName);
+    this.ownerTagName = normalize(ownerTagName);
     this.resolved = resolved;
     this.incomingConnectionIds = Collections.unmodifiableList(new ArrayList<String>(incomingConnectionIds));
     this.outgoingConnectionIds = Collections.unmodifiableList(new ArrayList<String>(outgoingConnectionIds));
@@ -92,6 +119,21 @@ public final class DexpiConnectionEndpointInfo implements Serializable {
   /** @return endpoint owner XML element name, or empty when absent */
   public String getOwnerElementName() {
     return ownerElementName;
+  }
+
+  /** @return explicit owner ComponentClass, or empty when absent */
+  public String getOwnerComponentClass() {
+    return ownerComponentClass;
+  }
+
+  /** @return explicit owner ComponentName, or empty when absent */
+  public String getOwnerComponentName() {
+    return ownerComponentName;
+  }
+
+  /** @return explicit owner TagName, or empty when absent */
+  public String getOwnerTagName() {
+    return ownerTagName;
   }
 
   /** @return whether the endpoint resolves in the source document */
@@ -174,6 +216,9 @@ public final class DexpiConnectionEndpointInfo implements Serializable {
     result.put("elementName", elementName);
     result.put("ownerId", ownerId);
     result.put("ownerElementName", ownerElementName);
+    result.put("ownerComponentClass", ownerComponentClass);
+    result.put("ownerComponentName", ownerComponentName);
+    result.put("ownerTagName", ownerTagName);
     result.put("resolved", Boolean.valueOf(resolved));
     result.put("incomingConnectionCount", Integer.valueOf(getIncomingConnectionCount()));
     result.put("outgoingConnectionCount", Integer.valueOf(getOutgoingConnectionCount()));

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
@@ -28,6 +28,12 @@ public final class DexpiConnectionInfo implements Serializable {
   private final String toOwnerId;
   private final String fromOwnerElementName;
   private final String toOwnerElementName;
+  private final String fromOwnerComponentClass;
+  private final String fromOwnerComponentName;
+  private final String fromOwnerTagName;
+  private final String toOwnerComponentClass;
+  private final String toOwnerComponentName;
+  private final String toOwnerTagName;
   private final boolean fromResolved;
   private final boolean toResolved;
 
@@ -70,6 +76,38 @@ public final class DexpiConnectionInfo implements Serializable {
   public DexpiConnectionInfo(String id, String sourceId, String segmentId, String fromId, String toId,
       String fromElementName, String toElementName, String fromOwnerId, String toOwnerId, String fromOwnerElementName,
       String toOwnerElementName, boolean fromResolved, boolean toResolved) {
+    this(id, sourceId, segmentId, fromId, toId, fromElementName, toElementName, fromOwnerId, toOwnerId,
+        fromOwnerElementName, toOwnerElementName, "", "", "", "", "", "", fromResolved, toResolved);
+  }
+
+  /**
+   * Creates immutable connection evidence with explicit endpoint-owner provenance.
+   *
+   * @param id stable evidence identity
+   * @param sourceId source connection identity, or empty when absent
+   * @param segmentId owning piping-network segment identity, or empty when absent
+   * @param fromId source endpoint identity
+   * @param toId target endpoint identity
+   * @param fromElementName resolved source XML element name
+   * @param toElementName resolved target XML element name
+   * @param fromOwnerId explicit source owner identity, or empty when absent
+   * @param toOwnerId explicit target owner identity, or empty when absent
+   * @param fromOwnerElementName source owner XML element name, or empty when absent
+   * @param toOwnerElementName target owner XML element name, or empty when absent
+   * @param fromOwnerComponentClass explicit source-owner ComponentClass, or empty when absent
+   * @param fromOwnerComponentName explicit source-owner ComponentName, or empty when absent
+   * @param fromOwnerTagName explicit source-owner TagName, or empty when absent
+   * @param toOwnerComponentClass explicit target-owner ComponentClass, or empty when absent
+   * @param toOwnerComponentName explicit target-owner ComponentName, or empty when absent
+   * @param toOwnerTagName explicit target-owner TagName, or empty when absent
+   * @param fromResolved whether the source endpoint resolves in the source document
+   * @param toResolved whether the target endpoint resolves in the source document
+   */
+  public DexpiConnectionInfo(String id, String sourceId, String segmentId, String fromId, String toId,
+      String fromElementName, String toElementName, String fromOwnerId, String toOwnerId, String fromOwnerElementName,
+      String toOwnerElementName, String fromOwnerComponentClass, String fromOwnerComponentName,
+      String fromOwnerTagName, String toOwnerComponentClass, String toOwnerComponentName, String toOwnerTagName,
+      boolean fromResolved, boolean toResolved) {
     this.id = normalize(id);
     this.sourceId = normalize(sourceId);
     this.segmentId = normalize(segmentId);
@@ -81,6 +119,12 @@ public final class DexpiConnectionInfo implements Serializable {
     this.toOwnerId = normalize(toOwnerId);
     this.fromOwnerElementName = normalize(fromOwnerElementName);
     this.toOwnerElementName = normalize(toOwnerElementName);
+    this.fromOwnerComponentClass = normalize(fromOwnerComponentClass);
+    this.fromOwnerComponentName = normalize(fromOwnerComponentName);
+    this.fromOwnerTagName = normalize(fromOwnerTagName);
+    this.toOwnerComponentClass = normalize(toOwnerComponentClass);
+    this.toOwnerComponentName = normalize(toOwnerComponentName);
+    this.toOwnerTagName = normalize(toOwnerTagName);
     this.fromResolved = fromResolved;
     this.toResolved = toResolved;
   }
@@ -145,6 +189,36 @@ public final class DexpiConnectionInfo implements Serializable {
     return toOwnerElementName;
   }
 
+  /** @return explicit source-owner ComponentClass, or empty when absent */
+  public String getFromOwnerComponentClass() {
+    return fromOwnerComponentClass;
+  }
+
+  /** @return explicit source-owner ComponentName, or empty when absent */
+  public String getFromOwnerComponentName() {
+    return fromOwnerComponentName;
+  }
+
+  /** @return explicit source-owner TagName, or empty when absent */
+  public String getFromOwnerTagName() {
+    return fromOwnerTagName;
+  }
+
+  /** @return explicit target-owner ComponentClass, or empty when absent */
+  public String getToOwnerComponentClass() {
+    return toOwnerComponentClass;
+  }
+
+  /** @return explicit target-owner ComponentName, or empty when absent */
+  public String getToOwnerComponentName() {
+    return toOwnerComponentName;
+  }
+
+  /** @return explicit target-owner TagName, or empty when absent */
+  public String getToOwnerTagName() {
+    return toOwnerTagName;
+  }
+
   /** @return whether both endpoint owners have explicit identities */
   public boolean isOwnershipResolved() {
     return !fromOwnerId.isEmpty() && !toOwnerId.isEmpty();
@@ -183,6 +257,12 @@ public final class DexpiConnectionInfo implements Serializable {
     result.put("toOwnerId", toOwnerId);
     result.put("fromOwnerElementName", fromOwnerElementName);
     result.put("toOwnerElementName", toOwnerElementName);
+    result.put("fromOwnerComponentClass", fromOwnerComponentClass);
+    result.put("fromOwnerComponentName", fromOwnerComponentName);
+    result.put("fromOwnerTagName", fromOwnerTagName);
+    result.put("toOwnerComponentClass", toOwnerComponentClass);
+    result.put("toOwnerComponentName", toOwnerComponentName);
+    result.put("toOwnerTagName", toOwnerTagName);
     result.put("fromResolved", Boolean.valueOf(fromResolved));
     result.put("toResolved", Boolean.valueOf(toResolved));
     return result;

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiConnectionInfo.java
@@ -105,9 +105,9 @@ public final class DexpiConnectionInfo implements Serializable {
    */
   public DexpiConnectionInfo(String id, String sourceId, String segmentId, String fromId, String toId,
       String fromElementName, String toElementName, String fromOwnerId, String toOwnerId, String fromOwnerElementName,
-      String toOwnerElementName, String fromOwnerComponentClass, String fromOwnerComponentName,
-      String fromOwnerTagName, String toOwnerComponentClass, String toOwnerComponentName, String toOwnerTagName,
-      boolean fromResolved, boolean toResolved) {
+      String toOwnerElementName, String fromOwnerComponentClass, String fromOwnerComponentName, String fromOwnerTagName,
+      String toOwnerComponentClass, String toOwnerComponentName, String toOwnerTagName, boolean fromResolved,
+      boolean toResolved) {
     this.id = normalize(id);
     this.sourceId = normalize(sourceId);
     this.segmentId = normalize(segmentId);

--- a/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
+++ b/src/main/java/neqsim/process/processmodel/dexpi/DexpiXmlReader.java
@@ -1116,7 +1116,10 @@ public final class DexpiXmlReader {
           fromElement == null ? "" : fromElement.getTagName(), toElement == null ? "" : toElement.getTagName(),
           fromOwner == null ? "" : fromOwner.getAttribute("ID"), toOwner == null ? "" : toOwner.getAttribute("ID"),
           fromOwner == null ? "" : fromOwner.getTagName(), toOwner == null ? "" : toOwner.getTagName(),
-          fromElement != null, toElement != null));
+          explicitAttribute(fromOwner, "ComponentClass"), explicitAttribute(fromOwner, "ComponentName"),
+          explicitTagName(fromOwner), explicitAttribute(toOwner, "ComponentClass"),
+          explicitAttribute(toOwner, "ComponentName"), explicitTagName(toOwner), fromElement != null,
+          toElement != null));
     }
     logger.info("Parsed {} material connections from DEXPI XML", connections.size());
     return connections;
@@ -1492,6 +1495,9 @@ public final class DexpiXmlReader {
           source ? connection.getFromElementName() : connection.getToElementName(),
           source ? connection.getFromOwnerId() : connection.getToOwnerId(),
           source ? connection.getFromOwnerElementName() : connection.getToOwnerElementName(),
+          source ? connection.getFromOwnerComponentClass() : connection.getToOwnerComponentClass(),
+          source ? connection.getFromOwnerComponentName() : connection.getToOwnerComponentName(),
+          source ? connection.getFromOwnerTagName() : connection.getToOwnerTagName(),
           source ? connection.isFromResolved() : connection.isToResolved());
       endpoints.put(endpointId, endpoint);
     }
@@ -1503,16 +1509,23 @@ public final class DexpiXmlReader {
     private final String elementName;
     private final String ownerId;
     private final String ownerElementName;
+    private final String ownerComponentClass;
+    private final String ownerComponentName;
+    private final String ownerTagName;
     private final boolean resolved;
     private final List<String> incomingConnectionIds = new ArrayList<String>();
     private final List<String> outgoingConnectionIds = new ArrayList<String>();
 
     private ConnectionEndpointAccumulator(String endpointId, String elementName, String ownerId,
-        String ownerElementName, boolean resolved) {
+        String ownerElementName, String ownerComponentClass, String ownerComponentName, String ownerTagName,
+        boolean resolved) {
       this.endpointId = endpointId;
       this.elementName = elementName;
       this.ownerId = ownerId;
       this.ownerElementName = ownerElementName;
+      this.ownerComponentClass = ownerComponentClass;
+      this.ownerComponentName = ownerComponentName;
+      this.ownerTagName = ownerTagName;
       this.resolved = resolved;
     }
 
@@ -1525,8 +1538,8 @@ public final class DexpiXmlReader {
     }
 
     private DexpiConnectionEndpointInfo toInfo() {
-      return new DexpiConnectionEndpointInfo(endpointId, elementName, ownerId, ownerElementName, resolved,
-          incomingConnectionIds, outgoingConnectionIds);
+      return new DexpiConnectionEndpointInfo(endpointId, elementName, ownerId, ownerElementName, ownerComponentClass,
+          ownerComponentName, ownerTagName, resolved, incomingConnectionIds, outgoingConnectionIds);
     }
   }
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -591,8 +591,7 @@ public class DexpiXmlReaderTest extends NeqSimTest {
   public void testReadWithDiagnosticsPreservesDirectConnectionOwnerProvenance() throws Exception {
     String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
         + "<PipingComponent ID=\"PC-DIRECT\" ComponentClass=\"GlobeValve\" ComponentName=\"ValveShape\""
-        + " TagName=\"XV-101\"/>"
-        + "<Equipment ID=\"E-DIRECT\" ComponentClass=\"Tank\" ComponentName=\"TankShape\">"
+        + " TagName=\"XV-101\"/>" + "<Equipment ID=\"E-DIRECT\" ComponentClass=\"Tank\" ComponentName=\"TankShape\">"
         + "<GenericAttributes><GenericAttribute Name=\"TagNameAssignmentClass\" Value=\"TK-101\"/>"
         + "</GenericAttributes></Equipment>"
         + "<PipingNetworkSegment ID=\"S-DIRECT\"><Connection ID=\"C-DIRECT\" FromID=\"PC-DIRECT\""

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -544,8 +544,11 @@ public class DexpiXmlReaderTest extends NeqSimTest {
   @Test
   public void testReadWithDiagnosticsPreservesParallelMaterialConnections() throws Exception {
     String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
-        + "<Equipment ID=\"E-OUT\"><Nozzle ID=\"N-OUT\"/></Equipment>"
-        + "<Equipment ID=\"E-IN\"><Nozzle ID=\"N-IN\"/></Equipment>"
+        + "<Equipment ID=\"E-OUT\" ComponentClass=\"CentrifugalPump\" ComponentName=\"ExportPump\""
+        + " TagName=\"P-101\"><Nozzle ID=\"N-OUT\"/></Equipment>"
+        + "<Equipment ID=\"E-IN\" ComponentClass=\"Separator\" ComponentName=\"InletSeparator\">"
+        + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"V-101\"/></GenericAttributes>"
+        + "<Nozzle ID=\"N-IN\"/></Equipment>"
         + "<PipingNetworkSegment ID=\"S-1\" ComponentClass=\"PipingNetworkSegment\">"
         + "<Connection FromID=\"N-OUT\" ToID=\"N-IN\"/></PipingNetworkSegment>"
         + "<PipingNetworkSegment ID=\"S-2\" ComponentClass=\"PipingNetworkSegment\">"
@@ -569,6 +572,12 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("E-IN", firstConnection.getToOwnerId());
     assertEquals("Equipment", firstConnection.getFromOwnerElementName());
     assertEquals("Equipment", firstConnection.getToOwnerElementName());
+    assertEquals("CentrifugalPump", firstConnection.getFromOwnerComponentClass());
+    assertEquals("ExportPump", firstConnection.getFromOwnerComponentName());
+    assertEquals("P-101", firstConnection.getFromOwnerTagName());
+    assertEquals("Separator", firstConnection.getToOwnerComponentClass());
+    assertEquals("InletSeparator", firstConnection.getToOwnerComponentName());
+    assertEquals("V-101", firstConnection.getToOwnerTagName());
     assertTrue(firstConnection.isResolved());
     assertTrue(firstConnection.isOwnershipResolved());
     assertEquals("S-2/connection-1", first.getConnections().get(1).getId());
@@ -576,6 +585,34 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(first.toJson().contains("\"connectionCount\": 2"));
     assertEquals(first.toJson(), second.toJson());
     assertThrows(UnsupportedOperationException.class, () -> first.getConnections().clear());
+  }
+
+  @Test
+  public void testReadWithDiagnosticsPreservesDirectConnectionOwnerProvenance() throws Exception {
+    String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
+        + "<PipingComponent ID=\"PC-DIRECT\" ComponentClass=\"GlobeValve\" ComponentName=\"ValveShape\""
+        + " TagName=\"XV-101\"/>"
+        + "<Equipment ID=\"E-DIRECT\" ComponentClass=\"Tank\" ComponentName=\"TankShape\">"
+        + "<GenericAttributes><GenericAttribute Name=\"TagNameAssignmentClass\" Value=\"TK-101\"/>"
+        + "</GenericAttributes></Equipment>"
+        + "<PipingNetworkSegment ID=\"S-DIRECT\"><Connection ID=\"C-DIRECT\" FromID=\"PC-DIRECT\""
+        + " ToID=\"E-DIRECT\"/></PipingNetworkSegment></PlantModel>";
+
+    DexpiXmlReader.ImportResult result = DexpiXmlReader
+        .readWithDiagnostics(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    DexpiConnectionInfo connection = result.getConnections().get(0);
+
+    assertEquals("PipingComponent", connection.getFromElementName());
+    assertEquals("PC-DIRECT", connection.getFromOwnerId());
+    assertEquals("GlobeValve", connection.getFromOwnerComponentClass());
+    assertEquals("ValveShape", connection.getFromOwnerComponentName());
+    assertEquals("XV-101", connection.getFromOwnerTagName());
+    assertEquals("Equipment", connection.getToElementName());
+    assertEquals("E-DIRECT", connection.getToOwnerId());
+    assertEquals("Tank", connection.getToOwnerComponentClass());
+    assertEquals("TankShape", connection.getToOwnerComponentName());
+    assertEquals("TK-101", connection.getToOwnerTagName());
+    assertTrue(connection.isOwnershipResolved());
   }
 
   @Test
@@ -625,6 +662,12 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     DexpiConnectionInfo legacy = new DexpiConnectionInfo("C", "C", "S", "A", "B", "Nozzle", "Nozzle", true, true);
     assertEquals("", legacy.getFromOwnerId());
     assertEquals("", legacy.getToOwnerId());
+    assertEquals("", legacy.getFromOwnerComponentClass());
+    assertEquals("", legacy.getFromOwnerComponentName());
+    assertEquals("", legacy.getFromOwnerTagName());
+    assertEquals("", legacy.getToOwnerComponentClass());
+    assertEquals("", legacy.getToOwnerComponentName());
+    assertEquals("", legacy.getToOwnerTagName());
   }
 
   @Test
@@ -632,7 +675,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
         + "<Equipment ID=\"E-A\"><Nozzle ID=\"N-A\"/></Equipment>"
         + "<Equipment ID=\"E-B\"><Nozzle ID=\"N-B\"/></Equipment>"
-        + "<PipingComponent ID=\"PC-J\"><Nozzle ID=\"N-J\"/></PipingComponent>"
+        + "<PipingComponent ID=\"PC-J\" ComponentClass=\"PipeFitting\" ComponentName=\"TeeShape\">"
+        + "<GenericAttributes><GenericAttribute Name=\"TagNameAssignmentClass\" Value=\"TEE-101\"/>"
+        + "</GenericAttributes><Nozzle ID=\"N-J\"/></PipingComponent>"
         + "<Equipment ID=\"E-C\"><Nozzle ID=\"N-C\"/></Equipment>"
         + "<PipingNetworkSegment ID=\"S-1\"><Connection ID=\"C-1\" FromID=\"N-A\" ToID=\"N-J\"/>"
         + "</PipingNetworkSegment>"
@@ -652,6 +697,10 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertEquals("N-J", junction.getEndpointId());
     assertEquals("Nozzle", junction.getElementName());
     assertEquals("PC-J", junction.getOwnerId());
+    assertEquals("PipingComponent", junction.getOwnerElementName());
+    assertEquals("PipeFitting", junction.getOwnerComponentClass());
+    assertEquals("TeeShape", junction.getOwnerComponentName());
+    assertEquals("TEE-101", junction.getOwnerTagName());
     assertTrue(junction.isResolved());
     assertEquals(2, junction.getIncomingConnectionCount());
     assertEquals(1, junction.getOutgoingConnectionCount());
@@ -665,6 +714,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     DexpiConnectionEndpointInfo unresolved = first.getConnectionEndpoints().get(4);
     assertEquals("UNKNOWN", unresolved.getEndpointId());
     assertFalse(unresolved.isResolved());
+    assertEquals("", unresolved.getOwnerComponentClass());
+    assertEquals("", unresolved.getOwnerComponentName());
+    assertEquals("", unresolved.getOwnerTagName());
     assertEquals(Collections.singletonList("C-4"), unresolved.getOutgoingConnectionIds());
     assertEquals(0, unresolved.getIncomingConnectionCount());
     assertEquals(DexpiConnectionEndpointInfo.IncidenceRole.SOURCE, unresolved.getIncidenceRole());
@@ -674,6 +726,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
     assertTrue(first.toJson().contains("\"connectionEndpointCount\": 5"));
     assertTrue(first.toJson().contains("\"incidenceRole\": \"MERGE\""));
     assertTrue(first.toJson().contains("\"potentialMultiConnectionNode\": true"));
+    assertTrue(first.toJson().contains("\"ownerComponentClass\": \"PipeFitting\""));
+    assertTrue(first.toJson().contains("\"ownerComponentName\": \"TeeShape\""));
+    assertTrue(first.toJson().contains("\"ownerTagName\": \"TEE-101\""));
     assertEquals(first.toJson(), second.toJson());
   }
 

--- a/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
+++ b/src/test/java/neqsim/process/processmodel/dexpi/DexpiXmlReaderTest.java
@@ -544,8 +544,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
   @Test
   public void testReadWithDiagnosticsPreservesParallelMaterialConnections() throws Exception {
     String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
-        + "<Equipment ID=\"E-OUT\" ComponentClass=\"CentrifugalPump\" ComponentName=\"ExportPump\""
-        + " TagName=\"P-101\"><Nozzle ID=\"N-OUT\"/></Equipment>"
+        + "<Equipment ID=\"E-OUT\" ComponentClass=\"CentrifugalPump\" ComponentName=\"ExportPump\">"
+        + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"P-101\"/></GenericAttributes>"
+        + "<Nozzle ID=\"N-OUT\"/></Equipment>"
         + "<Equipment ID=\"E-IN\" ComponentClass=\"Separator\" ComponentName=\"InletSeparator\">"
         + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"V-101\"/></GenericAttributes>"
         + "<Nozzle ID=\"N-IN\"/></Equipment>"
@@ -590,8 +591,9 @@ public class DexpiXmlReaderTest extends NeqSimTest {
   @Test
   public void testReadWithDiagnosticsPreservesDirectConnectionOwnerProvenance() throws Exception {
     String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<PlantModel>"
-        + "<PipingComponent ID=\"PC-DIRECT\" ComponentClass=\"GlobeValve\" ComponentName=\"ValveShape\""
-        + " TagName=\"XV-101\"/>" + "<Equipment ID=\"E-DIRECT\" ComponentClass=\"Tank\" ComponentName=\"TankShape\">"
+        + "<PipingComponent ID=\"PC-DIRECT\" ComponentClass=\"GlobeValve\" ComponentName=\"ValveShape\">"
+        + "<GenericAttributes><GenericAttribute Name=\"TagName\" Value=\"XV-101\"/></GenericAttributes>"
+        + "</PipingComponent><Equipment ID=\"E-DIRECT\" ComponentClass=\"Tank\" ComponentName=\"TankShape\">"
         + "<GenericAttributes><GenericAttribute Name=\"TagNameAssignmentClass\" Value=\"TK-101\"/>"
         + "</GenericAttributes></Equipment>"
         + "<PipingNetworkSegment ID=\"S-DIRECT\"><Connection ID=\"C-DIRECT\" FromID=\"PC-DIRECT\""


### PR DESCRIPTION
## Summary

Adds immutable source provenance for resolved material-connection endpoint owners in the Proteus-compatible DEXPI reader.

- preserves each resolved owner's explicit `ComponentClass`, `ComponentName`, and `TagName` on source-ordered `DexpiConnectionInfo` occurrences
- projects the same evidence into first-reference-ordered `DexpiConnectionEndpointInfo` records
- keeps missing metadata and unresolved owners empty without invented values
- preserves parallel occurrences, direction, incidence evidence, deterministic JSON, legacy constructors, existing APIs/fields, Java 8 compatibility, topology, rendering, simulation, and exports
- documents the evidence boundary and non-inferences
- applies the exact hosted Spotless repair from initial head `f814f35179ad19ab921fb90be7dee5672e352de6`

## Capability contract

**Roadmaps:** #1332 and #2899  
**Exact base:** `4e3ea7808470066d1406ef62660713086a813624`  
**Exact head:** `62c783b689dbb4d4db0ac1543d05eac26cb6f991`  
**Complexity:** O(V+E) source parsing and endpoint projection  
**Autonomous portfolio after reservation:** **7/10**

## Validation

Status: **READY TO MERGE**

All eight exact-head workflows pass: 19 successful jobs, one expected PaperLab skip, zero failures, and zero pending jobs.

- Java 8 and Java 21 fast tests pass on Ubuntu and Windows
- all four Java 21 slow-test shards pass
- Javadocs, Spotless, pre-commit, documentation/search, notebook/focused handover, engineering-diagram performance, CodeQL, and PaperLab/reference gates pass
- the bounded fixture repair uses the supported explicit `GenericAttribute` encoding; production code and the five-file semantic scope are unchanged
- final scope is eight commits across five intended files, zero commits behind `master`
- the draft is mergeable with no reviews or unresolved threads

## Documentation impact

Documentation is updated for the owner-provenance evidence boundary and non-inferences. No user workflow or configuration change is introduced.

## Engineering boundary

This change preserves explicit source-reference evidence only. It does not derive metadata, infer hydraulic continuity, identify a fitting or branch, establish process or control intent, assign safeguard or SIS credit, modify live topology, certify a drawing, claim standards conformance, or provide engineering approval.

## Publication policy

Draft only. No merge, rebase, ready-for-review transition, conformance claim, certification, or engineering approval is authorized.